### PR TITLE
fix(selection): preserve checkbox indeterminate state

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -11,26 +11,37 @@ function Checkbox({
   checked,
   className,
   defaultChecked,
+  onCheckedChange,
   ...props
 }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
-  const iconState = checked ?? defaultChecked
+  const isControlled = checked !== undefined
+  const [uncontrolledChecked, setUncontrolledChecked] = React.useState(
+    defaultChecked ?? false,
+  )
+  const currentChecked = isControlled ? checked : uncontrolledChecked
 
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
-      checked={checked}
+      checked={currentChecked}
       className={cn(
         "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground dark:data-[state=indeterminate]:bg-primary data-[state=indeterminate]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
-      defaultChecked={defaultChecked}
+      onCheckedChange={(nextChecked) => {
+        if (!isControlled) {
+          setUncontrolledChecked(nextChecked)
+        }
+
+        onCheckedChange?.(nextChecked)
+      }}
       {...props}
     >
       <CheckboxPrimitive.Indicator
         data-slot="checkbox-indicator"
         className="grid place-content-center text-current transition-none"
       >
-        {iconState === "indeterminate" ? (
+        {currentChecked === "indeterminate" ? (
           <MinusIcon
             aria-hidden="true"
             className="size-3.5"

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
@@ -239,6 +239,12 @@ export function ManagedSiteTokenBatchExportDialog({
   const allExecutableSelected =
     executableItems.length > 0 &&
     selectedExecutableCount === executableItems.length
+  const executableSelectionChecked =
+    selectedExecutableCount === 0
+      ? false
+      : selectedExecutableCount === executableItems.length
+        ? true
+        : "indeterminate"
 
   const selectedExecutionIds = useMemo(
     () => Array.from(selectedIds),
@@ -444,7 +450,7 @@ export function ManagedSiteTokenBatchExportDialog({
             <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3">
               <label className="flex items-center gap-2 text-sm">
                 <Checkbox
-                  checked={allExecutableSelected}
+                  checked={executableSelectionChecked}
                   disabled={executableItems.length === 0}
                   aria-label={t(
                     "keyManagement:batchManagedSiteExport.actions.selectAll",

--- a/src/features/KeyManagement/components/TokenList.tsx
+++ b/src/features/KeyManagement/components/TokenList.tsx
@@ -383,6 +383,12 @@ export function TokenList(props: TokenListProps) {
   )
   const allFilteredSelected =
     filteredTokens.length > 0 && selectedVisibleCount === filteredTokens.length
+  const visibleSelectionChecked =
+    selectedVisibleCount === 0
+      ? false
+      : selectedVisibleCount === filteredTokens.length
+        ? true
+        : "indeterminate"
   const selectedBatchItems = useMemo(
     () =>
       tokens
@@ -562,7 +568,7 @@ export function TokenList(props: TokenListProps) {
       <div className="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-md border p-3">
         <label className="flex items-center gap-2 text-sm">
           <Checkbox
-            checked={allFilteredSelected}
+            checked={visibleSelectionChecked}
             disabled={filteredTokens.length === 0}
             onCheckedChange={toggleFilteredSelection}
           />

--- a/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
+++ b/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
@@ -4,6 +4,7 @@ import {
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline"
 import dayjs from "dayjs"
+import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 
 import ManagedSiteChannelLinkButton from "~/components/ManagedSiteChannelLinkButton"
@@ -52,12 +53,21 @@ export default function ResultsTable({
   const { t } = useTranslation("managedSiteModelSync")
 
   const allSelected = items.length > 0 && selectedIds.size === items.length
+  const someSelected = selectedIds.size > 0 && !allSelected
+  const selectAllRef = useRef<HTMLInputElement | null>(null)
   const columns = {
     status: visibleColumns?.status ?? true,
     message: visibleColumns?.message ?? true,
     attempts: visibleColumns?.attempts ?? true,
     finishedAt: visibleColumns?.finishedAt ?? true,
   }
+
+  useEffect(() => {
+    const element = selectAllRef.current
+    if (!element) return
+
+    element.indeterminate = someSelected
+  }, [someSelected])
 
   return (
     <Card padding="none">
@@ -67,6 +77,7 @@ export default function ResultsTable({
             <tr>
               <th className="px-4 py-3 text-left">
                 <input
+                  ref={selectAllRef}
                   type="checkbox"
                   checked={allSelected}
                   onChange={(e) => onSelectAll(e.target.checked)}

--- a/tests/components/ui/checkbox.test.tsx
+++ b/tests/components/ui/checkbox.test.tsx
@@ -58,4 +58,29 @@ describe("Checkbox", () => {
       container.querySelector('[data-slot="checkbox-indeterminate-icon"]'),
     ).toBeNull()
   })
+
+  it("updates the icon when an uncontrolled indeterminate checkbox is clicked", async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <Checkbox defaultChecked="indeterminate" aria-label="partial default" />,
+    )
+
+    expect(screen.getByRole("checkbox")).toHaveAttribute(
+      "aria-checked",
+      "mixed",
+    )
+    expect(
+      container.querySelector('[data-slot="checkbox-indeterminate-icon"]'),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("checkbox"))
+
+    expect(screen.getByRole("checkbox")).toBeChecked()
+    expect(
+      container.querySelector('[data-slot="checkbox-checked-icon"]'),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-slot="checkbox-indeterminate-icon"]'),
+    ).toBeNull()
+  })
 })

--- a/tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx
@@ -249,6 +249,19 @@ describe("TokenList batch export selection", () => {
     ).toBeDisabled()
   })
 
+  it("shows the visible-selection checkbox as mixed when only part of the filtered list is selected", async () => {
+    const user = userEvent.setup()
+    renderTokenList()
+
+    const visibleSelection = await screen.findByRole("checkbox", {
+      name: "keyManagement:batchManagedSiteExport.selection.visible",
+    })
+
+    await user.click(await screen.findByRole("checkbox", { name: "Token 1" }))
+
+    expect(visibleSelection).toHaveAttribute("aria-checked", "mixed")
+  })
+
   it("uses the frozen open-time selection for completion mapping", async () => {
     const user = userEvent.setup()
     const onManagedSiteImportSuccess = vi.fn()

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -61,7 +61,7 @@ vi.mock("~/components/ui", async (importOriginal) => {
       "aria-label": ariaLabel,
       onCheckedChange,
     }: {
-      checked?: boolean
+      checked?: boolean | "indeterminate"
       disabled?: boolean
       "aria-label"?: string
       onCheckedChange?: (checked: boolean) => void
@@ -69,10 +69,10 @@ vi.mock("~/components/ui", async (importOriginal) => {
       <button
         type="button"
         role="checkbox"
-        aria-checked={checked === true}
+        aria-checked={checked === "indeterminate" ? "mixed" : checked === true}
         aria-label={ariaLabel}
         disabled={disabled}
-        onClick={() => onCheckedChange?.(!checked)}
+        onClick={() => onCheckedChange?.(checked !== true)}
       />
     ),
     DestructiveConfirmDialog: ({
@@ -392,6 +392,11 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
         name: "Account 1 / Token 2",
       }),
     )
+    expect(
+      screen.getByRole("checkbox", {
+        name: "keyManagement:batchManagedSiteExport.actions.selectAll",
+      }),
+    ).toHaveAttribute("aria-checked", "mixed")
     await user.click(
       screen.getByRole("checkbox", {
         name: "keyManagement:batchManagedSiteExport.actions.selectAll",

--- a/tests/features/ManagedSiteModelSync/components.test.tsx
+++ b/tests/features/ManagedSiteModelSync/components.test.tsx
@@ -255,8 +255,15 @@ describe("ManagedSiteModelSync components", () => {
       />,
     )
 
-    fireEvent.click(screen.getAllByRole("checkbox")[0])
-    fireEvent.click(screen.getAllByRole("checkbox")[1])
+    const [selectAllCheckbox, firstRowCheckbox] = screen.getAllByRole(
+      "checkbox",
+    ) as HTMLInputElement[]
+
+    expect(selectAllCheckbox).not.toBeChecked()
+    expect(selectAllCheckbox.indeterminate).toBe(true)
+
+    fireEvent.click(selectAllCheckbox)
+    fireEvent.click(firstRowCheckbox)
     fireEvent.click(
       screen.getAllByTitle(
         "managedSiteModelSync:execution.table.syncChannel",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced checkbox component with indeterminate/mixed state support for clearer visual feedback when only some items are selected.
  * Improved "select all" checkbox behavior in batch export dialogs, token lists, and results tables to display three-state selection status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->