### PR TITLE
feat(check-in): add lastDetectedAt timestamp for stale status detection

### DIFF
--- a/locales/en/account.json
+++ b/locales/en/account.json
@@ -32,7 +32,8 @@
       "customCheckInUrl": "External check-in URL, click to go: {{url}}",
       "checkInUnsupported": "Site may not support check-in",
       "checkedInToday": "Checked in today, click to view",
-      "notCheckedInToday": "Not checked in today, click to go"
+      "notCheckedInToday": "Not checked in today, click to go",
+      "checkInStatusOutdated": "Check-in status wasn't detected today (last check time: {{time}}). Click to refresh"
     }
   },
   "stats": {

--- a/locales/zh_CN/account.json
+++ b/locales/zh_CN/account.json
@@ -32,7 +32,8 @@
       "customCheckInUrl": "外部签到地址，点我去签到: {{url}}",
       "checkInUnsupported": "站点可能不支持签到",
       "checkedInToday": "今日已签到，点我查看",
-      "notCheckedInToday": "今日未签到，点我去签到"
+      "notCheckedInToday": "今日未签到，点我去签到",
+      "checkInStatusOutdated": "签到状态不是今日检测（上次检测时间：{{time}}），点我刷新"
     }
   },
   "stats": {

--- a/services/accountStorage.ts
+++ b/services/accountStorage.ts
@@ -516,6 +516,7 @@ class AccountStorageService {
 
       const today = new Date()
       const todayDate = today.toISOString().split("T")[0]
+      const detectedAt = today.getTime()
       const currentCheckIn = account.checkIn ?? { enableDetection: false }
 
       return this.updateAccount(id, {
@@ -525,6 +526,7 @@ class AccountStorageService {
             ...(currentCheckIn.siteStatus ?? {}),
             isCheckedInToday: true,
             lastCheckInDate: todayDate,
+            lastDetectedAt: detectedAt,
           },
         },
       })

--- a/services/apiService/anyrouter/index.ts
+++ b/services/apiService/anyrouter/index.ts
@@ -80,6 +80,11 @@ export async function fetchAccountData(
     checkInPromise,
   ])
 
+  const didDetectCheckInStatus = checkIn?.enableDetection === true
+  const checkInDetectedAt = didDetectCheckInStatus
+    ? Date.now()
+    : checkIn.siteStatus?.lastDetectedAt
+
   return {
     quota,
     ...todayUsage,
@@ -88,7 +93,15 @@ export async function fetchAccountData(
       ...checkIn,
       siteStatus: {
         ...(checkIn.siteStatus ?? {}),
-        isCheckedInToday: !(canCheckIn ?? true),
+        // `canCheckIn` means "can check in today" (i.e. NOT checked-in yet).
+        // Map it into the UI-facing `isCheckedInToday` flag and keep `undefined`
+        // when upstream does not provide a reliable status.
+        isCheckedInToday: didDetectCheckInStatus
+          ? canCheckIn === undefined
+            ? undefined
+            : !canCheckIn
+          : checkIn.siteStatus?.isCheckedInToday,
+        lastDetectedAt: checkInDetectedAt,
       },
     },
   }

--- a/services/apiService/wong/index.ts
+++ b/services/apiService/wong/index.ts
@@ -209,6 +209,11 @@ export async function fetchAccountData(
     checkInPromise,
   ])
 
+  const didDetectCheckInStatus = checkIn?.enableDetection === true
+  const checkInDetectedAt = didDetectCheckInStatus
+    ? Date.now()
+    : checkIn.siteStatus?.lastDetectedAt
+
   return {
     quota,
     ...todayUsage,
@@ -217,7 +222,15 @@ export async function fetchAccountData(
       ...checkIn,
       siteStatus: {
         ...(checkIn.siteStatus ?? {}),
-        isCheckedInToday: !(canCheckIn ?? true),
+        // `canCheckIn` means "can check in today" (i.e. NOT checked-in yet).
+        // Map it into the UI-facing `isCheckedInToday` flag and keep `undefined`
+        // when upstream does not provide a reliable status.
+        isCheckedInToday: didDetectCheckInStatus
+          ? canCheckIn === undefined
+            ? undefined
+            : !canCheckIn
+          : checkIn.siteStatus?.isCheckedInToday,
+        lastDetectedAt: checkInDetectedAt,
       },
     },
   }

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -1,11 +1,12 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
 import SiteInfo from "~/features/AccountManagement/components/AccountList/SiteInfo"
 
