### PR TITLE
feat(updates): add release-channel update reminders for manual installs

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/components/dialogs/UpdateLogDialog"
 import { ThemeAwareToaster } from "~/components/ThemeAwareToaster"
 import { DeviceProvider } from "~/contexts/DeviceContext"
+import { ReleaseUpdateStatusProvider } from "~/contexts/ReleaseUpdateStatusContext"
 import { ThemeProvider } from "~/contexts/ThemeContext"
 import { UserPreferencesProvider } from "~/contexts/UserPreferencesContext"
 
@@ -30,16 +31,18 @@ export function AppLayout({ children }: AppLayoutProps) {
     <DeviceProvider>
       <UserPreferencesProvider>
         <ThemeProvider>
-          <ChannelDialogProvider>
-            <UpdateLogDialogProvider>
-              <ChangelogOnUpdateUiOpenHandler />
-              <AutoCheckinUiOpenPretrigger />
-              <UpdateLogDialogContainer />
-              {children}
-              <ChannelDialogContainer />
-              <DuplicateChannelWarningDialogContainer />
-            </UpdateLogDialogProvider>
-          </ChannelDialogProvider>
+          <ReleaseUpdateStatusProvider>
+            <ChannelDialogProvider>
+              <UpdateLogDialogProvider>
+                <ChangelogOnUpdateUiOpenHandler />
+                <AutoCheckinUiOpenPretrigger />
+                <UpdateLogDialogContainer />
+                {children}
+                <ChannelDialogContainer />
+                <DuplicateChannelWarningDialogContainer />
+              </UpdateLogDialogProvider>
+            </ChannelDialogProvider>
+          </ReleaseUpdateStatusProvider>
           <ThemeAwareToaster reverseOrder={false} />
         </ThemeProvider>
       </UserPreferencesProvider>

--- a/src/components/ReleaseUpdateStatusPanel.tsx
+++ b/src/components/ReleaseUpdateStatusPanel.tsx
@@ -204,6 +204,11 @@ export function ReleaseUpdateStatusPanel() {
   )
 
   const handleCheckNow = async () => {
+    if (presentation.state === RELEASE_UPDATE_PRESENTATION_STATES.Ineligible) {
+      toast.error(getReasonDescription(statusReason, t))
+      return
+    }
+
     const next = await checkNow()
     const outcome = deriveReleaseUpdateCheckOutcome(next)
 
@@ -231,11 +236,13 @@ export function ReleaseUpdateStatusPanel() {
           description={statusDescription}
           leftContent={
             <div className="space-y-1">
-              <BodySmall>
-                {t("about:releaseUpdate.currentVersion", {
-                  version: status?.currentVersion ?? "0.0.0",
-                })}
-              </BodySmall>
+              {status?.currentVersion && (
+                <BodySmall>
+                  {t("about:releaseUpdate.currentVersion", {
+                    version: status.currentVersion,
+                  })}
+                </BodySmall>
+              )}
               <BodySmall>{latestVersionLine}</BodySmall>
               {lastChecked && (
                 <BodySmall>

--- a/src/components/ReleaseUpdateStatusPanel.tsx
+++ b/src/components/ReleaseUpdateStatusPanel.tsx
@@ -133,6 +133,36 @@ function getStatusHelper(options: {
 }
 
 /**
+ * Map the derived release-update state to the latest-version detail line.
+ */
+function getLatestVersionLine(options: {
+  latestVersion: string | null
+  state: ReturnType<typeof deriveReleaseUpdatePresentation>["state"]
+  t: TFunction
+}): string {
+  const { latestVersion, state, t } = options
+
+  if (latestVersion) {
+    return t("about:releaseUpdate.latestVersion", {
+      version: latestVersion,
+    })
+  }
+
+  switch (state) {
+    case RELEASE_UPDATE_PRESENTATION_STATES.Loading:
+    case RELEASE_UPDATE_PRESENTATION_STATES.NotChecked:
+      return t("settings:releaseUpdate.latestVersionPending")
+    case RELEASE_UPDATE_PRESENTATION_STATES.Unavailable:
+    case RELEASE_UPDATE_PRESENTATION_STATES.CheckFailed:
+    case RELEASE_UPDATE_PRESENTATION_STATES.Ineligible:
+    case RELEASE_UPDATE_PRESENTATION_STATES.UpdateAvailable:
+    case RELEASE_UPDATE_PRESENTATION_STATES.UpToDate:
+    default:
+      return t("settings:releaseUpdate.latestVersionUnavailable")
+  }
+}
+
+/**
  * Shared release-update status panel rendered in About and Settings surfaces.
  */
 export function ReleaseUpdateStatusPanel() {
@@ -145,13 +175,11 @@ export function ReleaseUpdateStatusPanel() {
     status,
   })
   const latestVersion = presentation.latestVersion
-  const latestVersionLine = latestVersion
-    ? t("about:releaseUpdate.latestVersion", {
-        version: latestVersion,
-      })
-    : status?.lastError
-      ? t("settings:releaseUpdate.latestVersionUnavailable")
-      : t("settings:releaseUpdate.latestVersionPending")
+  const latestVersionLine = getLatestVersionLine({
+    latestVersion,
+    state: presentation.state,
+    t,
+  })
 
   const statusReason = status?.reason ?? RELEASE_UPDATE_REASONS.Unknown
   const statusTitle = getStatusTitle({

--- a/src/components/ReleaseUpdateStatusPanel.tsx
+++ b/src/components/ReleaseUpdateStatusPanel.tsx
@@ -1,0 +1,249 @@
+import {
+  ArrowDownTrayIcon,
+  ArrowPathIcon,
+  ArrowTopRightOnSquareIcon,
+  CloudArrowDownIcon,
+} from "@heroicons/react/24/outline"
+import type { TFunction } from "i18next"
+import toast from "react-hot-toast"
+import { useTranslation } from "react-i18next"
+
+import { BodySmall, Button, Card, CardItem, CardList } from "~/components/ui"
+import { useReleaseUpdateStatus } from "~/contexts/ReleaseUpdateStatusContext"
+import {
+  deriveReleaseUpdateCheckOutcome,
+  deriveReleaseUpdatePresentation,
+  RELEASE_UPDATE_CHECK_OUTCOMES,
+  RELEASE_UPDATE_PRESENTATION_STATES,
+} from "~/services/updates/presentation"
+import {
+  LATEST_STABLE_RELEASE_URL,
+  RELEASE_UPDATE_REASONS,
+  type ReleaseUpdateReason,
+} from "~/services/updates/releaseUpdateStatus"
+
+/**
+ * Format the last release-check timestamp for a localized status line.
+ */
+function formatCheckedAt(
+  timestamp: number | null,
+  locale: string,
+): string | null {
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+    return null
+  }
+
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(timestamp)
+  } catch {
+    return new Date(timestamp).toLocaleString()
+  }
+}
+
+/**
+ * Map install-eligibility reasons to localized title text for the panel.
+ */
+function getReasonDescription(
+  reason: ReleaseUpdateReason,
+  t: TFunction,
+): string {
+  switch (reason) {
+    case RELEASE_UPDATE_REASONS.ChromiumDevelopment:
+      return t("settings:releaseUpdate.reasons.chromium-development")
+    case RELEASE_UPDATE_REASONS.StoreBuild:
+      return t("settings:releaseUpdate.reasons.store-build")
+    case RELEASE_UPDATE_REASONS.FirefoxAmbiguous:
+      return t("settings:releaseUpdate.reasons.firefox-ambiguous")
+    case RELEASE_UPDATE_REASONS.SafariUnsupported:
+      return t("settings:releaseUpdate.reasons.safari-unsupported")
+    case RELEASE_UPDATE_REASONS.ApiUnavailable:
+      return t("settings:releaseUpdate.reasons.api-unavailable")
+    case RELEASE_UPDATE_REASONS.Unknown:
+    default:
+      return t("settings:releaseUpdate.reasons.unknown")
+  }
+}
+
+/**
+ * Map the derived release-update state to the primary status title shown in the panel.
+ */
+function getStatusTitle(options: {
+  state: ReturnType<typeof deriveReleaseUpdatePresentation>["state"]
+  t: TFunction
+  reason: ReleaseUpdateReason
+}): string {
+  const { state, t, reason } = options
+
+  switch (state) {
+    case RELEASE_UPDATE_PRESENTATION_STATES.Loading:
+      return t("common:status.loading")
+    case RELEASE_UPDATE_PRESENTATION_STATES.Unavailable:
+      return t("settings:releaseUpdate.states.unavailable")
+    case RELEASE_UPDATE_PRESENTATION_STATES.UpdateAvailable:
+      return t("settings:releaseUpdate.states.updateAvailable")
+    case RELEASE_UPDATE_PRESENTATION_STATES.CheckFailed:
+      return t("settings:releaseUpdate.states.checkFailed")
+    case RELEASE_UPDATE_PRESENTATION_STATES.UpToDate:
+      return t("settings:releaseUpdate.states.upToDate")
+    case RELEASE_UPDATE_PRESENTATION_STATES.NotChecked:
+      return t("settings:releaseUpdate.states.notChecked")
+    case RELEASE_UPDATE_PRESENTATION_STATES.Ineligible:
+    default:
+      return getReasonDescription(reason, t)
+  }
+}
+
+/**
+ * Map the derived release-update state to the secondary helper copy shown in the panel.
+ */
+function getStatusHelper(options: {
+  state: ReturnType<typeof deriveReleaseUpdatePresentation>["state"]
+  t: TFunction
+  reason: ReleaseUpdateReason
+}): string | undefined {
+  const { state, t, reason } = options
+
+  switch (state) {
+    case RELEASE_UPDATE_PRESENTATION_STATES.Loading:
+      return undefined
+    case RELEASE_UPDATE_PRESENTATION_STATES.Unavailable:
+      return t("settings:releaseUpdate.helpers.unavailable")
+    case RELEASE_UPDATE_PRESENTATION_STATES.UpdateAvailable:
+      switch (reason) {
+        case RELEASE_UPDATE_REASONS.StoreBuild:
+          return t("settings:releaseUpdate.helpers.storeUpdate")
+        case RELEASE_UPDATE_REASONS.ChromiumDevelopment:
+          return t("settings:releaseUpdate.helpers.manualUpdate")
+        default:
+          return t("settings:releaseUpdate.helpers.manualUpdateGeneric")
+      }
+    case RELEASE_UPDATE_PRESENTATION_STATES.CheckFailed:
+      return t("settings:releaseUpdate.helpers.checkFailed")
+    case RELEASE_UPDATE_PRESENTATION_STATES.UpToDate:
+      return t("settings:releaseUpdate.helpers.upToDate")
+    case RELEASE_UPDATE_PRESENTATION_STATES.NotChecked:
+      return t("settings:releaseUpdate.helpers.notChecked")
+    case RELEASE_UPDATE_PRESENTATION_STATES.Ineligible:
+    default:
+      return t("settings:releaseUpdate.helpers.openLatest")
+  }
+}
+
+/**
+ * Shared release-update status panel rendered in About and Settings surfaces.
+ */
+export function ReleaseUpdateStatusPanel() {
+  const { t, i18n } = useTranslation(["settings", "about", "common"])
+  const { status, isLoading, isChecking, checkNow } = useReleaseUpdateStatus()
+
+  const lastChecked = formatCheckedAt(status?.checkedAt ?? null, i18n.language)
+  const presentation = deriveReleaseUpdatePresentation({
+    isLoading,
+    status,
+  })
+  const latestVersion = presentation.latestVersion
+  const latestVersionLine = latestVersion
+    ? t("about:releaseUpdate.latestVersion", {
+        version: latestVersion,
+      })
+    : status?.lastError
+      ? t("settings:releaseUpdate.latestVersionUnavailable")
+      : t("settings:releaseUpdate.latestVersionPending")
+
+  const statusReason = status?.reason ?? RELEASE_UPDATE_REASONS.Unknown
+  const statusTitle = getStatusTitle({
+    state: presentation.state,
+    t,
+    reason: statusReason,
+  })
+  const statusDescription = getStatusHelper({
+    state: presentation.state,
+    t,
+    reason: statusReason,
+  })
+  const hasUpdate = presentation.hasUpdate
+  const actionHref = status?.releaseUrl ?? LATEST_STABLE_RELEASE_URL
+  const actionLabel = hasUpdate
+    ? t("settings:releaseUpdate.downloadUpdate")
+    : t("settings:releaseUpdate.openLatest")
+  const actionIcon = hasUpdate ? (
+    <ArrowDownTrayIcon className="h-4 w-4" />
+  ) : (
+    <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+  )
+
+  const handleCheckNow = async () => {
+    const next = await checkNow()
+    const outcome = deriveReleaseUpdateCheckOutcome(next)
+
+    switch (outcome) {
+      case RELEASE_UPDATE_CHECK_OUTCOMES.CheckFailed:
+        toast.error(t("settings:releaseUpdate.states.checkFailed"))
+        return
+      case RELEASE_UPDATE_CHECK_OUTCOMES.UpdateAvailable:
+        toast.success(t("settings:releaseUpdate.states.updateAvailable"))
+        return
+      case RELEASE_UPDATE_CHECK_OUTCOMES.UpToDate:
+      default:
+        toast.success(t("settings:releaseUpdate.states.upToDate"))
+    }
+  }
+
+  return (
+    <Card padding="none">
+      <CardList>
+        <CardItem
+          icon={
+            <CloudArrowDownIcon className="h-5 w-5 text-sky-600 dark:text-sky-400" />
+          }
+          title={statusTitle}
+          description={statusDescription}
+          leftContent={
+            <div className="space-y-1">
+              <BodySmall>
+                {t("about:releaseUpdate.currentVersion", {
+                  version: status?.currentVersion ?? "0.0.0",
+                })}
+              </BodySmall>
+              <BodySmall>{latestVersionLine}</BodySmall>
+              {lastChecked && (
+                <BodySmall>
+                  {t("settings:releaseUpdate.lastChecked", {
+                    time: lastChecked,
+                  })}
+                </BodySmall>
+              )}
+            </div>
+          }
+          rightContent={
+            <div className="flex flex-wrap justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void handleCheckNow()}
+                loading={isChecking}
+                leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+              >
+                {t("settings:releaseUpdate.checkNow")}
+              </Button>
+              <Button
+                asChild
+                variant={hasUpdate ? "default" : "secondary"}
+                size="sm"
+                rightIcon={actionIcon}
+              >
+                <a href={actionHref} target="_blank" rel="noopener noreferrer">
+                  {actionLabel}
+                </a>
+              </Button>
+            </div>
+          }
+        />
+      </CardList>
+    </Card>
+  )
+}

--- a/src/components/VersionBadge.tsx
+++ b/src/components/VersionBadge.tsx
@@ -1,4 +1,10 @@
+import { ArrowUpCircleIcon } from "@heroicons/react/24/solid"
+import { useTranslation } from "react-i18next"
+
 import { Badge } from "~/components/ui"
+import { useReleaseUpdateStatus } from "~/contexts/ReleaseUpdateStatusContext"
+import { cn } from "~/lib/utils"
+import { hasAvailableReleaseUpdate } from "~/services/updates/presentation"
 import { getManifest } from "~/utils/browser/browserApi"
 import { getDocsChangelogUrl } from "~/utils/navigation/docsLinks"
 
@@ -30,20 +36,35 @@ export function VersionBadge({
   className,
 }: VersionBadgeProps) {
   const { version } = getManifest()
+  const { t } = useTranslation("settings")
+  const { status } = useReleaseUpdateStatus()
   if (!version) return null
 
-  const changelogUrl = getDocsChangelogUrl(version)
+  const hasUpdate = hasAvailableReleaseUpdate(status)
+  const href =
+    hasUpdate && status ? status.releaseUrl : getDocsChangelogUrl(version)
+  const ariaLabel = hasUpdate
+    ? t("releaseUpdate.versionBadge.updateAvailableAriaLabel", { version })
+    : t("releaseUpdate.versionBadge.changelogAriaLabel", { version })
 
   return (
     <Badge asChild variant={variant} size={size} className={className}>
       <a
-        href={changelogUrl}
+        href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="tap-highlight-transparent touch-manipulation"
-        aria-label={`v${version} changelog`}
+        className={cn(
+          "tap-highlight-transparent inline-flex touch-manipulation items-center gap-1.5",
+        )}
+        aria-label={ariaLabel}
       >
-        v{version}
+        <span>v{version}</span>
+        {hasUpdate && (
+          <ArrowUpCircleIcon
+            aria-hidden="true"
+            className="h-5 w-5 text-amber-500"
+          />
+        )}
       </a>
     </Badge>
   )

--- a/src/components/ui/CardItem.tsx
+++ b/src/components/ui/CardItem.tsx
@@ -57,6 +57,7 @@ const CardItem = React.forwardRef<HTMLDivElement, CardSectionProps>(
     ref,
   ) => {
     const isClickable = onClick || interactive
+    const hasHeaderContent = !!(title || description)
 
     const Component = (isClickable ? "button" : "div") as any
 
@@ -96,7 +97,11 @@ const CardItem = React.forwardRef<HTMLDivElement, CardSectionProps>(
                     {description}
                   </BodySmall>
                 )}
-                {leftContent}
+                {leftContent && (
+                  <div className={cn(hasHeaderContent && "mt-2")}>
+                    {leftContent}
+                  </div>
+                )}
               </div>
             </div>
             {rightContent && (

--- a/src/constants/extensionStores.ts
+++ b/src/constants/extensionStores.ts
@@ -1,5 +1,11 @@
 import type { ExtensionStoreId } from "~/utils/browser"
 
+// Firefox is intentionally excluded here because its add-on/runtime ID scheme
+// differs from Chromium-family extension IDs and cannot be matched reliably
+// through the same runtime-id mapping used for Chrome/Edge store builds.
+// In practice we also do not maintain a separate Firefox release-store runtime
+// ID mapping here because AMO review is typically fast enough that very few
+// users would need a distinct "release" channel lookup from this table.
 export const EXTENSION_STORE_IDS: Record<
   Exclude<ExtensionStoreId, "firefox">,
   string

--- a/src/constants/extensionStores.ts
+++ b/src/constants/extensionStores.ts
@@ -1,5 +1,13 @@
 import type { ExtensionStoreId } from "~/utils/browser"
 
+export const EXTENSION_STORE_IDS: Record<
+  Exclude<ExtensionStoreId, "firefox">,
+  string
+> = {
+  chrome: "lapnciffpekdengooeolaienkeoilfeo",
+  edge: "pcokpjaffghgipcgjhapgdpeddlhblaa",
+}
+
 export const EXTENSION_STORE_LISTING_URLS: Record<ExtensionStoreId, string> = {
   chrome:
     "https://chromewebstore.google.com/detail/lapnciffpekdengooeolaienkeoilfeo",

--- a/src/constants/runtimeActions.ts
+++ b/src/constants/runtimeActions.ts
@@ -23,6 +23,7 @@ export const RuntimeActionPrefixes = {
   OpenSettings: "openSettings:",
   Permissions: "permissions:",
   Preferences: "preferences:",
+  ReleaseUpdate: "releaseUpdate:",
   RedemptionAssist: "redemptionAssist:",
   UsageHistory: "usageHistory:",
   WebdavAutoSync: "webdavAutoSync:",
@@ -120,6 +121,15 @@ export const RuntimeActionIds = {
   PreferencesRefreshContextMenus: composeRuntimeAction(
     RuntimeActionPrefixes.Preferences,
     "refreshContextMenus",
+  ),
+
+  ReleaseUpdateGetStatus: composeRuntimeAction(
+    RuntimeActionPrefixes.ReleaseUpdate,
+    "getStatus",
+  ),
+  ReleaseUpdateCheckNow: composeRuntimeAction(
+    RuntimeActionPrefixes.ReleaseUpdate,
+    "checkNow",
   ),
 
   AutoRefreshSetup: composeRuntimeAction(

--- a/src/contexts/ReleaseUpdateStatusContext.tsx
+++ b/src/contexts/ReleaseUpdateStatusContext.tsx
@@ -77,9 +77,6 @@ function useCreateReleaseUpdateStatus(): ReleaseUpdateStatusContextValue {
       }
 
       setError(response.error)
-      if (status) {
-        return status
-      }
       return null
     } finally {
       setIsChecking(false)

--- a/src/contexts/ReleaseUpdateStatusContext.tsx
+++ b/src/contexts/ReleaseUpdateStatusContext.tsx
@@ -1,0 +1,129 @@
+import { createContext, useContext, useEffect, useState } from "react"
+import type { ReactNode } from "react"
+
+import { type ReleaseUpdateStatus } from "~/services/updates/releaseUpdateStatus"
+import {
+  requestReleaseUpdateCheckNow,
+  requestReleaseUpdateStatus,
+} from "~/services/updates/runtime"
+
+type ReleaseUpdateStatusContextValue = {
+  status: ReleaseUpdateStatus | null
+  isLoading: boolean
+  isChecking: boolean
+  error: string | null
+  refresh: () => Promise<void>
+  checkNow: () => Promise<ReleaseUpdateStatus | null>
+}
+
+const ReleaseUpdateStatusContext = createContext<
+  ReleaseUpdateStatusContextValue | undefined
+>(undefined)
+
+/**
+ * Build the shared release-update state used by UI consumers within one app surface.
+ */
+function useCreateReleaseUpdateStatus(): ReleaseUpdateStatusContextValue {
+  const [status, setStatus] = useState<ReleaseUpdateStatus | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isChecking, setIsChecking] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    void (async () => {
+      const response = await requestReleaseUpdateStatus()
+      if (cancelled) {
+        return
+      }
+
+      if (response.success) {
+        setStatus(response.data)
+        setError(null)
+      } else {
+        setError(response.error)
+      }
+
+      setIsLoading(false)
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const refresh = async () => {
+    const response = await requestReleaseUpdateStatus()
+
+    if (response.success) {
+      setStatus(response.data)
+      setError(null)
+      return
+    }
+
+    setError(response.error)
+  }
+
+  const checkNow = async () => {
+    setIsChecking(true)
+
+    try {
+      const response = await requestReleaseUpdateCheckNow()
+      if (response.success) {
+        setStatus(response.data)
+        setError(null)
+        return response.data
+      }
+
+      setError(response.error)
+      if (status) {
+        return status
+      }
+      return null
+    } finally {
+      setIsChecking(false)
+    }
+  }
+
+  return {
+    status,
+    isLoading,
+    isChecking,
+    error,
+    refresh,
+    checkNow,
+  }
+}
+
+/**
+ * Share one release-update request lifecycle across the current app surface.
+ */
+export function ReleaseUpdateStatusProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const value = useCreateReleaseUpdateStatus()
+
+  return (
+    <ReleaseUpdateStatusContext.Provider value={value}>
+      {children}
+    </ReleaseUpdateStatusContext.Provider>
+  )
+}
+
+/**
+ * Read shared release-update state provided by the app shell.
+ */
+export function useReleaseUpdateStatus(): ReleaseUpdateStatusContextValue {
+  const value = useContext(ReleaseUpdateStatusContext)
+
+  if (!value) {
+    throw new Error(
+      "useReleaseUpdateStatus must be used within a ReleaseUpdateStatusProvider",
+    )
+  }
+
+  return value
+}

--- a/src/contexts/ReleaseUpdateStatusContext.tsx
+++ b/src/contexts/ReleaseUpdateStatusContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react"
+import { createContext, useContext, useEffect, useRef, useState } from "react"
 import type { ReactNode } from "react"
 
 import { type ReleaseUpdateStatus } from "~/services/updates/releaseUpdateStatus"
@@ -6,6 +6,7 @@ import {
   requestReleaseUpdateCheckNow,
   requestReleaseUpdateStatus,
 } from "~/services/updates/runtime"
+import { getErrorMessage } from "~/utils/core/error"
 
 type ReleaseUpdateStatusContextValue = {
   status: ReleaseUpdateStatus | null
@@ -20,6 +21,8 @@ const ReleaseUpdateStatusContext = createContext<
   ReleaseUpdateStatusContextValue | undefined
 >(undefined)
 
+const RELEASE_UPDATE_REQUEST_ERROR = "Background request failed."
+
 /**
  * Build the shared release-update state used by UI consumers within one app surface.
  */
@@ -28,24 +31,33 @@ function useCreateReleaseUpdateStatus(): ReleaseUpdateStatusContextValue {
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isChecking, setIsChecking] = useState(false)
+  const checkInFlightCountRef = useRef(0)
 
   useEffect(() => {
     let cancelled = false
 
     void (async () => {
-      const response = await requestReleaseUpdateStatus()
-      if (cancelled) {
-        return
-      }
+      try {
+        const response = await requestReleaseUpdateStatus()
+        if (cancelled) {
+          return
+        }
 
-      if (response.success) {
-        setStatus(response.data)
-        setError(null)
-      } else {
-        setError(response.error)
+        if (response.success) {
+          setStatus(response.data)
+          setError(null)
+        } else {
+          setError(response.error)
+        }
+      } catch (requestError) {
+        if (!cancelled) {
+          setError(getErrorMessage(requestError, RELEASE_UPDATE_REQUEST_ERROR))
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
       }
-
-      setIsLoading(false)
     })()
 
     return () => {
@@ -54,18 +66,23 @@ function useCreateReleaseUpdateStatus(): ReleaseUpdateStatusContextValue {
   }, [])
 
   const refresh = async () => {
-    const response = await requestReleaseUpdateStatus()
+    try {
+      const response = await requestReleaseUpdateStatus()
 
-    if (response.success) {
-      setStatus(response.data)
-      setError(null)
-      return
+      if (response.success) {
+        setStatus(response.data)
+        setError(null)
+        return
+      }
+
+      setError(response.error)
+    } catch (requestError) {
+      setError(getErrorMessage(requestError, RELEASE_UPDATE_REQUEST_ERROR))
     }
-
-    setError(response.error)
   }
 
   const checkNow = async () => {
+    checkInFlightCountRef.current += 1
     setIsChecking(true)
 
     try {
@@ -78,8 +95,15 @@ function useCreateReleaseUpdateStatus(): ReleaseUpdateStatusContextValue {
 
       setError(response.error)
       return null
+    } catch (requestError) {
+      setError(getErrorMessage(requestError, RELEASE_UPDATE_REQUEST_ERROR))
+      return null
     } finally {
-      setIsChecking(false)
+      checkInFlightCountRef.current = Math.max(
+        0,
+        checkInFlightCountRef.current - 1,
+      )
+      setIsChecking(checkInFlightCountRef.current > 0)
     }
   }
 

--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -16,6 +16,7 @@ import { handleLdohSiteLookupMessage } from "~/services/integrations/ldohSiteLoo
 import { handleChannelConfigMessage } from "~/services/managedSites/channelConfigStorage"
 import { handleManagedSiteModelSyncMessage } from "~/services/models/modelSync"
 import { handleRedemptionAssistMessage } from "~/services/redemption/redemptionAssist"
+import { handleReleaseUpdateMessage } from "~/services/updates/releaseUpdateService"
 import { handleWebAiApiCheckMessage } from "~/services/verification/webAiApiCheck/background"
 import { handleWebdavAutoSyncMessage } from "~/services/webdav/webdavAutoSyncService"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
@@ -240,6 +241,16 @@ export function setupRuntimeMessageListeners() {
       }
 
       // 处理自动刷新相关消息
+      if (
+        hasRuntimeActionPrefix(
+          request.action,
+          RuntimeActionPrefixes.ReleaseUpdate,
+        )
+      ) {
+        void handleReleaseUpdateMessage(request, sendResponse)
+        return true
+      }
+
       if (
         hasRuntimeActionPrefix(
           request.action,

--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -240,7 +240,7 @@ export function setupRuntimeMessageListeners() {
         return true
       }
 
-      // 处理自动刷新相关消息
+      // 处理 release-update 相关消息，路由到 handleReleaseUpdateMessage
       if (
         hasRuntimeActionPrefix(
           request.action,

--- a/src/entrypoints/background/servicesInit.ts
+++ b/src/entrypoints/background/servicesInit.ts
@@ -5,6 +5,7 @@ import { usageHistoryScheduler } from "~/services/history/usageHistory/scheduler
 import { modelMetadataService } from "~/services/models/modelMetadata"
 import { modelSyncScheduler } from "~/services/models/modelSync"
 import { redemptionAssistService } from "~/services/redemption/redemptionAssist"
+import { releaseUpdateService } from "~/services/updates/releaseUpdateService"
 import { webdavAutoSyncService } from "~/services/webdav/webdavAutoSyncService"
 import { createLogger } from "~/utils/core/logger"
 import { initBackgroundI18n } from "~/utils/i18n/background"
@@ -54,6 +55,7 @@ export async function initializeServices() {
         modelSyncScheduler.initialize(),
         autoCheckinScheduler.initialize(),
         dailyBalanceHistoryScheduler.initialize(),
+        releaseUpdateService.initialize(),
       ])
 
       await initBackgroundI18n().catch((error) => {

--- a/src/entrypoints/options/components/ThemeToggle/index.tsx
+++ b/src/entrypoints/options/components/ThemeToggle/index.tsx
@@ -80,7 +80,7 @@ const ThemeToggle = () => {
       }
       leftContent={
         <Caption
-          className={`${COLORS.text.tertiary} mt-1 ${ANIMATIONS.transition.base}`}
+          className={`${COLORS.text.tertiary} ${ANIMATIONS.transition.base}`}
         >
           {t("theme.currentTheme", {
             theme: themeOptions.find((opt) => opt.mode === themeMode)?.label,

--- a/src/features/About/About.tsx
+++ b/src/features/About/About.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next"
 import FeatureList from "~/components/FeatureList"
 import LinkCard from "~/components/LinkCard"
 import { PageHeader } from "~/components/PageHeader"
+import { ReleaseUpdateStatusPanel } from "~/components/ReleaseUpdateStatusPanel"
 import { Heading4 } from "~/components/ui"
 import { FEATURES, FUTURE_FEATURES } from "~/constants/about"
 import { EXTENSION_STORE_LISTING_URLS } from "~/constants/extensionStores"
@@ -126,6 +127,11 @@ export default function About() {
               iconClass="text-blue-600 dark:text-blue-400"
             />
           </div>
+        </section>
+
+        <section>
+          <Heading4 className="mb-4">{t("releaseUpdate.title")}</Heading4>
+          <ReleaseUpdateStatusPanel />
         </section>
 
         <section>

--- a/src/locales/en/about.json
+++ b/src/locales/en/about.json
@@ -30,6 +30,11 @@
   "privacyText": "All data of this plugin is stored locally in the browser and will not be actively uploaded to any server. Your account information and usage data are completely under your control, ensuring privacy and security",
   "privacyTitle": "Privacy Protection",
   "projectLinks": "Project Links",
+  "releaseUpdate": {
+    "currentVersion": "Current version: v{{version}}",
+    "latestVersion": "Latest stable: v{{version}}",
+    "title": "Version Updates"
+  },
   "starRepo": "Go star it",
   "stores": {
     "chrome": "Chrome Web Store",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -343,6 +343,43 @@
     "shieldTitle": "Temp-window protection bypass",
     "title": "Refresh Settings"
   },
+  "releaseUpdate": {
+    "checkNow": "Check now",
+    "downloadUpdate": "Download update",
+    "helpers": {
+      "checkFailed": "Try again later, or open the release page to verify the latest version manually.",
+      "manualUpdate": "This install is updated manually. Open the release page to get the new version.",
+      "manualUpdateGeneric": "Update through your current install channel, or open the release page if you need to update manually.",
+      "notChecked": "Run “Check now” to confirm whether your current version needs an update.",
+      "openLatest": "Open the release page to review the latest stable release and release notes.",
+      "storeUpdate": "This install usually updates automatically. You can also check the store or release page for the newest version.",
+      "unavailable": "Try again later, or open the release page to review the latest stable release directly.",
+      "upToDate": "Open the release page if you want to review what changed in this version."
+    },
+    "lastChecked": "Last checked: {{time}}",
+    "latestVersionPending": "Latest stable: not checked yet",
+    "latestVersionUnavailable": "Latest stable: unavailable",
+    "openLatest": "Open latest release",
+    "reasons": {
+      "api-unavailable": "This browser environment does not support automatic detection. You can still check the latest stable release manually",
+      "chromium-development": "This install channel can check the latest stable release. Run a manual check to compare versions",
+      "firefox-ambiguous": "Firefox cannot reliably determine the install channel right now. Manually check the latest stable release when needed",
+      "safari-unsupported": "Safari does not support automatic detection yet. Open the release page to review the latest stable release",
+      "store-build": "This install channel does not support automatic detection, but you can still check the latest stable release manually",
+      "unknown": "This install channel does not currently support automatic detection. You can still check the latest stable release manually"
+    },
+    "states": {
+      "checkFailed": "Check failed, so the latest stable release could not be retrieved",
+      "notChecked": "The latest stable release has not been checked yet. Run a manual check to compare versions",
+      "unavailable": "Update status is currently unavailable",
+      "updateAvailable": "A newer version is available to upgrade",
+      "upToDate": "Check complete. Your current version is already the latest stable release"
+    },
+    "versionBadge": {
+      "changelogAriaLabel": "Version {{version}} changelog",
+      "updateAvailableAriaLabel": "Version {{version}} update available"
+    }
+  },
   "sorting": {
     "checkInDesc": "Place sites that need check-in at the front",
     "checkInRequirement": "Check-in Requirement",

--- a/src/locales/ja/about.json
+++ b/src/locales/ja/about.json
@@ -30,6 +30,11 @@
   "privacyText": "このプラグインのすべてのデータはブラウザ内にローカル保存され、いかなるサーバーにも積極的に送信されることはありません。アカウント情報と利用データは完全にあなたの管理下にあり、プライバシーと安全性を確保します。",
   "privacyTitle": "プライバシー保護",
   "projectLinks": "プロジェクトリンク",
+  "releaseUpdate": {
+    "currentVersion": "現在のバージョン: v{{version}}",
+    "latestVersion": "最新安定版: v{{version}}",
+    "title": "バージョン更新"
+  },
   "starRepo": "Star を付けに行く",
   "stores": {
     "chrome": "Chrome ウェブストア",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -343,6 +343,43 @@
     "shieldTitle": "一時ウィンドウによる保護回避",
     "title": "更新設定"
   },
+  "releaseUpdate": {
+    "checkNow": "今すぐ確認",
+    "downloadUpdate": "更新をダウンロード",
+    "helpers": {
+      "checkFailed": "後でもう一度試すか、リリースページで最新バージョンを手動確認してください。",
+      "manualUpdate": "現在のインストールは手動更新です。リリースページから新しいバージョンを取得してください。",
+      "manualUpdateGeneric": "現在のインストール経路で更新してください。必要ならリリースページから手動更新してください。",
+      "notChecked": "「今すぐ確認」を実行すると、現在のバージョンに更新が必要か確認できます。",
+      "openLatest": "リリースページで最新安定版と更新内容を確認できます。",
+      "storeUpdate": "このインストールは通常自動更新されます。必要ならストアまたはリリースページで最新バージョンを確認してください。",
+      "unavailable": "後でもう一度試すか、リリースページで最新安定版を直接確認してください。",
+      "upToDate": "必要ならリリースページでこのバージョンの変更内容を確認できます。"
+    },
+    "lastChecked": "最終確認: {{time}}",
+    "latestVersionPending": "最新安定版: 未確認",
+    "latestVersionUnavailable": "最新安定版: 取得不可",
+    "openLatest": "最新リリースを開く",
+    "reasons": {
+      "api-unavailable": "現在のブラウザ環境では自動検出を利用できません。必要なら最新安定版を手動で確認してください",
+      "chromium-development": "現在のインストール経路では最新安定版を確認できます。手動チェックでバージョン差分を確認してください",
+      "firefox-ambiguous": "Firefox では現在インストール経路を確実に判定できません。必要に応じて最新安定版を手動で確認してください",
+      "safari-unsupported": "Safari はまだ自動検出に対応していません。リリースページで最新安定版を確認してください",
+      "store-build": "現在のインストール経路は自動検出に対応していませんが、最新安定版は手動で確認できます",
+      "unknown": "現在のインストール経路は自動検出に対応していません。必要に応じて最新安定版を手動で確認してください"
+    },
+    "states": {
+      "checkFailed": "確認に失敗したため、最新安定版の情報を取得できませんでした",
+      "notChecked": "最新安定版はまだ確認していません。手動チェックで比較できます",
+      "unavailable": "更新状態を取得できませんでした",
+      "updateAvailable": "アップグレード可能な新しいバージョンがあります",
+      "upToDate": "確認完了。現在のバージョンはすでに最新安定版です"
+    },
+    "versionBadge": {
+      "changelogAriaLabel": "バージョン {{version}} の更新履歴",
+      "updateAvailableAriaLabel": "バージョン {{version}} に更新があります"
+    }
+  },
   "sorting": {
     "checkInDesc": "チェックインが必要なサイトを先頭に表示します",
     "checkInRequirement": "チェックイン要件",

--- a/src/locales/zh-CN/about.json
+++ b/src/locales/zh-CN/about.json
@@ -30,6 +30,11 @@
   "privacyText": "本插件所有数据均存储在本地浏览器中，不会主动上传到任何服务器。您的账号信息和使用数据完全由您自己掌控，确保隐私安全",
   "privacyTitle": "隐私保护",
   "projectLinks": "项目链接",
+  "releaseUpdate": {
+    "currentVersion": "当前版本：v{{version}}",
+    "latestVersion": "最新正式版：v{{version}}",
+    "title": "版本更新"
+  },
   "starRepo": "去点个Star",
   "stores": {
     "chrome": "Chrome 应用商店",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -343,6 +343,43 @@
     "shieldTitle": "临时窗口绕过防火墙防护",
     "title": "刷新设置"
   },
+  "releaseUpdate": {
+    "checkNow": "立即检查",
+    "downloadUpdate": "下载更新",
+    "helpers": {
+      "checkFailed": "可稍后重试，或前往发布页手动查看最新版本。",
+      "manualUpdate": "当前安装为手动更新渠道，请前往发布页获取新版本。",
+      "manualUpdateGeneric": "请按当前安装渠道完成更新，必要时可前往发布页手动获取新版本。",
+      "notChecked": "点击“立即检查”后即可确认当前版本是否需要更新。",
+      "openLatest": "可前往发布页查看最新正式版与更新内容。",
+      "storeUpdate": "当前安装通常会自动更新，也可前往商店或发布页查看最新版本。",
+      "unavailable": "可稍后重试，或直接前往发布页查看最新正式版。",
+      "upToDate": "可前往发布页查看更新内容，确认本次版本包含的变更。"
+    },
+    "lastChecked": "最近检查：{{time}}",
+    "latestVersionPending": "最新正式版：待检查",
+    "latestVersionUnavailable": "最新正式版：暂未获取",
+    "openLatest": "查看最新版本",
+    "reasons": {
+      "api-unavailable": "当前浏览器环境不支持自动检测，可手动检查最新正式版",
+      "chromium-development": "当前安装渠道支持检查最新正式版，可手动发起检查",
+      "firefox-ambiguous": "Firefox 当前无法可靠判断安装渠道，建议按需手动检查最新正式版",
+      "safari-unsupported": "Safari 暂不支持自动检测，建议前往发布页查看最新正式版",
+      "store-build": "当前安装渠道不支持自动检测，但仍可手动检查最新正式版",
+      "unknown": "当前安装渠道暂不支持自动检测，可手动检查最新正式版"
+    },
+    "states": {
+      "checkFailed": "检查失败，暂未获取最新正式版信息",
+      "notChecked": "尚未检查最新正式版，可手动检查",
+      "unavailable": "暂时无法读取更新状态",
+      "updateAvailable": "发现可升级的新版本",
+      "upToDate": "已完成检查，当前版本已是最新正式版"
+    },
+    "versionBadge": {
+      "changelogAriaLabel": "版本 {{version}} 更新日志",
+      "updateAvailableAriaLabel": "版本 {{version}} 有可用更新"
+    }
+  },
   "sorting": {
     "checkInDesc": "将需要签到的站点排在前面",
     "checkInRequirement": "签到需求",

--- a/src/locales/zh-TW/about.json
+++ b/src/locales/zh-TW/about.json
@@ -30,6 +30,11 @@
   "privacyText": "本外掛所有資料均儲存在本地瀏覽器中，不會主動上傳到任何伺服器。您的帳號資訊和使用資料完全由您自己掌控，確保隱私安全",
   "privacyTitle": "隱私保護",
   "projectLinks": "專案連結",
+  "releaseUpdate": {
+    "currentVersion": "目前版本：v{{version}}",
+    "latestVersion": "最新正式版：v{{version}}",
+    "title": "版本更新"
+  },
   "starRepo": "去點個Star",
   "stores": {
     "chrome": "Chrome 應用商店",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -343,6 +343,43 @@
     "shieldTitle": "臨時視窗繞過防火牆防護",
     "title": "重新整理設定"
   },
+  "releaseUpdate": {
+    "checkNow": "立即檢查",
+    "downloadUpdate": "下載更新",
+    "helpers": {
+      "checkFailed": "可稍後重試，或前往發布頁手動查看最新版本。",
+      "manualUpdate": "目前安裝為手動更新管道，請前往發布頁取得新版本。",
+      "manualUpdateGeneric": "請依目前安裝管道完成更新，必要時可前往發布頁手動取得新版本。",
+      "notChecked": "點擊「立即檢查」後即可確認目前版本是否需要更新。",
+      "openLatest": "可前往發布頁查看最新正式版與更新內容。",
+      "storeUpdate": "目前安裝通常會自動更新，也可前往商店或發布頁查看最新版本。",
+      "unavailable": "可稍後重試，或直接前往發布頁查看最新正式版。",
+      "upToDate": "可前往發布頁查看更新內容，確認本次版本包含的變更。"
+    },
+    "lastChecked": "最近檢查：{{time}}",
+    "latestVersionPending": "最新正式版：待檢查",
+    "latestVersionUnavailable": "最新正式版：暫未取得",
+    "openLatest": "查看最新版本",
+    "reasons": {
+      "api-unavailable": "目前瀏覽器環境不支援自動偵測，可手動檢查最新正式版",
+      "chromium-development": "目前安裝管道支援檢查最新正式版，可手動發起檢查",
+      "firefox-ambiguous": "Firefox 目前無法可靠判斷安裝管道，建議按需手動檢查最新正式版",
+      "safari-unsupported": "Safari 暫不支援自動偵測，建議前往發布頁查看最新正式版",
+      "store-build": "目前安裝管道不支援自動偵測，但仍可手動檢查最新正式版",
+      "unknown": "目前安裝管道暫不支援自動偵測，可手動檢查最新正式版"
+    },
+    "states": {
+      "checkFailed": "檢查失敗，暫未取得最新正式版資訊",
+      "notChecked": "尚未檢查最新正式版，可手動檢查",
+      "unavailable": "暫時無法讀取更新狀態",
+      "updateAvailable": "發現可升級的新版本",
+      "upToDate": "已完成檢查，目前版本已是最新正式版"
+    },
+    "versionBadge": {
+      "changelogAriaLabel": "版本 {{version}} 更新日誌",
+      "updateAvailableAriaLabel": "版本 {{version}} 有可用更新"
+    }
+  },
   "sorting": {
     "checkInDesc": "將需要簽到的站點排在前面",
     "checkInRequirement": "簽到需求",

--- a/src/services/core/storageKeys.ts
+++ b/src/services/core/storageKeys.ts
@@ -48,6 +48,11 @@ export const STORAGE_LOCKS = {
    */
   CHANGELOG_ON_UPDATE: "all-api-hub:changelog-on-update",
   /**
+   * Exclusive lock used for read-modify-write sequences touching cached release
+   * update status.
+   */
+  RELEASE_UPDATE: "all-api-hub:release-update",
+  /**
    * Exclusive lock used for read-modify-write sequences touching the LDOH site
    * lookup cache.
    */
@@ -90,6 +95,10 @@ const CHANGELOG_ON_UPDATE_STORAGE_KEYS = {
   PENDING_VERSION: "changelogOnUpdate_pendingVersion",
 } as const
 
+const RELEASE_UPDATE_STORAGE_KEYS = {
+  STATUS: "releaseUpdate_status",
+} as const
+
 /**
  * Centralized storage keys registry.
  *
@@ -106,5 +115,6 @@ export const STORAGE_KEYS = {
   ...USER_PREFERENCES_STORAGE_KEYS,
   CHANGELOG_ON_UPDATE_PENDING_VERSION:
     CHANGELOG_ON_UPDATE_STORAGE_KEYS.PENDING_VERSION,
+  RELEASE_UPDATE_STATUS: RELEASE_UPDATE_STORAGE_KEYS.STATUS,
   DAILY_BALANCE_HISTORY_STORE: DAILY_BALANCE_HISTORY_STORAGE_KEYS.STORE,
 } as const

--- a/src/services/updates/presentation.ts
+++ b/src/services/updates/presentation.ts
@@ -1,0 +1,145 @@
+import type { ReleaseUpdateStatus } from "./releaseUpdateStatus"
+
+export const RELEASE_UPDATE_PRESENTATION_STATES = {
+  Loading: "loading",
+  Unavailable: "unavailable",
+  UpdateAvailable: "update-available",
+  CheckFailed: "check-failed",
+  UpToDate: "up-to-date",
+  NotChecked: "not-checked",
+  Ineligible: "ineligible",
+} as const
+
+type ReleaseUpdatePresentationState =
+  (typeof RELEASE_UPDATE_PRESENTATION_STATES)[keyof typeof RELEASE_UPDATE_PRESENTATION_STATES]
+
+const RELEASE_UPDATE_ACTION_KINDS = {
+  DownloadUpdate: "download-update",
+  OpenLatest: "open-latest",
+} as const
+
+type ReleaseUpdateActionKind =
+  (typeof RELEASE_UPDATE_ACTION_KINDS)[keyof typeof RELEASE_UPDATE_ACTION_KINDS]
+
+export const RELEASE_UPDATE_CHECK_OUTCOMES = {
+  CheckFailed: "check-failed",
+  UpdateAvailable: "update-available",
+  UpToDate: "up-to-date",
+} as const
+
+type ReleaseUpdateCheckOutcome =
+  (typeof RELEASE_UPDATE_CHECK_OUTCOMES)[keyof typeof RELEASE_UPDATE_CHECK_OUTCOMES]
+
+/**
+ * Return a trimmed latest-version string when one is available.
+ */
+export function getReleaseUpdateLatestVersion(
+  status: ReleaseUpdateStatus | null | undefined,
+): string | null {
+  return typeof status?.latestVersion === "string" &&
+    status.latestVersion.trim()
+    ? status.latestVersion
+    : null
+}
+
+/**
+ * Whether the current release-update status indicates a newer version exists.
+ */
+export function hasAvailableReleaseUpdate(
+  status: ReleaseUpdateStatus | null | undefined,
+): boolean {
+  return !!(status?.updateAvailable && getReleaseUpdateLatestVersion(status))
+}
+
+/**
+ * Derive the semantic UI state used by release-update surfaces.
+ */
+export function deriveReleaseUpdatePresentation(options: {
+  isLoading: boolean
+  status: ReleaseUpdateStatus | null | undefined
+}): {
+  actionKind: ReleaseUpdateActionKind
+  hasUpdate: boolean
+  latestVersion: string | null
+  state: ReleaseUpdatePresentationState
+} {
+  const { isLoading, status } = options
+  const latestVersion = getReleaseUpdateLatestVersion(status)
+  const hasUpdate = hasAvailableReleaseUpdate(status)
+
+  if (isLoading) {
+    return {
+      actionKind: RELEASE_UPDATE_ACTION_KINDS.OpenLatest,
+      hasUpdate,
+      latestVersion,
+      state: RELEASE_UPDATE_PRESENTATION_STATES.Loading,
+    }
+  }
+
+  if (!status) {
+    return {
+      actionKind: RELEASE_UPDATE_ACTION_KINDS.OpenLatest,
+      hasUpdate,
+      latestVersion,
+      state: RELEASE_UPDATE_PRESENTATION_STATES.Unavailable,
+    }
+  }
+
+  if (hasUpdate) {
+    return {
+      actionKind: RELEASE_UPDATE_ACTION_KINDS.DownloadUpdate,
+      hasUpdate,
+      latestVersion,
+      state: RELEASE_UPDATE_PRESENTATION_STATES.UpdateAvailable,
+    }
+  }
+
+  if (status.lastError) {
+    return {
+      actionKind: RELEASE_UPDATE_ACTION_KINDS.OpenLatest,
+      hasUpdate,
+      latestVersion,
+      state: RELEASE_UPDATE_PRESENTATION_STATES.CheckFailed,
+    }
+  }
+
+  if (latestVersion && status.checkedAt) {
+    return {
+      actionKind: RELEASE_UPDATE_ACTION_KINDS.OpenLatest,
+      hasUpdate,
+      latestVersion,
+      state: RELEASE_UPDATE_PRESENTATION_STATES.UpToDate,
+    }
+  }
+
+  if (status.eligible) {
+    return {
+      actionKind: RELEASE_UPDATE_ACTION_KINDS.OpenLatest,
+      hasUpdate,
+      latestVersion,
+      state: RELEASE_UPDATE_PRESENTATION_STATES.NotChecked,
+    }
+  }
+
+  return {
+    actionKind: RELEASE_UPDATE_ACTION_KINDS.OpenLatest,
+    hasUpdate,
+    latestVersion,
+    state: RELEASE_UPDATE_PRESENTATION_STATES.Ineligible,
+  }
+}
+
+/**
+ * Collapse a freshly fetched check result into the toast state shown to users.
+ */
+export function deriveReleaseUpdateCheckOutcome(
+  status: ReleaseUpdateStatus | null | undefined,
+): ReleaseUpdateCheckOutcome {
+  if (!status || status.lastError) {
+    return RELEASE_UPDATE_CHECK_OUTCOMES.CheckFailed
+  }
+
+  return hasAvailableReleaseUpdate(status)
+    ? RELEASE_UPDATE_CHECK_OUTCOMES.UpdateAvailable
+    : RELEASE_UPDATE_CHECK_OUTCOMES.UpToDate
+}

--- a/src/services/updates/releaseUpdateService.ts
+++ b/src/services/updates/releaseUpdateService.ts
@@ -43,6 +43,7 @@ class ReleaseUpdateService {
 
   private storage: Storage
   private isInitialized = false
+  private initializationPromise: Promise<void> | null = null
 
   constructor() {
     this.storage = new Storage({
@@ -56,26 +57,45 @@ class ReleaseUpdateService {
       return
     }
 
-    if (hasAlarmsAPI()) {
-      onAlarm(async (alarm) => {
-        if (alarm.name !== ReleaseUpdateService.ALARM_NAME) {
-          return
-        }
-
-        try {
-          await this.runScheduledCheck()
-        } catch (error) {
-          logger.error("Scheduled release update check failed", error)
-        }
-      })
-
-      await this.setupAlarm()
-    } else {
-      logger.warn("Alarms API not available; automatic release checks disabled")
+    if (this.initializationPromise) {
+      await this.initializationPromise
+      return
     }
 
-    await this.ensureBaseStatus()
-    this.isInitialized = true
+    const initializationPromise = (async () => {
+      if (hasAlarmsAPI()) {
+        onAlarm(async (alarm) => {
+          if (alarm.name !== ReleaseUpdateService.ALARM_NAME) {
+            return
+          }
+
+          try {
+            await this.runScheduledCheck()
+          } catch (error) {
+            logger.error("Scheduled release update check failed", error)
+          }
+        })
+
+        await this.setupAlarm()
+      } else {
+        logger.warn(
+          "Alarms API not available; automatic release checks disabled",
+        )
+      }
+
+      await this.ensureBaseStatus()
+      this.isInitialized = true
+    })()
+
+    this.initializationPromise = initializationPromise
+
+    try {
+      await initializationPromise
+    } finally {
+      if (this.initializationPromise === initializationPromise) {
+        this.initializationPromise = null
+      }
+    }
   }
 
   async getStatus(): Promise<ReleaseUpdateStatus> {
@@ -84,6 +104,10 @@ class ReleaseUpdateService {
 
   async checkNow(): Promise<ReleaseUpdateStatus> {
     const base = await this.ensureBaseStatus()
+    if (!base.eligible) {
+      return base
+    }
+
     return await this.refreshStatus(base, { allowNetwork: true })
   }
 
@@ -113,14 +137,19 @@ class ReleaseUpdateService {
   }
 
   private async ensureBaseStatus(): Promise<ReleaseUpdateStatus> {
-    const stored = await this.readStoredStatus()
-    const next = await this.buildBaseStatus(stored)
+    return await withExtensionStorageWriteLock(
+      STORAGE_LOCKS.RELEASE_UPDATE,
+      async () => {
+        const stored = await this.readStoredStatus()
+        const next = await this.buildBaseStatus(stored)
 
-    if (!stored || !areStatusesEquivalent(stored, next)) {
-      await this.writeStatus(next)
-    }
+        if (!stored || !areStatusesEquivalent(stored, next)) {
+          await this.writeStatusUnlocked(next)
+        }
 
-    return next
+        return next
+      },
+    )
   }
 
   private async refreshStatus(
@@ -193,9 +222,18 @@ class ReleaseUpdateService {
   }
 
   private async writeStatus(status: ReleaseUpdateStatus): Promise<void> {
-    await withExtensionStorageWriteLock(STORAGE_LOCKS.RELEASE_UPDATE, () =>
-      this.storage.set(STORAGE_KEYS.RELEASE_UPDATE_STATUS, status),
+    await withExtensionStorageWriteLock(
+      STORAGE_LOCKS.RELEASE_UPDATE,
+      async () => {
+        await this.writeStatusUnlocked(status)
+      },
     )
+  }
+
+  private async writeStatusUnlocked(
+    status: ReleaseUpdateStatus,
+  ): Promise<void> {
+    await this.storage.set(STORAGE_KEYS.RELEASE_UPDATE_STATUS, status)
   }
 }
 

--- a/src/services/updates/releaseUpdateService.ts
+++ b/src/services/updates/releaseUpdateService.ts
@@ -63,7 +63,11 @@ class ReleaseUpdateService {
     }
 
     const initializationPromise = (async () => {
+      await this.ensureBaseStatus()
+
       if (hasAlarmsAPI()) {
+        await this.setupAlarm()
+
         onAlarm(async (alarm) => {
           if (alarm.name !== ReleaseUpdateService.ALARM_NAME) {
             return
@@ -75,15 +79,11 @@ class ReleaseUpdateService {
             logger.error("Scheduled release update check failed", error)
           }
         })
-
-        await this.setupAlarm()
       } else {
         logger.warn(
           "Alarms API not available; automatic release checks disabled",
         )
       }
-
-      await this.ensureBaseStatus()
       this.isInitialized = true
     })()
 
@@ -197,19 +197,23 @@ class ReleaseUpdateService {
     const detected = await detectInstallEligibility()
     const fallback = createDefaultReleaseUpdateStatus(currentVersion)
     const isSameVersion = stored?.currentVersion === currentVersion
+    const canReuseStoredReleaseFields = isSameVersion && detected.eligible
 
     return {
       ...fallback,
       eligible: detected.eligible,
       reason: detected.reason,
-      latestVersion: isSameVersion ? stored?.latestVersion ?? null : null,
-      updateAvailable:
-        isSameVersion && detected.eligible
-          ? stored?.updateAvailable ?? false
-          : false,
-      releaseUrl: stored?.releaseUrl ?? fallback.releaseUrl,
-      checkedAt: isSameVersion ? stored?.checkedAt ?? null : null,
-      lastError: isSameVersion ? stored?.lastError ?? null : null,
+      latestVersion: canReuseStoredReleaseFields
+        ? stored?.latestVersion ?? null
+        : null,
+      updateAvailable: canReuseStoredReleaseFields
+        ? stored?.updateAvailable ?? false
+        : false,
+      releaseUrl: canReuseStoredReleaseFields
+        ? stored?.releaseUrl ?? fallback.releaseUrl
+        : fallback.releaseUrl,
+      checkedAt: canReuseStoredReleaseFields ? stored?.checkedAt ?? null : null,
+      lastError: canReuseStoredReleaseFields ? stored?.lastError ?? null : null,
     }
   }
 

--- a/src/services/updates/releaseUpdateService.ts
+++ b/src/services/updates/releaseUpdateService.ts
@@ -1,0 +1,428 @@
+import { Storage } from "@plasmohq/storage"
+
+import { EXTENSION_STORE_IDS } from "~/constants/extensionStores"
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { STORAGE_KEYS, STORAGE_LOCKS } from "~/services/core/storageKeys"
+import { withExtensionStorageWriteLock } from "~/services/core/storageWriteLock"
+import {
+  createAlarm,
+  getAlarm,
+  getManifest,
+  hasAlarmsAPI,
+  onAlarm,
+} from "~/utils/browser/browserApi"
+import { getErrorMessage } from "~/utils/core/error"
+import { createLogger } from "~/utils/core/logger"
+
+import {
+  createDefaultReleaseUpdateStatus,
+  LATEST_STABLE_RELEASE_URL,
+  RELEASE_UPDATE_REASONS,
+  type ReleaseUpdateReason,
+  type ReleaseUpdateStatus,
+} from "./releaseUpdateStatus"
+import { parseReleaseUpdateStatus } from "./statusCodec"
+
+const logger = createLogger("ReleaseUpdateService")
+const GITHUB_LATEST_RELEASE_API_URL =
+  "https://api.github.com/repos/qixing-jk/all-api-hub/releases/latest"
+const DAILY_CHECK_PERIOD_MINUTES = 24 * 60
+
+type DetectInstallEligibilityResult = {
+  eligible: boolean
+  reason: ReleaseUpdateReason
+}
+
+type LatestReleaseInfo = {
+  latestVersion: string
+  releaseUrl: string
+}
+
+class ReleaseUpdateService {
+  static readonly ALARM_NAME = "releaseUpdateDailyCheck"
+
+  private storage: Storage
+  private isInitialized = false
+
+  constructor() {
+    this.storage = new Storage({
+      area: "local",
+    })
+  }
+
+  async initialize() {
+    if (this.isInitialized) {
+      logger.debug("Release update service already initialized")
+      return
+    }
+
+    if (hasAlarmsAPI()) {
+      onAlarm(async (alarm) => {
+        if (alarm.name !== ReleaseUpdateService.ALARM_NAME) {
+          return
+        }
+
+        try {
+          await this.runScheduledCheck()
+        } catch (error) {
+          logger.error("Scheduled release update check failed", error)
+        }
+      })
+
+      await this.setupAlarm()
+    } else {
+      logger.warn("Alarms API not available; automatic release checks disabled")
+    }
+
+    await this.ensureBaseStatus()
+    this.isInitialized = true
+  }
+
+  async getStatus(): Promise<ReleaseUpdateStatus> {
+    return await this.ensureBaseStatus()
+  }
+
+  async checkNow(): Promise<ReleaseUpdateStatus> {
+    const base = await this.ensureBaseStatus()
+    return await this.refreshStatus(base, { allowNetwork: true })
+  }
+
+  private async runScheduledCheck(): Promise<ReleaseUpdateStatus> {
+    const base = await this.ensureBaseStatus()
+    if (!base.eligible) {
+      return base
+    }
+
+    return await this.refreshStatus(base, { allowNetwork: true })
+  }
+
+  private async setupAlarm(): Promise<void> {
+    const existingAlarm = await getAlarm(ReleaseUpdateService.ALARM_NAME)
+    if (
+      existingAlarm?.periodInMinutes != null &&
+      Math.abs(existingAlarm.periodInMinutes - DAILY_CHECK_PERIOD_MINUTES) <
+        0.001
+    ) {
+      return
+    }
+
+    await createAlarm(ReleaseUpdateService.ALARM_NAME, {
+      periodInMinutes: DAILY_CHECK_PERIOD_MINUTES,
+      delayInMinutes: DAILY_CHECK_PERIOD_MINUTES,
+    })
+  }
+
+  private async ensureBaseStatus(): Promise<ReleaseUpdateStatus> {
+    const stored = await this.readStoredStatus()
+    const next = await this.buildBaseStatus(stored)
+
+    if (!stored || !areStatusesEquivalent(stored, next)) {
+      await this.writeStatus(next)
+    }
+
+    return next
+  }
+
+  private async refreshStatus(
+    base: ReleaseUpdateStatus,
+    options?: { allowNetwork?: boolean },
+  ): Promise<ReleaseUpdateStatus> {
+    if (!options?.allowNetwork) {
+      return base
+    }
+
+    try {
+      const latestRelease = await fetchLatestStableRelease()
+      const next: ReleaseUpdateStatus = {
+        ...base,
+        latestVersion: latestRelease.latestVersion,
+        updateAvailable:
+          compareNormalizedVersions(
+            normalizeVersion(base.currentVersion),
+            latestRelease.latestVersion,
+          ) < 0,
+        releaseUrl: latestRelease.releaseUrl,
+        checkedAt: Date.now(),
+        lastError: null,
+      }
+
+      await this.writeStatus(next)
+      return next
+    } catch (error) {
+      logger.warn("Failed to fetch latest stable release", error)
+
+      const next: ReleaseUpdateStatus = {
+        ...base,
+        lastError: getErrorMessage(error),
+      }
+
+      await this.writeStatus(next)
+      return next
+    }
+  }
+
+  private async buildBaseStatus(
+    stored: ReleaseUpdateStatus | null,
+  ): Promise<ReleaseUpdateStatus> {
+    const currentVersion = getCurrentManifestVersion()
+    const detected = await detectInstallEligibility()
+    const fallback = createDefaultReleaseUpdateStatus(currentVersion)
+    const isSameVersion = stored?.currentVersion === currentVersion
+
+    return {
+      ...fallback,
+      eligible: detected.eligible,
+      reason: detected.reason,
+      latestVersion: isSameVersion ? stored?.latestVersion ?? null : null,
+      updateAvailable:
+        isSameVersion && detected.eligible
+          ? stored?.updateAvailable ?? false
+          : false,
+      releaseUrl: stored?.releaseUrl ?? fallback.releaseUrl,
+      checkedAt: isSameVersion ? stored?.checkedAt ?? null : null,
+      lastError: isSameVersion ? stored?.lastError ?? null : null,
+    }
+  }
+
+  private async readStoredStatus(): Promise<ReleaseUpdateStatus | null> {
+    const raw = (await this.storage.get(
+      STORAGE_KEYS.RELEASE_UPDATE_STATUS,
+    )) as unknown
+
+    return parseReleaseUpdateStatus(raw)
+  }
+
+  private async writeStatus(status: ReleaseUpdateStatus): Promise<void> {
+    await withExtensionStorageWriteLock(STORAGE_LOCKS.RELEASE_UPDATE, () =>
+      this.storage.set(STORAGE_KEYS.RELEASE_UPDATE_STATUS, status),
+    )
+  }
+}
+
+/**
+ * Detect whether the current installation can safely participate in automatic
+ * new-version reminders.
+ */
+async function detectInstallEligibility(): Promise<DetectInstallEligibilityResult> {
+  const runtimeUrl = getRuntimeBaseUrl()
+  if (runtimeUrl.startsWith("safari-web-extension://")) {
+    return { eligible: false, reason: RELEASE_UPDATE_REASONS.SafariUnsupported }
+  }
+
+  const getSelf = (browser as any)?.management?.getSelf as
+    | (() => Promise<{ installType?: string }>)
+    | undefined
+
+  if (typeof getSelf !== "function") {
+    return {
+      eligible: false,
+      reason: runtimeUrl.startsWith("moz-extension://")
+        ? RELEASE_UPDATE_REASONS.FirefoxAmbiguous
+        : RELEASE_UPDATE_REASONS.ApiUnavailable,
+    }
+  }
+
+  try {
+    const info = await getSelf()
+    const installType = info?.installType
+
+    if (runtimeUrl.startsWith("moz-extension://")) {
+      return {
+        eligible: false,
+        reason: RELEASE_UPDATE_REASONS.FirefoxAmbiguous,
+      }
+    }
+
+    if (installType === "development") {
+      return {
+        eligible: true,
+        reason: RELEASE_UPDATE_REASONS.ChromiumDevelopment,
+      }
+    }
+
+    if (isKnownChromiumStoreBuild()) {
+      return { eligible: false, reason: RELEASE_UPDATE_REASONS.StoreBuild }
+    }
+
+    return { eligible: false, reason: RELEASE_UPDATE_REASONS.Unknown }
+  } catch (error) {
+    logger.debug("management.getSelf failed", error)
+    return {
+      eligible: false,
+      reason: runtimeUrl.startsWith("moz-extension://")
+        ? RELEASE_UPDATE_REASONS.FirefoxAmbiguous
+        : RELEASE_UPDATE_REASONS.ApiUnavailable,
+    }
+  }
+}
+
+/**
+ * Read the packaged extension version from the runtime manifest.
+ */
+function getCurrentManifestVersion(): string {
+  return getManifest().version?.trim() || "0.0.0"
+}
+
+/**
+ * Resolve the runtime base URL for browser-family detection.
+ */
+function getRuntimeBaseUrl(): string {
+  try {
+    return browser.runtime.getURL("")
+  } catch {
+    return ""
+  }
+}
+
+/**
+ * Check whether the current Chromium runtime ID matches a known store build.
+ */
+function isKnownChromiumStoreBuild(): boolean {
+  const runtimeId = browser.runtime?.id
+  if (typeof runtimeId !== "string" || !runtimeId) {
+    return false
+  }
+
+  return Object.values(EXTENSION_STORE_IDS).includes(runtimeId)
+}
+
+/**
+ * Fetch the latest stable GitHub release metadata used for comparisons.
+ */
+async function fetchLatestStableRelease(): Promise<LatestReleaseInfo> {
+  const response = await fetch(GITHUB_LATEST_RELEASE_API_URL, {
+    headers: {
+      Accept: "application/vnd.github+json",
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub release request failed with HTTP ${response.status}`,
+    )
+  }
+
+  const payload = (await response.json()) as Record<string, unknown>
+  const latestVersion = normalizeVersion(
+    typeof payload.tag_name === "string" && payload.tag_name
+      ? payload.tag_name
+      : typeof payload.name === "string"
+        ? payload.name
+        : null,
+  )
+
+  if (!latestVersion) {
+    throw new Error("Latest stable release payload did not contain a version.")
+  }
+
+  return {
+    latestVersion,
+    releaseUrl:
+      typeof payload.html_url === "string" && payload.html_url
+        ? payload.html_url
+        : LATEST_STABLE_RELEASE_URL,
+  }
+}
+
+/**
+ * Normalize semver-like version strings into a comparable dotted form.
+ */
+function normalizeVersion(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const normalized = value.trim().replace(/^v/i, "")
+  if (!/^\d+(?:\.\d+)*$/.test(normalized)) {
+    return null
+  }
+
+  return normalized
+}
+
+/**
+ * Compare two normalized dotted versions numerically.
+ */
+function compareNormalizedVersions(
+  left: string | null,
+  right: string | null,
+): number {
+  if (!left && !right) return 0
+  if (!left) return -1
+  if (!right) return 1
+
+  const leftParts = left.split(".").map((part) => Number.parseInt(part, 10))
+  const rightParts = right.split(".").map((part) => Number.parseInt(part, 10))
+  const length = Math.max(leftParts.length, rightParts.length)
+
+  for (let index = 0; index < length; index++) {
+    const leftPart = leftParts[index] ?? 0
+    const rightPart = rightParts[index] ?? 0
+
+    if (leftPart !== rightPart) {
+      return leftPart - rightPart
+    }
+  }
+
+  return 0
+}
+
+/**
+ * Compare two release-update status objects for storage write deduplication.
+ */
+function areStatusesEquivalent(
+  left: ReleaseUpdateStatus,
+  right: ReleaseUpdateStatus,
+): boolean {
+  return (
+    left.eligible === right.eligible &&
+    left.reason === right.reason &&
+    left.currentVersion === right.currentVersion &&
+    left.latestVersion === right.latestVersion &&
+    left.updateAvailable === right.updateAvailable &&
+    left.releaseUrl === right.releaseUrl &&
+    left.checkedAt === right.checkedAt &&
+    left.lastError === right.lastError
+  )
+}
+
+export const releaseUpdateService = new ReleaseUpdateService()
+
+/**
+ * Background runtime handler for release-update status queries and manual checks.
+ */
+export const handleReleaseUpdateMessage = async (
+  request: { action?: string },
+  sendResponse: (response: {
+    success: boolean
+    data?: ReleaseUpdateStatus
+    error?: string
+  }) => void,
+) => {
+  try {
+    switch (request.action) {
+      case RuntimeActionIds.ReleaseUpdateGetStatus: {
+        sendResponse({
+          success: true,
+          data: await releaseUpdateService.getStatus(),
+        })
+        break
+      }
+      case RuntimeActionIds.ReleaseUpdateCheckNow: {
+        sendResponse({
+          success: true,
+          data: await releaseUpdateService.checkNow(),
+        })
+        break
+      }
+      default:
+        sendResponse({ success: false, error: "Unknown action" })
+    }
+  } catch (error) {
+    logger.error("Release update message handling failed", error)
+    sendResponse({
+      success: false,
+      error: getErrorMessage(error),
+    })
+  }
+}

--- a/src/services/updates/releaseUpdateStatus.ts
+++ b/src/services/updates/releaseUpdateStatus.ts
@@ -1,0 +1,47 @@
+export const RELEASE_UPDATE_REASONS = {
+  ChromiumDevelopment: "chromium-development",
+  StoreBuild: "store-build",
+  FirefoxAmbiguous: "firefox-ambiguous",
+  SafariUnsupported: "safari-unsupported",
+  ApiUnavailable: "api-unavailable",
+  Unknown: "unknown",
+} as const
+
+export type ReleaseUpdateReason =
+  (typeof RELEASE_UPDATE_REASONS)[keyof typeof RELEASE_UPDATE_REASONS]
+
+export const RELEASE_UPDATE_REASON_VALUES = Object.values(
+  RELEASE_UPDATE_REASONS,
+) as ReleaseUpdateReason[]
+
+export type ReleaseUpdateStatus = {
+  eligible: boolean
+  reason: ReleaseUpdateReason
+  currentVersion: string
+  latestVersion: string | null
+  updateAvailable: boolean
+  releaseUrl: string
+  checkedAt: number | null
+  lastError: string | null
+}
+
+export const LATEST_STABLE_RELEASE_URL =
+  "https://github.com/qixing-jk/all-api-hub/releases/latest"
+
+/**
+ * Create a baseline release-update status before any remote check runs.
+ */
+export function createDefaultReleaseUpdateStatus(
+  currentVersion: string,
+): ReleaseUpdateStatus {
+  return {
+    eligible: false,
+    reason: RELEASE_UPDATE_REASONS.Unknown,
+    currentVersion,
+    latestVersion: null,
+    updateAvailable: false,
+    releaseUrl: LATEST_STABLE_RELEASE_URL,
+    checkedAt: null,
+    lastError: null,
+  }
+}

--- a/src/services/updates/runtime.ts
+++ b/src/services/updates/runtime.ts
@@ -1,0 +1,104 @@
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import {
+  sendRuntimeActionMessage,
+  type SendMessageRetryOptions,
+} from "~/utils/browser/browserApi"
+
+import { type ReleaseUpdateStatus } from "./releaseUpdateStatus"
+import { parseReleaseUpdateStatus } from "./statusCodec"
+
+type ReleaseUpdateRuntimeSuccess = {
+  success: true
+  data: ReleaseUpdateStatus
+}
+
+type ReleaseUpdateRuntimeFailure = {
+  success: false
+  error: string
+}
+
+type ReleaseUpdateRuntimeResponse =
+  | ReleaseUpdateRuntimeSuccess
+  | ReleaseUpdateRuntimeFailure
+
+/**
+ * Normalize runtime failures into the shared response shape.
+ */
+function toFailureResponse(error: string): ReleaseUpdateRuntimeFailure {
+  return { success: false, error }
+}
+
+/**
+ * Send a release-update action to background and normalize its response.
+ */
+async function requestReleaseUpdateAction(
+  action:
+    | typeof RuntimeActionIds.ReleaseUpdateGetStatus
+    | typeof RuntimeActionIds.ReleaseUpdateCheckNow,
+  options?: SendMessageRetryOptions,
+): Promise<ReleaseUpdateRuntimeResponse> {
+  let response: unknown
+
+  try {
+    response = await sendRuntimeActionMessage(
+      {
+        action,
+      },
+      options,
+    )
+  } catch (error) {
+    return toFailureResponse(
+      error instanceof Error && error.message
+        ? error.message
+        : "Background request failed.",
+    )
+  }
+
+  if (!response || typeof response !== "object") {
+    return toFailureResponse("No response from background.")
+  }
+
+  const record = response as Record<string, unknown>
+  if (record.success === false) {
+    const error = record.error
+    return toFailureResponse(
+      typeof error === "string" && error ? error : "Background request failed.",
+    )
+  }
+
+  if (record.success === true) {
+    const status = parseReleaseUpdateStatus(record.data)
+    if (status) {
+      return {
+        success: true,
+        data: status,
+      }
+    }
+  }
+
+  return toFailureResponse("Invalid response from background.")
+}
+
+/**
+ * Read the cached release-update status from the background service.
+ */
+export async function requestReleaseUpdateStatus(
+  options?: SendMessageRetryOptions,
+): Promise<ReleaseUpdateRuntimeResponse> {
+  return await requestReleaseUpdateAction(
+    RuntimeActionIds.ReleaseUpdateGetStatus,
+    options,
+  )
+}
+
+/**
+ * Force an immediate release-update check via the background service.
+ */
+export async function requestReleaseUpdateCheckNow(
+  options?: SendMessageRetryOptions,
+): Promise<ReleaseUpdateRuntimeResponse> {
+  return await requestReleaseUpdateAction(
+    RuntimeActionIds.ReleaseUpdateCheckNow,
+    options,
+  )
+}

--- a/src/services/updates/statusCodec.ts
+++ b/src/services/updates/statusCodec.ts
@@ -1,9 +1,34 @@
+import { trimToNull } from "~/utils/core/string"
+import { tryParseUrl } from "~/utils/core/urlParsing"
+
 import {
   createDefaultReleaseUpdateStatus,
   RELEASE_UPDATE_REASON_VALUES,
   type ReleaseUpdateReason,
   type ReleaseUpdateStatus,
 } from "./releaseUpdateStatus"
+
+/**
+ * Normalize a persisted release URL and fall back when the value is missing or unsafe.
+ */
+function normalizeReleaseUrl(value: unknown, fallback: string): string {
+  const normalized = trimToNull(value)
+  if (!normalized) {
+    return fallback
+  }
+
+  const parsed = tryParseUrl(normalized)
+  if (
+    parsed &&
+    (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+    parsed.hostname
+  ) {
+    return parsed.toString()
+  }
+
+  // Fall back to the latest stable release URL when persisted data is malformed.
+  return fallback
+}
 
 /**
  * Check whether an unknown string is one of the supported release-update reasons.
@@ -26,12 +51,12 @@ export function parseReleaseUpdateStatus(
   }
 
   const record = raw as Record<string, unknown>
-  const currentVersion = record.currentVersion
-  if (typeof currentVersion !== "string" || !currentVersion.trim()) {
+  const normalizedCurrentVersion = trimToNull(record.currentVersion)
+  if (!normalizedCurrentVersion) {
     return null
   }
 
-  const fallback = createDefaultReleaseUpdateStatus(currentVersion)
+  const fallback = createDefaultReleaseUpdateStatus(normalizedCurrentVersion)
 
   return {
     eligible:
@@ -41,21 +66,17 @@ export function parseReleaseUpdateStatus(
     reason: isReleaseUpdateReason(record.reason)
       ? record.reason
       : fallback.reason,
-    currentVersion,
-    latestVersion:
-      typeof record.latestVersion === "string" ? record.latestVersion : null,
+    currentVersion: normalizedCurrentVersion,
+    latestVersion: trimToNull(record.latestVersion),
     updateAvailable:
       typeof record.updateAvailable === "boolean"
         ? record.updateAvailable
         : fallback.updateAvailable,
-    releaseUrl:
-      typeof record.releaseUrl === "string" && record.releaseUrl
-        ? record.releaseUrl
-        : fallback.releaseUrl,
+    releaseUrl: normalizeReleaseUrl(record.releaseUrl, fallback.releaseUrl),
     checkedAt:
       typeof record.checkedAt === "number" && Number.isFinite(record.checkedAt)
         ? record.checkedAt
         : null,
-    lastError: typeof record.lastError === "string" ? record.lastError : null,
+    lastError: trimToNull(record.lastError),
   }
 }

--- a/src/services/updates/statusCodec.ts
+++ b/src/services/updates/statusCodec.ts
@@ -1,0 +1,61 @@
+import {
+  createDefaultReleaseUpdateStatus,
+  RELEASE_UPDATE_REASON_VALUES,
+  type ReleaseUpdateReason,
+  type ReleaseUpdateStatus,
+} from "./releaseUpdateStatus"
+
+/**
+ * Check whether an unknown string is one of the supported release-update reasons.
+ */
+function isReleaseUpdateReason(value: unknown): value is ReleaseUpdateReason {
+  return (
+    typeof value === "string" &&
+    RELEASE_UPDATE_REASON_VALUES.includes(value as ReleaseUpdateReason)
+  )
+}
+
+/**
+ * Validate and normalize a persisted/runtime release-update payload.
+ */
+export function parseReleaseUpdateStatus(
+  raw: unknown,
+): ReleaseUpdateStatus | null {
+  if (!raw || typeof raw !== "object") {
+    return null
+  }
+
+  const record = raw as Record<string, unknown>
+  const currentVersion = record.currentVersion
+  if (typeof currentVersion !== "string" || !currentVersion.trim()) {
+    return null
+  }
+
+  const fallback = createDefaultReleaseUpdateStatus(currentVersion)
+
+  return {
+    eligible:
+      typeof record.eligible === "boolean"
+        ? record.eligible
+        : fallback.eligible,
+    reason: isReleaseUpdateReason(record.reason)
+      ? record.reason
+      : fallback.reason,
+    currentVersion,
+    latestVersion:
+      typeof record.latestVersion === "string" ? record.latestVersion : null,
+    updateAvailable:
+      typeof record.updateAvailable === "boolean"
+        ? record.updateAvailable
+        : fallback.updateAvailable,
+    releaseUrl:
+      typeof record.releaseUrl === "string" && record.releaseUrl
+        ? record.releaseUrl
+        : fallback.releaseUrl,
+    checkedAt:
+      typeof record.checkedAt === "number" && Number.isFinite(record.checkedAt)
+        ? record.checkedAt
+        : null,
+    lastError: typeof record.lastError === "string" ? record.lastError : null,
+  }
+}

--- a/src/utils/core/string.ts
+++ b/src/utils/core/string.ts
@@ -3,6 +3,18 @@
  */
 
 /**
+ * Trim a maybe-string value and collapse blank inputs to `null`.
+ * @param value - The raw value to normalize.
+ * @returns The trimmed string, or `null` when the value is not a non-empty string.
+ */
+export function trimToNull(value: unknown): string | null {
+  if (typeof value !== "string") return null
+
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+/**
  * 解析逗号分隔的字符串为数组
  * @param value - 逗号分隔的字符串
  * @returns 去除空白后的字符串数组
@@ -11,7 +23,7 @@ export function parseDelimitedList(value?: string | null): string[] {
   if (!value) return []
   return value
     .split(/[,]/)
-    .map((item) => item.trim())
+    .map((item) => trimToNull(item) ?? "")
     .filter(Boolean)
 }
 
@@ -21,5 +33,7 @@ export function parseDelimitedList(value?: string | null): string[] {
  * @returns 规范化后的数组
  */
 export function normalizeList(values: string[] = []): string[] {
-  return Array.from(new Set(values.map((item) => item.trim()).filter(Boolean)))
+  return Array.from(
+    new Set(values.map((item) => trimToNull(item) ?? "").filter(Boolean)),
+  )
 }

--- a/tests/components/CardItem.test.tsx
+++ b/tests/components/CardItem.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { CardItem } from "~/components/ui/CardItem"
+
+describe("CardItem", () => {
+  it("adds top spacing above left content when header copy is present", () => {
+    render(
+      <CardItem
+        title="Title"
+        leftContent={<span data-testid="left-content">Left content</span>}
+      />,
+    )
+
+    expect(screen.getByTestId("left-content").parentElement).toHaveClass("mt-2")
+  })
+
+  it("omits top spacing above left content when header copy is absent", () => {
+    render(
+      <CardItem
+        leftContent={<span data-testid="left-content">Left content</span>}
+      />,
+    )
+
+    expect(screen.getByTestId("left-content").parentElement).not.toHaveClass(
+      "mt-2",
+    )
+  })
+})

--- a/tests/components/CardItem.test.tsx
+++ b/tests/components/CardItem.test.tsx
@@ -26,4 +26,15 @@ describe("CardItem", () => {
       "mt-2",
     )
   })
+
+  it("adds top spacing above left content when only description is present", () => {
+    render(
+      <CardItem
+        description="Desc"
+        leftContent={<span data-testid="left-content">Left</span>}
+      />,
+    )
+
+    expect(screen.getByTestId("left-content").parentElement).toHaveClass("mt-2")
+  })
 })

--- a/tests/components/ReleaseUpdateStatusPanel.test.tsx
+++ b/tests/components/ReleaseUpdateStatusPanel.test.tsx
@@ -282,6 +282,29 @@ describe("ReleaseUpdateStatusPanel", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("shows an ineligible toast and skips checking when the install cannot use release checks", async () => {
+    const user = userEvent.setup()
+    const checkNow = vi.fn()
+
+    mockHookState({
+      status: buildStatus({
+        eligible: false,
+        reason: "store-build",
+      }),
+      checkNow,
+    })
+
+    renderSubject()
+    await user.click(
+      screen.getByRole("button", { name: "settings:releaseUpdate.checkNow" }),
+    )
+
+    expect(checkNow).not.toHaveBeenCalled()
+    expect(toastMocks.error).toHaveBeenCalledWith(
+      "settings:releaseUpdate.reasons.store-build",
+    )
+  })
+
   it("falls back to localized unavailable copy instead of exposing raw errors", () => {
     mockHookState({
       status: null,
@@ -296,6 +319,7 @@ describe("ReleaseUpdateStatusPanel", () => {
     expect(
       screen.getByText("settings:releaseUpdate.latestVersionUnavailable"),
     ).toBeInTheDocument()
+    expect(screen.queryByText("0.0.0")).not.toBeInTheDocument()
     expect(screen.queryByText("No listeners available")).not.toBeInTheDocument()
   })
 })

--- a/tests/components/ReleaseUpdateStatusPanel.test.tsx
+++ b/tests/components/ReleaseUpdateStatusPanel.test.tsx
@@ -261,6 +261,27 @@ describe("ReleaseUpdateStatusPanel", () => {
     ).toBeInTheDocument()
   })
 
+  it("shows an unavailable latest-version line for ineligible installs before any check", () => {
+    mockHook(
+      buildStatus({
+        eligible: false,
+        reason: "store-build",
+      }),
+    )
+
+    renderSubject()
+
+    expect(
+      screen.getByText("settings:releaseUpdate.reasons.store-build"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("settings:releaseUpdate.latestVersionUnavailable"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("settings:releaseUpdate.latestVersionPending"),
+    ).not.toBeInTheDocument()
+  })
+
   it("falls back to localized unavailable copy instead of exposing raw errors", () => {
     mockHookState({
       status: null,
@@ -271,6 +292,9 @@ describe("ReleaseUpdateStatusPanel", () => {
 
     expect(
       screen.getByText("settings:releaseUpdate.states.unavailable"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("settings:releaseUpdate.latestVersionUnavailable"),
     ).toBeInTheDocument()
     expect(screen.queryByText("No listeners available")).not.toBeInTheDocument()
   })

--- a/tests/components/ReleaseUpdateStatusPanel.test.tsx
+++ b/tests/components/ReleaseUpdateStatusPanel.test.tsx
@@ -1,14 +1,18 @@
+import userEvent from "@testing-library/user-event"
+import React from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import { ReleaseUpdateStatusPanel } from "~/components/ReleaseUpdateStatusPanel"
 import type { ReleaseUpdateStatus } from "~/services/updates/releaseUpdateStatus"
-import { render, screen } from "~~/tests/test-utils/render"
+import { render, screen, waitFor } from "~~/tests/test-utils/render"
+
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}))
 
 vi.mock("react-hot-toast", () => ({
-  default: {
-    error: vi.fn(),
-    success: vi.fn(),
-  },
+  default: toastMocks,
 }))
 
 const mockUseReleaseUpdateStatus = vi.fn()
@@ -44,6 +48,37 @@ function mockHook(status: ReleaseUpdateStatus | null) {
   })
 }
 
+function mockInteractiveHook(params: {
+  initialStatus: ReleaseUpdateStatus | null
+  nextError?: string | null
+  nextStatus: ReleaseUpdateStatus | null
+}) {
+  const checkNow = vi.fn(async () => params.nextStatus)
+
+  mockUseReleaseUpdateStatus.mockImplementation(() => {
+    const [status, setStatus] = React.useState(params.initialStatus)
+    const [error, setError] = React.useState<string | null>(null)
+
+    return {
+      status,
+      isLoading: false,
+      isChecking: false,
+      error,
+      refresh: vi.fn(),
+      checkNow: async () => {
+        const next = await checkNow()
+        setError(params.nextError ?? null)
+        if (next) {
+          setStatus(next)
+        }
+        return next
+      },
+    }
+  })
+
+  return checkNow
+}
+
 function mockHookState(overrides: {
   checkNow?: ReturnType<typeof vi.fn>
   error?: string | null
@@ -69,6 +104,96 @@ const renderSubject = () =>
   })
 
 describe("ReleaseUpdateStatusPanel", () => {
+  it("shows an error toast when checking now returns a failed status", async () => {
+    const user = userEvent.setup()
+
+    mockInteractiveHook({
+      initialStatus: buildStatus(),
+      nextStatus: buildStatus({
+        checkedAt: Date.now(),
+        lastError: "network error",
+      }),
+    })
+
+    renderSubject()
+    await user.click(
+      screen.getByRole("button", { name: "settings:releaseUpdate.checkNow" }),
+    )
+
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith(
+        "settings:releaseUpdate.states.checkFailed",
+      )
+      expect(
+        screen.getByText("settings:releaseUpdate.states.checkFailed"),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("updates the panel and shows a success toast when checking now finds an update", async () => {
+    const user = userEvent.setup()
+
+    mockInteractiveHook({
+      initialStatus: buildStatus(),
+      nextStatus: buildStatus({
+        checkedAt: Date.now(),
+        latestVersion: "3.32.0",
+        updateAvailable: true,
+        releaseUrl:
+          "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.32.0",
+      }),
+    })
+
+    renderSubject()
+    await user.click(
+      screen.getByRole("button", { name: "settings:releaseUpdate.checkNow" }),
+    )
+
+    await waitFor(() => {
+      expect(toastMocks.success).toHaveBeenCalledWith(
+        "settings:releaseUpdate.states.updateAvailable",
+      )
+      expect(
+        screen.getByText("settings:releaseUpdate.states.updateAvailable"),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("link", {
+          name: "settings:releaseUpdate.downloadUpdate",
+        }),
+      ).toHaveAttribute(
+        "href",
+        "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.32.0",
+      )
+    })
+  })
+
+  it("updates the panel and shows a success toast when checking now confirms the latest version", async () => {
+    const user = userEvent.setup()
+
+    mockInteractiveHook({
+      initialStatus: buildStatus(),
+      nextStatus: buildStatus({
+        checkedAt: Date.now(),
+        latestVersion: "3.31.0",
+        updateAvailable: false,
+      }),
+    })
+
+    renderSubject()
+    await user.click(
+      screen.getByRole("button", { name: "settings:releaseUpdate.checkNow" }),
+    )
+
+    await waitFor(() => {
+      expect(toastMocks.success).toHaveBeenCalledWith(
+        "settings:releaseUpdate.states.upToDate",
+      )
+      expect(
+        screen.getByText("settings:releaseUpdate.states.upToDate"),
+      ).toBeInTheDocument()
+    })
+  })
+
   it("shows not-checked copy instead of up-to-date before the first check", () => {
     mockHook(buildStatus())
 

--- a/tests/components/ReleaseUpdateStatusPanel.test.tsx
+++ b/tests/components/ReleaseUpdateStatusPanel.test.tsx
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { ReleaseUpdateStatusPanel } from "~/components/ReleaseUpdateStatusPanel"
+import type { ReleaseUpdateStatus } from "~/services/updates/releaseUpdateStatus"
+import { render, screen } from "~~/tests/test-utils/render"
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+const mockUseReleaseUpdateStatus = vi.fn()
+
+vi.mock("~/contexts/ReleaseUpdateStatusContext", () => ({
+  useReleaseUpdateStatus: () => mockUseReleaseUpdateStatus(),
+}))
+
+function buildStatus(
+  overrides: Partial<ReleaseUpdateStatus> = {},
+): ReleaseUpdateStatus {
+  return {
+    eligible: true,
+    reason: "chromium-development",
+    currentVersion: "3.31.0",
+    latestVersion: null,
+    updateAvailable: false,
+    releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
+    checkedAt: null,
+    lastError: null,
+    ...overrides,
+  }
+}
+
+function mockHook(status: ReleaseUpdateStatus | null) {
+  mockUseReleaseUpdateStatus.mockReturnValue({
+    status,
+    isLoading: false,
+    isChecking: false,
+    error: null,
+    refresh: vi.fn(),
+    checkNow: vi.fn(),
+  })
+}
+
+function mockHookState(overrides: {
+  checkNow?: ReturnType<typeof vi.fn>
+  error?: string | null
+  isChecking?: boolean
+  isLoading?: boolean
+  status?: ReleaseUpdateStatus | null
+}) {
+  mockUseReleaseUpdateStatus.mockReturnValue({
+    status: overrides.status ?? null,
+    isLoading: overrides.isLoading ?? false,
+    isChecking: overrides.isChecking ?? false,
+    error: overrides.error ?? null,
+    refresh: vi.fn(),
+    checkNow: overrides.checkNow ?? vi.fn(),
+  })
+}
+
+const renderSubject = () =>
+  render(<ReleaseUpdateStatusPanel />, {
+    withReleaseUpdateStatusProvider: false,
+    withThemeProvider: false,
+    withUserPreferencesProvider: false,
+  })
+
+describe("ReleaseUpdateStatusPanel", () => {
+  it("shows not-checked copy instead of up-to-date before the first check", () => {
+    mockHook(buildStatus())
+
+    renderSubject()
+
+    expect(
+      screen.getByText("settings:releaseUpdate.states.notChecked"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("settings:releaseUpdate.latestVersionPending"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("settings:releaseUpdate.helpers.notChecked"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("settings:releaseUpdate.states.upToDate"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows a direct download action when a newer version is available", () => {
+    mockHook(
+      buildStatus({
+        eligible: true,
+        reason: "chromium-development",
+        latestVersion: "3.32.0",
+        updateAvailable: true,
+        releaseUrl:
+          "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.32.0",
+        checkedAt: Date.now(),
+      }),
+    )
+
+    renderSubject()
+
+    expect(
+      screen.getByText("settings:releaseUpdate.states.updateAvailable"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("settings:releaseUpdate.helpers.manualUpdate"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", {
+        name: "settings:releaseUpdate.downloadUpdate",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.32.0",
+    )
+  })
+
+  it("shows an unavailable latest-version line after a failed check", () => {
+    mockHook(
+      buildStatus({
+        lastError: "network error",
+      }),
+    )
+
+    renderSubject()
+
+    expect(
+      screen.getByText("settings:releaseUpdate.states.checkFailed"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("settings:releaseUpdate.latestVersionUnavailable"),
+    ).toBeInTheDocument()
+  })
+
+  it("falls back to localized unavailable copy instead of exposing raw errors", () => {
+    mockHookState({
+      status: null,
+      error: "No listeners available",
+    })
+
+    renderSubject()
+
+    expect(
+      screen.getByText("settings:releaseUpdate.states.unavailable"),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("No listeners available")).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/VersionBadge.test.tsx
+++ b/tests/components/VersionBadge.test.tsx
@@ -3,6 +3,26 @@ import { describe, expect, it, vi } from "vitest"
 import { VersionBadge } from "~/components/VersionBadge"
 import { render, screen } from "~~/tests/test-utils/render"
 
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: { version?: string }) => {
+        switch (key) {
+          case "releaseUpdate.versionBadge.changelogAriaLabel":
+            return `changelog for v${options?.version}`
+          case "releaseUpdate.versionBadge.updateAvailableAriaLabel":
+            return `update available for v${options?.version}`
+          default:
+            return key
+        }
+      },
+    }),
+  }
+})
+
 vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("~/utils/browser/browserApi")>()
@@ -20,6 +40,17 @@ vi.mock("~/utils/navigation/docsLinks", () => ({
   getDocsChangelogUrl: vi.fn(),
 }))
 
+vi.mock("~/contexts/ReleaseUpdateStatusContext", () => ({
+  useReleaseUpdateStatus: vi.fn(() => ({
+    status: null,
+    isLoading: false,
+    isChecking: false,
+    error: null,
+    refresh: vi.fn(),
+    checkNow: vi.fn(),
+  })),
+}))
+
 describe("VersionBadge", () => {
   it("renders current version and links to changelog", async () => {
     const { getManifest } = await import("~/utils/browser/browserApi")
@@ -30,9 +61,11 @@ describe("VersionBadge", () => {
       "https://example.com/changelog.html#_1-2-3",
     )
 
-    render(<VersionBadge />)
+    render(<VersionBadge />, { withReleaseUpdateStatusProvider: false })
 
-    const link = await screen.findByRole("link", { name: "v1.2.3 changelog" })
+    const link = await screen.findByRole("link", {
+      name: "changelog for v1.2.3",
+    })
     expect(link).toHaveAttribute(
       "href",
       "https://example.com/changelog.html#_1-2-3",
@@ -44,8 +77,71 @@ describe("VersionBadge", () => {
 
     vi.mocked(getManifest).mockReturnValue({} as any)
 
-    render(<VersionBadge />)
+    render(<VersionBadge />, { withReleaseUpdateStatusProvider: false })
 
     expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+
+  it("links to the latest release and shows a marker when an update is available", async () => {
+    const { getManifest } = await import("~/utils/browser/browserApi")
+    const { useReleaseUpdateStatus } = await import(
+      "~/contexts/ReleaseUpdateStatusContext"
+    )
+
+    vi.mocked(getManifest).mockReturnValue({ version: "1.2.3" } as any)
+    vi.mocked(useReleaseUpdateStatus).mockReturnValue({
+      status: {
+        eligible: true,
+        reason: "chromium-development",
+        currentVersion: "1.2.3",
+        latestVersion: "1.3.0",
+        updateAvailable: true,
+        releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
+        checkedAt: 0,
+        lastError: null,
+      },
+      isLoading: false,
+      isChecking: false,
+      error: null,
+      refresh: vi.fn(),
+      checkNow: vi.fn(),
+    })
+
+    render(<VersionBadge />, { withReleaseUpdateStatusProvider: false })
+
+    const link = await screen.findByRole("link", {
+      name: "update available for v1.2.3",
+    })
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/qixing-jk/all-api-hub/releases/latest",
+    )
+  })
+
+  it("uses the translated aria label while keeping the visible version compact", async () => {
+    const { getManifest } = await import("~/utils/browser/browserApi")
+    const { getDocsChangelogUrl } = await import("~/utils/navigation/docsLinks")
+    const { useReleaseUpdateStatus } = await import(
+      "~/contexts/ReleaseUpdateStatusContext"
+    )
+
+    vi.mocked(getManifest).mockReturnValue({ version: "2.0.0" } as any)
+    vi.mocked(getDocsChangelogUrl).mockReturnValue(
+      "https://example.com/changelog.html#_2-0-0",
+    )
+    vi.mocked(useReleaseUpdateStatus).mockReturnValue({
+      status: null,
+      isLoading: false,
+      isChecking: false,
+      error: null,
+      refresh: vi.fn(),
+      checkNow: vi.fn(),
+    })
+
+    render(<VersionBadge />, { withReleaseUpdateStatusProvider: false })
+
+    expect(
+      await screen.findByRole("link", { name: "changelog for v2.0.0" }),
+    ).toHaveTextContent("v2.0.0")
   })
 })

--- a/tests/contexts/ReleaseUpdateStatusContext.test.tsx
+++ b/tests/contexts/ReleaseUpdateStatusContext.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
+import { useState } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import {
@@ -28,6 +30,29 @@ function Consumer({ label }: { label: string }) {
 
 function Wrapper({ children }: { children: ReactNode }) {
   return <ReleaseUpdateStatusProvider>{children}</ReleaseUpdateStatusProvider>
+}
+
+function CheckNowConsumer() {
+  const { checkNow, error, status } = useReleaseUpdateStatus()
+  const [result, setResult] = useState("idle")
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          void checkNow().then((next) => {
+            setResult(next ? next.currentVersion : "null")
+          })
+        }}
+      >
+        check-now
+      </button>
+      <div>{`status:${status?.currentVersion ?? "none"}`}</div>
+      <div>{`error:${error ?? "none"}`}</div>
+      <div>{`result:${result}`}</div>
+    </>
+  )
 }
 
 describe("ReleaseUpdateStatusProvider", () => {
@@ -72,5 +97,44 @@ describe("ReleaseUpdateStatusProvider", () => {
     })
 
     expect(requestReleaseUpdateStatusMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns null when a manual check fails instead of returning stale status", async () => {
+    const user = userEvent.setup()
+
+    requestReleaseUpdateStatusMock.mockResolvedValue({
+      success: true,
+      data: {
+        eligible: true,
+        reason: "chromium-development",
+        currentVersion: "3.31.0",
+        latestVersion: null,
+        updateAvailable: false,
+        releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
+        checkedAt: null,
+        lastError: null,
+      },
+    })
+    requestReleaseUpdateCheckNowMock.mockResolvedValue({
+      success: false,
+      error: "runtime failed",
+    })
+
+    render(
+      <Wrapper>
+        <CheckNowConsumer />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("status:3.31.0")).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole("button", { name: "check-now" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("result:null")).toBeInTheDocument()
+      expect(screen.getByText("error:runtime failed")).toBeInTheDocument()
+    })
   })
 })

--- a/tests/contexts/ReleaseUpdateStatusContext.test.tsx
+++ b/tests/contexts/ReleaseUpdateStatusContext.test.tsx
@@ -2,12 +2,13 @@ import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { useState } from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   ReleaseUpdateStatusProvider,
   useReleaseUpdateStatus,
 } from "~/contexts/ReleaseUpdateStatusContext"
+import type { ReleaseUpdateStatus } from "~/services/updates/releaseUpdateStatus"
 
 const { requestReleaseUpdateCheckNowMock, requestReleaseUpdateStatusMock } =
   vi.hoisted(() => ({
@@ -20,24 +21,58 @@ vi.mock("~/services/updates/runtime", () => ({
   requestReleaseUpdateStatus: requestReleaseUpdateStatusMock,
 }))
 
+function buildStatus(
+  overrides: Partial<ReleaseUpdateStatus> = {},
+): ReleaseUpdateStatus {
+  return {
+    eligible: true,
+    reason: "chromium-development",
+    currentVersion: "3.31.0",
+    latestVersion: null,
+    updateAvailable: false,
+    releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
+    checkedAt: null,
+    lastError: null,
+    ...overrides,
+  }
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+
+  return { promise, resolve, reject }
+}
+
 function Consumer({ label }: { label: string }) {
   const { isLoading, status } = useReleaseUpdateStatus()
 
   return (
-    <div>{`${label}:${isLoading ? "loading" : status?.currentVersion}`}</div>
+    <div>{`${label}:${isLoading ? "loading" : status?.currentVersion ?? "none"}`}</div>
   )
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
-  return <ReleaseUpdateStatusProvider>{children}</ReleaseUpdateStatusProvider>
-}
-
-function CheckNowConsumer() {
-  const { checkNow, error, status } = useReleaseUpdateStatus()
+function StatusConsumer() {
+  const { checkNow, error, isChecking, isLoading, refresh, status } =
+    useReleaseUpdateStatus()
   const [result, setResult] = useState("idle")
 
   return (
     <>
+      <button
+        type="button"
+        onClick={() => {
+          void refresh().then(() => {
+            setResult("refreshed")
+          })
+        }}
+      >
+        refresh
+      </button>
       <button
         type="button"
         onClick={() => {
@@ -48,6 +83,8 @@ function CheckNowConsumer() {
       >
         check-now
       </button>
+      <div>{`loading:${isLoading ? "yes" : "no"}`}</div>
+      <div>{`checking:${isChecking ? "yes" : "no"}`}</div>
       <div>{`status:${status?.currentVersion ?? "none"}`}</div>
       <div>{`error:${error ?? "none"}`}</div>
       <div>{`result:${result}`}</div>
@@ -55,33 +92,19 @@ function CheckNowConsumer() {
   )
 }
 
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ReleaseUpdateStatusProvider>{children}</ReleaseUpdateStatusProvider>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
 describe("ReleaseUpdateStatusProvider", () => {
   it("shares one initial fetch across multiple consumers", async () => {
     requestReleaseUpdateStatusMock.mockResolvedValue({
       success: true,
-      data: {
-        eligible: true,
-        reason: "chromium-development",
-        currentVersion: "3.31.0",
-        latestVersion: null,
-        updateAvailable: false,
-        releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
-        checkedAt: null,
-        lastError: null,
-      },
-    })
-    requestReleaseUpdateCheckNowMock.mockResolvedValue({
-      success: true,
-      data: {
-        eligible: true,
-        reason: "chromium-development",
-        currentVersion: "3.31.0",
-        latestVersion: null,
-        updateAvailable: false,
-        releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
-        checkedAt: null,
-        lastError: null,
-      },
+      data: buildStatus(),
     })
 
     render(
@@ -99,21 +122,113 @@ describe("ReleaseUpdateStatusProvider", () => {
     expect(requestReleaseUpdateStatusMock).toHaveBeenCalledTimes(1)
   })
 
+  it("exposes an initial fetch error when the status request returns success false", async () => {
+    requestReleaseUpdateStatusMock.mockResolvedValue({
+      success: false,
+      error: "status unavailable",
+    })
+
+    render(
+      <Wrapper>
+        <StatusConsumer />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("loading:no")).toBeInTheDocument()
+      expect(screen.getByText("status:none")).toBeInTheDocument()
+      expect(screen.getByText("error:status unavailable")).toBeInTheDocument()
+    })
+  })
+
+  it("exposes an initial fetch error when the status request rejects", async () => {
+    requestReleaseUpdateStatusMock.mockRejectedValue(new Error("boom"))
+
+    render(
+      <Wrapper>
+        <StatusConsumer />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("loading:no")).toBeInTheDocument()
+      expect(screen.getByText("status:none")).toBeInTheDocument()
+      expect(screen.getByText("error:boom")).toBeInTheDocument()
+    })
+  })
+
+  it("refreshes status data when refresh succeeds", async () => {
+    const user = userEvent.setup()
+
+    requestReleaseUpdateStatusMock
+      .mockResolvedValueOnce({
+        success: true,
+        data: buildStatus(),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: buildStatus({
+          currentVersion: "3.32.0",
+          checkedAt: 1,
+        }),
+      })
+
+    render(
+      <Wrapper>
+        <StatusConsumer />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("status:3.31.0")).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole("button", { name: "refresh" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("status:3.32.0")).toBeInTheDocument()
+      expect(screen.getByText("error:none")).toBeInTheDocument()
+      expect(screen.getByText("result:refreshed")).toBeInTheDocument()
+    })
+
+    expect(requestReleaseUpdateStatusMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("preserves the last known status and surfaces an error when refresh rejects", async () => {
+    const user = userEvent.setup()
+
+    requestReleaseUpdateStatusMock
+      .mockResolvedValueOnce({
+        success: true,
+        data: buildStatus(),
+      })
+      .mockRejectedValueOnce(new Error("refresh exploded"))
+
+    render(
+      <Wrapper>
+        <StatusConsumer />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("status:3.31.0")).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole("button", { name: "refresh" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("status:3.31.0")).toBeInTheDocument()
+      expect(screen.getByText("error:refresh exploded")).toBeInTheDocument()
+      expect(screen.getByText("result:refreshed")).toBeInTheDocument()
+    })
+  })
+
   it("returns null when a manual check fails instead of returning stale status", async () => {
     const user = userEvent.setup()
 
     requestReleaseUpdateStatusMock.mockResolvedValue({
       success: true,
-      data: {
-        eligible: true,
-        reason: "chromium-development",
-        currentVersion: "3.31.0",
-        latestVersion: null,
-        updateAvailable: false,
-        releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
-        checkedAt: null,
-        lastError: null,
-      },
+      data: buildStatus(),
     })
     requestReleaseUpdateCheckNowMock.mockResolvedValue({
       success: false,
@@ -122,7 +237,7 @@ describe("ReleaseUpdateStatusProvider", () => {
 
     render(
       <Wrapper>
-        <CheckNowConsumer />
+        <StatusConsumer />
       </Wrapper>,
     )
 
@@ -135,6 +250,72 @@ describe("ReleaseUpdateStatusProvider", () => {
     await waitFor(() => {
       expect(screen.getByText("result:null")).toBeInTheDocument()
       expect(screen.getByText("error:runtime failed")).toBeInTheDocument()
+      expect(screen.getByText("status:3.31.0")).toBeInTheDocument()
+    })
+  })
+
+  it("keeps isChecking true until all overlapping checks finish", async () => {
+    const user = userEvent.setup()
+    const firstCheck = createDeferred<{
+      success: true
+      data: ReleaseUpdateStatus
+    }>()
+    const secondCheck = createDeferred<{
+      success: true
+      data: ReleaseUpdateStatus
+    }>()
+
+    requestReleaseUpdateStatusMock.mockResolvedValue({
+      success: true,
+      data: buildStatus(),
+    })
+    requestReleaseUpdateCheckNowMock
+      .mockImplementationOnce(() => firstCheck.promise)
+      .mockImplementationOnce(() => secondCheck.promise)
+
+    render(
+      <Wrapper>
+        <StatusConsumer />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("status:3.31.0")).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole("button", { name: "check-now" }))
+    await user.click(screen.getByRole("button", { name: "check-now" }))
+
+    await waitFor(() => {
+      expect(requestReleaseUpdateCheckNowMock).toHaveBeenCalledTimes(2)
+      expect(screen.getByText("checking:yes")).toBeInTheDocument()
+    })
+
+    firstCheck.resolve({
+      success: true,
+      data: buildStatus({
+        currentVersion: "3.32.0",
+        checkedAt: 1,
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("status:3.32.0")).toBeInTheDocument()
+      expect(screen.getByText("checking:yes")).toBeInTheDocument()
+    })
+
+    secondCheck.resolve({
+      success: true,
+      data: buildStatus({
+        currentVersion: "3.33.0",
+        checkedAt: 2,
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("status:3.33.0")).toBeInTheDocument()
+      expect(screen.getByText("checking:no")).toBeInTheDocument()
+      expect(screen.getByText("result:3.33.0")).toBeInTheDocument()
     })
   })
 })

--- a/tests/contexts/ReleaseUpdateStatusContext.test.tsx
+++ b/tests/contexts/ReleaseUpdateStatusContext.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  ReleaseUpdateStatusProvider,
+  useReleaseUpdateStatus,
+} from "~/contexts/ReleaseUpdateStatusContext"
+
+const { requestReleaseUpdateCheckNowMock, requestReleaseUpdateStatusMock } =
+  vi.hoisted(() => ({
+    requestReleaseUpdateCheckNowMock: vi.fn(),
+    requestReleaseUpdateStatusMock: vi.fn(),
+  }))
+
+vi.mock("~/services/updates/runtime", () => ({
+  requestReleaseUpdateCheckNow: requestReleaseUpdateCheckNowMock,
+  requestReleaseUpdateStatus: requestReleaseUpdateStatusMock,
+}))
+
+function Consumer({ label }: { label: string }) {
+  const { isLoading, status } = useReleaseUpdateStatus()
+
+  return (
+    <div>{`${label}:${isLoading ? "loading" : status?.currentVersion}`}</div>
+  )
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ReleaseUpdateStatusProvider>{children}</ReleaseUpdateStatusProvider>
+}
+
+describe("ReleaseUpdateStatusProvider", () => {
+  it("shares one initial fetch across multiple consumers", async () => {
+    requestReleaseUpdateStatusMock.mockResolvedValue({
+      success: true,
+      data: {
+        eligible: true,
+        reason: "chromium-development",
+        currentVersion: "3.31.0",
+        latestVersion: null,
+        updateAvailable: false,
+        releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
+        checkedAt: null,
+        lastError: null,
+      },
+    })
+    requestReleaseUpdateCheckNowMock.mockResolvedValue({
+      success: true,
+      data: {
+        eligible: true,
+        reason: "chromium-development",
+        currentVersion: "3.31.0",
+        latestVersion: null,
+        updateAvailable: false,
+        releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
+        checkedAt: null,
+        lastError: null,
+      },
+    })
+
+    render(
+      <Wrapper>
+        <Consumer label="one" />
+        <Consumer label="two" />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("one:3.31.0")).toBeInTheDocument()
+      expect(screen.getByText("two:3.31.0")).toBeInTheDocument()
+    })
+
+    expect(requestReleaseUpdateStatusMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/entrypoints/background/runtimeMessages.more.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.more.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   getCookieHeaderForUrlResult: vi.fn(),
   hasCookieReadPermissionForUrl: vi.fn(),
   handleManagedSiteModelSyncMessage: vi.fn(),
+  handleReleaseUpdateMessage: vi.fn(),
   handleAutoCheckinMessage: vi.fn(),
   handleAutoRefreshMessage: vi.fn(),
   handleChannelConfigMessage: vi.fn(),
@@ -74,6 +75,10 @@ vi.mock("~/entrypoints/background/tempWindowPool", () => ({
 
 vi.mock("~/services/models/modelSync", () => ({
   handleManagedSiteModelSyncMessage: mocks.handleManagedSiteModelSyncMessage,
+}))
+
+vi.mock("~/services/updates/releaseUpdateService", () => ({
+  handleReleaseUpdateMessage: mocks.handleReleaseUpdateMessage,
 }))
 
 vi.mock("~/services/checkin/autoCheckin/scheduler", () => ({
@@ -284,6 +289,28 @@ describe("setupRuntimeMessageListeners additional routing", () => {
         ...item.expectedArgs,
       )
     }
+  })
+
+  it("routes release update actions to the dedicated handler", async () => {
+    const listener = await loadListener()
+    const sendResponse = vi.fn()
+
+    expect(
+      listener(
+        {
+          action: RuntimeActionIds.ReleaseUpdateGetStatus,
+        },
+        {},
+        sendResponse,
+      ),
+    ).toBe(true)
+
+    expect(mocks.handleReleaseUpdateMessage).toHaveBeenCalledWith(
+      {
+        action: RuntimeActionIds.ReleaseUpdateGetStatus,
+      },
+      sendResponse,
+    )
   })
 
   it("routes additional prefix-based actions to their feature handlers", async () => {

--- a/tests/entrypoints/background/servicesInit.test.ts
+++ b/tests/entrypoints/background/servicesInit.test.ts
@@ -11,6 +11,7 @@ const {
   modelMetadataInitMock,
   autoRefreshInitMock,
   redemptionAssistInitMock,
+  releaseUpdateInitMock,
   initBackgroundI18nMock,
 } = vi.hoisted(() => ({
   usageInitMock: vi.fn(),
@@ -21,6 +22,7 @@ const {
   modelMetadataInitMock: vi.fn(),
   autoRefreshInitMock: vi.fn(),
   redemptionAssistInitMock: vi.fn(),
+  releaseUpdateInitMock: vi.fn(),
   initBackgroundI18nMock: vi.fn(),
 }))
 
@@ -56,6 +58,10 @@ vi.mock("~/services/redemption/redemptionAssist", () => ({
   redemptionAssistService: { initialize: redemptionAssistInitMock },
 }))
 
+vi.mock("~/services/updates/releaseUpdateService", () => ({
+  releaseUpdateService: { initialize: releaseUpdateInitMock },
+}))
+
 vi.mock("~/utils/i18n/background", () => ({
   initBackgroundI18n: initBackgroundI18nMock,
 }))
@@ -77,6 +83,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
       modelSync: false,
       autoCheckin: false,
       dailyBalance: false,
+      releaseUpdate: false,
     }
 
     let i18nObservedAllAlarmInits = false
@@ -100,6 +107,9 @@ describe("initializeServices alarm bootstrap ordering", () => {
     const dailyBalanceInit: InitMock = vi.fn(async () => {
       alarmInitCalled.dailyBalance = true
     })
+    const releaseUpdateInit: InitMock = vi.fn(async () => {
+      alarmInitCalled.releaseUpdate = true
+    })
 
     const modelMetadataInit: InitMock = vi.fn(async () => {})
     const autoRefreshInit: InitMock = vi.fn(async () => {})
@@ -110,6 +120,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     modelSyncInitMock.mockImplementation(modelSyncInit)
     autoCheckinInitMock.mockImplementation(autoCheckinInit)
     dailyBalanceInitMock.mockImplementation(dailyBalanceInit)
+    releaseUpdateInitMock.mockImplementation(releaseUpdateInit)
     modelMetadataInitMock.mockImplementation(modelMetadataInit)
     autoRefreshInitMock.mockImplementation(autoRefreshInit)
     redemptionAssistInitMock.mockImplementation(redemptionAssistInit)
@@ -120,7 +131,8 @@ describe("initializeServices alarm bootstrap ordering", () => {
         alarmInitCalled.webdav &&
         alarmInitCalled.modelSync &&
         alarmInitCalled.autoCheckin &&
-        alarmInitCalled.dailyBalance
+        alarmInitCalled.dailyBalance &&
+        alarmInitCalled.releaseUpdate
       return i18nPromise
     })
 
@@ -131,6 +143,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(modelSyncInit).toHaveBeenCalledTimes(1)
     expect(autoCheckinInit).toHaveBeenCalledTimes(1)
     expect(dailyBalanceInit).toHaveBeenCalledTimes(1)
+    expect(releaseUpdateInit).toHaveBeenCalledTimes(1)
     expect(i18nObservedAllAlarmInits).toBe(true)
 
     resolveI18n?.()
@@ -159,6 +172,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     modelSyncInitMock.mockResolvedValue(undefined)
     autoCheckinInitMock.mockResolvedValue(undefined)
     dailyBalanceInitMock.mockResolvedValue(undefined)
+    releaseUpdateInitMock.mockResolvedValue(undefined)
     modelMetadataInitMock.mockResolvedValue(undefined)
     autoRefreshInitMock.mockResolvedValue(undefined)
     redemptionAssistInitMock.mockResolvedValue(undefined)
@@ -171,6 +185,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(modelSyncInitMock).toHaveBeenCalledTimes(1)
     expect(autoCheckinInitMock).toHaveBeenCalledTimes(1)
     expect(dailyBalanceInitMock).toHaveBeenCalledTimes(1)
+    expect(releaseUpdateInitMock).toHaveBeenCalledTimes(1)
     expect(initBackgroundI18nMock).toHaveBeenCalledTimes(1)
 
     resolveI18n?.()
@@ -187,6 +202,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(modelSyncInitMock).toHaveBeenCalledTimes(1)
     expect(autoCheckinInitMock).toHaveBeenCalledTimes(1)
     expect(dailyBalanceInitMock).toHaveBeenCalledTimes(1)
+    expect(releaseUpdateInitMock).toHaveBeenCalledTimes(1)
     expect(initBackgroundI18nMock).toHaveBeenCalledTimes(1)
     expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
     expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)
@@ -204,6 +220,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     modelSyncInitMock.mockResolvedValue(undefined)
     autoCheckinInitMock.mockResolvedValue(undefined)
     dailyBalanceInitMock.mockResolvedValue(undefined)
+    releaseUpdateInitMock.mockResolvedValue(undefined)
     modelMetadataInitMock.mockResolvedValue(undefined)
     autoRefreshInitMock.mockResolvedValue(undefined)
     redemptionAssistInitMock.mockResolvedValue(undefined)
@@ -215,6 +232,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(modelSyncInitMock).toHaveBeenCalledTimes(1)
     expect(autoCheckinInitMock).toHaveBeenCalledTimes(1)
     expect(dailyBalanceInitMock).toHaveBeenCalledTimes(1)
+    expect(releaseUpdateInitMock).toHaveBeenCalledTimes(1)
     expect(initBackgroundI18nMock).toHaveBeenCalledTimes(1)
     expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
     expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)

--- a/tests/entrypoints/popup/HeaderSection.test.tsx
+++ b/tests/entrypoints/popup/HeaderSection.test.tsx
@@ -58,6 +58,17 @@ vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
   }),
 }))
 
+vi.mock("~/contexts/ReleaseUpdateStatusContext", () => ({
+  useReleaseUpdateStatus: () => ({
+    status: null,
+    isLoading: false,
+    isChecking: false,
+    error: null,
+    refresh: vi.fn(),
+    checkNow: vi.fn(),
+  }),
+}))
+
 vi.mock("~/utils/navigation", () => ({
   openApiCredentialProfilesPage: vi.fn(),
   openBugReportPage: vi.fn(),
@@ -92,7 +103,7 @@ describe("popup HeaderSection", () => {
   })
 
   it("shows open side panel button in popup", async () => {
-    render(<HeaderSection />)
+    render(<HeaderSection />, { withReleaseUpdateStatusProvider: false })
 
     expect(
       await screen.findByRole("button", {
@@ -103,7 +114,7 @@ describe("popup HeaderSection", () => {
 
   it("hides open side panel button inside side panel", async () => {
     mockedIsExtensionSidePanel.mockReturnValue(true)
-    render(<HeaderSection />)
+    render(<HeaderSection />, { withReleaseUpdateStatusProvider: false })
 
     expect(
       screen.queryByRole("button", { name: "common:actions.openSidePanel" }),
@@ -117,7 +128,7 @@ describe("popup HeaderSection", () => {
       reason: "missing",
     })
 
-    render(<HeaderSection />)
+    render(<HeaderSection />, { withReleaseUpdateStatusProvider: false })
 
     expect(
       screen.queryByRole("button", { name: "common:actions.openSidePanel" }),
@@ -125,7 +136,7 @@ describe("popup HeaderSection", () => {
   })
 
   it("routes the open side panel button through the shared navigation helper", async () => {
-    render(<HeaderSection />)
+    render(<HeaderSection />, { withReleaseUpdateStatusProvider: false })
 
     fireEvent.click(
       await screen.findByRole("button", {
@@ -137,7 +148,9 @@ describe("popup HeaderSection", () => {
   })
 
   it("routes open full page to account manager for accounts view", async () => {
-    render(<HeaderSection activeView="accounts" />)
+    render(<HeaderSection activeView="accounts" />, {
+      withReleaseUpdateStatusProvider: false,
+    })
 
     fireEvent.click(
       await screen.findByRole("button", { name: "ui:navigation.account" }),
@@ -147,7 +160,9 @@ describe("popup HeaderSection", () => {
   })
 
   it("routes open full page to bookmark manager for bookmarks view", async () => {
-    render(<HeaderSection activeView="bookmarks" />)
+    render(<HeaderSection activeView="bookmarks" />, {
+      withReleaseUpdateStatusProvider: false,
+    })
 
     fireEvent.click(
       await screen.findByRole("button", { name: "ui:navigation.bookmark" }),
@@ -157,7 +172,9 @@ describe("popup HeaderSection", () => {
   })
 
   it("routes open full page to API credential profiles for API credentials view", async () => {
-    render(<HeaderSection activeView="apiCredentialProfiles" />)
+    render(<HeaderSection activeView="apiCredentialProfiles" />, {
+      withReleaseUpdateStatusProvider: false,
+    })
 
     fireEvent.click(
       await screen.findByRole("button", {
@@ -171,7 +188,7 @@ describe("popup HeaderSection", () => {
   it("opens feedback actions from the header menu", async () => {
     const user = userEvent.setup()
 
-    render(<HeaderSection />)
+    render(<HeaderSection />, { withReleaseUpdateStatusProvider: false })
 
     await user.click(
       await screen.findByRole("button", { name: "ui:feedback.trigger" }),

--- a/tests/features/About/About.test.tsx
+++ b/tests/features/About/About.test.tsx
@@ -1,12 +1,23 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import About from "~/features/About/About"
 import { getFeedbackDestinationUrls } from "~/utils/navigation/feedbackLinks"
 import { render, screen } from "~~/tests/test-utils/render"
 
+vi.mock("~/contexts/ReleaseUpdateStatusContext", () => ({
+  useReleaseUpdateStatus: () => ({
+    status: null,
+    isLoading: false,
+    isChecking: false,
+    error: null,
+    refresh: vi.fn(),
+    checkNow: vi.fn(),
+  }),
+}))
+
 describe("About", () => {
   it("shows feedback and support links wired to the shared destinations", async () => {
-    render(<About />)
+    render(<About />, { withReleaseUpdateStatusProvider: false })
 
     expect(
       await screen.findByText("about:feedbackSection.title"),

--- a/tests/features/BasicSettings/PermissionOnboardingDialog.languageSelection.test.tsx
+++ b/tests/features/BasicSettings/PermissionOnboardingDialog.languageSelection.test.tsx
@@ -107,6 +107,17 @@ vi.mock("~/utils/core/toastHelpers", () => ({
   showResultToast: toastHelperMocks.showResultToast,
 }))
 
+vi.mock("~/contexts/ReleaseUpdateStatusContext", () => ({
+  useReleaseUpdateStatus: () => ({
+    status: null,
+    isLoading: false,
+    isChecking: false,
+    error: null,
+    refresh: vi.fn(),
+    checkNow: vi.fn(),
+  }),
+}))
+
 const SETTINGS_RESOURCES = {
   en: { settings: enSettings },
   ja: { settings: jaSettings },

--- a/tests/services/updates/presentation.test.ts
+++ b/tests/services/updates/presentation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  deriveReleaseUpdateCheckOutcome,
+  deriveReleaseUpdatePresentation,
+  getReleaseUpdateLatestVersion,
+  hasAvailableReleaseUpdate,
+} from "~/services/updates/presentation"
+import type { ReleaseUpdateStatus } from "~/services/updates/releaseUpdateStatus"
+
+function buildStatus(
+  overrides: Partial<ReleaseUpdateStatus> = {},
+): ReleaseUpdateStatus {
+  return {
+    eligible: true,
+    reason: "chromium-development",
+    currentVersion: "3.31.0",
+    latestVersion: null,
+    updateAvailable: false,
+    releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
+    checkedAt: null,
+    lastError: null,
+    ...overrides,
+  }
+}
+
+describe("release update presentation", () => {
+  it("treats blank latest versions as unavailable update metadata", () => {
+    const status = buildStatus({
+      latestVersion: "   ",
+      updateAvailable: true,
+    })
+
+    expect(getReleaseUpdateLatestVersion(status)).toBeNull()
+    expect(hasAvailableReleaseUpdate(status)).toBe(false)
+  })
+
+  it("derives the not-checked state before the first successful check", () => {
+    expect(
+      deriveReleaseUpdatePresentation({
+        isLoading: false,
+        status: buildStatus(),
+      }),
+    ).toMatchObject({
+      actionKind: "open-latest",
+      hasUpdate: false,
+      latestVersion: null,
+      state: "not-checked",
+    })
+  })
+
+  it("derives the ineligible state when checks are not supported for the install channel", () => {
+    expect(
+      deriveReleaseUpdatePresentation({
+        isLoading: false,
+        status: buildStatus({
+          eligible: false,
+          reason: "store-build",
+        }),
+      }),
+    ).toMatchObject({
+      actionKind: "open-latest",
+      hasUpdate: false,
+      state: "ineligible",
+    })
+  })
+
+  it("collapses manual check results into toast outcomes", () => {
+    expect(
+      deriveReleaseUpdateCheckOutcome(
+        buildStatus({
+          latestVersion: "3.32.0",
+          updateAvailable: true,
+          checkedAt: Date.now(),
+        }),
+      ),
+    ).toBe("update-available")
+
+    expect(
+      deriveReleaseUpdateCheckOutcome(
+        buildStatus({
+          latestVersion: "3.31.0",
+          checkedAt: Date.now(),
+        }),
+      ),
+    ).toBe("up-to-date")
+
+    expect(
+      deriveReleaseUpdateCheckOutcome(
+        buildStatus({
+          lastError: "network error",
+        }),
+      ),
+    ).toBe("check-failed")
+  })
+})

--- a/tests/services/updates/releaseUpdateService.test.ts
+++ b/tests/services/updates/releaseUpdateService.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { fakeBrowser } from "wxt/testing/fake-browser"
 
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 
@@ -55,8 +56,8 @@ vi.mock("~/utils/browser/browserApi", () => ({
 }))
 
 describe("releaseUpdateService", () => {
-  const originalBrowser = (globalThis as any).browser
   const originalFetch = globalThis.fetch
+  const browserAny = fakeBrowser as any
 
   beforeEach(async () => {
     vi.resetModules()
@@ -64,21 +65,18 @@ describe("releaseUpdateService", () => {
 
     const { Storage } = await import("@plasmohq/storage")
     ;(Storage as any).__store.clear()
-    ;(globalThis as any).browser = {
-      runtime: {
-        id: "test-extension-id",
-        getURL: vi.fn(() => "chrome-extension://test-extension-id/"),
-      },
-      management: {
-        getSelf: vi.fn().mockResolvedValue({ installType: "normal" }),
-      },
-    }
+    browserAny.runtime.id = "test-extension-id"
+    browserAny.runtime.getURL = vi.fn(
+      () => "chrome-extension://test-extension-id/",
+    )
+    browserAny.management.getSelf = vi
+      .fn()
+      .mockResolvedValue({ installType: "normal" })
 
     globalThis.fetch = vi.fn()
   })
 
   afterEach(() => {
-    ;(globalThis as any).browser = originalBrowser
     globalThis.fetch = originalFetch
   })
 
@@ -125,12 +123,11 @@ describe("releaseUpdateService", () => {
   })
 
   it("classifies Firefox installs as ambiguous when install type cannot disambiguate origin", async () => {
-    ;(globalThis as any).browser = {
-      runtime: {
-        id: "{bc73541a-133d-4b50-b261-36ea20df0d24}",
-        getURL: vi.fn(() => "moz-extension://firefox-extension/"),
-      },
-    }
+    browserAny.runtime.id = "{bc73541a-133d-4b50-b261-36ea20df0d24}"
+    browserAny.runtime.getURL = vi.fn(
+      () => "moz-extension://firefox-extension/",
+    )
+    browserAny.management.getSelf = undefined
 
     const { releaseUpdateService } = await import(
       "~/services/updates/releaseUpdateService"
@@ -164,5 +161,62 @@ describe("releaseUpdateService", () => {
     expect(onAlarmMock).toHaveBeenCalledTimes(1)
     expect(getAlarmMock).toHaveBeenCalledWith("releaseUpdateDailyCheck")
     expect(createAlarmMock).not.toHaveBeenCalled()
+  })
+
+  it("memoizes concurrent initialization so alarm handlers are only registered once", async () => {
+    let resolveAlarm: (() => void) | undefined
+
+    getAlarmMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAlarm = () => resolve(null)
+        }),
+    )
+
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    const first = releaseUpdateService.initialize()
+    const second = releaseUpdateService.initialize()
+
+    expect(onAlarmMock).toHaveBeenCalledTimes(1)
+    expect(getAlarmMock).toHaveBeenCalledTimes(1)
+
+    if (resolveAlarm) {
+      resolveAlarm()
+    }
+    await Promise.all([first, second])
+
+    expect(createAlarmMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns the base status without fetching when the install is ineligible", async () => {
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    const status = await releaseUpdateService.checkNow()
+
+    expect(status).toMatchObject({
+      eligible: false,
+      reason: "unknown",
+      currentVersion: "3.32.0",
+      latestVersion: null,
+      updateAvailable: false,
+      lastError: null,
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+
+    const { Storage } = await import("@plasmohq/storage")
+    expect(
+      (Storage as any).__store.get(STORAGE_KEYS.RELEASE_UPDATE_STATUS),
+    ).toEqual(
+      expect.objectContaining({
+        eligible: false,
+        latestVersion: null,
+        updateAvailable: false,
+      }),
+    )
   })
 })

--- a/tests/services/updates/releaseUpdateService.test.ts
+++ b/tests/services/updates/releaseUpdateService.test.ts
@@ -180,18 +180,55 @@ describe("releaseUpdateService", () => {
     const first = releaseUpdateService.initialize()
     const second = releaseUpdateService.initialize()
 
-    expect(onAlarmMock).toHaveBeenCalledTimes(1)
-    expect(getAlarmMock).toHaveBeenCalledTimes(1)
+    for (let index = 0; index < 10 && !resolveAlarm; index++) {
+      await Promise.resolve()
+    }
+
+    expect(resolveAlarm).toEqual(expect.any(Function))
 
     if (resolveAlarm) {
       resolveAlarm()
     }
     await Promise.all([first, second])
 
+    expect(getAlarmMock).toHaveBeenCalledTimes(1)
+    expect(onAlarmMock).toHaveBeenCalledTimes(1)
     expect(createAlarmMock).toHaveBeenCalledTimes(1)
   })
 
-  it("returns the base status without fetching when the install is ineligible", async () => {
+  it("registers the alarm listener only once when initialization retries after a setup failure", async () => {
+    createAlarmMock
+      .mockRejectedValueOnce(new Error("alarm setup failed"))
+      .mockResolvedValueOnce(undefined)
+
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    await expect(releaseUpdateService.initialize()).rejects.toThrow(
+      "alarm setup failed",
+    )
+    expect(onAlarmMock).not.toHaveBeenCalled()
+
+    await releaseUpdateService.initialize()
+
+    expect(onAlarmMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns the base status without fetching and clears stale release metadata when the install is ineligible", async () => {
+    const { Storage } = await import("@plasmohq/storage")
+    ;(Storage as any).__store.set(STORAGE_KEYS.RELEASE_UPDATE_STATUS, {
+      eligible: true,
+      reason: "chromium-development",
+      currentVersion: "3.32.0",
+      latestVersion: "3.40.0",
+      updateAvailable: true,
+      releaseUrl:
+        "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.40.0",
+      checkedAt: 123,
+      lastError: "old error",
+    })
+
     const { releaseUpdateService } = await import(
       "~/services/updates/releaseUpdateService"
     )
@@ -204,11 +241,12 @@ describe("releaseUpdateService", () => {
       currentVersion: "3.32.0",
       latestVersion: null,
       updateAvailable: false,
+      releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
+      checkedAt: null,
       lastError: null,
     })
     expect(globalThis.fetch).not.toHaveBeenCalled()
 
-    const { Storage } = await import("@plasmohq/storage")
     expect(
       (Storage as any).__store.get(STORAGE_KEYS.RELEASE_UPDATE_STATUS),
     ).toEqual(
@@ -216,6 +254,9 @@ describe("releaseUpdateService", () => {
         eligible: false,
         latestVersion: null,
         updateAvailable: false,
+        releaseUrl: "https://github.com/qixing-jk/all-api-hub/releases/latest",
+        checkedAt: null,
+        lastError: null,
       }),
     )
   })

--- a/tests/services/updates/releaseUpdateService.test.ts
+++ b/tests/services/updates/releaseUpdateService.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+
+const {
+  createAlarmMock,
+  getAlarmMock,
+  getManifestMock,
+  hasAlarmsApiMock,
+  onAlarmMock,
+  withExtensionStorageWriteLockMock,
+} = vi.hoisted(() => ({
+  createAlarmMock: vi.fn(),
+  getAlarmMock: vi.fn(),
+  getManifestMock: vi.fn(() => ({
+    manifest_version: 3,
+    version: "3.32.0",
+    optional_permissions: [],
+  })),
+  hasAlarmsApiMock: vi.fn(() => true),
+  onAlarmMock: vi.fn(),
+  withExtensionStorageWriteLockMock: vi.fn(
+    async (_key: string, work: () => Promise<unknown>) => await work(),
+  ),
+}))
+
+vi.mock("@plasmohq/storage", () => {
+  const store = new Map<string, unknown>()
+  const set = vi.fn(async (key: string, value: unknown) => {
+    store.set(key, value)
+  })
+  const get = vi.fn(async (key: string) => store.get(key))
+
+  function Storage(this: any) {
+    this.set = set
+    this.get = get
+  }
+
+  ;(Storage as any).__store = store
+  ;(Storage as any).__mocks = { set, get }
+
+  return { Storage, __esModule: true }
+})
+
+vi.mock("~/services/core/storageWriteLock", () => ({
+  withExtensionStorageWriteLock: withExtensionStorageWriteLockMock,
+}))
+
+vi.mock("~/utils/browser/browserApi", () => ({
+  createAlarm: createAlarmMock,
+  getAlarm: getAlarmMock,
+  getManifest: getManifestMock,
+  hasAlarmsAPI: hasAlarmsApiMock,
+  onAlarm: onAlarmMock,
+}))
+
+describe("releaseUpdateService", () => {
+  const originalBrowser = (globalThis as any).browser
+  const originalFetch = globalThis.fetch
+
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    const { Storage } = await import("@plasmohq/storage")
+    ;(Storage as any).__store.clear()
+    ;(globalThis as any).browser = {
+      runtime: {
+        id: "test-extension-id",
+        getURL: vi.fn(() => "chrome-extension://test-extension-id/"),
+      },
+      management: {
+        getSelf: vi.fn().mockResolvedValue({ installType: "normal" }),
+      },
+    }
+
+    globalThis.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    ;(globalThis as any).browser = originalBrowser
+    globalThis.fetch = originalFetch
+  })
+
+  it("marks Chromium development installs as eligible and stores latest stable status", async () => {
+    ;(globalThis as any).browser.management.getSelf.mockResolvedValueOnce({
+      installType: "development",
+    })
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        tag_name: "v3.40.0",
+        html_url:
+          "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.40.0",
+      }),
+    } as Response)
+
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    const status = await releaseUpdateService.checkNow()
+
+    expect(status).toMatchObject({
+      eligible: true,
+      reason: "chromium-development",
+      currentVersion: "3.32.0",
+      latestVersion: "3.40.0",
+      updateAvailable: true,
+      releaseUrl:
+        "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.40.0",
+      lastError: null,
+    })
+    expect(status.checkedAt).toEqual(expect.any(Number))
+
+    const { Storage } = await import("@plasmohq/storage")
+    expect(
+      (Storage as any).__store.get(STORAGE_KEYS.RELEASE_UPDATE_STATUS),
+    ).toEqual(
+      expect.objectContaining({
+        eligible: true,
+        latestVersion: "3.40.0",
+      }),
+    )
+  })
+
+  it("classifies Firefox installs as ambiguous when install type cannot disambiguate origin", async () => {
+    ;(globalThis as any).browser = {
+      runtime: {
+        id: "{bc73541a-133d-4b50-b261-36ea20df0d24}",
+        getURL: vi.fn(() => "moz-extension://firefox-extension/"),
+      },
+    }
+
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    const status = await releaseUpdateService.getStatus()
+
+    expect(status).toMatchObject({
+      eligible: false,
+      reason: "firefox-ambiguous",
+      currentVersion: "3.32.0",
+      latestVersion: null,
+      updateAvailable: false,
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it("registers the daily alarm once and preserves an existing matching schedule", async () => {
+    getAlarmMock.mockResolvedValueOnce({
+      name: "releaseUpdateDailyCheck",
+      periodInMinutes: 24 * 60,
+    })
+
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    await releaseUpdateService.initialize()
+    await releaseUpdateService.initialize()
+
+    expect(onAlarmMock).toHaveBeenCalledTimes(1)
+    expect(getAlarmMock).toHaveBeenCalledWith("releaseUpdateDailyCheck")
+    expect(createAlarmMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/updates/runtime.test.ts
+++ b/tests/services/updates/runtime.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { sendRuntimeActionMessageMock } = vi.hoisted(() => ({
+  sendRuntimeActionMessageMock: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/browserApi", () => ({
+  sendRuntimeActionMessage: sendRuntimeActionMessageMock,
+}))
+
+describe("release update runtime client", () => {
+  it("returns a failure response when the background request throws", async () => {
+    sendRuntimeActionMessageMock.mockRejectedValueOnce(
+      new Error("No listeners available"),
+    )
+
+    const { requestReleaseUpdateStatus } = await import(
+      "~/services/updates/runtime"
+    )
+
+    await expect(requestReleaseUpdateStatus()).resolves.toEqual({
+      success: false,
+      error: "No listeners available",
+    })
+  })
+})

--- a/tests/services/updates/runtime.test.ts
+++ b/tests/services/updates/runtime.test.ts
@@ -9,6 +9,42 @@ vi.mock("~/utils/browser/browserApi", () => ({
 }))
 
 describe("release update runtime client", () => {
+  it("returns a parsed success response when the background request succeeds", async () => {
+    sendRuntimeActionMessageMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        eligible: true,
+        reason: "chromium-development",
+        currentVersion: "3.31.0",
+        latestVersion: "3.32.0",
+        updateAvailable: true,
+        releaseUrl:
+          "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.32.0",
+        checkedAt: 1,
+        lastError: null,
+      },
+    })
+
+    const { requestReleaseUpdateStatus } = await import(
+      "~/services/updates/runtime"
+    )
+
+    await expect(requestReleaseUpdateStatus()).resolves.toEqual({
+      success: true,
+      data: {
+        eligible: true,
+        reason: "chromium-development",
+        currentVersion: "3.31.0",
+        latestVersion: "3.32.0",
+        updateAvailable: true,
+        releaseUrl:
+          "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.32.0",
+        checkedAt: 1,
+        lastError: null,
+      },
+    })
+  })
+
   it("returns a failure response when the background request throws", async () => {
     sendRuntimeActionMessageMock.mockRejectedValueOnce(
       new Error("No listeners available"),

--- a/tests/services/updates/statusCodec.test.ts
+++ b/tests/services/updates/statusCodec.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createDefaultReleaseUpdateStatus,
+  RELEASE_UPDATE_REASONS,
+} from "~/services/updates/releaseUpdateStatus"
+import { parseReleaseUpdateStatus } from "~/services/updates/statusCodec"
+
+describe("parseReleaseUpdateStatus", () => {
+  it("returns null for non-object payloads and whitespace-only current versions", () => {
+    expect(parseReleaseUpdateStatus(null)).toBeNull()
+    expect(parseReleaseUpdateStatus("invalid")).toBeNull()
+    expect(
+      parseReleaseUpdateStatus({
+        currentVersion: "   ",
+      }),
+    ).toBeNull()
+  })
+
+  it("trims the current version and falls back invalid reason and release URL values", () => {
+    const parsed = parseReleaseUpdateStatus({
+      currentVersion: " 3.31.0 ",
+      reason: "not-a-real-reason",
+      releaseUrl: "javascript:alert(1)",
+    })
+
+    expect(parsed).toMatchObject({
+      currentVersion: "3.31.0",
+      reason: RELEASE_UPDATE_REASONS.Unknown,
+      releaseUrl: createDefaultReleaseUpdateStatus("3.31.0").releaseUrl,
+    })
+  })
+
+  it("normalizes blank latestVersion and malformed checkedAt and lastError fields", () => {
+    const parsed = parseReleaseUpdateStatus({
+      currentVersion: "3.31.0",
+      latestVersion: "   ",
+      checkedAt: "yesterday",
+      lastError: 123,
+    })
+
+    expect(parsed).toMatchObject({
+      currentVersion: "3.31.0",
+      latestVersion: null,
+      checkedAt: null,
+      lastError: null,
+    })
+  })
+
+  it("accepts and normalizes valid https release URLs", () => {
+    const parsed = parseReleaseUpdateStatus({
+      currentVersion: "3.31.0",
+      reason: RELEASE_UPDATE_REASONS.ChromiumDevelopment,
+      releaseUrl:
+        " https://github.com/qixing-jk/all-api-hub/releases/tag/v3.31.0 ",
+      lastError: " network issue ",
+    })
+
+    expect(parsed).toMatchObject({
+      currentVersion: "3.31.0",
+      reason: RELEASE_UPDATE_REASONS.ChromiumDevelopment,
+      releaseUrl:
+        "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.31.0",
+      lastError: "network issue",
+    })
+  })
+
+  it("falls back to the default release URL when releaseUrl is empty or non-string", () => {
+    const fallback = createDefaultReleaseUpdateStatus("3.31.0").releaseUrl
+
+    expect(
+      parseReleaseUpdateStatus({
+        currentVersion: "3.31.0",
+        releaseUrl: "",
+      }),
+    ).toMatchObject({ releaseUrl: fallback })
+
+    expect(
+      parseReleaseUpdateStatus({
+        currentVersion: "3.31.0",
+        releaseUrl: 42,
+      }),
+    ).toMatchObject({ releaseUrl: fallback })
+  })
+})

--- a/tests/services/updates/statusCodec.test.ts
+++ b/tests/services/updates/statusCodec.test.ts
@@ -65,6 +65,24 @@ describe("parseReleaseUpdateStatus", () => {
     })
   })
 
+  it("accepts and normalizes valid http release URLs", () => {
+    const parsed = parseReleaseUpdateStatus({
+      currentVersion: "3.31.0",
+      reason: RELEASE_UPDATE_REASONS.ChromiumDevelopment,
+      releaseUrl:
+        " http://github.com/qixing-jk/all-api-hub/releases/tag/v3.31.0 ",
+      lastError: " network issue ",
+    })
+
+    expect(parsed).toMatchObject({
+      currentVersion: "3.31.0",
+      reason: RELEASE_UPDATE_REASONS.ChromiumDevelopment,
+      releaseUrl:
+        "http://github.com/qixing-jk/all-api-hub/releases/tag/v3.31.0",
+      lastError: "network issue",
+    })
+  })
+
   it("falls back to the default release URL when releaseUrl is empty or non-string", () => {
     const fallback = createDefaultReleaseUpdateStatus("3.31.0").releaseUrl
 

--- a/tests/test-utils/render.test.tsx
+++ b/tests/test-utils/render.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { renderHook, waitFor } from "~~/tests/test-utils/render"
+
+const { requestReleaseUpdateCheckNowMock, requestReleaseUpdateStatusMock } =
+  vi.hoisted(() => ({
+    requestReleaseUpdateCheckNowMock: vi.fn(),
+    requestReleaseUpdateStatusMock: vi.fn(),
+  }))
+
+vi.mock("~/services/updates/runtime", () => ({
+  requestReleaseUpdateCheckNow: requestReleaseUpdateCheckNowMock,
+  requestReleaseUpdateStatus: requestReleaseUpdateStatusMock,
+}))
+
+describe("test render utilities", () => {
+  it("supports renderHook with withReleaseUpdateStatusProvider false", async () => {
+    const { result } = renderHook(() => "ok", {
+      withReleaseUpdateStatusProvider: false,
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe("ok")
+    })
+    expect(requestReleaseUpdateStatusMock).not.toHaveBeenCalled()
+    expect(requestReleaseUpdateCheckNowMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/test-utils/render.tsx
+++ b/tests/test-utils/render.tsx
@@ -1,4 +1,9 @@
-import { render, renderHook, type RenderOptions } from "@testing-library/react"
+import {
+  render,
+  renderHook,
+  type RenderHookOptions,
+  type RenderOptions,
+} from "@testing-library/react"
 import type { ReactElement, ReactNode } from "react"
 import { I18nextProvider } from "react-i18next"
 
@@ -57,6 +62,13 @@ interface AppRenderOptions extends Omit<RenderOptions, "wrapper"> {
   withThemeProvider?: boolean
 }
 
+interface AppRenderHookOptions<Props>
+  extends Omit<RenderHookOptions<Props>, "wrapper"> {
+  withReleaseUpdateStatusProvider?: boolean
+  withUserPreferencesProvider?: boolean
+  withThemeProvider?: boolean
+}
+
 const customRender = (ui: ReactElement, options?: AppRenderOptions) => {
   const {
     withReleaseUpdateStatusProvider = true,
@@ -79,19 +91,18 @@ const customRender = (ui: ReactElement, options?: AppRenderOptions) => {
   })
 }
 
-const customRenderHook: typeof renderHook = (callback, options) => {
+const customRenderHook = <Result, Props>(
+  callback: (initialProps: Props) => Result,
+  options?: AppRenderHookOptions<Props>,
+) => {
   const {
     withReleaseUpdateStatusProvider = true,
     withUserPreferencesProvider = true,
     withThemeProvider = true,
     ...renderHookOptions
-  } = (options ?? {}) as {
-    withReleaseUpdateStatusProvider?: boolean
-    withUserPreferencesProvider?: boolean
-    withThemeProvider?: boolean
-  }
+  } = options ?? {}
 
-  return renderHook(callback, {
+  return renderHook<Result, Props>(callback, {
     wrapper: ({ children }) => (
       <AppProviders
         withReleaseUpdateStatusProvider={withReleaseUpdateStatusProvider}

--- a/tests/test-utils/render.tsx
+++ b/tests/test-utils/render.tsx
@@ -4,12 +4,14 @@ import { I18nextProvider } from "react-i18next"
 
 import { ChannelDialogProvider } from "~/components/dialogs/ChannelDialog"
 import { DeviceProvider } from "~/contexts/DeviceContext"
+import { ReleaseUpdateStatusProvider } from "~/contexts/ReleaseUpdateStatusContext"
 import { ThemeProvider } from "~/contexts/ThemeContext"
 import { UserPreferencesProvider } from "~/contexts/UserPreferencesContext"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
 interface AppProvidersProps {
   children: ReactNode
+  withReleaseUpdateStatusProvider?: boolean
   withUserPreferencesProvider?: boolean
   withThemeProvider?: boolean
 }
@@ -20,6 +22,7 @@ function IdentityProvider({ children }: { children: ReactNode }) {
 
 const AppProviders = ({
   children,
+  withReleaseUpdateStatusProvider = true,
   withUserPreferencesProvider = true,
   withThemeProvider = true,
 }: AppProvidersProps) => {
@@ -29,14 +32,19 @@ const AppProviders = ({
   const ActiveThemeProvider = withThemeProvider
     ? ThemeProvider
     : IdentityProvider
+  const ActiveReleaseUpdateStatusProvider = withReleaseUpdateStatusProvider
+    ? ReleaseUpdateStatusProvider
+    : IdentityProvider
 
   return (
     <I18nextProvider i18n={testI18n}>
       <DeviceProvider>
         <PreferencesProvider>
-          <ChannelDialogProvider>
-            <ActiveThemeProvider>{children}</ActiveThemeProvider>
-          </ChannelDialogProvider>
+          <ActiveThemeProvider>
+            <ActiveReleaseUpdateStatusProvider>
+              <ChannelDialogProvider>{children}</ChannelDialogProvider>
+            </ActiveReleaseUpdateStatusProvider>
+          </ActiveThemeProvider>
         </PreferencesProvider>
       </DeviceProvider>
     </I18nextProvider>
@@ -44,12 +52,14 @@ const AppProviders = ({
 }
 
 interface AppRenderOptions extends Omit<RenderOptions, "wrapper"> {
+  withReleaseUpdateStatusProvider?: boolean
   withUserPreferencesProvider?: boolean
   withThemeProvider?: boolean
 }
 
 const customRender = (ui: ReactElement, options?: AppRenderOptions) => {
   const {
+    withReleaseUpdateStatusProvider = true,
     withUserPreferencesProvider = true,
     withThemeProvider = true,
     ...renderOptions
@@ -58,6 +68,7 @@ const customRender = (ui: ReactElement, options?: AppRenderOptions) => {
   return render(ui, {
     wrapper: ({ children }) => (
       <AppProviders
+        withReleaseUpdateStatusProvider={withReleaseUpdateStatusProvider}
         withUserPreferencesProvider={withUserPreferencesProvider}
         withThemeProvider={withThemeProvider}
       >
@@ -70,10 +81,12 @@ const customRender = (ui: ReactElement, options?: AppRenderOptions) => {
 
 const customRenderHook: typeof renderHook = (callback, options) => {
   const {
+    withReleaseUpdateStatusProvider = true,
     withUserPreferencesProvider = true,
     withThemeProvider = true,
     ...renderHookOptions
   } = (options ?? {}) as {
+    withReleaseUpdateStatusProvider?: boolean
     withUserPreferencesProvider?: boolean
     withThemeProvider?: boolean
   }
@@ -81,6 +94,7 @@ const customRenderHook: typeof renderHook = (callback, options) => {
   return renderHook(callback, {
     wrapper: ({ children }) => (
       <AppProviders
+        withReleaseUpdateStatusProvider={withReleaseUpdateStatusProvider}
         withUserPreferencesProvider={withUserPreferencesProvider}
         withThemeProvider={withThemeProvider}
       >

--- a/tests/test-utils/render.tsx
+++ b/tests/test-utils/render.tsx
@@ -69,13 +69,44 @@ interface AppRenderHookOptions<Props>
   withThemeProvider?: boolean
 }
 
-const customRender = (ui: ReactElement, options?: AppRenderOptions) => {
+type ProviderToggleOptions = Pick<
+  AppProvidersProps,
+  | "withReleaseUpdateStatusProvider"
+  | "withUserPreferencesProvider"
+  | "withThemeProvider"
+>
+
+function normalizeProviderOptions<T extends ProviderToggleOptions>(
+  options?: T,
+): {
+  providerOptions: Required<ProviderToggleOptions>
+  remainingOptions: Omit<T, keyof ProviderToggleOptions>
+} {
   const {
     withReleaseUpdateStatusProvider = true,
     withUserPreferencesProvider = true,
     withThemeProvider = true,
-    ...renderOptions
-  } = options ?? {}
+    ...remainingOptions
+  } = (options ?? {}) as T & ProviderToggleOptions
+
+  return {
+    providerOptions: {
+      withReleaseUpdateStatusProvider,
+      withUserPreferencesProvider,
+      withThemeProvider,
+    },
+    remainingOptions: remainingOptions as Omit<T, keyof ProviderToggleOptions>,
+  }
+}
+
+const customRender = (ui: ReactElement, options?: AppRenderOptions) => {
+  const { providerOptions, remainingOptions } =
+    normalizeProviderOptions(options)
+  const {
+    withReleaseUpdateStatusProvider,
+    withUserPreferencesProvider,
+    withThemeProvider,
+  } = providerOptions
 
   return render(ui, {
     wrapper: ({ children }) => (
@@ -87,7 +118,7 @@ const customRender = (ui: ReactElement, options?: AppRenderOptions) => {
         {children}
       </AppProviders>
     ),
-    ...renderOptions,
+    ...remainingOptions,
   })
 }
 
@@ -95,12 +126,13 @@ const customRenderHook = <Result, Props>(
   callback: (initialProps: Props) => Result,
   options?: AppRenderHookOptions<Props>,
 ) => {
+  const { providerOptions, remainingOptions } =
+    normalizeProviderOptions(options)
   const {
-    withReleaseUpdateStatusProvider = true,
-    withUserPreferencesProvider = true,
-    withThemeProvider = true,
-    ...renderHookOptions
-  } = options ?? {}
+    withReleaseUpdateStatusProvider,
+    withUserPreferencesProvider,
+    withThemeProvider,
+  } = providerOptions
 
   return renderHook<Result, Props>(callback, {
     wrapper: ({ children }) => (
@@ -112,7 +144,7 @@ const customRenderHook = <Result, Props>(
         {children}
       </AppProviders>
     ),
-    ...renderHookOptions,
+    ...remainingOptions,
   })
 }
 

--- a/tests/utils/string.test.ts
+++ b/tests/utils/string.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  normalizeList,
+  parseDelimitedList,
+  trimToNull,
+} from "~/utils/core/string"
+
+describe("string utils", () => {
+  it("trimToNull returns null for blank or non-string values", () => {
+    expect(trimToNull("  value  ")).toBe("value")
+    expect(trimToNull("   ")).toBeNull()
+    expect(trimToNull(null)).toBeNull()
+    expect(trimToNull(42)).toBeNull()
+  })
+
+  it("parseDelimitedList trims items and drops blanks", () => {
+    expect(parseDelimitedList(" alpha, , beta ,  gamma  ")).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ])
+  })
+
+  it("normalizeList trims, removes blanks, and de-duplicates values", () => {
+    expect(normalizeList([" alpha ", "", "beta", "alpha", " beta "])).toEqual([
+      "alpha",
+      "beta",
+    ])
+  })
+})

--- a/tests/utils/string.test.ts
+++ b/tests/utils/string.test.ts
@@ -20,10 +20,20 @@ describe("string utils", () => {
       "beta",
       "gamma",
     ])
+    expect(parseDelimitedList("")).toEqual([])
+    expect(parseDelimitedList("   ")).toEqual([])
+    expect(parseDelimitedList(null)).toEqual([])
+    expect(parseDelimitedList(undefined)).toEqual([])
   })
 
   it("normalizeList trims, removes blanks, and de-duplicates values", () => {
     expect(normalizeList([" alpha ", "", "beta", "alpha", " beta "])).toEqual([
+      "alpha",
+      "beta",
+    ])
+    expect(normalizeList([])).toEqual([])
+    expect(normalizeList(["", "  "])).toEqual([])
+    expect(normalizeList([" alpha ", " ", "beta", "alpha", " beta "])).toEqual([
       "alpha",
       "beta",
     ])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release update panel on About page with manual "Check now", toasts for outcomes, and direct open/download actions; periodic background checks enabled.

* **UI Improvements**
  * Version badge now indicates available updates and links to the release; small spacing/accessibility tweaks.

* **Localization**
  * Added release-update strings for English, Japanese, Simplified Chinese, and Traditional Chinese.

* **Tests**
  * Extensive tests covering UI, context, service/runtime, presentation, codec, and utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->