### PR TITLE
fix(i18n): restore mistakenly removed CLI proxy provider i18n keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ Prereqs: Node.js 20+ and pnpm 10+.
 - When adding short badge, chip, button, or helper-copy translations, avoid `t(key, { count })` unless plural key families are explicitly intended and already modeled in locale files.
 - For compact UI labels that include a number, prefer rendering the numeric count separately and translating only the static label text so `i18n:extract` does not rewrite the key into `_one` / `_other` variants unexpectedly.
 - Treat any unexpected `_one`, `_other`, or similar extract-generated key-family rewrites as a signal to change the calling pattern or key shape, not as something to patch manually in locale JSON.
+- After running `pnpm run i18n:extract`, inspect the locale diff before proceeding. Confirm the intended new keys are still present and no required keys were removed as "unused" by the extractor.
+- If `i18n:extract` removes keys you expected to keep, fix the source usage or extractor configuration instead of re-adding locale JSON by hand. In this repo, prefer direct extractable calls such as `t("ns:key")` over wrapper names like `translate("ns:key")` unless the wrapper is explicitly configured in `i18next.config.ts`.
 - After changing translation keys, locale JSON, or any UI code that adds new `t(...)` usages, run `pnpm run i18n:extract:ci` and ensure it reports no unexpected updates before handoff.
 - Keep locale key shapes stable across languages; do not let one language drift into a pluralized or structurally different key family unless that family is intentionally introduced for every locale.
 

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -76,6 +76,10 @@
       },
       "description": "Create or update a provider entry in CLIProxyAPI.",
       "descriptions": {
+        "baseUrlClaudeApiKey": "Usually the Anthropic API root URL without /v1/messages.",
+        "baseUrlCodexApiKey": "Usually the provider root URL. A common default is https://api.openai.com.",
+        "baseUrlGeminiApiKey": "Usually the Gemini API root URL without /v1/models/....",
+        "baseUrlOpenAICompatibility": "Usually the upstream OpenAI-compatible base URL ending in /v1.",
         "models": "Map upstream model names to optional aliases (name -> alias). When available, upstream models are loaded from /v1/models for selection.",
         "modelsManual": "Map upstream model names to optional aliases (name -> alias). Enter values manually for this provider family in this release.",
         "providerType": "Choose which CLIProxyAPI provider family to import into.",
@@ -89,11 +93,33 @@
         "proxyUrl": "Proxy URL (optional)"
       },
       "placeholders": {
+        "baseUrlClaudeApiKey": "https://api.anthropic.com",
+        "baseUrlCodexApiKey": "https://api.openai.com",
+        "baseUrlGeminiApiKey": "https://generativelanguage.googleapis.com",
+        "baseUrlOpenAICompatibility": "https://example.com/v1",
         "modelAlias": "Model alias (optional)",
         "modelName": "Model name, e.g. claude",
         "name": "e.g. Acme Relay",
         "providerType": "Select a provider family",
         "proxyUrl": "http://localhost:3000"
+      },
+      "providerTypes": {
+        "claudeApiKey": {
+          "description": "Use an Anthropic Claude API key style provider entry.",
+          "label": "Claude API Key"
+        },
+        "codexApiKey": {
+          "description": "Use a Codex / OpenAI API key style provider entry.",
+          "label": "Codex API Key"
+        },
+        "geminiApiKey": {
+          "description": "Use a Google Gemini API key style provider entry.",
+          "label": "Gemini API Key"
+        },
+        "openaiCompatibility": {
+          "description": "Use a standard OpenAI-compatible provider with a configurable provider name.",
+          "label": "OpenAI Compatibility"
+        }
       },
       "title": "Import to CLIProxyAPI"
     },

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -76,6 +76,10 @@
       },
       "description": "CLIProxyAPI にプロバイダーエントリを作成または更新します。",
       "descriptions": {
+        "baseUrlClaudeApiKey": "通常は /v1/messages を含まない Anthropic API のルート URL を入力します。",
+        "baseUrlCodexApiKey": "通常は Provider のルート URL を入力します。一般的な既定値は https://api.openai.com です。",
+        "baseUrlGeminiApiKey": "通常は /v1/models/... を含まない Gemini API のルート URL を入力します。",
+        "baseUrlOpenAICompatibility": "通常は /v1 で終わる OpenAI 互換の上流ベース URL を入力します。",
         "models": "上流モデル名を任意の別名へマッピングします（name -> alias）。利用可能な場合は /v1/models から上流モデルを読み込んで選択できます。",
         "modelsManual": "上流モデル名を任意の別名へマッピングします（name -> alias）。このリリースでは、このプロバイダーファミリーは手動入力してください。",
         "providerType": "どの CLIProxyAPI プロバイダーファミリーにインポートするか選択します。",
@@ -89,11 +93,33 @@
         "proxyUrl": "プロキシ URL（任意）"
       },
       "placeholders": {
+        "baseUrlClaudeApiKey": "https://api.anthropic.com",
+        "baseUrlCodexApiKey": "https://api.openai.com",
+        "baseUrlGeminiApiKey": "https://generativelanguage.googleapis.com",
+        "baseUrlOpenAICompatibility": "https://example.com/v1",
         "modelAlias": "モデル別名（任意）",
         "modelName": "モデル名。例: claude",
         "name": "例: Acme Relay",
         "providerType": "プロバイダーファミリーを選択",
         "proxyUrl": "http://localhost:3000"
+      },
+      "providerTypes": {
+        "claudeApiKey": {
+          "description": "Anthropic Claude 形式の API Key Provider エントリを使います。",
+          "label": "Claude API Key"
+        },
+        "codexApiKey": {
+          "description": "Codex / OpenAI 形式の API Key Provider エントリを使います。",
+          "label": "Codex API Key"
+        },
+        "geminiApiKey": {
+          "description": "Google Gemini 形式の API Key Provider エントリを使います。",
+          "label": "Gemini API Key"
+        },
+        "openaiCompatibility": {
+          "description": "Provider 名を自由に設定できる標準的な OpenAI 互換 Provider を使います。",
+          "label": "OpenAI 互換"
+        }
       },
       "title": "CLIProxyAPI にインポート"
     },

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -76,6 +76,10 @@
       },
       "description": "在 CLIProxyAPI 中创建或更新一个 Provider 条目。",
       "descriptions": {
+        "baseUrlClaudeApiKey": "通常填写不带 /v1/messages 的 Anthropic API 根地址。",
+        "baseUrlCodexApiKey": "通常填写 Provider 根地址，常见默认值如 https://api.openai.com。",
+        "baseUrlGeminiApiKey": "通常填写不带 /v1/models/... 的 Gemini API 根地址。",
+        "baseUrlOpenAICompatibility": "通常填写以上游 /v1 结尾的 OpenAI 兼容基础地址。",
         "models": "将上游模型名称映射到可选别名（name -> alias）。若可用，会加载上游可用模型供选择。",
         "modelsManual": "将上游模型名称映射到可选别名（name -> alias）。当前版本中此 Provider 类型需手动输入上游模型。",
         "providerType": "选择要导入到哪个 CLIProxyAPI Provider 类型。",
@@ -89,11 +93,33 @@
         "proxyUrl": "代理 URL（可选）"
       },
       "placeholders": {
+        "baseUrlClaudeApiKey": "https://api.anthropic.com",
+        "baseUrlCodexApiKey": "https://api.openai.com",
+        "baseUrlGeminiApiKey": "https://generativelanguage.googleapis.com",
+        "baseUrlOpenAICompatibility": "https://example.com/v1",
         "modelAlias": "模型别名（可选）",
         "modelName": "模型名称，例如 claude",
         "name": "例如：Acme Relay",
         "providerType": "选择 Provider 类型",
         "proxyUrl": "http://localhost:3000"
+      },
+      "providerTypes": {
+        "claudeApiKey": {
+          "description": "适用于 Anthropic Claude 风格的 API Key Provider 条目。",
+          "label": "Claude API Key"
+        },
+        "codexApiKey": {
+          "description": "适用于 Codex / OpenAI 风格的 API Key Provider 条目。",
+          "label": "Codex API Key"
+        },
+        "geminiApiKey": {
+          "description": "适用于 Google Gemini 风格的 API Key Provider 条目。",
+          "label": "Gemini API Key"
+        },
+        "openaiCompatibility": {
+          "description": "适用于标准 OpenAI 兼容 Provider，可自定义 Provider 名称。",
+          "label": "OpenAI 兼容"
+        }
       },
       "title": "导入到 CLIProxyAPI"
     },

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -76,6 +76,10 @@
       },
       "description": "在 CLIProxyAPI 中建立或更新一個 Provider 條目。",
       "descriptions": {
+        "baseUrlClaudeApiKey": "通常填寫不帶 /v1/messages 的 Anthropic API 根位址。",
+        "baseUrlCodexApiKey": "通常填寫 Provider 根位址，常見預設值如 https://api.openai.com。",
+        "baseUrlGeminiApiKey": "通常填寫不帶 /v1/models/... 的 Gemini API 根位址。",
+        "baseUrlOpenAICompatibility": "通常填寫以上游 /v1 結尾的 OpenAI 相容基礎位址。",
         "models": "將上游模型名稱對映到可選別名（name -> alias）。若可用，會載入上游可用模型供選擇。",
         "modelsManual": "將上游模型名稱對映到可選別名（name -> alias）。當前版本中此 Provider 型別需手動輸入上游模型。",
         "providerType": "選擇要匯入到哪個 CLIProxyAPI Provider 型別。",
@@ -89,11 +93,33 @@
         "proxyUrl": "代理 URL（可選）"
       },
       "placeholders": {
+        "baseUrlClaudeApiKey": "https://api.anthropic.com",
+        "baseUrlCodexApiKey": "https://api.openai.com",
+        "baseUrlGeminiApiKey": "https://generativelanguage.googleapis.com",
+        "baseUrlOpenAICompatibility": "https://example.com/v1",
         "modelAlias": "模型別名（可選）",
         "modelName": "模型名稱，例如 claude",
         "name": "例如：Acme Relay",
         "providerType": "選擇 Provider 型別",
         "proxyUrl": "http://localhost:3000"
+      },
+      "providerTypes": {
+        "claudeApiKey": {
+          "description": "適用於 Anthropic Claude 風格的 API Key Provider 條目。",
+          "label": "Claude API Key"
+        },
+        "codexApiKey": {
+          "description": "適用於 Codex / OpenAI 風格的 API Key Provider 條目。",
+          "label": "Codex API Key"
+        },
+        "geminiApiKey": {
+          "description": "適用於 Google Gemini 風格的 API Key Provider 條目。",
+          "label": "Gemini API Key"
+        },
+        "openaiCompatibility": {
+          "description": "適用於標準 OpenAI 相容 Provider，可自訂 Provider 名稱。",
+          "label": "OpenAI 相容"
+        }
       },
       "title": "匯入到 CLIProxyAPI"
     },

