### PR TITLE
fix(api): ensure consistent sk- prefix for API keys

### DIFF
--- a/entrypoints/options/pages/KeyManagement/hooks/useKeyManagement.ts
+++ b/entrypoints/options/pages/KeyManagement/hooks/useKeyManagement.ts
@@ -94,8 +94,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
 
   const copyKey = async (key: string, name: string) => {
     try {
-      const textToCopy = key.startsWith("sk-") ? key : "sk-" + key
-      await navigator.clipboard.writeText(textToCopy)
+      await navigator.clipboard.writeText(key)
       toast.success(t("keyManagement:messages.keyCopied", { name }))
     } catch (error) {
       toast.error(t("keyManagement:messages.copyFailed"))

--- a/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -102,10 +102,7 @@ export default function AccountActionButtons({
         if (tokensResponse.length === 1) {
           // Single token - copy directly
           const token = tokensResponse[0]
-          const textToCopy = token.key.startsWith("sk-")
-            ? token.key
-            : "sk-" + token.key
-          await navigator.clipboard.writeText(textToCopy)
+          await navigator.clipboard.writeText(token.key)
           toast.success(t("actions.keyCopied"))
         } else if (tokensResponse.length > 1) {
           // Multiple tokens - open dialog

--- a/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -79,8 +79,7 @@ export function useCopyKeyDialog(isOpen: boolean, account: DisplaySiteData) {
 
   const copyKey = async (key: string) => {
     try {
-      const textToCopy = key.startsWith("sk-") ? key : "sk-" + key
-      await navigator.clipboard.writeText(textToCopy)
+      await navigator.clipboard.writeText(key)
       setCopiedKey(key)
       toast.success(t("ui:dialog.copyKey.keyCopied"))
 

--- a/services/apiService/common/index.ts
+++ b/services/apiService/common/index.ts
@@ -46,6 +46,7 @@ import type {
   ManagedSiteChannelListData,
   UpdateChannelPayload,
 } from "~/types/managedSite"
+import { normalizeApiTokenKey } from "~/utils/apiKey"
 
 const CHANNEL_API_BASE = "/api/channel/"
 
@@ -790,14 +791,14 @@ export async function fetchAccountTokens(
     // 处理不同的响应格式
     if (Array.isArray(tokensData)) {
       // 直接返回数组格式
-      return tokensData
+      return tokensData.map(normalizeApiTokenKey)
     } else if (
       tokensData &&
       typeof tokensData === "object" &&
       "items" in tokensData
     ) {
       // 分页格式，返回 items 数组
-      return tokensData.items || []
+      return (tokensData.items || []).map(normalizeApiTokenKey)
     } else {
       // 其他情况，返回空数组
       console.warn("Unexpected token response format:", tokensData)
@@ -923,9 +924,10 @@ export async function fetchTokenById(
   tokenId: number,
 ): Promise<ApiToken> {
   try {
-    return await fetchApiData<ApiToken>(request, {
+    const token = await fetchApiData<ApiToken>(request, {
       endpoint: `/api/token/${tokenId}`,
     })
+    return normalizeApiTokenKey(token)
   } catch (error) {
     console.error("获取令牌详情失败:", error)
     throw error

--- a/services/apiService/oneHub/index.ts
+++ b/services/apiService/oneHub/index.ts
@@ -11,6 +11,7 @@ import type {
   PaginatedTokenDate,
 } from "~/services/apiService/oneHub/type"
 import type { ApiToken } from "~/types"
+import { normalizeApiTokenKey } from "~/utils/apiKey"
 import {
   transformModelPricing,
   transformUserGroup,
@@ -68,14 +69,14 @@ export const fetchAccountTokens = async (
     // 处理不同的响应格式
     if (Array.isArray(tokensData)) {
       // 直接返回数组格式
-      return tokensData
+      return tokensData.map(normalizeApiTokenKey)
     } else if (
       tokensData &&
       typeof tokensData === "object" &&
       "data" in tokensData
     ) {
       // 分页格式，返回 data 数组
-      return tokensData.data || []
+      return (tokensData.data || []).map(normalizeApiTokenKey)
     } else {
       // 其他情况，返回空数组
       console.warn("Unexpected token response format:", tokensData)

--- a/tests/services/apiService/common/tokenApi.test.ts
+++ b/tests/services/apiService/common/tokenApi.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  fetchAccountTokens,
+  fetchTokenById,
+} from "~/services/apiService/common"
+import { fetchApiData } from "~/services/apiService/common/utils"
+import { AuthTypeEnum } from "~/types"
+
+const { mockFetchApi, mockFetchApiData } = vi.hoisted(() => ({
+  mockFetchApi: vi.fn(),
+  mockFetchApiData: vi.fn(),
+}))
+
+vi.mock("i18next", () => ({
+  default: {
+    t: vi.fn((key: string) => key),
+  },
+}))
+
+vi.mock("~/constants/ui", () => ({
+  UI_CONSTANTS: {},
+}))
+
+vi.mock("~/services/accountStorage", () => ({
+  accountStorage: {},
+}))
+
+vi.mock("~/services/apiService/common/utils", () => ({
+  fetchApi: mockFetchApi,
+  fetchApiData: mockFetchApiData,
+  aggregateUsageData: vi.fn(),
+  extractAmount: vi.fn(),
+  getTodayTimestampRange: vi.fn(),
+}))
+
+const mockedFetchApiData = fetchApiData as unknown as ReturnType<typeof vi.fn>
+
+describe("apiService common token APIs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("fetchAccountTokens normalizes token.key with sk- prefix (array response)", async () => {
+    mockedFetchApiData.mockResolvedValueOnce([
+      { id: 1, key: "plain-key" },
+      { id: 2, key: "sk-already" },
+      { id: 3, key: "  sk-trim  " },
+    ])
+
+    const request = {
+      baseUrl: "https://example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        userId: 1,
+        accessToken: "token",
+      },
+    }
+
+    const result = await fetchAccountTokens(request as any)
+
+    expect(mockedFetchApiData).toHaveBeenCalledTimes(1)
+    const endpoint = mockedFetchApiData.mock.calls[0][1].endpoint as string
+    expect(endpoint).toContain("/api/token/?")
+    expect(endpoint).toContain("p=0")
+    expect(endpoint).toContain("size=100")
+
+    expect(result.map((token: any) => token.key)).toEqual([
+      "sk-plain-key",
+      "sk-already",
+      "sk-trim",
+    ])
+  })
+
+  it("fetchAccountTokens normalizes token.key with sk- prefix (paginated response)", async () => {
+    mockedFetchApiData.mockResolvedValueOnce({
+      items: [{ id: 1, key: "plain" }],
+    })
+
+    const request = {
+      baseUrl: "https://example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        userId: 1,
+        accessToken: "token",
+      },
+    }
+
+    const result = await fetchAccountTokens(request as any)
+    expect(result.map((token: any) => token.key)).toEqual(["sk-plain"])
+  })
+
+  it("fetchTokenById normalizes token.key with sk- prefix", async () => {
+    mockedFetchApiData.mockResolvedValueOnce({ id: 99, key: "abc" })
+
+    const request = {
+      baseUrl: "https://example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        userId: 1,
+        accessToken: "token",
+      },
+    }
+
+    const result = await fetchTokenById(request as any, 99)
+
+    expect(mockedFetchApiData).toHaveBeenCalledWith(request, {
+      endpoint: "/api/token/99",
+    })
+    expect((result as any).key).toBe("sk-abc")
+  })
+})

--- a/tests/services/apiService/oneHub/index.test.ts
+++ b/tests/services/apiService/oneHub/index.test.ts
@@ -113,6 +113,21 @@ describe("OneHub API service", () => {
     expect(result).toEqual(tokens)
   })
 
+  it("fetchAccountTokens should normalize token.key with sk- prefix", async () => {
+    mockedFetchApiData.mockResolvedValueOnce([
+      { id: 1, key: "plain" },
+      { id: 2, key: "sk-already" },
+      { id: 3, key: "  sk-trim  " },
+    ])
+
+    const result = await fetchAccountTokens(baseRequest as any)
+    expect(result.map((token: any) => token.key)).toEqual([
+      "sk-plain",
+      "sk-already",
+      "sk-trim",
+    ])
+  })
+
   it("fetchAccountTokens should return data field when response is paginated object", async () => {
     const tokens = [{ id: 1 }, { id: 2 }]
     mockedFetchApiData.mockResolvedValueOnce({ data: tokens })

--- a/utils/apiKey.ts
+++ b/utils/apiKey.ts
@@ -1,0 +1,25 @@
+import type { ApiToken } from "~/types"
+
+/**
+ * Ensures API keys are consistently represented with an `sk-` prefix.
+ *
+ * The application treats upstream API tokens as OpenAI-style keys. Normalizing
+ * them at ingestion time keeps UI and integrations free from scattered `sk-`
+ * prefix handling.
+ */
+export function ensureSkPrefixedKey(key: string): string {
+  const trimmed = key.trim()
+  if (!trimmed) return trimmed
+  return /^sk-/i.test(trimmed) ? trimmed : `sk-${trimmed}`
+}
+
+/**
+ * Normalizes an ApiToken so callers can safely assume `token.key` includes `sk-`.
+ */
+export function normalizeApiTokenKey(token: ApiToken): ApiToken {
+  if (!token || typeof token.key !== "string") return token
+
+  const normalizedKey = ensureSkPrefixedKey(token.key)
+  if (normalizedKey === token.key) return token
+  return { ...token, key: normalizedKey }
+}


### PR DESCRIPTION
- Add utility functions to normalize API keys with sk- prefix
- Apply normalization in token fetch APIs (common & oneHub)
- Remove redundant sk- prefix handling in UI components
- Add tests for key normalization logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved inconsistent API token key formatting across the application.
  * Improved key copy functionality to preserve the exact key format.

* **Tests**
  * Added comprehensive test coverage for token key handling in various API response formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->