### PR TITLE
feat(api-credentials): add usage telemetry and manual refresh

### DIFF
--- a/src/components/ui/clearableField.tsx
+++ b/src/components/ui/clearableField.tsx
@@ -6,7 +6,7 @@ import { cn } from "~/lib/utils"
 type ClearableFieldValue = string | number | readonly string[] | undefined
 
 /**
- *
+ * Converts supported input values into a string for emptiness checks.
  */
 function getClearableFieldValue(value: ClearableFieldValue) {
   if (typeof value === "string" || typeof value === "number") {
@@ -26,7 +26,7 @@ interface ClearableFieldButtonProps
 }
 
 /**
- *
+ * Renders the compact clear button used by clearable form fields.
  */
 function ClearableFieldButton({
   className,

--- a/src/entrypoints/popup/components/ApiCredentialProfilesStatsSection.tsx
+++ b/src/entrypoints/popup/components/ApiCredentialProfilesStatsSection.tsx
@@ -2,12 +2,10 @@ import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { BodySmall, Caption } from "~/components/ui"
-import { UI_CONSTANTS } from "~/constants/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { useApiCredentialProfiles } from "~/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles"
 import { SiteHealthStatus } from "~/types"
-import { getCurrencySymbol } from "~/utils/core/formatters"
-import { getDisplayMoneyValue } from "~/utils/core/money"
+import { formatTelemetryMoney } from "~/utils/core/money"
 
 import { AnimatedStatValue } from "./AnimatedStatValue"
 
@@ -47,7 +45,7 @@ export default function ApiCredentialProfilesStatsSection() {
   }, [profiles])
 
   const telemetryStats = useMemo(() => {
-    return profiles.reduce(
+    const stats = profiles.reduce(
       (acc, profile) => {
         const snapshot = profile.telemetrySnapshot
         if (!snapshot) return acc
@@ -55,7 +53,10 @@ export default function ApiCredentialProfilesStatsSection() {
         if (snapshot.health.status === SiteHealthStatus.Healthy) {
           acc.healthyCount += 1
         }
-        acc.balanceUsd += snapshot.balanceUsd ?? 0
+        if (typeof snapshot.balanceUsd === "number") {
+          acc.balanceUsd += snapshot.balanceUsd
+          acc.balanceSources += 1
+        }
         if (typeof snapshot.todayCostUsd === "number") {
           acc.todayUsageUsd += snapshot.todayCostUsd
           acc.todayUsageSources += 1
@@ -65,22 +66,20 @@ export default function ApiCredentialProfilesStatsSection() {
       {
         healthyCount: 0,
         balanceUsd: 0,
+        balanceSources: 0,
         profileTelemetryCount: 0,
         todayUsageSources: 0,
         todayUsageUsd: 0,
       },
     )
-  }, [profiles])
 
-  const formatMoney = (valueUsd: number) => {
-    const value =
-      currencyType === "CNY"
-        ? valueUsd * UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
-        : valueUsd
-    return `${getCurrencySymbol(currencyType)}${getDisplayMoneyValue(
-      value,
-    ).toFixed(UI_CONSTANTS.MONEY.DECIMALS)}`
-  }
+    return {
+      ...stats,
+      balanceUsd: stats.balanceSources > 0 ? stats.balanceUsd : undefined,
+      todayUsageUsd:
+        stats.profileTelemetryCount > 0 ? stats.todayUsageUsd : undefined,
+    }
+  }, [profiles])
 
   return (
     <div className="space-y-3">
@@ -133,7 +132,9 @@ export default function ApiCredentialProfilesStatsSection() {
             {t("apiCredentialProfiles:stats.totalBalance")}
           </Caption>
           <span className="text-base font-semibold">
-            {formatMoney(telemetryStats.balanceUsd)}
+            {telemetryStats.balanceUsd === undefined
+              ? t("apiCredentialProfiles:telemetry.notProvided")
+              : formatTelemetryMoney(telemetryStats.balanceUsd, currencyType)}
           </span>
         </div>
         <div className="space-y-1">
@@ -141,10 +142,13 @@ export default function ApiCredentialProfilesStatsSection() {
             {t("apiCredentialProfiles:stats.todayUsage")}
           </Caption>
           <span className="text-base font-semibold text-emerald-600 dark:text-emerald-400">
-            {telemetryStats.profileTelemetryCount > 0 &&
+            {telemetryStats.todayUsageUsd === undefined ||
             telemetryStats.todayUsageSources === 0
               ? t("apiCredentialProfiles:telemetry.notProvided")
-              : formatMoney(telemetryStats.todayUsageUsd)}
+              : formatTelemetryMoney(
+                  telemetryStats.todayUsageUsd,
+                  currencyType,
+                )}
           </span>
         </div>
       </div>

--- a/src/entrypoints/popup/components/ApiCredentialProfilesStatsSection.tsx
+++ b/src/entrypoints/popup/components/ApiCredentialProfilesStatsSection.tsx
@@ -2,7 +2,12 @@ import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { BodySmall, Caption } from "~/components/ui"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { useApiCredentialProfiles } from "~/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles"
+import { SiteHealthStatus } from "~/types"
+import { getCurrencySymbol } from "~/utils/core/formatters"
+import { getDisplayMoneyValue } from "~/utils/core/money"
 
 import { AnimatedStatValue } from "./AnimatedStatValue"
 
@@ -12,6 +17,7 @@ import { AnimatedStatValue } from "./AnimatedStatValue"
 export default function ApiCredentialProfilesStatsSection() {
   const { t } = useTranslation(["apiCredentialProfiles"])
   const { profiles, isLoading } = useApiCredentialProfiles()
+  const { currencyType } = useUserPreferencesContext()
   const [hasLoaded, setHasLoaded] = useState(false)
 
   useEffect(() => {
@@ -39,6 +45,32 @@ export default function ApiCredentialProfilesStatsSection() {
     }
     return tagIds.size
   }, [profiles])
+
+  const telemetryStats = useMemo(() => {
+    return profiles.reduce(
+      (acc, profile) => {
+        const snapshot = profile.telemetrySnapshot
+        if (!snapshot) return acc
+        if (snapshot.health.status === SiteHealthStatus.Healthy) {
+          acc.healthyCount += 1
+        }
+        acc.balanceUsd += snapshot.balanceUsd ?? 0
+        acc.todayUsageUsd += snapshot.todayCostUsd ?? 0
+        return acc
+      },
+      { healthyCount: 0, balanceUsd: 0, todayUsageUsd: 0 },
+    )
+  }, [profiles])
+
+  const formatMoney = (valueUsd: number) => {
+    const value =
+      currencyType === "CNY"
+        ? valueUsd * UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
+        : valueUsd
+    return `${getCurrencySymbol(currencyType)}${getDisplayMoneyValue(
+      value,
+    ).toFixed(UI_CONSTANTS.MONEY.DECIMALS)}`
+  }
 
   return (
     <div className="space-y-3">
@@ -72,6 +104,35 @@ export default function ApiCredentialProfilesStatsSection() {
             size="md"
             isInitialLoad={isInitialLoad}
           />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        <div className="space-y-1">
+          <Caption className="font-medium">
+            {t("apiCredentialProfiles:stats.healthyProfiles")}
+          </Caption>
+          <AnimatedStatValue
+            value={telemetryStats.healthyCount}
+            size="md"
+            isInitialLoad={isInitialLoad}
+          />
+        </div>
+        <div className="space-y-1">
+          <Caption className="font-medium">
+            {t("apiCredentialProfiles:stats.totalBalance")}
+          </Caption>
+          <span className="text-base font-semibold">
+            {formatMoney(telemetryStats.balanceUsd)}
+          </span>
+        </div>
+        <div className="space-y-1">
+          <Caption className="font-medium">
+            {t("apiCredentialProfiles:stats.todayUsage")}
+          </Caption>
+          <span className="text-base font-semibold text-emerald-600 dark:text-emerald-400">
+            {formatMoney(telemetryStats.todayUsageUsd)}
+          </span>
         </div>
       </div>
     </div>

--- a/src/entrypoints/popup/components/ApiCredentialProfilesStatsSection.tsx
+++ b/src/entrypoints/popup/components/ApiCredentialProfilesStatsSection.tsx
@@ -51,14 +51,24 @@ export default function ApiCredentialProfilesStatsSection() {
       (acc, profile) => {
         const snapshot = profile.telemetrySnapshot
         if (!snapshot) return acc
+        acc.profileTelemetryCount += 1
         if (snapshot.health.status === SiteHealthStatus.Healthy) {
           acc.healthyCount += 1
         }
         acc.balanceUsd += snapshot.balanceUsd ?? 0
-        acc.todayUsageUsd += snapshot.todayCostUsd ?? 0
+        if (typeof snapshot.todayCostUsd === "number") {
+          acc.todayUsageUsd += snapshot.todayCostUsd
+          acc.todayUsageSources += 1
+        }
         return acc
       },
-      { healthyCount: 0, balanceUsd: 0, todayUsageUsd: 0 },
+      {
+        healthyCount: 0,
+        balanceUsd: 0,
+        profileTelemetryCount: 0,
+        todayUsageSources: 0,
+        todayUsageUsd: 0,
+      },
     )
   }, [profiles])
 
@@ -131,7 +141,10 @@ export default function ApiCredentialProfilesStatsSection() {
             {t("apiCredentialProfiles:stats.todayUsage")}
           </Caption>
           <span className="text-base font-semibold text-emerald-600 dark:text-emerald-400">
-            {formatMoney(telemetryStats.todayUsageUsd)}
+            {telemetryStats.profileTelemetryCount > 0 &&
+            telemetryStats.todayUsageSources === 0
+              ? t("apiCredentialProfiles:telemetry.notProvided")
+              : formatMoney(telemetryStats.todayUsageUsd)}
           </span>
         </div>
       </div>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -172,6 +172,9 @@ export function ApiCredentialProfileListItem({
   ])
   const { currencyType } = useUserPreferencesContext()
   const telemetry = profile.telemetrySnapshot
+  const missingTelemetryValue = telemetry?.source
+    ? t("apiCredentialProfiles:telemetry.notProvided")
+    : "-"
   const health = telemetry?.health
   const healthTitle = [
     t("apiCredentialProfiles:telemetry.health"),
@@ -320,7 +323,9 @@ export function ApiCredentialProfileListItem({
                       {t("apiCredentialProfiles:telemetry.todayUsage")}
                     </div>
                     <div className="font-semibold text-emerald-600 dark:text-emerald-400">
-                      {formatMoney(telemetry?.todayCostUsd, currencyType)}
+                      {telemetry?.todayCostUsd !== undefined
+                        ? formatMoney(telemetry.todayCostUsd, currencyType)
+                        : missingTelemetryValue}
                     </div>
                   </div>
                   <div>
@@ -330,7 +335,7 @@ export function ApiCredentialProfileListItem({
                     <div className="dark:text-dark-text-primary font-semibold text-gray-900">
                       {typeof telemetry?.todayRequests === "number"
                         ? telemetry.todayRequests.toLocaleString()
-                        : "-"}
+                        : missingTelemetryValue}
                     </div>
                   </div>
                   <div>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -29,18 +29,13 @@ import {
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu"
 import type { ManagedSiteType } from "~/constants/siteType"
-import { UI_CONSTANTS } from "~/constants/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { getApiVerificationApiTypeLabel } from "~/services/verification/aiApiVerification/i18n"
 import type { ApiVerificationHistorySummary } from "~/services/verification/verificationResultHistory"
 import { SiteHealthStatus } from "~/types"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
-import {
-  formatLocaleDateTime,
-  formatTokenCount,
-  getCurrencySymbol,
-} from "~/utils/core/formatters"
-import { getDisplayMoneyValue } from "~/utils/core/money"
+import { formatLocaleDateTime, formatTokenCount } from "~/utils/core/formatters"
+import { formatTelemetryMoney } from "~/utils/core/money"
 
 /**
  * Formats a secret for display (masked by default, revealable per-profile).
@@ -125,20 +120,18 @@ function getTelemetrySourceLabel(
 }
 
 /**
- * Formats a USD telemetry amount using the user's selected display currency.
+ * Returns a localized label for telemetry health states.
  */
-function formatMoney(
-  valueUsd: number | undefined,
-  currencyType: "USD" | "CNY",
+function getHealthStatusLabel(
+  t: TFunction,
+  status: SiteHealthStatus | undefined,
 ): string {
-  if (typeof valueUsd !== "number" || !Number.isFinite(valueUsd)) return "-"
-  const value =
-    currencyType === "CNY"
-      ? valueUsd * UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
-      : valueUsd
-  return `${getCurrencySymbol(currencyType)}${getDisplayMoneyValue(
-    value,
-  ).toFixed(UI_CONSTANTS.MONEY.DECIMALS)}`
+  if (status === SiteHealthStatus.Healthy)
+    return t("account:healthStatus.healthy")
+  if (status === SiteHealthStatus.Warning)
+    return t("account:healthStatus.warning")
+  if (status === SiteHealthStatus.Error) return t("account:healthStatus.error")
+  return t("account:healthStatus.unknown")
 }
 
 /**
@@ -169,16 +162,17 @@ export function ApiCredentialProfileListItem({
     "aiApiVerification",
     "keyManagement",
     "common",
+    "account",
   ])
   const { currencyType } = useUserPreferencesContext()
   const telemetry = profile.telemetrySnapshot
-  const missingTelemetryValue = telemetry?.source
+  const missingTelemetryValue = telemetry
     ? t("apiCredentialProfiles:telemetry.notProvided")
     : "-"
   const health = telemetry?.health
   const healthTitle = [
     t("apiCredentialProfiles:telemetry.health"),
-    health?.status ?? SiteHealthStatus.Unknown,
+    getHealthStatusLabel(t, health?.status),
     health?.reason || telemetry?.lastError || "",
   ]
     .filter(Boolean)
@@ -312,19 +306,33 @@ export function ApiCredentialProfileListItem({
                     <div className="dark:text-dark-text-tertiary text-gray-500">
                       {t("apiCredentialProfiles:telemetry.balance")}
                     </div>
-                    <div className="dark:text-dark-text-primary font-semibold text-gray-900">
+                    <div
+                      className="dark:text-dark-text-primary font-semibold text-gray-900"
+                      data-testid="api-credential-telemetry-balance"
+                    >
                       {telemetry?.unlimitedQuota
                         ? t("common:quota.unlimited")
-                        : formatMoney(telemetry?.balanceUsd, currencyType)}
+                        : telemetry?.balanceUsd !== undefined
+                          ? formatTelemetryMoney(
+                              telemetry.balanceUsd,
+                              currencyType,
+                            )
+                          : missingTelemetryValue}
                     </div>
                   </div>
                   <div>
                     <div className="dark:text-dark-text-tertiary text-gray-500">
                       {t("apiCredentialProfiles:telemetry.todayUsage")}
                     </div>
-                    <div className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    <div
+                      className="font-semibold text-emerald-600 dark:text-emerald-400"
+                      data-testid="api-credential-telemetry-today-usage"
+                    >
                       {telemetry?.todayCostUsd !== undefined
-                        ? formatMoney(telemetry.todayCostUsd, currencyType)
+                        ? formatTelemetryMoney(
+                            telemetry.todayCostUsd,
+                            currencyType,
+                          )
                         : missingTelemetryValue}
                     </div>
                   </div>
@@ -332,7 +340,10 @@ export function ApiCredentialProfileListItem({
                     <div className="dark:text-dark-text-tertiary text-gray-500">
                       {t("apiCredentialProfiles:telemetry.todayRequests")}
                     </div>
-                    <div className="dark:text-dark-text-primary font-semibold text-gray-900">
+                    <div
+                      className="dark:text-dark-text-primary font-semibold text-gray-900"
+                      data-testid="api-credential-telemetry-today-requests"
+                    >
                       {typeof telemetry?.todayRequests === "number"
                         ? telemetry.todayRequests.toLocaleString()
                         : missingTelemetryValue}
@@ -344,13 +355,14 @@ export function ApiCredentialProfileListItem({
                     </div>
                     <div
                       className="dark:text-dark-text-primary truncate font-semibold text-gray-900"
+                      data-testid="api-credential-telemetry-models"
                       title={telemetry?.models?.preview.join(", ")}
                     >
                       {telemetry?.models
                         ? t("apiCredentialProfiles:telemetry.modelCount", {
                             count: telemetry.models.count,
                           })
-                        : "-"}
+                        : missingTelemetryValue}
                     </div>
                   </div>
                 </div>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -310,7 +310,9 @@ export function ApiCredentialProfileListItem({
                       {t("apiCredentialProfiles:telemetry.balance")}
                     </div>
                     <div className="dark:text-dark-text-primary font-semibold text-gray-900">
-                      {formatMoney(telemetry?.balanceUsd, currencyType)}
+                      {telemetry?.unlimitedQuota
+                        ? t("common:quota.unlimited")
+                        : formatMoney(telemetry?.balanceUsd, currencyType)}
                     </div>
                   </div>
                   <div>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -271,6 +271,8 @@ export function ApiCredentialProfileListItem({
                         health?.status,
                       )}`}
                       title={healthTitle}
+                      aria-label={healthTitle}
+                      role="img"
                     />
                     <span className="dark:text-dark-text-secondary text-xs font-medium text-gray-700">
                       {t("apiCredentialProfiles:telemetry.title")}

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowPathIcon,
   ArrowUpTrayIcon,
   CommandLineIcon,
   CpuChipIcon,
@@ -9,6 +10,7 @@ import {
   TrashIcon,
   WrenchScrewdriverIcon,
 } from "@heroicons/react/24/outline"
+import type { TFunction } from "i18next"
 import { useTranslation } from "react-i18next"
 
 import { VerificationHistorySummary } from "~/components/dialogs/VerifyApiDialog/VerificationHistorySummary"
@@ -27,9 +29,18 @@ import {
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu"
 import type { ManagedSiteType } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { getApiVerificationApiTypeLabel } from "~/services/verification/aiApiVerification/i18n"
 import type { ApiVerificationHistorySummary } from "~/services/verification/verificationResultHistory"
+import { SiteHealthStatus } from "~/types"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import {
+  formatLocaleDateTime,
+  formatTokenCount,
+  getCurrencySymbol,
+} from "~/utils/core/formatters"
+import { getDisplayMoneyValue } from "~/utils/core/money"
 
 /**
  * Formats a secret for display (masked by default, revealable per-profile).
@@ -66,14 +77,68 @@ interface ApiCredentialProfileListItemProps {
   onOpenModelManagement: (profile: ApiCredentialProfile) => void
   onVerify: (profile: ApiCredentialProfile) => void
   onVerifyCliSupport: (profile: ApiCredentialProfile) => void
+  onRefreshTelemetry: (profile: ApiCredentialProfile) => void
   onEdit: (profile: ApiCredentialProfile) => void
   onDelete: (profile: ApiCredentialProfile) => void
   onExport: (
     profile: ApiCredentialProfile,
     action: ApiCredentialProfileExportAction,
   ) => void
+  isTelemetryRefreshing: boolean
   managedSiteType: ManagedSiteType
   managedSiteLabel: string
+}
+
+/**
+ * Maps telemetry health to the small status indicator color.
+ */
+function getHealthIndicatorColor(status: SiteHealthStatus | undefined): string {
+  if (status === SiteHealthStatus.Healthy) return "bg-green-500"
+  if (status === SiteHealthStatus.Warning) return "bg-yellow-500"
+  if (status === SiteHealthStatus.Error) return "bg-red-500"
+  return "bg-gray-400"
+}
+
+/**
+ * Returns the localized label for the telemetry source shown on the profile card.
+ */
+function getTelemetrySourceLabel(
+  t: TFunction,
+  source: string | undefined,
+): string {
+  if (!source) return t("apiCredentialProfiles:telemetry.source.notAvailable")
+  if (source === "models")
+    return t("apiCredentialProfiles:telemetry.source.models")
+  if (source === "openaiBilling") {
+    return t("apiCredentialProfiles:telemetry.source.openaiBilling")
+  }
+  if (source === "newApiTokenUsage") {
+    return t("apiCredentialProfiles:telemetry.source.newApiTokenUsage")
+  }
+  if (source === "sub2apiUsage") {
+    return t("apiCredentialProfiles:telemetry.source.sub2apiUsage")
+  }
+  if (source === "customReadOnlyEndpoint") {
+    return t("apiCredentialProfiles:telemetry.source.customReadOnlyEndpoint")
+  }
+  return source
+}
+
+/**
+ * Formats a USD telemetry amount using the user's selected display currency.
+ */
+function formatMoney(
+  valueUsd: number | undefined,
+  currencyType: "USD" | "CNY",
+): string {
+  if (typeof valueUsd !== "number" || !Number.isFinite(valueUsd)) return "-"
+  const value =
+    currencyType === "CNY"
+      ? valueUsd * UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
+      : valueUsd
+  return `${getCurrencySymbol(currencyType)}${getDisplayMoneyValue(
+    value,
+  ).toFixed(UI_CONSTANTS.MONEY.DECIMALS)}`
 }
 
 /**
@@ -91,9 +156,11 @@ export function ApiCredentialProfileListItem({
   onOpenModelManagement,
   onVerify,
   onVerifyCliSupport,
+  onRefreshTelemetry,
   onEdit,
   onDelete,
   onExport,
+  isTelemetryRefreshing,
   managedSiteType,
   managedSiteLabel,
 }: ApiCredentialProfileListItemProps) {
@@ -103,6 +170,16 @@ export function ApiCredentialProfileListItem({
     "keyManagement",
     "common",
   ])
+  const { currencyType } = useUserPreferencesContext()
+  const telemetry = profile.telemetrySnapshot
+  const health = telemetry?.health
+  const healthTitle = [
+    t("apiCredentialProfiles:telemetry.health"),
+    health?.status ?? SiteHealthStatus.Unknown,
+    health?.reason || telemetry?.lastError || "",
+  ]
+    .filter(Boolean)
+    .join(": ")
 
   return (
     <Card>
@@ -187,6 +264,113 @@ export function ApiCredentialProfileListItem({
                   summary={verificationSummary}
                   className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:gap-2"
                 />
+              </div>
+
+              <div className="dark:bg-dark-bg-tertiary/60 rounded-lg border border-gray-100 bg-gray-50 p-2 dark:border-gray-800">
+                <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span
+                      className={`h-2 w-2 shrink-0 rounded-full ${getHealthIndicatorColor(
+                        health?.status,
+                      )}`}
+                      title={healthTitle}
+                    />
+                    <span className="dark:text-dark-text-secondary text-xs font-medium text-gray-700">
+                      {t("apiCredentialProfiles:telemetry.title")}
+                    </span>
+                    {telemetry?.source ? (
+                      <Badge variant="outline" size="sm">
+                        {getTelemetrySourceLabel(t, telemetry.source)}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <button
+                    type="button"
+                    className="dark:text-dark-text-tertiary dark:hover:text-dark-text-primary inline-flex shrink-0 items-center gap-1 text-[11px] text-gray-500 transition-colors hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                    onClick={() => onRefreshTelemetry(profile)}
+                    disabled={isTelemetryRefreshing}
+                    aria-label={t(
+                      "apiCredentialProfiles:telemetry.actions.refresh",
+                    )}
+                  >
+                    <ArrowPathIcon
+                      className={`h-3.5 w-3.5 ${
+                        isTelemetryRefreshing ? "animate-spin" : ""
+                      }`}
+                    />
+                    {isTelemetryRefreshing
+                      ? t("apiCredentialProfiles:telemetry.refreshing")
+                      : t("apiCredentialProfiles:telemetry.actions.refresh")}
+                  </button>
+                </div>
+
+                <div className="grid grid-cols-2 gap-2 text-[11px] sm:grid-cols-4">
+                  <div>
+                    <div className="dark:text-dark-text-tertiary text-gray-500">
+                      {t("apiCredentialProfiles:telemetry.balance")}
+                    </div>
+                    <div className="dark:text-dark-text-primary font-semibold text-gray-900">
+                      {formatMoney(telemetry?.balanceUsd, currencyType)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="dark:text-dark-text-tertiary text-gray-500">
+                      {t("apiCredentialProfiles:telemetry.todayUsage")}
+                    </div>
+                    <div className="font-semibold text-emerald-600 dark:text-emerald-400">
+                      {formatMoney(telemetry?.todayCostUsd, currencyType)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="dark:text-dark-text-tertiary text-gray-500">
+                      {t("apiCredentialProfiles:telemetry.todayRequests")}
+                    </div>
+                    <div className="dark:text-dark-text-primary font-semibold text-gray-900">
+                      {typeof telemetry?.todayRequests === "number"
+                        ? telemetry.todayRequests.toLocaleString()
+                        : "-"}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="dark:text-dark-text-tertiary text-gray-500">
+                      {t("apiCredentialProfiles:telemetry.models")}
+                    </div>
+                    <div
+                      className="dark:text-dark-text-primary truncate font-semibold text-gray-900"
+                      title={telemetry?.models?.preview.join(", ")}
+                    >
+                      {telemetry?.models
+                        ? t("apiCredentialProfiles:telemetry.modelCount", {
+                            count: telemetry.models.count,
+                          })
+                        : "-"}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="dark:text-dark-text-tertiary mt-2 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-gray-500">
+                  <span>
+                    {t("apiCredentialProfiles:telemetry.lastSync")}:{" "}
+                    {formatLocaleDateTime(
+                      telemetry?.lastSyncTime,
+                      t("common:labels.notAvailable"),
+                    )}
+                  </span>
+                  {telemetry?.todayTokens ? (
+                    <span>
+                      {t("apiCredentialProfiles:telemetry.todayTokens")}:{" "}
+                      {formatTokenCount(
+                        telemetry.todayTokens.upload +
+                          telemetry.todayTokens.download,
+                      )}
+                    </span>
+                  ) : null}
+                  {telemetry?.lastError ? (
+                    <span className="text-amber-600 dark:text-amber-300">
+                      {telemetry.lastError}
+                    </span>
+                  ) : null}
+                </div>
               </div>
             </div>
 

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
@@ -37,9 +37,9 @@ export function ApiCredentialProfilesList({
           onOpenModelManagement={controller.handleOpenModelManagement}
           onRefreshTelemetry={controller.handleRefreshTelemetry}
           onExport={controller.handleExport}
-          isTelemetryRefreshing={
-            controller.refreshingTelemetryProfileId === profile.id
-          }
+          isTelemetryRefreshing={controller.refreshingTelemetryProfileIds.includes(
+            profile.id,
+          )}
           managedSiteType={controller.managedSiteType}
           managedSiteLabel={controller.managedSiteLabel}
           onVerify={(p) => controller.setVerifyingProfile(p)}

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
@@ -35,7 +35,11 @@ export function ApiCredentialProfilesList({
           onCopyApiKey={controller.handleCopyApiKey}
           onCopyBundle={controller.handleCopyBundle}
           onOpenModelManagement={controller.handleOpenModelManagement}
+          onRefreshTelemetry={controller.handleRefreshTelemetry}
           onExport={controller.handleExport}
+          isTelemetryRefreshing={
+            controller.refreshingTelemetryProfileId === profile.id
+          }
           managedSiteType={controller.managedSiteType}
           managedSiteLabel={controller.managedSiteLabel}
           onVerify={(p) => controller.setVerifyingProfile(p)}

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
@@ -251,9 +251,9 @@ export function useApiCredentialProfilesController() {
     useState<ApiCredentialProfile | null>(null)
   const [cliVerifyingProfile, setCliVerifyingProfile] =
     useState<ApiCredentialProfile | null>(null)
-  const refreshingTelemetryProfileIdRef = useRef<string | null>(null)
-  const [refreshingTelemetryProfileId, setRefreshingTelemetryProfileId] =
-    useState<string | null>(null)
+  const refreshingTelemetryProfileIdsRef = useRef(new Set<string>())
+  const [refreshingTelemetryProfileIds, setRefreshingTelemetryProfileIds] =
+    useState<string[]>([])
 
   const [ccSwitchProfile, setCCSwitchProfile] =
     useState<ApiCredentialProfile | null>(null)
@@ -335,10 +335,12 @@ export function useApiCredentialProfilesController() {
 
   const handleRefreshTelemetry = useCallback(
     async (profile: ApiCredentialProfile) => {
-      if (refreshingTelemetryProfileIdRef.current) return
+      if (refreshingTelemetryProfileIdsRef.current.has(profile.id)) return
 
-      refreshingTelemetryProfileIdRef.current = profile.id
-      setRefreshingTelemetryProfileId(profile.id)
+      refreshingTelemetryProfileIdsRef.current.add(profile.id)
+      setRefreshingTelemetryProfileIds([
+        ...refreshingTelemetryProfileIdsRef.current,
+      ])
       try {
         await toast.promise(refreshApiCredentialProfileTelemetry(profile.id), {
           loading: t("apiCredentialProfiles:telemetry.messages.refreshing"),
@@ -349,8 +351,10 @@ export function useApiCredentialProfilesController() {
           },
         })
       } finally {
-        refreshingTelemetryProfileIdRef.current = null
-        setRefreshingTelemetryProfileId(null)
+        refreshingTelemetryProfileIdsRef.current.delete(profile.id)
+        setRefreshingTelemetryProfileIds([
+          ...refreshingTelemetryProfileIdsRef.current,
+        ])
       }
     },
     [t],
@@ -413,7 +417,7 @@ export function useApiCredentialProfilesController() {
     setVerifyingProfile,
     cliVerifyingProfile,
     setCliVerifyingProfile,
-    refreshingTelemetryProfileId,
+    refreshingTelemetryProfileIds,
     handleRefreshTelemetry,
 
     ccSwitchProfile,

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next"
 import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { refreshApiCredentialProfileTelemetry } from "~/services/apiCredentialProfiles/telemetry"
 import { OpenInCherryStudio } from "~/services/integrations/cherryStudio"
 import { getManagedSiteLabel } from "~/services/managedSites/utils/managedSite"
 import { tagStorage } from "~/services/tags/tagStorage"
@@ -247,6 +248,8 @@ export function useApiCredentialProfilesController() {
     useState<ApiCredentialProfile | null>(null)
   const [cliVerifyingProfile, setCliVerifyingProfile] =
     useState<ApiCredentialProfile | null>(null)
+  const [refreshingTelemetryProfileId, setRefreshingTelemetryProfileId] =
+    useState<string | null>(null)
 
   const [ccSwitchProfile, setCCSwitchProfile] =
     useState<ApiCredentialProfile | null>(null)
@@ -326,6 +329,27 @@ export function useApiCredentialProfilesController() {
     ],
   )
 
+  const handleRefreshTelemetry = useCallback(
+    async (profile: ApiCredentialProfile) => {
+      if (refreshingTelemetryProfileId) return
+
+      setRefreshingTelemetryProfileId(profile.id)
+      try {
+        await toast.promise(refreshApiCredentialProfileTelemetry(profile.id), {
+          loading: t("apiCredentialProfiles:telemetry.messages.refreshing"),
+          success: t("apiCredentialProfiles:telemetry.messages.refreshed"),
+          error: (error) =>
+            error instanceof Error && error.message
+              ? error.message
+              : t("apiCredentialProfiles:telemetry.messages.refreshFailed"),
+        })
+      } finally {
+        setRefreshingTelemetryProfileId(null)
+      }
+    },
+    [refreshingTelemetryProfileId, t],
+  )
+
   const [deletingProfile, setDeletingProfile] =
     useState<ApiCredentialProfile | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -383,6 +407,8 @@ export function useApiCredentialProfilesController() {
     setVerifyingProfile,
     cliVerifyingProfile,
     setCliVerifyingProfile,
+    refreshingTelemetryProfileId,
+    handleRefreshTelemetry,
 
     ccSwitchProfile,
     setCCSwitchProfile,

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -18,6 +18,7 @@ import {
 import type { Tag } from "~/types"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
+import { createLogger } from "~/utils/core/logger"
 import { showResultToast } from "~/utils/core/toastHelpers"
 import { openModelsPage } from "~/utils/navigation"
 
@@ -38,6 +39,8 @@ type SaveApiCredentialProfileInput = {
 type RuntimeBroadcastMessage = {
   type?: (typeof RuntimeMessageTypes)[keyof typeof RuntimeMessageTypes]
 }
+
+const logger = createLogger("ApiCredentialProfilesController")
 
 /**
  * Controller hook for managing API credential profiles, including CRUD operations,
@@ -248,6 +251,7 @@ export function useApiCredentialProfilesController() {
     useState<ApiCredentialProfile | null>(null)
   const [cliVerifyingProfile, setCliVerifyingProfile] =
     useState<ApiCredentialProfile | null>(null)
+  const refreshingTelemetryProfileIdRef = useRef<string | null>(null)
   const [refreshingTelemetryProfileId, setRefreshingTelemetryProfileId] =
     useState<string | null>(null)
 
@@ -331,23 +335,25 @@ export function useApiCredentialProfilesController() {
 
   const handleRefreshTelemetry = useCallback(
     async (profile: ApiCredentialProfile) => {
-      if (refreshingTelemetryProfileId) return
+      if (refreshingTelemetryProfileIdRef.current) return
 
+      refreshingTelemetryProfileIdRef.current = profile.id
       setRefreshingTelemetryProfileId(profile.id)
       try {
         await toast.promise(refreshApiCredentialProfileTelemetry(profile.id), {
           loading: t("apiCredentialProfiles:telemetry.messages.refreshing"),
           success: t("apiCredentialProfiles:telemetry.messages.refreshed"),
-          error: (error) =>
-            error instanceof Error && error.message
-              ? error.message
-              : t("apiCredentialProfiles:telemetry.messages.refreshFailed"),
+          error: (error) => {
+            logger.warn("Telemetry refresh failed", error)
+            return t("apiCredentialProfiles:telemetry.messages.refreshFailed")
+          },
         })
       } finally {
+        refreshingTelemetryProfileIdRef.current = null
         setRefreshingTelemetryProfileId(null)
       }
     },
-    [refreshingTelemetryProfileId, t],
+    [t],
   )
 
   const [deletingProfile, setDeletingProfile] =

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -77,8 +77,40 @@
   },
   "stats": {
     "baseUrls": "Base URLs",
+    "healthyProfiles": "Healthy",
+    "todayUsage": "Today usage",
+    "totalBalance": "Total balance",
     "totalProfiles": "Total profiles",
     "usedTags": "Used tags"
+  },
+  "telemetry": {
+    "actions": {
+      "refresh": "Refresh"
+    },
+    "balance": "Balance",
+    "health": "Health",
+    "lastSync": "Last refresh",
+    "messages": {
+      "refreshed": "Credential usage refreshed",
+      "refreshFailed": "Failed to refresh credential usage",
+      "refreshing": "Refreshing credential usage..."
+    },
+    "modelCount_one": "{{count}} model",
+    "modelCount_other": "{{count}} models",
+    "models": "Models",
+    "refreshing": "Refreshing",
+    "source": {
+      "customReadOnlyEndpoint": "Custom",
+      "models": "Models",
+      "newApiTokenUsage": "NewAPI Token",
+      "notAvailable": "Not queried",
+      "openaiBilling": "OpenAI Billing",
+      "sub2apiUsage": "Sub2API"
+    },
+    "title": "Balance and usage",
+    "todayRequests": "Requests today",
+    "todayTokens": "Tokens today",
+    "todayUsage": "Today usage"
   },
   "title": "API credential profiles",
   "verify": {

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -98,6 +98,7 @@
     "modelCount_one": "{{count}} model",
     "modelCount_other": "{{count}} models",
     "models": "Models",
+    "notProvided": "Not provided",
     "refreshing": "Refreshing",
     "source": {
       "customReadOnlyEndpoint": "Custom",

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -77,8 +77,40 @@
   },
   "stats": {
     "baseUrls": "Base URL 数",
+    "healthyProfiles": "正常",
+    "todayUsage": "本日の使用量",
+    "totalBalance": "合計残高",
     "totalProfiles": "プロファイル総数",
     "usedTags": "使用中のタグ"
+  },
+  "telemetry": {
+    "actions": {
+      "refresh": "更新"
+    },
+    "balance": "残高",
+    "health": "状態",
+    "lastSync": "最終更新",
+    "messages": {
+      "refreshed": "認証情報の使用量を更新しました",
+      "refreshFailed": "認証情報の使用量更新に失敗しました",
+      "refreshing": "認証情報の使用量を更新中..."
+    },
+    "modelCount_one": "{{count}} 件",
+    "modelCount_other": "{{count}} 件",
+    "models": "モデル",
+    "refreshing": "更新中",
+    "source": {
+      "customReadOnlyEndpoint": "カスタム",
+      "models": "モデル",
+      "newApiTokenUsage": "NewAPI Token",
+      "notAvailable": "未取得",
+      "openaiBilling": "OpenAI Billing",
+      "sub2apiUsage": "Sub2API"
+    },
+    "title": "残高と使用量",
+    "todayRequests": "本日のリクエスト",
+    "todayTokens": "本日の Tokens",
+    "todayUsage": "本日の使用量"
   },
   "title": "API 認証情報プロファイル",
   "verify": {

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -98,6 +98,7 @@
     "modelCount_one": "{{count}} 件",
     "modelCount_other": "{{count}} 件",
     "models": "モデル",
+    "notProvided": "未提供",
     "refreshing": "更新中",
     "source": {
       "customReadOnlyEndpoint": "カスタム",

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -95,7 +95,6 @@
       "refreshFailed": "認証情報の使用量更新に失敗しました",
       "refreshing": "認証情報の使用量を更新中..."
     },
-    "modelCount_one": "{{count}} 件",
     "modelCount_other": "{{count}} 件",
     "models": "モデル",
     "notProvided": "未提供",

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -97,6 +97,7 @@
     },
     "modelCount": "{{count}} 个",
     "models": "模型",
+    "notProvided": "未提供",
     "refreshing": "刷新中",
     "source": {
       "customReadOnlyEndpoint": "自定义",

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -77,8 +77,39 @@
   },
   "stats": {
     "baseUrls": "Base URL",
+    "healthyProfiles": "健康凭证",
+    "todayUsage": "今日用量",
+    "totalBalance": "总余额",
     "totalProfiles": "凭证总数",
     "usedTags": "使用标签"
+  },
+  "telemetry": {
+    "actions": {
+      "refresh": "刷新"
+    },
+    "balance": "余额",
+    "health": "健康状态",
+    "lastSync": "最近刷新",
+    "messages": {
+      "refreshed": "已刷新凭证用量",
+      "refreshFailed": "刷新凭证用量失败",
+      "refreshing": "正在刷新凭证用量…"
+    },
+    "modelCount": "{{count}} 个",
+    "models": "模型",
+    "refreshing": "刷新中",
+    "source": {
+      "customReadOnlyEndpoint": "自定义",
+      "models": "模型",
+      "newApiTokenUsage": "NewAPI Token",
+      "notAvailable": "未查询",
+      "openaiBilling": "OpenAI Billing",
+      "sub2apiUsage": "Sub2API"
+    },
+    "title": "余额与用量",
+    "todayRequests": "今日请求",
+    "todayTokens": "今日 Tokens",
+    "todayUsage": "今日用量"
   },
   "title": "API 凭证",
   "verify": {

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -77,8 +77,40 @@
   },
   "stats": {
     "baseUrls": "Base URL",
+    "healthyProfiles": "健康憑證",
+    "todayUsage": "今日用量",
+    "totalBalance": "總餘額",
     "totalProfiles": "憑證總數",
     "usedTags": "使用標籤"
+  },
+  "telemetry": {
+    "actions": {
+      "refresh": "重新整理"
+    },
+    "balance": "餘額",
+    "health": "健康狀態",
+    "lastSync": "最近重新整理",
+    "messages": {
+      "refreshed": "已重新整理憑證用量",
+      "refreshFailed": "重新整理憑證用量失敗",
+      "refreshing": "正在重新整理憑證用量…"
+    },
+    "modelCount_one": "{{count}} 個",
+    "modelCount_other": "{{count}} 個",
+    "models": "模型",
+    "refreshing": "重新整理中",
+    "source": {
+      "customReadOnlyEndpoint": "自訂",
+      "models": "模型",
+      "newApiTokenUsage": "NewAPI Token",
+      "notAvailable": "未查詢",
+      "openaiBilling": "OpenAI Billing",
+      "sub2apiUsage": "Sub2API"
+    },
+    "title": "餘額與用量",
+    "todayRequests": "今日請求",
+    "todayTokens": "今日 Tokens",
+    "todayUsage": "今日用量"
   },
   "title": "API 憑證",
   "verify": {

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -95,7 +95,6 @@
       "refreshFailed": "重新整理憑證用量失敗",
       "refreshing": "正在重新整理憑證用量…"
     },
-    "modelCount_one": "{{count}} 個",
     "modelCount_other": "{{count}} 個",
     "models": "模型",
     "notProvided": "未提供",

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -98,6 +98,7 @@
     "modelCount_one": "{{count}} 個",
     "modelCount_other": "{{count}} 個",
     "models": "模型",
+    "notProvided": "未提供",
     "refreshing": "重新整理中",
     "source": {
       "customReadOnlyEndpoint": "自訂",

--- a/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
+++ b/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
@@ -16,6 +16,12 @@ import {
 import type {
   ApiCredentialProfile,
   ApiCredentialProfilesConfig,
+  ApiCredentialTelemetryAttempt,
+  ApiCredentialTelemetryCapabilityMode,
+  ApiCredentialTelemetryConfig,
+  ApiCredentialTelemetryCustomEndpoint,
+  ApiCredentialTelemetryJsonPathMap,
+  ApiCredentialTelemetrySnapshot,
 } from "~/types/apiCredentialProfiles"
 import { API_CREDENTIAL_PROFILES_CONFIG_VERSION } from "~/types/apiCredentialProfiles"
 import { safeRandomUUID } from "~/utils/core/identifier"
@@ -33,9 +39,23 @@ type ApiCredentialProfileCreateInput = {
   apiKey: string
   tagIds?: string[]
   notes?: string
+  telemetryConfig?: Partial<ApiCredentialTelemetryConfig>
 }
 
 type ApiCredentialProfileUpdateInput = Partial<ApiCredentialProfileCreateInput>
+
+const TELEMETRY_CAPABILITY_MODES: ApiCredentialTelemetryCapabilityMode[] = [
+  "disabled",
+  "auto",
+  "openaiBilling",
+  "newApiTokenUsage",
+  "sub2apiUsage",
+  "customReadOnlyEndpoint",
+]
+
+const DEFAULT_TELEMETRY_CONFIG: ApiCredentialTelemetryConfig = {
+  mode: "auto",
+}
 
 const createDefaultConfig = (): ApiCredentialProfilesConfig => ({
   version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
@@ -97,6 +117,286 @@ function normalizeTagIdList(input: unknown): string[] {
   }
 
   return tagIds
+}
+
+/**
+ * Coerces a numeric-like value into a finite number.
+ */
+function coerceFiniteNumber(raw: unknown): number | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw
+  if (typeof raw === "string" && raw.trim()) {
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+/**
+ * Normalizes configured JSON paths for a custom telemetry endpoint.
+ */
+function coerceJsonPathMap(raw: unknown): ApiCredentialTelemetryJsonPathMap {
+  const obj =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
+  const out: ApiCredentialTelemetryJsonPathMap = {}
+  const keys: Array<keyof ApiCredentialTelemetryJsonPathMap> = [
+    "balanceUsd",
+    "todayCostUsd",
+    "todayRequests",
+    "todayPromptTokens",
+    "todayCompletionTokens",
+    "todayTotalTokens",
+    "totalUsedUsd",
+    "totalGrantedUsd",
+    "totalAvailableUsd",
+    "expiresAt",
+  ]
+
+  for (const key of keys) {
+    const value = obj[key]
+    if (typeof value === "string" && value.trim()) {
+      out[key] = value.trim()
+    }
+  }
+
+  return out
+}
+
+/**
+ * Coerces custom endpoint telemetry config into a usable persisted shape.
+ */
+function coerceCustomEndpoint(
+  raw: unknown,
+): ApiCredentialTelemetryCustomEndpoint | undefined {
+  const obj =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
+  const endpoint =
+    typeof obj.endpoint === "string" && obj.endpoint.trim()
+      ? obj.endpoint.trim()
+      : ""
+  const jsonPaths = coerceJsonPathMap(obj.jsonPaths)
+
+  if (!endpoint || Object.keys(jsonPaths).length === 0) {
+    return undefined
+  }
+
+  return { endpoint, jsonPaths }
+}
+
+/**
+ * Coerces profile telemetry config and falls back to automatic probing.
+ */
+export function coerceApiCredentialTelemetryConfig(
+  raw: unknown,
+): ApiCredentialTelemetryConfig {
+  const obj =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
+  const rawMode = typeof obj.mode === "string" ? obj.mode : ""
+  const mode = TELEMETRY_CAPABILITY_MODES.includes(
+    rawMode as ApiCredentialTelemetryCapabilityMode,
+  )
+    ? (rawMode as ApiCredentialTelemetryCapabilityMode)
+    : DEFAULT_TELEMETRY_CONFIG.mode
+  const customEndpoint = coerceCustomEndpoint(obj.customEndpoint)
+
+  return {
+    mode,
+    ...(customEndpoint ? { customEndpoint } : {}),
+  }
+}
+
+/**
+ * Normalizes persisted telemetry endpoint attempts.
+ */
+function coerceTelemetryAttempts(
+  raw: unknown,
+): ApiCredentialTelemetryAttempt[] {
+  if (!Array.isArray(raw)) return []
+
+  return raw
+    .map((item): ApiCredentialTelemetryAttempt | null => {
+      if (!item || typeof item !== "object") return null
+      const candidate = item as Record<string, unknown>
+      const rawSource = candidate.source
+      const source =
+        typeof rawSource === "string" &&
+        (rawSource === "models" ||
+          TELEMETRY_CAPABILITY_MODES.includes(
+            rawSource as ApiCredentialTelemetryCapabilityMode,
+          ))
+          ? (rawSource as ApiCredentialTelemetryAttempt["source"])
+          : null
+      const endpoint =
+        typeof candidate.endpoint === "string" ? candidate.endpoint.trim() : ""
+      const rawStatus = candidate.status
+      const status =
+        rawStatus === "success" ||
+        rawStatus === "unsupported" ||
+        rawStatus === "error"
+          ? rawStatus
+          : null
+
+      if (!source || !endpoint || !status) return null
+
+      const message =
+        typeof candidate.message === "string" && candidate.message.trim()
+          ? candidate.message.trim()
+          : undefined
+
+      return {
+        source,
+        endpoint,
+        status,
+        ...(message ? { message } : {}),
+      }
+    })
+    .filter((item): item is ApiCredentialTelemetryAttempt => item !== null)
+}
+
+/**
+ * Normalizes a persisted telemetry snapshot and drops unusable snapshots.
+ */
+function coerceTelemetrySnapshot(
+  raw: unknown,
+): ApiCredentialTelemetrySnapshot | undefined {
+  const obj =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
+  const lastSyncTime = coerceFiniteNumber(obj.lastSyncTime)
+  if (!lastSyncTime || lastSyncTime <= 0) return undefined
+
+  const rawHealth =
+    obj.health && typeof obj.health === "object" ? obj.health : {}
+  const healthRecord = rawHealth as Record<string, unknown>
+  const health = {
+    status:
+      healthRecord.status === "healthy" ||
+      healthRecord.status === "warning" ||
+      healthRecord.status === "error" ||
+      healthRecord.status === "unknown"
+        ? healthRecord.status
+        : "unknown",
+    ...(typeof healthRecord.reason === "string" && healthRecord.reason.trim()
+      ? { reason: healthRecord.reason.trim() }
+      : {}),
+  } as ApiCredentialTelemetrySnapshot["health"]
+
+  const rawSource = obj.source
+  const source =
+    typeof rawSource === "string" &&
+    (rawSource === "models" ||
+      TELEMETRY_CAPABILITY_MODES.includes(
+        rawSource as ApiCredentialTelemetryCapabilityMode,
+      ))
+      ? (rawSource as ApiCredentialTelemetrySnapshot["source"])
+      : undefined
+
+  const rawModels =
+    obj.models && typeof obj.models === "object"
+      ? (obj.models as Record<string, unknown>)
+      : null
+  const models =
+    rawModels &&
+    typeof rawModels.count === "number" &&
+    Number.isFinite(rawModels.count)
+      ? {
+          count: Math.max(0, Math.trunc(rawModels.count)),
+          preview: Array.isArray(rawModels.preview)
+            ? rawModels.preview
+                .filter((item): item is string => typeof item === "string")
+                .map((item) => item.trim())
+                .filter(Boolean)
+                .slice(0, 20)
+            : [],
+        }
+      : undefined
+
+  const todayPromptTokens = coerceFiniteNumber(
+    (obj.todayTokens as Record<string, unknown> | undefined)?.upload,
+  )
+  const todayCompletionTokens = coerceFiniteNumber(
+    (obj.todayTokens as Record<string, unknown> | undefined)?.download,
+  )
+
+  return {
+    health,
+    lastSyncTime,
+    ...(coerceFiniteNumber(obj.lastSuccessTime)
+      ? { lastSuccessTime: coerceFiniteNumber(obj.lastSuccessTime) }
+      : {}),
+    ...(typeof obj.lastError === "string" && obj.lastError.trim()
+      ? { lastError: obj.lastError.trim() }
+      : {}),
+    ...(source ? { source } : {}),
+    ...(coerceFiniteNumber(obj.balanceUsd) !== undefined
+      ? { balanceUsd: coerceFiniteNumber(obj.balanceUsd) }
+      : {}),
+    ...(coerceFiniteNumber(obj.todayCostUsd) !== undefined
+      ? { todayCostUsd: coerceFiniteNumber(obj.todayCostUsd) }
+      : {}),
+    ...(coerceFiniteNumber(obj.todayRequests) !== undefined
+      ? { todayRequests: coerceFiniteNumber(obj.todayRequests) }
+      : {}),
+    ...(todayPromptTokens !== undefined || todayCompletionTokens !== undefined
+      ? {
+          todayTokens: {
+            upload: todayPromptTokens ?? 0,
+            download: todayCompletionTokens ?? 0,
+          },
+        }
+      : {}),
+    ...(coerceFiniteNumber(obj.totalUsedUsd) !== undefined
+      ? { totalUsedUsd: coerceFiniteNumber(obj.totalUsedUsd) }
+      : {}),
+    ...(coerceFiniteNumber(obj.totalGrantedUsd) !== undefined
+      ? { totalGrantedUsd: coerceFiniteNumber(obj.totalGrantedUsd) }
+      : {}),
+    ...(coerceFiniteNumber(obj.totalAvailableUsd) !== undefined
+      ? { totalAvailableUsd: coerceFiniteNumber(obj.totalAvailableUsd) }
+      : {}),
+    ...(coerceFiniteNumber(obj.expiresAt) !== undefined
+      ? { expiresAt: coerceFiniteNumber(obj.expiresAt) }
+      : {}),
+    ...(models ? { models } : {}),
+    attempts: coerceTelemetryAttempts(obj.attempts),
+  }
+}
+
+/**
+ * Keeps the newest telemetry snapshot when duplicate profiles are merged.
+ */
+function mergeTelemetrySnapshot(
+  first?: ApiCredentialTelemetrySnapshot,
+  second?: ApiCredentialTelemetrySnapshot,
+): ApiCredentialTelemetrySnapshot | undefined {
+  if (!first) return second
+  if (!second) return first
+
+  const firstRank = Math.max(
+    first.lastSuccessTime ?? 0,
+    first.lastSyncTime ?? 0,
+  )
+  const secondRank = Math.max(
+    second.lastSuccessTime ?? 0,
+    second.lastSyncTime ?? 0,
+  )
+  return secondRank >= firstRank ? second : first
+}
+
+/**
+ * Preserves explicit telemetry config when duplicate profiles are merged.
+ */
+function mergeTelemetryConfig(
+  newer: ApiCredentialTelemetryConfig | undefined,
+  older: ApiCredentialTelemetryConfig | undefined,
+): ApiCredentialTelemetryConfig {
+  const normalizedNewer = coerceApiCredentialTelemetryConfig(newer)
+  const normalizedOlder = coerceApiCredentialTelemetryConfig(older)
+  if (normalizedNewer.mode !== DEFAULT_TELEMETRY_CONFIG.mode) {
+    return normalizedNewer
+  }
+  if (normalizedOlder.mode !== DEFAULT_TELEMETRY_CONFIG.mode) {
+    return normalizedOlder
+  }
+  return normalizedNewer
 }
 
 /**
@@ -165,6 +465,14 @@ function dedupeProfiles(profiles: ApiCredentialProfile[]): {
       createdAt:
         Math.min(newer.createdAt || 0, older.createdAt || 0) || newer.createdAt,
       tagIds: mergedTagIds,
+      telemetryConfig: mergeTelemetryConfig(
+        newer.telemetryConfig,
+        older.telemetryConfig,
+      ),
+      telemetrySnapshot: mergeTelemetrySnapshot(
+        newer.telemetrySnapshot,
+        older.telemetrySnapshot,
+      ),
     })
   }
 
@@ -231,6 +539,10 @@ export function coerceApiCredentialProfilesConfig(
       apiKey,
       tagIds,
       notes: notes.trim(),
+      telemetryConfig: coerceApiCredentialTelemetryConfig(
+        candidate.telemetryConfig,
+      ),
+      telemetrySnapshot: coerceTelemetrySnapshot(candidate.telemetrySnapshot),
       createdAt,
       updatedAt,
     })
@@ -404,6 +716,9 @@ class ApiCredentialProfilesStorageService {
       apiKey: normalizedKey,
       tagIds: normalizeTagIdList(input.tagIds),
       notes: typeof input.notes === "string" ? input.notes.trim() : "",
+      telemetryConfig: coerceApiCredentialTelemetryConfig(
+        input.telemetryConfig,
+      ),
       createdAt: now,
       updatedAt: now,
     }
@@ -493,6 +808,16 @@ class ApiCredentialProfilesStorageService {
           typeof updates.notes === "string"
             ? updates.notes.trim()
             : current.notes,
+        telemetryConfig:
+          updates.telemetryConfig !== undefined
+            ? coerceApiCredentialTelemetryConfig(updates.telemetryConfig)
+            : current.telemetryConfig,
+        telemetrySnapshot:
+          nextApiType !== current.apiType ||
+          nextBaseUrl !== current.baseUrl ||
+          nextApiKey !== current.apiKey
+            ? undefined
+            : current.telemetrySnapshot,
         updatedAt: Date.now(),
       }
 
@@ -523,6 +848,40 @@ class ApiCredentialProfilesStorageService {
       }
 
       return next
+    })
+  }
+
+  /**
+   * Persist the latest read-only telemetry query snapshot for a profile.
+   */
+  async updateTelemetrySnapshot(
+    id: string,
+    snapshot: ApiCredentialTelemetrySnapshot,
+  ): Promise<ApiCredentialProfile> {
+    return this.withStorageWriteLock(async () => {
+      const config = cloneConfig(await this.readConfig())
+      const profiles = Array.isArray(config.profiles) ? config.profiles : []
+      const index = profiles.findIndex((profile) => profile.id === id)
+      if (index === -1) {
+        throw new Error("Profile not found.")
+      }
+
+      const nextProfile: ApiCredentialProfile = {
+        ...profiles[index],
+        telemetrySnapshot: coerceTelemetrySnapshot(snapshot) ?? snapshot,
+      }
+
+      const nextProfiles = profiles.map((profile) =>
+        profile.id === id ? nextProfile : profile,
+      )
+
+      await this.saveConfig({
+        version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
+        profiles: nextProfiles,
+        lastUpdated: Date.now(),
+      })
+
+      return nextProfile
     })
   }
 

--- a/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
+++ b/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
@@ -343,6 +343,9 @@ function coerceTelemetrySnapshot(
           },
         }
       : {}),
+    ...(typeof obj.unlimitedQuota === "boolean"
+      ? { unlimitedQuota: obj.unlimitedQuota }
+      : {}),
     ...(coerceFiniteNumber(obj.totalUsedUsd) !== undefined
       ? { totalUsedUsd: coerceFiniteNumber(obj.totalUsedUsd) }
       : {}),

--- a/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
+++ b/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
@@ -23,7 +23,11 @@ import type {
   ApiCredentialTelemetryJsonPathMap,
   ApiCredentialTelemetrySnapshot,
 } from "~/types/apiCredentialProfiles"
-import { API_CREDENTIAL_PROFILES_CONFIG_VERSION } from "~/types/apiCredentialProfiles"
+import {
+  API_CREDENTIAL_PROFILES_CONFIG_VERSION,
+  API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES,
+  DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG,
+} from "~/types/apiCredentialProfiles"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 
@@ -43,19 +47,6 @@ type ApiCredentialProfileCreateInput = {
 }
 
 type ApiCredentialProfileUpdateInput = Partial<ApiCredentialProfileCreateInput>
-
-const TELEMETRY_CAPABILITY_MODES: ApiCredentialTelemetryCapabilityMode[] = [
-  "disabled",
-  "auto",
-  "openaiBilling",
-  "newApiTokenUsage",
-  "sub2apiUsage",
-  "customReadOnlyEndpoint",
-]
-
-const DEFAULT_TELEMETRY_CONFIG: ApiCredentialTelemetryConfig = {
-  mode: "auto",
-}
 
 const createDefaultConfig = (): ApiCredentialProfilesConfig => ({
   version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
@@ -191,11 +182,11 @@ export function coerceApiCredentialTelemetryConfig(
   const obj =
     raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
   const rawMode = typeof obj.mode === "string" ? obj.mode : ""
-  const mode = TELEMETRY_CAPABILITY_MODES.includes(
+  const mode = API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES.includes(
     rawMode as ApiCredentialTelemetryCapabilityMode,
   )
     ? (rawMode as ApiCredentialTelemetryCapabilityMode)
-    : DEFAULT_TELEMETRY_CONFIG.mode
+    : DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode
   const customEndpoint = coerceCustomEndpoint(obj.customEndpoint)
 
   return {
@@ -220,7 +211,7 @@ function coerceTelemetryAttempts(
       const source =
         typeof rawSource === "string" &&
         (rawSource === "models" ||
-          TELEMETRY_CAPABILITY_MODES.includes(
+          API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES.includes(
             rawSource as ApiCredentialTelemetryCapabilityMode,
           ))
           ? (rawSource as ApiCredentialTelemetryAttempt["source"])
@@ -283,7 +274,7 @@ function coerceTelemetrySnapshot(
   const source =
     typeof rawSource === "string" &&
     (rawSource === "models" ||
-      TELEMETRY_CAPABILITY_MODES.includes(
+      API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES.includes(
         rawSource as ApiCredentialTelemetryCapabilityMode,
       ))
       ? (rawSource as ApiCredentialTelemetrySnapshot["source"])
@@ -393,10 +384,10 @@ function mergeTelemetryConfig(
 ): ApiCredentialTelemetryConfig {
   const normalizedNewer = coerceApiCredentialTelemetryConfig(newer)
   const normalizedOlder = coerceApiCredentialTelemetryConfig(older)
-  if (normalizedNewer.mode !== DEFAULT_TELEMETRY_CONFIG.mode) {
+  if (normalizedNewer.mode !== DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode) {
     return normalizedNewer
   }
-  if (normalizedOlder.mode !== DEFAULT_TELEMETRY_CONFIG.mode) {
+  if (normalizedOlder.mode !== DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode) {
     return normalizedOlder
   }
   return normalizedNewer
@@ -869,9 +860,14 @@ class ApiCredentialProfilesStorageService {
         throw new Error("Profile not found.")
       }
 
+      const telemetrySnapshot = coerceTelemetrySnapshot(snapshot)
+      if (!telemetrySnapshot) {
+        throw new Error("Invalid telemetry snapshot.")
+      }
+
       const nextProfile: ApiCredentialProfile = {
         ...profiles[index],
-        telemetrySnapshot: coerceTelemetrySnapshot(snapshot) ?? snapshot,
+        telemetrySnapshot,
       }
 
       const nextProfiles = profiles.map((profile) =>

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -45,6 +45,20 @@ type JsonFetchResult = {
 }
 
 const OPENAI_BILLING_LIMIT_BALANCE_MAX_USD = 1_000_000
+const REDACTED_QUERY_VALUE = "[REDACTED]"
+
+const TELEMETRY_ENDPOINTS = {
+  models: {
+    google: "/v1beta/models",
+    openAiCompatible: "/v1/models",
+  },
+  openAiBilling: {
+    subscription: "/v1/dashboard/billing/subscription",
+    usage: "/v1/dashboard/billing/usage",
+  },
+  newApiTokenUsage: "/api/usage/token/",
+  sub2ApiUsage: "/v1/usage",
+} as const
 
 class TelemetryEndpointError extends Error {
   constructor(
@@ -130,6 +144,39 @@ function getPathValue(input: unknown, path: string): unknown {
 }
 
 /**
+ * Redacts sensitive query values before attempts are persisted with snapshots.
+ */
+function sanitizeTelemetryEndpoint(
+  endpoint: string,
+  secrets: string[],
+): string {
+  const redactedEndpoint = toSanitizedErrorSummary(endpoint, secrets)
+  const parsed = new URL(redactedEndpoint, "https://telemetry.local")
+
+  for (const key of Array.from(parsed.searchParams.keys())) {
+    parsed.searchParams.set(key, REDACTED_QUERY_VALUE)
+  }
+
+  return `${parsed.pathname}${parsed.search}`
+}
+
+/**
+ * Resolves the model catalog endpoint used for telemetry attempts.
+ */
+function getModelsEndpoint(profile: ApiCredentialProfile): string {
+  return profile.apiType === "google"
+    ? TELEMETRY_ENDPOINTS.models.google
+    : TELEMETRY_ENDPOINTS.models.openAiCompatible
+}
+
+/**
+ * Builds the OpenAI-compatible billing usage endpoint for the current date range.
+ */
+function createOpenAiBillingUsageEndpoint(start: string, end: string): string {
+  return `${TELEMETRY_ENDPOINTS.openAiBilling.usage}?start_date=${start}&end_date=${end}`
+}
+
+/**
  * Fetches a read-only telemetry endpoint with bearer-token authentication.
  */
 async function fetchJson(params: {
@@ -191,10 +238,11 @@ function createAttempt(
   endpoint: string,
   status: ApiCredentialTelemetryAttempt["status"],
   message?: string,
+  secrets: string[] = [],
 ): ApiCredentialTelemetryAttempt {
   return {
     source,
-    endpoint,
+    endpoint: sanitizeTelemetryEndpoint(endpoint, secrets),
     status,
     ...(message ? { message } : {}),
   }
@@ -215,6 +263,7 @@ function attemptFromError(
       error.endpoint || endpoint,
       error.unsupported ? "unsupported" : "error",
       toSanitizedErrorSummary(error, secrets),
+      secrets,
     )
   }
 
@@ -223,6 +272,7 @@ function attemptFromError(
     endpoint,
     "error",
     toSanitizedErrorSummary(error, secrets),
+    secrets,
   )
 }
 
@@ -253,9 +303,7 @@ function parseOpenAiBillingUsage(
     hardLimit !== undefined &&
     hardLimit >= OPENAI_BILLING_LIMIT_BALANCE_MAX_USD
   ) {
-    return {
-      ...(usedUsd !== undefined ? { totalUsedUsd: usedUsd } : {}),
-    }
+    return {}
   }
 
   return {
@@ -275,7 +323,7 @@ async function queryOpenAiBilling(
 ): Promise<AdapterSuccess> {
   const subscription = await fetchJson({
     baseUrl: profile.baseUrl,
-    endpoint: "/v1/dashboard/billing/subscription",
+    endpoint: TELEMETRY_ENDPOINTS.openAiBilling.subscription,
     apiKey: profile.apiKey,
   })
   const subscriptionData = dataLike(subscription.json)
@@ -291,7 +339,7 @@ async function queryOpenAiBilling(
   const now = new Date()
   const start = `${now.getFullYear()}-01-01`
   const end = now.toISOString().slice(0, 10)
-  const usageEndpoint = `/v1/dashboard/billing/usage?start_date=${start}&end_date=${end}`
+  const usageEndpoint = createOpenAiBillingUsageEndpoint(start, end)
   const usage = await fetchJson({
     baseUrl: profile.baseUrl,
     endpoint: usageEndpoint,
@@ -313,7 +361,7 @@ async function queryNewApiTokenUsage(
 ): Promise<AdapterSuccess> {
   const result = await fetchJson({
     baseUrl: profile.baseUrl,
-    endpoint: "/api/usage/token/",
+    endpoint: TELEMETRY_ENDPOINTS.newApiTokenUsage,
     apiKey: profile.apiKey,
   })
   const data = dataLike(result.json)
@@ -358,7 +406,7 @@ async function querySub2ApiUsage(
 ): Promise<AdapterSuccess> {
   const result = await fetchJson({
     baseUrl: profile.baseUrl,
-    endpoint: "/v1/usage",
+    endpoint: TELEMETRY_ENDPOINTS.sub2ApiUsage,
     apiKey: profile.apiKey,
   })
   const data = dataLike(result.json)
@@ -522,11 +570,12 @@ async function queryModels(
     attempts.push(
       createAttempt(
         "models",
-        profile.apiType === "google" ? "/v1beta/models" : "/v1/models",
+        getModelsEndpoint(profile),
         modelIds.length > 0 ? "success" : "unsupported",
         modelIds.length > 0
           ? `Fetched ${modelIds.length} models`
           : "No models returned",
+        [profile.apiKey],
       ),
     )
     return {
@@ -535,12 +584,9 @@ async function queryModels(
     }
   } catch (error) {
     attempts.push(
-      attemptFromError(
-        "models",
-        profile.apiType === "google" ? "/v1beta/models" : "/v1/models",
-        error,
-        [profile.apiKey],
-      ),
+      attemptFromError("models", getModelsEndpoint(profile), error, [
+        profile.apiKey,
+      ]),
     )
     return undefined
   }
@@ -589,7 +635,10 @@ function hasUsageData(data: TelemetryPatch): boolean {
     data.todayRequests !== undefined ||
     data.todayTokens !== undefined ||
     data.unlimitedQuota === true ||
-    data.totalAvailableUsd !== undefined
+    data.totalUsedUsd !== undefined ||
+    data.totalGrantedUsd !== undefined ||
+    data.totalAvailableUsd !== undefined ||
+    data.expiresAt !== undefined
   )
 }
 
@@ -605,12 +654,14 @@ export async function refreshApiCredentialProfileTelemetry(
   }
 
   const config = coerceApiCredentialTelemetryConfig(profile.telemetryConfig)
+  const modes = resolveModes(config)
   const attempts: ApiCredentialTelemetryAttempt[] = []
   const now = Date.now()
-  const models = await queryModels(profile, attempts)
+  const models =
+    modes.length > 0 ? await queryModels(profile, attempts) : undefined
   let usageResult: AdapterSuccess | null = null
 
-  for (const mode of resolveModes(config)) {
+  for (const mode of modes) {
     try {
       const result = await runUsageAdapter(profile, mode, config)
       if (hasUsageData(result.data)) {
@@ -621,6 +672,7 @@ export async function refreshApiCredentialProfileTelemetry(
             result.endpoint,
             "success",
             "Fetched usage",
+            [profile.apiKey],
           ),
         )
         break
@@ -632,16 +684,17 @@ export async function refreshApiCredentialProfileTelemetry(
           result.endpoint,
           "unsupported",
           "No usage fields returned",
+          [profile.apiKey],
         ),
       )
     } catch (error) {
       const endpoint =
         mode === "openaiBilling"
-          ? "/v1/dashboard/billing/subscription"
+          ? TELEMETRY_ENDPOINTS.openAiBilling.subscription
           : mode === "newApiTokenUsage"
-            ? "/api/usage/token/"
+            ? TELEMETRY_ENDPOINTS.newApiTokenUsage
             : mode === "sub2apiUsage"
-              ? "/v1/usage"
+              ? TELEMETRY_ENDPOINTS.sub2ApiUsage
               : config.customEndpoint?.endpoint || "custom"
       attempts.push(attemptFromError(mode, endpoint, error, [profile.apiKey]))
     }

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -1,0 +1,688 @@
+import { UI_CONSTANTS } from "~/constants/ui"
+import {
+  apiCredentialProfilesStorage,
+  coerceApiCredentialTelemetryConfig,
+} from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
+import { fetchApiCredentialModelIds } from "~/services/apiCredentialProfiles/modelCatalog"
+import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
+import { SiteHealthStatus } from "~/types"
+import type {
+  ApiCredentialProfile,
+  ApiCredentialTelemetryAttempt,
+  ApiCredentialTelemetryCapabilityMode,
+  ApiCredentialTelemetryConfig,
+  ApiCredentialTelemetryJsonPathMap,
+  ApiCredentialTelemetrySnapshot,
+} from "~/types/apiCredentialProfiles"
+import { getErrorMessage } from "~/utils/core/error"
+import { joinUrl } from "~/utils/core/url"
+
+type TelemetryPatch = Partial<
+  Pick<
+    ApiCredentialTelemetrySnapshot,
+    | "balanceUsd"
+    | "todayCostUsd"
+    | "todayRequests"
+    | "todayTokens"
+    | "totalUsedUsd"
+    | "totalGrantedUsd"
+    | "totalAvailableUsd"
+    | "expiresAt"
+  >
+>
+
+type AdapterSuccess = {
+  source: ApiCredentialTelemetryCapabilityMode
+  endpoint: string
+  data: TelemetryPatch
+}
+
+type JsonFetchResult = {
+  endpoint: string
+  json: unknown
+}
+
+const OPENAI_BILLING_LIMIT_BALANCE_MAX_USD = 1_000_000
+
+class TelemetryEndpointError extends Error {
+  constructor(
+    message: string,
+    public endpoint: string,
+    public statusCode?: number,
+    public unsupported: boolean = false,
+  ) {
+    super(message)
+    this.name = "TelemetryEndpointError"
+  }
+}
+
+/**
+ * Checks whether an unknown value can be safely read as a plain object.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value))
+}
+
+/**
+ * Unwraps common response envelopes so telemetry parsers can read fields.
+ */
+function dataLike(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) return {}
+  if (isRecord(value.data)) return value.data
+  return value
+}
+
+/**
+ * Reads a finite number from numeric or numeric-string response fields.
+ */
+function readNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+/**
+ * Converts One API quota units into USD.
+ */
+function quotaToUsd(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined
+  return value / UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+}
+
+/**
+ * Normalizes second or millisecond timestamps into milliseconds.
+ */
+function normalizeTimestamp(value: unknown): number | undefined {
+  const parsed = readNumber(value)
+  if (parsed === undefined || parsed <= 0) return undefined
+  return parsed < 1e12 ? Math.round(parsed * 1000) : Math.round(parsed)
+}
+
+/**
+ * Reads a nested value from an object using a dot-separated path.
+ */
+function getPathValue(input: unknown, path: string): unknown {
+  const segments = path
+    .split(".")
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+  let current = input
+
+  for (const segment of segments) {
+    if (!isRecord(current)) return undefined
+    current = current[segment]
+  }
+
+  return current
+}
+
+/**
+ * Classifies non-JSON response bodies before JSON parsing.
+ */
+function classifyBodyIssue(contentType: string, text: string): string | null {
+  const trimmed = text.trim()
+  if (!trimmed) return "Empty response"
+
+  const lowerContentType = contentType.toLowerCase()
+  const lowerText = trimmed.slice(0, 500).toLowerCase()
+  const looksHtml =
+    lowerContentType.includes("text/html") ||
+    lowerContentType.includes("application/xhtml+xml") ||
+    lowerText.startsWith("<!doctype html") ||
+    lowerText.startsWith("<html") ||
+    lowerText.includes("cloudflare") ||
+    lowerText.includes("cf-ray") ||
+    lowerText.includes("waf")
+
+  if (looksHtml) {
+    if (lowerText.includes("cloudflare") || lowerText.includes("cf-ray")) {
+      return "Cloudflare or origin protection returned HTML"
+    }
+    return "HTML response, likely WAF or unsupported endpoint"
+  }
+
+  return null
+}
+
+/**
+ * Fetches a read-only telemetry endpoint with bearer-token authentication.
+ */
+async function fetchJson(params: {
+  baseUrl: string
+  endpoint: string
+  apiKey: string
+}): Promise<JsonFetchResult> {
+  const url = joinUrl(params.baseUrl, params.endpoint)
+  let response: Response
+
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+    })
+  } catch (error) {
+    throw new TelemetryEndpointError(
+      `Network request failed: ${getErrorMessage(error)}`,
+      params.endpoint,
+    )
+  }
+
+  const contentType = response.headers.get("content-type") ?? ""
+  const text = await response.text()
+  const bodyIssue = classifyBodyIssue(contentType, text)
+
+  if (!response.ok) {
+    throw new TelemetryEndpointError(
+      bodyIssue ?? `HTTP ${response.status}`,
+      params.endpoint,
+      response.status,
+      response.status === 404 || response.status === 405,
+    )
+  }
+
+  if (bodyIssue) {
+    throw new TelemetryEndpointError(bodyIssue, params.endpoint)
+  }
+
+  try {
+    return {
+      endpoint: params.endpoint,
+      json: JSON.parse(text),
+    }
+  } catch {
+    throw new TelemetryEndpointError("Non-JSON response", params.endpoint)
+  }
+}
+
+/**
+ * Creates a normalized telemetry attempt entry for the profile snapshot.
+ */
+function createAttempt(
+  source: ApiCredentialTelemetryAttempt["source"],
+  endpoint: string,
+  status: ApiCredentialTelemetryAttempt["status"],
+  message?: string,
+): ApiCredentialTelemetryAttempt {
+  return {
+    source,
+    endpoint,
+    status,
+    ...(message ? { message } : {}),
+  }
+}
+
+/**
+ * Converts thrown endpoint errors into sanitized telemetry attempt entries.
+ */
+function attemptFromError(
+  source: ApiCredentialTelemetryAttempt["source"],
+  endpoint: string,
+  error: unknown,
+  secrets: string[],
+): ApiCredentialTelemetryAttempt {
+  if (error instanceof TelemetryEndpointError) {
+    return createAttempt(
+      source,
+      error.endpoint || endpoint,
+      error.unsupported ? "unsupported" : "error",
+      toSanitizedErrorSummary(error, secrets),
+    )
+  }
+
+  return createAttempt(
+    source,
+    endpoint,
+    "error",
+    toSanitizedErrorSummary(error, secrets),
+  )
+}
+
+/**
+ * Parses OpenAI-compatible subscription and usage responses into telemetry.
+ */
+function parseOpenAiBillingUsage(
+  subscription: unknown,
+  usage: unknown,
+): TelemetryPatch {
+  const sub = dataLike(subscription)
+  const usageRecord = dataLike(usage)
+  const hardLimit = readNumber(sub.hard_limit_usd)
+  const balance = readNumber(sub.balance)
+  const totalUsageRaw = readNumber(usageRecord.total_usage)
+  const usedUsd =
+    totalUsageRaw === undefined
+      ? readNumber(usageRecord.used_usd)
+      : totalUsageRaw / 100
+
+  if (balance !== undefined) {
+    return { balanceUsd: balance }
+  }
+
+  // Many compatible gateways return huge hard limits as compatibility sentinels
+  // rather than real user balance. Do not surface those as spendable balance.
+  if (
+    hardLimit !== undefined &&
+    hardLimit >= OPENAI_BILLING_LIMIT_BALANCE_MAX_USD
+  ) {
+    return {
+      ...(usedUsd !== undefined ? { totalUsedUsd: usedUsd } : {}),
+    }
+  }
+
+  return {
+    ...(hardLimit !== undefined && usedUsd !== undefined
+      ? { balanceUsd: Math.max(0, hardLimit - usedUsd) }
+      : {}),
+    ...(hardLimit !== undefined ? { totalGrantedUsd: hardLimit } : {}),
+    ...(usedUsd !== undefined ? { totalUsedUsd: usedUsd } : {}),
+  }
+}
+
+/**
+ * Queries OpenAI-compatible billing endpoints for balance and usage data.
+ */
+async function queryOpenAiBilling(
+  profile: ApiCredentialProfile,
+): Promise<AdapterSuccess> {
+  const subscription = await fetchJson({
+    baseUrl: profile.baseUrl,
+    endpoint: "/v1/dashboard/billing/subscription",
+    apiKey: profile.apiKey,
+  })
+  const subscriptionData = dataLike(subscription.json)
+  const directBalance = readNumber(subscriptionData.balance)
+  if (directBalance !== undefined) {
+    return {
+      source: "openaiBilling",
+      endpoint: subscription.endpoint,
+      data: { balanceUsd: directBalance },
+    }
+  }
+
+  const now = new Date()
+  const start = `${now.getFullYear()}-01-01`
+  const end = now.toISOString().slice(0, 10)
+  const usageEndpoint = `/v1/dashboard/billing/usage?start_date=${start}&end_date=${end}`
+  const usage = await fetchJson({
+    baseUrl: profile.baseUrl,
+    endpoint: usageEndpoint,
+    apiKey: profile.apiKey,
+  })
+
+  return {
+    source: "openaiBilling",
+    endpoint: subscription.endpoint,
+    data: parseOpenAiBillingUsage(subscription.json, usage.json),
+  }
+}
+
+/**
+ * Queries New API token usage endpoints for quota-based usage data.
+ */
+async function queryNewApiTokenUsage(
+  profile: ApiCredentialProfile,
+): Promise<AdapterSuccess> {
+  const result = await fetchJson({
+    baseUrl: profile.baseUrl,
+    endpoint: "/api/usage/token/",
+    apiKey: profile.apiKey,
+  })
+  const data = dataLike(result.json)
+  const totalGranted = readNumber(data.total_granted)
+  const totalUsed = readNumber(data.total_used)
+  const totalAvailable = readNumber(data.total_available)
+
+  return {
+    source: "newApiTokenUsage",
+    endpoint: result.endpoint,
+    data: {
+      ...(quotaToUsd(totalAvailable) !== undefined
+        ? { balanceUsd: quotaToUsd(totalAvailable) }
+        : {}),
+      ...(quotaToUsd(totalUsed) !== undefined
+        ? { totalUsedUsd: quotaToUsd(totalUsed) }
+        : {}),
+      ...(quotaToUsd(totalGranted) !== undefined
+        ? { totalGrantedUsd: quotaToUsd(totalGranted) }
+        : {}),
+      ...(quotaToUsd(totalAvailable) !== undefined
+        ? { totalAvailableUsd: quotaToUsd(totalAvailable) }
+        : {}),
+      ...(normalizeTimestamp(data.expires_at) !== undefined
+        ? { expiresAt: normalizeTimestamp(data.expires_at) }
+        : {}),
+    },
+  }
+}
+
+/**
+ * Queries Sub2API usage endpoints for balance and daily usage data.
+ */
+async function querySub2ApiUsage(
+  profile: ApiCredentialProfile,
+): Promise<AdapterSuccess> {
+  const result = await fetchJson({
+    baseUrl: profile.baseUrl,
+    endpoint: "/v1/usage",
+    apiKey: profile.apiKey,
+  })
+  const data = dataLike(result.json)
+  const usage = isRecord(data.usage) ? data.usage : {}
+  const today = isRecord(usage.today) ? usage.today : {}
+  const total = isRecord(usage.total) ? usage.total : {}
+  const balance = readNumber(data.balance) ?? readNumber(data.remaining)
+  const todayPromptTokens = readNumber(today.prompt_tokens)
+  const todayCompletionTokens = readNumber(today.completion_tokens)
+  const todayTotalTokens =
+    readNumber(today.tokens) ?? readNumber(today.total_tokens)
+
+  return {
+    source: "sub2apiUsage",
+    endpoint: result.endpoint,
+    data: {
+      ...(balance !== undefined ? { balanceUsd: balance } : {}),
+      ...(readNumber(today.cost) !== undefined
+        ? { todayCostUsd: readNumber(today.cost) }
+        : {}),
+      ...(readNumber(today.requests) !== undefined
+        ? { todayRequests: readNumber(today.requests) }
+        : {}),
+      ...(todayPromptTokens !== undefined ||
+      todayCompletionTokens !== undefined ||
+      todayTotalTokens !== undefined
+        ? {
+            todayTokens: {
+              upload: todayPromptTokens ?? todayTotalTokens ?? 0,
+              download: todayCompletionTokens ?? 0,
+            },
+          }
+        : {}),
+      ...(readNumber(total.cost) !== undefined
+        ? { totalUsedUsd: readNumber(total.cost) }
+        : {}),
+    },
+  }
+}
+
+/**
+ * Resolves a custom endpoint while keeping it on the profile origin.
+ */
+function resolveCustomEndpoint(
+  profile: ApiCredentialProfile,
+  endpoint: string,
+): string {
+  const trimmed = endpoint.trim()
+  if (!trimmed) throw new Error("Custom endpoint is empty")
+
+  const base = new URL(profile.baseUrl)
+  const resolved = new URL(trimmed, base.origin)
+  if (resolved.origin !== base.origin) {
+    throw new Error("Custom endpoint must stay on the profile base URL origin")
+  }
+
+  return `${resolved.pathname}${resolved.search}`
+}
+
+/**
+ * Maps a custom telemetry JSON response through configured JSON paths.
+ */
+function mapCustomJson(
+  json: unknown,
+  paths: ApiCredentialTelemetryJsonPathMap,
+): TelemetryPatch {
+  const todayPromptTokens = paths.todayPromptTokens
+    ? readNumber(getPathValue(json, paths.todayPromptTokens))
+    : undefined
+  const todayCompletionTokens = paths.todayCompletionTokens
+    ? readNumber(getPathValue(json, paths.todayCompletionTokens))
+    : undefined
+  const todayTotalTokens = paths.todayTotalTokens
+    ? readNumber(getPathValue(json, paths.todayTotalTokens))
+    : undefined
+
+  return {
+    ...(paths.balanceUsd
+      ? { balanceUsd: readNumber(getPathValue(json, paths.balanceUsd)) }
+      : {}),
+    ...(paths.todayCostUsd
+      ? { todayCostUsd: readNumber(getPathValue(json, paths.todayCostUsd)) }
+      : {}),
+    ...(paths.todayRequests
+      ? { todayRequests: readNumber(getPathValue(json, paths.todayRequests)) }
+      : {}),
+    ...(todayPromptTokens !== undefined ||
+    todayCompletionTokens !== undefined ||
+    todayTotalTokens !== undefined
+      ? {
+          todayTokens: {
+            upload: todayPromptTokens ?? todayTotalTokens ?? 0,
+            download: todayCompletionTokens ?? 0,
+          },
+        }
+      : {}),
+    ...(paths.totalUsedUsd
+      ? { totalUsedUsd: readNumber(getPathValue(json, paths.totalUsedUsd)) }
+      : {}),
+    ...(paths.totalGrantedUsd
+      ? {
+          totalGrantedUsd: readNumber(
+            getPathValue(json, paths.totalGrantedUsd),
+          ),
+        }
+      : {}),
+    ...(paths.totalAvailableUsd
+      ? {
+          totalAvailableUsd: readNumber(
+            getPathValue(json, paths.totalAvailableUsd),
+          ),
+        }
+      : {}),
+    ...(paths.expiresAt
+      ? { expiresAt: normalizeTimestamp(getPathValue(json, paths.expiresAt)) }
+      : {}),
+  }
+}
+
+/**
+ * Queries a configured custom read-only endpoint for telemetry data.
+ */
+async function queryCustomReadOnlyEndpoint(
+  profile: ApiCredentialProfile,
+  config: ApiCredentialTelemetryConfig,
+): Promise<AdapterSuccess> {
+  if (!config.customEndpoint) {
+    throw new Error("Custom endpoint is not configured")
+  }
+
+  const endpoint = resolveCustomEndpoint(
+    profile,
+    config.customEndpoint.endpoint,
+  )
+  const result = await fetchJson({
+    baseUrl: profile.baseUrl,
+    endpoint,
+    apiKey: profile.apiKey,
+  })
+
+  return {
+    source: "customReadOnlyEndpoint",
+    endpoint: result.endpoint,
+    data: mapCustomJson(result.json, config.customEndpoint.jsonPaths),
+  }
+}
+
+/**
+ * Queries the profile's model endpoint and records the outcome as telemetry.
+ */
+async function queryModels(
+  profile: ApiCredentialProfile,
+  attempts: ApiCredentialTelemetryAttempt[],
+) {
+  try {
+    const modelIds = await fetchApiCredentialModelIds({
+      apiType: profile.apiType,
+      baseUrl: profile.baseUrl,
+      apiKey: profile.apiKey,
+    })
+    attempts.push(
+      createAttempt(
+        "models",
+        profile.apiType === "google" ? "/v1beta/models" : "/v1/models",
+        modelIds.length > 0 ? "success" : "unsupported",
+        modelIds.length > 0
+          ? `Fetched ${modelIds.length} models`
+          : "No models returned",
+      ),
+    )
+    return {
+      count: modelIds.length,
+      preview: modelIds.slice(0, 20),
+    }
+  } catch (error) {
+    attempts.push(
+      attemptFromError(
+        "models",
+        profile.apiType === "google" ? "/v1beta/models" : "/v1/models",
+        error,
+        [profile.apiKey],
+      ),
+    )
+    return undefined
+  }
+}
+
+/**
+ * Runs the selected telemetry adapter for a profile.
+ */
+async function runUsageAdapter(
+  profile: ApiCredentialProfile,
+  mode: ApiCredentialTelemetryCapabilityMode,
+  config: ApiCredentialTelemetryConfig,
+): Promise<AdapterSuccess> {
+  if (mode === "openaiBilling") return await queryOpenAiBilling(profile)
+  if (mode === "newApiTokenUsage") return await queryNewApiTokenUsage(profile)
+  if (mode === "sub2apiUsage") return await querySub2ApiUsage(profile)
+  if (mode === "customReadOnlyEndpoint") {
+    return await queryCustomReadOnlyEndpoint(profile, config)
+  }
+
+  throw new Error(`Unsupported telemetry mode: ${mode}`)
+}
+
+/**
+ * Expands the configured telemetry mode into concrete adapter attempts.
+ */
+function resolveModes(
+  config: ApiCredentialTelemetryConfig,
+): ApiCredentialTelemetryCapabilityMode[] {
+  if (config.mode === "disabled") return []
+  if (config.mode === "auto") {
+    return ["openaiBilling", "newApiTokenUsage", "sub2apiUsage"]
+  }
+  return [config.mode]
+}
+
+/**
+ * Checks whether an adapter returned user-facing usage data.
+ */
+function hasUsageData(data: TelemetryPatch): boolean {
+  return (
+    data.balanceUsd !== undefined ||
+    data.todayCostUsd !== undefined ||
+    data.todayRequests !== undefined ||
+    data.todayTokens !== undefined ||
+    data.totalAvailableUsd !== undefined
+  )
+}
+
+/**
+ * Refreshes and persists telemetry for one API credential profile.
+ */
+export async function refreshApiCredentialProfileTelemetry(
+  profileId: string,
+): Promise<ApiCredentialTelemetrySnapshot> {
+  const profile = await apiCredentialProfilesStorage.getProfileById(profileId)
+  if (!profile) {
+    throw new Error("Profile not found.")
+  }
+
+  const config = coerceApiCredentialTelemetryConfig(profile.telemetryConfig)
+  const attempts: ApiCredentialTelemetryAttempt[] = []
+  const now = Date.now()
+  const models = await queryModels(profile, attempts)
+  let usageResult: AdapterSuccess | null = null
+
+  for (const mode of resolveModes(config)) {
+    try {
+      const result = await runUsageAdapter(profile, mode, config)
+      if (hasUsageData(result.data)) {
+        usageResult = result
+        attempts.push(
+          createAttempt(
+            result.source,
+            result.endpoint,
+            "success",
+            "Fetched usage",
+          ),
+        )
+        break
+      }
+
+      attempts.push(
+        createAttempt(
+          result.source,
+          result.endpoint,
+          "unsupported",
+          "No usage fields returned",
+        ),
+      )
+    } catch (error) {
+      const endpoint =
+        mode === "openaiBilling"
+          ? "/v1/dashboard/billing/subscription"
+          : mode === "newApiTokenUsage"
+            ? "/api/usage/token/"
+            : mode === "sub2apiUsage"
+              ? "/v1/usage"
+              : config.customEndpoint?.endpoint || "custom"
+      attempts.push(attemptFromError(mode, endpoint, error, [profile.apiKey]))
+    }
+  }
+
+  const modelSucceeded = Boolean(models && models.count > 0)
+  const usageSucceeded = Boolean(usageResult)
+  const lastError =
+    usageSucceeded || modelSucceeded
+      ? undefined
+      : attempts.find((attempt) => attempt.status === "error")?.message ||
+        "No supported telemetry endpoint returned data"
+
+  const snapshot: ApiCredentialTelemetrySnapshot = {
+    health:
+      usageSucceeded || modelSucceeded
+        ? { status: SiteHealthStatus.Healthy }
+        : {
+            status: SiteHealthStatus.Warning,
+            reason: lastError,
+          },
+    lastSyncTime: now,
+    ...(usageSucceeded || modelSucceeded ? { lastSuccessTime: now } : {}),
+    ...(lastError ? { lastError } : {}),
+    ...(usageResult?.source ? { source: usageResult.source } : {}),
+    ...(usageResult?.data ?? {}),
+    ...(models ? { models } : {}),
+    attempts,
+  }
+
+  await apiCredentialProfilesStorage.updateTelemetrySnapshot(
+    profile.id,
+    snapshot,
+  )
+  return snapshot
+}

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -4,8 +4,10 @@ import {
   coerceApiCredentialTelemetryConfig,
 } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { fetchApiCredentialModelIds } from "~/services/apiCredentialProfiles/modelCatalog"
+import { ApiError } from "~/services/apiService/common/errors"
+import { fetchApi } from "~/services/apiService/common/utils"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
-import { SiteHealthStatus } from "~/types"
+import { AuthTypeEnum, SiteHealthStatus } from "~/types"
 import type {
   ApiCredentialProfile,
   ApiCredentialTelemetryAttempt,
@@ -15,7 +17,6 @@ import type {
   ApiCredentialTelemetrySnapshot,
 } from "~/types/apiCredentialProfiles"
 import { getErrorMessage } from "~/utils/core/error"
-import { joinUrl } from "~/utils/core/url"
 
 type TelemetryPatch = Partial<
   Pick<
@@ -129,34 +130,6 @@ function getPathValue(input: unknown, path: string): unknown {
 }
 
 /**
- * Classifies non-JSON response bodies before JSON parsing.
- */
-function classifyBodyIssue(contentType: string, text: string): string | null {
-  const trimmed = text.trim()
-  if (!trimmed) return "Empty response"
-
-  const lowerContentType = contentType.toLowerCase()
-  const lowerText = trimmed.slice(0, 500).toLowerCase()
-  const looksHtml =
-    lowerContentType.includes("text/html") ||
-    lowerContentType.includes("application/xhtml+xml") ||
-    lowerText.startsWith("<!doctype html") ||
-    lowerText.startsWith("<html") ||
-    lowerText.includes("cloudflare") ||
-    lowerText.includes("cf-ray") ||
-    lowerText.includes("waf")
-
-  if (looksHtml) {
-    if (lowerText.includes("cloudflare") || lowerText.includes("cf-ray")) {
-      return "Cloudflare or origin protection returned HTML"
-    }
-    return "HTML response, likely WAF or unsupported endpoint"
-  }
-
-  return null
-}
-
-/**
  * Fetches a read-only telemetry endpoint with bearer-token authentication.
  */
 async function fetchJson(params: {
@@ -164,48 +137,49 @@ async function fetchJson(params: {
   endpoint: string
   apiKey: string
 }): Promise<JsonFetchResult> {
-  const url = joinUrl(params.baseUrl, params.endpoint)
-  let response: Response
-
   try {
-    response = await fetch(url, {
-      method: "GET",
-      headers: {
-        Accept: "application/json",
-        Authorization: `Bearer ${params.apiKey}`,
+    const json = await fetchApi<unknown>(
+      {
+        baseUrl: params.baseUrl,
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: params.apiKey,
+        },
       },
-    })
+      {
+        endpoint: params.endpoint,
+        options: {
+          method: "GET",
+          headers: {
+            Accept: "application/json",
+          },
+        },
+      },
+      true,
+    )
+
+    return {
+      endpoint: params.endpoint,
+      json,
+    }
   } catch (error) {
+    if (error instanceof ApiError) {
+      throw new TelemetryEndpointError(
+        error.message,
+        error.endpoint ?? params.endpoint,
+        error.statusCode,
+        error.statusCode === 404 || error.statusCode === 405,
+      )
+    }
+
+    if (error instanceof SyntaxError) {
+      throw new TelemetryEndpointError("Non-JSON response", params.endpoint)
+    }
+
     throw new TelemetryEndpointError(
       `Network request failed: ${getErrorMessage(error)}`,
       params.endpoint,
     )
-  }
-
-  const contentType = response.headers.get("content-type") ?? ""
-  const text = await response.text()
-  const bodyIssue = classifyBodyIssue(contentType, text)
-
-  if (!response.ok) {
-    throw new TelemetryEndpointError(
-      bodyIssue ?? `HTTP ${response.status}`,
-      params.endpoint,
-      response.status,
-      response.status === 404 || response.status === 405,
-    )
-  }
-
-  if (bodyIssue) {
-    throw new TelemetryEndpointError(bodyIssue, params.endpoint)
-  }
-
-  try {
-    return {
-      endpoint: params.endpoint,
-      json: JSON.parse(text),
-    }
-  } catch {
-    throw new TelemetryEndpointError("Non-JSON response", params.endpoint)
   }
 }
 

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -151,13 +151,17 @@ function sanitizeTelemetryEndpoint(
   secrets: string[],
 ): string {
   const redactedEndpoint = toSanitizedErrorSummary(endpoint, secrets)
-  const parsed = new URL(redactedEndpoint, "https://telemetry.local")
+  try {
+    const parsed = new URL(redactedEndpoint, "https://telemetry.local")
 
-  for (const key of Array.from(parsed.searchParams.keys())) {
-    parsed.searchParams.set(key, REDACTED_QUERY_VALUE)
+    for (const key of Array.from(parsed.searchParams.keys())) {
+      parsed.searchParams.set(key, REDACTED_QUERY_VALUE)
+    }
+
+    return `${parsed.pathname}${parsed.search}`
+  } catch {
+    return redactedEndpoint
   }
-
-  return `${parsed.pathname}${parsed.search}`
 }
 
 /**
@@ -303,7 +307,7 @@ function parseOpenAiBillingUsage(
     hardLimit !== undefined &&
     hardLimit >= OPENAI_BILLING_LIMIT_BALANCE_MAX_USD
   ) {
-    return {}
+    return usedUsd !== undefined ? { totalUsedUsd: usedUsd } : {}
   }
 
   return {

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -583,7 +583,9 @@ function resolveModes(
 ): ApiCredentialTelemetryCapabilityMode[] {
   if (config.mode === "disabled") return []
   if (config.mode === "auto") {
-    return ["openaiBilling", "newApiTokenUsage", "sub2apiUsage"]
+    // Prefer provider-specific key telemetry. OpenAI billing endpoints often
+    // expose compatibility limits, not spendable gateway balance.
+    return ["newApiTokenUsage", "sub2apiUsage", "openaiBilling"]
   }
   return [config.mode]
 }

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -24,6 +24,7 @@ type TelemetryPatch = Partial<
     | "todayCostUsd"
     | "todayRequests"
     | "todayTokens"
+    | "unlimitedQuota"
     | "totalUsedUsd"
     | "totalGrantedUsd"
     | "totalAvailableUsd"
@@ -90,6 +91,14 @@ function readNumber(value: unknown): number | undefined {
 function quotaToUsd(value: number | undefined): number | undefined {
   if (value === undefined) return undefined
   return value / UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+}
+
+/**
+ * Converts quota units into a non-negative USD amount.
+ */
+function nonNegativeQuotaToUsd(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined
+  return quotaToUsd(Math.max(0, value))
 }
 
 /**
@@ -337,23 +346,29 @@ async function queryNewApiTokenUsage(
   const totalGranted = readNumber(data.total_granted)
   const totalUsed = readNumber(data.total_used)
   const totalAvailable = readNumber(data.total_available)
+  const unlimitedQuota =
+    data.unlimited_quota === true ||
+    (totalGranted !== undefined && totalGranted < 0)
+  const balanceUsd = unlimitedQuota
+    ? undefined
+    : nonNegativeQuotaToUsd(totalAvailable)
+  const totalUsedUsd = nonNegativeQuotaToUsd(totalUsed)
+  const totalGrantedUsd = unlimitedQuota
+    ? undefined
+    : nonNegativeQuotaToUsd(totalGranted)
+  const totalAvailableUsd = unlimitedQuota
+    ? undefined
+    : nonNegativeQuotaToUsd(totalAvailable)
 
   return {
     source: "newApiTokenUsage",
     endpoint: result.endpoint,
     data: {
-      ...(quotaToUsd(totalAvailable) !== undefined
-        ? { balanceUsd: quotaToUsd(totalAvailable) }
-        : {}),
-      ...(quotaToUsd(totalUsed) !== undefined
-        ? { totalUsedUsd: quotaToUsd(totalUsed) }
-        : {}),
-      ...(quotaToUsd(totalGranted) !== undefined
-        ? { totalGrantedUsd: quotaToUsd(totalGranted) }
-        : {}),
-      ...(quotaToUsd(totalAvailable) !== undefined
-        ? { totalAvailableUsd: quotaToUsd(totalAvailable) }
-        : {}),
+      ...(unlimitedQuota ? { unlimitedQuota: true } : {}),
+      ...(balanceUsd !== undefined ? { balanceUsd } : {}),
+      ...(totalUsedUsd !== undefined ? { totalUsedUsd } : {}),
+      ...(totalGrantedUsd !== undefined ? { totalGrantedUsd } : {}),
+      ...(totalAvailableUsd !== undefined ? { totalAvailableUsd } : {}),
       ...(normalizeTimestamp(data.expires_at) !== undefined
         ? { expiresAt: normalizeTimestamp(data.expires_at) }
         : {}),
@@ -599,6 +614,7 @@ function hasUsageData(data: TelemetryPatch): boolean {
     data.todayCostUsd !== undefined ||
     data.todayRequests !== undefined ||
     data.todayTokens !== undefined ||
+    data.unlimitedQuota === true ||
     data.totalAvailableUsd !== undefined
   )
 }

--- a/src/services/apiService/common/utils.ts
+++ b/src/services/apiService/common/utils.ts
@@ -171,6 +171,10 @@ const createBaseRequest = (
   options: RequestInit = {},
 ): RequestInit => {
   const method = (options.method ?? "GET").toUpperCase()
+  const requestOptions = { ...options }
+  delete requestOptions.credentials
+  delete requestOptions.headers
+  delete requestOptions.method
 
   const defaultHeaders: HeadersInit = {
     ...headers,
@@ -185,7 +189,7 @@ const createBaseRequest = (
       ...(options.headers || {}), // 用户自定义 headers 可覆盖默认值
     },
     credentials,
-    ...options,
+    ...requestOptions,
   }
 }
 

--- a/src/types/apiCredentialProfiles.ts
+++ b/src/types/apiCredentialProfiles.ts
@@ -67,6 +67,7 @@ export type ApiCredentialTelemetrySnapshot = {
   todayCostUsd?: number
   todayRequests?: number
   todayTokens?: TokenUsage
+  unlimitedQuota?: boolean
   totalUsedUsd?: number
   totalGrantedUsd?: number
   totalAvailableUsd?: number

--- a/src/types/apiCredentialProfiles.ts
+++ b/src/types/apiCredentialProfiles.ts
@@ -1,9 +1,79 @@
 import type { ApiVerificationApiType } from "~/services/verification/aiApiVerification"
+import type { HealthStatus, TokenUsage } from "~/types"
 
 /**
  * Current schema version for the API credential profiles storage payload.
  */
-export const API_CREDENTIAL_PROFILES_CONFIG_VERSION = 2
+export const API_CREDENTIAL_PROFILES_CONFIG_VERSION = 3
+
+export type ApiCredentialTelemetryCapabilityMode =
+  | "disabled"
+  | "auto"
+  | "openaiBilling"
+  | "newApiTokenUsage"
+  | "sub2apiUsage"
+  | "customReadOnlyEndpoint"
+
+export type ApiCredentialTelemetryJsonPathMap = {
+  balanceUsd?: string
+  todayCostUsd?: string
+  todayRequests?: string
+  todayPromptTokens?: string
+  todayCompletionTokens?: string
+  todayTotalTokens?: string
+  totalUsedUsd?: string
+  totalGrantedUsd?: string
+  totalAvailableUsd?: string
+  expiresAt?: string
+}
+
+export type ApiCredentialTelemetryCustomEndpoint = {
+  /**
+   * Read-only endpoint path or URL under the profile base URL origin.
+   */
+  endpoint: string
+  jsonPaths: ApiCredentialTelemetryJsonPathMap
+}
+
+export type ApiCredentialTelemetryConfig = {
+  mode: ApiCredentialTelemetryCapabilityMode
+  customEndpoint?: ApiCredentialTelemetryCustomEndpoint
+}
+
+export type ApiCredentialTelemetryAttemptStatus =
+  | "success"
+  | "unsupported"
+  | "error"
+
+export type ApiCredentialTelemetryAttempt = {
+  source: ApiCredentialTelemetryCapabilityMode | "models"
+  endpoint: string
+  status: ApiCredentialTelemetryAttemptStatus
+  message?: string
+}
+
+export type ApiCredentialModelTelemetry = {
+  count: number
+  preview: string[]
+}
+
+export type ApiCredentialTelemetrySnapshot = {
+  health: HealthStatus
+  lastSyncTime: number
+  lastSuccessTime?: number
+  lastError?: string
+  source?: ApiCredentialTelemetryCapabilityMode | "models"
+  balanceUsd?: number
+  todayCostUsd?: number
+  todayRequests?: number
+  todayTokens?: TokenUsage
+  totalUsedUsd?: number
+  totalGrantedUsd?: number
+  totalAvailableUsd?: number
+  expiresAt?: number
+  models?: ApiCredentialModelTelemetry
+  attempts: ApiCredentialTelemetryAttempt[]
+}
 
 /**
  * Standalone persisted API credential bundle (baseUrl + apiKey) that is not tied
@@ -29,6 +99,8 @@ export type ApiCredentialProfile = {
    */
   tagIds: string[]
   notes: string
+  telemetryConfig?: ApiCredentialTelemetryConfig
+  telemetrySnapshot?: ApiCredentialTelemetrySnapshot
   createdAt: number
   updatedAt: number
 }

--- a/src/types/apiCredentialProfiles.ts
+++ b/src/types/apiCredentialProfiles.ts
@@ -40,6 +40,21 @@ export type ApiCredentialTelemetryConfig = {
   customEndpoint?: ApiCredentialTelemetryCustomEndpoint
 }
 
+export const API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES: ApiCredentialTelemetryCapabilityMode[] =
+  [
+    "disabled",
+    "auto",
+    "openaiBilling",
+    "newApiTokenUsage",
+    "sub2apiUsage",
+    "customReadOnlyEndpoint",
+  ]
+
+export const DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG: ApiCredentialTelemetryConfig =
+  {
+    mode: "auto",
+  }
+
 export type ApiCredentialTelemetryAttemptStatus =
   | "success"
   | "unsupported"

--- a/src/utils/core/money.ts
+++ b/src/utils/core/money.ts
@@ -1,4 +1,5 @@
-import { UI_CONSTANTS } from "~/constants/ui"
+import { CURRENCY_SYMBOLS, UI_CONSTANTS } from "~/constants/ui"
+import type { CurrencyType } from "~/types"
 
 /**
  * Formatting options for money-like numeric values used across the UI.
@@ -64,4 +65,23 @@ export const formatMoneyFixed = (
   { decimals, minNonZero }: MoneyFormatOptions = DEFAULT_MONEY_FORMAT_OPTIONS,
 ): string => {
   return getDisplayMoneyValue(value, { decimals, minNonZero }).toFixed(decimals)
+}
+
+/**
+ * Formats a USD telemetry amount in the selected display currency.
+ */
+export const formatTelemetryMoney = (
+  valueUsd: number | undefined,
+  currencyType: CurrencyType,
+): string => {
+  if (typeof valueUsd !== "number" || !Number.isFinite(valueUsd)) return "-"
+
+  const value =
+    currencyType === "CNY"
+      ? valueUsd * UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
+      : valueUsd
+
+  return `${CURRENCY_SYMBOLS[currencyType]}${getDisplayMoneyValue(
+    value,
+  ).toFixed(UI_CONSTANTS.MONEY.DECIMALS)}`
 }

--- a/src/utils/core/sanitizeUrlForLog.ts
+++ b/src/utils/core/sanitizeUrlForLog.ts
@@ -6,5 +6,5 @@ import { tryParseUrlPrefix } from "~/utils/core/urlParsing"
  * @returns The formatted URL.
  */
 export function sanitizeUrlForLog(url: string) {
-  return tryParseUrlPrefix(url) ?? url
+  return tryParseUrlPrefix(url) ?? url.replace(/[?#].*$/, "")
 }

--- a/tests/entrypoints/popup/ApiCredentialProfilesStatsSection.test.tsx
+++ b/tests/entrypoints/popup/ApiCredentialProfilesStatsSection.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest"
+
+import ApiCredentialProfilesStatsSection from "~/entrypoints/popup/components/ApiCredentialProfilesStatsSection"
+import { SiteHealthStatus } from "~/types"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import { render, screen } from "~~/tests/test-utils/render"
+
+const { mockUseApiCredentialProfiles, mockUseUserPreferencesContext } =
+  vi.hoisted(() => ({
+    mockUseApiCredentialProfiles: vi.fn(),
+    mockUseUserPreferencesContext: vi.fn(),
+  }))
+
+vi.mock("react-countup", () => ({
+  default: ({ end }: { end: number }) => <span>{end}</span>,
+}))
+
+vi.mock("~/contexts/UserPreferencesContext", () => ({
+  useUserPreferencesContext: () => mockUseUserPreferencesContext(),
+}))
+
+vi.mock(
+  "~/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles",
+  () => ({
+    useApiCredentialProfiles: () => mockUseApiCredentialProfiles(),
+  }),
+)
+
+function buildProfile(
+  overrides: Partial<ApiCredentialProfile> = {},
+): ApiCredentialProfile {
+  return {
+    id: "profile-1",
+    name: "Profile",
+    apiType: "openai-compatible",
+    baseUrl: "https://api.example.com",
+    apiKey: "sk-profile",
+    tagIds: [],
+    notes: "",
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+describe("ApiCredentialProfilesStatsSection", () => {
+  it("shows telemetry totals when refreshed snapshots are available", () => {
+    mockUseUserPreferencesContext.mockReturnValue({ currencyType: "USD" })
+    mockUseApiCredentialProfiles.mockReturnValue({
+      isLoading: false,
+      profiles: [
+        buildProfile({
+          id: "profile-1",
+          tagIds: ["team-a"],
+          telemetrySnapshot: {
+            attempts: [],
+            balanceUsd: 12.5,
+            health: { status: SiteHealthStatus.Healthy },
+            lastSyncTime: 1000,
+            todayCostUsd: 1.25,
+          },
+        }),
+        buildProfile({
+          id: "profile-2",
+          baseUrl: "https://other.example.com",
+          tagIds: ["team-a", "team-b"],
+          telemetrySnapshot: {
+            attempts: [],
+            balanceUsd: 2,
+            health: { status: SiteHealthStatus.Warning },
+            lastSyncTime: 1000,
+          },
+        }),
+      ],
+    })
+
+    render(<ApiCredentialProfilesStatsSection />, {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    expect(screen.getByText("$14.50")).toBeInTheDocument()
+    expect(screen.getByText("$1.25")).toBeInTheDocument()
+  })
+
+  it("does not present missing telemetry as a zero balance", () => {
+    mockUseUserPreferencesContext.mockReturnValue({ currencyType: "USD" })
+    mockUseApiCredentialProfiles.mockReturnValue({
+      isLoading: false,
+      profiles: [buildProfile()],
+    })
+
+    render(<ApiCredentialProfilesStatsSection />, {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    expect(
+      screen.getAllByText("apiCredentialProfiles:telemetry.notProvided"),
+    ).toHaveLength(2)
+  })
+
+  it("does not present refreshed snapshots without balance as a zero balance", () => {
+    mockUseUserPreferencesContext.mockReturnValue({ currencyType: "USD" })
+    mockUseApiCredentialProfiles.mockReturnValue({
+      isLoading: false,
+      profiles: [
+        buildProfile({
+          telemetrySnapshot: {
+            attempts: [],
+            health: { status: SiteHealthStatus.Healthy },
+            lastSyncTime: 1000,
+            models: { count: 2, preview: ["gpt-4o", "o3"] },
+          },
+        }),
+      ],
+    })
+
+    render(<ApiCredentialProfilesStatsSection />, {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    expect(screen.queryByText("$0.00")).not.toBeInTheDocument()
+    expect(
+      screen.getAllByText("apiCredentialProfiles:telemetry.notProvided"),
+    ).toHaveLength(2)
+  })
+})

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
@@ -3,7 +3,36 @@ import { describe, expect, it, vi } from "vitest"
 import { ApiCredentialProfileListItem } from "~/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem"
 import { SiteHealthStatus } from "~/types"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
-import { render, screen } from "~~/tests/test-utils/render"
+import { fireEvent, render, screen } from "~~/tests/test-utils/render"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, options?: { count?: number }) => {
+        if (key === "common:quota.unlimited") return "Unlimited"
+        if (key === "apiCredentialProfiles:telemetry.notProvided") {
+          return "Not provided"
+        }
+        if (key === "apiCredentialProfiles:telemetry.modelCount") {
+          return `${options?.count ?? 0} models`
+        }
+        if (key === "account:healthStatus.warning") return "Warning"
+        if (key === "account:healthStatus.healthy") return "Healthy"
+        if (key === "apiCredentialProfiles:telemetry.health") return "Health"
+        if (key === "apiCredentialProfiles:telemetry.actions.refresh") {
+          return "Refresh telemetry"
+        }
+        if (key === "apiCredentialProfiles:telemetry.refreshing") {
+          return "Refreshing telemetry"
+        }
+        return key
+      },
+    }),
+  }
+})
 
 vi.mock(
   "~/components/dialogs/VerifyApiDialog/VerificationHistorySummary",
@@ -92,7 +121,14 @@ function buildProfile(
   }
 }
 
-function renderListItem(profile: ApiCredentialProfile) {
+function renderListItem(
+  profile: ApiCredentialProfile,
+  overrides: {
+    isTelemetryRefreshing?: boolean
+    onRefreshTelemetry?: (profile: ApiCredentialProfile) => void
+  } = {},
+) {
+  const onRefreshTelemetry = overrides.onRefreshTelemetry ?? vi.fn()
   return render(
     <ApiCredentialProfileListItem
       profile={profile}
@@ -106,11 +142,11 @@ function renderListItem(profile: ApiCredentialProfile) {
       onOpenModelManagement={vi.fn()}
       onVerify={vi.fn()}
       onVerifyCliSupport={vi.fn()}
-      onRefreshTelemetry={vi.fn()}
+      onRefreshTelemetry={onRefreshTelemetry}
       onEdit={vi.fn()}
       onDelete={vi.fn()}
       onExport={vi.fn()}
-      isTelemetryRefreshing={false}
+      isTelemetryRefreshing={overrides.isTelemetryRefreshing ?? false}
       managedSiteType="new-api"
       managedSiteLabel="New API"
     />,
@@ -128,13 +164,13 @@ describe("ApiCredentialProfileListItem", () => {
 
     expect(
       screen.getByTestId("api-credential-telemetry-balance"),
-    ).toHaveTextContent("common:quota.unlimited")
+    ).toHaveTextContent("Unlimited")
     expect(
       screen.getByTestId("api-credential-telemetry-today-usage"),
-    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    ).toHaveTextContent("Not provided")
     expect(
       screen.getByTestId("api-credential-telemetry-today-requests"),
-    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    ).toHaveTextContent("Not provided")
   })
 
   it("explicitly marks missing balance from a successful usage source as not provided", () => {
@@ -153,7 +189,7 @@ describe("ApiCredentialProfileListItem", () => {
 
     expect(
       screen.getByTestId("api-credential-telemetry-balance"),
-    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    ).toHaveTextContent("Not provided")
   })
 
   it("uses not provided fallbacks for model-only refreshed snapshots", () => {
@@ -171,16 +207,16 @@ describe("ApiCredentialProfileListItem", () => {
 
     expect(
       screen.getByTestId("api-credential-telemetry-balance"),
-    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    ).toHaveTextContent("Not provided")
     expect(
       screen.getByTestId("api-credential-telemetry-today-usage"),
-    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    ).toHaveTextContent("Not provided")
     expect(
       screen.getByTestId("api-credential-telemetry-today-requests"),
-    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    ).toHaveTextContent("Not provided")
     expect(
       screen.getByTestId("api-credential-telemetry-models"),
-    ).toHaveTextContent("apiCredentialProfiles:telemetry.modelCount")
+    ).toHaveTextContent("2 models")
   })
 
   it("renders dash fallbacks when telemetry has never been refreshed", () => {
@@ -200,7 +236,7 @@ describe("ApiCredentialProfileListItem", () => {
     ).toHaveTextContent("-")
   })
 
-  it("uses localized health status text in the telemetry tooltip", () => {
+  it("exposes localized health status text accessibly", () => {
     renderListItem(
       buildProfile({
         telemetrySnapshot: {
@@ -215,7 +251,47 @@ describe("ApiCredentialProfileListItem", () => {
     )
 
     expect(
-      document.querySelector('[title*="account:healthStatus.warning"]'),
-    ).toBeInTheDocument()
+      screen.getByLabelText("Health: Warning: quota is low"),
+    ).toHaveAttribute("role", "img")
+  })
+
+  it("wires the telemetry refresh button and reflects the refreshing state", () => {
+    const onRefreshTelemetry = vi.fn()
+
+    const { rerender } = renderListItem(buildProfile(), { onRefreshTelemetry })
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh telemetry" }))
+
+    expect(onRefreshTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "profile-1" }),
+    )
+
+    rerender(
+      <ApiCredentialProfileListItem
+        profile={buildProfile()}
+        verificationSummary={null}
+        tagNames={[]}
+        visibleKeys={new Set()}
+        toggleKeyVisibility={vi.fn()}
+        onCopyBaseUrl={vi.fn()}
+        onCopyApiKey={vi.fn()}
+        onCopyBundle={vi.fn()}
+        onOpenModelManagement={vi.fn()}
+        onVerify={vi.fn()}
+        onVerifyCliSupport={vi.fn()}
+        onRefreshTelemetry={onRefreshTelemetry}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onExport={vi.fn()}
+        isTelemetryRefreshing
+        managedSiteType="new-api"
+        managedSiteLabel="New API"
+      />,
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Refresh telemetry" }),
+    ).toBeDisabled()
+    expect(screen.getByText("Refreshing telemetry")).toBeInTheDocument()
   })
 })

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { ApiCredentialProfileListItem } from "~/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem"
+import { SiteHealthStatus } from "~/types"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import { render, screen } from "~~/tests/test-utils/render"
+
+vi.mock(
+  "~/components/dialogs/VerifyApiDialog/VerificationHistorySummary",
+  () => ({
+    VerificationHistorySummary: () => (
+      <div data-testid="verification-summary" />
+    ),
+  }),
+)
+
+vi.mock("~/components/icons/CCSwitchIcon", () => ({
+  CCSwitchIcon: () => <span data-testid="cc-switch-icon" />,
+}))
+
+vi.mock("~/components/icons/CherryIcon", () => ({
+  CherryIcon: () => <span data-testid="cherry-icon" />,
+}))
+
+vi.mock("~/components/icons/ClaudeCodeRouterIcon", () => ({
+  ClaudeCodeRouterIcon: () => <span data-testid="claude-code-router-icon" />,
+}))
+
+vi.mock("~/components/icons/CliProxyIcon", () => ({
+  CliProxyIcon: () => <span data-testid="cli-proxy-icon" />,
+}))
+
+vi.mock("~/components/icons/KiloCodeIcon", () => ({
+  KiloCodeIcon: () => <span data-testid="kilo-code-icon" />,
+}))
+
+vi.mock("~/components/icons/ManagedSiteIcon", () => ({
+  ManagedSiteIcon: () => <span data-testid="managed-site-icon" />,
+}))
+
+vi.mock("~/components/ui", () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+  Heading6: ({ children }: any) => <h6>{children}</h6>,
+  IconButton: ({ children, ...props }: any) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("~/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, ...props }: any) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: any) => <>{children}</>,
+}))
+
+vi.mock("~/contexts/UserPreferencesContext", () => ({
+  useUserPreferencesContext: () => ({ currencyType: "USD" }),
+}))
+
+function buildProfile(
+  overrides: Partial<ApiCredentialProfile> = {},
+): ApiCredentialProfile {
+  return {
+    id: "profile-1",
+    name: "NewAPI Unlimited",
+    apiType: "openai-compatible",
+    baseUrl: "https://newapi.example.com",
+    apiKey: "sk-newapi",
+    tagIds: [],
+    notes: "",
+    createdAt: 1,
+    updatedAt: 1,
+    telemetrySnapshot: {
+      attempts: [],
+      health: { status: SiteHealthStatus.Healthy },
+      lastSuccessTime: 1,
+      lastSyncTime: 1,
+      source: "newApiTokenUsage",
+      totalUsedUsd: 1.88131,
+      unlimitedQuota: true,
+    },
+    ...overrides,
+  }
+}
+
+describe("ApiCredentialProfileListItem", () => {
+  it("explicitly marks missing daily telemetry from a successful source as not provided", () => {
+    render(
+      <ApiCredentialProfileListItem
+        profile={buildProfile()}
+        verificationSummary={null}
+        tagNames={[]}
+        visibleKeys={new Set()}
+        toggleKeyVisibility={vi.fn()}
+        onCopyBaseUrl={vi.fn()}
+        onCopyApiKey={vi.fn()}
+        onCopyBundle={vi.fn()}
+        onOpenModelManagement={vi.fn()}
+        onVerify={vi.fn()}
+        onVerifyCliSupport={vi.fn()}
+        onRefreshTelemetry={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onExport={vi.fn()}
+        isTelemetryRefreshing={false}
+        managedSiteType="new-api"
+        managedSiteLabel="New API"
+      />,
+      {
+        withReleaseUpdateStatusProvider: false,
+        withThemeProvider: false,
+        withUserPreferencesProvider: false,
+      },
+    )
+
+    expect(screen.getByText("common:quota.unlimited")).toBeInTheDocument()
+    expect(
+      screen.getAllByText("apiCredentialProfiles:telemetry.notProvided"),
+    ).toHaveLength(2)
+  })
+})

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
@@ -92,39 +92,130 @@ function buildProfile(
   }
 }
 
+function renderListItem(profile: ApiCredentialProfile) {
+  return render(
+    <ApiCredentialProfileListItem
+      profile={profile}
+      verificationSummary={null}
+      tagNames={[]}
+      visibleKeys={new Set()}
+      toggleKeyVisibility={vi.fn()}
+      onCopyBaseUrl={vi.fn()}
+      onCopyApiKey={vi.fn()}
+      onCopyBundle={vi.fn()}
+      onOpenModelManagement={vi.fn()}
+      onVerify={vi.fn()}
+      onVerifyCliSupport={vi.fn()}
+      onRefreshTelemetry={vi.fn()}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      onExport={vi.fn()}
+      isTelemetryRefreshing={false}
+      managedSiteType="new-api"
+      managedSiteLabel="New API"
+    />,
+    {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    },
+  )
+}
+
 describe("ApiCredentialProfileListItem", () => {
   it("explicitly marks missing daily telemetry from a successful source as not provided", () => {
-    render(
-      <ApiCredentialProfileListItem
-        profile={buildProfile()}
-        verificationSummary={null}
-        tagNames={[]}
-        visibleKeys={new Set()}
-        toggleKeyVisibility={vi.fn()}
-        onCopyBaseUrl={vi.fn()}
-        onCopyApiKey={vi.fn()}
-        onCopyBundle={vi.fn()}
-        onOpenModelManagement={vi.fn()}
-        onVerify={vi.fn()}
-        onVerifyCliSupport={vi.fn()}
-        onRefreshTelemetry={vi.fn()}
-        onEdit={vi.fn()}
-        onDelete={vi.fn()}
-        onExport={vi.fn()}
-        isTelemetryRefreshing={false}
-        managedSiteType="new-api"
-        managedSiteLabel="New API"
-      />,
-      {
-        withReleaseUpdateStatusProvider: false,
-        withThemeProvider: false,
-        withUserPreferencesProvider: false,
-      },
+    renderListItem(buildProfile())
+
+    expect(
+      screen.getByTestId("api-credential-telemetry-balance"),
+    ).toHaveTextContent("common:quota.unlimited")
+    expect(
+      screen.getByTestId("api-credential-telemetry-today-usage"),
+    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    expect(
+      screen.getByTestId("api-credential-telemetry-today-requests"),
+    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+  })
+
+  it("explicitly marks missing balance from a successful usage source as not provided", () => {
+    renderListItem(
+      buildProfile({
+        telemetrySnapshot: {
+          attempts: [],
+          health: { status: SiteHealthStatus.Healthy },
+          lastSuccessTime: 1,
+          lastSyncTime: 1,
+          source: "customReadOnlyEndpoint",
+          todayRequests: 42,
+        },
+      }),
     )
 
-    expect(screen.getByText("common:quota.unlimited")).toBeInTheDocument()
     expect(
-      screen.getAllByText("apiCredentialProfiles:telemetry.notProvided"),
-    ).toHaveLength(2)
+      screen.getByTestId("api-credential-telemetry-balance"),
+    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+  })
+
+  it("uses not provided fallbacks for model-only refreshed snapshots", () => {
+    renderListItem(
+      buildProfile({
+        telemetrySnapshot: {
+          attempts: [],
+          health: { status: SiteHealthStatus.Healthy },
+          lastSuccessTime: 1,
+          lastSyncTime: 1,
+          models: { count: 2, preview: ["gpt-4o", "o3"] },
+        },
+      }),
+    )
+
+    expect(
+      screen.getByTestId("api-credential-telemetry-balance"),
+    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    expect(
+      screen.getByTestId("api-credential-telemetry-today-usage"),
+    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    expect(
+      screen.getByTestId("api-credential-telemetry-today-requests"),
+    ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
+    expect(
+      screen.getByTestId("api-credential-telemetry-models"),
+    ).toHaveTextContent("apiCredentialProfiles:telemetry.modelCount")
+  })
+
+  it("renders dash fallbacks when telemetry has never been refreshed", () => {
+    renderListItem(buildProfile({ telemetrySnapshot: undefined }))
+
+    expect(
+      screen.getByTestId("api-credential-telemetry-balance"),
+    ).toHaveTextContent("-")
+    expect(
+      screen.getByTestId("api-credential-telemetry-today-usage"),
+    ).toHaveTextContent("-")
+    expect(
+      screen.getByTestId("api-credential-telemetry-today-requests"),
+    ).toHaveTextContent("-")
+    expect(
+      screen.getByTestId("api-credential-telemetry-models"),
+    ).toHaveTextContent("-")
+  })
+
+  it("uses localized health status text in the telemetry tooltip", () => {
+    renderListItem(
+      buildProfile({
+        telemetrySnapshot: {
+          attempts: [],
+          health: {
+            reason: "quota is low",
+            status: SiteHealthStatus.Warning,
+          },
+          lastSyncTime: 1,
+        },
+      }),
+    )
+
+    expect(
+      document.querySelector('[title*="account:healthStatus.warning"]'),
+    ).toBeInTheDocument()
   })
 })

--- a/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
+++ b/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
@@ -1,0 +1,154 @@
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { useApiCredentialProfilesController } from "~/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import { act, renderHook } from "~~/tests/test-utils/render"
+
+const {
+  deleteProfileMock,
+  refreshTelemetryMock,
+  tagStorageListTagsMock,
+  toastPromiseMock,
+} = vi.hoisted(() => ({
+  deleteProfileMock: vi.fn(),
+  refreshTelemetryMock: vi.fn(),
+  tagStorageListTagsMock: vi.fn(),
+  toastPromiseMock: vi.fn(),
+}))
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    error: vi.fn(),
+    promise: (...args: unknown[]) => toastPromiseMock(...args),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock("~/components/dialogs/ChannelDialog", () => ({
+  ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
+  useChannelDialog: () => ({ openWithCredentials: vi.fn() }),
+}))
+
+vi.mock("~/contexts/UserPreferencesContext", () => ({
+  useUserPreferencesContext: () => ({
+    claudeCodeRouterApiKey: "",
+    claudeCodeRouterBaseUrl: "",
+    cliProxyBaseUrl: "",
+    cliProxyManagementKey: "",
+    managedSiteType: "new-api",
+  }),
+}))
+
+vi.mock("~/services/apiCredentialProfiles/telemetry", () => ({
+  refreshApiCredentialProfileTelemetry: (...args: unknown[]) =>
+    refreshTelemetryMock(...args),
+}))
+
+vi.mock("~/services/managedSites/utils/managedSite", () => ({
+  getManagedSiteLabel: () => "New API",
+}))
+
+vi.mock("~/services/tags/tagStorage", () => ({
+  tagStorage: {
+    listTags: () => tagStorageListTagsMock(),
+  },
+}))
+
+vi.mock("~/services/verification/verificationResultHistory", async () => {
+  const actual = await vi.importActual<
+    typeof import("~/services/verification/verificationResultHistory")
+  >("~/services/verification/verificationResultHistory")
+
+  return {
+    ...actual,
+    useVerificationResultHistorySummaries: () => ({ summariesByKey: {} }),
+  }
+})
+
+vi.mock("~/utils/browser/browserApi", async () => {
+  const actual = await vi.importActual<
+    typeof import("~/utils/browser/browserApi")
+  >("~/utils/browser/browserApi")
+
+  return {
+    ...actual,
+    onRuntimeMessage: () => () => {},
+  }
+})
+
+vi.mock("~/utils/navigation", () => ({
+  openModelsPage: vi.fn(),
+}))
+
+vi.mock(
+  "~/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles",
+  () => ({
+    useApiCredentialProfiles: () => ({
+      createProfile: vi.fn(),
+      deleteProfile: deleteProfileMock,
+      isLoading: false,
+      profiles: [],
+      updateProfile: vi.fn(),
+    }),
+  }),
+)
+
+function buildProfile(): ApiCredentialProfile {
+  return {
+    id: "profile-1",
+    name: "Profile",
+    apiType: "openai-compatible",
+    baseUrl: "https://api.example.com",
+    apiKey: "sk-profile",
+    tagIds: [],
+    notes: "",
+    createdAt: 1,
+    updatedAt: 1,
+  }
+}
+
+describe("useApiCredentialProfilesController", () => {
+  it("guards telemetry refreshes synchronously and localizes errors", async () => {
+    tagStorageListTagsMock.mockResolvedValue([])
+    let resolveRefresh: (() => void) | undefined
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = resolve
+    })
+    refreshTelemetryMock.mockReturnValue(refreshPromise)
+    toastPromiseMock.mockImplementation(
+      async (
+        promise: Promise<unknown>,
+        options: { error: (error: unknown) => string },
+      ) => {
+        expect(options.error(new Error("Profile not found."))).toBe(
+          "apiCredentialProfiles:telemetry.messages.refreshFailed",
+        )
+        await promise
+      },
+    )
+
+    const { result } = renderHook(() => useApiCredentialProfilesController(), {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+    const profile = buildProfile()
+
+    let firstRefresh!: Promise<void>
+    await act(async () => {
+      firstRefresh = result.current.handleRefreshTelemetry(profile)
+      await result.current.handleRefreshTelemetry(profile)
+    })
+
+    expect(refreshTelemetryMock).toHaveBeenCalledTimes(1)
+    expect(result.current.refreshingTelemetryProfileId).toBe("profile-1")
+
+    await act(async () => {
+      resolveRefresh?.()
+      await firstRefresh
+    })
+
+    expect(result.current.refreshingTelemetryProfileId).toBeNull()
+  })
+})

--- a/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
+++ b/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
@@ -109,13 +109,19 @@ function buildProfile(): ApiCredentialProfile {
 }
 
 describe("useApiCredentialProfilesController", () => {
-  it("guards telemetry refreshes synchronously and localizes errors", async () => {
+  it("allows concurrent refreshes for different profiles and localizes errors", async () => {
     tagStorageListTagsMock.mockResolvedValue([])
-    let resolveRefresh: (() => void) | undefined
-    const refreshPromise = new Promise<void>((resolve) => {
-      resolveRefresh = resolve
+    let resolveFirstRefresh: (() => void) | undefined
+    let resolveSecondRefresh: (() => void) | undefined
+    const firstRefreshPromise = new Promise<void>((resolve) => {
+      resolveFirstRefresh = resolve
     })
-    refreshTelemetryMock.mockReturnValue(refreshPromise)
+    const secondRefreshPromise = new Promise<void>((resolve) => {
+      resolveSecondRefresh = resolve
+    })
+    refreshTelemetryMock
+      .mockReturnValueOnce(firstRefreshPromise)
+      .mockReturnValueOnce(secondRefreshPromise)
     toastPromiseMock.mockImplementation(
       async (
         promise: Promise<unknown>,
@@ -133,22 +139,40 @@ describe("useApiCredentialProfilesController", () => {
       withThemeProvider: false,
       withUserPreferencesProvider: false,
     })
-    const profile = buildProfile()
+    const firstProfile = buildProfile()
+    const secondProfile = buildProfile()
+    secondProfile.id = "profile-2"
 
     let firstRefresh!: Promise<void>
+    let duplicateRefresh!: Promise<void>
+    let secondRefresh!: Promise<void>
     await act(async () => {
-      firstRefresh = result.current.handleRefreshTelemetry(profile)
-      await result.current.handleRefreshTelemetry(profile)
+      firstRefresh = result.current.handleRefreshTelemetry(firstProfile)
+      duplicateRefresh = result.current.handleRefreshTelemetry(firstProfile)
+      secondRefresh = result.current.handleRefreshTelemetry(secondProfile)
     })
 
-    expect(refreshTelemetryMock).toHaveBeenCalledTimes(1)
-    expect(result.current.refreshingTelemetryProfileId).toBe("profile-1")
+    expect(refreshTelemetryMock).toHaveBeenCalledTimes(2)
+    expect(refreshTelemetryMock).toHaveBeenNthCalledWith(1, "profile-1")
+    expect(refreshTelemetryMock).toHaveBeenNthCalledWith(2, "profile-2")
+    expect(result.current.refreshingTelemetryProfileIds).toEqual([
+      "profile-1",
+      "profile-2",
+    ])
 
     await act(async () => {
-      resolveRefresh?.()
+      resolveFirstRefresh?.()
       await firstRefresh
+      await duplicateRefresh
     })
 
-    expect(result.current.refreshingTelemetryProfileId).toBeNull()
+    expect(result.current.refreshingTelemetryProfileIds).toEqual(["profile-2"])
+
+    await act(async () => {
+      resolveSecondRefresh?.()
+      await secondRefresh
+    })
+
+    expect(result.current.refreshingTelemetryProfileIds).toEqual([])
   })
 })

--- a/tests/services/apiCredentialProfilesStorage.more.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.more.test.ts
@@ -8,6 +8,8 @@ import {
 } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { API_CREDENTIAL_PROFILES_STORAGE_KEYS } from "~/services/core/storageKeys"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
+import { SiteHealthStatus } from "~/types"
+import { API_CREDENTIAL_PROFILES_CONFIG_VERSION } from "~/types/apiCredentialProfiles"
 
 const storageData = new Map<string, any>()
 
@@ -161,7 +163,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
       { now: 54321 },
     )
 
-    expect(coerced.version).toBe(2)
+    expect(coerced.version).toBe(API_CREDENTIAL_PROFILES_CONFIG_VERSION)
     expect(coerced.lastUpdated).toBe(54321)
     expect(coerced.profiles).toEqual([
       expect.objectContaining({
@@ -235,6 +237,143 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     ).toEqual(
       expect.objectContaining({
         tagIds: ["remote", "local"],
+      }),
+    )
+  })
+
+  it("coerces telemetry config and snapshot fields for backup compatibility", () => {
+    const coerced = coerceApiCredentialProfilesConfig(
+      {
+        profiles: [
+          {
+            id: "profile-1",
+            name: "Profile",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com",
+            apiKey: "sk-1",
+            telemetryConfig: {
+              mode: "customReadOnlyEndpoint",
+              customEndpoint: {
+                endpoint: "/usage",
+                jsonPaths: {
+                  balanceUsd: "data.balance",
+                  todayRequests: "data.today.requests",
+                },
+              },
+            },
+            telemetrySnapshot: {
+              health: { status: SiteHealthStatus.Healthy },
+              lastSyncTime: 1000,
+              lastSuccessTime: 1000,
+              balanceUsd: "12.5",
+              todayTokens: { upload: "100", download: 50 },
+              models: { count: 2, preview: ["gpt-4o", "", 1] },
+              attempts: [
+                {
+                  source: "newApiTokenUsage",
+                  endpoint: "/api/usage/token/",
+                  status: "success",
+                  message: "ok",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      { now: 12345 },
+    )
+
+    expect(coerced.profiles[0]).toEqual(
+      expect.objectContaining({
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+          customEndpoint: {
+            endpoint: "/usage",
+            jsonPaths: {
+              balanceUsd: "data.balance",
+              todayRequests: "data.today.requests",
+            },
+          },
+        },
+        telemetrySnapshot: expect.objectContaining({
+          lastSyncTime: 1000,
+          balanceUsd: 12.5,
+          todayTokens: { upload: 100, download: 50 },
+          models: { count: 2, preview: ["gpt-4o"] },
+          attempts: [
+            {
+              source: "newApiTokenUsage",
+              endpoint: "/api/usage/token/",
+              status: "success",
+              message: "ok",
+            },
+          ],
+        }),
+      }),
+    )
+  })
+
+  it("merges telemetry snapshots by newest successful query without changing identity winner", () => {
+    const merged = mergeApiCredentialProfilesConfigs({
+      now: 67890,
+      local: {
+        version: 2,
+        lastUpdated: 1,
+        profiles: [
+          {
+            id: "local-1",
+            name: "Local",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com",
+            apiKey: "sk-1",
+            tagIds: ["local"],
+            notes: "",
+            createdAt: 1,
+            updatedAt: 10,
+            telemetryConfig: { mode: "auto" },
+            telemetrySnapshot: {
+              health: { status: SiteHealthStatus.Healthy },
+              lastSyncTime: 5000,
+              lastSuccessTime: 5000,
+              balanceUsd: 1,
+              attempts: [],
+            },
+          },
+        ],
+      },
+      incoming: {
+        version: 2,
+        lastUpdated: 2,
+        profiles: [
+          {
+            id: "incoming-1",
+            name: "Incoming",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com",
+            apiKey: "sk-1",
+            tagIds: ["remote"],
+            notes: "",
+            createdAt: 2,
+            updatedAt: 20,
+            telemetryConfig: { mode: "newApiTokenUsage" },
+            telemetrySnapshot: {
+              health: { status: SiteHealthStatus.Healthy },
+              lastSyncTime: 9000,
+              lastSuccessTime: 9000,
+              balanceUsd: 9,
+              attempts: [],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(merged.profiles).toHaveLength(1)
+    expect(merged.profiles[0]).toEqual(
+      expect.objectContaining({
+        id: "incoming-1",
+        telemetryConfig: { mode: "newApiTokenUsage" },
+        telemetrySnapshot: expect.objectContaining({ balanceUsd: 9 }),
       }),
     )
   })
@@ -492,7 +631,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     const config = await apiCredentialProfilesStorage.getConfig()
 
     expect(config).toEqual({
-      version: 2,
+      version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
       profiles: [],
       lastUpdated: Date.now(),
     })

--- a/tests/services/apiCredentialProfilesStorage.more.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.more.test.ts
@@ -378,6 +378,31 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     )
   })
 
+  it("rejects invalid telemetry snapshots instead of storing raw data", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Telemetry",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://telemetry.example.com",
+      apiKey: "sk-telemetry",
+    })
+
+    await expect(
+      apiCredentialProfilesStorage.updateTelemetrySnapshot(profile.id, {
+        attempts: [],
+        health: { status: SiteHealthStatus.Healthy },
+        lastSyncTime: Number.NaN,
+      }),
+    ).rejects.toThrow("Invalid telemetry snapshot.")
+
+    await expect(
+      apiCredentialProfilesStorage.getProfileById(profile.id),
+    ).resolves.toEqual(
+      expect.not.objectContaining({
+        telemetrySnapshot: expect.anything(),
+      }),
+    )
+  })
+
   it("imports and merges configs through the storage service", async () => {
     const imported = await apiCredentialProfilesStorage.importConfig({
       profiles: [

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -335,4 +335,113 @@ describe("api credential profile telemetry", () => {
       ]),
     )
   })
+
+  it("skips credentialed network calls when telemetry is disabled", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Disabled",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://disabled.example.com",
+      apiKey: "sk-disabled",
+      telemetryConfig: { mode: "disabled" },
+    })
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(fetchApiCredentialModelIdsMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        attempts: [],
+        health: {
+          reason: "No supported telemetry endpoint returned data",
+          status: SiteHealthStatus.Warning,
+        },
+      }),
+    )
+  })
+
+  it("accepts custom total-only telemetry as a successful refresh", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Custom Totals",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://custom-total.example.com",
+      apiKey: "sk-custom-total",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "/usage/totals",
+          jsonPaths: {
+            expiresAt: "data.expiresAt",
+            totalUsedUsd: "data.total.used",
+          },
+        },
+      },
+    })
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: {
+            expiresAt: 1776556800,
+            total: { used: 8.75 },
+          },
+        }),
+      ),
+    )
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        expiresAt: 1776556800000,
+        source: "customReadOnlyEndpoint",
+        totalUsedUsd: 8.75,
+      }),
+    )
+    expect(snapshot.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          endpoint: "/usage/totals",
+          source: "customReadOnlyEndpoint",
+          status: "success",
+        }),
+      ]),
+    )
+  })
+
+  it("redacts custom endpoint query values before persisting attempts", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Custom Query",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://custom-query.example.com",
+      apiKey: "sk-custom-query",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "/usage?token=sk-custom-query&cursor=secret-cursor",
+          jsonPaths: {
+            balanceUsd: "balance",
+          },
+        },
+      },
+    })
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ balance: 4.5 })),
+    )
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+    const customAttempt = snapshot.attempts.find(
+      (attempt) => attempt.source === "customReadOnlyEndpoint",
+    )
+
+    expect(customAttempt?.endpoint).toContain("/usage?")
+    expect(customAttempt?.endpoint).not.toContain("sk-custom-query")
+    expect(customAttempt?.endpoint).not.toContain("secret-cursor")
+    expect(customAttempt?.endpoint).toContain("REDACTED")
+  })
 })

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -201,7 +201,7 @@ describe("api credential profile telemetry", () => {
     expect(snapshot.unlimitedQuota).toBeUndefined()
   })
 
-  it("falls through auto presets and classifies HTML/WAF responses", async () => {
+  it("falls through auto presets after unsupported usage endpoint responses", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
       name: "Auto",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
@@ -213,8 +213,8 @@ describe("api credential profile telemetry", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
-        new Response("<!doctype html><title>Cloudflare</title>", {
-          status: 403,
+        new Response("<!doctype html><title>Not found</title>", {
+          status: 404,
           headers: { "content-type": "text/html" },
         }),
       )
@@ -236,8 +236,7 @@ describe("api credential profile telemetry", () => {
       expect.arrayContaining([
         expect.objectContaining({
           source: "newApiTokenUsage",
-          status: "error",
-          message: expect.stringContaining("Cloudflare"),
+          status: "unsupported",
         }),
         expect.objectContaining({
           source: "sub2apiUsage",

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -121,7 +121,6 @@ describe("api credential profile telemetry", () => {
 
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse({ message: "missing" }, 404))
       .mockResolvedValueOnce(
         new Response("<!doctype html><title>Cloudflare</title>", {
           status: 403,
@@ -145,10 +144,6 @@ describe("api credential profile telemetry", () => {
     expect(snapshot.attempts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          source: "openaiBilling",
-          status: "unsupported",
-        }),
-        expect.objectContaining({
           source: "newApiTokenUsage",
           status: "error",
           message: expect.stringContaining("Cloudflare"),
@@ -161,12 +156,59 @@ describe("api credential profile telemetry", () => {
     )
   })
 
+  it("prefers NewAPI token telemetry before OpenAI billing in auto mode", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "NewAPI Auto",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://newapi-auto.example.com",
+      apiKey: "sk-newapi-auto",
+    })
+
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        message: "",
+        data: {
+          total_granted: 5000000,
+          total_used: 1250000,
+          total_available: 3750000,
+        },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://newapi-auto.example.com/api/usage/token/",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-newapi-auto",
+        }),
+      }),
+    )
+    expect(snapshot.source).toBe("newApiTokenUsage")
+    expect(snapshot.balanceUsd).toBe(7.5)
+    expect(snapshot.totalUsedUsd).toBe(2.5)
+    expect(snapshot.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "newApiTokenUsage",
+          status: "success",
+        }),
+      ]),
+    )
+  })
+
   it("does not treat huge OpenAI billing hard limits as real balance", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
       name: "Gateway",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
       baseUrl: "https://gateway.example.com",
       apiKey: "sk-gateway",
+      telemetryConfig: { mode: "openaiBilling" },
     })
 
     const fetchMock = vi
@@ -187,33 +229,18 @@ describe("api credential profile telemetry", () => {
           total_usage: 188.131,
         }),
       )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          success: true,
-          message: "",
-          data: {
-            total_granted: 5000000,
-            total_used: 1250000,
-            total_available: 3750000,
-          },
-        }),
-      )
     vi.stubGlobal("fetch", fetchMock)
 
     const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
 
-    expect(snapshot.source).toBe("newApiTokenUsage")
-    expect(snapshot.balanceUsd).toBe(7.5)
-    expect(snapshot.totalUsedUsd).toBe(2.5)
+    expect(snapshot.source).toBeUndefined()
+    expect(snapshot.balanceUsd).toBeUndefined()
+    expect(snapshot.totalGrantedUsd).toBeUndefined()
     expect(snapshot.attempts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           source: "openaiBilling",
           status: "unsupported",
-        }),
-        expect.objectContaining({
-          source: "newApiTokenUsage",
-          status: "success",
         }),
       ]),
     )

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
+import { refreshApiCredentialProfileTelemetry } from "~/services/apiCredentialProfiles/telemetry"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
+import { SiteHealthStatus } from "~/types"
+
+const storageData = new Map<string, any>()
+const fetchApiCredentialModelIdsMock = vi.fn()
+
+vi.mock("@plasmohq/storage", () => {
+  class Storage {
+    async set(key: string, value: any) {
+      storageData.set(key, value)
+    }
+
+    async get(key: string) {
+      return storageData.get(key)
+    }
+
+    async remove(key: string) {
+      storageData.delete(key)
+    }
+  }
+
+  return { Storage }
+})
+
+vi.mock("~/services/apiCredentialProfiles/modelCatalog", () => ({
+  fetchApiCredentialModelIds: (...args: any[]) =>
+    fetchApiCredentialModelIdsMock(...args),
+}))
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+describe("api credential profile telemetry", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-19T00:00:00.000Z"))
+    storageData.clear()
+    fetchApiCredentialModelIdsMock.mockResolvedValue(["gpt-4o", "o3"])
+    await apiCredentialProfilesStorage.clearAllData()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it("refreshes NewAPI token telemetry and persists a healthy snapshot", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "NewAPI",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://newapi.example.com",
+      apiKey: "sk-newapi",
+      telemetryConfig: { mode: "newApiTokenUsage" },
+    })
+
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        message: "",
+        data: {
+          total_granted: 5000000,
+          total_used: 1250000,
+          total_available: 3750000,
+          expires_at: 1776556800,
+        },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://newapi.example.com/api/usage/token/",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-newapi",
+        }),
+      }),
+    )
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        health: { status: SiteHealthStatus.Healthy },
+        source: "newApiTokenUsage",
+        balanceUsd: 7.5,
+        totalUsedUsd: 2.5,
+        totalGrantedUsd: 10,
+        totalAvailableUsd: 7.5,
+        models: { count: 2, preview: ["gpt-4o", "o3"] },
+      }),
+    )
+
+    await expect(
+      apiCredentialProfilesStorage.getProfileById(profile.id),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        telemetrySnapshot: expect.objectContaining({
+          balanceUsd: 7.5,
+        }),
+      }),
+    )
+  })
+
+  it("falls through auto presets and classifies HTML/WAF responses", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Auto",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://auto.example.com",
+      apiKey: "sk-auto",
+    })
+    fetchApiCredentialModelIdsMock.mockRejectedValue(new Error("models failed"))
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ message: "missing" }, 404))
+      .mockResolvedValueOnce(
+        new Response("<!doctype html><title>Cloudflare</title>", {
+          status: 403,
+          headers: { "content-type": "text/html" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          balance: 12,
+          usage: { today: { requests: 3, cost: 1.25, tokens: 4000 } },
+        }),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(snapshot.source).toBe("sub2apiUsage")
+    expect(snapshot.balanceUsd).toBe(12)
+    expect(snapshot.todayCostUsd).toBe(1.25)
+    expect(snapshot.todayRequests).toBe(3)
+    expect(snapshot.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "openaiBilling",
+          status: "unsupported",
+        }),
+        expect.objectContaining({
+          source: "newApiTokenUsage",
+          status: "error",
+          message: expect.stringContaining("Cloudflare"),
+        }),
+        expect.objectContaining({
+          source: "sub2apiUsage",
+          status: "success",
+        }),
+      ]),
+    )
+  })
+
+  it("does not treat huge OpenAI billing hard limits as real balance", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Gateway",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://gateway.example.com",
+      apiKey: "sk-gateway",
+    })
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          object: "billing_subscription",
+          has_payment_method: true,
+          soft_limit_usd: 100000000,
+          hard_limit_usd: 100000000,
+          system_hard_limit_usd: 100000000,
+          access_until: 0,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          object: "list",
+          total_usage: 188.131,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          message: "",
+          data: {
+            total_granted: 5000000,
+            total_used: 1250000,
+            total_available: 3750000,
+          },
+        }),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(snapshot.source).toBe("newApiTokenUsage")
+    expect(snapshot.balanceUsd).toBe(7.5)
+    expect(snapshot.totalUsedUsd).toBe(2.5)
+    expect(snapshot.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "openaiBilling",
+          status: "unsupported",
+        }),
+        expect.objectContaining({
+          source: "newApiTokenUsage",
+          status: "success",
+        }),
+      ]),
+    )
+  })
+})

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -5,8 +5,10 @@ import { refreshApiCredentialProfileTelemetry } from "~/services/apiCredentialPr
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { SiteHealthStatus } from "~/types"
 
-const storageData = new Map<string, any>()
-const fetchApiCredentialModelIdsMock = vi.fn()
+const { fetchApiCredentialModelIdsMock, storageData } = vi.hoisted(() => ({
+  fetchApiCredentialModelIdsMock: vi.fn(),
+  storageData: new Map<string, any>(),
+}))
 
 vi.mock("@plasmohq/storage", () => {
   class Storage {
@@ -292,7 +294,7 @@ describe("api credential profile telemetry", () => {
     )
   })
 
-  it("does not treat huge OpenAI billing hard limits as real balance", async () => {
+  it("preserves total usage when huge OpenAI billing hard limits are sentinel values", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
       name: "Gateway",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
@@ -323,14 +325,15 @@ describe("api credential profile telemetry", () => {
 
     const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
 
-    expect(snapshot.source).toBeUndefined()
+    expect(snapshot.source).toBe("openaiBilling")
     expect(snapshot.balanceUsd).toBeUndefined()
     expect(snapshot.totalGrantedUsd).toBeUndefined()
+    expect(snapshot.totalUsedUsd).toBe(1.88131)
     expect(snapshot.attempts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           source: "openaiBilling",
-          status: "unsupported",
+          status: "success",
         }),
       ]),
     )
@@ -443,5 +446,45 @@ describe("api credential profile telemetry", () => {
     expect(customAttempt?.endpoint).not.toContain("sk-custom-query")
     expect(customAttempt?.endpoint).not.toContain("secret-cursor")
     expect(customAttempt?.endpoint).toContain("REDACTED")
+  })
+
+  it("persists an error attempt when the custom endpoint string is malformed", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Malformed Custom Endpoint",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://custom-malformed.example.com",
+      apiKey: "sk-malformed",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "http://%",
+          jsonPaths: {
+            balanceUsd: "balance",
+          },
+        },
+      },
+    })
+
+    fetchApiCredentialModelIdsMock.mockRejectedValueOnce(
+      new Error("models failed"),
+    )
+    vi.stubGlobal("fetch", vi.fn())
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(snapshot.health).toEqual({
+      reason: "models failed",
+      status: SiteHealthStatus.Warning,
+    })
+    expect(snapshot.attempts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          endpoint: "http://%",
+          message: expect.stringContaining("Invalid URL"),
+          source: "customReadOnlyEndpoint",
+          status: "error",
+        }),
+      ]),
+    )
   })
 })

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -110,6 +110,97 @@ describe("api credential profile telemetry", () => {
     )
   })
 
