### PR TITLE
feat: Unify warning toasts and add follow-up actions for partial-success states

### DIFF
--- a/src/components/ThemeAwareToaster.tsx
+++ b/src/components/ThemeAwareToaster.tsx
@@ -2,6 +2,7 @@ import { XMarkIcon } from "@heroicons/react/24/outline"
 import type { CSSProperties } from "react"
 import toast, { ToastBar, Toaster } from "react-hot-toast"
 
+import { getThemeAwareToastStyles } from "~/components/toast/themeAwareToastStyles"
 import { useTheme } from "~/contexts/ThemeContext"
 
 interface ThemeAwareToasterProps {
@@ -25,21 +26,6 @@ export const ThemeAwareToaster = ({
 }: ThemeAwareToasterProps) => {
   const { resolvedTheme } = useTheme()
 
-  const getToastStyles = () => {
-    if (resolvedTheme === "dark") {
-      return {
-        background: "#1e293b",
-        color: "#f1f5f9",
-        border: "1px solid #334155",
-      }
-    }
-    return {
-      background: "#fff",
-      color: "#363636",
-      border: "1px solid #e5e7eb",
-    }
-  }
-
   return (
     <Toaster
       position={position}
@@ -50,7 +36,7 @@ export const ThemeAwareToaster = ({
       toastOptions={{
         className: "rounded-lg shadow-lg",
         duration: 4000,
-        style: getToastStyles(),
+        style: getThemeAwareToastStyles(resolvedTheme),
         success: {
           duration: 3000,
           iconTheme: {

--- a/src/components/toast/WarningToast.tsx
+++ b/src/components/toast/WarningToast.tsx
@@ -1,0 +1,47 @@
+import { XMarkIcon } from "@heroicons/react/24/outline"
+import toast, { ToastBar, type Toast } from "react-hot-toast"
+
+import { useTheme } from "~/contexts/ThemeContext"
+
+import { getThemeAwareToastStyles } from "./themeAwareToastStyles"
+import { WarningToastIcon } from "./WarningToastIcon"
+
+interface WarningToastProps {
+  toastInstance: Toast
+  message: string
+}
+
+/**
+ * Shared warning toast UI for non-fatal states that still need user attention.
+ * Keeps the same rounded card / dismiss affordance as the default toaster while
+ * giving warning flows their own visual emphasis.
+ */
+export function WarningToast({ toastInstance, message }: WarningToastProps) {
+  const { resolvedTheme } = useTheme()
+
+  const warningToast: Toast = {
+    ...toastInstance,
+    className: [toastInstance.className, "rounded-lg shadow-lg"]
+      .filter(Boolean)
+      .join(" "),
+    style: {
+      ...getThemeAwareToastStyles(resolvedTheme),
+      ...toastInstance.style,
+    },
+    icon: <WarningToastIcon resolvedTheme={resolvedTheme} />,
+  }
+
+  return (
+    <ToastBar toast={{ ...warningToast, message }}>
+      {({ icon, message: renderedMessage }) => (
+        <>
+          {icon}
+          {renderedMessage}
+          <button type="button" onClick={() => toast.dismiss(toastInstance.id)}>
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </>
+      )}
+    </ToastBar>
+  )
+}

--- a/src/components/toast/WarningToast.tsx
+++ b/src/components/toast/WarningToast.tsx
@@ -45,8 +45,10 @@ export function WarningToast({
     setIsActionPending(true)
     try {
       await action.onClick()
-    } finally {
       toast.dismiss(toastInstance.id)
+    } catch {
+      // Keep the warning toast available so callers can surface retry/error UI.
+    } finally {
       setIsActionPending(false)
     }
   }
@@ -61,9 +63,7 @@ export function WarningToast({
             {action ? (
               <button
                 type="button"
-                onClick={() => {
-                  void handleActionClick()
-                }}
+                onClick={handleActionClick}
                 disabled={isActionPending}
                 className="w-fit text-sm font-medium text-blue-600 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60 dark:text-blue-400"
               >
@@ -71,7 +71,11 @@ export function WarningToast({
               </button>
             ) : null}
           </div>
-          <button type="button" onClick={() => toast.dismiss(toastInstance.id)}>
+          <button
+            type="button"
+            aria-label="Close notification"
+            onClick={() => toast.dismiss(toastInstance.id)}
+          >
             <XMarkIcon className="h-4 w-4" />
           </button>
         </>

--- a/src/components/toast/WarningToast.tsx
+++ b/src/components/toast/WarningToast.tsx
@@ -1,14 +1,17 @@
 import { XMarkIcon } from "@heroicons/react/24/outline"
+import { useState } from "react"
 import toast, { ToastBar, type Toast } from "react-hot-toast"
 
 import { useTheme } from "~/contexts/ThemeContext"
 
 import { getThemeAwareToastStyles } from "./themeAwareToastStyles"
+import type { WarningToastAction } from "./types"
 import { WarningToastIcon } from "./WarningToastIcon"
 
 interface WarningToastProps {
   toastInstance: Toast
   message: string
+  action?: WarningToastAction
 }
 
 /**
@@ -16,8 +19,13 @@ interface WarningToastProps {
  * Keeps the same rounded card / dismiss affordance as the default toaster while
  * giving warning flows their own visual emphasis.
  */
-export function WarningToast({ toastInstance, message }: WarningToastProps) {
+export function WarningToast({
+  toastInstance,
+  message,
+  action,
+}: WarningToastProps) {
   const { resolvedTheme } = useTheme()
+  const [isActionPending, setIsActionPending] = useState(false)
 
   const warningToast: Toast = {
     ...toastInstance,
@@ -31,12 +39,38 @@ export function WarningToast({ toastInstance, message }: WarningToastProps) {
     icon: <WarningToastIcon resolvedTheme={resolvedTheme} />,
   }
 
+  const handleActionClick = async () => {
+    if (!action || isActionPending) return
+
+    setIsActionPending(true)
+    try {
+      await action.onClick()
+    } finally {
+      toast.dismiss(toastInstance.id)
+      setIsActionPending(false)
+    }
+  }
+
   return (
     <ToastBar toast={{ ...warningToast, message }}>
       {({ icon, message: renderedMessage }) => (
         <>
           {icon}
-          {renderedMessage}
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="min-w-0">{renderedMessage}</div>
+            {action ? (
+              <button
+                type="button"
+                onClick={() => {
+                  void handleActionClick()
+                }}
+                disabled={isActionPending}
+                className="w-fit text-sm font-medium text-blue-600 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60 dark:text-blue-400"
+              >
+                {action.label}
+              </button>
+            ) : null}
+          </div>
           <button type="button" onClick={() => toast.dismiss(toastInstance.id)}>
             <XMarkIcon className="h-4 w-4" />
           </button>

--- a/src/components/toast/WarningToastIcon.tsx
+++ b/src/components/toast/WarningToastIcon.tsx
@@ -1,0 +1,23 @@
+import { ExclamationTriangleIcon } from "@heroicons/react/24/solid"
+
+interface WarningToastIconProps {
+  resolvedTheme?: string
+}
+
+/**
+ * Shared warning icon used by both the custom warning toast and its runtime
+ * fallback path so warning feedback keeps one visual source of truth.
+ */
+export function WarningToastIcon({ resolvedTheme }: WarningToastIconProps) {
+  return (
+    <div className="flex min-w-5 items-center justify-center">
+      <ExclamationTriangleIcon
+        className={
+          resolvedTheme === "dark"
+            ? "h-5 w-5 text-amber-400"
+            : "h-5 w-5 text-amber-500"
+        }
+      />
+    </div>
+  )
+}

--- a/src/components/toast/themeAwareToastStyles.ts
+++ b/src/components/toast/themeAwareToastStyles.ts
@@ -1,5 +1,5 @@
 /**
- *
+ * Returns theme-aware styles for toast notifications based on the resolved theme.
  */
 export function getThemeAwareToastStyles(resolvedTheme?: string) {
   if (resolvedTheme === "dark") {

--- a/src/components/toast/themeAwareToastStyles.ts
+++ b/src/components/toast/themeAwareToastStyles.ts
@@ -1,0 +1,18 @@
+/**
+ *
+ */
+export function getThemeAwareToastStyles(resolvedTheme?: string) {
+  if (resolvedTheme === "dark") {
+    return {
+      background: "#1e293b",
+      color: "#f1f5f9",
+      border: "1px solid #334155",
+    }
+  }
+
+  return {
+    background: "#fff",
+    color: "#363636",
+    border: "1px solid #e5e7eb",
+  }
+}

--- a/src/components/toast/types.ts
+++ b/src/components/toast/types.ts
@@ -1,0 +1,4 @@
+export interface WarningToastAction {
+  label: string
+  onClick: () => void | Promise<void>
+}

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -53,6 +53,7 @@ import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
+import { showWarningToast } from "~/utils/core/toastHelpers"
 import { sanitizeOriginUrl } from "~/utils/core/url"
 import {
   openKeysPage,
@@ -340,7 +341,7 @@ export default function AccountActionButtons({
 
       if (!managedConfig) {
         openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        toast.success(t("actions.channelLocateConfigMissing"))
+        showWarningToast(t("actions.channelLocateConfigMissing"))
         return
       }
 
@@ -369,13 +370,13 @@ export default function AccountActionButtons({
 
       if (tokensResponse.length === 0) {
         openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        toast.success(t("actions.channelLocateNoKeyFallback"))
+        showWarningToast(t("actions.channelLocateNoKeyFallback"))
         return
       }
 
       if (tokensResponse.length > 1) {
         openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        toast.success(t("actions.channelLocateMultipleKeysFallback"))
+        showWarningToast(t("actions.channelLocateMultipleKeysFallback"))
         return
       }
 
@@ -410,7 +411,7 @@ export default function AccountActionButtons({
           },
         )
         openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        toast.success(t("actions.channelLocateInputPreparationFallback"))
+        showWarningToast(t("actions.channelLocateInputPreparationFallback"))
         return
       }
 
@@ -420,7 +421,7 @@ export default function AccountActionButtons({
 
       if (!searchBaseUrl || formData.models.length === 0) {
         openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        toast.success(t("actions.channelLocateInputPreparationFallback"))
+        showWarningToast(t("actions.channelLocateInputPreparationFallback"))
         return
       }
 

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -330,6 +330,10 @@ export default function AccountActionButtons({
     if (!normalizedAccountBaseUrl) {
       return
     }
+    const handleChannelLocateFallback = (message: string) => {
+      openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
+      showWarningToast(message)
+    }
 
     const secretsToRedact = new Set<string>(
       [site.token, site.cookieAuthSessionCookie].filter(Boolean) as string[],
@@ -340,9 +344,9 @@ export default function AccountActionButtons({
       const managedConfig = await service.getConfig()
 
       if (!managedConfig) {
-        openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        showWarningToast(t("actions.channelLocateConfigMissing"))
-        return
+        return handleChannelLocateFallback(
+          t("actions.channelLocateConfigMissing"),
+        )
       }
 
       if (managedConfig.token) {
@@ -369,15 +373,15 @@ export default function AccountActionButtons({
       }
 
       if (tokensResponse.length === 0) {
-        openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        showWarningToast(t("actions.channelLocateNoKeyFallback"))
-        return
+        return handleChannelLocateFallback(
+          t("actions.channelLocateNoKeyFallback"),
+        )
       }
 
       if (tokensResponse.length > 1) {
-        openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        showWarningToast(t("actions.channelLocateMultipleKeysFallback"))
-        return
+        return handleChannelLocateFallback(
+          t("actions.channelLocateMultipleKeysFallback"),
+        )
       }
 
       const apiToken = tokensResponse[0]
@@ -410,9 +414,9 @@ export default function AccountActionButtons({
             siteType: site.siteType,
           },
         )
-        openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        showWarningToast(t("actions.channelLocateInputPreparationFallback"))
-        return
+        return handleChannelLocateFallback(
+          t("actions.channelLocateInputPreparationFallback"),
+        )
       }
 
       const searchBaseUrl = normalizeManagedSiteChannelBaseUrl(
@@ -420,9 +424,9 @@ export default function AccountActionButtons({
       )
 
       if (!searchBaseUrl || formData.models.length === 0) {
-        openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        showWarningToast(t("actions.channelLocateInputPreparationFallback"))
-        return
+        return handleChannelLocateFallback(
+          t("actions.channelLocateInputPreparationFallback"),
+        )
       }
 
       const resolution = await resolveManagedSiteChannelMatch({

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -1011,14 +1011,15 @@ export function useAccountDialog({
       }
 
       const feedbackMessage =
-        result.message ??
-        (mode === DIALOG_MODES.ADD
-          ? t("messages.addSuccess", {
-              name: siteName,
-            })
-          : t("messages.updateSuccess", {
-              name: siteName,
-            }))
+        typeof result.message === "string" && result.message.trim().length > 0
+          ? result.message
+          : mode === DIALOG_MODES.ADD
+            ? t("messages.addSuccess", {
+                name: siteName,
+              })
+            : t("messages.updateSuccess", {
+                name: siteName,
+              })
 
       if (result.feedbackLevel === "warning") {
         const warningAccountId =

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -42,6 +42,7 @@ import {
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
+import { showWarningToast } from "~/utils/core/toastHelpers"
 import {
   normalizeUrlForOriginKey,
   tryParseOrigin,
@@ -1009,16 +1010,21 @@ export function useAccountDialog({
         throw new Error(result.message || t("messages.saveFailed"))
       }
 
-      toast.success(
+      const feedbackMessage =
         result.message ??
-          (mode === DIALOG_MODES.ADD
-            ? t("messages.addSuccess", {
-                name: siteName,
-              })
-            : t("messages.updateSuccess", {
-                name: siteName,
-              })),
-      )
+        (mode === DIALOG_MODES.ADD
+          ? t("messages.addSuccess", {
+              name: siteName,
+            })
+          : t("messages.updateSuccess", {
+              name: siteName,
+            }))
+
+      if (result.feedbackLevel === "warning") {
+        showWarningToast(feedbackMessage)
+      } else {
+        toast.success(feedbackMessage)
+      }
 
       if (
         siteType === SUB2API &&

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -1021,7 +1021,63 @@ export function useAccountDialog({
             }))
 
       if (result.feedbackLevel === "warning") {
-        showWarningToast(feedbackMessage)
+        const warningAccountId =
+          typeof result.accountId === "string" && result.accountId.trim()
+            ? result.accountId.trim()
+            : null
+
+        showWarningToast(feedbackMessage, {
+          action: warningAccountId
+            ? {
+                label: t("common:actions.refresh"),
+                onClick: async () => {
+                  const accountName =
+                    siteName.trim() ||
+                    t("messages:toast.success.accountSaveSuccess")
+                  const toastId = toast.loading(
+                    t("messages:toast.loading.refreshingAccount", {
+                      accountName,
+                    }),
+                  )
+
+                  try {
+                    const refreshResult = await accountStorage.refreshAccount(
+                      warningAccountId,
+                      true,
+                    )
+
+                    if (!refreshResult?.refreshed) {
+                      toast.error(
+                        t("messages:toast.error.refreshAccount", {
+                          accountName,
+                        }),
+                        { id: toastId },
+                      )
+                      return
+                    }
+
+                    toast.success(
+                      t("messages:toast.success.refreshAccount", {
+                        accountName,
+                      }),
+                      { id: toastId },
+                    )
+                  } catch (error) {
+                    toast.error(
+                      t("messages:toast.error.refreshAccount", {
+                        accountName,
+                      }),
+                      { id: toastId },
+                    )
+                    logger.error("Post-save warning refresh failed", {
+                      accountId: warningAccountId,
+                      error: getErrorMessage(error),
+                    })
+                  }
+                },
+              }
+            : undefined,
+        })
       } else {
         toast.success(feedbackMessage)
       }

--- a/src/features/BasicSettings/components/dialogs/ClearModelRedirectMappingsDialog.tsx
+++ b/src/features/BasicSettings/components/dialogs/ClearModelRedirectMappingsDialog.tsx
@@ -15,6 +15,7 @@ import { ModelRedirectService } from "~/services/models/modelRedirect"
 import { isEmptyModelMapping } from "~/services/models/modelRedirect/utils"
 import type { ManagedSiteChannel } from "~/types/managedSite"
 import { getErrorMessage } from "~/utils/core/error"
+import { showWarningToast } from "~/utils/core/toastHelpers"
 
 interface ClearModelRedirectMappingsDialogProps {
   isOpen: boolean
@@ -217,7 +218,7 @@ export function ClearModelRedirectMappingsDialog({
 
       if (result.success) {
         if (result.clearedChannels > 0 && result.skippedChannels > 0) {
-          toast.success(
+          showWarningToast(
             t("bulkClear.messages.successWithSkips", {
               cleared: result.clearedChannels,
               skipped: result.skippedChannels,
@@ -230,7 +231,7 @@ export function ClearModelRedirectMappingsDialog({
             }),
           )
         } else {
-          toast.success(t("bulkClear.messages.nothingToClear"))
+          showWarningToast(t("bulkClear.messages.nothingToClear"))
         }
         setIsConfirmOpen(false)
         onClose()

--- a/src/features/BasicSettings/components/tabs/UsageHistorySync/UsageHistorySyncTab.tsx
+++ b/src/features/BasicSettings/components/tabs/UsageHistorySync/UsageHistorySyncTab.tsx
@@ -16,6 +16,7 @@ import { hasAlarmsAPI, sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { formatLocaleDateTime } from "~/utils/core/formatters"
 import { createLogger } from "~/utils/core/logger"
+import { showWarningToast } from "~/utils/core/toastHelpers"
 
 import UsageHistorySyncSettingsSection from "./UsageHistorySyncSettingsSection"
 import UsageHistorySyncStateTable, {
@@ -26,6 +27,15 @@ import UsageHistorySyncStateTable, {
  * Unified logger scoped to the Basic Settings usage-history sync tab.
  */
 const logger = createLogger("UsageHistorySyncTab")
+
+const hasNonSuccessUsageHistoryTotals = (totals: {
+  skipped?: number
+  error?: number
+  unsupported?: number
+}) =>
+  (totals.skipped ?? 0) > 0 ||
+  (totals.error ?? 0) > 0 ||
+  (totals.unsupported ?? 0) > 0
 
 /**
  * Basic Settings tab for usage-history synchronization: sync settings + per-account sync state.
@@ -147,7 +157,7 @@ export default function UsageHistorySyncTab() {
       }
 
       if (response?.data?.warning) {
-        toast(
+        showWarningToast(
           t("messages.warning.scheduleFallback", {
             warning: response.data.warning,
           }),
@@ -208,15 +218,18 @@ export default function UsageHistorySyncTab() {
 
         const totals = response?.data?.totals
         if (totals) {
-          toast.success(
-            t("messages.success.syncCompleted", {
-              success: totals.success ?? 0,
-              skipped: totals.skipped ?? 0,
-              error: totals.error ?? 0,
-              unsupported: totals.unsupported ?? 0,
-            }),
-            { id: toastId },
-          )
+          const message = t("messages.success.syncCompleted", {
+            success: totals.success ?? 0,
+            skipped: totals.skipped ?? 0,
+            error: totals.error ?? 0,
+            unsupported: totals.unsupported ?? 0,
+          })
+
+          if (hasNonSuccessUsageHistoryTotals(totals)) {
+            showWarningToast(message, { id: toastId })
+          } else {
+            toast.success(message, { id: toastId })
+          }
         } else {
           toast.success(t("messages.success.syncCompletedNoSummary"), {
             id: toastId,

--- a/src/features/BasicSettings/components/tabs/UsageHistorySync/UsageHistorySyncTab.tsx
+++ b/src/features/BasicSettings/components/tabs/UsageHistorySync/UsageHistorySyncTab.tsx
@@ -27,6 +27,7 @@ import UsageHistorySyncStateTable, {
  * Unified logger scoped to the Basic Settings usage-history sync tab.
  */
 const logger = createLogger("UsageHistorySyncTab")
+const USAGE_HISTORY_STATE_SECTION_ID = "usage-history-sync-state"
 
 const hasNonSuccessUsageHistoryTotals = (totals: {
   skipped?: number
@@ -36,6 +37,12 @@ const hasNonSuccessUsageHistoryTotals = (totals: {
   (totals.skipped ?? 0) > 0 ||
   (totals.error ?? 0) > 0 ||
   (totals.unsupported ?? 0) > 0
+
+const scrollToUsageHistoryStateSection = () => {
+  document
+    .getElementById(USAGE_HISTORY_STATE_SECTION_ID)
+    ?.scrollIntoView({ behavior: "smooth", block: "start" })
+}
 
 /**
  * Basic Settings tab for usage-history synchronization: sync settings + per-account sync state.
@@ -218,17 +225,34 @@ export default function UsageHistorySyncTab() {
 
         const totals = response?.data?.totals
         if (totals) {
-          const message = t("messages.success.syncCompleted", {
-            success: totals.success ?? 0,
-            skipped: totals.skipped ?? 0,
-            error: totals.error ?? 0,
-            unsupported: totals.unsupported ?? 0,
-          })
-
           if (hasNonSuccessUsageHistoryTotals(totals)) {
-            showWarningToast(message, { id: toastId })
+            showWarningToast(
+              t("messages.warning.syncCompletedWithIssues", {
+                success: totals.success ?? 0,
+                skipped: totals.skipped ?? 0,
+                error: totals.error ?? 0,
+                unsupported: totals.unsupported ?? 0,
+              }),
+              {
+                id: toastId,
+                action: {
+                  label: t("syncTab.actions.viewStatus"),
+                  onClick: () => {
+                    scrollToUsageHistoryStateSection()
+                  },
+                },
+              },
+            )
           } else {
-            toast.success(message, { id: toastId })
+            toast.success(
+              t("messages.success.syncCompleted", {
+                success: totals.success ?? 0,
+                skipped: totals.skipped ?? 0,
+                error: totals.error ?? 0,
+                unsupported: totals.unsupported ?? 0,
+              }),
+              { id: toastId },
+            )
           }
         } else {
           toast.success(t("messages.success.syncCompletedNoSummary"), {
@@ -285,7 +309,7 @@ export default function UsageHistorySyncTab() {
       />
 
       <SettingSection
-        id="usage-history-sync-state"
+        id={USAGE_HISTORY_STATE_SECTION_ID}
         title={t("syncTab.stateTitle")}
         description={t("syncTab.stateDescription")}
       >

--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -18,6 +18,7 @@ import type {
 } from "~/types/managedSiteModelSync"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
+import { showWarningToast } from "~/utils/core/toastHelpers"
 
 import ActionBar from "./components/ActionBar"
 import EmptyResults from "./components/EmptyResults"
@@ -37,6 +38,9 @@ const TAB_INDEX = {
   history: 0,
   manual: 1,
 } as const
+
+const hasModelSyncFailures = (execution: ExecutionResult) =>
+  execution.statistics.failureCount > 0
 
 /**
  * New API Model Sync dashboard showing history, manual runs, progress, and filters.
@@ -310,12 +314,16 @@ export default function ManagedSiteModelSync({
       })
 
       if (response.success) {
-        toast.success(
-          t("messages.success.syncCompleted", {
-            success: response.data.statistics.successCount,
-            total: response.data.statistics.total,
-          }),
-        )
+        const message = t("messages.success.syncCompleted", {
+          success: response.data.statistics.successCount,
+          total: response.data.statistics.total,
+        })
+
+        if (hasModelSyncFailures(response.data)) {
+          showWarningToast(message)
+        } else {
+          toast.success(message)
+        }
         setLastExecution(response.data)
       } else {
         toast.error(t("messages.error.syncFailed", { error: response.error }))
@@ -341,12 +349,16 @@ export default function ManagedSiteModelSync({
       })
 
       if (response.success) {
-        toast.success(
-          t("messages.success.syncCompleted", {
-            success: response.data.statistics.successCount,
-            total: response.data.statistics.total,
-          }),
-        )
+        const message = t("messages.success.syncCompleted", {
+          success: response.data.statistics.successCount,
+          total: response.data.statistics.total,
+        })
+
+        if (hasModelSyncFailures(response.data)) {
+          showWarningToast(message)
+        } else {
+          toast.success(message)
+        }
         setLastExecution(response.data)
         if (source === "history") {
           setHistorySelectedIds(new Set())
@@ -368,12 +380,16 @@ export default function ManagedSiteModelSync({
       })
 
       if (response.success) {
-        toast.success(
-          t("messages.success.syncCompleted", {
-            success: response.data.statistics.successCount,
-            total: response.data.statistics.total,
-          }),
-        )
+        const message = t("messages.success.syncCompleted", {
+          success: response.data.statistics.successCount,
+          total: response.data.statistics.total,
+        })
+
+        if (hasModelSyncFailures(response.data)) {
+          showWarningToast(message)
+        } else {
+          toast.success(message)
+        }
         setLastExecution(response.data)
       } else {
         toast.error(t("messages.error.syncFailed", { error: response.error }))

--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -314,15 +314,27 @@ export default function ManagedSiteModelSync({
       })
 
       if (response.success) {
-        const message = t("messages.success.syncCompleted", {
-          success: response.data.statistics.successCount,
-          total: response.data.statistics.total,
-        })
-
         if (hasModelSyncFailures(response.data)) {
-          showWarningToast(message)
+          showWarningToast(
+            t("messages.warning.syncCompletedWithFailures", {
+              success: response.data.statistics.successCount,
+              total: response.data.statistics.total,
+              failed: response.data.statistics.failureCount,
+            }),
+            {
+              action: {
+                label: t("execution.actions.retryFailed"),
+                onClick: handleRetryFailed,
+              },
+            },
+          )
         } else {
-          toast.success(message)
+          toast.success(
+            t("messages.success.syncCompleted", {
+              success: response.data.statistics.successCount,
+              total: response.data.statistics.total,
+            }),
+          )
         }
         setLastExecution(response.data)
       } else {
@@ -349,15 +361,27 @@ export default function ManagedSiteModelSync({
       })
 
       if (response.success) {
-        const message = t("messages.success.syncCompleted", {
-          success: response.data.statistics.successCount,
-          total: response.data.statistics.total,
-        })
-
         if (hasModelSyncFailures(response.data)) {
-          showWarningToast(message)
+          showWarningToast(
+            t("messages.warning.syncCompletedWithFailures", {
+              success: response.data.statistics.successCount,
+              total: response.data.statistics.total,
+              failed: response.data.statistics.failureCount,
+            }),
+            {
+              action: {
+                label: t("execution.actions.retryFailed"),
+                onClick: handleRetryFailed,
+              },
+            },
+          )
         } else {
-          toast.success(message)
+          toast.success(
+            t("messages.success.syncCompleted", {
+              success: response.data.statistics.successCount,
+              total: response.data.statistics.total,
+            }),
+          )
         }
         setLastExecution(response.data)
         if (source === "history") {
@@ -380,15 +404,27 @@ export default function ManagedSiteModelSync({
       })
 
       if (response.success) {
-        const message = t("messages.success.syncCompleted", {
-          success: response.data.statistics.successCount,
-          total: response.data.statistics.total,
-        })
-
         if (hasModelSyncFailures(response.data)) {
-          showWarningToast(message)
+          showWarningToast(
+            t("messages.warning.syncCompletedWithFailures", {
+              success: response.data.statistics.successCount,
+              total: response.data.statistics.total,
+              failed: response.data.statistics.failureCount,
+            }),
+            {
+              action: {
+                label: t("execution.actions.retryFailed"),
+                onClick: handleRetryFailed,
+              },
+            },
+          )
         } else {
-          toast.success(message)
+          toast.success(
+            t("messages.success.syncCompleted", {
+              success: response.data.statistics.successCount,
+              total: response.data.statistics.total,
+            }),
+          )
         }
         setLastExecution(response.data)
       } else {

--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -307,6 +307,55 @@ export default function ManagedSiteModelSync({
     routeParams?.tab,
   ])
 
+  /**
+   * Shows a toast notification based on the execution result, highlighting any failures and providing a retry action if needed.
+   */
+  function notifySyncCompletion(execution: ExecutionResult) {
+    if (hasModelSyncFailures(execution)) {
+      showWarningToast(
+        t("messages.warning.syncCompletedWithFailures", {
+          success: execution.statistics.successCount,
+          total: execution.statistics.total,
+          failed: execution.statistics.failureCount,
+        }),
+        {
+          action: {
+            label: t("execution.actions.retryFailed"),
+            onClick: handleRetryFailed,
+          },
+        },
+      )
+      return
+    }
+
+    toast.success(
+      t("messages.success.syncCompleted", {
+        success: execution.statistics.successCount,
+        total: execution.statistics.total,
+      }),
+    )
+  }
+
+  /**
+   * Handles retrying only the failed channels from the last execution, showing appropriate success or error toasts based on the result.
+   */
+  async function handleRetryFailed() {
+    try {
+      const response = await sendRuntimeMessage({
+        action: RuntimeActionIds.ModelSyncTriggerFailedOnly,
+      })
+
+      if (response.success) {
+        notifySyncCompletion(response.data)
+        setLastExecution(response.data)
+      } else {
+        toast.error(t("messages.error.syncFailed", { error: response.error }))
+      }
+    } catch (error: any) {
+      toast.error(t("messages.error.syncFailed", { error: error.message }))
+    }
+  }
+
   const handleRunAll = async () => {
     try {
       const response = await sendRuntimeMessage({
@@ -314,28 +363,7 @@ export default function ManagedSiteModelSync({
       })
 
       if (response.success) {
-        if (hasModelSyncFailures(response.data)) {
-          showWarningToast(
-            t("messages.warning.syncCompletedWithFailures", {
-              success: response.data.statistics.successCount,
-              total: response.data.statistics.total,
-              failed: response.data.statistics.failureCount,
-            }),
-            {
-              action: {
-                label: t("execution.actions.retryFailed"),
-                onClick: handleRetryFailed,
-              },
-            },
-          )
-        } else {
-          toast.success(
-            t("messages.success.syncCompleted", {
-              success: response.data.statistics.successCount,
-              total: response.data.statistics.total,
-            }),
-          )
-        }
+        notifySyncCompletion(response.data)
         setLastExecution(response.data)
       } else {
         toast.error(t("messages.error.syncFailed", { error: response.error }))
@@ -361,72 +389,13 @@ export default function ManagedSiteModelSync({
       })
 
       if (response.success) {
-        if (hasModelSyncFailures(response.data)) {
-          showWarningToast(
-            t("messages.warning.syncCompletedWithFailures", {
-              success: response.data.statistics.successCount,
-              total: response.data.statistics.total,
-              failed: response.data.statistics.failureCount,
-            }),
-            {
-              action: {
-                label: t("execution.actions.retryFailed"),
-                onClick: handleRetryFailed,
-              },
-            },
-          )
-        } else {
-          toast.success(
-            t("messages.success.syncCompleted", {
-              success: response.data.statistics.successCount,
-              total: response.data.statistics.total,
-            }),
-          )
-        }
+        notifySyncCompletion(response.data)
         setLastExecution(response.data)
         if (source === "history") {
           setHistorySelectedIds(new Set())
         } else {
           setManualSelectedIds(new Set())
         }
-      } else {
-        toast.error(t("messages.error.syncFailed", { error: response.error }))
-      }
-    } catch (error: any) {
-      toast.error(t("messages.error.syncFailed", { error: error.message }))
-    }
-  }
-
-  const handleRetryFailed = async () => {
-    try {
-      const response = await sendRuntimeMessage({
-        action: RuntimeActionIds.ModelSyncTriggerFailedOnly,
-      })
-
-      if (response.success) {
-        if (hasModelSyncFailures(response.data)) {
-          showWarningToast(
-            t("messages.warning.syncCompletedWithFailures", {
-              success: response.data.statistics.successCount,
-              total: response.data.statistics.total,
-              failed: response.data.statistics.failureCount,
-            }),
-            {
-              action: {
-                label: t("execution.actions.retryFailed"),
-                onClick: handleRetryFailed,
-              },
-            },
-          )
-        } else {
-          toast.success(
-            t("messages.success.syncCompleted", {
-              success: response.data.statistics.successCount,
-              total: response.data.statistics.total,
-            }),
-          )
-        }
-        setLastExecution(response.data)
       } else {
         toast.error(t("messages.error.syncFailed", { error: response.error }))
       }

--- a/src/locales/en/managedSiteModelSync.json
+++ b/src/locales/en/managedSiteModelSync.json
@@ -87,6 +87,9 @@
     "success": {
       "settingsSaved": "Settings saved successfully",
       "syncCompleted": "Sync completed: {{success}}/{{total}} succeeded"
+    },
+    "warning": {
+      "syncCompletedWithFailures": "Sync finished, but {{failed}} channel(s) still failed ({{success}}/{{total}} succeeded). You can retry only the failed items."
     }
   },
   "settings": {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -195,8 +195,8 @@
     "noChannelsToSync": "No channels to sync"
   },
   "warnings": {
-    "accountSavedWithoutDataRefresh": "Account saved successfully, but failed to fetch account data. You can refresh the data later from the account list.",
-    "accountUpdatedWithoutDataRefresh": "Account configuration saved, but failed to refresh latest data"
+    "accountSavedWithoutDataRefresh": "Account saved, but the latest balance, quota, and today's usage could not be fetched. The current values may be placeholders. Refresh this account later from the account list.",
+    "accountUpdatedWithoutDataRefresh": "Account settings saved, but the latest balance, quota, and today's usage could not be refreshed. The current values may still be stale. Refresh this account later from the account list."
   },
   "webdav": {
     "authFailed": "Authentication failed, please check username/password",

--- a/src/locales/en/usageAnalytics.json
+++ b/src/locales/en/usageAnalytics.json
@@ -145,7 +145,8 @@
       "syncCompletedNoSummary": "Sync completed"
     },
     "warning": {
-      "scheduleFallback": "Schedule fallback applied: {{warning}}"
+      "scheduleFallback": "This browser does not support scheduled sync, so it has been switched to \"After account refresh\": {{warning}}",
+      "syncCompletedWithIssues": "Sync completed with follow-up needed (success: {{success}}, skipped: {{skipped}}, error: {{error}}, unsupported: {{unsupported}})"
     }
   },
   "settings": {
@@ -184,7 +185,8 @@
       "refreshStatus": "Refresh status",
       "syncAccount": "Sync account",
       "syncing": "Syncing...",
-      "syncSelected": "Sync selected"
+      "syncSelected": "Sync selected",
+      "viewStatus": "View sync status"
     },
     "noAccounts": "No accounts found.",
     "searchPlaceholder": "Type to search…",

--- a/src/locales/ja/managedSiteModelSync.json
+++ b/src/locales/ja/managedSiteModelSync.json
@@ -85,6 +85,9 @@
     "success": {
       "settingsSaved": "設定を正常に保存しました",
       "syncCompleted": "同期完了: {{success}}/{{total}} 成功"
+    },
+    "warning": {
+      "syncCompletedWithFailures": "同期は完了しましたが、{{failed}} 件のチャネルがまだ失敗しています（成功: {{success}}/{{total}}）。失敗分のみ再試行できます。"
     }
   },
   "settings": {

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -193,8 +193,8 @@
     "noChannelsToSync": "同期するチャネルがありません"
   },
   "warnings": {
-    "accountSavedWithoutDataRefresh": "アカウントは正常に保存されましたが、アカウントデータの取得に失敗しました。後でアカウント一覧から更新できます。",
-    "accountUpdatedWithoutDataRefresh": "アカウント設定は保存されましたが、最新データの更新に失敗しました"
+    "accountSavedWithoutDataRefresh": "アカウントは保存されましたが、最新の残高・クォータ・本日の使用量を取得できませんでした。現在の表示は仮の値の可能性があります。後でアカウント一覧から更新してください。",
+    "accountUpdatedWithoutDataRefresh": "アカウント設定は保存されましたが、最新の残高・クォータ・本日の使用量を更新できませんでした。現在の表示は古いままの可能性があります。後でアカウント一覧から更新してください。"
   },
   "webdav": {
     "authFailed": "認証に失敗しました。ユーザー名 / パスワードを確認してください",

--- a/src/locales/ja/usageAnalytics.json
+++ b/src/locales/ja/usageAnalytics.json
@@ -145,7 +145,8 @@
       "syncCompletedNoSummary": "同期が完了しました"
     },
     "warning": {
-      "scheduleFallback": "スケジュールのフォールバックを適用しました: {{warning}}"
+      "scheduleFallback": "このブラウザでは定期実行をサポートしていないため、「アカウント更新後」に自動で切り替えました: {{warning}}",
+      "syncCompletedWithIssues": "同期は完了しましたが、未完了のアカウントがあります（成功: {{success}}、スキップ: {{skipped}}、エラー: {{error}}、未対応: {{unsupported}}）"
     }
   },
   "settings": {
@@ -184,7 +185,8 @@
       "refreshStatus": "状態を更新",
       "syncAccount": "アカウントを同期",
       "syncing": "同期中...",
-      "syncSelected": "選択分を同期"
+      "syncSelected": "選択分を同期",
+      "viewStatus": "同期状態を見る"
     },
     "noAccounts": "アカウントが見つかりません。",
     "searchPlaceholder": "入力して検索…",

--- a/src/locales/zh-CN/managedSiteModelSync.json
+++ b/src/locales/zh-CN/managedSiteModelSync.json
@@ -85,6 +85,9 @@
     "success": {
       "settingsSaved": "设置保存成功",
       "syncCompleted": "同步完成：{{success}}/{{total}} 成功"
+    },
+    "warning": {
+      "syncCompletedWithFailures": "同步已完成，但仍有 {{failed}} 个渠道失败（成功：{{success}}/{{total}}）。你可以直接重试失败项。"
     }
   },
   "settings": {

--- a/src/locales/zh-CN/messages.json
+++ b/src/locales/zh-CN/messages.json
@@ -193,8 +193,8 @@
     "noChannelsToSync": "没有可同步的渠道"
   },
   "warnings": {
-    "accountSavedWithoutDataRefresh": "账号保存成功，但获取账号数据失败。您可以稍后从账号列表刷新数据。",
-    "accountUpdatedWithoutDataRefresh": "账号配置已保存，但刷新最新数据失败"
+    "accountSavedWithoutDataRefresh": "账号已保存，但未能获取余额、额度和今日用量，当前显示可能为占位值。请稍后在账号列表中刷新。",
+    "accountUpdatedWithoutDataRefresh": "账号配置已保存，但未能刷新最新余额、额度和今日用量，当前显示可能仍是旧数据。请稍后在账号列表中刷新。"
   },
   "webdav": {
     "authFailed": "鉴权失败，请检查用户名/密码",

--- a/src/locales/zh-CN/usageAnalytics.json
+++ b/src/locales/zh-CN/usageAnalytics.json
@@ -145,7 +145,8 @@
       "syncCompletedNoSummary": "同步完成"
     },
     "warning": {
-      "scheduleFallback": "已应用调度回退：{{warning}}"
+      "scheduleFallback": "当前浏览器不支持定时调度，已自动改为“账号刷新后同步”：{{warning}}",
+      "syncCompletedWithIssues": "同步已完成，但仍有未完成账号（成功：{{success}}，跳过：{{skipped}}，失败：{{error}}，不支持：{{unsupported}}）"
     }
   },
   "settings": {
@@ -184,7 +185,8 @@
       "refreshStatus": "刷新状态",
       "syncAccount": "同步该账号",
       "syncing": "同步中...",
-      "syncSelected": "同步已选"
+      "syncSelected": "同步已选",
+      "viewStatus": "查看同步状态"
     },
     "noAccounts": "未找到任何账号。",
     "searchPlaceholder": "输入关键词搜索…",

--- a/src/locales/zh-TW/managedSiteModelSync.json
+++ b/src/locales/zh-TW/managedSiteModelSync.json
@@ -85,6 +85,9 @@
     "success": {
       "settingsSaved": "設定儲存成功",
       "syncCompleted": "同步完成：{{success}}/{{total}} 成功"
+    },
+    "warning": {
+      "syncCompletedWithFailures": "同步已完成，但仍有 {{failed}} 個渠道失敗（成功：{{success}}/{{total}}）。你可以直接重試失敗項。"
     }
   },
   "settings": {

--- a/src/locales/zh-TW/messages.json
+++ b/src/locales/zh-TW/messages.json
@@ -193,8 +193,8 @@
     "noChannelsToSync": "沒有可同步的渠道"
   },
   "warnings": {
-    "accountSavedWithoutDataRefresh": "帳號儲存成功，但獲取帳號資料失敗。您可以稍後從帳號列表重新整理資料。",
-    "accountUpdatedWithoutDataRefresh": "帳號配置已儲存，但重新整理最新資料失敗"
+    "accountSavedWithoutDataRefresh": "帳號已儲存，但未能取得餘額、額度與今日用量，目前顯示可能是佔位值。請稍後在帳號列表中重新整理。",
+    "accountUpdatedWithoutDataRefresh": "帳號配置已儲存，但未能重新整理最新餘額、額度與今日用量，目前顯示可能仍是舊資料。請稍後在帳號列表中重新整理。"
   },
   "webdav": {
     "authFailed": "鑑權失敗，請檢查使用者名稱/密碼",

--- a/src/locales/zh-TW/usageAnalytics.json
+++ b/src/locales/zh-TW/usageAnalytics.json
@@ -145,7 +145,8 @@
       "syncCompletedNoSummary": "同步完成"
     },
     "warning": {
-      "scheduleFallback": "已應用排程回退：{{warning}}"
+      "scheduleFallback": "目前瀏覽器不支援定時排程，已自動改為「帳號重新整理後同步」：{{warning}}",
+      "syncCompletedWithIssues": "同步已完成，但仍有未完成的帳號（成功：{{success}}，跳過：{{skipped}}，失敗：{{error}}，不支援：{{unsupported}}）"
     }
   },
   "settings": {
@@ -184,7 +185,8 @@
       "refreshStatus": "重新整理狀態",
       "syncAccount": "同步該帳號",
       "syncing": "同步中...",
-      "syncSelected": "同步已選"
+      "syncSelected": "同步已選",
+      "viewStatus": "查看同步狀態"
     },
     "noAccounts": "未找到任何帳號。",
     "searchPlaceholder": "輸入關鍵詞搜尋…",

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -638,6 +638,7 @@ export async function validateAndSaveAccount(
       success: true,
       message: t("messages:toast.success.accountSaveSuccess"),
       accountId,
+      feedbackLevel: "success",
     }
   } catch (error) {
     // FALLBACK: 即使获取数据失败也要保存配置
@@ -702,6 +703,7 @@ export async function validateAndSaveAccount(
         success: true,
         message: t("messages:warnings.accountSavedWithoutDataRefresh"),
         accountId,
+        feedbackLevel: "warning",
       }
     } catch (saveError) {
       logger.error("Failed to save account", saveError)
@@ -872,6 +874,7 @@ export async function validateAndUpdateAccount(
       success: true,
       message: t("messages:toast.success.accountUpdateSuccess"),
       accountId,
+      feedbackLevel: "success",
     }
   } catch (error) {
     // FALLBACK: 即使获取数据失败也要保存配置
@@ -928,6 +931,7 @@ export async function validateAndUpdateAccount(
       success: true,
       message: t("messages:warnings.accountUpdatedWithoutDataRefresh"),
       accountId,
+      feedbackLevel: "warning",
     }
   }
 }

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -40,6 +40,7 @@ import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { extractSessionCookieHeader } from "~/utils/browser/cookieString"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
+import { showWarningToast } from "~/utils/core/toastHelpers"
 import { t } from "~/utils/i18n/core"
 
 const logger = createLogger("AccountOperations")
@@ -1196,15 +1197,19 @@ async function autoProvisionKeyOnAccountAdd(
       displaySiteData,
     })
 
-    toast.success(
-      created
-        ? t("messages:accountOperations.autoProvisionCreated", {
-            accountName: displaySiteData.name || account.site_name,
-          })
-        : t("messages:accountOperations.autoProvisionAlreadyHad", {
-            accountName: displaySiteData.name || account.site_name,
-          }),
-    )
+    if (created) {
+      toast.success(
+        t("messages:accountOperations.autoProvisionCreated", {
+          accountName: displaySiteData.name || account.site_name,
+        }),
+      )
+    } else {
+      showWarningToast(
+        t("messages:accountOperations.autoProvisionAlreadyHad", {
+          accountName: displaySiteData.name || account.site_name,
+        }),
+      )
+    }
   } catch (error) {
     toast.error(
       t("messages:accountOperations.autoProvisionFailed", {

--- a/src/types/serviceResponse.ts
+++ b/src/types/serviceResponse.ts
@@ -34,6 +34,7 @@ export interface AccountValidationResponse
  */
 export interface AccountSaveResponse extends ServiceResponse<void> {
   accountId?: string // Present on success
+  feedbackLevel?: "success" | "warning"
 }
 
 /**

--- a/src/utils/core/toastHelpers.ts
+++ b/src/utils/core/toastHelpers.ts
@@ -1,6 +1,7 @@
 import { createElement } from "react"
 import toast, { type ToastOptions } from "react-hot-toast"
 
+import type { WarningToastAction } from "~/components/toast/types"
 import { WarningToast } from "~/components/toast/WarningToast"
 import { WarningToastIcon } from "~/components/toast/WarningToastIcon"
 import { t } from "~/utils/i18n/core"
@@ -28,6 +29,10 @@ const getDefaultToastMessage = (success: boolean) =>
 
 const WARNING_TOAST_DEFAULTS: ToastOptions = {
   duration: 5000,
+}
+
+type WarningToastOptions = ToastOptions & {
+  action?: WarningToastAction
 }
 
 type WarningToastFallbackApi = {
@@ -92,7 +97,7 @@ export const showResetToast = (success: boolean): void => {
  */
 export const showWarningToast = (
   message: string,
-  options?: ToastOptions,
+  options?: WarningToastOptions,
 ): void => {
   const normalizedMessage = normalizeToastMessage(message)
   if (!normalizedMessage) return
@@ -116,6 +121,7 @@ export const showWarningToast = (
         createElement(WarningToast, {
           toastInstance,
           message: normalizedMessage,
+          action: options?.action,
         }),
       mergedOptions,
     )

--- a/src/utils/core/toastHelpers.ts
+++ b/src/utils/core/toastHelpers.ts
@@ -1,5 +1,8 @@
-import toast from "react-hot-toast"
+import { createElement } from "react"
+import toast, { type ToastOptions } from "react-hot-toast"
 
+import { WarningToast } from "~/components/toast/WarningToast"
+import { WarningToastIcon } from "~/components/toast/WarningToastIcon"
 import { t } from "~/utils/i18n/core"
 
 type ToastResultObject = {
@@ -22,6 +25,18 @@ const getDefaultToastMessage = (success: boolean) =>
   success
     ? t("messages:toast.success.operationCompleted")
     : t("messages:toast.error.operationFailedGeneric")
+
+const WARNING_TOAST_DEFAULTS: ToastOptions = {
+  duration: 5000,
+}
+
+type WarningToastFallbackApi = {
+  success?: (message: string) => void
+  custom?: (
+    renderer: (toastInstance: any) => ReturnType<typeof createElement>,
+    options?: ToastOptions,
+  ) => void
+}
 
 /**
  * Shows a toast notification based on the success status of an operation.
@@ -67,4 +82,58 @@ export const showResetToast = (success: boolean): void => {
   const successMsg = t("settings:messages.updateSuccess")
   const errorMsg = t("settings:danger.resetFailed")
   showResultToast(success, successMsg, errorMsg)
+}
+
+/**
+ * Shows a warning-style toast using the generic toast container so callers can
+ * reuse a consistent non-error, non-success feedback treatment.
+ * @param message - The warning message to display.
+ * @param options - Optional toast overrides.
+ */
+export const showWarningToast = (
+  message: string,
+  options?: ToastOptions,
+): void => {
+  const normalizedMessage = normalizeToastMessage(message)
+  if (!normalizedMessage) return
+  const toastRuntime = toast as unknown
+  const toastApi = toastRuntime as WarningToastFallbackApi
+  const callableToast = toastRuntime as
+    | ((
+        message: string,
+        options?: ToastOptions & { icon?: ReturnType<typeof createElement> },
+      ) => void)
+    | undefined
+
+  const mergedOptions = {
+    ...WARNING_TOAST_DEFAULTS,
+    ...options,
+  }
+
+  if (typeof toastApi.custom === "function") {
+    toastApi.custom(
+      (toastInstance) =>
+        createElement(WarningToast, {
+          toastInstance,
+          message: normalizedMessage,
+        }),
+      mergedOptions,
+    )
+    return
+  }
+
+  // Compatibility fallback for simplified test mocks or environments that do
+  // not expose toast.custom. Runtime in this repo uses react-hot-toast with
+  // toast.custom available, so this path is only a graceful downgrade.
+  if (typeof toastRuntime === "function" && callableToast) {
+    callableToast(normalizedMessage, {
+      ...mergedOptions,
+      icon: createElement(WarningToastIcon),
+    })
+    return
+  }
+
+  if (typeof toastApi.success === "function") {
+    toastApi.success(normalizedMessage)
+  }
 }

--- a/tests/components/toast/WarningToast.test.tsx
+++ b/tests/components/toast/WarningToast.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { WarningToast } from "~/components/toast/WarningToast"
+
+const { dismissMock } = vi.hoisted(() => ({
+  dismissMock: vi.fn(),
+}))
+
+vi.mock("~/contexts/ThemeContext", () => ({
+  useTheme: () => ({
+    resolvedTheme: "light",
+  }),
+}))
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    dismiss: dismissMock,
+  },
+  ToastBar: ({ toast, children }: any) => (
+    <div data-testid="toast-bar">
+      {typeof children === "function"
+        ? children({
+            icon: toast.icon,
+            message: <span data-testid="toast-message">{toast.message}</span>,
+          })
+        : children}
+    </div>
+  ),
+}))
+
+describe("WarningToast", () => {
+  it("renders the message and dismisses when the close button is clicked", () => {
+    render(
+      <WarningToast
+        toastInstance={{
+          id: "warning-toast-id",
+          type: "custom",
+          visible: true,
+          dismissed: false,
+          height: 0,
+          ariaProps: {
+            role: "status",
+            "aria-live": "polite",
+          },
+          message: "",
+          createdAt: Date.now(),
+          pauseDuration: 0,
+          position: "bottom-center",
+        }}
+        message="Latest account data is stale"
+      />,
+    )
+
+    expect(screen.getByText("Latest account data is stale")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button"))
+
+    expect(dismissMock).toHaveBeenCalledWith("warning-toast-id")
+  })
+})

--- a/tests/components/toast/WarningToast.test.tsx
+++ b/tests/components/toast/WarningToast.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import { WarningToast } from "~/components/toast/WarningToast"
@@ -57,5 +57,41 @@ describe("WarningToast", () => {
     fireEvent.click(screen.getByRole("button"))
 
     expect(dismissMock).toHaveBeenCalledWith("warning-toast-id")
+  })
+
+  it("renders an action and runs it before dismissing the toast", async () => {
+    const actionMock = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <WarningToast
+        toastInstance={{
+          id: "warning-toast-id",
+          type: "custom",
+          visible: true,
+          dismissed: false,
+          height: 0,
+          ariaProps: {
+            role: "status",
+            "aria-live": "polite",
+          },
+          message: "",
+          createdAt: Date.now(),
+          pauseDuration: 0,
+          position: "bottom-center",
+        }}
+        message="Model sync finished with failed channels"
+        action={{
+          label: "Retry failed only",
+          onClick: actionMock,
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry failed only" }))
+
+    await waitFor(() => {
+      expect(actionMock).toHaveBeenCalledTimes(1)
+      expect(dismissMock).toHaveBeenCalledWith("warning-toast-id")
+    })
   })
 })

--- a/tests/components/toast/WarningToast.test.tsx
+++ b/tests/components/toast/WarningToast.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { WarningToast } from "~/components/toast/WarningToast"
 
@@ -30,6 +30,10 @@ vi.mock("react-hot-toast", () => ({
 }))
 
 describe("WarningToast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it("renders the message and dismisses when the close button is clicked", () => {
     render(
       <WarningToast
@@ -54,8 +58,9 @@ describe("WarningToast", () => {
 
     expect(screen.getByText("Latest account data is stale")).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole("button"))
+    fireEvent.click(screen.getByRole("button", { name: "Close notification" }))
 
+    expect(dismissMock).toHaveBeenCalledTimes(1)
     expect(dismissMock).toHaveBeenCalledWith("warning-toast-id")
   })
 
@@ -91,7 +96,56 @@ describe("WarningToast", () => {
 
     await waitFor(() => {
       expect(actionMock).toHaveBeenCalledTimes(1)
+      expect(dismissMock).toHaveBeenCalledTimes(1)
       expect(dismissMock).toHaveBeenCalledWith("warning-toast-id")
+    })
+  })
+
+  it("keeps the toast open and re-enables the action when the action rejects", async () => {
+    const actionMock = vi.fn().mockRejectedValue(new Error("retry failed"))
+
+    render(
+      <WarningToast
+        toastInstance={{
+          id: "warning-toast-id",
+          type: "custom",
+          visible: true,
+          dismissed: false,
+          height: 0,
+          ariaProps: {
+            role: "status",
+            "aria-live": "polite",
+          },
+          message: "",
+          createdAt: Date.now(),
+          pauseDuration: 0,
+          position: "bottom-center",
+        }}
+        message="Model sync finished with failed channels"
+        action={{
+          label: "Retry failed only",
+          onClick: actionMock,
+        }}
+      />,
+    )
+
+    const retryButton = screen.getByRole("button", {
+      name: "Retry failed only",
+    })
+
+    fireEvent.click(retryButton)
+
+    await waitFor(() => {
+      expect(actionMock).toHaveBeenCalledTimes(1)
+      expect(retryButton).toBeEnabled()
+    })
+
+    expect(dismissMock).not.toHaveBeenCalled()
+
+    fireEvent.click(retryButton)
+
+    await waitFor(() => {
+      expect(actionMock).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/tests/entrypoints/options/UsageHistorySyncTab.test.tsx
+++ b/tests/entrypoints/options/UsageHistorySyncTab.test.tsx
@@ -390,10 +390,26 @@ describe("UsageHistorySyncTab", () => {
       )
     })
 
-    expect(toast.success).not.toHaveBeenCalledWith(
-      "usageAnalytics:messages.warning.syncCompletedWithIssues",
-      { id: "sync-toast" },
+    const warningOptions = mockShowWarningToast.mock.calls[0]?.[1]
+    const warningAction = warningOptions?.action
+    expect(warningAction).toEqual(
+      expect.objectContaining({
+        label: "usageAnalytics:syncTab.actions.viewStatus",
+      }),
     )
+
+    const stateSection = document.getElementById("usage-history-sync-state")
+    expect(stateSection).toBeTruthy()
+    const scrollIntoViewMock = vi.fn()
+    stateSection!.scrollIntoView = scrollIntoViewMock
+
+    warningAction?.onClick()
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    })
+    expect(toast.success).not.toHaveBeenCalled()
   })
 
   it("clears the syncing state and shows an error toast when a full sync fails", async () => {

--- a/tests/entrypoints/options/UsageHistorySyncTab.test.tsx
+++ b/tests/entrypoints/options/UsageHistorySyncTab.test.tsx
@@ -380,13 +380,18 @@ describe("UsageHistorySyncTab", () => {
 
     await waitFor(() => {
       expect(mockShowWarningToast).toHaveBeenCalledWith(
-        "usageAnalytics:messages.success.syncCompleted",
-        { id: "sync-toast" },
+        "usageAnalytics:messages.warning.syncCompletedWithIssues",
+        expect.objectContaining({
+          id: "sync-toast",
+          action: expect.objectContaining({
+            label: "usageAnalytics:syncTab.actions.viewStatus",
+          }),
+        }),
       )
     })
 
     expect(toast.success).not.toHaveBeenCalledWith(
-      "usageAnalytics:messages.success.syncCompleted",
+      "usageAnalytics:messages.warning.syncCompletedWithIssues",
       { id: "sync-toast" },
     )
   })

--- a/tests/entrypoints/options/UsageHistorySyncTab.test.tsx
+++ b/tests/entrypoints/options/UsageHistorySyncTab.test.tsx
@@ -15,13 +15,14 @@ import {
   within,
 } from "~~/tests/test-utils/render"
 
-const { mockToast } = vi.hoisted(() => ({
+const { mockToast, mockShowWarningToast } = vi.hoisted(() => ({
   mockToast: Object.assign(vi.fn(), {
     dismiss: vi.fn(),
     error: vi.fn(),
     loading: vi.fn(),
     success: vi.fn(),
   }),
+  mockShowWarningToast: vi.fn(),
 }))
 
 vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
@@ -53,6 +54,10 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
 
 vi.mock("react-hot-toast", () => ({
   default: mockToast,
+}))
+
+vi.mock("~/utils/core/toastHelpers", () => ({
+  showWarningToast: mockShowWarningToast,
 }))
 
 describe("UsageHistorySyncTab", () => {
@@ -180,7 +185,7 @@ describe("UsageHistorySyncTab", () => {
     )
 
     await waitFor(() => {
-      expect(toast).toHaveBeenCalledWith(
+      expect(mockShowWarningToast).toHaveBeenCalledWith(
         "usageAnalytics:messages.warning.scheduleFallback",
       )
     })
@@ -355,6 +360,35 @@ describe("UsageHistorySyncTab", () => {
 
     expect(accountStorage.getEnabledAccounts).toHaveBeenCalledTimes(2)
     expect(usageHistoryStorage.getStore).toHaveBeenCalledTimes(2)
+  })
+
+  it("uses a warning toast when manual sync finishes with skipped or unsupported accounts", async () => {
+    vi.mocked(sendRuntimeMessage).mockResolvedValueOnce({
+      success: true,
+      data: {
+        totals: { success: 1, skipped: 1, error: 0, unsupported: 1 },
+      },
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "usageAnalytics:actions.syncNow",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockShowWarningToast).toHaveBeenCalledWith(
+        "usageAnalytics:messages.success.syncCompleted",
+        { id: "sync-toast" },
+      )
+    })
+
+    expect(toast.success).not.toHaveBeenCalledWith(
+      "usageAnalytics:messages.success.syncCompleted",
+      { id: "sync-toast" },
+    )
   })
 
   it("clears the syncing state and shows an error toast when a full sync fails", async () => {

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -1237,6 +1237,7 @@ describe("AccountActionButtons", () => {
         }),
       )
     })
+    expect(toastSuccessMock).not.toHaveBeenCalled()
     expect(managedService.prepareChannelFormData).not.toHaveBeenCalled()
   })
 
@@ -1361,6 +1362,7 @@ describe("AccountActionButtons", () => {
         }),
       )
     })
+    expect(toastSuccessMock).not.toHaveBeenCalled()
     expect(managedService.prepareChannelFormData).not.toHaveBeenCalled()
     expect(managedService.findMatchingChannel).not.toHaveBeenCalled()
   })
@@ -1537,6 +1539,7 @@ describe("AccountActionButtons", () => {
         }),
       )
     })
+    expect(toastSuccessMock).not.toHaveBeenCalled()
     expect(fetchAccountTokensMock).not.toHaveBeenCalled()
     expect(managedService.prepareChannelFormData).not.toHaveBeenCalled()
   })

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -25,6 +25,7 @@ const {
   toastLoadingMock,
   toastSuccessMock,
   toastErrorMock,
+  toastCustomMock,
   hasValidManagedSiteConfigMock,
   clipboardWriteTextMock,
 } = vi.hoisted(() => ({
@@ -59,6 +60,7 @@ const {
   toastLoadingMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
+  toastCustomMock: vi.fn(),
   hasValidManagedSiteConfigMock: vi.fn(() => true),
   clipboardWriteTextMock: vi.fn(),
 }))
@@ -69,6 +71,7 @@ vi.mock("react-hot-toast", () => ({
     loading: toastLoadingMock,
     success: toastSuccessMock,
     error: toastErrorMock,
+    custom: toastCustomMock,
   },
 }))
 
@@ -1227,8 +1230,11 @@ describe("AccountActionButtons", () => {
       expect(openManagedSiteChannelsPageMock).toHaveBeenCalledWith({
         search: "https://api.example.com",
       })
-      expect(toastSuccessMock).toHaveBeenCalledWith(
-        "account:actions.channelLocateNoKeyFallback",
+      expect(toastCustomMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          duration: 5000,
+        }),
       )
     })
     expect(managedService.prepareChannelFormData).not.toHaveBeenCalled()
@@ -1348,8 +1354,11 @@ describe("AccountActionButtons", () => {
       expect(openManagedSiteChannelsPageMock).toHaveBeenCalledWith({
         search: "https://api.example.com",
       })
-      expect(toastSuccessMock).toHaveBeenCalledWith(
-        "account:actions.channelLocateMultipleKeysFallback",
+      expect(toastCustomMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          duration: 5000,
+        }),
       )
     })
     expect(managedService.prepareChannelFormData).not.toHaveBeenCalled()
@@ -1521,8 +1530,11 @@ describe("AccountActionButtons", () => {
       expect(openManagedSiteChannelsPageMock).toHaveBeenCalledWith({
         search: "https://api.example.com",
       })
-      expect(toastSuccessMock).toHaveBeenCalledWith(
-        "account:actions.channelLocateConfigMissing",
+      expect(toastCustomMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          duration: 5000,
+        }),
       )
     })
     expect(fetchAccountTokensMock).not.toHaveBeenCalled()

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -367,9 +367,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         label: "common:actions.refresh",
       }),
     )
-    expect(toast.success).not.toHaveBeenCalledWith(
-      "Account saved, but latest metrics are placeholders.",
-    )
+    expect(toast.success).not.toHaveBeenCalled()
   })
 
   it("uses a warning toast for partial-success updates when latest account data stays stale", async () => {
@@ -433,9 +431,70 @@ describe("useAccountDialog save and auto-config flows", () => {
         label: "common:actions.refresh",
       }),
     )
-    expect(toast.success).not.toHaveBeenCalledWith(
-      "Account settings saved, but latest metrics are still stale.",
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the local warning copy when a partial-success save returns an empty message", async () => {
+    mockValidateAndSaveAccount.mockResolvedValueOnce({
+      success: true,
+      accountId: "saved-account-id",
+      message: "",
+      feedbackLevel: "warning",
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://api.example.com")
+      result.current.setters.setSiteName("Example")
+      result.current.setters.setUsername("user")
+      result.current.setters.setAccessToken("token")
+      result.current.setters.setUserId("1")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType("one-api")
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    expect(toast.custom).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        duration: 5000,
+      }),
     )
+    const saveWarningRenderer = vi.mocked(toast.custom).mock.calls[0]?.[0] as
+      | ((toastInstance: any) => any)
+      | undefined
+    const saveWarningElement = saveWarningRenderer?.({
+      id: "warning-toast-id",
+      type: "custom",
+      visible: true,
+      dismissed: false,
+      height: 0,
+      ariaProps: {
+        role: "status",
+        "aria-live": "polite",
+      },
+      message: "",
+      createdAt: Date.now(),
+      pauseDuration: 0,
+      position: "bottom-center",
+    } as any)
+    expect(saveWarningElement?.props.message).toBe(
+      "accountDialog:messages.addSuccess",
+    )
+    expect(saveWarningElement?.props.action).toEqual(
+      expect.objectContaining({
+        label: "common:actions.refresh",
+      }),
+    )
+    expect(toast.success).not.toHaveBeenCalled()
   })
 
   it("prevents the native form submit and delegates to the normal save flow", async () => {

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -338,9 +338,35 @@ describe("useAccountDialog save and auto-config flows", () => {
       await result.current.handlers.handleSaveAccount()
     })
 
-    expect(toast.custom).toHaveBeenCalledWith(expect.any(Function), {
-      duration: 5000,
-    })
+    expect(toast.custom).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        duration: 5000,
+      }),
+    )
+    const saveWarningRenderer = vi.mocked(toast.custom).mock.calls[0]?.[0] as
+      | ((toastInstance: any) => any)
+      | undefined
+    const saveWarningElement = saveWarningRenderer?.({
+      id: "warning-toast-id",
+      type: "custom",
+      visible: true,
+      dismissed: false,
+      height: 0,
+      ariaProps: {
+        role: "status",
+        "aria-live": "polite",
+      },
+      message: "",
+      createdAt: Date.now(),
+      pauseDuration: 0,
+      position: "bottom-center",
+    } as any)
+    expect(saveWarningElement?.props.action).toEqual(
+      expect.objectContaining({
+        label: "common:actions.refresh",
+      }),
+    )
     expect(toast.success).not.toHaveBeenCalledWith(
       "Account saved, but latest metrics are placeholders.",
     )
@@ -378,9 +404,35 @@ describe("useAccountDialog save and auto-config flows", () => {
       await result.current.handlers.handleSaveAccount()
     })
 
-    expect(toast.custom).toHaveBeenCalledWith(expect.any(Function), {
-      duration: 5000,
-    })
+    expect(toast.custom).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        duration: 5000,
+      }),
+    )
+    const updateWarningRenderer = vi.mocked(toast.custom).mock.calls[0]?.[0] as
+      | ((toastInstance: any) => any)
+      | undefined
+    const updateWarningElement = updateWarningRenderer?.({
+      id: "warning-toast-id",
+      type: "custom",
+      visible: true,
+      dismissed: false,
+      height: 0,
+      ariaProps: {
+        role: "status",
+        "aria-live": "polite",
+      },
+      message: "",
+      createdAt: Date.now(),
+      pauseDuration: 0,
+      position: "bottom-center",
+    } as any)
+    expect(updateWarningElement?.props.action).toEqual(
+      expect.objectContaining({
+        label: "common:actions.refresh",
+      }),
+    )
     expect(toast.success).not.toHaveBeenCalledWith(
       "Account settings saved, but latest metrics are still stale.",
     )

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -11,6 +11,7 @@ import { buildSiteAccount } from "~~/tests/test-utils/factories"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
 const {
+  mockToast,
   mockValidateAndSaveAccount,
   mockValidateAndUpdateAccount,
   mockOpenWithAccount,
@@ -18,6 +19,7 @@ const {
   mockGetManagedSiteConfig,
   mockOpenSettingsTab,
 } = vi.hoisted(() => ({
+  mockToast: vi.fn(),
   mockValidateAndSaveAccount: vi.fn(),
   mockValidateAndUpdateAccount: vi.fn(),
   mockOpenWithAccount: vi.fn(),
@@ -26,13 +28,19 @@ const {
   mockOpenSettingsTab: vi.fn().mockResolvedValue(undefined),
 }))
 
-vi.mock("react-hot-toast", () => ({
-  default: {
+vi.mock("react-hot-toast", () => {
+  const toastMock = Object.assign(mockToast, {
     success: vi.fn(),
     error: vi.fn(),
     loading: vi.fn(),
-  },
-}))
+    custom: vi.fn(),
+    dismiss: vi.fn(),
+  })
+
+  return {
+    default: toastMock,
+  }
+})
 
 vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
@@ -100,6 +108,7 @@ describe("useAccountDialog save and auto-config flows", () => {
       success: true,
       accountId: "saved-account-id",
       message: "Saved successfully",
+      feedbackLevel: "success",
     })
     mockGetManagedSiteConfig.mockResolvedValue({
       baseUrl: "https://managed.example.com",
@@ -108,6 +117,7 @@ describe("useAccountDialog save and auto-config flows", () => {
     })
     mockValidateAndUpdateAccount.mockResolvedValue({
       success: true,
+      feedbackLevel: "success",
     })
   })
 
@@ -297,6 +307,82 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
     expect(toast.success).toHaveBeenCalledWith(
       "accountDialog:messages.updateSuccess",
+    )
+  })
+
+  it("uses a warning toast for partial-success saves when account data refresh fails", async () => {
+    mockValidateAndSaveAccount.mockResolvedValueOnce({
+      success: true,
+      accountId: "saved-account-id",
+      message: "Account saved, but latest metrics are placeholders.",
+      feedbackLevel: "warning",
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://api.example.com")
+      result.current.setters.setSiteName("Example")
+      result.current.setters.setUsername("user")
+      result.current.setters.setAccessToken("token")
+      result.current.setters.setUserId("1")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType("one-api")
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    expect(toast.custom).toHaveBeenCalledWith(expect.any(Function), {
+      duration: 5000,
+    })
+    expect(toast.success).not.toHaveBeenCalledWith(
+      "Account saved, but latest metrics are placeholders.",
+    )
+  })
+
+  it("uses a warning toast for partial-success updates when latest account data stays stale", async () => {
+    mockValidateAndUpdateAccount.mockResolvedValueOnce({
+      success: true,
+      accountId: "existing-account-id",
+      message: "Account settings saved, but latest metrics are still stale.",
+      feedbackLevel: "warning",
+    })
+
+    const { result } = renderEditHook({
+      account: {
+        id: "existing-account-id",
+      },
+    })
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://edit.example.com")
+      result.current.setters.setSiteName("Edit Example")
+      result.current.setters.setUsername("user")
+      result.current.setters.setAccessToken("token")
+      result.current.setters.setUserId("1")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType("one-api")
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    expect(toast.custom).toHaveBeenCalledWith(expect.any(Function), {
+      duration: 5000,
+    })
+    expect(toast.success).not.toHaveBeenCalledWith(
+      "Account settings saved, but latest metrics are still stale.",
     )
   })
 

--- a/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
+++ b/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
@@ -15,23 +15,32 @@ import { RuntimeActionIds } from "~/constants/runtimeActions"
 import ManagedSiteModelSync from "~/features/ManagedSiteModelSync/ManagedSiteModelSync"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
-const { mockSendRuntimeMessage, mockUseUserPreferencesContext, loggerMocks } =
-  vi.hoisted(() => ({
-    mockSendRuntimeMessage: vi.fn(),
-    mockUseUserPreferencesContext: vi.fn(),
-    loggerMocks: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
-    },
-  }))
+const {
+  mockSendRuntimeMessage,
+  mockUseUserPreferencesContext,
+  mockShowWarningToast,
+  loggerMocks,
+} = vi.hoisted(() => ({
+  mockSendRuntimeMessage: vi.fn(),
+  mockUseUserPreferencesContext: vi.fn(),
+  mockShowWarningToast: vi.fn(),
+  loggerMocks: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
 
 vi.mock("react-hot-toast", () => ({
   default: {
     success: vi.fn(),
     error: vi.fn(),
   },
+}))
+
+vi.mock("~/utils/core/toastHelpers", () => ({
+  showWarningToast: mockShowWarningToast,
 }))
 
 vi.mock("~/utils/core/logger", () => ({
@@ -201,6 +210,122 @@ describe("ManagedSiteModelSync page", () => {
       })
     })
     expect(toast.success).toHaveBeenCalled()
+  })
+
+  it("uses a warning toast when run-all completes with failed channels still present", async () => {
+    mockSendRuntimeMessage.mockImplementation(async (message: any) => {
+      switch (message.action) {
+        case RuntimeActionIds.ModelSyncTriggerAll:
+          return {
+            success: true,
+            data: {
+              items: [
+                {
+                  channelId: 101,
+                  channelName: "Alpha",
+                  ok: true,
+                  attempts: 1,
+                  finishedAt: 1_700_000_005_000,
+                },
+                {
+                  channelId: 102,
+                  channelName: "Beta",
+                  ok: false,
+                  message: "rate limited",
+                  attempts: 2,
+                  finishedAt: 1_700_000_006_000,
+                },
+              ],
+              statistics: {
+                total: 2,
+                successCount: 1,
+                failureCount: 1,
+                durationMs: 2000,
+                startedAt: 1_700_000_004_000,
+                endedAt: 1_700_000_006_000,
+              },
+            },
+          }
+        default:
+          return {
+            success: true,
+            data:
+              message.action === RuntimeActionIds.ModelSyncGetLastExecution
+                ? {
+                    items: [
+                      {
+                        channelId: 101,
+                        channelName: "Alpha",
+                        ok: false,
+                        message: "failed",
+                        attempts: 2,
+                        finishedAt: 1_700_000_000_000,
+                        httpStatus: 500,
+                      },
+                      {
+                        channelId: 102,
+                        channelName: "Beta",
+                        ok: true,
+                        attempts: 1,
+                        finishedAt: 1_700_000_001_000,
+                      },
+                    ],
+                    statistics: {
+                      total: 2,
+                      successCount: 1,
+                      failureCount: 1,
+                      durationMs: 4000,
+                      startedAt: 1_700_000_000_000,
+                      endedAt: 1_700_000_004_000,
+                    },
+                  }
+                : message.action === RuntimeActionIds.ModelSyncGetProgress
+                  ? {
+                      isRunning: false,
+                      completed: 0,
+                      total: 0,
+                      failed: 0,
+                    }
+                  : message.action === RuntimeActionIds.ModelSyncGetNextRun
+                    ? { nextScheduledAt: "2026-03-28T10:00:00.000Z" }
+                    : message.action ===
+                        RuntimeActionIds.ModelSyncGetPreferences
+                      ? {
+                          enableSync: true,
+                          intervalMs: 2 * 60 * 60 * 1000,
+                        }
+                      : message.action ===
+                          RuntimeActionIds.ModelSyncListChannels
+                        ? {
+                            items: [
+                              { id: 201, name: "Manual Alpha" },
+                              { id: 202, name: "Manual Beta" },
+                            ],
+                          }
+                        : undefined,
+          }
+      }
+    })
+
+    render(<ManagedSiteModelSync />)
+
+    expect(await screen.findByText("Alpha#101")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "managedSiteModelSync:execution.actions.runAll",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockShowWarningToast).toHaveBeenCalledWith(
+        "managedSiteModelSync:messages.success.syncCompleted",
+      )
+    })
+
+    expect(toast.success).not.toHaveBeenCalledWith(
+      "managedSiteModelSync:messages.success.syncCompleted",
+    )
   })
 
   it("uses manual route params to load and preselect channels", async () => {

--- a/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
+++ b/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
@@ -319,12 +319,17 @@ describe("ManagedSiteModelSync page", () => {
 
     await waitFor(() => {
       expect(mockShowWarningToast).toHaveBeenCalledWith(
-        "managedSiteModelSync:messages.success.syncCompleted",
+        "managedSiteModelSync:messages.warning.syncCompletedWithFailures",
+        expect.objectContaining({
+          action: expect.objectContaining({
+            label: "managedSiteModelSync:execution.actions.retryFailed",
+          }),
+        }),
       )
     })
 
     expect(toast.success).not.toHaveBeenCalledWith(
-      "managedSiteModelSync:messages.success.syncCompleted",
+      "managedSiteModelSync:messages.warning.syncCompletedWithFailures",
     )
   })
 

--- a/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
+++ b/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
@@ -328,9 +328,7 @@ describe("ManagedSiteModelSync page", () => {
       )
     })
 
-    expect(toast.success).not.toHaveBeenCalledWith(
-      "managedSiteModelSync:messages.warning.syncCompletedWithFailures",
-    )
+    expect(toast.success).not.toHaveBeenCalled()
   })
 
   it("uses manual route params to load and preselect channels", async () => {

--- a/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
+++ b/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
@@ -17,6 +17,7 @@ const {
   ensureDefaultApiTokenForAccountMock,
   toastSuccessMock,
   toastErrorMock,
+  toastCustomMock,
   toastLoadingMock,
   toastDismissMock,
 } = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ const {
   ensureDefaultApiTokenForAccountMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
+  toastCustomMock: vi.fn(),
   toastLoadingMock: vi.fn(),
   toastDismissMock: vi.fn(),
 }))
@@ -32,6 +34,7 @@ vi.mock("react-hot-toast", () => ({
   default: {
     success: toastSuccessMock,
     error: toastErrorMock,
+    custom: toastCustomMock,
     loading: toastLoadingMock,
     dismiss: toastDismissMock,
   },
@@ -80,6 +83,7 @@ describe("accountOperations auto-provision key on add", () => {
     ensureDefaultApiTokenForAccountMock.mockReset()
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
+    toastCustomMock.mockReset()
     toastLoadingMock.mockReset()
     toastDismissMock.mockReset()
 
@@ -95,7 +99,7 @@ describe("accountOperations auto-provision key on add", () => {
 
     ensureDefaultApiTokenForAccountMock.mockResolvedValue({
       token: { id: 1, name: "t", key: "k" },
-      created: false,
+      created: true,
     })
 
     await accountStorage.clearAllData()
@@ -131,6 +135,39 @@ describe("accountOperations auto-provision key on add", () => {
 
     expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledTimes(1)
     expect(toastSuccessMock).toHaveBeenCalledTimes(1)
+    expect(toastCustomMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("uses warning toast when auto-provision is skipped because an API key already exists", async () => {
+    ensureDefaultApiTokenForAccountMock.mockResolvedValueOnce({
+      token: { id: 1, name: "t", key: "k" },
+      created: false,
+    })
+
+    const result = await validateAndSaveAccount(
+      "https://api.example.com",
+      "Test Site",
+      "tester",
+      "test-token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      "unknown",
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result.success).toBe(true)
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledTimes(1)
+    expect(toastCustomMock).toHaveBeenCalledTimes(1)
+    expect(toastSuccessMock).not.toHaveBeenCalled()
     expect(toastErrorMock).not.toHaveBeenCalled()
   })
 
@@ -212,6 +249,7 @@ describe("accountOperations auto-provision key on add", () => {
 
     expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledTimes(1)
     expect(toastSuccessMock).toHaveBeenCalledTimes(1)
+    expect(toastCustomMock).not.toHaveBeenCalled()
     expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledWith(
       expect.objectContaining({
         displaySiteData: expect.objectContaining({

--- a/tests/services/accountOperations.test.ts
+++ b/tests/services/accountOperations.test.ts
@@ -80,6 +80,7 @@ describe("accountOperations", () => {
       )
 
       expect(result.success).toBe(true)
+      expect(result.feedbackLevel).toBe("success")
       expect(mockUpdateAccount).toHaveBeenCalledWith(
         "account-1",
         expect.objectContaining({
@@ -109,6 +110,10 @@ describe("accountOperations", () => {
       )
 
       expect(result.success).toBe(true)
+      expect(result).toMatchObject({
+        message: "messages:warnings.accountUpdatedWithoutDataRefresh",
+        feedbackLevel: "warning",
+      })
       expect(mockUpdateAccount).toHaveBeenCalledWith(
         "account-1",
         expect.objectContaining({

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -102,6 +102,7 @@ describe("accountOperations validateAndSaveAccount", () => {
 
     expect(result.success).toBe(true)
     expect(result.accountId).toBeTruthy()
+    expect(result.feedbackLevel).toBe("success")
 
     const saved = await accountStorage.getAccountById(result.accountId!)
     expect(saved).not.toBeNull()
@@ -160,6 +161,7 @@ describe("accountOperations validateAndSaveAccount", () => {
     expect(result).toMatchObject({
       success: true,
       message: "messages:warnings.accountSavedWithoutDataRefresh",
+      feedbackLevel: "warning",
     })
 
     const saved = await accountStorage.getAccountById(result.accountId!)
@@ -214,6 +216,7 @@ describe("accountOperations validateAndSaveAccount", () => {
       expect(result).toMatchObject({
         success: true,
         message: "messages:warnings.accountSavedWithoutDataRefresh",
+        feedbackLevel: "warning",
       })
 
       const saved = await accountStorage.getAccountById(result.accountId!)

--- a/tests/utils/toastHelpers.test.ts
+++ b/tests/utils/toastHelpers.test.ts
@@ -4,14 +4,25 @@ import {
   showResetToast,
   showResultToast,
   showUpdateToast,
+  showWarningToast,
 } from "~/utils/core/toastHelpers"
 
-vi.mock("react-hot-toast", () => ({
-  default: {
+const { mockToast } = vi.hoisted(() => ({
+  mockToast: vi.fn(),
+}))
+
+vi.mock("react-hot-toast", () => {
+  const toastMock = Object.assign(mockToast, {
     success: vi.fn(),
     error: vi.fn(),
-  },
-}))
+    custom: vi.fn(),
+    dismiss: vi.fn(),
+  })
+
+  return {
+    default: toastMock,
+  }
+})
 
 describe("toastHelpers", () => {
   describe("showResultToast", () => {
@@ -83,6 +94,29 @@ describe("toastHelpers", () => {
       const toast = (await import("react-hot-toast")).default
       showResetToast(false)
       expect(toast.error).toHaveBeenCalledWith("settings:danger.resetFailed")
+    })
+  })
+
+  describe("showWarningToast", () => {
+    it("shows a generic warning toast with the shared wrapper defaults", async () => {
+      const toast = (await import("react-hot-toast")).default
+      showWarningToast("Review this partial-success state")
+      expect(toast.custom).toHaveBeenCalledWith(expect.any(Function), {
+        duration: 5000,
+      })
+    })
+
+    it("falls back to the shared warning icon when toast.custom is unavailable", async () => {
+      const toast = (await import("react-hot-toast")).default as any
+      toast.custom = undefined
+      vi.clearAllMocks()
+
+      showWarningToast("Fallback warning")
+
+      expect(mockToast).toHaveBeenCalledWith("Fallback warning", {
+        duration: 5000,
+        icon: expect.any(Object),
+      })
     })
   })
 })

--- a/tests/utils/toastHelpers.test.ts
+++ b/tests/utils/toastHelpers.test.ts
@@ -106,6 +106,45 @@ describe("toastHelpers", () => {
       })
     })
 
+    it("passes an optional action through to the shared warning toast renderer", async () => {
+      const toast = (await import("react-hot-toast")).default
+      vi.clearAllMocks()
+
+      const actionMock = vi.fn()
+      showWarningToast("Warning with action", {
+        action: {
+          label: "Retry failed only",
+          onClick: actionMock,
+        },
+      })
+
+      const renderer = vi.mocked(toast.custom).mock.calls[0]?.[0] as
+        | ((toastInstance: any) => any)
+        | undefined
+      expect(renderer).toBeTypeOf("function")
+
+      const element = renderer?.({
+        id: "warning-toast-id",
+        type: "custom",
+        visible: true,
+        dismissed: false,
+        height: 0,
+        ariaProps: {
+          role: "status",
+          "aria-live": "polite",
+        },
+        message: "",
+        createdAt: Date.now(),
+        pauseDuration: 0,
+        position: "bottom-center",
+      } as any)
+
+      expect(element?.props.action).toEqual({
+        label: "Retry failed only",
+        onClick: actionMock,
+      })
+    })
+
     it("falls back to the shared warning icon when toast.custom is unavailable", async () => {
       const toast = (await import("react-hot-toast")).default as any
       toast.custom = undefined

--- a/tests/utils/toastHelpers.test.ts
+++ b/tests/utils/toastHelpers.test.ts
@@ -147,15 +147,21 @@ describe("toastHelpers", () => {
 
     it("falls back to the shared warning icon when toast.custom is unavailable", async () => {
       const toast = (await import("react-hot-toast")).default as any
-      toast.custom = undefined
-      vi.clearAllMocks()
+      const originalCustom = toast.custom
 
-      showWarningToast("Fallback warning")
+      try {
+        toast.custom = undefined
+        vi.clearAllMocks()
 
-      expect(mockToast).toHaveBeenCalledWith("Fallback warning", {
-        duration: 5000,
-        icon: expect.any(Object),
-      })
+        showWarningToast("Fallback warning")
+
+        expect(mockToast).toHaveBeenCalledWith("Fallback warning", {
+          duration: 5000,
+          icon: expect.any(Object),
+        })
+      } finally {
+        toast.custom = originalCustom
+      }
     })
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Warning toast notifications for partial/completed-with-issues flows, including optional action buttons (Refresh, Retry, View Status).
  - Theme-aware toast styling for improved light/dark appearance.

* **Localization**
  - Added and updated sync- and warning-related messages across en/ja/zh-CN/zh-TW locales.

* **User-facing Messaging**
  - More specific account feedback when balance/quota/usage cannot be refreshed.

* **Tests**
  - Added/updated tests covering warning toasts, actions, and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->