### PR TITLE
feat(model-list): sort all-accounts selectors by loaded model count

### DIFF
--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -22,6 +22,7 @@ import type { DisplaySiteData } from "~/types"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import { pushWithinOptionsPage } from "~/utils/navigation"
 
+import { sortModelListAccounts } from "./accountOrdering"
 import { AccountSelector } from "./components/AccountSelector"
 import { AccountSummaryBar } from "./components/AccountSummaryBar"
 import { ControlPanel } from "./components/ControlPanel"
@@ -109,6 +110,15 @@ export default function ModelList(props: {
       ),
     [providers, getProviderFilteredCount],
   )
+  const sortedAccounts = useMemo(
+    () =>
+      sortModelListAccounts({
+        accounts,
+        accountQueryStates,
+        accountSummaryCountsByAccountId,
+      }),
+    [accountQueryStates, accountSummaryCountsByAccountId, accounts],
+  )
 
   const handleGroupClick = (group: string) => {
     setSelectedGroups([group])
@@ -131,14 +141,27 @@ export default function ModelList(props: {
     !shouldShowSourceSetupEmptyState && !selectedSource
 
   const accountSummaryItems = useMemo(() => {
-    return (accountQueryStates ?? []).map((state) => ({
-      accountId: state.account.id,
-      name: state.account.name,
-      count: accountSummaryCountsByAccountId.get(state.account.id) ?? 0,
-      isLoading: state.isLoading,
-      errorType: state.errorType,
-    }))
-  }, [accountQueryStates, accountSummaryCountsByAccountId])
+    const stateByAccountId = new Map(
+      (accountQueryStates ?? []).map((state) => [state.account.id, state]),
+    )
+
+    return sortedAccounts.flatMap((account) => {
+      const state = stateByAccountId.get(account.id)
+      if (!state) {
+        return []
+      }
+
+      return [
+        {
+          accountId: state.account.id,
+          name: state.account.name,
+          count: accountSummaryCountsByAccountId.get(state.account.id) ?? 0,
+          isLoading: state.isLoading,
+          errorType: state.errorType,
+        },
+      ]
+    })
+  }, [accountQueryStates, accountSummaryCountsByAccountId, sortedAccounts])
 
   const modelVerificationTargets = useMemo(() => {
     return filteredModels.reduce<ApiVerificationHistoryTarget[]>(
@@ -274,7 +297,7 @@ export default function ModelList(props: {
       <AccountSelector
         selectedSourceValue={selectedSourceValue}
         setSelectedSourceValue={setSelectedSourceValue}
-        accounts={accounts}
+        accounts={sortedAccounts}
         profiles={profiles}
         selectorOpen={isSourceSelectorOpen}
         onSelectorOpenChange={setIsSourceSelectorOpen}

--- a/src/features/ModelList/accountOrdering.ts
+++ b/src/features/ModelList/accountOrdering.ts
@@ -1,0 +1,78 @@
+import type { DisplaySiteData } from "~/types"
+
+type AccountQueryStateLike = {
+  account: Pick<DisplaySiteData, "id">
+  isLoading?: boolean
+  hasError?: boolean
+  errorType?: "invalid-format" | "load-failed"
+}
+
+interface SortModelListAccountsParams {
+  accounts: DisplaySiteData[]
+  accountQueryStates: AccountQueryStateLike[]
+  accountSummaryCountsByAccountId: Map<string, number>
+}
+
+/** Returns true once every all-accounts query has settled. */
+function hasAccountLoadingCompleted(
+  accounts: DisplaySiteData[],
+  accountQueryStates: AccountQueryStateLike[],
+) {
+  return (
+    accounts.length > 0 &&
+    accountQueryStates.length === accounts.length &&
+    accountQueryStates.every((state) => !state.isLoading)
+  )
+}
+
+/** Normalizes account failures across explicit flags and typed error states. */
+function hasAccountLoadError(state?: AccountQueryStateLike) {
+  return Boolean(state?.hasError || state?.errorType)
+}
+
+/**
+ * Sorts model-list accounts once all all-accounts refreshes have settled.
+ * Successful accounts are ordered by model count descending, while failed
+ * accounts are always pushed to the end. Until every account finishes loading,
+ * the original account order is preserved to avoid a jumping selector.
+ */
+export function sortModelListAccounts({
+  accounts,
+  accountQueryStates,
+  accountSummaryCountsByAccountId,
+}: SortModelListAccountsParams) {
+  if (!hasAccountLoadingCompleted(accounts, accountQueryStates)) {
+    return accounts
+  }
+
+  const originalIndexByAccountId = new Map(
+    accounts.map((account, index) => [account.id, index]),
+  )
+  const queryStateByAccountId = new Map(
+    accountQueryStates.map((state) => [state.account.id, state]),
+  )
+
+  return [...accounts].sort((leftAccount, rightAccount) => {
+    const leftState = queryStateByAccountId.get(leftAccount.id)
+    const rightState = queryStateByAccountId.get(rightAccount.id)
+    const leftHasError = hasAccountLoadError(leftState)
+    const rightHasError = hasAccountLoadError(rightState)
+
+    if (leftHasError !== rightHasError) {
+      return leftHasError ? 1 : -1
+    }
+
+    const countDifference =
+      (accountSummaryCountsByAccountId.get(rightAccount.id) ?? 0) -
+      (accountSummaryCountsByAccountId.get(leftAccount.id) ?? 0)
+
+    if (countDifference !== 0) {
+      return countDifference
+    }
+
+    return (
+      (originalIndexByAccountId.get(leftAccount.id) ?? 0) -
+      (originalIndexByAccountId.get(rightAccount.id) ?? 0)
+    )
+  })
+}

--- a/src/features/ModelList/accountOrdering.ts
+++ b/src/features/ModelList/accountOrdering.ts
@@ -18,10 +18,14 @@ function hasAccountLoadingCompleted(
   accounts: DisplaySiteData[],
   accountQueryStates: AccountQueryStateLike[],
 ) {
-  return (
-    accounts.length > 0 &&
-    accountQueryStates.length === accounts.length &&
-    accountQueryStates.every((state) => !state.isLoading)
+  if (accounts.length === 0) {
+    return false
+  }
+
+  return accounts.every((account) =>
+    accountQueryStates.some(
+      (state) => state.account.id === account.id && !state.isLoading,
+    ),
   )
 }
 

--- a/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
@@ -16,6 +16,7 @@ import { render, screen } from "~~/tests/test-utils/render"
 
 const mockUseModelListData = vi.fn()
 const mockSetAllAccountsFilterAccountIds = vi.fn()
+const mockAccountSelector = vi.fn()
 
 vi.mock("~/features/ModelList/hooks/useModelListData", () => ({
   useModelListData: (...args: any[]) => mockUseModelListData(...args),
@@ -76,7 +77,10 @@ const ALL_ACCOUNTS_SOURCE = createAllAccountsSource()
 const PROFILE_SOURCE = createProfileSource(PROFILE)
 
 vi.mock("~/features/ModelList/components/AccountSelector", () => ({
-  AccountSelector: () => <div>Account Selector</div>,
+  AccountSelector: (props: any) => {
+    mockAccountSelector(props)
+    return <div>Account Selector</div>
+  },
 }))
 
 vi.mock("~/features/ModelList/components/StatusIndicator", () => ({
@@ -309,6 +313,7 @@ function buildState(overrides: Record<string, any> = {}) {
 
 describe("ModelList page flows", () => {
   beforeEach(() => {
+    mockAccountSelector.mockReset()
     mockSetAllAccountsFilterAccountIds.mockReset()
     mockUseModelListData.mockReset()
   })
@@ -513,6 +518,118 @@ describe("ModelList page flows", () => {
     ).toBeInTheDocument()
     expect(screen.queryByText("Summary Status Primary Account:0")).toBeNull()
     expect(screen.queryByText("Summary Status Backup Account:0")).toBeNull()
+  })
+
+  it("sorts the account selector and summary badges after all-account refreshes settle", async () => {
+    mockUseModelListData.mockReturnValue(
+      buildState({
+        selectedSource: ALL_ACCOUNTS_SOURCE,
+        selectedSourceValue: ALL_ACCOUNTS_SOURCE.value,
+        currentAccount: null,
+        sourceCapabilities: ALL_ACCOUNTS_SOURCE.capabilities,
+        pricingData: null,
+        pricingContexts: [
+          { account: ACCOUNT, pricing: { data: [{ model_name: "gpt-4" }] } },
+          {
+            account: SECOND_ACCOUNT,
+            pricing: {
+              data: [
+                { model_name: "gpt-4o-mini" },
+                { model_name: "claude-3-5-sonnet" },
+              ],
+            },
+          },
+        ],
+        accountSummaryCountsByAccountId: new Map([
+          [ACCOUNT.id, 1],
+          [SECOND_ACCOUNT.id, 2],
+        ]),
+        accountQueryStates: [
+          {
+            account: ACCOUNT,
+            isLoading: false,
+            hasError: false,
+            errorType: undefined,
+          },
+          {
+            account: SECOND_ACCOUNT,
+            isLoading: false,
+            hasError: false,
+            errorType: undefined,
+          },
+        ],
+      }),
+    )
+
+    render(<ModelList />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    await screen.findByText("Account Summary Bar active:none")
+
+    expect(mockAccountSelector).toHaveBeenCalled()
+    expect(
+      mockAccountSelector.mock.calls
+        .at(-1)?.[0]
+        .accounts.map((account: any) => account.id),
+    ).toEqual([SECOND_ACCOUNT.id, ACCOUNT.id])
+    expect(
+      screen
+        .getAllByRole("button")
+        .filter((button) => button.textContent?.startsWith("Summary "))
+        .map((button) => button.textContent),
+    ).toEqual(["Summary Backup Account:2", "Summary Primary Account:1"])
+  })
+
+  it("keeps the original account order while all-account refreshes are still loading", async () => {
+    mockUseModelListData.mockReturnValue(
+      buildState({
+        selectedSource: ALL_ACCOUNTS_SOURCE,
+        selectedSourceValue: ALL_ACCOUNTS_SOURCE.value,
+        currentAccount: null,
+        sourceCapabilities: ALL_ACCOUNTS_SOURCE.capabilities,
+        pricingData: null,
+        pricingContexts: [{ account: ACCOUNT, pricing: { data: [] } }],
+        accountSummaryCountsByAccountId: new Map([
+          [ACCOUNT.id, 1],
+          [SECOND_ACCOUNT.id, 3],
+        ]),
+        accountQueryStates: [
+          {
+            account: ACCOUNT,
+            isLoading: false,
+            hasError: false,
+            errorType: undefined,
+          },
+          {
+            account: SECOND_ACCOUNT,
+            isLoading: true,
+            hasError: false,
+            errorType: undefined,
+          },
+        ],
+      }),
+    )
+
+    render(<ModelList />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    await screen.findByText("Account Summary Bar active:none")
+
+    expect(
+      mockAccountSelector.mock.calls
+        .at(-1)?.[0]
+        .accounts.map((account: any) => account.id),
+    ).toEqual([ACCOUNT.id, SECOND_ACCOUNT.id])
+    expect(
+      screen
+        .getAllByRole("button")
+        .filter((button) => button.textContent?.startsWith("Summary "))
+        .map((button) => button.textContent),
+    ).toEqual(["Summary Primary Account:1", "Summary Backup Account:3"])
   })
 
   it("aggregates total model count from all account pricing contexts", async () => {

--- a/tests/entrypoints/options/pages/ModelList/accountOrdering.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/accountOrdering.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+
+import { sortModelListAccounts } from "~/features/ModelList/accountOrdering"
+import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
+
+function createAccount(id: string, name: string): DisplaySiteData {
+  return {
+    id,
+    name,
+    username: "tester",
+    balance: { USD: 0, CNY: 0 },
+    todayConsumption: { USD: 0, CNY: 0 },
+    todayIncome: { USD: 0, CNY: 0 },
+    todayTokens: { upload: 0, download: 0 },
+    health: { status: SiteHealthStatus.Healthy },
+    siteType: "new-api",
+    baseUrl: `https://${id}.example.com`,
+    token: "token",
+    userId: 1,
+    authType: AuthTypeEnum.AccessToken,
+    checkIn: { enableDetection: false },
+  }
+}
+
+describe("sortModelListAccounts", () => {
+  it("sorts successful accounts by model count and pushes failed accounts last", () => {
+    const primaryAccount = createAccount("acc-1", "Primary")
+    const backupAccount = createAccount("acc-2", "Backup")
+    const failedAccount = createAccount("acc-3", "Failed")
+
+    const sortedAccounts = sortModelListAccounts({
+      accounts: [primaryAccount, backupAccount, failedAccount],
+      accountQueryStates: [
+        {
+          account: primaryAccount,
+          isLoading: false,
+          hasError: false,
+        },
+        {
+          account: backupAccount,
+          isLoading: false,
+          hasError: false,
+        },
+        {
+          account: failedAccount,
+          isLoading: false,
+          hasError: true,
+          errorType: "load-failed",
+        },
+      ],
+      accountSummaryCountsByAccountId: new Map([
+        [primaryAccount.id, 1],
+        [backupAccount.id, 3],
+        [failedAccount.id, 99],
+      ]),
+    })
+
+    expect(sortedAccounts.map((account) => account.id)).toEqual([
+      backupAccount.id,
+      primaryAccount.id,
+      failedAccount.id,
+    ])
+  })
+
+  it("preserves the original order until every account finishes loading", () => {
+    const primaryAccount = createAccount("acc-1", "Primary")
+    const backupAccount = createAccount("acc-2", "Backup")
+
+    const sortedAccounts = sortModelListAccounts({
+      accounts: [primaryAccount, backupAccount],
+      accountQueryStates: [
+        {
+          account: primaryAccount,
+          isLoading: false,
+          hasError: false,
+        },
+        {
+          account: backupAccount,
+          isLoading: true,
+          hasError: false,
+        },
+      ],
+      accountSummaryCountsByAccountId: new Map([
+        [primaryAccount.id, 1],
+        [backupAccount.id, 3],
+      ]),
+    })
+
+    expect(sortedAccounts.map((account) => account.id)).toEqual([
+      primaryAccount.id,
+      backupAccount.id,
+    ])
+  })
+})

--- a/tests/entrypoints/options/pages/ModelList/accountOrdering.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/accountOrdering.test.ts
@@ -91,4 +91,72 @@ describe("sortModelListAccounts", () => {
       backupAccount.id,
     ])
   })
+
+  it("preserves the original order when query states do not cover every account", () => {
+    const primaryAccount = createAccount("acc-1", "Primary")
+    const backupAccount = createAccount("acc-2", "Backup")
+
+    const sortedAccounts = sortModelListAccounts({
+      accounts: [primaryAccount, backupAccount],
+      accountQueryStates: [
+        {
+          account: primaryAccount,
+          isLoading: false,
+          hasError: false,
+        },
+        {
+          account: primaryAccount,
+          isLoading: false,
+          hasError: false,
+        },
+      ],
+      accountSummaryCountsByAccountId: new Map([
+        [primaryAccount.id, 1],
+        [backupAccount.id, 3],
+      ]),
+    })
+
+    expect(sortedAccounts.map((account) => account.id)).toEqual([
+      primaryAccount.id,
+      backupAccount.id,
+    ])
+  })
+
+  it("preserves original order when counts are equal", () => {
+    const primaryAccount = createAccount("acc-1", "Primary")
+    const backupAccount = createAccount("acc-2", "Backup")
+    const tertiaryAccount = createAccount("acc-3", "Tertiary")
+
+    const sortedAccounts = sortModelListAccounts({
+      accounts: [primaryAccount, backupAccount, tertiaryAccount],
+      accountQueryStates: [
+        {
+          account: primaryAccount,
+          isLoading: false,
+          hasError: false,
+        },
+        {
+          account: backupAccount,
+          isLoading: false,
+          hasError: false,
+        },
+        {
+          account: tertiaryAccount,
+          isLoading: false,
+          hasError: false,
+        },
+      ],
+      accountSummaryCountsByAccountId: new Map([
+        [primaryAccount.id, 2],
+        [backupAccount.id, 2],
+        [tertiaryAccount.id, 2],
+      ]),
+    })
+
+    expect(sortedAccounts.map((account) => account.id)).toEqual([
+      primaryAccount.id,
+      backupAccount.id,
+      tertiaryAccount.id,
+    ])
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model list accounts are now ordered intelligently: non-error accounts sorted by model-count (desc) and error accounts listed last. Sorting happens only after all account queries finish; while loading, original order is retained. Account selector and summary badges now reflect this ordering.

* **Tests**
  * Added tests and mocks covering sorting, load-state gating, and summary-badge ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->