### PR TITLE
[codex] feat(import-export): 支持导出账号密钥快照

### DIFF
--- a/e2e/importExportKeyExport.spec.ts
+++ b/e2e/importExportKeyExport.spec.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises"
+
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  createStoredAccount,
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  seedStoredAccounts,
+  stubLlmMetadataIndex,
+  stubNewApiSiteRoutes,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  expectPermissionOnboardingHidden,
+  getServiceWorker,
+} from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page)
+  await forceExtensionLanguage(page, "en")
+  await stubLlmMetadataIndex(context)
+})
+
+test("exports account keys while preserving per-account failures in the backup file", async ({
+  context,
+  extensionId,
+  page,
+}, testInfo) => {
+  const serviceWorker = await getServiceWorker(context)
+
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: "export-ok-account",
+      site_name: "Export OK",
+      site_url: "https://export-ok.example.com",
+      account_info: {
+        id: 11,
+        access_token: "export-ok-token",
+        username: "export-ok-user",
+      },
+    }),
+    createStoredAccount({
+      id: "export-bad-account",
+      site_name: "Export Bad",
+      site_url: "https://export-bad.example.com",
+      account_info: {
+        id: 22,
+        access_token: "export-bad-token",
+        username: "export-bad-user",
+      },
+    }),
+  ])
+
+  await stubNewApiSiteRoutes(context, {
+    baseUrl: "https://export-ok.example.com",
+    userId: 11,
+    username: "export-ok-user",
+    accessToken: "export-ok-token",
+    initialTokens: [
+      {
+        id: 101,
+        user_id: 11,
+        key: "sk-export-real",
+        status: 1,
+        name: "Export Primary Key",
+        created_time: 1_700_000_000,
+        accessed_time: 1_700_000_000,
+        expired_time: -1,
+        remain_quota: -1,
+        unlimited_quota: true,
+        model_limits_enabled: false,
+        model_limits: "",
+        allow_ips: "",
+        used_quota: 0,
+        group: "vip",
+      },
+    ],
+  })
+
+  await context.route("https://export-bad.example.com/api/token/**", (route) =>
+    route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: false,
+        message: "upstream timeout",
+      }),
+    }),
+  )
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#importExport`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+  page.removeAllListeners("console")
+
+  await page.evaluate(() => {
+    const originalCreateObjectURL = URL.createObjectURL.bind(URL)
+    const originalCreateElement = document.createElement.bind(document)
+
+    ;(window as typeof window & { __lastExportedBackupText?: string }).__lastExportedBackupText =
+      undefined
+
+    URL.createObjectURL = (object: Blob | MediaSource) => {
+      if (object instanceof Blob) {
+        void object.text().then((text) => {
+          ;(
+            window as typeof window & { __lastExportedBackupText?: string }
+          ).__lastExportedBackupText = text
+        })
+      }
+
+      return originalCreateObjectURL(object)
+    }
+
+    document.createElement = ((tagName: string, options?: ElementCreationOptions) => {
+      const element = originalCreateElement(tagName, options)
+
+      if (tagName.toLowerCase() === "a") {
+        ;(element as HTMLAnchorElement).click = () => {
+          // Swallow the synthetic download click so the page stays on the
+          // options screen while we inspect the generated Blob content.
+        }
+      }
+
+      return element
+    }) as typeof document.createElement
+  })
+
+  await page.getByRole("checkbox", { name: "Include account keys in export" }).click()
+  await page
+    .locator("#export-section")
+    .getByRole("button", { name: "Export" })
+    .first()
+    .evaluate((button) => {
+      ;(button as HTMLButtonElement).click()
+    })
+  await page.waitForTimeout(2000)
+
+  await expect(page.getByText("Data exported successfully")).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      return await page.evaluate(() => {
+        return (
+          window as typeof window & { __lastExportedBackupText?: string }
+        ).__lastExportedBackupText
+      })
+    })
+    .toBeTruthy()
+
+  const exportedRaw = await page.evaluate(() => {
+    return (
+      window as typeof window & { __lastExportedBackupText?: string }
+    ).__lastExportedBackupText
+  })
+  if (!exportedRaw) {
+    throw new Error("missing exported backup payload")
+  }
+
+  const exportedPath = testInfo.outputPath("import-export-with-keys.json")
+  await fs.writeFile(exportedPath, exportedRaw ?? "", "utf8")
+  const exported = JSON.parse(exportedRaw) as {
+    accountKeySnapshots?: Array<{
+      accountId: string
+      accountName: string
+      baseUrl: string
+      siteType: string
+      tokens: Array<{
+        id: number
+        name: string
+        key: string
+        group?: string
+      }>
+    }>
+    accountKeySnapshotErrors?: Array<{
+      accountId: string
+      accountName: string
+      baseUrl: string
+      siteType: string
+      errorMessage: string
+    }>
+  }
+
+  expect(exported.accountKeySnapshots).toMatchObject([
+    {
+      accountId: "export-ok-account",
+      accountName: "Export OK",
+      baseUrl: "https://export-ok.example.com",
+      siteType: "new-api",
+      tokens: [
+        {
+          id: 101,
+          name: "Export Primary Key",
+          key: "sk-export-real",
+          group: "vip",
+        },
+      ],
+    },
+  ])
+
+  expect(exported.accountKeySnapshotErrors).toMatchObject([
+    {
+      accountId: "export-bad-account",
+      accountName: "Export Bad",
+      baseUrl: "https://export-bad.example.com",
+      siteType: "new-api",
+      errorMessage: "请求失败: 500",
+    },
+  ])
+})

