### PR TITLE
fix: stabilize detectSiteType fallback for auth error messages

### DIFF
--- a/src/services/apiService/common/compatHeaders.ts
+++ b/src/services/apiService/common/compatHeaders.ts
@@ -1,3 +1,12 @@
+import {
+  NEO_API,
+  NEW_API,
+  RIX_API,
+  VELOERA,
+  VO_API,
+  type SiteType,
+} from "~/constants/siteType"
+
 /**
  * Compatibility headers for One-API/New-API family deployments.
  *
@@ -5,14 +14,35 @@
  * the same `userId` value across multiple known keys.
  */
 
-const COMPAT_USER_ID_HEADER_NAMES = [
-  "New-API-User",
-  "Veloera-User",
-  "voapi-user",
-  "User-id",
-  "Rix-Api-User",
-  "neo-api-user",
-] as const
+const COMPAT_USER_ID_HEADER_TO_SITE_TYPE = {
+  "New-API-User": NEW_API,
+  "Veloera-User": VELOERA,
+  "voapi-user": VO_API,
+  // Added in commit cb7527d2b15a2c99bc39827fe3ae1d7590622428 for Super-API
+  // compatibility. Keep sending it as a broad fallback header, but do not
+  // treat it as a site-specific detection signal from error messages because
+  // the name itself is too generic.
+  "User-id": NEW_API,
+  "Rix-Api-User": RIX_API,
+  "neo-api-user": NEO_API,
+} as const satisfies Record<string, SiteType>
+
+/**
+ * Error-message detection should only use header names that carry an
+ * unambiguous site-family signal. Generic compatibility headers like `User-id`
+ * are intentionally excluded to avoid over-classifying unrelated deployments.
+ */
+export const COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE = {
+  "New-API-User": NEW_API,
+  "Veloera-User": VELOERA,
+  "voapi-user": VO_API,
+  "Rix-Api-User": RIX_API,
+  "neo-api-user": NEO_API,
+} as const satisfies Record<string, SiteType>
+
+const COMPAT_USER_ID_HEADER_NAMES = Object.keys(
+  COMPAT_USER_ID_HEADER_TO_SITE_TYPE,
+) as Array<keyof typeof COMPAT_USER_ID_HEADER_TO_SITE_TYPE>
 
 type CompatUserIdHeaderName = (typeof COMPAT_USER_ID_HEADER_NAMES)[number]
 