-const { mockOpenAccountBaseUrl } = vi.hoisted(() => ({
+const { mockOpenAccountBaseUrl, mockHandleRefreshAccount } = vi.hoisted(() => ({
   mockOpenAccountBaseUrl: vi.fn(),
+  mockHandleRefreshAccount: vi.fn(),
 }))
 
 vi.mock("react-i18next", () => ({
@@ -23,7 +24,7 @@ vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
 
 vi.mock("~/features/AccountManagement/hooks/AccountActionsContext", () => ({
   useAccountActionsContext: () => ({
-    handleRefreshAccount: vi.fn(),
+    handleRefreshAccount: mockHandleRefreshAccount,
     refreshingAccountId: null,
     handleMarkCustomCheckInAsCheckedIn: vi.fn(),
   }),
@@ -79,5 +80,109 @@ describe("SiteInfo", () => {
     expect(mockOpenAccountBaseUrl).toHaveBeenCalledWith(
       expect.objectContaining({ baseUrl: "https://example.com" }),
     )
+  })
+
+  it("shows a warning check-in indicator when the last check-in status detection is not today", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 0, 2, 10, 0, 0))
+
+    try {
+      mockHandleRefreshAccount.mockClear()
+
+      render(
+        <SiteInfo
+          site={
+            {
+              id: "acc-1",
+              name: "Site",
+              username: "user",
+              baseUrl: "https://example.com",
+              siteType: "test",
+              token: "token",
+              userId: 1,
+              authType: "access_token",
+              balance: { USD: 0, CNY: 0 },
+              todayConsumption: { USD: 0, CNY: 0 },
+              todayIncome: { USD: 0, CNY: 0 },
+              todayTokens: { upload: 0, download: 0 },
+              health: { status: "healthy" },
+              checkIn: {
+                enableDetection: true,
+                siteStatus: {
+                  isCheckedInToday: true,
+                  lastDetectedAt: new Date(2026, 0, 1, 12, 0, 0).getTime(),
+                },
+              },
+            } as any
+          }
+        />,
+      )
+
+      expect(
+        screen.getByRole("button", { name: "list.site.checkInStatusOutdated" }),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: "list.site.checkedInToday" }),
+      ).not.toBeInTheDocument()
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "list.site.checkInStatusOutdated" }),
+      )
+
+      expect(mockHandleRefreshAccount).toHaveBeenCalledTimes(1)
+      expect(mockHandleRefreshAccount).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "acc-1" }),
+        true,
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("shows the normal check-in indicator when status was detected today", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 0, 2, 10, 0, 0))
+
+    try {
+      render(
+        <SiteInfo
+          site={
+            {
+              id: "acc-1",
+              name: "Site",
+              username: "user",
+              baseUrl: "https://example.com",
+              siteType: "test",
+              token: "token",
+              userId: 1,
+              authType: "access_token",
+              balance: { USD: 0, CNY: 0 },
+              todayConsumption: { USD: 0, CNY: 0 },
+              todayIncome: { USD: 0, CNY: 0 },
+              todayTokens: { upload: 0, download: 0 },
+              health: { status: "healthy" },
+              checkIn: {
+                enableDetection: true,
+                siteStatus: {
+                  isCheckedInToday: false,
+                  lastDetectedAt: new Date(2026, 0, 2, 9, 0, 0).getTime(),
+                },
+              },
+            } as any
+          }
+        />,
+      )
+
+      expect(
+        screen.getByRole("button", { name: "list.site.notCheckedInToday" }),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", {
+          name: "list.site.checkInStatusOutdated",
+        }),
+      ).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/types/index.ts
+++ b/types/index.ts
@@ -178,6 +178,15 @@ export interface CheckInConfig {
      * Used by the auto check-in scheduler to reset the daily state.
      */
     lastCheckInDate?: string
+
+    /**
+     * Timestamp (ms) of the last successful check-in status detection for this account.
+     *
+     * This is used by the UI to warn users when the displayed check-in status may be stale
+     * (e.g., status was detected on a previous day, so "checked in" / "not checked in"
+     * might not represent today's real state).
+     */
+    lastDetectedAt?: number
   }
 
   /**


### PR DESCRIPTION
#420
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Check-in indicators now show an "outdated" warning when status wasn't detected today, display the last detection time, and offer a refresh action.

* **Localization**
  * Added English and Chinese messages for the outdated check-in status notification.

* **Tests**
  * Added/updated tests covering outdated vs. detected-today check-in indicators and the refresh behavior, using deterministic timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->