--- a/e2e/importExportKeyExport.spec.ts
+++ b/e2e/importExportKeyExport.spec.ts
@@ -100,8 +100,9 @@ test("exports account keys while preserving per-account failures in the backup f
     const originalCreateObjectURL = URL.createObjectURL.bind(URL)
     const originalCreateElement = document.createElement.bind(document)
 
-    ;(window as typeof window & { __lastExportedBackupText?: string }).__lastExportedBackupText =
-      undefined
+    ;(
+      window as typeof window & { __lastExportedBackupText?: string }
+    ).__lastExportedBackupText = undefined
 
     URL.createObjectURL = (object: Blob | MediaSource) => {
       if (object instanceof Blob) {
@@ -115,7 +116,10 @@ test("exports account keys while preserving per-account failures in the backup f
       return originalCreateObjectURL(object)
     }
 
-    document.createElement = ((tagName: string, options?: ElementCreationOptions) => {
+    document.createElement = ((
+      tagName: string,
+      options?: ElementCreationOptions,
+    ) => {
       const element = originalCreateElement(tagName, options)
 
       if (tagName.toLowerCase() === "a") {
@@ -129,7 +133,9 @@ test("exports account keys while preserving per-account failures in the backup f
     }) as typeof document.createElement
   })
 
-  await page.getByRole("checkbox", { name: "Include account keys in export" }).click()
+  await page
+    .getByRole("checkbox", { name: "Include account keys in export" })
+    .click()
   await page
     .locator("#export-section")
     .getByRole("button", { name: "Export" })
@@ -137,24 +143,20 @@ test("exports account keys while preserving per-account failures in the backup f
     .evaluate((button) => {
       ;(button as HTMLButtonElement).click()
     })
-  await page.waitForTimeout(2000)
-
   await expect(page.getByText("Data exported successfully")).toBeVisible()
 
   await expect
     .poll(async () => {
       return await page.evaluate(() => {
-        return (
-          window as typeof window & { __lastExportedBackupText?: string }
-        ).__lastExportedBackupText
+        return (window as typeof window & { __lastExportedBackupText?: string })
+          .__lastExportedBackupText
       })
     })
     .toBeTruthy()
 
   const exportedRaw = await page.evaluate(() => {
-    return (
-      window as typeof window & { __lastExportedBackupText?: string }
-    ).__lastExportedBackupText
+    return (window as typeof window & { __lastExportedBackupText?: string })
+      .__lastExportedBackupText
   })
   if (!exportedRaw) {
     throw new Error("missing exported backup payload")

--- a/src/features/ImportExport/ImportExport.tsx
+++ b/src/features/ImportExport/ImportExport.tsx
@@ -9,6 +9,11 @@ import ImportSection from "./components/ImportSection"
 import WebDAVAutoSyncSettings from "./components/WebDAVAutoSyncSettings"
 import WebDAVSettings from "./components/WebDAVSettings"
 import { useImportExport } from "./hooks/useImportExport"
+import {
+  handleExportAccounts,
+  handleExportAll,
+  handleExportPreferences,
+} from "./utils"
 
 /**
  * Import/Export page combining manual export/import sections plus WebDAV backup and notices.
@@ -39,7 +44,11 @@ export default function ImportExport() {
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:items-stretch">
         <ExportSection
           isExporting={isExporting}
-          setIsExporting={setIsExporting}
+          onExportAll={(options) => handleExportAll(setIsExporting, options)}
+          onExportAccounts={(options) =>
+            handleExportAccounts(setIsExporting, options)
+          }
+          onExportPreferences={() => handleExportPreferences(setIsExporting)}
         />
         <ImportSection
           importData={importData}

--- a/src/features/ImportExport/components/ExportSection.tsx
+++ b/src/features/ImportExport/components/ExportSection.tsx
@@ -1,4 +1,5 @@
 import { ArrowUpTrayIcon } from "@heroicons/react/24/outline"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -8,25 +9,34 @@ import {
   CardHeader,
   CardItem,
   CardList,
+  Checkbox,
   CardTitle,
+  Label,
 } from "~/components/ui"
-
-import {
-  handleExportAccounts,
-  handleExportAll,
-  handleExportPreferences,
-} from "../utils"
 
 interface ExportSectionProps {
   isExporting: boolean
-  setIsExporting: (isExporting: boolean) => void
+  onExportAll: (options: { includeAccountKeys: boolean }) => void
+  onExportAccounts: (options: { includeAccountKeys: boolean }) => void
+  onExportPreferences: () => void
 }
 
 /**
  * Export section offering controls for full backup, account data, and user settings.
  */
-const ExportSection = ({ isExporting, setIsExporting }: ExportSectionProps) => {
+const ExportSection = ({
+  isExporting,
+  onExportAll,
+  onExportAccounts,
+  onExportPreferences,
+}: ExportSectionProps) => {
   const { t } = useTranslation("importExport")
+  const [includeAccountKeys, setIncludeAccountKeys] = useState(false)
+
+  const exportOptions = {
+    includeAccountKeys,
+  }
+
   return (
     <section id="export-section" className="flex h-full">
       <Card padding="none" className="flex flex-1 flex-col">
@@ -36,6 +46,21 @@ const ExportSection = ({ isExporting, setIsExporting }: ExportSectionProps) => {
             <CardTitle className="mb-0">{t("export.title")}</CardTitle>
           </div>
           <CardDescription>{t("export.description")}</CardDescription>
+          <div className="mt-3 flex items-start gap-2">
+            <Checkbox
+              id="include-account-keys"
+              checked={includeAccountKeys}
+              onCheckedChange={(checked) => setIncludeAccountKeys(checked === true)}
+            />
+            <div className="space-y-1">
+              <Label htmlFor="include-account-keys">
+                {t("export.includeAccountKeys")}
+              </Label>
+              <p className="text-muted-foreground text-sm">
+                {t("export.includeAccountKeysDescription")}
+              </p>
+            </div>
+          </div>
         </CardHeader>
 
         <CardList className="flex flex-1 flex-col">
@@ -45,7 +70,7 @@ const ExportSection = ({ isExporting, setIsExporting }: ExportSectionProps) => {
             description={t("export.fullBackupDescription")}
             rightContent={
               <Button
-                onClick={() => handleExportAll(setIsExporting)}
+                onClick={() => onExportAll(exportOptions)}
                 disabled={isExporting}
                 variant="success"
                 size="sm"
@@ -64,7 +89,7 @@ const ExportSection = ({ isExporting, setIsExporting }: ExportSectionProps) => {
             description={t("export.accountDataDescription")}
             rightContent={
               <Button
-                onClick={() => handleExportAccounts(setIsExporting)}
+                onClick={() => onExportAccounts(exportOptions)}
                 disabled={isExporting}
                 variant="default"
                 size="sm"
@@ -83,7 +108,7 @@ const ExportSection = ({ isExporting, setIsExporting }: ExportSectionProps) => {
             description={t("export.userSettingsDescription")}
             rightContent={
               <Button
-                onClick={() => handleExportPreferences(setIsExporting)}
+                onClick={onExportPreferences}
                 disabled={isExporting}
                 variant="secondary"
                 size="sm"

--- a/src/features/ImportExport/components/ExportSection.tsx
+++ b/src/features/ImportExport/components/ExportSection.tsx
@@ -9,8 +9,8 @@ import {
   CardHeader,
   CardItem,
   CardList,
-  Checkbox,
   CardTitle,
+  Checkbox,
   Label,
 } from "~/components/ui"
 
@@ -50,7 +50,9 @@ const ExportSection = ({
             <Checkbox
               id="include-account-keys"
               checked={includeAccountKeys}
-              onCheckedChange={(checked) => setIncludeAccountKeys(checked === true)}
+              onCheckedChange={(checked) =>
+                setIncludeAccountKeys(checked === true)
+              }
             />
             <div className="space-y-1">
               <Label htmlFor="include-account-keys">
@@ -108,7 +110,7 @@ const ExportSection = ({
             description={t("export.userSettingsDescription")}
             rightContent={
               <Button
-                onClick={onExportPreferences}
+                onClick={() => onExportPreferences()}
                 disabled={isExporting}
                 variant="secondary"
                 size="sm"

--- a/src/features/ImportExport/components/ImportSection.tsx
+++ b/src/features/ImportExport/components/ImportSection.tsx
@@ -22,6 +22,7 @@ interface ImportSectionProps {
   validation: {
     valid: boolean
     hasAccounts?: boolean
+    hasAccountKeySnapshots?: boolean
     hasPreferences?: boolean
     hasChannelConfigs?: boolean
     hasApiCredentialProfiles?: boolean
@@ -86,6 +87,9 @@ const ImportSection = ({
                     <div className="space-y-1 text-sm">
                       {validation.hasAccounts && (
                         <p>• {t("import.containsAccountData")}</p>
+                      )}
+                      {validation.hasAccountKeySnapshots && (
+                        <p>• {t("import.containsAccountKeys")}</p>
                       )}
                       {validation.hasPreferences && (
                         <p>• {t("import.containsUserSettings")}</p>

--- a/src/features/ImportExport/utils.ts
+++ b/src/features/ImportExport/utils.ts
@@ -1,6 +1,11 @@
 import toast from "react-hot-toast"
 
 import { accountStorage } from "~/services/accounts/accountStorage"
+import {
+  canManageDisplayAccountTokens,
+  fetchDisplayAccountTokens,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import {
   BACKUP_VERSION,
@@ -8,6 +13,8 @@ import {
   importFromBackupObject as importFromBackupObjectService,
   normalizeBackupForMerge,
   parseBackupSummary,
+  type BackupAccountKeySnapshot,
+  type BackupAccountKeySnapshotError,
   type BackupAccountsPartialV2,
   type BackupFullV2,
   type BackupPreferencesPartialV2,
@@ -19,6 +26,8 @@ import {
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
+import type { AccountStorageConfig } from "~/types"
+import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
 
@@ -33,6 +42,150 @@ export type {
   BackupPreferencesPartialV2,
   BackupV2,
   RawBackupData,
+}
+
+interface ExportOptions {
+  includeAccountKeys?: boolean
+}
+
+interface PreparedExportResult<TData> {
+  data: TData
+  accountKeySnapshots: BackupAccountKeySnapshot[]
+  accountKeySnapshotErrors: BackupAccountKeySnapshotError[]
+}
+
+const BACKUP_EXPORT_ERROR_MESSAGE_FALLBACK = "unknown export error"
+const BACKUP_EXPORT_ERROR_MESSAGE_MAX_LENGTH = 200
+
+const summarizeBackupExportErrorMessage = (error: unknown) => {
+  const rawMessage = getErrorMessage(
+    error,
+    BACKUP_EXPORT_ERROR_MESSAGE_FALLBACK,
+  )
+  const normalizedMessage = rawMessage.replace(/\s+/g, " ").trim()
+
+  if (!normalizedMessage) {
+    return BACKUP_EXPORT_ERROR_MESSAGE_FALLBACK
+  }
+
+  if (/<!doctype html|<html[\s>]/i.test(normalizedMessage)) {
+    if (/just a moment|cloudflare/i.test(normalizedMessage)) {
+      return "Cloudflare challenge page returned"
+    }
+
+    return "HTML error response returned"
+  }
+
+  if (normalizedMessage.length > BACKUP_EXPORT_ERROR_MESSAGE_MAX_LENGTH) {
+    return `${normalizedMessage.slice(
+      0,
+      BACKUP_EXPORT_ERROR_MESSAGE_MAX_LENGTH,
+    )}...`
+  }
+
+  return normalizedMessage
+}
+
+const downloadJsonFile = (data: unknown, filename: string) => {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json",
+  })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+const withOptionalAccountKeySections = <TData extends object>(
+  data: TData,
+  accountKeyExportResult?: {
+    snapshots: BackupAccountKeySnapshot[]
+    errors: BackupAccountKeySnapshotError[]
+  },
+) => {
+  return {
+    ...data,
+    ...(accountKeyExportResult?.snapshots.length
+      ? { accountKeySnapshots: accountKeyExportResult.snapshots }
+      : {}),
+    ...(accountKeyExportResult?.errors.length
+      ? { accountKeySnapshotErrors: accountKeyExportResult.errors }
+      : {}),
+  }
+}
+
+const buildAccountKeySnapshots = async (
+  accountData: AccountStorageConfig,
+): Promise<{
+  snapshots: BackupAccountKeySnapshot[]
+  errors: BackupAccountKeySnapshotError[]
+}> => {
+  const displayAccounts = accountStorage.convertToDisplayData(
+    accountData.accounts,
+  )
+  const manageableAccounts = displayAccounts.filter(
+    canManageDisplayAccountTokens,
+  )
+
+  const results = await Promise.all(
+    manageableAccounts.map(async (account) => {
+      try {
+        const tokens = await fetchDisplayAccountTokens(account)
+        const resolvedTokens = await Promise.all(
+          tokens.map((token) =>
+            resolveDisplayAccountTokenForSecret(account, token),
+          ),
+        )
+
+        return {
+          ok: true as const,
+          snapshot: {
+            accountId: account.id,
+            accountName: account.name,
+            baseUrl: account.baseUrl,
+            siteType: account.siteType,
+            tokens: resolvedTokens,
+          },
+        }
+      } catch (error) {
+        logger.warn("Failed to export account keys for backup", {
+          accountId: account.id,
+          accountName: account.name,
+          error,
+        })
+
+        return {
+          ok: false as const,
+          exportError: {
+            accountId: account.id,
+            accountName: account.name,
+            baseUrl: account.baseUrl,
+            siteType: account.siteType,
+            errorMessage: summarizeBackupExportErrorMessage(error),
+          },
+        }
+      }
+    }),
+  )
+
+  return results.reduce<{
+    snapshots: BackupAccountKeySnapshot[]
+    errors: BackupAccountKeySnapshotError[]
+  }>(
+    (acc, result) => {
+      if (result.ok) {
+        acc.snapshots.push(result.snapshot)
+      } else {
+        acc.errors.push(result.exportError)
+      }
+      return acc
+    },
+    { snapshots: [], errors: [] },
+  )
 }
 
 /**
@@ -58,33 +211,31 @@ export async function importFromBackupObject(
   }
 }
 
-// 导出所有数据
-/**
- * Export all persisted data (accounts, preferences, channelConfigs) as a
- * full V2 backup file and trigger a browser download.
- */
-export const handleExportAll = async (
-  setIsExporting: (isExporting: boolean) => void,
-) => {
-  try {
-    setIsExporting(true)
+const prepareFullExport = async (
+  options?: ExportOptions,
+): Promise<PreparedExportResult<BackupFullV2>> => {
+  const accountDataPromise = accountStorage.exportData()
 
-    // 获取账号数据、用户偏好设置以及通道配置
-    const [
-      accountData,
-      tagStore,
-      preferencesData,
-      channelConfigs,
-      apiCredentialProfiles,
-    ] = await Promise.all([
-      accountStorage.exportData(),
-      tagStorage.exportTagStore(),
-      userPreferences.exportPreferences(),
-      channelConfigStorage.exportConfigs(),
-      apiCredentialProfilesStorage.exportConfig(),
-    ])
+  const [
+    accountData,
+    tagStore,
+    preferencesData,
+    channelConfigs,
+    apiCredentialProfiles,
+    accountKeyExportResult,
+  ] = await Promise.all([
+    accountDataPromise,
+    tagStorage.exportTagStore(),
+    userPreferences.exportPreferences(),
+    channelConfigStorage.exportConfigs(),
+    apiCredentialProfilesStorage.exportConfig(),
+    options?.includeAccountKeys
+      ? accountDataPromise.then(buildAccountKeySnapshots)
+      : undefined,
+  ])
 
-    const exportData: BackupFullV2 = {
+  const data = withOptionalAccountKeySections(
+    {
       version: BACKUP_VERSION,
       timestamp: Date.now(),
       accounts: accountData,
@@ -92,20 +243,88 @@ export const handleExportAll = async (
       preferences: preferencesData,
       channelConfigs,
       apiCredentialProfiles,
-    }
+    } satisfies BackupFullV2,
+    accountKeyExportResult,
+  )
 
-    // 创建下载链接
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
-      type: "application/json",
-    })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-    link.href = url
-    link.download = `all-api-hub-backup-${new Date().toISOString().split("T")[0]}.json`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
+  return {
+    data,
+    accountKeySnapshots: accountKeyExportResult?.snapshots ?? [],
+    accountKeySnapshotErrors: accountKeyExportResult?.errors ?? [],
+  }
+}
+
+const prepareAccountsExport = async (
+  options?: ExportOptions,
+): Promise<PreparedExportResult<BackupAccountsPartialV2>> => {
+  const accountData = await accountStorage.exportData()
+  const [tagStore, accountKeyExportResult] = await Promise.all([
+    tagStorage.exportTagStore(),
+    options?.includeAccountKeys
+      ? buildAccountKeySnapshots(accountData)
+      : undefined,
+  ])
+
+  const data = withOptionalAccountKeySections(
+    {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      type: "accounts",
+      accounts: accountData,
+      tagStore,
+    } satisfies BackupAccountsPartialV2,
+    accountKeyExportResult,
+  )
+
+  return {
+    data,
+    accountKeySnapshots: accountKeyExportResult?.snapshots ?? [],
+    accountKeySnapshotErrors: accountKeyExportResult?.errors ?? [],
+  }
+}
+
+const preparePreferencesExport = async (): Promise<
+  PreparedExportResult<BackupPreferencesPartialV2>
+> => {
+  const preferencesData = await userPreferences.exportPreferences()
+
+  return {
+    data: {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      type: "preferences",
+      preferences: preferencesData,
+    },
+    accountKeySnapshots: [],
+    accountKeySnapshotErrors: [],
+  }
+}
+
+const downloadPreparedExport = <TData extends object>(
+  prepared: PreparedExportResult<TData>,
+  filename: string,
+) => {
+  downloadJsonFile(prepared.data, filename)
+}
+
+// 导出所有数据
+/**
+ * Export all persisted data (accounts, preferences, channelConfigs) as a
+ * full V2 backup file and trigger a browser download.
+ */
+export const handleExportAll = async (
+  setIsExporting: (isExporting: boolean) => void,
+  options?: ExportOptions,
+) => {
+  try {
+    setIsExporting(true)
+
+    const prepared = await prepareFullExport(options)
+
+    downloadPreparedExport(
+      prepared,
+      `all-api-hub-backup-${new Date().toISOString().split("T")[0]}.json`,
+    )
 
     toast.success(t("importExport:export.dataExported"))
   } catch (error) {
@@ -123,33 +342,17 @@ export const handleExportAll = async (
  */
 export const handleExportAccounts = async (
   setIsExporting: (isExporting: boolean) => void,
+  options?: ExportOptions,
 ) => {
   try {
     setIsExporting(true)
 
-    const [accountData, tagStore] = await Promise.all([
-      accountStorage.exportData(),
-      tagStorage.exportTagStore(),
-    ])
-    const exportData: BackupAccountsPartialV2 = {
-      version: BACKUP_VERSION,
-      timestamp: Date.now(),
-      type: "accounts",
-      accounts: accountData,
-      tagStore,
-    }
+    const prepared = await prepareAccountsExport(options)
 
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
-      type: "application/json",
-    })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-    link.href = url
-    link.download = `accounts-backup-${new Date().toISOString().split("T")[0]}.json`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
+    downloadPreparedExport(
+      prepared,
+      `accounts-backup-${new Date().toISOString().split("T")[0]}.json`,
+    )
 
     toast.success(t("importExport:export.accountsExported"))
   } catch (error) {
@@ -171,25 +374,12 @@ export const handleExportPreferences = async (
   try {
     setIsExporting(true)
 
-    const preferencesData = await userPreferences.exportPreferences()
-    const exportData: BackupPreferencesPartialV2 = {
-      version: BACKUP_VERSION,
-      timestamp: Date.now(),
-      type: "preferences",
-      preferences: preferencesData,
-    }
+    const prepared = await preparePreferencesExport()
 
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
-      type: "application/json",
-    })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-    link.href = url
-    link.download = `preferences-backup-${new Date().toISOString().split("T")[0]}.json`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
+    downloadPreparedExport(
+      prepared,
+      `preferences-backup-${new Date().toISOString().split("T")[0]}.json`,
+    )
 
     toast.success(t("importExport:export.settingsExported"))
   } catch (error) {

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -7,6 +7,8 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { useAccountData } from "~/hooks/useAccountData"
 import {
   createDisplayAccountApiContext,
+  fetchDisplayAccountTokens,
+  InvalidTokenPayloadError,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { getManagedSiteTokenChannelStatus } from "~/services/managedSites/tokenChannelStatus"
@@ -464,27 +466,10 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
       }))
 
       try {
-        const { service, request } = createDisplayAccountApiContext(account)
-        const tokens = await service.fetchAccountTokens(request)
+        const tokens = await fetchDisplayAccountTokens(account)
 
         if (!isEpochActive(loadEpoch)) return
         if (!isLatestAccountRequest(accountId, requestEpoch)) return
-
-        if (!Array.isArray(tokens)) {
-          const errorMessage = loadFailedMessageRef.current
-          setTokenInventories((prev) => ({
-            ...prev,
-            [accountId]: {
-              status: "error",
-              tokens: prev[accountId]?.tokens ?? [],
-              errorMessage,
-            },
-          }))
-          if (toastOnError) {
-            toast.error(errorMessage)
-          }
-          return
-        }
 
         const tokensWithAccount = tokens.map((token) => ({
           ...token,
@@ -505,7 +490,9 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
         if (!isLatestAccountRequest(accountId, requestEpoch)) return
 
         const errorMessage =
-          getErrorMessage(error) || loadFailedMessageRef.current
+          error instanceof InvalidTokenPayloadError
+            ? loadFailedMessageRef.current
+            : getErrorMessage(error) || loadFailedMessageRef.current
         logger.error("获取账号密钥失败", errorMessage)
         setTokenInventories((prev) => ({
           ...prev,

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -80,6 +80,10 @@ const normalizeOrigin = (baseUrl: string) => {
   return normalizeUrlForOriginKey(baseUrl, { stripTrailingSlashes: false })
 }
 
+const shouldUseGenericTokenLoadError = (errorMessage: string) => {
+  return /\b(request timeout|timeout|timed out)\b/i.test(errorMessage)
+}
+
 const hashStringForCache = (value: string) => {
   let hash = 2166136261
 
@@ -489,10 +493,12 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
         if (!isEpochActive(loadEpoch)) return
         if (!isLatestAccountRequest(accountId, requestEpoch)) return
 
+        const rawErrorMessage = getErrorMessage(error)
         const errorMessage =
-          error instanceof InvalidTokenPayloadError
+          error instanceof InvalidTokenPayloadError ||
+          shouldUseGenericTokenLoadError(rawErrorMessage)
             ? loadFailedMessageRef.current
-            : getErrorMessage(error) || loadFailedMessageRef.current
+            : rawErrorMessage || loadFailedMessageRef.current
         logger.error("获取账号密钥失败", errorMessage)
         setTokenInventories((prev) => ({
           ...prev,

--- a/src/locales/en/importExport.json
+++ b/src/locales/en/importExport.json
@@ -19,7 +19,7 @@
   "import": {
     "backupTime": "Backup Time",
     "containsAccountData": "Contains account data",
-    "containsAccountKeys": "Contains account key snapshots",
+    "containsAccountKeys": "Detected account key snapshots (ignored on import)",
     "containsApiCredentialProfiles": "Contains API credential profiles",
     "containsChannelConfigs": "Contains channel configuration",
     "containsUserSettings": "Contains user settings",

--- a/src/locales/en/importExport.json
+++ b/src/locales/en/importExport.json
@@ -9,6 +9,8 @@
     "exportFailed": "Export failed, please try again",
     "fullBackup": "Full Export",
     "fullBackupDescription": "Export account data and user settings. Use manual export/import when you need to migrate device-local settings instead of WebDAV sync.",
+    "includeAccountKeys": "Include account keys in export",
+    "includeAccountKeysDescription": "Also export the currently accessible key snapshots for each account. The backup file will contain sensitive secrets, so store it carefully.",
     "settingsExported": "User settings exported successfully",
     "title": "Export Data",
     "userSettings": "User Settings",
@@ -17,6 +19,7 @@
   "import": {
     "backupTime": "Backup Time",
     "containsAccountData": "Contains account data",
+    "containsAccountKeys": "Contains account key snapshots",
     "containsApiCredentialProfiles": "Contains API credential profiles",
     "containsChannelConfigs": "Contains channel configuration",
     "containsUserSettings": "Contains user settings",

--- a/src/locales/ja/importExport.json
+++ b/src/locales/ja/importExport.json
@@ -9,6 +9,8 @@
     "exportFailed": "エクスポートに失敗しました。もう一度お試しください",
     "fullBackup": "完全エクスポート",
     "fullBackupDescription": "アカウントデータとユーザー設定をエクスポートします。WebDAV 同期ではなく端末ローカル設定を移行したい場合は、手動のエクスポート / インポートを使用してください。",
+    "includeAccountKeys": "エクスポートにアカウントキーを含める",
+    "includeAccountKeysDescription": "各アカウントで現在アクセス可能なキーのスナップショットも追加でエクスポートします。バックアップファイルには機密情報が含まれるため、厳重に保管してください。",
     "settingsExported": "ユーザー設定を正常にエクスポートしました",
     "title": "データをエクスポート",
     "userSettings": "ユーザー設定",
@@ -17,6 +19,7 @@
   "import": {
     "backupTime": "バックアップ時刻",
     "containsAccountData": "アカウントデータを含む",
+    "containsAccountKeys": "アカウントキーのスナップショットを含む",
     "containsApiCredentialProfiles": "API 認証情報プロファイルを含む",
     "containsChannelConfigs": "チャネル設定を含む",
     "containsUserSettings": "ユーザー設定を含む",

--- a/src/locales/ja/importExport.json
+++ b/src/locales/ja/importExport.json
@@ -19,7 +19,7 @@
   "import": {
     "backupTime": "バックアップ時刻",
     "containsAccountData": "アカウントデータを含む",
-    "containsAccountKeys": "アカウントキーのスナップショットを含む",
+    "containsAccountKeys": "アカウントキーのスナップショットを検出（インポート時は無視）",
     "containsApiCredentialProfiles": "API 認証情報プロファイルを含む",
     "containsChannelConfigs": "チャネル設定を含む",
     "containsUserSettings": "ユーザー設定を含む",

--- a/src/locales/zh-CN/importExport.json
+++ b/src/locales/zh-CN/importExport.json
@@ -9,6 +9,8 @@
     "exportFailed": "导出失败，请重试",
     "fullBackup": "完整导出",
     "fullBackupDescription": "导出账号数据和用户设置。如需迁移设备本地设置，请优先使用手动导出/导入，而不是 WebDAV 同步。",
+    "includeAccountKeys": "导出时包含密钥",
+    "includeAccountKeysDescription": "额外导出各账号当前可访问的密钥快照。备份文件会包含敏感信息，请妥善保管。",
     "settingsExported": "用户设置导出成功",
     "title": "导出数据",
     "userSettings": "用户设置",
@@ -17,6 +19,7 @@
   "import": {
     "backupTime": "备份时间",
     "containsAccountData": "包含账号数据",
+    "containsAccountKeys": "包含账号密钥快照",
     "containsApiCredentialProfiles": "包含 API 配置",
     "containsChannelConfigs": "包含渠道配置",
     "containsUserSettings": "包含用户设置",

--- a/src/locales/zh-CN/importExport.json
+++ b/src/locales/zh-CN/importExport.json
@@ -19,7 +19,7 @@
   "import": {
     "backupTime": "备份时间",
     "containsAccountData": "包含账号数据",
-    "containsAccountKeys": "包含账号密钥快照",
+    "containsAccountKeys": "检测到账号密钥快照（导入时会忽略）",
     "containsApiCredentialProfiles": "包含 API 配置",
     "containsChannelConfigs": "包含渠道配置",
     "containsUserSettings": "包含用户设置",

--- a/src/locales/zh-TW/importExport.json
+++ b/src/locales/zh-TW/importExport.json
@@ -19,7 +19,7 @@
   "import": {
     "backupTime": "備份時間",
     "containsAccountData": "包含帳號資料",
-    "containsAccountKeys": "包含帳號密鑰快照",
+    "containsAccountKeys": "偵測到帳號密鑰快照（匯入時會忽略）",
     "containsApiCredentialProfiles": "包含 API 配置",
     "containsChannelConfigs": "包含渠道配置",
     "containsUserSettings": "包含使用者設定",

--- a/src/locales/zh-TW/importExport.json
+++ b/src/locales/zh-TW/importExport.json
@@ -9,6 +9,8 @@
     "exportFailed": "匯出失敗，請重試",
     "fullBackup": "完整匯出",
     "fullBackupDescription": "匯出帳號資料和使用者設定。如需遷移裝置本地設定，請優先使用手動匯出/匯入，而不是 WebDAV 同步。",
+    "includeAccountKeys": "匯出時包含密鑰",
+    "includeAccountKeysDescription": "額外匯出各帳號目前可存取的密鑰快照。備份檔案會包含敏感資訊，請妥善保管。",
     "settingsExported": "使用者設定匯出成功",
     "title": "匯出資料",
     "userSettings": "使用者設定",
@@ -17,6 +19,7 @@
   "import": {
     "backupTime": "備份時間",
     "containsAccountData": "包含帳號資料",
+    "containsAccountKeys": "包含帳號密鑰快照",
     "containsApiCredentialProfiles": "包含 API 配置",
     "containsChannelConfigs": "包含渠道配置",
     "containsUserSettings": "包含使用者設定",

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -1161,6 +1161,7 @@ class AccountStorageService {
         tagIds: normalized.tagIds,
         tags: normalized.tags,
         siteType: normalized.site_type,
+        cookieAuthSessionCookie: normalized.cookieAuth?.sessionCookie,
         checkIn: normalized.checkIn,
         can_check_in: normalized.can_check_in,
         supports_check_in: normalized.supports_check_in,

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -7,6 +7,8 @@ const hasNonEmptyString = (value: unknown): value is string =>
   typeof value === "string" && value.trim().length > 0
 
 const logger = createLogger("DisplayAccountApiContext")
+const DISPLAY_ACCOUNT_API_TIMEOUT_MS = 20_000
+const DISPLAY_ACCOUNT_API_TIMEOUT_MESSAGE = "request timeout"
 
 export class InvalidTokenPayloadError extends Error {
   readonly code = "INVALID_TOKEN_PAYLOAD"
@@ -27,6 +29,41 @@ export class InvalidTokenPayloadError extends Error {
     this.baseUrl = params.baseUrl
     this.siteType = params.siteType
     this.responseType = params.responseType
+  }
+}
+
+const withDisplayAccountApiTimeout = async <T>(
+  params: {
+    account: Pick<DisplaySiteData, "id" | "baseUrl" | "siteType">
+    operation: "fetchAccountTokens" | "resolveApiTokenKey"
+    promise: Promise<T>
+  },
+): Promise<T> => {
+  const { account, operation, promise } = params
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          logger.warn("Display-account API request timed out", {
+            accountId: account.id,
+            baseUrl: account.baseUrl,
+            siteType: account.siteType,
+            operation,
+            timeoutMs: DISPLAY_ACCOUNT_API_TIMEOUT_MS,
+          })
+
+          reject(new Error(DISPLAY_ACCOUNT_API_TIMEOUT_MESSAGE))
+        }, DISPLAY_ACCOUNT_API_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
   }
 }
 
@@ -89,7 +126,11 @@ export async function fetchDisplayAccountTokens(
   >,
 ): Promise<ApiToken[]> {
   const { service, request } = createDisplayAccountApiContext(account)
-  const tokensResponse = await service.fetchAccountTokens(request)
+  const tokensResponse = await withDisplayAccountApiTimeout({
+    account,
+    operation: "fetchAccountTokens",
+    promise: service.fetchAccountTokens(request),
+  })
 
   if (Array.isArray(tokensResponse)) {
     return tokensResponse
@@ -130,7 +171,11 @@ export async function resolveDisplayAccountTokenForSecret<
   token: TToken,
 ): Promise<TToken> {
   const { service, request } = createDisplayAccountApiContext(account)
-  const resolvedKey = await service.resolveApiTokenKey(request, token)
+  const resolvedKey = await withDisplayAccountApiTimeout({
+    account,
+    operation: "resolveApiTokenKey",
+    promise: service.resolveApiTokenKey(request, token),
+  })
 
   if (resolvedKey === token.key) {
     return token

--- a/src/services/importExport/importExportService.ts
+++ b/src/services/importExport/importExportService.ts
@@ -202,7 +202,9 @@ export function parseBackupSummary(
     const data = JSON.parse(importData) as RawBackupData
 
     const hasAccounts = Boolean(data.accounts || data.type === "accounts")
-    const hasAccountKeySnapshots = Boolean((data as any).accountKeySnapshots)
+    const hasAccountKeySnapshots =
+      Array.isArray((data as any).accountKeySnapshots) &&
+      (data as any).accountKeySnapshots.length > 0
     const hasPreferences = Boolean(
       data.preferences || data.type === "preferences",
     )

--- a/src/services/importExport/importExportService.ts
+++ b/src/services/importExport/importExportService.ts
@@ -7,7 +7,7 @@ import { channelConfigStorage } from "~/services/managedSites/channelConfigStora
 import type { UserPreferences } from "~/services/preferences/userPreferences"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
-import type { AccountStorageConfig, TagStore } from "~/types"
+import type { AccountStorageConfig, ApiToken, TagStore } from "~/types"
 import type { ApiCredentialProfilesConfig } from "~/types/apiCredentialProfiles"
 import type { ChannelConfigMap } from "~/types/channelConfig"
 import { formatLocaleDateTime } from "~/utils/core/formatters"
@@ -44,11 +44,28 @@ export const BACKUP_VERSION = "2.0"
 interface ParsedBackupSummary {
   valid: boolean
   hasAccounts: boolean
+  hasAccountKeySnapshots: boolean
   hasPreferences: boolean
   hasChannelConfigs: boolean
   hasTagStore: boolean
   hasApiCredentialProfiles: boolean
   timestamp: string
+}
+
+export interface BackupAccountKeySnapshot {
+  accountId: string
+  accountName: string
+  baseUrl: string
+  siteType: string
+  tokens: ApiToken[]
+}
+
+export interface BackupAccountKeySnapshotError {
+  accountId: string
+  accountName: string
+  baseUrl: string
+  siteType: string
+  errorMessage: string
 }
 
 /**
@@ -59,6 +76,16 @@ export interface BackupFullV2 {
   version: string
   timestamp: number
   accounts: AccountStorageConfig
+  /**
+   * Optional account key export snapshot.
+   *
+   * Present only when the user explicitly opts in to exporting account keys.
+   */
+  accountKeySnapshots?: BackupAccountKeySnapshot[]
+  /**
+   * Optional per-account key export failures captured during a partial-success export.
+   */
+  accountKeySnapshotErrors?: BackupAccountKeySnapshotError[]
   /**
    * Global tag store snapshot.
    *
@@ -84,6 +111,16 @@ export interface BackupAccountsPartialV2 {
   timestamp: number
   type: "accounts"
   accounts: AccountStorageConfig
+  /**
+   * Optional account key export snapshot.
+   *
+   * Present only when the user explicitly opts in to exporting account keys.
+   */
+  accountKeySnapshots?: BackupAccountKeySnapshot[]
+  /**
+   * Optional per-account key export failures captured during a partial-success export.
+   */
+  accountKeySnapshotErrors?: BackupAccountKeySnapshotError[]
   /**
    * Global tag store snapshot.
    *
@@ -117,6 +154,8 @@ type LegacyBackupLike = {
   timestamp?: number | string
   type?: "accounts" | "preferences" | "channelConfigs" | string
   accounts?: any
+  accountKeySnapshots?: any
+  accountKeySnapshotErrors?: any
   preferences?: any
   channelConfigs?: any
   tagStore?: any
@@ -163,6 +202,7 @@ export function parseBackupSummary(
     const data = JSON.parse(importData) as RawBackupData
 
     const hasAccounts = Boolean(data.accounts || data.type === "accounts")
+    const hasAccountKeySnapshots = Boolean((data as any).accountKeySnapshots)
     const hasPreferences = Boolean(
       data.preferences || data.type === "preferences",
     )
@@ -179,6 +219,7 @@ export function parseBackupSummary(
     return {
       valid: true,
       hasAccounts,
+      hasAccountKeySnapshots,
       hasPreferences,
       hasChannelConfigs,
       hasTagStore,

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -1638,6 +1638,38 @@ describe("useKeyManagement enabled account filtering", () => {
     expect(result.current.tokens).toEqual([])
   })
 
+  it("maps timeout token-load failures to the fallback toast message", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "timeout-acc",
+      name: "Timeout Account",
+    })
+
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+
+    const fetchAccountTokens = vi
+      .fn()
+      .mockRejectedValue(new Error("request timeout"))
+    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount(account.id)
+    })
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+        "keyManagement:messages.loadFailed",
+      )
+    })
+    expect(result.current.tokens).toEqual([])
+  })
+
   it("copies a resolved token secret to the clipboard and shows success feedback", async () => {
     const account = createDisplayAccount({
       id: "copy-acc",

--- a/tests/features/ImportExport/components/sections.test.tsx
+++ b/tests/features/ImportExport/components/sections.test.tsx
@@ -8,22 +8,6 @@ import ImportSection from "~/features/ImportExport/components/ImportSection"
 import { WebDAVDecryptPasswordModal } from "~/features/ImportExport/components/WebDAVDecryptPasswordModal"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
-const {
-  mockHandleExportAll,
-  mockHandleExportAccounts,
-  mockHandleExportPreferences,
-} = vi.hoisted(() => ({
-  mockHandleExportAll: vi.fn(),
-  mockHandleExportAccounts: vi.fn(),
-  mockHandleExportPreferences: vi.fn(),
-}))
-
-vi.mock("~/features/ImportExport/utils", () => ({
-  handleExportAll: mockHandleExportAll,
-  handleExportAccounts: mockHandleExportAccounts,
-  handleExportPreferences: mockHandleExportPreferences,
-}))
-
 function render(ui: ReactNode) {
   return rtlRender(<I18nextProvider i18n={testI18n}>{ui}</I18nextProvider>)
 }
@@ -33,11 +17,18 @@ describe("ImportExport section components", () => {
     vi.clearAllMocks()
   })
 
-  it("routes export actions to utility helpers", () => {
-    const setIsExporting = vi.fn()
+  it("routes export actions through the provided callbacks", () => {
+    const onExportAll = vi.fn()
+    const onExportAccounts = vi.fn()
+    const onExportPreferences = vi.fn()
 
     render(
-      <ExportSection isExporting={false} setIsExporting={setIsExporting} />,
+      <ExportSection
+        isExporting={false}
+        onExportAll={onExportAll}
+        onExportAccounts={onExportAccounts}
+        onExportPreferences={onExportPreferences}
+      />,
     )
 
     const buttons = screen.getAllByRole("button", {
@@ -48,9 +39,47 @@ describe("ImportExport section components", () => {
     fireEvent.click(buttons[1])
     fireEvent.click(buttons[2])
 
-    expect(mockHandleExportAll).toHaveBeenCalledWith(setIsExporting)
-    expect(mockHandleExportAccounts).toHaveBeenCalledWith(setIsExporting)
-    expect(mockHandleExportPreferences).toHaveBeenCalledWith(setIsExporting)
+    expect(onExportAll).toHaveBeenCalledWith({
+      includeAccountKeys: false,
+    })
+    expect(onExportAccounts).toHaveBeenCalledWith({
+      includeAccountKeys: false,
+    })
+    expect(onExportPreferences).toHaveBeenCalledWith()
+  })
+
+  it("passes the include-account-keys option from the export toggle", () => {
+    const onExportAll = vi.fn()
+    const onExportAccounts = vi.fn()
+
+    render(
+      <ExportSection
+        isExporting={false}
+        onExportAll={onExportAll}
+        onExportAccounts={onExportAccounts}
+        onExportPreferences={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "importExport:export.includeAccountKeys",
+      }),
+    )
+
+    const buttons = screen.getAllByRole("button", {
+      name: "common:actions.export",
+    })
+
+    fireEvent.click(buttons[0])
+    fireEvent.click(buttons[1])
+
+    expect(onExportAll).toHaveBeenCalledWith({
+      includeAccountKeys: true,
+    })
+    expect(onExportAccounts).toHaveBeenCalledWith({
+      includeAccountKeys: true,
+    })
   })
 
   it("renders import validation details and forwards input events", () => {
@@ -68,6 +97,7 @@ describe("ImportExport section components", () => {
         validation={{
           valid: true,
           hasAccounts: true,
+          hasAccountKeySnapshots: true,
           hasPreferences: true,
           hasChannelConfigs: true,
           hasApiCredentialProfiles: true,
@@ -98,6 +128,9 @@ describe("ImportExport section components", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(/importExport:import\.containsAccountData/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/importExport:import\.containsAccountKeys/),
     ).toBeInTheDocument()
     expect(setImportData).toHaveBeenCalledWith('{"version":3}')
     expect(handleFileImport).toHaveBeenCalledTimes(1)

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -8,6 +8,7 @@ import {
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { getApiService } from "~/services/apiService"
+import type { ApiToken } from "~/types"
 import { AuthTypeEnum } from "~/types"
 
 vi.mock("~/services/apiService", () => ({
@@ -27,6 +28,7 @@ const ACCOUNT = {
 describe("fetchDisplayAccountTokens", () => {
   beforeEach(() => {
     vi.mocked(getApiService).mockReset()
+    vi.useRealTimers()
   })
 
   it("returns the token array when the API payload is valid", async () => {
@@ -77,6 +79,21 @@ describe("fetchDisplayAccountTokens", () => {
     }
   })
 
+  it("times out hung token inventory requests", async () => {
+    vi.useFakeTimers()
+
+    const fetchAccountTokens = vi.fn(
+      () => new Promise<ApiToken[]>(() => undefined),
+    )
+    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+
+    const requestPromise = fetchDisplayAccountTokens(ACCOUNT as any)
+    const rejection = expect(requestPromise).rejects.toThrow("request timeout")
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    await rejection
+  })
+
   it("returns the original token object when the resolved secret key is unchanged", async () => {
     const token = { id: 1, key: "sk-test", status: 1 }
     const resolveApiTokenKey = vi.fn().mockResolvedValue("sk-test")
@@ -107,6 +124,25 @@ describe("fetchDisplayAccountTokens", () => {
       name: "Masked",
     })
     expect(result).not.toBe(token)
+  })
+
+  it("times out hung secret-key resolution requests", async () => {
+    vi.useFakeTimers()
+
+    const token = { id: 1, key: "sk-masked", status: 1, name: "Masked" }
+    const resolveApiTokenKey = vi.fn(
+      () => new Promise<string>(() => undefined),
+    )
+    vi.mocked(getApiService).mockReturnValue({ resolveApiTokenKey } as any)
+
+    const requestPromise = resolveDisplayAccountTokenForSecret(
+      ACCOUNT as any,
+      token as any,
+    )
+    const rejection = expect(requestPromise).rejects.toThrow("request timeout")
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    await rejection
   })
 
   it("only allows token management for enabled accounts with complete auth context", () => {

--- a/tests/setup.shared.ts
+++ b/tests/setup.shared.ts
@@ -7,8 +7,6 @@ import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest"
 // Use WXT official fakeBrowser for WebExtension API mocking
 import { fakeBrowser } from "wxt/testing/fake-browser"
 
-import { server } from "./msw/server"
-
 registerI18nextPlugin(initReactI18next)
 
 await init({
@@ -64,6 +62,64 @@ vi.mock("@lobehub/icons", () => {
 // No need to manually mock chrome API - fakeBrowser provides complete implementation
 
 const globalAny = globalThis as any
+
+const createStorageMock = (): Storage => {
+  const store = new Map<string, string>()
+
+  return {
+    get length() {
+      return store.size
+    },
+    clear() {
+      store.clear()
+    },
+    getItem(key: string) {
+      return store.get(String(key)) ?? null
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null
+    },
+    removeItem(key: string) {
+      store.delete(String(key))
+    },
+    setItem(key: string, value: string) {
+      store.set(String(key), String(value))
+    },
+  }
+}
+
+const ensureStorage = (storageKey: "localStorage" | "sessionStorage") => {
+  const existing = globalAny[storageKey]
+
+  if (
+    existing &&
+    typeof existing.getItem === "function" &&
+    typeof existing.setItem === "function" &&
+    typeof existing.removeItem === "function" &&
+    typeof existing.clear === "function" &&
+    typeof existing.key === "function"
+  ) {
+    return
+  }
+
+  const storage = createStorageMock()
+  Object.defineProperty(globalThis, storageKey, {
+    configurable: true,
+    value: storage,
+  })
+
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, storageKey, {
+      configurable: true,
+      value: storage,
+    })
+  }
+}
+
+ensureStorage("localStorage")
+ensureStorage("sessionStorage")
+
+const { server } = await import("./msw/server")
 
 if (!globalAny.browser) {
   globalAny.browser = fakeBrowser

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -361,9 +361,16 @@ describe("importFromBackupObject", () => {
           tokens: [
             {
               id: 101,
+              user_id: 1,
               name: "Primary Key",
               key: "sk-should-be-ignored",
               status: 1,
+              created_time: 1,
+              accessed_time: 1,
+              expired_time: -1,
+              remain_quota: -1,
+              unlimited_quota: true,
+              used_quota: 0,
             },
           ],
         },

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -339,6 +339,71 @@ describe("importFromBackupObject", () => {
     })
   })
 
+  it("imports backups with account key snapshots while ignoring the snapshot payload", async () => {
+    const backup: BackupFullV2 = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accounts: {
+        accounts: [{ id: "a1", name: "Imported Account" } as any],
+        bookmarks: [{ id: "b1" } as any],
+        pinnedAccountIds: ["a1"],
+        orderedAccountIds: ["a1"],
+        last_updated: Date.now(),
+      } as any,
+      preferences: { themeMode: "dark" } as any,
+      channelConfigs: { 1: { enabled: true } } as any,
+      accountKeySnapshots: [
+        {
+          accountId: "a1",
+          accountName: "Imported Account",
+          baseUrl: "https://example.com",
+          siteType: "new-api",
+          tokens: [
+            {
+              id: 101,
+              name: "Primary Key",
+              key: "sk-should-be-ignored",
+              status: 1,
+            },
+          ],
+        },
+      ],
+      accountKeySnapshotErrors: [
+        {
+          accountId: "a2",
+          accountName: "Failed Account",
+          baseUrl: "https://failed.example.com",
+          siteType: "new-api",
+          errorMessage: "request timeout",
+        },
+      ],
+    }
+
+    const result = await importFromBackupObject(backup as BackupV2)
+
+    expect(mockAccountStorageImportData).toHaveBeenCalledWith({
+      accounts: [{ id: "a1", name: "Imported Account" }],
+      bookmarks: [{ id: "b1" }],
+      pinnedAccountIds: ["a1"],
+      orderedAccountIds: ["a1"],
+    })
+    expect(mockUserPreferencesImport).toHaveBeenCalledWith({
+      themeMode: "dark",
+    })
+    expect(mockChannelConfigImport).toHaveBeenCalledWith({
+      1: { enabled: true },
+    })
+    expect(mockFetchDisplayAccountTokens).not.toHaveBeenCalled()
+    expect(mockResolveDisplayAccountTokenForSecret).not.toHaveBeenCalled()
+    expect(result.allImported).toBe(true)
+    expect(result.sections).toEqual({
+      accounts: true,
+      preferences: true,
+      channelConfigs: true,
+      apiCredentialProfiles: false,
+    })
+  })
+
   it("merges API credential profiles when present in V2 backup", async () => {
     const backup: BackupFullV2 = {
       version: BACKUP_VERSION,

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -191,7 +191,15 @@ describe("parseBackupSummary", () => {
     const payload: RawBackupData = {
       version: BACKUP_VERSION,
       timestamp: Date.now(),
-      accountKeySnapshots: [],
+      accountKeySnapshots: [
+        {
+          accountId: "acc-1",
+          accountName: "Account 1",
+          baseUrl: "https://example.com",
+          siteType: "new-api",
+          tokens: [],
+        },
+      ],
     }
 
     const result = parseBackupSummary(JSON.stringify(payload), "unknown")
@@ -199,6 +207,49 @@ describe("parseBackupSummary", () => {
     expect(result && "valid" in result && result.valid).toBe(true)
     if (result && "valid" in result && result.valid) {
       expect(result.hasAccountKeySnapshots).toBe(true)
+    }
+  })
+
+  it("ignores empty or malformed account key snapshot sections in summary parsing", () => {
+    const emptySnapshotPayload: RawBackupData = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accountKeySnapshots: [],
+    }
+    const malformedSnapshotPayload = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accountKeySnapshots: {
+        accountId: "acc-1",
+      },
+    }
+
+    const emptyResult = parseBackupSummary(
+      JSON.stringify(emptySnapshotPayload),
+      "unknown",
+    )
+    const malformedResult = parseBackupSummary(
+      JSON.stringify(malformedSnapshotPayload),
+      "unknown",
+    )
+
+    expect(emptyResult && "valid" in emptyResult && emptyResult.valid).toBe(
+      true,
+    )
+    expect(
+      malformedResult && "valid" in malformedResult && malformedResult.valid,
+    ).toBe(true)
+
+    if (emptyResult && "valid" in emptyResult && emptyResult.valid) {
+      expect(emptyResult.hasAccountKeySnapshots).toBe(false)
+    }
+
+    if (
+      malformedResult &&
+      "valid" in malformedResult &&
+      malformedResult.valid
+    ) {
+      expect(malformedResult.hasAccountKeySnapshots).toBe(false)
     }
   })
 

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -11,6 +11,10 @@ import {
   type RawBackupData,
 } from "~/features/ImportExport/utils"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import {
+  fetchDisplayAccountTokens,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
 import { userPreferences } from "~/services/preferences/userPreferences"
@@ -21,9 +25,16 @@ import { DEFAULT_WEBDAV_SETTINGS } from "~/types/webdav"
 
 vi.mock("~/services/accounts/accountStorage", () => ({
   accountStorage: {
+    convertToDisplayData: vi.fn(),
     importData: vi.fn(),
     exportData: vi.fn(),
   },
+}))
+
+vi.mock("~/services/accounts/utils/apiServiceRequest", () => ({
+  canManageDisplayAccountTokens: vi.fn((account) => Boolean(account)),
+  fetchDisplayAccountTokens: vi.fn(),
+  resolveDisplayAccountTokenForSecret: vi.fn(),
 }))
 
 vi.mock("~/services/preferences/userPreferences", () => ({
@@ -79,6 +90,15 @@ const mockAccountStorageImportData =
   accountStorage.importData as unknown as ReturnType<typeof vi.fn>
 const mockAccountStorageExportData =
   accountStorage.exportData as unknown as ReturnType<typeof vi.fn>
+const mockAccountStorageConvertToDisplayData =
+  accountStorage.convertToDisplayData as unknown as ReturnType<typeof vi.fn>
+const mockCanManageDisplayAccountTokens = (
+  await import("~/services/accounts/utils/apiServiceRequest")
+).canManageDisplayAccountTokens as unknown as ReturnType<typeof vi.fn>
+const mockFetchDisplayAccountTokens =
+  fetchDisplayAccountTokens as unknown as ReturnType<typeof vi.fn>
+const mockResolveDisplayAccountTokenForSecret =
+  resolveDisplayAccountTokenForSecret as unknown as ReturnType<typeof vi.fn>
 
 const mockUserPreferencesImport =
   userPreferences.importPreferences as unknown as ReturnType<typeof vi.fn>
@@ -164,6 +184,21 @@ describe("parseBackupSummary", () => {
     expect(result && "valid" in result && result.valid).toBe(true)
     if (result && "valid" in result && result.valid) {
       expect(result.hasApiCredentialProfiles).toBe(true)
+    }
+  })
+
+  it("detects account key snapshots when present", () => {
+    const payload: RawBackupData = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accountKeySnapshots: [],
+    }
+
+    const result = parseBackupSummary(JSON.stringify(payload), "unknown")
+
+    expect(result && "valid" in result && result.valid).toBe(true)
+    if (result && "valid" in result && result.valid) {
+      expect(result.hasAccountKeySnapshots).toBe(true)
     }
   })
 
@@ -759,6 +794,12 @@ describe("export handlers", () => {
     mockTagStoreExport.mockResolvedValue({ version: 1, tagsById: {} })
     mockUserPreferencesExport.mockResolvedValue({} as any)
     mockChannelConfigExport.mockResolvedValue({} as any)
+    mockResolveDisplayAccountTokenForSecret.mockImplementation(
+      async (_account, token) => token,
+    )
+    mockCanManageDisplayAccountTokens.mockImplementation((account) =>
+      Boolean(account),
+    )
   })
 
   afterEach(() => {
@@ -778,6 +819,28 @@ describe("export handlers", () => {
       handleExportAccounts: mod.handleExportAccounts,
       handleExportPreferences: mod.handleExportPreferences,
     }
+  }
+
+  function parseExportPayload() {
+    const createObjectUrl = URL.createObjectURL as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const blob = createObjectUrl.mock.calls[0]?.[0] as Blob
+
+    expect(blob).toBeInstanceOf(Blob)
+    return new Promise<Record<string, unknown>>((resolve, reject) => {
+      const reader = new FileReader()
+
+      reader.onload = () => {
+        try {
+          resolve(JSON.parse(String(reader.result ?? "")))
+        } catch (error) {
+          reject(error)
+        }
+      }
+      reader.onerror = () => reject(reader.error)
+      reader.readAsText(blob)
+    })
   }
 
   it("handleExportAll exports accounts, preferences and channelConfigs", async () => {
@@ -804,6 +867,237 @@ describe("export handlers", () => {
 
     expect(mockAccountStorageExportData).toHaveBeenCalled()
     expect(mockTagStoreExport).toHaveBeenCalled()
+  })
+
+  it("handleExportAll omits account key snapshots by default", async () => {
+    const { handleExportAll } = await loadHandlers()
+
+    await handleExportAll(vi.fn())
+
+    expect(mockAccountStorageConvertToDisplayData).not.toHaveBeenCalled()
+    expect(mockFetchDisplayAccountTokens).not.toHaveBeenCalled()
+
+    await expect(parseExportPayload()).resolves.not.toHaveProperty(
+      "accountKeySnapshots",
+    )
+  })
+
+  it("handleExportAll includes resolved account key snapshots when requested", async () => {
+    const { handleExportAll } = await loadHandlers()
+
+    mockAccountStorageExportData.mockResolvedValueOnce({
+      accounts: [
+        {
+          id: "account-1",
+          site_name: "Primary",
+        },
+      ],
+      bookmarks: [],
+      pinnedAccountIds: [],
+      orderedAccountIds: [],
+      last_updated: 0,
+    })
+    mockAccountStorageConvertToDisplayData.mockReturnValueOnce([
+      {
+        id: "account-1",
+        name: "Primary",
+        baseUrl: "https://example.com",
+        siteType: "new-api",
+        authType: "access_token",
+        userId: 1,
+        token: "session-token",
+      },
+    ])
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce([
+      {
+        id: 101,
+        name: "Default",
+        key: "sk-masked",
+        status: 1,
+      },
+    ])
+    mockResolveDisplayAccountTokenForSecret.mockResolvedValueOnce({
+      id: 101,
+      name: "Default",
+      key: "sk-live-secret",
+      status: 1,
+    })
+
+    await handleExportAll(vi.fn(), { includeAccountKeys: true })
+
+    expect(mockAccountStorageConvertToDisplayData).toHaveBeenCalledWith([
+      {
+        id: "account-1",
+        site_name: "Primary",
+      },
+    ])
+    expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith({
+      id: "account-1",
+      name: "Primary",
+      baseUrl: "https://example.com",
+      siteType: "new-api",
+      authType: "access_token",
+      userId: 1,
+      token: "session-token",
+    })
+    expect(mockResolveDisplayAccountTokenForSecret).toHaveBeenCalledWith(
+      {
+        id: "account-1",
+        name: "Primary",
+        baseUrl: "https://example.com",
+        siteType: "new-api",
+        authType: "access_token",
+        userId: 1,
+        token: "session-token",
+      },
+      {
+        id: 101,
+        name: "Default",
+        key: "sk-masked",
+        status: 1,
+      },
+    )
+
+    await expect(parseExportPayload()).resolves.toMatchObject({
+      accountKeySnapshots: [
+        {
+          accountId: "account-1",
+          accountName: "Primary",
+          baseUrl: "https://example.com",
+          siteType: "new-api",
+          tokens: [
+            {
+              id: 101,
+              name: "Default",
+              key: "sk-live-secret",
+              status: 1,
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("handleExportAll keeps exporting when one account key fetch fails", async () => {
+    const { handleExportAll } = await loadHandlers()
+
+    mockAccountStorageExportData.mockResolvedValueOnce({
+      accounts: [
+        {
+          id: "account-1",
+          site_name: "Primary",
+        },
+        {
+          id: "account-2",
+          site_name: "Broken",
+        },
+      ],
+      bookmarks: [],
+      pinnedAccountIds: [],
+      orderedAccountIds: [],
+      last_updated: 0,
+    })
+    mockAccountStorageConvertToDisplayData.mockReturnValueOnce([
+      {
+        id: "account-1",
+        name: "Primary",
+        baseUrl: "https://ok.example.com",
+        siteType: "new-api",
+        authType: "access_token",
+        userId: 1,
+        token: "session-token-1",
+      },
+      {
+        id: "account-2",
+        name: "Broken",
+        baseUrl: "https://bad.example.com",
+        siteType: "new-api",
+        authType: "access_token",
+        userId: 2,
+        token: "session-token-2",
+      },
+    ])
+    mockFetchDisplayAccountTokens
+      .mockResolvedValueOnce([
+        {
+          id: 101,
+          name: "Default",
+          key: "sk-masked",
+          status: 1,
+        },
+      ])
+      .mockRejectedValueOnce(new Error("upstream timeout"))
+    mockResolveDisplayAccountTokenForSecret.mockResolvedValueOnce({
+      id: 101,
+      name: "Default",
+      key: "sk-live-secret",
+      status: 1,
+    })
+
+    await handleExportAll(vi.fn(), { includeAccountKeys: true })
+
+    await expect(parseExportPayload()).resolves.toMatchObject({
+      accountKeySnapshots: [
+        {
+          accountId: "account-1",
+          accountName: "Primary",
+        },
+      ],
+      accountKeySnapshotErrors: [
+        {
+          accountId: "account-2",
+          accountName: "Broken",
+          baseUrl: "https://bad.example.com",
+          siteType: "new-api",
+          errorMessage: "upstream timeout",
+        },
+      ],
+    })
+  })
+
+  it("handleExportAll sanitizes HTML error pages in account key export failures", async () => {
+    const { handleExportAll } = await loadHandlers()
+
+    mockAccountStorageExportData.mockResolvedValueOnce({
+      accounts: [
+        {
+          id: "account-html-error",
+          site_name: "HTML Error",
+        },
+      ],
+      bookmarks: [],
+      pinnedAccountIds: [],
+      orderedAccountIds: [],
+      last_updated: 0,
+    })
+    mockAccountStorageConvertToDisplayData.mockReturnValueOnce([
+      {
+        id: "account-html-error",
+        name: "HTML Error",
+        baseUrl: "https://html-error.example.com",
+        siteType: "new-api",
+        authType: "access_token",
+        userId: 9,
+        token: "session-token-html",
+      },
+    ])
+    mockFetchDisplayAccountTokens.mockRejectedValueOnce(
+      new Error(
+        '<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title></head><body>challenge</body></html>',
+      ),
+    )
+
+    await handleExportAll(vi.fn(), { includeAccountKeys: true })
+
+    await expect(parseExportPayload()).resolves.toMatchObject({
+      accountKeySnapshotErrors: [
+        {
+          accountId: "account-html-error",
+          accountName: "HTML Error",
+          errorMessage: "Cloudflare challenge page returned",
+        },
+      ],
+    })
   })
 
   it("handleExportPreferences exports only preferences data", async () => {


### PR DESCRIPTION
## What Changed
- 为导出备份新增可选的账号密钥快照导出能力，显式勾选后会把账号 token/key 快照写入备份文件
- 为单账号密钥拉取增加超时与异常收敛，导出时保留按账号维度的部分成功/部分失败结果
- 导入同类备份时继续只恢复账号、偏好、channel config 和 profiles，忽略 `accountKeySnapshots` / `accountKeySnapshotErrors` 字段，不把密钥重新导回本地
- 补充 import/export、账号 token 拉取和 key management 的相关测试，并重新产出可手工验证的 Chrome 构建包

## Why
- 当前备份只能恢复账号配置，无法在需要迁移或排障时保留账号下的真实密钥快照
- 这次改动的核心是新增导出能力，不应该被描述成单纯 bugfix
- 同时需要保证备份文件向后兼容：即便带有密钥快照，导入时也不能把这些密钥重新写回本地

## Validation
- `pnpm vitest --run tests/utils/importExportUtils.test.ts`
- `pnpm vitest --run tests/services/accounts/apiServiceRequest.test.ts tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx`
- `pnpm build`
- `pnpm zip`
- `pnpm compile`
- `pnpm knip`

## Notes
- 备份文件中的账号密钥快照属于敏感数据，只有在用户显式勾选后才会写入导出文件
- 导入逻辑保持保守：当前 PR 不引入“从备份重新导入密钥”的行为


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional toggle to include account key snapshots in exported backups; export shows success message and includes per-account snapshot data or per-account export errors.
  * Import validation now indicates when backups contain account key snapshots.

* **Improvements**
  * API requests now have timeout protection for more reliable exports and token handling.
  * Export process better surfaces and sanitizes per-account export errors.

* **Tests**
  * End-to-end and unit tests added/updated to cover export/import flows and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->