### PR TITLE
feat(key-management): allow editing managed-site batch export models

### DIFF
--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
@@ -8,6 +8,7 @@ import {
   Badge,
   Button,
   Checkbox,
+  CompactMultiSelect,
   DestructiveConfirmDialog,
   Modal,
 } from "~/components/ui"
@@ -43,8 +44,49 @@ const isExecutablePreviewItem = (
   (item.status === MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY ||
     item.status === MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING)
 
+const canEditItemModels = (item: ManagedSiteTokenBatchExportPreviewItem) =>
+  isExecutablePreviewItem(item) ||
+  (Boolean(item.draft) &&
+    item.status === MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED &&
+    item.blockingReasonCode ===
+      MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED)
+
 const formatValues = (items: string[] | undefined) =>
   items && items.length > 0 ? items.join(", ") : "-"
+
+const toModelOptions = (models: string[]) =>
+  models.map((model) => ({ label: model, value: model }))
+
+const normalizeModels = (models: string[]) =>
+  Array.from(new Set(models.map((model) => model.trim()).filter(Boolean)))
+
+const countPreviewItems = (items: ManagedSiteTokenBatchExportPreviewItem[]) =>
+  items.reduce(
+    (accumulator, item) => {
+      switch (item.status) {
+        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY:
+          accumulator.readyCount += 1
+          break
+        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING:
+          accumulator.warningCount += 1
+          break
+        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED:
+          accumulator.skippedCount += 1
+          break
+        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED:
+          accumulator.blockedCount += 1
+          break
+      }
+
+      return accumulator
+    },
+    {
+      readyCount: 0,
+      warningCount: 0,
+      skippedCount: 0,
+      blockedCount: 0,
+    },
+  )
 
 const getWarningText = (t: TFunction, code: string) => {
   switch (code) {
@@ -165,7 +207,12 @@ export function ManagedSiteTokenBatchExportDialog({
   items,
   onCompleted,
 }: ManagedSiteTokenBatchExportDialogProps) {
-  const { t } = useTranslation(["keyManagement", "settings", "common"])
+  const { t } = useTranslation([
+    "keyManagement",
+    "settings",
+    "common",
+    "channelDialog",
+  ])
   const [preview, setPreview] =
     useState<ManagedSiteTokenBatchExportPreview | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
@@ -250,6 +297,15 @@ export function ManagedSiteTokenBatchExportDialog({
     () => Array.from(selectedIds),
     [selectedIds],
   )
+  const modelOptions = useMemo(
+    () =>
+      toModelOptions(
+        normalizeModels(
+          preview?.items.flatMap((item) => item.draft?.models ?? []) ?? [],
+        ),
+      ),
+    [preview],
+  )
 
   const handleClose = () => {
     if (isRunning) return
@@ -281,6 +337,83 @@ export function ManagedSiteTokenBatchExportDialog({
         next.add(item.id)
       }
       return next
+    })
+  }
+
+  const handleItemModelsChange = (
+    item: ManagedSiteTokenBatchExportPreviewItem,
+    models: string[],
+  ) => {
+    if (!item.draft || executionResult || isRunning) return
+
+    const normalizedModels = normalizeModels(models)
+
+    setPreview((currentPreview) => {
+      if (!currentPreview) return currentPreview
+
+      const nextItems = currentPreview.items.map((previewItem) => {
+        if (previewItem.id !== item.id || !previewItem.draft) {
+          return previewItem
+        }
+
+        if (normalizedModels.length === 0) {
+          return {
+            ...previewItem,
+            draft: {
+              ...previewItem.draft,
+              models: [],
+            },
+            status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+            blockingReasonCode:
+              MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+          }
+        }
+
+        if (
+          canEditItemModels(previewItem) &&
+          !isExecutablePreviewItem(previewItem)
+        ) {
+          return {
+            ...previewItem,
+            draft: {
+              ...previewItem.draft,
+              models: normalizedModels,
+            },
+            status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+            blockingReasonCode: undefined,
+            blockingMessage: undefined,
+          }
+        }
+
+        return {
+          ...previewItem,
+          draft: {
+            ...previewItem.draft,
+            models: normalizedModels,
+          },
+        }
+      })
+
+      return {
+        ...currentPreview,
+        items: nextItems,
+        ...countPreviewItems(nextItems),
+      }
+    })
+
+    setSelectedIds((currentSelectedIds) => {
+      const nextSelectedIds = new Set(currentSelectedIds)
+      if (normalizedModels.length === 0) {
+        nextSelectedIds.delete(item.id)
+      } else if (
+        item.status ===
+          MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED &&
+        item.blockingReasonCode ===
+          MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED
+      ) {
+        nextSelectedIds.add(item.id)
+      }
+      return nextSelectedIds
     })
   }
 
@@ -573,9 +706,34 @@ export function ManagedSiteTokenBatchExportDialog({
                             "keyManagement:batchManagedSiteExport.fields.models",
                           )}
                         </span>
-                        <span className="ml-2 break-words">
-                          {formatValues(item.draft?.models)}
-                        </span>
+                        {item.draft &&
+                        !executionResult &&
+                        canEditItemModels(item) ? (
+                          <div className="mt-1">
+                            <CompactMultiSelect
+                              options={modelOptions}
+                              selected={item.draft.models}
+                              onChange={(models) =>
+                                handleItemModelsChange(item, models)
+                              }
+                              placeholder={t(
+                                "channelDialog:fields.models.placeholder",
+                              )}
+                              aria-label={t(
+                                "keyManagement:batchManagedSiteExport.fields.editModelsLabel",
+                                {
+                                  name: `${item.accountName} / ${item.tokenName}`,
+                                },
+                              )}
+                              allowCustom
+                              disabled={isRunning}
+                            />
+                          </div>
+                        ) : (
+                          <span className="ml-2 break-words">
+                            {formatValues(item.draft?.models)}
+                          </span>
+                        )}
                       </div>
                     </div>
 

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
@@ -373,6 +373,8 @@ export function ManagedSiteTokenBatchExportDialog({
           canEditItemModels(previewItem) &&
           !isExecutablePreviewItem(previewItem)
         ) {
+          // Manually supplied models make a models-required blocked row executable,
+          // but keep it as WARNING after clearing the blocking fields for confirmation.
           return {
             ...previewItem,
             draft: {

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -56,6 +56,7 @@
     "description": "Review {{selectedCount}} selected keys before creating channels in {{site}}.",
     "fields": {
       "baseUrl": "Base URL",
+      "editModelsLabel": "Edit models for {{name}}",
       "groups": "Groups",
       "models": "Models"
     },

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -53,6 +53,7 @@
     "description": "{{site}} に作成する前に、選択済み {{selectedCount}} 件のキーを確認します。",
     "fields": {
       "baseUrl": "Base URL",
+      "editModelsLabel": "{{name}} のモデル一覧を編集",
       "groups": "グループ",
       "models": "モデル"
     },

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -53,6 +53,7 @@
     "description": "创建到 {{site}} 前，先检查 {{selectedCount}} 个已选择密钥。",
     "fields": {
       "baseUrl": "Base URL",
+      "editModelsLabel": "编辑 {{name}} 的模型列表",
       "groups": "分组",
       "models": "模型"
     },

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -53,6 +53,7 @@
     "description": "建立到 {{site}} 前，先檢查 {{selectedCount}} 個已選金鑰。",
     "fields": {
       "baseUrl": "Base URL",
+      "editModelsLabel": "編輯 {{name}} 的模型列表",
       "groups": "分組",
       "models": "模型"
     },

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -75,6 +75,28 @@ vi.mock("~/components/ui", async (importOriginal) => {
         onClick={() => onCheckedChange?.(checked !== true)}
       />
     ),
+    CompactMultiSelect: ({
+      selected,
+      onChange,
+      "aria-label": ariaLabel,
+    }: {
+      selected: string[]
+      onChange: (values: string[]) => void
+      "aria-label"?: string
+    }) => (
+      <div>
+        <div data-testid={ariaLabel}>{selected.join(",")}</div>
+        <button
+          type="button"
+          onClick={() => onChange(["gpt-4o-mini", "custom-model"])}
+        >
+          Set editable models
+        </button>
+        <button type="button" onClick={() => onChange([])}>
+          Clear editable models
+        </button>
+      </div>
+    ),
     DestructiveConfirmDialog: ({
       isOpen,
       onClose,
@@ -445,6 +467,146 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
         "keyManagement:batchManagedSiteExport.results.summary",
       ),
     ).toBeInTheDocument()
+  })
+
+  it("passes edited models to batch execution", async () => {
+    const user = userEvent.setup()
+    mockPreparePreview.mockResolvedValue(preview)
+    mockExecuteBatchExport.mockResolvedValue({
+      totalSelected: 2,
+      attemptedCount: 2,
+      createdCount: 2,
+      failedCount: 0,
+      skippedCount: 0,
+      items: [
+        {
+          id: "account-1:1",
+          accountName: "Account 1",
+          tokenName: "Token 1",
+          success: true,
+          skipped: false,
+        },
+        {
+          id: "account-1:2",
+          accountName: "Account 1",
+          tokenName: "Token 2",
+          success: true,
+          skipped: false,
+        },
+      ],
+    })
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(screen.getAllByText("Set editable models")[0])
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      }),
+    )
+    await user.click(
+      screen.getAllByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      })[1],
+    )
+
+    await waitFor(() => {
+      expect(mockExecuteBatchExport).toHaveBeenCalledTimes(1)
+    })
+    const call = mockExecuteBatchExport.mock.calls[0][0]
+    expect(call.preview.items[0].draft.models).toEqual([
+      "gpt-4o-mini",
+      "custom-model",
+    ])
+    expect(call.selectedItemIds).toEqual(["account-1:1", "account-1:2"])
+  })
+
+  it("lets users unblock rows that only lack models", async () => {
+    const user = userEvent.setup()
+    mockPreparePreview.mockResolvedValue({
+      siteType: NEW_API,
+      totalCount: 1,
+      readyCount: 0,
+      warningCount: 0,
+      skippedCount: 0,
+      blockedCount: 1,
+      items: [
+        {
+          id: "account-1:9",
+          accountId: "account-1",
+          accountName: "Account 1",
+          tokenId: 9,
+          tokenName: "Token 9",
+          status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+          warningCodes: [],
+          blockingReasonCode:
+            MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+          draft: {
+            name: "Account 1 - Token 9",
+            type: 1,
+            key: "test-key-9",
+            base_url: "https://example.com",
+            models: [],
+            groups: ["default"],
+            priority: 0,
+            weight: 0,
+            status: 1,
+          },
+        },
+      ],
+    })
+    mockExecuteBatchExport.mockResolvedValue({
+      totalSelected: 1,
+      attemptedCount: 1,
+      createdCount: 1,
+      failedCount: 0,
+      skippedCount: 0,
+      items: [
+        {
+          id: "account-1:9",
+          accountName: "Account 1",
+          tokenName: "Token 9",
+          success: true,
+          skipped: false,
+        },
+      ],
+    })
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 9")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      }),
+    ).toBeDisabled()
+
+    await user.click(screen.getByText("Set editable models"))
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      }),
+    )
+    await user.click(
+      screen.getAllByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      })[1],
+    )
+
+    await waitFor(() => {
+      expect(mockExecuteBatchExport).toHaveBeenCalledTimes(1)
+    })
+    const call = mockExecuteBatchExport.mock.calls[0][0]
+    expect(call.preview.items[0]).toMatchObject({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+      blockingReasonCode: undefined,
+    })
+    expect(call.preview.items[0].draft.models).toEqual([
+      "gpt-4o-mini",
+      "custom-model",
+    ])
+    expect(call.selectedItemIds).toEqual(["account-1:9"])
   })
 
   it("renders warning, skipped, blocked, and execution result details", async () => {

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -269,6 +269,76 @@ const richPreview: ManagedSiteTokenBatchExportPreview = {
   ],
 }
 
+const modelsRequiredPreview: ManagedSiteTokenBatchExportPreview = {
+  siteType: NEW_API,
+  totalCount: 3,
+  readyCount: 0,
+  warningCount: 0,
+  skippedCount: 1,
+  blockedCount: 2,
+  items: [
+    {
+      id: "account-1:9",
+      accountId: "account-1",
+      accountName: "Account 1",
+      tokenId: 9,
+      tokenName: "Token 9",
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+      warningCodes: [],
+      blockingReasonCode:
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+      draft: {
+        name: "Account 1 - Token 9",
+        type: 1,
+        key: "test-key-9",
+        base_url: "https://example.com",
+        models: [],
+        groups: ["default"],
+        priority: 0,
+        weight: 0,
+        status: 1,
+      },
+    },
+    {
+      id: "account-1:3",
+      accountId: "account-1",
+      accountName: "Account 1",
+      tokenId: 3,
+      tokenName: "Token 3",
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED,
+      warningCodes: [],
+      draft: {
+        name: "Account 1 - Token 3",
+        type: 1,
+        key: "test-key-3",
+        base_url: "https://example.com",
+        models: ["gpt-4o-mini"],
+        groups: ["default"],
+        priority: 0,
+        weight: 0,
+        status: 1,
+      },
+      matchedChannel: {
+        id: 8,
+        name: "Existing channel",
+      },
+    },
+    {
+      id: "account-1:4",
+      accountId: "account-1",
+      accountName: "Account 1",
+      tokenId: 4,
+      tokenName: "Token 4",
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+      warningCodes: [],
+      blockingReasonCode:
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.BASE_URL_REQUIRED,
+      blockingMessage: "missing base URL",
+      draft: null,
+    },
+  ],
+}
+
 const renderDialog = (props?: {
   onClose?: () => void
   onCompleted?: (result: unknown) => void
@@ -524,38 +594,7 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
 
   it("lets users unblock rows that only lack models", async () => {
     const user = userEvent.setup()
-    mockPreparePreview.mockResolvedValue({
-      siteType: NEW_API,
-      totalCount: 1,
-      readyCount: 0,
-      warningCount: 0,
-      skippedCount: 0,
-      blockedCount: 1,
-      items: [
-        {
-          id: "account-1:9",
-          accountId: "account-1",
-          accountName: "Account 1",
-          tokenId: 9,
-          tokenName: "Token 9",
-          status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
-          warningCodes: [],
-          blockingReasonCode:
-            MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
-          draft: {
-            name: "Account 1 - Token 9",
-            type: 1,
-            key: "test-key-9",
-            base_url: "https://example.com",
-            models: [],
-            groups: ["default"],
-            priority: 0,
-            weight: 0,
-            status: 1,
-          },
-        },
-      ],
-    })
+    mockPreparePreview.mockResolvedValue(modelsRequiredPreview)
     mockExecuteBatchExport.mockResolvedValue({
       totalSelected: 1,
       attemptedCount: 1,
@@ -607,6 +646,28 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
       "custom-model",
     ])
     expect(call.selectedItemIds).toEqual(["account-1:9"])
+  })
+
+  it("re-blocks edited rows when models are cleared", async () => {
+    const user = userEvent.setup()
+    mockPreparePreview.mockResolvedValue(modelsRequiredPreview)
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 9")).toBeInTheDocument()
+
+    await user.click(screen.getByText("Set editable models"))
+    await user.click(screen.getByText("Clear editable models"))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "keyManagement:batchManagedSiteExport.actions.start",
+        }),
+      ).toBeDisabled()
+    })
+
+    expect(mockExecuteBatchExport).not.toHaveBeenCalled()
   })
 
   it("renders warning, skipped, blocked, and execution result details", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit models inline for items in the batch export dialog; selections, preview counts and item status update dynamically when models change.

* **Localization**
  * Added model-editing label translations for English, Japanese, Simplified Chinese, and Traditional Chinese.

* **Tests**
  * Added tests covering editing/clearing models, state transitions from blocked to executable, and execution payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->