### PR TITLE
feat: add shield settings for temporary window fallback

### DIFF
--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -44,6 +44,7 @@ export { Switch, switchVariants } from "./Switch"
 export { EmptyState } from "./EmptyState"
 export { Modal } from "./Dialog/Modal"
 export { Separator } from "./Separator"
+export { Checkbox } from "./checkbox"
 
 // Typography Components
 export {

--- a/entrypoints/options/pages/BasicSettings/components/AutoRefreshTab.tsx
+++ b/entrypoints/options/pages/BasicSettings/components/AutoRefreshTab.tsx
@@ -1,10 +1,14 @@
 import RefreshSettings from "./RefreshSettings"
+import ShieldSettings from "./ShieldSettings"
 
 export default function AutoRefreshTab() {
   return (
     <div className="space-y-6">
       <section id="auto-refresh">
         <RefreshSettings />
+      </section>
+      <section id="shield-settings">
+        <ShieldSettings />
       </section>
     </div>
   )

--- a/entrypoints/options/pages/BasicSettings/components/RefreshSettings.tsx
+++ b/entrypoints/options/pages/BasicSettings/components/RefreshSettings.tsx
@@ -5,8 +5,7 @@ import { useTranslation } from "react-i18next"
 import { SettingSection } from "~/components/SettingSection"
 import { Card, CardItem, CardList, Input, Switch } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
-
-import { showUpdateToast } from "../../../../../utils/toastHelpers.ts"
+import { showUpdateToast } from "~/utils/toastHelpers.ts"
 
 export default function RefreshSettings() {
   const { t } = useTranslation("settings")
@@ -116,7 +115,7 @@ export default function RefreshSettings() {
                     placeholder="360"
                     className="w-24"
                   />
-                  <span className="text-sm text-gray-500 dark:text-dark-text-secondary">
+                  <span className="dark:text-dark-text-secondary text-sm text-gray-500">
                     {t("common:time.seconds")}
                   </span>
                 </div>
@@ -155,7 +154,7 @@ export default function RefreshSettings() {
                   placeholder="60"
                   className="w-24"
                 />
-                <span className="text-sm text-gray-500 dark:text-dark-text-secondary">
+                <span className="dark:text-dark-text-secondary text-sm text-gray-500">
                   {t("common:time.seconds")}
                 </span>
               </div>

--- a/entrypoints/options/pages/BasicSettings/components/ShieldSettings.tsx
+++ b/entrypoints/options/pages/BasicSettings/components/ShieldSettings.tsx
@@ -1,0 +1,144 @@
+import { useTranslation } from "react-i18next"
+
+import { SettingSection } from "~/components/SettingSection"
+import {
+  BodySmall,
+  Card,
+  CardItem,
+  CardList,
+  Checkbox,
+  Muted,
+  Switch
+} from "~/components/ui"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { isFirefox } from "~/utils/browser.ts"
+
+export default function ShieldSettings() {
+  const { t } = useTranslation("settings")
+  const { tempWindowFallback, updateTempWindowFallback } =
+    useUserPreferencesContext()
+
+  const isFirefoxEnv = isFirefox()
+
+  const shieldEnabled = tempWindowFallback.enabled
+  const shieldPopup = tempWindowFallback.useInPopup
+  const shieldSidepanel = tempWindowFallback.useInSidePanel
+  const shieldOptions = tempWindowFallback.useInOptions
+  const shieldAutoRefresh = tempWindowFallback.useForAutoRefresh
+  const shieldManualRefresh = tempWindowFallback.useForManualRefresh
+
+  return (
+    <SettingSection
+      id="shield-settings"
+      title={t("refresh.shieldTitle")}
+      description={t("refresh.shieldDescription")}>
+      <Card padding="none">
+        <CardList>
+          <CardItem
+            title={t("refresh.shieldEnabled")}
+            description={t("refresh.shieldEnabledDesc")}
+            rightContent={
+              <Switch
+                checked={shieldEnabled}
+                onChange={(value) =>
+                  updateTempWindowFallback({ enabled: value })
+                }
+              />
+            }
+          />
+
+          <CardItem
+            title={t("refresh.shieldContextsTitle")}
+            description={t("refresh.shieldContextsDesc")}
+            rightContent={
+              <div className="flex flex-col space-y-2 text-left">
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                  <label className="flex items-center space-x-2">
+                    <Checkbox
+                      checked={shieldPopup}
+                      disabled={!shieldEnabled || isFirefoxEnv}
+                      onCheckedChange={(checked) =>
+                        updateTempWindowFallback({
+                          useInPopup: Boolean(checked)
+                        })
+                      }
+                    />
+                    <BodySmall className="dark:text-dark-text-secondary text-gray-700">
+                      {t("refresh.shieldPopup")}
+                    </BodySmall>
+                  </label>
+
+                  <label className="flex items-center space-x-2">
+                    <Checkbox
+                      checked={shieldSidepanel}
+                      disabled={!shieldEnabled}
+                      onCheckedChange={(checked) =>
+                        updateTempWindowFallback({
+                          useInSidePanel: Boolean(checked)
+                        })
+                      }
+                    />
+                    <BodySmall className="dark:text-dark-text-secondary text-gray-700">
+                      {t("refresh.shieldSidepanel")}
+                    </BodySmall>
+                  </label>
+
+                  <label className="flex items-center space-x-2">
+                    <Checkbox
+                      checked={shieldOptions}
+                      disabled={!shieldEnabled}
+                      onCheckedChange={(checked) =>
+                        updateTempWindowFallback({
+                          useInOptions: Boolean(checked)
+                        })
+                      }
+                    />
+                    <BodySmall className="dark:text-dark-text-secondary text-gray-700">
+                      {t("refresh.shieldOptions")}
+                    </BodySmall>
+                  </label>
+
+                  <label className="flex items-center space-x-2">
+                    <Checkbox
+                      checked={shieldAutoRefresh}
+                      disabled={!shieldEnabled}
+                      onCheckedChange={(checked) =>
+                        updateTempWindowFallback({
+                          useForAutoRefresh: Boolean(checked)
+                        })
+                      }
+                    />
+                    <BodySmall className="dark:text-dark-text-secondary text-gray-700">
+                      {t("refresh.shieldAutoRefresh")}
+                    </BodySmall>
+                  </label>
+
+                  <label className="flex items-center space-x-2">
+                    <Checkbox
+                      checked={shieldManualRefresh}
+                      disabled={!shieldEnabled}
+                      onCheckedChange={(checked) =>
+                        updateTempWindowFallback({
+                          useForManualRefresh: Boolean(checked)
+                        })
+                      }
+                    />
+                    <BodySmall className="dark:text-dark-text-secondary text-gray-700">
+                      {t("refresh.shieldManualRefresh")}
+                    </BodySmall>
+                  </label>
+                </div>
+
+                {isFirefoxEnv && (
+                  <Muted className="mt-1">
+                    {t("refresh.shieldPopupFirefoxNote")}
+                  </Muted>
+                )}
+              </div>
+            }
+          />
+        </CardList>
+      </Card>
+    </SettingSection>
+  )
+}

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -34,7 +34,19 @@
     "refreshOnOpen": "Auto-refresh when opening plugin",
     "refreshOnOpenDesc": "Auto-refresh account data when opening the plugin popup",
     "minRefreshInterval": "Minimum Refresh Interval",
-    "minRefreshIntervalDesc": "Minimum time interval for auto-refresh to avoid frequent requests (manual refresh is not restricted)"
+    "minRefreshIntervalDesc": "Minimum time interval for auto-refresh to avoid frequent requests (manual refresh is not restricted)",
+    "shieldTitle": "Temp-window protection bypass",
+    "shieldDescription": "Configure how the extension uses a temporary window with cookies to automatically bypass website protection pages (for example Cloudflare 5s checks) and then fetch data.",
+    "shieldEnabled": "Enable protection bypass (temp window)",
+    "shieldEnabledDesc": "When disabled, the extension will not open a temporary window to bypass website protection pages.",
+    "shieldContextsTitle": "Use protection bypass in these contexts",
+    "shieldContextsDesc": "Choose where the temp-window protection bypass is allowed. Individual options are ignored when the main switch is disabled.",
+    "shieldPopup": "Use in popup",
+    "shieldSidepanel": "Use in side panel",
+    "shieldOptions": "Use on options page",
+    "shieldAutoRefresh": "Use for automatic refresh",
+    "shieldManualRefresh": "Use for manual refresh",
+    "shieldPopupFirefoxNote": "In Firefox popup, shielded data requests are always disabled to avoid closing the popup. This setting is still saved for other browsers."
   },
   "sorting": {
     "title": "Sorting Priority Settings",

--- a/locales/zh_CN/settings.json
+++ b/locales/zh_CN/settings.json
@@ -32,9 +32,21 @@
     "refreshInterval": "刷新间隔",
     "refreshIntervalDesc": "设置自动刷新的时间间隔（默认360秒，建议不要设置过小以避免频繁请求）",
     "refreshOnOpen": "打开插件时自动刷新",
-    "refreshOnOpenDesc": "当打开插件弹出层时自动刷新账号数据",
+    "refreshOnOpenDesc": "当打开插件弹出窗口时自动刷新账号数据",
     "minRefreshInterval": "最小刷新间隔",
-    "minRefreshIntervalDesc": "自动刷新时的最小时间间隔，避免频繁请求（手动刷新不受限制）"
+    "minRefreshIntervalDesc": "自动刷新时的最小时间间隔，避免频繁请求（手动刷新不受限制）",
+    "shieldTitle": "临时窗口绕过防火墙防护",
+    "shieldDescription": "配置扩展如何使用带 Cookie 的临时窗口，自动通过网站的防护页面（例如 Cloudflare 5 秒盾）然后再获取数据。",
+    "shieldEnabled": "启用防护绕过（临时窗口）",
+    "shieldEnabledDesc": "关闭后，扩展不会通过打开临时窗口来绕过网站防护页面。",
+    "shieldContextsTitle": "在以下场景使用防护绕过",
+    "shieldContextsDesc": "选择允许使用临时窗口防护绕过的场景。当总开关关闭时，这些选项将被忽略。",
+    "shieldPopup": "在弹出窗口中使用",
+    "shieldSidepanel": "在侧边栏中使用",
+    "shieldOptions": "在设置页面中使用",
+    "shieldAutoRefresh": "用于自动刷新",
+    "shieldManualRefresh": "用于手动刷新",
+    "shieldPopupFirefoxNote": "在 Firefox 弹出窗口中，为避免弹窗被关闭，受保护的数据请求始终处于禁用状态。此设置仍会保存在其他浏览器中生效。"
   },
   "sorting": {
     "title": "排序优先级设置",

--- a/services/userPreferences.ts
+++ b/services/userPreferences.ts
@@ -35,6 +35,15 @@ import { DeepPartial } from "~/types/utils.ts"
 import { deepOverride } from "~/utils"
 import { DEFAULT_SORTING_PRIORITY_CONFIG } from "~/utils/sortingPriority"
 
+export interface TempWindowFallbackPreferences {
+  enabled: boolean
+  useInPopup: boolean
+  useInSidePanel: boolean
+  useInOptions: boolean
+  useForAutoRefresh: boolean
+  useForManualRefresh: boolean
+}
+
 // 用户偏好设置类型定义
 export interface UserPreferences {
   themeMode: ThemeMode
@@ -111,6 +120,11 @@ export interface UserPreferences {
   redemptionAssist?: {
     enabled: boolean
   }
+
+  /**
+   * 临时窗口过盾相关设置
+   */
+  tempWindowFallback?: TempWindowFallbackPreferences
 
   /**
    * 最后更新时间
@@ -227,7 +241,15 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   sortingPriorityConfig: undefined,
   themeMode: "system",
   language: undefined, // Default to undefined to trigger browser detection
-  preferencesVersion: CURRENT_PREFERENCES_VERSION
+  preferencesVersion: CURRENT_PREFERENCES_VERSION,
+  tempWindowFallback: {
+    enabled: true,
+    useInPopup: true,
+    useInSidePanel: true,
+    useInOptions: true,
+    useForAutoRefresh: true,
+    useForManualRefresh: true
+  }
 }
 
 class UserPreferencesService {


### PR DESCRIPTION
- introduce ShieldSettings component with toggle and context options
- implement tempWindowFallback preferences in UserPreferencesContext
- add TempWindowFallbackPreferences interface and defaults
- update shouldUseTempWindowFallback with context-aware logic
- export Checkbox component from ui index
- fix RefreshSettings import path and style ordering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shield feature to control protected request handling with toggles for popup, side panel, options, and auto/manual refresh.
  * New Shield settings section in preferences; settings can be updated and persisted from the UI.
  * Exposed a Checkbox UI component for use across the app.

* **Documentation**
  * Added English and Chinese localization strings for the Shield feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->