### PR TITLE
feat(api-credential-profiles): add telemetry config to profile dialog

### DIFF
--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -22,6 +22,11 @@ import {
 import { Modal } from "~/components/ui/Dialog/Modal"
 import { TagPicker } from "~/features/AccountManagement/components/TagPicker"
 import {
+  coerceApiCredentialTelemetryJsonPathMap,
+  isSupportedApiCredentialTelemetryEndpoint,
+  type ApiCredentialTelemetryJsonPathField,
+} from "~/services/apiCredentialProfiles/telemetryConfig"
+import {
   API_TYPES,
   type ApiVerificationApiType,
 } from "~/services/verification/aiApiVerification"
@@ -79,21 +84,6 @@ function normalizeBaseUrl(
     : normalizeOpenAiFamilyBaseUrl(baseUrl)
 }
 
-type TelemetryJsonPathField = keyof ApiCredentialTelemetryJsonPathMap
-
-const TELEMETRY_JSON_PATH_FIELDS: TelemetryJsonPathField[] = [
-  "balanceUsd",
-  "todayCostUsd",
-  "todayRequests",
-  "todayPromptTokens",
-  "todayCompletionTokens",
-  "todayTotalTokens",
-  "totalUsedUsd",
-  "totalGrantedUsd",
-  "totalAvailableUsd",
-  "expiresAt",
-]
-
 /**
  * Falls back to the default telemetry preset when the profile has no mode yet.
  */
@@ -101,74 +91,6 @@ function normalizeTelemetryMode(
   mode: ApiCredentialTelemetryConfig["mode"] | undefined,
 ): ApiCredentialTelemetryCapabilityMode {
   return mode ?? DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode
-}
-
-/**
- * Accepts the simple dot-path format supported by custom telemetry mapping.
- */
-function isSupportedJsonPath(path: string): boolean {
-  const segments = path.split(".").map((segment) => segment.trim())
-  return segments.length > 0 && segments.every(Boolean)
-}
-
-/**
- * Normalizes whitespace inside dot-separated JSON paths before persistence.
- */
-function normalizeJsonPath(path: string): string {
-  return path
-    .split(".")
-    .map((segment) => segment.trim())
-    .join(".")
-}
-
-/**
- * Accepts only root-relative paths or same-origin HTTP(S) telemetry URLs.
- */
-function isSupportedTelemetryEndpoint(
-  endpoint: string,
-  baseUrl: string,
-): boolean {
-  const trimmed = endpoint.trim()
-  if (!trimmed) return false
-
-  try {
-    const profileBaseUrl = new URL(baseUrl)
-
-    if (trimmed.startsWith("/")) {
-      const resolvedPathUrl = new URL(trimmed, profileBaseUrl.origin)
-      return (
-        resolvedPathUrl.origin === profileBaseUrl.origin &&
-        (resolvedPathUrl.protocol === "http:" ||
-          resolvedPathUrl.protocol === "https:")
-      )
-    }
-
-    const endpointUrl = new URL(trimmed)
-    return (
-      endpointUrl.origin === profileBaseUrl.origin &&
-      (endpointUrl.protocol === "http:" || endpointUrl.protocol === "https:")
-    )
-  } catch {
-    return false
-  }
-}
-
-/**
- * Trims and drops empty custom telemetry JSON path mappings before save.
- */
-function normalizeJsonPaths(
-  paths: ApiCredentialTelemetryJsonPathMap,
-): ApiCredentialTelemetryJsonPathMap {
-  const next: ApiCredentialTelemetryJsonPathMap = {}
-
-  for (const field of TELEMETRY_JSON_PATH_FIELDS) {
-    const value = paths[field]
-    if (typeof value === "string" && value.trim()) {
-      next[field] = normalizeJsonPath(value)
-    }
-  }
-
-  return next
 }
 
 /**
@@ -356,21 +278,25 @@ export function ApiCredentialProfileDialog({
         )
       } else if (
         normalizedBaseUrl &&
-        !isSupportedTelemetryEndpoint(trimmedEndpoint, normalizedBaseUrl)
+        !isSupportedApiCredentialTelemetryEndpoint(
+          normalizedBaseUrl,
+          trimmedEndpoint,
+        )
       ) {
         nextErrors.telemetryEndpoint = t(
           "apiCredentialProfiles:dialog.errors.telemetryEndpointInvalid",
         )
       }
 
-      const jsonPaths = normalizeJsonPaths(customJsonPaths)
-      if (Object.keys(jsonPaths).length === 0) {
+      const jsonPaths = coerceApiCredentialTelemetryJsonPathMap(customJsonPaths)
+      const rawJsonPathCount = Object.values(customJsonPaths).filter(
+        (value) => typeof value === "string" && value.trim(),
+      ).length
+      if (rawJsonPathCount === 0) {
         nextErrors.telemetryJsonPaths = t(
           "apiCredentialProfiles:dialog.errors.telemetryJsonPathRequired",
         )
-      } else if (
-        Object.values(jsonPaths).some((path) => !isSupportedJsonPath(path))
-      ) {
+      } else if (Object.keys(jsonPaths).length !== rawJsonPathCount) {
         nextErrors.telemetryJsonPaths = t(
           "apiCredentialProfiles:dialog.errors.telemetryJsonPathInvalid",
         )
@@ -390,13 +316,13 @@ export function ApiCredentialProfileDialog({
       mode: "customReadOnlyEndpoint",
       customEndpoint: {
         endpoint: customEndpoint.trim(),
-        jsonPaths: normalizeJsonPaths(customJsonPaths),
+        jsonPaths: coerceApiCredentialTelemetryJsonPathMap(customJsonPaths),
       },
     }
   }
 
   const handleJsonPathChange =
-    (field: TelemetryJsonPathField) =>
+    (field: ApiCredentialTelemetryJsonPathField) =>
     (event: ChangeEvent<HTMLInputElement>) => {
       setCustomJsonPaths((prev) => ({
         ...prev,

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -6,6 +6,7 @@ import {
   PencilIcon,
   PlusIcon,
 } from "@heroicons/react/24/outline"
+import type { ChangeEvent } from "react"
 import { useEffect, useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -30,7 +31,13 @@ import {
   normalizeOpenAiFamilyBaseUrl,
 } from "~/services/verification/webAiApiCheck/extractCredentials"
 import type { Tag } from "~/types"
-import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import type {
+  ApiCredentialProfile,
+  ApiCredentialTelemetryCapabilityMode,
+  ApiCredentialTelemetryConfig,
+  ApiCredentialTelemetryJsonPathMap,
+} from "~/types/apiCredentialProfiles"
+import { DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG } from "~/types/apiCredentialProfiles"
 import { createLogger } from "~/utils/core/logger"
 
 /**
@@ -46,6 +53,7 @@ type SaveProfileInput = {
   apiKey: string
   tagIds: string[]
   notes: string
+  telemetryConfig?: ApiCredentialTelemetryConfig
 }
 
 interface ApiCredentialProfileDialogProps {
@@ -69,6 +77,56 @@ function normalizeBaseUrl(
   return apiType === API_TYPES.GOOGLE
     ? normalizeGoogleFamilyBaseUrl(baseUrl)
     : normalizeOpenAiFamilyBaseUrl(baseUrl)
+}
+
+type TelemetryJsonPathField = keyof ApiCredentialTelemetryJsonPathMap
+
+const TELEMETRY_JSON_PATH_FIELDS: TelemetryJsonPathField[] = [
+  "balanceUsd",
+  "todayCostUsd",
+  "todayRequests",
+  "todayPromptTokens",
+  "todayCompletionTokens",
+  "todayTotalTokens",
+  "totalUsedUsd",
+  "totalGrantedUsd",
+  "totalAvailableUsd",
+  "expiresAt",
+]
+
+/**
+ * Falls back to the default telemetry preset when the profile has no mode yet.
+ */
+function normalizeTelemetryMode(
+  mode: ApiCredentialTelemetryConfig["mode"] | undefined,
+): ApiCredentialTelemetryCapabilityMode {
+  return mode ?? DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode
+}
+
+/**
+ * Accepts the simple dot-path format supported by custom telemetry mapping.
+ */
+function isSupportedJsonPath(path: string): boolean {
+  const segments = path.split(".").map((segment) => segment.trim())
+  return segments.length > 0 && segments.every(Boolean)
+}
+
+/**
+ * Trims and drops empty custom telemetry JSON path mappings before save.
+ */
+function normalizeJsonPaths(
+  paths: ApiCredentialTelemetryJsonPathMap,
+): ApiCredentialTelemetryJsonPathMap {
+  const next: ApiCredentialTelemetryJsonPathMap = {}
+
+  for (const field of TELEMETRY_JSON_PATH_FIELDS) {
+    const value = paths[field]
+    if (typeof value === "string" && value.trim()) {
+      next[field] = value.trim()
+    }
+  }
+
+  return next
 }
 
 /**
@@ -101,6 +159,13 @@ export function ApiCredentialProfileDialog({
   const [apiKey, setApiKey] = useState("")
   const [tagIds, setTagIds] = useState<string[]>([])
   const [notes, setNotes] = useState("")
+  const [telemetryMode, setTelemetryMode] =
+    useState<ApiCredentialTelemetryCapabilityMode>(
+      DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode,
+    )
+  const [customEndpoint, setCustomEndpoint] = useState("")
+  const [customJsonPaths, setCustomJsonPaths] =
+    useState<ApiCredentialTelemetryJsonPathMap>({})
 
   const [showKey, setShowKey] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
@@ -109,12 +174,17 @@ export function ApiCredentialProfileDialog({
     name?: string
     baseUrl?: string
     apiKey?: string
+    telemetryEndpoint?: string
+    telemetryJsonPaths?: string
   }>({})
 
   const nameInputId = "api-credential-profile-name"
   const baseUrlInputId = "api-credential-profile-baseUrl"
   const apiKeyInputId = "api-credential-profile-apiKey"
   const notesInputId = "api-credential-profile-notes"
+  const telemetryModeInputId = "api-credential-profile-telemetry-mode"
+  const customEndpointInputId =
+    "api-credential-profile-telemetry-custom-endpoint"
 
   useEffect(() => {
     if (!isOpen) return
@@ -129,6 +199,11 @@ export function ApiCredentialProfileDialog({
       setApiKey(profile.apiKey ?? "")
       setTagIds(profile.tagIds ?? [])
       setNotes(profile.notes ?? "")
+      setTelemetryMode(normalizeTelemetryMode(profile.telemetryConfig?.mode))
+      setCustomEndpoint(profile.telemetryConfig?.customEndpoint?.endpoint ?? "")
+      setCustomJsonPaths(
+        profile.telemetryConfig?.customEndpoint?.jsonPaths ?? {},
+      )
       return
     }
 
@@ -138,12 +213,77 @@ export function ApiCredentialProfileDialog({
     setApiKey("")
     setTagIds([])
     setNotes("")
+    setTelemetryMode(DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode)
+    setCustomEndpoint("")
+    setCustomJsonPaths({})
   }, [isOpen, profile])
 
   const normalizedBaseUrlPreview = useMemo(() => {
     const normalized = normalizeBaseUrl(apiType, baseUrl)
     return normalized ?? ""
   }, [apiType, baseUrl])
+
+  const telemetryJsonPathFields = useMemo(
+    () => [
+      {
+        field: "balanceUsd" as const,
+        label: t("apiCredentialProfiles:dialog.telemetryJsonPaths.balanceUsd"),
+      },
+      {
+        field: "todayCostUsd" as const,
+        label: t(
+          "apiCredentialProfiles:dialog.telemetryJsonPaths.todayCostUsd",
+        ),
+      },
+      {
+        field: "todayRequests" as const,
+        label: t(
+          "apiCredentialProfiles:dialog.telemetryJsonPaths.todayRequests",
+        ),
+      },
+      {
+        field: "todayPromptTokens" as const,
+        label: t(
+          "apiCredentialProfiles:dialog.telemetryJsonPaths.todayPromptTokens",
+        ),
+      },
+      {
+        field: "todayCompletionTokens" as const,
+        label: t(
+          "apiCredentialProfiles:dialog.telemetryJsonPaths.todayCompletionTokens",
+        ),
+      },
+      {
+        field: "todayTotalTokens" as const,
+        label: t(
+          "apiCredentialProfiles:dialog.telemetryJsonPaths.todayTotalTokens",
+        ),
+      },
+      {
+        field: "totalUsedUsd" as const,
+        label: t(
+          "apiCredentialProfiles:dialog.telemetryJsonPaths.totalUsedUsd",
+        ),
+      },
+      {
+        field: "totalGrantedUsd" as const,
+        label: t(
+          "apiCredentialProfiles:dialog.telemetryJsonPaths.totalGrantedUsd",
+        ),
+      },
+      {
+        field: "totalAvailableUsd" as const,
+        label: t(
+          "apiCredentialProfiles:dialog.telemetryJsonPaths.totalAvailableUsd",
+        ),
+      },
+      {
+        field: "expiresAt" as const,
+        label: t("apiCredentialProfiles:dialog.telemetryJsonPaths.expiresAt"),
+      },
+    ],
+    [t],
+  )
 
   const validate = () => {
     const nextErrors: typeof errors = {}
@@ -165,9 +305,53 @@ export function ApiCredentialProfileDialog({
       )
     }
 
+    if (telemetryMode === "customReadOnlyEndpoint") {
+      if (!customEndpoint.trim()) {
+        nextErrors.telemetryEndpoint = t(
+          "apiCredentialProfiles:dialog.errors.telemetryEndpointRequired",
+        )
+      }
+
+      const jsonPaths = normalizeJsonPaths(customJsonPaths)
+      if (Object.keys(jsonPaths).length === 0) {
+        nextErrors.telemetryJsonPaths = t(
+          "apiCredentialProfiles:dialog.errors.telemetryJsonPathRequired",
+        )
+      } else if (
+        Object.values(jsonPaths).some((path) => !isSupportedJsonPath(path))
+      ) {
+        nextErrors.telemetryJsonPaths = t(
+          "apiCredentialProfiles:dialog.errors.telemetryJsonPathInvalid",
+        )
+      }
+    }
+
     setErrors(nextErrors)
     return Object.keys(nextErrors).length === 0 ? normalizedBaseUrl : null
   }
+
+  const buildTelemetryConfig = (): ApiCredentialTelemetryConfig => {
+    if (telemetryMode !== "customReadOnlyEndpoint") {
+      return { mode: telemetryMode }
+    }
+
+    return {
+      mode: "customReadOnlyEndpoint",
+      customEndpoint: {
+        endpoint: customEndpoint.trim(),
+        jsonPaths: normalizeJsonPaths(customJsonPaths),
+      },
+    }
+  }
+
+  const handleJsonPathChange =
+    (field: TelemetryJsonPathField) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setCustomJsonPaths((prev) => ({
+        ...prev,
+        [field]: event.target.value,
+      }))
+    }
 
   const handleClose = () => {
     if (isSaving) return
@@ -188,6 +372,7 @@ export function ApiCredentialProfileDialog({
         apiKey: apiKey.trim(),
         tagIds,
         notes: notes.trim(),
+        telemetryConfig: buildTelemetryConfig(),
       })
 
       toast.success(
@@ -368,6 +553,131 @@ export function ApiCredentialProfileDialog({
             disabled={isSaving}
           />
         </FormField>
+
+        <FormField
+          label={t("apiCredentialProfiles:dialog.fields.telemetryPreset")}
+          description={t("apiCredentialProfiles:dialog.hints.telemetryPreset")}
+          htmlFor={telemetryModeInputId}
+        >
+          <SearchableSelect
+            id={telemetryModeInputId}
+            aria-label={t(
+              "apiCredentialProfiles:dialog.fields.telemetryPreset",
+            )}
+            options={[
+              {
+                value: "auto",
+                label: t("apiCredentialProfiles:dialog.telemetryModes.auto"),
+              },
+              {
+                value: "disabled",
+                label: t(
+                  "apiCredentialProfiles:dialog.telemetryModes.disabled",
+                ),
+              },
+              {
+                value: "newApiTokenUsage",
+                label: t(
+                  "apiCredentialProfiles:dialog.telemetryModes.newApiTokenUsage",
+                ),
+              },
+              {
+                value: "sub2apiUsage",
+                label: t(
+                  "apiCredentialProfiles:dialog.telemetryModes.sub2apiUsage",
+                ),
+              },
+              {
+                value: "openaiBilling",
+                label: t(
+                  "apiCredentialProfiles:dialog.telemetryModes.openaiBilling",
+                ),
+              },
+              {
+                value: "customReadOnlyEndpoint",
+                label: t(
+                  "apiCredentialProfiles:dialog.telemetryModes.customReadOnlyEndpoint",
+                ),
+              },
+            ]}
+            value={telemetryMode}
+            onChange={(value) =>
+              setTelemetryMode(value as ApiCredentialTelemetryCapabilityMode)
+            }
+            placeholder={t(
+              "apiCredentialProfiles:dialog.placeholders.telemetryPreset",
+            )}
+            disabled={isSaving}
+          />
+        </FormField>
+
+        {telemetryMode === "customReadOnlyEndpoint" && (
+          <details
+            open
+            className="dark:border-dark-bg-tertiary rounded-lg border border-gray-200 p-3"
+          >
+            <summary className="dark:text-dark-text-primary cursor-pointer text-sm font-medium text-gray-700">
+              {t("apiCredentialProfiles:dialog.customTelemetry.title")}
+            </summary>
+            <div className="mt-3 space-y-4">
+              <FormField
+                label={t(
+                  "apiCredentialProfiles:dialog.fields.telemetryEndpoint",
+                )}
+                required
+                error={errors.telemetryEndpoint}
+                description={t(
+                  "apiCredentialProfiles:dialog.hints.telemetryEndpoint",
+                )}
+                htmlFor={customEndpointInputId}
+              >
+                <Input
+                  id={customEndpointInputId}
+                  value={customEndpoint}
+                  onChange={(e) => setCustomEndpoint(e.target.value)}
+                  placeholder={t(
+                    "apiCredentialProfiles:dialog.placeholders.telemetryEndpoint",
+                  )}
+                  disabled={isSaving}
+                />
+              </FormField>
+
+              <div className="space-y-2">
+                <div>
+                  <div className="dark:text-dark-text-primary text-sm font-medium text-gray-700">
+                    {t("apiCredentialProfiles:dialog.customTelemetry.paths")}
+                  </div>
+                  <p className="dark:text-dark-text-secondary text-xs text-gray-500">
+                    {t("apiCredentialProfiles:dialog.hints.telemetryJsonPaths")}
+                  </p>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {telemetryJsonPathFields.map(({ field, label }) => {
+                    const inputId = `api-credential-profile-telemetry-path-${field}`
+                    return (
+                      <FormField key={field} label={label} htmlFor={inputId}>
+                        <Input
+                          id={inputId}
+                          value={customJsonPaths[field] ?? ""}
+                          onChange={handleJsonPathChange(field)}
+                          placeholder={t(
+                            "apiCredentialProfiles:dialog.placeholders.telemetryJsonPath",
+                          )}
+                          disabled={isSaving}
+                        />
+                      </FormField>
+                    )
+                  })}
+                </div>
+                {errors.telemetryJsonPaths && (
+                  <p className="text-xs text-red-600 dark:text-red-400">
+                    {errors.telemetryJsonPaths}
+                  </p>
+                )}
+              </div>
+            </div>
+          </details>
+        )}
 
         <div className="dark:text-dark-text-tertiary text-xs text-gray-500">
           {t("apiCredentialProfiles:dialog.meta.apiTypeHint", {

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -112,6 +112,48 @@ function isSupportedJsonPath(path: string): boolean {
 }
 
 /**
+ * Normalizes whitespace inside dot-separated JSON paths before persistence.
+ */
+function normalizeJsonPath(path: string): string {
+  return path
+    .split(".")
+    .map((segment) => segment.trim())
+    .join(".")
+}
+
+/**
+ * Accepts only root-relative paths or same-origin HTTP(S) telemetry URLs.
+ */
+function isSupportedTelemetryEndpoint(
+  endpoint: string,
+  baseUrl: string,
+): boolean {
+  const trimmed = endpoint.trim()
+  if (!trimmed) return false
+
+  try {
+    const profileBaseUrl = new URL(baseUrl)
+
+    if (trimmed.startsWith("/")) {
+      const resolvedPathUrl = new URL(trimmed, profileBaseUrl.origin)
+      return (
+        resolvedPathUrl.origin === profileBaseUrl.origin &&
+        (resolvedPathUrl.protocol === "http:" ||
+          resolvedPathUrl.protocol === "https:")
+      )
+    }
+
+    const endpointUrl = new URL(trimmed)
+    return (
+      endpointUrl.origin === profileBaseUrl.origin &&
+      (endpointUrl.protocol === "http:" || endpointUrl.protocol === "https:")
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
  * Trims and drops empty custom telemetry JSON path mappings before save.
  */
 function normalizeJsonPaths(
@@ -122,7 +164,7 @@ function normalizeJsonPaths(
   for (const field of TELEMETRY_JSON_PATH_FIELDS) {
     const value = paths[field]
     if (typeof value === "string" && value.trim()) {
-      next[field] = value.trim()
+      next[field] = normalizeJsonPath(value)
     }
   }
 
@@ -306,9 +348,18 @@ export function ApiCredentialProfileDialog({
     }
 
     if (telemetryMode === "customReadOnlyEndpoint") {
-      if (!customEndpoint.trim()) {
+      const trimmedEndpoint = customEndpoint.trim()
+
+      if (!trimmedEndpoint) {
         nextErrors.telemetryEndpoint = t(
           "apiCredentialProfiles:dialog.errors.telemetryEndpointRequired",
+        )
+      } else if (
+        normalizedBaseUrl &&
+        !isSupportedTelemetryEndpoint(trimmedEndpoint, normalizedBaseUrl)
+      ) {
+        nextErrors.telemetryEndpoint = t(
+          "apiCredentialProfiles:dialog.errors.telemetryEndpointInvalid",
         )
       }
 

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles.ts
@@ -5,7 +5,10 @@ import {
   subscribeToApiCredentialProfilesChanges,
 } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import type { ApiVerificationApiType } from "~/services/verification/aiApiVerification"
-import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import type {
+  ApiCredentialProfile,
+  ApiCredentialTelemetryConfig,
+} from "~/types/apiCredentialProfiles"
 import { createLogger } from "~/utils/core/logger"
 
 /**
@@ -20,6 +23,7 @@ type CreateProfileInput = {
   apiKey: string
   tagIds?: string[]
   notes?: string
+  telemetryConfig?: ApiCredentialTelemetryConfig
 }
 
 type UpdateProfileInput = Partial<CreateProfileInput>

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
@@ -16,7 +16,10 @@ import {
   useVerificationResultHistorySummaries,
 } from "~/services/verification/verificationResultHistory"
 import type { Tag } from "~/types"
-import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import type {
+  ApiCredentialProfile,
+  ApiCredentialTelemetryConfig,
+} from "~/types/apiCredentialProfiles"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 import { showResultToast } from "~/utils/core/toastHelpers"
@@ -34,6 +37,7 @@ type SaveApiCredentialProfileInput = {
   apiKey: string
   tagIds: string[]
   notes: string
+  telemetryConfig?: ApiCredentialTelemetryConfig
 }
 
 type RuntimeBroadcastMessage = {
@@ -169,6 +173,7 @@ export function useApiCredentialProfilesController() {
           apiKey: input.apiKey,
           tagIds: input.tagIds,
           notes: input.notes,
+          telemetryConfig: input.telemetryConfig,
         })
         return
       }
@@ -180,6 +185,7 @@ export function useApiCredentialProfilesController() {
         apiKey: input.apiKey,
         tagIds: input.tagIds,
         notes: input.notes,
+        telemetryConfig: input.telemetryConfig,
       })
     },
     [createProfile, updateProfile],

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -29,6 +29,7 @@
       "baseUrlInvalid": "Base URL is invalid.",
       "keyRequired": "API key is required.",
       "nameRequired": "Name is required.",
+      "telemetryEndpointInvalid": "Custom telemetry endpoint must be a root-relative path or same-origin HTTP(S) URL.",
       "telemetryEndpointRequired": "Custom telemetry endpoint is required.",
       "telemetryJsonPathInvalid": "JSON paths must use dot-separated fields, for example data.balance.",
       "telemetryJsonPathRequired": "Configure at least one JSON path mapping."

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -20,22 +20,34 @@
   "description": "Store standalone API base URLs and keys for reuse and verification.",
   "dialog": {
     "addTitle": "Add API credential profile",
+    "customTelemetry": {
+      "paths": "JSON path mappings",
+      "title": "Custom read-only query configuration"
+    },
     "editTitle": "Edit API credential profile",
     "errors": {
       "baseUrlInvalid": "Base URL is invalid.",
       "keyRequired": "API key is required.",
-      "nameRequired": "Name is required."
+      "nameRequired": "Name is required.",
+      "telemetryEndpointRequired": "Custom telemetry endpoint is required.",
+      "telemetryJsonPathInvalid": "JSON paths must use dot-separated fields, for example data.balance.",
+      "telemetryJsonPathRequired": "Configure at least one JSON path mapping."
     },
     "fields": {
       "apiKey": "API key",
       "baseUrl": "Base URL",
       "name": "Name",
       "notes": "Notes",
-      "tags": "Tags"
+      "tags": "Tags",
+      "telemetryEndpoint": "Custom telemetry endpoint",
+      "telemetryPreset": "Balance/usage query method"
     },
     "hints": {
       "baseUrlNormalized": "Will be saved as: {{baseUrl}}",
-      "tags": "Optional. Shared with accounts and bookmarks."
+      "tags": "Optional. Shared with accounts and bookmarks.",
+      "telemetryEndpoint": "Only read-only GET paths under the profile base URL origin are allowed. Use a path such as /usage or a same-origin URL.",
+      "telemetryJsonPaths": "Enter dot-separated paths in the response JSON. At least one path is required. Empty metrics remain not provided.",
+      "telemetryPreset": "Auto probes the built-in presets in order. You can also pin this key to one query method."
     },
     "meta": {
       "apiTypeHint": "Verification uses: {{apiType}}"
@@ -45,7 +57,30 @@
       "baseUrl": "https://example.com/api",
       "name": "My profile",
       "notes": "Optional notes",
-      "tags": "Select tags"
+      "tags": "Select tags",
+      "telemetryEndpoint": "/api/usage",
+      "telemetryJsonPath": "data.balance",
+      "telemetryPreset": "Select query method"
+    },
+    "telemetryJsonPaths": {
+      "balanceUsd": "Balance USD",
+      "expiresAt": "Expiration time",
+      "todayCompletionTokens": "Completion tokens today",
+      "todayCostUsd": "Cost today USD",
+      "todayPromptTokens": "Prompt tokens today",
+      "todayRequests": "Requests today",
+      "todayTotalTokens": "Total tokens today",
+      "totalAvailableUsd": "Total available USD",
+      "totalGrantedUsd": "Total granted USD",
+      "totalUsedUsd": "Total used USD"
+    },
+    "telemetryModes": {
+      "auto": "Auto",
+      "customReadOnlyEndpoint": "Custom Read-only Endpoint",
+      "disabled": "Disabled",
+      "newApiTokenUsage": "NewAPI Token",
+      "openaiBilling": "OpenAI Billing",
+      "sub2apiUsage": "Sub2API"
     }
   },
   "empty": {

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -29,6 +29,7 @@
       "baseUrlInvalid": "Base URL が不正です。",
       "keyRequired": "API キーは必須です。",
       "nameRequired": "名前は必須です。",
+      "telemetryEndpointInvalid": "カスタム使用量取得エンドポイントはルート相対パス、または同一オリジンの HTTP(S) URL である必要があります。",
       "telemetryEndpointRequired": "カスタム使用量取得エンドポイントは必須です。",
       "telemetryJsonPathInvalid": "JSON path は data.balance のようなドット区切りフィールドで入力してください。",
       "telemetryJsonPathRequired": "少なくとも 1 つの JSON path マッピングを設定してください。"

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -20,22 +20,34 @@
   "description": "再利用や検証のために、独立した API の Base URL とキーを保存します。",
   "dialog": {
     "addTitle": "API 認証情報プロファイルを追加",
+    "customTelemetry": {
+      "paths": "JSON path マッピング",
+      "title": "カスタム読み取り専用取得設定"
+    },
     "editTitle": "API 認証情報プロファイルを編集",
     "errors": {
       "baseUrlInvalid": "Base URL が不正です。",
       "keyRequired": "API キーは必須です。",
-      "nameRequired": "名前は必須です。"
+      "nameRequired": "名前は必須です。",
+      "telemetryEndpointRequired": "カスタム使用量取得エンドポイントは必須です。",
+      "telemetryJsonPathInvalid": "JSON path は data.balance のようなドット区切りフィールドで入力してください。",
+      "telemetryJsonPathRequired": "少なくとも 1 つの JSON path マッピングを設定してください。"
     },
     "fields": {
       "apiKey": "API キー",
       "baseUrl": "Base URL",
       "name": "名前",
       "notes": "メモ",
-      "tags": "タグ"
+      "tags": "タグ",
+      "telemetryEndpoint": "カスタム使用量取得エンドポイント",
+      "telemetryPreset": "残高/使用量の取得方法"
     },
     "hints": {
       "baseUrlNormalized": "保存時の値: {{baseUrl}}",
-      "tags": "任意です。アカウントやブックマークと共有されます。"
+      "tags": "任意です。アカウントやブックマークと共有されます。",
+      "telemetryEndpoint": "プロファイルの Base URL と同一オリジンの読み取り専用 GET パスのみ許可されます。/usage のようなパス、または同一オリジン URL を使用してください。",
+      "telemetryJsonPaths": "レスポンス JSON 内のドット区切りパスを入力してください。少なくとも 1 つ必要です。空欄の指標は未提供のままになります。",
+      "telemetryPreset": "Auto は内蔵プリセットを順番に試します。このキーで使う取得方法を固定することもできます。"
     },
     "meta": {
       "apiTypeHint": "検証で使用する API 種別: {{apiType}}"
@@ -45,7 +57,30 @@
       "baseUrl": "https://example.com/api",
       "name": "マイプロファイル",
       "notes": "任意のメモ",
-      "tags": "タグを選択"
+      "tags": "タグを選択",
+      "telemetryEndpoint": "/api/usage",
+      "telemetryJsonPath": "data.balance",
+      "telemetryPreset": "取得方法を選択"
+    },
+    "telemetryJsonPaths": {
+      "balanceUsd": "残高 USD",
+      "expiresAt": "有効期限",
+      "todayCompletionTokens": "本日の Completion Tokens",
+      "todayCostUsd": "本日の費用 USD",
+      "todayPromptTokens": "本日の Prompt Tokens",
+      "todayRequests": "本日のリクエスト数",
+      "todayTotalTokens": "本日の合計 Tokens",
+      "totalAvailableUsd": "合計利用可能 USD",
+      "totalGrantedUsd": "合計付与 USD",
+      "totalUsedUsd": "合計使用済み USD"
+    },
+    "telemetryModes": {
+      "auto": "Auto",
+      "customReadOnlyEndpoint": "Custom Read-only Endpoint",
+      "disabled": "Disabled",
+      "newApiTokenUsage": "NewAPI Token",
+      "openaiBilling": "OpenAI Billing",
+      "sub2apiUsage": "Sub2API"
     }
   },
   "empty": {

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -20,22 +20,34 @@
   "description": "管理独立的 API Base URL 与密钥，便于复用与验证。",
   "dialog": {
     "addTitle": "添加 API 凭证",
+    "customTelemetry": {
+      "paths": "JSON path 映射",
+      "title": "自定义只读查询配置"
+    },
     "editTitle": "编辑 API 凭证",
     "errors": {
       "baseUrlInvalid": "Base URL 无效。",
       "keyRequired": "密钥不能为空。",
-      "nameRequired": "名称不能为空。"
+      "nameRequired": "名称不能为空。",
+      "telemetryEndpointRequired": "自定义查询地址不能为空。",
+      "telemetryJsonPathInvalid": "JSON path 需使用点分隔字段，例如 data.balance。",
+      "telemetryJsonPathRequired": "至少配置一个 JSON path 映射。"
     },
     "fields": {
       "apiKey": "密钥",
       "baseUrl": "Base URL",
       "name": "名称",
       "notes": "备注",
-      "tags": "标签"
+      "tags": "标签",
+      "telemetryEndpoint": "自定义查询地址",
+      "telemetryPreset": "余额/用量查询方式"
     },
     "hints": {
       "baseUrlNormalized": "保存后将规范化为：{{baseUrl}}",
-      "tags": "可选。与账号/书签共用全局标签。"
+      "tags": "可选。与账号/书签共用全局标签。",
+      "telemetryEndpoint": "仅允许 profile Base URL 同源下的只读 GET 地址，可使用 /usage 或完整同源 URL。",
+      "telemetryJsonPaths": "填写响应 JSON 中的点分隔字段路径，至少填写一个。未填写的指标会保持未提供。",
+      "telemetryPreset": "Auto 会按内置顺序探测；也可以为当前密钥固定一种查询方式。"
     },
     "meta": {
       "apiTypeHint": "验证将使用：{{apiType}}"
@@ -45,7 +57,30 @@
       "baseUrl": "https://example.com/api",
       "name": "例如：我的凭证",
       "notes": "可选备注",
-      "tags": "选择标签"
+      "tags": "选择标签",
+      "telemetryEndpoint": "/api/usage",
+      "telemetryJsonPath": "data.balance",
+      "telemetryPreset": "选择查询方式"
+    },
+    "telemetryJsonPaths": {
+      "balanceUsd": "余额 USD",
+      "expiresAt": "过期时间",
+      "todayCompletionTokens": "今日 Completion Tokens",
+      "todayCostUsd": "今日费用 USD",
+      "todayPromptTokens": "今日 Prompt Tokens",
+      "todayRequests": "今日请求数",
+      "todayTotalTokens": "今日总 Tokens",
+      "totalAvailableUsd": "总可用 USD",
+      "totalGrantedUsd": "总额度 USD",
+      "totalUsedUsd": "总已用 USD"
+    },
+    "telemetryModes": {
+      "auto": "Auto（自动探测）",
+      "customReadOnlyEndpoint": "Custom Read-only Endpoint",
+      "disabled": "Disabled（禁用）",
+      "newApiTokenUsage": "NewAPI Token",
+      "openaiBilling": "OpenAI Billing",
+      "sub2apiUsage": "Sub2API"
     }
   },
   "empty": {

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -29,6 +29,7 @@
       "baseUrlInvalid": "Base URL 无效。",
       "keyRequired": "密钥不能为空。",
       "nameRequired": "名称不能为空。",
+      "telemetryEndpointInvalid": "自定义查询地址必须是根相对路径或同源 HTTP(S) URL。",
       "telemetryEndpointRequired": "自定义查询地址不能为空。",
       "telemetryJsonPathInvalid": "JSON path 需使用点分隔字段，例如 data.balance。",
       "telemetryJsonPathRequired": "至少配置一个 JSON path 映射。"

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -29,6 +29,7 @@
       "baseUrlInvalid": "Base URL 無效。",
       "keyRequired": "金鑰不能為空。",
       "nameRequired": "名稱不能為空。",
+      "telemetryEndpointInvalid": "自訂查詢地址必須是根相對路徑或同源 HTTP(S) URL。",
       "telemetryEndpointRequired": "自訂查詢地址不能為空。",
       "telemetryJsonPathInvalid": "JSON path 需使用點分隔欄位，例如 data.balance。",
       "telemetryJsonPathRequired": "至少設定一個 JSON path 映射。"

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -20,22 +20,34 @@
   "description": "管理獨立的 API Base URL 與金鑰，便於複用與驗證。",
   "dialog": {
     "addTitle": "新增 API 憑證",
+    "customTelemetry": {
+      "paths": "JSON path 映射",
+      "title": "自訂唯讀查詢設定"
+    },
     "editTitle": "編輯 API 憑證",
     "errors": {
       "baseUrlInvalid": "Base URL 無效。",
       "keyRequired": "金鑰不能為空。",
-      "nameRequired": "名稱不能為空。"
+      "nameRequired": "名稱不能為空。",
+      "telemetryEndpointRequired": "自訂查詢地址不能為空。",
+      "telemetryJsonPathInvalid": "JSON path 需使用點分隔欄位，例如 data.balance。",
+      "telemetryJsonPathRequired": "至少設定一個 JSON path 映射。"
     },
     "fields": {
       "apiKey": "金鑰",
       "baseUrl": "Base URL",
       "name": "名稱",
       "notes": "備註",
-      "tags": "標籤"
+      "tags": "標籤",
+      "telemetryEndpoint": "自訂查詢地址",
+      "telemetryPreset": "餘額/用量查詢方式"
     },
     "hints": {
       "baseUrlNormalized": "儲存後將規範化為：{{baseUrl}}",
-      "tags": "可選。與帳號/書籤共用全域性標籤。"
+      "tags": "可選。與帳號/書籤共用全域性標籤。",
+      "telemetryEndpoint": "僅允許 profile Base URL 同源下的唯讀 GET 地址，可使用 /usage 或完整同源 URL。",
+      "telemetryJsonPaths": "填寫回應 JSON 中的點分隔欄位路徑，至少填寫一個。未填寫的指標會保持未提供。",
+      "telemetryPreset": "Auto 會按內建順序探測；也可以為當前金鑰固定一種查詢方式。"
     },
     "meta": {
       "apiTypeHint": "驗證將使用：{{apiType}}"
@@ -45,7 +57,30 @@
       "baseUrl": "https://example.com/api",
       "name": "例如：我的憑證",
       "notes": "可選備註",
-      "tags": "選擇標籤"
+      "tags": "選擇標籤",
+      "telemetryEndpoint": "/api/usage",
+      "telemetryJsonPath": "data.balance",
+      "telemetryPreset": "選擇查詢方式"
+    },
+    "telemetryJsonPaths": {
+      "balanceUsd": "餘額 USD",
+      "expiresAt": "過期時間",
+      "todayCompletionTokens": "今日 Completion Tokens",
+      "todayCostUsd": "今日費用 USD",
+      "todayPromptTokens": "今日 Prompt Tokens",
+      "todayRequests": "今日請求數",
+      "todayTotalTokens": "今日總 Tokens",
+      "totalAvailableUsd": "總可用 USD",
+      "totalGrantedUsd": "總額度 USD",
+      "totalUsedUsd": "總已用 USD"
+    },
+    "telemetryModes": {
+      "auto": "Auto（自動探測）",
+      "customReadOnlyEndpoint": "Custom Read-only Endpoint",
+      "disabled": "Disabled（停用）",
+      "newApiTokenUsage": "NewAPI Token",
+      "openaiBilling": "OpenAI Billing",
+      "sub2apiUsage": "Sub2API"
     }
   },
   "empty": {

--- a/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
+++ b/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
@@ -1,5 +1,6 @@
 import { Storage } from "@plasmohq/storage"
 
+import { coerceApiCredentialTelemetryCustomEndpoint } from "~/services/apiCredentialProfiles/telemetryConfig"
 import {
   API_CREDENTIAL_PROFILES_STORAGE_KEYS,
   STORAGE_LOCKS,
@@ -19,8 +20,6 @@ import type {
   ApiCredentialTelemetryAttempt,
   ApiCredentialTelemetryCapabilityMode,
   ApiCredentialTelemetryConfig,
-  ApiCredentialTelemetryCustomEndpoint,
-  ApiCredentialTelemetryJsonPathMap,
   ApiCredentialTelemetrySnapshot,
 } from "~/types/apiCredentialProfiles"
 import {
@@ -123,61 +122,11 @@ function coerceFiniteNumber(raw: unknown): number | undefined {
 }
 
 /**
- * Normalizes configured JSON paths for a custom telemetry endpoint.
- */
-function coerceJsonPathMap(raw: unknown): ApiCredentialTelemetryJsonPathMap {
-  const obj =
-    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
-  const out: ApiCredentialTelemetryJsonPathMap = {}
-  const keys: Array<keyof ApiCredentialTelemetryJsonPathMap> = [
-    "balanceUsd",
-    "todayCostUsd",
-    "todayRequests",
-    "todayPromptTokens",
-    "todayCompletionTokens",
-    "todayTotalTokens",
-    "totalUsedUsd",
-    "totalGrantedUsd",
-    "totalAvailableUsd",
-    "expiresAt",
-  ]
-
-  for (const key of keys) {
-    const value = obj[key]
-    if (typeof value === "string" && value.trim()) {
-      out[key] = value.trim()
-    }
-  }
-
-  return out
-}
-
-/**
- * Coerces custom endpoint telemetry config into a usable persisted shape.
- */
-function coerceCustomEndpoint(
-  raw: unknown,
-): ApiCredentialTelemetryCustomEndpoint | undefined {
-  const obj =
-    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
-  const endpoint =
-    typeof obj.endpoint === "string" && obj.endpoint.trim()
-      ? obj.endpoint.trim()
-      : ""
-  const jsonPaths = coerceJsonPathMap(obj.jsonPaths)
-
-  if (!endpoint || Object.keys(jsonPaths).length === 0) {
-    return undefined
-  }
-
-  return { endpoint, jsonPaths }
-}
-
-/**
  * Coerces profile telemetry config and falls back to automatic probing.
  */
 export function coerceApiCredentialTelemetryConfig(
   raw: unknown,
+  options?: { baseUrl?: string },
 ): ApiCredentialTelemetryConfig {
   const obj =
     raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
@@ -187,7 +136,10 @@ export function coerceApiCredentialTelemetryConfig(
   )
     ? (rawMode as ApiCredentialTelemetryCapabilityMode)
     : DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode
-  const customEndpoint = coerceCustomEndpoint(obj.customEndpoint)
+  const customEndpoint = coerceApiCredentialTelemetryCustomEndpoint(
+    obj.customEndpoint,
+    options?.baseUrl,
+  )
 
   return {
     mode,
@@ -381,9 +333,14 @@ function mergeTelemetrySnapshot(
 function mergeTelemetryConfig(
   newer: ApiCredentialTelemetryConfig | undefined,
   older: ApiCredentialTelemetryConfig | undefined,
+  baseUrl?: string,
 ): ApiCredentialTelemetryConfig {
-  const normalizedNewer = coerceApiCredentialTelemetryConfig(newer)
-  const normalizedOlder = coerceApiCredentialTelemetryConfig(older)
+  const normalizedNewer = coerceApiCredentialTelemetryConfig(newer, {
+    baseUrl,
+  })
+  const normalizedOlder = coerceApiCredentialTelemetryConfig(older, {
+    baseUrl,
+  })
   if (normalizedNewer.mode !== DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode) {
     return normalizedNewer
   }
@@ -462,6 +419,7 @@ function dedupeProfiles(profiles: ApiCredentialProfile[]): {
       telemetryConfig: mergeTelemetryConfig(
         newer.telemetryConfig,
         older.telemetryConfig,
+        newer.baseUrl,
       ),
       telemetrySnapshot: mergeTelemetrySnapshot(
         newer.telemetrySnapshot,
@@ -535,6 +493,7 @@ export function coerceApiCredentialProfilesConfig(
       notes: notes.trim(),
       telemetryConfig: coerceApiCredentialTelemetryConfig(
         candidate.telemetryConfig,
+        { baseUrl },
       ),
       telemetrySnapshot: coerceTelemetrySnapshot(candidate.telemetrySnapshot),
       createdAt,
@@ -712,6 +671,7 @@ class ApiCredentialProfilesStorageService {
       notes: typeof input.notes === "string" ? input.notes.trim() : "",
       telemetryConfig: coerceApiCredentialTelemetryConfig(
         input.telemetryConfig,
+        { baseUrl: normalizedBaseUrl },
       ),
       createdAt: now,
       updatedAt: now,
@@ -804,7 +764,9 @@ class ApiCredentialProfilesStorageService {
             : current.notes,
         telemetryConfig:
           updates.telemetryConfig !== undefined
-            ? coerceApiCredentialTelemetryConfig(updates.telemetryConfig)
+            ? coerceApiCredentialTelemetryConfig(updates.telemetryConfig, {
+                baseUrl: nextBaseUrl,
+              })
             : current.telemetryConfig,
         telemetrySnapshot:
           nextApiType !== current.apiType ||

--- a/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
+++ b/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
@@ -748,6 +748,11 @@ class ApiCredentialProfilesStorageService {
         throw new Error("Base URL is invalid.")
       }
 
+      const shouldReCoerceTelemetryConfig =
+        updates.telemetryConfig !== undefined ||
+        nextApiType !== current.apiType ||
+        nextBaseUrl !== current.baseUrl
+
       const next: ApiCredentialProfile = {
         ...current,
         name: nextName,
@@ -762,12 +767,16 @@ class ApiCredentialProfilesStorageService {
           typeof updates.notes === "string"
             ? updates.notes.trim()
             : current.notes,
-        telemetryConfig:
-          updates.telemetryConfig !== undefined
-            ? coerceApiCredentialTelemetryConfig(updates.telemetryConfig, {
+        telemetryConfig: shouldReCoerceTelemetryConfig
+          ? coerceApiCredentialTelemetryConfig(
+              updates.telemetryConfig !== undefined
+                ? updates.telemetryConfig
+                : current.telemetryConfig,
+              {
                 baseUrl: nextBaseUrl,
-              })
-            : current.telemetryConfig,
+              },
+            )
+          : current.telemetryConfig,
         telemetrySnapshot:
           nextApiType !== current.apiType ||
           nextBaseUrl !== current.baseUrl ||

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -690,10 +690,24 @@ export async function refreshApiCredentialProfileTelemetry(
 
   const modelSucceeded = Boolean(models && models.count > 0)
   const usageSucceeded = Boolean(usageResult)
+  const customEndpointError = attempts.find((attempt) => {
+    if (
+      attempt.status !== "error" ||
+      attempt.source !== "customReadOnlyEndpoint"
+    ) {
+      return false
+    }
+
+    return (
+      attempt.message === "Custom endpoint is not configured" ||
+      attempt.endpoint === config.customEndpoint?.endpoint
+    )
+  })?.message
   const lastError =
     usageSucceeded || modelSucceeded
       ? undefined
-      : attempts.find((attempt) => attempt.status === "error")?.message ||
+      : customEndpointError ||
+        attempts.find((attempt) => attempt.status === "error")?.message ||
         "No supported telemetry endpoint returned data"
 
   const snapshot: ApiCredentialTelemetrySnapshot = {

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -4,6 +4,7 @@ import {
   coerceApiCredentialTelemetryConfig,
 } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { fetchApiCredentialModelIds } from "~/services/apiCredentialProfiles/modelCatalog"
+import { resolveApiCredentialTelemetryEndpoint } from "~/services/apiCredentialProfiles/telemetryConfig"
 import { ApiError } from "~/services/apiService/common/errors"
 import { fetchApi } from "~/services/apiService/common/utils"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
@@ -452,25 +453,6 @@ async function querySub2ApiUsage(
 }
 
 /**
- * Resolves a custom endpoint while keeping it on the profile origin.
- */
-function resolveCustomEndpoint(
-  profile: ApiCredentialProfile,
-  endpoint: string,
-): string {
-  const trimmed = endpoint.trim()
-  if (!trimmed) throw new Error("Custom endpoint is empty")
-
-  const base = new URL(profile.baseUrl)
-  const resolved = new URL(trimmed, base.origin)
-  if (resolved.origin !== base.origin) {
-    throw new Error("Custom endpoint must stay on the profile base URL origin")
-  }
-
-  return `${resolved.pathname}${resolved.search}`
-}
-
-/**
  * Maps a custom telemetry JSON response through configured JSON paths.
  */
 function mapCustomJson(
@@ -541,8 +523,8 @@ async function queryCustomReadOnlyEndpoint(
     throw new Error("Custom endpoint is not configured")
   }
 
-  const endpoint = resolveCustomEndpoint(
-    profile,
+  const endpoint = resolveApiCredentialTelemetryEndpoint(
+    profile.baseUrl,
     config.customEndpoint.endpoint,
   )
   const result = await fetchJson({
@@ -657,7 +639,9 @@ export async function refreshApiCredentialProfileTelemetry(
     throw new Error("Profile not found.")
   }
 
-  const config = coerceApiCredentialTelemetryConfig(profile.telemetryConfig)
+  const config = coerceApiCredentialTelemetryConfig(profile.telemetryConfig, {
+    baseUrl: profile.baseUrl,
+  })
   const modes = resolveModes(config)
   const attempts: ApiCredentialTelemetryAttempt[] = []
   const now = Date.now()

--- a/src/services/apiCredentialProfiles/telemetryConfig.ts
+++ b/src/services/apiCredentialProfiles/telemetryConfig.ts
@@ -1,0 +1,129 @@
+import type {
+  ApiCredentialTelemetryCustomEndpoint,
+  ApiCredentialTelemetryJsonPathMap,
+} from "~/types/apiCredentialProfiles"
+
+export type ApiCredentialTelemetryJsonPathField =
+  keyof ApiCredentialTelemetryJsonPathMap
+
+const API_CREDENTIAL_TELEMETRY_JSON_PATH_FIELDS: ApiCredentialTelemetryJsonPathField[] =
+  [
+    "balanceUsd",
+    "todayCostUsd",
+    "todayRequests",
+    "todayPromptTokens",
+    "todayCompletionTokens",
+    "todayTotalTokens",
+    "totalUsedUsd",
+    "totalGrantedUsd",
+    "totalAvailableUsd",
+    "expiresAt",
+  ]
+
+/**
+ * Accepts the simple dot-path format supported by custom telemetry mapping.
+ */
+function isSupportedApiCredentialTelemetryJsonPath(path: string): boolean {
+  const segments = path.split(".").map((segment) => segment.trim())
+  return segments.length > 0 && segments.every(Boolean)
+}
+
+/**
+ * Normalizes whitespace inside dot-separated JSON paths before persistence.
+ */
+function normalizeApiCredentialTelemetryJsonPath(path: string): string {
+  return path
+    .split(".")
+    .map((segment) => segment.trim())
+    .join(".")
+}
+
+/**
+ * Trims and drops empty custom telemetry JSON path mappings before save.
+ */
+export function coerceApiCredentialTelemetryJsonPathMap(
+  raw: unknown,
+): ApiCredentialTelemetryJsonPathMap {
+  const obj =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
+  const out: ApiCredentialTelemetryJsonPathMap = {}
+
+  for (const key of API_CREDENTIAL_TELEMETRY_JSON_PATH_FIELDS) {
+    const value = obj[key]
+    if (typeof value !== "string" || !value.trim()) continue
+
+    const normalized = normalizeApiCredentialTelemetryJsonPath(value)
+    if (isSupportedApiCredentialTelemetryJsonPath(normalized)) {
+      out[key] = normalized
+    }
+  }
+
+  return out
+}
+
+/**
+ * Resolves a custom endpoint while keeping it on the profile origin.
+ */
+export function resolveApiCredentialTelemetryEndpoint(
+  baseUrl: string,
+  endpoint: string,
+): string {
+  const trimmed = endpoint.trim()
+  if (!trimmed) throw new Error("Custom endpoint is empty")
+
+  const profileBaseUrl = new URL(baseUrl)
+  const resolved = trimmed.startsWith("/")
+    ? new URL(trimmed, profileBaseUrl.origin)
+    : new URL(trimmed)
+
+  if (resolved.origin !== profileBaseUrl.origin) {
+    throw new Error("Custom endpoint must stay on the profile base URL origin")
+  }
+
+  if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+    throw new Error("Custom endpoint must use HTTP(S)")
+  }
+
+  return `${resolved.pathname}${resolved.search}`
+}
+
+/**
+ * Accepts only root-relative paths or same-origin HTTP(S) telemetry URLs.
+ */
+export function isSupportedApiCredentialTelemetryEndpoint(
+  baseUrl: string,
+  endpoint: string,
+): boolean {
+  try {
+    resolveApiCredentialTelemetryEndpoint(baseUrl, endpoint)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Coerces custom endpoint telemetry config into a usable persisted shape.
+ */
+export function coerceApiCredentialTelemetryCustomEndpoint(
+  raw: unknown,
+  baseUrl?: string,
+): ApiCredentialTelemetryCustomEndpoint | undefined {
+  const obj =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}
+  const endpoint =
+    typeof obj.endpoint === "string" && obj.endpoint.trim()
+      ? obj.endpoint.trim()
+      : ""
+  const jsonPaths = coerceApiCredentialTelemetryJsonPathMap(obj.jsonPaths)
+
+  if (
+    !endpoint ||
+    Object.keys(jsonPaths).length === 0 ||
+    (baseUrl && !isSupportedApiCredentialTelemetryEndpoint(baseUrl, endpoint))
+  ) {
+    return undefined
+  }
+
+  return { endpoint, jsonPaths }
+}

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
@@ -1,0 +1,302 @@
+import type { ComponentProps, ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ApiCredentialProfileDialog } from "~/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock("@headlessui/react", () => ({
+  DialogTitle: ({
+    children,
+    className,
+  }: {
+    children: ReactNode
+    className?: string
+  }) => <div className={className}>{children}</div>,
+}))
+
+vi.mock("~/features/AccountManagement/components/TagPicker", () => ({
+  TagPicker: () => <div data-testid="tag-picker" />,
+}))
+
+vi.mock("~/components/ui/Dialog/Modal", () => ({
+  Modal: ({
+    children,
+    footer,
+    header,
+    isOpen,
+  }: {
+    children: ReactNode
+    footer?: ReactNode
+    header?: ReactNode
+    isOpen: boolean
+  }) =>
+    isOpen ? (
+      <div>
+        <div>{header}</div>
+        <div>{children}</div>
+        <div>{footer}</div>
+      </div>
+    ) : null,
+}))
+
+vi.mock("~/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/components/ui")>()
+
+  return {
+    ...actual,
+    SearchableSelect: ({
+      "aria-label": ariaLabel,
+      id,
+      onChange,
+      options,
+      value,
+      disabled,
+    }: {
+      "aria-label"?: string
+      id?: string
+      onChange: (value: string) => void
+      options: Array<{ value: string; label: string }>
+      value: string
+      disabled?: boolean
+    }) => (
+      <select
+        aria-label={ariaLabel}
+        id={id}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    ),
+  }
+})
+
+vi.mock("~/services/verification/aiApiVerification/i18n", () => ({
+  getApiVerificationApiTypeLabel: (_t: unknown, apiType: string) => apiType,
+}))
+
+function buildProfile(
+  overrides: Partial<ApiCredentialProfile> = {},
+): ApiCredentialProfile {
+  return {
+    id: "profile-1",
+    name: "Profile",
+    apiType: "openai-compatible",
+    baseUrl: "https://api.example.com",
+    apiKey: "sk-profile",
+    tagIds: [],
+    notes: "Saved notes",
+    telemetryConfig: { mode: "auto" },
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+function renderDialog(
+  props: Partial<ComponentProps<typeof ApiCredentialProfileDialog>> = {},
+) {
+  const onSave = props.onSave ?? vi.fn().mockResolvedValue(undefined)
+
+  render(
+    <ApiCredentialProfileDialog
+      isOpen
+      onClose={vi.fn()}
+      tags={[]}
+      createTag={vi.fn()}
+      renameTag={vi.fn()}
+      deleteTag={vi.fn()}
+      onSave={onSave}
+      {...props}
+    />,
+    {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    },
+  )
+
+  return { onSave }
+}
+
+describe("ApiCredentialProfileDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("saves new profiles with auto telemetry by default", async () => {
+    const { onSave } = renderDialog()
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.name",
+      ),
+      {
+        target: { value: "Auto profile" },
+      },
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.baseUrl",
+      ),
+      {
+        target: { value: "https://auto.example.com/v1/models" },
+      },
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.apiKey",
+      ),
+      {
+        target: { value: "sk-auto" },
+      },
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "common:actions.save" }))
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        id: undefined,
+        name: "Auto profile",
+        apiType: "openai-compatible",
+        baseUrl: "https://auto.example.com",
+        apiKey: "sk-auto",
+        tagIds: [],
+        notes: "",
+        telemetryConfig: {
+          mode: "auto",
+        },
+      })
+    })
+  })
+
+  it("validates and saves custom telemetry endpoint mappings", async () => {
+    const { onSave } = renderDialog()
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.name",
+      ),
+      {
+        target: { value: "Custom profile" },
+      },
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.baseUrl",
+      ),
+      {
+        target: { value: "https://custom.example.com" },
+      },
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.apiKey",
+      ),
+      {
+        target: { value: "sk-custom" },
+      },
+    )
+    fireEvent.change(
+      screen.getByLabelText(
+        "apiCredentialProfiles:dialog.fields.telemetryPreset",
+      ),
+      {
+        target: { value: "customReadOnlyEndpoint" },
+      },
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "common:actions.save" }))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(
+      screen.getByText(
+        "apiCredentialProfiles:dialog.errors.telemetryEndpointRequired",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "apiCredentialProfiles:dialog.errors.telemetryJsonPathRequired",
+      ),
+    ).toBeInTheDocument()
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.telemetryEndpoint",
+      ),
+      {
+        target: { value: "/usage/read-only" },
+      },
+    )
+    fireEvent.change(
+      screen.getAllByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.telemetryJsonPath",
+      )[0]!,
+      {
+        target: { value: "data.balance" },
+      },
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "common:actions.save" }))
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          telemetryConfig: {
+            mode: "customReadOnlyEndpoint",
+            customEndpoint: {
+              endpoint: "/usage/read-only",
+              jsonPaths: {
+                balanceUsd: "data.balance",
+              },
+            },
+          },
+        }),
+      )
+    })
+  })
+
+  it("replays stored telemetry config when editing an existing profile", () => {
+    renderDialog({
+      profile: buildProfile({
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+          customEndpoint: {
+            endpoint: "/usage/totals",
+            jsonPaths: {
+              balanceUsd: "data.balance",
+              totalUsedUsd: "data.total.used",
+            },
+          },
+        },
+      }),
+    })
+
+    expect(screen.getByDisplayValue("Profile")).toHaveValue("Profile")
+    expect(
+      screen.getByLabelText(
+        "apiCredentialProfiles:dialog.fields.telemetryPreset",
+      ),
+    ).toHaveValue("customReadOnlyEndpoint")
+    expect(screen.getByDisplayValue("/usage/totals")).toHaveValue(
+      "/usage/totals",
+    )
+    expect(screen.getByDisplayValue("data.balance")).toHaveValue("data.balance")
+    expect(screen.getByDisplayValue("data.total.used")).toHaveValue(
+      "data.total.used",
+    )
+  })
+})

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
@@ -238,7 +238,7 @@ describe("ApiCredentialProfileDialog", () => {
         "apiCredentialProfiles:dialog.placeholders.telemetryEndpoint",
       ),
       {
-        target: { value: "/usage/read-only" },
+        target: { value: "https://evil.example.com/usage/read-only" },
       },
     )
     fireEvent.change(
@@ -246,7 +246,38 @@ describe("ApiCredentialProfileDialog", () => {
         "apiCredentialProfiles:dialog.placeholders.telemetryJsonPath",
       )[0]!,
       {
-        target: { value: "data.balance" },
+        target: { value: "data..balance" },
+      },
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "common:actions.save" }))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(
+      screen.getByText(
+        "apiCredentialProfiles:dialog.errors.telemetryEndpointInvalid",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "apiCredentialProfiles:dialog.errors.telemetryJsonPathInvalid",
+      ),
+    ).toBeInTheDocument()
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.telemetryEndpoint",
+      ),
+      {
+        target: { value: "https://custom.example.com/usage/read-only" },
+      },
+    )
+    fireEvent.change(
+      screen.getAllByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.telemetryJsonPath",
+      )[0]!,
+      {
+        target: { value: "data. balance" },
       },
     )
 
