### PR TITLE
feat(account): add one-click refresh for disabled accounts

### DIFF
--- a/src/features/AccountManagement/AccountManagement.tsx
+++ b/src/features/AccountManagement/AccountManagement.tsx
@@ -24,9 +24,16 @@ const logger = createLogger("AccountManagementPage")
 function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
   const { t } = useTranslation(["account", "common"])
   const { openAddAccount } = useDialogStateContext()
-  const { displayData, handleRefresh, isRefreshing } = useAccountDataContext()
+  const {
+    displayData,
+    handleRefresh,
+    handleRefreshDisabledAccounts,
+    isRefreshing,
+    isRefreshingDisabledAccounts,
+  } = useAccountDataContext()
   const { handleOpenExternalCheckIns } = useAccountActionsContext()
   const [isDedupeDialogOpen, setIsDedupeDialogOpen] = useState(false)
+  const disabledAccounts = displayData.filter((account) => account.disabled)
 
   const externalCheckInAccounts = displayData.filter((account) => {
     const customUrl = account.checkIn?.customCheckIn?.url
@@ -34,6 +41,8 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
   })
 
   const canOpenExternalCheckIns = externalCheckInAccounts.length > 0
+  const canRefreshDisabledAccounts = disabledAccounts.length > 0
+  const isAnyRefreshRunning = isRefreshing || isRefreshingDisabledAccounts
 
   // Open all configured external check-in sites and sync the checked-in status.
   const handleOpenExternalCheckInsClick = async (
@@ -80,6 +89,31 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
     }
   }, [handleRefresh, t])
 
