### PR TITLE
fix(model-list): replace zero-count fallback with loading/error states

### DIFF
--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -135,6 +135,7 @@ export default function ModelList(props: {
       accountId: state.account.id,
       name: state.account.name,
       count: accountSummaryCountsByAccountId.get(state.account.id) ?? 0,
+      isLoading: state.isLoading,
       errorType: state.errorType,
     }))
   }, [accountQueryStates, accountSummaryCountsByAccountId])

--- a/src/features/ModelList/components/AccountSummaryBar.tsx
+++ b/src/features/ModelList/components/AccountSummaryBar.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from "react-i18next"
 
 import { Badge, Card, CardContent } from "~/components/ui"
+import { cn } from "~/lib/utils"
 
 interface AccountSummaryItem {
   accountId: string
   name: string
   count: number
+  isLoading?: boolean
   errorType?: "invalid-format" | "load-failed"
 }
 
@@ -35,6 +37,34 @@ export function AccountSummaryBar({
     return null
   }
 
+  const renderStatus = (item: AccountSummaryItem) => {
+    if (item.isLoading) {
+      return t("accountSummary.loading")
+    }
+
+    if (item.errorType === "load-failed") {
+      return t("accountSummary.loadFailed")
+    }
+
+    if (item.errorType === "invalid-format") {
+      return t("accountSummary.incompatible")
+    }
+
+    return t("accountSummary.models", { count: item.count })
+  }
+
+  const getStatusClassName = (item: AccountSummaryItem) => {
+    if (item.isLoading) {
+      return "text-amber-600 dark:text-amber-300"
+    }
+
+    if (item.errorType) {
+      return "text-red-500 dark:text-red-400"
+    }
+
+    return "text-emerald-600 dark:text-emerald-400"
+  }
+
   return (
     <Card className="mb-4">
       <CardContent className="py-3">
@@ -54,16 +84,9 @@ export function AccountSummaryBar({
                 onClick={() => onAccountClick?.(item.accountId)}
               >
                 <span className="truncate font-medium">{item.name}</span>
-                <span className="dark:text-dark-text-tertiary ml-2 text-gray-500">
-                  {t("accountSummary.models", { count: item.count })}
+                <span className={cn("ml-2", getStatusClassName(item))}>
+                  {renderStatus(item)}
                 </span>
-                {item.errorType && (
-                  <span className="ml-2 text-xs text-red-500 dark:text-red-400">
-                    {item.errorType === "load-failed"
-                      ? t("accountSummary.loadFailed")
-                      : t("accountSummary.incompatible")}
-                  </span>
-                )}
               </Badge>
             ))}
           </div>

--- a/src/features/ModelList/components/AccountSummaryBar.tsx
+++ b/src/features/ModelList/components/AccountSummaryBar.tsx
@@ -17,6 +17,11 @@ interface AccountSummaryBarProps {
   onAccountClick?: (accountId: string) => void
 }
 
+interface StatusPresentation {
+  label: string
+  className: string
+}
+
 /**
  * Shows clickable badges summarizing model counts per account.
  * @param props Component props.
@@ -37,32 +42,34 @@ export function AccountSummaryBar({
     return null
   }
 
-  const renderStatus = (item: AccountSummaryItem) => {
+  const getStatusPresentation = (
+    item: AccountSummaryItem,
+  ): StatusPresentation => {
     if (item.isLoading) {
-      return t("accountSummary.loading")
+      return {
+        label: t("accountSummary.loading"),
+        className: "text-amber-600 dark:text-amber-300",
+      }
     }
 
     if (item.errorType === "load-failed") {
-      return t("accountSummary.loadFailed")
+      return {
+        label: t("accountSummary.loadFailed"),
+        className: "text-red-500 dark:text-red-400",
+      }
     }
 
     if (item.errorType === "invalid-format") {
-      return t("accountSummary.incompatible")
+      return {
+        label: t("accountSummary.incompatible"),
+        className: "text-red-500 dark:text-red-400",
+      }
     }
 
-    return t("accountSummary.models", { count: item.count })
-  }
-
-  const getStatusClassName = (item: AccountSummaryItem) => {
-    if (item.isLoading) {
-      return "text-amber-600 dark:text-amber-300"
+    return {
+      label: t("accountSummary.models", { count: item.count }),
+      className: "text-emerald-600 dark:text-emerald-400",
     }
-
-    if (item.errorType) {
-      return "text-red-500 dark:text-red-400"
-    }
-
-    return "text-emerald-600 dark:text-emerald-400"
   }
 
   return (
@@ -73,22 +80,28 @@ export function AccountSummaryBar({
             {t("accountSummary.title")}
           </div>
           <div className="flex flex-wrap gap-2">
-            {items.map((item) => (
-              <Badge
-                key={item.accountId}
-                variant={
-                  activeAccountIdSet.has(item.accountId) ? "info" : "secondary"
-                }
-                size="default"
-                className="cursor-pointer"
-                onClick={() => onAccountClick?.(item.accountId)}
-              >
-                <span className="truncate font-medium">{item.name}</span>
-                <span className={cn("ml-2", getStatusClassName(item))}>
-                  {renderStatus(item)}
-                </span>
-              </Badge>
-            ))}
+            {items.map((item) => {
+              const statusPresentation = getStatusPresentation(item)
+
+              return (
+                <Badge
+                  key={item.accountId}
+                  variant={
+                    activeAccountIdSet.has(item.accountId)
+                      ? "info"
+                      : "secondary"
+                  }
+                  size="default"
+                  className="cursor-pointer"
+                  onClick={() => onAccountClick?.(item.accountId)}
+                >
+                  <span className="truncate font-medium">{item.name}</span>
+                  <span className={cn("ml-2", statusPresentation.className)}>
+                    {statusPresentation.label}
+                  </span>
+                </Badge>
+              )
+            })}
           </div>
         </div>
       </CardContent>

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -39,6 +39,7 @@ type AccountErrorType = "invalid-format" | "load-failed"
 
 interface AccountQueryState {
   account: DisplaySiteData
+  isLoading: boolean
   hasData: boolean
   hasError: boolean
   errorType?: AccountErrorType
@@ -653,6 +654,8 @@ function useAllAccountsModelData(
         const error = query?.error as { code?: string } | null | undefined
         const hasData = !!query?.data
         const hasError = !!query?.error
+        const isLoading =
+          !hasData && Boolean(query?.isPending || query?.isFetching)
 
         let errorType: AccountErrorType | undefined
         if (error?.code === "INVALID_FORMAT") {
@@ -663,6 +666,7 @@ function useAllAccountsModelData(
 
         return {
           account,
+          isLoading,
           hasData,
           hasError,
           errorType,

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -2,6 +2,7 @@
   "accountSummary": {
     "incompatible": "format incompatible",
     "loadFailed": "load failed",
+    "loading": "loading",
     "models_one": "{{count}} model",
     "models_other": "{{count}} models",
     "title": "Accounts overview"

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -2,6 +2,7 @@
   "accountSummary": {
     "incompatible": "形式非互換",
     "loadFailed": "読み込み失敗",
+    "loading": "読み込み中",
     "models_other": "{{count}} モデル",
     "title": "アカウント概要"
   },

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -2,6 +2,7 @@
   "accountSummary": {
     "incompatible": "格式不兼容",
     "loadFailed": "加载失败",
+    "loading": "加载中",
     "models": "{{count}} 个模型",
     "title": "账号概览"
   },

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -2,6 +2,7 @@
   "accountSummary": {
     "incompatible": "格式不相容",
     "loadFailed": "載入失敗",
+    "loading": "載入中",
     "models_other": "{{count}} 個模型",
     "title": "帳號概覽"
   },

--- a/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
@@ -98,6 +98,12 @@ vi.mock("~/features/ModelList/components/AccountSummaryBar", () => ({
         {activeAccountIds?.length ? activeAccountIds.join(",") : "none"}
       </div>
       {items.map((item: any) => (
+        <div key={`status-${item.accountId}`}>
+          Summary Status {item.name}:
+          {item.isLoading ? "loading" : item.errorType ?? item.count}
+        </div>
+      ))}
+      {items.map((item: any) => (
         <button
           key={item.accountId}
           type="button"
@@ -468,6 +474,45 @@ describe("ModelList page flows", () => {
     expect(
       screen.getByRole("button", { name: "Summary Backup Account:1" }),
     ).toBeInTheDocument()
+  })
+
+  it("forwards loading and error states to the account summary bar instead of falling back to counts", async () => {
+    mockUseModelListData.mockReturnValue(
+      buildState({
+        selectedSource: ALL_ACCOUNTS_SOURCE,
+        selectedSourceValue: ALL_ACCOUNTS_SOURCE.value,
+        currentAccount: null,
+        sourceCapabilities: ALL_ACCOUNTS_SOURCE.capabilities,
+        pricingData: null,
+        pricingContexts: [{ accountId: ACCOUNT.id }],
+        accountSummaryCountsByAccountId: new Map([
+          [ACCOUNT.id, 0],
+          [SECOND_ACCOUNT.id, 0],
+        ]),
+        accountQueryStates: [
+          { account: ACCOUNT, isLoading: true, errorType: null },
+          {
+            account: SECOND_ACCOUNT,
+            isLoading: false,
+            errorType: "load-failed",
+          },
+        ],
+      }),
+    )
+
+    render(<ModelList />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    expect(
+      await screen.findByText("Summary Status Primary Account:loading"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Summary Status Backup Account:load-failed"),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Summary Status Primary Account:0")).toBeNull()
+    expect(screen.queryByText("Summary Status Backup Account:0")).toBeNull()
   })
 
   it("aggregates total model count from all account pricing contexts", async () => {

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -211,6 +211,104 @@ describe("useModelData all-accounts loading", () => {
     expect(calledAccountIds).toEqual(expect.arrayContaining(["a", "b"]))
   })
 
+  it("marks all-account queries as loading before each account returns data", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    const firstDeferred = createDeferred<{
+      data: never[]
+      group_ratio: Record<string, never>
+      success: true
+      usable_group: Record<string, never>
+    }>()
+    const secondDeferred = createDeferred<{
+      data: never[]
+      group_ratio: Record<string, never>
+      success: true
+      usable_group: Record<string, never>
+    }>()
+    const fetchModelPricing = vi.fn().mockImplementation(({ accountId }) => {
+      return accountId === "a" ? firstDeferred.promise : secondDeferred.promise
+    })
+    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+
+    const accounts = [
+      createDisplayAccount({
+        id: "a",
+        baseUrl: "https://a.example.com",
+        userId: 1,
+      }),
+      createDisplayAccount({
+        id: "b",
+        baseUrl: "https://b.example.com",
+        userId: 2,
+      }),
+    ]
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.current.accountQueryStates).toEqual([
+        expect.objectContaining({
+          account: expect.objectContaining({ id: "a" }),
+          isLoading: true,
+          hasData: false,
+          hasError: false,
+          errorType: undefined,
+        }),
+        expect.objectContaining({
+          account: expect.objectContaining({ id: "b" }),
+          isLoading: true,
+          hasData: false,
+          hasError: false,
+          errorType: undefined,
+        }),
+      ])
+    })
+
+    await act(async () => {
+      firstDeferred.resolve({
+        data: [],
+        group_ratio: {},
+        success: true,
+        usable_group: {},
+      })
+      secondDeferred.resolve({
+        data: [],
+        group_ratio: {},
+        success: true,
+        usable_group: {},
+      })
+      await Promise.all([firstDeferred.promise, secondDeferred.promise])
+    })
+
+    await waitFor(() => {
+      expect(result.current.accountQueryStates).toEqual([
+        expect.objectContaining({
+          account: expect.objectContaining({ id: "a" }),
+          isLoading: false,
+          hasData: true,
+          hasError: false,
+          errorType: undefined,
+        }),
+        expect.objectContaining({
+          account: expect.objectContaining({ id: "b" }),
+          isLoading: false,
+          hasData: true,
+          hasError: false,
+          errorType: undefined,
+        }),
+      ])
+    })
+  })
+
   it("loads a profile-backed model catalog without a SiteAccount", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
@@ -796,12 +894,14 @@ describe("useModelData all-accounts loading", () => {
         expect(result.current.accountQueryStates).toEqual([
           expect.objectContaining({
             account: expect.objectContaining({ id: "bad-format" }),
+            isLoading: false,
             hasData: false,
             hasError: true,
             errorType: "invalid-format",
           }),
           expect.objectContaining({
             account: expect.objectContaining({ id: "load-failed" }),
+            isLoading: false,
             hasData: false,
             hasError: true,
             errorType: "load-failed",

--- a/tests/features/ModelList/components/AccountSummaryBar.test.tsx
+++ b/tests/features/ModelList/components/AccountSummaryBar.test.tsx
@@ -87,8 +87,7 @@ describe("AccountSummaryBar", () => {
       "text-amber-600",
       "dark:text-amber-300",
     )
-    expect(screen.queryByText(/0 model/i)).toBeNull()
-    expect(screen.queryByText(/0 models/i)).toBeNull()
+    expect(screen.queryByText("accountSummary.models")).toBeNull()
   })
 
   it("shows only the error label when an account load fails", () => {
@@ -110,7 +109,6 @@ describe("AccountSummaryBar", () => {
       "text-red-500",
       "dark:text-red-400",
     )
-    expect(screen.queryByText(/0 model/i)).toBeNull()
-    expect(screen.queryByText(/0 models/i)).toBeNull()
+    expect(screen.queryByText("accountSummary.models")).toBeNull()
   })
 })

--- a/tests/features/ModelList/components/AccountSummaryBar.test.tsx
+++ b/tests/features/ModelList/components/AccountSummaryBar.test.tsx
@@ -57,10 +57,60 @@ describe("AccountSummaryBar", () => {
     expect(primaryBadge).toHaveClass("bg-blue-100", "text-blue-700")
     expect(backupBadge).toHaveClass("bg-blue-100", "text-blue-700")
     expect(dormantBadge).toHaveClass("bg-secondary")
+    expect(screen.getAllByText("accountSummary.models")[0]).toHaveClass(
+      "text-emerald-600",
+      "dark:text-emerald-400",
+    )
 
     await user.click(primaryBadge!)
 
     expect(onAccountClick).toHaveBeenCalledWith("account-1")
     expect(onAccountClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows a loading label instead of a zero-model count while an account is still loading", () => {
+    render(
+      <AccountSummaryBar
+        items={[
+          {
+            accountId: "account-loading",
+            name: "Loading Account",
+            count: 0,
+            isLoading: true,
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("Loading Account")).toBeInTheDocument()
+    expect(screen.getByText("accountSummary.loading")).toHaveClass(
+      "text-amber-600",
+      "dark:text-amber-300",
+    )
+    expect(screen.queryByText(/0 model/i)).toBeNull()
+    expect(screen.queryByText(/0 models/i)).toBeNull()
+  })
+
+  it("shows only the error label when an account load fails", () => {
+    render(
+      <AccountSummaryBar
+        items={[
+          {
+            accountId: "account-error",
+            name: "Broken Account",
+            count: 0,
+            errorType: "load-failed",
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("Broken Account")).toBeInTheDocument()
+    expect(screen.getByText("accountSummary.loadFailed")).toHaveClass(
+      "text-red-500",
+      "dark:text-red-400",
+    )
+    expect(screen.queryByText(/0 model/i)).toBeNull()
+    expect(screen.queryByText(/0 models/i)).toBeNull()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account summaries now show a single status per account: loading, error, or model count, with distinct styling for each (loading = amber).

* **Localization**
  * Added "loading" translations for English, Japanese, Simplified Chinese, and Traditional Chinese.

* **Tests**
  * Updated and added tests to verify per-account loading states, error mappings, styling, and that counts are not shown while loading or erroring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->