### PR TITLE
Security: Potential command injection in shell execution with interpolated device ID

### DIFF
--- a/scripts/android-dev.js
+++ b/scripts/android-dev.js
@@ -21,6 +21,11 @@ if (!deviceId) {
   process.exit(1)
 }
 
+if (!/^[A-Za-z0-9._:-]+$/.test(deviceId)) {
+  console.error("设备 ID 非法")
+  process.exit(1)
+}
+
 // 构建 WXT
 console.log("开始构建 WXT...")
 execSync("wxt build -b firefox --mode development", { stdio: "inherit" })


### PR DESCRIPTION
## Problem

The script interpolates `deviceId` into a shell command string passed to `execSync`. Although `deviceId` is parsed from `adb devices`, it is not strictly sanitized for shell metacharacters. If a malicious or malformed device identifier is introduced, this can lead to command injection in developer environments.

**Severity**: `medium`
**File**: `scripts/android-dev.js`

## Solution

Avoid shell interpolation. Use `spawnSync`/`execFileSync` with argument arrays (no shell), or strictly validate `deviceId` against a conservative regex (e.g., `^[A-Za-z0-9._:-]+$`) before use.

## Changes

- `scripts/android-dev.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for Android device identifiers in the development script. Invalid device IDs are now properly rejected with an error message, ensuring only valid devices are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->