@@ -258,7 +289,7 @@ describe("ApiCredentialProfileDialog", () => {
           telemetryConfig: {
             mode: "customReadOnlyEndpoint",
             customEndpoint: {
-              endpoint: "/usage/read-only",
+              endpoint: "https://custom.example.com/usage/read-only",
               jsonPaths: {
                 balanceUsd: "data.balance",
               },

--- a/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
+++ b/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
@@ -107,6 +107,7 @@ function buildProfile(): ApiCredentialProfile {
     apiKey: "sk-profile",
     tagIds: [],
     notes: "",
+    telemetryConfig: { mode: "auto" },
     createdAt: 1,
     updatedAt: 1,
   }

--- a/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
+++ b/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
@@ -1,20 +1,24 @@
 import type { ReactNode } from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useApiCredentialProfilesController } from "~/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import { act, renderHook } from "~~/tests/test-utils/render"
 
 const {
+  createProfileMock,
   deleteProfileMock,
   refreshTelemetryMock,
   tagStorageListTagsMock,
   toastPromiseMock,
+  updateProfileMock,
 } = vi.hoisted(() => ({
+  createProfileMock: vi.fn(),
   deleteProfileMock: vi.fn(),
   refreshTelemetryMock: vi.fn(),
   tagStorageListTagsMock: vi.fn(),
   toastPromiseMock: vi.fn(),
+  updateProfileMock: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -85,11 +89,11 @@ vi.mock(
   "~/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles",
   () => ({
     useApiCredentialProfiles: () => ({
-      createProfile: vi.fn(),
+      createProfile: createProfileMock,
       deleteProfile: deleteProfileMock,
       isLoading: false,
       profiles: [],
-      updateProfile: vi.fn(),
+      updateProfile: updateProfileMock,
     }),
   }),
 )
@@ -109,6 +113,81 @@ function buildProfile(): ApiCredentialProfile {
 }
 
 describe("useApiCredentialProfilesController", () => {
+  beforeEach(() => {
+    createProfileMock.mockReset()
+    deleteProfileMock.mockReset()
+    refreshTelemetryMock.mockReset()
+    tagStorageListTagsMock.mockReset()
+    toastPromiseMock.mockReset()
+    updateProfileMock.mockReset()
+  })
+
+  it("passes telemetry config through create and update flows", async () => {
+    tagStorageListTagsMock.mockResolvedValue([])
+    createProfileMock.mockResolvedValue(buildProfile())
+    updateProfileMock.mockResolvedValue(buildProfile())
+
+    const { result } = renderHook(() => useApiCredentialProfilesController(), {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    await act(async () => {
+      await result.current.handleSave({
+        name: "Custom",
+        apiType: "openai-compatible",
+        baseUrl: "https://custom.example.com",
+        apiKey: "sk-custom",
+        tagIds: [],
+        notes: "",
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+          customEndpoint: {
+            endpoint: "/usage",
+            jsonPaths: {
+              balanceUsd: "data.balance",
+            },
+          },
+        },
+      })
+    })
+
+    expect(createProfileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+          customEndpoint: {
+            endpoint: "/usage",
+            jsonPaths: {
+              balanceUsd: "data.balance",
+            },
+          },
+        },
+      }),
+    )
+
+    await act(async () => {
+      await result.current.handleSave({
+        id: "profile-1",
+        name: "Disabled",
+        apiType: "openai-compatible",
+        baseUrl: "https://disabled.example.com",
+        apiKey: "sk-disabled",
+        tagIds: [],
+        notes: "",
+        telemetryConfig: { mode: "disabled" },
+      })
+    })
+
+    expect(updateProfileMock).toHaveBeenCalledWith(
+      "profile-1",
+      expect.objectContaining({
+        telemetryConfig: { mode: "disabled" },
+      }),
+    )
+  })
+
   it("allows concurrent refreshes for different profiles and localizes errors", async () => {
     tagStorageListTagsMock.mockResolvedValue([])
     let resolveFirstRefresh: (() => void) | undefined

--- a/tests/services/apiCredentialProfilesStorage.more.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.more.test.ts
@@ -6,6 +6,7 @@ import {
   mergeApiCredentialProfilesConfigs,
   subscribeToApiCredentialProfilesChanges,
 } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
+import { isSupportedApiCredentialTelemetryEndpoint } from "~/services/apiCredentialProfiles/telemetryConfig"
 import { API_CREDENTIAL_PROFILES_STORAGE_KEYS } from "~/services/core/storageKeys"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { SiteHealthStatus } from "~/types"
@@ -422,6 +423,15 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     )
   })
 
+  it("rejects custom telemetry endpoints when the profile origin is not HTTP(S)", () => {
+    expect(
+      isSupportedApiCredentialTelemetryEndpoint(
+        "ftp://example.com/root",
+        "/usage/read-only",
+      ),
+    ).toBe(false)
+  })
+
   it("merges telemetry snapshots by newest successful query without changing identity winner", () => {
     const merged = mergeApiCredentialProfilesConfigs({
       now: 67890,
@@ -693,6 +703,44 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     const profiles = await apiCredentialProfilesStorage.listProfiles()
 
     expect(profiles.map((profile) => profile.id)).toEqual(["newer", "older"])
+  })
+
+  it("re-coerces stored telemetry config when the profile base URL changes", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Custom telemetry profile",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://old.example.com/v1/models",
+      apiKey: "sk-old",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "https://old.example.com/usage/read-only",
+          jsonPaths: {
+            balanceUsd: "data.balance",
+          },
+        },
+      },
+    })
+
+    const updated = await apiCredentialProfilesStorage.updateProfile(
+      profile.id,
+      {
+        baseUrl: "https://new.example.com/v1/models",
+      },
+    )
+
+    expect(updated.telemetryConfig).toEqual({
+      mode: "customReadOnlyEndpoint",
+    })
+    await expect(
+      apiCredentialProfilesStorage.getProfileById(profile.id),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+        },
+      }),
+    )
   })
 
   it("validates update operations and removes tag ids from matching profiles only", async () => {

--- a/tests/services/apiCredentialProfilesStorage.more.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.more.test.ts
@@ -313,6 +313,81 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     )
   })
 
