### PR TITLE
fix(ModelList): preserve expanded state across model data refreshes

### DIFF
--- a/src/features/ModelList/components/ModelDisplay.tsx
+++ b/src/features/ModelList/components/ModelDisplay.tsx
@@ -1,4 +1,5 @@
 import { CpuChipIcon } from "@heroicons/react/24/outline"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Virtuoso } from "react-virtuoso"
 
@@ -44,6 +45,17 @@ interface ModelDisplayProps {
 }
 
 /**
+ * Builds a stable identity for a model row across refreshes and reordering.
+ */
+function getModelItemKey(item: CalculatedModelItem) {
+  const source = item.source as ModelManagementItemSource
+  const sourceKey =
+    source.kind === "profile" ? source.profile.id : source.account.id
+
+  return `${source.kind}:${sourceKey}:${item.model.model_name}`
+}
+
+/**
  * Virtualized list displaying model cards with pricing and availability data.
  * @param props Component props describing the rendered model list.
  * @returns Virtualized model list or empty state when no matches.
@@ -65,6 +77,31 @@ export function ModelDisplay(props: ModelDisplayProps) {
     onFilterAccount,
   } = props
   const { t } = useTranslation("modelList")
+  const modelKeys = useMemo(() => models.map(getModelItemKey), [models])
+  const [expandedModelKeys, setExpandedModelKeys] = useState<string[]>([])
+
+  useEffect(() => {
+    const activeModelKeys = new Set(modelKeys)
+
+    setExpandedModelKeys((currentKeys) => {
+      const nextKeys = currentKeys.filter((key) => activeModelKeys.has(key))
+      return nextKeys.length === currentKeys.length ? currentKeys : nextKeys
+    })
+  }, [modelKeys])
+
+  const expandedModelKeySet = useMemo(
+    () => new Set(expandedModelKeys),
+    [expandedModelKeys],
+  )
+
+  const toggleModelExpand = useCallback((itemKey: string) => {
+    setExpandedModelKeys((currentKeys) =>
+      currentKeys.includes(itemKey)
+        ? currentKeys.filter((key) => key !== itemKey)
+        : [...currentKeys, itemKey],
+    )
+  }, [])
+
   if (models.length === 0) {
     return (
       <EmptyState
@@ -78,6 +115,7 @@ export function ModelDisplay(props: ModelDisplayProps) {
     <div className="h-[70vh]">
       <Virtuoso
         data={models}
+        computeItemKey={(_, item) => getModelItemKey(item)}
         components={{
           Item: ({ children, ...props }) => (
             <div className="my-3 first:mt-0" {...props}>
@@ -85,7 +123,8 @@ export function ModelDisplay(props: ModelDisplayProps) {
             </div>
           ),
         }}
-        itemContent={(index, item) => {
+        itemContent={(_index, item) => {
+          const itemKey = getModelItemKey(item)
           const sourceForModel = item.source as ModelManagementItemSource
           const accountForModel =
             sourceForModel.kind === "account"
@@ -114,7 +153,6 @@ export function ModelDisplay(props: ModelDisplayProps) {
 
           return (
             <ModelItem
-              key={`${item.model.model_name}-${index}`}
               model={item.model}
               calculatedPrice={item.calculatedPrice}
               exchangeRate={exchangeRate}
@@ -136,6 +174,8 @@ export function ModelDisplay(props: ModelDisplayProps) {
               onVerifyModel={onVerifyModel}
               onVerifyCliSupport={onVerifyCliSupport}
               onOpenModelKeyDialog={onOpenModelKeyDialog}
+              isExpanded={expandedModelKeySet.has(itemKey)}
+              onToggleExpand={() => toggleModelExpand(itemKey)}
             />
           )
         }}

--- a/src/features/ModelList/components/ModelDisplay.tsx
+++ b/src/features/ModelList/components/ModelDisplay.tsx
@@ -5,7 +5,10 @@ import { Virtuoso } from "react-virtuoso"
 
 import { EmptyState } from "~/components/ui"
 import { UI_CONSTANTS } from "~/constants/ui"
-import type { CalculatedModelItem } from "~/features/ModelList/hooks/useFilteredModels"
+import {
+  getModelItemKey,
+  type CalculatedModelItem,
+} from "~/features/ModelList/hooks/useFilteredModels"
 import type {
   ModelManagementItemSource,
   ModelManagementSourceCapabilities,
@@ -43,18 +46,6 @@ interface ModelDisplayProps {
   displayCapabilities?: ModelManagementSourceCapabilities
   onFilterAccount?: (accountId: string) => void
 }
-
-/**
- * Builds a stable identity for a model row across refreshes and reordering.
- */
-function getModelItemKey(item: CalculatedModelItem) {
-  const source = item.source as ModelManagementItemSource
-  const sourceKey =
-    source.kind === "profile" ? source.profile.id : source.account.id
-
-  return `${source.kind}:${sourceKey}:${item.model.model_name}`
-}
-
 /**
  * Virtualized list displaying model cards with pricing and availability data.
  * @param props Component props describing the rendered model list.

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -47,6 +47,8 @@ interface ModelItemProps {
     modelId: string,
     modelEnableGroups: string[],
   ) => void
+  isExpanded?: boolean
+  onToggleExpand?: () => void
 }
 
 /**
@@ -74,9 +76,22 @@ export default function ModelItem(props: ModelItemProps) {
     onVerifyModel,
     onVerifyCliSupport,
     onOpenModelKeyDialog,
+    isExpanded: controlledIsExpanded,
+    onToggleExpand,
   } = props
   const { t } = useTranslation("modelList")
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [uncontrolledIsExpanded, setUncontrolledIsExpanded] = useState(false)
+
+  const isExpanded = controlledIsExpanded ?? uncontrolledIsExpanded
+
+  const handleToggleExpand = () => {
+    if (onToggleExpand) {
+      onToggleExpand()
+      return
+    }
+
+    setUncontrolledIsExpanded((current) => !current)
+  }
 
   const handleCopyModelName = async () => {
     try {
@@ -185,7 +200,7 @@ export default function ModelItem(props: ModelItemProps) {
               {canExpand && (
                 <ModelItemExpandButton
                   isExpanded={isExpanded}
-                  onToggleExpand={() => setIsExpanded(!isExpanded)}
+                  onToggleExpand={handleToggleExpand}
                 />
               )}
             </div>

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -10,6 +10,7 @@ import type {
 import type { ModelPricing } from "~/services/apiService/common/type"
 import type { CalculatedPrice } from "~/services/models/utils/modelPricing"
 import type { ApiVerificationHistorySummary } from "~/services/verification/verificationResultHistory"
+import { createLogger } from "~/utils/core/logger"
 import { tryParseUrl } from "~/utils/core/urlParsing"
 
 import { ModelItemDescription } from "./ModelItemDescription"
@@ -17,6 +18,8 @@ import { ModelItemDetails } from "./ModelItemDetails"
 import { ModelItemExpandButton } from "./ModelItemExpandButton"
 import { ModelItemHeader } from "./ModelItemHeader"
 import { ModelItemPricing } from "./ModelItemPricing"
+
+const logger = createLogger("ModelItem")
 
 interface ModelItemProps {
   model: ModelPricing
@@ -81,11 +84,30 @@ export default function ModelItem(props: ModelItemProps) {
   } = props
   const { t } = useTranslation("modelList")
   const [uncontrolledIsExpanded, setUncontrolledIsExpanded] = useState(false)
+  const isExpansionControlled =
+    controlledIsExpanded !== undefined && onToggleExpand !== undefined
+  const hasExpansionPropMismatch =
+    (controlledIsExpanded !== undefined) !== (onToggleExpand !== undefined)
+  const isExpanded = isExpansionControlled
+    ? controlledIsExpanded
+    : uncontrolledIsExpanded
 
-  const isExpanded = controlledIsExpanded ?? uncontrolledIsExpanded
+  useEffect(() => {
+    if (!hasExpansionPropMismatch || process.env.NODE_ENV === "production") {
+      return
+    }
+
+    logger.warn(
+      "ModelItem expects isExpanded and onToggleExpand to be provided together. Falling back to uncontrolled expansion state.",
+      {
+        controlledIsExpandedProvided: controlledIsExpanded !== undefined,
+        onToggleExpandProvided: onToggleExpand !== undefined,
+      },
+    )
+  }, [controlledIsExpanded, hasExpansionPropMismatch, onToggleExpand])
 
   const handleToggleExpand = () => {
-    if (onToggleExpand) {
+    if (isExpansionControlled) {
       onToggleExpand()
       return
     }

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -176,7 +176,9 @@ function comparePriceKeys(
 }
 
 /** Creates a stable identifier for a calculated model item. */
