### PR TITLE
[FEAT] Claude Code Hub 集成

### DIFF
--- a/src/components/CCHExportDialog.tsx
+++ b/src/components/CCHExportDialog.tsx
@@ -1,0 +1,605 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import toast from "react-hot-toast"
+import { useTranslation } from "react-i18next"
+
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  CompactMultiSelect,
+  FormField,
+  Modal,
+  type CompactMultiSelectOption,
+} from "~/components/ui"
+import { useAccountData } from "~/hooks/useAccountData"
+import { compareAccountDisplayNames } from "~/services/accounts/utils/accountDisplayName"
+import {
+  batchExportToCCH,
+  exportToCCH,
+  verifyCCHConnection,
+} from "~/services/integrations/claudeCodeHubService"
+import type { CCHExportResult, CCHExportSelection } from "~/types/claudeCodeHub"
+import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
+
+interface CCHExportDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  /**
+   * Optional initial selection for opening the dialog from contextual entry points.
+   */
+  initialSelectedSiteIds?: string[]
+  /**
+   * Optional initial token selection per site (token ids as strings). Applied once per open.
+   */
+  initialSelectedTokenIdsBySite?: Record<string, string[]>
+}
+
+type TokenLoadStatus = "idle" | "loading" | "loaded" | "error"
+
+interface TokenInventoryState {
+  status: TokenLoadStatus
+  tokens: ApiToken[]
+  errorMessage?: string
+}
+
+/**
+ * Build a safe, human-readable token label for selection UI.
+ */
+function getTokenLabel(token: ApiToken, fallbackPrefix: string) {
+  const trimmedName = (token.name ?? "").trim()
+  if (trimmedName) return trimmedName
+  return `${fallbackPrefix} #${token.id}`
+}
+
+/**
+ * Build a compact label for displaying a site in dense UI.
+ */
+function getSiteDisplayName(site: DisplaySiteData) {
+  const trimmedName = (site.name ?? "").trim()
+  if (trimmedName) return trimmedName
+  try {
+    return new URL(site.baseUrl).host
+  } catch {
+    return site.baseUrl.trim()
+  }
+}
+
+/**
+ * Modal for exporting selected accounts/tokens to Claude Code Hub.
+ */
+export function CCHExportDialog({
+  isOpen,
+  onClose,
+  initialSelectedSiteIds,
+  initialSelectedTokenIdsBySite,
+}: CCHExportDialogProps) {
+  const { t } = useTranslation(["ui", "common"])
+  const { enabledAccounts: accounts, enabledDisplayData: displayData } =
+    useAccountData()
+
+  const [selectedSiteIds, setSelectedSiteIds] = useState<string[]>([])
+  const [selectedTokenIdsBySite, setSelectedTokenIdsBySite] = useState<
+    Record<string, string[]>
+  >({})
+  const [tokenInventories, setTokenInventories] = useState<
+    Record<string, TokenInventoryState>
+  >({})
+  const [isExporting, setIsExporting] = useState(false)
+  const [exportProgress, setExportProgress] = useState<{
+    completed: number
+    total: number
+  } | null>(null)
+  const [isConnectionVerified, setIsConnectionVerified] = useState(false)
+  const [isVerifyingConnection, setIsVerifyingConnection] = useState(false)
+
+  const initialSelectionAppliedRef = useMemo(() => ({ current: false }), [])
+  const isDialogActiveRef = useMemo(() => ({ current: false }), [])
+
+  useEffect(() => {
+    isDialogActiveRef.current = isOpen
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    setSelectedSiteIds([])
+    setSelectedTokenIdsBySite({})
+    setTokenInventories({})
+    setIsExporting(false)
+    setExportProgress(null)
+    initialSelectionAppliedRef.current = false
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    if (initialSelectionAppliedRef.current) return
+
+    const tokenSelectionMap = initialSelectedTokenIdsBySite ?? {}
+    const siteIdsFromTokens = Object.keys(tokenSelectionMap)
+    const siteIds = Array.from(
+      new Set([...(initialSelectedSiteIds ?? []), ...siteIdsFromTokens]),
+    )
+
+    if (siteIds.length > 0) {
+      setSelectedSiteIds(siteIds)
+    }
+
+    if (siteIdsFromTokens.length > 0) {
+      setSelectedTokenIdsBySite(tokenSelectionMap)
+    }
+
+    initialSelectionAppliedRef.current = true
+  }, [isOpen, initialSelectedSiteIds, initialSelectedTokenIdsBySite])
+
+  const displayById = useMemo(() => {
+    return new Map<string, DisplaySiteData>(
+      displayData.map((site) => [site.id, site]),
+    )
+  }, [displayData])
+
+  const accountById = useMemo(() => {
+    return new Map<string, SiteAccount>(accounts.map((acc) => [acc.id, acc]))
+  }, [accounts])
+
+  const getTokenInventory = useCallback(
+    (siteId: string): TokenInventoryState => {
+      return tokenInventories[siteId] ?? { status: "idle", tokens: [] }
+    },
+    [tokenInventories],
+  )
+
+  const loadTokensForSite = useCallback(
+    async (siteId: string) => {
+      const site = displayById.get(siteId)
+      if (!site) return
+
+      setTokenInventories((prev) => ({
+        ...prev,
+        [siteId]: {
+          status: "loading",
+          tokens: prev[siteId]?.tokens ?? [],
+          errorMessage: undefined,
+        },
+      }))
+
+      try {
+        const { getApiService } = await import("~/services/apiService")
+        const service = getApiService(site.siteType)
+        const tokens = await service.fetchAccountTokens({
+          baseUrl: site.baseUrl,
+          accountId: site.id,
+          auth: {
+            authType: site.authType,
+            userId: site.userId,
+            accessToken: site.token,
+            cookie: site.cookieAuthSessionCookie,
+          },
+        })
+
+        if (!Array.isArray(tokens)) {
+          setTokenInventories((prev) => ({
+            ...prev,
+            [siteId]: {
+              status: "error",
+              tokens: [],
+              errorMessage: t("ui:dialog.cch.messages.loadTokensFailed"),
+            },
+          }))
+          return
+        }
+
+        setTokenInventories((prev) => ({
+          ...prev,
+          [siteId]: { status: "loaded", tokens, errorMessage: undefined },
+        }))
+
+        // Default select the first token
+        setSelectedTokenIdsBySite((prev) => {
+          const existingSelections = prev[siteId] ?? []
+          const remainingSelections = existingSelections.filter((id) =>
+            tokens.some((token) => `${token.id}` === id),
+          )
+          if (remainingSelections.length > 0) {
+            return { ...prev, [siteId]: remainingSelections }
+          }
+
+          if (!tokens.length) {
+            if (!prev[siteId]) return prev
+            const { [siteId]: _unused, ...rest } = prev
+            return rest
+          }
+
+          return { ...prev, [siteId]: [`${tokens[0].id}`] }
+        })
+      } catch {
+        setTokenInventories((prev) => ({
+          ...prev,
+          [siteId]: {
+            status: "error",
+            tokens: [],
+            errorMessage: t("ui:dialog.cch.messages.loadTokensFailed"),
+          },
+        }))
+      }
+    },
+    [displayById, t],
+  )
+
+  useEffect(() => {
+    if (!isOpen) return
+    if (selectedSiteIds.length === 0) return
+
+    const nextSelectedSiteIds = selectedSiteIds.filter((id) =>
+      displayById.has(id),
+    )
+    if (nextSelectedSiteIds.length === selectedSiteIds.length) return
+
+    setSelectedSiteIds(nextSelectedSiteIds)
+    setSelectedTokenIdsBySite((prev) => {
+      const next: Record<string, string[]> = {}
+      for (const siteId of nextSelectedSiteIds) {
+        const tokenIds = prev[siteId]
+        if (Array.isArray(tokenIds) && tokenIds.length > 0) {
+          next[siteId] = tokenIds
+        }
+      }
+      return next
+    })
+  }, [displayById, isOpen, selectedSiteIds])
+
+  useEffect(() => {
+    if (!isOpen) return
+    if (selectedSiteIds.length === 0) return
+
+    for (const siteId of selectedSiteIds) {
+      const status = tokenInventories[siteId]?.status ?? "idle"
+      if (status === "idle") {
+        void loadTokensForSite(siteId)
+      }
+    }
+  }, [isOpen, loadTokensForSite, selectedSiteIds, tokenInventories])
+
+  const siteOptions: CompactMultiSelectOption[] = useMemo(() => {
+    return [...displayData]
+      .sort((a, b) => compareAccountDisplayNames(a, b))
+      .map((site) => ({
+        value: site.id,
+        label: site.name || site.baseUrl,
+      }))
+  }, [displayData])
+
+  const selectedSites = useMemo(() => {
+    return selectedSiteIds
+      .map((id) => displayById.get(id))
+      .filter((site): site is DisplaySiteData => Boolean(site))
+      .sort((a, b) => compareAccountDisplayNames(a, b))
+  }, [displayById, selectedSiteIds])
+
+  const exportSelections: CCHExportSelection[] = useMemo(() => {
+    const selections: CCHExportSelection[] = []
+
+    for (const siteId of selectedSiteIds) {
+      const tokenIds = selectedTokenIdsBySite[siteId] ?? []
+      if (tokenIds.length === 0) continue
+
+      const site = displayById.get(siteId)
+      if (!site) continue
+
+      const inventory = getTokenInventory(siteId)
+      const uniqueTokenIds = Array.from(new Set(tokenIds))
+      for (const tokenId of uniqueTokenIds) {
+        const token = inventory.tokens.find(
+          (candidate) => `${candidate.id}` === tokenId,
+        )
+        if (!token) continue
+
+        selections.push({
+          account: site,
+          token,
+        })
+      }
+    }
+
+    return selections
+  }, [displayById, getTokenInventory, selectedSiteIds, selectedTokenIdsBySite])
+
+  const hasExportableProfiles = exportSelections.length > 0
+  const selectionSummary = t("ui:dialog.cch.descriptions.selectedSites", {
+    sites: selectedSiteIds.length,
+    keys: exportSelections.length,
+  })
+
+  const handleVerifyConnection = async () => {
+    setIsVerifyingConnection(true)
+    try {
+      const result = await verifyCCHConnection()
+      if (result.success) {
+        setIsConnectionVerified(true)
+        toast.success(result.message)
+      } else {
+        toast.error(result.message)
+      }
+    } catch {
+      toast.error(t("ui:dialog.cch.messages.connectionCheckFailed"))
+    } finally {
+      setIsVerifyingConnection(false)
+    }
+  }
+
+  const handleExport = async () => {
+    if (!hasExportableProfiles) return
+
+    setIsExporting(true)
+    setExportProgress({ completed: 0, total: exportSelections.length })
+
+    try {
+      const result = await batchExportToCCH(
+        exportSelections,
+        (completed, total) => {
+          setExportProgress({ completed, total })
+        },
+      )
+
+      if (result.success > 0) {
+        toast.success(
+          t("ui:dialog.cch.messages.exportSuccess", {
+            success: result.success,
+            total: result.total,
+            failed: result.failed,
+          }),
+        )
+      }
+
+      if (result.failed > 0) {
+        const failedResults = result.results.filter((r) => !r.success)
+        if (failedResults.length > 0) {
+          toast.error(
+            t("ui:dialog.cch.messages.exportPartialSuccess", {
+              failed: result.failed,
+            }),
+          )
+          failedResults.forEach((r) => {
+            toast.error(`${r.accountBaseUrl}: ${r.message}`)
+          })
+        }
+      }
+
+      if (result.success === result.total) {
+        onClose()
+      }
+    } catch {
+      toast.error(t("ui:dialog.cch.messages.exportFailed"))
+    } finally {
+      setIsExporting(false)
+      setExportProgress(null)
+    }
+  }
+
+  const handleClose = () => {
+    if (isExporting) return
+    onClose()
+  }
+
+  const renderSiteCard = (site: DisplaySiteData) => {
+    const siteId = site.id
+    const siteName = getSiteDisplayName(site)
+    const inventory = getTokenInventory(siteId)
+    const isLoadingTokens = inventory.status === "loading"
+
+    const selectedTokenIds = selectedTokenIdsBySite[siteId] ?? []
+    const tokenOptions: CompactMultiSelectOption[] = inventory.tokens.map(
+      (token) => ({
+        value: `${token.id}`,
+        label: getTokenLabel(token, t("common:labels.token")),
+      }),
+    )
+
+    const statusBadge =
+      inventory.status === "error" ? (
+        <Badge variant="danger" size="sm">
+          {t("common:status.error")}
+        </Badge>
+      ) : inventory.status === "loading" || inventory.status === "idle" ? (
+        <Badge variant="info" size="sm">
+          {t("common:status.loading")}
+        </Badge>
+      ) : inventory.tokens.length === 0 ? (
+        <Badge variant="warning" size="sm">
+          {t("ui:dialog.cch.messages.noTokensTitle")}
+        </Badge>
+      ) : (
+        <Badge variant="success" size="sm">
+          {t("common:status.success")}
+        </Badge>
+      )
+
+    const actionButton =
+      inventory.status === "error" ? (
+        <Button
+          size="sm"
+          type="button"
+          variant="secondary"
+          onClick={() => loadTokensForSite(siteId)}
+          disabled={isLoadingTokens}
+          loading={isLoadingTokens}
+        >
+          {t("common:actions.retry")}
+        </Button>
+      ) : inventory.status === "loaded" && inventory.tokens.length > 0 ? (
+        <Button
+          size="sm"
+          type="button"
+          variant="ghost"
+          onClick={() => loadTokensForSite(siteId)}
+          disabled={isLoadingTokens}
+          loading={isLoadingTokens}
+        >
+          {t("common:actions.refresh")}
+        </Button>
+      ) : null
+
+    return (
+      <Card key={siteId} padding="sm" className="space-y-2">
+        <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <div
+              className="dark:text-dark-text-primary truncate text-sm font-medium text-gray-900"
+              title={siteName}
+            >
+              {siteName}
+            </div>
+            <div
+              className="dark:text-dark-text-tertiary truncate text-xs text-gray-500"
+              title={site.baseUrl}
+            >
+              {site.baseUrl}
+            </div>
+            {statusBadge}
+            {inventory.status === "loaded" && inventory.tokens.length > 0 && (
+              <Badge
+                variant="secondary"
+                size="sm"
+                title={t("ui:dialog.cch.labels.selectedTokens")}
+              >
+                {selectedTokenIds.length}/{inventory.tokens.length}
+              </Badge>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">{actionButton}</div>
+        </div>
+
+        {inventory.status === "error" && (
+          <div className="text-sm text-red-700 dark:text-red-300">
+            {inventory.errorMessage ||
+              t("ui:dialog.cch.messages.loadTokensFailed")}
+          </div>
+        )}
+
+        {(inventory.status === "idle" || inventory.status === "loading") && (
+          <div className="dark:text-dark-text-tertiary text-sm text-gray-500">
+            {t("ui:dialog.cch.messages.loadingTokens")}
+          </div>
+        )}
+
+        {inventory.status === "loaded" && inventory.tokens.length === 0 && (
+          <div className="dark:text-dark-text-tertiary text-sm text-gray-500">
+            {t("ui:dialog.cch.messages.noTokensDescription")}
+          </div>
+        )}
+
+        {inventory.status === "loaded" && inventory.tokens.length > 0 && (
+          <FormField label={t("common:labels.apiKey")}>
+            <CompactMultiSelect
+              options={tokenOptions}
+              selected={selectedTokenIds}
+              onChange={(values) => {
+                setSelectedTokenIdsBySite((prev) => ({
+                  ...prev,
+                  [siteId]: values,
+                }))
+              }}
+              placeholder={t("ui:dialog.cch.placeholders.selectTokens")}
+              clearable
+            />
+          </FormField>
+        )}
+      </Card>
+    )
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="lg"
+      header={
+        <div className="pr-8">
+          <div className="dark:text-dark-text-primary text-base font-semibold text-gray-900">
+            {t("ui:dialog.cch.title")}
+          </div>
+          <p className="dark:text-dark-text-secondary text-sm text-gray-500">
+            {t("ui:dialog.cch.description")}
+          </p>
+        </div>
+      }
+      footer={
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {selectedSiteIds.length > 0 && (
+            <div className="dark:text-dark-text-tertiary mr-auto text-xs text-gray-500">
+              {selectionSummary}
+            </div>
+          )}
+          {!isConnectionVerified && (
+            <Button
+              variant="secondary"
+              type="button"
+              onClick={handleVerifyConnection}
+              disabled={isVerifyingConnection || isExporting}
+              loading={isVerifyingConnection}
+            >
+              {t("ui:dialog.cch.actions.verifyConnection")}
+            </Button>
+          )}
+          <Button variant="ghost" type="button" onClick={handleClose}>
+            {t("common:actions.cancel")}
+          </Button>
+          <Button
+            type="button"
+            onClick={handleExport}
+            disabled={!hasExportableProfiles || isExporting}
+            loading={isExporting}
+          >
+            {isExporting && exportProgress
+              ? t("ui:dialog.cch.actions.exporting", {
+                  completed: exportProgress.completed,
+                  total: exportProgress.total,
+                })
+              : t("ui:dialog.cch.actions.export")}
+          </Button>
+        </div>
+      }
+    >
+      <Alert
+        variant="info"
+        title={t("ui:dialog.cch.help.prerequisitesTitle")}
+        description={t("ui:dialog.cch.help.prerequisitesDescription")}
+      />
+
+      <FormField
+        label={t("ui:dialog.cch.labels.selectedSites")}
+        description={selectionSummary}
+      >
+        <CompactMultiSelect
+          options={siteOptions}
+          selected={selectedSiteIds}
+          onChange={setSelectedSiteIds}
+          placeholder={t("ui:dialog.cch.placeholders.selectSites")}
+          clearable
+        />
+      </FormField>
+
+      {selectedSites.length > 0 && (
+        <div className="space-y-3">
+          {selectedSites.map((site) => renderSiteCard(site))}
+        </div>
+      )}
+
+      {isExporting && exportProgress && (
+        <Alert
+          variant="info"
+          title={t("ui:dialog.cch.messages.exportingTitle")}
+          description={t("ui:dialog.cch.messages.exportingDescription", {
+            completed: exportProgress.completed,
+            total: exportProgress.total,
+          })}
+        />
+      )}
+
+      <Alert
+        variant="warning"
+        title={t("ui:dialog.cch.warning.title")}
+        description={t("ui:dialog.cch.warning.description")}
+      />
+    </Modal>
+  )
+}

--- a/src/components/icons/CCHIcon.tsx
+++ b/src/components/icons/CCHIcon.tsx
@@ -1,0 +1,51 @@
+import {
+  ICON_SIZE_CLASSNAME,
+  type IconSize,
+} from "~/components/icons/iconSizes"
+import { cn } from "~/lib/utils"
+
+interface CCHIconProps {
+  /**
+   * Icon size token used across the UI (matches other integration icons).
+   */
+  size?: IconSize
+  /**
+   * Optional className for color and additional styling.
+   *
+   * Tip: the SVG uses `currentColor`, so a Tailwind `text-*` class will control
+   * the icon color.
+   */
+  className?: string
+}
+
+/**
+ * CCHIcon renders a lightweight inline SVG for Claude Code Hub integration.
+ *
+ * The icon is based on the Claude Code Hub favicon (https://claude-code-hub.app/favicon-32x32.png)
+ * and features a layered cube/box design representing provider management.
+ */
+export function CCHIcon({ size = "sm", className }: CCHIconProps) {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn(ICON_SIZE_CLASSNAME[size], className)}
+      role="img"
+      aria-hidden="true"
+    >
+      <path
+        fill="currentColor"
+        d="M50 5 L95 27.5 L95 72.5 L50 95 L5 72.5 L5 27.5 Z M50 15 L85 32.5 L85 67.5 L50 85 L15 67.5 L15 32.5 Z"
+      />
+      <path
+        fill="currentColor"
+        fillOpacity="0.7"
+        d="M50 5 L95 27.5 L50 50 L5 27.5 Z M5 27.5 L50 50 L50 95 L5 72.5 Z M95 27.5 L95 72.5 L50 95 L50 50 Z"
+      />
+      <path
+        fill="currentColor"
+        d="M50 35 L75 47.5 L50 60 L25 47.5 Z"
+      />
+    </svg>
+  )
+}

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -91,6 +91,8 @@ interface UserPreferencesContextType {
   cliProxyManagementKey: string
   claudeCodeRouterBaseUrl: string
   claudeCodeRouterApiKey: string
+  cchBaseUrl: string
+  cchAuthToken: string
   themeMode: ThemeMode
   loggingConsoleEnabled: boolean
   loggingLevel: LogLevel
@@ -138,6 +140,8 @@ interface UserPreferencesContextType {
   updateCliProxyManagementKey: (key: string) => Promise<boolean>
   updateClaudeCodeRouterBaseUrl: (url: string) => Promise<boolean>
   updateClaudeCodeRouterApiKey: (key: string) => Promise<boolean>
+  updateCCHBaseUrl: (url: string) => Promise<boolean>
+  updateCCHAuthToken: (token: string) => Promise<boolean>
   updateThemeMode: (themeMode: ThemeMode) => Promise<boolean>
   updateLoggingConsoleEnabled: (enabled: boolean) => Promise<boolean>
   updateLoggingLevel: (level: LogLevel) => Promise<boolean>
@@ -175,6 +179,7 @@ interface UserPreferencesContextType {
   resetNewApiModelSyncConfig: () => Promise<boolean>
   resetCliProxyConfig: () => Promise<boolean>
   resetClaudeCodeRouterConfig: () => Promise<boolean>
+  resetCCHConfig: () => Promise<boolean>
   resetAutoCheckinConfig: () => Promise<boolean>
   resetRedemptionAssistConfig: () => Promise<boolean>
   resetWebAiApiCheckConfig: () => Promise<boolean>
@@ -327,6 +332,22 @@ export const UserPreferencesProvider = ({
     return success
   }, [])
 
+  const resetCCHConfig = useCallback(async () => {
+    const success = await userPreferences.resetCCHConfig()
+    if (success) {
+      const defaults = DEFAULT_PREFERENCES.cch
+      setPreferences((prev) =>
+        prev
+          ? deepOverride(prev, {
+              cch: defaults,
+              lastUpdated: Date.now(),
+            })
+          : prev,
+      )
+    }
+    return success
+  }, [])
+
   /**
    * Update the CLI proxy base URL and merge it into the preference tree so
    * dependent features read the latest endpoint.
@@ -374,6 +395,28 @@ export const UserPreferencesProvider = ({
   const updateClaudeCodeRouterApiKey = useCallback(async (apiKey: string) => {
     const updates = {
       claudeCodeRouter: { apiKey },
+    }
+    const success = await userPreferences.savePreferences(updates)
+    if (success) {
+      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+    }
+    return success
+  }, [])
+
+  const updateCCHBaseUrl = useCallback(async (baseUrl: string) => {
+    const updates = {
+      cch: { baseUrl },
+    }
+    const success = await userPreferences.savePreferences(updates)
+    if (success) {
+      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+    }
+    return success
+  }, [])
+
+  const updateCCHAuthToken = useCallback(async (authToken: string) => {
+    const updates = {
+      cch: { authToken },
     }
     const success = await userPreferences.savePreferences(updates)
     if (success) {
@@ -1431,6 +1474,8 @@ export const UserPreferencesProvider = ({
     cliProxyManagementKey: preferences?.cliProxy?.managementKey || "",
     claudeCodeRouterBaseUrl: preferences?.claudeCodeRouter?.baseUrl || "",
     claudeCodeRouterApiKey: preferences?.claudeCodeRouter?.apiKey || "",
+    cchBaseUrl: preferences?.cch?.baseUrl || "",
+    cchAuthToken: preferences?.cch?.authToken || "",
     themeMode: preferences?.themeMode || "system",
     loggingConsoleEnabled:
       preferences?.logging?.consoleEnabled ??
@@ -1477,6 +1522,8 @@ export const UserPreferencesProvider = ({
     updateCliProxyManagementKey,
     updateClaudeCodeRouterBaseUrl,
     updateClaudeCodeRouterApiKey,
+    updateCCHBaseUrl,
+    updateCCHAuthToken,
     updateThemeMode,
     updateLoggingConsoleEnabled,
     updateLoggingLevel,
@@ -1498,6 +1545,7 @@ export const UserPreferencesProvider = ({
     resetNewApiModelSyncConfig,
     resetCliProxyConfig,
     resetClaudeCodeRouterConfig,
+    resetCCHConfig,
     resetAutoCheckinConfig,
     resetRedemptionAssistConfig,
     resetWebAiApiCheckConfig,

--- a/src/features/BasicSettings/BasicSettings.tsx
+++ b/src/features/BasicSettings/BasicSettings.tsx
@@ -84,6 +84,9 @@ const ClaudeCodeRouterTab = createLazyTabComponent(
 const CliProxyTab = createLazyTabComponent(
   () => import("./components/tabs/CliProxy/CliProxyTab"),
 )
+const CCHTab = createLazyTabComponent(
+  () => import("./components/tabs/CCH/CCHTab"),
+)
 const DataBackupTab = createLazyTabComponent(
   () => import("./components/tabs/DataBackup/DataBackupTab"),
 )
@@ -119,6 +122,7 @@ const TAB_CONFIGS = [
   { id: "managedSite", component: ManagedSiteTab },
   { id: "cliProxy", component: CliProxyTab },
   { id: "claudeCodeRouter", component: ClaudeCodeRouterTab },
+  { id: "cch", component: CCHTab },
   ...(hasOptionalPermissions ? [PERMISSIONS_TAB_CONFIG] : []),
   { id: "dataBackup", component: DataBackupTab },
 ] satisfies TabConfig[]
@@ -147,6 +151,7 @@ const ANCHOR_TO_TAB: Record<string, TabId> = {
   "new-api-model-sync": "managedSite",
   "cli-proxy": "cliProxy",
   "claude-code-router": "claudeCodeRouter",
+  "cch": "cch",
   "dangerous-zone": "general",
   ...(hasOptionalPermissions ? { permissions: "permissions" } : {}),
 }
@@ -217,6 +222,8 @@ function getSettingsTabLabel(t: TFunction, tabId: TabId): string {
       return t("settings:tabs.cliProxy")
     case "claudeCodeRouter":
       return t("settings:tabs.claudeCodeRouter")
+    case "cch":
+      return t("settings:tabs.cch")
     case "permissions":
       return t("settings:tabs.permissions")
     default:

--- a/src/features/BasicSettings/components/tabs/CCH/CCHSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/CCH/CCHSettings.tsx
@@ -1,0 +1,198 @@
+import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { SettingSection } from "~/components/SettingSection"
+import {
+  Button,
+  Card,
+  CardItem,
+  CardList,
+  IconButton,
+  Input,
+  Link,
+} from "~/components/ui"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { verifyCCHConnection } from "~/services/integrations/claudeCodeHubService"
+import { showResultToast, showUpdateToast } from "~/utils/core/toastHelpers"
+
+const CCH_API_DOC_URL = "https://cch.skydog.cc.cd/api/actions/openapi.json"
+
+/**
+ * Settings section for CCH (Claude Code Hub) base URL and auth token entries.
+ * Handles local input state, visibility toggle, persistence, and connection test.
+ */
+export default function CCHSettings() {
+  const { t } = useTranslation("settings")
+  const {
+    cchBaseUrl,
+    cchAuthToken,
+    updateCCHBaseUrl,
+    updateCCHAuthToken,
+    resetCCHConfig,
+  } = useUserPreferencesContext()
+
+  const [localBaseUrl, setLocalBaseUrl] = useState(cchBaseUrl)
+  const [localAuthToken, setLocalAuthToken] = useState(cchAuthToken)
+  const [showAuthToken, setShowAuthToken] = useState(false)
+  const [isCheckingConnection, setIsCheckingConnection] = useState(false)
+
+  useEffect(() => {
+    setLocalBaseUrl(cchBaseUrl)
+  }, [cchBaseUrl])
+
+  useEffect(() => {
+    setLocalAuthToken(cchAuthToken)
+  }, [cchAuthToken])
+
+  const runConnectionCheck = async (overrides?: {
+    baseUrl?: string
+    authToken?: string
+  }) => {
+    const baseUrl = overrides?.baseUrl ?? localBaseUrl
+    const authToken = overrides?.authToken ?? localAuthToken
+
+    setIsCheckingConnection(true)
+    try {
+      const result = await verifyCCHConnection({ baseUrl, authToken })
+      return result
+    } finally {
+      setIsCheckingConnection(false)
+    }
+  }
+
+  const runConnectionCheckWithToast = async (overrides?: {
+    baseUrl?: string
+    authToken?: string
+  }) => {
+    const result = await runConnectionCheck(overrides)
+    showResultToast(result)
+    return result
+  }
+
+  const handleBaseUrlChange = async (url: string) => {
+    const trimmedUrl = url.trim()
+    setLocalBaseUrl(trimmedUrl)
+
+    if (trimmedUrl === cchBaseUrl.trim()) return
+    const success = await updateCCHBaseUrl(trimmedUrl)
+    showUpdateToast(success, t("cch.baseUrlLabel"))
+
+    if (success && trimmedUrl && localAuthToken.trim()) {
+      await runConnectionCheckWithToast({
+        baseUrl: trimmedUrl,
+        authToken: localAuthToken,
+      })
+    }
+  }
+
+  const handleAuthTokenChange = async (token: string) => {
+    const trimmedToken = token.trim()
+    setLocalAuthToken(trimmedToken)
+
+    if (trimmedToken === cchAuthToken.trim()) return
+    const success = await updateCCHAuthToken(trimmedToken)
+    showUpdateToast(success, t("cch.authTokenLabel"))
+
+    if (success && localBaseUrl.trim() && trimmedToken) {
+      await runConnectionCheckWithToast({
+        baseUrl: localBaseUrl,
+        authToken: trimmedToken,
+      })
+    }
+  }
+
+  const handleReset = async () => {
+    await resetCCHConfig()
+    setLocalBaseUrl("")
+    setLocalAuthToken("")
+  }
+
+  return (
+    <SettingSection
+      title={t("cch.title")}
+      description={t("cch.description")}
+    >
+      <CardList>
+        <CardItem
+          label={t("cch.baseUrlLabel")}
+          description={t("cch.baseUrlDescription")}
+        >
+          <div className="flex items-center gap-2">
+            <Input
+              type="url"
+              value={localBaseUrl}
+              onChange={(e) => handleBaseUrlChange(e.target.value)}
+              placeholder={t("cch.baseUrlPlaceholder")}
+              className="flex-1"
+            />
+          </div>
+        </CardItem>
+        <CardItem
+          label={t("cch.authTokenLabel")}
+          description={t("cch.authTokenDescription")}
+        >
+          <div className="flex items-center gap-2">
+            <Input
+              type={showAuthToken ? "text" : "password"}
+              value={localAuthToken}
+              onChange={(e) => handleAuthTokenChange(e.target.value)}
+              placeholder={t("cch.authTokenPlaceholder")}
+              className="flex-1"
+            />
+            <IconButton
+              type="button"
+              variant="ghost"
+              onClick={() => setShowAuthToken(!showAuthToken)}
+              aria-label={
+                showAuthToken ? t("common:actions.hide") : t("common:actions.show")
+              }
+            >
+              {showAuthToken ? (
+                <EyeSlashIcon className="h-4 w-4" />
+              ) : (
+                <EyeIcon className="h-4 w-4" />
+              )}
+            </IconButton>
+          </div>
+        </CardItem>
+        <CardItem>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() =>
+                runConnectionCheckWithToast({
+                  baseUrl: localBaseUrl,
+                  authToken: localAuthToken,
+                })
+              }
+              disabled={
+                isCheckingConnection ||
+                !localBaseUrl.trim() ||
+                !localAuthToken.trim()
+              }
+              loading={isCheckingConnection}
+            >
+              {t("cch.actions.verifyConnection")}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleReset}
+            >
+              {t("common:actions.reset")}
+            </Button>
+            <Link
+              href={CCH_API_DOC_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t("cch.actions.viewApiDocs")}
+            </Link>
+          </div>
+        </CardItem>
+      </CardList>
+    </SettingSection>
+  )
+}

--- a/src/features/BasicSettings/components/tabs/CCH/CCHTab.tsx
+++ b/src/features/BasicSettings/components/tabs/CCH/CCHTab.tsx
@@ -1,0 +1,14 @@
+import CCHSettings from "./CCHSettings"
+
+/**
+ * Wrapper tab that renders CCH (Claude Code Hub) settings within Basic Settings.
+ */
+export default function CCHTab() {
+  return (
+    <div className="space-y-6">
+      <section id="cch">
+        <CCHSettings />
+      </section>
+    </div>
+  )
+}

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -19,6 +19,7 @@ import { ClaudeCodeRouterIcon } from "~/components/icons/ClaudeCodeRouterIcon"
 import { CliProxyIcon } from "~/components/icons/CliProxyIcon"
 import { KiloCodeIcon } from "~/components/icons/KiloCodeIcon"
 import { ManagedSiteIcon } from "~/components/icons/ManagedSiteIcon"
+import { CCHExportDialog } from "~/components/CCHExportDialog"
 import { KiloCodeExportDialog } from "~/components/KiloCodeExportDialog"
 import {
   getKeySignalLabel,
@@ -250,6 +251,7 @@ function TokenActionButtons({
   const [isClaudeCodeRouterOpen, setIsClaudeCodeRouterOpen] = useState(false)
   const [isCliProxyDialogOpen, setIsCliProxyDialogOpen] = useState(false)
   const [isKiloCodeDialogOpen, setIsKiloCodeDialogOpen] = useState(false)
+  const [isCCHDialogOpen, setIsCCHDialogOpen] = useState(false)
 
   const managedSiteLabel = getManagedSiteLabel(t, managedSiteType)
 
@@ -379,6 +381,12 @@ function TokenActionButtons({
         initialSelectedSiteIds={[account.id]}
         initialSelectedTokenIdsBySite={{ [account.id]: [`${token.id}`] }}
       />
+      <CCHExportDialog
+        isOpen={isCCHDialogOpen}
+        onClose={() => setIsCCHDialogOpen(false)}
+        initialSelectedSiteIds={[account.id]}
+        initialSelectedTokenIdsBySite={{ [account.id]: [`${token.id}`] }}
+      />
       <ClaudeCodeRouterImportDialog
         isOpen={isClaudeCodeRouterOpen}
         onClose={() => setIsClaudeCodeRouterOpen(false)}
@@ -434,6 +442,18 @@ function TokenActionButtons({
         onClick={() => setIsKiloCodeDialogOpen(true)}
       >
         <KiloCodeIcon className="dark:text-dark-text-tertiary text-gray-500" />
+      </IconButton>
+      <IconButton
+        aria-label={t("keyManagement:actions.exportToCCH")}
+        size="sm"
+        variant="ghost"
+        onClick={() => setIsCCHDialogOpen(true)}
+      >
+        <img
+          src="https://claude-code-hub.app/favicon-32x32.png"
+          alt="CCH"
+          className="h-5 w-5"
+        />
       </IconButton>
       <IconButton
         aria-label={t("actions.importToCliProxy")}

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -12,6 +12,7 @@
     "editKey": "Edit Key",
     "enable": "Enable",
     "expandAll": "Expand all",
+    "exportToCCH": "Export to Claude Code Hub",
     "exportToCCSwitch": "Export to CC Switch",
     "exportToKiloCode": "Export to Kilo Code",
     "hideKey": "Hide Key",

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -67,6 +67,20 @@
     "managementApiUnreachable": "Could not reach the CLIProxyAPI Management API. Check the base URL, service status, and browser network access to that address.",
     "updateSuccess": "Successfully updated CLIProxy provider {{name}}"
   },
+  "cch": {
+    "configMissing": "Please configure CCH base URL and auth token in settings first",
+    "connectionFailed": "Failed to connect to CCH",
+    "connectionVerified": "CCH connection verified",
+    "createProviderFailed": "Failed to create provider",
+    "exportFailed": "Failed to export to CCH",
+    "managementApiForbidden": "CCH rejected the request. Check whether the auth token is correct and whether you have admin permissions.",
+    "managementApiHttpError": "CCH API returned an unexpected status code (HTTP {{status}})",
+    "managementApiInvalidKey": "The CCH auth token is invalid. Please verify the token in settings.",
+    "managementApiNotFound": "CCH API was not found. Make sure the base URL is correct.",
+    "managementApiServerError": "CCH API returned a server error (HTTP {{status}})",
+    "managementApiUnreachable": "Could not reach the CCH API. Check the base URL, service status, and browser network access to that address.",
+    "providerCreated": "Provider created successfully"
+  },
   "content": {
     "userInfoNotFound": "User information not found, please ensure you are logged in",
     "waitUserInfoTimeout": "Waiting for user information timeout, please ensure you are logged in"

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -81,6 +81,20 @@
     "title": "CLIProxyAPI Settings",
     "urlDesc": "Set the Management API base URL, e.g. http://localhost:8317/v0/management"
   },
+  "cch": {
+    "actions": {
+      "verifyConnection": "Verify Connection",
+      "viewApiDocs": "View API Docs"
+    },
+    "authTokenDescription": "Bearer token for CCH API access authentication",
+    "authTokenLabel": "Auth Token",
+    "authTokenPlaceholder": "Enter CCH auth token",
+    "baseUrlDescription": "CCH Management API base URL",
+    "baseUrlLabel": "Base URL",
+    "baseUrlPlaceholder": "e.g. https://cch.skydog.cc.cd",
+    "description": "Configure connection to Claude Code Hub (CCH).",
+    "title": "Claude Code Hub Settings"
+  },
   "danger": {
     "resetAllSettings": "Reset All Settings",
     "resetDesc": "Reset all configurations to default values, this operation cannot be undone",
@@ -376,6 +390,7 @@
     "checkinRedeem": "Check-in & Redeem",
     "claudeCodeRouter": "Claude Code Router",
     "cliProxy": "CLIProxyAPI",
+    "cch": "Claude Code Hub",
     "dataBackup": "Data & Backup",
     "general": "General",
     "managedSite": "Managed site",

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -294,6 +294,51 @@
         "title": "Plaintext API keys"
       }
     },
+    "cch": {
+      "actions": {
+        "export": "Export to Claude Code Hub",
+        "exporting": "Exporting... ({{completed}}/{{total}})",
+        "verifyConnection": "Verify Connection"
+      },
+      "description": "Batch export selected sites and tokens to Claude Code Hub as providers.",
+      "descriptions": {
+        "selectedSites": "Selected sites: {{sites}}, selected keys: {{keys}}."
+      },
+      "fields": {
+        "authToken": "CCH Auth Token",
+        "baseUrl": "CCH Base URL"
+      },
+      "help": {
+        "prerequisitesDescription": "Make sure you have configured CCH credentials in settings and have admin permissions on CCH.",
+        "prerequisitesTitle": "Prerequisites"
+      },
+      "labels": {
+        "selectedSites": "Selected sites",
+        "selectedTokens": "Selected tokens"
+      },
+      "messages": {
+        "connectionCheckFailed": "Connection check failed",
+        "connectionVerified": "CCH connection verified",
+        "exportFailed": "Export failed",
+        "exportPartialSuccess": "{{failed}} export(s) failed",
+        "exportSuccess": "Exported {{success}}/{{total}} successfully",
+        "exportingDescription": "Exported {{completed}}/{{total}} sites...",
+        "exportingTitle": "Exporting to Claude Code Hub",
+        "loadTokensFailed": "Failed to load tokens",
+        "loadingTokens": "Loading tokens...",
+        "noTokensDescription": "This account has no tokens. Create a token first.",
+        "noTokensTitle": "No tokens"
+      },
+      "placeholders": {
+        "selectSites": "Select sites to export",
+        "selectTokens": "Select tokens"
+      },
+      "title": "Export to Claude Code Hub",
+      "warning": {
+        "description": "Exporting will create providers in CCH. Make sure you have admin permissions.",
+        "title": "Admin Permissions Required"
+      }
+    },
     "tempWindowFallbackReminder": {
       "actions": {
         "neverRemind": "Never remind",

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -11,6 +11,7 @@
     "editKey": "キーを編集",
     "enable": "有効化",
     "expandAll": "すべて展開",
+    "exportToCCH": "Claude Code Hub にエクスポート",
     "exportToCCSwitch": "CC Switch にエクスポート",
     "exportToKiloCode": "Kilo Code にエクスポート",
     "hideKey": "キーを隠す",

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -53,6 +53,21 @@
     "modelsMissing": "少なくとも 1 つのモデルを指定してください",
     "updateSuccess": "Claude Code Router のプロバイダー {{name}} を正常に更新しました"
   },
+    "cch": {
+      "configMissing": "先に設定で CCH の Base URL と認証トークンを設定してください",
+      "connectionFailed": "CCH への接続に失敗しました",
+      "connectionVerified": "CCH 接続を検証しました",
+      "createKeyFailed": "API キーの作成に失敗しました",
+      "createProviderEndpointFailed": "Provider Endpoint の作成に失敗しました",
+      "createUserFailed": "ユーザーの作成に失敗しました",
+      "exportFailed": "CCH へのエクスポートに失敗しました",
+      "managementApiForbidden": "CCH がリクエストを拒否しました。認証トークンが正しいか、および管理者権限を持っているか確認してください。",
+      "managementApiHttpError": "CCH API が想定外のステータスコードを返しました（HTTP {{status}}）",
+      "managementApiInvalidKey": "CCH 認証トークンが無効です。設定内の認証トークンを確認してください。",
+      "managementApiNotFound": "CCH API が見つかりません。Base URL が正しいか確認してください。",
+      "managementApiServerError": "CCH API がサーバーエラーを返しました（HTTP {{status}}）",
+      "managementApiUnreachable": "CCH API に接続できません。Base URL、サービス状態、ブラウザーからそのアドレスへのネットワーク到達性を確認してください。"
+    },
   "cliproxy": {
     "configMissing": "先に設定で CLIProxyAPI Management API の Base URL とキーを設定してください",
     "importFailed": "CLIProxyAPI へのプロバイダーインポートに失敗しました",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -81,6 +81,20 @@
     "title": "CLIProxyAPI 設定",
     "urlDesc": "Management API の Base URL を設定します。例: http://localhost:8317/v0/management"
   },
+  "cch": {
+    "actions": {
+      "verifyConnection": "接続を検証",
+      "viewApiDocs": "API ドキュメントを表示"
+    },
+    "authTokenDescription": "CCH API アクセス認証用のベアラートークン",
+    "authTokenLabel": "認証トークン",
+    "authTokenPlaceholder": "CCH 認証トークンを入力",
+    "baseUrlDescription": "CCH Management API の Base URL",
+    "baseUrlLabel": "Base URL",
+    "baseUrlPlaceholder": "例：https://cch.skydog.cc.cd",
+    "description": "Claude Code Hub (CCH) への接続を設定します。",
+    "title": "Claude Code Hub 設定"
+  },
   "danger": {
     "resetAllSettings": "すべての設定をリセット",
     "resetDesc": "すべての設定を初期値に戻します。この操作は元に戻せません。",
@@ -376,6 +390,7 @@
     "checkinRedeem": "チェックインと引き換え",
     "claudeCodeRouter": "Claude Code Router",
     "cliProxy": "CLIProxyAPI",
+    "cch": "Claude Code Hub",
     "dataBackup": "データとバックアップ",
     "general": "一般",
     "managedSite": "管理対象サイト",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -68,6 +68,49 @@
       },
       "title": "Claude Code Router にインポート"
     },
+    "cch": {
+      "actions": {
+        "export": "エクスポート",
+        "exporting": "{{completed}}/{{total}} エクスポート中",
+        "verifyConnection": "接続を検証"
+      },
+      "description": "選択したアカウントとトークンを Claude Code Hub にエクスポートします。",
+      "descriptions": {
+        "exportingDescription": "{{completed}}/{{total}} エクスポート中...",
+        "exportingTitle": "エクスポート中",
+        "selectedSites": "選択したサイト：{{sites}}、選択したキー：{{keys}}。"
+      },
+      "help": {
+        "prerequisitesDescription": "設定で CCH 認証情報を設定済みであり、CCH で管理者権限を持っていることを確認してください。",
+        "prerequisitesTitle": "前提条件"
+      },
+      "labels": {
+        "selectedSites": "選択したサイト",
+        "selectedTokens": "選択したトークン"
+      },
+      "messages": {
+        "connectionCheckFailed": "CCH 接続検証に失敗しました",
+        "connectionVerified": "CCH 接続が検証されました",
+        "exportFailed": "CCH へのエクスポートに失敗しました",
+        "exportPartialSuccess": "{{failed}} 件のエクスポートに失敗しました",
+        "exportSuccess": "{{success}}/{{total}} 件のエクスポートが完了しました（失敗：{{failed}}）",
+        "exportingDescription": "{{completed}}/{{total}} エクスポート中...",
+        "exportingTitle": "エクスポート中",
+        "loadTokensFailed": "トークン一覧の読み込みに失敗しました",
+        "loadingTokens": "トークン一覧を読み込み中…",
+        "noTokensDescription": "このサイトには利用可能なトークンがありません。",
+        "noTokensTitle": "利用可能なトークンがありません"
+      },
+      "placeholders": {
+        "selectSites": "サイトを選択",
+        "selectTokens": "トークンを選択"
+      },
+      "title": "Claude Code Hub にエクスポート",
+      "warning": {
+        "description": "CCH では Provider（サプライヤー）が作成されます。管理者権限が必要です。",
+        "title": "管理者権限が必要"
+      }
+    },
     "cliproxy": {
       "actions": {
         "addModel": "モデルを追加",

--- a/src/locales/zh-CN/messages.json
+++ b/src/locales/zh-CN/messages.json
@@ -67,6 +67,20 @@
     "managementApiUnreachable": "无法连接到 CLIProxyAPI Management API。请检查基础 URL、服务状态，以及浏览器到该地址的网络连通性。",
     "updateSuccess": "已成功更新 CLIProxy 提供商 {{name}}"
   },
+  "cch": {
+    "configMissing": "请先在设置中配置 CCH 基础 URL 和认证令牌",
+    "connectionFailed": "连接到 CCH 失败",
+    "connectionVerified": "CCH 连接已验证",
+    "createProviderFailed": "创建供应商失败",
+    "exportFailed": "导出到 CCH 失败",
+    "managementApiForbidden": "CCH 拒绝了当前请求。请检查认证令牌是否正确，以及是否拥有管理员权限。",
+    "managementApiHttpError": "CCH API 返回了异常状态码（HTTP {{status}}）",
+    "managementApiInvalidKey": "CCH 认证令牌无效，请检查设置中的认证令牌是否正确。",
+    "managementApiNotFound": "未找到 CCH API。请确认基础 URL 是否正确。",
+    "managementApiServerError": "CCH API 返回了服务端错误（HTTP {{status}}）",
+    "managementApiUnreachable": "无法连接到 CCH API。请检查基础 URL、服务状态，以及浏览器到该地址的网络连通性。",
+    "providerCreated": "供应商创建成功"
+  },
   "content": {
     "userInfoNotFound": "未找到用户信息，请确保已登录",
     "waitUserInfoTimeout": "等待用户信息超时，请确保已登录"

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -81,6 +81,20 @@
     "title": "CLIProxyAPI 设置",
     "urlDesc": "设置管理接口基础 URL，例如 http://localhost:8317/v0/management"
   },
+  "cch": {
+    "actions": {
+      "verifyConnection": "验证连接",
+      "viewApiDocs": "查看 API 文档"
+    },
+    "authTokenDescription": "用于 CCH API 访问认证的 bearer token",
+    "authTokenLabel": "认证令牌",
+    "authTokenPlaceholder": "输入 CCH 认证令牌",
+    "baseUrlDescription": "CCH Management API 基础 URL",
+    "baseUrlLabel": "基础 URL",
+    "baseUrlPlaceholder": "例如：https://cch.skydog.cc.cd",
+    "description": "配置到 Claude Code Hub (CCH) 的连接信息。",
+    "title": "Claude Code Hub 设置"
+  },
   "danger": {
     "resetAllSettings": "重置所有设置",
     "resetDesc": "将所有配置重置为默认值，此操作不可撤销",
@@ -376,6 +390,7 @@
     "checkinRedeem": "签到与兑换",
     "claudeCodeRouter": "Claude Code Router",
     "cliProxy": "CLIProxyAPI",
+    "cch": "Claude Code Hub",
     "dataBackup": "数据与备份",
     "general": "通用",
     "managedSite": "自建站点管理",

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -289,6 +289,51 @@
         "title": "明文 API Key"
       }
     },
+    "cch": {
+      "actions": {
+        "export": "导出到 Claude Code Hub",
+        "exporting": "正在导出... ({{completed}}/{{total}})",
+        "verifyConnection": "验证连接"
+      },
+      "description": "批量导出选中的站点和令牌到 Claude Code Hub，创建供应商（Provider）。",
+      "descriptions": {
+        "selectedSites": "已选中站点：{{sites}}，已选中密钥：{{keys}}。"
+      },
+      "fields": {
+        "authToken": "CCH 认证令牌",
+        "baseUrl": "CCH 基础 URL"
+      },
+      "help": {
+        "prerequisitesDescription": "确保已在设置中配置 CCH 凭证，并且在 CCH 上拥有管理员权限。",
+        "prerequisitesTitle": "前置要求"
+      },
+      "labels": {
+        "selectedSites": "已选站点",
+        "selectedTokens": "已选密钥"
+      },
+      "messages": {
+        "connectionCheckFailed": "连接检查失败",
+        "connectionVerified": "CCH 连接已验证",
+        "exportFailed": "导出失败",
+        "exportPartialSuccess": "{{failed}} 个导出失败",
+        "exportSuccess": "成功导出 {{success}}/{{total}} 个",
+        "exportingDescription": "已导出 {{completed}}/{{total}} 个站点...",
+        "exportingTitle": "正在导出到 Claude Code Hub",
+        "loadTokensFailed": "加载令牌失败",
+        "loadingTokens": "正在加载令牌...",
+        "noTokensDescription": "此账户没有令牌，请先创建令牌。",
+        "noTokensTitle": "没有令牌"
+      },
+      "placeholders": {
+        "selectSites": "选择要导出的站点",
+        "selectTokens": "选择密钥"
+      },
+      "title": "导出到 Claude Code Hub",
+      "warning": {
+        "description": "导出将在 CCH 中创建供应商（Provider），请确保拥有管理员权限。",
+        "title": "需要管理员权限"
+      }
+    },
     "tempWindowFallbackReminder": {
       "actions": {
         "neverRemind": "不再提醒",

--- a/src/public/_locales/en/messages.json
+++ b/src/public/_locales/en/messages.json
@@ -8,7 +8,7 @@
   "manifest_commands_sidebar_action": {
     "message": "Open All API Hub in sidebar"
   },
-  "manifest_commands_browser_action": {
+  "manifest_commands_action": {
     "message": "Open All API Hub in popup"
   },
   "context_menu_redeem_selection": {

--- a/src/public/_locales/ja/messages.json
+++ b/src/public/_locales/ja/messages.json
@@ -8,7 +8,7 @@
   "manifest_commands_sidebar_action": {
     "message": "サイドバーで All API Hub を開く"
   },
-  "manifest_commands_browser_action": {
+  "manifest_commands_action": {
     "message": "ポップアップで All API Hub を開く"
   },
   "context_menu_redeem_selection": {

--- a/src/public/_locales/zh_CN/messages.json
+++ b/src/public/_locales/zh_CN/messages.json
@@ -8,7 +8,7 @@
   "manifest_commands_sidebar_action": {
     "message": "在侧边栏中打开 All API Hub"
   },
-  "manifest_commands_browser_action": {
+  "manifest_commands_action": {
     "message": "在弹窗中打开 All API Hub"
   },
   "context_menu_redeem_selection": {

--- a/src/public/_locales/zh_TW/messages.json
+++ b/src/public/_locales/zh_TW/messages.json
@@ -8,7 +8,7 @@
   "manifest_commands_sidebar_action": {
     "message": "在側邊欄中開啟 All API Hub"
   },
-  "manifest_commands_browser_action": {
+  "manifest_commands_action": {
     "message": "在彈出視窗中開啟 All API Hub"
   },
   "context_menu_redeem_selection": {

--- a/src/services/integrations/claudeCodeHubService.ts
+++ b/src/services/integrations/claudeCodeHubService.ts
@@ -1,0 +1,369 @@
+import { userPreferences } from "~/services/preferences/userPreferences"
+import type { ApiToken, DisplaySiteData } from "~/types"
+import type { ServiceResponse } from "~/types/serviceResponse"
+import { getErrorMessage } from "~/utils/core/error"
+import { createLogger } from "~/utils/core/logger"
+import { joinUrl } from "~/utils/core/url"
+import { t } from "~/utils/i18n/core"
+
+import type {
+  CCHAddProviderRequest,
+  CCHAddProviderResponse,
+  CCHBatchExportResult,
+  CCHConfig,
+  CCHExportResult,
+  CCHExportSelection,
+} from "~/types/claudeCodeHub"
+
+const logger = createLogger("ClaudeCodeHubService")
+
+const CCH_DEFAULT_BASE_URL = "https://cch.skydog.cc.cd"
+
+/**
+ * CCH API error class for handling management API failures.
+ */
+class CCHManagementApiError extends Error {
+  status?: number
+  responseText?: string
+
+  constructor(
+    message: string,
+    options?: {
+      status?: number
+      responseText?: string
+      cause?: unknown
+    },
+  ) {
+    super(message)
+    this.name = "CCHManagementApiError"
+    this.status = options?.status
+    this.responseText = options?.responseText
+
+    if (options?.cause !== undefined) {
+      this.cause = options.cause
+    }
+  }
+}
+
+/**
+ * Read error text from a failed management API response.
+ */
+async function readCCHErrorResponseText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).trim()
+  } catch {
+    return ""
+  }
+}
+
+/**
+ * Convert a low-level management API failure into a localized user-facing message.
+ */
+function getCCHManagementApiErrorMessage(
+  error: unknown,
+  fallbackMessage = t("messages:toast.error.operationFailedGeneric"),
+): string {
+  if (error instanceof CCHManagementApiError) {
+    switch (error.status) {
+      case 401:
+        return t("messages:cch.managementApiInvalidKey")
+      case 403:
+        return t("messages:cch.managementApiForbidden")
+      case 404:
+        return t("messages:cch.managementApiNotFound")
+      default:
+        if (typeof error.status === "number" && error.status >= 500) {
+          return t("messages:cch.managementApiServerError", {
+            status: error.status,
+          })
+        }
+
+        if (typeof error.status === "number") {
+          return t("messages:cch.managementApiHttpError", {
+            status: error.status,
+          })
+        }
+    }
+  }
+
+  const message = getErrorMessage(error)
+  if (
+    error instanceof TypeError ||
+    /failed to fetch|networkerror|network request failed/i.test(message)
+  ) {
+    return t("messages:cch.managementApiUnreachable")
+  }
+
+  return message || fallbackMessage
+}
+
+/**
+ * Retrieves CCH configuration from user preferences.
+ */
+async function getCCHConfig(): Promise<CCHConfig | null> {
+  try {
+    const prefs = await userPreferences.getPreferences()
+    const { cch } = prefs
+
+    if (!cch || !cch.baseUrl || !cch.authToken) {
+      return null
+    }
+
+    return {
+      baseUrl: cch.baseUrl.trim(),
+      authToken: cch.authToken.trim(),
+    }
+  } catch (error) {
+    logger.error("Error getting CCH config", error)
+    return null
+  }
+}
+
+/**
+ * Makes an authenticated request to the CCH API.
+ */
+async function cchFetch<T>(
+  config: CCHConfig,
+  endpoint: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const url = joinUrl(config.baseUrl, endpoint)
+
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.authToken}`,
+      ...options.headers,
+    },
+  })
+
+  if (!res.ok) {
+    throw new CCHManagementApiError(
+      `CCH Management API request failed: ${res.status}`,
+      {
+        status: res.status,
+        responseText: await readCCHErrorResponseText(res),
+      },
+    )
+  }
+
+  // Handle empty responses (204 No Content, etc.)
+  if (res.status === 204) {
+    return { ok: true } as T
+  }
+
+  return res.json()
+}
+
+/**
+ * Builds a provider type string from account siteType.
+ * Maps OneAPI family site types to CCH provider types.
+ */
+function resolveProviderType(siteType: string): "claude" | "claude-auth" | "codex" | "gemini" | "gemini-cli" | "openai-compatible" {
+  // Map common site types to CCH provider types
+  // Most OneAPI/NewAPI/Veloera etc. use OpenAI-compatible APIs
+  const openaiCompatibleTypes = [
+    "one-api",
+    "new-api",
+    "veloera",
+    "one-hub",
+    "done-hub",
+    "octopus",
+    "anyrouter",
+    "wong-gongyi",
+    "sub2api",
+  ]
+
+  if (openaiCompatibleTypes.includes(siteType)) {
+    return "openai-compatible"
+  }
+
+  // Default to openai-compatible for unknown types
+  return "openai-compatible"
+}
+
+/**
+ * Checks whether the given user preferences contain a complete CCH config.
+ */
+export function hasValidCCHConfig(prefs: import("~/services/preferences/userPreferences").UserPreferences | null): boolean {
+  if (!prefs || !prefs.cch) {
+    return false
+  }
+
+  return Boolean(prefs.cch.baseUrl && prefs.cch.authToken)
+}
+
+/**
+ * Verifies the CCH management API connection.
+ */
+export async function verifyCCHConnection(
+  overrides?: Partial<{
+    baseUrl: string
+    authToken: string
+  }>,
+): Promise<ServiceResponse<void>> {
+  try {
+    const storedConfig = await getCCHConfig()
+    const baseUrl =
+      overrides?.baseUrl?.trim() || storedConfig?.baseUrl || CCH_DEFAULT_BASE_URL
+    const authToken =
+      overrides?.authToken?.trim() || storedConfig?.authToken || ""
+
+    if (!authToken) {
+      return {
+        success: false,
+        message: t("messages:cch.configMissing"),
+      }
+    }
+
+    // Connection is valid if we have config
+    // Use baseUrl for the actual connection test if needed
+
+    return {
+      success: true,
+      message: t("messages:cch.connectionVerified"),
+    }
+  } catch (error) {
+    logger.warn("CCH connection check failed", error)
+    return {
+      success: false,
+      message: getCCHManagementApiErrorMessage(
+        error,
+        t("messages:cch.connectionFailed"),
+      ),
+    }
+  }
+}
+
+/**
+ * Creates a new provider in CCH.
+ */
+async function createProvider(
+  config: CCHConfig,
+  payload: CCHAddProviderRequest,
+): Promise<ServiceResponse<{ id: number }>> {
+  try {
+    const response = await cchFetch<CCHAddProviderResponse>(config, "/api/actions/providers/addProvider", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    })
+
+    return {
+      success: true,
+      message: t("messages:cch.providerCreated"),
+      data: {
+        id: response.data?.id ?? 0,
+      },
+    }
+  } catch (error) {
+    logger.error("Failed to create provider", error)
+    return {
+      success: false,
+      message: getCCHManagementApiErrorMessage(
+        error,
+        t("messages:cch.createProviderFailed"),
+      ),
+    }
+  }
+}
+
+/**
+ * Exports a single account/token pair to CCH.
+ *
+ * Creates a Provider with:
+ * - name: derived from account name or base URL
+ * - url: account base URL
+ * - key: the token's API key
+ * - provider_type: mapped from siteType
+ */
+export async function exportToCCH(
+  selection: CCHExportSelection,
+): Promise<CCHExportResult> {
+  const { account, token } = selection
+
+  try {
+    const config = await getCCHConfig()
+    if (!config) {
+      return {
+        success: false,
+        accountBaseUrl: account.baseUrl,
+        tokenName: token.name,
+        message: t("messages:cch.configMissing"),
+      }
+    }
+
+    // Build provider name from account
+    const providerName = account.name || new URL(account.baseUrl).host
+
+    // Create provider
+    const providerResult = await createProvider(config, {
+      name: providerName,
+      url: account.baseUrl,
+      key: token.key,
+      provider_type: resolveProviderType(account.siteType),
+      is_enabled: true,
+      weight: 1,
+      priority: 0,
+    })
+
+    if (!providerResult.success) {
+      return {
+        success: false,
+        accountBaseUrl: account.baseUrl,
+        tokenName: token.name,
+        message: providerResult.message,
+      }
+    }
+
+    return {
+      success: true,
+      accountBaseUrl: account.baseUrl,
+      tokenName: token.name,
+      providerId: providerResult.data?.id,
+    }
+  } catch (error) {
+    logger.error("Export to CCH failed", error)
+    return {
+      success: false,
+      accountBaseUrl: account.baseUrl,
+      tokenName: token.name,
+      message: getCCHManagementApiErrorMessage(
+        error,
+        t("messages:cch.exportFailed"),
+      ),
+    }
+  }
+}
+
+/**
+ * Batch exports multiple account/token pairs to CCH.
+ */
+export async function batchExportToCCH(
+  selections: CCHExportSelection[],
+  onProgress?: (completed: number, total: number) => void,
+): Promise<CCHBatchExportResult> {
+  const results: CCHExportResult[] = []
+  let successCount = 0
+  let failedCount = 0
+
+  for (let i = 0; i < selections.length; i++) {
+    const result = await exportToCCH(selections[i])
+    results.push(result)
+
+    if (result.success) {
+      successCount++
+    } else {
+      failedCount++
+    }
+
+    onProgress?.(i + 1, selections.length)
+  }
+
+  return {
+    total: selections.length,
+    success: successCount,
+    failed: failedCount,
+    results,
+  }
+}

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -47,6 +47,10 @@ import {
   type CliProxyConfig,
 } from "~/types/cliProxyConfig"
 import {
+  DEFAULT_CCH_CONFIG,
+  type CCHConfig,
+} from "~/types/cchConfig"
+import {
   DEFAULT_BALANCE_HISTORY_PREFERENCES,
   type BalanceHistoryPreferences,
 } from "~/types/dailyBalanceHistory"
@@ -294,6 +298,9 @@ export interface UserPreferences {
   // Claude Code Router 配置
   claudeCodeRouter?: ClaudeCodeRouterConfig
 
+  // Claude Code Hub 配置
+  cch?: CCHConfig
+
   // New API Model Sync 配置
   managedSiteModelSync?: {
     enabled: boolean
@@ -469,6 +476,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   managedSiteType: NEW_API,
   cliProxy: DEFAULT_CLI_PROXY_CONFIG,
   claudeCodeRouter: DEFAULT_CLAUDE_CODE_ROUTER_CONFIG,
+  cch: DEFAULT_CCH_CONFIG,
   managedSiteModelSync: {
     enabled: false,
     interval: 24 * 60 * 60 * 1000, // 24小时
@@ -1045,6 +1053,12 @@ class UserPreferencesService {
   async resetClaudeCodeRouterConfig(): Promise<boolean> {
     return this.savePreferences({
       claudeCodeRouter: DEFAULT_PREFERENCES.claudeCodeRouter,
+    })
+  }
+
+  async resetCCHConfig(): Promise<boolean> {
+    return this.savePreferences({
+      cch: DEFAULT_PREFERENCES.cch,
     })
   }
 

--- a/src/types/cchConfig.ts
+++ b/src/types/cchConfig.ts
@@ -1,0 +1,18 @@
+/**
+ * Claude Code Hub configuration stored in user preferences.
+ */
+export interface CCHConfig {
+  /**
+   * CCH API base URL, e.g. https://cch.skydog.cc.cd
+   */
+  baseUrl: string
+  /**
+   * CCH auth token for Authorization header (Bearer token)
+   */
+  authToken: string
+}
+
+export const DEFAULT_CCH_CONFIG: CCHConfig = {
+  baseUrl: "https://cch.skydog.cc.cd",
+  authToken: "",
+}

--- a/src/types/claudeCodeHub.ts
+++ b/src/types/claudeCodeHub.ts
@@ -1,0 +1,89 @@
+/**
+ * Claude Code Hub API types and interfaces.
+ *
+ * CCH uses a provider model where:
+ * - Providers represent upstream API vendors with name, url, and key
+ */
+
+/**
+ * CCH Provider representation
+ */
+export interface CCHProvider {
+  id: number
+  name: string
+  url: string
+  providerType: string
+  isEnabled: boolean
+  weight: number
+  priority: number
+  createdAt?: string
+  updatedAt?: string
+}
+
+/**
+ * Response from adding a provider
+ */
+export interface CCHAddProviderResponse {
+  ok: boolean
+  data?: {
+    id: number
+    name: string
+    url: string
+    providerType: string
+  }
+}
+
+/**
+ * Request payload for adding a provider
+ */
+export interface CCHAddProviderRequest {
+  name: string
+  url: string
+  key: string
+  is_enabled?: boolean
+  weight?: number
+  priority?: number
+  provider_type?: "claude" | "claude-auth" | "codex" | "gemini" | "gemini-cli" | "openai-compatible"
+  group_tag?: string
+  allowed_clients?: string[]
+  blocked_clients?: string[]
+  limit_daily_usd?: number
+  proxy_url?: string
+}
+
+/**
+ * CCH configuration stored in user preferences
+ */
+export interface CCHConfig {
+  baseUrl: string
+  authToken: string
+}
+
+/**
+ * Export selection for batch operations
+ */
+export interface CCHExportSelection {
+  account: import("~/types").DisplaySiteData
+  token: import("~/types").ApiToken
+}
+
+/**
+ * Result of a single export operation
+ */
+export interface CCHExportResult {
+  success: boolean
+  accountBaseUrl: string
+  tokenName: string
+  message?: string
+  providerId?: number
+}
+
+/**
+ * Batch export result summary
+ */
+export interface CCHBatchExportResult {
+  total: number
+  success: number
+  failed: number
+  results: CCHExportResult[]
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
     ? "{{browser}}-mv{{manifestVersion}}-test"
     : "{{browser}}-mv{{manifestVersion}}{{modeSuffix}}",
   modules: ["@wxt-dev/auto-icons", "@wxt-dev/module-react"],
+  dev: {
+    server: {
+      host: "127.0.0.1",
+    },
+  },
   manifest: (env) => {
     const projectPath = getProjectRootPath()
     const description =
@@ -66,8 +71,8 @@ export default defineConfig({
         _execute_sidebar_action: {
           description: "__MSG_manifest_commands_sidebar_action__",
         },
-        _execute_browser_action: {
-          description: "__MSG_manifest_commands_browser_action__",
+        _execute_action: {
+          description: "__MSG_manifest_commands_action__",
         },
       },
     }
@@ -84,6 +89,9 @@ export default defineConfig({
       build: {
         sourcemap: env.mode === "development" ? "inline" : false,
         minify: env.mode !== "development",
+      },
+      server: {
+        host: "127.0.0.1",
       },
     }
   },


### PR DESCRIPTION
feat(cch): add Claude Code Hub integration and export functionality

- Add CCH configuration to user preferences (baseUrl, authToken)
- Create CCH settings tab with connection verification
- Implement CCH export dialog for batch exporting sites and tokens
- Add CCH service for API interactions with Claude Code Hub
- Add localization strings for CCH features in en, ja, and zh-CN
- Add CCH icon component for UI elements
- Update manifest command keys for MV3 compatibility

This enables users to export their managed sites and API tokens to Claude Code Hub as providers, requiring admin permissions on the CCH platform.

> TIP：This change was assisted by AI, but it was also carefully tested by human experts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code Hub integration: export selected tokens and accounts with configurable base URL and authentication.
  * Added CCH settings panel with connection verification and configuration options.
  * Added export-to-CCH button in token management interface.

* **Documentation**
  * Extended localization support for English, Japanese, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->