### PR TITLE
feat(account): exclude disabled accounts from refresh and UI operations

### DIFF
--- a/entrypoints/options/pages/BalanceHistory/index.tsx
+++ b/entrypoints/options/pages/BalanceHistory/index.tsx
@@ -125,7 +125,7 @@ export default function BalanceHistory() {
     try {
       setIsLoading(true)
       const [nextAccounts, nextStore, nextTagStore] = await Promise.all([
-        accountStorage.getAllAccounts(),
+        accountStorage.getEnabledAccounts(),
         dailyBalanceHistoryStorage.getStore(),
         tagStorage.getTagStore(),
       ])

--- a/entrypoints/options/pages/BasicSettings/components/UsageHistorySyncTab.tsx
+++ b/entrypoints/options/pages/BasicSettings/components/UsageHistorySyncTab.tsx
@@ -72,7 +72,7 @@ export default function UsageHistorySyncTab() {
     try {
       setIsLoading(true)
       const [nextAccounts, nextStore] = await Promise.all([
-        accountStorage.getAllAccounts(),
+        accountStorage.getEnabledAccounts(),
         usageHistoryStorage.getStore(),
       ])
       setAccounts(nextAccounts)

--- a/services/accountStorage.ts
+++ b/services/accountStorage.ts
@@ -935,7 +935,7 @@ class AccountStorageService {
    * Refresh all accounts concurrently; summarizes results.
    */
   async refreshAllAccounts(force: boolean = false) {
-    const accounts = await this.getAllAccounts()
+    const accounts = await this.getEnabledAccounts()
     const includeTodayCashflow =
       (await userPreferences.getPreferences()).showTodayCashflow ?? true
     let successCount = 0

--- a/services/dailyBalanceHistory/scheduler.ts
+++ b/services/dailyBalanceHistory/scheduler.ts
@@ -217,7 +217,7 @@ class DailyBalanceHistoryScheduler {
         return { started: false, skipped: true }
       }
 
-      const accounts = await accountStorage.getAllAccounts()
+      const accounts = await accountStorage.getEnabledAccounts()
       const results = await Promise.allSettled(
         accounts.map((account) =>
           accountStorage.refreshAccount(account.id, true, {

--- a/services/usageHistory/scheduler.ts
+++ b/services/usageHistory/scheduler.ts
@@ -207,11 +207,13 @@ class UsageHistoryScheduler {
         ? await Promise.all(
             params.accountIds.map((id) => accountStorage.getAccountById(id)),
           ).then((values) =>
-            values.filter((value): value is NonNullable<typeof value> =>
-              Boolean(value),
-            ),
+            values
+              .filter((value): value is NonNullable<typeof value> =>
+                Boolean(value),
+              )
+              .filter((account) => account.disabled !== true),
           )
-        : await accountStorage.getAllAccounts()
+        : await accountStorage.getEnabledAccounts()
 
       const perAccount: Array<
         Awaited<ReturnType<typeof syncUsageHistoryForAccount>>

--- a/tests/entrypoints/options/BalanceHistory.test.tsx
+++ b/tests/entrypoints/options/BalanceHistory.test.tsx
@@ -36,7 +36,7 @@ vi.mock("~/components/charts/echarts", async () => {
 })
 
 vi.mock("~/services/accountStorage", () => ({
-  accountStorage: { getAllAccounts: vi.fn() },
+  accountStorage: { getAllAccounts: vi.fn(), getEnabledAccounts: vi.fn() },
 }))
 
 vi.mock("~/services/dailyBalanceHistory/storage", () => ({
@@ -119,7 +119,7 @@ describe("BalanceHistory options page", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([] as any)
+    vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([] as any)
     vi.mocked(tagStorage.getTagStore).mockResolvedValue({
       version: 1,
       tagsById: {},
@@ -198,7 +198,7 @@ describe("BalanceHistory options page", () => {
       `^${escapeRegExp(TAG_NAME_WORK)}\\D*${TAG_WORK_ACCOUNT_COUNT}$`,
     )
 
-    vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([
+    vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([
       {
         id: ACCOUNT_ID_A,
         site_name: SITE_A_NAME,
@@ -285,7 +285,7 @@ describe("BalanceHistory options page", () => {
       const nowUnixSeconds = Math.floor(fixedNowMs / 1000)
       const todayKey = getDayKeyFromUnixSeconds(nowUnixSeconds)
 
-      vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([
+      vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([
         {
           id: "a1",
           site_name: "Site A",
@@ -360,7 +360,7 @@ describe("BalanceHistory options page", () => {
       const nowUnixSeconds = Math.floor(fixedNowMs / 1000)
       const todayKey = getDayKeyFromUnixSeconds(nowUnixSeconds)
 
-      vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([
+      vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([
         {
           id: "a1",
           site_name: "Site A",
@@ -458,7 +458,7 @@ describe("BalanceHistory options page", () => {
       const nowUnixSeconds = Math.floor(fixedNowMs / 1000)
       const todayKey = getDayKeyFromUnixSeconds(nowUnixSeconds)
 
-      vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([
+      vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([
         {
           id: "a1",
           site_name: "Site A",

--- a/tests/entrypoints/options/UsageHistorySyncTab.test.tsx
+++ b/tests/entrypoints/options/UsageHistorySyncTab.test.tsx
@@ -18,7 +18,7 @@ vi.mock("~/contexts/UserPreferencesContext", () => ({
 }))
 
 vi.mock("~/services/accountStorage", () => ({
-  accountStorage: { getAllAccounts: vi.fn() },
+  accountStorage: { getAllAccounts: vi.fn(), getEnabledAccounts: vi.fn() },
 }))
 
 vi.mock("~/services/usageHistory/storage", () => ({
@@ -71,7 +71,7 @@ describe("UsageHistorySyncTab", () => {
       loadPreferences,
     } as any)
 
-    vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([
+    vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([
       { id: "a1", site_name: "Account 1" },
     ] as any)
     vi.mocked(usageHistoryStorage.getStore).mockResolvedValue({
@@ -116,7 +116,7 @@ describe("UsageHistorySyncTab", () => {
       loadPreferences: vi.fn().mockResolvedValue(undefined),
     } as any)
 
-    vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([
+    vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([
       { id: "a1", site_name: "Account 1" },
       { id: "a2", site_name: "Account 2" },
     ] as any)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account filtering throughout the app to ensure only enabled accounts appear in Balance History, Usage Analytics, and scheduled sync operations.
  * Improved handling of disabled accounts by excluding them from filter options, export selections, analytics aggregation, and reporting features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->