### PR TITLE
fix(webdav): handle Nutstore 409 AncestorsNotFound as missing backup

### DIFF
--- a/src/services/webdav/webdavService.ts
+++ b/src/services/webdav/webdavService.ts
@@ -25,6 +25,12 @@ function buildAuthHeader(username: string, password: string) {
 const CONFIG_VERSION = "1-0"
 
 /**
+ * Jianguoyun/Nutstore returns this DAV exception inside a 409 XML payload when
+ * a requested file's parent collection has not been created yet.
+ */
+const WEBDAV_ANCESTORS_NOT_FOUND_MARKER = "AncestorsNotFound"
+
+/**
  * Program identifier used in default WebDAV backup paths.
  */
 export const PROGRAM_NAME = "all-api-hub"
@@ -159,6 +165,31 @@ async function getWebDavConfig(): Promise<WebDAVConfig> {
 }
 
 /**
+ * Detects "missing remote backup" responses across WebDAV providers.
+ *
+ * Jianguoyun/Nutstore returns `409 Conflict` with an XML body containing
+ * `AncestorsNotFound` for a first-time GET before the backup directory exists.
+ */
+async function isMissingWebdavBackupResponse(
+  response: Pick<Response, "status" | "text">,
+) {
+  if (response.status === 404) {
+    return true
+  }
+
+  if (response.status !== 409) {
+    return false
+  }
+
+  try {
+    const body = await response.text()
+    return body.includes(WEBDAV_ANCESTORS_NOT_FOUND_MARKER)
+  } catch {
+    return false
+  }
+}
+
+/**
  * Read WebDAV backup encryption settings from user preferences.
  *
  * When enabled, uploads will wrap the backup JSON in an encrypted envelope.
@@ -227,7 +258,8 @@ export async function downloadBackupRaw(custom?: Partial<WebDAVConfig>) {
   if (res.status === 200) {
     return await res.text()
   }
-  if (res.status === 404) throw new WebdavFileNotFoundError()
+  if (await isMissingWebdavBackupResponse(res))
+    throw new WebdavFileNotFoundError()
   if (res.status === 401 || res.status === 403)
     throw new Error(t("messages:webdav.authFailed"))
   throw new Error(t("messages:webdav.downloadFailed", { status: res.status }))

--- a/tests/services/webdavService.test.ts
+++ b/tests/services/webdavService.test.ts
@@ -151,6 +151,42 @@ describe("webdavService", () => {
       expect(error.message).toBe("messages:webdav.fileNotFound")
     })
 
+    it("treats Nutstore 409 AncestorsNotFound as fileNotFound", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
+      const text = vi
+        .fn()
+        .mockResolvedValue(
+          '<?xml version="1.0"?><d:error><s:exception>AncestorsNotFound</s:exception></d:error>',
+        )
+      globalAny.fetch.mockResolvedValue({
+        status: 409,
+        text,
+      })
+
+      const error = await downloadBackup().catch((thrown) => thrown)
+
+      expect(text).toHaveBeenCalledTimes(1)
+      expect(error).toBeInstanceOf(WebdavFileNotFoundError)
+      expect(error.code).toBe(WEBDAV_FILE_NOT_FOUND_ERROR_CODE)
+      expect(error.message).toBe("messages:webdav.fileNotFound")
+    })
+
+    it("keeps unrelated 409 responses as downloadFailed", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
+      globalAny.fetch.mockResolvedValue({
+        status: 409,
+        text: vi
+          .fn()
+          .mockResolvedValue(
+            '<?xml version="1.0"?><d:error><s:exception>Conflict</s:exception></d:error>',
+          ),
+      })
+
+      await expect(downloadBackup()).rejects.toThrow(
+        "messages:webdav.downloadFailed",
+      )
+    })
+
     it("throws authFailed for 401/403", async () => {
       mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
       globalAny.fetch.mockResolvedValue({ status: 403 })


### PR DESCRIPTION
Resolves #633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for WebDAV backup downloads to correctly identify specific error conditions as file-not-found errors, enhancing reliability of backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->