+  it("treats NewAPI unlimited token quota as unlimited instead of negative balance", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "NewAPI Unlimited",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://newapi-unlimited.example.com",
+      apiKey: "sk-newapi-unlimited",
+      telemetryConfig: { mode: "newApiTokenUsage" },
+    })
+
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        code: true,
+        message: "ok",
+        data: {
+          expires_at: 0,
+          model_limits: {},
+          model_limits_enabled: false,
+          name: "test",
+          object: "token_usage",
+          total_available: -940656,
+          total_granted: -1,
+          total_used: 940655,
+          unlimited_quota: true,
+        },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        health: { status: SiteHealthStatus.Healthy },
+        source: "newApiTokenUsage",
+        unlimitedQuota: true,
+        totalUsedUsd: 1.88131,
+      }),
+    )
+    expect(snapshot.balanceUsd).toBeUndefined()
+    expect(snapshot.totalGrantedUsd).toBeUndefined()
+    expect(snapshot.totalAvailableUsd).toBeUndefined()
+
+    await expect(
+      apiCredentialProfilesStorage.getProfileById(profile.id),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        telemetrySnapshot: expect.objectContaining({
+          unlimitedQuota: true,
+          totalUsedUsd: 1.88131,
+        }),
+      }),
+    )
+  })
+
+  it("clamps overdrawn NewAPI token balance to zero for limited tokens", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "NewAPI Overdrawn",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://newapi-overdrawn.example.com",
+      apiKey: "sk-newapi-overdrawn",
+      telemetryConfig: { mode: "newApiTokenUsage" },
+    })
+
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        success: true,
+        message: "",
+        data: {
+          total_granted: 1000000,
+          total_used: 1250000,
+          total_available: -250000,
+          unlimited_quota: false,
+        },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        source: "newApiTokenUsage",
+        balanceUsd: 0,
+        totalAvailableUsd: 0,
+        totalGrantedUsd: 2,
+        totalUsedUsd: 2.5,
+      }),
+    )
+    expect(snapshot.unlimitedQuota).toBeUndefined()
+  })
+
   it("falls through auto presets and classifies HTML/WAF responses", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
       name: "Auto",

--- a/tests/services/apiService/common/fetchApi.test.ts
+++ b/tests/services/apiService/common/fetchApi.test.ts
@@ -164,6 +164,46 @@ describe("apiService common fetchApi helpers", () => {
     expect(result).toEqual(data)
   })
 
+  it("fetchApiData merges custom headers without dropping auth headers", async () => {
+    let capturedAccept: string | null = null
+    let capturedAuthorization: string | null = null
+
+    server.use(
+      http.get(API_URL, ({ request }) => {
+        capturedAccept = request.headers.get("accept")
+        capturedAuthorization = request.headers.get("authorization")
+        return HttpResponse.json({
+          success: true,
+          data: { ok: true },
+          message: "ok",
+        })
+      }),
+    )
+
+    await expect(
+      fetchApiData<{ ok: boolean }>(
+        {
+          baseUrl: BASE_URL,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            accessToken: "token",
+          },
+        },
+        {
+          endpoint: ENDPOINT,
+          options: {
+            headers: {
+              Accept: "application/json",
+            },
+          },
+        },
+      ),
+    ).resolves.toEqual({ ok: true })
+
+    expect(capturedAccept).toBe("application/json")
+    expect(capturedAuthorization).toBe("Bearer token")
+  })
+
   it("fetchApiData applies the site API limiter with a normalized origin key", async () => {
     server.use(
       http.get(/^https:\/\/example\.com\/base\//, () => {

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -115,6 +115,7 @@ describe("unified logger", () => {
       backupPayload: "backup-secret",
       url: "https://example.com/path?token=leak#fragment",
       rawUrl: "https://example.com/other?x=y#hash",
+      endpoint: "/usage?token=leak#fragment",
       nested: {
         adminToken: "admin-secret",
         managementKey: "mgmt-secret",
@@ -137,6 +138,7 @@ describe("unified logger", () => {
 
     expect(details.url).toBe("https://example.com/path")
     expect(details.rawUrl).toBe("https://example.com/other")
+    expect(details.endpoint).toBe("/usage")
 
     expect(details.nested.adminToken).toBe("[REDACTED]")
     expect(details.nested.managementKey).toBe("[REDACTED]")

--- a/tests/utils/money.test.ts
+++ b/tests/utils/money.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   formatMoneyFixed,
+  formatTelemetryMoney,
   getDisplayMoneyValue,
   normalizeMoneyForDisplay,
 } from "~/utils/core/money"
@@ -48,5 +49,15 @@ describe("money utils", () => {
 
   it("formatMoneyFixed should honor custom decimals for rounded integer output", () => {
     expect(formatMoneyFixed(12.6, { decimals: 0, minNonZero: 0.01 })).toBe("13")
+  })
+
+  it("formatTelemetryMoney should return fallback text for invalid values", () => {
+    expect(formatTelemetryMoney(undefined, "USD")).toBe("-")
+    expect(formatTelemetryMoney(Number.NaN, "USD")).toBe("-")
+  })
+
+  it("formatTelemetryMoney should format USD and CNY values", () => {
+    expect(formatTelemetryMoney(12.345, "USD")).toBe("$12.35")
+    expect(formatTelemetryMoney(1, "CNY")).toMatch(/^¥/)
   })
 })

--- a/tests/utils/sanitizeUrlForLog.test.ts
+++ b/tests/utils/sanitizeUrlForLog.test.ts
@@ -9,6 +9,10 @@ describe("sanitizeUrlForLog", () => {
     ).toBe("https://example.com/path/to")
   })
 
+  it("drops query parameters and fragments from relative endpoints", () => {
+    expect(sanitizeUrlForLog("/usage?token=secret#fragment")).toBe("/usage")
+  })
+
   it("returns the original string when the input is not a parseable URL", () => {
     expect(sanitizeUrlForLog("not a valid url")).toBe("not a valid url")
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-profile telemetry panel with health, balance, today usage, model info, last sync and per-item refresh controls
  * Aggregated stats for healthy profiles, total balance and today usage
  * Telemetry refresh persists snapshots, redacts sensitive endpoint/query values, and respects telemetry config
  * Currency-aware balance formatting (USD/CNY) and localized telemetry strings

* **Localization**
  * Added telemetry UI strings for English, Japanese, Simplified Chinese, and Traditional Chinese

* **Tests**
  * Extensive unit/integration tests covering refresh flows, persistence, redaction, edge cases, and UI rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->