### PR TITLE
feat(redemption): add post-redeem account balance refresh

### DIFF
--- a/src/services/redemption/redemptionAssist.ts
+++ b/src/services/redemption/redemptionAssist.ts
@@ -22,6 +22,29 @@ import {
  */
 const logger = createLogger("RedemptionAssist")
 
+/**
+ * After a successful redeem, attempt to refresh the account data to reflect any changes.
+ * @param accountId ID of the account that was redeemed against.
+ */
+async function bestEffortRefreshAccountAfterSuccessfulRedeem(
+  accountId: string,
+) {
+  try {
+    const result = await accountStorage.refreshAccount(accountId, true)
+    if (result?.refreshed !== true) {
+      logger.debug("Post-redeem refresh did not refresh", {
+        accountId,
+        refreshed: result?.refreshed ?? null,
+      })
+    }
+  } catch (error) {
+    logger.warn("Post-redeem refresh failed", {
+      accountId,
+      error,
+    })
+  }
+}
+
 interface RedemptionAssistRuntimeSettings {
   enabled: boolean
   relaxedCodeValidation: boolean
@@ -367,7 +390,16 @@ class RedemptionAssistService {
    */
   async autoRedeem(accountId: string, code: string) {
     // Delegate to redeemService which handles i18n and error messages
-    return redeemService.redeemCodeForAccount(accountId, code)
+    const redeemResult = await redeemService.redeemCodeForAccount(
+      accountId,
+      code,
+    )
+
+    if (redeemResult.success) {
+      await bestEffortRefreshAccountAfterSuccessfulRedeem(accountId)
+    }
+
+    return redeemResult
   }
 
   /**
@@ -414,6 +446,11 @@ class RedemptionAssistService {
         account.id,
         code,
       )
+
+      if (redeemResult.success) {
+        await bestEffortRefreshAccountAfterSuccessfulRedeem(account.id)
+      }
+
       // Flatten the result so it matches the RedeemResult shape used elsewhere
       return {
         ...redeemResult,

--- a/tests/services/redemptionAssist.test.ts
+++ b/tests/services/redemptionAssist.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
@@ -14,6 +14,13 @@ vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
       getPreferences: vi.fn(),
     },
   }
+})
+
+afterEach(() => {
+  vi.doUnmock("~/services/accounts/accountStorage")
+  vi.doUnmock("~/services/redemption/redeemService")
+  vi.resetModules()
+  vi.restoreAllMocks()
 })
 
 describe("redemptionAssist shouldPrompt batch filtering", () => {
@@ -65,6 +72,259 @@ describe("redemptionAssist shouldPrompt batch filtering", () => {
     expect(sendResponse).toHaveBeenCalledWith({
       success: true,
       promptableCodes: [validHex],
+    })
+  })
+})
+
+describe("redemptionAssist post-redeem refresh", () => {
+  it("refreshes account after successful auto redeem (explicit account)", async () => {
+    vi.resetModules()
+
+    const refreshAccount = vi.fn().mockResolvedValue({ refreshed: true })
+    const redeemCodeForAccount = vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "ok" })
+
+    vi.doMock("~/services/accounts/accountStorage", () => ({
+      accountStorage: {
+        refreshAccount,
+      },
+    }))
+
+    vi.doMock("~/services/redemption/redeemService", () => ({
+      redeemService: {
+        redeemCodeForAccount,
+      },
+    }))
+
+    const { handleRedemptionAssistMessage } = await import(
+      "~/services/redemption/redemptionAssist"
+    )
+
+    const sendResponse = vi.fn()
+
+    await handleRedemptionAssistMessage(
+      {
+        action: RuntimeActionIds.RedemptionAssistAutoRedeem,
+        accountId: "acc_1",
+        code: "CODE_1",
+      },
+      {} as any,
+      sendResponse,
+    )
+
+    expect(redeemCodeForAccount).toHaveBeenCalledWith("acc_1", "CODE_1")
+    expect(refreshAccount).toHaveBeenCalledWith("acc_1", true)
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: { success: true, message: "ok" },
+    })
+  })
+
+  it("refreshes account after successful auto redeem by url (inferred account)", async () => {
+    vi.resetModules()
+
+    const { userPreferences } = await import(
+      "~/services/preferences/userPreferences"
+    )
+    const getPreferencesMock = vi.mocked(userPreferences.getPreferences)
+    getPreferencesMock.mockResolvedValue(DEFAULT_PREFERENCES)
+
+    const refreshAccount = vi.fn().mockResolvedValue({ refreshed: true })
+    const redeemCodeForAccount = vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "ok" })
+
+    const displayAccount = {
+      id: "acc_2",
+      baseUrl: "https://example.com",
+      checkIn: {
+        customCheckIn: {
+          url: "https://example.com/checkin",
+        },
+      },
+    }
+
+    vi.doMock("~/services/accounts/accountStorage", () => ({
+      accountStorage: {
+        refreshAccount,
+        getEnabledAccounts: vi.fn().mockResolvedValue([]),
+        convertToDisplayData: vi.fn().mockReturnValue([displayAccount]),
+      },
+    }))
+
+    vi.doMock("~/services/redemption/redeemService", () => ({
+      redeemService: {
+        redeemCodeForAccount,
+      },
+    }))
+
+    const { handleRedemptionAssistMessage } = await import(
+      "~/services/redemption/redemptionAssist"
+    )
+
+    const sendResponse = vi.fn()
+
+    await handleRedemptionAssistMessage(
+      {
+        action: RuntimeActionIds.RedemptionAssistAutoRedeemByUrl,
+        url: "https://example.com/redeem",
+        code: "CODE_2",
+      },
+      {} as any,
+      sendResponse,
+    )
+
+    expect(redeemCodeForAccount).toHaveBeenCalledWith("acc_2", "CODE_2")
+    expect(refreshAccount).toHaveBeenCalledWith("acc_2", true)
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        success: true,
+        message: "ok",
+        selectedAccount: displayAccount,
+      },
+    })
+  })
+
+  it("swallows refresh failures and still reports redemption success", async () => {
+    vi.resetModules()
+
+    const refreshAccount = vi.fn().mockRejectedValue(new Error("refresh boom"))
+    const redeemCodeForAccount = vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "ok" })
+
+    vi.doMock("~/services/accounts/accountStorage", () => ({
+      accountStorage: {
+        refreshAccount,
+      },
+    }))
+
+    vi.doMock("~/services/redemption/redeemService", () => ({
+      redeemService: {
+        redeemCodeForAccount,
+      },
+    }))
+
+    const { handleRedemptionAssistMessage } = await import(
+      "~/services/redemption/redemptionAssist"
+    )
+
+    const sendResponse = vi.fn()
+
+    await handleRedemptionAssistMessage(
+      {
+        action: RuntimeActionIds.RedemptionAssistAutoRedeem,
+        accountId: "acc_3",
+        code: "CODE_3",
+      },
+      {} as any,
+      sendResponse,
+    )
+
+    expect(refreshAccount).toHaveBeenCalledWith("acc_3", true)
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: { success: true, message: "ok" },
+    })
+  })
+
+  it("awaits refresh before responding", async () => {
+    vi.resetModules()
+
+    let resolveRefresh: ((value: { refreshed: true }) => void) | undefined
+    const refreshAccount = vi.fn(
+      () =>
+        new Promise<{ refreshed: true }>((resolve) => {
+          resolveRefresh = resolve
+        }),
+    )
+    const redeemCodeForAccount = vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "ok" })
+
+    vi.doMock("~/services/accounts/accountStorage", () => ({
+      accountStorage: {
+        refreshAccount,
+      },
+    }))
+
+    vi.doMock("~/services/redemption/redeemService", () => ({
+      redeemService: {
+        redeemCodeForAccount,
+      },
+    }))
+
+    const { handleRedemptionAssistMessage } = await import(
+      "~/services/redemption/redemptionAssist"
+    )
+
+    const sendResponse = vi.fn()
+
+    const handlePromise = handleRedemptionAssistMessage(
+      {
+        action: RuntimeActionIds.RedemptionAssistAutoRedeem,
+        accountId: "acc_await",
+        code: "CODE_AWAIT",
+      },
+      {} as any,
+      sendResponse,
+    )
+
+    await Promise.resolve()
+    expect(refreshAccount).toHaveBeenCalledWith("acc_await", true)
+    expect(sendResponse).not.toHaveBeenCalled()
+
+    resolveRefresh?.({ refreshed: true })
+    await handlePromise
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: { success: true, message: "ok" },
+    })
+  })
+
+  it("does not refresh when redemption fails", async () => {
+    vi.resetModules()
+
+    const refreshAccount = vi.fn().mockResolvedValue({ refreshed: true })
+    const redeemCodeForAccount = vi
+      .fn()
+      .mockResolvedValue({ success: false, message: "nope" })
+
+    vi.doMock("~/services/accounts/accountStorage", () => ({
+      accountStorage: {
+        refreshAccount,
+      },
+    }))
+
+    vi.doMock("~/services/redemption/redeemService", () => ({
+      redeemService: {
+        redeemCodeForAccount,
+      },
+    }))
+
+    const { handleRedemptionAssistMessage } = await import(
+      "~/services/redemption/redemptionAssist"
+    )
+
+    const sendResponse = vi.fn()
+
+    await handleRedemptionAssistMessage(
+      {
+        action: RuntimeActionIds.RedemptionAssistAutoRedeem,
+        accountId: "acc_4",
+        code: "CODE_4",
+      },
+      {} as any,
+      sendResponse,
+    )
+
+    expect(refreshAccount).not.toHaveBeenCalled()
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: { success: false, message: "nope" },
     })
   })
 })


### PR DESCRIPTION
resolves #550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Account data now automatically refreshes after successfully redeeming promotional codes, ensuring you see the latest account state immediately.
  * Refresh failures are handled gracefully without affecting your redemption success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->