### PR TITLE
fix: OpenAI 兼容模型请求透传 userId

### DIFF
--- a/src/services/apiService/common/type.ts
+++ b/src/services/apiService/common/type.ts
@@ -366,6 +366,8 @@ export interface OpenAIAuthParams {
   baseUrl: string
   /** API Key */
   apiKey: string
+  /** Optional user id for New-API style compatibility headers */
+  userId?: number | string
 }
 
 // 上游模型列表（OpenAI格式）

--- a/src/services/apiService/openaiCompatible/index.ts
+++ b/src/services/apiService/openaiCompatible/index.ts
@@ -18,6 +18,7 @@ export const fetchOpenAICompatibleModels = async (params: OpenAIAuthParams) => {
     auth: {
       authType: AuthTypeEnum.AccessToken,
       accessToken: params.apiKey,
+      userId: params.userId,
     },
   }
   try {

--- a/src/services/managedSites/providers/doneHubService.ts
+++ b/src/services/managedSites/providers/doneHubService.ts
@@ -221,6 +221,7 @@ export async function fetchAvailableModels(
     const upstreamModels = await fetchOpenAICompatibleModelIds({
       baseUrl: account.baseUrl,
       apiKey: token.key,
+      userId: account.userId,
     })
     if (upstreamModels && upstreamModels.length > 0) {
       candidateSources.push(upstreamModels)
@@ -277,6 +278,7 @@ export async function prepareChannelFormData(
   const availableModels = await fetchOpenAICompatibleModelIds({
     baseUrl: account.baseUrl,
     apiKey: token.key,
+    userId: account.userId,
   })
 
   if (!availableModels.length) {

--- a/src/services/managedSites/providers/newApi.ts
+++ b/src/services/managedSites/providers/newApi.ts
@@ -251,6 +251,7 @@ export async function fetchAvailableModels(
     const upstreamModels = await fetchOpenAICompatibleModelIds({
       baseUrl: account.baseUrl,
       apiKey: token.key,
+      userId: account.userId,
     })
     if (upstreamModels && upstreamModels.length > 0) {
       candidateSources.push(upstreamModels)
@@ -307,6 +308,7 @@ export async function prepareChannelFormData(
   const availableModels = await fetchOpenAICompatibleModelIds({
     baseUrl: account.baseUrl,
     apiKey: token.key,
+    userId: account.userId,
   })
 
   if (!availableModels.length) {

--- a/src/services/managedSites/providers/octopus.ts
+++ b/src/services/managedSites/providers/octopus.ts
@@ -377,6 +377,7 @@ export async function fetchAvailableModels(
     const upstreamModels = await fetchOpenAICompatibleModelIds({
       baseUrl: account.baseUrl,
       apiKey: token.key,
+      userId: account.userId,
     })
     if (upstreamModels?.length > 0) {
       candidateSources.push(upstreamModels)
@@ -412,6 +413,7 @@ export async function prepareChannelFormData(
   const availableModels = await fetchOpenAICompatibleModelIds({
     baseUrl: account.baseUrl,
     apiKey: token.key,
+    userId: account.userId,
   })
 
   if (!availableModels.length) {

--- a/src/services/managedSites/providers/veloera.ts
+++ b/src/services/managedSites/providers/veloera.ts
@@ -198,6 +198,7 @@ export async function fetchAvailableModels(
     const upstreamModels = await fetchOpenAICompatibleModelIds({
       baseUrl: account.baseUrl,
       apiKey: token.key,
+      userId: account.userId,
     })
     if (upstreamModels && upstreamModels.length > 0) {
       candidateSources.push(upstreamModels)
@@ -254,6 +255,7 @@ export async function prepareChannelFormData(
   const availableModels = await fetchOpenAICompatibleModelIds({
     baseUrl: account.baseUrl,
     apiKey: token.key,
+    userId: account.userId,
   })
 
   if (!availableModels.length) {


### PR DESCRIPTION
Fixes #612

## 变更
- 为 OpenAI 兼容模型请求新增可选 userId，并自动带上兼容 user-id 请求头。
- managed-site 导入流程中透传 account.userId，避免需要 user-id 头的站点返回 401。

## 测试
- 未运行（非交互环境）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Improvements**
* Implemented user-scoped model discovery across all supported service providers to enhance OpenAI-compatible API compatibility.
* Strengthened authentication parameter handling with improved user context tracking for more accurate model availability information.
* Enhanced service provider integrations to support better multi-provider model fetching with proper user identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->