### PR TITLE
fix: refresh settings state and apply language after preferences import

### DIFF
--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -61,6 +61,10 @@ type RuntimeMutationResponse = {
   data?: unknown
 }
 
+type PreferenceSaveOptions = {
+  expectedLastUpdated?: number
+}
+
 const INVALID_RUNTIME_MUTATION_RESPONSE: RuntimeMutationResponse = {
   success: false,
   error: "Invalid response from background",
@@ -93,6 +97,19 @@ function normalizeRuntimeMutationResponse(
   return isRuntimeMutationResponse(value)
     ? value
     : INVALID_RUNTIME_MUTATION_RESPONSE
+}
+
+/**
+ * Persist a preference patch and only include the optimistic concurrency guard
+ * when a caller is saving from a tracked local draft snapshot.
+ */
+function savePreferencesWithOptions(
+  updates: Parameters<typeof userPreferences.savePreferences>[0],
+  options?: PreferenceSaveOptions,
+) {
+  return typeof options?.expectedLastUpdated === "number"
+    ? userPreferences.savePreferences(updates, options)
+    : userPreferences.savePreferences(updates)
 }
 
 // 1. 定义 Context 的值类型
@@ -164,26 +181,87 @@ interface UserPreferencesContextType {
     enabled: boolean,
   ) => Promise<boolean>
   updateWarnOnDuplicateAccountAdd: (enabled: boolean) => Promise<boolean>
-  updateNewApiBaseUrl: (url: string) => Promise<boolean>
-  updateNewApiAdminToken: (token: string) => Promise<boolean>
-  updateNewApiUserId: (userId: string) => Promise<boolean>
-  updateNewApiUsername: (username: string) => Promise<boolean>
-  updateNewApiPassword: (password: string) => Promise<boolean>
-  updateNewApiTotpSecret: (totpSecret: string) => Promise<boolean>
-  updateDoneHubBaseUrl: (url: string) => Promise<boolean>
-  updateDoneHubAdminToken: (token: string) => Promise<boolean>
-  updateDoneHubUserId: (userId: string) => Promise<boolean>
-  updateVeloeraBaseUrl: (url: string) => Promise<boolean>
-  updateVeloeraAdminToken: (token: string) => Promise<boolean>
-  updateVeloeraUserId: (userId: string) => Promise<boolean>
-  updateOctopusBaseUrl: (url: string) => Promise<boolean>
-  updateOctopusUsername: (username: string) => Promise<boolean>
-  updateOctopusPassword: (password: string) => Promise<boolean>
+  updateNewApiBaseUrl: (
+    url: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateNewApiAdminToken: (
+    token: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateNewApiUserId: (
+    userId: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateNewApiUsername: (
+    username: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateNewApiPassword: (
+    password: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateNewApiTotpSecret: (
+    totpSecret: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateDoneHubBaseUrl: (
+    url: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateDoneHubAdminToken: (
+    token: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateDoneHubUserId: (
+    userId: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateVeloeraBaseUrl: (
+    url: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateVeloeraAdminToken: (
+    token: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateVeloeraUserId: (
+    userId: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateOctopusBaseUrl: (
+    url: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateOctopusUsername: (
+    username: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateOctopusPassword: (
+    password: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateOctopusConfig: (
+    updates: Partial<NonNullable<UserPreferences["octopus"]>>,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
   updateManagedSiteType: (siteType: ManagedSiteType) => Promise<boolean>
-  updateCliProxyBaseUrl: (url: string) => Promise<boolean>
-  updateCliProxyManagementKey: (key: string) => Promise<boolean>
-  updateClaudeCodeRouterBaseUrl: (url: string) => Promise<boolean>
-  updateClaudeCodeRouterApiKey: (key: string) => Promise<boolean>
+  updateCliProxyBaseUrl: (
+    url: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateCliProxyManagementKey: (
+    key: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateClaudeCodeRouterBaseUrl: (
+    url: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
+  updateClaudeCodeRouterApiKey: (
+    key: string,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
   updateThemeMode: (themeMode: ThemeMode) => Promise<boolean>
   updateLoggingConsoleEnabled: (enabled: boolean) => Promise<boolean>
   updateLoggingLevel: (level: LogLevel) => Promise<boolean>
@@ -205,12 +283,16 @@ interface UserPreferencesContextType {
   updateWebAiApiCheck: (
     updates: Partial<WebAiApiCheckPreferences>,
   ) => Promise<boolean>
-  updateWebdavSettings: (updates: Partial<WebDAVSettings>) => Promise<boolean>
+  updateWebdavSettings: (
+    updates: Partial<WebDAVSettings>,
+    options?: PreferenceSaveOptions,
+  ) => Promise<boolean>
   updateWebdavAutoSyncSettings: (
     updates: Pick<
       Partial<WebDAVSettings>,
       "autoSync" | "syncInterval" | "syncStrategy"
     >,
+    options?: PreferenceSaveOptions,
   ) => Promise<RuntimeMutationResponse>
   updateTempWindowFallback: (
     updates: Partial<TempWindowFallbackPreferences>,
@@ -246,6 +328,11 @@ const UserPreferencesContext = createContext<
 /**
  * Top-level provider that loads persisted user preferences, exposes update
  * helpers, and keeps background scripts informed about configuration changes.
+ *
+ * `preferences` is the latest persisted snapshot for the UI. Editable settings
+ * panels may keep local drafts, but `loadPreferences()` is the canonical way to
+ * rehydrate the saved snapshot after external mutations such as import, restore,
+ * or reset flows.
  */
 export const UserPreferencesProvider = ({
   children,
@@ -404,27 +491,12 @@ export const UserPreferencesProvider = ({
    * Update the CLI proxy base URL and merge it into the preference tree so
    * dependent features read the latest endpoint.
    */
-  const updateCliProxyBaseUrl = useCallback(async (baseUrl: string) => {
-    const updates = {
-      cliProxy: { baseUrl },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
-
-  /**
-   * Persist the CLI proxy management key token used for authenticated calls.
-   * @param managementKey - User-provided secret for the CLI proxy service.
-   */
-  const updateCliProxyManagementKey = useCallback(
-    async (managementKey: string) => {
+  const updateCliProxyBaseUrl = useCallback(
+    async (baseUrl: string, options?: PreferenceSaveOptions) => {
       const updates = {
-        cliProxy: { managementKey },
+        cliProxy: { baseUrl },
       }
-      const success = await userPreferences.savePreferences(updates)
+      const success = await savePreferencesWithOptions(updates, options)
       if (success) {
         setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
       }
@@ -433,27 +505,51 @@ export const UserPreferencesProvider = ({
     [],
   )
 
-  const updateClaudeCodeRouterBaseUrl = useCallback(async (baseUrl: string) => {
-    const updates = {
-      claudeCodeRouter: { baseUrl },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  /**
+   * Persist the CLI proxy management key token used for authenticated calls.
+   * @param managementKey - User-provided secret for the CLI proxy service.
+   */
+  const updateCliProxyManagementKey = useCallback(
+    async (managementKey: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        cliProxy: { managementKey },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateClaudeCodeRouterApiKey = useCallback(async (apiKey: string) => {
-    const updates = {
-      claudeCodeRouter: { apiKey },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateClaudeCodeRouterBaseUrl = useCallback(
+    async (baseUrl: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        claudeCodeRouter: { baseUrl },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
+
+  const updateClaudeCodeRouterApiKey = useCallback(
+    async (apiKey: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        claudeCodeRouter: { apiKey },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
   const updateTempWindowFallbackReminder = useCallback(
     async (updates: Partial<TempWindowFallbackReminderPreferences>) => {
@@ -636,170 +732,232 @@ export const UserPreferencesProvider = ({
     return success
   }, [])
 
-  const updateNewApiBaseUrl = useCallback(async (baseUrl: string) => {
-    const updates = {
-      newApi: { baseUrl },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateNewApiBaseUrl = useCallback(
+    async (baseUrl: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        newApi: { baseUrl },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateNewApiAdminToken = useCallback(async (adminToken: string) => {
-    const updates = {
-      newApi: { adminToken },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateNewApiAdminToken = useCallback(
+    async (adminToken: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        newApi: { adminToken },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateNewApiUserId = useCallback(async (userId: string) => {
-    const updates = {
-      newApi: { userId },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateNewApiUserId = useCallback(
+    async (userId: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        newApi: { userId },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateNewApiUsername = useCallback(async (username: string) => {
-    const updates = {
-      newApi: { username },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateNewApiUsername = useCallback(
+    async (username: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        newApi: { username },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateNewApiPassword = useCallback(async (password: string) => {
-    const updates = {
-      newApi: { password },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateNewApiPassword = useCallback(
+    async (password: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        newApi: { password },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateNewApiTotpSecret = useCallback(async (totpSecret: string) => {
-    const updates = {
-      newApi: { totpSecret },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateNewApiTotpSecret = useCallback(
+    async (totpSecret: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        newApi: { totpSecret },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateDoneHubBaseUrl = useCallback(async (baseUrl: string) => {
-    const updates = {
-      doneHub: { baseUrl },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateDoneHubBaseUrl = useCallback(
+    async (baseUrl: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        doneHub: { baseUrl },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateDoneHubAdminToken = useCallback(async (adminToken: string) => {
-    const updates = {
-      doneHub: { adminToken },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateDoneHubAdminToken = useCallback(
+    async (adminToken: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        doneHub: { adminToken },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateDoneHubUserId = useCallback(async (userId: string) => {
-    const updates = {
-      doneHub: { userId },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateDoneHubUserId = useCallback(
+    async (userId: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        doneHub: { userId },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateVeloeraBaseUrl = useCallback(async (baseUrl: string) => {
-    const updates = {
-      veloera: { baseUrl },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateVeloeraBaseUrl = useCallback(
+    async (baseUrl: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        veloera: { baseUrl },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateVeloeraAdminToken = useCallback(async (adminToken: string) => {
-    const updates = {
-      veloera: { adminToken },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateVeloeraAdminToken = useCallback(
+    async (adminToken: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        veloera: { adminToken },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateVeloeraUserId = useCallback(async (userId: string) => {
-    const updates = {
-      veloera: { userId },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateVeloeraUserId = useCallback(
+    async (userId: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        veloera: { userId },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateOctopusBaseUrl = useCallback(async (baseUrl: string) => {
-    const updates = {
-      octopus: { baseUrl },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateOctopusBaseUrl = useCallback(
+    async (baseUrl: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        octopus: { baseUrl },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateOctopusUsername = useCallback(async (username: string) => {
-    const updates = {
-      octopus: { username },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateOctopusUsername = useCallback(
+    async (username: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        octopus: { username },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
 
-  const updateOctopusPassword = useCallback(async (password: string) => {
-    const updates = {
-      octopus: { password },
-    }
-    const success = await userPreferences.savePreferences(updates)
-    if (success) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return success
-  }, [])
+  const updateOctopusPassword = useCallback(
+    async (password: string, options?: PreferenceSaveOptions) => {
+      const updates = {
+        octopus: { password },
+      }
+      const success = await savePreferencesWithOptions(updates, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
+      }
+      return success
+    },
+    [],
+  )
+
+  const updateOctopusConfig = useCallback(
+    async (
+      updates: Partial<NonNullable<UserPreferences["octopus"]>>,
+      options?: PreferenceSaveOptions,
+    ) => {
+      const patch = {
+        octopus: updates,
+      }
+      const success = await savePreferencesWithOptions(patch, options)
+      if (success) {
+        setPreferences((prev) => (prev ? deepOverride(prev, patch) : null))
+      }
+      return success
+    },
+    [],
+  )
 
   const updateManagedSiteType = useCallback(
     async (siteType: ManagedSiteType) => {
@@ -1074,10 +1232,16 @@ export const UserPreferencesProvider = ({
   )
 
   const updateWebdavSettings = useCallback(
-    async (updates: Partial<WebDAVSettings>) => {
-      const success = await userPreferences.savePreferences({
-        webdav: updates,
-      })
+    async (
+      updates: Partial<WebDAVSettings>,
+      options?: PreferenceSaveOptions,
+    ) => {
+      const success = await savePreferencesWithOptions(
+        {
+          webdav: updates,
+        },
+        options,
+      )
 
       if (success) {
         setPreferences((prev) => {
@@ -1105,12 +1269,21 @@ export const UserPreferencesProvider = ({
         Partial<WebDAVSettings>,
         "autoSync" | "syncInterval" | "syncStrategy"
       >,
+      options?: PreferenceSaveOptions,
     ) => {
       const response = normalizeRuntimeMutationResponse(
-        await sendRuntimeMessage({
-          action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
-          settings: updates,
-        }),
+        await sendRuntimeMessage(
+          typeof options?.expectedLastUpdated === "number"
+            ? {
+                action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+                settings: updates,
+                expectedLastUpdated: options.expectedLastUpdated,
+              }
+            : {
+                action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+                settings: updates,
+              },
+        ),
       )
 
       if (response.success) {
@@ -1592,6 +1765,7 @@ export const UserPreferencesProvider = ({
     updateOctopusBaseUrl,
     updateOctopusUsername,
     updateOctopusPassword,
+    updateOctopusConfig,
     updateManagedSiteType,
     updateCliProxyBaseUrl,
     updateCliProxyManagementKey,

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -38,7 +38,6 @@ import {
   DEFAULT_BALANCE_HISTORY_PREFERENCES,
   type BalanceHistoryPreferences,
 } from "~/types/dailyBalanceHistory"
-import { DEFAULT_DONE_HUB_CONFIG } from "~/types/doneHubConfig"
 import type { LogLevel } from "~/types/logging"
 import type { ModelRedirectPreferences } from "~/types/managedSiteModelRedirect"
 import type { SortingPriorityConfig } from "~/types/sorting"
@@ -108,8 +107,19 @@ function savePreferencesWithOptions(
   options?: PreferenceSaveOptions,
 ) {
   return typeof options?.expectedLastUpdated === "number"
-    ? userPreferences.savePreferences(updates, options)
-    : userPreferences.savePreferences(updates)
+    ? userPreferences.savePreferencesWithResult(updates, options)
+    : userPreferences.savePreferencesWithResult(updates)
+}
+
+/**
+ * Narrow an unknown runtime response payload to a persisted preferences snapshot.
+ */
+function isUserPreferencesSnapshot(value: unknown): value is UserPreferences {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    typeof (value as UserPreferences).lastUpdated === "number"
+  )
 }
 
 // 1. 定义 Context 的值类型
@@ -362,6 +372,24 @@ export const UserPreferencesProvider = ({
     void loadPreferences()
   }, [loadPreferences])
 
+  const persistPreferenceUpdates = useCallback(
+    async (
+      updates: Parameters<typeof userPreferences.savePreferences>[0],
+      options?: PreferenceSaveOptions,
+    ) => {
+      const savedPreferences = await savePreferencesWithOptions(
+        updates,
+        options,
+      )
+      if (savedPreferences) {
+        setPreferences(savedPreferences)
+        return true
+      }
+      return false
+    },
+    [],
+  )
+
   /**
    * Persist the currently visible balance tab and mirror it in React state.
    * @param activeTab - Consumption vs balance tab identifier.
@@ -474,18 +502,10 @@ export const UserPreferencesProvider = ({
   const resetClaudeCodeRouterConfig = useCallback(async () => {
     const success = await userPreferences.resetClaudeCodeRouterConfig()
     if (success) {
-      const defaults = DEFAULT_PREFERENCES.claudeCodeRouter
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              claudeCodeRouter: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
+      await loadPreferences()
     }
     return success
-  }, [])
+  }, [loadPreferences])
 
   /**
    * Update the CLI proxy base URL and merge it into the preference tree so
@@ -493,16 +513,14 @@ export const UserPreferencesProvider = ({
    */
   const updateCliProxyBaseUrl = useCallback(
     async (baseUrl: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        cliProxy: { baseUrl },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          cliProxy: { baseUrl },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   /**
@@ -511,44 +529,38 @@ export const UserPreferencesProvider = ({
    */
   const updateCliProxyManagementKey = useCallback(
     async (managementKey: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        cliProxy: { managementKey },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          cliProxy: { managementKey },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateClaudeCodeRouterBaseUrl = useCallback(
     async (baseUrl: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        claudeCodeRouter: { baseUrl },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          claudeCodeRouter: { baseUrl },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateClaudeCodeRouterApiKey = useCallback(
     async (apiKey: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        claudeCodeRouter: { apiKey },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          claudeCodeRouter: { apiKey },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateTempWindowFallbackReminder = useCallback(
@@ -734,212 +746,182 @@ export const UserPreferencesProvider = ({
 
   const updateNewApiBaseUrl = useCallback(
     async (baseUrl: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        newApi: { baseUrl },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          newApi: { baseUrl },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateNewApiAdminToken = useCallback(
     async (adminToken: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        newApi: { adminToken },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          newApi: { adminToken },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateNewApiUserId = useCallback(
     async (userId: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        newApi: { userId },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          newApi: { userId },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateNewApiUsername = useCallback(
     async (username: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        newApi: { username },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          newApi: { username },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateNewApiPassword = useCallback(
     async (password: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        newApi: { password },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          newApi: { password },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateNewApiTotpSecret = useCallback(
     async (totpSecret: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        newApi: { totpSecret },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          newApi: { totpSecret },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateDoneHubBaseUrl = useCallback(
     async (baseUrl: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        doneHub: { baseUrl },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          doneHub: { baseUrl },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateDoneHubAdminToken = useCallback(
     async (adminToken: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        doneHub: { adminToken },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          doneHub: { adminToken },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateDoneHubUserId = useCallback(
     async (userId: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        doneHub: { userId },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          doneHub: { userId },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateVeloeraBaseUrl = useCallback(
     async (baseUrl: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        veloera: { baseUrl },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          veloera: { baseUrl },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateVeloeraAdminToken = useCallback(
     async (adminToken: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        veloera: { adminToken },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          veloera: { adminToken },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateVeloeraUserId = useCallback(
     async (userId: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        veloera: { userId },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          veloera: { userId },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateOctopusBaseUrl = useCallback(
     async (baseUrl: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        octopus: { baseUrl },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          octopus: { baseUrl },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateOctopusUsername = useCallback(
     async (username: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        octopus: { username },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          octopus: { username },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateOctopusPassword = useCallback(
     async (password: string, options?: PreferenceSaveOptions) => {
-      const updates = {
-        octopus: { password },
-      }
-      const success = await savePreferencesWithOptions(updates, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          octopus: { password },
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateOctopusConfig = useCallback(
@@ -947,16 +929,14 @@ export const UserPreferencesProvider = ({
       updates: Partial<NonNullable<UserPreferences["octopus"]>>,
       options?: PreferenceSaveOptions,
     ) => {
-      const patch = {
-        octopus: updates,
-      }
-      const success = await savePreferencesWithOptions(patch, options)
-      if (success) {
-        setPreferences((prev) => (prev ? deepOverride(prev, patch) : null))
-      }
-      return success
+      return persistPreferenceUpdates(
+        {
+          octopus: updates,
+        },
+        options,
+      )
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateManagedSiteType = useCallback(
@@ -1236,31 +1216,14 @@ export const UserPreferencesProvider = ({
       updates: Partial<WebDAVSettings>,
       options?: PreferenceSaveOptions,
     ) => {
-      const success = await savePreferencesWithOptions(
+      return persistPreferenceUpdates(
         {
           webdav: updates,
         },
         options,
       )
-
-      if (success) {
-        setPreferences((prev) => {
-          if (!prev) return null
-          const merged = deepOverride(
-            prev.webdav ?? DEFAULT_PREFERENCES.webdav,
-            updates,
-          )
-          return {
-            ...prev,
-            webdav: merged,
-            lastUpdated: Date.now(),
-          }
-        })
-      }
-
-      return success
     },
-    [],
+    [persistPreferenceUpdates],
   )
 
   const updateWebdavAutoSyncSettings = useCallback(
@@ -1286,7 +1249,9 @@ export const UserPreferencesProvider = ({
         ),
       )
 
-      if (response.success) {
+      if (response.success && isUserPreferencesSnapshot(response.data)) {
+        setPreferences(response.data)
+      } else if (response.success) {
         setPreferences((prev) => {
           if (!prev) return null
           const merged = deepOverride(
@@ -1296,7 +1261,6 @@ export const UserPreferencesProvider = ({
           return {
             ...prev,
             webdav: merged,
-            lastUpdated: Date.now(),
           }
         })
       }
@@ -1414,66 +1378,34 @@ export const UserPreferencesProvider = ({
   const resetNewApiConfig = useCallback(async () => {
     const success = await userPreferences.resetNewApiConfig()
     if (success) {
-      const defaults = DEFAULT_PREFERENCES.newApi
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              newApi: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
+      await loadPreferences()
     }
     return success
-  }, [])
+  }, [loadPreferences])
 
   const resetDoneHubConfig = useCallback(async () => {
     const success = await userPreferences.resetDoneHubConfig()
     if (success) {
-      const defaults = DEFAULT_DONE_HUB_CONFIG
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              doneHub: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
+      await loadPreferences()
     }
     return success
-  }, [])
+  }, [loadPreferences])
 
   const resetVeloeraConfig = useCallback(async () => {
     const success = await userPreferences.resetVeloeraConfig()
     if (success) {
-      const defaults = DEFAULT_PREFERENCES.veloera
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              veloera: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
+      await loadPreferences()
     }
     return success
-  }, [])
+  }, [loadPreferences])
 
   const resetOctopusConfig = useCallback(async () => {
     const success = await userPreferences.resetOctopusConfig()
     if (success) {
-      const defaults = DEFAULT_PREFERENCES.octopus
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              octopus: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
+      await loadPreferences()
     }
     return success
-  }, [])
+  }, [loadPreferences])
 
   const resetNewApiModelSyncConfig = useCallback(async () => {
     const success = await userPreferences.resetNewApiModelSyncConfig()
@@ -1500,18 +1432,10 @@ export const UserPreferencesProvider = ({
   const resetCliProxyConfig = useCallback(async () => {
     const success = await userPreferences.resetCliProxyConfig()
     if (success) {
-      const defaults = DEFAULT_PREFERENCES.cliProxy
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              cliProxy: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
+      await loadPreferences()
     }
     return success
-  }, [])
+  }, [loadPreferences])
 
   const resetAutoCheckinConfig = useCallback(async () => {
     const success = await userPreferences.resetAutoCheckinConfig()
@@ -1592,18 +1516,10 @@ export const UserPreferencesProvider = ({
   const resetWebdavConfig = useCallback(async () => {
     const success = await userPreferences.resetWebdavConfig()
     if (success) {
-      const defaults = DEFAULT_PREFERENCES.webdav
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              webdav: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
+      await loadPreferences()
     }
     return success
-  }, [])
+  }, [loadPreferences])
 
   const resetLoggingSettings = useCallback(async () => {
     const defaults = DEFAULT_PREFERENCES.logging

--- a/src/features/BasicSettings/components/tabs/ClaudeCodeRouter/ClaudeCodeRouterSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ClaudeCodeRouter/ClaudeCodeRouterSettings.tsx
@@ -1,10 +1,11 @@
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
-import { useEffect, useState } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
 import { Card, CardItem, CardList, IconButton, Input } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 
 /**
@@ -14,6 +15,7 @@ import { showUpdateToast } from "~/utils/core/toastHelpers"
 export default function ClaudeCodeRouterSettings() {
   const { t } = useTranslation(["settings", "keyManagement"])
   const {
+    preferences,
     claudeCodeRouterBaseUrl,
     claudeCodeRouterApiKey,
     updateClaudeCodeRouterBaseUrl,
@@ -21,27 +23,38 @@ export default function ClaudeCodeRouterSettings() {
     resetClaudeCodeRouterConfig,
   } = useUserPreferencesContext()
 
-  const [localBaseUrl, setLocalBaseUrl] = useState(claudeCodeRouterBaseUrl)
-  const [localKey, setLocalKey] = useState(claudeCodeRouterApiKey)
+  const savedConfig = useMemo(
+    () => ({
+      baseUrl: claudeCodeRouterBaseUrl,
+      apiKey: claudeCodeRouterApiKey,
+    }),
+    [claudeCodeRouterApiKey, claudeCodeRouterBaseUrl],
+  )
+  const {
+    draft: localConfig,
+    setDraft: setLocalConfig,
+    expectedLastUpdated,
+  } = usePreferenceDraft({
+    savedValue: savedConfig,
+    savedVersion: preferences.lastUpdated,
+  })
   const [showKey, setShowKey] = useState(false)
-
-  useEffect(() => {
-    setLocalBaseUrl(claudeCodeRouterBaseUrl)
-  }, [claudeCodeRouterBaseUrl])
-
-  useEffect(() => {
-    setLocalKey(claudeCodeRouterApiKey)
-  }, [claudeCodeRouterApiKey])
+  const localBaseUrl = localConfig.baseUrl
+  const localKey = localConfig.apiKey
 
   const handleBaseUrlChange = async (url: string) => {
     if (url === claudeCodeRouterBaseUrl) return
-    const success = await updateClaudeCodeRouterBaseUrl(url)
+    const success = await updateClaudeCodeRouterBaseUrl(url, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("settings:claudeCodeRouter.baseUrlLabel"))
   }
 
   const handleKeyChange = async (key: string) => {
     if (key === claudeCodeRouterApiKey) return
-    const success = await updateClaudeCodeRouterApiKey(key)
+    const success = await updateClaudeCodeRouterApiKey(key, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("settings:claudeCodeRouter.apiKeyLabel"))
   }
 
@@ -61,7 +74,12 @@ export default function ClaudeCodeRouterSettings() {
               <Input
                 type="text"
                 value={localBaseUrl}
-                onChange={(e) => setLocalBaseUrl(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    baseUrl: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleBaseUrlChange(e.target.value)}
                 placeholder={t("settings:claudeCodeRouter.baseUrlPlaceholder")}
               />
@@ -76,7 +94,12 @@ export default function ClaudeCodeRouterSettings() {
                 <Input
                   type={showKey ? "text" : "password"}
                   value={localKey}
-                  onChange={(e) => setLocalKey(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      apiKey: e.target.value,
+                    }))
+                  }
                   onBlur={(e) => handleKeyChange(e.target.value)}
                   placeholder={t("settings:claudeCodeRouter.apiKeyPlaceholder")}
                   rightIcon={

--- a/src/features/BasicSettings/components/tabs/CliProxy/CliProxySettings.tsx
+++ b/src/features/BasicSettings/components/tabs/CliProxy/CliProxySettings.tsx
@@ -1,5 +1,5 @@
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
-import { useEffect, useState } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
@@ -13,6 +13,7 @@ import {
   Link,
 } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { verifyCliProxyManagementConnection } from "~/services/integrations/cliProxyService"
 import { showResultToast, showUpdateToast } from "~/utils/core/toastHelpers"
 
@@ -25,6 +26,7 @@ const CLI_PROXY_MANAGEMENT_DOC_URL = "https://help.router-for.me/management/api"
 export default function CliProxySettings() {
   const { t } = useTranslation("settings")
   const {
+    preferences,
     cliProxyBaseUrl,
     cliProxyManagementKey,
     updateCliProxyBaseUrl,
@@ -32,18 +34,25 @@ export default function CliProxySettings() {
     resetCliProxyConfig,
   } = useUserPreferencesContext()
 
-  const [localBaseUrl, setLocalBaseUrl] = useState(cliProxyBaseUrl)
-  const [localKey, setLocalKey] = useState(cliProxyManagementKey)
+  const savedConfig = useMemo(
+    () => ({
+      baseUrl: cliProxyBaseUrl,
+      managementKey: cliProxyManagementKey,
+    }),
+    [cliProxyBaseUrl, cliProxyManagementKey],
+  )
+  const {
+    draft: localConfig,
+    setDraft: setLocalConfig,
+    expectedLastUpdated,
+  } = usePreferenceDraft({
+    savedValue: savedConfig,
+    savedVersion: preferences.lastUpdated,
+  })
   const [showKey, setShowKey] = useState(false)
   const [isCheckingConnection, setIsCheckingConnection] = useState(false)
-
-  useEffect(() => {
-    setLocalBaseUrl(cliProxyBaseUrl)
-  }, [cliProxyBaseUrl])
-
-  useEffect(() => {
-    setLocalKey(cliProxyManagementKey)
-  }, [cliProxyManagementKey])
+  const localBaseUrl = localConfig.baseUrl
+  const localKey = localConfig.managementKey
 
   const runConnectionCheck = async (overrides?: {
     baseUrl?: string
@@ -75,10 +84,12 @@ export default function CliProxySettings() {
 
   const handleBaseUrlChange = async (url: string) => {
     const trimmedUrl = url.trim()
-    setLocalBaseUrl(trimmedUrl)
+    setLocalConfig((prev) => ({ ...prev, baseUrl: trimmedUrl }))
 
     if (trimmedUrl === cliProxyBaseUrl.trim()) return
-    const success = await updateCliProxyBaseUrl(trimmedUrl)
+    const success = await updateCliProxyBaseUrl(trimmedUrl, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("cliProxy.baseUrlLabel"))
 
     if (success && trimmedUrl && localKey.trim()) {
@@ -91,10 +102,12 @@ export default function CliProxySettings() {
 
   const handleKeyChange = async (key: string) => {
     const trimmedKey = key.trim()
-    setLocalKey(trimmedKey)
+    setLocalConfig((prev) => ({ ...prev, managementKey: trimmedKey }))
 
     if (trimmedKey === cliProxyManagementKey.trim()) return
-    const success = await updateCliProxyManagementKey(trimmedKey)
+    const success = await updateCliProxyManagementKey(trimmedKey, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("cliProxy.managementKeyLabel"))
 
     if (success && localBaseUrl.trim() && trimmedKey) {
@@ -121,7 +134,12 @@ export default function CliProxySettings() {
               <Input
                 type="text"
                 value={localBaseUrl}
-                onChange={(e) => setLocalBaseUrl(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    baseUrl: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleBaseUrlChange(e.target.value)}
                 placeholder="http://localhost:8317/v0/management"
               />
@@ -136,7 +154,12 @@ export default function CliProxySettings() {
                 <Input
                   type={showKey ? "text" : "password"}
                   value={localKey}
-                  onChange={(e) => setLocalKey(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      managementKey: e.target.value,
+                    }))
+                  }
                   onBlur={(e) => handleKeyChange(e.target.value)}
                   rightIcon={
                     <IconButton

--- a/src/features/BasicSettings/components/tabs/ManagedSite/DoneHubSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/DoneHubSettings.tsx
@@ -1,5 +1,5 @@
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
-import { useEffect, useState } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
@@ -13,6 +13,7 @@ import {
 } from "~/components/ui"
 import { DONE_HUB, getSiteApiRouter } from "~/constants/siteType"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { isManagedSiteAdminUserIdInputValid } from "~/services/managedSites/utils/adminUserId"
 import { createTab } from "~/utils/browser/browserApi"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
@@ -25,6 +26,7 @@ import { joinUrl } from "~/utils/core/url"
 export default function DoneHubSettings() {
   const { t } = useTranslation("settings")
   const {
+    preferences,
     doneHubBaseUrl,
     doneHubAdminToken,
     doneHubUserId,
@@ -34,33 +36,41 @@ export default function DoneHubSettings() {
     resetDoneHubConfig,
   } = useUserPreferencesContext()
 
-  const [localBaseUrl, setLocalBaseUrl] = useState(doneHubBaseUrl)
-  const [localAdminToken, setLocalAdminToken] = useState(doneHubAdminToken)
+  const savedConfig = useMemo(
+    () => ({
+      baseUrl: doneHubBaseUrl,
+      adminToken: doneHubAdminToken,
+      userId: doneHubUserId,
+    }),
+    [doneHubAdminToken, doneHubBaseUrl, doneHubUserId],
+  )
+  const {
+    draft: localConfig,
+    setDraft: setLocalConfig,
+    expectedLastUpdated,
+  } = usePreferenceDraft({
+    savedValue: savedConfig,
+    savedVersion: preferences.lastUpdated,
+  })
   const [showAdminToken, setShowAdminToken] = useState(false)
-  const [localUserId, setLocalUserId] = useState(doneHubUserId)
-
-  useEffect(() => {
-    setLocalBaseUrl(doneHubBaseUrl)
-  }, [doneHubBaseUrl])
-
-  useEffect(() => {
-    setLocalAdminToken(doneHubAdminToken)
-  }, [doneHubAdminToken])
-
-  useEffect(() => {
-    setLocalUserId(doneHubUserId)
-  }, [doneHubUserId])
+  const localBaseUrl = localConfig.baseUrl
+  const localAdminToken = localConfig.adminToken
+  const localUserId = localConfig.userId
 
   const handleBaseUrlChange = async (url: string) => {
     const clean = url.trim()
     if (clean === doneHubBaseUrl) return
-    const success = await updateDoneHubBaseUrl(clean)
+    const success = await updateDoneHubBaseUrl(clean, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("doneHub.fields.baseUrlLabel"))
   }
 
   const handleAdminTokenChange = async (token: string) => {
     if (token === doneHubAdminToken) return
-    const success = await updateDoneHubAdminToken(token)
+    const success = await updateDoneHubAdminToken(token, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("doneHub.fields.adminTokenLabel"))
   }
 
@@ -68,9 +78,11 @@ export default function DoneHubSettings() {
     const trimmedId = id.trim()
     if (!isManagedSiteAdminUserIdInputValid(trimmedId)) return
 
-    setLocalUserId(trimmedId)
+    setLocalConfig((prev) => ({ ...prev, userId: trimmedId }))
     if (trimmedId === doneHubUserId) return
-    const success = await updateDoneHubUserId(trimmedId)
+    const success = await updateDoneHubUserId(trimmedId, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("doneHub.fields.userIdLabel"))
   }
 
@@ -110,7 +122,12 @@ export default function DoneHubSettings() {
               <Input
                 type="text"
                 value={localBaseUrl}
-                onChange={(e) => setLocalBaseUrl(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    baseUrl: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleBaseUrlChange(e.target.value)}
                 placeholder={t("doneHub.fields.baseUrlPlaceholder")}
               />
@@ -141,7 +158,12 @@ export default function DoneHubSettings() {
                 <Input
                   type={showAdminToken ? "text" : "password"}
                   value={localAdminToken}
-                  onChange={(e) => setLocalAdminToken(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      adminToken: e.target.value,
+                    }))
+                  }
                   onBlur={(e) => handleAdminTokenChange(e.target.value)}
                   rightIcon={
                     <IconButton
@@ -175,7 +197,12 @@ export default function DoneHubSettings() {
                 inputMode="numeric"
                 pattern="[0-9]*"
                 value={localUserId}
-                onChange={(e) => setLocalUserId(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    userId: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleUserIdChange(e.target.value)}
                 error={userIdError}
                 aria-invalid={Boolean(userIdError)}

--- a/src/features/BasicSettings/components/tabs/ManagedSite/NewApiSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/NewApiSettings.tsx
@@ -1,5 +1,5 @@
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
-import { useEffect, useState } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
@@ -16,6 +16,7 @@ import { getSiteApiRouter, NEW_API } from "~/constants/siteType"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { NewApiManagedVerificationDialog } from "~/features/ManagedSiteVerification/NewApiManagedVerificationDialog"
 import { useNewApiManagedVerification } from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
+import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { isManagedSiteAdminUserIdInputValid } from "~/services/managedSites/utils/adminUserId"
 import { createTab } from "~/utils/browser/browserApi"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
@@ -28,6 +29,7 @@ import { joinUrl } from "~/utils/core/url"
 export default function NewApiSettings() {
   const { t } = useTranslation("settings")
   const {
+    preferences,
     newApiBaseUrl,
     newApiAdminToken,
     newApiUserId,
@@ -43,50 +45,56 @@ export default function NewApiSettings() {
     resetNewApiConfig,
   } = useUserPreferencesContext()
 
-  const [localBaseUrl, setLocalBaseUrl] = useState(newApiBaseUrl)
-  const [localAdminToken, setLocalAdminToken] = useState(newApiAdminToken)
+  const savedConfig = useMemo(
+    () => ({
+      baseUrl: newApiBaseUrl,
+      adminToken: newApiAdminToken,
+      userId: newApiUserId,
+      username: newApiUsername,
+      password: newApiPassword,
+      totpSecret: newApiTotpSecret,
+    }),
+    [
+      newApiAdminToken,
+      newApiBaseUrl,
+      newApiPassword,
+      newApiTotpSecret,
+      newApiUserId,
+      newApiUsername,
+    ],
+  )
+  const {
+    draft: localConfig,
+    setDraft: setLocalConfig,
+    expectedLastUpdated,
+  } = usePreferenceDraft({
+    savedValue: savedConfig,
+    savedVersion: preferences.lastUpdated,
+  })
   const [showAdminToken, setShowAdminToken] = useState(false)
-  const [localUserId, setLocalUserId] = useState(newApiUserId)
-  const [localUsername, setLocalUsername] = useState(newApiUsername)
-  const [localPassword, setLocalPassword] = useState(newApiPassword)
-  const [localTotpSecret, setLocalTotpSecret] = useState(newApiTotpSecret)
   const [showPassword, setShowPassword] = useState(false)
   const [showTotpSecret, setShowTotpSecret] = useState(false)
   const verification = useNewApiManagedVerification()
-
-  useEffect(() => {
-    setLocalBaseUrl(newApiBaseUrl)
-  }, [newApiBaseUrl])
-
-  useEffect(() => {
-    setLocalAdminToken(newApiAdminToken)
-  }, [newApiAdminToken])
-
-  useEffect(() => {
-    setLocalUserId(newApiUserId)
-  }, [newApiUserId])
-
-  useEffect(() => {
-    setLocalUsername(newApiUsername)
-  }, [newApiUsername])
-
-  useEffect(() => {
-    setLocalPassword(newApiPassword)
-  }, [newApiPassword])
-
-  useEffect(() => {
-    setLocalTotpSecret(newApiTotpSecret)
-  }, [newApiTotpSecret])
+  const localBaseUrl = localConfig.baseUrl
+  const localAdminToken = localConfig.adminToken
+  const localUserId = localConfig.userId
+  const localUsername = localConfig.username
+  const localPassword = localConfig.password
+  const localTotpSecret = localConfig.totpSecret
 
   const handleNewApiBaseUrlChange = async (url: string) => {
     if (url === newApiBaseUrl) return
-    const success = await updateNewApiBaseUrl(url)
+    const success = await updateNewApiBaseUrl(url, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("newApi.fields.baseUrlLabel"))
   }
 
   const handleNewApiAdminTokenChange = async (token: string) => {
     if (token === newApiAdminToken) return
-    const success = await updateNewApiAdminToken(token)
+    const success = await updateNewApiAdminToken(token, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("newApi.fields.adminTokenLabel"))
   }
 
@@ -94,31 +102,39 @@ export default function NewApiSettings() {
     const trimmedId = id.trim()
     if (!isManagedSiteAdminUserIdInputValid(trimmedId)) return
 
-    setLocalUserId(trimmedId)
+    setLocalConfig((prev) => ({ ...prev, userId: trimmedId }))
     if (trimmedId === newApiUserId) return
-    const success = await updateNewApiUserId(trimmedId)
+    const success = await updateNewApiUserId(trimmedId, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("newApi.fields.userIdLabel"))
   }
 
   const handleNewApiUsernameChange = async (username: string) => {
     const trimmedUsername = username.trim()
-    setLocalUsername(trimmedUsername)
+    setLocalConfig((prev) => ({ ...prev, username: trimmedUsername }))
     if (trimmedUsername === newApiUsername) return
-    const success = await updateNewApiUsername(trimmedUsername)
+    const success = await updateNewApiUsername(trimmedUsername, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("newApi.fields.usernameLabel"))
   }
 
   const handleNewApiPasswordChange = async (password: string) => {
     if (password === newApiPassword) return
-    const success = await updateNewApiPassword(password)
+    const success = await updateNewApiPassword(password, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("newApi.fields.passwordLabel"))
   }
 
   const handleNewApiTotpSecretChange = async (totpSecret: string) => {
     const trimmedTotpSecret = totpSecret.trim()
-    setLocalTotpSecret(trimmedTotpSecret)
+    setLocalConfig((prev) => ({ ...prev, totpSecret: trimmedTotpSecret }))
     if (trimmedTotpSecret === newApiTotpSecret) return
-    const success = await updateNewApiTotpSecret(trimmedTotpSecret)
+    const success = await updateNewApiTotpSecret(trimmedTotpSecret, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("newApi.fields.totpSecretLabel"))
   }
 
@@ -171,7 +187,12 @@ export default function NewApiSettings() {
               <Input
                 type="text"
                 value={localBaseUrl}
-                onChange={(e) => setLocalBaseUrl(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    baseUrl: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleNewApiBaseUrlChange(e.target.value)}
                 placeholder={t("newApi.fields.baseUrlPlaceholder")}
               />
@@ -202,7 +223,12 @@ export default function NewApiSettings() {
                 <Input
                   type={showAdminToken ? "text" : "password"}
                   value={localAdminToken}
-                  onChange={(e) => setLocalAdminToken(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      adminToken: e.target.value,
+                    }))
+                  }
                   onBlur={(e) => handleNewApiAdminTokenChange(e.target.value)}
                   rightIcon={
                     <IconButton
@@ -236,7 +262,12 @@ export default function NewApiSettings() {
                 inputMode="numeric"
                 pattern="[0-9]*"
                 value={localUserId}
-                onChange={(e) => setLocalUserId(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    userId: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleNewApiUserIdChange(e.target.value)}
                 error={userIdError}
                 aria-invalid={Boolean(userIdError)}
@@ -251,7 +282,12 @@ export default function NewApiSettings() {
               <Input
                 type="text"
                 value={localUsername}
-                onChange={(e) => setLocalUsername(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    username: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleNewApiUsernameChange(e.target.value)}
                 placeholder={t("newApi.fields.usernamePlaceholder")}
               />
@@ -266,7 +302,12 @@ export default function NewApiSettings() {
                 <Input
                   type={showPassword ? "text" : "password"}
                   value={localPassword}
-                  onChange={(e) => setLocalPassword(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      password: e.target.value,
+                    }))
+                  }
                   onBlur={(e) => handleNewApiPasswordChange(e.target.value)}
                   placeholder={t("newApi.fields.passwordPlaceholder")}
                   rightIcon={
@@ -300,7 +341,12 @@ export default function NewApiSettings() {
                 <Input
                   type={showTotpSecret ? "text" : "password"}
                   value={localTotpSecret}
-                  onChange={(e) => setLocalTotpSecret(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      totpSecret: e.target.value,
+                    }))
+                  }
                   onBlur={(e) => handleNewApiTotpSecretChange(e.target.value)}
                   placeholder={t("newApi.fields.totpSecretPlaceholder")}
                   rightIcon={

--- a/src/features/BasicSettings/components/tabs/ManagedSite/OctopusSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/OctopusSettings.tsx
@@ -1,5 +1,5 @@
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
-import { useEffect, useState } from "react"
+import { useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -13,6 +13,7 @@ import {
   Input,
 } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { octopusAuthManager } from "~/services/apiService/octopus/auth"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 
@@ -23,51 +24,63 @@ import { showUpdateToast } from "~/utils/core/toastHelpers"
 export default function OctopusSettings() {
   const { t } = useTranslation("settings")
   const {
+    preferences,
     octopusBaseUrl,
     octopusUsername,
     octopusPassword,
     updateOctopusBaseUrl,
+    updateOctopusConfig,
     updateOctopusUsername,
     updateOctopusPassword,
     resetOctopusConfig,
   } = useUserPreferencesContext()
 
-  const [localBaseUrl, setLocalBaseUrl] = useState(octopusBaseUrl)
-  const [localUsername, setLocalUsername] = useState(octopusUsername)
-  const [localPassword, setLocalPassword] = useState(octopusPassword)
+  const savedConfig = useMemo(
+    () => ({
+      baseUrl: octopusBaseUrl,
+      username: octopusUsername,
+      password: octopusPassword,
+    }),
+    [octopusBaseUrl, octopusPassword, octopusUsername],
+  )
+  const {
+    draft: localConfig,
+    setDraft: setLocalConfig,
+    expectedLastUpdated,
+  } = usePreferenceDraft({
+    savedValue: savedConfig,
+    savedVersion: preferences.lastUpdated,
+  })
   const [showPassword, setShowPassword] = useState(false)
   const [isValidating, setIsValidating] = useState(false)
-
-  useEffect(() => {
-    setLocalBaseUrl(octopusBaseUrl)
-  }, [octopusBaseUrl])
-
-  useEffect(() => {
-    setLocalUsername(octopusUsername)
-  }, [octopusUsername])
-
-  useEffect(() => {
-    setLocalPassword(octopusPassword)
-  }, [octopusPassword])
+  const localBaseUrl = localConfig.baseUrl
+  const localUsername = localConfig.username
+  const localPassword = localConfig.password
 
   const handleBaseUrlChange = async (url: string) => {
     url = url.trim()
     if (url === octopusBaseUrl) return
-    const success = await updateOctopusBaseUrl(url)
+    const success = await updateOctopusBaseUrl(url, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("octopus.fields.baseUrlLabel"))
   }
 
   const handleUsernameChange = async (username: string) => {
     username = username.trim()
     if (username === octopusUsername) return
-    const success = await updateOctopusUsername(username)
+    const success = await updateOctopusUsername(username, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("octopus.fields.usernameLabel"))
   }
 
   const handlePasswordChange = async (password: string) => {
     password = password.trim()
     if (password === octopusPassword) return
-    const success = await updateOctopusPassword(password)
+    const success = await updateOctopusPassword(password, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("octopus.fields.passwordLabel"))
   }
 
@@ -82,9 +95,12 @@ export default function OctopusSettings() {
     }
 
     // Persist trimmed values to ensure stored inputs match validated values
-    setLocalBaseUrl(trimmedUrl)
-    setLocalUsername(trimmedUsername)
-    setLocalPassword(trimmedPassword)
+    setLocalConfig((prev) => ({
+      ...prev,
+      baseUrl: trimmedUrl,
+      username: trimmedUsername,
+      password: trimmedPassword,
+    }))
 
     setIsValidating(true)
     try {
@@ -96,12 +112,22 @@ export default function OctopusSettings() {
 
       if (result.success) {
         // Persist validated config to storage
-        await Promise.all([
-          updateOctopusBaseUrl(trimmedUrl),
-          updateOctopusUsername(trimmedUsername),
-          updateOctopusPassword(trimmedPassword),
-        ])
-        toast.success(t("octopus.validation.success"))
+        const success = await updateOctopusConfig(
+          {
+            baseUrl: trimmedUrl,
+            username: trimmedUsername,
+            password: trimmedPassword,
+          },
+          {
+            expectedLastUpdated,
+          },
+        )
+
+        if (success) {
+          toast.success(t("octopus.validation.success"))
+        } else {
+          toast.error(t("settings:messages.updateFailed"))
+        }
       } else {
         toast.error(result.error || t("octopus.validation.failed"))
       }
@@ -128,7 +154,12 @@ export default function OctopusSettings() {
               <Input
                 type="text"
                 value={localBaseUrl}
-                onChange={(e) => setLocalBaseUrl(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    baseUrl: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleBaseUrlChange(e.target.value)}
                 placeholder={t("octopus.fields.baseUrlPlaceholder")}
               />
@@ -142,7 +173,12 @@ export default function OctopusSettings() {
               <Input
                 type="text"
                 value={localUsername}
-                onChange={(e) => setLocalUsername(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    username: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleUsernameChange(e.target.value)}
                 placeholder={t("octopus.fields.usernamePlaceholder")}
               />
@@ -157,7 +193,12 @@ export default function OctopusSettings() {
                 <Input
                   type={showPassword ? "text" : "password"}
                   value={localPassword}
-                  onChange={(e) => setLocalPassword(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      password: e.target.value,
+                    }))
+                  }
                   onBlur={(e) => handlePasswordChange(e.target.value)}
                   placeholder={t("octopus.fields.passwordPlaceholder")}
                   rightIcon={

--- a/src/features/BasicSettings/components/tabs/ManagedSite/VeloeraSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/VeloeraSettings.tsx
@@ -1,5 +1,5 @@
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
-import { useEffect, useState } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
@@ -13,6 +13,7 @@ import {
 } from "~/components/ui"
 import { getSiteApiRouter, VELOERA } from "~/constants/siteType"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { isManagedSiteAdminUserIdInputValid } from "~/services/managedSites/utils/adminUserId"
 import { createTab } from "~/utils/browser/browserApi"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
@@ -25,6 +26,7 @@ import { joinUrl } from "~/utils/core/url"
 export default function VeloeraSettings() {
   const { t } = useTranslation("settings")
   const {
+    preferences,
     veloeraBaseUrl,
     veloeraAdminToken,
     veloeraUserId,
@@ -34,32 +36,40 @@ export default function VeloeraSettings() {
     resetVeloeraConfig,
   } = useUserPreferencesContext()
 
-  const [localBaseUrl, setLocalBaseUrl] = useState(veloeraBaseUrl)
-  const [localAdminToken, setLocalAdminToken] = useState(veloeraAdminToken)
+  const savedConfig = useMemo(
+    () => ({
+      baseUrl: veloeraBaseUrl,
+      adminToken: veloeraAdminToken,
+      userId: veloeraUserId,
+    }),
+    [veloeraAdminToken, veloeraBaseUrl, veloeraUserId],
+  )
+  const {
+    draft: localConfig,
+    setDraft: setLocalConfig,
+    expectedLastUpdated,
+  } = usePreferenceDraft({
+    savedValue: savedConfig,
+    savedVersion: preferences.lastUpdated,
+  })
   const [showAdminToken, setShowAdminToken] = useState(false)
-  const [localUserId, setLocalUserId] = useState(veloeraUserId)
-
-  useEffect(() => {
-    setLocalBaseUrl(veloeraBaseUrl)
-  }, [veloeraBaseUrl])
-
-  useEffect(() => {
-    setLocalAdminToken(veloeraAdminToken)
-  }, [veloeraAdminToken])
-
-  useEffect(() => {
-    setLocalUserId(veloeraUserId)
-  }, [veloeraUserId])
+  const localBaseUrl = localConfig.baseUrl
+  const localAdminToken = localConfig.adminToken
+  const localUserId = localConfig.userId
 
   const handleVeloeraBaseUrlChange = async (url: string) => {
     if (url === veloeraBaseUrl) return
-    const success = await updateVeloeraBaseUrl(url)
+    const success = await updateVeloeraBaseUrl(url, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("veloera.fields.baseUrlLabel"))
   }
 
   const handleVeloeraAdminTokenChange = async (token: string) => {
     if (token === veloeraAdminToken) return
-    const success = await updateVeloeraAdminToken(token)
+    const success = await updateVeloeraAdminToken(token, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("veloera.fields.adminTokenLabel"))
   }
 
@@ -67,9 +77,11 @@ export default function VeloeraSettings() {
     const trimmedId = id.trim()
     if (!isManagedSiteAdminUserIdInputValid(trimmedId)) return
 
-    setLocalUserId(trimmedId)
+    setLocalConfig((prev) => ({ ...prev, userId: trimmedId }))
     if (trimmedId === veloeraUserId) return
-    const success = await updateVeloeraUserId(trimmedId)
+    const success = await updateVeloeraUserId(trimmedId, {
+      expectedLastUpdated,
+    })
     showUpdateToast(success, t("veloera.fields.userIdLabel"))
   }
 
@@ -109,7 +121,12 @@ export default function VeloeraSettings() {
               <Input
                 type="text"
                 value={localBaseUrl}
-                onChange={(e) => setLocalBaseUrl(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    baseUrl: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleVeloeraBaseUrlChange(e.target.value)}
                 placeholder={t("veloera.fields.baseUrlPlaceholder")}
               />
@@ -140,7 +157,12 @@ export default function VeloeraSettings() {
                 <Input
                   type={showAdminToken ? "text" : "password"}
                   value={localAdminToken}
-                  onChange={(e) => setLocalAdminToken(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      adminToken: e.target.value,
+                    }))
+                  }
                   onBlur={(e) => handleVeloeraAdminTokenChange(e.target.value)}
                   rightIcon={
                     <IconButton
@@ -174,7 +196,12 @@ export default function VeloeraSettings() {
                 inputMode="numeric"
                 pattern="[0-9]*"
                 value={localUserId}
-                onChange={(e) => setLocalUserId(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    userId: e.target.value,
+                  }))
+                }
                 onBlur={(e) => handleVeloeraUserIdChange(e.target.value)}
                 error={userIdError}
                 aria-invalid={Boolean(userIdError)}

--- a/src/features/BasicSettings/components/tabs/ManagedSite/VeloeraSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/VeloeraSettings.tsx
@@ -58,16 +58,22 @@ export default function VeloeraSettings() {
   const localUserId = localConfig.userId
 
   const handleVeloeraBaseUrlChange = async (url: string) => {
-    if (url === veloeraBaseUrl) return
-    const success = await updateVeloeraBaseUrl(url, {
+    const trimmedUrl = url.trim()
+    setLocalConfig((prev) => ({ ...prev, baseUrl: trimmedUrl }))
+
+    if (trimmedUrl === veloeraBaseUrl.trim()) return
+    const success = await updateVeloeraBaseUrl(trimmedUrl, {
       expectedLastUpdated,
     })
     showUpdateToast(success, t("veloera.fields.baseUrlLabel"))
   }
 
   const handleVeloeraAdminTokenChange = async (token: string) => {
-    if (token === veloeraAdminToken) return
-    const success = await updateVeloeraAdminToken(token, {
+    const trimmedToken = token.trim()
+    setLocalConfig((prev) => ({ ...prev, adminToken: trimmedToken }))
+
+    if (trimmedToken === veloeraAdminToken.trim()) return
+    const success = await updateVeloeraAdminToken(trimmedToken, {
       expectedLastUpdated,
     })
     showUpdateToast(success, t("veloera.fields.adminTokenLabel"))

--- a/src/features/BasicSettings/components/tabs/ManagedSite/VeloeraSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/VeloeraSettings.tsx
@@ -84,7 +84,7 @@ export default function VeloeraSettings() {
     if (!isManagedSiteAdminUserIdInputValid(trimmedId)) return
 
     setLocalConfig((prev) => ({ ...prev, userId: trimmedId }))
-    if (trimmedId === veloeraUserId) return
+    if (trimmedId === veloeraUserId.trim()) return
     const success = await updateVeloeraUserId(trimmedId, {
       expectedLastUpdated,
     })

--- a/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
@@ -4,7 +4,7 @@ import {
   ClockIcon,
   XCircleIcon,
 } from "@heroicons/react/24/outline"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -27,6 +27,7 @@ import {
 } from "~/components/ui"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { WEBDAV_SYNC_STRATEGIES, WebDAVSettings } from "~/types/webdav"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { formatTimestamp } from "~/utils/core/formatters"
@@ -46,16 +47,31 @@ export default function WebDAVAutoSyncSettings() {
     useUserPreferencesContext()
   const persistedWebdavSettings = preferences.webdav
 
-  // Auto-sync settings
-  const [autoSyncEnabled, setAutoSyncEnabled] = useState(
-    persistedWebdavSettings.autoSync ?? false,
+  const savedConfig = useMemo(
+    () => ({
+      autoSync: persistedWebdavSettings.autoSync ?? false,
+      syncInterval: persistedWebdavSettings.syncInterval ?? 3600,
+      syncStrategy:
+        persistedWebdavSettings.syncStrategy ?? WEBDAV_SYNC_STRATEGIES.MERGE,
+    }),
+    [
+      persistedWebdavSettings.autoSync,
+      persistedWebdavSettings.syncInterval,
+      persistedWebdavSettings.syncStrategy,
+    ],
   )
-  const [syncInterval, setSyncInterval] = useState(
-    persistedWebdavSettings.syncInterval ?? 3600,
-  )
-  const [syncStrategy, setSyncStrategy] = useState<
-    WebDAVSettings["syncStrategy"]
-  >(persistedWebdavSettings.syncStrategy ?? WEBDAV_SYNC_STRATEGIES.MERGE)
+  const {
+    draft: localConfig,
+    setDraft: setLocalConfig,
+    expectedLastUpdated,
+  } = usePreferenceDraft({
+    savedValue: savedConfig,
+    savedVersion: preferences.lastUpdated,
+  })
+  const autoSyncEnabled = localConfig.autoSync
+  const syncInterval = localConfig.syncInterval
+  const syncStrategy =
+    localConfig.syncStrategy as WebDAVSettings["syncStrategy"]
 
   // Status
   const [isSyncing, setIsSyncing] = useState(false)
@@ -86,29 +102,22 @@ export default function WebDAVAutoSyncSettings() {
   }, [])
 
   useEffect(() => {
-    setAutoSyncEnabled(persistedWebdavSettings.autoSync ?? false)
-    setSyncInterval(persistedWebdavSettings.syncInterval ?? 3600)
-    setSyncStrategy(
-      persistedWebdavSettings.syncStrategy ?? WEBDAV_SYNC_STRATEGIES.MERGE,
-    )
-  }, [
-    persistedWebdavSettings.autoSync,
-    persistedWebdavSettings.syncInterval,
-    persistedWebdavSettings.syncStrategy,
-  ])
-
-  useEffect(() => {
     void loadStatus()
   }, [loadStatus])
 
   const handleSaveSettings = async () => {
     setSavingSettings(true)
     try {
-      const response = await updateWebdavAutoSyncSettings({
-        autoSync: autoSyncEnabled,
-        syncInterval,
-        syncStrategy,
-      })
+      const response = await updateWebdavAutoSyncSettings(
+        {
+          autoSync: autoSyncEnabled,
+          syncInterval,
+          syncStrategy,
+        },
+        {
+          expectedLastUpdated,
+        },
+      )
 
       if (response.success) {
         toast.success(t("settings:messages.updateSuccess"))
@@ -201,7 +210,15 @@ export default function WebDAVAutoSyncSettings() {
           description={t("webdav.autoSync.enableDesc")}
         >
           <div className="flex items-center gap-2">
-            <Switch checked={autoSyncEnabled} onChange={setAutoSyncEnabled} />
+            <Switch
+              checked={autoSyncEnabled}
+              onChange={(checked) =>
+                setLocalConfig((prev) => ({
+                  ...prev,
+                  autoSync: checked,
+                }))
+              }
+            />
             <span className="text-sm text-gray-700 dark:text-gray-300">
               {autoSyncEnabled
                 ? t("common:status.enabled")
@@ -223,7 +240,12 @@ export default function WebDAVAutoSyncSettings() {
                 max={86400}
                 step={60}
                 value={syncInterval}
-                onChange={(e) => setSyncInterval(Number(e.target.value))}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    syncInterval: Number(e.target.value),
+                  }))
+                }
                 placeholder="3600"
               />
               <p className="mt-1 text-xs text-gray-500">
@@ -241,7 +263,10 @@ export default function WebDAVAutoSyncSettings() {
               <Select
                 value={syncStrategy ?? ""}
                 onValueChange={(value) =>
-                  setSyncStrategy(value as WebDAVSettings["syncStrategy"])
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    syncStrategy: value as WebDAVSettings["syncStrategy"],
+                  }))
                 }
               >
                 <SelectTrigger>

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -211,9 +211,12 @@ export default function WebDAVSettings() {
 
   const persistWebdavConfig = async (
     updates: Partial<WebDAVSettings> = webdavConfig,
+    options?: {
+      expectedLastUpdated?: number
+    },
   ) => {
     const success = await updateWebdavSettings(updates, {
-      expectedLastUpdated,
+      expectedLastUpdated: options?.expectedLastUpdated ?? expectedLastUpdated,
     })
     if (!success) {
       throw new PersistWebdavConfigError()
@@ -422,11 +425,27 @@ export default function WebDAVSettings() {
 
       const data = JSON.parse(content)
       const result = await handleImportWithSelection(data)
+      let importedPreferencesLastUpdated: number | null = null
+
+      if (result.allImported || result.sections?.preferences) {
+        const refreshedPreferences = await userPreferences.getPreferences()
+        importedPreferencesLastUpdated = refreshedPreferences.lastUpdated
+        await loadPreferences()
+        await applyPreferenceLanguage(await userPreferences.getLanguage())
+      }
+
       if (saveDecryptPassword) {
         try {
-          await persistWebdavConfig({
-            backupEncryptionPassword: pwd,
-          })
+          await persistWebdavConfig(
+            {
+              backupEncryptionPassword: pwd,
+            },
+            importedPreferencesLastUpdated === null
+              ? undefined
+              : {
+                  expectedLastUpdated: importedPreferencesLastUpdated,
+                },
+          )
           setLocalConfig((prev) => ({
             ...prev,
             backupEncryptionPassword: pwd,
@@ -437,10 +456,6 @@ export default function WebDAVSettings() {
         }
       }
 
-      if (result.allImported || result.sections?.preferences) {
-        await loadPreferences()
-        await applyPreferenceLanguage(await userPreferences.getLanguage())
-      }
       if (result.allImported) {
         toast.success(t("importExport:import.importSuccess"))
       }

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -56,6 +56,7 @@ import {
   type WebDAVSyncDataKey,
 } from "~/types/webdav"
 import { createLogger } from "~/utils/core/logger"
+import { applyPreferenceLanguage } from "~/utils/i18n/applyPreferenceLanguage"
 
 import {
   BACKUP_VERSION,
@@ -380,6 +381,7 @@ export default function WebDAVSettings() {
       const result = await handleImportWithSelection(data)
       if (result.allImported || result.sections?.preferences) {
         await loadPreferences()
+        await applyPreferenceLanguage(await userPreferences.getLanguage())
       }
       if (result.allImported) {
         toast.success(t("importExport:import.importSuccess"))
@@ -437,6 +439,7 @@ export default function WebDAVSettings() {
 
       if (result.allImported || result.sections?.preferences) {
         await loadPreferences()
+        await applyPreferenceLanguage(await userPreferences.getLanguage())
       }
       if (result.allImported) {
         toast.success(t("importExport:import.importSuccess"))

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -26,6 +26,7 @@ import {
   Switch,
 } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
@@ -53,7 +54,6 @@ import {
   WEBDAV_SYNC_DATA_KEYS,
   type WebDAVSettings,
   type WebDAVSyncDataKey,
-  type WebDAVSyncDataSelection,
 } from "~/types/webdav"
 import { createLogger } from "~/utils/core/logger"
 
@@ -104,30 +104,48 @@ function getWebdavSyncDataLabel(t: TFunction, key: WebDAVSyncDataKey) {
  */
 export default function WebDAVSettings() {
   const { t } = useTranslation("importExport")
-  const { preferences, updateWebdavSettings } = useUserPreferencesContext()
+  const { preferences, updateWebdavSettings, loadPreferences } =
+    useUserPreferencesContext()
   const persistedWebdavSettings = preferences.webdav
 
-  // 配置表单
-  const [webdavUrl, setWebdavUrl] = useState(persistedWebdavSettings.url ?? "")
-  const [webdavUsername, setWebdavUsername] = useState(
-    persistedWebdavSettings.username ?? "",
+  const savedConfig = useMemo(
+    () => ({
+      url: persistedWebdavSettings.url ?? "",
+      username: persistedWebdavSettings.username ?? "",
+      password: persistedWebdavSettings.password ?? "",
+      syncData: resolveWebdavSyncDataSelection(
+        persistedWebdavSettings.syncData,
+      ),
+      backupEncryptionEnabled: Boolean(
+        persistedWebdavSettings.backupEncryptionEnabled,
+      ),
+      backupEncryptionPassword:
+        persistedWebdavSettings.backupEncryptionPassword ?? "",
+    }),
+    [
+      persistedWebdavSettings.backupEncryptionEnabled,
+      persistedWebdavSettings.backupEncryptionPassword,
+      persistedWebdavSettings.password,
+      persistedWebdavSettings.syncData,
+      persistedWebdavSettings.url,
+      persistedWebdavSettings.username,
+    ],
   )
-  const [webdavPassword, setWebdavPassword] = useState(
-    persistedWebdavSettings.password ?? "",
-  )
+  const {
+    draft: localConfig,
+    setDraft: setLocalConfig,
+    expectedLastUpdated,
+  } = usePreferenceDraft({
+    savedValue: savedConfig,
+    savedVersion: preferences.lastUpdated,
+  })
+  const webdavUrl = localConfig.url
+  const webdavUsername = localConfig.username
+  const webdavPassword = localConfig.password
+  const syncDataSelection = localConfig.syncData
+  const backupEncryptionEnabled = localConfig.backupEncryptionEnabled
+  const backupEncryptionPassword = localConfig.backupEncryptionPassword
   const [showPassword, setShowPassword] = useState(false)
-
-  const [syncDataSelection, setSyncDataSelection] =
-    useState<WebDAVSyncDataSelection>(() =>
-      resolveWebdavSyncDataSelection(persistedWebdavSettings.syncData),
-    )
-
-  const [backupEncryptionEnabled, setBackupEncryptionEnabled] = useState(
-    Boolean(persistedWebdavSettings.backupEncryptionEnabled),
-  )
-  const [backupEncryptionPassword, setBackupEncryptionPassword] = useState(
-    persistedWebdavSettings.backupEncryptionPassword ?? "",
-  )
   const [showBackupEncryptionPassword, setShowBackupEncryptionPassword] =
     useState(false)
 
@@ -163,9 +181,12 @@ export default function WebDAVSettings() {
     key: WebDAVSyncDataKey,
     checked: boolean | "indeterminate",
   ) => {
-    setSyncDataSelection((previousSelection) => ({
-      ...previousSelection,
-      [key]: checked === true,
+    setLocalConfig((previousConfig) => ({
+      ...previousConfig,
+      syncData: {
+        ...previousConfig.syncData,
+        [key]: checked === true,
+      },
     }))
   }
 
@@ -190,7 +211,9 @@ export default function WebDAVSettings() {
   const persistWebdavConfig = async (
     updates: Partial<WebDAVSettings> = webdavConfig,
   ) => {
-    const success = await updateWebdavSettings(updates)
+    const success = await updateWebdavSettings(updates, {
+      expectedLastUpdated,
+    })
     if (!success) {
       throw new PersistWebdavConfigError()
     }
@@ -355,6 +378,9 @@ export default function WebDAVSettings() {
 
       const data = JSON.parse(content)
       const result = await handleImportWithSelection(data)
+      if (result.allImported || result.sections?.preferences) {
+        await loadPreferences()
+      }
       if (result.allImported) {
         toast.success(t("importExport:import.importSuccess"))
       }
@@ -394,20 +420,26 @@ export default function WebDAVSettings() {
 
       const data = JSON.parse(content)
       const result = await handleImportWithSelection(data)
-      if (result.allImported) {
-        toast.success(t("importExport:import.importSuccess"))
-      }
-
       if (saveDecryptPassword) {
         try {
           await persistWebdavConfig({
             backupEncryptionPassword: pwd,
           })
-          setBackupEncryptionPassword(pwd)
+          setLocalConfig((prev) => ({
+            ...prev,
+            backupEncryptionPassword: pwd,
+          }))
         } catch (error) {
           logger.error("Failed to persist WebDAV decrypt password", error)
           toast.error(t("settings:messages.saveSettingsFailed"))
         }
+      }
+
+      if (result.allImported || result.sections?.preferences) {
+        await loadPreferences()
+      }
+      if (result.allImported) {
+        toast.success(t("importExport:import.importSuccess"))
       }
 
       setDecryptDialogOpen(false)
@@ -448,7 +480,12 @@ export default function WebDAVSettings() {
                   type="url"
                   placeholder={t("webdav.webdavUrlExample")}
                   value={webdavUrl}
-                  onChange={(e) => setWebdavUrl(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      url: e.target.value,
+                    }))
+                  }
                 />
               </FormField>
             </div>
@@ -460,7 +497,12 @@ export default function WebDAVSettings() {
                 type="text"
                 placeholder={t("webdav.username")}
                 value={webdavUsername}
-                onChange={(e) => setWebdavUsername(e.target.value)}
+                onChange={(e) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    username: e.target.value,
+                  }))
+                }
               />
             </FormField>
 
@@ -472,7 +514,12 @@ export default function WebDAVSettings() {
                   type={showPassword ? "text" : "password"}
                   placeholder={t("webdav.password")}
                   value={webdavPassword}
-                  onChange={(e) => setWebdavPassword(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      password: e.target.value,
+                    }))
+                  }
                   rightIcon={
                     <IconButton
                       variant="ghost"
@@ -538,7 +585,12 @@ export default function WebDAVSettings() {
               </div>
               <Switch
                 checked={backupEncryptionEnabled}
-                onChange={setBackupEncryptionEnabled}
+                onChange={(checked) =>
+                  setLocalConfig((prev) => ({
+                    ...prev,
+                    backupEncryptionEnabled: checked,
+                  }))
+                }
               />
             </div>
 
@@ -553,7 +605,12 @@ export default function WebDAVSettings() {
                   type={showBackupEncryptionPassword ? "text" : "password"}
                   placeholder={t("webdav.encryption.passwordPlaceholder")}
                   value={backupEncryptionPassword}
-                  onChange={(e) => setBackupEncryptionPassword(e.target.value)}
+                  onChange={(e) =>
+                    setLocalConfig((prev) => ({
+                      ...prev,
+                      backupEncryptionPassword: e.target.value,
+                    }))
+                  }
                   rightIcon={
                     <IconButton
                       variant="ghost"

--- a/src/features/ImportExport/hooks/useImportExport.ts
+++ b/src/features/ImportExport/hooks/useImportExport.ts
@@ -2,6 +2,7 @@ import { useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
@@ -14,6 +15,7 @@ const logger = createLogger("ImportExportHook")
 
 export const useImportExport = () => {
   const { t } = useTranslation()
+  const { loadPreferences } = useUserPreferencesContext()
   const [isExporting, setIsExporting] = useState(false)
   const [isImporting, setIsImporting] = useState(false)
   const [importData, setImportData] = useState("")
@@ -43,6 +45,9 @@ export const useImportExport = () => {
 
       const data = JSON.parse(importData)
       const result = await importFromBackupObject(data)
+      if (result.allImported || result.sections?.preferences) {
+        await loadPreferences()
+      }
       if (result.allImported) {
         toast.success(t("importExport:import.importSuccess"))
       }

--- a/src/features/ImportExport/hooks/useImportExport.ts
+++ b/src/features/ImportExport/hooks/useImportExport.ts
@@ -3,8 +3,10 @@ import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { userPreferences } from "~/services/preferences/userPreferences"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
+import { applyPreferenceLanguage } from "~/utils/i18n/applyPreferenceLanguage"
 
 import { importFromBackupObject, parseBackupSummary } from "../utils"
 
@@ -47,6 +49,7 @@ export const useImportExport = () => {
       const result = await importFromBackupObject(data)
       if (result.allImported || result.sections?.preferences) {
         await loadPreferences()
+        await applyPreferenceLanguage(await userPreferences.getLanguage())
       }
       if (result.allImported) {
         toast.success(t("importExport:import.importSuccess"))

--- a/src/hooks/usePreferenceDraft.ts
+++ b/src/hooks/usePreferenceDraft.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react"
+
+type UsePreferenceDraftOptions<T> = {
+  savedValue: T
+  savedVersion: number
+  isEqual?: (left: T, right: T) => boolean
+}
+
+/**
+ * Compare draft values with a serialization fallback for small settings objects.
+ */
+function defaultIsEqual<T>(left: T, right: T) {
+  if (Object.is(left, right)) {
+    return true
+  }
+
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+/**
+ * Manage a local settings draft against a persisted preference snapshot.
+ *
+ * Clean drafts rehydrate automatically from storage refreshes. Dirty drafts keep
+ * their local edits and retain the version they branched from so stale writes can
+ * be rejected safely.
+ */
+export function usePreferenceDraft<T>({
+  savedValue,
+  savedVersion,
+  isEqual = defaultIsEqual,
+}: UsePreferenceDraftOptions<T>) {
+  const [draft, setDraft] = useState(savedValue)
+  const [baselineValue, setBaselineValue] = useState(savedValue)
+  const [baselineVersion, setBaselineVersion] = useState(savedVersion)
+
+  const isDirty = !isEqual(draft, baselineValue)
+
+  useEffect(() => {
+    if (!isDirty) {
+      setDraft(savedValue)
+      setBaselineValue(savedValue)
+      setBaselineVersion(savedVersion)
+      return
+    }
+
+    if (isEqual(draft, savedValue)) {
+      setBaselineValue(savedValue)
+      setBaselineVersion(savedVersion)
+    }
+  }, [draft, isDirty, isEqual, savedValue, savedVersion])
+
+  return {
+    draft,
+    setDraft,
+    isDirty,
+    expectedLastUpdated: baselineVersion,
+  }
+}

--- a/src/hooks/usePreferenceDraft.ts
+++ b/src/hooks/usePreferenceDraft.ts
@@ -3,6 +3,11 @@ import { useEffect, useState } from "react"
 type UsePreferenceDraftOptions<T> = {
   savedValue: T
   savedVersion: number
+  /**
+   * Optional comparator for `usePreferenceDraft`. Keep this callback stable
+   * across renders, for example by defining it at module scope or memoizing it
+   * with `useCallback`, because it participates in the reconciliation effect.
+   */
   isEqual?: (left: T, right: T) => boolean
 }
 

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -169,6 +169,7 @@
   },
   "messages": {
     "confirmReset": "Confirm Reset",
+    "preferencesChangedExternally": "Preferences changed externally. Refresh and try again.",
     "resetConfirmDesc": "Are you sure you want to reset {{name}} to default settings? This operation cannot be undone.",
     "resetFailed": "Failed to reset {{name}}",
     "resetSuccess": "{{name}} has been reset to default settings",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -169,6 +169,7 @@
   },
   "messages": {
     "confirmReset": "リセットの確認",
+    "preferencesChangedExternally": "設定が他の場所で変更されました。更新してからもう一度お試しください。",
     "resetConfirmDesc": "{{name}} を既定設定に戻しますか？ この操作は元に戻せません。",
     "resetFailed": "{{name}} のリセットに失敗しました",
     "resetSuccess": "{{name}} を既定設定にリセットしました",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -169,6 +169,7 @@
   },
   "messages": {
     "confirmReset": "确认重置",
+    "preferencesChangedExternally": "偏好设置已在其他位置发生变化，请刷新后重试。",
     "resetConfirmDesc": "确定要将{{name}}重置为默认设置吗？此操作无法撤销。",
     "resetFailed": "重置{{name}}失败",
     "resetSuccess": "{{name}}已重置为默认设置",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -169,6 +169,7 @@
   },
   "messages": {
     "confirmReset": "確認重置",
+    "preferencesChangedExternally": "偏好設定已在其他地方變更，請重新整理後再試。",
     "resetConfirmDesc": "確定要將{{name}}重置為預設設定嗎？此操作無法撤銷。",
     "resetFailed": "重置{{name}}失敗",
     "resetSuccess": "{{name}}已重置為預設設定",

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -621,36 +621,36 @@ class UserPreferencesService {
     },
   ): Promise<UserPreferences | null> {
     const updatedPreferences = await this.withStorageWriteLock(async () => {
-        const currentPreferences = await this.getPreferences()
-        if (
-          typeof options?.expectedLastUpdated === "number" &&
-          Number.isFinite(options.expectedLastUpdated) &&
-          currentPreferences.lastUpdated !== options.expectedLastUpdated
-        ) {
-          return null
-        }
+      const currentPreferences = await this.getPreferences()
+      if (
+        typeof options?.expectedLastUpdated === "number" &&
+        Number.isFinite(options.expectedLastUpdated) &&
+        currentPreferences.lastUpdated !== options.expectedLastUpdated
+      ) {
+        return null
+      }
 
-        const timestamp = Date.now()
-        const sharedPreferencesLastUpdated = patchTouchesSharedPreferences(
-          preferences,
-        )
-          ? timestamp
-          : getSharedPreferencesLastUpdated(currentPreferences)
+      const timestamp = Date.now()
+      const sharedPreferencesLastUpdated = patchTouchesSharedPreferences(
+        preferences,
+      )
+        ? timestamp
+        : getSharedPreferencesLastUpdated(currentPreferences)
 
-        const nextPreferences = stampPreferencesMetadata(
-          deepOverride(currentPreferences, preferences),
-          {
-            lastUpdated: timestamp,
-            sharedPreferencesLastUpdated,
-          },
-        )
+      const nextPreferences = stampPreferencesMetadata(
+        deepOverride(currentPreferences, preferences),
+        {
+          lastUpdated: timestamp,
+          sharedPreferencesLastUpdated,
+        },
+      )
 
-        await this.storage.set(
-          USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
-          nextPreferences,
-        )
+      await this.storage.set(
+        USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
+        nextPreferences,
+      )
 
-        return nextPreferences
+      return nextPreferences
     })
     if (!updatedPreferences) {
       logger.debug("跳过过期的偏好设置写入", {

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -620,8 +620,7 @@ class UserPreferencesService {
       expectedLastUpdated?: number
     },
   ): Promise<UserPreferences | null> {
-    try {
-      const updatedPreferences = await this.withStorageWriteLock(async () => {
+    const updatedPreferences = await this.withStorageWriteLock(async () => {
         const currentPreferences = await this.getPreferences()
         if (
           typeof options?.expectedLastUpdated === "number" &&
@@ -652,25 +651,21 @@ class UserPreferencesService {
         )
 
         return nextPreferences
+    })
+    if (!updatedPreferences) {
+      logger.debug("跳过过期的偏好设置写入", {
+        expectedLastUpdated: options?.expectedLastUpdated,
       })
-      if (!updatedPreferences) {
-        logger.debug("跳过过期的偏好设置写入", {
-          expectedLastUpdated: options?.expectedLastUpdated,
-        })
-        return null
-      }
-
-      logger.debug("偏好设置保存成功", {
-        lastUpdated: updatedPreferences.lastUpdated,
-        sharedPreferencesLastUpdated:
-          updatedPreferences.sharedPreferencesLastUpdated,
-        preferencesVersion: updatedPreferences.preferencesVersion,
-      })
-      return updatedPreferences
-    } catch (error) {
-      logger.error("保存偏好设置失败", error)
       return null
     }
+
+    logger.debug("偏好设置保存成功", {
+      lastUpdated: updatedPreferences.lastUpdated,
+      sharedPreferencesLastUpdated:
+        updatedPreferences.sharedPreferencesLastUpdated,
+      preferencesVersion: updatedPreferences.preferencesVersion,
+    })
+    return updatedPreferences
   }
 
   /**

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -612,14 +612,14 @@ class UserPreferencesService {
   }
 
   /**
-   * Save partial user preferences (deep merge) and stamp timestamps/version.
+   * Save partial user preferences (deep merge) and return the stamped snapshot.
    */
-  async savePreferences(
+  async savePreferencesWithResult(
     preferences: DeepPartial<UserPreferences>,
     options?: {
       expectedLastUpdated?: number
     },
-  ): Promise<boolean> {
+  ): Promise<UserPreferences | null> {
     try {
       const updatedPreferences = await this.withStorageWriteLock(async () => {
         const currentPreferences = await this.getPreferences()
@@ -657,7 +657,7 @@ class UserPreferencesService {
         logger.debug("跳过过期的偏好设置写入", {
           expectedLastUpdated: options?.expectedLastUpdated,
         })
-        return false
+        return null
       }
 
       logger.debug("偏好设置保存成功", {
@@ -666,7 +666,28 @@ class UserPreferencesService {
           updatedPreferences.sharedPreferencesLastUpdated,
         preferencesVersion: updatedPreferences.preferencesVersion,
       })
-      return true
+      return updatedPreferences
+    } catch (error) {
+      logger.error("保存偏好设置失败", error)
+      return null
+    }
+  }
+
+  /**
+   * Save partial user preferences (deep merge) and stamp timestamps/version.
+   */
+  async savePreferences(
+    preferences: DeepPartial<UserPreferences>,
+    options?: {
+      expectedLastUpdated?: number
+    },
+  ): Promise<boolean> {
+    try {
+      const updatedPreferences = await this.savePreferencesWithResult(
+        preferences,
+        options,
+      )
+      return updatedPreferences !== null
     } catch (error) {
       logger.error("保存偏好设置失败", error)
       return false

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -66,6 +66,16 @@ import {
 
 const logger = createLogger("WebdavAutoSync")
 
+type UpdateWebdavAutoSyncSettingsResult =
+  | {
+      ok: true
+      savedPreferences: UserPreferences
+    }
+  | {
+      ok: false
+      reason: "conflict" | "error"
+    }
+
 /**
  * Convert the persisted WebDAV sync interval (seconds) to a safe alarms cadence (minutes).
  *
@@ -1369,29 +1379,38 @@ class WebdavAutoSyncService {
       syncStrategy?: WebDAVSettings["syncStrategy"]
     },
     options?: { expectedLastUpdated?: number },
-  ) {
+  ): Promise<UpdateWebdavAutoSyncSettingsResult> {
     try {
-      // Update the nested webdav object
-      const success =
+      const savedPreferences =
         typeof options?.expectedLastUpdated === "number"
-          ? await userPreferences.savePreferences(
+          ? await userPreferences.savePreferencesWithResult(
               {
                 webdav: settings,
               },
               options,
             )
-          : await userPreferences.savePreferences({
+          : await userPreferences.savePreferencesWithResult({
               webdav: settings,
             })
-      if (!success) {
-        return false
+      if (!savedPreferences) {
+        return {
+          ok: false,
+          reason: "conflict",
+        }
       }
+
       await this.setupAutoSync() // 重新设置调度（alarm）
       logger.info("设置已更新", settings)
-      return true
+      return {
+        ok: true,
+        savedPreferences,
+      }
     } catch (error) {
       logger.error("更新设置失败", error)
-      return false
+      return {
+        ok: false,
+        reason: "error",
+      }
     }
   }
 
@@ -1485,7 +1504,7 @@ export const handleWebdavAutoSyncMessage = async (
         break
 
       case RuntimeActionIds.WebdavAutoSyncUpdateSettings: {
-        const success = await webdavAutoSyncService.updateSettings(
+        const result = await webdavAutoSyncService.updateSettings(
           request.settings,
           typeof request.expectedLastUpdated === "number"
             ? {
@@ -1494,11 +1513,17 @@ export const handleWebdavAutoSyncMessage = async (
             : undefined,
         )
         sendResponse(
-          success
-            ? { success: true }
+          result.ok
+            ? {
+                success: true,
+                data: result.savedPreferences,
+              }
             : {
                 success: false,
-                error: "Preferences changed externally. Refresh and try again.",
+                error:
+                  result.reason === "conflict"
+                    ? t("settings:messages.preferencesChangedExternally")
+                    : t("settings:messages.saveSettingsFailed"),
               },
         )
         break

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -1381,17 +1381,12 @@ class WebdavAutoSyncService {
     options?: { expectedLastUpdated?: number },
   ): Promise<UpdateWebdavAutoSyncSettingsResult> {
     try {
-      const savedPreferences =
-        typeof options?.expectedLastUpdated === "number"
-          ? await userPreferences.savePreferencesWithResult(
-              {
-                webdav: settings,
-              },
-              options,
-            )
-          : await userPreferences.savePreferencesWithResult({
-              webdav: settings,
-            })
+      const savedPreferences = await userPreferences.savePreferencesWithResult(
+        {
+          webdav: settings,
+        },
+        options,
+      )
       if (!savedPreferences) {
         return {
           ok: false,

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -1362,20 +1362,36 @@ class WebdavAutoSyncService {
    *
    * Persists partial webdav settings and reconfigures scheduler.
    */
-  async updateSettings(settings: {
-    autoSync?: boolean
-    syncInterval?: number
-    syncStrategy?: WebDAVSettings["syncStrategy"]
-  }) {
+  async updateSettings(
+    settings: {
+      autoSync?: boolean
+      syncInterval?: number
+      syncStrategy?: WebDAVSettings["syncStrategy"]
+    },
+    options?: { expectedLastUpdated?: number },
+  ) {
     try {
       // Update the nested webdav object
-      await userPreferences.savePreferences({
-        webdav: settings,
-      })
+      const success =
+        typeof options?.expectedLastUpdated === "number"
+          ? await userPreferences.savePreferences(
+              {
+                webdav: settings,
+              },
+              options,
+            )
+          : await userPreferences.savePreferences({
+              webdav: settings,
+            })
+      if (!success) {
+        return false
+      }
       await this.setupAutoSync() // 重新设置调度（alarm）
       logger.info("设置已更新", settings)
+      return true
     } catch (error) {
       logger.error("更新设置失败", error)
+      return false
     }
   }
 
@@ -1469,8 +1485,22 @@ export const handleWebdavAutoSyncMessage = async (
         break
 
       case RuntimeActionIds.WebdavAutoSyncUpdateSettings: {
-        await webdavAutoSyncService.updateSettings(request.settings)
-        sendResponse({ success: true })
+        const success = await webdavAutoSyncService.updateSettings(
+          request.settings,
+          typeof request.expectedLastUpdated === "number"
+            ? {
+                expectedLastUpdated: request.expectedLastUpdated,
+              }
+            : undefined,
+        )
+        sendResponse(
+          success
+            ? { success: true }
+            : {
+                success: false,
+                error: "Preferences changed externally. Refresh and try again.",
+              },
+        )
         break
       }
 

--- a/src/utils/i18n/applyPreferenceLanguage.ts
+++ b/src/utils/i18n/applyPreferenceLanguage.ts
@@ -1,0 +1,26 @@
+import i18n from "./core"
+import { normalizeAppLanguage } from "./language"
+
+/**
+ * Apply a persisted UI language preference to the active i18n instance when it
+ * differs from the current runtime language.
+ */
+export async function applyPreferenceLanguage(
+  language?: string | null,
+): Promise<boolean> {
+  const nextLanguage = normalizeAppLanguage(language)
+  if (!nextLanguage) {
+    return false
+  }
+
+  const currentLanguage = normalizeAppLanguage(
+    i18n.resolvedLanguage || i18n.language,
+  )
+
+  if (nextLanguage === currentLanguage) {
+    return false
+  }
+
+  await i18n.changeLanguage(nextLanguage)
+  return true
+}

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -448,19 +448,23 @@ describe("UserPreferencesContext", () => {
         level: "warn",
       },
     )
-    expect(mockedUserPreferences.savePreferences).toHaveBeenCalledWith(
+    expect(
+      mockedUserPreferences.savePreferencesWithResult,
+    ).toHaveBeenCalledWith({
+      newApi: { baseUrl: "https://new-api.example" },
+    })
+    expect(
+      mockedUserPreferences.savePreferencesWithResult,
+    ).toHaveBeenCalledWith(
       {
-        newApi: { baseUrl: "https://new-api.example" },
+        managedSiteModelSync: {
+          enabled: false,
+          allowedModels: ["gpt-4o"],
+          rateLimit: { requestsPerMinute: 15, burst: 3 },
+        },
       },
       undefined,
     )
-    expect(mockedUserPreferences.savePreferences).toHaveBeenCalledWith({
-      managedSiteModelSync: {
-        enabled: false,
-        allowedModels: ["gpt-4o"],
-        rateLimit: { requestsPerMinute: 15, burst: 3 },
-      },
-    })
 
     expect((latestContext as any)?.currencyType).toBe("CNY")
     expect((latestContext as any)?.sortField).toBe(DATA_TYPE_INCOME)
@@ -982,7 +986,7 @@ describe("UserPreferencesContext", () => {
     preferences.managedSiteType = VELOERA
 
     mockedUserPreferences.updateActiveTab.mockResolvedValue(false)
-    mockedUserPreferences.savePreferences.mockResolvedValue(false)
+    mockedUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
     mockedUserPreferences.updateCurrencyType.mockResolvedValue(false)
     mockedUserPreferences.updateSortConfig.mockResolvedValue(false)
     mockedUserPreferences.setSortingPriorityConfig.mockResolvedValue(false)
@@ -1102,7 +1106,7 @@ describe("UserPreferencesContext", () => {
       password: "stored-octopus-password",
     }
 
-    mockedUserPreferences.savePreferences.mockResolvedValue(false)
+    mockedUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
 
     const context = await renderProvider(preferences)
 

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -30,6 +30,10 @@ import { DEFAULT_OCTOPUS_CONFIG } from "~/types/octopusConfig"
 import { SortingCriteriaType } from "~/types/sorting"
 import { deepOverride } from "~/utils"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
+import {
+  createPersistedPreferencesFixture,
+  setupMockPreferencePersistence,
+} from "~~/tests/test-utils/mockPreferencePersistence"
 
 const { loggerMocks } = vi.hoisted(() => ({
   loggerMocks: {
@@ -108,9 +112,11 @@ const mockedSendRuntimeMessage = sendRuntimeMessage as unknown as ReturnType<
 let latestContext: ReturnType<typeof useUserPreferencesContext> | null = null
 
 const clonePreferences = (): UserPreferences =>
-  JSON.parse(JSON.stringify(DEFAULT_PREFERENCES)) as UserPreferences
+  createPersistedPreferencesFixture()
 
-let persistedPreferences = clonePreferences()
+let preferencePersistence = setupMockPreferencePersistence(
+  mockedUserPreferences as any,
+)
 
 const createDeferred = <T,>() => {
   let resolve!: (value: T | PromiseLike<T>) => void
@@ -142,13 +148,7 @@ const Probe = ({ children }: { children?: ReactNode }) => {
 const renderProvider = async (
   preferences: UserPreferences = clonePreferences(),
 ) => {
-  persistedPreferences = JSON.parse(
-    JSON.stringify(preferences),
-  ) as UserPreferences
-  mockedUserPreferences.getPreferences.mockImplementation(
-    async () =>
-      JSON.parse(JSON.stringify(persistedPreferences)) as UserPreferences,
-  )
+  preferencePersistence.setPersistedPreferences(preferences)
 
   render(
     <UserPreferencesProvider>
@@ -168,36 +168,19 @@ describe("UserPreferencesContext", () => {
     latestContext = null
     vi.clearAllMocks()
 
-    persistedPreferences = clonePreferences()
-    mockedUserPreferences.getPreferences.mockImplementation(
-      async () =>
-        JSON.parse(JSON.stringify(persistedPreferences)) as UserPreferences,
-    )
-    mockedUserPreferences.savePreferences.mockImplementation(
-      async (updates) => {
-        persistedPreferences = deepOverride(persistedPreferences, updates)
-        persistedPreferences.lastUpdated += 1
-        return true
-      },
-    )
-    mockedUserPreferences.savePreferencesWithResult.mockImplementation(
-      async (updates, options) => {
-        const success = await mockedUserPreferences.savePreferences(
-          updates,
-          options,
-        )
-        return success
-          ? (JSON.parse(
-              JSON.stringify(persistedPreferences),
-            ) as UserPreferences)
-          : null
-      },
+    preferencePersistence = setupMockPreferencePersistence(
+      mockedUserPreferences as any,
+      clonePreferences(),
     )
     const applyPersistedUpdate = (
       updates: Partial<UserPreferences> | Record<string, unknown>,
     ) => {
-      persistedPreferences = deepOverride(persistedPreferences, updates)
-      persistedPreferences.lastUpdated += 1
+      const nextPreferences = deepOverride(
+        preferencePersistence.getPersistedPreferences(),
+        updates,
+      )
+      nextPreferences.lastUpdated += 1
+      preferencePersistence.setPersistedPreferences(nextPreferences)
       return true
     }
     mockedUserPreferences.updateActiveTab.mockImplementation(

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -1636,6 +1636,83 @@ describe("UserPreferencesContext", () => {
     expect((latestContext as any)?.preferences.webdav.autoSync).toBe(true)
   })
 
+  it("hydrates the provider from the saved WebDAV snapshot returned by background updates", async () => {
+    const preferences = clonePreferences()
+    preferences.webdav = {
+      ...preferences.webdav,
+      autoSync: true,
+      syncInterval: 300,
+    }
+    const savedPreferences = deepOverride(preferences, {
+      webdav: {
+        autoSync: false,
+        syncInterval: 900,
+        syncStrategy: "upload_only",
+      },
+      lastUpdated: preferences.lastUpdated + 5,
+    })
+    mockedSendRuntimeMessage.mockResolvedValue({
+      success: true,
+      data: savedPreferences,
+    })
+
+    const context = await renderProvider(preferences)
+
+    await act(async () => {
+      await context.updateWebdavAutoSyncSettings(
+        {
+          autoSync: false,
+          syncInterval: 900,
+          syncStrategy: "upload_only",
+        },
+        { expectedLastUpdated: preferences.lastUpdated },
+      )
+    })
+
+    expect(mockedSendRuntimeMessage).toHaveBeenCalledWith({
+      action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+      settings: {
+        autoSync: false,
+        syncInterval: 900,
+        syncStrategy: "upload_only",
+      },
+      expectedLastUpdated: preferences.lastUpdated,
+    })
+    expect((latestContext as any)?.preferences).toEqual(savedPreferences)
+  })
+
+  it("merges WebDAV auto-sync updates locally when background omits a saved snapshot", async () => {
+    const preferences = clonePreferences()
+    preferences.webdav = {
+      ...preferences.webdav,
+      autoSync: true,
+      syncInterval: 300,
+      syncStrategy: "merge",
+    }
+    mockedSendRuntimeMessage.mockResolvedValue({
+      success: true,
+    })
+
+    const context = await renderProvider(preferences)
+
+    await act(async () => {
+      await context.updateWebdavAutoSyncSettings({
+        autoSync: false,
+        syncInterval: 600,
+      })
+    })
+
+    expect((latestContext as any)?.preferences.webdav).toEqual({
+      ...preferences.webdav,
+      autoSync: false,
+      syncInterval: 600,
+      syncStrategy: "merge",
+    })
+    expect((latestContext as any)?.preferences.lastUpdated).toBe(
+      preferences.lastUpdated,
+    )
+  })
+
   it("refreshes context menus when feature enabled state changes and preserves existing nested settings", async () => {
     const preferences = clonePreferences()
     preferences.redemptionAssist = {

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -28,6 +28,7 @@ import { DEFAULT_BALANCE_HISTORY_PREFERENCES } from "~/types/dailyBalanceHistory
 import { DEFAULT_DONE_HUB_CONFIG } from "~/types/doneHubConfig"
 import { DEFAULT_OCTOPUS_CONFIG } from "~/types/octopusConfig"
 import { SortingCriteriaType } from "~/types/sorting"
+import { deepOverride } from "~/utils"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 
 const { loggerMocks } = vi.hoisted(() => ({
@@ -65,6 +66,7 @@ vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
       ...actual.userPreferences,
       getPreferences: vi.fn(),
       savePreferences: vi.fn(),
+      savePreferencesWithResult: vi.fn(),
       updateActiveTab: vi.fn(),
       updateCurrencyType: vi.fn(),
       updateSortConfig: vi.fn(),
@@ -108,6 +110,8 @@ let latestContext: ReturnType<typeof useUserPreferencesContext> | null = null
 const clonePreferences = (): UserPreferences =>
   JSON.parse(JSON.stringify(DEFAULT_PREFERENCES)) as UserPreferences
 
+let persistedPreferences = clonePreferences()
+
 const createDeferred = <T,>() => {
   let resolve!: (value: T | PromiseLike<T>) => void
   let reject!: (reason?: unknown) => void
@@ -138,7 +142,13 @@ const Probe = ({ children }: { children?: ReactNode }) => {
 const renderProvider = async (
   preferences: UserPreferences = clonePreferences(),
 ) => {
-  mockedUserPreferences.getPreferences.mockResolvedValue(preferences)
+  persistedPreferences = JSON.parse(
+    JSON.stringify(preferences),
+  ) as UserPreferences
+  mockedUserPreferences.getPreferences.mockImplementation(
+    async () =>
+      JSON.parse(JSON.stringify(persistedPreferences)) as UserPreferences,
+  )
 
   render(
     <UserPreferencesProvider>
@@ -158,39 +168,152 @@ describe("UserPreferencesContext", () => {
     latestContext = null
     vi.clearAllMocks()
 
-    mockedUserPreferences.getPreferences.mockResolvedValue(clonePreferences())
-    mockedUserPreferences.savePreferences.mockResolvedValue(true)
-    mockedUserPreferences.updateActiveTab.mockResolvedValue(true)
-    mockedUserPreferences.updateCurrencyType.mockResolvedValue(true)
-    mockedUserPreferences.updateSortConfig.mockResolvedValue(true)
-    mockedUserPreferences.setSortingPriorityConfig.mockResolvedValue(true)
-    mockedUserPreferences.updateOpenChangelogOnUpdate.mockResolvedValue(true)
-    mockedUserPreferences.updateAutoProvisionKeyOnAccountAdd.mockResolvedValue(
-      true,
+    persistedPreferences = clonePreferences()
+    mockedUserPreferences.getPreferences.mockImplementation(
+      async () =>
+        JSON.parse(JSON.stringify(persistedPreferences)) as UserPreferences,
     )
-    mockedUserPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd.mockResolvedValue(
-      true,
+    mockedUserPreferences.savePreferences.mockImplementation(
+      async (updates) => {
+        persistedPreferences = deepOverride(persistedPreferences, updates)
+        persistedPreferences.lastUpdated += 1
+        return true
+      },
     )
-    mockedUserPreferences.updateWarnOnDuplicateAccountAdd.mockResolvedValue(
-      true,
+    mockedUserPreferences.savePreferencesWithResult.mockImplementation(
+      async (updates, options) => {
+        const success = await mockedUserPreferences.savePreferences(
+          updates,
+          options,
+        )
+        return success
+          ? (JSON.parse(
+              JSON.stringify(persistedPreferences),
+            ) as UserPreferences)
+          : null
+      },
     )
-    mockedUserPreferences.updateManagedSiteType.mockResolvedValue(true)
-    mockedUserPreferences.updateLoggingPreferences.mockResolvedValue(true)
+    const applyPersistedUpdate = (
+      updates: Partial<UserPreferences> | Record<string, unknown>,
+    ) => {
+      persistedPreferences = deepOverride(persistedPreferences, updates)
+      persistedPreferences.lastUpdated += 1
+      return true
+    }
+    mockedUserPreferences.updateActiveTab.mockImplementation(
+      async (activeTab) => applyPersistedUpdate({ activeTab }),
+    )
+    mockedUserPreferences.updateCurrencyType.mockImplementation(
+      async (currencyType) => applyPersistedUpdate({ currencyType }),
+    )
+    mockedUserPreferences.updateSortConfig.mockImplementation(
+      async (sortField, sortOrder) =>
+        applyPersistedUpdate({ sortField, sortOrder }),
+    )
+    mockedUserPreferences.setSortingPriorityConfig.mockImplementation(
+      async (sortingPriorityConfig) =>
+        applyPersistedUpdate({ sortingPriorityConfig }),
+    )
+    mockedUserPreferences.updateOpenChangelogOnUpdate.mockImplementation(
+      async (openChangelogOnUpdate) =>
+        applyPersistedUpdate({ openChangelogOnUpdate }),
+    )
+    mockedUserPreferences.updateAutoProvisionKeyOnAccountAdd.mockImplementation(
+      async (autoProvisionKeyOnAccountAdd) =>
+        applyPersistedUpdate({ autoProvisionKeyOnAccountAdd }),
+    )
+    mockedUserPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd.mockImplementation(
+      async (autoFillCurrentSiteUrlOnAccountAdd) =>
+        applyPersistedUpdate({ autoFillCurrentSiteUrlOnAccountAdd }),
+    )
+    mockedUserPreferences.updateWarnOnDuplicateAccountAdd.mockImplementation(
+      async (warnOnDuplicateAccountAdd) =>
+        applyPersistedUpdate({ warnOnDuplicateAccountAdd }),
+    )
+    mockedUserPreferences.updateManagedSiteType.mockImplementation(
+      async (managedSiteType) => applyPersistedUpdate({ managedSiteType }),
+    )
+    mockedUserPreferences.updateLoggingPreferences.mockImplementation(
+      async (updates) => applyPersistedUpdate({ logging: updates }),
+    )
     mockedUserPreferences.resetToDefaults.mockResolvedValue(true)
-    mockedUserPreferences.resetDisplaySettings.mockResolvedValue(true)
-    mockedUserPreferences.resetAutoRefreshConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetNewApiConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetDoneHubConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetVeloeraConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetOctopusConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetNewApiModelSyncConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetCliProxyConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetClaudeCodeRouterConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetAutoCheckinConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetRedemptionAssist.mockResolvedValue(true)
-    mockedUserPreferences.resetWebAiApiCheck.mockResolvedValue(true)
-    mockedUserPreferences.resetModelRedirectConfig.mockResolvedValue(true)
-    mockedUserPreferences.resetWebdavConfig.mockResolvedValue(true)
+    mockedUserPreferences.resetDisplaySettings.mockImplementation(async () =>
+      applyPersistedUpdate({
+        activeTab: DEFAULT_PREFERENCES.activeTab,
+        currencyType: DEFAULT_PREFERENCES.currencyType,
+        showTodayCashflow: DEFAULT_PREFERENCES.showTodayCashflow,
+        sortField: DEFAULT_PREFERENCES.sortField,
+        sortOrder: DEFAULT_PREFERENCES.sortOrder,
+      }),
+    )
+    mockedUserPreferences.resetAutoRefreshConfig.mockImplementation(async () =>
+      applyPersistedUpdate({
+        accountAutoRefresh: DEFAULT_PREFERENCES.accountAutoRefresh,
+      }),
+    )
+    mockedUserPreferences.resetNewApiConfig.mockImplementation(async () =>
+      applyPersistedUpdate({
+        newApi: DEFAULT_PREFERENCES.newApi,
+      }),
+    )
+    mockedUserPreferences.resetDoneHubConfig.mockImplementation(async () =>
+      applyPersistedUpdate({
+        doneHub: DEFAULT_DONE_HUB_CONFIG,
+      }),
+    )
+    mockedUserPreferences.resetVeloeraConfig.mockImplementation(async () =>
+      applyPersistedUpdate({
+        veloera: DEFAULT_PREFERENCES.veloera,
+      }),
+    )
+    mockedUserPreferences.resetOctopusConfig.mockImplementation(async () =>
+      applyPersistedUpdate({
+        octopus: DEFAULT_PREFERENCES.octopus,
+      }),
+    )
+    mockedUserPreferences.resetNewApiModelSyncConfig.mockImplementation(
+      async () =>
+        applyPersistedUpdate({
+          managedSiteModelSync: DEFAULT_PREFERENCES.managedSiteModelSync,
+        }),
+    )
+    mockedUserPreferences.resetCliProxyConfig.mockImplementation(async () =>
+      applyPersistedUpdate({
+        cliProxy: DEFAULT_PREFERENCES.cliProxy,
+      }),
+    )
+    mockedUserPreferences.resetClaudeCodeRouterConfig.mockImplementation(
+      async () =>
+        applyPersistedUpdate({
+          claudeCodeRouter: DEFAULT_PREFERENCES.claudeCodeRouter,
+        }),
+    )
+    mockedUserPreferences.resetAutoCheckinConfig.mockImplementation(async () =>
+      applyPersistedUpdate({
+        autoCheckin: DEFAULT_PREFERENCES.autoCheckin,
+      }),
+    )
+    mockedUserPreferences.resetRedemptionAssist.mockImplementation(async () =>
+      applyPersistedUpdate({
+        redemptionAssist: DEFAULT_PREFERENCES.redemptionAssist,
+      }),
+    )
+    mockedUserPreferences.resetWebAiApiCheck.mockImplementation(async () =>
+      applyPersistedUpdate({
+        webAiApiCheck: DEFAULT_PREFERENCES.webAiApiCheck,
+      }),
+    )
+    mockedUserPreferences.resetModelRedirectConfig.mockImplementation(
+      async () =>
+        applyPersistedUpdate({
+          modelRedirect: DEFAULT_PREFERENCES.modelRedirect,
+        }),
+    )
+    mockedUserPreferences.resetWebdavConfig.mockImplementation(async () =>
+      applyPersistedUpdate({
+        webdav: DEFAULT_PREFERENCES.webdav,
+      }),
+    )
     mockedUserPreferences.resetSortingPriorityConfig.mockResolvedValue(true)
     mockedSendRuntimeMessage.mockResolvedValue(undefined)
   })
@@ -342,9 +465,12 @@ describe("UserPreferencesContext", () => {
         level: "warn",
       },
     )
-    expect(mockedUserPreferences.savePreferences).toHaveBeenCalledWith({
-      newApi: { baseUrl: "https://new-api.example" },
-    })
+    expect(mockedUserPreferences.savePreferences).toHaveBeenCalledWith(
+      {
+        newApi: { baseUrl: "https://new-api.example" },
+      },
+      undefined,
+    )
     expect(mockedUserPreferences.savePreferences).toHaveBeenCalledWith({
       managedSiteModelSync: {
         enabled: false,

--- a/tests/entrypoints/options/BasicSettingsTabs.test.tsx
+++ b/tests/entrypoints/options/BasicSettingsTabs.test.tsx
@@ -173,6 +173,119 @@ describe("BasicSettings tab layout", () => {
     )
   })
 
+  it("persists New API base URL, admin token, and numeric user ID changes with the current snapshot version", async () => {
+    const user = userEvent.setup()
+    const contextValue = createContextValue({
+      newApiUserId: "10",
+    })
+    mockedUseUserPreferencesContext.mockReturnValue(contextValue)
+
+    render(<NewApiSettings />)
+
+    const baseUrlInput = screen.getByPlaceholderText(
+      "settings:newApi.fields.baseUrlPlaceholder",
+    )
+    const adminTokenInput = screen.getByDisplayValue("managed-admin-token")
+    const userIdInput = screen.getByDisplayValue("10")
+
+    fireEvent.change(baseUrlInput, {
+      target: { value: "https://managed-next.example" },
+    })
+    fireEvent.blur(baseUrlInput)
+
+    fireEvent.change(adminTokenInput, {
+      target: { value: "next-admin-token" },
+    })
+    fireEvent.blur(adminTokenInput)
+
+    fireEvent.change(userIdInput, {
+      target: { value: " 42 " },
+    })
+    fireEvent.blur(userIdInput)
+
+    await waitFor(() => {
+      expect(contextValue.updateNewApiBaseUrl).toHaveBeenCalledWith(
+        "https://managed-next.example",
+        {
+          expectedLastUpdated: 1,
+        },
+      )
+      expect(contextValue.updateNewApiAdminToken).toHaveBeenCalledWith(
+        "next-admin-token",
+        {
+          expectedLastUpdated: 1,
+        },
+      )
+      expect(contextValue.updateNewApiUserId).toHaveBeenCalledWith("42", {
+        expectedLastUpdated: 1,
+      })
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "settings:newApi.fields.showToken",
+      }),
+    )
+
+    expect(adminTokenInput).toHaveAttribute("type", "text")
+    expect(showUpdateToastMock).toHaveBeenCalledWith(
+      true,
+      "settings:newApi.fields.baseUrlLabel",
+    )
+    expect(showUpdateToastMock).toHaveBeenCalledWith(
+      true,
+      "settings:newApi.fields.adminTokenLabel",
+    )
+    expect(showUpdateToastMock).toHaveBeenCalledWith(
+      true,
+      "settings:newApi.fields.userIdLabel",
+    )
+  })
+
+  it("skips persisting unchanged New API draft values after blur", () => {
+    const contextValue = createContextValue()
+    mockedUseUserPreferencesContext.mockReturnValue(contextValue)
+
+    render(<NewApiSettings />)
+
+    fireEvent.blur(
+      screen.getByPlaceholderText("settings:newApi.fields.baseUrlPlaceholder"),
+    )
+    fireEvent.blur(screen.getByDisplayValue("managed-admin-token"))
+
+    const userIdInput = screen.getByDisplayValue("1")
+    fireEvent.change(userIdInput, {
+      target: { value: " 1 " },
+    })
+    fireEvent.blur(userIdInput)
+
+    const usernameInput = screen.getByPlaceholderText(
+      "settings:newApi.fields.usernamePlaceholder",
+    )
+    fireEvent.change(usernameInput, {
+      target: { value: " admin " },
+    })
+    fireEvent.blur(usernameInput)
+
+    fireEvent.blur(screen.getByDisplayValue("secret-password"))
+
+    const totpInput = screen.getByPlaceholderText(
+      "settings:newApi.fields.totpSecretPlaceholder",
+    )
+    fireEvent.change(totpInput, {
+      target: { value: " JBSWY3DPEHPK3PXP " },
+    })
+    fireEvent.blur(totpInput)
+
+    expect(contextValue.updateNewApiBaseUrl).not.toHaveBeenCalled()
+    expect(contextValue.updateNewApiAdminToken).not.toHaveBeenCalled()
+    expect(contextValue.updateNewApiUserId).not.toHaveBeenCalled()
+    expect(contextValue.updateNewApiUsername).not.toHaveBeenCalled()
+    expect(contextValue.updateNewApiPassword).not.toHaveBeenCalled()
+    expect(contextValue.updateNewApiTotpSecret).not.toHaveBeenCalled()
+    expect(showUpdateToastMock).not.toHaveBeenCalled()
+  })
+
   it("resets the New API settings section through the shared SettingSection flow", async () => {
     const user = userEvent.setup()
     const contextValue = createContextValue()

--- a/tests/entrypoints/options/BasicSettingsTabs.test.tsx
+++ b/tests/entrypoints/options/BasicSettingsTabs.test.tsx
@@ -58,6 +58,7 @@ vi.mock(
 )
 
 const createContextValue = (overrides: Record<string, unknown> = {}) => ({
+  preferences: { lastUpdated: 1 },
   newApiBaseUrl: "https://managed.example",
   newApiAdminToken: "managed-admin-token",
   newApiUserId: "1",
@@ -149,16 +150,25 @@ describe("BasicSettings tab layout", () => {
     await waitFor(() =>
       expect(contextValue.updateNewApiUsername).toHaveBeenCalledWith(
         "next-admin",
+        {
+          expectedLastUpdated: 1,
+        },
       ),
     )
     await waitFor(() =>
       expect(contextValue.updateNewApiPassword).toHaveBeenCalledWith(
         " next-password ",
+        {
+          expectedLastUpdated: 1,
+        },
       ),
     )
     await waitFor(() =>
       expect(contextValue.updateNewApiTotpSecret).toHaveBeenCalledWith(
         "JBSWY3DPEHPK3PXQ",
+        {
+          expectedLastUpdated: 1,
+        },
       ),
     )
   })

--- a/tests/entrypoints/options/ClaudeCodeRouterSettings.test.tsx
+++ b/tests/entrypoints/options/ClaudeCodeRouterSettings.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { I18nextProvider } from "react-i18next"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import ClaudeCodeRouterSettings from "~/features/BasicSettings/components/tabs/ClaudeCodeRouter/ClaudeCodeRouterSettings"
+import { showUpdateToast } from "~/utils/core/toastHelpers"
+import { testI18n } from "~~/tests/test-utils/i18n"
+
+vi.mock("~/contexts/UserPreferencesContext", () => ({
+  useUserPreferencesContext: vi.fn(),
+}))
+
+vi.mock("~/utils/core/toastHelpers", () => ({
+  showUpdateToast: vi.fn(),
+}))
+
+describe("ClaudeCodeRouterSettings", () => {
+  const createContextValue = (overrides: Record<string, unknown> = {}) =>
+    ({
+      preferences: { lastUpdated: 1 },
+      claudeCodeRouterBaseUrl: "http://router.local",
+      claudeCodeRouterApiKey: "router-key",
+      updateClaudeCodeRouterBaseUrl: vi.fn().mockResolvedValue(true),
+      updateClaudeCodeRouterApiKey: vi.fn().mockResolvedValue(true),
+      resetClaudeCodeRouterConfig: vi.fn().mockResolvedValue(true),
+      ...overrides,
+    }) as any
+
+  const renderSubject = () =>
+    render(
+      <I18nextProvider i18n={testI18n}>
+        <ClaudeCodeRouterSettings />
+      </I18nextProvider>,
+    )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useUserPreferencesContext).mockReturnValue(createContextValue())
+  })
+
+  it("persists base URL and API key updates with the current preferences version", async () => {
+    const updateClaudeCodeRouterBaseUrl = vi.fn().mockResolvedValue(true)
+    const updateClaudeCodeRouterApiKey = vi.fn().mockResolvedValue(true)
+    vi.mocked(useUserPreferencesContext).mockReturnValue(
+      createContextValue({
+        updateClaudeCodeRouterBaseUrl,
+        updateClaudeCodeRouterApiKey,
+      }),
+    )
+
+    renderSubject()
+
+    const baseUrlInput = screen.getByPlaceholderText(
+      "settings:claudeCodeRouter.baseUrlPlaceholder",
+    )
+    fireEvent.change(baseUrlInput, {
+      target: { value: "http://next-router.local" },
+    })
+    fireEvent.blur(baseUrlInput)
+
+    const apiKeyInput = screen.getByDisplayValue("router-key")
+    fireEvent.change(apiKeyInput, {
+      target: { value: "next-router-key" },
+    })
+    fireEvent.blur(apiKeyInput)
+
+    await waitFor(() => {
+      expect(updateClaudeCodeRouterBaseUrl).toHaveBeenCalledWith(
+        "http://next-router.local",
+        {
+          expectedLastUpdated: 1,
+        },
+      )
+      expect(updateClaudeCodeRouterApiKey).toHaveBeenCalledWith(
+        "next-router-key",
+        {
+          expectedLastUpdated: 1,
+        },
+      )
+    })
+
+    expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
+      true,
+      "settings:claudeCodeRouter.baseUrlLabel",
+    )
+    expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
+      true,
+      "settings:claudeCodeRouter.apiKeyLabel",
+    )
+  })
+
+  it("toggles the API key visibility label", () => {
+    renderSubject()
+
+    const toggle = screen.getByRole("button", {
+      name: "keyManagement:actions.showKey",
+    })
+    fireEvent.click(toggle)
+
+    expect(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.hideKey",
+      }),
+    ).toBeInTheDocument()
+  })
+})

--- a/tests/entrypoints/options/ClaudeCodeRouterSettings.test.tsx
+++ b/tests/entrypoints/options/ClaudeCodeRouterSettings.test.tsx
@@ -16,7 +16,14 @@ vi.mock("~/utils/core/toastHelpers", () => ({
 }))
 
 describe("ClaudeCodeRouterSettings", () => {
-  const createContextValue = (overrides: Record<string, unknown> = {}) =>
+  type UserPreferencesContextValue = ReturnType<
+    typeof useUserPreferencesContext
+  >
+  type MockUserPreferencesContextValue = Partial<UserPreferencesContextValue>
+
+  const createContextValue = (
+    overrides: MockUserPreferencesContextValue = {},
+  ): UserPreferencesContextValue =>
     ({
       preferences: { lastUpdated: 1 },
       claudeCodeRouterBaseUrl: "http://router.local",
@@ -25,7 +32,7 @@ describe("ClaudeCodeRouterSettings", () => {
       updateClaudeCodeRouterApiKey: vi.fn().mockResolvedValue(true),
       resetClaudeCodeRouterConfig: vi.fn().mockResolvedValue(true),
       ...overrides,
-    }) as any
+    }) as unknown as UserPreferencesContextValue
 
   const renderSubject = () =>
     render(
@@ -36,7 +43,9 @@ describe("ClaudeCodeRouterSettings", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(useUserPreferencesContext).mockReturnValue(createContextValue())
+    vi.mocked(useUserPreferencesContext).mockImplementation(() =>
+      createContextValue(),
+    )
   })
 
   it("persists base URL and API key updates with the current preferences version", async () => {
@@ -78,24 +87,28 @@ describe("ClaudeCodeRouterSettings", () => {
           expectedLastUpdated: 1,
         },
       )
+      expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
+        true,
+        "settings:claudeCodeRouter.baseUrlLabel",
+      )
+      expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
+        true,
+        "settings:claudeCodeRouter.apiKeyLabel",
+      )
     })
-
-    expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-      true,
-      "settings:claudeCodeRouter.baseUrlLabel",
-    )
-    expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-      true,
-      "settings:claudeCodeRouter.apiKeyLabel",
-    )
   })
 
-  it("toggles the API key visibility label", () => {
+  it("toggles the API key visibility label and input type", () => {
     renderSubject()
 
+    const apiKeyInput = screen.getByPlaceholderText(
+      "settings:claudeCodeRouter.apiKeyPlaceholder",
+    )
     const toggle = screen.getByRole("button", {
       name: "keyManagement:actions.showKey",
     })
+
+    expect(apiKeyInput).toHaveAttribute("type", "password")
     fireEvent.click(toggle)
 
     expect(
@@ -103,5 +116,6 @@ describe("ClaudeCodeRouterSettings", () => {
         name: "keyManagement:actions.hideKey",
       }),
     ).toBeInTheDocument()
+    expect(apiKeyInput).toHaveAttribute("type", "text")
   })
 })

--- a/tests/entrypoints/options/CliProxySettings.test.tsx
+++ b/tests/entrypoints/options/CliProxySettings.test.tsx
@@ -196,12 +196,14 @@ describe("CliProxySettings", () => {
   })
 
   it("refreshes clean draft fields when the saved preferences snapshot changes", async () => {
+    const updateCliProxyBaseUrl = vi.fn().mockResolvedValue(true)
+    const updateCliProxyManagementKey = vi.fn().mockResolvedValue(true)
     let contextValue = {
       preferences: { lastUpdated: 1 },
       cliProxyBaseUrl: "http://localhost:8317/v0/management",
       cliProxyManagementKey: "secret-key",
-      updateCliProxyBaseUrl: vi.fn().mockResolvedValue(true),
-      updateCliProxyManagementKey: vi.fn().mockResolvedValue(true),
+      updateCliProxyBaseUrl,
+      updateCliProxyManagementKey,
       resetCliProxyConfig: vi.fn().mockResolvedValue(true),
     }
     vi.mocked(useUserPreferencesContext).mockImplementation(
@@ -228,6 +230,36 @@ describe("CliProxySettings", () => {
         screen.getByPlaceholderText("http://localhost:8317/v0/management"),
       ).toHaveValue("http://localhost:9000/v0/management")
       expect(screen.getByDisplayValue("next-secret-key")).toBeInTheDocument()
+    })
+
+    const baseUrlInput = screen.getByPlaceholderText(
+      "http://localhost:8317/v0/management",
+    )
+    const managementKeyInput = screen.getByDisplayValue("next-secret-key")
+
+    fireEvent.change(baseUrlInput, {
+      target: { value: "http://localhost:9010/v0/management" },
+    })
+    fireEvent.blur(baseUrlInput)
+
+    fireEvent.change(managementKeyInput, {
+      target: { value: "post-refresh-secret" },
+    })
+    fireEvent.blur(managementKeyInput)
+
+    await waitFor(() => {
+      expect(updateCliProxyBaseUrl).toHaveBeenLastCalledWith(
+        "http://localhost:9010/v0/management",
+        {
+          expectedLastUpdated: 2,
+        },
+      )
+      expect(updateCliProxyManagementKey).toHaveBeenLastCalledWith(
+        "post-refresh-secret",
+        {
+          expectedLastUpdated: 2,
+        },
+      )
     })
   })
 })

--- a/tests/entrypoints/options/CliProxySettings.test.tsx
+++ b/tests/entrypoints/options/CliProxySettings.test.tsx
@@ -33,6 +33,7 @@ describe("CliProxySettings", () => {
     vi.clearAllMocks()
 
     vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 1 },
       cliProxyBaseUrl: "http://localhost:8317/v0/management",
       cliProxyManagementKey: "secret-key",
       updateCliProxyBaseUrl: vi.fn().mockResolvedValue(true),
@@ -56,6 +57,7 @@ describe("CliProxySettings", () => {
   it("trims the base URL before persisting and re-checks the connection", async () => {
     const updateCliProxyBaseUrl = vi.fn().mockResolvedValue(true)
     vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 1 },
       cliProxyBaseUrl: "http://localhost:8317/v0/management",
       cliProxyManagementKey: "secret-key",
       updateCliProxyBaseUrl,
@@ -77,6 +79,9 @@ describe("CliProxySettings", () => {
     await waitFor(() => {
       expect(updateCliProxyBaseUrl).toHaveBeenCalledWith(
         "http://localhost:9000/v0/management",
+        {
+          expectedLastUpdated: 1,
+        },
       )
     })
 
@@ -104,6 +109,7 @@ describe("CliProxySettings", () => {
       message: "messages:toast.error.operationFailedGeneric",
     })
     vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 1 },
       cliProxyBaseUrl: "http://localhost:8317/v0/management",
       cliProxyManagementKey: "secret-key",
       updateCliProxyBaseUrl: vi.fn().mockResolvedValue(true),
@@ -123,6 +129,9 @@ describe("CliProxySettings", () => {
     await waitFor(() => {
       expect(updateCliProxyManagementKey).toHaveBeenCalledWith(
         "next-secret-key",
+        {
+          expectedLastUpdated: 1,
+        },
       )
     })
 
@@ -183,6 +192,42 @@ describe("CliProxySettings", () => {
     expect(verifyCliProxyManagementConnection).toHaveBeenCalledWith({
       baseUrl: "http://localhost:8317/v0/management",
       managementKey: "secret-key",
+    })
+  })
+
+  it("refreshes clean draft fields when the saved preferences snapshot changes", async () => {
+    let contextValue = {
+      preferences: { lastUpdated: 1 },
+      cliProxyBaseUrl: "http://localhost:8317/v0/management",
+      cliProxyManagementKey: "secret-key",
+      updateCliProxyBaseUrl: vi.fn().mockResolvedValue(true),
+      updateCliProxyManagementKey: vi.fn().mockResolvedValue(true),
+      resetCliProxyConfig: vi.fn().mockResolvedValue(true),
+    }
+    vi.mocked(useUserPreferencesContext).mockImplementation(
+      () => contextValue as any,
+    )
+
+    const { rerender } = renderSubject()
+
+    contextValue = {
+      ...contextValue,
+      preferences: { lastUpdated: 2 },
+      cliProxyBaseUrl: "http://localhost:9000/v0/management",
+      cliProxyManagementKey: "next-secret-key",
+    }
+
+    rerender(
+      <I18nextProvider i18n={testI18n}>
+        <CliProxySettings />
+      </I18nextProvider>,
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("http://localhost:8317/v0/management"),
+      ).toHaveValue("http://localhost:9000/v0/management")
+      expect(screen.getByDisplayValue("next-secret-key")).toBeInTheDocument()
     })
   })
 })

--- a/tests/entrypoints/options/DoneHubSettings.test.tsx
+++ b/tests/entrypoints/options/DoneHubSettings.test.tsx
@@ -117,4 +117,80 @@ describe("DoneHubSettings", () => {
     ).toBeInTheDocument()
     expect(vi.mocked(showUpdateToast)).not.toHaveBeenCalled()
   })
+
+  it("persists admin token and numeric user ID updates with the current preferences version", async () => {
+    const updateDoneHubAdminToken = vi.fn().mockResolvedValue(true)
+    const updateDoneHubUserId = vi.fn().mockResolvedValue(true)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 2 },
+      doneHubBaseUrl: "https://donehub.example.com",
+      doneHubAdminToken: "old-token",
+      doneHubUserId: "100",
+      updateDoneHubBaseUrl: vi.fn().mockResolvedValue(true),
+      updateDoneHubAdminToken,
+      updateDoneHubUserId,
+      resetDoneHubConfig: vi.fn().mockResolvedValue(true),
+    } as any)
+
+    renderSubject()
+
+    const adminTokenInput = screen.getByDisplayValue("old-token")
+    const userIdInput = screen.getByDisplayValue("100")
+
+    fireEvent.change(adminTokenInput, {
+      target: { value: "next-token" },
+    })
+    fireEvent.blur(adminTokenInput)
+
+    fireEvent.change(userIdInput, {
+      target: { value: " 200 " },
+    })
+    fireEvent.blur(userIdInput)
+
+    await waitFor(() => {
+      expect(updateDoneHubAdminToken).toHaveBeenCalledWith("next-token", {
+        expectedLastUpdated: 2,
+      })
+      expect(updateDoneHubUserId).toHaveBeenCalledWith("200", {
+        expectedLastUpdated: 2,
+      })
+    })
+
+    expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
+      true,
+      "settings:doneHub.fields.adminTokenLabel",
+    )
+    expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
+      true,
+      "settings:doneHub.fields.userIdLabel",
+    )
+  })
+
+  it("skips persisting unchanged admin token and trimmed user ID values", () => {
+    const contextValue = {
+      preferences: { lastUpdated: 2 },
+      doneHubBaseUrl: "https://donehub.example.com",
+      doneHubAdminToken: "same-token",
+      doneHubUserId: "100",
+      updateDoneHubBaseUrl: vi.fn().mockResolvedValue(true),
+      updateDoneHubAdminToken: vi.fn().mockResolvedValue(true),
+      updateDoneHubUserId: vi.fn().mockResolvedValue(true),
+      resetDoneHubConfig: vi.fn().mockResolvedValue(true),
+    } as any
+    vi.mocked(useUserPreferencesContext).mockReturnValue(contextValue)
+
+    renderSubject()
+
+    fireEvent.blur(screen.getByDisplayValue("same-token"))
+
+    const userIdInput = screen.getByDisplayValue("100")
+    fireEvent.change(userIdInput, {
+      target: { value: " 100 " },
+    })
+    fireEvent.blur(userIdInput)
+
+    expect(contextValue.updateDoneHubAdminToken).not.toHaveBeenCalled()
+    expect(contextValue.updateDoneHubUserId).not.toHaveBeenCalled()
+    expect(vi.mocked(showUpdateToast)).not.toHaveBeenCalled()
+  })
 })

--- a/tests/entrypoints/options/DoneHubSettings.test.tsx
+++ b/tests/entrypoints/options/DoneHubSettings.test.tsx
@@ -30,6 +30,7 @@ describe("DoneHubSettings", () => {
   it("trims the base URL before persisting", async () => {
     const updateDoneHubBaseUrl = vi.fn().mockResolvedValue(true)
     vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 1 },
       doneHubBaseUrl: "https://api.example.com",
       doneHubAdminToken: "",
       doneHubUserId: "",
@@ -53,6 +54,9 @@ describe("DoneHubSettings", () => {
     await waitFor(() => {
       expect(updateDoneHubBaseUrl).toHaveBeenCalledWith(
         "https://donehub.example.com",
+        {
+          expectedLastUpdated: 1,
+        },
       )
     })
   })
@@ -60,6 +64,7 @@ describe("DoneHubSettings", () => {
   it("skips persisting when the trimmed base URL is unchanged", () => {
     const updateDoneHubBaseUrl = vi.fn().mockResolvedValue(true)
     vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 1 },
       doneHubBaseUrl: "https://donehub.example.com",
       doneHubAdminToken: "",
       doneHubUserId: "",
@@ -87,6 +92,7 @@ describe("DoneHubSettings", () => {
   it("shows an inline error and skips persisting when the admin user ID is not numeric", async () => {
     const updateDoneHubUserId = vi.fn().mockResolvedValue(true)
     vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 1 },
       doneHubBaseUrl: "https://donehub.example.com",
       doneHubAdminToken: "",
       doneHubUserId: "100",

--- a/tests/entrypoints/options/ManagedSiteTab.test.tsx
+++ b/tests/entrypoints/options/ManagedSiteTab.test.tsx
@@ -35,6 +35,7 @@ vi.mock(
 )
 
 const createContextValue = (overrides: Record<string, unknown> = {}) => ({
+  preferences: { lastUpdated: 1 },
   managedSiteType: "new-api",
   updateManagedSiteType: vi.fn().mockResolvedValue(true),
   newApiBaseUrl: "https://managed.example",

--- a/tests/entrypoints/options/OctopusSettings.test.tsx
+++ b/tests/entrypoints/options/OctopusSettings.test.tsx
@@ -10,12 +10,14 @@ import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
 const {
   mockedUseUserPreferencesContext,
   mockUpdateOctopusBaseUrl,
+  mockUpdateOctopusConfig,
   mockUpdateOctopusUsername,
   mockUpdateOctopusPassword,
   mockResetOctopusConfig,
 } = vi.hoisted(() => ({
   mockedUseUserPreferencesContext: vi.fn(),
   mockUpdateOctopusBaseUrl: vi.fn(),
+  mockUpdateOctopusConfig: vi.fn(),
   mockUpdateOctopusUsername: vi.fn(),
   mockUpdateOctopusPassword: vi.fn(),
   mockResetOctopusConfig: vi.fn(),
@@ -153,10 +155,12 @@ const mockedValidateConfig = octopusAuthManager.validateConfig as ReturnType<
 const mockedShowUpdateToast = showUpdateToast as ReturnType<typeof vi.fn>
 
 const createContextValue = (overrides: Record<string, unknown> = {}) => ({
+  preferences: { lastUpdated: 1 },
   octopusBaseUrl: "https://octopus.example.com",
   octopusUsername: "admin",
   octopusPassword: "secret",
   updateOctopusBaseUrl: mockUpdateOctopusBaseUrl,
+  updateOctopusConfig: mockUpdateOctopusConfig,
   updateOctopusUsername: mockUpdateOctopusUsername,
   updateOctopusPassword: mockUpdateOctopusPassword,
   resetOctopusConfig: mockResetOctopusConfig,
@@ -179,6 +183,7 @@ describe("OctopusSettings", () => {
     vi.clearAllMocks()
 
     mockUpdateOctopusBaseUrl.mockResolvedValue(true)
+    mockUpdateOctopusConfig.mockResolvedValue(true)
     mockUpdateOctopusUsername.mockResolvedValue(true)
     mockUpdateOctopusPassword.mockResolvedValue(true)
     mockResetOctopusConfig.mockResolvedValue(true)
@@ -200,6 +205,9 @@ describe("OctopusSettings", () => {
     await waitFor(() => {
       expect(mockUpdateOctopusBaseUrl).toHaveBeenCalledWith(
         "https://new-octopus.example.com",
+        {
+          expectedLastUpdated: 1,
+        },
       )
     })
 
@@ -223,7 +231,9 @@ describe("OctopusSettings", () => {
     fireEvent.blur(passwordInput)
 
     await waitFor(() => {
-      expect(mockUpdateOctopusPassword).toHaveBeenCalledWith("next-secret")
+      expect(mockUpdateOctopusPassword).toHaveBeenCalledWith("next-secret", {
+        expectedLastUpdated: 1,
+      })
     })
 
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
@@ -240,7 +250,7 @@ describe("OctopusSettings", () => {
     })
   })
 
-  it("toggles password visibility and syncs local inputs when context values change", async () => {
+  it("toggles password visibility and refreshes clean local inputs when context values change", async () => {
     let contextValue = createContextValue()
     mockedUseUserPreferencesContext.mockImplementation(() => contextValue)
 
@@ -258,23 +268,8 @@ describe("OctopusSettings", () => {
     )
     expect(passwordInput).toHaveAttribute("type", "text")
 
-    fireEvent.change(
-      screen.getByLabelText("settings:octopus.fields.baseUrlPlaceholder"),
-      {
-        target: { value: "https://draft.example.com" },
-      },
-    )
-    fireEvent.change(
-      screen.getByLabelText("settings:octopus.fields.usernamePlaceholder"),
-      {
-        target: { value: "draft-user" },
-      },
-    )
-    fireEvent.change(passwordInput, {
-      target: { value: "draft-password" },
-    })
-
     contextValue = createContextValue({
+      preferences: { lastUpdated: 2 },
       octopusBaseUrl: "https://updated.example.com",
       octopusUsername: "updated-user",
       octopusPassword: "updated-password",
@@ -293,6 +288,56 @@ describe("OctopusSettings", () => {
         screen.getByLabelText("settings:octopus.fields.passwordPlaceholder"),
       ).toHaveValue("updated-password")
     })
+  })
+
+  it("keeps dirty local inputs during external refreshes and guards stale saves with the original snapshot version", async () => {
+    let contextValue = createContextValue({
+      preferences: { lastUpdated: 10 },
+    })
+    mockedUseUserPreferencesContext.mockImplementation(() => contextValue)
+    mockUpdateOctopusBaseUrl.mockResolvedValue(false)
+
+    const { rerender } = render(<OctopusSettings />)
+
+    const baseUrlInput = screen.getByLabelText(
+      "settings:octopus.fields.baseUrlPlaceholder",
+    )
+    fireEvent.change(baseUrlInput, {
+      target: { value: "https://draft.example.com" },
+    })
+
+    contextValue = createContextValue({
+      preferences: { lastUpdated: 11 },
+      octopusBaseUrl: "https://imported.example.com",
+      octopusUsername: "imported-user",
+      octopusPassword: "imported-password",
+    })
+
+    rerender(<OctopusSettings />)
+
+    expect(baseUrlInput).toHaveValue("https://draft.example.com")
+    expect(
+      screen.getByLabelText("settings:octopus.fields.usernamePlaceholder"),
+    ).toHaveValue("admin")
+    expect(
+      screen.getByLabelText("settings:octopus.fields.passwordPlaceholder"),
+    ).toHaveValue("secret")
+
+    fireEvent.blur(baseUrlInput)
+
+    await waitFor(() => {
+      expect(mockUpdateOctopusBaseUrl).toHaveBeenCalledWith(
+        "https://draft.example.com",
+        {
+          expectedLastUpdated: 10,
+        },
+      )
+    })
+
+    expect(mockedShowUpdateToast).toHaveBeenCalledWith(
+      false,
+      "settings:octopus.fields.baseUrlLabel",
+    )
   })
 
   it("shows a missing-fields error without validating when required values are blank", async () => {
@@ -317,8 +362,7 @@ describe("OctopusSettings", () => {
     )
     expect(mockedValidateConfig).not.toHaveBeenCalled()
     expect(mockUpdateOctopusBaseUrl).not.toHaveBeenCalled()
-    expect(mockUpdateOctopusUsername).not.toHaveBeenCalled()
-    expect(mockUpdateOctopusPassword).not.toHaveBeenCalled()
+    expect(mockUpdateOctopusConfig).not.toHaveBeenCalled()
   })
 
   it("validates trimmed config, disables the button in flight, and persists successful values", async () => {
@@ -378,12 +422,15 @@ describe("OctopusSettings", () => {
     deferredValidation.resolve({ success: true })
 
     await waitFor(() => {
-      expect(mockUpdateOctopusBaseUrl).toHaveBeenCalledWith(
-        "https://validated.example.com",
-      )
-      expect(mockUpdateOctopusUsername).toHaveBeenCalledWith("validated-user")
-      expect(mockUpdateOctopusPassword).toHaveBeenCalledWith(
-        "validated-password",
+      expect(mockUpdateOctopusConfig).toHaveBeenCalledWith(
+        {
+          baseUrl: "https://validated.example.com",
+          username: "validated-user",
+          password: "validated-password",
+        },
+        {
+          expectedLastUpdated: 1,
+        },
       )
       expect(toast.success).toHaveBeenCalledWith(
         "settings:octopus.validation.success",
@@ -419,9 +466,7 @@ describe("OctopusSettings", () => {
       )
     })
 
-    expect(mockUpdateOctopusBaseUrl).not.toHaveBeenCalled()
-    expect(mockUpdateOctopusUsername).not.toHaveBeenCalled()
-    expect(mockUpdateOctopusPassword).not.toHaveBeenCalled()
+    expect(mockUpdateOctopusConfig).not.toHaveBeenCalled()
     expect(toast.success).not.toHaveBeenCalled()
   })
 

--- a/tests/entrypoints/options/OctopusSettings.test.tsx
+++ b/tests/entrypoints/options/OctopusSettings.test.tsx
@@ -504,4 +504,72 @@ describe("OctopusSettings", () => {
       )
     })
   })
+
+  it("persists trimmed usernames and skips unchanged base URL and password values", async () => {
+    render(<OctopusSettings />)
+
+    const baseUrlInput = screen.getByLabelText(
+      "settings:octopus.fields.baseUrlPlaceholder",
+    )
+    const usernameInput = screen.getByLabelText(
+      "settings:octopus.fields.usernamePlaceholder",
+    )
+    const passwordInput = screen.getByLabelText(
+      "settings:octopus.fields.passwordPlaceholder",
+    )
+
+    fireEvent.change(baseUrlInput, {
+      target: { value: "  https://octopus.example.com  " },
+    })
+    fireEvent.blur(baseUrlInput)
+
+    fireEvent.change(usernameInput, {
+      target: { value: "  next-admin  " },
+    })
+    fireEvent.blur(usernameInput)
+
+    fireEvent.change(passwordInput, {
+      target: { value: "  secret  " },
+    })
+    fireEvent.blur(passwordInput)
+
+    await waitFor(() => {
+      expect(mockUpdateOctopusUsername).toHaveBeenCalledWith("next-admin", {
+        expectedLastUpdated: 1,
+      })
+    })
+
+    expect(mockUpdateOctopusBaseUrl).not.toHaveBeenCalled()
+    expect(mockUpdateOctopusPassword).not.toHaveBeenCalled()
+    expect(mockedShowUpdateToast).toHaveBeenCalledWith(
+      true,
+      "settings:octopus.fields.usernameLabel",
+    )
+  })
+
+  it("shows the generic update failure when validation passes but persistence is rejected", async () => {
+    mockUpdateOctopusConfig.mockResolvedValue(false)
+
+    render(<OctopusSettings />)
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "settings:octopus.validation.validate",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockUpdateOctopusConfig).toHaveBeenCalledWith(
+        {
+          baseUrl: "https://octopus.example.com",
+          username: "admin",
+          password: "secret",
+        },
+        {
+          expectedLastUpdated: 1,
+        },
+      )
+      expect(toast.error).toHaveBeenCalledWith("settings:messages.updateFailed")
+    })
+  })
 })

--- a/tests/entrypoints/options/VeloeraSettings.test.tsx
+++ b/tests/entrypoints/options/VeloeraSettings.test.tsx
@@ -20,6 +20,19 @@ describe("VeloeraSettings", () => {
     vi.clearAllMocks()
   })
 
+  const createContextValue = (overrides: Record<string, unknown> = {}) =>
+    ({
+      preferences: { lastUpdated: 1 },
+      veloeraBaseUrl: "https://veloera.example.com",
+      veloeraAdminToken: "stored-token",
+      veloeraUserId: "200",
+      updateVeloeraBaseUrl: vi.fn().mockResolvedValue(true),
+      updateVeloeraAdminToken: vi.fn().mockResolvedValue(true),
+      updateVeloeraUserId: vi.fn().mockResolvedValue(true),
+      resetVeloeraConfig: vi.fn().mockResolvedValue(true),
+      ...overrides,
+    }) as any
+
   const renderSubject = () =>
     render(
       <I18nextProvider i18n={testI18n}>
@@ -29,16 +42,12 @@ describe("VeloeraSettings", () => {
 
   it("shows an inline error and skips persisting when the admin user ID is not numeric", async () => {
     const updateVeloeraUserId = vi.fn().mockResolvedValue(true)
-    vi.mocked(useUserPreferencesContext).mockReturnValue({
-      preferences: { lastUpdated: 1 },
-      veloeraBaseUrl: "https://veloera.example.com",
-      veloeraAdminToken: "",
-      veloeraUserId: "200",
-      updateVeloeraBaseUrl: vi.fn().mockResolvedValue(true),
-      updateVeloeraAdminToken: vi.fn().mockResolvedValue(true),
-      updateVeloeraUserId,
-      resetVeloeraConfig: vi.fn().mockResolvedValue(true),
-    } as any)
+    vi.mocked(useUserPreferencesContext).mockReturnValue(
+      createContextValue({
+        veloeraAdminToken: "",
+        updateVeloeraUserId,
+      }),
+    )
 
     renderSubject()
 
@@ -54,5 +63,40 @@ describe("VeloeraSettings", () => {
       await screen.findByText("messages:errors.validation.userIdNumeric"),
     ).toBeInTheDocument()
     expect(vi.mocked(showUpdateToast)).not.toHaveBeenCalled()
+  })
+
+  it("trims the base URL and admin token before persisting", async () => {
+    const updateVeloeraBaseUrl = vi.fn().mockResolvedValue(true)
+    const updateVeloeraAdminToken = vi.fn().mockResolvedValue(true)
+    vi.mocked(useUserPreferencesContext).mockReturnValue(
+      createContextValue({
+        updateVeloeraBaseUrl,
+        updateVeloeraAdminToken,
+      }),
+    )
+
+    renderSubject()
+
+    const baseUrlInput = screen.getByDisplayValue("https://veloera.example.com")
+    fireEvent.change(baseUrlInput, {
+      target: { value: "  https://trimmed.veloera.example.com  " },
+    })
+    fireEvent.blur(baseUrlInput)
+
+    const adminTokenInput = screen.getByDisplayValue("stored-token")
+    fireEvent.change(adminTokenInput, {
+      target: { value: "  next-token  " },
+    })
+    fireEvent.blur(adminTokenInput)
+
+    expect(updateVeloeraBaseUrl).toHaveBeenCalledWith(
+      "https://trimmed.veloera.example.com",
+      {
+        expectedLastUpdated: 1,
+      },
+    )
+    expect(updateVeloeraAdminToken).toHaveBeenCalledWith("next-token", {
+      expectedLastUpdated: 1,
+    })
   })
 })

--- a/tests/entrypoints/options/VeloeraSettings.test.tsx
+++ b/tests/entrypoints/options/VeloeraSettings.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { I18nextProvider } from "react-i18next"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -97,6 +97,63 @@ describe("VeloeraSettings", () => {
     )
     expect(updateVeloeraAdminToken).toHaveBeenCalledWith("next-token", {
       expectedLastUpdated: 1,
+    })
+  })
+
+  it("skips persisting the admin user ID when only legacy whitespace differs", () => {
+    const updateVeloeraUserId = vi.fn().mockResolvedValue(true)
+    vi.mocked(useUserPreferencesContext).mockReturnValue(
+      createContextValue({
+        veloeraUserId: " 200 ",
+        updateVeloeraUserId,
+      }),
+    )
+
+    renderSubject()
+
+    const input = document.querySelectorAll("input")[2]
+    expect(input).toBeTruthy()
+    if (!input) {
+      throw new Error("Expected Veloera user ID input to be rendered")
+    }
+    fireEvent.change(input, {
+      target: { value: "200" },
+    })
+    fireEvent.blur(input)
+
+    expect(updateVeloeraUserId).not.toHaveBeenCalled()
+    expect(vi.mocked(showUpdateToast)).not.toHaveBeenCalled()
+  })
+
+  it("trims and persists a changed admin user ID", async () => {
+    const updateVeloeraUserId = vi.fn().mockResolvedValue(true)
+    vi.mocked(useUserPreferencesContext).mockReturnValue(
+      createContextValue({
+        updateVeloeraUserId,
+      }),
+    )
+
+    renderSubject()
+
+    const input = document.querySelectorAll("input")[2]
+    expect(input).toBeTruthy()
+    if (!input) {
+      throw new Error("Expected Veloera user ID input to be rendered")
+    }
+
+    fireEvent.change(input, {
+      target: { value: " 201 " },
+    })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(updateVeloeraUserId).toHaveBeenCalledWith("201", {
+        expectedLastUpdated: 1,
+      })
+      expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
+        true,
+        "settings:veloera.fields.userIdLabel",
+      )
     })
   })
 })

--- a/tests/entrypoints/options/VeloeraSettings.test.tsx
+++ b/tests/entrypoints/options/VeloeraSettings.test.tsx
@@ -30,6 +30,7 @@ describe("VeloeraSettings", () => {
   it("shows an inline error and skips persisting when the admin user ID is not numeric", async () => {
     const updateVeloeraUserId = vi.fn().mockResolvedValue(true)
     vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 1 },
       veloeraBaseUrl: "https://veloera.example.com",
       veloeraAdminToken: "",
       veloeraUserId: "200",

--- a/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
@@ -4,6 +4,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import toast from "react-hot-toast"
 import { I18nextProvider } from "react-i18next"
@@ -215,6 +216,85 @@ describe("WebDAVAutoSyncSettings", () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("settings:messages.updateFailed")
+    })
+  })
+
+  it("surfaces thrown save failures and unsuccessful sync responses", async () => {
+    mockSendRuntimeMessage.mockImplementation(async (message: any) => {
+      switch (message.action) {
+        case RuntimeActionIds.WebdavAutoSyncGetStatus:
+          return { success: true, data: null }
+        case RuntimeActionIds.WebdavAutoSyncUpdateSettings:
+          throw new Error("save exploded")
+        case RuntimeActionIds.WebdavAutoSyncSyncNow:
+          return { success: false, message: "sync rejected" }
+        default:
+          return { success: true }
+      }
+    })
+
+    render(<WebDAVAutoSyncSettings />)
+
+    expect(
+      await screen.findByRole("button", {
+        name: "importExport:webdav.autoSync.saveSettings",
+      }),
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.autoSync.saveSettings",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("save exploded")
+    })
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.autoSync.syncNow",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("sync rejected")
+    })
+  })
+
+  it("saves edited interval and strategy values from the local draft", async () => {
+    const user = userEvent.setup()
+
+    render(<WebDAVAutoSyncSettings />)
+
+    expect(await screen.findByDisplayValue("1800")).toBeInTheDocument()
+
+    fireEvent.change(screen.getByDisplayValue("1800"), {
+      target: { value: "900" },
+    })
+
+    await user.click(screen.getByRole("combobox"))
+    await user.click(
+      screen.getByRole("option", {
+        name: "importExport:webdav.autoSync.strategyMerge",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.autoSync.saveSettings",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockSendRuntimeMessage).toHaveBeenCalledWith({
+        action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+        settings: {
+          autoSync: true,
+          syncInterval: 900,
+          syncStrategy: WEBDAV_SYNC_STRATEGIES.MERGE,
+        },
+      })
     })
   })
 })

--- a/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
@@ -73,6 +73,7 @@ describe("WebDAVAutoSyncSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUserPreferences.getPreferences.mockResolvedValue({
+      lastUpdated: 1,
       webdav: {
         autoSync: true,
         syncInterval: 1800,
@@ -124,6 +125,7 @@ describe("WebDAVAutoSyncSettings", () => {
     await waitFor(() => {
       expect(mockSendRuntimeMessage).toHaveBeenCalledWith({
         action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+        expectedLastUpdated: 1,
         settings: {
           autoSync: false,
           syncInterval: 1800,
@@ -267,11 +269,11 @@ describe("WebDAVAutoSyncSettings", () => {
 
     render(<WebDAVAutoSyncSettings />)
 
-    expect(await screen.findByDisplayValue("1800")).toBeInTheDocument()
+    const syncIntervalInput = await screen.findByDisplayValue("1800")
+    expect(syncIntervalInput).toBeInTheDocument()
 
-    fireEvent.change(screen.getByDisplayValue("1800"), {
-      target: { value: "900" },
-    })
+    await user.clear(syncIntervalInput)
+    await user.type(syncIntervalInput, "900")
 
     await user.click(screen.getByRole("combobox"))
     await user.click(
@@ -280,7 +282,7 @@ describe("WebDAVAutoSyncSettings", () => {
       }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole("button", {
         name: "importExport:webdav.autoSync.saveSettings",
       }),
@@ -289,6 +291,7 @@ describe("WebDAVAutoSyncSettings", () => {
     await waitFor(() => {
       expect(mockSendRuntimeMessage).toHaveBeenCalledWith({
         action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+        expectedLastUpdated: 1,
         settings: {
           autoSync: true,
           syncInterval: 900,

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -18,6 +18,7 @@ import {
 import { testI18n } from "~~/tests/test-utils/i18n"
 
 const {
+  mockApplyPreferenceLanguage,
   mockUserPreferences,
   mockAccountStorage,
   mockTagStorage,
@@ -35,8 +36,10 @@ const {
   mockImportFromBackupObject,
   loggerMocks,
 } = vi.hoisted(() => ({
+  mockApplyPreferenceLanguage: vi.fn(),
   mockUserPreferences: {
     getPreferences: vi.fn(),
+    getLanguage: vi.fn(),
     savePreferences: vi.fn(),
     exportPreferences: vi.fn(),
   },
@@ -71,6 +74,11 @@ vi.mock("react-hot-toast", () => ({
 
 vi.mock("~/utils/core/logger", () => ({
   createLogger: () => loggerMocks,
+}))
+
+vi.mock("~/utils/i18n/applyPreferenceLanguage", () => ({
+  applyPreferenceLanguage: (...args: unknown[]) =>
+    mockApplyPreferenceLanguage(...args),
 }))
 
 vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
@@ -175,6 +183,7 @@ describe("WebDAVSettings", () => {
     mockUserPreferences.getPreferences.mockResolvedValue(
       createPreferencesFixture(),
     )
+    mockUserPreferences.getLanguage.mockResolvedValue("ja")
     mockUserPreferences.savePreferences.mockResolvedValue(true)
     mockUserPreferences.exportPreferences.mockResolvedValue({
       themeMode: "dark",
@@ -192,6 +201,7 @@ describe("WebDAVSettings", () => {
       imported: true,
     })
     mockImportFromBackupObject.mockResolvedValue({ allImported: true })
+    mockApplyPreferenceLanguage.mockResolvedValue(true)
     mockDecryptWebdavBackupEnvelope.mockResolvedValue('{"version":2}')
     mockTestWebdavConnection.mockResolvedValue(undefined)
     mockUploadBackup.mockResolvedValue(undefined)
@@ -332,6 +342,8 @@ describe("WebDAVSettings", () => {
         { imported: true },
         { preserveWebdav: true },
       )
+      expect(mockUserPreferences.getLanguage).toHaveBeenCalledTimes(1)
+      expect(mockApplyPreferenceLanguage).toHaveBeenCalledWith("ja")
     })
     expect(mockUserPreferences.savePreferences).toHaveBeenNthCalledWith(
       2,
@@ -516,6 +528,8 @@ describe("WebDAVSettings", () => {
         { imported: true },
         { preserveWebdav: true },
       )
+      expect(mockUserPreferences.getLanguage).toHaveBeenCalledTimes(1)
+      expect(mockApplyPreferenceLanguage).toHaveBeenCalledWith("ja")
       expect(mockUserPreferences.getPreferences).toHaveBeenCalledTimes(2)
       expect(toast.success).toHaveBeenCalledWith(
         "importExport:import.importSuccess",

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -11,12 +11,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { UserPreferencesProvider } from "~/contexts/UserPreferencesContext"
 import WebDAVSettings from "~/features/ImportExport/components/WebDAVSettings"
-import {
-  DEFAULT_PREFERENCES,
-  type UserPreferences,
-} from "~/services/preferences/userPreferences"
-import { deepOverride } from "~/utils"
 import { testI18n } from "~~/tests/test-utils/i18n"
+import {
+  createPersistedPreferencesFixture,
+  setupMockPreferencePersistence,
+} from "~~/tests/test-utils/mockPreferencePersistence"
 
 const {
   mockApplyPreferenceLanguage,
@@ -152,27 +151,6 @@ function render(ui: ReactNode) {
   )
 }
 
-const createPreferencesFixture = (): UserPreferences => ({
-  ...structuredClone(DEFAULT_PREFERENCES),
-  showTodayCashflow: true,
-  webdav: {
-    ...structuredClone(DEFAULT_PREFERENCES.webdav),
-    url: "https://dav.example.com/backup.json",
-    username: "alice",
-    password: "pw",
-    backupEncryptionEnabled: true,
-    backupEncryptionPassword: "stored-secret",
-    syncData: {
-      accounts: true,
-      bookmarks: true,
-      apiCredentialProfiles: true,
-      preferences: true,
-    },
-  },
-})
-
-let persistedPreferences = createPreferencesFixture()
-
 const ENCRYPTED_BACKUP_ENVELOPE = {
   version: 1,
   algorithm: "aes-gcm",
@@ -184,23 +162,24 @@ const ENCRYPTED_BACKUP_ENVELOPE = {
 describe("WebDAVSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    persistedPreferences = createPreferencesFixture()
-    mockUserPreferences.getPreferences.mockImplementation(async () =>
-      structuredClone(persistedPreferences),
-    )
-    mockUserPreferences.savePreferences.mockImplementation(async (updates) => {
-      persistedPreferences = deepOverride(persistedPreferences, updates)
-      persistedPreferences.lastUpdated += 1
-      return true
-    })
-    mockUserPreferences.savePreferencesWithResult.mockImplementation(
-      async (updates, options) => {
-        const success = await mockUserPreferences.savePreferences(
-          updates,
-          options,
-        )
-        return success ? structuredClone(persistedPreferences) : null
-      },
+    setupMockPreferencePersistence(
+      mockUserPreferences,
+      createPersistedPreferencesFixture({
+        showTodayCashflow: true,
+        webdav: {
+          url: "https://dav.example.com/backup.json",
+          username: "alice",
+          password: "pw",
+          backupEncryptionEnabled: true,
+          backupEncryptionPassword: "stored-secret",
+          syncData: {
+            accounts: true,
+            bookmarks: true,
+            apiCredentialProfiles: true,
+            preferences: true,
+          },
+        },
+      }),
     )
     mockUserPreferences.getLanguage.mockResolvedValue("ja")
     mockUserPreferences.exportPreferences.mockResolvedValue({

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -224,7 +224,9 @@ describe("WebDAVSettings", () => {
       screen.getByRole("button", { name: "importExport:webdav.saveConfig" }),
     )
     await waitFor(() => {
-      expect(mockUserPreferences.savePreferences).toHaveBeenCalledWith(
+      expect(
+        mockUserPreferences.savePreferencesWithResult,
+      ).toHaveBeenCalledWith(
         {
           webdav: {
             url: "https://dav.example.com/backup.json",
@@ -342,7 +344,9 @@ describe("WebDAVSettings", () => {
       expect(mockUserPreferences.getLanguage).toHaveBeenCalledTimes(1)
       expect(mockApplyPreferenceLanguage).toHaveBeenCalledWith("ja")
     })
-    expect(mockUserPreferences.savePreferences).toHaveBeenNthCalledWith(
+    expect(
+      mockUserPreferences.savePreferencesWithResult,
+    ).toHaveBeenNthCalledWith(
       2,
       {
         webdav: {
@@ -359,7 +363,9 @@ describe("WebDAVSettings", () => {
     )
 
     await waitFor(() => {
-      expect(mockUserPreferences.savePreferences).toHaveBeenLastCalledWith(
+      expect(
+        mockUserPreferences.savePreferencesWithResult,
+      ).toHaveBeenLastCalledWith(
         {
           webdav: {
             url: "https://dav.example.com/backup.json",
@@ -386,7 +392,7 @@ describe("WebDAVSettings", () => {
   })
 
   it("surfaces the save failure message when saving the WebDAV config fails", async () => {
-    mockUserPreferences.savePreferences.mockResolvedValue(false)
+    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
 
     render(<WebDAVSettings />)
 
@@ -410,7 +416,7 @@ describe("WebDAVSettings", () => {
   })
 
   it("shows the action-specific connection failure message when persisting settings fails", async () => {
-    mockUserPreferences.savePreferences.mockResolvedValue(false)
+    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
 
     render(<WebDAVSettings />)
 
@@ -647,8 +653,12 @@ describe("WebDAVSettings", () => {
     mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
       ENCRYPTED_BACKUP_ENVELOPE,
     )
-    mockUserPreferences.savePreferences.mockResolvedValueOnce(true)
-    mockUserPreferences.savePreferences.mockResolvedValueOnce(false)
+    const defaultSavePreferencesWithResult =
+      mockUserPreferences.savePreferencesWithResult.getMockImplementation()
+    mockUserPreferences.savePreferencesWithResult.mockImplementationOnce(
+      defaultSavePreferencesWithResult!,
+    )
+    mockUserPreferences.savePreferencesWithResult.mockResolvedValueOnce(null)
 
     render(<WebDAVSettings />)
 
@@ -735,7 +745,9 @@ describe("WebDAVSettings", () => {
         { imported: true },
         { preserveWebdav: true },
       )
-      expect(mockUserPreferences.savePreferences).toHaveBeenNthCalledWith(
+      expect(
+        mockUserPreferences.savePreferencesWithResult,
+      ).toHaveBeenNthCalledWith(
         2,
         {
           webdav: {

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -15,6 +15,7 @@ import {
   DEFAULT_PREFERENCES,
   type UserPreferences,
 } from "~/services/preferences/userPreferences"
+import { deepOverride } from "~/utils"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
 const {
@@ -41,6 +42,7 @@ const {
     getPreferences: vi.fn(),
     getLanguage: vi.fn(),
     savePreferences: vi.fn(),
+    savePreferencesWithResult: vi.fn(),
     exportPreferences: vi.fn(),
   },
   mockAccountStorage: { exportData: vi.fn() },
@@ -169,6 +171,8 @@ const createPreferencesFixture = (): UserPreferences => ({
   },
 })
 
+let persistedPreferences = createPreferencesFixture()
+
 const ENCRYPTED_BACKUP_ENVELOPE = {
   version: 1,
   algorithm: "aes-gcm",
@@ -180,11 +184,25 @@ const ENCRYPTED_BACKUP_ENVELOPE = {
 describe("WebDAVSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUserPreferences.getPreferences.mockResolvedValue(
-      createPreferencesFixture(),
+    persistedPreferences = createPreferencesFixture()
+    mockUserPreferences.getPreferences.mockImplementation(async () =>
+      structuredClone(persistedPreferences),
+    )
+    mockUserPreferences.savePreferences.mockImplementation(async (updates) => {
+      persistedPreferences = deepOverride(persistedPreferences, updates)
+      persistedPreferences.lastUpdated += 1
+      return true
+    })
+    mockUserPreferences.savePreferencesWithResult.mockImplementation(
+      async (updates, options) => {
+        const success = await mockUserPreferences.savePreferences(
+          updates,
+          options,
+        )
+        return success ? structuredClone(persistedPreferences) : null
+      },
     )
     mockUserPreferences.getLanguage.mockResolvedValue("ja")
-    mockUserPreferences.savePreferences.mockResolvedValue(true)
     mockUserPreferences.exportPreferences.mockResolvedValue({
       themeMode: "dark",
     })

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -217,21 +217,26 @@ describe("WebDAVSettings", () => {
       screen.getByRole("button", { name: "importExport:webdav.saveConfig" }),
     )
     await waitFor(() => {
-      expect(mockUserPreferences.savePreferences).toHaveBeenCalledWith({
-        webdav: {
-          url: "https://dav.example.com/backup.json",
-          username: "alice",
-          password: "pw",
-          backupEncryptionEnabled: true,
-          backupEncryptionPassword: "stored-secret",
-          syncData: {
-            accounts: true,
-            bookmarks: true,
-            apiCredentialProfiles: true,
-            preferences: true,
+      expect(mockUserPreferences.savePreferences).toHaveBeenCalledWith(
+        {
+          webdav: {
+            url: "https://dav.example.com/backup.json",
+            username: "alice",
+            password: "pw",
+            backupEncryptionEnabled: true,
+            backupEncryptionPassword: "stored-secret",
+            syncData: {
+              accounts: true,
+              bookmarks: true,
+              apiCredentialProfiles: true,
+              preferences: true,
+            },
           },
         },
-      })
+        {
+          expectedLastUpdated: 0,
+        },
+      )
     })
     expect(toast.success).toHaveBeenCalledWith(
       "settings:messages.updateSuccess",
@@ -328,32 +333,43 @@ describe("WebDAVSettings", () => {
         { preserveWebdav: true },
       )
     })
-    expect(mockUserPreferences.savePreferences).toHaveBeenCalledWith({
-      webdav: {
-        backupEncryptionPassword: "manual-secret",
+    expect(mockUserPreferences.savePreferences).toHaveBeenNthCalledWith(
+      2,
+      {
+        webdav: {
+          backupEncryptionPassword: "manual-secret",
+        },
       },
-    })
+      {
+        expectedLastUpdated: expect.any(Number),
+      },
+    )
 
     fireEvent.click(
       screen.getByRole("button", { name: "importExport:webdav.saveConfig" }),
     )
 
     await waitFor(() => {
-      expect(mockUserPreferences.savePreferences).toHaveBeenLastCalledWith({
-        webdav: {
-          url: "https://dav.example.com/backup.json",
-          username: "alice",
-          password: "pw",
-          backupEncryptionEnabled: true,
-          backupEncryptionPassword: "manual-secret",
-          syncData: {
-            accounts: true,
-            bookmarks: true,
-            apiCredentialProfiles: true,
-            preferences: true,
+      expect(mockUserPreferences.savePreferences).toHaveBeenLastCalledWith(
+        {
+          webdav: {
+            url: "https://dav.example.com/backup.json",
+            username: "alice",
+            password: "pw",
+            backupEncryptionEnabled: true,
+            backupEncryptionPassword: "manual-secret",
+            syncData: {
+              accounts: true,
+              bookmarks: true,
+              apiCredentialProfiles: true,
+              preferences: true,
+            },
           },
         },
-      })
+        {
+          expectedLastUpdated: expect.any(Number),
+        },
+      )
     })
     expect(toast.success).toHaveBeenCalledWith(
       "importExport:import.importSuccess",
@@ -500,6 +516,7 @@ describe("WebDAVSettings", () => {
         { imported: true },
         { preserveWebdav: true },
       )
+      expect(mockUserPreferences.getPreferences).toHaveBeenCalledTimes(2)
       expect(toast.success).toHaveBeenCalledWith(
         "importExport:import.importSuccess",
       )

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -710,6 +710,72 @@ describe("WebDAVSettings", () => {
     })
   })
 
+  it("persists the decrypt password with the current draft version when the imported backup excludes preferences", async () => {
+    mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
+    mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
+      ENCRYPTED_BACKUP_ENVELOPE,
+    )
+    mockImportFromBackupObject.mockResolvedValueOnce({
+      allImported: false,
+      sections: {
+        accounts: true,
+      },
+    })
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+
+    fireEvent.change(screen.getAllByDisplayValue("stored-secret")[0], {
+      target: { value: "" },
+    })
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.downloadImport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(document.getElementById("decryptPassword")).toBeTruthy()
+    })
+    fireEvent.change(
+      document.getElementById("decryptPassword") as HTMLInputElement,
+      {
+        target: { value: "manual-secret" },
+      },
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.encryption.decryptAction",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockImportFromBackupObject).toHaveBeenCalledWith(
+        { imported: true },
+        { preserveWebdav: true },
+      )
+      expect(mockUserPreferences.savePreferences).toHaveBeenNthCalledWith(
+        2,
+        {
+          webdav: {
+            backupEncryptionPassword: "manual-secret",
+          },
+        },
+        {
+          expectedLastUpdated: 1,
+        },
+      )
+    })
+
+    expect(mockUserPreferences.getLanguage).not.toHaveBeenCalled()
+    expect(mockApplyPreferenceLanguage).not.toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalledWith(
+      "importExport:import.importSuccess",
+    )
+  })
+
   it("blocks manual decrypt/import when sync data becomes empty", async () => {
     mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
     mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
@@ -802,6 +868,7 @@ describe("WebDAVSettings", () => {
     fireEvent.change(backupPasswordInput, {
       target: { value: "" },
     })
+    fireEvent.click(screen.getByRole("switch"))
     fireEvent.click(
       screen.getByRole("button", {
         name: "importExport:webdav.downloadImport",
@@ -823,5 +890,6 @@ describe("WebDAVSettings", () => {
     expect(
       document.getElementById("decryptPassword") as HTMLInputElement,
     ).toHaveAttribute("type", "text")
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false")
   })
 })

--- a/tests/features/ImportExport/hooks/useImportExport.test.tsx
+++ b/tests/features/ImportExport/hooks/useImportExport.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { useImportExport } from "~/features/ImportExport/hooks/useImportExport"
 
 const {
+  applyPreferenceLanguageMock,
+  getLanguageMock,
   importFromBackupObjectMock,
   loggerErrorMock,
   parseBackupSummaryMock,
@@ -11,6 +13,8 @@ const {
   toastErrorMock,
   toastSuccessMock,
 } = vi.hoisted(() => ({
+  applyPreferenceLanguageMock: vi.fn(),
+  getLanguageMock: vi.fn(),
   importFromBackupObjectMock: vi.fn(),
   loggerErrorMock: vi.fn(),
   parseBackupSummaryMock: vi.fn(),
@@ -50,6 +54,17 @@ vi.mock("~/contexts/UserPreferencesContext", () => ({
   }),
 }))
 
+vi.mock("~/services/preferences/userPreferences", () => ({
+  userPreferences: {
+    getLanguage: getLanguageMock,
+  },
+}))
+
+vi.mock("~/utils/i18n/applyPreferenceLanguage", () => ({
+  applyPreferenceLanguage: (...args: unknown[]) =>
+    applyPreferenceLanguageMock(...args),
+}))
+
 vi.mock("~/features/ImportExport/utils", () => ({
   importFromBackupObject: (...args: unknown[]) =>
     importFromBackupObjectMock(...args),
@@ -72,6 +87,8 @@ describe("useImportExport", () => {
     vi.clearAllMocks()
     vi.stubGlobal("FileReader", MockFileReader as unknown as typeof FileReader)
     loadPreferencesMock.mockResolvedValue(undefined)
+    getLanguageMock.mockResolvedValue("ja")
+    applyPreferenceLanguageMock.mockResolvedValue(true)
   })
 
   it("loads selected backup file text into state and ignores empty file selections", async () => {
@@ -143,6 +160,8 @@ describe("useImportExport", () => {
       "importExport:import.importSuccess",
     )
     expect(loadPreferencesMock).toHaveBeenCalledTimes(1)
+    expect(getLanguageMock).toHaveBeenCalledTimes(1)
+    expect(applyPreferenceLanguageMock).toHaveBeenCalledWith("ja")
     expect(result.current.isImporting).toBe(false)
 
     importFromBackupObjectMock.mockResolvedValueOnce({ allImported: false })
@@ -153,6 +172,28 @@ describe("useImportExport", () => {
 
     expect(toastSuccessMock).toHaveBeenCalledTimes(1)
     expect(loadPreferencesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("refreshes and reapplies the persisted language for preference-only imports", async () => {
+    importFromBackupObjectMock.mockResolvedValueOnce({
+      allImported: false,
+      sections: { preferences: true },
+    })
+
+    const { result } = renderHook(() => useImportExport())
+
+    act(() => {
+      result.current.setImportData('{"version":6}')
+    })
+
+    await act(async () => {
+      await result.current.handleImport()
+    })
+
+    expect(loadPreferencesMock).toHaveBeenCalledTimes(1)
+    expect(getLanguageMock).toHaveBeenCalledTimes(1)
+    expect(applyPreferenceLanguageMock).toHaveBeenCalledWith("ja")
+    expect(toastSuccessMock).not.toHaveBeenCalled()
   })
 
   it("surfaces format errors for malformed JSON and detailed fallback errors for import failures", async () => {

--- a/tests/features/ImportExport/hooks/useImportExport.test.tsx
+++ b/tests/features/ImportExport/hooks/useImportExport.test.tsx
@@ -7,12 +7,14 @@ const {
   importFromBackupObjectMock,
   loggerErrorMock,
   parseBackupSummaryMock,
+  loadPreferencesMock,
   toastErrorMock,
   toastSuccessMock,
 } = vi.hoisted(() => ({
   importFromBackupObjectMock: vi.fn(),
   loggerErrorMock: vi.fn(),
   parseBackupSummaryMock: vi.fn(),
+  loadPreferencesMock: vi.fn(),
   toastErrorMock: vi.fn(),
   toastSuccessMock: vi.fn(),
 }))
@@ -42,6 +44,12 @@ vi.mock("~/utils/core/logger", () => ({
   }),
 }))
 
+vi.mock("~/contexts/UserPreferencesContext", () => ({
+  useUserPreferencesContext: () => ({
+    loadPreferences: loadPreferencesMock,
+  }),
+}))
+
 vi.mock("~/features/ImportExport/utils", () => ({
   importFromBackupObject: (...args: unknown[]) =>
     importFromBackupObjectMock(...args),
@@ -63,6 +71,7 @@ describe("useImportExport", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubGlobal("FileReader", MockFileReader as unknown as typeof FileReader)
+    loadPreferencesMock.mockResolvedValue(undefined)
   })
 
   it("loads selected backup file text into state and ignores empty file selections", async () => {
@@ -133,6 +142,7 @@ describe("useImportExport", () => {
     expect(toastSuccessMock).toHaveBeenCalledWith(
       "importExport:import.importSuccess",
     )
+    expect(loadPreferencesMock).toHaveBeenCalledTimes(1)
     expect(result.current.isImporting).toBe(false)
 
     importFromBackupObjectMock.mockResolvedValueOnce({ allImported: false })
@@ -142,6 +152,7 @@ describe("useImportExport", () => {
     })
 
     expect(toastSuccessMock).toHaveBeenCalledTimes(1)
+    expect(loadPreferencesMock).toHaveBeenCalledTimes(1)
   })
 
   it("surfaces format errors for malformed JSON and detailed fallback errors for import failures", async () => {

--- a/tests/services/userPreferences.sharedPreferences.test.ts
+++ b/tests/services/userPreferences.sharedPreferences.test.ts
@@ -210,6 +210,41 @@ describe("userPreferences shared preference timestamps", () => {
     expect(storedAfter.activeTab).toBe(DATA_TYPE_CASHFLOW)
   })
 
+  it("rethrows storage failures from savePreferencesWithResult and keeps savePreferences as a safe boolean wrapper", async () => {
+    await storage.set(USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES, {
+      ...DEFAULT_PREFERENCES,
+      themeMode: "system",
+      lastUpdated: 7100,
+      sharedPreferencesLastUpdated: 7100,
+    })
+
+    const storageSetSpy = vi
+      .spyOn((userPreferences as any).storage, "set")
+      .mockRejectedValue(new Error("save failed"))
+
+    try {
+      await expect(
+        userPreferences.savePreferencesWithResult({
+          themeMode: "dark",
+        }),
+      ).rejects.toThrow("save failed")
+
+      await expect(
+        userPreferences.savePreferences({
+          themeMode: "dark",
+        }),
+      ).resolves.toBe(false)
+
+      const storedAfter = (await storage.get(
+        USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
+      )) as any
+      expect(storedAfter.themeMode).toBe("system")
+      expect(storedAfter.lastUpdated).toBe(7100)
+    } finally {
+      storageSetSpy.mockRestore()
+    }
+  })
+
   it("refreshes sharedPreferencesLastUpdated for manual imports", async () => {
     const backupTimestamp = 7000
     const importedAt = 8000

--- a/tests/services/webdavAutoSyncService.lifecycle.test.ts
+++ b/tests/services/webdavAutoSyncService.lifecycle.test.ts
@@ -297,7 +297,7 @@ describe("webdavAutoSyncService lifecycle", () => {
       .mockResolvedValue(undefined)
     const updateSpy = vi
       .spyOn(webdavAutoSyncService, "updateSettings")
-      .mockResolvedValue(undefined)
+      .mockResolvedValue(true)
     vi.spyOn(webdavAutoSyncService, "getStatus").mockReturnValue({
       isRunning: true,
       isInitialized: true,

--- a/tests/services/webdavAutoSyncService.lifecycle.test.ts
+++ b/tests/services/webdavAutoSyncService.lifecycle.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   isMessageReceiverUnavailableError: vi.fn(),
   getPreferences: vi.fn(),
   savePreferences: vi.fn(),
+  savePreferencesWithResult: vi.fn(),
 }))
 
 vi.mock("~/utils/core/error", () => ({
@@ -51,6 +52,7 @@ vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
       ...actual.userPreferences,
       getPreferences: mocks.getPreferences,
       savePreferences: mocks.savePreferences,
+      savePreferencesWithResult: mocks.savePreferencesWithResult,
     },
   }
 })
@@ -113,6 +115,22 @@ describe("webdavAutoSyncService lifecycle", () => {
     })
     mocks.sendRuntimeMessage.mockResolvedValue(undefined)
     mocks.isMessageReceiverUnavailableError.mockReturnValue(false)
+    mocks.savePreferences.mockResolvedValue(true)
+    mocks.savePreferencesWithResult.mockImplementation(
+      async (updates, options) => {
+        const success = await mocks.savePreferences(updates, options)
+        return success
+          ? {
+              lastUpdated: 1,
+              webdav: {
+                autoSync: false,
+                syncInterval: 3600,
+                syncStrategy: "merge",
+              },
+            }
+          : null
+      },
+    )
   })
 
   it("initializes once and only reacts to the WebDAV alarm", async () => {
@@ -297,7 +315,17 @@ describe("webdavAutoSyncService lifecycle", () => {
       .mockResolvedValue(undefined)
     const updateSpy = vi
       .spyOn(webdavAutoSyncService, "updateSettings")
-      .mockResolvedValue(true)
+      .mockResolvedValue({
+        ok: true,
+        savedPreferences: {
+          lastUpdated: 1,
+          webdav: {
+            autoSync: false,
+            syncInterval: 3600,
+            syncStrategy: "merge",
+          },
+        },
+      } as any)
     vi.spyOn(webdavAutoSyncService, "getStatus").mockReturnValue({
       isRunning: true,
       isInitialized: true,
@@ -325,7 +353,17 @@ describe("webdavAutoSyncService lifecycle", () => {
           action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
           settings: { autoSync: false },
         },
-        expected: { success: true },
+        expected: {
+          success: true,
+          data: {
+            lastUpdated: 1,
+            webdav: {
+              autoSync: false,
+              syncInterval: 3600,
+              syncStrategy: "merge",
+            },
+          },
+        },
       },
       {
         request: { action: RuntimeActionIds.WebdavAutoSyncGetStatus },
@@ -356,7 +394,7 @@ describe("webdavAutoSyncService lifecycle", () => {
     expect(setupSpy).toHaveBeenCalledTimes(1)
     expect(syncNowSpy).toHaveBeenCalledTimes(1)
     expect(stopSpy).toHaveBeenCalledTimes(1)
-    expect(updateSpy).toHaveBeenCalledWith({ autoSync: false })
+    expect(updateSpy).toHaveBeenCalledWith({ autoSync: false }, undefined)
 
     setupSpy.mockRejectedValueOnce(new Error("handler exploded"))
     const sendResponse = vi.fn()
@@ -382,13 +420,16 @@ describe("webdavAutoSyncService lifecycle", () => {
       syncStrategy: "merge",
     })
 
-    expect(mocks.savePreferences).toHaveBeenCalledWith({
-      webdav: {
-        autoSync: true,
-        syncInterval: 1800,
-        syncStrategy: "merge",
+    expect(mocks.savePreferences).toHaveBeenCalledWith(
+      {
+        webdav: {
+          autoSync: true,
+          syncInterval: 1800,
+          syncStrategy: "merge",
+        },
       },
-    })
+      undefined,
+    )
     expect(setupSpy).toHaveBeenCalledTimes(1)
   })
 
@@ -398,11 +439,16 @@ describe("webdavAutoSyncService lifecycle", () => {
       .spyOn(service, "setupAutoSync")
       .mockResolvedValue(undefined)
 
-    mocks.savePreferences.mockRejectedValueOnce(new Error("save failed"))
+    mocks.savePreferencesWithResult.mockRejectedValueOnce(
+      new Error("save failed"),
+    )
 
     await expect(
       service.updateSettings({ autoSync: false, syncInterval: 900 }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({
+      ok: false,
+      reason: "error",
+    })
 
     expect(setupSpy).not.toHaveBeenCalled()
   })

--- a/tests/services/webdavAutoSyncService.lifecycle.test.ts
+++ b/tests/services/webdavAutoSyncService.lifecycle.test.ts
@@ -408,6 +408,21 @@ describe("webdavAutoSyncService lifecycle", () => {
     })
   })
 
+  it("stops auto-sync alarms and clears the scheduled flag when an alarm was active", async () => {
+    const service = createService()
+    ;(service as any).isScheduled = true
+    mocks.clearAlarm.mockResolvedValueOnce(true).mockResolvedValueOnce(true)
+
+    await expect(service.stopAutoSync()).resolves.toBeUndefined()
+
+    expect(mocks.clearAlarm).toHaveBeenNthCalledWith(1, "webdavAutoSync")
+    expect(mocks.clearAlarm).toHaveBeenNthCalledWith(
+      2,
+      "webdavAutoSyncBestEffortUpload",
+    )
+    expect(service.getStatus().isRunning).toBe(false)
+  })
+
   it("persists updated settings and re-runs scheduler setup", async () => {
     const service = createService()
     const setupSpy = vi
@@ -505,6 +520,48 @@ describe("webdavAutoSyncService lifecycle", () => {
     })
     expect(updateSpy).toHaveBeenNthCalledWith(1, { autoSync: false }, undefined)
     expect(updateSpy).toHaveBeenNthCalledWith(2, { autoSync: true }, undefined)
+  })
+
+  it("forwards optimistic concurrency hints through the WebDAV settings message handler", async () => {
+    const updateSpy = vi
+      .spyOn(webdavAutoSyncService, "updateSettings")
+      .mockResolvedValueOnce({
+        ok: true,
+        savedPreferences: {
+          lastUpdated: 9,
+          webdav: {
+            autoSync: false,
+            syncInterval: 900,
+            syncStrategy: "merge",
+          },
+        },
+      } as any)
+
+    const sendResponse = vi.fn()
+    await handleWebdavAutoSyncMessage(
+      {
+        action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+        settings: { autoSync: false, syncInterval: 900 },
+        expectedLastUpdated: 7,
+      },
+      sendResponse,
+    )
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      { autoSync: false, syncInterval: 900 },
+      { expectedLastUpdated: 7 },
+    )
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        lastUpdated: 9,
+        webdav: {
+          autoSync: false,
+          syncInterval: 900,
+          syncStrategy: "merge",
+        },
+      },
+    })
   })
 
   it("swallows settings persistence failures without re-running scheduler setup", async () => {

--- a/tests/services/webdavAutoSyncService.lifecycle.test.ts
+++ b/tests/services/webdavAutoSyncService.lifecycle.test.ts
@@ -433,6 +433,80 @@ describe("webdavAutoSyncService lifecycle", () => {
     expect(setupSpy).toHaveBeenCalledTimes(1)
   })
 
+  it("returns a conflict result when guarded settings persistence is rejected as stale", async () => {
+    const service = createService()
+    const setupSpy = vi
+      .spyOn(service, "setupAutoSync")
+      .mockResolvedValue(undefined)
+
+    mocks.savePreferencesWithResult.mockResolvedValueOnce(null)
+
+    await expect(
+      service.updateSettings(
+        { autoSync: false, syncInterval: 900 },
+        { expectedLastUpdated: 7 },
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "conflict",
+    })
+
+    expect(setupSpy).not.toHaveBeenCalled()
+    expect(mocks.savePreferencesWithResult).toHaveBeenCalledWith(
+      {
+        webdav: {
+          autoSync: false,
+          syncInterval: 900,
+        },
+      },
+      {
+        expectedLastUpdated: 7,
+      },
+    )
+  })
+
+  it("maps update-settings conflict and generic failures to distinct response messages", async () => {
+    const updateSpy = vi
+      .spyOn(webdavAutoSyncService, "updateSettings")
+      .mockResolvedValueOnce({
+        ok: false,
+        reason: "conflict",
+      } as any)
+      .mockResolvedValueOnce({
+        ok: false,
+        reason: "error",
+      } as any)
+
+    const conflictResponse = vi.fn()
+    await handleWebdavAutoSyncMessage(
+      {
+        action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+        settings: { autoSync: false },
+      },
+      conflictResponse,
+    )
+
+    const errorResponse = vi.fn()
+    await handleWebdavAutoSyncMessage(
+      {
+        action: RuntimeActionIds.WebdavAutoSyncUpdateSettings,
+        settings: { autoSync: true },
+      },
+      errorResponse,
+    )
+
+    expect(conflictResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "settings:messages.preferencesChangedExternally",
+    })
+    expect(errorResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "settings:messages.saveSettingsFailed",
+    })
+    expect(updateSpy).toHaveBeenNthCalledWith(1, { autoSync: false }, undefined)
+    expect(updateSpy).toHaveBeenNthCalledWith(2, { autoSync: true }, undefined)
+  })
+
   it("swallows settings persistence failures without re-running scheduler setup", async () => {
     const service = createService()
     const setupSpy = vi

--- a/tests/test-utils/mockPreferencePersistence.ts
+++ b/tests/test-utils/mockPreferencePersistence.ts
@@ -1,0 +1,55 @@
+import { vi } from "vitest"
+
+import {
+  DEFAULT_PREFERENCES,
+  type UserPreferences,
+} from "~/services/preferences/userPreferences"
+import type { DeepPartial } from "~/types/utils"
+import { deepOverride } from "~/utils"
+
+type PersistenceMock = ReturnType<typeof vi.fn>
+
+type PreferencePersistenceMocks = {
+  getPreferences: PersistenceMock
+  savePreferences: PersistenceMock
+  savePreferencesWithResult: PersistenceMock
+}
+
+export function createPersistedPreferencesFixture(
+  overrides?: DeepPartial<UserPreferences>,
+): UserPreferences {
+  return overrides
+    ? deepOverride(structuredClone(DEFAULT_PREFERENCES), overrides)
+    : structuredClone(DEFAULT_PREFERENCES)
+}
+
+export function setupMockPreferencePersistence(
+  mocks: PreferencePersistenceMocks,
+  initialPreferences = createPersistedPreferencesFixture(),
+) {
+  let persistedPreferences = structuredClone(initialPreferences)
+
+  const getPersistedPreferences = () => structuredClone(persistedPreferences)
+
+  const setPersistedPreferences = (nextPreferences: UserPreferences) => {
+    persistedPreferences = structuredClone(nextPreferences)
+  }
+
+  mocks.getPreferences.mockImplementation(async () => getPersistedPreferences())
+  mocks.savePreferences.mockImplementation(async (updates) => {
+    persistedPreferences = deepOverride(persistedPreferences, updates)
+    persistedPreferences.lastUpdated += 1
+    return true
+  })
+  mocks.savePreferencesWithResult.mockImplementation(
+    async (updates, options) => {
+      const success = await mocks.savePreferences(updates, options)
+      return success ? getPersistedPreferences() : null
+    },
+  )
+
+  return {
+    getPersistedPreferences,
+    setPersistedPreferences,
+  }
+}

--- a/tests/test-utils/mockPreferencePersistence.ts
+++ b/tests/test-utils/mockPreferencePersistence.ts
@@ -36,17 +36,18 @@ export function setupMockPreferencePersistence(
   }
 
   mocks.getPreferences.mockImplementation(async () => getPersistedPreferences())
-  mocks.savePreferences.mockImplementation(async (updates) => {
+  mocks.savePreferencesWithResult.mockImplementation(async (updates) => {
     persistedPreferences = deepOverride(persistedPreferences, updates)
     persistedPreferences.lastUpdated += 1
-    return true
+    return getPersistedPreferences()
   })
-  mocks.savePreferencesWithResult.mockImplementation(
-    async (updates, options) => {
-      const success = await mocks.savePreferences(updates, options)
-      return success ? getPersistedPreferences() : null
-    },
-  )
+  mocks.savePreferences.mockImplementation(async (updates, options) => {
+    const savedPreferences = await mocks.savePreferencesWithResult(
+      updates,
+      options,
+    )
+    return savedPreferences !== null
+  })
 
   return {
     getPersistedPreferences,

--- a/tests/utils/applyPreferenceLanguage.test.ts
+++ b/tests/utils/applyPreferenceLanguage.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { i18nCoreMock } = vi.hoisted(() => ({
+  i18nCoreMock: {
+    resolvedLanguage: "en" as string | undefined,
+    language: "en",
+    changeLanguage: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+vi.mock("~/utils/i18n/core", () => ({
+  default: i18nCoreMock,
+}))
+
+import { applyPreferenceLanguage } from "~/utils/i18n/applyPreferenceLanguage"
+
+describe("applyPreferenceLanguage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    i18nCoreMock.resolvedLanguage = "en"
+    i18nCoreMock.language = "en"
+  })
+
+  it("returns false for unsupported or empty persisted languages", async () => {
+    await expect(applyPreferenceLanguage("fr-FR")).resolves.toBe(false)
+    await expect(applyPreferenceLanguage("   ")).resolves.toBe(false)
+
+    expect(i18nCoreMock.changeLanguage).not.toHaveBeenCalled()
+  })
+
+  it("returns false when the normalized persisted language already matches the runtime language", async () => {
+    i18nCoreMock.resolvedLanguage = undefined
+    i18nCoreMock.language = "zh-TW"
+
+    await expect(applyPreferenceLanguage("zh-HK")).resolves.toBe(false)
+
+    expect(i18nCoreMock.changeLanguage).not.toHaveBeenCalled()
+  })
+
+  it("changes language when the normalized persisted language differs from the runtime language", async () => {
+    await expect(applyPreferenceLanguage("ja-JP")).resolves.toBe(true)
+
+    expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
+  })
+})

--- a/tests/utils/applyPreferenceLanguage.test.ts
+++ b/tests/utils/applyPreferenceLanguage.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { applyPreferenceLanguage } from "~/utils/i18n/applyPreferenceLanguage"
+
 const { i18nCoreMock } = vi.hoisted(() => ({
   i18nCoreMock: {
     resolvedLanguage: "en" as string | undefined,
@@ -11,8 +13,6 @@ const { i18nCoreMock } = vi.hoisted(() => ({
 vi.mock("~/utils/i18n/core", () => ({
   default: i18nCoreMock,
 }))
-
-import { applyPreferenceLanguage } from "~/utils/i18n/applyPreferenceLanguage"
 
 describe("applyPreferenceLanguage", () => {
   beforeEach(() => {

--- a/tests/utils/applyPreferenceLanguage.test.ts
+++ b/tests/utils/applyPreferenceLanguage.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { JAPANESE_LANG } from "~/constants/i18n"
 import { applyPreferenceLanguage } from "~/utils/i18n/applyPreferenceLanguage"
 
 const { i18nCoreMock } = vi.hoisted(() => ({
@@ -24,6 +25,9 @@ describe("applyPreferenceLanguage", () => {
   it("returns false for unsupported or empty persisted languages", async () => {
     await expect(applyPreferenceLanguage("fr-FR")).resolves.toBe(false)
     await expect(applyPreferenceLanguage("   ")).resolves.toBe(false)
+    await expect(applyPreferenceLanguage("")).resolves.toBe(false)
+    await expect(applyPreferenceLanguage(null)).resolves.toBe(false)
+    await expect(applyPreferenceLanguage(undefined)).resolves.toBe(false)
 
     expect(i18nCoreMock.changeLanguage).not.toHaveBeenCalled()
   })
@@ -40,6 +44,6 @@ describe("applyPreferenceLanguage", () => {
   it("changes language when the normalized persisted language differs from the runtime language", async () => {
     await expect(applyPreferenceLanguage("ja-JP")).resolves.toBe(true)
 
-    expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
+    expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith(JAPANESE_LANG)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft-based editing for many settings with version-aware (optimistic) saves; centralized persistence and a new partial-Octopus update; imported preferences can auto-apply UI language.
* **Bug Fixes**
  * Improved conflict detection and clearer localized messaging when preferences change externally; safer save semantics to avoid partial writes.
* **Chores**
  * Refined WebDAV/import flows and preference persistence behavior; added localized message keys.
* **Tests**
  * Expanded coverage for versioned saves, import language handling, conflict/error paths, and draft refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->