### PR TITLE
Expand redemption assist default whitelist

### DIFF
--- a/services/userPreferences.ts
+++ b/services/userPreferences.ts
@@ -359,7 +359,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
     relaxedCodeValidation: true,
     urlWhitelist: {
       enabled: true,
-      patterns: ["cdk.linux.do", "cdk.hybgzs.com", "qd.x666.me"],
+      patterns: ["cdk\\.linux\\.do", "cdk\\.hybgzs\\.com", "qd\\.x666\\.me"],
       includeAccountSiteUrls: true,
       includeCheckInAndRedeemUrls: true,
     },

--- a/services/userPreferences.ts
+++ b/services/userPreferences.ts
@@ -359,7 +359,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
     relaxedCodeValidation: true,
     urlWhitelist: {
       enabled: true,
-      patterns: ["cdk.linux.do"],
+      patterns: ["cdk.linux.do", "cdk.hybgzs.com", "qd.x666.me"],
       includeAccountSiteUrls: true,
       includeCheckInAndRedeemUrls: true,
     },

--- a/tests/services/redemptionAssist.test.ts
+++ b/tests/services/redemptionAssist.test.ts
@@ -84,35 +84,29 @@ describe("redemptionAssist shouldPrompt batch filtering", () => {
     )
 
     const validHex = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
-    const sendResponse = vi.fn()
 
-    await handleRedemptionAssistMessage(
-      {
-        action: RuntimeActionIds.RedemptionAssistShouldPrompt,
-        url: "https://cdk.hybgzs.com/entertainment/wheel",
-        codes: [validHex],
-      },
-      { tab: { id: 99 } } as any,
-      sendResponse,
-    )
+    const testUrls = [
+      "https://cdk.hybgzs.com/entertainment/wheel",
+      "https://qd.x666.me",
+    ]
 
-    await handleRedemptionAssistMessage(
-      {
-        action: RuntimeActionIds.RedemptionAssistShouldPrompt,
-        url: "https://qd.x666.me",
-        codes: [validHex],
-      },
-      { tab: { id: 99 } } as any,
-      sendResponse,
-    )
+    for (const url of testUrls) {
+      const sendResponse = vi.fn()
 
-    expect(sendResponse).toHaveBeenNthCalledWith(1, {
-      success: true,
-      promptableCodes: [validHex],
-    })
-    expect(sendResponse).toHaveBeenNthCalledWith(2, {
-      success: true,
-      promptableCodes: [validHex],
-    })
+      await handleRedemptionAssistMessage(
+        {
+          action: RuntimeActionIds.RedemptionAssistShouldPrompt,
+          url,
+          codes: [validHex],
+        },
+        { tab: { id: 99 } } as any,
+        sendResponse,
+      )
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: true,
+        promptableCodes: [validHex],
+      })
+    }
   })
 })

--- a/tests/services/redemptionAssist.test.ts
+++ b/tests/services/redemptionAssist.test.ts
@@ -7,6 +7,13 @@ vi.mock("i18next", () => ({
   t: (key: string) => key,
 }))
 
+vi.mock("~/services/accountStorage", () => ({
+  accountStorage: {
+    getEnabledAccounts: vi.fn().mockResolvedValue([]),
+    convertToDisplayData: vi.fn(() => []),
+  },
+}))
+
 vi.mock("~/services/userPreferences", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("~/services/userPreferences")>()
@@ -60,6 +67,50 @@ describe("redemptionAssist shouldPrompt batch filtering", () => {
     )
 
     expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      promptableCodes: [validHex],
+    })
+  })
+
+  it("allows prompt on common redemption sites by default", async () => {
+    vi.resetModules()
+    const { userPreferences } = await import("~/services/userPreferences")
+    const getPreferencesMock = vi.mocked(userPreferences.getPreferences)
+
+    getPreferencesMock.mockResolvedValue(DEFAULT_PREFERENCES)
+
+    const { handleRedemptionAssistMessage } = await import(
+      "~/services/redemptionAssist"
+    )
+
+    const validHex = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+    const sendResponse = vi.fn()
+
+    await handleRedemptionAssistMessage(
+      {
+        action: RuntimeActionIds.RedemptionAssistShouldPrompt,
+        url: "https://cdk.hybgzs.com/entertainment/wheel",
+        codes: [validHex],
+      },
+      { tab: { id: 99 } } as any,
+      sendResponse,
+    )
+
+    await handleRedemptionAssistMessage(
+      {
+        action: RuntimeActionIds.RedemptionAssistShouldPrompt,
+        url: "https://qd.x666.me",
+        codes: [validHex],
+      },
+      { tab: { id: 99 } } as any,
+      sendResponse,
+    )
+
+    expect(sendResponse).toHaveBeenNthCalledWith(1, {
+      success: true,
+      promptableCodes: [validHex],
+    })
+    expect(sendResponse).toHaveBeenNthCalledWith(2, {
       success: true,
       promptableCodes: [validHex],
     })

--- a/tests/services/userPreferences.test.ts
+++ b/tests/services/userPreferences.test.ts
@@ -30,7 +30,7 @@ describe("userPreferences", () => {
       ).toBe(true)
       expect(
         DEFAULT_PREFERENCES.redemptionAssist?.urlWhitelist.patterns,
-      ).toEqual(["cdk.linux.do"])
+      ).toEqual(["cdk.linux.do", "cdk.hybgzs.com", "qd.x666.me"])
       expect(DEFAULT_PREFERENCES.tempWindowFallbackReminder?.dismissed).toBe(
         false,
       )

--- a/tests/services/userPreferences.test.ts
+++ b/tests/services/userPreferences.test.ts
@@ -30,7 +30,7 @@ describe("userPreferences", () => {
       ).toBe(true)
       expect(
         DEFAULT_PREFERENCES.redemptionAssist?.urlWhitelist.patterns,
-      ).toEqual(["cdk.linux.do", "cdk.hybgzs.com", "qd.x666.me"])
+      ).toEqual(["cdk\\.linux\\.do", "cdk\\.hybgzs\\.com", "qd\\.x666\\.me"])
       expect(DEFAULT_PREFERENCES.tempWindowFallbackReminder?.dismissed).toBe(
         false,
       )


### PR DESCRIPTION
Summary
- Add cdk.hybgzs.com and qd.x666.me to the default Redemption Assist URL whitelist.
- Escape dots in the default regex patterns to avoid accidental matches.

Tests
- pnpm test:ci
- pnpm zip:all

Refs
- #281
