### PR TITLE
feat: show managed-site channels and model sync pages when unconfigured

### DIFF
--- a/src/components/ManagedSiteConfigRequiredState.tsx
+++ b/src/components/ManagedSiteConfigRequiredState.tsx
@@ -1,0 +1,38 @@
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import { useTranslation } from "react-i18next"
+
+import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
+import { EmptyState } from "~/components/ui"
+import { openSettingsTab } from "~/utils/navigation"
+
+interface ManagedSiteConfigRequiredStateProps {
+  description: string
+  className?: string
+}
+
+/**
+ * Shared empty state shown when a managed-site page is available but the
+ * currently selected managed-site backend has not been configured yet.
+ */
+export default function ManagedSiteConfigRequiredState({
+  description,
+  className,
+}: ManagedSiteConfigRequiredStateProps) {
+  const { t } = useTranslation("common")
+
+  return (
+    <EmptyState
+      className={className}
+      icon={<ExclamationTriangleIcon className="h-12 w-12 text-yellow-500" />}
+      title={t("status.configurationRequired")}
+      description={description}
+      action={{
+        label: t("actions.goToSettings"),
+        rightIcon: <WorkflowTransitionIcon className="h-4 w-4" aria-hidden />,
+        onClick: () => {
+          void openSettingsTab("managedSite", { preserveHistory: true })
+        },
+      }}
+    />
+  )
+}

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -8,6 +8,8 @@ export type EmptyStateAction = {
   label: string
   onClick: () => void
   variant?: React.ComponentProps<typeof Button>["variant"]
+  leftIcon?: React.ReactNode
+  rightIcon?: React.ReactNode
   icon?: React.ReactNode
   disabled?: boolean
   loading?: boolean
@@ -83,7 +85,8 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
           <Button
             variant={resolvedActions[0].variant || "default"}
             onClick={resolvedActions[0].onClick}
-            leftIcon={resolvedActions[0].icon}
+            leftIcon={resolvedActions[0].leftIcon ?? resolvedActions[0].icon}
+            rightIcon={resolvedActions[0].rightIcon}
             disabled={resolvedActions[0].disabled}
             loading={resolvedActions[0].loading}
           >
@@ -96,7 +99,8 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
                 key={`${resolvedAction.label}-${index}`}
                 variant={resolvedAction.variant || "default"}
                 onClick={resolvedAction.onClick}
-                leftIcon={resolvedAction.icon}
+                leftIcon={resolvedAction.leftIcon ?? resolvedAction.icon}
+                rightIcon={resolvedAction.rightIcon}
                 disabled={resolvedAction.disabled}
                 loading={resolvedAction.loading}
               >

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -10,6 +10,7 @@ export type EmptyStateAction = {
   variant?: React.ComponentProps<typeof Button>["variant"]
   leftIcon?: React.ReactNode
   rightIcon?: React.ReactNode
+  /** @deprecated Prefer `leftIcon`. When both are set, `leftIcon` takes precedence. */
   icon?: React.ReactNode
   disabled?: boolean
   loading?: boolean

--- a/src/entrypoints/options/components/Sidebar.tsx
+++ b/src/entrypoints/options/components/Sidebar.tsx
@@ -12,7 +12,6 @@ import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { getMenuItemLabel } from "~/features/OptionsMenu/getMenuItemLabel"
 import { cn } from "~/lib/utils"
-import { hasValidManagedSiteConfig } from "~/services/managedSites/managedSiteService"
 
 import { menuItems } from "../constants"
 
@@ -175,14 +174,6 @@ function Sidebar({
                 if (
                   item.id === MENU_ITEM_IDS.AUTO_CHECKIN &&
                   !preferences?.autoCheckin?.globalEnabled
-                ) {
-                  return null
-                }
-
-                if (
-                  !hasValidManagedSiteConfig(preferences ?? null) &&
-                  (item.id === MENU_ITEM_IDS.MANAGED_SITE_MODEL_SYNC ||
-                    item.id === MENU_ITEM_IDS.MANAGED_SITE_CHANNELS)
                 ) {
                   return null
                 }

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -205,10 +205,6 @@ export default function ManagedSiteChannels({
     preferences,
     managedSiteType,
   )
-  const configMissingMessage = getManagedSiteConfigMissingMessage(
-    t,
-    getManagedSiteMessagesKeyFromSiteType(managedSiteType),
-  )
 
   const [channels, setChannels] = useState<ChannelRow[]>([])
   const [isLoading, setIsLoading] = useState(false)
@@ -1005,7 +1001,12 @@ export default function ManagedSiteChannels({
       />
 
       {isConfigMissing ? (
-        <ManagedSiteConfigRequiredState description={configMissingMessage} />
+        <ManagedSiteConfigRequiredState
+          description={getManagedSiteConfigMissingMessage(
+            t,
+            getManagedSiteMessagesKeyFromSiteType(managedSiteType),
+          )}
+        />
       ) : (
         <>
           {error && (

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -44,6 +44,7 @@ import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
+import ManagedSiteConfigRequiredState from "~/components/ManagedSiteConfigRequiredState"
 import ManagedSiteTypeSwitcher from "~/components/ManagedSiteTypeSwitcher"
 import { PageHeader } from "~/components/PageHeader"
 import {
@@ -96,9 +97,13 @@ import { loadNewApiChannelKeyWithVerification } from "~/features/ManagedSiteVeri
 import { NewApiManagedVerificationDialog } from "~/features/ManagedSiteVerification/NewApiManagedVerificationDialog"
 import { useNewApiManagedVerification } from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
 import { cn } from "~/lib/utils"
-import { getManagedSiteService } from "~/services/managedSites/managedSiteService"
+import {
+  getManagedSiteService,
+  hasValidManagedSiteConfig,
+} from "~/services/managedSites/managedSiteService"
 import {
   getManagedSiteConfigMissingMessage,
+  getManagedSiteMessagesKeyFromSiteType,
   getManagedSiteTargetOptions,
   needsManagedSiteChannelKeyResolution,
 } from "~/services/managedSites/utils/managedSite"
@@ -196,14 +201,18 @@ export default function ManagedSiteChannels({
   const isNewApiManagedSite = managedSiteType === NEW_API
   const supportsDetailBackedRealKeyLoading =
     managedSiteType === DONE_HUB || managedSiteType === VELOERA
+  const isConfigMissing = !hasValidManagedSiteConfig(
+    preferences,
+    managedSiteType,
+  )
+  const configMissingMessage = getManagedSiteConfigMissingMessage(
+    t,
+    getManagedSiteMessagesKeyFromSiteType(managedSiteType),
+  )
 
   const [channels, setChannels] = useState<ChannelRow[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [configMissing, setConfigMissing] = useState(false)
-  const [configMissingMessage, setConfigMissingMessage] = useState<
-    string | null
-  >(null)
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     base_url: false,
@@ -243,21 +252,16 @@ export default function ManagedSiteChannels({
   const hasMigrationTargets = migrationTargets.length > 0
 
   const refreshChannels = useCallback(async () => {
+    if (isConfigMissing) {
+      setChannels([])
+      setError(null)
+      setIsLoading(false)
+      return
+    }
+
     setIsLoading(true)
     setError(null)
     try {
-      const service = await getManagedSiteService()
-      const config = await service.getConfig()
-      if (!config) {
-        setConfigMissing(true)
-        setConfigMissingMessage(
-          getManagedSiteConfigMissingMessage(t, service.messagesKey),
-        )
-        setChannels([])
-        return
-      }
-      setConfigMissing(false)
-      setConfigMissingMessage(null)
       const response = await sendRuntimeMessage({
         action: RuntimeActionIds.ModelSyncListChannels,
       })
@@ -272,13 +276,11 @@ export default function ManagedSiteChannels({
     } finally {
       setIsLoading(false)
     }
-  }, [t])
+  }, [isConfigMissing, t])
 
   useLayoutEffect(() => {
     setChannels([])
     setError(null)
-    setConfigMissing(false)
-    setConfigMissingMessage(null)
   }, [managedSiteType])
 
   useEffect(() => {
@@ -954,7 +956,7 @@ export default function ManagedSiteChannels({
   }
 
   const isInitialLoading =
-    isLoading && channels.length === 0 && !error && !configMissing
+    isLoading && channels.length === 0 && !error && !isConfigMissing
 
   return (
     <div className="space-y-6 p-6">
@@ -971,397 +973,410 @@ export default function ManagedSiteChannels({
               size="sm"
               triggerClassName="w-auto min-w-[172px]"
             />
-            <Button
-              variant="outline"
-              onClick={() => void refreshChannels()}
-              disabled={isLoading}
-              loading={isLoading && channels.length > 0}
-              leftIcon={<RefreshCcw className="h-4 w-4" />}
-            >
-              {t("toolbar.refresh")}
-            </Button>
-            <Button
-              variant={isMigrationMode ? "default" : "outline"}
-              onClick={handleToggleMigrationMode}
-              leftIcon={<ArrowRightLeft className="h-4 w-4" />}
-            >
-              <span>
-                {isMigrationMode
-                  ? t("toolbar.exitMigrationMode")
-                  : t("toolbar.enterMigrationMode")}
-              </span>
-              <Badge variant="warning" size="sm" className="shrink-0">
-                {t("migration.betaBadge")}
-              </Badge>
-            </Button>
+            {!isConfigMissing && (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() => void refreshChannels()}
+                  disabled={isLoading}
+                  loading={isLoading && channels.length > 0}
+                  leftIcon={<RefreshCcw className="h-4 w-4" />}
+                >
+                  {t("toolbar.refresh")}
+                </Button>
+                <Button
+                  variant={isMigrationMode ? "default" : "outline"}
+                  onClick={handleToggleMigrationMode}
+                  leftIcon={<ArrowRightLeft className="h-4 w-4" />}
+                >
+                  <span>
+                    {isMigrationMode
+                      ? t("toolbar.exitMigrationMode")
+                      : t("toolbar.enterMigrationMode")}
+                  </span>
+                  <Badge variant="warning" size="sm" className="shrink-0">
+                    {t("migration.betaBadge")}
+                  </Badge>
+                </Button>
+              </>
+            )}
           </div>
         }
       />
 
-      {configMissing && (
-        <Alert variant="warning">
-          <AlertTitle>{t("alerts.configMissing.title")}</AlertTitle>
-          <AlertDescription>
-            {configMissingMessage ?? t("alerts.configMissing.description")}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {error && !configMissing && (
-        <Alert variant="destructive">
-          <AlertTitle>{t("alerts.loadError.title")}</AlertTitle>
-          <AlertDescription>
-            {t("alerts.loadError.description", { error })}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {/* Responsive toolbar: search input takes its own row on small screens, buttons wrap in a 2-column grid. */}
-      <div className="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-center">
-        <div className="relative w-full md:max-w-sm">
-          <Input
-            value={searchValue}
-            onChange={(event) => handleSearchChange(event.target.value)}
-            placeholder={t("toolbar.searchPlaceholder")}
-            className="ps-9"
-          />
-          <ListFilter className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-          {searchValue && (
-            <button
-              type="button"
-              aria-label={t("toolbar.clearSearch")}
-              className="text-muted-foreground/80 absolute top-1/2 right-2 -translate-y-1/2"
-              onClick={() => handleSearchChange("")}
-            >
-              <CircleX className="h-4 w-4" />
-            </button>
+      {isConfigMissing ? (
+        <ManagedSiteConfigRequiredState description={configMissingMessage} />
+      ) : (
+        <>
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>{t("alerts.loadError.title")}</AlertTitle>
+              <AlertDescription>
+                {t("alerts.loadError.description", { error })}
+              </AlertDescription>
+            </Alert>
           )}
-        </div>
 
-        <div className="grid grid-cols-2 gap-2 md:flex md:flex-1 md:items-center md:gap-2">
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                leftIcon={<Filter className="h-4 w-4" />}
-              >
-                {t("toolbar.status")}
-                {selectedStatuses.length > 0 && (
-                  <span className="text-muted-foreground ml-2 text-xs">
-                    ({selectedStatuses.length})
-                  </span>
-                )}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-64" align="start">
-              <div className="space-y-2">
-                <p className="text-muted-foreground text-xs font-medium">
-                  {t("filter.statusLabel")}
-                </p>
-                <div className="space-y-2">
-                  {uniqueStatusValues.map((value) => (
-                    <div
-                      key={value}
-                      className="flex items-center justify-between gap-2"
-                    >
-                      <div className="flex items-center gap-2">
-                        <Checkbox
-                          id={`status-${value}`}
-                          checked={selectedStatuses.includes(value)}
-                          onCheckedChange={(checked: CheckboxState) =>
-                            handleStatusChange(checked, value)
-                          }
-                        />
-                        <Label
-                          htmlFor={`status-${value}`}
-                          className="text-sm font-normal"
-                        >
-                          {getManagedSiteChannelStatusFilterLabel(t, value)}
-                        </Label>
-                      </div>
-                      <span className="text-muted-foreground text-xs">
-                        {statusCounts.get(value) ?? 0}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </PopoverContent>
-          </Popover>
+          {/* Responsive toolbar: search input takes its own row on small screens, buttons wrap in a 2-column grid. */}
+          <div className="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-center">
+            <div className="relative w-full md:max-w-sm">
+              <Input
+                value={searchValue}
+                onChange={(event) => handleSearchChange(event.target.value)}
+                placeholder={t("toolbar.searchPlaceholder")}
+                className="ps-9"
+              />
+              <ListFilter className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+              {searchValue && (
+                <button
+                  type="button"
+                  aria-label={t("toolbar.clearSearch")}
+                  className="text-muted-foreground/80 absolute top-1/2 right-2 -translate-y-1/2"
+                  onClick={() => handleSearchChange("")}
+                >
+                  <CircleX className="h-4 w-4" />
+                </button>
+              )}
+            </div>
 
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                leftIcon={<Columns3 className="h-4 w-4" />}
-              >
-                {t("toolbar.columns")}
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuLabel>
-                {t("toolbar.toggleColumns")}
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {table
-                .getAllLeafColumns()
-                .filter((column) => column.getCanHide())
-                .map((column) => (
-                  <DropdownMenuCheckboxItem
-                    key={column.id}
-                    className="capitalize"
-                    checked={column.getIsVisible()}
-                    onCheckedChange={(value: CheckboxState) =>
-                      column.toggleVisibility(!!value)
-                    }
-                    onSelect={(event: Event) => event.preventDefault()}
+            <div className="grid grid-cols-2 gap-2 md:flex md:flex-1 md:items-center md:gap-2">
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    leftIcon={<Filter className="h-4 w-4" />}
                   >
-                    {getManagedSiteChannelColumnLabel(t, column.id)}
-                  </DropdownMenuCheckboxItem>
-                ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          <div className="col-span-2 grid grid-cols-2 gap-2 md:ml-auto md:flex md:items-center md:justify-end md:gap-2">
-            {isMigrationMode && hasMigrationTargets && (
-              <Button
-                variant="outline"
-                disabled={!selectedCount}
-                onClick={() =>
-                  openMigrationDialog(selectedRows.map((row) => row.original))
-                }
-                leftIcon={<ArrowRightLeft className="h-4 w-4" />}
-              >
-                {t("toolbar.migrateSelected")}
-              </Button>
-            )}
-            {isMigrationMode && hasMigrationTargets && (
-              <Button
-                variant="outline"
-                disabled={!filteredCount}
-                onClick={() =>
-                  openMigrationDialog(filteredRows.map((row) => row.original))
-                }
-                leftIcon={<ArrowRightLeft className="h-4 w-4" />}
-              >
-                {t("toolbar.migrateFiltered")}
-              </Button>
-            )}
-            {!isMigrationMode && (
-              <Button
-                variant="outline"
-                disabled={!selectedCount}
-                onClick={() =>
-                  scheduleDelete(selectedRows.map((row) => row.original.id))
-                }
-                leftIcon={<Trash2 className="h-4 w-4" />}
-              >
-                {t("toolbar.deleteSelected")}
-              </Button>
-            )}
-            {!isMigrationMode && (
-              <Button
-                variant="outline"
-                disabled={!selectedCount}
-                onClick={() =>
-                  handleSyncChannels(selectedRows.map((row) => row.original.id))
-                }
-                leftIcon={<RefreshCcw className="h-4 w-4" />}
-              >
-                {t("toolbar.syncSelected")}
-              </Button>
-            )}
-            {!isMigrationMode && (
-              <Button
-                onClick={handleOpenCreateDialog}
-                leftIcon={<Plus className="h-4 w-4" />}
-              >
-                {t("toolbar.addChannel")}
-              </Button>
-            )}
-          </div>
-        </div>
-      </div>
-
-      <div className="border-border bg-background overflow-hidden rounded-lg border">
-        <Table>
-          <TableHeader>
-            {table
-              .getHeaderGroups()
-              .map((headerGroup: HeaderGroup<ChannelRow>) => (
-                <TableRow key={headerGroup.id} className="hover:bg-transparent">
-                  {headerGroup.headers.map((header) => (
-                    <TableHead
-                      key={header.id}
-                      className={cn(
-                        header.column.id === "actions" &&
-                          cn(
-                            "bg-background sticky right-0 border-l",
-                            Z_INDEX.tableStickyHeader,
-                          ),
-                      )}
-                      style={{ width: header.getSize() }}
-                    >
-                      {header.isPlaceholder ? null : header.column.getCanSort() ? (
-                        <button
-                          type="button"
-                          className="flex w-full items-center gap-2"
-                          onClick={header.column.getToggleSortingHandler()}
+                    {t("toolbar.status")}
+                    {selectedStatuses.length > 0 && (
+                      <span className="text-muted-foreground ml-2 text-xs">
+                        ({selectedStatuses.length})
+                      </span>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-64" align="start">
+                  <div className="space-y-2">
+                    <p className="text-muted-foreground text-xs font-medium">
+                      {t("filter.statusLabel")}
+                    </p>
+                    <div className="space-y-2">
+                      {uniqueStatusValues.map((value) => (
+                        <div
+                          key={value}
+                          className="flex items-center justify-between gap-2"
                         >
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                          {header.column.getIsSorted() === "asc" && (
-                            <ChevronUp className="h-3.5 w-3.5 opacity-60" />
-                          )}
-                          {header.column.getIsSorted() === "desc" && (
-                            <ChevronDown className="h-3.5 w-3.5 opacity-60" />
-                          )}
-                        </button>
-                      ) : (
-                        flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )
-                      )}
-                    </TableHead>
-                  ))}
-                </TableRow>
-              ))}
-          </TableHeader>
-          <TableBody>
-            {isInitialLoading ? (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-32 text-center"
-                >
-                  <div className="text-muted-foreground flex items-center justify-center gap-2">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    {t("table.loading")}
+                          <div className="flex items-center gap-2">
+                            <Checkbox
+                              id={`status-${value}`}
+                              checked={selectedStatuses.includes(value)}
+                              onCheckedChange={(checked: CheckboxState) =>
+                                handleStatusChange(checked, value)
+                              }
+                            />
+                            <Label
+                              htmlFor={`status-${value}`}
+                              className="text-sm font-normal"
+                            >
+                              {getManagedSiteChannelStatusFilterLabel(t, value)}
+                            </Label>
+                          </div>
+                          <span className="text-muted-foreground text-xs">
+                            {statusCounts.get(value) ?? 0}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
                   </div>
-                </TableCell>
-              </TableRow>
-            ) : table.getRowModel().rows.length ? (
-              table.getRowModel().rows.map((row: Row<ChannelRow>) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                  className="group align-middle"
-                >
-                  {row
-                    .getVisibleCells()
-                    .map((cell: Cell<ChannelRow, unknown>) => (
-                      <TableCell
-                        key={cell.id}
-                        data-state={
-                          cell.column.id === "actions" && row.getIsSelected()
-                            ? "selected"
-                            : undefined
+                </PopoverContent>
+              </Popover>
+
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    leftIcon={<Columns3 className="h-4 w-4" />}
+                  >
+                    {t("toolbar.columns")}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-48">
+                  <DropdownMenuLabel>
+                    {t("toolbar.toggleColumns")}
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {table
+                    .getAllLeafColumns()
+                    .filter((column) => column.getCanHide())
+                    .map((column) => (
+                      <DropdownMenuCheckboxItem
+                        key={column.id}
+                        className="capitalize"
+                        checked={column.getIsVisible()}
+                        onCheckedChange={(value: CheckboxState) =>
+                          column.toggleVisibility(!!value)
                         }
-                        className={cn(
-                          "py-3",
-                          cell.column.id === "actions" &&
-                            cn(
-                              "bg-background group-hover:bg-muted/50 data-[state=selected]:bg-muted sticky right-0 border-l",
-                              Z_INDEX.tableStickyCell,
-                            ),
-                        )}
+                        onSelect={(event: Event) => event.preventDefault()}
                       >
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </TableCell>
+                        {getManagedSiteChannelColumnLabel(t, column.id)}
+                      </DropdownMenuCheckboxItem>
                     ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-32 text-center"
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <div className="col-span-2 grid grid-cols-2 gap-2 md:ml-auto md:flex md:items-center md:justify-end md:gap-2">
+                {isMigrationMode && hasMigrationTargets && (
+                  <Button
+                    variant="outline"
+                    disabled={!selectedCount}
+                    onClick={() =>
+                      openMigrationDialog(
+                        selectedRows.map((row) => row.original),
+                      )
+                    }
+                    leftIcon={<ArrowRightLeft className="h-4 w-4" />}
+                  >
+                    {t("toolbar.migrateSelected")}
+                  </Button>
+                )}
+                {isMigrationMode && hasMigrationTargets && (
+                  <Button
+                    variant="outline"
+                    disabled={!filteredCount}
+                    onClick={() =>
+                      openMigrationDialog(
+                        filteredRows.map((row) => row.original),
+                      )
+                    }
+                    leftIcon={<ArrowRightLeft className="h-4 w-4" />}
+                  >
+                    {t("toolbar.migrateFiltered")}
+                  </Button>
+                )}
+                {!isMigrationMode && (
+                  <Button
+                    variant="outline"
+                    disabled={!selectedCount}
+                    onClick={() =>
+                      scheduleDelete(selectedRows.map((row) => row.original.id))
+                    }
+                    leftIcon={<Trash2 className="h-4 w-4" />}
+                  >
+                    {t("toolbar.deleteSelected")}
+                  </Button>
+                )}
+                {!isMigrationMode && (
+                  <Button
+                    variant="outline"
+                    disabled={!selectedCount}
+                    onClick={() =>
+                      handleSyncChannels(
+                        selectedRows.map((row) => row.original.id),
+                      )
+                    }
+                    leftIcon={<RefreshCcw className="h-4 w-4" />}
+                  >
+                    {t("toolbar.syncSelected")}
+                  </Button>
+                )}
+                {!isMigrationMode && (
+                  <Button
+                    onClick={handleOpenCreateDialog}
+                    leftIcon={<Plus className="h-4 w-4" />}
+                  >
+                    {t("toolbar.addChannel")}
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="border-border bg-background overflow-hidden rounded-lg border">
+            <Table>
+              <TableHeader>
+                {table
+                  .getHeaderGroups()
+                  .map((headerGroup: HeaderGroup<ChannelRow>) => (
+                    <TableRow
+                      key={headerGroup.id}
+                      className="hover:bg-transparent"
+                    >
+                      {headerGroup.headers.map((header) => (
+                        <TableHead
+                          key={header.id}
+                          className={cn(
+                            header.column.id === "actions" &&
+                              cn(
+                                "bg-background sticky right-0 border-l",
+                                Z_INDEX.tableStickyHeader,
+                              ),
+                          )}
+                          style={{ width: header.getSize() }}
+                        >
+                          {header.isPlaceholder ? null : header.column.getCanSort() ? (
+                            <button
+                              type="button"
+                              className="flex w-full items-center gap-2"
+                              onClick={header.column.getToggleSortingHandler()}
+                            >
+                              {flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
+                              )}
+                              {header.column.getIsSorted() === "asc" && (
+                                <ChevronUp className="h-3.5 w-3.5 opacity-60" />
+                              )}
+                              {header.column.getIsSorted() === "desc" && (
+                                <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+                              )}
+                            </button>
+                          ) : (
+                            flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )
+                          )}
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  ))}
+              </TableHeader>
+              <TableBody>
+                {isInitialLoading ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={columns.length}
+                      className="h-32 text-center"
+                    >
+                      <div className="text-muted-foreground flex items-center justify-center gap-2">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        {t("table.loading")}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ) : table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row: Row<ChannelRow>) => (
+                    <TableRow
+                      key={row.id}
+                      data-state={row.getIsSelected() && "selected"}
+                      className="group align-middle"
+                    >
+                      {row
+                        .getVisibleCells()
+                        .map((cell: Cell<ChannelRow, unknown>) => (
+                          <TableCell
+                            key={cell.id}
+                            data-state={
+                              cell.column.id === "actions" &&
+                              row.getIsSelected()
+                                ? "selected"
+                                : undefined
+                            }
+                            className={cn(
+                              "py-3",
+                              cell.column.id === "actions" &&
+                                cn(
+                                  "bg-background group-hover:bg-muted/50 data-[state=selected]:bg-muted sticky right-0 border-l",
+                                  Z_INDEX.tableStickyCell,
+                                ),
+                            )}
+                          >
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext(),
+                            )}
+                          </TableCell>
+                        ))}
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={columns.length}
+                      className="h-32 text-center"
+                    >
+                      <div className="text-muted-foreground text-sm">
+                        {t("table.empty")}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4 text-sm">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="rows-per-page" className="text-xs font-medium">
+                {t("table.rowsPerPage")}
+              </Label>
+              <Select
+                value={String(table.getState().pagination.pageSize)}
+                onValueChange={(value: string) =>
+                  table.setPageSize(Number(value))
+                }
+              >
+                <SelectTrigger
+                  id="rows-per-page"
+                  size="sm"
+                  aria-label={t("table.rowsPerPage")}
+                  className="w-[110px]"
                 >
-                  <div className="text-muted-foreground text-sm">
-                    {t("table.empty")}
-                  </div>
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+                  <SelectValue placeholder={t("table.rowsPerPage") ?? ""} />
+                </SelectTrigger>
+                <SelectContent>
+                  {rowsPerPageOptions.map((option) => (
+                    <SelectItem key={option} value={String(option)}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
 
-      <div className="flex flex-wrap items-center gap-4 text-sm">
-        <div className="flex items-center gap-2">
-          <Label htmlFor="rows-per-page" className="text-xs font-medium">
-            {t("table.rowsPerPage")}
-          </Label>
-          <Select
-            value={String(table.getState().pagination.pageSize)}
-            onValueChange={(value: string) => table.setPageSize(Number(value))}
-          >
-            <SelectTrigger
-              id="rows-per-page"
-              size="sm"
-              aria-label={t("table.rowsPerPage")}
-              className="w-[110px]"
-            >
-              <SelectValue placeholder={t("table.rowsPerPage") ?? ""} />
-            </SelectTrigger>
-            <SelectContent>
-              {rowsPerPageOptions.map((option) => (
-                <SelectItem key={option} value={String(option)}>
-                  {option}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+            <div className="text-muted-foreground ml-auto">
+              {table.getRowCount() ? (
+                <span>
+                  {t("table.paginationSummary", {
+                    start:
+                      table.getState().pagination.pageIndex *
+                        table.getState().pagination.pageSize +
+                      1,
+                    end: Math.min(
+                      (table.getState().pagination.pageIndex + 1) *
+                        table.getState().pagination.pageSize,
+                      table.getRowCount(),
+                    ),
+                    total: table.getRowCount(),
+                  })}
+                </span>
+              ) : (
+                <span>{t("table.noEntries")}</span>
+              )}
+            </div>
 
-        <div className="text-muted-foreground ml-auto">
-          {table.getRowCount() ? (
-            <span>
-              {t("table.paginationSummary", {
-                start:
-                  table.getState().pagination.pageIndex *
-                    table.getState().pagination.pageSize +
-                  1,
-                end: Math.min(
-                  (table.getState().pagination.pageIndex + 1) *
-                    table.getState().pagination.pageSize,
-                  table.getRowCount(),
-                ),
-                total: table.getRowCount(),
-              })}
-            </span>
-          ) : (
-            <span>{t("table.noEntries")}</span>
-          )}
-        </div>
-
-        <div className="flex items-center gap-2">
-          <Button
-            size="icon"
-            variant="outline"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-            aria-label={t("table.paginationPrev")}
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </Button>
-          <Button
-            size="icon"
-            variant="outline"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-            aria-label={t("table.paginationNext")}
-          >
-            <ChevronRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
+            <div className="flex items-center gap-2">
+              <Button
+                size="icon"
+                variant="outline"
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+                aria-label={t("table.paginationPrev")}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                size="icon"
+                variant="outline"
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+                aria-label={t("table.paginationNext")}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
 
       <DestructiveConfirmDialog
         isOpen={isDeleteDialogOpen}

--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -5,11 +5,17 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import ManagedSiteConfigRequiredState from "~/components/ManagedSiteConfigRequiredState"
 import ManagedSiteTypeSwitcher from "~/components/ManagedSiteTypeSwitcher"
 import { PageHeader } from "~/components/PageHeader"
 import { Button, EmptyState, Input } from "~/components/ui"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { hasValidManagedSiteConfig } from "~/services/managedSites/managedSiteService"
+import {
+  getManagedSiteConfigMissingMessage,
+  getManagedSiteMessagesKeyFromSiteType,
+} from "~/services/managedSites/utils/managedSite"
 import type { ManagedSiteChannel } from "~/types/managedSite"
 import type {
   ExecutionItemResult,
@@ -59,9 +65,22 @@ export default function ManagedSiteModelSync({
   refreshKey,
   routeParams,
 }: ManagedSiteModelSyncProps) {
-  const { t } = useTranslation(["managedSiteModelSync", "settings"])
-  const { managedSiteType } = useUserPreferencesContext()
+  const { t } = useTranslation([
+    "managedSiteModelSync",
+    "settings",
+    "messages",
+    "common",
+  ])
+  const { managedSiteType, preferences } = useUserPreferencesContext()
   const hasInitializedTab = useRef(false)
+  const isConfigMissing = !hasValidManagedSiteConfig(
+    preferences,
+    managedSiteType,
+  )
+  const configMissingMessage = getManagedSiteConfigMissingMessage(
+    t,
+    getManagedSiteMessagesKeyFromSiteType(managedSiteType),
+  )
   const [lastExecution, setLastExecution] = useState<ExecutionResult | null>(
     null,
   )
@@ -175,6 +194,11 @@ export default function ManagedSiteModelSync({
   }, [t])
 
   useEffect(() => {
+    if (isConfigMissing) {
+      setIsLoading(false)
+      return
+    }
+
     void loadLastExecution()
     void loadProgress()
     void loadNextRun()
@@ -198,6 +222,7 @@ export default function ManagedSiteModelSync({
       browser.runtime.onMessage.removeListener(handleMessage)
     }
   }, [
+    isConfigMissing,
     loadLastExecution,
     loadNextRun,
     loadPreferences,
@@ -210,13 +235,16 @@ export default function ManagedSiteModelSync({
     setLastExecution(null)
     setProgress(null)
     setNextScheduledAt(null)
+    setIsAutoSyncEnabled(false)
+    setIntervalMs(undefined)
     setHistorySelectedIds(new Set())
     setManualSelectedIds(new Set())
     setRunningChannelId(null)
     setChannels([])
     setChannelsError(null)
     setHasAttemptedChannelsLoad(false)
-  }, [managedSiteType])
+    setIsLoading(!isConfigMissing)
+  }, [isConfigMissing, managedSiteType])
 
   useEffect(() => {
     if (!progress?.isRunning) {
@@ -237,6 +265,7 @@ export default function ManagedSiteModelSync({
 
   useEffect(() => {
     if (
+      !isConfigMissing &&
       selectedTab === TAB_INDEX.manual &&
       channels.length === 0 &&
       !isChannelsLoading &&
@@ -247,12 +276,17 @@ export default function ManagedSiteModelSync({
   }, [
     channels.length,
     hasAttemptedChannelsLoad,
+    isConfigMissing,
     isChannelsLoading,
     loadChannels,
     selectedTab,
   ])
 
   useEffect(() => {
+    if (isConfigMissing) {
+      return
+    }
+
     if (refreshKey) {
       void loadLastExecution()
       void loadProgress()
@@ -260,6 +294,7 @@ export default function ManagedSiteModelSync({
       void loadPreferences()
     }
   }, [
+    isConfigMissing,
     loadLastExecution,
     loadNextRun,
     loadPreferences,
@@ -268,6 +303,10 @@ export default function ManagedSiteModelSync({
   ])
 
   useEffect(() => {
+    if (isConfigMissing) {
+      return
+    }
+
     const channelIdRaw = routeParams?.channelId?.trim()
     const channelId = channelIdRaw ? Number(channelIdRaw) : NaN
     const requestedTab = routeParams?.tab?.trim()
@@ -300,6 +339,7 @@ export default function ManagedSiteModelSync({
   }, [
     channels.length,
     hasAttemptedChannelsLoad,
+    isConfigMissing,
     isChannelsLoading,
     loadChannels,
     routeParams?.channelId,
@@ -405,6 +445,10 @@ export default function ManagedSiteModelSync({
   }
 
   const handleRefresh = () => {
+    if (isConfigMissing) {
+      return
+    }
+
     void loadLastExecution()
     void loadProgress()
     void loadNextRun()
@@ -531,7 +575,7 @@ export default function ManagedSiteModelSync({
 
   const isInitialLoading = isLoading && lastExecution === null
 
-  if (isInitialLoading) {
+  if (!isConfigMissing && isInitialLoading) {
     return <LoadingSkeleton />
   }
 
@@ -725,28 +769,37 @@ export default function ManagedSiteModelSync({
         spacing="compact"
       />
 
-      <div className="mb-6">
-        <OverviewCard
-          enabled={isAutoSyncEnabled}
-          intervalMs={intervalMs}
-          nextScheduledAt={nextScheduledAt}
-          lastRunAt={lastExecution?.statistics?.endedAt ?? null}
+      {isConfigMissing ? (
+        <ManagedSiteConfigRequiredState
+          description={configMissingMessage}
+          className="mt-6"
         />
-      </div>
+      ) : (
+        <>
+          <div className="mb-6">
+            <OverviewCard
+              enabled={isAutoSyncEnabled}
+              intervalMs={intervalMs}
+              nextScheduledAt={nextScheduledAt}
+              lastRunAt={lastExecution?.statistics?.endedAt ?? null}
+            />
+          </div>
 
-      {progress?.isRunning && (
-        <div className="mb-6">
-          <ProgressCard progress={progress} />
-        </div>
+          {progress?.isRunning && (
+            <div className="mb-6">
+              <ProgressCard progress={progress} />
+            </div>
+          )}
+
+          {lastExecution?.statistics && (
+            <div className="mb-6">
+              <StatisticsCard statistics={lastExecution.statistics} />
+            </div>
+          )}
+
+          {renderTabs()}
+        </>
       )}
-
-      {lastExecution?.statistics && (
-        <div className="mb-6">
-          <StatisticsCard statistics={lastExecution.statistics} />
-        </div>
-      )}
-
-      {renderTabs()}
     </div>
   )
 }

--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -77,10 +77,6 @@ export default function ManagedSiteModelSync({
     preferences,
     managedSiteType,
   )
-  const configMissingMessage = getManagedSiteConfigMissingMessage(
-    t,
-    getManagedSiteMessagesKeyFromSiteType(managedSiteType),
-  )
   const [lastExecution, setLastExecution] = useState<ExecutionResult | null>(
     null,
   )
@@ -445,10 +441,6 @@ export default function ManagedSiteModelSync({
   }
 
   const handleRefresh = () => {
-    if (isConfigMissing) {
-      return
-    }
-
     void loadLastExecution()
     void loadProgress()
     void loadNextRun()
@@ -771,7 +763,10 @@ export default function ManagedSiteModelSync({
 
       {isConfigMissing ? (
         <ManagedSiteConfigRequiredState
-          description={configMissingMessage}
+          description={getManagedSiteConfigMissingMessage(
+            t,
+            getManagedSiteMessagesKeyFromSiteType(managedSiteType),
+          )}
           className="mt-6"
         />
       ) : (

--- a/src/features/ManagedSiteModelSync/components/EmptyResults.tsx
+++ b/src/features/ManagedSiteModelSync/components/EmptyResults.tsx
@@ -1,16 +1,7 @@
-import {
-  ArrowPathIcon,
-  ExclamationTriangleIcon,
-  MagnifyingGlassIcon,
-} from "@heroicons/react/24/outline"
-import { useEffect, useState } from "react"
+import { ArrowPathIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
 import { EmptyState } from "~/components/ui"
-import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
-import { hasValidManagedSiteConfig } from "~/services/managedSites/managedSiteService"
-import { userPreferences } from "~/services/preferences/userPreferences"
-import { pushWithinOptionsPage } from "~/utils/navigation"
 
 interface EmptyResultsProps {
   hasHistory: boolean
@@ -24,35 +15,8 @@ interface EmptyResultsProps {
 export default function EmptyResults(props: EmptyResultsProps) {
   const { hasHistory } = props
   const { t } = useTranslation("managedSiteModelSync")
-  const [hasValidConfig, setHasValidConfig] = useState(true)
-
-  useEffect(() => {
-    const checkConfig = async () => {
-      const prefs = await userPreferences.getPreferences()
-      setHasValidConfig(hasValidManagedSiteConfig(prefs))
-    }
-    void checkConfig()
-  }, [])
 
   if (!hasHistory) {
-    // Show config warning if config is invalid
-    if (!hasValidConfig) {
-      return (
-        <EmptyState
-          title={t("execution.empty.configWarningDesc")}
-          icon={
-            <ExclamationTriangleIcon className="h-12 w-12 text-yellow-500" />
-          }
-          action={{
-            onClick: () => {
-              pushWithinOptionsPage(`#${MENU_ITEM_IDS.BASIC}`)
-            },
-            label: t("execution.empty.goToSettings"),
-          }}
-        />
-      )
-    }
-
     return (
       <EmptyState
         title={t("execution.empty.noData")}

--- a/src/features/ManagedSiteModelSync/components/EmptyResults.tsx
+++ b/src/features/ManagedSiteModelSync/components/EmptyResults.tsx
@@ -8,9 +8,9 @@ interface EmptyResultsProps {
 }
 
 /**
- * Displays empty states for execution history with config awareness.
- * @param props Component props containing history awareness.
- * @returns Appropriate empty state prompting config or search actions.
+ * Displays empty states for execution history.
+ * @param props Component props indicating whether history is present.
+ * @returns Appropriate empty state for "no data" or "no results".
  */
 export default function EmptyResults(props: EmptyResultsProps) {
   const { hasHistory } = props

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -7,6 +7,7 @@
     "delete": "Delete",
     "edit": "Edit",
     "export": "Export",
+    "goToSettings": "Go to Settings",
     "import": "Import",
     "more": "More",
     "openSidePanel": "Open in SidePanel",
@@ -31,6 +32,7 @@
     "unlimited": "Unlimited"
   },
   "status": {
+    "configurationRequired": "Configuration required",
     "creating": "Creating...",
     "disabled": "Disabled",
     "enabled": "Enabled",

--- a/src/locales/en/managedSiteChannels.json
+++ b/src/locales/en/managedSiteChannels.json
@@ -1,9 +1,5 @@
 {
   "alerts": {
-    "configMissing": {
-      "description": "Please configure your managed site credentials in settings before managing channels.",
-      "title": "Missing configuration"
-    },
     "loadError": {
       "description": "{{error}}",
       "title": "Unable to load channels"

--- a/src/locales/en/managedSiteModelSync.json
+++ b/src/locales/en/managedSiteModelSync.json
@@ -8,8 +8,6 @@
       "runSelected": "Run Selected"
     },
     "empty": {
-      "configWarningDesc": "Please configure your managed site base URL, admin token, and user ID before running model list sync",
-      "goToSettings": "Go to Settings",
       "noData": "No execution history yet",
       "noDataDesc": "Click \"Run All\" to start synchronizing all channels",
       "noResults": "No matching results",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -7,6 +7,7 @@
     "delete": "削除",
     "edit": "編集",
     "export": "エクスポート",
+    "goToSettings": "設定へ移動",
     "import": "インポート",
     "more": "その他",
     "openSidePanel": "サイドパネルで開く",
@@ -31,6 +32,7 @@
     "unlimited": "無制限"
   },
   "status": {
+    "configurationRequired": "設定が必要です",
     "creating": "作成中...",
     "disabled": "無効",
     "enabled": "有効",

--- a/src/locales/ja/managedSiteChannels.json
+++ b/src/locales/ja/managedSiteChannels.json
@@ -1,9 +1,5 @@
 {
   "alerts": {
-    "configMissing": {
-      "description": "チャネルを管理する前に、設定で管理対象サイトの認証情報を構成してください。",
-      "title": "設定が不足しています"
-    },
     "loadError": {
       "description": "{{error}}",
       "title": "チャネルを読み込めません"

--- a/src/locales/ja/managedSiteModelSync.json
+++ b/src/locales/ja/managedSiteModelSync.json
@@ -8,8 +8,6 @@
       "runSelected": "選択分を実行"
     },
     "empty": {
-      "configWarningDesc": "モデル一覧同期を実行する前に、管理対象サイトの Base URL、管理者トークン、ユーザー ID を設定してください",
-      "goToSettings": "設定へ移動",
       "noData": "まだ実行履歴がありません",
       "noDataDesc": "「すべて実行」をクリックして全チャネルの同期を開始してください",
       "noResults": "一致する結果がありません",

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -7,6 +7,7 @@
     "delete": "删除",
     "edit": "编辑",
     "export": "导出",
+    "goToSettings": "前往设置",
     "import": "导入",
     "more": "更多",
     "openSidePanel": "在侧边栏中打开",
@@ -31,6 +32,7 @@
     "unlimited": "无限额度"
   },
   "status": {
+    "configurationRequired": "缺少配置",
     "creating": "创建中...",
     "disabled": "已禁用",
     "enabled": "已启用",

--- a/src/locales/zh-CN/managedSiteChannels.json
+++ b/src/locales/zh-CN/managedSiteChannels.json
@@ -1,9 +1,5 @@
 {
   "alerts": {
-    "configMissing": {
-      "description": "请先在设置中配置托管站点凭据，然后再管理渠道。",
-      "title": "缺少配置"
-    },
     "loadError": {
       "description": "{{error}}",
       "title": "无法加载渠道"

--- a/src/locales/zh-CN/managedSiteModelSync.json
+++ b/src/locales/zh-CN/managedSiteModelSync.json
@@ -8,8 +8,6 @@
       "runSelected": "执行所选"
     },
     "empty": {
-      "configWarningDesc": "请先配置管理站点的基础 URL、管理员令牌和用户 ID，然后再执行模型列表同步",
-      "goToSettings": "前往设置",
       "noData": "暂无执行记录",
       "noDataDesc": "点击\"执行全部\"开始同步所有渠道",
       "noResults": "没有匹配的结果",

--- a/src/locales/zh-TW/common.json
+++ b/src/locales/zh-TW/common.json
@@ -7,6 +7,7 @@
     "delete": "刪除",
     "edit": "編輯",
     "export": "匯出",
+    "goToSettings": "前往設定",
     "import": "匯入",
     "more": "更多",
     "openSidePanel": "在側邊欄中開啟",
@@ -31,6 +32,7 @@
     "unlimited": "無限額度"
   },
   "status": {
+    "configurationRequired": "缺少配置",
     "creating": "建立中...",
     "disabled": "已禁用",
     "enabled": "已啟用",

--- a/src/locales/zh-TW/managedSiteChannels.json
+++ b/src/locales/zh-TW/managedSiteChannels.json
@@ -1,9 +1,5 @@
 {
   "alerts": {
-    "configMissing": {
-      "description": "請先在設定中配置託管站點憑據，然後再管理渠道。",
-      "title": "缺少配置"
-    },
     "loadError": {
       "description": "{{error}}",
       "title": "無法載入渠道"

--- a/src/locales/zh-TW/managedSiteModelSync.json
+++ b/src/locales/zh-TW/managedSiteModelSync.json
@@ -8,8 +8,6 @@
       "runSelected": "執行所選"
     },
     "empty": {
-      "configWarningDesc": "請先配置管理站點的基礎 URL、管理員令牌和使用者 ID，然後再執行模型列表同步",
-      "goToSettings": "前往設定",
       "noData": "暫無執行記錄",
       "noDataDesc": "點擊\"執行全部\"開始同步所有渠道",
       "noResults": "沒有匹配的結果",

--- a/tests/components/EmptyState.test.tsx
+++ b/tests/components/EmptyState.test.tsx
@@ -6,7 +6,7 @@ import { render, screen } from "~~/tests/test-utils/render"
 describe("EmptyState", () => {
   it("renders a trailing action icon when rightIcon is provided", async () => {
     const onClick = vi.fn()
-    const { container } = render(
+    render(
       <EmptyState
         icon={<span data-testid="state-icon">state</span>}
         title="Configuration required"
@@ -23,16 +23,25 @@ describe("EmptyState", () => {
     )
 
     const button = await screen.findByRole("button", { name: "Open settings" })
-    expect(button).toBeInTheDocument()
-    expect(screen.getByTestId("right-icon")).toHaveTextContent("arrow")
-    expect(container.querySelector("button span:last-child")).toHaveTextContent(
-      "arrow",
+    const rightIcon = screen.getByTestId("right-icon")
+    const labelNode = Array.from(button.childNodes).find(
+      (node) =>
+        node.nodeType === Node.TEXT_NODE &&
+        node.textContent?.includes("Open settings"),
     )
+
+    expect(button).toBeInTheDocument()
+    expect(labelNode).toBeTruthy()
+    expect(rightIcon).toHaveTextContent("arrow")
+    expect(
+      rightIcon.parentElement!.compareDocumentPosition(labelNode!) &
+        Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy()
   })
 
   it("keeps the legacy action icon as the leading button icon", async () => {
     const onClick = vi.fn()
-    const { container } = render(
+    render(
       <EmptyState
         icon={<span data-testid="state-icon">state</span>}
         title="Configuration required"
@@ -49,10 +58,19 @@ describe("EmptyState", () => {
     )
 
     const button = await screen.findByRole("button", { name: "Open settings" })
+    const leftIcon = screen.getByTestId("left-icon")
+    const labelNode = Array.from(button.childNodes).find(
+      (node) =>
+        node.nodeType === Node.TEXT_NODE &&
+        node.textContent?.includes("Open settings"),
+    )
+
     expect(button).toBeInTheDocument()
-    expect(screen.getByTestId("left-icon")).toHaveTextContent("gear")
+    expect(labelNode).toBeTruthy()
+    expect(leftIcon).toHaveTextContent("gear")
     expect(
-      container.querySelector("button span:first-child"),
-    ).toHaveTextContent("gear")
+      leftIcon.parentElement!.compareDocumentPosition(labelNode!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
   })
 })

--- a/tests/components/EmptyState.test.tsx
+++ b/tests/components/EmptyState.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { EmptyState } from "~/components/ui"
+import { render, screen } from "~~/tests/test-utils/render"
+
+describe("EmptyState", () => {
+  it("renders a trailing action icon when rightIcon is provided", async () => {
+    const onClick = vi.fn()
+    const { container } = render(
+      <EmptyState
+        icon={<span data-testid="state-icon">state</span>}
+        title="Configuration required"
+        action={{
+          label: "Open settings",
+          onClick,
+          rightIcon: (
+            <span data-testid="right-icon" aria-hidden="true">
+              arrow
+            </span>
+          ),
+        }}
+      />,
+    )
+
+    const button = await screen.findByRole("button", { name: "Open settings" })
+    expect(button).toBeInTheDocument()
+    expect(screen.getByTestId("right-icon")).toHaveTextContent("arrow")
+    expect(container.querySelector("button span:last-child")).toHaveTextContent(
+      "arrow",
+    )
+  })
+
+  it("keeps the legacy action icon as the leading button icon", async () => {
+    const onClick = vi.fn()
+    const { container } = render(
+      <EmptyState
+        icon={<span data-testid="state-icon">state</span>}
+        title="Configuration required"
+        action={{
+          label: "Open settings",
+          onClick,
+          icon: (
+            <span data-testid="left-icon" aria-hidden="true">
+              gear
+            </span>
+          ),
+        }}
+      />,
+    )
+
+    const button = await screen.findByRole("button", { name: "Open settings" })
+    expect(button).toBeInTheDocument()
+    expect(screen.getByTestId("left-icon")).toHaveTextContent("gear")
+    expect(
+      container.querySelector("button span:first-child"),
+    ).toHaveTextContent("gear")
+  })
+})

--- a/tests/entrypoints/options/Sidebar.test.tsx
+++ b/tests/entrypoints/options/Sidebar.test.tsx
@@ -5,11 +5,9 @@ import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import Sidebar from "~/entrypoints/options/components/Sidebar"
 import { fireEvent, render, screen, within } from "~~/tests/test-utils/render"
 
-const { hasValidManagedSiteConfigMock, useUserPreferencesContextMock } =
-  vi.hoisted(() => ({
-    hasValidManagedSiteConfigMock: vi.fn(),
-    useUserPreferencesContextMock: vi.fn(),
-  }))
+const { useUserPreferencesContextMock } = vi.hoisted(() => ({
+  useUserPreferencesContextMock: vi.fn(),
+}))
 
 vi.mock("framer-motion", () => ({
   motion: {
@@ -38,14 +36,9 @@ vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
   }
 })
 
-vi.mock("~/services/managedSites/managedSiteService", () => ({
-  hasValidManagedSiteConfig: hasValidManagedSiteConfigMock,
-}))
-
 describe("Options Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    hasValidManagedSiteConfigMock.mockReturnValue(true)
     useUserPreferencesContextMock.mockReturnValue({
       preferences: {
         autoCheckin: {
@@ -108,8 +101,7 @@ describe("Options Sidebar", () => {
     expect(onCollapseToggle).toHaveBeenCalledTimes(1)
   })
 
-  it("uses collapsed desktop labels and hides gated menu items when features are unavailable", () => {
-    hasValidManagedSiteConfigMock.mockReturnValue(false)
+  it("uses collapsed desktop labels and keeps managed-site pages visible when config is missing", () => {
     useUserPreferencesContextMock.mockReturnValue({
       preferences: {
         autoCheckin: {
@@ -140,15 +132,15 @@ describe("Options Sidebar", () => {
       within(nav).queryByRole("button", { name: "ui:navigation.autoCheckin" }),
     ).toBeNull()
     expect(
-      within(nav).queryByRole("button", {
+      within(nav).getByRole("button", {
         name: "ui:navigation.managedSiteChannels",
       }),
-    ).toBeNull()
+    ).toBeInTheDocument()
     expect(
-      within(nav).queryByRole("button", {
+      within(nav).getByRole("button", {
         name: "ui:navigation.managedSiteModelSync",
       }),
-    ).toBeNull()
+    ).toBeInTheDocument()
 
     expect(
       screen.getAllByRole("button", {

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -19,7 +19,7 @@ import {
   NEW_API_MANAGED_SESSION_STATUSES,
 } from "~/services/managedSites/providers/newApiSession"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
-import { navigateWithinOptionsPage } from "~/utils/navigation"
+import { navigateWithinOptionsPage, openSettingsTab } from "~/utils/navigation"
 import {
   fireEvent,
   render,
@@ -33,10 +33,14 @@ vi.mock("~/utils/browser/browserApi", async (importActual) => {
   return { ...actual, sendRuntimeMessage: vi.fn() }
 })
 
-vi.mock("~/services/managedSites/managedSiteService", () => ({
-  getManagedSiteService: vi.fn(),
-  getManagedSiteServiceForType: vi.fn(),
-}))
+vi.mock("~/services/managedSites/managedSiteService", async (importActual) => {
+  const actual = (await importActual()) as any
+  return {
+    ...actual,
+    getManagedSiteService: vi.fn(),
+    getManagedSiteServiceForType: vi.fn(),
+  }
+})
 
 vi.mock(
   "~/services/managedSites/providers/newApiSession",
@@ -61,6 +65,7 @@ vi.mock("~/utils/navigation", async (importActual) => {
   return {
     ...actual,
     navigateWithinOptionsPage: vi.fn(),
+    openSettingsTab: vi.fn(),
   }
 })
 
@@ -261,11 +266,18 @@ describe("ManagedSiteChannels", () => {
               adminToken: "",
               userId: "",
             },
-      octopus: {
-        baseUrl: "",
-        username: "",
-        password: "",
-      },
+      octopus:
+        managedSiteType === OCTOPUS
+          ? {
+              baseUrl: "https://octopus.example",
+              username: "octopus-admin",
+              password: "octopus-password",
+            }
+          : {
+              baseUrl: "",
+              username: "",
+              password: "",
+            },
     }
   }
 
@@ -682,6 +694,12 @@ describe("ManagedSiteChannels", () => {
 
   it("shows a config warning and skips the channel query when managed-site config is missing", async () => {
     const preferences = buildPreferences({ managedSiteType: NEW_API })
+    preferences.newApi = {
+      ...preferences.newApi,
+      baseUrl: "",
+      adminToken: "",
+      userId: "",
+    }
 
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       preferences,
@@ -693,22 +711,27 @@ describe("ManagedSiteChannels", () => {
       newApiTotpSecret: preferences.newApi.totpSecret,
     } as any)
 
-    vi.mocked(getManagedSiteService).mockResolvedValue({
-      siteType: NEW_API,
-      messagesKey: "newapi",
-      getConfig: vi.fn().mockResolvedValue(null),
-    } as any)
-
     render(<ManagedSiteChannels />)
 
     expect(
-      await screen.findByText("managedSiteChannels:alerts.configMissing.title"),
+      await screen.findByText("common:status.configurationRequired"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("messages:newapi.configMissing"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "common:actions.goToSettings" }),
     ).toBeInTheDocument()
     expect(sendRuntimeMessage).not.toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalled()
-    expect(
-      screen.getByText("managedSiteChannels:table.empty"),
-    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:actions.goToSettings" }),
+    )
+
+    expect(openSettingsTab).toHaveBeenCalledWith("managedSite", {
+      preserveHistory: true,
+    })
   })
 
   it("shows a load error alert when fetching channels fails", async () => {

--- a/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
+++ b/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
@@ -19,11 +19,13 @@ const {
   mockSendRuntimeMessage,
   mockUseUserPreferencesContext,
   mockShowWarningToast,
+  mockOpenSettingsTab,
   loggerMocks,
 } = vi.hoisted(() => ({
   mockSendRuntimeMessage: vi.fn(),
   mockUseUserPreferencesContext: vi.fn(),
   mockShowWarningToast: vi.fn(),
+  mockOpenSettingsTab: vi.fn(),
   loggerMocks: {
     error: vi.fn(),
     info: vi.fn(),
@@ -60,6 +62,10 @@ vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: mockUseUserPreferencesContext,
 }))
 
+vi.mock("~/utils/navigation", () => ({
+  openSettingsTab: mockOpenSettingsTab,
+}))
+
 vi.mock("~/components/ManagedSiteTypeSwitcher", () => ({
   default: ({ ariaLabel }: { ariaLabel: string }) => (
     <div data-testid="managed-site-switcher">{ariaLabel}</div>
@@ -84,6 +90,14 @@ describe("ManagedSiteModelSync page", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseUserPreferencesContext.mockReturnValue({
+      preferences: {
+        managedSiteType: "new-api",
+        newApi: {
+          baseUrl: "https://admin.example",
+          adminToken: "token",
+          userId: "1",
+        },
+      },
       managedSiteType: "new-api",
     })
     mockSendRuntimeMessage.mockImplementation(async (message: any) => {
@@ -210,6 +224,38 @@ describe("ManagedSiteModelSync page", () => {
       })
     })
     expect(toast.success).toHaveBeenCalled()
+  })
+
+  it("shows a configuration empty state and skips model-sync loading when managed-site config is missing", async () => {
+    mockUseUserPreferencesContext.mockReturnValue({
+      preferences: {
+        managedSiteType: "new-api",
+        newApi: {
+          baseUrl: "",
+          adminToken: "",
+          userId: "",
+        },
+      },
+      managedSiteType: "new-api",
+    })
+
+    render(<ManagedSiteModelSync />)
+
+    expect(
+      await screen.findByText("common:status.configurationRequired"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("messages:newapi.configMissing"),
+    ).toBeInTheDocument()
+    expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:actions.goToSettings" }),
+    )
+
+    expect(mockOpenSettingsTab).toHaveBeenCalledWith("managedSite", {
+      preserveHistory: true,
+    })
   })
 
   it("keeps the current history snapshot rendered while a manual refresh is loading", async () => {

--- a/tests/features/ManagedSiteModelSync/components.test.tsx
+++ b/tests/features/ManagedSiteModelSync/components.test.tsx
@@ -17,27 +17,6 @@ import ResultsTable from "~/features/ManagedSiteModelSync/components/ResultsTabl
 import StatisticsCard from "~/features/ManagedSiteModelSync/components/StatisticsCard"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
-const { mockHasValidManagedSiteConfig, mockPushWithinOptionsPage } = vi.hoisted(
-  () => ({
-    mockHasValidManagedSiteConfig: vi.fn(),
-    mockPushWithinOptionsPage: vi.fn(),
-  }),
-)
-
-vi.mock("~/services/preferences/userPreferences", () => ({
-  userPreferences: {
-    getPreferences: vi.fn(async () => ({})),
-  },
-}))
-
-vi.mock("~/services/managedSites/managedSiteService", () => ({
-  hasValidManagedSiteConfig: mockHasValidManagedSiteConfig,
-}))
-
-vi.mock("~/utils/navigation", () => ({
-  pushWithinOptionsPage: mockPushWithinOptionsPage,
-}))
-
 vi.mock("~/components/ManagedSiteChannelLinkButton", () => ({
   default: ({
     channelId,
@@ -61,7 +40,6 @@ function render(ui: ReactNode) {
 describe("ManagedSiteModelSync components", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockHasValidManagedSiteConfig.mockReturnValue(true)
   })
 
   it("renders overview, progress, and statistics states", () => {
@@ -295,24 +273,14 @@ describe("ManagedSiteModelSync components", () => {
     expect(onSelectItem).toHaveBeenCalledWith(11, false)
     expect(onRunSingle).toHaveBeenCalledWith(11)
 
-    mockHasValidManagedSiteConfig.mockReturnValue(false)
     render(<EmptyResults hasHistory={false} />)
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          "managedSiteModelSync:execution.empty.configWarningDesc",
-        ),
+        screen.getByText("managedSiteModelSync:execution.empty.noData"),
       ).toBeInTheDocument()
     })
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "managedSiteModelSync:execution.empty.goToSettings",
-      }),
-    )
-    expect(mockPushWithinOptionsPage).toHaveBeenCalled()
 
-    mockHasValidManagedSiteConfig.mockReturnValue(true)
     render(<EmptyResults hasHistory />)
     expect(
       screen.getByText("managedSiteModelSync:execution.empty.noResults"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Managed Site menu items are now always visible in the sidebar.
  * Unified "Configuration required" empty state with a "Go to Settings" action when managed-site config is missing.

* **UI**
  * Empty state actions support left/right icons with improved icon positioning.

* **Localization**
  * Added common translations for "Go to Settings" and "Configuration required"; removed some legacy config-warning locale keys.

* **Tests**
  * Added/updated tests for EmptyState icon behavior and settings-navigation interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->