### PR TITLE
feat(key-management): display group identifier in selection labels

### DIFF
--- a/entrypoints/options/pages/KeyManagement/components/AddTokenDialog/TokenForm/GroupSelection.tsx
+++ b/entrypoints/options/pages/KeyManagement/components/AddTokenDialog/TokenForm/GroupSelection.tsx
@@ -29,7 +29,16 @@ export function GroupSelection({
       <SearchableSelect
         options={Object.entries(groups).map(([key, groupInfo]) => ({
           value: key,
-          label: `${groupInfo.desc} (${t("dialog.groupRate")}: ${groupInfo.ratio})`,
+          label: (() => {
+            const desc = groupInfo.desc?.trim()
+            const ratioLabel = `${t("dialog.groupRate")} ${groupInfo.ratio}`
+
+            if (!desc || desc === key) {
+              return `${key} (${ratioLabel})`
+            }
+
+            return `${key} - ${desc} (${ratioLabel})`
+          })(),
         }))}
         value={group ?? ""}
         onChange={handleSelectChange}

--- a/tests/entrypoints/options/pages/KeyManagement/GroupSelection.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/GroupSelection.test.tsx
@@ -1,0 +1,66 @@
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import { GroupSelection } from "~/entrypoints/options/pages/KeyManagement/components/AddTokenDialog/TokenForm/GroupSelection"
+import keyManagementEn from "~/locales/en/keyManagement.json"
+import uiEn from "~/locales/en/ui.json"
+import { testI18n } from "~/tests/test-utils/i18n"
+import { fireEvent, render, screen, within } from "~/tests/test-utils/render"
+
+describe("GroupSelection", () => {
+  beforeAll(() => {
+    testI18n.addResourceBundle("en", "ui", uiEn, true, true)
+    testI18n.addResourceBundle(
+      "en",
+      "keyManagement",
+      keyManagementEn,
+      true,
+      true,
+    )
+  })
+
+  it("renders group options with the group identifier in the label", async () => {
+    const handleSelectChange = vi.fn()
+
+    render(
+      <GroupSelection
+        group="level1"
+        handleSelectChange={handleSelectChange}
+        groups={{
+          level1: { desc: "Default Group", ratio: 1 },
+          level3: { desc: "User Group", ratio: 1.5 },
+        }}
+      />,
+    )
+
+    const combo = await screen.findByRole("combobox")
+    expect(combo).toHaveTextContent("level1 - Default Group")
+
+    fireEvent.click(combo)
+
+    const dropdown = await screen.findByRole("dialog")
+    expect(
+      within(dropdown).getByText("level1 - Default Group (Rate: 1)"),
+    ).toBeInTheDocument()
+    expect(
+      within(dropdown).getByText("level3 - User Group (Rate: 1.5)"),
+    ).toBeInTheDocument()
+  })
+
+  it("avoids duplicating description when it matches the group identifier", async () => {
+    render(
+      <GroupSelection
+        group="level2"
+        handleSelectChange={() => {}}
+        groups={{
+          level2: { desc: "level2", ratio: 1 },
+        }}
+      />,
+    )
+
+    const combo = await screen.findByRole("combobox")
+    fireEvent.click(combo)
+
+    const dropdown = await screen.findByRole("dialog")
+    expect(within(dropdown).getByText("level2 (Rate: 1)")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group label formatting in token management dialogs to display group names, descriptions, and rates more clearly. Groups with descriptions matching their identifiers now display concisely without duplication.

* **Tests**
  * Added comprehensive test coverage for group selection functionality to ensure proper rendering and handling of group information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->