### PR TITLE
feat(ui): add clear buttons to shared and business inputs

### DIFF
--- a/src/components/ChannelFiltersEditor.tsx
+++ b/src/components/ChannelFiltersEditor.tsx
@@ -125,6 +125,8 @@ export default function ChannelFiltersEditor(props: ChannelFiltersEditorProps) {
                         onFieldChange(filter.id, "name", event.target.value)
                       }
                       placeholder={t("filters.placeholders.name")}
+                      onClear={() => onFieldChange(filter.id, "name", "")}
+                      clearButtonLabel={t("common:actions.clear")}
                     />
                   </div>
                   <div className="space-y-2">
@@ -180,6 +182,8 @@ export default function ChannelFiltersEditor(props: ChannelFiltersEditorProps) {
                         onFieldChange(filter.id, "pattern", event.target.value)
                       }
                       placeholder={t("filters.placeholders.pattern")}
+                      onClear={() => onFieldChange(filter.id, "pattern", "")}
+                      clearButtonLabel={t("common:actions.clear")}
                     />
                     <p className="text-muted-foreground text-xs">
                       {filter.isRegex
@@ -223,6 +227,8 @@ export default function ChannelFiltersEditor(props: ChannelFiltersEditorProps) {
                     }
                     placeholder={t("filters.placeholders.description")}
                     rows={2}
+                    onClear={() => onFieldChange(filter.id, "description", "")}
+                    clearButtonLabel={t("common:actions.clear")}
                   />
                 </div>
               </div>
@@ -246,6 +252,8 @@ export default function ChannelFiltersEditor(props: ChannelFiltersEditorProps) {
             onChange={(event) => onChangeJsonText(event.target.value)}
             placeholder={t("filters.jsonEditor.placeholder")}
             rows={10}
+            onClear={() => onChangeJsonText("")}
+            clearButtonLabel={t("common:actions.clear")}
           />
           <p className="text-muted-foreground text-xs">
             {t("filters.jsonEditor.hint")}

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,6 +1,10 @@
 import { cva, type VariantProps } from "class-variance-authority"
 import React from "react"
 
+import {
+  ClearableFieldButton,
+  getClearableFieldValue,
+} from "~/components/ui/clearableField"
 import { cn } from "~/lib/utils"
 
 const textareaVariants = cva(
@@ -34,6 +38,8 @@ export interface TextareaProps
   success?: string
   showCount?: boolean
   maxLength?: number
+  onClear?: () => void
+  clearButtonLabel?: string
 }
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
@@ -47,24 +53,64 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       showCount,
       maxLength,
       value,
+      onClear,
+      clearButtonLabel = "Clear",
       ...props
     },
     ref,
   ) => {
+    const textareaRef = React.useRef<HTMLTextAreaElement | null>(null)
     const textareaVariant = error ? "error" : success ? "success" : variant
     const currentLength = typeof value === "string" ? value.length : 0
+    const showClearButton =
+      Boolean(onClear) &&
+      getClearableFieldValue(value).length > 0 &&
+      !props.disabled &&
+      !props.readOnly
+
+    const setTextareaRef = (node: HTMLTextAreaElement | null) => {
+      textareaRef.current = node
+
+      if (typeof ref === "function") {
+        ref(node)
+      } else if (ref) {
+        ref.current = node
+      }
+    }
+
+    const focusTextareaAfterClear = () => {
+      const focusTextarea = () => textareaRef.current?.focus()
+
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(focusTextarea)
+        return
+      }
+
+      focusTextarea()
+    }
 
     return (
       <div className="relative">
         <textarea
           className={cn(
             textareaVariants({ variant: textareaVariant, size, className }),
+            showClearButton && "pr-10",
           )}
-          ref={ref}
+          ref={setTextareaRef}
           value={value}
           maxLength={maxLength}
           {...props}
         />
+        {showClearButton && (
+          <ClearableFieldButton
+            label={clearButtonLabel}
+            onClick={() => {
+              onClear?.()
+              focusTextareaAfterClear()
+            }}
+            className="absolute top-2 right-2"
+          />
+        )}
         {(error || success) && (
           <p
             className={cn(

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -68,15 +68,18 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       !props.disabled &&
       !props.readOnly
 
-    const setTextareaRef = (node: HTMLTextAreaElement | null) => {
-      textareaRef.current = node
+    const setTextareaRef = React.useCallback(
+      (node: HTMLTextAreaElement | null) => {
+        textareaRef.current = node
 
-      if (typeof ref === "function") {
-        ref(node)
-      } else if (ref) {
-        ref.current = node
-      }
-    }
+        if (typeof ref === "function") {
+          ref(node)
+        } else if (ref) {
+          ref.current = node
+        }
+      },
+      [ref],
+    )
 
     const focusTextareaAfterClear = () => {
       const focusTextarea = () => textareaRef.current?.focus()

--- a/src/components/ui/clearableField.tsx
+++ b/src/components/ui/clearableField.tsx
@@ -35,6 +35,7 @@ function ClearableFieldButton({
 }: ClearableFieldButtonProps) {
   return (
     <button
+      {...props}
       type="button"
       className={cn(
         "flex h-5 w-5 items-center justify-center rounded-full text-gray-400 transition-colors hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-gray-500 dark:hover:text-gray-300",
@@ -42,7 +43,6 @@ function ClearableFieldButton({
       )}
       aria-label={label}
       title={label}
-      {...props}
     >
       <XIcon className="size-4" />
     </button>

--- a/src/components/ui/clearableField.tsx
+++ b/src/components/ui/clearableField.tsx
@@ -1,0 +1,52 @@
+import { XIcon } from "lucide-react"
+import React from "react"
+
+import { cn } from "~/lib/utils"
+
+type ClearableFieldValue = string | number | readonly string[] | undefined
+
+/**
+ *
+ */
+function getClearableFieldValue(value: ClearableFieldValue) {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.join("")
+  }
+
+  return ""
+}
+
+interface ClearableFieldButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string
+}
+
+/**
+ *
+ */
+function ClearableFieldButton({
+  className,
+  label,
+  ...props
+}: ClearableFieldButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex h-5 w-5 items-center justify-center rounded-full text-gray-400 transition-colors hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-gray-500 dark:hover:text-gray-300",
+        className,
+      )}
+      aria-label={label}
+      title={label}
+      {...props}
+    >
+      <XIcon className="size-4" />
+    </button>
+  )
+}
+
+export { ClearableFieldButton, getClearableFieldValue }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,10 @@
 import { cva, type VariantProps } from "class-variance-authority"
 import React from "react"
 
+import {
+  ClearableFieldButton,
+  getClearableFieldValue,
+} from "~/components/ui/clearableField"
 import { cn } from "~/lib/utils"
 
 const inputVariants = cva(
@@ -53,6 +57,8 @@ export interface InputProps
   containerClassName?: string
   leftIcon?: React.ReactNode
   rightIcon?: React.ReactNode
+  onClear?: () => void
+  clearButtonLabel?: string
   error?: string
   success?: string
 }
@@ -66,15 +72,47 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       size,
       leftIcon,
       rightIcon,
+      onClear,
+      clearButtonLabel = "Clear",
       error,
       success,
       ...props
     },
     ref,
   ) => {
+    const inputRef = React.useRef<HTMLInputElement | null>(null)
     const inputVariant = error ? "error" : success ? "success" : variant
     const variantSize = typeof size === "string" ? size : undefined
     const nativeSize = typeof size === "number" ? size : undefined
+    const showClearButton =
+      Boolean(onClear) &&
+      getClearableFieldValue(props.value).length > 0 &&
+      !props.disabled &&
+      !props.readOnly
+    const showRightContent = Boolean(rightIcon) || showClearButton
+    const rightPaddingClass =
+      rightIcon && showClearButton ? "pr-16" : showRightContent ? "pr-10" : ""
+
+    const setInputRef = (node: HTMLInputElement | null) => {
+      inputRef.current = node
+
+      if (typeof ref === "function") {
+        ref(node)
+      } else if (ref) {
+        ref.current = node
+      }
+    }
+
+    const focusInputAfterClear = () => {
+      const focusInput = () => inputRef.current?.focus()
+
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(focusInput)
+        return
+      }
+
+      focusInput()
+    }
 
     return (
       <div className={cn("relative", containerClassName)}>
@@ -91,17 +129,28 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
               className,
             }),
             leftIcon && "pl-10",
-            rightIcon && "pr-10",
+            rightPaddingClass,
           )}
           size={nativeSize}