--- a/src/services/integrations/cliProxyProviderTypes.ts
+++ b/src/services/integrations/cliProxyProviderTypes.ts
@@ -64,21 +64,19 @@ export const CLI_PROXY_PROVIDER_METADATA: Record<
  * Resolve the localized provider-type label used by CLI proxy UI surfaces.
  */
 export function getCliProxyProviderTypeLabel(
-  translate: (key: string) => string,
+  t: (key: string) => string,
   providerType: CliProxyProviderType,
 ) {
   switch (providerType) {
     case CLI_PROXY_PROVIDER_TYPES.CODEX_API_KEY:
-      return translate("ui:dialog.cliproxy.providerTypes.codexApiKey.label")
+      return t("ui:dialog.cliproxy.providerTypes.codexApiKey.label")
     case CLI_PROXY_PROVIDER_TYPES.CLAUDE_API_KEY:
-      return translate("ui:dialog.cliproxy.providerTypes.claudeApiKey.label")
+      return t("ui:dialog.cliproxy.providerTypes.claudeApiKey.label")
     case CLI_PROXY_PROVIDER_TYPES.GEMINI_API_KEY:
-      return translate("ui:dialog.cliproxy.providerTypes.geminiApiKey.label")
+      return t("ui:dialog.cliproxy.providerTypes.geminiApiKey.label")
     case CLI_PROXY_PROVIDER_TYPES.OPENAI_COMPATIBILITY:
     default:
-      return translate(
-        "ui:dialog.cliproxy.providerTypes.openaiCompatibility.label",
-      )
+      return t("ui:dialog.cliproxy.providerTypes.openaiCompatibility.label")
   }
 }
 
