### PR TITLE
feat(TagFilter): add overflow display mode control

### DIFF
--- a/tests/components/TagFilter.test.tsx
+++ b/tests/components/TagFilter.test.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { describe, expect, it } from "vitest"
 
 import { TagFilter } from "~/components/ui"
-import { fireEvent, render, screen } from "~/tests/test-utils/render"
+import { fireEvent, render, screen, within } from "~/tests/test-utils/render"
 
 /**
  * Renders the TagFilter component in multi-select mode for interaction tests.
@@ -97,7 +97,7 @@ describe("TagFilter", () => {
     expect(groupBButton).toHaveAttribute("aria-pressed", "false")
   })
 
-  it("collapses overflow tags into a More popover", async () => {
+  it("expands overflow tags inline by default", async () => {
     const Wrapper = () => {
       const [value, setValue] = React.useState<string[]>([])
 
@@ -121,10 +121,58 @@ describe("TagFilter", () => {
 
     const moreButton = await screen.findByRole("button", { name: /More/i })
     expect(moreButton).toBeInTheDocument()
+    expect(screen.queryByText("Tag 4")).not.toBeInTheDocument()
+    expect(screen.queryByText("Tag 5")).not.toBeInTheDocument()
 
     fireEvent.click(moreButton)
 
     expect(await screen.findByText("Tag 4")).toBeInTheDocument()
     expect(await screen.findByText("Tag 5")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /More/i }),
+    ).not.toBeInTheDocument()
+    expect(document.querySelector('[data-slot="popover-content"]')).toBeNull()
+  })
+
+  it("keeps overflow tags in a popover when overflowDisplay='popover'", async () => {
+    const Wrapper = () => {
+      const [value, setValue] = React.useState<string[]>([])
+
+      return (
+        <TagFilter
+          options={[
+            { value: "tag-1", label: "Tag 1" },
+            { value: "tag-2", label: "Tag 2" },
+            { value: "tag-3", label: "Tag 3" },
+            { value: "tag-4", label: "Tag 4" },
+            { value: "tag-5", label: "Tag 5" },
+          ]}
+          value={value}
+          onChange={setValue}
+          maxVisible={3}
+          overflowDisplay="popover"
+        />
+      )
+    }
+
+    render(<Wrapper />)
+
+    const moreButton = await screen.findByRole("button", { name: /More/i })
+    expect(moreButton).toBeInTheDocument()
+    expect(screen.queryByText("Tag 4")).not.toBeInTheDocument()
+    expect(screen.queryByText("Tag 5")).not.toBeInTheDocument()
+    expect(document.querySelector('[data-slot="popover-content"]')).toBeNull()
+
+    fireEvent.click(moreButton)
+
+    const popoverContent = document.querySelector(
+      '[data-slot="popover-content"]',
+    )
+    expect(popoverContent).not.toBeNull()
+
+    const { getByText } = within(popoverContent as HTMLElement)
+    expect(getByText("Tag 4")).toBeInTheDocument()
+    expect(getByText("Tag 5")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /More/i })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tag filters now feature configurable overflow handling: expand overflow tags inline by default, or switch to popover mode for the previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->