### PR TITLE
fix(account): add options page refresh action

### DIFF
--- a/src/features/AccountManagement/AccountManagement.tsx
+++ b/src/features/AccountManagement/AccountManagement.tsx
@@ -1,5 +1,7 @@
+import { ArrowPathIcon } from "@heroicons/react/24/outline"
 import { CalendarCheck2, Search, UserRound } from "lucide-react"
-import { useState, type MouseEvent } from "react"
+import { useCallback, useState, type MouseEvent } from "react"
+import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { PageHeader } from "~/components/PageHeader"
@@ -10,7 +12,10 @@ import { useAccountActionsContext } from "~/features/AccountManagement/hooks/Acc
 import { useAccountDataContext } from "~/features/AccountManagement/hooks/AccountDataContext"
 import { AccountManagementProvider } from "~/features/AccountManagement/hooks/AccountManagementProvider"
 import { useDialogStateContext } from "~/features/AccountManagement/hooks/DialogStateContext"
+import { createLogger } from "~/utils/core/logger"
 import { getExternalCheckInOpenOptions } from "~/utils/core/shortcutKeys"
+
+const logger = createLogger("AccountManagementPage")
 
 /**
  * Renders the Account Management page body: header with CTA and account list.
@@ -18,7 +23,7 @@ import { getExternalCheckInOpenOptions } from "~/utils/core/shortcutKeys"
 function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
   const { t } = useTranslation(["account", "common"])
   const { openAddAccount } = useDialogStateContext()
-  const { displayData } = useAccountDataContext()
+  const { displayData, handleRefresh, isRefreshing } = useAccountDataContext()
   const { handleOpenExternalCheckIns } = useAccountActionsContext()
   const [isDedupeDialogOpen, setIsDedupeDialogOpen] = useState(false)
 
@@ -40,6 +45,40 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
     })
   }
 
+  const handleGlobalRefresh = useCallback(async () => {
+    try {
+      await toast.promise(handleRefresh(true), {
+        loading: t("account:refresh.refreshingAll"),
+        success: (result) => {
+          if (result.failed > 0) {
+            return t("account:refresh.refreshComplete", {
+              success: result.success,
+              failed: result.failed,
+            })
+          }
+
+          const sum = result.success + result.failed
+          if (sum === 0) {
+            return null
+          }
+
+          const { refreshedCount } = result
+          if (refreshedCount < sum) {
+            return t("account:refresh.refreshPartialSkipped", {
+              success: refreshedCount,
+              skipped: sum - refreshedCount,
+            })
+          }
+
+          return t("account:refresh.refreshSuccess")
+        },
+        error: t("account:refresh.refreshFailed"),
+      })
+    } catch (error) {
+      logger.error("Error during global refresh", error)
+    }
+  }, [handleRefresh, t])
+
   return (
     <div className="dark:bg-dark-bg-secondary flex flex-col bg-white p-6">
       <PageHeader
@@ -48,6 +87,15 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
         description={t("account:description")}
         actions={
           <div className="flex flex-wrap items-center gap-2">
+            <Button
+              onClick={() => void handleGlobalRefresh()}
+              variant="secondary"
+              leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+              loading={isRefreshing}
+              disabled={isRefreshing}
+            >
+              {t("common:actions.refresh")}
+            </Button>
             {canOpenExternalCheckIns && (
               <Button
                 onClick={handleOpenExternalCheckInsClick}

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -93,7 +93,12 @@ interface AccountDataContextType {
   loadAccountData: () => Promise<void>
   handleRefresh: (
     force?: boolean,
-  ) => Promise<{ success: number; failed: number; latestSyncTime?: number }>
+  ) => Promise<{
+    success: number
+    failed: number
+    latestSyncTime?: number
+    refreshedCount: number
+  }>
   handleSort: (field: SortField) => void
   sortField: SortField
   sortOrder: SortOrder

--- a/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
+++ b/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
@@ -62,6 +62,7 @@ beforeEach(() => {
   handleRefreshMock.mockResolvedValue({
     success: 0,
     failed: 0,
+    latestSyncTime: 0,
     refreshedCount: 0,
   })
 })

--- a/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
+++ b/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
@@ -6,6 +6,13 @@ import BookmarkManagement from "~/entrypoints/options/pages/BookmarkManagement"
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
 const openAddAccountMock = vi.fn()
+const handleRefreshMock = vi.fn()
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    promise: (promise: Promise<unknown>) => promise,
+  },
+}))
 
 vi.mock("~/features/AccountManagement/hooks/AccountManagementProvider", () => ({
   AccountManagementProvider: ({ children }: { children: ReactNode }) => (
@@ -25,6 +32,8 @@ vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
   ),
   useAccountDataContext: () => ({
     displayData: [],
+    isRefreshing: false,
+    handleRefresh: handleRefreshMock,
   }),
 }))
 
@@ -49,6 +58,12 @@ vi.mock("~/features/SiteBookmarks/components/BookmarkDialog", () => ({
 
 beforeEach(() => {
   openAddAccountMock.mockReset()
+  handleRefreshMock.mockReset()
+  handleRefreshMock.mockResolvedValue({
+    success: 0,
+    failed: 0,
+    refreshedCount: 0,
+  })
 })
 
 describe("options AccountManagement page", () => {
@@ -65,6 +80,17 @@ describe("options AccountManagement page", () => {
     expect(
       screen.queryByRole("button", { name: "bookmark:switch.bookmarks" }),
     ).not.toBeInTheDocument()
+  })
+
+  it("renders a refresh action and triggers a forced global refresh", async () => {
+    render(<AccountManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "common:actions.refresh" }),
+    )
+
+    expect(handleRefreshMock).toHaveBeenCalledTimes(1)
+    expect(handleRefreshMock).toHaveBeenCalledWith(true)
   })
 })
 


### PR DESCRIPTION
## Summary
- add a global refresh action to the options account management header
- reuse the existing account refresh flow and toast messaging from the shared account data context
- add an options page regression test that verifies the refresh button triggers a forced refresh

## Test Plan
- pnpm exec eslint src/features/AccountManagement/AccountManagement.tsx tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
- pnpm exec vitest related --run src/features/AccountManagement/AccountManagement.tsx tests/entrypoints/options/AccountAndBookmarkPages.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global refresh button to the Account Management header that shows loading/disabled state and reports success, partial results, or errors via toast notifications.

* **Tests**
  * Added tests verifying the refresh button behavior, including invocation of the refresh handler and correct toast-related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->