### PR TITLE
fix: Fix external check-in marking when popup closes early

### DIFF
--- a/entrypoints/background/runtimeMessages.ts
+++ b/entrypoints/background/runtimeMessages.ts
@@ -4,6 +4,7 @@ import { applyActionClickBehavior } from "~/entrypoints/background/actionClickBe
 import { handleAutoCheckinMessage } from "~/services/autoCheckin/scheduler"
 import { handleAutoRefreshMessage } from "~/services/autoRefreshService"
 import { handleChannelConfigMessage } from "~/services/channelConfigStorage"
+import { handleExternalCheckInMessage } from "~/services/externalCheckInService"
 import { handleManagedSiteModelSyncMessage } from "~/services/modelSync"
 import { handleRedemptionAssistMessage } from "~/services/redemptionAssist"
 import { handleWebdavAutoSyncMessage } from "~/services/webdav/webdavAutoSyncService"
@@ -102,6 +103,12 @@ export function setupRuntimeMessageListeners() {
           .catch((error) => {
             sendResponse({ success: false, error: getErrorMessage(error) })
           })
+        return true
+      }
+
+      // Bulk external check-in must run in background so it isn't interrupted by popup teardown.
+      if (request.action?.startsWith("externalCheckIn:")) {
+        void handleExternalCheckInMessage(request, sendResponse)
         return true
       }
 

--- a/services/externalCheckInService.ts
+++ b/services/externalCheckInService.ts
@@ -1,0 +1,176 @@
+import { getSiteApiRouter } from "~/constants/siteType"
+import { accountStorage } from "~/services/accountStorage"
+import { createTab } from "~/utils/browserApi"
+import { getErrorMessage } from "~/utils/error"
+import { joinUrl } from "~/utils/url"
+
+/**
+ * External custom check-in flow (background-only).
+ *
+ * Why this lives in background:
+ * - The popup UI can be closed at any moment (including programmatically), which can interrupt
+ *   in-flight async work when executed in the popup context.
+ * - Opening tabs/windows and persisting "checked-in today" state must be atomic: we only mark
+ *   the account after the check-in URL was opened successfully.
+ *
+ * Message contract:
+ * - Request: `{ action: "externalCheckIn:openAndMark", accountIds: string[] }`
+ * - Response: `{ success: boolean, data?: { results, openedCount, markedCount, failedCount, totalCount }, error?: string }`
+ *
+ * Semantics:
+ * - Redeem page opening is best-effort and never blocks the check-in marking.
+ * - The account is marked as checked-in only when the check-in tab is created successfully.
+ */
+type ExternalCheckInOpenResult = {
+  accountId: string
+  openedCheckIn: boolean
+  openedRedeem: boolean | null
+  markedCheckedIn: boolean
+  error?: string
+  redeemError?: string
+}
+
+/**
+ *
+ */
+export async function handleExternalCheckInMessage(
+  request: any,
+  sendResponse: (response: any) => void,
+) {
+  try {
+    switch (request.action) {
+      case "externalCheckIn:openAndMark": {
+        const accountIds: unknown = request.accountIds
+
+        if (!Array.isArray(accountIds) || accountIds.length === 0) {
+          sendResponse({ success: false, error: "Missing accountIds" })
+          return
+        }
+
+        const results: ExternalCheckInOpenResult[] = []
+
+        for (const accountId of accountIds) {
+          if (typeof accountId !== "string" || !accountId.trim()) {
+            results.push({
+              accountId: String(accountId),
+              openedCheckIn: false,
+              openedRedeem: null,
+              markedCheckedIn: false,
+              error: "Invalid accountId",
+            })
+            continue
+          }
+
+          try {
+            const account = await accountStorage.getAccountById(accountId)
+            if (!account) {
+              results.push({
+                accountId,
+                openedCheckIn: false,
+                openedRedeem: null,
+                markedCheckedIn: false,
+                error: "Account not found",
+              })
+              continue
+            }
+
+            const checkInUrl = account.checkIn?.customCheckIn?.url
+            if (typeof checkInUrl !== "string" || !checkInUrl.trim()) {
+              results.push({
+                accountId,
+                openedCheckIn: false,
+                openedRedeem: null,
+                markedCheckedIn: false,
+                error: "Missing custom check-in URL",
+              })
+              continue
+            }
+
+            const shouldOpenRedeem =
+              account.checkIn?.customCheckIn?.openRedeemWithCheckIn ?? true
+
+            let openedRedeem: boolean | null = null
+            let redeemError: string | undefined
+
+            if (shouldOpenRedeem) {
+              openedRedeem = false
+              const redeemUrl =
+                account.checkIn?.customCheckIn?.redeemUrl ||
+                joinUrl(
+                  account.site_url,
+                  getSiteApiRouter(account.site_type).redeemPath,
+                )
+
+              try {
+                const redeemTab = await createTab(redeemUrl, true)
+                openedRedeem = Boolean(redeemTab?.id)
+                if (!openedRedeem) {
+                  redeemError = "Failed to open redeem tab"
+                }
+              } catch (error) {
+                redeemError = getErrorMessage(error)
+              }
+            }
+
+            const checkInTab = await createTab(checkInUrl, true)
+            const openedCheckIn = Boolean(checkInTab?.id)
+
+            if (!openedCheckIn) {
+              results.push({
+                accountId,
+                openedCheckIn: false,
+                openedRedeem,
+                markedCheckedIn: false,
+                error: "Failed to open check-in tab",
+                redeemError,
+              })
+              continue
+            }
+
+            // Only mark the account after we are sure the check-in link was opened.
+            const markedCheckedIn =
+              await accountStorage.markAccountAsCustomCheckedIn(accountId)
+
+            results.push({
+              accountId,
+              openedCheckIn: true,
+              openedRedeem,
+              markedCheckedIn,
+              redeemError,
+            })
+          } catch (error) {
+            results.push({
+              accountId,
+              openedCheckIn: false,
+              openedRedeem: null,
+              markedCheckedIn: false,
+              error: getErrorMessage(error),
+            })
+          }
+        }
+
+        const openedCount = results.filter((r) => r.openedCheckIn).length
+        const markedCount = results.filter((r) => r.markedCheckedIn).length
+        const failedCount = results.length - openedCount
+
+        sendResponse({
+          success: failedCount === 0,
+          data: {
+            results,
+            openedCount,
+            markedCount,
+            failedCount,
+            totalCount: results.length,
+          },
+        })
+        return
+      }
+
+      default:
+        sendResponse({ success: false, error: "Unknown action" })
+        return
+    }
+  } catch (error) {
+    sendResponse({ success: false, error: getErrorMessage(error) })
+  }
+}

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -5,7 +5,6 @@ import { isExtensionPopup } from "~/utils/browser"
 import { createTab as createTabApi, getExtensionURL } from "~/utils/browserApi"
 import {
   openCheckInAndRedeem,
-  openExternalCheckInPages,
   openKeysPage,
   openModelsPage,
   openMultiplePages,
@@ -157,48 +156,5 @@ describe("navigation utilities", () => {
     const calls = mockedCreateTab.mock.calls.map((call) => call[0] as string)
     expect(calls).toContain("https://redeem.custom")
     expect(calls).toContain("https://checkin.custom")
-  })
-
-  it("openExternalCheckInPages should open custom check-in and optional redeem pages", async () => {
-    const accounts = [
-      {
-        baseUrl: "https://alpha.example.com",
-        siteType: "one-api",
-        checkIn: {
-          customCheckIn: {
-            url: "https://checkin.alpha",
-            redeemUrl: "https://redeem.alpha",
-            openRedeemWithCheckIn: true,
-          },
-        },
-      },
-      {
-        baseUrl: "https://beta.example.com",
-        siteType: "one-api",
-        checkIn: {
-          customCheckIn: {
-            url: "https://checkin.beta",
-            openRedeemWithCheckIn: false,
-          },
-        },
-      },
-      {
-        baseUrl: "https://gamma.example.com",
-        siteType: "one-api",
-        checkIn: {
-          customCheckIn: {
-            url: "",
-          },
-        },
-      },
-    ] as any
-
-    await openExternalCheckInPages(accounts)
-
-    const calls = mockedCreateTab.mock.calls.map((call) => call[0] as string)
-    expect(calls).toContain("https://checkin.alpha")
-    expect(calls).toContain("https://redeem.alpha")
-    expect(calls).toContain("https://checkin.beta")
-    expect(calls).not.toContain("https://gamma.example.com/redeem")
   })
 })

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -424,14 +424,6 @@ const _openRedeemPage = async (account: DisplaySiteData) => {
   await createActiveTab(redeemUrl)
 }
 