@@ -86,25 +84,19 @@ export function getCliProxyProviderTypeLabel(
  * Resolve the localized provider-type description used by CLI proxy UI surfaces.
  */
 export function getCliProxyProviderTypeDescription(
-  translate: (key: string) => string,
+  t: (key: string) => string,
   providerType: CliProxyProviderType,
 ) {
   switch (providerType) {
     case CLI_PROXY_PROVIDER_TYPES.CODEX_API_KEY:
-      return translate(
-        "ui:dialog.cliproxy.providerTypes.codexApiKey.description",
-      )
+      return t("ui:dialog.cliproxy.providerTypes.codexApiKey.description")
     case CLI_PROXY_PROVIDER_TYPES.CLAUDE_API_KEY:
-      return translate(
-        "ui:dialog.cliproxy.providerTypes.claudeApiKey.description",
-      )
+      return t("ui:dialog.cliproxy.providerTypes.claudeApiKey.description")
     case CLI_PROXY_PROVIDER_TYPES.GEMINI_API_KEY:
-      return translate(
-        "ui:dialog.cliproxy.providerTypes.geminiApiKey.description",
-      )
+      return t("ui:dialog.cliproxy.providerTypes.geminiApiKey.description")
     case CLI_PROXY_PROVIDER_TYPES.OPENAI_COMPATIBILITY:
     default:
-      return translate(
+      return t(
         "ui:dialog.cliproxy.providerTypes.openaiCompatibility.description",
       )
   }
@@ -114,21 +106,19 @@ export function getCliProxyProviderTypeDescription(
  * Resolve the localized base-URL description for a CLI proxy provider type.
  */
 export function getCliProxyProviderBaseUrlDescription(
-  translate: (key: string) => string,
+  t: (key: string) => string,
   providerType: CliProxyProviderType,
 ) {
   switch (providerType) {
     case CLI_PROXY_PROVIDER_TYPES.CODEX_API_KEY:
-      return translate("ui:dialog.cliproxy.descriptions.baseUrlCodexApiKey")
+      return t("ui:dialog.cliproxy.descriptions.baseUrlCodexApiKey")
     case CLI_PROXY_PROVIDER_TYPES.CLAUDE_API_KEY:
-      return translate("ui:dialog.cliproxy.descriptions.baseUrlClaudeApiKey")
+      return t("ui:dialog.cliproxy.descriptions.baseUrlClaudeApiKey")
     case CLI_PROXY_PROVIDER_TYPES.GEMINI_API_KEY:
-      return translate("ui:dialog.cliproxy.descriptions.baseUrlGeminiApiKey")
+      return t("ui:dialog.cliproxy.descriptions.baseUrlGeminiApiKey")
     case CLI_PROXY_PROVIDER_TYPES.OPENAI_COMPATIBILITY:
     default:
-      return translate(
-        "ui:dialog.cliproxy.descriptions.baseUrlOpenAICompatibility",
-      )
+      return t("ui:dialog.cliproxy.descriptions.baseUrlOpenAICompatibility")
   }
 }
 
@@ -136,21 +126,19 @@ export function getCliProxyProviderBaseUrlDescription(
  * Resolve the localized base-URL placeholder for a CLI proxy provider type.
  */
 export function getCliProxyProviderBaseUrlPlaceholder(
-  translate: (key: string) => string,
+  t: (key: string) => string,
   providerType: CliProxyProviderType,
 ) {
   switch (providerType) {
     case CLI_PROXY_PROVIDER_TYPES.CODEX_API_KEY:
-      return translate("ui:dialog.cliproxy.placeholders.baseUrlCodexApiKey")
+      return t("ui:dialog.cliproxy.placeholders.baseUrlCodexApiKey")
     case CLI_PROXY_PROVIDER_TYPES.CLAUDE_API_KEY:
-      return translate("ui:dialog.cliproxy.placeholders.baseUrlClaudeApiKey")
+      return t("ui:dialog.cliproxy.placeholders.baseUrlClaudeApiKey")
     case CLI_PROXY_PROVIDER_TYPES.GEMINI_API_KEY:
-      return translate("ui:dialog.cliproxy.placeholders.baseUrlGeminiApiKey")
+      return t("ui:dialog.cliproxy.placeholders.baseUrlGeminiApiKey")
     case CLI_PROXY_PROVIDER_TYPES.OPENAI_COMPATIBILITY:
     default:
-      return translate(
-        "ui:dialog.cliproxy.placeholders.baseUrlOpenAICompatibility",
-      )
+      return t("ui:dialog.cliproxy.placeholders.baseUrlOpenAICompatibility")
   }
 }
 
@@ -352,7 +340,7 @@ export function getCliProxyProviderDisplayName(
     providerBaseUrl?: string | null
     providerName?: string | null
   },
-  translate: (key: string) => string,
+  t: (key: string) => string,
 ) {
   const { providerBaseUrl, providerName } = options
   const normalizedName = providerName?.trim() ?? ""
@@ -364,7 +352,7 @@ export function getCliProxyProviderDisplayName(
     return normalizedName
   }
 
-  const label = getCliProxyProviderTypeLabel(translate, providerType)
+  const label = getCliProxyProviderTypeLabel(t, providerType)
   const normalizedBaseUrl = normalizeCliProxyProviderBaseUrl(
     providerType,
     providerBaseUrl,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple upstream provider types (Claude, Codex/OpenAI, Gemini, and OpenAI-compatible) with custom base URLs in CLIProxyAPI integration.
  * Expanded UI localization for provider configuration across English, Japanese, Simplified Chinese, and Traditional Chinese.

* **Documentation**
  * Added guidelines for i18n workflow and locale key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->