### PR TITLE
fix(webdav): prepare backup directory before write-like reads

### DIFF
--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -254,7 +254,9 @@ export default function WebDAVSettings() {
       let remoteBackup: any | null = null
 
       try {
-        const remoteContent = await downloadBackup(webdavConfig)
+        const remoteContent = await downloadBackup(webdavConfig, {
+          prepareForWrite: true,
+        })
         remoteBackup = JSON.parse(remoteContent)
       } catch (error: any) {
         if (!isWebdavFileNotFoundError(error)) {

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -301,7 +301,9 @@ class WebdavAutoSyncService {
     let remoteData: any | null = null
 
     try {
-      const content = await downloadBackup()
+      const content = await downloadBackup(undefined, {
+        prepareForWrite: true,
+      })
       remoteData = JSON.parse(content)
       logger.info("成功下载远程数据", { timestamp: remoteData?.timestamp })
     } catch (error: any) {

--- a/src/services/webdav/webdavService.ts
+++ b/src/services/webdav/webdavService.ts
@@ -164,6 +164,48 @@ async function getWebDavConfig(): Promise<WebDAVConfig> {
   return prefs.webdav
 }
 
+type WebdavBackupRequestOptions = {
+  prepareForWrite?: boolean
+}
+
+type ResolvedWebdavBackupRequestContext = {
+  cfg: WebDAVConfig
+  targetUrl: string
+}
+
+/**
+ * Resolves the effective WebDAV config and normalized backup target path.
+ */
+async function resolveWebdavBackupRequestContext(
+  custom?: Partial<WebDAVConfig>,
+): Promise<ResolvedWebdavBackupRequestContext> {
+  const cfg = { ...(await getWebDavConfig()), ...custom }
+  if (!cfg.url || !cfg.username || !cfg.password) {
+    throw new Error(t("messages:webdav.configIncomplete"))
+  }
+
+  return {
+    cfg,
+    targetUrl: ensureFilename(cfg.url),
+  }
+}
+
+/**
+ * Prepares the backup collection for flows that are expected to upload later.
+ *
+ * This prevents first-time syncs from depending on provider-specific `GET`
+ * responses when the backup directory has not been created yet.
+ */
+async function prepareWebdavBackupTargetForWrite(
+  context: ResolvedWebdavBackupRequestContext,
+) {
+  await ensureBackupDirectory(
+    context.targetUrl,
+    context.cfg.username,
+    context.cfg.password,
+  )
+}
+
 /**
  * Detects "missing remote backup" responses across WebDAV providers.
  *
@@ -213,11 +255,7 @@ async function getWebdavEncryptionConfig() {
  * errors.
  */
 export async function testWebdavConnection(custom?: Partial<WebDAVConfig>) {
-  const cfg = { ...(await getWebDavConfig()), ...custom }
-  if (!cfg.url || !cfg.username || !cfg.password) {
-    throw new Error(t("messages:webdav.configIncomplete"))
-  }
-  const targetUrl = ensureFilename(cfg.url)
+  const { cfg, targetUrl } = await resolveWebdavBackupRequestContext(custom)
 
   const res = await fetch(targetUrl, {
     method: "GET",
@@ -239,14 +277,19 @@ export async function testWebdavConnection(custom?: Partial<WebDAVConfig>) {
  *
  * This function does not attempt to detect or decrypt encrypted envelopes.
  * It is intended for UI flows that need to decide how to prompt the user when
- * no password is available or decryption fails.
+ * no password is available or decryption fails. Pass `prepareForWrite` when
+ * the caller is about to upload after reading the current remote payload.
  */
-export async function downloadBackupRaw(custom?: Partial<WebDAVConfig>) {
-  const cfg = { ...(await getWebDavConfig()), ...custom }
-  if (!cfg.url || !cfg.username || !cfg.password) {
-    throw new Error(t("messages:webdav.configIncomplete"))
+export async function downloadBackupRaw(
+  custom?: Partial<WebDAVConfig>,
+  options: WebdavBackupRequestOptions = {},
+) {
+  const context = await resolveWebdavBackupRequestContext(custom)
+  const { cfg, targetUrl } = context
+
+  if (options.prepareForWrite) {
+    await prepareWebdavBackupTargetForWrite(context)
   }
-  const targetUrl = ensureFilename(cfg.url)
 
   const res = await fetch(targetUrl, {
     method: "GET",
@@ -274,8 +317,11 @@ export async function downloadBackupRaw(custom?: Partial<WebDAVConfig>) {
  *   using the stored encryption password and throw a localized error message on
  *   missing/incorrect passwords.
  */
-export async function downloadBackup(custom?: Partial<WebDAVConfig>) {
-  const raw = await downloadBackupRaw(custom)
+export async function downloadBackup(
+  custom?: Partial<WebDAVConfig>,
+  options: WebdavBackupRequestOptions = {},
+) {
+  const raw = await downloadBackupRaw(custom, options)
   const envelope = tryParseEncryptedWebdavBackupEnvelope(raw)
   if (!envelope) return raw
 
@@ -306,11 +352,8 @@ export async function uploadBackup(
   content: string,
   custom?: Partial<WebDAVConfig>,
 ) {
-  const cfg = { ...(await getWebDavConfig()), ...custom }
-  if (!cfg.url || !cfg.username || !cfg.password) {
-    throw new Error(t("messages:webdav.configIncomplete"))
-  }
-  const targetUrl = ensureFilename(cfg.url)
+  const context = await resolveWebdavBackupRequestContext(custom)
+  const { cfg, targetUrl } = context
 
   const encCfg = await getWebdavEncryptionConfig()
   let contentToUpload = content
@@ -326,7 +369,7 @@ export async function uploadBackup(
   }
 
   // Ensure backup directory exists when using folder-style input
-  await ensureBackupDirectory(targetUrl, cfg.username, cfg.password)
+  await prepareWebdavBackupTargetForWrite(context)
 
   const res = await fetch(targetUrl, {
     method: "PUT",

--- a/tests/services/webdavAutoSyncService.test.ts
+++ b/tests/services/webdavAutoSyncService.test.ts
@@ -442,6 +442,9 @@ describe("WebdavAutoSyncService.syncWithWebdav (selective sync)", () => {
     })
 
     await expect(service.syncWithWebdav()).resolves.toBeUndefined()
+    expect(mockDownloadBackup).toHaveBeenCalledWith(undefined, {
+      prepareForWrite: true,
+    })
 
     const uploaded = JSON.parse(mockUploadBackup.mock.calls[0][0])
     expect(

--- a/tests/services/webdavService.test.ts
+++ b/tests/services/webdavService.test.ts
@@ -151,6 +151,26 @@ describe("webdavService", () => {
       expect(error.message).toBe("messages:webdav.fileNotFound")
     })
 
+    it("prepares the backup directory before write-like reads", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
+      globalAny.fetch
+        .mockResolvedValueOnce({ status: 201 })
+        .mockResolvedValueOnce({ status: 404 })
+
+      const error = await downloadBackup(undefined, {
+        prepareForWrite: true,
+      }).catch((thrown) => thrown)
+
+      expect(error).toBeInstanceOf(WebdavFileNotFoundError)
+      expect(globalAny.fetch).toHaveBeenCalledTimes(2)
+      expect((globalAny.fetch.mock.calls[0][1] as RequestInit).method).toBe(
+        "MKCOL",
+      )
+      expect((globalAny.fetch.mock.calls[1][1] as RequestInit).method).toBe(
+        "GET",
+      )
+    })
+
     it("treats Nutstore 409 AncestorsNotFound as fileNotFound", async () => {
       mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
       const text = vi


### PR DESCRIPTION
## Summary by CodeRabbit

* **Improvements**
  * Enhanced WebDAV sync and export operations to ensure backup target directories are properly prepared before writing, improving reliability during cloud synchronization and backup uploads.

* **Tests**
  * Added and updated test coverage for WebDAV backup operations to verify directory preparation occurs during remote backup retrieval.