### PR TITLE
fix(user-preferences): change autoProvisionKeyOnAccountAdd default to false

### DIFF
--- a/contexts/UserPreferencesContext.tsx
+++ b/contexts/UserPreferencesContext.tsx
@@ -1264,7 +1264,7 @@ export const UserPreferencesProvider = ({
     autoProvisionKeyOnAccountAdd:
       preferences?.autoProvisionKeyOnAccountAdd ??
       DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd ??
-      true,
+      false,
     newApiBaseUrl: preferences?.newApi?.baseUrl || "",
     newApiAdminToken: preferences?.newApi?.adminToken || "",
     newApiUserId: preferences?.newApi?.userId || "",

--- a/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-15

--- a/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/README.md
+++ b/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/README.md
@@ -1,0 +1,3 @@
+# auto-provision-key-default-off
+
+Default-off: disable autoProvisionKeyOnAccountAdd and update spec/docs

--- a/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/design.md
+++ b/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The `account-key-auto-provisioning` capability allows automatically ensuring an eligible account has at least one API token by creating a default token when the remote token list is empty. This is controlled by the user preference `autoProvisionKeyOnAccountAdd`.
+
+The current OpenSpec requirement states the setting defaults to enabled, and the implementation follows that behavior (including a `true` fallback when preferences cannot be read). We want to switch the default to disabled to make the behavior opt-in and reduce surprising upstream writes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Default `autoProvisionKeyOnAccountAdd` to disabled for new installs and for existing installs where the field is missing.
+- Keep the setting functional: enabling it should restore the existing auto-provision-on-add behavior.
+- Ensure preference-read failures fall back to the configured default (disabled) rather than force-enabling provisioning.
+- Align OpenSpec requirements with the implementation to avoid spec drift.
+
+**Non-Goals:**
+
+- Do not force-change users who already have an explicit stored value (e.g., `true`) for this preference.
+- Do not change the token provisioning flow, eligibility gating, or manual bulk repair behavior.
+
+## Decisions
+
+- **Default source of truth:** Set `DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd = false` and treat it as the fallback value wherever the preference is read.
+  - *Rationale:* Keeps behavior consistent and avoids hard-coded `true` fallbacks that can diverge from defaults.
+- **No breaking migration:** Rely on preference defaulting/merge behavior so that only missing values adopt the new default; explicit stored values remain respected.
+  - *Rationale:* Avoids surprising changes for users who intentionally enabled the feature.
+
+## Risks / Trade-offs
+
+- **Users may expect keys to exist after adding an account** → Mitigation: the toggle remains available and manual “repair missing keys” is still present.
+- **Spec/implementation drift risk** → Mitigation: update the spec requirement and archive the change to sync main specs.
+
+## Migration Plan
+
+- Ship the new default (`false`) and ensure account-add behavior uses `DEFAULT_PREFERENCES` for fallbacks.
+- No data migration is required; missing preference values will be persisted with the new default on next preference load.
+- Rollback is a revert of the default value and fallback behavior.

--- a/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/proposal.md
+++ b/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Adding an account currently defaults to automatically creating a remote API token when no tokens exist. This has side effects (writes to the upstream site) and can surprise users who only want to monitor balances/models without provisioning credentials.
+
+We need to change the default to safer, opt-in behavior and keep the OpenSpec requirements aligned with the implementation.
+
+## What Changes
+
+- Change the default value of `autoProvisionKeyOnAccountAdd` from enabled to disabled.
+- Ensure the account-add flow uses the configured preference, and falls back to the default preference value when preferences are missing/unreadable.
+- Update tests to reflect the new default and fallback behavior.
+- Update the `account-key-auto-provisioning` spec to match the new default.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `account-key-auto-provisioning`: The `autoProvisionKeyOnAccountAdd` setting default changes from **enabled** to **disabled**.
+
+## Impact
+
+- Affects account-add post-save behavior (auto-provision trigger), preference defaults, and the default state of the Options toggle.
+- No API surface changes; manual bulk repair and the toggle behavior remain unchanged.

--- a/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/specs/account-key-auto-provisioning/spec.md
+++ b/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/specs/account-key-auto-provisioning/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Auto-provision on account add is configurable
+The system MUST provide a user setting to enable or disable automatic default-key (token) provisioning when adding an account.
+
+The setting MUST be persisted in user preferences as `autoProvisionKeyOnAccountAdd` and MUST default to **disabled**.
+
+#### Scenario: Auto-provision enabled runs after successful add
+- **GIVEN** auto-provision on add is enabled
+- **WHEN** a user successfully adds an account
+- **THEN** the system MUST run the key auto-provisioning flow for that account
+
+#### Scenario: Auto-provision disabled does not run after successful add
+- **GIVEN** auto-provision on add is disabled
+- **WHEN** a user successfully adds an account
+- **THEN** the system MUST NOT run the key auto-provisioning flow for that account

--- a/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/tasks.md
+++ b/openspec/changes/archive/2026-02-15-auto-provision-key-default-off/tasks.md
@@ -1,0 +1,23 @@
+## 1. Specs (avoid drift)
+
+- [x] 1.1 Update `account-key-auto-provisioning` requirement so `autoProvisionKeyOnAccountAdd` defaults to **disabled** (`openspec/changes/*/specs/account-key-auto-provisioning/spec.md`).
+
+## 2. Implementation (default-off)
+
+- [x] 2.1 Change `DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd` default to `false` (`services/userPreferences.ts`).
+- [x] 2.2 Ensure the account-add flow falls back to `DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd` (do not hard-code `true` on preference read failure) (`services/accountOperations.ts`).
+- [x] 2.3 Ensure `UserPreferencesContext` fallback default matches the new default (`contexts/UserPreferencesContext.tsx`).
+
+## 3. Tests
+
+- [x] 3.1 Update unit tests to reflect the new default (`tests/services/userPreferences.test.ts`).
+- [x] 3.2 Update missing-preference wiring tests to treat missing `autoProvisionKeyOnAccountAdd` as disabled (`tests/services/userPreferences.autoProvisionKeyOnAccountAdd.test.ts`).
+- [x] 3.3 Update account-add behavior tests for preference-read failure fallback (`tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts`).
+
+## 4. Tooling reliability
+
+- [x] 4.1 Exclude `WorkTrees/**` from Vitest discovery so local worktrees do not break CI/test runs (`vitest.config.ts`).
+
+## 5. Sync main specs
+
+- [x] 5.1 Archive the change to apply the delta spec into `openspec/specs/account-key-auto-provisioning/spec.md`.

--- a/openspec/specs/account-key-auto-provisioning/spec.md
+++ b/openspec/specs/account-key-auto-provisioning/spec.md
@@ -6,7 +6,7 @@ TBD - created by archiving change auto-create-account-keys. Update Purpose after
 ### Requirement: Auto-provision on account add is configurable
 The system MUST provide a user setting to enable or disable automatic default-key (token) provisioning when adding an account.
 
-The setting MUST be persisted in user preferences as `autoProvisionKeyOnAccountAdd` and MUST default to **enabled**.
+The setting MUST be persisted in user preferences as `autoProvisionKeyOnAccountAdd` and MUST default to **disabled**.
 
 #### Scenario: Auto-provision enabled runs after successful add
 - **GIVEN** auto-provision on add is enabled

--- a/services/accountOperations.ts
+++ b/services/accountOperations.ts
@@ -15,7 +15,10 @@ import {
 import { accountStorage } from "~/services/accountStorage"
 import { getApiService } from "~/services/apiService"
 import { autoDetectSmart } from "~/services/autoDetectService"
-import { userPreferences } from "~/services/userPreferences"
+import {
+  DEFAULT_PREFERENCES,
+  userPreferences,
+} from "~/services/userPreferences"
 import {
   ApiToken,
   AuthTypeEnum,
@@ -398,13 +401,14 @@ export async function validateAndSaveAccount(
     }
   }
 
-  let shouldAutoProvisionKeyOnAccountAdd = true
-  let includeTodayCashflow = true
+  let shouldAutoProvisionKeyOnAccountAdd =
+    DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd ?? false
+  let includeTodayCashflow = DEFAULT_PREFERENCES.showTodayCashflow ?? true
   try {
     const prefs = await userPreferences.getPreferences()
     shouldAutoProvisionKeyOnAccountAdd =
-      prefs.autoProvisionKeyOnAccountAdd ?? true
-    includeTodayCashflow = prefs.showTodayCashflow ?? true
+      prefs.autoProvisionKeyOnAccountAdd ?? shouldAutoProvisionKeyOnAccountAdd
+    includeTodayCashflow = prefs.showTodayCashflow ?? includeTodayCashflow
   } catch (error) {
     logger.warn(
       "Failed to read user preferences; falling back to defaults",

--- a/services/userPreferences.ts
+++ b/services/userPreferences.ts
@@ -407,7 +407,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   sortOrder: "desc", // 与 UI_CONSTANTS.SORT.DEFAULT_ORDER 保持一致
   actionClickBehavior: "popup",
   openChangelogOnUpdate: true,
-  autoProvisionKeyOnAccountAdd: true,
+  autoProvisionKeyOnAccountAdd: false, // 默认关闭，避免添加账号时无意创建密钥
   accountAutoRefresh: DEFAULT_ACCOUNT_AUTO_REFRESH,
   usageHistory: DEFAULT_USAGE_HISTORY_PREFERENCES,
   balanceHistory: DEFAULT_BALANCE_HISTORY_PREFERENCES,

--- a/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
+++ b/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
@@ -163,7 +163,7 @@ describe("accountOperations auto-provision key on add", () => {
     expect(toastErrorMock).not.toHaveBeenCalled()
   })
 
-  it("defaults to enabling auto-provision when preferences read fails", async () => {
+  it("defaults to disabling auto-provision when preferences read fails", async () => {
     vi.spyOn(userPreferences, "getPreferences").mockRejectedValueOnce(
       new Error("prefs-fail"),
     )
@@ -188,7 +188,7 @@ describe("accountOperations auto-provision key on add", () => {
     await flushPromises()
     await flushPromises()
 
-    expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledTimes(1)
+    expect(ensureDefaultApiTokenForAccountMock).not.toHaveBeenCalled()
   })
 
   it("skips auto-provision for sub2api accounts", async () => {

--- a/tests/services/userPreferences.autoProvisionKeyOnAccountAdd.test.ts
+++ b/tests/services/userPreferences.autoProvisionKeyOnAccountAdd.test.ts
@@ -10,11 +10,11 @@ import {
 
 /**
  * Validates that autoProvisionKeyOnAccountAdd is:
- * - treated as enabled when missing from stored preferences
+ * - treated as disabled when missing from stored preferences
  * - persisted when updated through the UserPreferencesService helper
  */
 describe("userPreferences autoProvisionKeyOnAccountAdd", () => {
-  it("treats missing autoProvisionKeyOnAccountAdd as enabled and saves back", async () => {
+  it("treats missing autoProvisionKeyOnAccountAdd as disabled and saves back", async () => {
     const storage = new Storage({ area: "local" })
     const storedWithoutFlag: any = { ...DEFAULT_PREFERENCES }
     delete storedWithoutFlag.autoProvisionKeyOnAccountAdd
@@ -25,12 +25,12 @@ describe("userPreferences autoProvisionKeyOnAccountAdd", () => {
     )
 
     const prefs = await userPreferences.getPreferences()
-    expect(prefs.autoProvisionKeyOnAccountAdd).toBe(true)
+    expect(prefs.autoProvisionKeyOnAccountAdd).toBe(false)
 
     const storedAfter = await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
     )
-    expect((storedAfter as any)?.autoProvisionKeyOnAccountAdd).toBe(true)
+    expect((storedAfter as any)?.autoProvisionKeyOnAccountAdd).toBe(false)
   })
 
   it("persists updates via updateAutoProvisionKeyOnAccountAdd", async () => {

--- a/tests/services/userPreferences.test.ts
+++ b/tests/services/userPreferences.test.ts
@@ -14,7 +14,7 @@ describe("userPreferences", () => {
       expect(DEFAULT_PREFERENCES.showTodayCashflow).toBe(true)
       expect(DEFAULT_PREFERENCES.showHealthStatus).toBe(true)
       expect(DEFAULT_PREFERENCES.themeMode).toBe("system")
-      expect(DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd).toBe(true)
+      expect(DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd).toBe(false)
       expect(DEFAULT_PREFERENCES.balanceHistory?.enabled).toBe(false)
       expect(DEFAULT_PREFERENCES.balanceHistory?.endOfDayCapture.enabled).toBe(
         false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic API key provisioning when adding new accounts is now disabled by default. Users who want automatic provisioning can re-enable this in their preferences.
  * When user preferences fail to load, the system now correctly defaults to disabled auto-provisioning instead of automatically provisioning keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->