-function getModelItemKey(item: Pick<CalculatedModelItem, "model" | "source">) {
+export function getModelItemKey(
+  item: Pick<CalculatedModelItem, "model" | "source">,
+) {
   const sourceId =
     item.source.kind === "account"
       ? item.source.account.id

--- a/tests/features/ModelList/components/ModelDisplay.test.tsx
+++ b/tests/features/ModelList/components/ModelDisplay.test.tsx
@@ -436,4 +436,89 @@ describe("ModelDisplay", () => {
       screen.getByRole("button", { name: "toggle-gpt-4o-mini" }),
     ).toBeInTheDocument()
   })
+
+  it("clears expanded state when a model is removed and later re-added", async () => {
+    const user = userEvent.setup()
+    const initialModels = [
+      createCalculatedModel({}),
+      createCalculatedModel({
+        model: {
+          model_name: "gemini-1.5-pro",
+          enable_groups: ["default"],
+        },
+      }),
+    ]
+    const modelsWithoutExpandedRow = [
+      createCalculatedModel({
+        model: {
+          model_name: "gemini-1.5-pro",
+          enable_groups: ["default"],
+        },
+      }),
+    ]
+    const readdedModels = [
+      createCalculatedModel({
+        calculatedPrice: {
+          inputUSD: 4,
+        },
+      }),
+      createCalculatedModel({
+        model: {
+          model_name: "gemini-1.5-pro",
+          enable_groups: ["default"],
+        },
+      }),
+    ]
+
+    const { rerender } = render(
+      <ModelDisplay
+        models={initialModels}
+        verificationSummariesByKey={{}}
+        showRealPrice={true}
+        showRatioColumn={true}
+        showEndpointTypes={true}
+        selectedGroups={[]}
+        handleGroupClick={vi.fn()}
+        availableGroups={["default", "vip"]}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "toggle-gpt-4o-mini" }))
+
+    expect(getRenderedModelItem("gpt-4o-mini")).toHaveAttribute(
+      "data-expanded",
+      "true",
+    )
+
+    rerender(
+      <ModelDisplay
+        models={modelsWithoutExpandedRow}
+        verificationSummariesByKey={{}}
+        showRealPrice={true}
+        showRatioColumn={true}
+        showEndpointTypes={true}
+        selectedGroups={[]}
+        handleGroupClick={vi.fn()}
+        availableGroups={["default", "vip"]}
+      />,
+    )
+
+    rerender(
+      <ModelDisplay
+        models={readdedModels}
+        verificationSummariesByKey={{}}
+        showRealPrice={true}
+        showRatioColumn={true}
+        showEndpointTypes={true}
+        selectedGroups={[]}
+        handleGroupClick={vi.fn()}
+        availableGroups={["default", "vip"]}
+      />,
+    )
+
+    expect(getRenderedModelItem("gpt-4o-mini")).toHaveAttribute(
+      "data-expanded",
+      "false",
+    )
+  })
 })

