### PR TITLE
feat: add declarativeNetRequestWithHostAccess for temp window cookie isolation

### DIFF
--- a/entrypoints/content/messageHandlers/handlers/tempWindowFetch.ts
+++ b/entrypoints/content/messageHandlers/handlers/tempWindowFetch.ts
@@ -41,7 +41,11 @@ export function handlePerformTempWindowFetch(
       }
 
       const normalizedOptions = normalizeFetchOptions(fetchOptions)
-      normalizedOptions.credentials = "include"
+      // Respect caller-provided credentials so token-auth flows can omit cookies.
+      // Cookie-auth flows should explicitly set credentials="include" when needed.
+      if (!normalizedOptions.credentials) {
+        normalizedOptions.credentials = "include"
+      }
 
       const requestHeaders = new Headers(normalizedOptions.headers)
       requestHeaders.set(EXTENSION_HEADER_NAME, EXTENSION_HEADER_VALUE)

--- a/entrypoints/options/pages/BasicSettings/components/PermissionList.tsx
+++ b/entrypoints/options/pages/BasicSettings/components/PermissionList.tsx
@@ -1,4 +1,4 @@
-import { Cookie, Network, ShieldAlert } from "lucide-react"
+import { Cookie, Network, ShieldAlert, SlidersHorizontal } from "lucide-react"
 import type { ReactNode } from "react"
 
 import { CardItem } from "~/components/ui/CardItem"
@@ -9,6 +9,9 @@ export const permissionIconMap: Partial<
   Record<ManifestOptionalPermissions, ReactNode>
 > = {
   cookies: <Cookie className="h-5 w-5 text-amber-500" />,
+  declarativeNetRequestWithHostAccess: (
+    <SlidersHorizontal className="h-5 w-5 text-emerald-500" />
+  ),
   webRequest: <Network className="h-5 w-5 text-blue-500" />,
   webRequestBlocking: <ShieldAlert className="h-5 w-5 text-purple-500" />,
 }

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -185,6 +185,10 @@
         "title": "Cookies",
         "description": "Allows All API Hub to read the necessary cookies for your connected accounts so authentication headers can be added when required."
       },
+      "declarativeNetRequestWithHostAccess": {
+        "title": "Declarative Net Request",
+        "description": "Allow applying request header rules by pressing Tab during the temporary window shield, attaching the correct cookies for different accounts, and avoiding data anomalies under multiple accounts."
+      },
       "webRequest": {
         "title": "Web Request",
         "description": "Lets the extension observe outgoing requests only when temp-window bypass or auto-refresh needs to add required headers."

--- a/locales/zh_CN/settings.json
+++ b/locales/zh_CN/settings.json
@@ -185,6 +185,10 @@
         "title": "Cookies",
         "description": "允许读取必要的 Cookie，用于在需要时自动附加认证信息。"
       },