+  it("normalizes valid custom telemetry endpoint details with shared helpers", () => {
+    const coerced = coerceApiCredentialProfilesConfig(
+      {
+        profiles: [
+          {
+            id: "profile-custom-normalized",
+            name: "Normalized Custom",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com/v1/models",
+            apiKey: "sk-custom",
+            telemetryConfig: {
+              mode: "customReadOnlyEndpoint",
+              customEndpoint: {
+                endpoint: " https://example.com/usage?cursor=1 ",
+                jsonPaths: {
+                  balanceUsd: " data. balance ",
+                },
+              },
+            },
+          },
+        ],
+      },
+      { now: 12345 },
+    )
+
+    expect(coerced.profiles[0]).toEqual(
+      expect.objectContaining({
+        baseUrl: "https://example.com",
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+          customEndpoint: {
+            endpoint: "https://example.com/usage?cursor=1",
+            jsonPaths: {
+              balanceUsd: "data.balance",
+            },
+          },
+        },
+      }),
+    )
+  })
+
+  it("drops cross-origin custom telemetry endpoint details while keeping the selected mode", () => {
+    const coerced = coerceApiCredentialProfilesConfig(
+      {
+        profiles: [
+          {
+            id: "profile-custom-cross-origin",
+            name: "Cross Origin Custom",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com",
+            apiKey: "sk-custom",
+            telemetryConfig: {
+              mode: "customReadOnlyEndpoint",
+              customEndpoint: {
+                endpoint: "https://evil.example.com/usage",
+                jsonPaths: {
+                  balanceUsd: "data.balance",
+                },
+              },
+            },
+          },
+        ],
+      },
+      { now: 12345 },
+    )
+
+    expect(coerced.profiles[0]).toEqual(
+      expect.objectContaining({
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+        },
+      }),
+    )
+  })
+
   it("drops incomplete custom telemetry endpoint details while keeping the selected mode", () => {
     const coerced = coerceApiCredentialProfilesConfig(
       {

--- a/tests/services/apiCredentialProfilesStorage.more.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.more.test.ts
@@ -313,6 +313,40 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     )
   })
 
+  it("drops incomplete custom telemetry endpoint details while keeping the selected mode", () => {
+    const coerced = coerceApiCredentialProfilesConfig(
+      {
+        profiles: [
+          {
+            id: "profile-custom-incomplete",
+            name: "Incomplete Custom",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com",
+            apiKey: "sk-custom",
+            telemetryConfig: {
+              mode: "customReadOnlyEndpoint",
+              customEndpoint: {
+                endpoint: "   ",
+                jsonPaths: {
+                  balanceUsd: "   ",
+                },
+              },
+            },
+          },
+        ],
+      },
+      { now: 12345 },
+    )
+
+    expect(coerced.profiles[0]).toEqual(
+      expect.objectContaining({
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+        },
+      }),
+    )
+  })
+
   it("merges telemetry snapshots by newest successful query without changing identity winner", () => {
     const merged = mergeApiCredentialProfilesConfigs({
       now: 67890,

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -448,7 +448,7 @@ describe("api credential profile telemetry", () => {
     expect(customAttempt?.endpoint).toContain("REDACTED")
   })
 
-  it("falls back to a configuration error when malformed custom endpoints are dropped during coercion", async () => {
+  it("prefers the custom configuration error when malformed custom endpoints are dropped during coercion", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
       name: "Malformed Custom Endpoint",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
@@ -473,9 +473,10 @@ describe("api credential profile telemetry", () => {
     const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
 
     expect(snapshot.health).toEqual({
-      reason: "models failed",
+      reason: "Custom endpoint is not configured",
       status: SiteHealthStatus.Warning,
     })
+    expect(snapshot.lastError).toBe("Custom endpoint is not configured")
     expect(snapshot.attempts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -448,7 +448,7 @@ describe("api credential profile telemetry", () => {
     expect(customAttempt?.endpoint).toContain("REDACTED")
   })
 
-  it("persists an error attempt when the custom endpoint string is malformed", async () => {
+  it("falls back to a configuration error when malformed custom endpoints are dropped during coercion", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
       name: "Malformed Custom Endpoint",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
@@ -479,8 +479,8 @@ describe("api credential profile telemetry", () => {
     expect(snapshot.attempts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          endpoint: "http://%",
-          message: expect.stringContaining("Invalid URL"),
+          endpoint: "/custom",
+          message: "Custom endpoint is not configured",
           source: "customReadOnlyEndpoint",
           status: "error",
         }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add telemetry configuration to API credential profiles with selectable presets and a custom read-only endpoint mode (collapsible UI, endpoint + JSON-path inputs); telemetry settings persist on save/edit.
* **Bug Fixes**
  * Stronger validation, normalization and error feedback for telemetry endpoint and JSON-path inputs (required, format, same-origin, trimming/coercion).
* **Documentation**
  * Added localized UI copy and validation messages for telemetry fields in multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->