-          ref={ref}
+          ref={setInputRef}
           {...props}
         />
-        {rightIcon && (
-          <div className="absolute inset-y-0 right-0 flex items-center pr-2">
-            <span className="text-gray-400 dark:text-gray-500">
-              {rightIcon}
-            </span>
+        {showRightContent && (
+          <div className="absolute inset-y-0 right-0 flex items-center gap-1 pr-2">
+            {rightIcon && (
+              <span className="text-gray-400 dark:text-gray-500">
+                {rightIcon}
+              </span>
+            )}
+            {showClearButton && (
+              <ClearableFieldButton
+                label={clearButtonLabel}
+                onClick={() => {
+                  onClear?.()
+                  focusInputAfterClear()
+                }}
+              />
+            )}
           </div>
         )}
         {(error || success) && (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -93,15 +93,18 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const rightPaddingClass =
       rightIcon && showClearButton ? "pr-16" : showRightContent ? "pr-10" : ""
 
-    const setInputRef = (node: HTMLInputElement | null) => {
-      inputRef.current = node
+    const setInputRef = React.useCallback(
+      (node: HTMLInputElement | null) => {
+        inputRef.current = node
 
-      if (typeof ref === "function") {
-        ref(node)
-      } else if (ref) {
-        ref.current = node
-      }
-    }
+        if (typeof ref === "function") {
+          ref(node)
+        } else if (ref) {
+          ref.current = node
+        }
+      },
+      [ref],
+    )
 
     const focusInputAfterClear = () => {
       const focusInput = () => inputRef.current?.focus()
@@ -136,9 +139,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           {...props}
         />
         {showRightContent && (
-          <div className="absolute inset-y-0 right-0 flex items-center gap-1 pr-2">
+          <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center gap-1 pr-2">
             {rightIcon && (
-              <span className="text-gray-400 dark:text-gray-500">
+              <span className="pointer-events-auto text-gray-400 dark:text-gray-500">
                 {rightIcon}
               </span>
             )}
@@ -149,6 +152,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                   onClear?.()
                   focusInputAfterClear()
                 }}
+                className="pointer-events-auto"
               />
             )}
           </div>

--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -3,14 +3,12 @@ import {
   GlobeAltIcon,
   InformationCircleIcon,
   PencilIcon,
-  XCircleIcon,
 } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
 import Tooltip from "~/components/Tooltip"
 import {
   Button,
-  IconButton,
   Input,
   Select,
   SelectContent,
@@ -103,20 +101,8 @@ export default function SiteInfoInput({
             placeholder="https://example.com"
             disabled={isDetected}
             data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput}
-            rightIcon={
-              url &&
-              !isDetected && (
-                <IconButton
-                  type="button"
-                  onClick={onClearUrl}
-                  variant="ghost"
-                  size="sm"
-                  aria-label="clear-url"
-                >
-                  <XCircleIcon className="h-5 w-5 text-gray-400" />
-                </IconButton>
-              )
-            }
+            onClear={onClearUrl}
+            clearButtonLabel="clear-url"
           />
         </div>
         <Tooltip

--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -66,7 +66,7 @@ export default function SiteInfoInput({
   onUseCurrentTab,
   onEditAccount,
 }: SiteInfoInputProps) {
-  const { t } = useTranslation("accountDialog")
+  const { t } = useTranslation(["accountDialog", "common"])
   const isSub2Api = siteType === SUB2API
 
   const handleEditClick = () => {
@@ -102,7 +102,7 @@ export default function SiteInfoInput({
             disabled={isDetected}
             data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput}
             onClear={onClearUrl}
-            clearButtonLabel="clear-url"
+            clearButtonLabel={t("common:actions.clear")}
           />
         </div>
         <Tooltip

--- a/src/features/AccountManagement/components/AccountList/AccountSearchInput.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountSearchInput.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
 import { Input } from "~/components/ui"
@@ -42,18 +42,8 @@ export default function AccountSearchInput({
         onKeyDown={handleKeyDown}
         placeholder={t("search.placeholder")}
         leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
-        rightIcon={
-          value && (
-            <button
-              type="button"
-              onClick={onClear}
-              className="flex h-5 w-5 items-center justify-center rounded-full text-gray-400 transition-colors hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-              aria-label={t("common:actions.clear")}
-            >
-              <XMarkIcon className="h-4 w-4" />
-            </button>
-          )
-        }
+        onClear={onClear}
+        clearButtonLabel={t("common:actions.clear")}
       />
     </div>
   )

--- a/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
+++ b/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
@@ -352,6 +352,8 @@ export function TagPicker({
               aria-expanded={isOpen}
               aria-controls={listboxId}
               aria-activedescendant={activeOptionId}
+              onClear={() => setQuery("")}
+              clearButtonLabel={t("common:actions.clear")}
             />
 
             {tagActionError && (

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
 import { KeyRound } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -166,18 +166,8 @@ export function ApiCredentialProfilesListView({
             onKeyDown={handleSearchKeyDown}
             placeholder={t("apiCredentialProfiles:controls.searchPlaceholder")}
             leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
-            rightIcon={
-              searchTerm && (
-                <button
-                  type="button"
-                  onClick={clearSearch}
-                  className="flex h-5 w-5 items-center justify-center rounded-full text-gray-400 transition-colors hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-                  aria-label={t("common:actions.clear")}
-                >
-                  <XMarkIcon className="h-4 w-4" />
-                </button>
-              )
-            }
+            onClear={clearSearch}
+            clearButtonLabel={t("common:actions.clear")}
           />
         </div>
 

--- a/src/features/AutoCheckin/components/FilterBar.tsx
+++ b/src/features/AutoCheckin/components/FilterBar.tsx
@@ -131,6 +131,8 @@ export default function FilterBar({
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}
           leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+          onClear={() => onKeywordChange("")}
+          clearButtonLabel={t("common:actions.clear")}
         />
       </div>
     </div>

--- a/src/features/ImportExport/components/ImportSection.tsx
+++ b/src/features/ImportExport/components/ImportSection.tsx
@@ -73,6 +73,8 @@ const ImportSection = ({
               onChange={(e) => setImportData(e.target.value)}
               placeholder={t("import.pasteJsonData")}
               className="h-16 w-full resize-none font-mono"
+              onClear={() => setImportData("")}
+              clearButtonLabel={t("common:actions.clear")}
             />
           </FormField>
 

--- a/src/features/KeyManagement/components/TokenSearchBar.tsx
+++ b/src/features/KeyManagement/components/TokenSearchBar.tsx
@@ -26,6 +26,8 @@ export function TokenSearchBar({
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
         leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+        onClear={() => setSearchTerm("")}
+        clearButtonLabel={t("common:actions.clear")}
       />
     </div>
   )

--- a/src/features/ManagedSiteModelSync/components/FilterBar.tsx
+++ b/src/features/ManagedSiteModelSync/components/FilterBar.tsx
@@ -102,6 +102,8 @@ export default function FilterBar({
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}
           leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+          onClear={() => onKeywordChange("")}
+          clearButtonLabel={t("common:actions.clear")}
         />
       </div>
     </div>

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -193,6 +193,8 @@ export function ControlPanel({
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+              onClear={() => setSearchTerm("")}
+              clearButtonLabel={t("common:actions.clear")}
             />
           </FormField>
 

--- a/src/features/SiteBookmarks/components/BookmarkSearchInput.tsx
+++ b/src/features/SiteBookmarks/components/BookmarkSearchInput.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
 import { Input } from "~/components/ui"
@@ -38,18 +38,8 @@ export default function BookmarkSearchInput({
         onKeyDown={handleKeyDown}
         placeholder={t("bookmark:search.placeholder")}
         leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
-        rightIcon={
-          value && (
-            <button
-              type="button"
-              onClick={onClear}
-              className="flex h-5 w-5 items-center justify-center rounded-full text-gray-400 transition-colors hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-              aria-label={t("common:actions.clear")}
-            >
-              <XMarkIcon className="h-4 w-4" />
-            </button>
-          )
-        }
+        onClear={onClear}
+        clearButtonLabel={t("common:actions.clear")}
       />
     </div>
   )

--- a/tests/components/ChannelFiltersEditor.test.tsx
+++ b/tests/components/ChannelFiltersEditor.test.tsx
@@ -298,9 +298,11 @@ describe("ChannelFiltersEditor", () => {
     const clearButtons = screen.getAllByRole("button", {
       name: "common:actions.clear",
     })
-    await user.click(clearButtons[0])
-    await user.click(clearButtons[1])
-    await user.click(clearButtons[2])
+    expect(clearButtons).toHaveLength(2)
+
+    for (const clearButton of clearButtons) {
+      await user.click(clearButton)
+    }
 
     expect(props.onFieldChange).toHaveBeenCalledWith("rule-1", "name", "")
     expect(props.onFieldChange).toHaveBeenCalledWith("rule-1", "pattern", "")
@@ -333,6 +335,28 @@ describe("ChannelFiltersEditor", () => {
     await user.click(screen.getByRole("button", { name: "filters.addRule" }))
 
     expect(props.onAddFilter).toHaveBeenCalledTimes(1)
+  })
+
+  it("clears a populated visual rule description", async () => {
+    const user = userEvent.setup()
+    const { props } = renderEditor({
+      filters: [
+        buildFilter({
+          description: "Clear this description",
+        }),
+      ],
+    })
+
+    const clearButtons = screen.getAllByRole("button", {
+      name: "common:actions.clear",
+    })
+    await user.click(clearButtons[2])
+
+    expect(props.onFieldChange).toHaveBeenCalledWith(
+      "rule-1",
+      "description",
+      "",
+    )
   })
 
   it("renders the json editor and propagates mode switches and text changes", async () => {

--- a/tests/components/ChannelFiltersEditor.test.tsx
+++ b/tests/components/ChannelFiltersEditor.test.tsx
@@ -20,31 +20,59 @@ vi.mock("~/components/ui", async (importOriginal) => {
   return {
     ...actual,
     Input: ({
+      clearButtonLabel,
+      onClear,
       value,
       onChange,
       placeholder,
     }: {
+      clearButtonLabel?: string
+      onClear?: () => void
       value: string
       onChange: (event: { target: { value: string } }) => void
       placeholder?: string
-    }) => <input value={value} onChange={onChange} placeholder={placeholder} />,
+    }) => (
+      <div>
+        <input value={value} onChange={onChange} placeholder={placeholder} />
+        {value && onClear ? (
+          <button
+            type="button"
+            aria-label={clearButtonLabel}
+            onClick={onClear}
+          />
+        ) : null}
+      </div>
+    ),
     Textarea: ({
+      clearButtonLabel,
+      onClear,
       value,
       onChange,
       placeholder,
       rows,
     }: {
+      clearButtonLabel?: string
+      onClear?: () => void
       value: string
       onChange: (event: { target: { value: string } }) => void
       placeholder?: string
       rows?: number
     }) => (
-      <textarea
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        rows={rows}
-      />
+      <div>
+        <textarea
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          rows={rows}
+        />
+        {value && onClear ? (
+          <button
+            type="button"
+            aria-label={clearButtonLabel}
+            onClick={onClear}
+          />
+        ) : null}
+      </div>
     ),
   }
 })
@@ -267,6 +295,16 @@ describe("ChannelFiltersEditor", () => {
       "Block provider-specific models",
     )
 
+    const clearButtons = screen.getAllByRole("button", {
+      name: "common:actions.clear",
+    })
+    await user.click(clearButtons[0])
+    await user.click(clearButtons[1])
+    await user.click(clearButtons[2])
+
+    expect(props.onFieldChange).toHaveBeenCalledWith("rule-1", "name", "")
+    expect(props.onFieldChange).toHaveBeenCalledWith("rule-1", "pattern", "")
+
     await user.click(
       screen.getByRole("button", { name: "filters.labels.delete" }),
     )
@@ -333,5 +371,10 @@ describe("ChannelFiltersEditor", () => {
       },
     )
     expect(props.onChangeJsonText).toHaveBeenCalledWith("[]")
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
+    expect(props.onChangeJsonText).toHaveBeenCalledWith("")
   })
 })

--- a/tests/components/Input.test.tsx
+++ b/tests/components/Input.test.tsx
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { Input } from "~/components/ui/input"
-import { render, screen } from "~~/tests/test-utils/render"
+import { Textarea } from "~/components/ui/Textarea"
+import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
 describe("Input", () => {
   it("forwards numeric size to the native input element", async () => {
@@ -17,5 +18,89 @@ describe("Input", () => {
     const input = await screen.findByLabelText("variant-size")
     expect(input).not.toHaveAttribute("size")
     expect(input).toHaveClass("text-xs")
+  })
+
+  it("shows a clear button for controlled values and calls the clear handler", async () => {
+    const onClear = vi.fn()
+
+    render(
+      <Input
+        aria-label="search"
+        value="saved prompt"
+        onChange={vi.fn()}
+        onClear={onClear}
+        clearButtonLabel="Clear search"
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole("button", { name: "Clear search" }))
+
+    expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not show the clear button for empty, disabled, or read-only inputs", () => {
+    const { rerender } = render(
+      <Input
+        aria-label="empty"
+        value=""
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        clearButtonLabel="Clear input"
+      />,
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "Clear input" }),
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <Input
+        aria-label="disabled"
+        value="disabled"
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        clearButtonLabel="Clear input"
+        disabled={true}
+      />,
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "Clear input" }),
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <Input
+        aria-label="read-only"
+        value="read-only"
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        clearButtonLabel="Clear input"
+        readOnly={true}
+      />,
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "Clear input" }),
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe("Textarea", () => {
+  it("shows a clear button for controlled values and calls the clear handler", async () => {
+    const onClear = vi.fn()
+
+    render(
+      <Textarea
+        aria-label="notes"
+        value="saved notes"
+        onChange={vi.fn()}
+        onClear={onClear}
+        clearButtonLabel="Clear notes"
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole("button", { name: "Clear notes" }))
+
+    expect(onClear).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/components/Input.test.tsx
+++ b/tests/components/Input.test.tsx
@@ -261,4 +261,50 @@ describe("Textarea", () => {
 
     expect(textareaRef).not.toHaveBeenCalled()
   })
+
+  it("does not show the clear button for empty, disabled, or read-only textareas", () => {
+    const { rerender } = render(
+      <Textarea
+        aria-label="empty"
+        value=""
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        clearButtonLabel="Clear textarea"
+      />,
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "Clear textarea" }),
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <Textarea
+        aria-label="disabled"
+        value="disabled"
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        clearButtonLabel="Clear textarea"
+        disabled={true}
+      />,
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "Clear textarea" }),
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <Textarea
+        aria-label="read-only"
+        value="read-only"
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        clearButtonLabel="Clear textarea"
+        readOnly={true}
+      />,
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "Clear textarea" }),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/tests/components/Input.test.tsx
+++ b/tests/components/Input.test.tsx
@@ -1,8 +1,36 @@
+import { createRef } from "react"
 import { describe, expect, it, vi } from "vitest"
 
+import {
+  ClearableFieldButton,
+  getClearableFieldValue,
+} from "~/components/ui/clearableField"
 import { Input } from "~/components/ui/input"
 import { Textarea } from "~/components/ui/Textarea"
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
+
+describe("clearable field helpers", () => {
+  it("normalizes array and missing values for clear-button visibility", () => {
+    expect(getClearableFieldValue(["open", "ai"])).toBe("openai")
+    expect(getClearableFieldValue(undefined)).toBe("")
+  })
+
+  it("keeps button behavior and label attributes from being overridden", async () => {
+    render(
+      <ClearableFieldButton
+        label="Clear field"
+        type="submit"
+        aria-label="Override"
+        title="Override"
+      />,
+    )
+
+    const button = await screen.findByRole("button", { name: "Clear field" })
+
+    expect(button).toHaveAttribute("type", "button")
+    expect(button).toHaveAttribute("title", "Clear field")
+  })
+})
 
 describe("Input", () => {
   it("forwards numeric size to the native input element", async () => {
@@ -36,6 +64,71 @@ describe("Input", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Clear search" }))
 
     expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  it("focuses the input immediately after clearing when animation frames are unavailable", async () => {
+    const onClear = vi.fn()
+    vi.stubGlobal("requestAnimationFrame", undefined)
+
+    try {
+      render(
+        <Input
+          aria-label="search"
+          value="saved prompt"
+          onChange={vi.fn()}
+          onClear={onClear}
+          clearButtonLabel="Clear search"
+        />,
+      )
+
+      const input = await screen.findByLabelText("search")
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Clear search" }),
+      )
+
+      expect(onClear).toHaveBeenCalledTimes(1)
+      expect(input).toHaveFocus()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it("forwards object refs to the native input element", async () => {
+    const inputRef = createRef<HTMLInputElement>()
+
+    render(<Input aria-label="object-ref" ref={inputRef} />)
+
+    const input = await screen.findByLabelText("object-ref")
+
+    expect(inputRef.current).toBe(input)
+  })
+
+  it("does not churn forwarded callback refs during value updates", async () => {
+    const inputRef = vi.fn()
+    const { rerender } = render(
+      <Input
+        aria-label="callback-ref"
+        value="one"
+        onChange={vi.fn()}
+        ref={inputRef}
+      />,
+    )
+
+    expect(inputRef).toHaveBeenLastCalledWith(
+      await screen.findByLabelText("callback-ref"),
+    )
+    inputRef.mockClear()
+
+    rerender(
+      <Input
+        aria-label="callback-ref"
+        value="two"
+        onChange={vi.fn()}
+        ref={inputRef}
+      />,
+    )
+
+    expect(inputRef).not.toHaveBeenCalled()
   })
 
   it("does not show the clear button for empty, disabled, or read-only inputs", () => {
@@ -102,5 +195,70 @@ describe("Textarea", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Clear notes" }))
 
     expect(onClear).toHaveBeenCalledTimes(1)
+  })
+
+  it("focuses the textarea immediately after clearing when animation frames are unavailable", async () => {
+    const onClear = vi.fn()
+    vi.stubGlobal("requestAnimationFrame", undefined)
+
+    try {
+      render(
+        <Textarea
+          aria-label="notes"
+          value="saved notes"
+          onChange={vi.fn()}
+          onClear={onClear}
+          clearButtonLabel="Clear notes"
+        />,
+      )
+
+      const textarea = await screen.findByLabelText("notes")
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Clear notes" }),
+      )
+
+      expect(onClear).toHaveBeenCalledTimes(1)
+      expect(textarea).toHaveFocus()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it("forwards object refs to the native textarea element", async () => {
+    const textareaRef = createRef<HTMLTextAreaElement>()
+
+    render(<Textarea aria-label="object-ref" ref={textareaRef} />)
+
+    const textarea = await screen.findByLabelText("object-ref")
+
+    expect(textareaRef.current).toBe(textarea)
+  })
+
+  it("does not churn forwarded callback refs during value updates", async () => {
+    const textareaRef = vi.fn()
+    const { rerender } = render(
+      <Textarea
+        aria-label="callback-ref"
+        value="one"
+        onChange={vi.fn()}
+        ref={textareaRef}
+      />,
+    )
+
+    expect(textareaRef).toHaveBeenLastCalledWith(
+      await screen.findByLabelText("callback-ref"),
+    )
+    textareaRef.mockClear()
+
+    rerender(
+      <Textarea
+        aria-label="callback-ref"
+        value="two"
+        onChange={vi.fn()}
+        ref={textareaRef}
+      />,
+    )
+
+    expect(textareaRef).not.toHaveBeenCalled()
   })
 })

--- a/tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
@@ -186,6 +186,10 @@ describe("ControlPanel profile capabilities", () => {
     expect(toast.success).toHaveBeenCalledWith(
       "modelList:messages.modelNamesCopied",
     )
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
+    expect(setSearchTerm).toHaveBeenCalledWith("")
     expect(await screen.findByText("modelList:totalModels")).toBeInTheDocument()
     expect(await screen.findByText("modelList:showing")).toBeInTheDocument()
   })

--- a/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
@@ -42,7 +42,9 @@ describe("AccountDialog SiteInfoInput", () => {
       "https://updated.example.com",
     )
 
-    await user.click(screen.getByRole("button", { name: "clear-url" }))
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
     expect(props.onClearUrl).toHaveBeenCalledTimes(1)
 
     await user.click(
@@ -109,7 +111,9 @@ describe("AccountDialog SiteInfoInput", () => {
         name: "accountDialog:siteInfo.authMethod",
       }),
     ).toBeDisabled()
-    expect(screen.queryByRole("button", { name: "clear-url" })).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "common:actions.clear" }),
+    ).toBeNull()
     expect(
       screen.queryByRole("button", {
         name: "accountDialog:siteInfo.useCurrent",

--- a/tests/features/AccountManagement/components/TagPicker.test.tsx
+++ b/tests/features/AccountManagement/components/TagPicker.test.tsx
@@ -85,6 +85,45 @@ describe("TagPicker", () => {
     })
   })
 
+  it("clears the tag search from the shared input clear button", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TagPicker
+        tags={[
+          { id: "t1", name: "Work", createdAt: 1, updatedAt: 1 },
+          { id: "t2", name: "Personal", createdAt: 1, updatedAt: 1 },
+        ]}
+        selectedTagIds={[]}
+        onSelectedTagIdsChange={vi.fn()}
+        onCreateTag={vi.fn()}
+        onRenameTag={vi.fn()}
+        onDeleteTag={vi.fn()}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "accountDialog:form.tagsPlaceholder",
+      }),
+    )
+    const input = await screen.findByPlaceholderText(
+      "accountDialog:form.tagsSearchPlaceholder",
+    )
+    await user.type(input, "work")
+
+    expect(screen.getByText("Work")).toBeInTheDocument()
+    expect(screen.queryByText("Personal")).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
+
+    expect(input).toHaveValue("")
+    expect(screen.getByText("Work")).toBeInTheDocument()
+    expect(screen.getByText("Personal")).toBeInTheDocument()
+  })
+
   it("does not offer duplicate creation and ignores Enter without an active option", async () => {
     const user = userEvent.setup()
 

--- a/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
+++ b/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { ApiCredentialProfilesListView } from "~/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView"
-import { render, screen } from "~~/tests/test-utils/render"
+import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
 vi.mock("~/hooks/useMediaQuery", () => ({
   useIsDesktop: () => true,
@@ -9,8 +9,20 @@ vi.mock("~/hooks/useMediaQuery", () => ({
 }))
 
 vi.mock("~/components/ui", () => ({
-  Input: ({ leftIcon: _leftIcon, rightIcon: _rightIcon, ...props }: any) => (
-    <input {...props} />
+  Input: ({
+    clearButtonLabel,
+    leftIcon: _leftIcon,
+    onClear,
+    rightIcon: _rightIcon,
+    value,
+    ...props
+  }: any) => (
+    <div>
+      <input value={value} {...props} />
+      {value && onClear ? (
+        <button type="button" aria-label={clearButtonLabel} onClick={onClear} />
+      ) : null}
+    </div>
   ),
   SearchableSelect: ({ value, onChange }: any) => (
     <select
@@ -74,5 +86,53 @@ describe("ApiCredentialProfilesListView", () => {
     expect(await screen.findByText("Existing Profile")).toBeInTheDocument()
     expect(screen.getByText("common:status.refreshing")).toBeInTheDocument()
     expect(screen.queryByText("common:status.loading")).not.toBeInTheDocument()
+  })
+
+  it("clears the profile search from the shared input clear button", async () => {
+    const controller = {
+      profiles: [
+        {
+          id: "profile-1",
+          name: "OpenAI Profile",
+          apiType: "openai",
+          baseUrl: "https://openai.example.com",
+          apiKey: "sk-test",
+          tagIds: [],
+          notes: "",
+        },
+        {
+          id: "profile-2",
+          name: "Anthropic Profile",
+          apiType: "anthropic",
+          baseUrl: "https://anthropic.example.com",
+          apiKey: "sk-test",
+          tagIds: [],
+          notes: "",
+        },
+      ],
+      isLoading: false,
+      tags: [],
+      tagNameById: new Map<string, string>(),
+      openAddDialog: vi.fn(),
+    } as any
+
+    render(<ApiCredentialProfilesListView controller={controller} />)
+
+    fireEvent.change(
+      await screen.findByPlaceholderText(
+        "apiCredentialProfiles:controls.searchPlaceholder",
+      ),
+      { target: { value: "openai" } },
+    )
+
+    expect(screen.getByText("OpenAI Profile")).toBeInTheDocument()
+    expect(screen.queryByText("Anthropic Profile")).not.toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
+
+    expect(screen.getByText("OpenAI Profile")).toBeInTheDocument()
+    expect(screen.getByText("Anthropic Profile")).toBeInTheDocument()
   })
 })

--- a/tests/features/AutoCheckin/components/FilterBar.test.tsx
+++ b/tests/features/AutoCheckin/components/FilterBar.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render as rtlRender, screen } from "@testing-library/react"
+import { I18nextProvider } from "react-i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import FilterBar, {
+  FILTER_STATUS,
+} from "~/features/AutoCheckin/components/FilterBar"
+import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { testI18n } from "~~/tests/test-utils/i18n"
+
+describe("AutoCheckin FilterBar", () => {
+  it("clears the keyword search from the shared input clear button", () => {
+    const onKeywordChange = vi.fn()
+
+    rtlRender(
+      <I18nextProvider i18n={testI18n}>
+        <FilterBar
+          accountResults={[
+            {
+              accountId: "account-1",
+              accountName: "Alpha",
+              status: CHECKIN_RESULT_STATUS.SUCCESS,
+            } as any,
+          ]}
+          status={FILTER_STATUS.ALL}
+          keyword="Alpha"
+          onStatusChange={vi.fn()}
+          onKeywordChange={onKeywordChange}
+        />
+      </I18nextProvider>,
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
+
+    expect(onKeywordChange).toHaveBeenCalledWith("")
+  })
+})

--- a/tests/features/ImportExport/components/sections.test.tsx
+++ b/tests/features/ImportExport/components/sections.test.tsx
@@ -92,6 +92,9 @@ describe("ImportExport section components", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "common:actions.import" }),
     )
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
 
     expect(
       screen.getByText("importExport:import.dataValid"),
@@ -100,6 +103,7 @@ describe("ImportExport section components", () => {
       screen.getByText(/importExport:import\.containsAccountData/),
     ).toBeInTheDocument()
     expect(setImportData).toHaveBeenCalledWith('{"version":3}')
+    expect(setImportData).toHaveBeenCalledWith("")
     expect(handleFileImport).toHaveBeenCalledTimes(1)
     expect(handleImport).toHaveBeenCalledTimes(1)
 

--- a/tests/features/KeyManagement/components/TokenSearchBar.test.tsx
+++ b/tests/features/KeyManagement/components/TokenSearchBar.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render as rtlRender, screen } from "@testing-library/react"
+import { I18nextProvider } from "react-i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import { TokenSearchBar } from "~/features/KeyManagement/components/TokenSearchBar"
+import { testI18n } from "~~/tests/test-utils/i18n"
+
+describe("TokenSearchBar", () => {
+  it("clears the token search from the shared input clear button", () => {
+    const setSearchTerm = vi.fn()
+
+    rtlRender(
+      <I18nextProvider i18n={testI18n}>
+        <TokenSearchBar searchTerm="sk-live" setSearchTerm={setSearchTerm} />
+      </I18nextProvider>,
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
+
+    expect(setSearchTerm).toHaveBeenCalledWith("")
+  })
+})

--- a/tests/features/ManagedSiteModelSync/components.test.tsx
+++ b/tests/features/ManagedSiteModelSync/components.test.tsx
@@ -191,7 +191,7 @@ describe("ManagedSiteModelSync components", () => {
             startedAt: 0,
             endedAt: 1000,
           }}
-          keyword=""
+          keyword="Alpha"
           onStatusChange={onStatusChange}
           onKeywordChange={onKeywordChange}
         />
@@ -236,6 +236,11 @@ describe("ManagedSiteModelSync components", () => {
     expect(onRefresh).toHaveBeenCalledTimes(1)
     expect(onStatusChange).toHaveBeenCalledWith("success")
     expect(onKeywordChange).toHaveBeenCalledWith("alpha")
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
+    expect(onKeywordChange).toHaveBeenCalledWith("")
   })
 
   it("renders results and empty states across branches", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear-button controls to inputs and textareas across the app (searches, filters, forms, tag/JSON previews, etc.). Buttons appear only when fields have content, use localized accessible labels, and restore focus to the field after clearing.
* **Tests**
  * Updated and added tests covering clear-button rendering, accessibility, focus behavior, and that clearing resets UI state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->