### PR TITLE
feat(model-list): support multi-account filtering in all-accounts view

### DIFF
--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -87,7 +87,7 @@ export default function ModelList(props: {
     isFallbackCatalogActive,
 
     filteredModels,
-    baseFilteredModels,
+    accountSummaryBaseModels,
     allProvidersFilteredCount,
     availableGroups,
 
@@ -95,8 +95,8 @@ export default function ModelList(props: {
     loadPricingData,
     getProviderFilteredCount,
     accountQueryStates,
-    allAccountsFilterAccountId,
-    setAllAccountsFilterAccountId,
+    allAccountsFilterAccountIds,
+    setAllAccountsFilterAccountIds,
   } = useModelListData(routeParams)
 
   const providers = getAllProviders()
@@ -115,11 +115,11 @@ export default function ModelList(props: {
   }
 
   const handleAccountSummaryClick = (accountId: string) => {
-    if (allAccountsFilterAccountId === accountId) {
-      setAllAccountsFilterAccountId(null)
-    } else {
-      setAllAccountsFilterAccountId(accountId)
-    }
+    setAllAccountsFilterAccountIds((currentAccountIds) =>
+      currentAccountIds.includes(accountId)
+        ? currentAccountIds.filter((id) => id !== accountId)
+        : [...currentAccountIds, accountId],
+    )
   }
 
   const hasModelData =
@@ -133,7 +133,7 @@ export default function ModelList(props: {
   const accountSummaryItems = useMemo(() => {
     const countMap = new Map<string, number>()
 
-    baseFilteredModels.forEach((item: any) => {
+    accountSummaryBaseModels.forEach((item: any) => {
       if (item.source?.kind !== "account") return
       const account = item.source.account
       countMap.set(account.id, (countMap.get(account.id) ?? 0) + 1)
@@ -145,7 +145,7 @@ export default function ModelList(props: {
       count: countMap.get(state.account.id) ?? 0,
       errorType: state.errorType,
     }))
-  }, [baseFilteredModels, accountQueryStates])
+  }, [accountQueryStates, accountSummaryBaseModels])
 
   const modelVerificationTargets = useMemo(() => {
     return filteredModels.reduce<ApiVerificationHistoryTarget[]>(
@@ -397,7 +397,7 @@ export default function ModelList(props: {
             accountSummaryItems.length > 0 && (
               <AccountSummaryBar
                 items={accountSummaryItems}
-                activeAccountId={allAccountsFilterAccountId}
+                activeAccountIds={allAccountsFilterAccountIds}
                 onAccountClick={handleAccountSummaryClick}
               />
             )}

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -87,7 +87,7 @@ export default function ModelList(props: {
     isFallbackCatalogActive,
 
     filteredModels,
-    accountSummaryBaseModels,
+    accountSummaryCountsByAccountId,
     allProvidersFilteredCount,
     availableGroups,
 
@@ -131,21 +131,13 @@ export default function ModelList(props: {
     !shouldShowSourceSetupEmptyState && !selectedSource
 
   const accountSummaryItems = useMemo(() => {
-    const countMap = new Map<string, number>()
-
-    accountSummaryBaseModels.forEach((item: any) => {
-      if (item.source?.kind !== "account") return
-      const account = item.source.account
-      countMap.set(account.id, (countMap.get(account.id) ?? 0) + 1)
-    })
-
     return (accountQueryStates ?? []).map((state) => ({
       accountId: state.account.id,
       name: state.account.name,
-      count: countMap.get(state.account.id) ?? 0,
+      count: accountSummaryCountsByAccountId.get(state.account.id) ?? 0,
       errorType: state.errorType,
     }))
-  }, [accountQueryStates, accountSummaryBaseModels])
+  }, [accountQueryStates, accountSummaryCountsByAccountId])
 
   const modelVerificationTargets = useMemo(() => {
     return filteredModels.reduce<ApiVerificationHistoryTarget[]>(

--- a/src/features/ModelList/components/AccountSummaryBar.tsx
+++ b/src/features/ModelList/components/AccountSummaryBar.tsx
@@ -11,7 +11,7 @@ interface AccountSummaryItem {
 
 interface AccountSummaryBarProps {
   items: AccountSummaryItem[]
-  activeAccountId?: string | null
+  activeAccountIds?: string[]
   onAccountClick?: (accountId: string) => void
 }
 
@@ -19,16 +19,17 @@ interface AccountSummaryBarProps {
  * Shows clickable badges summarizing model counts per account.
  * @param props Component props.
  * @param props.items Accounts with model counts and error states.
- * @param props.activeAccountId Currently highlighted account id.
+ * @param props.activeAccountIds Currently highlighted account ids.
  * @param props.onAccountClick Callback when a badge is clicked.
  * @returns Card containing account summary badges or null when empty.
  */
 export function AccountSummaryBar({
   items,
-  activeAccountId,
+  activeAccountIds = [],
   onAccountClick,
 }: AccountSummaryBarProps) {
   const { t } = useTranslation("modelList")
+  const activeAccountIdSet = new Set(activeAccountIds)
 
   if (!items || items.length === 0) {
     return null
@@ -46,9 +47,7 @@ export function AccountSummaryBar({
               <Badge
                 key={item.accountId}
                 variant={
-                  activeAccountId && activeAccountId === item.accountId
-                    ? "info"
-                    : "secondary"
+                  activeAccountIdSet.has(item.accountId) ? "info" : "secondary"
                 }
                 size="default"
                 className="cursor-pointer"

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -473,7 +473,10 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
   ])
 
   const accountFilteredBaseRawModels = useMemo(() => {
-    if (accountFilterAccountIds.length === 0) {
+    if (
+      selectedSource?.kind !== "all-accounts" ||
+      accountFilterAccountIds.length === 0
+    ) {
       return baseFilteredRawModels
     }
 
@@ -484,24 +487,26 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
         item.source.kind !== "account" ||
         selectedAccountIds.has(item.source.account.id),
     )
-  }, [accountFilterAccountIds, baseFilteredRawModels])
+  }, [accountFilterAccountIds, baseFilteredRawModels, selectedSource?.kind])
 
-  const accountSummaryBaseModels = useMemo(
-    () =>
-      resolveCalculatedModels({
-        rawItems: baseFilteredRawModels,
-        groupCandidates: effectiveGroupCandidates,
-        supportsGroupFiltering:
-          selectedSource?.capabilities.supportsGroupFiltering ?? false,
-        showRealPrice,
-      }),
-    [
-      baseFilteredRawModels,
-      effectiveGroupCandidates,
-      selectedSource?.capabilities.supportsGroupFiltering,
-      showRealPrice,
-    ],
-  )
+  const accountSummaryCountsByAccountId = useMemo(() => {
+    if (selectedSource?.kind !== "all-accounts") {
+      return new Map<string, number>()
+    }
+
+    const countMap = new Map<string, number>()
+
+    baseFilteredRawModels.forEach((item) => {
+      if (item.source.kind !== "account") {
+        return
+      }
+
+      const accountId = item.source.account.id
+      countMap.set(accountId, (countMap.get(accountId) ?? 0) + 1)
+    })
+
+    return countMap
+  }, [baseFilteredRawModels, selectedSource?.kind])
 
   const baseFilteredModels = useMemo(
     () =>
@@ -686,7 +691,7 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
 
   return {
     filteredModels,
-    accountSummaryBaseModels,
+    accountSummaryCountsByAccountId,
     baseFilteredModels,
     allProvidersFilteredCount: baseFilteredModels.length,
     getProviderFilteredCount,

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -35,7 +35,7 @@ interface UseFilteredModelsProps {
   selectedProvider: ProviderType | "all"
   sortMode: ModelListSortMode
   showRealPrice: boolean
-  accountFilterAccountId?: string | null
+  accountFilterAccountIds?: string[]
 }
 
 type BillingMode = "token-based" | "per-call"
@@ -288,6 +288,28 @@ function resolveBestCalculatedItem(
   return bestResult
 }
 
+/** Maps raw priced rows into calculated display rows for the current filters. */
+function resolveCalculatedModels(params: {
+  rawItems: RawModelItem[]
+  groupCandidates: string[]
+  supportsGroupFiltering: boolean
+  showRealPrice: boolean
+}) {
+  const { rawItems, groupCandidates, supportsGroupFiltering, showRealPrice } =
+    params
+
+  return rawItems
+    .map((item) =>
+      resolveBestCalculatedItem(
+        item,
+        groupCandidates,
+        supportsGroupFiltering,
+        showRealPrice,
+      ),
+    )
+    .filter((item): item is CalculatedModelItem => item !== null)
+}
+
 /**
  * Derives filtered model list with pricing and helper metadata for UI controls.
  * Applies group, search, provider, and account filters on priced models.
@@ -299,7 +321,7 @@ function resolveBestCalculatedItem(
  * @param params.selectedGroups Candidate user groups used for filtering/comparison.
  * @param params.searchTerm Search keyword for model name/description.
  * @param params.selectedProvider Provider filter value or "all".
- * @param params.accountFilterAccountId Optional account id filter in all-accounts mode.
+ * @param params.accountFilterAccountIds Optional account id filters in all-accounts mode.
  * @returns Filtered models plus counts and available groups metadata.
  */
 export function useFilteredModels(params: UseFilteredModelsProps) {
@@ -313,7 +335,7 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     selectedProvider,
     sortMode,
     showRealPrice,
-    accountFilterAccountId,
+    accountFilterAccountIds = [],
   } = params
 
   const rawModelItems = useMemo<RawModelItem[]>(() => {
@@ -451,37 +473,52 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
   ])
 
   const accountFilteredBaseRawModels = useMemo(() => {
-    if (!accountFilterAccountId) {
+    if (accountFilterAccountIds.length === 0) {
       return baseFilteredRawModels
     }
+
+    const selectedAccountIds = new Set(accountFilterAccountIds)
 
     return baseFilteredRawModels.filter(
       (item) =>
         item.source.kind !== "account" ||
-        item.source.account.id === accountFilterAccountId,
+        selectedAccountIds.has(item.source.account.id),
     )
-  }, [accountFilterAccountId, baseFilteredRawModels])
+  }, [accountFilterAccountIds, baseFilteredRawModels])
 
-  const baseFilteredModels = useMemo(() => {
-    const supportsGroupFiltering =
-      selectedSource?.capabilities.supportsGroupFiltering ?? false
+  const accountSummaryBaseModels = useMemo(
+    () =>
+      resolveCalculatedModels({
+        rawItems: baseFilteredRawModels,
+        groupCandidates: effectiveGroupCandidates,
+        supportsGroupFiltering:
+          selectedSource?.capabilities.supportsGroupFiltering ?? false,
+        showRealPrice,
+      }),
+    [
+      baseFilteredRawModels,
+      effectiveGroupCandidates,
+      selectedSource?.capabilities.supportsGroupFiltering,
+      showRealPrice,
+    ],
+  )
 
-    return accountFilteredBaseRawModels
-      .map((item) =>
-        resolveBestCalculatedItem(
-          item,
-          effectiveGroupCandidates,
-          supportsGroupFiltering,
-          showRealPrice,
-        ),
-      )
-      .filter((item): item is CalculatedModelItem => item !== null)
-  }, [
-    accountFilteredBaseRawModels,
-    effectiveGroupCandidates,
-    selectedSource?.capabilities.supportsGroupFiltering,
-    showRealPrice,
-  ])
+  const baseFilteredModels = useMemo(
+    () =>
+      resolveCalculatedModels({
+        rawItems: accountFilteredBaseRawModels,
+        groupCandidates: effectiveGroupCandidates,
+        supportsGroupFiltering:
+          selectedSource?.capabilities.supportsGroupFiltering ?? false,
+        showRealPrice,
+      }),
+    [
+      accountFilteredBaseRawModels,
+      effectiveGroupCandidates,
+      selectedSource?.capabilities.supportsGroupFiltering,
+      showRealPrice,
+    ],
+  )
 
   const filteredModels = useMemo(() => {
     const providerFilteredModels =
@@ -649,6 +686,7 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
 
   return {
     filteredModels,
+    accountSummaryBaseModels,
     baseFilteredModels,
     allProvidersFilteredCount: baseFilteredModels.length,
     getProviderFilteredCount,

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -494,13 +494,14 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
       return new Map<string, number>()
     }
 
+    // In all-accounts mode rawModelItems are built only from pricingContexts,
+    // so the filtered summary rows are account-backed by construction.
+    const accountSummaryItems = baseFilteredRawModels as Array<
+      RawModelItem & { source: ReturnType<typeof createAccountSource> }
+    >
     const countMap = new Map<string, number>()
 
-    baseFilteredRawModels.forEach((item) => {
-      if (item.source.kind !== "account") {
-        return
-      }
-
+    accountSummaryItems.forEach((item) => {
       const accountId = item.source.account.id
       countMap.set(accountId, (countMap.get(accountId) ?? 0) + 1)
     })

--- a/src/features/ModelList/hooks/useModelListData.ts
+++ b/src/features/ModelList/hooks/useModelListData.ts
@@ -43,8 +43,8 @@ export function useModelListData(routeParams?: Record<string, string>) {
     sortMode,
     setSortMode,
     showRealPrice,
-    allAccountsFilterAccountId,
-    setAllAccountsFilterAccountId,
+    allAccountsFilterAccountIds,
+    setAllAccountsFilterAccountIds,
   } = state
 
   const routeSelectedSourceValue = useMemo(() => {
@@ -125,12 +125,12 @@ export function useModelListData(routeParams?: Record<string, string>) {
 
   useEffect(() => {
     if (selectedSource?.kind === "all-accounts") return
-    if (allAccountsFilterAccountId === null) return
-    setAllAccountsFilterAccountId(null)
+    if (allAccountsFilterAccountIds.length === 0) return
+    setAllAccountsFilterAccountIds([])
   }, [
-    allAccountsFilterAccountId,
+    allAccountsFilterAccountIds,
     selectedSource?.kind,
-    setAllAccountsFilterAccountId,
+    setAllAccountsFilterAccountIds,
   ])
 
   const currentAccount = useMemo(
@@ -194,7 +194,7 @@ export function useModelListData(routeParams?: Record<string, string>) {
     selectedProvider,
     sortMode,
     showRealPrice,
-    accountFilterAccountId: allAccountsFilterAccountId,
+    accountFilterAccountIds: allAccountsFilterAccountIds,
   })
 
   return {

--- a/src/features/ModelList/hooks/useModelListState.ts
+++ b/src/features/ModelList/hooks/useModelListState.ts
@@ -29,9 +29,8 @@ export function useModelListState() {
   const [selectedBillingMode, setSelectedBillingMode] =
     useState<ModelListBillingMode>(MODEL_LIST_BILLING_MODES.ALL)
   const [selectedGroups, setSelectedGroups] = useState<string[]>([]) // 当前选中的候选分组；空数组表示所有分组
-  const [allAccountsFilterAccountId, setAllAccountsFilterAccountId] = useState<
-    string | null
-  >(null) // 在"所有账号"模式下用于临时筛选特定账号
+  const [allAccountsFilterAccountIds, setAllAccountsFilterAccountIds] =
+    useState<string[]>([]) // 在"所有账号"模式下用于临时筛选一个或多个账号
 
   // 显示选项
   const [showRealPrice, setShowRealPrice] = useState(false) // 是否显示真实价格
@@ -51,8 +50,8 @@ export function useModelListState() {
     setSelectedBillingMode,
     selectedGroups,
     setSelectedGroups,
-    allAccountsFilterAccountId,
-    setAllAccountsFilterAccountId,
+    allAccountsFilterAccountIds,
+    setAllAccountsFilterAccountIds,
     showRealPrice,
     setShowRealPrice,
     showRatioColumn,

--- a/tests/entrypoints/options/pages/ModelList/ModelList.emptyStateActions.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelList.emptyStateActions.test.tsx
@@ -140,7 +140,7 @@ function buildState(overrides: Record<string, unknown> = {}) {
     accountFallback: null,
     isFallbackCatalogActive: false,
     filteredModels: [],
-    accountSummaryBaseModels: [],
+    accountSummaryCountsByAccountId: new Map(),
     baseFilteredModels: [],
     availableGroups: [],
     loadPricingData: vi.fn(),

--- a/tests/entrypoints/options/pages/ModelList/ModelList.emptyStateActions.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelList.emptyStateActions.test.tsx
@@ -140,13 +140,14 @@ function buildState(overrides: Record<string, unknown> = {}) {
     accountFallback: null,
     isFallbackCatalogActive: false,
     filteredModels: [],
+    accountSummaryBaseModels: [],
     baseFilteredModels: [],
     availableGroups: [],
     loadPricingData: vi.fn(),
     getProviderFilteredCount: vi.fn(() => 0),
     accountQueryStates: [],
-    allAccountsFilterAccountId: null,
-    setAllAccountsFilterAccountId: vi.fn(),
+    allAccountsFilterAccountIds: [],
+    setAllAccountsFilterAccountIds: vi.fn(),
     ...overrides,
   }
 }

--- a/tests/entrypoints/options/pages/ModelList/ModelListModelKeyFlow.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListModelKeyFlow.test.tsx
@@ -119,7 +119,7 @@ vi.mock("~/features/ModelList/hooks/useModelListData", () => ({
     loadErrorMessage: null,
 
     filteredModels: [],
-    accountSummaryBaseModels: [],
+    accountSummaryCountsByAccountId: new Map(),
     baseFilteredModels: [],
     availableGroups: [],
 

--- a/tests/entrypoints/options/pages/ModelList/ModelListModelKeyFlow.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListModelKeyFlow.test.tsx
@@ -119,14 +119,15 @@ vi.mock("~/features/ModelList/hooks/useModelListData", () => ({
     loadErrorMessage: null,
 
     filteredModels: [],
+    accountSummaryBaseModels: [],
     baseFilteredModels: [],
     availableGroups: [],
 
     loadPricingData: vi.fn(),
     getProviderFilteredCount: vi.fn(() => 0),
     accountQueryStates: [],
-    allAccountsFilterAccountId: null,
-    setAllAccountsFilterAccountId: vi.fn(),
+    allAccountsFilterAccountIds: [],
+    setAllAccountsFilterAccountIds: vi.fn(),
   })),
 }))
 

--- a/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
@@ -283,12 +283,7 @@ function buildState(overrides: Record<string, any> = {}) {
         source: ACCOUNT_SOURCE,
       },
     ],
-    accountSummaryBaseModels: [
-      {
-        model: { model_name: "gpt-4" },
-        source: ACCOUNT_SOURCE,
-      },
-    ],
+    accountSummaryCountsByAccountId: new Map([[ACCOUNT.id, 1]]),
     baseFilteredModels: [
       {
         model: { model_name: "gpt-4" },
@@ -349,20 +344,10 @@ describe("ModelList page flows", () => {
         pricingData: null,
         pricingContexts: [{ accountId: ACCOUNT.id }],
         isFallbackCatalogActive: true,
-        accountSummaryBaseModels: [
-          {
-            model: { model_name: "gpt-4" },
-            source: createAccountSource(ACCOUNT),
-          },
-          {
-            model: { model_name: "claude-3-5-sonnet" },
-            source: createAccountSource(ACCOUNT),
-          },
-          {
-            model: { model_name: "gpt-4o-mini" },
-            source: createAccountSource(SECOND_ACCOUNT),
-          },
-        ],
+        accountSummaryCountsByAccountId: new Map([
+          [ACCOUNT.id, 2],
+          [SECOND_ACCOUNT.id, 1],
+        ]),
         baseFilteredModels: [
           {
             model: { model_name: "gpt-4" },
@@ -415,20 +400,10 @@ describe("ModelList page flows", () => {
         pricingData: null,
         pricingContexts: [{ accountId: ACCOUNT.id }],
         isFallbackCatalogActive: true,
-        accountSummaryBaseModels: [
-          {
-            model: { model_name: "gpt-4" },
-            source: createAccountSource(ACCOUNT),
-          },
-          {
-            model: { model_name: "claude-3-5-sonnet" },
-            source: createAccountSource(ACCOUNT),
-          },
-          {
-            model: { model_name: "gpt-4o-mini" },
-            source: createAccountSource(SECOND_ACCOUNT),
-          },
-        ],
+        accountSummaryCountsByAccountId: new Map([
+          [ACCOUNT.id, 2],
+          [SECOND_ACCOUNT.id, 1],
+        ]),
         baseFilteredModels: [
           {
             model: { model_name: "gpt-4" },
@@ -465,20 +440,10 @@ describe("ModelList page flows", () => {
         pricingData: null,
         pricingContexts: [{ accountId: ACCOUNT.id }],
         allAccountsFilterAccountIds: ["acc-1"],
-        accountSummaryBaseModels: [
-          {
-            model: { model_name: "gpt-4" },
-            source: createAccountSource(ACCOUNT),
-          },
-          {
-            model: { model_name: "claude-3-5-sonnet" },
-            source: createAccountSource(ACCOUNT),
-          },
-          {
-            model: { model_name: "gpt-4o-mini" },
-            source: createAccountSource(SECOND_ACCOUNT),
-          },
-        ],
+        accountSummaryCountsByAccountId: new Map([
+          [ACCOUNT.id, 2],
+          [SECOND_ACCOUNT.id, 1],
+        ]),
         baseFilteredModels: [
           {
             model: { model_name: "gpt-4" },

--- a/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
@@ -15,7 +15,7 @@ import { AuthTypeEnum } from "~/types"
 import { render, screen } from "~~/tests/test-utils/render"
 
 const mockUseModelListData = vi.fn()
-const mockSetAllAccountsFilterAccountId = vi.fn()
+const mockSetAllAccountsFilterAccountIds = vi.fn()
 
 vi.mock("~/features/ModelList/hooks/useModelListData", () => ({
   useModelListData: (...args: any[]) => mockUseModelListData(...args),
@@ -91,9 +91,12 @@ vi.mock("~/features/ModelList/components/StatusIndicator", () => ({
 }))
 
 vi.mock("~/features/ModelList/components/AccountSummaryBar", () => ({
-  AccountSummaryBar: ({ items, activeAccountId, onAccountClick }: any) => (
+  AccountSummaryBar: ({ items, activeAccountIds, onAccountClick }: any) => (
     <div>
-      <div>Account Summary Bar active:{activeAccountId ?? "none"}</div>
+      <div>
+        Account Summary Bar active:
+        {activeAccountIds?.length ? activeAccountIds.join(",") : "none"}
+      </div>
       {items.map((item: any) => (
         <button
           key={item.accountId}
@@ -280,6 +283,12 @@ function buildState(overrides: Record<string, any> = {}) {
         source: ACCOUNT_SOURCE,
       },
     ],
+    accountSummaryBaseModels: [
+      {
+        model: { model_name: "gpt-4" },
+        source: ACCOUNT_SOURCE,
+      },
+    ],
     baseFilteredModels: [
       {
         model: { model_name: "gpt-4" },
@@ -291,15 +300,15 @@ function buildState(overrides: Record<string, any> = {}) {
     loadPricingData: vi.fn(),
     getProviderFilteredCount: vi.fn(() => 0),
     accountQueryStates: [],
-    allAccountsFilterAccountId: null,
-    setAllAccountsFilterAccountId: mockSetAllAccountsFilterAccountId,
+    allAccountsFilterAccountIds: [],
+    setAllAccountsFilterAccountIds: mockSetAllAccountsFilterAccountIds,
     ...overrides,
   }
 }
 
 describe("ModelList page flows", () => {
   beforeEach(() => {
-    mockSetAllAccountsFilterAccountId.mockReset()
+    mockSetAllAccountsFilterAccountIds.mockReset()
     mockUseModelListData.mockReset()
   })
 
@@ -340,6 +349,20 @@ describe("ModelList page flows", () => {
         pricingData: null,
         pricingContexts: [{ accountId: ACCOUNT.id }],
         isFallbackCatalogActive: true,
+        accountSummaryBaseModels: [
+          {
+            model: { model_name: "gpt-4" },
+            source: createAccountSource(ACCOUNT),
+          },
+          {
+            model: { model_name: "claude-3-5-sonnet" },
+            source: createAccountSource(ACCOUNT),
+          },
+          {
+            model: { model_name: "gpt-4o-mini" },
+            source: createAccountSource(SECOND_ACCOUNT),
+          },
+        ],
         baseFilteredModels: [
           {
             model: { model_name: "gpt-4" },
@@ -376,7 +399,12 @@ describe("ModelList page flows", () => {
     await user.click(
       screen.getByRole("button", { name: "Summary Primary Account:2" }),
     )
-    expect(mockSetAllAccountsFilterAccountId).toHaveBeenCalledWith("acc-1")
+    expect(mockSetAllAccountsFilterAccountIds).toHaveBeenCalledWith(
+      expect.any(Function),
+    )
+    expect(
+      mockSetAllAccountsFilterAccountIds.mock.calls.at(-1)?.[0]([]),
+    ).toEqual(["acc-1"])
 
     mockUseModelListData.mockReturnValue(
       buildState({
@@ -387,6 +415,20 @@ describe("ModelList page flows", () => {
         pricingData: null,
         pricingContexts: [{ accountId: ACCOUNT.id }],
         isFallbackCatalogActive: true,
+        accountSummaryBaseModels: [
+          {
+            model: { model_name: "gpt-4" },
+            source: createAccountSource(ACCOUNT),
+          },
+          {
+            model: { model_name: "claude-3-5-sonnet" },
+            source: createAccountSource(ACCOUNT),
+          },
+          {
+            model: { model_name: "gpt-4o-mini" },
+            source: createAccountSource(SECOND_ACCOUNT),
+          },
+        ],
         baseFilteredModels: [
           {
             model: { model_name: "gpt-4" },
@@ -394,7 +436,7 @@ describe("ModelList page flows", () => {
           },
         ],
         accountQueryStates: [{ account: ACCOUNT, errorType: null }],
-        allAccountsFilterAccountId: "acc-1",
+        allAccountsFilterAccountIds: ["acc-1"],
       }),
     )
 
@@ -405,9 +447,62 @@ describe("ModelList page flows", () => {
     ).toBeInTheDocument()
 
     await user.click(
-      screen.getByRole("button", { name: "Summary Primary Account:1" }),
+      screen.getByRole("button", { name: "Summary Primary Account:2" }),
     )
-    expect(mockSetAllAccountsFilterAccountId).toHaveBeenCalledWith(null)
+    expect(mockSetAllAccountsFilterAccountIds).toHaveBeenCalledTimes(2)
+    expect(
+      mockSetAllAccountsFilterAccountIds.mock.calls.at(-1)?.[0](["acc-1"]),
+    ).toEqual([])
+  })
+
+  it("keeps summary counts sourced from the pre-account-filter model set", async () => {
+    mockUseModelListData.mockReturnValue(
+      buildState({
+        selectedSource: ALL_ACCOUNTS_SOURCE,
+        selectedSourceValue: ALL_ACCOUNTS_SOURCE.value,
+        currentAccount: null,
+        sourceCapabilities: ALL_ACCOUNTS_SOURCE.capabilities,
+        pricingData: null,
+        pricingContexts: [{ accountId: ACCOUNT.id }],
+        allAccountsFilterAccountIds: ["acc-1"],
+        accountSummaryBaseModels: [
+          {
+            model: { model_name: "gpt-4" },
+            source: createAccountSource(ACCOUNT),
+          },
+          {
+            model: { model_name: "claude-3-5-sonnet" },
+            source: createAccountSource(ACCOUNT),
+          },
+          {
+            model: { model_name: "gpt-4o-mini" },
+            source: createAccountSource(SECOND_ACCOUNT),
+          },
+        ],
+        baseFilteredModels: [
+          {
+            model: { model_name: "gpt-4" },
+            source: createAccountSource(ACCOUNT),
+          },
+        ],
+        accountQueryStates: [
+          { account: ACCOUNT, errorType: null },
+          { account: SECOND_ACCOUNT, errorType: null },
+        ],
+      }),
+    )
+
+    render(<ModelList />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    expect(
+      await screen.findByRole("button", { name: "Summary Primary Account:2" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Summary Backup Account:1" }),
+    ).toBeInTheDocument()
   })
 
   it("aggregates total model count from all account pricing contexts", async () => {
@@ -545,7 +640,12 @@ describe("ModelList page flows", () => {
       await screen.findByRole("button", { name: "Filter account" }),
     )
 
-    expect(mockSetAllAccountsFilterAccountId).toHaveBeenCalledWith(ACCOUNT.id)
+    expect(mockSetAllAccountsFilterAccountIds).toHaveBeenCalledWith(
+      expect.any(Function),
+    )
+    expect(
+      mockSetAllAccountsFilterAccountIds.mock.calls.at(-1)?.[0]([]),
+    ).toEqual([ACCOUNT.id])
   })
 
   it("does not expose row account filtering outside the all-accounts view", () => {

--- a/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
@@ -111,6 +111,28 @@ describe("useFilteredModels", () => {
     expect(result.current.filteredModels[0]?.source.kind).toBe("profile")
   })
 
+  it("ignores stale account filters outside the all-accounts source", async () => {
+    const account = createDisplayAccount({
+      id: "account-single",
+      name: "Single Account",
+      baseUrl: "https://single.example.com",
+      userId: 1,
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingData: createPricingResponse(["gpt-4o-mini", "claude-3-5-sonnet"]),
+      selectedSource: createAccountSource(account),
+      accountFilterAccountIds: ["different-account"],
+    })
+
+    await waitFor(() => expect(result.current.filteredModels).toHaveLength(2))
+
+    expect(
+      result.current.filteredModels.map((item) => item.model.model_name),
+    ).toEqual(["gpt-4o-mini", "claude-3-5-sonnet"])
+    expect(result.current.accountSummaryCountsByAccountId.size).toBe(0)
+  })
+
   it("computes provider counts from the account-filtered model set", async () => {
     const accountA = createDisplayAccount({
       id: "account-a",
@@ -196,10 +218,12 @@ describe("useFilteredModels", () => {
       ),
     ).toEqual(["account-a", "account-c"])
     expect(
-      result.current.accountSummaryBaseModels.map((item) =>
-        item.source.kind === "account" ? item.source.account.id : "profile",
-      ),
-    ).toEqual(["account-a", "account-b", "account-c"])
+      Array.from(result.current.accountSummaryCountsByAccountId.entries()),
+    ).toEqual([
+      ["account-a", 1],
+      ["account-b", 1],
+      ["account-c", 1],
+    ])
   })
 
   it("applies single-account group pricing and exposes available account groups", async () => {

--- a/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
@@ -102,7 +102,7 @@ describe("useFilteredModels", () => {
     const { result } = renderUseFilteredModels({
       pricingData: createPricingResponse(["gpt-4o-mini"]),
       selectedSource: profileSource,
-      accountFilterAccountId: "account-1",
+      accountFilterAccountIds: ["account-1"],
     })
 
     await waitFor(() => expect(result.current).not.toBeNull())
@@ -137,7 +137,7 @@ describe("useFilteredModels", () => {
         },
       ],
       selectedSource: createAllAccountsSource(),
-      accountFilterAccountId: "account-a",
+      accountFilterAccountIds: ["account-a"],
     })
 
     await waitFor(() => expect(result.current).not.toBeNull())
@@ -147,6 +147,59 @@ describe("useFilteredModels", () => {
     expect(result.current.getProviderFilteredCount("OpenAI")).toBe(1)
     expect(result.current.getProviderFilteredCount("Claude")).toBe(1)
     expect(result.current.getProviderFilteredCount("Gemini")).toBe(0)
+  })
+
+  it("keeps rows from every selected account when multiple account filters are active", async () => {
+    const accountA = createDisplayAccount({
+      id: "account-a",
+      name: "Account A",
+      baseUrl: "https://a.example.com",
+      userId: 1,
+    })
+    const accountB = createDisplayAccount({
+      id: "account-b",
+      name: "Account B",
+      baseUrl: "https://b.example.com",
+      userId: 2,
+    })
+    const accountC = createDisplayAccount({
+      id: "account-c",
+      name: "Account C",
+      baseUrl: "https://c.example.com",
+      userId: 3,
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingContexts: [
+        {
+          account: accountA,
+          pricing: createPricingResponse(["gpt-4o-mini"]),
+        },
+        {
+          account: accountB,
+          pricing: createPricingResponse(["claude-3-5-sonnet"]),
+        },
+        {
+          account: accountC,
+          pricing: createPricingResponse(["gemini-1.5-pro"]),
+        },
+      ],
+      selectedSource: createAllAccountsSource(),
+      accountFilterAccountIds: ["account-a", "account-c"],
+    })
+
+    await waitFor(() => expect(result.current.filteredModels).toHaveLength(2))
+
+    expect(
+      result.current.filteredModels.map((item) =>
+        item.source.kind === "account" ? item.source.account.id : "profile",
+      ),
+    ).toEqual(["account-a", "account-c"])
+    expect(
+      result.current.accountSummaryBaseModels.map((item) =>
+        item.source.kind === "account" ? item.source.account.id : "profile",
+      ),
+    ).toEqual(["account-a", "account-b", "account-c"])
   })
 
   it("applies single-account group pricing and exposes available account groups", async () => {

--- a/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
@@ -322,6 +322,36 @@ describe("useModelListData", () => {
     })
   })
 
+  it("clears the all-accounts account filter when leaving the all-accounts view", async () => {
+    const { result } = renderHook(() => useModelListData())
+
+    act(() => {
+      result.current.setSelectedSourceValue("all")
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedSource?.kind).toBe("all-accounts")
+    })
+
+    act(() => {
+      result.current.setAllAccountsFilterAccountIds(["acc-1"])
+    })
+
+    expect(result.current.allAccountsFilterAccountIds).toEqual(["acc-1"])
+
+    act(() => {
+      result.current.setSelectedSourceValue("account:acc-1")
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedSource?.kind).toBe("account")
+    })
+
+    await waitFor(() => {
+      expect(result.current.allAccountsFilterAccountIds).toEqual([])
+    })
+  })
+
   it("resets price sorting when the selected source cannot provide pricing", async () => {
     mockUseModelData.mockReturnValue({
       pricingData: {

--- a/tests/features/ModelList/components/AccountSummaryBar.test.tsx
+++ b/tests/features/ModelList/components/AccountSummaryBar.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { AccountSummaryBar } from "~/features/ModelList/components/AccountSummaryBar"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+describe("AccountSummaryBar", () => {
+  it("renders multiple active account badges and forwards click ids", async () => {
+    const user = userEvent.setup()
+    const onAccountClick = vi.fn()
+
+    render(
+      <AccountSummaryBar
+        items={[
+          {
+            accountId: "account-1",
+            name: "Primary Account",
+            count: 2,
+          },
+          {
+            accountId: "account-2",
+            name: "Backup Account",
+            count: 1,
+          },
+          {
+            accountId: "account-3",
+            name: "Dormant Account",
+            count: 5,
+          },
+        ]}
+        activeAccountIds={["account-1", "account-2"]}
+        onAccountClick={onAccountClick}
+      />,
+    )
+
+    const primaryBadge = screen
+      .getByText("Primary Account")
+      .closest("[data-slot='badge']")
+    const backupBadge = screen
+      .getByText("Backup Account")
+      .closest("[data-slot='badge']")
+    const dormantBadge = screen
+      .getByText("Dormant Account")
+      .closest("[data-slot='badge']")
+
+    expect(primaryBadge).toHaveClass("bg-blue-100", "text-blue-700")
+    expect(backupBadge).toHaveClass("bg-blue-100", "text-blue-700")
+    expect(dormantBadge).toHaveClass("bg-secondary")
+
+    await user.click(primaryBadge!)
+
+    expect(onAccountClick).toHaveBeenCalledWith("account-1")
+    expect(onAccountClick).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-account filtering: select multiple accounts to view models simultaneously; account summary bar now accepts and highlights multiple active accounts and shows per-account counts.

* **Tests**
  * Expanded test coverage for multi-account filtering, summary-count behavior, state-reset when switching sources, and visual/interaction tests for the account summary bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->