### PR TITLE
fix(managedSites): replace token.models with live model discovery

### DIFF
--- a/src/services/managedSites/providers/doneHubService.ts
+++ b/src/services/managedSites/providers/doneHubService.ts
@@ -10,6 +10,7 @@ import {
   findManagedSiteChannelByComparableInputs,
   findManagedSiteChannelsByBaseUrlAndModels,
 } from "~/services/managedSites/utils/channelMatching"
+import { fetchManagedSiteAvailableModels } from "~/services/managedSites/utils/fetchManagedSiteAvailableModels"
 import { fetchTokenScopedModels } from "~/services/managedSites/utils/fetchTokenScopedModels"
 import {
   UserPreferences,
@@ -32,7 +33,7 @@ import type {
 } from "~/types/serviceResponse"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
-import { normalizeList, parseDelimitedList } from "~/utils/core/string"
+import { normalizeList } from "~/utils/core/string"
 import { t } from "~/utils/i18n/core"
 
 import { resolveDefaultChannelGroups } from "./defaultChannelGroups"
@@ -239,41 +240,7 @@ export async function fetchAvailableModels(
   account: DisplaySiteData,
   token: ApiToken,
 ): Promise<string[]> {
-  const candidateSources: string[][] = []
-
-  const tokenModelList = parseDelimitedList(token.models)
-  if (tokenModelList.length > 0) {
-    candidateSources.push(tokenModelList)
-  }
-
-  const { models: tokenScopedModels } = await fetchTokenScopedModels(
-    account,
-    token,
-  )
-  candidateSources.push(tokenScopedModels)
-
-  try {
-    const fallbackModels = await getApiService(
-      account.siteType,
-    ).fetchAccountAvailableModels({
-      baseUrl: account.baseUrl,
-      accountId: account.id,
-      auth: {
-        authType: account.authType,
-        userId: account.userId,
-        accessToken: account.token,
-        cookie: account.cookieAuthSessionCookie,
-      },
-    })
-    if (fallbackModels && fallbackModels.length > 0) {
-      candidateSources.push(fallbackModels)
-    }
-  } catch (error) {
-    logger.warn("Failed to fetch fallback models", error)
-  }
-
-  const merged = candidateSources.flat()
-  return normalizeList(merged)
+  return await fetchManagedSiteAvailableModels(account, token)
 }
 
 /**

--- a/src/services/managedSites/providers/newApi.ts
+++ b/src/services/managedSites/providers/newApi.ts
@@ -17,6 +17,7 @@ import {
   findManagedSiteChannelByComparableInputs,
   findManagedSiteChannelsByBaseUrlAndModels,
 } from "~/services/managedSites/utils/channelMatching"
+import { fetchManagedSiteAvailableModels } from "~/services/managedSites/utils/fetchManagedSiteAvailableModels"
 import { fetchTokenScopedModels } from "~/services/managedSites/utils/fetchTokenScopedModels"
 import { ApiToken, AuthTypeEnum, DisplaySiteData, SiteAccount } from "~/types"
 import type { AccountToken } from "~/types"
@@ -35,7 +36,7 @@ import type {
 } from "~/types/serviceResponse"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
-import { normalizeList, parseDelimitedList } from "~/utils/core/string"
+import { normalizeList } from "~/utils/core/string"
 import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
 import { t } from "~/utils/i18n/core"
 
@@ -285,47 +286,13 @@ const getNewApiManagedSessionConfig = async (
 
 /**
  * 获取账号支持的模型列表。
- * 优先使用 API 密钥携带的模型列表，回退到上游接口与账号可用模型。
+ * 仅基于实时探测结果返回模型，不读取 token.models 这类静态限制元数据。
  */
 export async function fetchAvailableModels(
   account: DisplaySiteData,
   token: ApiToken,
 ): Promise<string[]> {
-  const candidateSources: string[][] = []
-
-  const tokenModelList = parseDelimitedList(token.models)
-  if (tokenModelList.length > 0) {
-    candidateSources.push(tokenModelList)
-  }
-
-  const { models: tokenScopedModels } = await fetchTokenScopedModels(
-    account,
-    token,
-  )
-  candidateSources.push(tokenScopedModels)
-
-  try {
-    const fallbackModels = await getApiService(
-      account.siteType,
-    ).fetchAccountAvailableModels({
-      baseUrl: account.baseUrl,
-      accountId: account.id,
-      auth: {
-        authType: account.authType,
-        userId: account.userId,
-        accessToken: account.token,
-        cookie: account.cookieAuthSessionCookie,
-      },
-    })
-    if (fallbackModels && fallbackModels.length > 0) {
-      candidateSources.push(fallbackModels)
-    }
-  } catch (error) {
-    logger.warn("Failed to fetch fallback models", error)
-  }
-
-  const merged = candidateSources.flat()
-  return normalizeList(merged)
+  return await fetchManagedSiteAvailableModels(account, token)
 }
 
 /**

--- a/src/services/managedSites/providers/octopus.ts
+++ b/src/services/managedSites/providers/octopus.ts
@@ -12,6 +12,7 @@ import type { ApiResponse } from "~/services/apiService/common/type"
 import * as octopusApi from "~/services/apiService/octopus"
 import type { ManagedSiteConfig } from "~/services/managedSites/managedSiteService"
 import { findManagedSiteChannelByComparableInputs } from "~/services/managedSites/utils/channelMatching"
+import { fetchManagedSiteAvailableModels } from "~/services/managedSites/utils/fetchManagedSiteAvailableModels"
 import { fetchTokenScopedModels } from "~/services/managedSites/utils/fetchTokenScopedModels"
 import {
   userPreferences,
@@ -40,7 +41,7 @@ import type {
 import type { OctopusConfig } from "~/types/octopusConfig"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
-import { normalizeList, parseDelimitedList } from "~/utils/core/string"
+import { normalizeList } from "~/utils/core/string"
 import { t } from "~/utils/i18n/core"
 
 const logger = createLogger("OctopusService")
@@ -383,20 +384,9 @@ export async function fetchAvailableModels(
   account: DisplaySiteData,
   token: ApiToken,
 ): Promise<string[]> {
-  const candidateSources: string[][] = []
-
-  const tokenModelList = parseDelimitedList(token.models)
-  if (tokenModelList.length > 0) {
-    candidateSources.push(tokenModelList)
-  }
-
-  const { models: tokenScopedModels } = await fetchTokenScopedModels(
-    account,
-    token,
-  )
-  candidateSources.push(tokenScopedModels)
-
-  return normalizeList(candidateSources.flat())
+  return await fetchManagedSiteAvailableModels(account, token, {
+    includeAccountFallback: false,
+  })
 }
 
 /**

--- a/src/services/managedSites/providers/veloera.ts
+++ b/src/services/managedSites/providers/veloera.ts
@@ -7,6 +7,7 @@ import { accountStorage } from "~/services/accounts/accountStorage"
 import { getApiService } from "~/services/apiService"
 import { fetchChannel as fetchVeloeraChannel } from "~/services/apiService/veloera"
 import { findManagedSiteChannelByComparableInputs } from "~/services/managedSites/utils/channelMatching"
+import { fetchManagedSiteAvailableModels } from "~/services/managedSites/utils/fetchManagedSiteAvailableModels"
 import { fetchTokenScopedModels } from "~/services/managedSites/utils/fetchTokenScopedModels"
 import { ApiToken, AuthTypeEnum, DisplaySiteData, SiteAccount } from "~/types"
 import type { AccountToken } from "~/types"
@@ -217,41 +218,7 @@ export async function fetchAvailableModels(
   account: DisplaySiteData,
   token: ApiToken,
 ): Promise<string[]> {
-  const candidateSources: string[][] = []
-
-  const tokenModelList = parseDelimitedList(token.models)
-  if (tokenModelList.length > 0) {
-    candidateSources.push(tokenModelList)
-  }
-
-  const { models: tokenScopedModels } = await fetchTokenScopedModels(
-    account,
-    token,
-  )
-  candidateSources.push(tokenScopedModels)
-
-  try {
-    const fallbackModels = await getApiService(
-      account.siteType,
-    ).fetchAccountAvailableModels({
-      baseUrl: account.baseUrl,
-      accountId: account.id,
-      auth: {
-        authType: account.authType,
-        userId: account.userId,
-        accessToken: account.token,
-        cookie: account.cookieAuthSessionCookie,
-      },
-    })
-    if (fallbackModels && fallbackModels.length > 0) {
-      candidateSources.push(fallbackModels)
-    }
-  } catch (error) {
-    logger.warn("Failed to fetch fallback models", error)
-  }
-
-  const merged = candidateSources.flat()
-  return normalizeList(merged)
+  return await fetchManagedSiteAvailableModels(account, token)
 }
 
 /**

--- a/src/services/managedSites/utils/fetchManagedSiteAvailableModels.ts
+++ b/src/services/managedSites/utils/fetchManagedSiteAvailableModels.ts
@@ -1,0 +1,73 @@
+import { getApiService } from "~/services/apiService"
+import type { ApiToken, DisplaySiteData } from "~/types"
+import { createLogger } from "~/utils/core/logger"
+import { normalizeList } from "~/utils/core/string"
+
+import { fetchTokenScopedModels } from "./fetchTokenScopedModels"
+
+const logger = createLogger("ManagedSites.fetchAvailableModels")
+
+type FetchManagedSiteAvailableModelsAccount = Pick<
+  DisplaySiteData,
+  | "siteType"
+  | "baseUrl"
+  | "id"
+  | "authType"
+  | "userId"
+  | "token"
+  | "cookieAuthSessionCookie"
+>
+
+type FetchManagedSiteAvailableModelsOptions = {
+  includeAccountFallback?: boolean
+}
+
+/**
+ * Resolves managed-site model options from live endpoints only.
+ *
+ * Source order:
+ * 1. Selected API key's live upstream `/models` result.
+ * 2. Optional account-level fallback such as `/api/user/models`.
+ *
+ * Token metadata fields like `token.models` / `model_limits` are intentionally
+ * excluded because they are restriction metadata, not a live availability probe.
+ */
+export async function fetchManagedSiteAvailableModels(
+  account: FetchManagedSiteAvailableModelsAccount,
+  token: Pick<ApiToken, "key">,
+  options: FetchManagedSiteAvailableModelsOptions = {},
+): Promise<string[]> {
+  const { includeAccountFallback = true } = options
+  const candidateSources: string[][] = []
+
+  const { models: tokenScopedModels } = await fetchTokenScopedModels(
+    account,
+    token,
+  )
+  candidateSources.push(tokenScopedModels)
+
+  if (includeAccountFallback) {
+    try {
+      const fallbackModels = await getApiService(
+        account.siteType,
+      ).fetchAccountAvailableModels({
+        baseUrl: account.baseUrl,
+        accountId: account.id,
+        auth: {
+          authType: account.authType,
+          userId: account.userId,
+          accessToken: account.token,
+          cookie: account.cookieAuthSessionCookie,
+        },
+      })
+
+      if (fallbackModels && fallbackModels.length > 0) {
+        candidateSources.push(fallbackModels)
+      }
+    } catch (error) {
+      logger.warn("Failed to fetch fallback models", error)
+    }
+  }
+
+  return normalizeList(candidateSources.flat())
+}

--- a/tests/services/managedSites/fetchManagedSiteAvailableModels.test.ts
+++ b/tests/services/managedSites/fetchManagedSiteAvailableModels.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AuthTypeEnum } from "~/types"
+
+const mockFetchAccountAvailableModels = vi.fn()
+const mockFetchOpenAICompatibleModelIds = vi.fn()
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: vi.fn(() => ({
+    fetchAccountAvailableModels: mockFetchAccountAvailableModels,
+  })),
+}))
+
+vi.mock("~/services/apiService/openaiCompatible", () => ({
+  fetchOpenAICompatibleModelIds: mockFetchOpenAICompatibleModelIds,
+}))
+
+const createAccount = () => ({
+  siteType: "new-api" as const,
+  baseUrl: "https://api.example.com",
+  id: "site-1",
+  authType: AuthTypeEnum.AccessToken,
+  userId: 1,
+  token: "account-access-token",
+  cookieAuthSessionCookie: "session=abc",
+})
+
+const createToken = (overrides: Record<string, unknown> = {}) => ({
+  key: "sk-live-token",
+  ...overrides,
+})
+
+describe("fetchManagedSiteAvailableModels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("ignores token.models metadata and keeps only live source results", async () => {
+    const { fetchManagedSiteAvailableModels } = await import(
+      "~/services/managedSites/utils/fetchManagedSiteAvailableModels"
+    )
+
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o-mini"])
+    mockFetchAccountAvailableModels.mockResolvedValueOnce([])
+
+    const result = await fetchManagedSiteAvailableModels(
+      createAccount(),
+      createToken({ models: "declared-a,declared-b" }),
+    )
+
+    expect(result).toEqual(["gpt-4o-mini"])
+  })
+
+  it("falls back to account model discovery when the live token probe fails", async () => {
+    const { fetchManagedSiteAvailableModels } = await import(
+      "~/services/managedSites/utils/fetchManagedSiteAvailableModels"
+    )
+
+    mockFetchOpenAICompatibleModelIds.mockRejectedValueOnce(
+      new Error("Upstream failed"),
+    )
+    mockFetchAccountAvailableModels.mockResolvedValueOnce(["claude-3-opus"])
+
+    const result = await fetchManagedSiteAvailableModels(
+      createAccount(),
+      createToken({ models: "declared-only-model" }),
+    )
+
+    expect(result).toEqual(["claude-3-opus"])
+    expect(result).not.toContain("declared-only-model")
+  })
+
+  it("can skip account fallback entirely for providers that require token-only live results", async () => {
+    const { fetchManagedSiteAvailableModels } = await import(
+      "~/services/managedSites/utils/fetchManagedSiteAvailableModels"
+    )
+
+    mockFetchOpenAICompatibleModelIds.mockRejectedValueOnce(
+      new Error("Upstream failed"),
+    )
+
+    const result = await fetchManagedSiteAvailableModels(
+      createAccount(),
+      createToken({ models: "declared-only-model" }),
+      {
+        includeAccountFallback: false,
+      },
+    )
+
+    expect(result).toEqual([])
+    expect(mockFetchAccountAvailableModels).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/newApiService/newApiService.test.ts
+++ b/tests/services/newApiService/newApiService.test.ts
@@ -718,20 +718,21 @@ describe("newApiService", () => {
   // ========================================================================
 
   describe("fetchAvailableModels", () => {
-    it("should return token models when available", async () => {
+    it("should ignore token.models metadata and return live upstream models", async () => {
       const { fetchAvailableModels } = await import(
         "~/services/managedSites/providers/newApi"
       )
       const account = createMockDisplaySiteData()
-      const token = createMockApiToken({ models: "gpt-4,gpt-3.5-turbo" })
+      const token = createMockApiToken({ models: "declared-a,declared-b" })
+
+      mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o-mini"])
 
       const result = await fetchAvailableModels(account, token)
 
-      expect(result).toContain("gpt-4")
-      expect(result).toContain("gpt-3.5-turbo")
+      expect(result).toEqual(["gpt-4o-mini"])
     })
 
-    it("should fallback to upstream models when token models empty", async () => {
+    it("should return upstream models when the live probe succeeds", async () => {
       const { fetchAvailableModels } = await import(
         "~/services/managedSites/providers/newApi"
       )
@@ -771,24 +772,22 @@ describe("newApiService", () => {
         "~/services/managedSites/providers/newApi"
       )
       const account = createMockDisplaySiteData()
-      const token = createMockApiToken({ models: "gpt-4,gpt-3.5-turbo" })
+      const token = createMockApiToken({ models: "declared-only-model" })
 
       mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([
         "gpt-4",
         "gpt-4-turbo",
       ])
-      mockFetchAccountAvailableModels.mockResolvedValueOnce([
-        "gpt-3.5-turbo",
-        "gpt-4",
-      ])
+      mockFetchAccountAvailableModels.mockResolvedValueOnce(["gpt-4o", "gpt-4"])
 
       const result = await fetchAvailableModels(account, token)
 
       const uniqueModels = new Set(result)
       expect(uniqueModels.size).toBe(result.length) // No duplicates
       expect(result).toContain("gpt-4")
-      expect(result).toContain("gpt-3.5-turbo")
       expect(result).toContain("gpt-4-turbo")
+      expect(result).toContain("gpt-4o")
+      expect(result).not.toContain("declared-only-model")
     })
 
     it("should handle errors swallowing and continue", async () => {
@@ -810,19 +809,23 @@ describe("newApiService", () => {
       expect(result).toEqual([])
     })
 
-    it("should normalize models list", async () => {
+    it("should normalize models returned by live sources", async () => {
       const { fetchAvailableModels } = await import(
         "~/services/managedSites/providers/newApi"
       )
       const account = createMockDisplaySiteData()
-      const token = createMockApiToken({
-        models: "  gpt-4  ,  gpt-3.5-turbo  , ",
-      })
+      const token = createMockApiToken({ models: "ignored-model" })
+
+      mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([
+        "  gpt-4  ",
+        "gpt-3.5-turbo",
+        "",
+        "gpt-4",
+      ])
 
       const result = await fetchAvailableModels(account, token)
 
-      expect(result).toContain("gpt-4")
-      expect(result).toContain("gpt-3.5-turbo")
+      expect(result).toEqual(["gpt-4", "gpt-3.5-turbo"])
     })
   })
 
@@ -1788,8 +1791,8 @@ describe("newApiService", () => {
   // Helper Functions
   // ========================================================================
 
-  describe("parseDelimitedList (via fetchAvailableModels)", () => {
-    it("should parse comma-delimited string", async () => {
+  describe("fetchAvailableModels metadata handling", () => {
+    it("should not fall back to token.models when live sources are unavailable", async () => {
       const { fetchAvailableModels } = await import(
         "~/services/managedSites/providers/newApi"
       )
@@ -1798,11 +1801,14 @@ describe("newApiService", () => {
         models: "gpt-4, gpt-3.5-turbo , claude-3",
       })
 
+      mockFetchOpenAICompatibleModelIds.mockRejectedValueOnce(
+        new Error("Upstream failed"),
+      )
+      mockFetchAccountAvailableModels.mockResolvedValueOnce([])
+
       const result = await fetchAvailableModels(account, token)
 
-      expect(result).toContain("gpt-4")
-      expect(result).toContain("gpt-3.5-turbo")
-      expect(result).toContain("claude-3")
+      expect(result).toEqual([])
     })
 
     it("should handle empty models string", async () => {


### PR DESCRIPTION
- Refactor model fetching to use live upstream sources only
- Remove token.models metadata from model resolution logic
- Add fetchManagedSiteAvailableModels utility with fallback control
- Update veloera, newApi, doneHubService, and octopus providers
- Add comprehensive test coverage for new behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated model availability detection across provider services for more consistent and reliable behavior.

* **Tests**
  * Added comprehensive test coverage for model discovery, including fallback scenarios when primary detection fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->