### PR TITLE
feat(api): add per-site API request limiting

### DIFF
--- a/src/services/apiService/common/siteRequestLimiter.ts
+++ b/src/services/apiService/common/siteRequestLimiter.ts
@@ -1,0 +1,172 @@
+type SiteRequestLimiterConfig = {
+  enabled?: boolean
+  maxConcurrentPerSite: number
+  requestsPerMinute: number
+  burst: number
+}
+
+type QueueItem = {
+  task: () => Promise<unknown>
+  resolve: (value: unknown) => void
+  reject: (reason?: unknown) => void
+}
+
+type SiteLimiterState = {
+  activeCount: number
+  tokens: number
+  lastRefillAt: number
+  queue: QueueItem[]
+  timer: ReturnType<typeof setTimeout> | undefined
+  cleanupTimer: ReturnType<typeof setTimeout> | undefined
+}
+
+const SITE_API_REQUEST_LIMITS = {
+  maxConcurrentPerSite: 2,
+  requestsPerMinute: 18,
+  burst: 4,
+} as const satisfies SiteRequestLimiterConfig
+
+const IDLE_STATE_TTL_MS = 5 * 60 * 1000
+
+/**
+ * Creates a per-site FIFO token-bucket limiter.
+ *
+ * Defaults are chosen to stay below New API's dashboard/web default of
+ * 60 requests / 180 seconds while still allowing a small local burst.
+ */
+export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
+  const enabled = config.enabled !== false
+  const maxConcurrentPerSite = Math.max(
+    1,
+    Math.floor(config.maxConcurrentPerSite),
+  )
+  const capacity = Math.max(1, Math.floor(config.burst))
+  const requestsPerMinute = Math.max(0, config.requestsPerMinute)
+  const refillRatePerMs = requestsPerMinute / 60_000
+  const states = new Map<string, SiteLimiterState>()
+
+  if (!enabled || requestsPerMinute <= 0) {
+    return async <T>(_key: string, task: () => Promise<T>): Promise<T> =>
+      await task()
+  }
+
+  const refillTokens = (state: SiteLimiterState) => {
+    const now = Date.now()
+    const elapsedMs = Math.max(0, now - state.lastRefillAt)
+    if (elapsedMs <= 0) return
+
+    state.tokens = Math.min(
+      capacity,
+      state.tokens + elapsedMs * refillRatePerMs,
+    )
+    state.lastRefillAt = now
+  }
+
+  const getState = (key: string) => {
+    let state = states.get(key)
+    if (!state) {
+      state = {
+        activeCount: 0,
+        tokens: capacity,
+        lastRefillAt: Date.now(),
+        queue: [],
+        timer: undefined,
+        cleanupTimer: undefined,
+      }
+      states.set(key, state)
+      return state
+    }
+
+    if (state.cleanupTimer) {
+      clearTimeout(state.cleanupTimer)
+      state.cleanupTimer = undefined
+    }
+
+    return state
+  }
+
+  const scheduleCleanup = (key: string, state: SiteLimiterState) => {
+    if (state.activeCount > 0 || state.queue.length > 0 || state.timer) return
+    if (state.cleanupTimer) return
+
+    state.cleanupTimer = setTimeout(() => {
+      if (
+        state.activeCount === 0 &&
+        state.queue.length === 0 &&
+        !state.timer &&
+        states.get(key) === state
+      ) {
+        states.delete(key)
+      }
+    }, IDLE_STATE_TTL_MS)
+  }
+
+  const schedule = (key: string, state: SiteLimiterState): void => {
+    if (state.timer) {
+      clearTimeout(state.timer)
+      state.timer = undefined
+    }
+
+    while (state.activeCount < maxConcurrentPerSite && state.queue.length > 0) {
+      refillTokens(state)
+
+      if (state.tokens < 1) {
+        const waitMs = Math.max(
+          1,
+          Math.ceil((1 - state.tokens) / refillRatePerMs),
+        )
+        state.timer = setTimeout(() => {
+          state.timer = undefined
+          schedule(key, state)
+        }, waitMs)
+        return
+      }
+
+      state.tokens -= 1
+      const item = state.queue.shift()
+      if (!item) continue
+
+      state.activeCount += 1
+      void Promise.resolve()
+        .then(item.task)
+        .then(item.resolve, item.reject)
+        .finally(() => {
+          state.activeCount -= 1
+          schedule(key, state)
+          scheduleCleanup(key, state)
+        })
+    }
+
+    scheduleCleanup(key, state)
+  }
+
+  return async <T>(key: string, task: () => Promise<T>): Promise<T> => {
+    if (!key) return await task()
+
+    const state = getState(key)
+
+    return await new Promise<T>((resolve, reject) => {
+      state.queue.push({
+        task: async () => await task(),
+        resolve: (value) => resolve(value as T),
+        reject,
+      })
+      schedule(key, state)
+    })
+  }
+}
+
+const productionSiteRequestLimiter = createSiteRequestLimiter({
+  ...SITE_API_REQUEST_LIMITS,
+  enabled: import.meta.env.MODE !== "test",
+})
+
+/**
+ * Runs a site API request through the process-local per-site limiter.
+ */
+export async function withSiteApiRequestLimit<T>(
+  key: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  return await productionSiteRequestLimiter(key, task)
+}