+      "declarativeNetRequestWithHostAccess": {
+        "title": "Declarative Net Request",
+        "description": "允许在临时窗口过盾期间按 Tab 应用请求头规则，为不同账号附加正确的 Cookie，避免多账号下的数据异常问题。"
+      },
       "webRequest": {
         "title": "网络请求",
         "description": "仅在临时窗口过盾或自动刷新需要时，监听请求并追加必要的请求头。"

--- a/services/apiService/common/utils.ts
+++ b/services/apiService/common/utils.ts
@@ -291,7 +291,9 @@ const _fetchApi = async <T>(
       authOptions = await createTokenAuthRequest(userId, token)
       break
     case AuthTypeEnum.None:
-      authOptions = {}
+      authOptions = {
+        credentials: "omit",
+      }
       break
     default:
       if (token) {

--- a/services/permissions/permissionManager.ts
+++ b/services/permissions/permissionManager.ts
@@ -11,7 +11,16 @@ import {
  * Aliases to manifest permission types for clearer signatures.
  */
 export type ManifestPermissions = browser._manifest.Permission
-export type ManifestOptionalPermissions = browser._manifest.OptionalPermission
+
+export const OPTIONAL_PERMISSION_IDS = {
+  Cookies: "cookies",
+  declarativeNetRequestWithHostAccess: "declarativeNetRequestWithHostAccess",
+  WebRequest: "webRequest",
+  WebRequestBlocking: "webRequestBlocking",
+} as const
+
+export type ManifestOptionalPermissions =
+  (typeof OPTIONAL_PERMISSION_IDS)[keyof typeof OPTIONAL_PERMISSION_IDS]
 
 /**
  * Read optional permissions declared in manifest.
@@ -31,9 +40,9 @@ export const OPTIONAL_PERMISSIONS: ManifestOptionalPermissions[] =
  * Optional permissions required for cookie interception flows.
  */
 export const COOKIE_INTERCEPTOR_PERMISSIONS: ManifestOptionalPermissions[] = [
-  "cookies",
-  "webRequest",
-  "webRequestBlocking",
+  OPTIONAL_PERMISSION_IDS.Cookies,
+  OPTIONAL_PERMISSION_IDS.WebRequest,
+  OPTIONAL_PERMISSION_IDS.WebRequestBlocking,
 ]
 
 /**
@@ -65,7 +74,9 @@ export const OPTIONAL_PERMISSION_DEFINITIONS: PermissionDefinition[] =
 export async function hasPermission(
   id: ManifestOptionalPermissions,
 ): Promise<boolean> {
-  return await containsPermissions({ permissions: [id] })
+  return await containsPermissions({
+    permissions: [id as unknown as browser._manifest.OptionalPermission],
+  })
 }
 
 /**
@@ -75,7 +86,9 @@ export async function hasPermissions(
   ids: ManifestOptionalPermissions[],
 ): Promise<boolean> {
   if (ids.length === 0) return true
-  return await containsPermissions({ permissions: ids })
+  return await containsPermissions({
+    permissions: ids as unknown as browser._manifest.OptionalPermission[],
+  })
 }
 
 /**
@@ -84,7 +97,9 @@ export async function hasPermissions(
 export async function requestPermission(
   id: ManifestOptionalPermissions,
 ): Promise<boolean> {
-  return await requestPermissions({ permissions: [id] })
+  return await requestPermissions({
+    permissions: [id as unknown as browser._manifest.OptionalPermission],
+  })
 }
 
 /**
@@ -93,7 +108,9 @@ export async function requestPermission(
 export async function removePermission(
   id: ManifestOptionalPermissions,
 ): Promise<boolean> {
-  return await removePermissions({ permissions: [id] })
+  return await removePermissions({
+    permissions: [id as unknown as browser._manifest.OptionalPermission],
+  })
 }
 
 /**
@@ -114,7 +131,9 @@ export async function ensurePermissions(
     return true
   }
 
-  return await requestPermissions({ permissions: missing })
+  return await requestPermissions({
+    permissions: missing as unknown as browser._manifest.OptionalPermission[],
+  })
 }
 
 /**

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -62,6 +62,17 @@ if (!globalAny.chrome) {
   globalAny.chrome = fakeBrowser
 }
 
+if (!globalAny.browser.runtime) {
+  globalAny.browser.runtime = {}
+}
+
+// fakeBrowser ships with a getManifest stub that throws "not implemented".
+// Override it unconditionally so modules can safely read optional permissions.
+globalAny.browser.runtime.getManifest = vi.fn(() => ({
+  manifest_version: 3,
+  optional_permissions: ["cookies", "declarativeNetRequestWithHostAccess"],
+}))
+
 globalAny.IntersectionObserver = class IntersectionObserver {
   disconnect() {}
   observe() {}

--- a/tests/utils/dnrCookieInjector.test.ts
+++ b/tests/utils/dnrCookieInjector.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  applyTempWindowCookieRule,
+  buildTempWindowCookieRule,
+  removeTempWindowCookieRule,
+  TEMP_WINDOW_DNR_RULE_ID_BASE,
+} from "~/utils/dnrCookieInjector"
+
+describe("dnrCookieInjector", () => {
+  let originalChrome: unknown
+
+  beforeEach(() => {
+    originalChrome = (globalThis as any).chrome
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    ;(globalThis as any).chrome = originalChrome
+  })
+
+  it("buildTempWindowCookieRule should create a per-tab rule with stable id and cookie header override", () => {
+    const rule = buildTempWindowCookieRule({
+      tabId: 123,
+      url: "https://example.com/api/user/self",
+      cookieHeader: "cf_clearance=abc; __cf_bm=def",
+    })
+
+    expect(rule.id).toBe(TEMP_WINDOW_DNR_RULE_ID_BASE + 123)
+    expect(rule.action.type).toBe("modifyHeaders")
+
+    const cookieOp = rule.action.requestHeaders?.find(
+      (h) => h.header.toLowerCase() === "cookie",
+    )
+    expect(cookieOp).toBeTruthy()
+    expect(cookieOp?.operation).toBe("set")
+    if (cookieOp && cookieOp.operation === "set" && "value" in cookieOp) {
+      expect(cookieOp.value).toContain("cf_clearance")
+    }
+
+    expect(rule.condition.tabIds).toEqual([123])
+    expect(rule.condition.urlFilter).toBe("||example.com/")
+  })
+
+  it("applyTempWindowCookieRule should call updateSessionRules with remove+add", async () => {
+    const updateSessionRules = vi.fn().mockResolvedValue(undefined)
+
+    ;(globalThis as any).chrome = {
+      declarativeNetRequest: { updateSessionRules },
+    }
+
+    const ruleId = await applyTempWindowCookieRule({
+      tabId: 5,
+      url: "https://example.com/api",
+      cookieHeader: "cf_clearance=abc",
+    })
+
+    expect(ruleId).toBe(TEMP_WINDOW_DNR_RULE_ID_BASE + 5)
+    expect(updateSessionRules).toHaveBeenCalledTimes(1)
+
+    const call = updateSessionRules.mock.calls[0]?.[0]
+    expect(call.removeRuleIds).toEqual([TEMP_WINDOW_DNR_RULE_ID_BASE + 5])
+    expect(call.addRules?.[0]?.id).toBe(TEMP_WINDOW_DNR_RULE_ID_BASE + 5)
+  })
+
+  it("removeTempWindowCookieRule should call updateSessionRules with remove only", async () => {
+    const updateSessionRules = vi.fn().mockResolvedValue(undefined)
+
+    ;(globalThis as any).chrome = {
+      declarativeNetRequest: { updateSessionRules },
+    }
+
+    await removeTempWindowCookieRule(42)
+
+    expect(updateSessionRules).toHaveBeenCalledTimes(1)
+    expect(updateSessionRules).toHaveBeenCalledWith({ removeRuleIds: [42] })
+  })
+})

--- a/utils/cookieHelper.ts
+++ b/utils/cookieHelper.ts
@@ -64,7 +64,6 @@ export async function getCookieHeaderForUrl(
     // 读取 cookies
     const cookies = await browser.cookies.getAll({
       url,
-      // Firefox 支持分区 cookie
       partitionKey: {},
     })
 

--- a/utils/dnrCookieInjector.ts
+++ b/utils/dnrCookieInjector.ts
@@ -1,0 +1,118 @@
+import {
+  COOKIE_AUTH_HEADER_NAME,
+  EXTENSION_HEADER_NAME,
+} from "~/utils/cookieHelper"
+
+/**
+ * DeclarativeNetRequest session-rule helpers.
+ *
+ * Chromium-based browsers can modify request headers using declarativeNetRequest.
+ * We use a short-lived, per-tab session rule during temp-window fetch so that:
+ * - token-auth requests can carry WAF-bypass cookies without leaking session cookies
+ * - requests are isolated to the temp window tab (fixes multi-account confusion)
+ */
+
+export const TEMP_WINDOW_DNR_RULE_ID_BASE = 1_000_000 as const
+
+export interface TempWindowCookieRuleParams {
+  tabId: number
+  url: string
+  cookieHeader: string
+}
+
+/**
+ * Checks whether the declarativeNetRequest session rules API is available.
+ */
+function hasDnrApi(): boolean {
+  try {
+    return Boolean(
+      (globalThis as any).chrome?.declarativeNetRequest?.updateSessionRules,
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Builds a stable rule ID for a given tab.
+ */
+function buildRuleId(tabId: number): number {
+  const safeTabId = Number.isFinite(tabId) ? Math.max(0, Math.floor(tabId)) : 0
+  return TEMP_WINDOW_DNR_RULE_ID_BASE + safeTabId
+}
+
+/**
+ * Build a session-scoped DNR rule that forces the Cookie header for a specific
+ * tab and URL.
+ */
+export function buildTempWindowCookieRule(params: TempWindowCookieRuleParams) {
+  const ruleId = buildRuleId(params.tabId)
+
+  return {
+    id: ruleId,
+    priority: 1,
+    action: {
+      type: "modifyHeaders",
+      requestHeaders: [
+        { header: EXTENSION_HEADER_NAME, operation: "remove" },
+        { header: COOKIE_AUTH_HEADER_NAME, operation: "remove" },
+        { header: "Cookie", operation: "set", value: params.cookieHeader },
+      ],
+    },
+    condition: {
+      tabIds: [params.tabId],
+      urlFilter: `||${new URL(params.url).hostname}/`,
+      isUrlFilterCaseSensitive: true,
+      resourceTypes: ["xmlhttprequest"],
+    },
+  } as const
+}
+
+/**
+ * Installs (or replaces) a temp-window Cookie override rule for the given tab.
+ * Returns the installed ruleId, or null when rule install is not possible.
+ */
+export async function applyTempWindowCookieRule(
+  params: TempWindowCookieRuleParams,
+): Promise<number | null> {
+  if (!params.cookieHeader) {
+    return null
+  }
+
+  if (!hasDnrApi()) {
+    return null
+  }
+
+  const ruleId = buildRuleId(params.tabId)
+  const rule = buildTempWindowCookieRule(params)
+
+  try {
+    await (globalThis as any).chrome.declarativeNetRequest.updateSessionRules({
+      removeRuleIds: [ruleId],
+      addRules: [rule],
+    })
+    return ruleId
+  } catch (error) {
+    console.warn("[DNR] Failed to install temp-window cookie rule", error)
+    return null
+  }
+}
+
+/**
+ * Best-effort removal of a previously installed temp-window cookie rule.
+ */
+export async function removeTempWindowCookieRule(
+  ruleId: number,
+): Promise<void> {
+  if (!hasDnrApi()) {
+    return
+  }
+
+  try {
+    await (globalThis as any).chrome.declarativeNetRequest.updateSessionRules({
+      removeRuleIds: [ruleId],
+    })
+  } catch (error) {
+    console.warn("[DNR] Failed to remove temp-window cookie rule", error)
+  }
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -19,7 +19,12 @@ export default defineConfig({
       ? {
           optional_permissions: ["cookies", "webRequest", "webRequestBlocking"],
         }
-      : {}),
+      : {
+          optional_permissions: [
+            "cookies",
+            "declarativeNetRequestWithHostAccess",
+          ],
+        }),
     host_permissions: ["https://*/*"],
     browser_specific_settings: {
       gecko: {


### PR DESCRIPTION
Fixes #204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tab cookie rule support for temporary windows to improve multi-account request handling
  * New declarative net request permission option added to settings (UI icon and localized text)

* **Bug Fixes**
  * Preserve caller-specified authentication options when present
  * Improved cookie-based security handling for temporary-window requests with better error handling and cleanup

* **Tests**
  * Added unit tests for cookie injection utilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->