### PR TITLE
feat(popup): display app version in header with changelog link

### DIFF
--- a/components/VersionBadge.tsx
+++ b/components/VersionBadge.tsx
@@ -1,0 +1,50 @@
+import { Badge } from "~/components/ui"
+import { getManifest } from "~/utils/browserApi"
+import { getDocsChangelogUrl } from "~/utils/docsLinks"
+
+export type VersionBadgeProps = {
+  /**
+   * Badge size variant.
+   */
+  size?: "default" | "sm"
+
+  /**
+   * Badge color variant.
+   */
+  variant?: "default" | "secondary" | "destructive" | "outline"
+
+  /**
+   * Optional extra className for the badge container.
+   */
+  className?: string
+}
+
+/**
+ * VersionBadge shows the current extension version and links to the changelog anchor for that version.
+ *
+ * This intentionally reads from the runtime manifest to reflect the actual packaged version used by the extension.
+ */
+export function VersionBadge({
+  size = "default",
+  variant = "secondary",
+  className,
+}: VersionBadgeProps) {
+  const { version } = getManifest()
+  if (!version) return null
+
+  const changelogUrl = getDocsChangelogUrl(version)
+
+  return (
+    <Badge asChild variant={variant} size={size} className={className}>
+      <a
+        href={changelogUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="tap-highlight-transparent touch-manipulation"
+        aria-label={`v${version} changelog`}
+      >
+        v{version}
+      </a>
+    </Badge>
+  )
+}

--- a/entrypoints/options/components/Header.tsx
+++ b/entrypoints/options/components/Header.tsx
@@ -3,9 +3,8 @@ import { useTranslation } from "react-i18next"
 
 import iconImage from "~/assets/icon.png"
 import { LanguageSwitcher } from "~/components/LanguageSwitcher"
-import { Badge, BodySmall, Heading5, IconButton } from "~/components/ui"
-import { getManifest } from "~/utils/browserApi"
-import { getDocsChangelogUrl } from "~/utils/docsLinks"
+import { BodySmall, Heading5, IconButton } from "~/components/ui"
+import { VersionBadge } from "~/components/VersionBadge"
 import { getRepository } from "~/utils/packageMeta"
 
 interface HeaderProps {
@@ -28,8 +27,6 @@ function Header({
 }: HeaderProps) {
   const { t } = useTranslation("ui")
   const repositoryUrl = getRepository()
-  const { version } = getManifest()
-  const changelogUrl = getDocsChangelogUrl(version)
 
   return (
     <header className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary sticky top-0 z-50 h-(--options-header-height) border-b border-gray-200 bg-white shadow-sm">
@@ -76,17 +73,8 @@ function Header({
                     {t("app.name")}
                   </a>
                 </Heading5>
-                <Badge asChild variant="secondary" className="text-xs">
-                  <a
-                    href={changelogUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="tap-highlight-transparent touch-manipulation"
-                    aria-label={`v${version} changelog`}
-                  >
-                    v{version}
-                  </a>
-                </Badge>
+                {/* Current extension version (links to the changelog). */}
+                <VersionBadge className="text-xs" />
               </div>
               <BodySmall className="dark:text-dark-text-tertiary hidden text-xs text-gray-500 sm:block sm:text-sm">
                 {t("app.description")}

--- a/entrypoints/popup/components/HeaderSection.tsx
+++ b/entrypoints/popup/components/HeaderSection.tsx
@@ -10,12 +10,11 @@ import { useTranslation } from "react-i18next"
 
 import iconImage from "~/assets/icon.png"
 import Tooltip from "~/components/Tooltip"
-import { Badge, BodySmall, Caption, IconButton } from "~/components/ui"
+import { BodySmall, Caption, IconButton } from "~/components/ui"
+import { VersionBadge } from "~/components/VersionBadge"
 import { COLORS } from "~/constants/designTokens"
 import { useAccountDataContext } from "~/features/AccountManagement/hooks/AccountDataContext"
 import { isExtensionSidePanel } from "~/utils/browser"
-import { getManifest } from "~/utils/browserApi"
-import { getDocsChangelogUrl } from "~/utils/docsLinks"
 import {
   openFullAccountManagerPage,
   openSettingsPage,
@@ -32,8 +31,6 @@ export default function HeaderSection() {
   const { t } = useTranslation(["ui", "account", "common"])
   const { isRefreshing, handleRefresh } = useAccountDataContext()
   const inSidePanel = isExtensionSidePanel()
-  const { version } = getManifest()
-  const changelogUrl = getDocsChangelogUrl(version)
 
   const handleGlobalRefresh = useCallback(async () => {
     try {
@@ -83,18 +80,8 @@ export default function HeaderSection() {
             <BodySmall weight="semibold" className="truncate">
               {t("ui:app.name")}
             </BodySmall>
-            {/* Keep version visible and link to the changelog, matching the options header behavior. */}
-            <Badge asChild variant="secondary" size="sm" className="shrink-0">
-              <a
-                href={changelogUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="tap-highlight-transparent touch-manipulation"
-                aria-label={`v${version} changelog`}
-              >
-                v{version}
-              </a>
-            </Badge>
+            {/* Current extension version (links to the changelog). */}
+            <VersionBadge size="sm" className="shrink-0" />
           </div>
           <Caption className="xs:block hidden truncate">
             {t("ui:app.description")}

--- a/tests/components/VersionBadge.test.tsx
+++ b/tests/components/VersionBadge.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { VersionBadge } from "~/components/VersionBadge"
+import { render, screen } from "~/tests/test-utils/render"
+
+vi.mock("~/utils/browserApi", () => ({
+  getManifest: vi.fn(),
+}))
+
+vi.mock("~/utils/docsLinks", () => ({
+  getDocsChangelogUrl: vi.fn(),
+}))
+
+describe("VersionBadge", () => {
+  it("renders current version and links to changelog", async () => {
+    const { getManifest } = await import("~/utils/browserApi")
+    const { getDocsChangelogUrl } = await import("~/utils/docsLinks")
+
+    vi.mocked(getManifest).mockReturnValue({ version: "1.2.3" } as any)
+    vi.mocked(getDocsChangelogUrl).mockReturnValue(
+      "https://example.com/changelog.html#_1-2-3",
+    )
+
+    render(<VersionBadge />)
+
+    const link = await screen.findByRole("link", { name: "v1.2.3 changelog" })
+    expect(link).toHaveAttribute(
+      "href",
+      "https://example.com/changelog.html#_1-2-3",
+    )
+  })
+
+  it("renders nothing when version is missing", async () => {
+    const { getManifest } = await import("~/utils/browserApi")
+
+    vi.mocked(getManifest).mockReturnValue({} as any)
+
+    render(<VersionBadge />)
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version badge now appears in the popup header, displaying the current extension version.

* **Improvements**
  * Refactored version display component for consistency across the application.

* **Tests**
  * Added comprehensive test coverage for version badge functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->