--- a/src/services/apiService/common/siteRequestLimiter.ts
+++ b/src/services/apiService/common/siteRequestLimiter.ts
@@ -29,6 +29,51 @@ const SITE_API_REQUEST_LIMITS = {
 const IDLE_STATE_TTL_MS = 5 * 60 * 1000
 
 /**
+ * Resolve a numeric limiter config field and reject NaN/Infinity early.
+ */
+function resolveFiniteNumber(
+  config: SiteRequestLimiterConfig,
+  field: keyof Pick<
+    SiteRequestLimiterConfig,
+    "maxConcurrentPerSite" | "requestsPerMinute" | "burst"
+  >,
+): number {
+  const value = Number(config[field])
+  if (!Number.isFinite(value)) {
+    throw new TypeError(`Site request limiter ${field} must be a finite number`)
+  }
+  return value
+}
+
+/**
+ * Resolve a limiter field that must create at least one slot/token.
+ */
+function resolvePositiveInteger(
+  config: SiteRequestLimiterConfig,
+  field: keyof Pick<SiteRequestLimiterConfig, "maxConcurrentPerSite" | "burst">,
+): number {
+  const value = resolveFiniteNumber(config, field)
+  if (value < 1) {
+    throw new TypeError(`Site request limiter ${field} must be >= 1`)
+  }
+  return Math.floor(value)
+}
+
+/**
+ * Resolve a limiter rate field where zero disables queued throttling.
+ */
+function resolveNonNegativeNumber(
+  config: SiteRequestLimiterConfig,
+  field: keyof Pick<SiteRequestLimiterConfig, "requestsPerMinute">,
+): number {
+  const value = resolveFiniteNumber(config, field)
+  if (value < 0) {
+    throw new TypeError(`Site request limiter ${field} must be >= 0`)
+  }
+  return value
+}
+
+/**
  * Creates a per-site FIFO token-bucket limiter.
  *
  * Defaults are chosen to stay below New API's dashboard/web default of
@@ -36,12 +81,15 @@ const IDLE_STATE_TTL_MS = 5 * 60 * 1000
  */
 export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
   const enabled = config.enabled !== false
-  const maxConcurrentPerSite = Math.max(
-    1,
-    Math.floor(config.maxConcurrentPerSite),
+  const maxConcurrentPerSite = resolvePositiveInteger(
+    config,
+    "maxConcurrentPerSite",
   )
-  const capacity = Math.max(1, Math.floor(config.burst))
-  const requestsPerMinute = Math.max(0, config.requestsPerMinute)
+  const capacity = resolvePositiveInteger(config, "burst")
+  const requestsPerMinute = resolveNonNegativeNumber(
+    config,
+    "requestsPerMinute",
+  )
   const refillRatePerMs = requestsPerMinute / 60_000
   const states = new Map<string, SiteLimiterState>()
 

--- a/src/services/apiService/common/utils.ts
+++ b/src/services/apiService/common/utils.ts
@@ -6,6 +6,7 @@ import {
   type ApiErrorCode,
 } from "~/services/apiService/common/errors"
 import { createMinIntervalLimiter } from "~/services/apiService/common/minIntervalLimiter"
+import { withSiteApiRequestLimit } from "~/services/apiService/common/siteRequestLimiter"
 import type {
   ApiResponse,
   ApiServiceRequest,
@@ -79,6 +80,16 @@ function isLogApiEndpoint(endpoint: string | undefined): boolean {
  */
 function resolveLogRateLimitKey(baseUrl: string): string {
   return normalizeUrlForOriginKey(baseUrl, { stripTrailingSlashes: true })
+}
+
+/**
+ * Extract the canonical site origin used for process-local API request limiting.
+ */
+function resolveSiteRequestLimitKey(baseUrl: string): string {
+  return normalizeUrlForOriginKey(baseUrl, {
+    lowerCase: true,
+    stripTrailingSlashes: true,
+  })
 }
 
 /**
@@ -399,27 +410,31 @@ const _fetchApi = async <T>(
       request.auth?.cookie ?? accountInfo?.cookieAuth?.sessionCookie,
   }
 
-  return await executeWithTempWindowFallback(context, async () => {
-    if (onlyData) {
-      return await apiRequestData<T>(
+  const siteRequestLimitKey = resolveSiteRequestLimitKey(baseUrl)
+
+  return await withSiteApiRequestLimit(siteRequestLimitKey, async () => {
+    return await executeWithTempWindowFallback(context, async () => {
+      if (onlyData) {
+        return await apiRequestData<T>(
+          url,
+          fetchOptions,
+          options.endpoint,
+          responseType,
+        )
+      }
+      const response = await apiRequest<T>(
         url,
         fetchOptions,
         options.endpoint,
         responseType,
       )
-    }
-    const response = await apiRequest<T>(
-      url,
-      fetchOptions,
-      options.endpoint,
-      responseType,
-    )
 
-    if (responseType === "json") {
-      return response as ApiResponse<T>
-    }
+      if (responseType === "json") {
+        return response as ApiResponse<T>
+      }
 
-    return response as T
+      return response as T
+    })
   })
 }
 

--- a/tests/services/apiService/common/fetchApi.test.ts
+++ b/tests/services/apiService/common/fetchApi.test.ts
@@ -24,6 +24,14 @@ const { mockLogRequestRateLimiter, mockCreateMinIntervalLimiter } = vi.hoisted(
   },
 )
 
+const { mockWithSiteApiRequestLimit } = vi.hoisted(() => {
+  const mockWithSiteApiRequestLimit = vi.fn(
+    async (_key: string, task: () => Promise<unknown>) => await task(),
+  )
+
+  return { mockWithSiteApiRequestLimit }
+})
+
 const { mockHasCookieInterceptorPermissions, mockGetPreferences } = vi.hoisted(
   () => ({
     mockHasCookieInterceptorPermissions: vi.fn(),
@@ -60,6 +68,16 @@ vi.mock("~/services/apiService/common/minIntervalLimiter", () => ({
   createMinIntervalLimiter: mockCreateMinIntervalLimiter,
 }))
 
+vi.mock("~/services/apiService/common/siteRequestLimiter", () => ({
+  SITE_API_REQUEST_LIMITS: {
+    maxConcurrentPerSite: 2,
+    requestsPerMinute: 18,
+    burst: 4,
+  },
+  createSiteRequestLimiter: vi.fn(),
+  withSiteApiRequestLimit: mockWithSiteApiRequestLimit,
+}))
+
 vi.mock("~/utils/browser/protectionBypass", () => ({
   isProtectionBypassFirefoxEnv: vi.fn(() => true),
 }))
@@ -90,6 +108,9 @@ describe("apiService common fetchApi helpers", () => {
     vi.restoreAllMocks()
     server.resetHandlers()
 
+    mockWithSiteApiRequestLimit.mockImplementation(
+      async (_key: string, task: () => Promise<unknown>) => await task(),
+    )
     mockHasCookieInterceptorPermissions.mockResolvedValue(true)
     mockGetPreferences.mockResolvedValue({
       tempWindowFallback: {
@@ -141,6 +162,69 @@ describe("apiService common fetchApi helpers", () => {
     expect(capturedCredentials).toBe("omit")
     expect(capturedAuthorization).toBe("Bearer token")
     expect(result).toEqual(data)
+  })
+
+  it("fetchApiData applies the site API limiter with a normalized origin key", async () => {
+    server.use(
+      http.get(/^https:\/\/example\.com\/base\//, () => {
+        return HttpResponse.json({
+          success: true,
+          data: { ok: true },
+          message: "ok",
+        })
+      }),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: "HTTPS://Example.com/base/",
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        },
+        { endpoint: "/api/user/self" },
+      ),
+    ).resolves.toEqual({ ok: true })
+
+    expect(mockWithSiteApiRequestLimit).toHaveBeenCalledTimes(1)
+    expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.any(Function),
+    )
+  })
+
+  it("fetchApiData uses the same site limiter key for different paths on the same origin", async () => {
+    server.use(
+      http.get(/^https:\/\/example\.com\/(?:base|admin)\//, () => {
+        return HttpResponse.json({
+          success: true,
+          data: { ok: true },
+          message: "ok",
+        })
+      }),
+    )
+
+    await fetchApiData(
+      {
+        baseUrl: "https://example.com/base/",
+        auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+      },
+      { endpoint: "/api/user/self" },
+    )
+    await fetchApiData(
+      {
+        baseUrl: "https://example.com/admin/",
+        auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+      },
+      { endpoint: "/api/status" },
+    )
+
+    expect(mockWithSiteApiRequestLimit).toHaveBeenCalledTimes(2)
+    expect(mockWithSiteApiRequestLimit.mock.calls[0][0]).toBe(
+      "https://example.com",
+    )
+    expect(mockWithSiteApiRequestLimit.mock.calls[1][0]).toBe(
+      "https://example.com",
+    )
   })
 
   it("fetchApiData forwards cookie auth headers and a session override cookie when available", async () => {
@@ -586,6 +670,11 @@ describe("apiService common fetchApi helpers", () => {
           auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
         },
         { endpoint },
+      )
+
+      expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
+        "https://example.com",
+        expect.any(Function),
       )
 
       if (shouldRateLimit) {

--- a/tests/services/apiService/common/siteRequestLimiter.test.ts
+++ b/tests/services/apiService/common/siteRequestLimiter.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { createSiteRequestLimiter } from "~/services/apiService/common/siteRequestLimiter"
+import {
+  createSiteRequestLimiter,
+  withSiteApiRequestLimit,
+} from "~/services/apiService/common/siteRequestLimiter"
 
 const flushMicrotasks = async () => {
   await Promise.resolve()
@@ -189,6 +192,54 @@ describe("createSiteRequestLimiter", () => {
     expect(events).toEqual(["first", "second", "third"])
   })
 
+  it("reschedules a pending token refill when more same-site work is queued", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    const events: string[] = []
+
+    await limiter("site-a", async () => {
+      events.push("first")
+    })
+
+    const second = limiter("site-a", async () => {
+      events.push("second")
+    })
+    await flushMicrotasks()
+    expect(events).toEqual(["first"])
+
+    const third = limiter("site-a", async () => {
+      events.push("third")
+    })
+    await flushMicrotasks()
+    expect(events).toEqual(["first"])
+
+    vi.advanceTimersByTime(1_000)
+    await second
+    await flushMicrotasks()
+    expect(events).toEqual(["first", "second"])
+
+    vi.advanceTimersByTime(1_000)
+    await third
+    expect(events).toEqual(["first", "second", "third"])
+  })
+
+  it("runs the idle cleanup timer after a site queue drains", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+
+    await limiter("site-a", async () => "done")
+    vi.advanceTimersByTime(5 * 60 * 1_000)
+    await flushMicrotasks()
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it("releases the concurrency slot when a task rejects", async () => {
     const limiter = createSiteRequestLimiter({
       maxConcurrentPerSite: 1,
@@ -251,5 +302,11 @@ describe("createSiteRequestLimiter", () => {
         [field]: value,
       }),
     ).toThrow(TypeError)
+  })
+
+  it("withSiteApiRequestLimit delegates to the production limiter", async () => {
+    await expect(
+      withSiteApiRequestLimit("site-a", async () => "wrapped"),
+    ).resolves.toBe("wrapped")
   })
 })

--- a/tests/services/apiService/common/siteRequestLimiter.test.ts
+++ b/tests/services/apiService/common/siteRequestLimiter.test.ts
@@ -231,4 +231,25 @@ describe("createSiteRequestLimiter", () => {
       "empty-key",
     )
   })
+
+  it.each([
+    ["maxConcurrentPerSite", Number.NaN],
+    ["maxConcurrentPerSite", Number.POSITIVE_INFINITY],
+    ["maxConcurrentPerSite", 0],
+    ["burst", Number.NaN],
+    ["burst", Number.POSITIVE_INFINITY],
+    ["burst", 0],
+    ["requestsPerMinute", Number.NaN],
+    ["requestsPerMinute", Number.POSITIVE_INFINITY],
+    ["requestsPerMinute", -1],
+  ])("rejects malformed %s config values", (field, value) => {
+    expect(() =>
+      createSiteRequestLimiter({
+        maxConcurrentPerSite: 1,
+        requestsPerMinute: 1,
+        burst: 1,
+        [field]: value,
+      }),
+    ).toThrow(TypeError)
+  })
 })

--- a/tests/services/apiService/common/siteRequestLimiter.test.ts
+++ b/tests/services/apiService/common/siteRequestLimiter.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createSiteRequestLimiter } from "~/services/apiService/common/siteRequestLimiter"
+
+const flushMicrotasks = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe("createSiteRequestLimiter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("limits concurrent work for the same site key", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 2,
+      requestsPerMinute: 600,
+      burst: 10,
+    })
+
+    const events: string[] = []
+    const releases: Array<() => void> = []
+    const createTask = (label: string) => async () => {
+      events.push(`${label}:start`)
+      await new Promise<void>((resolve) => {
+        releases.push(resolve)
+      })
+      events.push(`${label}:end`)
+    }
+
+    const first = limiter("site-a", createTask("first"))
+    const second = limiter("site-a", createTask("second"))
+    const third = limiter("site-a", createTask("third"))
+
+    await flushMicrotasks()
+    expect(events).toEqual(["first:start", "second:start"])
+
+    releases[0]?.()
+    await first
+    await flushMicrotasks()
+
+    expect(events).toEqual([
+      "first:start",
+      "second:start",
+      "first:end",
+      "third:start",
+    ])
+
+    releases[1]?.()
+    await second
+    await flushMicrotasks()
+
+    expect(events).toEqual([
+      "first:start",
+      "second:start",
+      "first:end",
+      "third:start",
+      "second:end",
+    ])
+
+    releases[2]?.()
+    await third
+    expect(events).toEqual([
+      "first:start",
+      "second:start",
+      "first:end",
+      "third:start",
+      "second:end",
+      "third:end",
+    ])
+  })
+
+  it("keeps FIFO order for queued same-site work", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 600,
+      burst: 10,
+    })
+
+    const events: string[] = []
+    const releases: Array<() => void> = []
+    const createTask = (label: string) => async () => {
+      events.push(`${label}:start`)
+      await new Promise<void>((resolve) => {
+        releases.push(resolve)
+      })
+      events.push(`${label}:end`)
+    }
+
+    const first = limiter("site-a", createTask("first"))
+    const second = limiter("site-a", createTask("second"))
+    const third = limiter("site-a", createTask("third"))
+
+    await flushMicrotasks()
+    expect(events).toEqual(["first:start"])
+
+    releases[0]?.()
+    await first
+    await flushMicrotasks()
+    expect(events).toEqual(["first:start", "first:end", "second:start"])
+
+    releases[1]?.()
+    await second
+    await flushMicrotasks()
+    expect(events).toEqual([
+      "first:start",
+      "first:end",
+      "second:start",
+      "second:end",
+      "third:start",
+    ])
+
+    releases[2]?.()
+    await third
+    expect(events).toEqual([
+      "first:start",
+      "first:end",
+      "second:start",
+      "second:end",
+      "third:start",
+      "third:end",
+    ])
+  })
+
+  it("does not block different site keys", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+
+    const events: string[] = []
+    let releaseSiteA: (() => void) | undefined
+
+    const first = limiter("site-a", async () => {
+      events.push("site-a:start")
+      await new Promise<void>((resolve) => {
+        releaseSiteA = resolve
+      })
+      events.push("site-a:end")
+    })
+    const second = limiter("site-b", async () => {
+      events.push("site-b:start")
+    })
+
+    await flushMicrotasks()
+    expect(events).toEqual(["site-a:start", "site-b:start"])
+
+    await second
+    releaseSiteA?.()
+    await first
+    expect(events).toEqual(["site-a:start", "site-b:start", "site-a:end"])
+  })
+
+  it("waits for token refill after the configured burst is consumed", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 2,
+    })
+    const events: string[] = []
+
+    await limiter("site-a", async () => {
+      events.push("first")
+    })
+    await limiter("site-a", async () => {
+      events.push("second")
+    })
+
+    const third = limiter("site-a", async () => {
+      events.push("third")
+    })
+
+    await flushMicrotasks()
+    expect(events).toEqual(["first", "second"])
+
+    vi.advanceTimersByTime(999)
+    await flushMicrotasks()
+    expect(events).toEqual(["first", "second"])
+
+    vi.advanceTimersByTime(1)
+    await third
+    expect(events).toEqual(["first", "second", "third"])
+  })
+
+  it("releases the concurrency slot when a task rejects", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 600,
+      burst: 10,
+    })
+    const events: string[] = []
+
+    const first = limiter("site-a", async () => {
+      events.push("first:start")
+      throw new Error("boom")
+    })
+    const second = limiter("site-a", async () => {
+      events.push("second:start")
+      return "ok"
+    })
+
+    await expect(first).rejects.toThrow("boom")
+    await expect(second).resolves.toBe("ok")
+    expect(events).toEqual(["first:start", "second:start"])
+  })
+
+  it("runs immediately when disabled or when the key is empty", async () => {
+    const disabledLimiter = createSiteRequestLimiter({
+      enabled: false,
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 1,
+      burst: 1,
+    })
+    const enabledLimiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 1,
+      burst: 1,
+    })
+
+    await expect(
+      disabledLimiter("site-a", async () => "disabled"),
+    ).resolves.toBe("disabled")
+    await expect(enabledLimiter("", async () => "empty-key")).resolves.toBe(
+      "empty-key",
+    )
+  })
+})

--- a/tests/services/apiService/common/siteRequestLimiter.test.ts
+++ b/tests/services/apiService/common/siteRequestLimiter.test.ts
@@ -210,13 +210,19 @@ describe("createSiteRequestLimiter", () => {
     await flushMicrotasks()
     expect(events).toEqual(["first"])
 
+    vi.advanceTimersByTime(400)
+
     const third = limiter("site-a", async () => {
       events.push("third")
     })
     await flushMicrotasks()
     expect(events).toEqual(["first"])
 
-    vi.advanceTimersByTime(1_000)
+    vi.advanceTimersByTime(599)
+    await flushMicrotasks()
+    expect(events).toEqual(["first"])
+
+    vi.advanceTimersByTime(1)
     await second
     await flushMicrotasks()
     expect(events).toEqual(["first", "second"])
@@ -275,12 +281,25 @@ describe("createSiteRequestLimiter", () => {
       burst: 1,
     })
 
+    let releasePending: (() => void) | undefined
+    const pendingRequest = enabledLimiter("site-a", async () => {
+      await new Promise<void>((resolve) => {
+        releasePending = resolve
+      })
+      return "pending"
+    })
+    await flushMicrotasks()
+    expect(releasePending).toBeTypeOf("function")
+
     await expect(
       disabledLimiter("site-a", async () => "disabled"),
     ).resolves.toBe("disabled")
     await expect(enabledLimiter("", async () => "empty-key")).resolves.toBe(
       "empty-key",
     )
+
+    releasePending?.()
+    await expect(pendingRequest).resolves.toBe("pending")
   })
 
   it.each([
@@ -304,7 +323,7 @@ describe("createSiteRequestLimiter", () => {
     ).toThrow(TypeError)
   })
 
-  it("withSiteApiRequestLimit delegates to the production limiter", async () => {
+  it("withSiteApiRequestLimit runs the wrapped task in test mode", async () => {
     await expect(
       withSiteApiRequestLimit("site-a", async () => "wrapped"),
     ).resolves.toBe("wrapped")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site-level API request rate limiting applied per-origin to API calls for fairer, more stable external request handling.
* **Bug Fixes / Reliability**
  * Prevents one site’s requests from blocking others, enforces per-site concurrency and burst limits, and cleans up idle site state.
* **Tests**
  * Added tests covering ordering, concurrency, token refill, error handling, idle cleanup, and config validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->