### PR TITLE
refactor(webdav): use user preferences context for settings and autosync

### DIFF
--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -61,6 +61,40 @@ type RuntimeMutationResponse = {
   data?: unknown
 }
 
+const INVALID_RUNTIME_MUTATION_RESPONSE: RuntimeMutationResponse = {
+  success: false,
+  error: "Invalid response from background",
+}
+
+/**
+ * Type guard to validate if an unknown value conforms to the RuntimeMutationResponse shape
+ */
+function isRuntimeMutationResponse(
+  value: unknown,
+): value is RuntimeMutationResponse {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return (
+    typeof candidate.success === "boolean" &&
+    (candidate.error === undefined || typeof candidate.error === "string") &&
+    (candidate.message === undefined || typeof candidate.message === "string")
+  )
+}
+
+/**
+ * Normalizes an unknown value into a RuntimeMutationResponse
+ */
+function normalizeRuntimeMutationResponse(
+  value: unknown,
+): RuntimeMutationResponse {
+  return isRuntimeMutationResponse(value)
+    ? value
+    : INVALID_RUNTIME_MUTATION_RESPONSE
+}
+
 // 1. 定义 Context 的值类型
 interface UserPreferencesContextType {
   preferences: UserPreferences
@@ -1072,10 +1106,12 @@ export const UserPreferencesProvider = ({
         "autoSync" | "syncInterval" | "syncStrategy"
       >,
     ) => {
-      const response = (await sendRuntimeMessage({
-        action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
-        settings: updates,
-      })) as RuntimeMutationResponse
+      const response = normalizeRuntimeMutationResponse(
+        await sendRuntimeMessage({
+          action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+          settings: updates,
+        }),
+      )
 
       if (response.success) {
         setPreferences((prev) => {

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -43,6 +43,7 @@ import type { LogLevel } from "~/types/logging"
 import type { ModelRedirectPreferences } from "~/types/managedSiteModelRedirect"
 import type { SortingPriorityConfig } from "~/types/sorting"
 import type { ThemeMode } from "~/types/theme"
+import type { WebDAVSettings } from "~/types/webdav"
 import { deepOverride } from "~/utils"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
@@ -52,6 +53,13 @@ const logger = createLogger("UserPreferencesContext")
 type UserManagedSiteModelSyncConfig = NonNullable<
   UserPreferences["managedSiteModelSync"]
 >
+
+type RuntimeMutationResponse = {
+  success: boolean
+  error?: string
+  message?: string
+  data?: unknown
+}
 
 // 1. 定义 Context 的值类型
 interface UserPreferencesContextType {
@@ -163,6 +171,13 @@ interface UserPreferencesContextType {
   updateWebAiApiCheck: (
     updates: Partial<WebAiApiCheckPreferences>,
   ) => Promise<boolean>
+  updateWebdavSettings: (updates: Partial<WebDAVSettings>) => Promise<boolean>
+  updateWebdavAutoSyncSettings: (
+    updates: Pick<
+      Partial<WebDAVSettings>,
+      "autoSync" | "syncInterval" | "syncStrategy"
+    >,
+  ) => Promise<RuntimeMutationResponse>
   updateTempWindowFallback: (
     updates: Partial<TempWindowFallbackPreferences>,
   ) => Promise<boolean>
@@ -1024,6 +1039,64 @@ export const UserPreferencesProvider = ({
     [],
   )
 
+  const updateWebdavSettings = useCallback(
+    async (updates: Partial<WebDAVSettings>) => {
+      const success = await userPreferences.savePreferences({
+        webdav: updates,
+      })
+
+      if (success) {
+        setPreferences((prev) => {
+          if (!prev) return null
+          const merged = deepOverride(
+            prev.webdav ?? DEFAULT_PREFERENCES.webdav,
+            updates,
+          )
+          return {
+            ...prev,
+            webdav: merged,
+            lastUpdated: Date.now(),
+          }
+        })
+      }
+
+      return success
+    },
+    [],
+  )
+
+  const updateWebdavAutoSyncSettings = useCallback(
+    async (
+      updates: Pick<
+        Partial<WebDAVSettings>,
+        "autoSync" | "syncInterval" | "syncStrategy"
+      >,
+    ) => {
+      const response = (await sendRuntimeMessage({
+        action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+        settings: updates,
+      })) as RuntimeMutationResponse
+
+      if (response.success) {
+        setPreferences((prev) => {
+          if (!prev) return null
+          const merged = deepOverride(
+            prev.webdav ?? DEFAULT_PREFERENCES.webdav,
+            updates,
+          )
+          return {
+            ...prev,
+            webdav: merged,
+            lastUpdated: Date.now(),
+          }
+        })
+      }
+
+      return response
+    },
+    [],
+  )
+
   const updateTempWindowFallback = useCallback(
     async (updates: Partial<TempWindowFallbackPreferences>) => {
       const success = await userPreferences.savePreferences({
@@ -1497,6 +1570,8 @@ export const UserPreferencesProvider = ({
     updateModelRedirect,
     updateRedemptionAssist,
     updateWebAiApiCheck,
+    updateWebdavSettings,
+    updateWebdavAutoSyncSettings,
     updateTempWindowFallback,
     updateTempWindowFallbackReminder,
     resetToDefaults,

--- a/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
@@ -26,7 +26,7 @@ import {
   Switch,
 } from "~/components/ui"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
-import { userPreferences } from "~/services/preferences/userPreferences"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { WEBDAV_SYNC_STRATEGIES, WebDAVSettings } from "~/types/webdav"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { formatTimestamp } from "~/utils/core/formatters"
@@ -42,13 +42,20 @@ const logger = createLogger("WebDAVAutoSyncSettings")
  */
 export default function WebDAVAutoSyncSettings() {
   const { t } = useTranslation("importExport")
+  const { preferences, updateWebdavAutoSyncSettings } =
+    useUserPreferencesContext()
+  const persistedWebdavSettings = preferences.webdav
 
   // Auto-sync settings
-  const [autoSyncEnabled, setAutoSyncEnabled] = useState(false)
-  const [syncInterval, setSyncInterval] = useState(3600)
+  const [autoSyncEnabled, setAutoSyncEnabled] = useState(
+    persistedWebdavSettings.autoSync ?? false,
+  )
+  const [syncInterval, setSyncInterval] = useState(
+    persistedWebdavSettings.syncInterval ?? 3600,
+  )
   const [syncStrategy, setSyncStrategy] = useState<
     WebDAVSettings["syncStrategy"]
-  >(WEBDAV_SYNC_STRATEGIES.MERGE)
+  >(persistedWebdavSettings.syncStrategy ?? WEBDAV_SYNC_STRATEGIES.MERGE)
 
   // Status
   const [isSyncing, setIsSyncing] = useState(false)
@@ -62,22 +69,9 @@ export default function WebDAVAutoSyncSettings() {
   const [syncing, setSyncing] = useState(false)
   const [savingSettings, setSavingSettings] = useState(false)
 
-  // Load initial settings
   useEffect(() => {
-    loadSettings()
-    loadStatus()
+    void loadStatus()
   }, [])
-
-  const loadSettings = async () => {
-    try {
-      const prefs = await userPreferences.getPreferences()
-      setAutoSyncEnabled(prefs.webdav.autoSync ?? false)
-      setSyncInterval(prefs.webdav.syncInterval ?? 3600)
-      setSyncStrategy(prefs.webdav.syncStrategy ?? WEBDAV_SYNC_STRATEGIES.MERGE)
-    } catch (error) {
-      logger.error("Failed to load auto-sync settings", error)
-    }
-  }
 
   const loadStatus = async () => {
     try {
@@ -98,13 +92,10 @@ export default function WebDAVAutoSyncSettings() {
   const handleSaveSettings = async () => {
     setSavingSettings(true)
     try {
-      const response = await sendRuntimeMessage({
-        action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
-        settings: {
-          autoSync: autoSyncEnabled,
-          syncInterval: syncInterval,
-          syncStrategy: syncStrategy,
-        },
+      const response = await updateWebdavAutoSyncSettings({
+        autoSync: autoSyncEnabled,
+        syncInterval,
+        syncStrategy,
       })
 
       if (response.success) {

--- a/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
@@ -4,7 +4,7 @@ import {
   ClockIcon,
   XCircleIcon,
 } from "@heroicons/react/24/outline"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -69,11 +69,7 @@ export default function WebDAVAutoSyncSettings() {
   const [syncing, setSyncing] = useState(false)
   const [savingSettings, setSavingSettings] = useState(false)
 
-  useEffect(() => {
-    void loadStatus()
-  }, [])
-
-  const loadStatus = async () => {
+  const loadStatus = useCallback(async () => {
     try {
       const response = await sendRuntimeMessage({
         action: RuntimeActionIds.WebdavAutoSyncGetStatus,
@@ -87,7 +83,23 @@ export default function WebDAVAutoSyncSettings() {
     } catch (error) {
       logger.error("Failed to load sync status", error)
     }
-  }
+  }, [])
+
+  useEffect(() => {
+    setAutoSyncEnabled(persistedWebdavSettings.autoSync ?? false)
+    setSyncInterval(persistedWebdavSettings.syncInterval ?? 3600)
+    setSyncStrategy(
+      persistedWebdavSettings.syncStrategy ?? WEBDAV_SYNC_STRATEGIES.MERGE,
+    )
+  }, [
+    persistedWebdavSettings.autoSync,
+    persistedWebdavSettings.syncInterval,
+    persistedWebdavSettings.syncStrategy,
+  ])
+
+  useEffect(() => {
+    void loadStatus()
+  }, [loadStatus])
 
   const handleSaveSettings = async () => {
     setSavingSettings(true)

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -76,6 +76,13 @@ const WEBDAV_SYNC_DATA_INPUT_IDS: Record<WebDAVSyncDataKey, string> = {
   preferences: "webdavSyncDataPreferences",
 }
 
+class PersistWebdavConfigError extends Error {
+  constructor() {
+    super("Failed to persist WebDAV settings")
+    this.name = "PersistWebdavConfigError"
+  }
+}
+
 /**
  * Resolve the localized label for a selectable WebDAV sync data section.
  */
@@ -185,7 +192,7 @@ export default function WebDAVSettings() {
   ) => {
     const success = await updateWebdavSettings(updates)
     if (!success) {
-      throw new Error(t("settings:messages.saveSettingsFailed"))
+      throw new PersistWebdavConfigError()
     }
   }
 
@@ -210,7 +217,11 @@ export default function WebDAVSettings() {
       toast.success(t("webdav.testSuccess"))
     } catch (e: any) {
       logger.error("WebDAV connection test failed", e)
-      toast.error(e?.message || t("webdav.testFailed"))
+      toast.error(
+        e instanceof PersistWebdavConfigError
+          ? t("webdav.testFailed")
+          : e?.message || t("webdav.testFailed"),
+      )
     } finally {
       setTesting(false)
     }
@@ -278,7 +289,11 @@ export default function WebDAVSettings() {
       toast.success(t("export.dataExported"))
     } catch (e: any) {
       logger.error("Failed to upload backup to WebDAV", e)
-      toast.error(e?.message || t("export.exportFailed"))
+      toast.error(
+        e instanceof PersistWebdavConfigError
+          ? t("export.exportFailed")
+          : e?.message || t("export.exportFailed"),
+      )
     } finally {
       setUploading(false)
     }
@@ -345,7 +360,11 @@ export default function WebDAVSettings() {
       }
     } catch (e: any) {
       logger.error("Failed to download/import WebDAV backup", e)
-      toast.error(e?.message || t("importExport:import.downloadImportFailed"))
+      toast.error(
+        e instanceof PersistWebdavConfigError
+          ? t("importExport:import.downloadImportFailed")
+          : e?.message || t("importExport:import.downloadImportFailed"),
+      )
     } finally {
       setDownloading(false)
     }
@@ -380,9 +399,14 @@ export default function WebDAVSettings() {
       }
 
       if (saveDecryptPassword) {
-        await persistWebdavConfig({
-          backupEncryptionPassword: pwd,
-        })
+        try {
+          await persistWebdavConfig({
+            backupEncryptionPassword: pwd,
+          })
+        } catch (error) {
+          logger.error("Failed to persist WebDAV decrypt password", error)
+          toast.error(t("settings:messages.saveSettingsFailed"))
+        }
       }
 
       setDecryptDialogOpen(false)

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -403,6 +403,7 @@ export default function WebDAVSettings() {
           await persistWebdavConfig({
             backupEncryptionPassword: pwd,
           })
+          setBackupEncryptionPassword(pwd)
         } catch (error) {
           logger.error("Failed to persist WebDAV decrypt password", error)
           toast.error(t("settings:messages.saveSettingsFailed"))

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -4,7 +4,7 @@ import {
   EyeSlashIcon,
 } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -25,6 +25,7 @@ import {
   Label,
   Switch,
 } from "~/components/ui"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
@@ -50,6 +51,7 @@ import {
   isWebdavSyncDataSelectionEmpty,
   resolveWebdavSyncDataSelection,
   WEBDAV_SYNC_DATA_KEYS,
+  type WebDAVSettings,
   type WebDAVSyncDataKey,
   type WebDAVSyncDataSelection,
 } from "~/types/webdav"
@@ -95,19 +97,30 @@ function getWebdavSyncDataLabel(t: TFunction, key: WebDAVSyncDataKey) {
  */
 export default function WebDAVSettings() {
   const { t } = useTranslation("importExport")
+  const { preferences, updateWebdavSettings } = useUserPreferencesContext()
+  const persistedWebdavSettings = preferences.webdav
+
   // 配置表单
-  const [webdavUrl, setWebdavUrl] = useState("")
-  const [webdavUsername, setWebdavUsername] = useState("")
-  const [webdavPassword, setWebdavPassword] = useState("")
+  const [webdavUrl, setWebdavUrl] = useState(persistedWebdavSettings.url ?? "")
+  const [webdavUsername, setWebdavUsername] = useState(
+    persistedWebdavSettings.username ?? "",
+  )
+  const [webdavPassword, setWebdavPassword] = useState(
+    persistedWebdavSettings.password ?? "",
+  )
   const [showPassword, setShowPassword] = useState(false)
 
   const [syncDataSelection, setSyncDataSelection] =
     useState<WebDAVSyncDataSelection>(() =>
-      resolveWebdavSyncDataSelection(null),
+      resolveWebdavSyncDataSelection(persistedWebdavSettings.syncData),
     )
 
-  const [backupEncryptionEnabled, setBackupEncryptionEnabled] = useState(false)
-  const [backupEncryptionPassword, setBackupEncryptionPassword] = useState("")
+  const [backupEncryptionEnabled, setBackupEncryptionEnabled] = useState(
+    Boolean(persistedWebdavSettings.backupEncryptionEnabled),
+  )
+  const [backupEncryptionPassword, setBackupEncryptionPassword] = useState(
+    persistedWebdavSettings.backupEncryptionPassword ?? "",
+  )
   const [showBackupEncryptionPassword, setShowBackupEncryptionPassword] =
     useState(false)
 
@@ -158,22 +171,6 @@ export default function WebDAVSettings() {
     return false
   }
 
-  // 初始加载
-  useEffect(() => {
-    ;(async () => {
-      const prefs = await userPreferences.getPreferences()
-      setWebdavUrl(prefs.webdav.url ?? "")
-      setWebdavUsername(prefs.webdav.username ?? "")
-      setWebdavPassword(prefs.webdav.password ?? "")
-
-      setBackupEncryptionEnabled(Boolean(prefs.webdav.backupEncryptionEnabled))
-      setBackupEncryptionPassword(prefs.webdav.backupEncryptionPassword ?? "")
-      setSyncDataSelection(
-        resolveWebdavSyncDataSelection(prefs.webdav.syncData),
-      )
-    })()
-  }, [])
-
   const webdavConfig = {
     url: webdavUrl,
     username: webdavUsername,
@@ -183,10 +180,19 @@ export default function WebDAVSettings() {
     syncData: syncDataSelection,
   }
 
+  const persistWebdavConfig = async (
+    updates: Partial<WebDAVSettings> = webdavConfig,
+  ) => {
+    const success = await updateWebdavSettings(updates)
+    if (!success) {
+      throw new Error(t("settings:messages.saveSettingsFailed"))
+    }
+  }
+
   const handleSaveConfig = async () => {
     setSaving(true)
     try {
-      await userPreferences.updateWebdavSettings(webdavConfig)
+      await persistWebdavConfig()
       toast.success(t("settings:messages.updateSuccess"))
     } catch (e) {
       logger.error("Failed to save WebDAV settings", e)
@@ -199,7 +205,7 @@ export default function WebDAVSettings() {
   const handleTestConnection = async () => {
     setTesting(true)
     try {
-      await userPreferences.updateWebdavSettings(webdavConfig)
+      await persistWebdavConfig()
       await testWebdavConnection(webdavConfig)
       toast.success(t("webdav.testSuccess"))
     } catch (e: any) {
@@ -225,7 +231,7 @@ export default function WebDAVSettings() {
         return
       }
 
-      await userPreferences.updateWebdavSettings(webdavConfig)
+      await persistWebdavConfig()
       const [
         accountData,
         tagStore,
@@ -303,7 +309,7 @@ export default function WebDAVSettings() {
         return
       }
 
-      await userPreferences.updateWebdavSettings(webdavConfig)
+      await persistWebdavConfig()
       const raw = await downloadBackupRaw(webdavConfig)
       const envelope = tryParseEncryptedWebdavBackupEnvelope(raw)
 
@@ -374,10 +380,9 @@ export default function WebDAVSettings() {
       }
 
       if (saveDecryptPassword) {
-        await userPreferences.updateWebdavSettings({
+        await persistWebdavConfig({
           backupEncryptionPassword: pwd,
         })
-        setBackupEncryptionPassword(pwd)
       }
 
       setDecryptDialogOpen(false)

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -1495,6 +1495,34 @@ describe("UserPreferencesContext", () => {
     })
   })
 
+  it("returns a safe fallback when the WebDAV auto-sync runtime response is invalid", async () => {
+    const preferences = clonePreferences()
+    preferences.webdav = {
+      ...preferences.webdav,
+      autoSync: true,
+      syncInterval: 300,
+    }
+    mockedSendRuntimeMessage.mockResolvedValue(undefined)
+
+    const context = await renderProvider(preferences)
+
+    let response: Awaited<
+      ReturnType<typeof context.updateWebdavAutoSyncSettings>
+    >
+
+    await act(async () => {
+      response = await context.updateWebdavAutoSyncSettings({
+        autoSync: false,
+      })
+    })
+
+    expect(response!).toEqual({
+      success: false,
+      error: "Invalid response from background",
+    })
+    expect((latestContext as any)?.preferences.webdav.autoSync).toBe(true)
+  })
+
   it("refreshes context menus when feature enabled state changes and preserves existing nested settings", async () => {
     const preferences = clonePreferences()
     preferences.redemptionAssist = {

--- a/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
@@ -10,13 +10,17 @@ import { I18nextProvider } from "react-i18next"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { UserPreferencesProvider } from "~/contexts/UserPreferencesContext"
 import WebDAVAutoSyncSettings from "~/features/ImportExport/components/WebDAVAutoSyncSettings"
 import { WEBDAV_SYNC_STRATEGIES } from "~/types/webdav"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
-const { mockGetPreferences, mockSendRuntimeMessage, loggerMocks } = vi.hoisted(
+const { mockUserPreferences, mockSendRuntimeMessage, loggerMocks } = vi.hoisted(
   () => ({
-    mockGetPreferences: vi.fn(),
+    mockUserPreferences: {
+      getPreferences: vi.fn(),
+      savePreferences: vi.fn(),
+    },
     mockSendRuntimeMessage: vi.fn(),
     loggerMocks: {
       error: vi.fn(),
@@ -38,24 +42,36 @@ vi.mock("~/utils/core/logger", () => ({
   createLogger: () => loggerMocks,
 }))
 
-vi.mock("~/services/preferences/userPreferences", () => ({
-  userPreferences: {
-    getPreferences: mockGetPreferences,
-  },
-}))
+vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/services/preferences/userPreferences")
+    >()
+  return {
+    ...actual,
+    userPreferences: {
+      ...actual.userPreferences,
+      ...mockUserPreferences,
+    },
+  }
+})
 
 vi.mock("~/utils/browser/browserApi", () => ({
   sendRuntimeMessage: mockSendRuntimeMessage,
 }))
 
 function render(ui: ReactNode) {
-  return rtlRender(<I18nextProvider i18n={testI18n}>{ui}</I18nextProvider>)
+  return rtlRender(
+    <I18nextProvider i18n={testI18n}>
+      <UserPreferencesProvider>{ui}</UserPreferencesProvider>
+    </I18nextProvider>,
+  )
 }
 
 describe("WebDAVAutoSyncSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetPreferences.mockResolvedValue({
+    mockUserPreferences.getPreferences.mockResolvedValue({
       webdav: {
         autoSync: true,
         syncInterval: 1800,
@@ -132,8 +148,7 @@ describe("WebDAVAutoSyncSettings", () => {
     expect(toast.success).toHaveBeenCalledWith("custom sync ok")
   })
 
-  it("surfaces load, save, and sync errors", async () => {
-    mockGetPreferences.mockRejectedValueOnce(new Error("prefs failed"))
+  it("surfaces status, save, and sync errors", async () => {
     mockSendRuntimeMessage.mockImplementation(async (message: any) => {
       switch (message.action) {
         case RuntimeActionIds.WebdavAutoSyncGetStatus:

--- a/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
@@ -186,4 +186,35 @@ describe("WebDAVAutoSyncSettings", () => {
       expect(toast.error).toHaveBeenCalledWith("sync failed")
     })
   })
+
+  it("falls back to the local update-failed copy when the runtime omits an error", async () => {
+    mockSendRuntimeMessage.mockImplementation(async (message: any) => {
+      switch (message.action) {
+        case RuntimeActionIds.WebdavAutoSyncGetStatus:
+          return { success: true, data: null }
+        case RuntimeActionIds.WebdavAutoSyncUpdateSettings:
+          return { success: false }
+        default:
+          return { success: true }
+      }
+    })
+
+    render(<WebDAVAutoSyncSettings />)
+
+    expect(
+      await screen.findByRole("button", {
+        name: "importExport:webdav.autoSync.saveSettings",
+      }),
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.autoSync.saveSettings",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("settings:messages.updateFailed")
+    })
+  })
 })

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -9,6 +9,7 @@ import toast from "react-hot-toast"
 import { I18nextProvider } from "react-i18next"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { UserPreferencesProvider } from "~/contexts/UserPreferencesContext"
 import WebDAVSettings from "~/features/ImportExport/components/WebDAVSettings"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
@@ -32,7 +33,7 @@ const {
 } = vi.hoisted(() => ({
   mockUserPreferences: {
     getPreferences: vi.fn(),
-    updateWebdavSettings: vi.fn(),
+    savePreferences: vi.fn(),
     exportPreferences: vi.fn(),
   },
   mockAccountStorage: { exportData: vi.fn() },
@@ -68,9 +69,19 @@ vi.mock("~/utils/core/logger", () => ({
   createLogger: () => loggerMocks,
 }))
 
-vi.mock("~/services/preferences/userPreferences", () => ({
-  userPreferences: mockUserPreferences,
-}))
+vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/services/preferences/userPreferences")
+    >()
+  return {
+    ...actual,
+    userPreferences: {
+      ...actual.userPreferences,
+      ...mockUserPreferences,
+    },
+  }
+})
 
 vi.mock("~/services/accounts/accountStorage", () => ({
   accountStorage: mockAccountStorage,
@@ -120,7 +131,11 @@ vi.mock("~/features/ImportExport/utils", async (importOriginal) => {
 })
 
 function render(ui: ReactNode) {
-  return rtlRender(<I18nextProvider i18n={testI18n}>{ui}</I18nextProvider>)
+  return rtlRender(
+    <I18nextProvider i18n={testI18n}>
+      <UserPreferencesProvider>{ui}</UserPreferencesProvider>
+    </I18nextProvider>,
+  )
 }
 
 describe("WebDAVSettings", () => {
@@ -141,7 +156,7 @@ describe("WebDAVSettings", () => {
         },
       },
     })
-    mockUserPreferences.updateWebdavSettings.mockResolvedValue(true)
+    mockUserPreferences.savePreferences.mockResolvedValue(true)
     mockUserPreferences.exportPreferences.mockResolvedValue({
       themeMode: "dark",
     })
@@ -183,7 +198,21 @@ describe("WebDAVSettings", () => {
       screen.getByRole("button", { name: "importExport:webdav.saveConfig" }),
     )
     await waitFor(() => {
-      expect(mockUserPreferences.updateWebdavSettings).toHaveBeenCalled()
+      expect(mockUserPreferences.savePreferences).toHaveBeenCalledWith({
+        webdav: {
+          url: "https://dav.example.com/backup.json",
+          username: "alice",
+          password: "pw",
+          backupEncryptionEnabled: true,
+          backupEncryptionPassword: "stored-secret",
+          syncData: {
+            accounts: true,
+            bookmarks: true,
+            apiCredentialProfiles: true,
+            preferences: true,
+          },
+        },
+      })
     })
     expect(toast.success).toHaveBeenCalledWith(
       "settings:messages.updateSuccess",
@@ -284,8 +313,10 @@ describe("WebDAVSettings", () => {
         { preserveWebdav: true },
       )
     })
-    expect(mockUserPreferences.updateWebdavSettings).toHaveBeenCalledWith({
-      backupEncryptionPassword: "manual-secret",
+    expect(mockUserPreferences.savePreferences).toHaveBeenCalledWith({
+      webdav: {
+        backupEncryptionPassword: "manual-secret",
+      },
     })
     expect(toast.success).toHaveBeenCalledWith(
       "importExport:import.importSuccess",

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -11,6 +11,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { UserPreferencesProvider } from "~/contexts/UserPreferencesContext"
 import WebDAVSettings from "~/features/ImportExport/components/WebDAVSettings"
+import {
+  DEFAULT_PREFERENCES,
+  type UserPreferences,
+} from "~/services/preferences/userPreferences"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
 const {
@@ -138,24 +142,31 @@ function render(ui: ReactNode) {
   )
 }
 
+const createPreferencesFixture = (): UserPreferences => ({
+  ...structuredClone(DEFAULT_PREFERENCES),
+  showTodayCashflow: true,
+  webdav: {
+    ...structuredClone(DEFAULT_PREFERENCES.webdav),
+    url: "https://dav.example.com/backup.json",
+    username: "alice",
+    password: "pw",
+    backupEncryptionEnabled: true,
+    backupEncryptionPassword: "stored-secret",
+    syncData: {
+      accounts: true,
+      bookmarks: true,
+      apiCredentialProfiles: true,
+      preferences: true,
+    },
+  },
+})
+
 describe("WebDAVSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUserPreferences.getPreferences.mockResolvedValue({
-      webdav: {
-        url: "https://dav.example.com/backup.json",
-        username: "alice",
-        password: "pw",
-        backupEncryptionEnabled: true,
-        backupEncryptionPassword: "stored-secret",
-        syncData: {
-          accounts: true,
-          bookmarks: true,
-          apiCredentialProfiles: true,
-          preferences: true,
-        },
-      },
-    })
+    mockUserPreferences.getPreferences.mockResolvedValue(
+      createPreferencesFixture(),
+    )
     mockUserPreferences.savePreferences.mockResolvedValue(true)
     mockUserPreferences.exportPreferences.mockResolvedValue({
       themeMode: "dark",
@@ -321,5 +332,24 @@ describe("WebDAVSettings", () => {
     expect(toast.success).toHaveBeenCalledWith(
       "importExport:import.importSuccess",
     )
+  })
+
+  it("shows the action-specific connection failure message when persisting settings fails", async () => {
+    mockUserPreferences.savePreferences.mockResolvedValue(false)
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.testConnection",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("importExport:webdav.testFailed")
+    })
+    expect(mockTestWebdavConnection).not.toHaveBeenCalled()
   })
 })

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -161,6 +161,14 @@ const createPreferencesFixture = (): UserPreferences => ({
   },
 })
 
+const ENCRYPTED_BACKUP_ENVELOPE = {
+  version: 1,
+  algorithm: "aes-gcm",
+  salt: "salt",
+  iv: "iv",
+  ciphertext: "cipher",
+} as const
+
 describe("WebDAVSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -277,13 +285,9 @@ describe("WebDAVSettings", () => {
 
   it("prompts for a decrypt password, imports the decrypted backup, and stores the password", async () => {
     mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
-    mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue({
-      version: 1,
-      algorithm: "aes-gcm",
-      salt: "salt",
-      iv: "iv",
-      ciphertext: "cipher",
-    })
+    mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
+      ENCRYPTED_BACKUP_ENVELOPE,
+    )
 
     render(<WebDAVSettings />)
 
@@ -356,6 +360,30 @@ describe("WebDAVSettings", () => {
     )
   })
 
+  it("surfaces the save failure message when saving the WebDAV config fails", async () => {
+    mockUserPreferences.savePreferences.mockResolvedValue(false)
+
+    render(<WebDAVSettings />)
+
+    expect(
+      await screen.findByDisplayValue("https://dav.example.com/backup.json"),
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "importExport:webdav.saveConfig" }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings:messages.saveSettingsFailed",
+      )
+    })
+    expect(loggerMocks.error).toHaveBeenCalledWith(
+      "Failed to save WebDAV settings",
+      expect.any(Error),
+    )
+  })
+
   it("shows the action-specific connection failure message when persisting settings fails", async () => {
     mockUserPreferences.savePreferences.mockResolvedValue(false)
 
@@ -373,5 +401,378 @@ describe("WebDAVSettings", () => {
       expect(toast.error).toHaveBeenCalledWith("importExport:webdav.testFailed")
     })
     expect(mockTestWebdavConnection).not.toHaveBeenCalled()
+  })
+
+  it("blocks download/import when the sync-data selection is empty", async () => {
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    screen
+      .getAllByRole("checkbox")
+      .slice(0, 4)
+      .forEach((checkbox) => fireEvent.click(checkbox))
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.downloadImport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "importExport:webdav.syncData.selectionRequired",
+      )
+    })
+    expect(mockDownloadBackupRaw).not.toHaveBeenCalled()
+  })
+
+  it("uploads a new backup when the remote WebDAV file does not exist", async () => {
+    const missingBackupError = new Error("missing backup")
+    mockDownloadBackup.mockRejectedValueOnce(missingBackupError)
+    mockIsWebdavFileNotFoundError.mockImplementation(
+      (error) => error === missingBackupError,
+    )
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "importExport:webdav.uploadBackup" }),
+    )
+
+    await waitFor(() => {
+      expect(mockMergeWebdavBackupPayloadBySelection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          remoteBackup: null,
+        }),
+      )
+      expect(mockUploadBackup).toHaveBeenCalled()
+    })
+    expect(toast.success).toHaveBeenCalledWith(
+      "importExport:export.dataExported",
+    )
+  })
+
+  it("surfaces the upload failure when fetching the remote backup fails unexpectedly", async () => {
+    const downloadError = new Error("download failed")
+    mockDownloadBackup.mockRejectedValueOnce(downloadError)
+    mockIsWebdavFileNotFoundError.mockReturnValue(false)
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "importExport:webdav.uploadBackup" }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("download failed")
+    })
+    expect(mockUploadBackup).not.toHaveBeenCalled()
+  })
+
+  it("imports an unencrypted WebDAV backup without opening the decrypt dialog", async () => {
+    mockDownloadBackupRaw.mockResolvedValueOnce('{"version":2,"accounts":[]}')
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.downloadImport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockBuildWebdavImportPayloadBySelection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rawBackup: {
+            version: 2,
+            accounts: [],
+          },
+        }),
+      )
+      expect(mockImportFromBackupObject).toHaveBeenCalledWith(
+        { imported: true },
+        { preserveWebdav: true },
+      )
+      expect(toast.success).toHaveBeenCalledWith(
+        "importExport:import.importSuccess",
+      )
+    })
+    expect(
+      screen.queryByText("importExport:webdav.encryption.decryptDialogTitle"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows the download/import failure message when importing the backup fails", async () => {
+    mockImportFromBackupObject.mockRejectedValueOnce(new Error("import failed"))
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.downloadImport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("import failed")
+    })
+  })
+
+  it("reopens the decrypt dialog with the stored password when automatic decrypt fails", async () => {
+    mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
+    mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
+      ENCRYPTED_BACKUP_ENVELOPE,
+    )
+    mockDecryptWebdavBackupEnvelope.mockRejectedValueOnce(
+      new Error("stored password failed"),
+    )
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("stored-secret")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.downloadImport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(document.getElementById("decryptPassword")).toBeTruthy()
+    })
+    const decryptPasswordInput = document.getElementById(
+      "decryptPassword",
+    ) as HTMLInputElement
+
+    expect(decryptPasswordInput.id).toBe("decryptPassword")
+    expect(decryptPasswordInput.value).toBe("stored-secret")
+    expect(toast.error).toHaveBeenCalledWith(
+      "importExport:webdav.encryption.decryptPrompt",
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:actions.cancel" }),
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("importExport:webdav.encryption.decryptDialogTitle"),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("shows the decrypt failure message when manual decrypt/import fails", async () => {
+    mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
+    mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
+      ENCRYPTED_BACKUP_ENVELOPE,
+    )
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    fireEvent.change(screen.getAllByDisplayValue("stored-secret")[0], {
+      target: { value: "" },
+    })
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.downloadImport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(document.getElementById("decryptPassword")).toBeTruthy()
+    })
+    const decryptPasswordInput = document.getElementById(
+      "decryptPassword",
+    ) as HTMLInputElement
+    fireEvent.change(decryptPasswordInput, {
+      target: { value: "manual-secret" },
+    })
+
+    mockDecryptWebdavBackupEnvelope.mockRejectedValueOnce(
+      new Error("manual decrypt failed"),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.encryption.decryptAction",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("manual decrypt failed")
+    })
+  })
+
+  it("shows both import success and save-settings failure when persisting the decrypt password fails", async () => {
+    mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
+    mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
+      ENCRYPTED_BACKUP_ENVELOPE,
+    )
+    mockUserPreferences.savePreferences.mockResolvedValueOnce(true)
+    mockUserPreferences.savePreferences.mockResolvedValueOnce(false)
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    fireEvent.change(screen.getAllByDisplayValue("stored-secret")[0], {
+      target: { value: "" },
+    })
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.downloadImport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(document.getElementById("decryptPassword")).toBeTruthy()
+    })
+    fireEvent.change(
+      document.getElementById("decryptPassword") as HTMLInputElement,
+      {
+        target: { value: "manual-secret" },
+      },
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.encryption.decryptAction",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "importExport:import.importSuccess",
+      )
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings:messages.saveSettingsFailed",
+      )
+    })
+  })
+
+  it("blocks manual decrypt/import when sync data becomes empty", async () => {
+    mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
+    mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
+      ENCRYPTED_BACKUP_ENVELOPE,
+    )
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    fireEvent.change(screen.getAllByDisplayValue("stored-secret")[0], {
+      target: { value: "" },
+    })
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.downloadImport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(document.getElementById("decryptPassword")).toBeTruthy()
+    })
+
+    screen
+      .getAllByRole("checkbox")
+      .slice(0, 4)
+      .forEach((checkbox) => fireEvent.click(checkbox))
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.encryption.decryptAction",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "importExport:webdav.syncData.selectionRequired",
+      )
+    })
+    expect(mockDecryptWebdavBackupEnvelope).not.toHaveBeenCalled()
+  })
+
+  it("updates the editable fields and toggles password visibility in both forms", async () => {
+    mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
+    mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
+      ENCRYPTED_BACKUP_ENVELOPE,
+    )
+
+    render(<WebDAVSettings />)
+
+    const urlInput = (await screen.findByDisplayValue(
+      "https://dav.example.com/backup.json",
+    )) as HTMLInputElement
+    const usernameInput = screen.getByDisplayValue("alice") as HTMLInputElement
+    const webdavPasswordInput = screen.getByDisplayValue(
+      "pw",
+    ) as HTMLInputElement
+    const backupPasswordInput = screen.getAllByDisplayValue(
+      "stored-secret",
+    )[0] as HTMLInputElement
+
+    fireEvent.change(urlInput, {
+      target: { value: "https://dav.example.com/backup-2.json" },
+    })
+    fireEvent.change(usernameInput, {
+      target: { value: "bob" },
+    })
+    fireEvent.change(webdavPasswordInput, {
+      target: { value: "pw-2" },
+    })
+
+    expect(urlInput.value).toBe("https://dav.example.com/backup-2.json")
+    expect(usernameInput.value).toBe("bob")
+    expect(webdavPasswordInput.value).toBe("pw-2")
+
+    fireEvent.click(
+      screen.getAllByRole("button", {
+        name: /importExport:webdav\.(show|hide)Password/,
+      })[0],
+    )
+    fireEvent.click(
+      screen.getAllByRole("button", {
+        name: /importExport:webdav\.(show|hide)Password/,
+      })[1],
+    )
+
+    expect(webdavPasswordInput).toHaveAttribute("type", "text")
+    expect(backupPasswordInput).toHaveAttribute("type", "text")
+
+    fireEvent.change(backupPasswordInput, {
+      target: { value: "" },
+    })
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.downloadImport",
+      }),
+    )
+
+    expect(
+      await screen.findByText(
+        "importExport:webdav.encryption.decryptDialogTitle",
+      ),
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getAllByRole("button", {
+        name: /importExport:webdav\.(show|hide)Password/,
+      })[2],
+    )
+
+    expect(
+      document.getElementById("decryptPassword") as HTMLInputElement,
+    ).toHaveAttribute("type", "text")
   })
 })

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -329,6 +329,28 @@ describe("WebDAVSettings", () => {
         backupEncryptionPassword: "manual-secret",
       },
     })
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "importExport:webdav.saveConfig" }),
+    )
+
+    await waitFor(() => {
+      expect(mockUserPreferences.savePreferences).toHaveBeenLastCalledWith({
+        webdav: {
+          url: "https://dav.example.com/backup.json",
+          username: "alice",
+          password: "pw",
+          backupEncryptionEnabled: true,
+          backupEncryptionPassword: "manual-secret",
+          syncData: {
+            accounts: true,
+            bookmarks: true,
+            apiCredentialProfiles: true,
+            preferences: true,
+          },
+        },
+      })
+    })
     expect(toast.success).toHaveBeenCalledWith(
       "importExport:import.importSuccess",
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebDAV auto-sync settings (strategy, interval, enable) persist via the central preferences provider and initialize UI state from persisted preferences.
  * WebDAV configuration and backup password persistence flows unified through the preferences provider.

* **Bug Fixes**
  * Invalid or failed runtime responses no longer mutate UI state; failures surface consistent error messages/toasts.

* **Tests**
  * Expanded coverage for WebDAV persistence, auto-sync flows, import/export, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->