### PR TITLE
fix(model-list): abort batch verification on stop

### DIFF
--- a/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
+++ b/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
@@ -205,6 +205,7 @@ export function BatchVerifyModelsDialog({
   const [isRunning, setIsRunning] = useState(false)
   const [hasStarted, setHasStarted] = useState(false)
   const shouldStopRef = useRef(false)
+  const batchAbortControllerRef = useRef<AbortController | null>(null)
   const previousDialogSnapshotRef = useRef({
     isOpen: false,
     items,
@@ -413,7 +414,10 @@ export function BatchVerifyModelsDialog({
   )
 
   const runOne = useCallback(
-    async (item: BatchVerifyModelItem) => {
+    async (item: BatchVerifyModelItem, abortSignal: AbortSignal) => {
+      const isStopped = () => shouldStopRef.current || abortSignal.aborted
+      if (isStopped()) return
+
       const startedAt = Date.now()
       updateRow(item.key, {
         status: BATCH_VERIFY_ROW_STATUSES.RUNNING,
@@ -439,6 +443,8 @@ export function BatchVerifyModelsDialog({
                 if (!isAccountBatchVerifyModelItem(item)) return null
                 const account = item.source.account
                 const tokens = await getAccountTokens(item)
+                if (isStopped()) return null
+
                 const token = pickBatchVerifyCompatibleToken(tokens, item)
                 if (!token) {
                   const summary = t(
@@ -454,6 +460,8 @@ export function BatchVerifyModelsDialog({
                 }
 
                 const resolvedToken = await getResolvedToken(item, token)
+                if (isStopped()) return null
+
                 return {
                   baseUrl: account.baseUrl,
                   apiKey: resolvedToken.key,
@@ -462,7 +470,7 @@ export function BatchVerifyModelsDialog({
                 }
               })()
 
-        if (!credentials) return
+        if (!credentials || isStopped()) return
 
         apiKey = credentials.apiKey
         const probesToRun = getApiVerificationProbeDefinitions(apiType).filter(
@@ -495,7 +503,7 @@ export function BatchVerifyModelsDialog({
         const results: ApiVerificationProbeResult[] = []
         let stoppedBeforeCompletingProbes = false
         for (const probe of probesToRun) {
-          if (shouldStopRef.current) {
+          if (isStopped()) {
             stoppedBeforeCompletingProbes = true
             break
           }
@@ -508,9 +516,19 @@ export function BatchVerifyModelsDialog({
               modelId: item.modelId,
               tokenMeta,
               probeId: probe.id,
+              abortSignal,
             })
+            if (isStopped()) {
+              stoppedBeforeCompletingProbes = true
+              break
+            }
             results.push(result)
           } catch (error) {
+            if (isStopped()) {
+              stoppedBeforeCompletingProbes = true
+              break
+            }
+
             const redactions =
               item.source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE
                 ? filterRedactions([
@@ -534,7 +552,7 @@ export function BatchVerifyModelsDialog({
           }
         }
 
-        if (stoppedBeforeCompletingProbes) return
+        if (stoppedBeforeCompletingProbes || isStopped()) return
 
         await persistResult(item, apiType, results).catch((persistError) => {
           logger.error("Failed to persist batch verification result", {
@@ -562,6 +580,8 @@ export function BatchVerifyModelsDialog({
           tokenName: credentials.tokenName,
         })
       } catch (error) {
+        if (isStopped()) return
+
         const redactions =
           item.source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE
             ? filterRedactions([
@@ -638,6 +658,8 @@ export function BatchVerifyModelsDialog({
     )
     shouldStopRef.current = false
     clearCachedTokenPromises()
+    const abortController = new AbortController()
+    batchAbortControllerRef.current = abortController
     setHasStarted(true)
     setIsRunning(true)
     setRows(
@@ -664,7 +686,7 @@ export function BatchVerifyModelsDialog({
         nextIndex += 1
         const item = selectedItems[index]
         if (!item) return
-        await runOne(item)
+        await runOne(item, abortController.signal)
       }
     }
 
@@ -678,12 +700,16 @@ export function BatchVerifyModelsDialog({
       if (shouldStopRef.current) {
         markUnfinishedRowsStopped()
       }
+      if (batchAbortControllerRef.current === abortController) {
+        batchAbortControllerRef.current = null
+      }
       setIsRunning(false)
     }
   }
 
   const stopBatch = () => {
     shouldStopRef.current = true
+    batchAbortControllerRef.current?.abort()
   }
 
   const statusVariant = (status: BatchVerifyRowStatus) => {

--- a/src/services/apiService/anthropic/index.ts
+++ b/src/services/apiService/anthropic/index.ts
@@ -5,6 +5,7 @@ import { createLogger } from "~/utils/core/logger"
 type AnthropicAuthParams = {
   baseUrl: string
   apiKey: string
+  abortSignal?: AbortSignal
 }
 
 type AnthropicModelItem = {
@@ -51,6 +52,7 @@ export async function fetchAnthropicModelIds(
         {
           endpoint,
           options: {
+            signal: params.abortSignal,
             headers: {
               "x-api-key": params.apiKey,
               "anthropic-version": ANTHROPIC_VERSION,

--- a/src/services/apiService/common/type.ts
+++ b/src/services/apiService/common/type.ts
@@ -383,6 +383,8 @@ export interface OpenAIAuthParams {
   baseUrl: string
   /** API Key */
   apiKey: string
+  /** Optional cancellation signal for caller-scoped checks. */
+  abortSignal?: AbortSignal
 }
 
 // 上游模型列表（OpenAI格式）

--- a/src/services/apiService/google/index.ts
+++ b/src/services/apiService/google/index.ts
@@ -5,6 +5,7 @@ import { createLogger } from "~/utils/core/logger"
 type GoogleAuthParams = {
   baseUrl: string
   apiKey: string
+  abortSignal?: AbortSignal
 }
 
 type GoogleModelsListResponse = {
@@ -47,6 +48,7 @@ export async function fetchGoogleModelIds(
         {
           endpoint,
           options: {
+            signal: params.abortSignal,
             headers: {
               "x-goog-api-key": params.apiKey,
             },

--- a/src/services/apiService/openaiCompatible/index.ts
+++ b/src/services/apiService/openaiCompatible/index.ts
@@ -25,6 +25,9 @@ export const fetchOpenAICompatibleModels = async (params: OpenAIAuthParams) => {
   try {
     return await fetchApiData<UpstreamModelList>(request, {
       endpoint: OPENAI_COMPATIBLE_MODELS_ENDPOINT,
+      ...(params.abortSignal
+        ? { options: { signal: params.abortSignal } }
+        : {}),
     })
   } catch (error) {
     logger.error("Failed to fetch upstream model list", error)

--- a/src/services/verification/aiApiVerification/apiVerificationService.ts
+++ b/src/services/verification/aiApiVerification/apiVerificationService.ts
@@ -19,6 +19,7 @@ type RunApiVerificationParams = {
   apiType: ApiVerificationApiType
   modelId?: string
   tokenMeta?: Pick<ApiToken, "models" | "model_limits" | "name" | "id">
+  abortSignal?: AbortSignal
 }
 
 /**
@@ -58,6 +59,7 @@ export async function runApiVerificationProbe(
     apiKey: params.apiKey,
     apiType: params.apiType,
     modelId: resolvedModelId,
+    abortSignal: params.abortSignal,
   })
 }
 
@@ -75,6 +77,7 @@ export async function runApiVerification(
     apiKey: params.apiKey,
     apiType: params.apiType,
     requestedModelId,
+    abortSignal: params.abortSignal,
   })
 
   return {

--- a/src/services/verification/aiApiVerification/probeRegistry.ts
+++ b/src/services/verification/aiApiVerification/probeRegistry.ts
@@ -17,6 +17,7 @@ type ProbeRunnerParams = {
   apiKey: string
   apiType: ApiVerificationApiType
   modelId?: string
+  abortSignal?: AbortSignal
 }
 
 /**
@@ -42,6 +43,7 @@ export const apiVerificationProbeRegistry: Record<
           baseUrl: params.baseUrl,
           apiKey: params.apiKey,
           apiType: params.apiType,
+          abortSignal: params.abortSignal,
         })
       ).result
     },
@@ -54,6 +56,7 @@ export const apiVerificationProbeRegistry: Record<
         apiKey: params.apiKey,
         apiType: params.apiType,
         modelId: params.modelId as string,
+        abortSignal: params.abortSignal,
       }),
   },
   "tool-calling": {
@@ -64,6 +67,7 @@ export const apiVerificationProbeRegistry: Record<
         apiKey: params.apiKey,
         apiType: params.apiType,
         modelId: params.modelId as string,
+        abortSignal: params.abortSignal,
       }),
   },
   "structured-output": {
@@ -74,6 +78,7 @@ export const apiVerificationProbeRegistry: Record<
         apiKey: params.apiKey,
         apiType: params.apiType,
         modelId: params.modelId as string,
+        abortSignal: params.abortSignal,
       }),
   },
   "web-search": {
@@ -84,6 +89,7 @@ export const apiVerificationProbeRegistry: Record<
         apiKey: params.apiKey,
         apiType: params.apiType,
         modelId: params.modelId as string,
+        abortSignal: params.abortSignal,
       }),
   },
 }

--- a/src/services/verification/aiApiVerification/probes/modelsProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/modelsProbe.ts
@@ -14,6 +14,7 @@ type RunModelsProbeParams = {
   baseUrl: string
   apiKey: string
   apiType: ApiVerificationApiType
+  abortSignal?: AbortSignal
 }
 
 /**
@@ -101,6 +102,7 @@ export async function runModelsProbe(
         return fetchOpenAICompatibleModelIds({
           baseUrl: normalizedBaseUrl,
           apiKey: params.apiKey,
+          abortSignal: params.abortSignal,
         })
       }
 
@@ -108,6 +110,7 @@ export async function runModelsProbe(
         return fetchAnthropicModelIds({
           baseUrl: normalizedBaseUrl,
           apiKey: params.apiKey,
+          abortSignal: params.abortSignal,
         })
       }
 
@@ -115,6 +118,7 @@ export async function runModelsProbe(
         return fetchGoogleModelIds({
           baseUrl: normalizedBaseUrl,
           apiKey: params.apiKey,
+          abortSignal: params.abortSignal,
         })
       }
 

--- a/src/services/verification/aiApiVerification/probes/modelsProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/modelsProbe.ts
@@ -8,7 +8,7 @@ import type {
   ApiVerificationProbeResult,
 } from "../types"
 import { API_TYPES } from "../types"
-import { toSanitizedErrorSummary } from "../utils"
+import { isAbortError, toSanitizedErrorSummary } from "../utils"
 
 type RunModelsProbeParams = {
   baseUrl: string
@@ -157,6 +157,10 @@ export async function runModelsProbe(
       },
     }
   } catch (error) {
+    if (isAbortError(error, params.abortSignal)) {
+      throw error
+    }
+
     return {
       result: {
         id: "models",

--- a/src/services/verification/aiApiVerification/probes/structuredOutputProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/structuredOutputProbe.ts
@@ -14,6 +14,7 @@ type RunStructuredOutputProbeParams = {
   apiKey: string
   apiType: ApiVerificationApiType
   modelId: string
+  abortSignal?: AbortSignal
 }
 
 /**
@@ -42,6 +43,7 @@ export async function runStructuredOutputProbe(
           ok: z.literal(true),
         }),
       }),
+      abortSignal: params.abortSignal,
     })
 
     return {

--- a/src/services/verification/aiApiVerification/probes/structuredOutputProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/structuredOutputProbe.ts
@@ -7,7 +7,7 @@ import type {
   ApiVerificationApiType,
   ApiVerificationProbeResult,
 } from "../types"
-import { toSanitizedErrorSummary } from "../utils"
+import { isAbortError, toSanitizedErrorSummary } from "../utils"
 
 type RunStructuredOutputProbeParams = {
   baseUrl: string
@@ -68,6 +68,10 @@ export async function runStructuredOutputProbe(
       },
     }
   } catch (error) {
+    if (isAbortError(error, params.abortSignal)) {
+      throw error
+    }
+
     const summary = toSanitizedErrorSummary(error, secretsToRedact)
     return {
       id: "structured-output",

--- a/src/services/verification/aiApiVerification/probes/textGenerationProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/textGenerationProbe.ts
@@ -13,6 +13,7 @@ type RunTextGenerationProbeParams = {
   apiKey: string
   apiType: ApiVerificationApiType
   modelId: string
+  abortSignal?: AbortSignal
 }
 
 /**
@@ -36,6 +37,7 @@ export async function runTextGenerationProbe(
     const result = await generateText({
       model,
       prompt,
+      abortSignal: params.abortSignal,
     })
 
     const text = (result.text ?? "").trim().toLowerCase()

--- a/src/services/verification/aiApiVerification/probes/textGenerationProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/textGenerationProbe.ts
@@ -6,7 +6,7 @@ import type {
   ApiVerificationApiType,
   ApiVerificationProbeResult,
 } from "../types"
-import { toSanitizedErrorSummary } from "../utils"
+import { isAbortError, toSanitizedErrorSummary } from "../utils"
 
 type RunTextGenerationProbeParams = {
   baseUrl: string
@@ -65,6 +65,10 @@ export async function runTextGenerationProbe(
         : { responsePreview: (result.text ?? "").slice(0, 80) },
     }
   } catch (error) {
+    if (isAbortError(error, params.abortSignal)) {
+      throw error
+    }
+
     return {
       id: "text-generation",
       status: "fail",

--- a/src/services/verification/aiApiVerification/probes/toolCallingProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/toolCallingProbe.ts
@@ -17,6 +17,7 @@ type RunToolCallingProbeParams = {
   apiKey: string
   apiType: ApiVerificationApiType
   modelId: string
+  abortSignal?: AbortSignal
 }
 
 /**
@@ -65,6 +66,7 @@ export async function runToolCallingProbe(
       prompt,
       tools: { verify_tool: verifyTool },
       toolChoice: "required",
+      abortSignal: params.abortSignal,
     })
 
     if (!toolCalled(result)) {

--- a/src/services/verification/aiApiVerification/probes/toolCallingProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/toolCallingProbe.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types"
 import {
   inferHttpStatus,
+  isAbortError,
   summaryKeyFromHttpStatus,
   toSanitizedErrorSummary,
 } from "../utils"
@@ -121,6 +122,10 @@ export async function runToolCallingProbe(
       },
     }
   } catch (error) {
+    if (isAbortError(error, params.abortSignal)) {
+      throw error
+    }
+
     const summary = toSanitizedErrorSummary(error, secretsToRedact)
     const inferredStatus = inferHttpStatus(error, summary)
     return {

--- a/src/services/verification/aiApiVerification/probes/webSearchProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/webSearchProbe.ts
@@ -6,7 +6,7 @@ import type {
   ApiVerificationApiType,
   ApiVerificationProbeResult,
 } from "../types"
-import { toSanitizedErrorSummary } from "../utils"
+import { isAbortError, toSanitizedErrorSummary } from "../utils"
 
 type RunWebSearchProbeParams = {
   baseUrl: string
@@ -150,6 +150,10 @@ export async function runWebSearchProbe(
       },
     }
   } catch (error) {
+    if (isAbortError(error, params.abortSignal)) {
+      throw error
+    }
+
     return {
       id: "web-search",
       status: "fail",

--- a/src/services/verification/aiApiVerification/probes/webSearchProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/webSearchProbe.ts
@@ -13,6 +13,7 @@ type RunWebSearchProbeParams = {
   apiKey: string
   apiType: ApiVerificationApiType
   modelId: string
+  abortSignal?: AbortSignal
 }
 
 /**
@@ -57,6 +58,7 @@ export async function runWebSearchProbe(
           }),
         },
         toolChoice: { type: "tool", toolName: "web_search" },
+        abortSignal: params.abortSignal,
       })
 
       const searched =
@@ -102,6 +104,7 @@ export async function runWebSearchProbe(
           google_search: google.tools.googleSearch({}),
         },
         toolChoice: { type: "tool", toolName: "google_search" },
+        abortSignal: params.abortSignal,
       })
 
       const searched =

--- a/src/services/verification/aiApiVerification/suiteRunner.ts
+++ b/src/services/verification/aiApiVerification/suiteRunner.ts
@@ -11,6 +11,7 @@ type RunApiVerificationSuiteParams = {
   apiKey: string
   apiType: ApiVerificationApiType
   requestedModelId?: string
+  abortSignal?: AbortSignal
 }
 
 type ApiVerificationSuiteResult = {
@@ -31,6 +32,7 @@ export async function runApiVerificationSuite(
     baseUrl: params.baseUrl,
     apiKey: params.apiKey,
     apiType: params.apiType,
+    abortSignal: params.abortSignal,
   })
   results.push(modelsProbe.result)
 
@@ -70,6 +72,7 @@ export async function runApiVerificationSuite(
         apiKey: params.apiKey,
         apiType: params.apiType,
         modelId: resolvedModelId,
+        abortSignal: params.abortSignal,
       }),
     )
   }

--- a/src/services/verification/aiApiVerification/utils.ts
+++ b/src/services/verification/aiApiVerification/utils.ts
@@ -24,6 +24,21 @@ export function toSanitizedErrorSummary(
 }
 
 /**
+ * Identify caller-initiated cancellation before probe error fallbacks convert it
+ * into a failed verification result.
+ */
+export function isAbortError(
+  error: unknown,
+  abortSignal?: AbortSignal,
+): boolean {
+  if (abortSignal?.aborted) return true
+  if (!error || typeof error !== "object") return false
+
+  const candidate = error as { code?: unknown; name?: unknown }
+  return candidate.name === "AbortError" || candidate.code === "ABORT_ERR"
+}
+
+/**
  * Map inferred HTTP status to a stable i18n summary key.
  *
  * These keys are shared between verification UIs (API verification + CLI support verification).

--- a/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
+++ b/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
@@ -177,19 +177,22 @@ describe("BatchVerifyModelsDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockRunApiVerificationProbe).toHaveBeenCalledWith({
-        baseUrl: "https://api.example.com",
-        apiKey: "sk-real",
-        apiType: API_TYPES.OPENAI,
-        modelId: "gpt-4o",
-        tokenMeta: {
-          id: 1,
-          name: "default-token",
-          model_limits: "",
-          models: "",
-        },
-        probeId: "text-generation",
-      })
+      expect(mockRunApiVerificationProbe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://api.example.com",
+          apiKey: "sk-real",
+          apiType: API_TYPES.OPENAI,
+          modelId: "gpt-4o",
+          tokenMeta: {
+            id: 1,
+            name: "default-token",
+            model_limits: "",
+            models: "",
+          },
+          probeId: "text-generation",
+          abortSignal: expect.any(AbortSignal),
+        }),
+      )
     })
     expect(
       await screen.findByText("modelList:batchVerify.messages.probeSummary"),
@@ -350,6 +353,82 @@ describe("BatchVerifyModelsDialog", () => {
       await screen.findByText("modelList:batchVerify.messages.stopped"),
     ).toBeInTheDocument()
     expect(mockRunApiVerificationProbe).toHaveBeenCalledTimes(1)
+    expect(mockUpsertLatestSummary).not.toHaveBeenCalled()
+  })
+
+  it("aborts the running probe request when the batch is stopped", async () => {
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce([
+      {
+        id: 1,
+        name: "default-token",
+        key: "masked",
+        status: 1,
+        group: "default",
+        model_limits_enabled: false,
+        model_limits: "",
+        models: "",
+      },
+    ])
+    mockResolveDisplayAccountTokenForSecret.mockResolvedValueOnce({
+      id: 1,
+      name: "default-token",
+      key: "sk-real",
+      status: 1,
+      group: "default",
+      model_limits_enabled: false,
+      model_limits: "",
+      models: "",
+    })
+
+    let receivedSignal: AbortSignal | undefined
+    mockRunApiVerificationProbe.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise((_, reject) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    renderDialog([
+      {
+        key: "account:acc-1:model:gpt-4o",
+        modelId: "gpt-4o",
+        enableGroups: ["default"],
+        source: { kind: "account", account },
+      },
+    ])
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "modelList:batchVerify.actions.start",
+      }),
+    )
+
+    const stopButton = await screen.findByRole("button", {
+      name: "modelList:batchVerify.actions.stop",
+    })
+    await waitFor(() => {
+      expect(mockRunApiVerificationProbe).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(stopButton)
+
+    await waitFor(() => {
+      expect(receivedSignal?.aborted).toBe(true)
+    })
+    expect(
+      await screen.findByText("modelList:batchVerify.messages.stopped"),
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByRole("button", {
+        name: "modelList:batchVerify.actions.rerun",
+      }),
+    ).toBeEnabled()
     expect(mockUpsertLatestSummary).not.toHaveBeenCalled()
   })
 
@@ -983,8 +1062,9 @@ describe("BatchVerifyModelsDialog", () => {
     })
 
     expect(
-      await screen.findByText("modelList:batchVerify.messages.stopped"),
-    ).toBeInTheDocument()
+      (await screen.findAllByText("modelList:batchVerify.messages.stopped"))
+        .length,
+    ).toBeGreaterThan(0)
   })
 
   it("runs profile-backed models with the profile api type and without account tokens", async () => {
@@ -1020,14 +1100,17 @@ describe("BatchVerifyModelsDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockRunApiVerificationProbe).toHaveBeenCalledWith({
-        baseUrl: "https://anthropic.example.com",
-        apiKey: "profile-secret",
-        apiType: API_TYPES.ANTHROPIC,
-        modelId: "claude-3-5-sonnet",
-        tokenMeta: undefined,
-        probeId: "text-generation",
-      })
+      expect(mockRunApiVerificationProbe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://anthropic.example.com",
+          apiKey: "profile-secret",
+          apiType: API_TYPES.ANTHROPIC,
+          modelId: "claude-3-5-sonnet",
+          tokenMeta: undefined,
+          probeId: "text-generation",
+          abortSignal: expect.any(AbortSignal),
+        }),
+      )
     })
     expect(mockFetchDisplayAccountTokens).not.toHaveBeenCalled()
     await waitFor(() => {

--- a/tests/services/aiApiVerification/probes.additional.test.ts
+++ b/tests/services/aiApiVerification/probes.additional.test.ts
@@ -5,6 +5,9 @@ const mocks = vi.hoisted(() => ({
   createModel: vi.fn(),
   createOpenAIProvider: vi.fn(),
   createGoogleProvider: vi.fn(),
+  fetchOpenAICompatibleModelIds: vi.fn(),
+  fetchAnthropicModelIds: vi.fn(),
+  fetchGoogleModelIds: vi.fn(),
 }))
 
 vi.mock("ai", () => ({
@@ -22,6 +25,25 @@ vi.mock("~/services/verification/aiApiVerification/providers", () => ({
   createGoogleProvider: mocks.createGoogleProvider,
 }))
 
+vi.mock("~/services/apiService/openaiCompatible", () => ({
+  fetchOpenAICompatibleModelIds: mocks.fetchOpenAICompatibleModelIds,
+}))
+
+vi.mock("~/services/apiService/anthropic", () => ({
+  fetchAnthropicModelIds: mocks.fetchAnthropicModelIds,
+}))
+
+vi.mock("~/services/apiService/google", () => ({
+  fetchGoogleModelIds: mocks.fetchGoogleModelIds,
+}))
+
+function createAbortedSignalFixture() {
+  const controller = new AbortController()
+  const abortError = new DOMException("Aborted", "AbortError")
+  controller.abort()
+  return { abortError, abortSignal: controller.signal }
+}
+
 describe("AI API verification probes", () => {
   beforeEach(() => {
     vi.resetModules()
@@ -30,6 +52,9 @@ describe("AI API verification probes", () => {
     mocks.createModel.mockReset()
     mocks.createOpenAIProvider.mockReset()
     mocks.createGoogleProvider.mockReset()
+    mocks.fetchOpenAICompatibleModelIds.mockReset()
+    mocks.fetchAnthropicModelIds.mockReset()
+    mocks.fetchGoogleModelIds.mockReset()
 
     mocks.createOpenAIProvider.mockImplementation(() => {
       const provider = ((modelId: string) => ({
@@ -54,6 +79,26 @@ describe("AI API verification probes", () => {
     })
 
     mocks.createModel.mockImplementation((params) => params)
+  })
+
+  describe("runModelsProbe", () => {
+    it("rethrows aborted model-list fetches", async () => {
+      const { abortError, abortSignal } = createAbortedSignalFixture()
+      mocks.fetchOpenAICompatibleModelIds.mockRejectedValueOnce(abortError)
+
+      const { runModelsProbe } = await import(
+        "~/services/verification/aiApiVerification/probes/modelsProbe"
+      )
+
+      await expect(
+        runModelsProbe({
+          apiType: "openai",
+          baseUrl: "https://example.com",
+          apiKey: "sk-secret",
+          abortSignal,
+        }),
+      ).rejects.toBe(abortError)
+    })
   })
 
   describe("runWebSearchProbe", () => {
@@ -151,6 +196,25 @@ describe("AI API verification probes", () => {
       expect(result.summary).not.toContain("sk-secret")
     })
 
+    it("rethrows aborted OpenAI web-search requests", async () => {
+      const { abortError, abortSignal } = createAbortedSignalFixture()
+      mocks.generateText.mockRejectedValueOnce(abortError)
+
+      const { runWebSearchProbe } = await import(
+        "~/services/verification/aiApiVerification/probes/webSearchProbe"
+      )
+
+      await expect(
+        runWebSearchProbe({
+          apiType: "openai",
+          baseUrl: "https://example.com",
+          apiKey: "sk-secret",
+          modelId: "gpt-4.1",
+          abortSignal,
+        }),
+      ).rejects.toBe(abortError)
+    })
+
     it("fails for OpenAI endpoints when neither tool results nor sources are returned", async () => {
       mocks.generateText.mockResolvedValueOnce({
         toolResults: [],
@@ -234,6 +298,25 @@ describe("AI API verification probes", () => {
           toolResultsCount: 1,
         },
       })
+    })
+
+    it("rethrows aborted Google web-search requests", async () => {
+      const { abortError, abortSignal } = createAbortedSignalFixture()
+      mocks.generateText.mockRejectedValueOnce(abortError)
+
+      const { runWebSearchProbe } = await import(
+        "~/services/verification/aiApiVerification/probes/webSearchProbe"
+      )
+
+      await expect(
+        runWebSearchProbe({
+          apiType: "google",
+          baseUrl: "https://generativelanguage.googleapis.com",
+          apiKey: "AIza-secret",
+          modelId: "gemini-2.5-pro",
+          abortSignal,
+        }),
+      ).rejects.toBe(abortError)
     })
 
     it("treats omitted OpenAI tool-results and sources arrays as an empty-result failure", async () => {
@@ -387,6 +470,25 @@ describe("AI API verification probes", () => {
       })
       expect(result.summary).not.toContain("sk-secret")
     })
+
+    it("rethrows aborted text-generation requests", async () => {
+      const { abortError, abortSignal } = createAbortedSignalFixture()
+      mocks.generateText.mockRejectedValueOnce(abortError)
+
+      const { runTextGenerationProbe } = await import(
+        "~/services/verification/aiApiVerification/probes/textGenerationProbe"
+      )
+
+      await expect(
+        runTextGenerationProbe({
+          apiType: "openai",
+          baseUrl: "https://example.com",
+          apiKey: "sk-secret",
+          modelId: "gpt-4.1",
+          abortSignal,
+        }),
+      ).rejects.toBe(abortError)
+    })
   })
 
   describe("runStructuredOutputProbe", () => {
@@ -463,6 +565,25 @@ describe("AI API verification probes", () => {
         status: "fail",
       })
       expect(result.summary).not.toContain("sk-secret")
+    })
+
+    it("rethrows aborted structured-output requests", async () => {
+      const { abortError, abortSignal } = createAbortedSignalFixture()
+      mocks.generateText.mockRejectedValueOnce(abortError)
+
+      const { runStructuredOutputProbe } = await import(
+        "~/services/verification/aiApiVerification/probes/structuredOutputProbe"
+      )
+
+      await expect(
+        runStructuredOutputProbe({
+          apiType: "openai",
+          baseUrl: "https://example.com",
+          apiKey: "sk-secret",
+          modelId: "gpt-4.1",
+          abortSignal,
+        }),
+      ).rejects.toBe(abortError)
     })
   })
 
@@ -617,6 +738,25 @@ describe("AI API verification probes", () => {
         status: "fail",
         summary: expect.any(String),
       })
+    })
+
+    it("rethrows aborted tool-calling requests", async () => {
+      const { abortError, abortSignal } = createAbortedSignalFixture()
+      mocks.generateText.mockRejectedValueOnce(abortError)
+
+      const { runToolCallingProbe } = await import(
+        "~/services/verification/aiApiVerification/probes/toolCallingProbe"
+      )
+
+      await expect(
+        runToolCallingProbe({
+          apiType: "openai",
+          baseUrl: "https://example.com",
+          apiKey: "sk-secret",
+          modelId: "gpt-4.1",
+          abortSignal,
+        }),
+      ).rejects.toBe(abortError)
     })
   })
 })

--- a/tests/services/apiService/openaiCompatible.index.test.ts
+++ b/tests/services/apiService/openaiCompatible.index.test.ts
@@ -53,6 +53,35 @@ describe("OpenAI-compatible model fetchers", () => {
     )
   })
 
+  it("passes caller abort signals to the model-list request", async () => {
+    const models = [{ id: "gpt-4.1" }]
+    const abortController = new AbortController()
+    mockFetchApiData.mockResolvedValueOnce(models)
+
+    await expect(
+      fetchOpenAICompatibleModels({
+        ...params,
+        abortSignal: abortController.signal,
+      } as any),
+    ).resolves.toEqual(models)
+
+    expect(mockFetchApiData).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://openai-compatible.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "secret-key",
+        },
+      },
+      {
+        endpoint: "/v1/models",
+        options: {
+          signal: abortController.signal,
+        },
+      },
+    )
+  })
+
   it("maps upstream models into plain model id lists", async () => {
     mockFetchApiData.mockResolvedValueOnce([
       { id: "gpt-4.1", owned_by: "openai" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can stop batch model verification at any time; in-flight provider requests are cancelled and UI shows a stopped state with rerun enabled.
  * Cancellation now works across supported model providers.

* **Bug Fixes**
  * Aborted requests are no longer recorded as probe failures; cancellations terminate processing promptly.

* **Tests**
  * Added coverage validating cancellation behavior across probes and providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->