### PR TITLE
fix(AccountManagement): resolve odd swap-like animation during reorder

### DIFF
--- a/src/features/AccountManagement/components/AccountList/index.tsx
+++ b/src/features/AccountManagement/components/AccountList/index.tsx
@@ -633,8 +633,8 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     dndRuntimeRef.current !== null
 
   const sortedIds = useMemo(
-    () => baseResults.map((item) => item.account.id),
-    [baseResults],
+    () => displayedResults.map((item) => item.account.id),
+    [displayedResults],
   )
 
   const updateSelectedAccountIds = (

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -55,6 +55,69 @@ import { tryParseOrigin } from "~/utils/core/urlParsing"
  */
 const logger = createLogger("AccountDataContext")
 
+/**
+ *
+ */
+function replaceIdListSubset(input: {
+  existingIds: string[]
+  subsetIdSet: Set<string>
+  nextSubsetIds: string[]
+}): string[] {
+  const existingIds = Array.isArray(input.existingIds) ? input.existingIds : []
+  const subsetIdSet = input.subsetIdSet
+
+  const seenSubset = new Set<string>()
+  const uniqueNextSubsetIds: string[] = []
+  for (const raw of input.nextSubsetIds) {
+    if (!subsetIdSet.has(raw)) continue
+    if (seenSubset.has(raw)) continue
+    seenSubset.add(raw)
+    uniqueNextSubsetIds.push(raw)
+  }
+
+  const existingSubsetIds = existingIds.filter((id) => subsetIdSet.has(id))
+  const missingExistingSubsetIds = existingSubsetIds.filter(
+    (id) => !seenSubset.has(id),
+  )
+  const queue = [...uniqueNextSubsetIds, ...missingExistingSubsetIds]
+
+  const result: string[] = []
+  const seen = new Set<string>()
+  let queueIndex = 0
+
+  const takeNextSubset = () => {
+    while (queueIndex < queue.length) {
+      const next = queue[queueIndex]
+      queueIndex += 1
+      if (seen.has(next)) continue
+      seen.add(next)
+      return next
+    }
+    return null
+  }
+
+  for (const id of existingIds) {
+    if (subsetIdSet.has(id)) {
+      const next = takeNextSubset()
+      if (next) {
+        result.push(next)
+      }
+      continue
+    }
+    if (seen.has(id)) continue
+    seen.add(id)
+    result.push(id)
+  }
+
+  while (queueIndex < queue.length) {
+    const next = takeNextSubset()
+    if (!next) break
+    result.push(next)
+  }
+
+  return result
+}
+
 // 1. 定义 Context 的值类型
 interface AccountDataContextType {
   accounts: SiteAccount[]
@@ -733,9 +796,12 @@ export const AccountDataProvider = ({
       // Ensure pinned accounts stay at top but allow pinned relative order to follow ids
       const pinnedSet = new Set(pinnedAccountIds)
       const accountIdSet = new Set(ids)
+      const allAccountIdSet = new Set(displayData.map((account) => account.id))
       const pinnedSegment = ids.filter((id) => pinnedSet.has(id))
       const nonPinnedSegment = ids.filter((id) => !pinnedSet.has(id))
       const merged = [...pinnedSegment, ...nonPinnedSegment]
+      const previousPinnedIds = pinnedAccountIds
+      const previousOrderedIds = orderedAccountIds
 
       // Check if pinned order has changed
       const pinnedAccountsInState = pinnedAccountIds.filter((id) =>
@@ -746,37 +812,69 @@ export const AccountDataProvider = ({
         pinnedSegment.length === pinnedAccountsInState.length &&
         pinnedSegment.some((id, index) => id !== pinnedAccountsInState[index])
 
-      if (shouldUpdatePinnedOrder) {
-        await accountStorage.setPinnedListSubset({
-          entryType: "account",
-          ids: pinnedSegment,
-        })
-      }
-
-      // Update overall order
-      await accountStorage.setOrderedListSubset({
-        entryType: "account",
-        ids: merged,
+      const optimisticPinnedIds = shouldUpdatePinnedOrder
+        ? replaceIdListSubset({
+            existingIds: previousPinnedIds,
+            subsetIdSet: allAccountIdSet,
+            nextSubsetIds: pinnedSegment,
+          })
+        : previousPinnedIds
+      const optimisticOrderedIds = replaceIdListSubset({
+        existingIds: previousOrderedIds,
+        subsetIdSet: allAccountIdSet,
+        nextSubsetIds: merged,
       })
 
-      const [nextPinnedIds, nextOrderedIds] = await Promise.all([
-        accountStorage.getPinnedList(),
-        accountStorage.getOrderedList(),
-      ])
+      setPinnedAccountIds(optimisticPinnedIds)
+      setOrderedAccountIds(optimisticOrderedIds)
 
-      setPinnedAccountIds(nextPinnedIds)
-      setOrderedAccountIds(nextOrderedIds)
+      try {
+        if (shouldUpdatePinnedOrder) {
+          const didPersistPinned = await accountStorage.setPinnedListSubset({
+            entryType: "account",
+            ids: pinnedSegment,
+          })
+
+          if (!didPersistPinned) {
+            throw new Error("Failed to persist pinned account order")
+          }
+        }
+
+        const didPersistOrder = await accountStorage.setOrderedListSubset({
+          entryType: "account",
+          ids: merged,
+        })
+
+        if (!didPersistOrder) {
+          throw new Error("Failed to persist bookmark order")
+        }
+
+        const [nextPinnedIds, nextOrderedIds] = await Promise.all([
+          accountStorage.getPinnedList(),
+          accountStorage.getOrderedList(),
+        ])
+
+        setPinnedAccountIds(nextPinnedIds)
+        setOrderedAccountIds(nextOrderedIds)
+      } catch (error) {
+        logger.error("Failed to persist bookmark reorder", { ids, error })
+        setPinnedAccountIds(previousPinnedIds)
+        setOrderedAccountIds(previousOrderedIds)
+      }
     },
-    [pinnedAccountIds],
+    [displayData, orderedAccountIds, pinnedAccountIds],
   )
 
   const handleBookmarkReorder = useCallback(
     async (ids: string[]) => {
       const pinnedSet = new Set(pinnedAccountIds)
       const bookmarkIdSet = new Set(ids)
+      const allBookmarkIdSet = new Set(bookmarks.map((bookmark) => bookmark.id))
       const pinnedSegment = ids.filter((id) => pinnedSet.has(id))
       const nonPinnedSegment = ids.filter((id) => !pinnedSet.has(id))
       const merged = [...pinnedSegment, ...nonPinnedSegment]
+      const previousPinnedIds = pinnedAccountIds
+      const previousOrderedIds = orderedAccountIds
 
       const pinnedBookmarksInState = pinnedAccountIds.filter((id) =>
         bookmarkIdSet.has(id),
@@ -787,27 +885,57 @@ export const AccountDataProvider = ({
         pinnedSegment.length === pinnedBookmarksInState.length &&
         pinnedSegment.some((id, index) => id !== pinnedBookmarksInState[index])
 
-      if (shouldUpdatePinnedOrder) {
-        await accountStorage.setPinnedListSubset({
-          entryType: "bookmark",
-          ids: pinnedSegment,
-        })
-      }
-
-      await accountStorage.setOrderedListSubset({
-        entryType: "bookmark",
-        ids: merged,
+      const optimisticPinnedIds = shouldUpdatePinnedOrder
+        ? replaceIdListSubset({
+            existingIds: previousPinnedIds,
+            subsetIdSet: allBookmarkIdSet,
+            nextSubsetIds: pinnedSegment,
+          })
+        : previousPinnedIds
+      const optimisticOrderedIds = replaceIdListSubset({
+        existingIds: previousOrderedIds,
+        subsetIdSet: allBookmarkIdSet,
+        nextSubsetIds: merged,
       })
 
-      const [nextPinnedIds, nextOrderedIds] = await Promise.all([
-        accountStorage.getPinnedList(),
-        accountStorage.getOrderedList(),
-      ])
+      setPinnedAccountIds(optimisticPinnedIds)
+      setOrderedAccountIds(optimisticOrderedIds)
 
-      setPinnedAccountIds(nextPinnedIds)
-      setOrderedAccountIds(nextOrderedIds)
+      try {
+        if (shouldUpdatePinnedOrder) {
+          const didPersistPinned = await accountStorage.setPinnedListSubset({
+            entryType: "bookmark",
+            ids: pinnedSegment,
+          })
+
+          if (!didPersistPinned) {
+            throw new Error("Failed to persist pinned bookmark order")
+          }
+        }
+
+        const didPersistOrder = await accountStorage.setOrderedListSubset({
+          entryType: "bookmark",
+          ids: merged,
+        })
+
+        if (!didPersistOrder) {
+          throw new Error("Failed to persist account order")
+        }
+
+        const [nextPinnedIds, nextOrderedIds] = await Promise.all([
+          accountStorage.getPinnedList(),
+          accountStorage.getOrderedList(),
+        ])
+
+        setPinnedAccountIds(nextPinnedIds)
+        setOrderedAccountIds(nextOrderedIds)
+      } catch (error) {
+        logger.error("Failed to persist account reorder", { ids, error })
+        setPinnedAccountIds(previousPinnedIds)
+        setOrderedAccountIds(previousOrderedIds)
+      }
     },
-    [pinnedAccountIds],
+    [bookmarks, orderedAccountIds, pinnedAccountIds],
   )
 
   // State to hold matched account scores from open tabs

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -56,7 +56,7 @@ import { tryParseOrigin } from "~/utils/core/urlParsing"
 const logger = createLogger("AccountDataContext")
 
 /**
- *
+ * Replaces only IDs that belong to `subsetIdSet`, preserving non-subset IDs in place.
  */
 function replaceIdListSubset(input: {
   existingIds: string[]
@@ -795,7 +795,7 @@ export const AccountDataProvider = ({
     async (ids: string[]) => {
       // Ensure pinned accounts stay at top but allow pinned relative order to follow ids
       const pinnedSet = new Set(pinnedAccountIds)
-      const accountIdSet = new Set(ids)
+      const visibleAccountIdSet = new Set(ids)
       const allAccountIdSet = new Set(displayData.map((account) => account.id))
       const pinnedSegment = ids.filter((id) => pinnedSet.has(id))
       const nonPinnedSegment = ids.filter((id) => !pinnedSet.has(id))
@@ -805,7 +805,7 @@ export const AccountDataProvider = ({
 
       // Check if pinned order has changed
       const pinnedAccountsInState = pinnedAccountIds.filter((id) =>
-        accountIdSet.has(id),
+        visibleAccountIdSet.has(id),
       )
       const shouldUpdatePinnedOrder =
         pinnedSegment.length > 0 &&
@@ -815,13 +815,13 @@ export const AccountDataProvider = ({
       const optimisticPinnedIds = shouldUpdatePinnedOrder
         ? replaceIdListSubset({
             existingIds: previousPinnedIds,
-            subsetIdSet: allAccountIdSet,
+            subsetIdSet: visibleAccountIdSet,
             nextSubsetIds: pinnedSegment,
           })
         : previousPinnedIds
       const optimisticOrderedIds = replaceIdListSubset({
         existingIds: previousOrderedIds,
-        subsetIdSet: allAccountIdSet,
+        subsetIdSet: visibleAccountIdSet,
         nextSubsetIds: merged,
       })
 
@@ -832,7 +832,7 @@ export const AccountDataProvider = ({
         if (shouldUpdatePinnedOrder) {
           const didPersistPinned = await accountStorage.setPinnedListSubset({
             entryType: "account",
-            ids: pinnedSegment,
+            ids: optimisticPinnedIds.filter((id) => allAccountIdSet.has(id)),
           })
 
           if (!didPersistPinned) {
@@ -842,80 +842,7 @@ export const AccountDataProvider = ({
 
         const didPersistOrder = await accountStorage.setOrderedListSubset({
           entryType: "account",
-          ids: merged,
-        })
-
-        if (!didPersistOrder) {
-          throw new Error("Failed to persist bookmark order")
-        }
-
-        const [nextPinnedIds, nextOrderedIds] = await Promise.all([
-          accountStorage.getPinnedList(),
-          accountStorage.getOrderedList(),
-        ])
-
-        setPinnedAccountIds(nextPinnedIds)
-        setOrderedAccountIds(nextOrderedIds)
-      } catch (error) {
-        logger.error("Failed to persist bookmark reorder", { ids, error })
-        setPinnedAccountIds(previousPinnedIds)
-        setOrderedAccountIds(previousOrderedIds)
-      }
-    },
-    [displayData, orderedAccountIds, pinnedAccountIds],
-  )
-
-  const handleBookmarkReorder = useCallback(
-    async (ids: string[]) => {
-      const pinnedSet = new Set(pinnedAccountIds)
-      const bookmarkIdSet = new Set(ids)
-      const allBookmarkIdSet = new Set(bookmarks.map((bookmark) => bookmark.id))
-      const pinnedSegment = ids.filter((id) => pinnedSet.has(id))
-      const nonPinnedSegment = ids.filter((id) => !pinnedSet.has(id))
-      const merged = [...pinnedSegment, ...nonPinnedSegment]
-      const previousPinnedIds = pinnedAccountIds
-      const previousOrderedIds = orderedAccountIds
-
-      const pinnedBookmarksInState = pinnedAccountIds.filter((id) =>
-        bookmarkIdSet.has(id),
-      )
-
-      const shouldUpdatePinnedOrder =
-        pinnedSegment.length > 0 &&
-        pinnedSegment.length === pinnedBookmarksInState.length &&
-        pinnedSegment.some((id, index) => id !== pinnedBookmarksInState[index])
-
-      const optimisticPinnedIds = shouldUpdatePinnedOrder
-        ? replaceIdListSubset({
-            existingIds: previousPinnedIds,
-            subsetIdSet: allBookmarkIdSet,
-            nextSubsetIds: pinnedSegment,
-          })
-        : previousPinnedIds
-      const optimisticOrderedIds = replaceIdListSubset({
-        existingIds: previousOrderedIds,
-        subsetIdSet: allBookmarkIdSet,
-        nextSubsetIds: merged,
-      })
-
-      setPinnedAccountIds(optimisticPinnedIds)
-      setOrderedAccountIds(optimisticOrderedIds)
-
-      try {
-        if (shouldUpdatePinnedOrder) {
-          const didPersistPinned = await accountStorage.setPinnedListSubset({
-            entryType: "bookmark",
-            ids: pinnedSegment,
-          })
-
-          if (!didPersistPinned) {
-            throw new Error("Failed to persist pinned bookmark order")
-          }
-        }
-
-        const didPersistOrder = await accountStorage.setOrderedListSubset({
-          entryType: "bookmark",
-          ids: merged,
+          ids: optimisticOrderedIds.filter((id) => allAccountIdSet.has(id)),
         })
 
         if (!didPersistOrder) {
@@ -931,6 +858,79 @@ export const AccountDataProvider = ({
         setOrderedAccountIds(nextOrderedIds)
       } catch (error) {
         logger.error("Failed to persist account reorder", { ids, error })
+        setPinnedAccountIds(previousPinnedIds)
+        setOrderedAccountIds(previousOrderedIds)
+      }
+    },
+    [displayData, orderedAccountIds, pinnedAccountIds],
+  )
+
+  const handleBookmarkReorder = useCallback(
+    async (ids: string[]) => {
+      const pinnedSet = new Set(pinnedAccountIds)
+      const visibleBookmarkIdSet = new Set(ids)
+      const allBookmarkIdSet = new Set(bookmarks.map((bookmark) => bookmark.id))
+      const pinnedSegment = ids.filter((id) => pinnedSet.has(id))
+      const nonPinnedSegment = ids.filter((id) => !pinnedSet.has(id))
+      const merged = [...pinnedSegment, ...nonPinnedSegment]
+      const previousPinnedIds = pinnedAccountIds
+      const previousOrderedIds = orderedAccountIds
+
+      const pinnedBookmarksInState = pinnedAccountIds.filter((id) =>
+        visibleBookmarkIdSet.has(id),
+      )
+
+      const shouldUpdatePinnedOrder =
+        pinnedSegment.length > 0 &&
+        pinnedSegment.length === pinnedBookmarksInState.length &&
+        pinnedSegment.some((id, index) => id !== pinnedBookmarksInState[index])
+
+      const optimisticPinnedIds = shouldUpdatePinnedOrder
+        ? replaceIdListSubset({
+            existingIds: previousPinnedIds,
+            subsetIdSet: visibleBookmarkIdSet,
+            nextSubsetIds: pinnedSegment,
+          })
+        : previousPinnedIds
+      const optimisticOrderedIds = replaceIdListSubset({
+        existingIds: previousOrderedIds,
+        subsetIdSet: visibleBookmarkIdSet,
+        nextSubsetIds: merged,
+      })
+
+      setPinnedAccountIds(optimisticPinnedIds)
+      setOrderedAccountIds(optimisticOrderedIds)
+
+      try {
+        if (shouldUpdatePinnedOrder) {
+          const didPersistPinned = await accountStorage.setPinnedListSubset({
+            entryType: "bookmark",
+            ids: optimisticPinnedIds.filter((id) => allBookmarkIdSet.has(id)),
+          })
+
+          if (!didPersistPinned) {
+            throw new Error("Failed to persist pinned bookmark order")
+          }
+        }
+
+        const didPersistOrder = await accountStorage.setOrderedListSubset({
+          entryType: "bookmark",
+          ids: optimisticOrderedIds.filter((id) => allBookmarkIdSet.has(id)),
+        })
+
+        if (!didPersistOrder) {
+          throw new Error("Failed to persist bookmark order")
+        }
+
+        const [nextPinnedIds, nextOrderedIds] = await Promise.all([
+          accountStorage.getPinnedList(),
+          accountStorage.getOrderedList(),
+        ])
+
+        setPinnedAccountIds(nextPinnedIds)
+        setOrderedAccountIds(nextOrderedIds)
+      } catch (error) {
+        logger.error("Failed to persist bookmark reorder", { ids, error })
         setPinnedAccountIds(previousPinnedIds)
         setOrderedAccountIds(previousOrderedIds)
       }

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -611,6 +611,46 @@ describe("AccountList", () => {
     ])
   })
 
+  it("reorders only the visible subset after filters are applied", async () => {
+    const user = userEvent.setup()
+    const handleReorder = vi.fn()
+
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        isManualSortFeatureEnabled: true,
+        handleReorder,
+      }),
+    )
+
+    render(<AccountList />)
+
+    await user.click(
+      screen.getByRole("button", { name: "common:status.enabled" }),
+    )
+
+    expect(screen.getAllByTestId("account-row")).toHaveLength(3)
+
+    await user.click(
+      screen.getAllByRole("button", {
+        name: "account:list.dragHandle",
+      })[0],
+    )
+
+    expect(await screen.findByTestId("dnd-context")).toBeInTheDocument()
+    expect(dndState.onDragEnd).toBeTypeOf("function")
+
+    dndState.onDragEnd?.({
+      active: { id: "enabled-alpha" },
+      over: { id: "enabled-gamma" },
+    })
+
+    expect(handleReorder).toHaveBeenCalledWith([
+      "enabled-gamma",
+      "enabled-alpha",
+      "unsynced-delta",
+    ])
+  })
+
   it("does not activate dnd from disabled search handles or bulk mode", async () => {
     const user = userEvent.setup()
 

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -452,6 +452,51 @@ describe("AccountDataContext handleReorder", () => {
       ids: ["p-1", "p-2", "u-1"],
     })
   })
+
+  it("optimistically updates account order before persistence finishes", async () => {
+    let resolveOrderedWrite: ((value: boolean) => void) | null = null
+
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    mockGetAllAccounts.mockResolvedValue([{ id: "acc-1" }, { id: "acc-2" }])
+    mockGetAllBookmarks.mockResolvedValue([])
+    mockGetOrderedList.mockResolvedValue(["acc-1", "acc-2"])
+    mockGetPinnedList.mockResolvedValue([])
+    mockGetAccountStats.mockResolvedValue(createEmptyStats())
+    mockSetOrderedListSubset.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveOrderedWrite = resolve
+        }),
+    )
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().orderedAccountIds).toEqual(["acc-1", "acc-2"])
+    })
+
+    let reorderPromise: Promise<void> | undefined
+
+    act(() => {
+      reorderPromise = getLatestCtx().handleReorder(["acc-2", "acc-1"])
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().orderedAccountIds).toEqual(["acc-2", "acc-1"])
+    })
+
+    await act(async () => {
+      mockGetPinnedList.mockResolvedValueOnce([])
+      mockGetOrderedList.mockResolvedValueOnce(["acc-2", "acc-1"])
+      resolveOrderedWrite?.(true)
+      await reorderPromise
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().orderedAccountIds).toEqual(["acc-2", "acc-1"])
+    })
+  })
 })
 
 describe("AccountDataContext initial load orchestration", () => {

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -33,6 +33,7 @@ function createMockIndexedAccountSearchEntries(
 }
 
 const {
+  mockLogger,
   mockGetAllAccounts,
   mockGetAllBookmarks,
   mockGetOrderedList,
@@ -63,6 +64,12 @@ const {
   mockSearchAccountSearchIndex,
   mockUpdateSortConfig,
 } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
   mockGetAllAccounts: vi.fn(),
   mockGetAllBookmarks: vi.fn(),
   mockGetOrderedList: vi.fn(),
@@ -187,6 +194,10 @@ vi.mock("~/services/tags/tagStorage", () => ({
 
 vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: () => mockUserPreferencesContext.current,
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => mockLogger,
 }))
 
 vi.mock("~/utils/browser/browserApi", () => ({
@@ -496,6 +507,90 @@ describe("AccountDataContext handleReorder", () => {
     await waitFor(() => {
       expect(getLatestCtx().orderedAccountIds).toEqual(["acc-2", "acc-1"])
     })
+  })
+
+  it("preserves hidden account ids when persisting a filtered reorder", async () => {
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    mockGetAllAccounts.mockResolvedValue([
+      { id: "a1" },
+      { id: "a2" },
+      { id: "a3" },
+      { id: "a4" },
+    ])
+    mockGetAllBookmarks.mockResolvedValue([])
+    mockGetOrderedList.mockResolvedValue(["a1", "a2", "a3", "a4"])
+    mockGetPinnedList.mockResolvedValue(["a1", "a2", "a3"])
+    mockGetAccountStats.mockResolvedValue(createEmptyStats())
+    mockSetPinnedListSubset.mockResolvedValue(true)
+    mockSetOrderedListSubset.mockResolvedValue(true)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().pinnedAccountIds).toEqual(["a1", "a2", "a3"])
+      expect(getLatestCtx().orderedAccountIds).toEqual(["a1", "a2", "a3", "a4"])
+    })
+
+    mockGetPinnedList.mockResolvedValueOnce(["a3", "a2", "a1"])
+    mockGetOrderedList.mockResolvedValueOnce(["a3", "a2", "a1", "a4"])
+
+    await act(async () => {
+      await getLatestCtx().handleReorder(["a3", "a1", "a4"])
+    })
+
+    expect(mockSetPinnedListSubset).toHaveBeenCalledWith({
+      entryType: "account",
+      ids: ["a3", "a2", "a1"],
+    })
+    expect(mockSetOrderedListSubset).toHaveBeenCalledWith({
+      entryType: "account",
+      ids: ["a3", "a2", "a1", "a4"],
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().pinnedAccountIds).toEqual(["a3", "a2", "a1"])
+      expect(getLatestCtx().orderedAccountIds).toEqual(["a3", "a2", "a1", "a4"])
+    })
+  })
+
+  it("rolls back failed account reorder writes and logs the account path", async () => {
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    mockGetAllAccounts.mockResolvedValue([{ id: "acc-1" }, { id: "acc-2" }])
+    mockGetAllBookmarks.mockResolvedValue([])
+    mockGetOrderedList.mockResolvedValue(["acc-1", "acc-2"])
+    mockGetPinnedList.mockResolvedValue([])
+    mockGetAccountStats.mockResolvedValue(createEmptyStats())
+    mockSetOrderedListSubset.mockResolvedValue(false)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().orderedAccountIds).toEqual(["acc-1", "acc-2"])
+    })
+
+    mockLogger.error.mockClear()
+
+    await act(async () => {
+      await getLatestCtx().handleReorder(["acc-2", "acc-1"])
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().orderedAccountIds).toEqual(["acc-1", "acc-2"])
+    })
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Failed to persist account reorder",
+      expect.objectContaining({
+        ids: ["acc-2", "acc-1"],
+        error: expect.any(Error),
+      }),
+    )
+
+    const [, details] = mockLogger.error.mock.calls.at(-1)!
+    expect(details.error).toBeInstanceOf(Error)
+    expect(details.error.message).toBe("Failed to persist account order")
   })
 })
 
@@ -909,6 +1004,90 @@ describe("AccountDataContext actions", () => {
       expect(getLatestCtx().pinnedAccountIds).toEqual(["b2", "b1"])
       expect(getLatestCtx().orderedAccountIds).toEqual(["b2", "b1", "b3"])
     })
+  })
+
+  it("preserves hidden bookmark ids when persisting a filtered reorder", async () => {
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    mockGetAllAccounts.mockResolvedValue([])
+    mockGetAllBookmarks.mockResolvedValue([
+      { id: "b1" },
+      { id: "b2" },
+      { id: "b3" },
+      { id: "b4" },
+    ])
+    mockGetOrderedList.mockResolvedValue(["b1", "b2", "b3", "b4"])
+    mockGetPinnedList.mockResolvedValue(["b1", "b2", "b3"])
+    mockGetAccountStats.mockResolvedValue(createEmptyStats())
+    mockSetPinnedListSubset.mockResolvedValue(true)
+    mockSetOrderedListSubset.mockResolvedValue(true)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().pinnedAccountIds).toEqual(["b1", "b2", "b3"])
+      expect(getLatestCtx().orderedAccountIds).toEqual(["b1", "b2", "b3", "b4"])
+    })
+
+    mockGetPinnedList.mockResolvedValueOnce(["b3", "b2", "b1"])
+    mockGetOrderedList.mockResolvedValueOnce(["b3", "b2", "b1", "b4"])
+
+    await act(async () => {
+      await getLatestCtx().handleBookmarkReorder(["b3", "b1", "b4"])
+    })
+
+    expect(mockSetPinnedListSubset).toHaveBeenCalledWith({
+      entryType: "bookmark",
+      ids: ["b3", "b2", "b1"],
+    })
+    expect(mockSetOrderedListSubset).toHaveBeenCalledWith({
+      entryType: "bookmark",
+      ids: ["b3", "b2", "b1", "b4"],
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().pinnedAccountIds).toEqual(["b3", "b2", "b1"])
+      expect(getLatestCtx().orderedAccountIds).toEqual(["b3", "b2", "b1", "b4"])
+    })
+  })
+
+  it("rolls back failed bookmark reorder writes and logs the bookmark path", async () => {
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    mockGetAllAccounts.mockResolvedValue([])
+    mockGetAllBookmarks.mockResolvedValue([{ id: "b1" }, { id: "b2" }])
+    mockGetOrderedList.mockResolvedValue(["b1", "b2"])
+    mockGetPinnedList.mockResolvedValue([])
+    mockGetAccountStats.mockResolvedValue(createEmptyStats())
+    mockSetOrderedListSubset.mockResolvedValue(false)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().orderedAccountIds).toEqual(["b1", "b2"])
+    })
+
+    mockLogger.error.mockClear()
+
+    await act(async () => {
+      await getLatestCtx().handleBookmarkReorder(["b2", "b1"])
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().orderedAccountIds).toEqual(["b1", "b2"])
+    })
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Failed to persist bookmark reorder",
+      expect.objectContaining({
+        ids: ["b2", "b1"],
+        error: expect.any(Error),
+      }),
+    )
+
+    const [, details] = mockLogger.error.mock.calls.at(-1)!
+    expect(details.error).toBeInstanceOf(Error)
+    expect(details.error.message).toBe("Failed to persist bookmark order")
   })
 
   it("toggles pin state through the provider and keeps local pinned ids in sync", async () => {

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -592,6 +592,112 @@ describe("AccountDataContext handleReorder", () => {
     expect(details.error).toBeInstanceOf(Error)
     expect(details.error.message).toBe("Failed to persist account order")
   })
+
+  it("rolls back account reorder when pinned persistence fails before ordered writes", async () => {
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    mockGetAllAccounts.mockResolvedValue([
+      { id: "p-1" },
+      { id: "p-2" },
+      { id: "u-1" },
+    ])
+    mockGetAllBookmarks.mockResolvedValue([])
+    mockGetOrderedList.mockResolvedValue(["p-1", "p-2", "u-1"])
+    mockGetPinnedList.mockResolvedValue(["p-1", "p-2"])
+    mockGetAccountStats.mockResolvedValue(createEmptyStats())
+    mockSetPinnedListSubset.mockResolvedValueOnce(false)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().pinnedAccountIds).toEqual(["p-1", "p-2"])
+      expect(getLatestCtx().orderedAccountIds).toEqual(["p-1", "p-2", "u-1"])
+    })
+
+    mockLogger.error.mockClear()
+
+    await act(async () => {
+      await getLatestCtx().handleReorder(["p-2", "p-1", "u-1"])
+    })
+
+    expect(mockSetPinnedListSubset).toHaveBeenCalledWith({
+      entryType: "account",
+      ids: ["p-2", "p-1"],
+    })
+    expect(mockSetOrderedListSubset).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(getLatestCtx().pinnedAccountIds).toEqual(["p-1", "p-2"])
+      expect(getLatestCtx().orderedAccountIds).toEqual(["p-1", "p-2", "u-1"])
+    })
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Failed to persist account reorder",
+      expect.objectContaining({
+        ids: ["p-2", "p-1", "u-1"],
+        error: expect.any(Error),
+      }),
+    )
+
+    const [, details] = mockLogger.error.mock.calls.at(-1)!
+    expect(details.error).toBeInstanceOf(Error)
+    expect(details.error.message).toBe("Failed to persist pinned account order")
+  })
+
+  it("rolls back account reorder when ordered persistence fails after pinned writes", async () => {
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    mockGetAllAccounts.mockResolvedValue([
+      { id: "p-1" },
+      { id: "p-2" },
+      { id: "u-1" },
+    ])
+    mockGetAllBookmarks.mockResolvedValue([])
+    mockGetOrderedList.mockResolvedValue(["p-1", "p-2", "u-1"])
+    mockGetPinnedList.mockResolvedValue(["p-1", "p-2"])
+    mockGetAccountStats.mockResolvedValue(createEmptyStats())
+    mockSetPinnedListSubset.mockResolvedValueOnce(true)
+    mockSetOrderedListSubset.mockResolvedValueOnce(false)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().pinnedAccountIds).toEqual(["p-1", "p-2"])
+      expect(getLatestCtx().orderedAccountIds).toEqual(["p-1", "p-2", "u-1"])
+    })
+
+    mockLogger.error.mockClear()
+
+    await act(async () => {
+      await getLatestCtx().handleReorder(["p-2", "p-1", "u-1"])
+    })
+
+    expect(mockSetPinnedListSubset).toHaveBeenCalledWith({
+      entryType: "account",
+      ids: ["p-2", "p-1"],
+    })
+    expect(mockSetOrderedListSubset).toHaveBeenCalledWith({
+      entryType: "account",
+      ids: ["p-2", "p-1", "u-1"],
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().pinnedAccountIds).toEqual(["p-1", "p-2"])
+      expect(getLatestCtx().orderedAccountIds).toEqual(["p-1", "p-2", "u-1"])
+    })
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Failed to persist account reorder",
+      expect.objectContaining({
+        ids: ["p-2", "p-1", "u-1"],
+        error: expect.any(Error),
+      }),
+    )
+
+    const [, details] = mockLogger.error.mock.calls.at(-1)!
+    expect(details.error).toBeInstanceOf(Error)
+    expect(details.error.message).toBe("Failed to persist account order")
+  })
 })
 
 describe("AccountDataContext initial load orchestration", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drag-and-drop reordering now respects active filters and only reorders visible items.

* **New Features**
  * Optimistic UI for account and bookmark reordering: UI updates instantly and persists changes, with automatic rollback and error logging on failure.
  * Reordering now preserves pinned vs. ordered subsets and excludes unavailable IDs from persisted order.

* **Tests**
  * Added tests for filtered reorders, optimistic updates, persistence success, rollback behavior, and error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->