--- a/tests/features/ModelList/components/ModelDisplay.test.tsx
+++ b/tests/features/ModelList/components/ModelDisplay.test.tsx
@@ -40,10 +40,12 @@ vi.mock("react-virtuoso", () => ({
   Virtuoso: ({
     data,
     itemContent,
+    computeItemKey,
     components,
   }: {
     data: any[]
     itemContent: (index: number, item: any) => React.ReactNode
+    computeItemKey?: (index: number, item: any) => React.Key
     components?: { Item?: React.ComponentType<any> }
   }) => {
     const Item = components?.Item ?? ((props: any) => <div {...props} />)
@@ -51,7 +53,12 @@ vi.mock("react-virtuoso", () => ({
     return (
       <div data-testid="virtuoso">
         {data.map((item, index) => (
-          <Item key={`${item.model.model_name}-${index}`}>
+          <Item
+            key={
+              computeItemKey?.(index, item) ??
+              `${item.model.model_name}-${index}`
+            }
+          >
             {itemContent(index, item)}
           </Item>
         ))}
@@ -74,7 +81,11 @@ vi.mock("~/features/ModelList/components/ModelItem", () => ({
         data-all-groups={String(props.isAllGroupsMode)}
         data-summary-status={props.verificationSummary?.status ?? "none"}
         data-source-kind={props.source.kind}
+        data-expanded={String(props.isExpanded ?? false)}
       >
+        <button type="button" onClick={props.onToggleExpand}>
+          toggle-{props.model.model_name}
+        </button>
         <button
           type="button"
           onClick={() =>
@@ -178,6 +189,18 @@ const createCalculatedModel = (
     groupRatios: { default: 1, vip: 2 },
     effectiveGroup: overrides.effectiveGroup,
   }
+}
+
+function getRenderedModelItem(modelId: string) {
+  const item = screen
+    .getAllByTestId("model-item")
+    .find((element) => element.getAttribute("data-model-id") === modelId)
+
+  if (!item) {
+    throw new Error(`Model item not found: ${modelId}`)
+  }
+
+  return item
 }
 
 describe("ModelDisplay", () => {
@@ -342,5 +365,75 @@ describe("ModelDisplay", () => {
     expect(
       screen.queryByRole("button", { name: "key-claude-3-5-sonnet" }),
     ).not.toBeInTheDocument()
+  })
+
+  it("preserves expanded state for the same model across refreshed model data", async () => {
+    const user = userEvent.setup()
+    const initialModels = [
+      createCalculatedModel({}),
+      createCalculatedModel({
+        model: {
+          model_name: "gemini-1.5-pro",
+          enable_groups: ["default"],
+        },
+      }),
+    ]
+    const refreshedModels = [
+      createCalculatedModel({
+        model: {
+          model_name: "gemini-1.5-pro",
+          enable_groups: ["default"],
+        },
+        calculatedPrice: {
+          inputUSD: 3,
+        },
+      }),
+      createCalculatedModel({
+        calculatedPrice: {
+          inputUSD: 4,
+        },
+      }),
+    ]
+
+    const { rerender } = render(
+      <ModelDisplay
+        models={initialModels}
+        verificationSummariesByKey={{}}
+        showRealPrice={true}
+        showRatioColumn={true}
+        showEndpointTypes={true}
+        selectedGroups={[]}
+        handleGroupClick={vi.fn()}
+        availableGroups={["default", "vip"]}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "toggle-gpt-4o-mini" }))
+
+    expect(getRenderedModelItem("gpt-4o-mini")).toHaveAttribute(
+      "data-expanded",
+      "true",
+    )
+
+    rerender(
+      <ModelDisplay
+        models={refreshedModels}
+        verificationSummariesByKey={{}}
+        showRealPrice={true}
+        showRatioColumn={true}
+        showEndpointTypes={true}
+        selectedGroups={[]}
+        handleGroupClick={vi.fn()}
+        availableGroups={["default", "vip"]}
+      />,
+    )
+
+    expect(getRenderedModelItem("gpt-4o-mini")).toHaveAttribute(
+      "data-expanded",
+      "true",
+    )
+    expect(
+      screen.getByRole("button", { name: "toggle-gpt-4o-mini" }),
+    ).toBeInTheDocument()
   })
 })

--- a/tests/features/ModelList/components/ModelItem.test.tsx
+++ b/tests/features/ModelList/components/ModelItem.test.tsx
@@ -1,13 +1,29 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import ModelItem from "~/features/ModelList/components/ModelItem"
+import type { ModelPricing } from "~/services/apiService/common/type"
+import type { CalculatedPrice } from "~/services/models/utils/modelPricing"
+
+const { loggerWarnSpy } = vi.hoisted(() => ({
+  loggerWarnSpy: vi.fn(),
+}))
 
 vi.mock("react-hot-toast", () => ({
   default: {
     success: vi.fn(),
     error: vi.fn(),
   },
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: loggerWarnSpy,
+    error: vi.fn(),
+  }),
 }))
 
 vi.mock("react-i18next", async (importOriginal) => {
@@ -53,62 +69,178 @@ vi.mock("~/features/ModelList/components/ModelItem/ModelItemDetails", () => ({
 vi.mock(
   "~/features/ModelList/components/ModelItem/ModelItemExpandButton",
   () => ({
-    ModelItemExpandButton: () => <button type="button">expand</button>,
+    ModelItemExpandButton: ({
+      isExpanded,
+      onToggleExpand,
+    }: {
+      isExpanded: boolean
+      onToggleExpand: () => void
+    }) => (
+      <button
+        type="button"
+        data-testid="expand-button"
+        data-expanded={String(isExpanded)}
+        onClick={onToggleExpand}
+      >
+        expand
+      </button>
+    ),
   }),
 )
 
+function createDefaultProps() {
+  const model: ModelPricing = {
+    model_name: "gpt-4o-mini",
+    model_description: "Fast model",
+    quota_type: 0,
+    model_ratio: 1,
+    model_price: 0,
+    completion_ratio: 1,
+    enable_groups: ["vip"],
+    supported_endpoint_types: [],
+  } as ModelPricing
+
+  const calculatedPrice: CalculatedPrice = {
+    inputUSD: 1,
+    outputUSD: 2,
+    inputCNY: 7,
+    outputCNY: 14,
+  } as CalculatedPrice
+
+  return {
+    model,
+    calculatedPrice,
+    exchangeRate: 7,
+    showRealPrice: false,
+    showRatioColumn: false,
+    showEndpointTypes: false,
+    groupRatios: {},
+    selectedGroups: [],
+    availableGroups: [],
+    source: {
+      kind: "account",
+      account: {
+        id: "account-1",
+        name: "Account One",
+      },
+      capabilities: {
+        supportsPricing: true,
+        supportsGroupFiltering: true,
+        supportsAccountSummary: false,
+        supportsTokenCompatibility: false,
+        supportsCredentialVerification: false,
+        supportsCliVerification: false,
+      },
+    } as any,
+  }
+}
+
 describe("ModelItem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it("falls back to the default group label when an unavailable model has no selected or effective group", () => {
-    render(
-      <ModelItem
-        model={
-          {
-            model_name: "gpt-4o-mini",
-            model_description: "Fast model",
-            quota_type: 0,
-            model_ratio: 1,
-            model_price: 0,
-            completion_ratio: 1,
-            enable_groups: ["vip"],
-            supported_endpoint_types: [],
-          } as any
-        }
-        calculatedPrice={
-          {
-            inputUSD: 1,
-            outputUSD: 2,
-            inputCNY: 7,
-            outputCNY: 14,
-          } as any
-        }
-        exchangeRate={7}
-        showRealPrice={false}
-        showRatioColumn={false}
-        showEndpointTypes={false}
-        groupRatios={{}}
-        selectedGroups={[]}
-        availableGroups={[]}
-        source={
-          {
-            kind: "account",
-            account: {
-              id: "account-1",
-              name: "Account One",
-            },
-            capabilities: {
-              supportsPricing: true,
-              supportsGroupFiltering: true,
-              supportsAccountSummary: false,
-              supportsTokenCompatibility: false,
-              supportsCredentialVerification: false,
-              supportsCliVerification: false,
-            },
-          } as any
-        }
-      />,
-    )
+    render(<ModelItem {...createDefaultProps()} />)
 
     expect(screen.getByText("clickSwitchGroup:default")).toBeInTheDocument()
     expect(screen.getByText("availableGroups: vip")).toBeInTheDocument()
   })
+
+  it("uses internal expansion state when expansion props are omitted", async () => {
+    const user = userEvent.setup()
+
+    render(<ModelItem {...createDefaultProps()} />)
+
+    expect(screen.queryByTestId("model-details")).not.toBeInTheDocument()
+    expect(screen.getByTestId("expand-button")).toHaveAttribute(
+      "data-expanded",
+      "false",
+    )
+
+    await user.click(screen.getByTestId("expand-button"))
+
+    expect(screen.getByTestId("model-details")).toBeInTheDocument()
+    expect(screen.getByTestId("expand-button")).toHaveAttribute(
+      "data-expanded",
+      "true",
+    )
+  })
+
+  it("treats expansion as controlled only when both props are provided", async () => {
+    const user = userEvent.setup()
+    const onToggleExpand = vi.fn()
+    const { rerender } = render(
+      <ModelItem
+        {...createDefaultProps()}
+        isExpanded={false}
+        onToggleExpand={onToggleExpand}
+      />,
+    )
+
+    await user.click(screen.getByTestId("expand-button"))
+
+    expect(onToggleExpand).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId("model-details")).not.toBeInTheDocument()
+    expect(screen.getByTestId("expand-button")).toHaveAttribute(
+      "data-expanded",
+      "false",
+    )
+
+    rerender(
+      <ModelItem
+        {...createDefaultProps()}
+        isExpanded={true}
+        onToggleExpand={onToggleExpand}
+      />,
+    )
+
+    expect(screen.getByTestId("model-details")).toBeInTheDocument()
+    expect(screen.getByTestId("expand-button")).toHaveAttribute(
+      "data-expanded",
+      "true",
+    )
+  })
+
+  it.each([
+    {
+      name: "isExpanded without onToggleExpand",
+      props: { isExpanded: true },
+      expectedCallbackCalls: 0,
+    },
+    {
+      name: "onToggleExpand without isExpanded",
+      props: { onToggleExpand: vi.fn() },
+      expectedCallbackCalls: 0,
+    },
+  ])(
+    "warns and falls back to uncontrolled expansion for %s",
+    async ({ props, expectedCallbackCalls }) => {
+      const user = userEvent.setup()
+
+      render(<ModelItem {...createDefaultProps()} {...props} />)
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        "ModelItem expects isExpanded and onToggleExpand to be provided together. Falling back to uncontrolled expansion state.",
+        {
+          controlledIsExpandedProvided: "isExpanded" in props,
+          onToggleExpandProvided: "onToggleExpand" in props,
+        },
+      )
+
+      await user.click(screen.getByTestId("expand-button"))
+
+      expect(screen.getByTestId("model-details")).toBeInTheDocument()
+      expect(screen.getByTestId("expand-button")).toHaveAttribute(
+        "data-expanded",
+        "true",
+      )
+
+      if ("onToggleExpand" in props) {
+        expect(props.onToggleExpand).toHaveBeenCalledTimes(
+          expectedCallbackCalls,
+        )
+      }
+    },
+  )
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Model items now persist expanded/collapsed state across list refreshes and reorders, and expansion is reliably cleared when an item is removed and later re-added.
  * Components now support both controlled and uncontrolled expansion modes for finer UI control.

* **Tests**
  * Added/updated tests to verify expansion persistence, clearing on removal, and controlled vs uncontrolled expansion behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->