+  const handleDisabledRefresh = useCallback(async () => {
+    try {
+      await toast.promise(handleRefreshDisabledAccounts(true), {
+        loading: t("account:refresh.refreshingDisabled"),
+        success: (result) =>
+          t(
+            result.failedCount > 0
+              ? "account:refresh.refreshDisabledCompleteWithFailures"
+              : "account:refresh.refreshDisabledComplete",
+            {
+              restored: result.reEnabledCount,
+              stillDisabled: Math.max(
+                result.processedCount - result.reEnabledCount,
+                0,
+              ),
+              failed: result.failedCount,
+            },
+          ),
+        error: t("account:refresh.refreshDisabledFailed"),
+      })
+    } catch (error) {
+      logger.error("Error during disabled account refresh", error)
+    }
+  }, [handleRefreshDisabledAccounts, t])
+
   return (
     <div className="dark:bg-dark-bg-secondary flex flex-col bg-white p-6">
       <PageHeader
@@ -93,10 +127,21 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
               variant="secondary"
               leftIcon={<ArrowPathIcon className="h-4 w-4" />}
               loading={isRefreshing}
-              disabled={isRefreshing}
+              disabled={isAnyRefreshRunning}
             >
               {t("common:actions.refresh")}
             </Button>
+            {canRefreshDisabledAccounts && (
+              <Button
+                onClick={() => void handleDisabledRefresh()}
+                variant="secondary"
+                leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                loading={isRefreshingDisabledAccounts}
+                disabled={isAnyRefreshRunning}
+              >
+                {t("account:actions.refreshDisabledAccounts")}
+              </Button>
+            )}
             {canOpenExternalCheckIns && (
               <Button
                 onClick={handleOpenExternalCheckInsClick}

--- a/src/features/AccountManagement/AccountManagement.tsx
+++ b/src/features/AccountManagement/AccountManagement.tsx
@@ -101,7 +101,9 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
             {
               restored: result.reEnabledCount,
               stillDisabled: Math.max(
-                result.processedCount - result.reEnabledCount,
+                result.processedCount -
+                  result.reEnabledCount -
+                  result.failedCount,
                 0,
               ),
               failed: result.failedCount,

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -129,6 +129,7 @@ interface AccountDataContextType {
   lastUpdateTime: Date | undefined
   isInitialLoad: boolean
   isRefreshing: boolean
+  isRefreshingDisabledAccounts: boolean
   prevTotalConsumption: CurrencyAmount
   prevBalances: CurrencyAmountMap
   /**
@@ -163,6 +164,12 @@ interface AccountDataContextType {
     failed: number
     latestSyncTime?: number
     refreshedCount: number
+  }>
+  handleRefreshDisabledAccounts: (force?: boolean) => Promise<{
+    processedCount: number
+    failedCount: number
+    reEnabledCount: number
+    latestSyncTime?: number
   }>
   handleSort: (field: SortField) => void
   sortField: SortField
@@ -213,6 +220,8 @@ export const AccountDataProvider = ({
   const [hasResolvedInitialOpenTabs, setHasResolvedInitialOpenTabs] =
     useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
+  const [isRefreshingDisabledAccounts, setIsRefreshingDisabledAccounts] =
+    useState(false)
   const [prevTotalConsumption, setPrevTotalConsumption] =
     useState<CurrencyAmount>({ USD: 0, CNY: 0 })
   const [prevBalances, setPrevBalances] = useState<CurrencyAmountMap>({})
@@ -578,6 +587,27 @@ export const AccountDataProvider = ({
         throw error
       } finally {
         setIsRefreshing(false)
+      }
+    },
+    [loadAccountData],
+  )
+
+  const handleRefreshDisabledAccounts = useCallback(
+    async (force: boolean = false) => {
+      setIsRefreshingDisabledAccounts(true)
+      try {
+        const refreshResult = await accountStorage.refreshDisabledAccounts(force)
+        await loadAccountData()
+        if (refreshResult.latestSyncTime > 0) {
+          setLastUpdateTime(new Date(refreshResult.latestSyncTime))
+        }
+        return refreshResult
+      } catch (error) {
+        logger.error("Failed to refresh disabled accounts", error)
+        await loadAccountData()
+        throw error
+      } finally {
+        setIsRefreshingDisabledAccounts(false)
       }
     },
     [loadAccountData],
@@ -1115,6 +1145,7 @@ export const AccountDataProvider = ({
       lastUpdateTime,
       isInitialLoad,
       isRefreshing,
+      isRefreshingDisabledAccounts,
       prevTotalConsumption,
       prevBalances,
       detectedSiteAccounts,
@@ -1135,6 +1166,7 @@ export const AccountDataProvider = ({
       togglePinAccount,
       loadAccountData,
       handleRefresh,
+      handleRefreshDisabledAccounts,
       handleSort,
       sortField,
       sortOrder,
@@ -1151,6 +1183,7 @@ export const AccountDataProvider = ({
       lastUpdateTime,
       isInitialLoad,
       isRefreshing,
+      isRefreshingDisabledAccounts,
       prevTotalConsumption,
       prevBalances,
       detectedSiteAccounts,
@@ -1171,6 +1204,7 @@ export const AccountDataProvider = ({
       togglePinAccount,
       loadAccountData,
       handleRefresh,
+      handleRefreshDisabledAccounts,
       handleSort,
       sortField,
       sortOrder,

--- a/src/locales/en/account.json
+++ b/src/locales/en/account.json
@@ -35,6 +35,7 @@
     "quickCheckin": "Quick check-in",
     "redeemPage": "Redeem/Top-up",
     "refresh": "Refresh",
+    "refreshDisabledAccounts": "Refresh disabled accounts",
     "scanDuplicates": "Scan duplicates",
     "scanDuplicatesHint": "Scan accounts for duplicates (origin + upstream user id) and clean them up safely.",
     "unpin": "Unpin account",
@@ -164,8 +165,12 @@
   },
   "refresh": {
     "refreshComplete": "Refresh complete: {{success}} success, {{failed}} failed",
+    "refreshDisabledComplete": "Disabled account probe complete: {{restored}} restored, {{stillDisabled}} still disabled",
+    "refreshDisabledCompleteWithFailures": "Disabled account probe complete: {{restored}} restored, {{stillDisabled}} still disabled, {{failed}} failed",
+    "refreshDisabledFailed": "Failed to refresh disabled accounts. Please try again later.",
     "refreshFailed": "Refresh failed, please try again later",
     "refreshingAll": "Refreshing all accounts...",
+    "refreshingDisabled": "Refreshing disabled accounts...",
     "refreshPartialSkipped": "Refresh complete: {{success}} success, {{skipped}} skipped",
     "refreshSuccess": "All accounts refreshed successfully!"
   },

--- a/src/locales/ja/account.json
+++ b/src/locales/ja/account.json
@@ -35,6 +35,7 @@
     "quickCheckin": "クイックチェックイン",
     "redeemPage": "引き換え / チャージ",
     "refresh": "更新",
+    "refreshDisabledAccounts": "無効なアカウントを更新",
     "scanDuplicates": "重複をスキャン",
     "scanDuplicatesHint": "重複アカウント（origin + 上流 user id）をスキャンし、安全に整理します。",
     "unpin": "アカウントのピン留め解除",
@@ -155,8 +156,12 @@
   },
   "refresh": {
     "refreshComplete": "更新完了: 成功 {{success}} 件、失敗 {{failed}} 件",
+    "refreshDisabledComplete": "無効アカウントの再検出が完了しました: {{restored}} 件を復旧、{{stillDisabled}} 件は無効のまま",
+    "refreshDisabledCompleteWithFailures": "無効アカウントの再検出が完了しました: {{restored}} 件を復旧、{{stillDisabled}} 件は無効のまま、{{failed}} 件失敗",
+    "refreshDisabledFailed": "無効アカウントの更新に失敗しました。後でもう一度お試しください。",
     "refreshFailed": "更新に失敗しました。しばらくしてからもう一度お試しください",
     "refreshingAll": "すべてのアカウントを更新中...",
+    "refreshingDisabled": "無効アカウントを更新中...",
     "refreshPartialSkipped": "更新完了: 成功 {{success}} 件、スキップ {{skipped}} 件",
     "refreshSuccess": "すべてのアカウントを正常に更新しました"
   },

--- a/src/locales/zh-CN/account.json
+++ b/src/locales/zh-CN/account.json
@@ -35,6 +35,7 @@
     "quickCheckin": "快速签到",
     "redeemPage": "充值页面",
     "refresh": "刷新",
+    "refreshDisabledAccounts": "刷新已禁用账号",
     "scanDuplicates": "扫描重复账号",
     "scanDuplicatesHint": "按 URL 源站 + 用户 ID 扫描重复账号并安全清理。",
     "unpin": "取消置顶",
@@ -155,8 +156,12 @@
   },
   "refresh": {
     "refreshComplete": "刷新完成: {{success}} 成功, {{failed}} 失败",
+    "refreshDisabledComplete": "已禁用账号探测完成：恢复 {{restored}} 个，仍禁用 {{stillDisabled}} 个",
+    "refreshDisabledCompleteWithFailures": "已禁用账号探测完成：恢复 {{restored}} 个，仍禁用 {{stillDisabled}} 个，失败 {{failed}} 个",
+    "refreshDisabledFailed": "刷新已禁用账号失败，请稍后重试",
     "refreshFailed": "刷新失败，请稍后重试",
     "refreshingAll": "正在刷新所有账号...",
+    "refreshingDisabled": "正在刷新已禁用账号...",
     "refreshPartialSkipped": "刷新完成: {{success}} 成功, {{skipped}} 跳过",
     "refreshSuccess": "所有账号刷新成功！"
   },

--- a/src/locales/zh-TW/account.json
+++ b/src/locales/zh-TW/account.json
@@ -35,6 +35,7 @@
     "quickCheckin": "快速簽到",
     "redeemPage": "充值頁面",
     "refresh": "重新整理",
+    "refreshDisabledAccounts": "重新整理已停用帳號",
     "scanDuplicates": "掃描重複帳號",
     "scanDuplicatesHint": "按 URL 源站 + 使用者 ID 掃描重複帳號並安全清理。",
     "unpin": "取消置頂",
@@ -155,8 +156,12 @@
   },
   "refresh": {
     "refreshComplete": "重新整理完成: {{success}} 成功, {{failed}} 失敗",
+    "refreshDisabledComplete": "已停用帳號探測完成：恢復 {{restored}} 個，仍停用 {{stillDisabled}} 個",
+    "refreshDisabledCompleteWithFailures": "已停用帳號探測完成：恢復 {{restored}} 個，仍停用 {{stillDisabled}} 個，失敗 {{failed}} 個",
+    "refreshDisabledFailed": "重新整理已停用帳號失敗，請稍後重試",
     "refreshFailed": "重新整理失敗，請稍後重試",
     "refreshingAll": "正在重新整理所有帳號...",
+    "refreshingDisabled": "正在重新整理已停用帳號...",
     "refreshPartialSkipped": "重新整理完成: {{success}} 成功, {{skipped}} 跳過",
     "refreshSuccess": "所有帳號重新整理成功！"
   },

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -52,6 +52,13 @@ export { ACCOUNT_STORAGE_KEYS }
 
 const logger = createLogger("AccountStorage")
 
+type RefreshAccountOptions = {
+  includeTodayCashflow?: boolean
+  balanceHistoryCaptureSource?: DailyBalanceHistoryCaptureSource
+  allowDisabled?: boolean
+  reEnableOnSuccess?: boolean
+}
+
 class AccountStorageService {
   private storage: Storage
 
@@ -888,10 +895,7 @@ class AccountStorageService {
   async refreshAccount(
     id: string,
     force: boolean = false,
-    options?: {
-      includeTodayCashflow?: boolean
-      balanceHistoryCaptureSource?: DailyBalanceHistoryCaptureSource
-    },
+    options?: RefreshAccountOptions,
   ) {
     const runRefresh = async () => {
       let account = await this.getAccountById(id)
@@ -900,7 +904,10 @@ class AccountStorageService {
         throw new Error(t("messages:storage.accountNotFound", { id }))
       }
 
-      if (AccountStorageService.isAccountDisabled(account)) {
+      if (
+        AccountStorageService.isAccountDisabled(account) &&
+        options?.allowDisabled !== true
+      ) {
         logger.debug("账号已禁用，跳过刷新", {
           accountId: account.id,
           siteName: account.site_name,
@@ -975,6 +982,10 @@ class AccountStorageService {
       }
 
       // 如果成功获取数据，更新账号信息
+      const shouldReEnable = Boolean(
+        options?.reEnableOnSuccess === true && result.success && result.data,
+      )
+
       if (result.success && result.data) {
         const manualBalanceUsd = account.manualBalanceUsd?.trim()
         const manualQuota =
@@ -1014,6 +1025,10 @@ class AccountStorageService {
           today_quota_consumption: result.data.today_quota_consumption,
           today_requests_count: result.data.today_requests_count,
           today_income: result.data.today_income,
+        }
+
+        if (shouldReEnable) {
+          updateData.disabled = false
         }
 
         // Persist any refreshed credentials/identity discovered during refresh.
@@ -1085,7 +1100,11 @@ class AccountStorageService {
         })
       }
 
-      return { account: updatedAccount, refreshed: true }
+      return {
+        account: updatedAccount,
+        refreshed: true,
+        reEnabled: shouldReEnable,
+      }
     }
 
     try {
@@ -1166,6 +1185,59 @@ class AccountStorageService {
       failed: failedCount,
       latestSyncTime,
       refreshedCount,
+    }
+  }
+
+  /**
+   * Re-probe disabled accounts and automatically re-enable the ones whose
+   * account data can be refreshed successfully.
+   */
+  async refreshDisabledAccounts(force: boolean = false) {
+    const accounts = (await this.getAllAccounts()).filter((account) =>
+      AccountStorageService.isAccountDisabled(account),
+    )
+    const includeTodayCashflow =
+      (await userPreferences.getPreferences()).showTodayCashflow ?? true
+    let processedCount = 0
+    let failedCount = 0
+    let reEnabledCount = 0
+    let latestSyncTime = 0
+
+    const results = await Promise.allSettled(
+      accounts.map((account) =>
+        this.refreshAccount(account.id, force, {
+          includeTodayCashflow,
+          allowDisabled: true,
+          reEnableOnSuccess: true,
+        }),
+      ),
+    )
+
+    results.forEach((result, index) => {
+      if (result.status === "fulfilled" && result.value) {
+        processedCount++
+        latestSyncTime = Math.max(
+          result.value.account?.last_sync_time || 0,
+          latestSyncTime,
+        )
+        if (result.value.reEnabled) {
+          reEnabledCount++
+        }
+      } else {
+        failedCount++
+        logger.error("刷新已禁用账号失败", {
+          accountId: accounts[index]?.id,
+          siteName: accounts[index]?.site_name,
+          reason: result.status === "rejected" ? result.reason : "未知错误",
+        })
+      }
+    })
+
+    return {
+      processedCount,
+      failedCount,
+      reEnabledCount,
+      latestSyncTime,
     }
   }
 

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -1086,8 +1086,12 @@ class AccountStorageService {
       }
 
       // 更新账号信息
-      await this.updateAccount(id, updateData)
-      const updatedAccount = await this.getAccountById(id)
+      const didPersist = await this.updateAccount(id, updateData)
+      const updatedAccount = didPersist
+        ? await this.getAccountById(id)
+        : account
+      const reEnabled =
+        didPersist && shouldReEnable && updatedAccount?.disabled === false
 
       // 记录健康状态变化
       if (account.health?.status !== result.healthStatus.status) {
@@ -1103,7 +1107,7 @@ class AccountStorageService {
       return {
         account: updatedAccount,
         refreshed: true,
-        reEnabled: shouldReEnable,
+        reEnabled,
       }
     }
 

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -1218,7 +1218,7 @@ class AccountStorageService {
     )
 
     results.forEach((result, index) => {
-      if (result.status === "fulfilled" && result.value) {
+      if (result.status === "fulfilled" && result.value?.refreshed) {
         processedCount++
         latestSyncTime = Math.max(
           result.value.account?.last_sync_time || 0,
@@ -1227,6 +1227,8 @@ class AccountStorageService {
         if (result.value.reEnabled) {
           reEnabledCount++
         }
+      } else if (result.status === "fulfilled" && result.value) {
+        return
       } else {
         failedCount++
         logger.error("刷新已禁用账号失败", {

--- a/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
+++ b/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
@@ -7,6 +7,14 @@ import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
 const openAddAccountMock = vi.fn()
 const handleRefreshMock = vi.fn()
+const handleRefreshDisabledAccountsMock = vi.fn()
+const accountDataContextState = vi.hoisted(() => ({
+  current: {
+    displayData: [] as any[],
+    isRefreshing: false,
+    isRefreshingDisabledAccounts: false,
+  },
+}))
 
 vi.mock("react-hot-toast", () => ({
   default: {
@@ -31,9 +39,9 @@ vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
     <>{children}</>
   ),
   useAccountDataContext: () => ({
-    displayData: [],
-    isRefreshing: false,
+    ...accountDataContextState.current,
     handleRefresh: handleRefreshMock,
+    handleRefreshDisabledAccounts: handleRefreshDisabledAccountsMock,
   }),
 }))
 
@@ -59,11 +67,23 @@ vi.mock("~/features/SiteBookmarks/components/BookmarkDialog", () => ({
 beforeEach(() => {
   openAddAccountMock.mockReset()
   handleRefreshMock.mockReset()
+  handleRefreshDisabledAccountsMock.mockReset()
+  accountDataContextState.current = {
+    displayData: [],
+    isRefreshing: false,
+    isRefreshingDisabledAccounts: false,
+  }
   handleRefreshMock.mockResolvedValue({
     success: 0,
     failed: 0,
     latestSyncTime: 0,
     refreshedCount: 0,
+  })
+  handleRefreshDisabledAccountsMock.mockResolvedValue({
+    processedCount: 0,
+    failedCount: 0,
+    reEnabledCount: 0,
+    latestSyncTime: 0,
   })
 })
 
@@ -92,6 +112,34 @@ describe("options AccountManagement page", () => {
 
     expect(handleRefreshMock).toHaveBeenCalledTimes(1)
     expect(handleRefreshMock).toHaveBeenCalledWith(true)
+  })
+
+  it("does not render the disabled-account refresh action when no disabled accounts exist", () => {
+    render(<AccountManagement />)
+
+    expect(
+      screen.queryByRole("button", {
+        name: "account:actions.refreshDisabledAccounts",
+      }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders the disabled-account refresh action and triggers a forced probe", async () => {
+    accountDataContextState.current = {
+      ...accountDataContextState.current,
+      displayData: [{ id: "disabled-1", disabled: true }],
+    }
+
+    render(<AccountManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "account:actions.refreshDisabledAccounts",
+      }),
+    )
+
+    expect(handleRefreshDisabledAccountsMock).toHaveBeenCalledTimes(1)
+    expect(handleRefreshDisabledAccountsMock).toHaveBeenCalledWith(true)
   })
 })
 

--- a/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
+++ b/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
@@ -3,11 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import AccountManagement from "~/entrypoints/options/pages/AccountManagement"
 import BookmarkManagement from "~/entrypoints/options/pages/BookmarkManagement"
-import { fireEvent, render, screen } from "~~/tests/test-utils/render"
+import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const openAddAccountMock = vi.fn()
 const handleRefreshMock = vi.fn()
 const handleRefreshDisabledAccountsMock = vi.fn()
+const mockLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+}))
+const toastPromiseMock = vi.hoisted(() => vi.fn())
 const accountDataContextState = vi.hoisted(() => ({
   current: {
     displayData: [] as any[],
@@ -18,8 +22,12 @@ const accountDataContextState = vi.hoisted(() => ({
 
 vi.mock("react-hot-toast", () => ({
   default: {
-    promise: (promise: Promise<unknown>) => promise,
+    promise: toastPromiseMock,
   },
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => mockLogger,
 }))
 
 vi.mock("~/features/AccountManagement/hooks/AccountManagementProvider", () => ({
@@ -68,6 +76,7 @@ beforeEach(() => {
   openAddAccountMock.mockReset()
   handleRefreshMock.mockReset()
   handleRefreshDisabledAccountsMock.mockReset()
+  mockLogger.error.mockReset()
   accountDataContextState.current = {
     displayData: [],
     isRefreshing: false,
@@ -85,6 +94,28 @@ beforeEach(() => {
     reEnabledCount: 0,
     latestSyncTime: 0,
   })
+  toastPromiseMock.mockImplementation(
+    async (
+      promise: Promise<unknown>,
+      messages?: {
+        success?: string | ((value: any) => string)
+        error?: string | ((error: unknown) => string)
+      },
+    ) => {
+      try {
+        const result = await promise
+        if (typeof messages?.success === "function") {
+          messages.success(result)
+        }
+        return result
+      } catch (error) {
+        if (typeof messages?.error === "function") {
+          messages.error(error)
+        }
+        throw error
+      }
+    },
+  )
 })
 
 describe("options AccountManagement page", () => {
@@ -140,6 +171,88 @@ describe("options AccountManagement page", () => {
 
     expect(handleRefreshDisabledAccountsMock).toHaveBeenCalledTimes(1)
     expect(handleRefreshDisabledAccountsMock).toHaveBeenCalledWith(true)
+  })
+
+  it("disables both refresh buttons while a refresh is already running", async () => {
+    accountDataContextState.current = {
+      displayData: [{ id: "disabled-1", disabled: true }],
+      isRefreshing: true,
+      isRefreshingDisabledAccounts: false,
+    }
+
+    render(<AccountManagement />)
+
+    const globalRefreshButton = await screen.findByRole("button", {
+      name: /common:actions\.refresh/,
+    })
+    const disabledRefreshButton = await screen.findByRole("button", {
+      name: /account:actions\.refreshDisabledAccounts/,
+    })
+
+    expect(globalRefreshButton).toBeDisabled()
+    expect(disabledRefreshButton).toBeDisabled()
+
+    fireEvent.click(disabledRefreshButton)
+
+    expect(handleRefreshDisabledAccountsMock).not.toHaveBeenCalled()
+  })
+
+  it("uses the failure-aware disabled-account summary branch", async () => {
+    accountDataContextState.current = {
+      ...accountDataContextState.current,
+      displayData: [{ id: "disabled-1", disabled: true }],
+    }
+    handleRefreshDisabledAccountsMock.mockResolvedValueOnce({
+      processedCount: 3,
+      failedCount: 1,
+      reEnabledCount: 1,
+      latestSyncTime: 0,
+    })
+
+    render(<AccountManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "account:actions.refreshDisabledAccounts",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toastPromiseMock).toHaveBeenCalled()
+    })
+
+    const [, messages] = toastPromiseMock.mock.calls.at(-1)!
+    expect(
+      (messages as any).success?.({
+        processedCount: 3,
+        failedCount: 1,
+        reEnabledCount: 1,
+      }),
+    ).toBe("account:refresh.refreshDisabledCompleteWithFailures")
+  })
+
+  it("logs an error when disabled-account refresh rejects", async () => {
+    accountDataContextState.current = {
+      ...accountDataContextState.current,
+      displayData: [{ id: "disabled-1", disabled: true }],
+    }
+    const refreshError = new Error("network")
+    handleRefreshDisabledAccountsMock.mockRejectedValueOnce(refreshError)
+
+    render(<AccountManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "account:actions.refreshDisabledAccounts",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Error during disabled account refresh",
+        refreshError,
+      )
+    })
   })
 })
 

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -53,6 +53,7 @@ const {
   mockPinAccount,
   mockUnpinAccount,
   mockRefreshAllAccounts,
+  mockRefreshDisabledAccounts,
   mockToastPromise,
   mockGetActiveTabs,
   mockGetAllTabs,
@@ -89,6 +90,7 @@ const {
   mockPinAccount: vi.fn(),
   mockUnpinAccount: vi.fn(),
   mockRefreshAllAccounts: vi.fn(),
+  mockRefreshDisabledAccounts: vi.fn(),
   mockToastPromise: vi.fn(),
   mockGetActiveTabs: vi.fn<() => Promise<browser.tabs.Tab[]>>(async () => []),
   mockGetAllTabs: vi.fn<() => Promise<browser.tabs.Tab[]>>(async () => []),
@@ -179,6 +181,7 @@ vi.mock("~/services/accounts/accountStorage", () => ({
     pinAccount: mockPinAccount,
     unpinAccount: mockUnpinAccount,
     refreshAllAccounts: mockRefreshAllAccounts,
+    refreshDisabledAccounts: mockRefreshDisabledAccounts,
     checkUrlExists: vi.fn(async () => null),
   },
 }))
@@ -264,6 +267,12 @@ beforeEach(() => {
     success: 0,
     failed: 0,
     refreshedCount: 0,
+    latestSyncTime: 0,
+  })
+  mockRefreshDisabledAccounts.mockResolvedValue({
+    processedCount: 0,
+    failedCount: 0,
+    reEnabledCount: 0,
     latestSyncTime: 0,
   })
   mockToastPromise.mockImplementation((promise: Promise<any>) => promise)
@@ -1524,6 +1533,40 @@ describe("AccountDataContext refresh orchestration", () => {
     })
 
     expect(mockRefreshAllAccounts).toHaveBeenCalledWith(true)
+  })
+
+  it("refreshes disabled accounts on demand and stores the returned sync time", async () => {
+    let resolveRefresh!: (value: any) => void
+    const refreshPromise = new Promise((resolve) => {
+      resolveRefresh = resolve
+    })
+
+    mockGetAllAccounts.mockResolvedValue([{ id: "disabled-1", disabled: true }])
+    mockRefreshDisabledAccounts.mockReturnValueOnce(refreshPromise)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await act(async () => {
+      void getLatestCtx().handleRefreshDisabledAccounts(true)
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().isRefreshingDisabledAccounts).toBe(true)
+    })
+
+    resolveRefresh({
+      processedCount: 2,
+      failedCount: 0,
+      reEnabledCount: 1,
+      latestSyncTime: 1_720_123_456_789,
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().isRefreshingDisabledAccounts).toBe(false)
+      expect(getLatestCtx().lastUpdateTime?.getTime()).toBe(1_720_123_456_789)
+    })
+
+    expect(mockRefreshDisabledAccounts).toHaveBeenCalledWith(true)
   })
 
   it("reloads account data after refresh failures and clears the refreshing state", async () => {

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -1569,6 +1569,39 @@ describe("AccountDataContext refresh orchestration", () => {
     expect(mockRefreshDisabledAccounts).toHaveBeenCalledWith(true)
   })
 
+  it("reloads account data after disabled-account refresh failures and clears the refreshing state", async () => {
+    const refreshError = new Error("disabled refresh failed")
+    mockGetAllAccounts.mockResolvedValue([{ id: "disabled-1", disabled: true }])
+    mockRefreshDisabledAccounts.mockRejectedValueOnce(refreshError)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().isInitialLoad).toBe(false)
+    })
+
+    const initialLoadCalls = mockGetAllAccounts.mock.calls.length
+    mockLogger.error.mockClear()
+
+    await act(async () => {
+      await expect(
+        getLatestCtx().handleRefreshDisabledAccounts(true),
+      ).rejects.toThrow("disabled refresh failed")
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().isRefreshingDisabledAccounts).toBe(false)
+      expect(mockGetAllAccounts.mock.calls.length).toBeGreaterThan(
+        initialLoadCalls,
+      )
+    })
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Failed to refresh disabled accounts",
+      refreshError,
+    )
+  })
+
   it("reloads account data after refresh failures and clears the refreshing state", async () => {
     mockGetAllAccounts.mockResolvedValue([{ id: "acc-1" }])
     mockRefreshAllAccounts.mockRejectedValueOnce(new Error("refresh failed"))

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -712,6 +712,54 @@ describe("accountStorage core behaviors", () => {
     }
   })
 
+  it("refreshDisabledAccounts only probes disabled accounts and summarizes restored results", async () => {
+    seedStorage([
+      createAccount({ id: "disabled-a", disabled: true }),
+      createAccount({ id: "enabled-b", disabled: false }),
+      createAccount({ id: "disabled-c", disabled: true }),
+    ])
+    storageData.set(USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES, {
+      showTodayCashflow: true,
+    })
+
+    const refreshAccountSpy = vi
+      .spyOn(accountStorage, "refreshAccount")
+      .mockResolvedValueOnce({
+        refreshed: true,
+        reEnabled: true,
+        account: { last_sync_time: 111 },
+      } as any)
+      .mockResolvedValueOnce({
+        refreshed: true,
+        reEnabled: false,
+        account: { last_sync_time: 222 },
+      } as any)
+
+    try {
+      const result = await accountStorage.refreshDisabledAccounts(true)
+
+      expect(refreshAccountSpy).toHaveBeenCalledTimes(2)
+      expect(refreshAccountSpy).toHaveBeenNthCalledWith(1, "disabled-a", true, {
+        includeTodayCashflow: true,
+        allowDisabled: true,
+        reEnableOnSuccess: true,
+      })
+      expect(refreshAccountSpy).toHaveBeenNthCalledWith(2, "disabled-c", true, {
+        includeTodayCashflow: true,
+        allowDisabled: true,
+        reEnableOnSuccess: true,
+      })
+      expect(result).toEqual({
+        processedCount: 2,
+        failedCount: 0,
+        reEnabledCount: 1,
+        latestSyncTime: 222,
+      })
+    } finally {
+      refreshAccountSpy.mockRestore()
+    }
+  })
+
   it("getAccountStats should aggregate numeric fields across accounts", async () => {
     const accountA = createAccount({
       id: "stats-a",
@@ -1263,6 +1311,42 @@ describe("accountStorage core behaviors", () => {
     expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
     expect(mockRefreshAccountData).not.toHaveBeenCalled()
     expect(mockFetchTodayIncome).not.toHaveBeenCalled()
+  })
+
+  it("refreshAccount should probe disabled accounts when explicitly allowed and re-enable them on success", async () => {
+    const account = createAccount({
+      id: "disabled-revive",
+      disabled: true,
+      site_url: "https://revive.example.com",
+      site_type: "test",
+    })
+    seedStorage([account])
+
+    const result = await accountStorage.refreshAccount("disabled-revive", true, {
+      allowDisabled: true,
+      reEnableOnSuccess: true,
+    })
+
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
+      baseUrl: "https://revive.example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        userId: 1,
+        accessToken: "token",
+        cookie: undefined,
+        refreshToken: undefined,
+        tokenExpiresAt: undefined,
+      },
+    })
+    expect(mockRefreshAccountData).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(
+      expect.objectContaining({
+        refreshed: true,
+        reEnabled: true,
+      }),
+    )
+    const updatedAccount = await accountStorage.getAccountById("disabled-revive")
+    expect(updatedAccount?.disabled).toBe(false)
   })
 
   it("refreshAccount should skip network refreshes when the min interval has not elapsed", async () => {

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -804,6 +804,51 @@ describe("accountStorage core behaviors", () => {
     }
   })
 
+  it("refreshDisabledAccounts defaults cashflow inclusion and ignores skipped probes", async () => {
+    seedStorage([
+      createAccount({ id: "disabled-a", disabled: true }),
+      createAccount({ id: "enabled-b", disabled: false }),
+      createAccount({ id: "disabled-c", disabled: true }),
+    ])
+
+    const refreshAccountSpy = vi
+      .spyOn(accountStorage, "refreshAccount")
+      .mockResolvedValueOnce({
+        refreshed: false,
+        reEnabled: false,
+        account: { last_sync_time: 999 },
+      } as any)
+      .mockResolvedValueOnce({
+        refreshed: true,
+        reEnabled: true,
+        account: { last_sync_time: 222 },
+      } as any)
+
+    try {
+      const result = await accountStorage.refreshDisabledAccounts()
+
+      expect(refreshAccountSpy).toHaveBeenCalledTimes(2)
+      expect(refreshAccountSpy).toHaveBeenNthCalledWith(1, "disabled-a", false, {
+        includeTodayCashflow: true,
+        allowDisabled: true,
+        reEnableOnSuccess: true,
+      })
+      expect(refreshAccountSpy).toHaveBeenNthCalledWith(2, "disabled-c", false, {
+        includeTodayCashflow: true,
+        allowDisabled: true,
+        reEnableOnSuccess: true,
+      })
+      expect(result).toEqual({
+        processedCount: 1,
+        failedCount: 0,
+        reEnabledCount: 1,
+        latestSyncTime: 222,
+      })
+    } finally {
+      refreshAccountSpy.mockRestore()
+    }
+  })
+
   it("getAccountStats should aggregate numeric fields across accounts", async () => {
     const accountA = createAccount({
       id: "stats-a",

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -760,6 +760,50 @@ describe("accountStorage core behaviors", () => {
     }
   })
 
+  it("refreshDisabledAccounts counts failed probes separately from restored accounts", async () => {
+    seedStorage([
+      createAccount({ id: "disabled-a", disabled: true }),
+      createAccount({ id: "enabled-b", disabled: false }),
+      createAccount({ id: "disabled-c", disabled: true }),
+    ])
+    storageData.set(USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES, {
+      showTodayCashflow: false,
+    })
+
+    const refreshAccountSpy = vi
+      .spyOn(accountStorage, "refreshAccount")
+      .mockResolvedValueOnce({
+        refreshed: true,
+        reEnabled: false,
+        account: { last_sync_time: 111 },
+      } as any)
+      .mockRejectedValueOnce(new Error("probe failed"))
+
+    try {
+      const result = await accountStorage.refreshDisabledAccounts(true)
+
+      expect(refreshAccountSpy).toHaveBeenCalledTimes(2)
+      expect(refreshAccountSpy).toHaveBeenNthCalledWith(1, "disabled-a", true, {
+        includeTodayCashflow: false,
+        allowDisabled: true,
+        reEnableOnSuccess: true,
+      })
+      expect(refreshAccountSpy).toHaveBeenNthCalledWith(2, "disabled-c", true, {
+        includeTodayCashflow: false,
+        allowDisabled: true,
+        reEnableOnSuccess: true,
+      })
+      expect(result).toEqual({
+        processedCount: 1,
+        failedCount: 1,
+        reEnabledCount: 0,
+        latestSyncTime: 111,
+      })
+    } finally {
+      refreshAccountSpy.mockRestore()
+    }
+  })
+
   it("getAccountStats should aggregate numeric fields across accounts", async () => {
     const accountA = createAccount({
       id: "stats-a",
@@ -1322,10 +1366,14 @@ describe("accountStorage core behaviors", () => {
     })
     seedStorage([account])
 
-    const result = await accountStorage.refreshAccount("disabled-revive", true, {
-      allowDisabled: true,
-      reEnableOnSuccess: true,
-    })
+    const result = await accountStorage.refreshAccount(
+      "disabled-revive",
+      true,
+      {
+        allowDisabled: true,
+        reEnableOnSuccess: true,
+      },
+    )
 
     expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
       baseUrl: "https://revive.example.com",
@@ -1345,8 +1393,47 @@ describe("accountStorage core behaviors", () => {
         reEnabled: true,
       }),
     )
-    const updatedAccount = await accountStorage.getAccountById("disabled-revive")
+    const updatedAccount =
+      await accountStorage.getAccountById("disabled-revive")
     expect(updatedAccount?.disabled).toBe(false)
+  })
+
+  it("refreshAccount should not report re-enabled when the persistence write fails", async () => {
+    const account = createAccount({
+      id: "disabled-persist-fail",
+      disabled: true,
+      site_url: "https://persist.example.com",
+      site_type: "test",
+    })
+    seedStorage([account])
+
+    const updateAccountSpy = vi
+      .spyOn(accountStorage, "updateAccount")
+      .mockResolvedValueOnce(false)
+
+    try {
+      const result = await accountStorage.refreshAccount(
+        "disabled-persist-fail",
+        true,
+        {
+          allowDisabled: true,
+          reEnableOnSuccess: true,
+        },
+      )
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          refreshed: true,
+          reEnabled: false,
+        }),
+      )
+      expect(
+        (await accountStorage.getAccountById("disabled-persist-fail"))
+          ?.disabled,
+      ).toBe(true)
+    } finally {
+      updateAccountSpy.mockRestore()
+    }
   })
 
   it("refreshAccount should skip network refreshes when the min interval has not elapsed", async () => {


### PR DESCRIPTION
Resolves #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refresh and re-probe disabled accounts separately; option to auto re-enable on success.
  * Secondary button appears to trigger disabled-account refresh when applicable.

* **UX Improvements**
  * Refresh buttons disable mutually while any refresh runs; distinct loading states and toast feedback (success/failure/partial).

* **Localization**
  * Added EN/JA/ZH-CN/ZH-TW strings for disabled-account refresh messages.

* **Tests**
  * Added coverage for disabled-account refresh flows and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->