--- a/src/services/apiService/common/utils.ts
+++ b/src/services/apiService/common/utils.ts
@@ -296,6 +296,7 @@ const apiRequest = async <T>(
 
   if (!response.ok) {
     let errorCode: ApiErrorCode = API_ERROR_CODES.HTTP_OTHER
+    let errorMessage = `请求失败: ${response.status}`
 
     if (response.status === 401) {
       errorCode = API_ERROR_CODES.HTTP_401
@@ -325,12 +326,28 @@ const apiRequest = async <T>(
       }
     }
 
-    throw new ApiError(
-      `请求失败: ${response.status}`,
-      response.status,
-      endpoint,
-      errorCode,
-    )
+    if (
+      responseType === "json" &&
+      errorCode !== API_ERROR_CODES.CONTENT_TYPE_MISMATCH
+    ) {
+      try {
+        const responseBody = (await response.clone().json()) as Partial<
+          ApiResponse<unknown>
+        >
+        if (
+          responseBody &&
+          typeof responseBody === "object" &&
+          typeof responseBody.message === "string" &&
+          responseBody.message.trim()
+        ) {
+          errorMessage = responseBody.message
+        }
+      } catch {
+        // Keep the generic HTTP status message when the error body is not parseable JSON.
+      }
+    }
+
+    throw new ApiError(errorMessage, response.status, endpoint, errorCode)
   }
   if (responseType === "json") {
     const contentType = response.headers.get("content-type") || ""

--- a/src/services/siteDetection/autoDetectService.ts
+++ b/src/services/siteDetection/autoDetectService.ts
@@ -397,11 +397,18 @@ export async function autoDetectSmart(url: string): Promise<AutoDetectResult> {
   if (capabilities.hasBackgroundMessaging) {
     // Background path uses a temporary browser context, which may be backed by
     // a window or a tab depending on the current temp-context mode and browser capabilities.
-    const result = await autoDetectViaBackground(url)
-    if (result.success) {
-      return result
+    try {
+      const result = await autoDetectViaBackground(url)
+      if (result.success) {
+        return result
+      }
+      logger.debug("Background 方式失败，降级到直接方式", { url })
+    } catch (error) {
+      logger.warn("Background 方式抛出异常，降级到直接方式", {
+        url,
+        error: getErrorMessage(error),
+      })
     }
-    logger.debug("Background 方式失败，降级到直接方式", { url })
   }
 
   // 3. Fallback: 使用直接方式（手机 或其他方式失败）

--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -1,4 +1,5 @@
 import { SITE_TITLE_RULES, UNKNOWN_SITE } from "~/constants/siteType"
+import { COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE } from "~/services/apiService/common/compatHeaders"
 import { ApiError } from "~/services/apiService/common/errors"
 import { fetchApi, fetchApiData } from "~/services/apiService/common/utils"
 import { AuthTypeEnum } from "~/types"
@@ -10,6 +11,15 @@ import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("DetectSiteType")
+const COMPAT_USER_ID_HEADER_MESSAGE_RULES = Object.entries(
+  COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE,
+).map(([headerName, siteType]) => ({
+  siteType,
+  regex: new RegExp(
+    headerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/-/g, "[-_ ]?"),
+    "i",
+  ),
+}))
 
 /**
  * Fetch the raw HTML title from the site root.
@@ -70,10 +80,36 @@ export const fetchSiteOriginalTitle = async (url: string) => {
 }
 
 /**
- * Probes the /api/user/self endpoint using cookie auth and extracts any
- * user-id-like suffix from an error message to help infer site type.
+ * Runs ordered matching against an API error message:
+ * 1. Known site-specific compat user-id header markers from upstream auth errors
+ * 2. Whole-message matching against existing site detection rules
  */
-async function getSiteUserIdType(url: string) {
+function detectSiteTypeFromApiErrorMessage(message: string): string {
+  const normalizedMessage = message.trim()
+  if (!normalizedMessage) {
+    return UNKNOWN_SITE
+  }
+
+  for (const knownRule of COMPAT_USER_ID_HEADER_MESSAGE_RULES) {
+    if (knownRule.regex.test(normalizedMessage)) {
+      return knownRule.siteType
+    }
+  }
+
+  for (const rule of SITE_TITLE_RULES) {
+    if (rule.regex.test(normalizedMessage)) {
+      return rule.name
+    }
+  }
+
+  return UNKNOWN_SITE
+}
+
+/**
+ * Probes the /api/user/self endpoint using cookie auth and infers the site
+ * type from upstream auth error messages when title detection fails.
+ */
+async function getSiteUserIdType(url: string): Promise<string> {
   try {
     await fetchApiData<unknown>(
       {
@@ -89,12 +125,11 @@ async function getSiteUserIdType(url: string) {
     )
   } catch (error) {
     if (error instanceof ApiError && error.message) {
-      const parts = error.message.split(" ")
-      return parts.length > 0 ? parts[parts.length - 1] : ""
+      return detectSiteTypeFromApiErrorMessage(error.message)
     }
     throw error
   }
-  return ""
+  return UNKNOWN_SITE
 }
 
 export const getSiteType = async (url: string) => {
@@ -108,12 +143,10 @@ export const getSiteType = async (url: string) => {
   }
 
   if (detected === UNKNOWN_SITE) {
-    const userIdString = await getSiteUserIdType(url)
-    for (const rule of SITE_TITLE_RULES) {
-      if (rule.regex.test(userIdString)) {
-        detected = rule.name
-        return detected
-      }
+    const detectedFromApiError = await getSiteUserIdType(url)
+    if (detectedFromApiError !== UNKNOWN_SITE) {
+      detected = detectedFromApiError
+      return detected
     }
   }
   return detected

--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -134,20 +134,11 @@ async function getSiteUserIdType(url: string): Promise<string> {
 
 export const getSiteType = async (url: string) => {
   const title = await fetchSiteOriginalTitle(url)
-  let detected = UNKNOWN_SITE
   for (const rule of SITE_TITLE_RULES) {
     if (rule.regex.test(title)) {
-      detected = rule.name
-      return detected
+      return rule.name
     }
   }
 
-  if (detected === UNKNOWN_SITE) {
-    const detectedFromApiError = await getSiteUserIdType(url)
-    if (detectedFromApiError !== UNKNOWN_SITE) {
-      detected = detectedFromApiError
-      return detected
-    }
-  }
-  return detected
+  return await getSiteUserIdType(url)
 }

--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -124,7 +124,7 @@ async function getSiteUserIdType(url: string): Promise<string> {
       },
     )
   } catch (error) {
-    if (error instanceof ApiError && error.message) {
+    if (error instanceof ApiError) {
       return detectSiteTypeFromApiErrorMessage(error.message)
     }
     throw error

--- a/tests/services/apiService/common/fetchApi.test.ts
+++ b/tests/services/apiService/common/fetchApi.test.ts
@@ -415,6 +415,34 @@ describe("apiService common fetchApi helpers", () => {
     ).rejects.toBeInstanceOf(ApiError)
   })
 
+  it("preserves backend JSON error messages for non-2xx responses", async () => {
+    server.use(
+      http.get(API_URL, () => {
+        return HttpResponse.json(
+          {
+            success: false,
+            message: "error: invalid user new-api",
+          },
+          { status: 400 },
+        )
+      }),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.Cookie },
+        },
+        { endpoint: ENDPOINT },
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "error: invalid user new-api",
+      code: ApiErrorCodes.HTTP_OTHER,
+    })
+  })
+
   it("classifies 401 HTML responses as CONTENT_TYPE_MISMATCH for JSON requests", async () => {
     server.use(
       http.get(API_URL, () => {

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -198,6 +198,40 @@ describe("autoDetectSmart", () => {
     })
   })
 
+  it("falls back to direct detection when background site-type detection throws", async () => {
+    mockGetActiveOrAllTabs.mockResolvedValue([
+      {
+        id: 30,
+        active: true,
+        url: "https://different.example.com/home",
+      },
+    ])
+    mockGetSiteType
+      .mockRejectedValueOnce(new Error("background detect failed"))
+      .mockResolvedValueOnce("new-api")
+    mockFetchUserInfo.mockResolvedValue({
+      id: 21,
+      username: "direct-user",
+    })
+
+    const result = await autoDetectSmart("https://example.com/console")
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        userId: 21,
+        user: {
+          id: 21,
+          username: "direct-user",
+        },
+        siteType: "new-api",
+        accessToken: undefined,
+        sub2apiAuth: undefined,
+      },
+    })
+    expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
+  })
+
   it("falls back to direct detection when browser tab and runtime capabilities are unavailable", async () => {
     browserAny.tabs = null
     browserAny.runtime = null

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -232,6 +232,37 @@ describe("autoDetectSmart", () => {
     expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
   })
 
+  it("falls back to direct detection when background auto-detect returns an unsuccessful result", async () => {
+    mockGetActiveOrAllTabs.mockResolvedValue([
+      {
+        id: 31,
+        active: true,
+        url: "https://different.example.com/home",
+      },
+    ])
+    mockFetchUserInfo.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      id: 22,
+      username: "direct-after-background-failure",
+    })
+
+    const result = await autoDetectSmart("https://example.com/console")
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        userId: 22,
+        user: {
+          id: 22,
+          username: "direct-after-background-failure",
+        },
+        siteType: "new-api",
+        accessToken: undefined,
+        sub2apiAuth: undefined,
+      },
+    })
+    expect(mockFetchUserInfo).toHaveBeenCalledTimes(2)
+  })
+
   it("falls back to direct detection when browser tab and runtime capabilities are unavailable", async () => {
     browserAny.tabs = null
     browserAny.runtime = null

--- a/tests/services/detectSiteType.fallback.test.ts
+++ b/tests/services/detectSiteType.fallback.test.ts
@@ -120,6 +120,17 @@ describe("detectSiteType temp-context fallbacks", () => {
     await expect(getSiteType("https://example.com")).resolves.toBe("unknown")
   })
 
+  it("returns UNKNOWN when the API error message is empty", async () => {
+    mocks.fetchApi.mockResolvedValue(
+      "<html><title>Mystery Control Panel</title></html>",
+    )
+    mocks.fetchApiData.mockRejectedValue(
+      new ApiError("", 401, "/api/user/self"),
+    )
+
+    await expect(getSiteType("https://example.com")).resolves.toBe("unknown")
+  })
+
   it("rethrows unexpected non-ApiError failures from the API fallback probe", async () => {
     mocks.fetchApi.mockResolvedValue(
       "<html><title>Mystery Control Panel</title></html>",

--- a/tests/services/detectSiteType.fallback.test.ts
+++ b/tests/services/detectSiteType.fallback.test.ts
@@ -109,6 +109,17 @@ describe("detectSiteType temp-context fallbacks", () => {
     await expect(getSiteType("https://example.com")).resolves.toBe(NEW_API)
   })
 
+  it("returns UNKNOWN when the API error message is blank", async () => {
+    mocks.fetchApi.mockResolvedValue(
+      "<html><title>Mystery Control Panel</title></html>",
+    )
+    mocks.fetchApiData.mockRejectedValue(
+      new ApiError("   ", 401, "/api/user/self"),
+    )
+
+    await expect(getSiteType("https://example.com")).resolves.toBe("unknown")
+  })
+
   it("rethrows unexpected non-ApiError failures from the API fallback probe", async () => {
     mocks.fetchApi.mockResolvedValue(
       "<html><title>Mystery Control Panel</title></html>",

--- a/tests/services/detectSiteType.test.ts
+++ b/tests/services/detectSiteType.test.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { SITE_TITLE_RULES, UNKNOWN_SITE } from "~/constants/siteType"
+import { NEW_API, SITE_TITLE_RULES, UNKNOWN_SITE } from "~/constants/siteType"
 import {
   fetchSiteOriginalTitle,
   getSiteType,
@@ -268,8 +268,7 @@ describe("detectSiteType", () => {
 
         const siteType = await getSiteType("https://example.com")
 
-        // Result depends on whether "new-api" matches any SITE_TITLE_RULES
-        expect(typeof siteType).toBe("string")
+        expect(siteType).toBe(NEW_API)
       })
 
       it("should handle API response without message", async () => {

--- a/tests/services/detectSiteType.test.ts
+++ b/tests/services/detectSiteType.test.ts
@@ -271,6 +271,98 @@ describe("detectSiteType", () => {
         expect(siteType).toBe(NEW_API)
       })
 
+      it("should detect site type from any token in the API error message", async () => {
+        const mockHTML = "<html><title>No Match</title></html>"
+        const mockApiResponse = {
+          success: false,
+          message: "new-api invalid user identifier changed",
+        }
+
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse(mockHTML, {
+              headers: { "Content-Type": "text/html" },
+            })
+          }),
+          http.get("https://example.com/api/user/self", () => {
+            return HttpResponse.json(mockApiResponse, { status: 400 })
+          }),
+        )
+
+        const siteType = await getSiteType("https://example.com")
+
+        expect(siteType).toBe(NEW_API)
+      })
+
+      it("should detect NEW_API from the upstream English New-Api-User header error", async () => {
+        const mockHTML = "<html><title>No Match</title></html>"
+        const mockApiResponse = {
+          success: false,
+          message: "Unauthorized, New-Api-User header not provided",
+        }
+
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse(mockHTML, {
+              headers: { "Content-Type": "text/html" },
+            })
+          }),
+          http.get("https://example.com/api/user/self", () => {
+            return HttpResponse.json(mockApiResponse, { status: 401 })
+          }),
+        )
+
+        const siteType = await getSiteType("https://example.com")
+
+        expect(siteType).toBe(NEW_API)
+      })
+
+      it("should detect NEW_API from the localized Chinese New-Api-User header error", async () => {
+        const mockHTML = "<html><title>No Match</title></html>"
+        const mockApiResponse = {
+          success: false,
+          message: "无权进行此操作，未提供 New-Api-User",
+        }
+
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse(mockHTML, {
+              headers: { "Content-Type": "text/html" },
+            })
+          }),
+          http.get("https://example.com/api/user/self", () => {
+            return HttpResponse.json(mockApiResponse, { status: 401 })
+          }),
+        )
+
+        const siteType = await getSiteType("https://example.com")
+
+        expect(siteType).toBe(NEW_API)
+      })
+
+      it("should not infer a site type from the generic User-id header error alone", async () => {
+        const mockHTML = "<html><title>No Match</title></html>"
+        const mockApiResponse = {
+          success: false,
+          message: "Unauthorized, User-id header not provided",
+        }
+
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse(mockHTML, {
+              headers: { "Content-Type": "text/html" },
+            })
+          }),
+          http.get("https://example.com/api/user/self", () => {
+            return HttpResponse.json(mockApiResponse, { status: 401 })
+          }),
+        )
+
+        const siteType = await getSiteType("https://example.com")
+
+        expect(siteType).toBe(UNKNOWN_SITE)
+      })
+
       it("should handle API response without message", async () => {
         const mockHTML = "<html><title>No Match</title></html>"
         const mockApiResponse = { success: true }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved site-type detection using API error responses and additional compatibility header signals.
  * Background auto-detect now fails gracefully and falls back to direct detection.

* **Bug Fixes**
  * Preserve backend JSON error messages for non-2xx responses so users see original error text.
  * Better handling when API error messages are blank or empty.

* **Tests**
  * Expanded tests covering new detection paths, error-message handling, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->