### PR TITLE
fix(AccountManagement): correct reminder dialog visibility logic

### DIFF
--- a/src/features/AccountManagement/components/TempWindowFallbackReminderGate.tsx
+++ b/src/features/AccountManagement/components/TempWindowFallbackReminderGate.tsx
@@ -94,7 +94,7 @@ export function TempWindowFallbackReminderGate() {
     }
   }, [blockCheckToken, issue, tempWindowFallback])
 
-  const shouldShowReminder = useMemo(() => {
+  const hasConfirmedReminderIssue = useMemo(() => {
     if (!issue || !blockCheckToken || resolvedBlockToken !== blockCheckToken) {
       return false
     }
@@ -108,7 +108,7 @@ export function TempWindowFallbackReminderGate() {
       return
     }
 
-    if (!shouldShowReminder) {
+    if (!hasConfirmedReminderIssue) {
       setIsOpen(false)
       return
     }
@@ -121,21 +121,26 @@ export function TempWindowFallbackReminderGate() {
     setIsOpen(true)
   }, [
     hasShownInThisSession,
-    shouldShowReminder,
+    hasConfirmedReminderIssue,
     tempWindowFallbackReminder.dismissed,
   ])
+
+  const isReminderDialogOpen =
+    hasConfirmedReminderIssue &&
+    !tempWindowFallbackReminder.dismissed &&
+    (isOpen || !hasShownInThisSession)
 
   const handleNeverRemind = async () => {
     await updateTempWindowFallbackReminder({ dismissed: true })
   }
 
-  if (!issue || !shouldShowReminder) {
+  if (!issue || !isReminderDialogOpen) {
     return null
   }
 
   return (
     <TempWindowFallbackReminderDialog
-      isOpen={isOpen}
+      isOpen={isReminderDialogOpen}
       issue={issue}
       onClose={() => setIsOpen(false)}
       onNeverRemind={handleNeverRemind}

--- a/src/features/AccountManagement/components/TempWindowFallbackReminderGate.tsx
+++ b/src/features/AccountManagement/components/TempWindowFallbackReminderGate.tsx
@@ -126,9 +126,7 @@ export function TempWindowFallbackReminderGate() {
   ])
 
   const isReminderDialogOpen =
-    hasConfirmedReminderIssue &&
-    !tempWindowFallbackReminder.dismissed &&
-    (isOpen || !hasShownInThisSession)
+    hasConfirmedReminderIssue && !tempWindowFallbackReminder.dismissed && isOpen
 
   const handleNeverRemind = async () => {
     await updateTempWindowFallbackReminder({ dismissed: true })

--- a/tests/features/AccountManagement/components/TempWindowFallbackReminderGate.test.tsx
+++ b/tests/features/AccountManagement/components/TempWindowFallbackReminderGate.test.tsx
@@ -132,7 +132,7 @@ describe("TempWindowFallbackReminderGate", () => {
     })
   })
 
-  it("opens once for the first disabled issue when the shared fallback gate reports disabled and stays closed after the user dismisses it in the same session", async () => {
+  it("opens once for the first disabled issue when the shared fallback gate reports disabled and stays unmounted after the user dismisses it in the same session", async () => {
     accountDataState.displayData = [
       {
         id: "acc-1",
@@ -166,16 +166,16 @@ describe("TempWindowFallbackReminderGate", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByTestId("temp-window-fallback-reminder"),
-      ).toHaveAttribute("data-open", "false")
+        screen.queryByTestId("temp-window-fallback-reminder"),
+      ).not.toBeInTheDocument()
     })
 
     rerender(<TempWindowFallbackReminderGate />)
 
     await waitFor(() => {
       expect(
-        screen.getByTestId("temp-window-fallback-reminder"),
-      ).toHaveAttribute("data-open", "false")
+        screen.queryByTestId("temp-window-fallback-reminder"),
+      ).not.toBeInTheDocument()
     })
   })
 
@@ -261,7 +261,7 @@ describe("TempWindowFallbackReminderGate", () => {
     })
   })
 
-  it("keeps the dialog closed when the reminder is already dismissed and persists the never-remind action", async () => {
+  it("keeps the dialog unmounted when the reminder is already dismissed and still persists the never-remind action once re-enabled", async () => {
     accountDataState.displayData = [
       {
         id: "acc-2",
@@ -282,16 +282,16 @@ describe("TempWindowFallbackReminderGate", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByTestId("temp-window-fallback-reminder"),
-      ).toHaveAttribute("data-open", "false")
-      expect(
-        screen.getByTestId("temp-window-fallback-reminder"),
-      ).toHaveAttribute("data-settings-tab", "permissions")
+        screen.queryByTestId("temp-window-fallback-reminder"),
+      ).not.toBeInTheDocument()
     })
 
     reminderPreferenceState.dismissed = false
     rerender(<TempWindowFallbackReminderGate />)
 
+    expect(
+      await screen.findByTestId("temp-window-fallback-reminder"),
+    ).toHaveAttribute("data-settings-tab", "permissions")
     fireEvent.click(await screen.findByRole("button", { name: "never remind" }))
 
     await waitFor(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reminder dialog now fully unmounts when dismissed (no lingering hidden UI) for a cleaner experience.

* **Refactor**
  * Improved visibility logic so the reminder opens and closes consistently based on confirmation and dismissal state.

* **Tests**
  * Updated automated tests to validate dialog unmounting and reappearance after toggling dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->