### PR TITLE
fix: remove React act warnings in tests and clean up CopyKeyDialog timeout

### DIFF
--- a/src/components/CliProxyExportDialog.tsx
+++ b/src/components/CliProxyExportDialog.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from "react"
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { CliProxyIcon } from "~/components/icons/CliProxyIcon"
@@ -162,6 +162,27 @@ export function CliProxyExportDialog(props: CliProxyExportDialogProps) {
     token.id,
   ])
   const [readyFormKey, setReadyFormKey] = useState<string | null>(null)
+  const lastModelSuggestionsKeyRef = useRef<string | null>(null)
+  const modelSuggestionsAccount = useMemo(
+    () => ({
+      siteType: account.siteType,
+      baseUrl: account.baseUrl,
+      id: account.id,
+      authType: account.authType,
+      userId: account.userId,
+      token: account.token,
+      cookieAuthSessionCookie: account.cookieAuthSessionCookie,
+    }),
+    [
+      account.siteType,
+      account.baseUrl,
+      account.id,
+      account.authType,
+      account.userId,
+      account.token,
+      account.cookieAuthSessionCookie,
+    ],
+  )
 
   const formId = useMemo(() => `cliproxy-export-form-${token.id}`, [token.id])
   const providerTypeFieldId = useMemo(
@@ -217,9 +238,31 @@ export function CliProxyExportDialog(props: CliProxyExportDialogProps) {
       readyFormKey !== formResetKey ||
       !providerTypeMetadata.supportsModelSuggestions
     ) {
+      lastModelSuggestionsKeyRef.current = null
       setAvailableUpstreamModels([])
       return
     }
+
+    const resolvedProviderBaseUrl = providerBaseUrl.trim() || account.baseUrl
+    const nextFetchKey = [
+      providerType,
+      resolvedProviderBaseUrl,
+      account.baseUrl,
+      account.siteType,
+      account.id,
+      account.authType,
+      account.userId,
+      account.token,
+      account.cookieAuthSessionCookie ?? "",
+      token.id,
+      token.key,
+    ].join("::")
+
+    if (lastModelSuggestionsKeyRef.current === nextFetchKey) {
+      return
+    }
+
+    lastModelSuggestionsKeyRef.current = nextFetchKey
 
     let isActive = true
     setAvailableUpstreamModels([])
@@ -228,9 +271,13 @@ export function CliProxyExportDialog(props: CliProxyExportDialogProps) {
       try {
         const modelIds = await fetchProviderModelSuggestions({
           providerType,
-          baseUrl: providerBaseUrl.trim() || account.baseUrl,
-          apiKey: (await resolveDisplayAccountTokenForSecret(account, token))
-            .key,
+          baseUrl: resolvedProviderBaseUrl,
+          apiKey: (
+            await resolveDisplayAccountTokenForSecret(
+              modelSuggestionsAccount,
+              token,
+            )
+          ).key,
         })
 
         const normalized = normalizeSuggestedModelIds(modelIds)
@@ -254,7 +301,14 @@ export function CliProxyExportDialog(props: CliProxyExportDialogProps) {
     providerTypeMetadata.supportsModelSuggestions,
     readyFormKey,
     formResetKey,
-    account,
+    account.baseUrl,
+    account.siteType,
+    account.id,
+    account.authType,
+    account.userId,
+    account.token,
+    account.cookieAuthSessionCookie,
+    modelSuggestionsAccount,
     token,
   ])
 

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
@@ -48,6 +48,21 @@ type ProbeItemState = {
 const MODEL_AUTO_FETCH_DEBOUNCE_MS = import.meta.env.MODE === "test" ? 0 : 300
 
 /**
+ * Build the initial probe UI state for the selected API type.
+ */
+function buildProbeState(apiType: ApiVerificationApiType): ProbeItemState[] {
+  return getApiVerificationProbeDefinitions(apiType).map(
+    (def): ProbeItemState => ({
+      id: def.id,
+      requiresModelId: def.requiresModelId,
+      isRunning: false,
+      attempts: 0,
+      result: null,
+    }),
+  )
+}
+
+/**
  * Always-mounted modal host rendered inside the content-script Shadow DOM root.
  *
  * The host listens for CustomEvents to open/close, so the rest of the content
@@ -100,10 +115,13 @@ export function ApiCheckModalHost() {
     [],
   )
 
-  const [probes, setProbes] = useState<ProbeItemState[]>([])
+  const [probes, setProbes] = useState<ProbeItemState[]>(() =>
+    buildProbeState(API_TYPES.OPENAI_COMPATIBLE),
+  )
   const [isRunningAll, setIsRunningAll] = useState(false)
   const [isSavingProfile, setIsSavingProfile] = useState(false)
   const [validationError, setValidationError] = useState<string | null>(null)
+  const hasInitializedApiTypeRef = useRef(false)
 
   const probeDefinitions = useMemo(
     () => getApiVerificationProbeDefinitions(apiType),
@@ -125,23 +143,17 @@ export function ApiCheckModalHost() {
     apiType === API_TYPES.GOOGLE
 
   const resetProbeState = (nextApiType: ApiVerificationApiType) => {
-    const defs = getApiVerificationProbeDefinitions(nextApiType)
-    setProbes(
-      defs.map(
-        (def): ProbeItemState => ({
-          id: def.id,
-          requiresModelId: def.requiresModelId,
-          isRunning: false,
-          attempts: 0,
-          result: null,
-        }),
-      ),
-    )
+    setProbes(buildProbeState(nextApiType))
   }
 
   useEffect(() => {
+    if (!hasInitializedApiTypeRef.current) {
+      hasInitializedApiTypeRef.current = true
+      return
+    }
     resetProbeState(apiType)
     // Reset model list UI when apiType changes.
+    setModelId("")
     setModelIds([])
     setFetchModelsError(null)
     setValidationError(null)

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -35,11 +35,21 @@ export function useCopyKeyDialog(
   const [createError, setCreateError] = useState<string | null>(null)
   const [copiedTokenId, setCopiedTokenId] = useState<number | null>(null)
   const [expandedTokens, setExpandedTokens] = useState<Set<number>>(new Set())
+  const copiedTokenResetTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
 
   const canCreateDefaultKey = useMemo(
     () => canManageDisplayAccountTokens(account),
     [account],
   )
+
+  const clearCopiedTokenResetTimeout = useCallback(() => {
+    if (copiedTokenResetTimeoutRef.current === null) return
+
+    clearTimeout(copiedTokenResetTimeoutRef.current)
+    copiedTokenResetTimeoutRef.current = null
+  }, [])
 
   const fetchTokens = useCallback(async () => {
     if (!account) return
@@ -80,6 +90,7 @@ export function useCopyKeyDialog(
     if (isOpen && account) {
       fetchTokens()
     } else {
+      clearCopiedTokenResetTimeout()
       setTokens([])
       setError(null)
       setIsCreating(false)
@@ -87,7 +98,13 @@ export function useCopyKeyDialog(
       setCopiedTokenId(null)
       setExpandedTokens(new Set())
     }
-  }, [isOpen, account, fetchTokens])
+  }, [account, clearCopiedTokenResetTimeout, fetchTokens, isOpen])
+
+  useEffect(() => {
+    return () => {
+      clearCopiedTokenResetTimeout()
+    }
+  }, [clearCopiedTokenResetTimeout])
 
   const copyKey = useCallback(
     async (token: ApiToken) => {
@@ -102,15 +119,17 @@ export function useCopyKeyDialog(
         setCopiedTokenId(token.id)
         toast.success(t("ui:dialog.copyKey.keyCopied"))
 
-        setTimeout(() => {
+        clearCopiedTokenResetTimeout()
+        copiedTokenResetTimeoutRef.current = setTimeout(() => {
           setCopiedTokenId(null)
+          copiedTokenResetTimeoutRef.current = null
         }, 2000)
       } catch (error) {
         logger.error("Failed to copy key to clipboard", { error })
         toast.error(t("ui:dialog.copyKey.copyFailedManual"))
       }
     },
-    [account, t],
+    [account, clearCopiedTokenResetTimeout, t],
   )
 
   /**

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -6,6 +6,7 @@ import {
   within,
 } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
 import toast from "react-hot-toast/headless"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -18,6 +19,20 @@ import {
 } from "~/entrypoints/content/webAiApiCheck/events"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { render } from "~~/tests/test-utils/render"
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+  return {
+    ...actual,
+    UserPreferencesProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useUserPreferencesContext: () => ({
+      themeMode: "system",
+      updateThemeMode: vi.fn().mockResolvedValue(true),
+    }),
+  }
+})
 
 vi.mock("react-hot-toast/headless", () => ({
   default: {

--- a/tests/components/CliProxyExportDialog.test.tsx
+++ b/tests/components/CliProxyExportDialog.test.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { CliProxyExportDialog } from "~/components/CliProxyExportDialog"
@@ -9,6 +10,20 @@ import {
   buildDisplaySiteData,
 } from "~~/tests/test-utils/factories"
 import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+  return {
+    ...actual,
+    UserPreferencesProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useUserPreferencesContext: () => ({
+      themeMode: "system",
+      updateThemeMode: vi.fn().mockResolvedValue(true),
+    }),
+  }
+})
 
 const mockFetchAnthropicModelIds = vi.fn()
 const mockFetchGoogleModelIds = vi.fn()

--- a/tests/entrypoints/popup/ActionButtons.test.tsx
+++ b/tests/entrypoints/popup/ActionButtons.test.tsx
@@ -1,6 +1,21 @@
+import type { ReactNode } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+  return {
+    ...actual,
+    UserPreferencesProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useUserPreferencesContext: () => ({
+      themeMode: "system",
+      updateThemeMode: vi.fn().mockResolvedValue(true),
+    }),
+  }
+})
 
 // Shared mocks to control account data and capture bulk check-in clicks.
 let displayDataMock: any[] = []

--- a/tests/entrypoints/popup/HeaderSection.test.tsx
+++ b/tests/entrypoints/popup/HeaderSection.test.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import HeaderSection from "~/entrypoints/popup/components/HeaderSection"
@@ -14,6 +15,20 @@ import {
   openSidePanelPage,
 } from "~/utils/navigation"
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+  return {
+    ...actual,
+    UserPreferencesProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useUserPreferencesContext: () => ({
+      themeMode: "system",
+      updateThemeMode: vi.fn().mockResolvedValue(true),
+    }),
+  }
+})
 
 vi.mock("~/assets/icon.png", () => ({
   default: "icon.png",

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -1,8 +1,23 @@
 import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import SiteInfo from "~/features/AccountManagement/components/AccountList/SiteInfo"
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+  return {
+    ...actual,
+    UserPreferencesProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useUserPreferencesContext: () => ({
+      themeMode: "system",
+      updateThemeMode: vi.fn().mockResolvedValue(true),
+    }),
+  }
+})
 
 const {
   mockOpenAccountBaseUrl,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timer cleanup in token copy dialog to prevent potential memory leaks
  * Improved initial state handling in API verification modal for better reliability

* **Refactor**
  * Optimized model suggestion fetching with caching to reduce redundant upstream API calls and improve responsiveness

* **Tests**
  * Updated test infrastructure with improved context mocking for better test isolation and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->