### PR TITLE
fix(modelSync): avoid duplicate alarm creation on setup

### DIFF
--- a/tests/services/modelSync/scheduler.test.ts
+++ b/tests/services/modelSync/scheduler.test.ts
@@ -5,7 +5,12 @@ import {
   DEFAULT_PREFERENCES,
   userPreferences,
 } from "~/services/userPreferences"
-import { clearAlarm, createAlarm, hasAlarmsAPI } from "~/utils/browserApi"
+import {
+  clearAlarm,
+  createAlarm,
+  getAlarm,
+  hasAlarmsAPI,
+} from "~/utils/browserApi"
 
 vi.mock("~/services/userPreferences", () => ({
   DEFAULT_PREFERENCES: {
@@ -44,6 +49,7 @@ const mockedUserPreferences = userPreferences as unknown as {
 const mockedBrowserApi = {
   clearAlarm: clearAlarm as unknown as ReturnType<typeof vi.fn>,
   createAlarm: createAlarm as unknown as ReturnType<typeof vi.fn>,
+  getAlarm: getAlarm as unknown as ReturnType<typeof vi.fn>,
   hasAlarmsAPI: hasAlarmsAPI as unknown as ReturnType<typeof vi.fn>,
 }
 
@@ -51,6 +57,7 @@ describe("modelSyncScheduler.setupAlarm", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockedBrowserApi.hasAlarmsAPI.mockReturnValue(true)
+    mockedBrowserApi.getAlarm.mockResolvedValue(undefined)
     mockedUserPreferences.getPreferences.mockResolvedValue({
       managedSiteModelSync: {
         ...(DEFAULT_PREFERENCES as any).managedSiteModelSync,
@@ -59,7 +66,49 @@ describe("modelSyncScheduler.setupAlarm", () => {
     })
   })
 
-  it("clears and recreates the canonical alarm when enabled", async () => {
+  it("clears and recreates the canonical alarm when enabled and missing", async () => {
+    mockedBrowserApi.getAlarm
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        name: "managedSiteModelSync",
+        scheduledTime: Date.now() + 60_000,
+        periodInMinutes: 1,
+      })
+
+    await modelSyncScheduler.setupAlarm()
+
+    expect(mockedBrowserApi.clearAlarm).toHaveBeenCalledWith(
+      "managedSiteModelSync",
+    )
+    expect(mockedBrowserApi.createAlarm).toHaveBeenCalled()
+  })
+
+  it("preserves an existing alarm when the interval matches", async () => {
+    mockedBrowserApi.getAlarm.mockResolvedValue({
+      name: "managedSiteModelSync",
+      scheduledTime: Date.now() + 60_000,
+      periodInMinutes: 1,
+    })
+
+    await modelSyncScheduler.setupAlarm()
+
+    expect(mockedBrowserApi.clearAlarm).not.toHaveBeenCalled()
+    expect(mockedBrowserApi.createAlarm).not.toHaveBeenCalled()
+  })
+
+  it("recreates the alarm when the interval changes", async () => {
+    mockedBrowserApi.getAlarm
+      .mockResolvedValueOnce({
+        name: "managedSiteModelSync",
+        scheduledTime: Date.now() + 60_000,
+        periodInMinutes: 2,
+      })
+      .mockResolvedValueOnce({
+        name: "managedSiteModelSync",
+        scheduledTime: Date.now() + 60_000,
+        periodInMinutes: 1,
+      })
+
     await modelSyncScheduler.setupAlarm()
 
     expect(mockedBrowserApi.clearAlarm).toHaveBeenCalledWith(


### PR DESCRIPTION
- Check for existing alarm before recreating
- Preserve matching alarms to prevent unnecessary rescheduling
- Only recreate when interval changes or alarm is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync scheduler efficiency by preventing unnecessary alarm recreation when sync intervals remain unchanged, reducing system resource usage during app restarts and preference updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->