### PR TITLE
feat(account): add opt-in current-site URL prefill for new accounts

### DIFF
--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -70,6 +70,7 @@ interface UserPreferencesContextType {
   actionClickBehavior: "popup" | "sidepanel"
   openChangelogOnUpdate: boolean
   autoProvisionKeyOnAccountAdd: boolean
+  autoFillCurrentSiteUrlOnAccountAdd: boolean
   warnOnDuplicateAccountAdd: boolean
   newApiBaseUrl: string
   newApiAdminToken: string
@@ -117,6 +118,9 @@ interface UserPreferencesContextType {
   ) => Promise<boolean>
   updateOpenChangelogOnUpdate: (enabled: boolean) => Promise<boolean>
   updateAutoProvisionKeyOnAccountAdd: (enabled: boolean) => Promise<boolean>
+  updateAutoFillCurrentSiteUrlOnAccountAdd: (
+    enabled: boolean,
+  ) => Promise<boolean>
   updateWarnOnDuplicateAccountAdd: (enabled: boolean) => Promise<boolean>
   updateNewApiBaseUrl: (url: string) => Promise<boolean>
   updateNewApiAdminToken: (token: string) => Promise<boolean>
@@ -285,6 +289,27 @@ export const UserPreferencesProvider = ({
       if (success) {
         setPreferences((prev) =>
           prev ? { ...prev, autoProvisionKeyOnAccountAdd: enabled } : prev,
+        )
+      }
+      return success
+    },
+    [],
+  )
+
+  /**
+   * Enable/disable automatically prefilling the add-account URL from the
+   * current browser tab.
+   * @param enabled - When true, add-account starts with the current site's origin.
+   */
+  const updateAutoFillCurrentSiteUrlOnAccountAdd = useCallback(
+    async (enabled: boolean) => {
+      const success =
+        await userPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd(enabled)
+      if (success) {
+        setPreferences((prev) =>
+          prev
+            ? { ...prev, autoFillCurrentSiteUrlOnAccountAdd: enabled }
+            : prev,
         )
       }
       return success
@@ -1388,6 +1413,10 @@ export const UserPreferencesProvider = ({
       preferences?.autoProvisionKeyOnAccountAdd ??
       DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd ??
       false,
+    autoFillCurrentSiteUrlOnAccountAdd:
+      preferences?.autoFillCurrentSiteUrlOnAccountAdd ??
+      DEFAULT_PREFERENCES.autoFillCurrentSiteUrlOnAccountAdd ??
+      false,
     warnOnDuplicateAccountAdd:
       preferences?.warnOnDuplicateAccountAdd ??
       DEFAULT_PREFERENCES.warnOnDuplicateAccountAdd ??
@@ -1437,6 +1466,7 @@ export const UserPreferencesProvider = ({
     updateActionClickBehavior,
     updateOpenChangelogOnUpdate,
     updateAutoProvisionKeyOnAccountAdd,
+    updateAutoFillCurrentSiteUrlOnAccountAdd,
     updateWarnOnDuplicateAccountAdd,
     updateNewApiBaseUrl,
     updateNewApiAdminToken,

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -95,8 +95,11 @@ export function useAccountDialog({
   onSuccess,
 }: UseAccountDialogProps) {
   const { t } = useTranslation(["accountDialog", "settings", "messages"])
-  const { warnOnDuplicateAccountAdd, managedSiteType } =
-    useUserPreferencesContext()
+  const {
+    warnOnDuplicateAccountAdd,
+    managedSiteType,
+    autoFillCurrentSiteUrlOnAccountAdd,
+  } = useUserPreferencesContext()
 
   const [url, setUrl] = useState("")
   const [isDetecting, setIsDetecting] = useState(false)
@@ -173,6 +176,7 @@ export function useAccountDialog({
   const duplicateAccountWarningAcknowledgedSiteUrlRef = useRef<string | null>(
     null,
   )
+  const hasConsumedAutoFillCurrentSiteUrlRef = useRef(false)
 
   const cancelPendingDuplicateAccountWarning = useCallback(() => {
     duplicateAccountWarningResolverRef.current?.(false)
@@ -349,6 +353,7 @@ export function useAccountDialog({
 
   const resetForm = useCallback(() => {
     duplicateAccountWarningAcknowledgedSiteUrlRef.current = null
+    hasConsumedAutoFillCurrentSiteUrlRef.current = false
     setUrl("")
     setIsDetected(false)
     setSiteName("")
@@ -511,6 +516,24 @@ export function useAccountDialog({
   }, [isOpen, mode, account, resetForm, loadAccountData, checkCurrentTab])
 
   useEffect(() => {
+    if (!isOpen || mode !== DIALOG_MODES.ADD) {
+      return
+    }
+    if (!autoFillCurrentSiteUrlOnAccountAdd) {
+      return
+    }
+    if (!currentTabUrl || url.trim()) {
+      return
+    }
+    if (hasConsumedAutoFillCurrentSiteUrlRef.current) {
+      return
+    }
+
+    hasConsumedAutoFillCurrentSiteUrlRef.current = true
+    setUrl(currentTabUrl)
+  }, [autoFillCurrentSiteUrlOnAccountAdd, currentTabUrl, isOpen, mode, url])
+
+  useEffect(() => {
     // 打开 popup 时立即检测一次
     checkCurrentTab()
 
@@ -560,6 +583,14 @@ export function useAccountDialog({
   const handleUseCurrentTabUrl = () => {
     if (currentTabUrl) {
       setUrl(currentTabUrl)
+    }
+  }
+
+  const handleClearUrl = () => {
+    hasConsumedAutoFillCurrentSiteUrlRef.current = true
+    setUrl("")
+    if (mode === DIALOG_MODES.ADD) {
+      setSiteName("")
     }
   }
 
@@ -1194,6 +1225,7 @@ export function useAccountDialog({
 
   const handleUrlChange = (newUrl: string) => {
     duplicateAccountWarningAcknowledgedSiteUrlRef.current = null
+    hasConsumedAutoFillCurrentSiteUrlRef.current = true
     if (newUrl.trim()) {
       try {
         const urlObj = new URL(newUrl)
@@ -1308,6 +1340,7 @@ export function useAccountDialog({
       handleAutoDetect,
       handleShowManualForm,
       handleSaveAccount,
+      handleClearUrl,
       handleUrlChange,
       handleSubmit,
       handleAutoConfig,

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -129,7 +129,7 @@ export default function AccountDialog({
               url={state.url}
               onUrlChange={handlers.handleUrlChange}
               isDetected={state.isDetected}
-              onClearUrl={() => setters.setUrl("")}
+              onClearUrl={handlers.handleClearUrl}
               siteType={state.siteType}
               authType={state.authType}
               onAuthTypeChange={setters.setAuthType}

--- a/src/features/BasicSettings/components/tabs/AccountManagement/AccountManagementTab.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/AccountManagementTab.tsx
@@ -10,6 +10,7 @@ import {
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { pushWithinOptionsPage } from "~/utils/navigation"
 
+import AutoFillCurrentSiteUrlOnAccountAddSettings from "./AutoFillCurrentSiteUrlOnAccountAddSettings"
 import AutoProvisionKeyOnAccountAddSettings from "./AutoProvisionKeyOnAccountAddSettings"
 import DuplicateAccountWarningOnAddSettings from "./DuplicateAccountWarningOnAddSettings"
 import SortingPrioritySettings from "./SortingPrioritySettings"
@@ -50,6 +51,7 @@ export default function AccountManagementTab() {
       </section>
 
       <AutoProvisionKeyOnAccountAddSettings />
+      <AutoFillCurrentSiteUrlOnAccountAddSettings />
       <DuplicateAccountWarningOnAddSettings />
 
       <section id="sorting-priority">

--- a/src/features/BasicSettings/components/tabs/AccountManagement/AutoFillCurrentSiteUrlOnAccountAddSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/AutoFillCurrentSiteUrlOnAccountAddSettings.tsx
@@ -1,0 +1,53 @@
+import { GlobeAltIcon } from "@heroicons/react/24/outline"
+import { useTranslation } from "react-i18next"
+
+import { SettingSection } from "~/components/SettingSection"
+import { Card, CardItem, CardList, Switch } from "~/components/ui"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { showUpdateToast } from "~/utils/core/toastHelpers"
+
+/**
+ * Settings section controlling whether the add-account dialog prefills the
+ * site URL from the current browser tab.
+ */
+export default function AutoFillCurrentSiteUrlOnAccountAddSettings() {
+  const { t } = useTranslation("settings")
+  const {
+    autoFillCurrentSiteUrlOnAccountAdd,
+    updateAutoFillCurrentSiteUrlOnAccountAdd,
+  } = useUserPreferencesContext()
+
+  const handleToggle = async (enabled: boolean) => {
+    const success = await updateAutoFillCurrentSiteUrlOnAccountAdd(enabled)
+    showUpdateToast(
+      success,
+      t("autoFillCurrentSiteUrlOnAccountAdd.toggleLabel"),
+    )
+  }
+
+  return (
+    <SettingSection
+      id="auto-fill-current-site-url-on-account-add"
+      title={t("autoFillCurrentSiteUrlOnAccountAdd.title")}
+      description={t("autoFillCurrentSiteUrlOnAccountAdd.description")}
+    >
+      <Card padding="none">
+        <CardList>
+          <CardItem
+            icon={
+              <GlobeAltIcon className="h-5 w-5 text-sky-600 dark:text-sky-400" />
+            }
+            title={t("autoFillCurrentSiteUrlOnAccountAdd.toggleLabel")}
+            description={t("autoFillCurrentSiteUrlOnAccountAdd.toggleDesc")}
+            rightContent={
+              <Switch
+                checked={autoFillCurrentSiteUrlOnAccountAdd}
+                onChange={handleToggle}
+              />
+            }
+          />
+        </CardList>
+      </Card>
+    </SettingSection>
+  )
+}

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -45,6 +45,12 @@
       "switchToLanguage": "Switch interface language to {{language}}"
     }
   },
+  "autoFillCurrentSiteUrlOnAccountAdd": {
+    "description": "Control whether Add Account starts with the current site's URL already filled in.",
+    "title": "Accounts",
+    "toggleDesc": "When enabled, opening Add Account prefills the URL field with the current browser tab's site origin. Detection still uses the existing next step.",
+    "toggleLabel": "Prefill URL from current site when adding accounts"
+  },
   "autoProvisionKeyOnAccountAdd": {
     "description": "Control whether All API Hub automatically provisions a default API key after you add an account.",
     "title": "API keys",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -45,6 +45,12 @@
       "switchToLanguage": "表示言語を {{language}} に切り替える"
     }
   },
+  "autoFillCurrentSiteUrlOnAccountAdd": {
+    "description": "アカウント追加時に、現在のサイト URL をあらかじめ入力するかどうかを制御します。",
+    "title": "アカウント",
+    "toggleDesc": "有効にすると、アカウント追加ダイアログを開いたときに現在のブラウザタブのサイト origin を URL 欄へ事前入力します。検出は既存の次の操作で続けます。",
+    "toggleLabel": "アカウント追加時に現在サイトの URL を事前入力"
+  },
   "autoProvisionKeyOnAccountAdd": {
     "description": "アカウント追加後に All API Hub が既定の API キーを自動作成するかどうかを制御します。",
     "title": "API キー",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -45,6 +45,12 @@
       "switchToLanguage": "切换界面语言为{{language}}"
     }
   },
+  "autoFillCurrentSiteUrlOnAccountAdd": {
+    "description": "控制新增账号时，是否自动把当前站点网址预填到 URL 输入框中。",
+    "title": "账号",
+    "toggleDesc": "开启后，打开新增账号弹窗时会把当前浏览器标签页的站点地址预填到 URL 输入框。识别流程仍需使用现有下一步操作。",
+    "toggleLabel": "新增账号时自动填充当前站点网址"
+  },
   "autoProvisionKeyOnAccountAdd": {
     "description": "控制添加账号后是否自动创建默认 API 密钥。",
     "title": "API 密钥",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -45,6 +45,12 @@
       "switchToLanguage": "切換介面語言為{{language}}"
     }
   },
+  "autoFillCurrentSiteUrlOnAccountAdd": {
+    "description": "控制新增帳號時，是否自動把目前站點網址預先填入 URL 欄位。",
+    "title": "帳號",
+    "toggleDesc": "開啟後，開啟新增帳號視窗時會把目前瀏覽器分頁的站點 origin 預填到 URL 欄位。識別流程仍需沿用現有的下一步操作。",
+    "toggleLabel": "新增帳號時自動填入目前站點網址"
+  },
   "autoProvisionKeyOnAccountAdd": {
     "description": "控制新增帳號後是否自動建立預設 API 金鑰。",
     "title": "API 金鑰",

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -206,6 +206,15 @@ export interface UserPreferences {
   autoProvisionKeyOnAccountAdd?: boolean
 
   /**
+   * Controls whether the add-account dialog automatically prefills the site URL
+   * field from the current browser tab's origin.
+   *
+   * Optional for backward compatibility with stored preferences created before
+   * this flag existed. Missing values MUST be treated as disabled via defaults.
+   */
+  autoFillCurrentSiteUrlOnAccountAdd?: boolean
+
+  /**
    * Controls whether All API Hub shows a confirmation modal when adding an
    * account whose site URL already exists in storage (possible duplicate).
    *
@@ -457,6 +466,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   actionClickBehavior: "popup",
   openChangelogOnUpdate: true,
   autoProvisionKeyOnAccountAdd: false, // 默认关闭，避免添加账号时无意创建密钥
+  autoFillCurrentSiteUrlOnAccountAdd: false,
   warnOnDuplicateAccountAdd: true,
   accountAutoRefresh: DEFAULT_ACCOUNT_AUTO_REFRESH,
   usageHistory: DEFAULT_USAGE_HISTORY_PREFERENCES,
@@ -685,6 +695,17 @@ class UserPreferencesService {
    */
   async updateAutoProvisionKeyOnAccountAdd(enabled: boolean): Promise<boolean> {
     return this.savePreferences({ autoProvisionKeyOnAccountAdd: enabled })
+  }
+
+  /**
+   * Enable/disable automatically prefilling the add-account URL field from the
+   * current browser tab.
+   * @param enabled - When true, add-account starts with the current site's origin.
+   */
+  async updateAutoFillCurrentSiteUrlOnAccountAdd(
+    enabled: boolean,
+  ): Promise<boolean> {
+    return this.savePreferences({ autoFillCurrentSiteUrlOnAccountAdd: enabled })
   }
 
   /**

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -71,6 +71,7 @@ vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
       setSortingPriorityConfig: vi.fn(),
       updateOpenChangelogOnUpdate: vi.fn(),
       updateAutoProvisionKeyOnAccountAdd: vi.fn(),
+      updateAutoFillCurrentSiteUrlOnAccountAdd: vi.fn(),
       updateWarnOnDuplicateAccountAdd: vi.fn(),
       updateManagedSiteType: vi.fn(),
       updateLoggingPreferences: vi.fn(),
@@ -154,6 +155,9 @@ describe("UserPreferencesContext", () => {
     mockedUserPreferences.setSortingPriorityConfig.mockResolvedValue(true)
     mockedUserPreferences.updateOpenChangelogOnUpdate.mockResolvedValue(true)
     mockedUserPreferences.updateAutoProvisionKeyOnAccountAdd.mockResolvedValue(
+      true,
+    )
+    mockedUserPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd.mockResolvedValue(
       true,
     )
     mockedUserPreferences.updateWarnOnDuplicateAccountAdd.mockResolvedValue(
@@ -247,6 +251,7 @@ describe("UserPreferencesContext", () => {
       await context.updateSortConfig(DATA_TYPE_INCOME, "asc")
       await context.updateOpenChangelogOnUpdate(false)
       await context.updateAutoProvisionKeyOnAccountAdd(true)
+      await context.updateAutoFillCurrentSiteUrlOnAccountAdd(true)
       await context.updateWarnOnDuplicateAccountAdd(false)
       await context.updateNewApiBaseUrl("https://new-api.example")
       await context.updateNewApiAdminToken("admin-token")
@@ -823,6 +828,9 @@ describe("UserPreferencesContext", () => {
     mockedUserPreferences.updateAutoProvisionKeyOnAccountAdd.mockResolvedValue(
       false,
     )
+    mockedUserPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd.mockResolvedValue(
+      false,
+    )
     mockedUserPreferences.updateWarnOnDuplicateAccountAdd.mockResolvedValue(
       false,
     )
@@ -836,6 +844,9 @@ describe("UserPreferencesContext", () => {
       expect(await context.updateActionClickBehavior("sidepanel")).toBe(false)
       expect(await context.updateOpenChangelogOnUpdate(false)).toBe(false)
       expect(await context.updateAutoProvisionKeyOnAccountAdd(true)).toBe(false)
+      expect(await context.updateAutoFillCurrentSiteUrlOnAccountAdd(true)).toBe(
+        false,
+      )
       expect(await context.updateWarnOnDuplicateAccountAdd(false)).toBe(false)
       expect(await context.updateDefaultTab(DATA_TYPE_CASHFLOW)).toBe(false)
       expect(await context.updateCurrencyType("CNY")).toBe(false)
@@ -1286,6 +1297,8 @@ describe("UserPreferencesContext", () => {
     delete (preferences as Partial<UserPreferences>).openChangelogOnUpdate
     delete (preferences as Partial<UserPreferences>)
       .autoProvisionKeyOnAccountAdd
+    delete (preferences as Partial<UserPreferences>)
+      .autoFillCurrentSiteUrlOnAccountAdd
     delete (preferences as Partial<UserPreferences>).warnOnDuplicateAccountAdd
     delete (preferences as Partial<UserPreferences>).managedSiteType
     delete (preferences as Partial<UserPreferences>).themeMode
@@ -1318,6 +1331,9 @@ describe("UserPreferencesContext", () => {
     )
     expect((latestContext as any)?.autoProvisionKeyOnAccountAdd).toBe(
       DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd,
+    )
+    expect((latestContext as any)?.autoFillCurrentSiteUrlOnAccountAdd).toBe(
+      DEFAULT_PREFERENCES.autoFillCurrentSiteUrlOnAccountAdd,
     )
     expect((latestContext as any)?.warnOnDuplicateAccountAdd).toBe(
       DEFAULT_PREFERENCES.warnOnDuplicateAccountAdd,

--- a/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
@@ -12,11 +12,19 @@ const {
   mockGetActiveTabs,
   onTabActivatedMock,
   onTabUpdatedMock,
+  mockUserPreferencesContext,
 } = vi.hoisted(() => ({
   mockGetSiteName: vi.fn(),
   mockGetActiveTabs: vi.fn(),
   onTabActivatedMock: vi.fn(),
   onTabUpdatedMock: vi.fn(),
+  mockUserPreferencesContext: {
+    current: {
+      warnOnDuplicateAccountAdd: true,
+      managedSiteType: "new-api",
+      autoFillCurrentSiteUrlOnAccountAdd: false,
+    },
+  },
 }))
 
 vi.mock("~/components/dialogs/ChannelDialog", () => ({
@@ -26,6 +34,16 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
     openSub2ApiTokenCreationDialog: vi.fn(),
   }),
 }))
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+
+  return {
+    ...actual,
+    useUserPreferencesContext: () => mockUserPreferencesContext.current,
+  }
+})
 
 vi.mock("~/services/accounts/accountOperations", async (importOriginal) => {
   const actual =
@@ -51,8 +69,21 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
 })
 
 describe("useAccountDialog current tab detection", () => {
+  const renderAccountDialogHook = (
+    props: Parameters<typeof useAccountDialog>[0],
+  ) =>
+    renderHook(() => useAccountDialog(props), {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUserPreferencesContext.current = {
+      warnOnDuplicateAccountAdd: true,
+      managedSiteType: "new-api",
+      autoFillCurrentSiteUrlOnAccountAdd: false,
+    }
 
     const queryMock = vi.fn(async () => [])
     ;(globalThis as any).browser = {
@@ -266,6 +297,206 @@ describe("useAccountDialog current tab detection", () => {
     })
 
     expect(result.current.state.url).toBe("https://picked.example.com")
+  })
+
+  it("prefills the add-account url from the current tab when the setting is enabled", async () => {
+    mockUserPreferencesContext.current = {
+      ...mockUserPreferencesContext.current,
+      autoFillCurrentSiteUrlOnAccountAdd: true,
+    }
+
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    tabsQueryMock.mockResolvedValue([
+      {
+        id: 8,
+        url: "https://prefill.example.com/dashboard?x=1",
+      },
+    ])
+
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBeTruthy()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://prefill.example.com",
+      )
+      expect(result.current.state.url).toBe("https://prefill.example.com")
+    })
+  })
+
+  it("keeps the url field empty when the setting is disabled", async () => {
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    tabsQueryMock.mockResolvedValue([
+      {
+        id: 9,
+        url: "https://manual.example.com/home",
+      },
+    ])
+
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBeTruthy()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://manual.example.com",
+      )
+    })
+    expect(result.current.state.url).toBe("")
+  })
+
+  it("does not overwrite a prefilled url after later active-tab updates", async () => {
+    mockUserPreferencesContext.current = {
+      ...mockUserPreferencesContext.current,
+      autoFillCurrentSiteUrlOnAccountAdd: true,
+    }
+
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    let activeUrl = "https://first.example.com/path"
+    tabsQueryMock.mockImplementation(async () => [
+      {
+        id: 10,
+        url: activeUrl,
+      },
+    ])
+
+    let activatedListener: (() => void | Promise<void>) | undefined
+    onTabActivatedMock.mockImplementation((listener) => {
+      activatedListener = listener
+      return () => {}
+    })
+
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBeTruthy()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.url).toBe("https://first.example.com")
+    })
+
+    activeUrl = "https://second.example.com/path"
+
+    await act(async () => {
+      await activatedListener?.()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://second.example.com",
+      )
+    })
+    expect(result.current.state.url).toBe("https://first.example.com")
+  })
+
+  it("does not overwrite a manually edited url after current-tab detection completes", async () => {
+    mockUserPreferencesContext.current = {
+      ...mockUserPreferencesContext.current,
+      autoFillCurrentSiteUrlOnAccountAdd: true,
+    }
+
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    let resolveTabs: ((value: any[]) => void) | null = null
+    tabsQueryMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTabs = resolve
+        }),
+    )
+
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.handlers.handleUrlChange("https://typed.example.com/path")
+    })
+
+    expect(result.current.state.url).toBe("https://typed.example.com")
+
+    await act(async () => {
+      resolveTabs?.([
+        {
+          id: 11,
+          url: "https://detected.example.com/path",
+        },
+      ])
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://detected.example.com",
+      )
+    })
+    expect(result.current.state.url).toBe("https://typed.example.com")
+  })
+
+  it("does not prefill in edit mode even when the setting is enabled", async () => {
+    mockUserPreferencesContext.current = {
+      ...mockUserPreferencesContext.current,
+      autoFillCurrentSiteUrlOnAccountAdd: true,
+    }
+
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    tabsQueryMock.mockResolvedValue([
+      {
+        id: 12,
+        url: "https://edit.example.com/path",
+      },
+    ])
+
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.EDIT,
+      account: {
+        id: "account-1",
+      } as any,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBeNull()
+    })
+    expect(result.current.state.url).toBe("")
   })
 
   it("refreshes current-tab detection when the active tab changes", async () => {

--- a/tests/services/userPreferences.autoFillCurrentSiteUrlOnAccountAdd.test.ts
+++ b/tests/services/userPreferences.autoFillCurrentSiteUrlOnAccountAdd.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import { Storage } from "@plasmohq/storage"
+
+import { USER_PREFERENCES_STORAGE_KEYS } from "~/services/core/storageKeys"
+import {
+  DEFAULT_PREFERENCES,
+  userPreferences,
+} from "~/services/preferences/userPreferences"
+
+describe("userPreferences autoFillCurrentSiteUrlOnAccountAdd", () => {
+  it("treats missing autoFillCurrentSiteUrlOnAccountAdd as disabled without saving back", async () => {
+    const storage = new Storage({ area: "local" })
+    const storedWithoutFlag: any = { ...DEFAULT_PREFERENCES }
+    delete storedWithoutFlag.autoFillCurrentSiteUrlOnAccountAdd
+
+    await storage.set(
+      USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
+      storedWithoutFlag,
+    )
+
+    const prefs = await userPreferences.getPreferences()
+    expect(prefs.autoFillCurrentSiteUrlOnAccountAdd).toBe(false)
+
+    const storedAfter = await storage.get(
+      USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
+    )
+    expect((storedAfter as any)?.autoFillCurrentSiteUrlOnAccountAdd).toBe(
+      undefined,
+    )
+  })
+
+  it("persists updates via updateAutoFillCurrentSiteUrlOnAccountAdd", async () => {
+    const storage = new Storage({ area: "local" })
+
+    await storage.set(USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES, {
+      ...DEFAULT_PREFERENCES,
+      autoFillCurrentSiteUrlOnAccountAdd: false,
+    })
+
+    const success =
+      await userPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd(true)
+    expect(success).toBe(true)
+
+    const prefs = await userPreferences.getPreferences()
+    expect(prefs.autoFillCurrentSiteUrlOnAccountAdd).toBe(true)
+  })
+})

--- a/tests/services/userPreferences.test.ts
+++ b/tests/services/userPreferences.test.ts
@@ -18,6 +18,7 @@ describe("userPreferences", () => {
       expect(DEFAULT_PREFERENCES.showHealthStatus).toBe(true)
       expect(DEFAULT_PREFERENCES.themeMode).toBe("system")
       expect(DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd).toBe(false)
+      expect(DEFAULT_PREFERENCES.autoFillCurrentSiteUrlOnAccountAdd).toBe(false)
       expect(DEFAULT_PREFERENCES.balanceHistory?.enabled).toBe(false)
       expect(DEFAULT_PREFERENCES.balanceHistory?.endOfDayCapture.enabled).toBe(
         false,


### PR DESCRIPTION
Resolves #709 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added a setting to automatically pre-fill the current website's URL when adding a new account. The feature is disabled by default and can be toggled in Account Management settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->