### PR TITLE
feat(account): add created_at sorting and display support

### DIFF
--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -62,7 +62,7 @@ interface PrefilledDialogDuplicateState {
 }
 
 /**
- *
+ * Narrows a display account union to a persisted site account record.
  */
 function isSiteAccount(
   account: DisplaySiteData | SiteAccount,
@@ -71,7 +71,8 @@ function isSiteAccount(
 }
 
 /**
- * Hook to easily trigger channel creation dialog from anywhere
+ * Exposes helpers for opening channel dialogs from account data,
+ * raw credentials, or custom initial values.
  */
 export function useChannelDialog() {
   const { t } = useTranslation(["messages", "channelDialog"])

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -62,6 +62,15 @@ interface PrefilledDialogDuplicateState {
 }
 
 /**
+ *
+ */
+function isSiteAccount(
+  account: DisplaySiteData | SiteAccount,
+): account is SiteAccount {
+  return "site_name" in account && "account_info" in account
+}
+
+/**
  * Hook to easily trigger channel creation dialog from anywhere
  */
 export function useChannelDialog() {
@@ -306,7 +315,7 @@ export function useChannelDialog() {
       // Get full account if needed
       let siteAccount: SiteAccount
 
-      if ("created_at" in account) {
+      if (isSiteAccount(account)) {
         siteAccount = account
         displaySiteData =
           (await accountStorage.getDisplayDataById(account.id)) ??

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,7 @@ export const DATA_TYPE_CASHFLOW = "cashflow"
 export const DATA_TYPE_CONSUMPTION = "consumption"
 export const DATA_TYPE_INCOME = "income"
 export const DATA_TYPE_BALANCE = "balance"
+export const DATA_TYPE_CREATED_AT = "created_at"
 
 export * from "./i18n"
 export * from "./siteType"

--- a/src/features/AccountManagement/components/AccountList/AccountListItem.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountListItem.tsx
@@ -17,10 +17,11 @@ interface AccountListItemProps {
   highlights?: SearchResultWithHighlight["highlights"]
   onCopyKey: (site: DisplaySiteData) => void
   onDeleteWithDialog: (site: DisplaySiteData) => void
+  showCreatedAt?: boolean
 }
 
 const AccountListItem: React.FC<AccountListItemProps> = React.memo(
-  ({ site, highlights, onCopyKey, onDeleteWithDialog }) => {
+  ({ site, highlights, onCopyKey, onDeleteWithDialog, showCreatedAt }) => {
     const { handleMouseEnter, handleMouseLeave } = useAccountListItem()
     const { isTouchDevice } = useDevice()
 
@@ -44,7 +45,11 @@ const AccountListItem: React.FC<AccountListItemProps> = React.memo(
           {/* 左侧：站点信息 - 可压缩 */}
           {/* Clip any accidental overflow so long names/links never overlap the middle action buttons. */}
           <div className="min-w-[60px] flex-1 overflow-x-hidden sm:min-w-[80px]">
-            <SiteInfo site={site} highlights={highlights} />
+            <SiteInfo
+              site={site}
+              highlights={highlights}
+              showCreatedAt={showCreatedAt}
+            />
           </div>
 
           {/* 中间：操作按钮 */}

--- a/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
+++ b/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowPathIcon,
+  CalendarDaysIcon,
   CheckCircleIcon,
   CurrencyYenIcon,
   ExclamationTriangleIcon,
@@ -59,6 +60,7 @@ import {
 interface SiteInfoProps {
   site: DisplaySiteData
   highlights?: SearchResultWithHighlight["highlights"]
+  showCreatedAt?: boolean
 }
 
 /**
@@ -95,8 +97,12 @@ function renderHighlightedFragments(
 /**
  * Site info row combining metadata, status chips, and context actions for a display account entry.
  */
-export default function SiteInfo({ site, highlights }: SiteInfoProps) {
-  const { t } = useTranslation(["account", "messages"])
+export default function SiteInfo({
+  site,
+  highlights,
+  showCreatedAt = false,
+}: SiteInfoProps) {
+  const { t } = useTranslation(["account", "messages", "common"])
   const {
     detectedSiteAccounts,
     isAccountPinned,
@@ -121,6 +127,11 @@ export default function SiteInfo({ site, highlights }: SiteInfoProps) {
   const ldohSearchUrl = getLdohSearchUrlForAccountUrl(site.baseUrl)
   const customCheckInUrl = site.checkIn?.customCheckIn?.url
   const customRedeemUrl = site.checkIn?.customCheckIn?.redeemUrl
+  const createdAtLabel = t("account:list.header.createdAt")
+  const createdAtText = formatLocaleDateTime(
+    site.created_at,
+    t("common:labels.notAvailable"),
+  )
 
   const healthCode = site.health?.code
   const canOpenHealthSettings =
@@ -536,6 +547,18 @@ export default function SiteInfo({ site, highlights }: SiteInfoProps) {
               : site.username}
           </Caption>
         </div>
+
+        {showCreatedAt && (
+          <div className="mt-0.5 flex min-w-0 items-start gap-1">
+            <CalendarDaysIcon className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
+            <Caption
+              className="truncate"
+              title={`${createdAtLabel}: ${createdAtText}`}
+            >
+              {createdAtLabel}: {createdAtText}
+            </Caption>
+          </div>
+        )}
 
         {highlights?.baseUrl && (
           <div className="mt-0.5 flex min-w-0 items-start gap-1">

--- a/src/features/AccountManagement/components/AccountList/SortableAccountListItem.tsx
+++ b/src/features/AccountManagement/components/AccountList/SortableAccountListItem.tsx
@@ -14,6 +14,7 @@ interface SortableAccountListItemProps {
   highlights?: SearchResultWithHighlight["highlights"]
   onCopyKey: (site: DisplaySiteData) => void
   onDeleteWithDialog: (site: DisplaySiteData) => void
+  showCreatedAt?: boolean
   isDragDisabled: boolean
   handleLabel: string
   showHandle: boolean
@@ -29,6 +30,7 @@ function SortableAccountListItem({
   highlights,
   onCopyKey,
   onDeleteWithDialog,
+  showCreatedAt,
   isDragDisabled,
   handleLabel,
   showHandle,
@@ -86,6 +88,7 @@ function SortableAccountListItem({
             highlights={highlights}
             onDeleteWithDialog={onDeleteWithDialog}
             onCopyKey={onCopyKey}
+            showCreatedAt={showCreatedAt}
           />
         </div>
       </div>

--- a/src/features/AccountManagement/components/AccountList/index.tsx
+++ b/src/features/AccountManagement/components/AccountList/index.tsx
@@ -35,6 +35,7 @@ import {
 import {
   DATA_TYPE_BALANCE,
   DATA_TYPE_CONSUMPTION,
+  DATA_TYPE_CREATED_AT,
   DATA_TYPE_INCOME,
 } from "~/constants"
 import { SITE_TITLE_RULES } from "~/constants/siteType"
@@ -758,6 +759,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
         <SortableAccountListItem
           key={item.account.id}
           site={item.account}
+          showCreatedAt={sortField === DATA_TYPE_CREATED_AT}
           className={cn(
             detectedAccount?.id === item.account.id &&
               "rounded-lg border-l-4 border-l-blue-500 bg-blue-50 dark:border-l-blue-400 dark:bg-blue-900/50",
@@ -965,7 +967,18 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
           <div className="flex items-center justify-between gap-2 sm:gap-4">
             {/* Account Name Column */}
             <div className="flex min-w-0 flex-1 items-center gap-2">
-              {renderSortButton("name", t("account:list.header.account"))}
+              <div className="flex min-w-0 items-center gap-0.5">
+                {renderSortButton("name", t("account:list.header.account"))}
+                <div className="dark:text-dark-text-tertiary text-[10px] text-gray-400 sm:text-xs">
+                  /
+                </div>
+                <div className="dark:text-dark-text-tertiary flex items-center text-[9px] text-gray-400 sm:text-[10px]">
+                  {renderSortButton(
+                    DATA_TYPE_CREATED_AT,
+                    t("account:list.header.createdAt"),
+                  )}
+                </div>
+              </div>
               <span className="text-[10px] font-medium sm:text-xs">
                 {t("common:total") + ": " + displayedResults.length}
               </span>

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next" // 1. 定义 Context 的值类型
 import {
   DATA_TYPE_BALANCE,
   DATA_TYPE_CONSUMPTION,
+  DATA_TYPE_CREATED_AT,
   DATA_TYPE_INCOME,
 } from "~/constants"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
@@ -91,9 +92,7 @@ interface AccountDataContextType {
   unpinAccount: (id: string) => Promise<boolean>
   togglePinAccount: (id: string) => Promise<boolean>
   loadAccountData: () => Promise<void>
-  handleRefresh: (
-    force?: boolean,
-  ) => Promise<{
+  handleRefresh: (force?: boolean) => Promise<{
     success: number
     failed: number
     latestSyncTime?: number
@@ -675,7 +674,7 @@ export const AccountDataProvider = ({
         newOrder = sortOrder === "asc" ? "desc" : "asc"
         setSortOrder(newOrder)
       } else {
-        newOrder = "asc"
+        newOrder = field === DATA_TYPE_CREATED_AT ? "desc" : "asc"
         setSortField(field)
         setSortOrder(newOrder)
       }

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -62,6 +62,8 @@ interface ControlPanelProps {
  * @param props.sourceCapabilities Capability flags for the active source.
  * @param props.searchTerm Current search keyword.
  * @param props.setSearchTerm Setter to update search keyword.
+ * @param props.sortMode Active sort mode.
+ * @param props.setSortMode Setter for sort mode.
  * @param props.selectedBillingMode Active billing-mode filter value.
  * @param props.setSelectedBillingMode Setter for billing-mode filter.
  * @param props.selectedGroups Active candidate group filter set.

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -49,7 +49,7 @@ interface ModelItemProps {
 }
 
 /**
- *
+ * Renders a single model row with pricing, availability, and expandable details.
  */
 export default function ModelItem(props: ModelItemProps) {
   const {

--- a/src/locales/en/account.json
+++ b/src/locales/en/account.json
@@ -131,6 +131,7 @@
     "header": {
       "account": "Account",
       "balance": "Balance",
+      "createdAt": "Created At",
       "todayConsumption": "Today's Consumption",
       "todayIncome": "Today's Income"
     },

--- a/src/locales/ja/account.json
+++ b/src/locales/ja/account.json
@@ -122,6 +122,7 @@
     "header": {
       "account": "アカウント",
       "balance": "残高",
+      "createdAt": "作成日時",
       "todayConsumption": "本日の消費",
       "todayIncome": "本日の収入"
     },

--- a/src/locales/zh-CN/account.json
+++ b/src/locales/zh-CN/account.json
@@ -122,6 +122,7 @@
     "header": {
       "account": "账号",
       "balance": "余额",
+      "createdAt": "创建时间",
       "todayConsumption": "今日消费",
       "todayIncome": "今日收入"
     },

--- a/src/locales/zh-TW/account.json
+++ b/src/locales/zh-TW/account.json
@@ -122,6 +122,7 @@
     "header": {
       "account": "帳號",
       "balance": "餘額",
+      "createdAt": "建立時間",
       "todayConsumption": "今日消費",
       "todayIncome": "今日收入"
     },

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -1297,6 +1297,7 @@ class AccountStorageService {
         },
         health: normalized.health,
         last_sync_time: normalized.last_sync_time,
+        created_at: normalized.created_at,
         baseUrl: normalized.site_url,
         token: normalized.account_info.access_token,
         userId: normalized.account_info.id,

--- a/src/services/preferences/utils/sortingPriority.ts
+++ b/src/services/preferences/utils/sortingPriority.ts
@@ -1,6 +1,7 @@
 import {
   DATA_TYPE_BALANCE,
   DATA_TYPE_CONSUMPTION,
+  DATA_TYPE_CREATED_AT,
   DATA_TYPE_INCOME,
 } from "~/constants"
 import { compareAccountDisplayNames } from "~/services/accounts/utils/accountDisplayName"
@@ -119,6 +120,19 @@ function compareByUserSortField(
       return sortOrder === "asc"
         ? a.todayIncome[currencyType] - b.todayIncome[currencyType]
         : b.todayIncome[currencyType] - a.todayIncome[currencyType]
+    case DATA_TYPE_CREATED_AT: {
+      const aCreatedAt =
+        typeof a.created_at === "number" && Number.isFinite(a.created_at)
+          ? a.created_at
+          : 0
+      const bCreatedAt =
+        typeof b.created_at === "number" && Number.isFinite(b.created_at)
+          ? b.created_at
+          : 0
+      return sortOrder === "asc"
+        ? aCreatedAt - bCreatedAt
+        : bCreatedAt - aCreatedAt
+    }
     default:
       return 0
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ import {
   DATA_TYPE_BALANCE,
   DATA_TYPE_CASHFLOW,
   DATA_TYPE_CONSUMPTION,
+  DATA_TYPE_CREATED_AT,
   DATA_TYPE_INCOME,
 } from "~/constants"
 import { TempWindowHealthStatusCode } from "~/types/tempWindow"
@@ -358,6 +359,7 @@ export type SortField =
   | typeof DATA_TYPE_CONSUMPTION
   | typeof DATA_TYPE_INCOME
   | typeof DATA_TYPE_BALANCE
+  | typeof DATA_TYPE_CREATED_AT
 export type SortOrder = "asc" | "desc"
 
 // 货币类型
@@ -386,6 +388,7 @@ export interface DisplaySiteData {
   todayTokens: TokenUsage
   health: HealthStatus
   last_sync_time?: number
+  created_at?: number
   siteType: string // 站点类型
   baseUrl: string // 站点 URL，用于复制功能
   token: string // 访问令牌，用于复制功能

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -358,6 +358,16 @@ describe("AccountList", () => {
     mockUseAccountDataContext.mockReturnValue(createAccountDataContextValue())
   })
 
+  it("renders the created-time sort control", () => {
+    render(<AccountList />)
+
+    expect(
+      screen.getByRole("button", {
+        name: "account:list.sort account:list.header.createdAt",
+      }),
+    ).toBeInTheDocument()
+  })
+
   it("filters accounts by enabled state and combines with tag filters", async () => {
     const user = userEvent.setup()
 

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import SiteInfo from "~/features/AccountManagement/components/AccountList/SiteInfo"
 import { TEMP_WINDOW_HEALTH_STATUS_CODES } from "~/types"
+import { formatLocaleDateTime } from "~/utils/core/formatters"
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
 vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
@@ -160,6 +161,43 @@ describe("SiteInfo", () => {
     expect(mockOpenAccountBaseUrl).toHaveBeenCalledWith(
       expect.objectContaining({ baseUrl: "https://example.com" }),
     )
+  })
+
+  it("renders a formatted created-time row", () => {
+    const createdAt = new Date(2026, 0, 2, 3, 4, 5).getTime()
+    const expected = formatLocaleDateTime(
+      createdAt,
+      "common:labels.notAvailable",
+    )
+
+    render(
+      <SiteInfo site={buildSite({ created_at: createdAt })} showCreatedAt />,
+    )
+
+    expect(
+      screen.getByText(`account:list.header.createdAt: ${expected}`),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTitle(`account:list.header.createdAt: ${expected}`),
+    ).toBeInTheDocument()
+  })
+
+  it("falls back when created time is unavailable", () => {
+    render(<SiteInfo site={buildSite({ created_at: 0 })} showCreatedAt />)
+
+    expect(
+      screen.getByText(
+        "account:list.header.createdAt: common:labels.notAvailable",
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("hides created time when created-time sorting is not active", () => {
+    render(<SiteInfo site={buildSite({ created_at: 123 })} />)
+
+    expect(
+      screen.queryByText(/account:list.header.createdAt:/),
+    ).not.toBeInTheDocument()
   })
 
   it("shows a warning check-in indicator when the last check-in status detection is not today", async () => {

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -3,7 +3,11 @@ import { useEffect } from "react"
 import { I18nextProvider } from "react-i18next"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { DATA_TYPE_BALANCE, DATA_TYPE_CONSUMPTION } from "~/constants"
+import {
+  DATA_TYPE_BALANCE,
+  DATA_TYPE_CONSUMPTION,
+  DATA_TYPE_CREATED_AT,
+} from "~/constants"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import {
   AccountDataProvider,
@@ -1156,6 +1160,44 @@ describe("AccountDataContext sorting behavior", () => {
       2,
       DATA_TYPE_BALANCE,
       "desc",
+    )
+  })
+
+  it("initializes created-time sorting to newest first and then toggles", async () => {
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().sortField).toBe("name")
+      expect(getLatestCtx().sortOrder).toBe("asc")
+    })
+
+    act(() => {
+      getLatestCtx().handleSort(DATA_TYPE_CREATED_AT)
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().sortField).toBe(DATA_TYPE_CREATED_AT)
+      expect(getLatestCtx().sortOrder).toBe("desc")
+    })
+
+    act(() => {
+      getLatestCtx().handleSort(DATA_TYPE_CREATED_AT)
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().sortField).toBe(DATA_TYPE_CREATED_AT)
+      expect(getLatestCtx().sortOrder).toBe("asc")
+    })
+
+    expect(mockUpdateSortConfig).toHaveBeenNthCalledWith(
+      1,
+      DATA_TYPE_CREATED_AT,
+      "desc",
+    )
+    expect(mockUpdateSortConfig).toHaveBeenNthCalledWith(
+      2,
+      DATA_TYPE_CREATED_AT,
+      "asc",
     )
   })
 

--- a/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
+++ b/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
@@ -9,7 +9,9 @@ vi.mock("~/hooks/useMediaQuery", () => ({
 }))
 
 vi.mock("~/components/ui", () => ({
-  Input: ({ leftIcon, rightIcon, ...props }: any) => <input {...props} />,
+  Input: ({ leftIcon: _leftIcon, rightIcon: _rightIcon, ...props }: any) => (
+    <input {...props} />
+  ),
   SearchableSelect: ({ value, onChange }: any) => (
     <select
       aria-label="api-type-filter"

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -232,6 +232,7 @@ describe("accountStorage core behaviors", () => {
 
   it("convertToDisplayData should normalize currency values", () => {
     const account = createAccount({
+      created_at: 1_700_000_000_000,
       exchange_rate: 7,
       account_info: {
         id: 1,
@@ -254,6 +255,7 @@ describe("accountStorage core behaviors", () => {
     expect(display.todayIncome.USD).toBeCloseTo(0.5)
     expect(display.todayTokens.upload).toBe(600)
     expect(display.todayTokens.download).toBe(400)
+    expect(display.created_at).toBe(1_700_000_000_000)
   })
 
   it("convertToDisplayData should handle arrays", () => {

--- a/tests/test-utils/factories.ts
+++ b/tests/test-utils/factories.ts
@@ -99,6 +99,7 @@ export function buildDisplaySiteData(
     todayIncome: { USD: 0, CNY: 0 },
     todayTokens: { upload: 0, download: 0 },
     health: { status: SiteHealthStatus.Healthy },
+    created_at: 0,
     siteType: "test",
     baseUrl: "https://example.com",
     token: "test-token",

--- a/tests/utils/sortingPriority.test.ts
+++ b/tests/utils/sortingPriority.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   DATA_TYPE_BALANCE,
   DATA_TYPE_CONSUMPTION,
+  DATA_TYPE_CREATED_AT,
   DATA_TYPE_INCOME,
 } from "~/constants"
 import {
@@ -1609,6 +1610,85 @@ describe("createDynamicSortComparator", () => {
 
       // Balances are equal, so comparison should be 0
       expect(comparator(account1, account2)).toBe(0)
+    })
+
+    it("should sort by created_at in both directions", () => {
+      const older = createDisplaySiteData({
+        id: "account-1",
+        created_at: 100,
+      })
+      const newer = createDisplaySiteData({
+        id: "account-2",
+        created_at: 200,
+      })
+      const config: SortingPriorityConfig = {
+        criteria: [
+          {
+            id: SortingCriteriaType.USER_SORT_FIELD,
+            enabled: true,
+            priority: 0,
+          },
+        ],
+        lastModified: Date.now(),
+      }
+
+      const descComparator = createDynamicSortComparator(
+        config,
+        null,
+        DATA_TYPE_CREATED_AT,
+        "USD",
+        "desc",
+      )
+      const ascComparator = createDynamicSortComparator(
+        config,
+        null,
+        DATA_TYPE_CREATED_AT,
+        "USD",
+        "asc",
+      )
+
+      expect(
+        [older, newer].sort(descComparator).map((item) => item.id),
+      ).toEqual(["account-2", "account-1"])
+      expect([older, newer].sort(ascComparator).map((item) => item.id)).toEqual(
+        ["account-1", "account-2"],
+      )
+    })
+
+    it("should treat missing created_at as 0 when sorting by created time", () => {
+      const missingTimestamp = createDisplaySiteData({
+        id: "account-1",
+        created_at: undefined,
+      })
+      const validTimestamp = createDisplaySiteData({
+        id: "account-2",
+        created_at: 50,
+      })
+      const config: SortingPriorityConfig = {
+        criteria: [
+          {
+            id: SortingCriteriaType.USER_SORT_FIELD,
+            enabled: true,
+            priority: 0,
+          },
+        ],
+        lastModified: Date.now(),
+      }
+
+      const comparator = createDynamicSortComparator(
+        config,
+        null,
+        DATA_TYPE_CREATED_AT,
+        "USD",
+        "desc",
+      )
+
+      expect(() => comparator(missingTimestamp, validTimestamp)).not.toThrow()
+      expect(
+        [missingTimestamp, validTimestamp]
+          .sort(comparator)
+          .map((item) => item.id),
+      ).toEqual(["account-2", "account-1"])
     })
 
     it("should handle default parameters", () => {


### PR DESCRIPTION
Resolves #724
Resolves #720


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to sort accounts by creation date with dedicated "Created At" sort control in account list header.
  * Account creation timestamps now display in the list when sorted by date, with calendar icon and proper locale formatting.
  * Sort defaults to newest-first order; defaults to oldest-first on subsequent toggles.
  * Unavailable creation dates display with fallback text.
  * Multi-language support for new feature (English, Japanese, Simplified Chinese, Traditional Chinese).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->