-/**
- * Returns true when the account has a usable external check-in URL.
- */
-const hasCustomCheckInUrl = (account: DisplaySiteData) => {
-  const customUrl = account.checkIn?.customCheckIn?.url
-  return typeof customUrl === "string" && customUrl.trim() !== ""
-}
-
 // 导出带自动关闭的版本
 /**
  * Launch the account manager root view, auto-closing the popup when invoked
@@ -564,34 +556,4 @@ export const openCheckInAndRedeem = async (account: DisplaySiteData) => {
     () => _openRedeemPage(account),
     () => _openCustomCheckInPage(account),
   ])
-}
-
-/**
- * Open all external check-in sites for accounts with custom URLs, optionally
- * opening redeem pages when configured.
- * @param accounts Accounts to inspect for external check-in URLs.
- */
-export const openExternalCheckInPages = async (accounts: DisplaySiteData[]) => {
-  const operations: (() => Promise<void> | void)[] = []
-
-  accounts.forEach((account) => {
-    if (!hasCustomCheckInUrl(account)) {
-      return
-    }
-
-    const shouldOpenRedeem =
-      account.checkIn?.customCheckIn?.openRedeemWithCheckIn ?? true
-
-    if (shouldOpenRedeem) {
-      operations.push(() => _openRedeemPage(account))
-    }
-
-    operations.push(() => _openCustomCheckInPage(account))
-  })
-
-  if (!operations.length) {
-    return
-  }
-
-  await openMultiplePages(operations)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * External check-in operations now execute reliably in the background without interruption from popup closure
  * Batch processing enables multiple accounts to be checked in simultaneously for improved efficiency
  * Enhanced error handling provides clearer feedback when some account checks fail, with detailed failure information

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->