### PR TITLE
feat(account-management): implement section-based account form layout

### DIFF
--- a/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
@@ -28,15 +28,14 @@ import {
   Textarea,
 } from "~/components/ui"
 import { SITE_TITLE_RULES, SUB2API, UNKNOWN_SITE } from "~/constants/siteType"
+import { AccountFormSection } from "~/features/AccountManagement/components/AccountDialog/AccountFormSection"
+import { ACCOUNT_FORM_MOBILE_DEFAULT_OPEN } from "~/features/AccountManagement/components/AccountDialog/accountFormSections"
+import type { AccountDialogDraft } from "~/features/AccountManagement/components/AccountDialog/models"
 import { TagPicker } from "~/features/AccountManagement/components/TagPicker"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import { isValidExchangeRate } from "~/services/accounts/accountOperations"
 import { AuthTypeEnum, type CheckInConfig, type Tag } from "~/types"
 import { formatLocaleDateTime } from "~/utils/core/formatters"
-
-import { AccountFormSection } from "./AccountFormSection"
-import { ACCOUNT_FORM_MOBILE_DEFAULT_OPEN } from "./accountFormSections"
-import type { AccountDialogDraft } from "./models"
 
 interface AccountFormProps {
   draft: AccountDialogDraft
@@ -422,6 +421,7 @@ export default function AccountForm({
                 }
                 placeholder={t("form.cookieAuthSessionCookiePlaceholder")}
                 rows={2}
+                required
               />
             </div>
           </FormField>
@@ -488,7 +488,8 @@ export default function AccountForm({
                 ...checkIn,
                 enableDetection,
                 // When detection turns on, default auto check-in to true unless
-                // the user has explicitly disabled it with false.
+                // the user has explicitly disabled it with false; turning
+                // detection off leaves the last preference untouched.
                 autoCheckInEnabled:
                   enableDetection && checkIn.autoCheckInEnabled !== false
                     ? checkIn.autoCheckInEnabled ?? true

--- a/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next"
 import {
   Alert,
   Button,
+  CardDescription,
   FormField,
   IconButton,
   Input,
@@ -33,10 +34,13 @@ import { isValidExchangeRate } from "~/services/accounts/accountOperations"
 import { AuthTypeEnum, type CheckInConfig, type Tag } from "~/types"
 import { formatLocaleDateTime } from "~/utils/core/formatters"
 
+import { AccountFormSection } from "./AccountFormSection"
+import { ACCOUNT_FORM_MOBILE_DEFAULT_OPEN } from "./accountFormSections"
 import type { AccountDialogDraft } from "./models"
 
 interface AccountFormProps {
   draft: AccountDialogDraft
+  isDetected: boolean
   isManualBalanceUsdInvalid: boolean
   showAccessToken: boolean
   isImportingCookies: boolean
@@ -64,6 +68,7 @@ interface AccountFormProps {
   renameTag: (tagId: string, name: string) => Promise<Tag>
   deleteTag: (tagId: string) => Promise<{ updatedAccounts: number }>
   onSiteTypeChange: (value: string) => void
+  onAuthTypeChange: (value: AuthTypeEnum) => void
   onCheckInChange: (value: CheckInConfig) => void
 }
 
@@ -72,6 +77,7 @@ interface AccountFormProps {
  */
 export default function AccountForm({
   draft,
+  isDetected,
   isManualBalanceUsdInvalid,
   showAccessToken,
   isImportingCookies,
@@ -99,6 +105,7 @@ export default function AccountForm({
   renameTag,
   deleteTag,
   onSiteTypeChange,
+  onAuthTypeChange,
   onCheckInChange,
 }: AccountFormProps) {
   const { t } = useTranslation("accountDialog")
@@ -124,502 +131,565 @@ export default function AccountForm({
   const [showSub2apiRefreshToken, setShowSub2apiRefreshToken] = useState(false)
 
   return (
-    <>
-      {/* 网站名称 */}
-      <FormField label={t("form.siteName")} required>
-        <Input
-          type="text"
-          value={siteName}
-          onChange={(e) => onSiteNameChange(e.target.value)}
-          placeholder="example.com"
-          leftIcon={<GlobeAltIcon className="h-5 w-5" />}
-          data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteNameInput}
-          required
-        />
-      </FormField>
-
-      {/* 站点类型 */}
-      <FormField label={t("form.siteType")}>
-        <Select
-          value={siteType ?? UNKNOWN_SITE}
-          onValueChange={onSiteTypeChange}
-        >
-          <SelectTrigger
-            className="w-full"
-            aria-label={t("form.siteType")}
-            title={t("form.siteType")}
-            data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteTypeTrigger}
-            data-site-type={siteType ?? UNKNOWN_SITE}
-          >
-            <div className="flex items-center gap-2">
-              <GlobeAltIcon className="text-muted-foreground h-5 w-5" />
-              <SelectValue placeholder={t("form.siteType")} />
-            </div>
-          </SelectTrigger>
-          <SelectContent>
-            {SITE_TITLE_RULES.map((rule) => (
-              <SelectItem key={rule.name} value={rule.name}>
-                {rule.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </FormField>
-
-      {/* 用户名 */}
-      <FormField label={t("form.username")} required>
-        <Input
-          type="text"
-          value={username}
-          onChange={(e) => onUsernameChange(e.target.value)}
-          placeholder={t("form.username")}
-          leftIcon={<UserIcon className="h-5 w-5" />}
-          data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.usernameInput}
-          required
-        />
-      </FormField>
-
-      {/* 用户 ID */}
-      <FormField label={t("form.userId")} required>
-        <Input
-          type="number"
-          value={userId}
-          onChange={(e) => onUserIdChange(e.target.value)}
-          placeholder={t("form.userIdNumber")}
-          leftIcon={<span className="font-mono text-sm">#</span>}
-          data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.userIdInput}
-          required
-        />
-      </FormField>
-
-      {/* 访问令牌 */}
-      {authType === AuthTypeEnum.AccessToken && (
-        <FormField label={t("form.accessToken")} required>
+    <div className="space-y-3">
+      <AccountFormSection
+        title={t("sections.siteInfo.title")}
+        defaultOpen={ACCOUNT_FORM_MOBILE_DEFAULT_OPEN["site-info"]}
+        testId={ACCOUNT_MANAGEMENT_TEST_IDS.accountFormSectionSiteInfo}
+      >
+        <FormField label={t("form.siteName")} required>
           <Input
-            type={showAccessToken ? "text" : "password"}
-            value={accessToken}
-            onChange={(e) => onAccessTokenChange(e.target.value)}
-            placeholder={t("form.accessToken")}
-            leftIcon={<KeyIcon className="h-5 w-5" />}
-            data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.accessTokenInput}
-            rightIcon={
-              <IconButton
-                type="button"
-                onClick={onToggleShowAccessToken}
-                variant="ghost"
-                size="sm"
-                aria-label={t("form.toggleAccessTokenVisibility")}
-              >
-                {showAccessToken ? (
-                  <EyeSlashIcon className="h-4 w-4" />
-                ) : (
-                  <EyeIcon className="h-4 w-4" />
-                )}
-              </IconButton>
-            }
+            type="text"
+            value={siteName}
+            onChange={(e) => onSiteNameChange(e.target.value)}
+            placeholder="example.com"
+            leftIcon={<GlobeAltIcon className="h-5 w-5" />}
+            data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteNameInput}
             required
           />
         </FormField>
-      )}
 
-      {isSub2Api && (
-        <div className="space-y-2">
-          <div className="flex w-full items-center justify-between">
-            <div className="flex-1">
-              <label
-                htmlFor="sub2api-refresh-token-mode"
-                className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
-              >
-                {t("form.sub2apiRefreshTokenMode")}
-              </label>
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                {t("form.sub2apiRefreshTokenModeDesc")}
-              </p>
-            </div>
-            <Switch
-              checked={sub2apiUseRefreshToken}
-              onChange={onSub2apiUseRefreshTokenChange}
-              id="sub2api-refresh-token-mode"
-              data-testid={
-                ACCOUNT_MANAGEMENT_TEST_IDS.sub2apiRefreshTokenSwitch
-              }
-              className={`${
-                sub2apiUseRefreshToken ? "bg-green-600" : "bg-gray-200"
-              } focus:ring-green-500`}
-            />
-          </div>
-
-          {sub2apiUseRefreshToken && (
-            <div className="space-y-2">
-              <Alert
-                variant="info"
-                title={t("form.sub2apiRefreshTokenWarningTitle")}
-                description={t("form.sub2apiRefreshTokenWarningDesc")}
-              />
-
-              <FormField label={t("form.sub2apiRefreshToken")} required>
-                <div className="space-y-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={onImportSub2apiSession}
-                    disabled={isImportingSub2apiSession}
-                    loading={isImportingSub2apiSession}
-                    className="w-full"
-                    data-testid={
-                      ACCOUNT_MANAGEMENT_TEST_IDS.sub2apiImportSessionButton
-                    }
-                    leftIcon={<ArrowDownTrayIcon className="h-4 w-4" />}
-                  >
-                    {t("form.sub2apiImportRefreshToken")}
-                  </Button>
-                  <Input
-                    type={showSub2apiRefreshToken ? "text" : "password"}
-                    value={sub2apiRefreshToken}
-                    onChange={(e) =>
-                      onSub2apiRefreshTokenChange(e.target.value)
-                    }
-                    placeholder={t("form.sub2apiRefreshTokenPlaceholder")}
-                    leftIcon={<KeyIcon className="h-5 w-5" />}
-                    data-testid={
-                      ACCOUNT_MANAGEMENT_TEST_IDS.sub2apiRefreshTokenInput
-                    }
-                    rightIcon={
-                      <IconButton
-                        type="button"
-                        onClick={() =>
-                          setShowSub2apiRefreshToken(!showSub2apiRefreshToken)
-                        }
-                        variant="ghost"
-                        size="sm"
-                        aria-label={t("form.toggleRefreshTokenVisibility")}
-                      >
-                        {showSub2apiRefreshToken ? (
-                          <EyeSlashIcon className="h-4 w-4" />
-                        ) : (
-                          <EyeIcon className="h-4 w-4" />
-                        )}
-                      </IconButton>
-                    }
-                    required
-                  />
-                </div>
-              </FormField>
-
-              {typeof sub2apiTokenExpiresAt === "number" && (
-                <FormField label={t("form.sub2apiTokenExpiresAt")}>
-                  <Input
-                    type="text"
-                    value={formatLocaleDateTime(
-                      sub2apiTokenExpiresAt,
-                      t("common:labels.notAvailable"),
-                    )}
-                    leftIcon={<CalendarDaysIcon className="h-5 w-5" />}
-                    disabled
-                  />
-                </FormField>
-              )}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Cookie Auth Session Cookie */}
-      {authType === AuthTypeEnum.Cookie && (
-        <FormField
-          label={t("form.cookieAuthSessionCookie")}
-          description={t("form.cookieAuthSessionCookieDesc")}
-          required
-        >
-          <div className="space-y-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={onImportCookieAuthSessionCookie}
-              disabled={isImportingCookies}
+        <FormField label={t("form.siteType")}>
+          <Select
+            value={siteType ?? UNKNOWN_SITE}
+            onValueChange={onSiteTypeChange}
+          >
+            <SelectTrigger
               className="w-full"
+              aria-label={t("form.siteType")}
+              title={t("form.siteType")}
+              data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteTypeTrigger}
+              data-site-type={siteType ?? UNKNOWN_SITE}
             >
-              <ArrowDownTrayIcon className="mr-2 h-4 w-4" />
-              {isImportingCookies
-                ? t("messages.importCookiesLoading")
-                : t("form.importCookieAuthSessionCookie")}
-            </Button>
-            {showCookiePermissionWarning && (
-              <Alert
-                variant="warning"
-                description={t("messages.importCookiesPermissionDenied")}
-              >
-                <div className="pt-1">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={onOpenCookiePermissionSettings}
-                  >
-                    {t("form.cookiePermissionHelpAction")}
-                  </Button>
-                </div>
-              </Alert>
+              <div className="flex items-center gap-2">
+                <GlobeAltIcon className="text-muted-foreground h-5 w-5" />
+                <SelectValue placeholder={t("form.siteType")} />
+              </div>
+            </SelectTrigger>
+            <SelectContent>
+              {SITE_TITLE_RULES.map((rule) => (
+                <SelectItem key={rule.name} value={rule.name}>
+                  {rule.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </FormField>
+      </AccountFormSection>
+
+      <AccountFormSection
+        title={t("sections.accountAuth.title")}
+        defaultOpen={ACCOUNT_FORM_MOBILE_DEFAULT_OPEN["account-auth"]}
+        testId={ACCOUNT_MANAGEMENT_TEST_IDS.accountFormSectionAuth}
+      >
+        <FormField
+          label={t("siteInfo.authMethod")}
+          description={isSub2Api ? t("siteInfo.sub2apiAuthOnly") : undefined}
+        >
+          <Select
+            value={authType}
+            onValueChange={(value) => onAuthTypeChange(value as AuthTypeEnum)}
+            disabled={isDetected || isSub2Api}
+          >
+            <SelectTrigger
+              className="w-full"
+              aria-label={t("siteInfo.authMethod")}
+              data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger}
+              data-auth-type={authType}
+            >
+              <div className="flex items-center gap-2">
+                <KeyIcon className="text-muted-foreground h-5 w-5" />
+                <SelectValue
+                  placeholder={t("siteInfo.authMethodPlaceholder")}
+                />
+              </div>
+            </SelectTrigger>
+            <SelectContent align="end" className="min-w-48">
+              <SelectItem value={AuthTypeEnum.AccessToken}>
+                {t("siteInfo.authType.accessToken")}
+              </SelectItem>
+              {!isSub2Api && (
+                <SelectItem value={AuthTypeEnum.Cookie}>
+                  {t("siteInfo.authType.cookieAuth")}
+                </SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+          {!isSub2Api && (
+            <CardDescription className="mt-2">
+              {t("siteInfo.cookieWarning")}
+            </CardDescription>
+          )}
+        </FormField>
+
+        <FormField label={t("form.username")} required>
+          <Input
+            type="text"
+            value={username}
+            onChange={(e) => onUsernameChange(e.target.value)}
+            placeholder={t("form.username")}
+            leftIcon={<UserIcon className="h-5 w-5" />}
+            data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.usernameInput}
+            required
+          />
+        </FormField>
+
+        <FormField label={t("form.userId")} required>
+          <Input
+            type="number"
+            value={userId}
+            onChange={(e) => onUserIdChange(e.target.value)}
+            placeholder={t("form.userIdNumber")}
+            leftIcon={<span className="font-mono text-sm">#</span>}
+            data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.userIdInput}
+            required
+          />
+        </FormField>
+
+        {authType === AuthTypeEnum.AccessToken && (
+          <FormField label={t("form.accessToken")} required>
+            <Input
+              type={showAccessToken ? "text" : "password"}
+              value={accessToken}
+              onChange={(e) => onAccessTokenChange(e.target.value)}
+              placeholder={t("form.accessToken")}
+              leftIcon={<KeyIcon className="h-5 w-5" />}
+              data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.accessTokenInput}
+              rightIcon={
+                <IconButton
+                  type="button"
+                  onClick={onToggleShowAccessToken}
+                  variant="ghost"
+                  size="sm"
+                  aria-label={t("form.toggleAccessTokenVisibility")}
+                >
+                  {showAccessToken ? (
+                    <EyeSlashIcon className="h-4 w-4" />
+                  ) : (
+                    <EyeIcon className="h-4 w-4" />
+                  )}
+                </IconButton>
+              }
+              required
+            />
+          </FormField>
+        )}
+
+        {isSub2Api && (
+          <div className="space-y-4">
+            <div className="flex w-full items-center justify-between gap-4">
+              <div className="flex-1">
+                <label
+                  htmlFor="sub2api-refresh-token-mode"
+                  className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
+                >
+                  {t("form.sub2apiRefreshTokenMode")}
+                </label>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {t("form.sub2apiRefreshTokenModeDesc")}
+                </p>
+              </div>
+              <Switch
+                checked={sub2apiUseRefreshToken}
+                onChange={onSub2apiUseRefreshTokenChange}
+                id="sub2api-refresh-token-mode"
+                data-testid={
+                  ACCOUNT_MANAGEMENT_TEST_IDS.sub2apiRefreshTokenSwitch
+                }
+                className={`${
+                  sub2apiUseRefreshToken ? "bg-green-600" : "bg-gray-200"
+                } focus:ring-green-500`}
+              />
+            </div>
+
+            {sub2apiUseRefreshToken && (
+              <div className="space-y-4">
+                <Alert
+                  variant="info"
+                  title={t("form.sub2apiRefreshTokenWarningTitle")}
+                  description={t("form.sub2apiRefreshTokenWarningDesc")}
+                />
+
+                <FormField label={t("form.sub2apiRefreshToken")} required>
+                  <div className="space-y-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={onImportSub2apiSession}
+                      disabled={isImportingSub2apiSession}
+                      loading={isImportingSub2apiSession}
+                      className="w-full"
+                      data-testid={
+                        ACCOUNT_MANAGEMENT_TEST_IDS.sub2apiImportSessionButton
+                      }
+                      leftIcon={<ArrowDownTrayIcon className="h-4 w-4" />}
+                    >
+                      {t("form.sub2apiImportRefreshToken")}
+                    </Button>
+                    <Input
+                      type={showSub2apiRefreshToken ? "text" : "password"}
+                      value={sub2apiRefreshToken}
+                      onChange={(e) =>
+                        onSub2apiRefreshTokenChange(e.target.value)
+                      }
+                      placeholder={t("form.sub2apiRefreshTokenPlaceholder")}
+                      leftIcon={<KeyIcon className="h-5 w-5" />}
+                      data-testid={
+                        ACCOUNT_MANAGEMENT_TEST_IDS.sub2apiRefreshTokenInput
+                      }
+                      rightIcon={
+                        <IconButton
+                          type="button"
+                          onClick={() =>
+                            setShowSub2apiRefreshToken(!showSub2apiRefreshToken)
+                          }
+                          variant="ghost"
+                          size="sm"
+                          aria-label={t("form.toggleRefreshTokenVisibility")}
+                        >
+                          {showSub2apiRefreshToken ? (
+                            <EyeSlashIcon className="h-4 w-4" />
+                          ) : (
+                            <EyeIcon className="h-4 w-4" />
+                          )}
+                        </IconButton>
+                      }
+                      required
+                    />
+                  </div>
+                </FormField>
+
+                {typeof sub2apiTokenExpiresAt === "number" && (
+                  <FormField label={t("form.sub2apiTokenExpiresAt")}>
+                    <Input
+                      type="text"
+                      value={formatLocaleDateTime(
+                        sub2apiTokenExpiresAt,
+                        t("common:labels.notAvailable"),
+                      )}
+                      leftIcon={<CalendarDaysIcon className="h-5 w-5" />}
+                      disabled
+                    />
+                  </FormField>
+                )}
+              </div>
             )}
+          </div>
+        )}
+
+        {authType === AuthTypeEnum.Cookie && (
+          <FormField
+            label={t("form.cookieAuthSessionCookie")}
+            description={t("form.cookieAuthSessionCookieDesc")}
+            required
+          >
+            <div className="space-y-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onImportCookieAuthSessionCookie}
+                disabled={isImportingCookies}
+                className="w-full"
+              >
+                <ArrowDownTrayIcon className="mr-2 h-4 w-4" />
+                {isImportingCookies
+                  ? t("messages.importCookiesLoading")
+                  : t("form.importCookieAuthSessionCookie")}
+              </Button>
+              {showCookiePermissionWarning && (
+                <Alert
+                  variant="warning"
+                  description={t("messages.importCookiesPermissionDenied")}
+                >
+                  <div className="pt-1">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={onOpenCookiePermissionSettings}
+                    >
+                      {t("form.cookiePermissionHelpAction")}
+                    </Button>
+                  </div>
+                </Alert>
+              )}
+              <Textarea
+                value={cookieAuthSessionCookie}
+                onChange={(e) =>
+                  onCookieAuthSessionCookieChange(e.target.value)
+                }
+                placeholder={t("form.cookieAuthSessionCookiePlaceholder")}
+                rows={2}
+              />
+            </div>
+          </FormField>
+        )}
+      </AccountFormSection>
+
+      <AccountFormSection
+        title={t("sections.tagsAndNotes.title")}
+        description={t("sections.tagsAndNotes.description")}
+        defaultOpen={ACCOUNT_FORM_MOBILE_DEFAULT_OPEN["tags-notes"]}
+        testId={ACCOUNT_MANAGEMENT_TEST_IDS.accountFormSectionTagsNotes}
+      >
+        <FormField
+          label={t("form.tags")}
+          description={t("form.tagsDescription")}
+        >
+          <TagPicker
+            tags={tags}
+            tagCountsById={tagCountsById}
+            selectedTagIds={tagIds}
+            onSelectedTagIdsChange={onSelectedTagIdsChange}
+            onCreateTag={createTag}
+            onRenameTag={renameTag}
+            onDeleteTag={deleteTag}
+            placeholder={t("form.tagsPlaceholder")}
+          />
+        </FormField>
+
+        <FormField label={t("form.notes")}>
+          <div className="relative">
             <Textarea
-              value={cookieAuthSessionCookie}
-              onChange={(e) => onCookieAuthSessionCookieChange(e.target.value)}
-              placeholder={t("form.cookieAuthSessionCookiePlaceholder")}
+              value={notes}
+              onChange={(e) => onNotesChange(e.target.value)}
+              placeholder={t("form.notesPlaceholder")}
               rows={2}
             />
           </div>
         </FormField>
-      )}
+      </AccountFormSection>
 
-      {/* 充值金额比例 */}
-      <FormField
-        label={t("form.exchangeRate")}
-        description={t("form.exchangeRateDesc")}
-        error={
-          !isValidExchangeRate(exchangeRate) && exchangeRate
-            ? t("form.validRateError")
-            : undefined
-        }
-        required
+      <AccountFormSection
+        title={t("sections.checkInConfig.title")}
+        defaultOpen={ACCOUNT_FORM_MOBILE_DEFAULT_OPEN["check-in"]}
+        testId={ACCOUNT_MANAGEMENT_TEST_IDS.accountFormSectionCheckIn}
       >
-        <Input
-          type="number"
-          step="any"
-          min="0"
-          value={exchangeRate}
-          onChange={(e) => onExchangeRateChange(e.target.value)}
-          placeholder={t("form.exchangeRatePlaceholder")}
-          leftIcon={<CurrencyDollarIcon className="h-5 w-5" />}
-          rightIcon={
-            <span className="dark:text-dark-text-secondary text-sm text-gray-500">
-              CNY
-            </span>
-          }
-          variant={
-            !isValidExchangeRate(exchangeRate) && exchangeRate
-              ? "error"
-              : "default"
-          }
-          required
-        />
-      </FormField>
-
-      <FormField
-        label={t("form.manualBalanceUsd")}
-        description={t("form.manualBalanceUsdDesc")}
-        error={
-          isManualBalanceUsdInvalid
-            ? t("form.manualBalanceUsdError")
-            : undefined
-        }
-      >
-        <Input
-          type="number"
-          step="any"
-          min="0"
-          value={manualBalanceUsd}
-          onChange={(e) => onManualBalanceUsdChange(e.target.value)}
-          placeholder={t("form.manualBalanceUsdPlaceholder")}
-          leftIcon={<CurrencyDollarIcon className="h-5 w-5" />}
-          rightIcon={
-            <span className="dark:text-dark-text-secondary text-sm text-gray-500">
-              USD
-            </span>
-          }
-          variant={isManualBalanceUsdInvalid ? "error" : "default"}
-        />
-      </FormField>
-
-      {/* Exclude from Total Balance */}
-      <div className="flex w-full items-center justify-between">
-        <div className="flex-1">
-          <label
-            htmlFor="exclude-from-total-balance"
-            className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
-          >
-            {t("form.excludeFromTotalBalance")}
-          </label>
-          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-            {t("form.excludeFromTotalBalanceDesc")}
-          </p>
-        </div>
-        <Switch
-          checked={excludeFromTotalBalance}
-          onChange={onExcludeFromTotalBalanceChange}
-          id="exclude-from-total-balance"
-          className={`${
-            excludeFromTotalBalance ? "bg-green-600" : "bg-gray-200"
-          } focus:ring-green-500`}
-        />
-      </div>
-
-      {/* 签到功能开关 */}
-      <div className="flex w-full items-center justify-between">
-        <div className="flex-1">
-          <label
-            htmlFor="supports-check-in"
-            className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
-          >
-            {t("form.checkInStatus")}
-          </label>
-          {isSub2Api && (
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {t("form.sub2apiCheckInUnsupported")}
-            </p>
-          )}
-        </div>
-        <Switch
-          checked={checkIn.enableDetection}
-          onChange={(enableDetection) =>
-            onCheckInChange({
-              ...checkIn,
-              enableDetection,
-              autoCheckInEnabled:
-                enableDetection && checkIn.autoCheckInEnabled !== false
-                  ? checkIn.autoCheckInEnabled ?? true
-                  : checkIn.autoCheckInEnabled,
-            })
-          }
-          id="supports-check-in"
-          disabled={isSub2Api}
-          className={`${
-            checkIn.enableDetection ? "bg-green-600" : "bg-gray-200"
-          } focus:ring-green-500`}
-        />
-      </div>
-
-      {/* 自动签到开关 */}
-      {checkIn.enableDetection && (
-        <div className="flex w-full items-center justify-between">
+        <div className="flex w-full items-center justify-between gap-4">
           <div className="flex-1">
             <label
-              htmlFor="auto-checkin-enabled"
+              htmlFor="supports-check-in"
               className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
             >
-              {t("form.autoCheckInEnabled")}
+              {t("form.checkInStatus")}
             </label>
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {t("form.autoCheckInEnabledDesc")}
-            </p>
+            {isSub2Api && (
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {t("form.sub2apiCheckInUnsupported")}
+              </p>
+            )}
           </div>
           <Switch
-            checked={checkIn.autoCheckInEnabled !== false}
-            onChange={(autoCheckInEnabled) =>
-              onCheckInChange({ ...checkIn, autoCheckInEnabled })
+            checked={checkIn.enableDetection}
+            onChange={(enableDetection) =>
+              onCheckInChange({
+                ...checkIn,
+                enableDetection,
+                autoCheckInEnabled:
+                  enableDetection && checkIn.autoCheckInEnabled !== false
+                    ? checkIn.autoCheckInEnabled ?? true
+                    : checkIn.autoCheckInEnabled,
+              })
             }
-            id="auto-checkin-enabled"
+            id="supports-check-in"
+            disabled={isSub2Api}
             className={`${
-              checkIn.autoCheckInEnabled !== false
-                ? "bg-green-600"
-                : "bg-gray-200"
+              checkIn.enableDetection ? "bg-green-600" : "bg-gray-200"
             } focus:ring-green-500`}
           />
         </div>
-      )}
 
-      {/* Custom Check-in URL */}
-      <FormField
-        label={t("form.customCheckInUrl")}
-        description={t("form.customCheckInDesc")}
-      >
-        <Input
-          type="url"
-          id="custom-checkin-url"
-          value={checkIn.customCheckIn?.url ?? ""}
-          onChange={(e) =>
-            onCheckInChange({
-              ...checkIn,
-              customCheckIn: {
-                ...(checkIn.customCheckIn ?? { openRedeemWithCheckIn: true }),
-                url: e.target.value,
-              },
-            })
-          }
-          placeholder="https://cdk.example.com/"
-          leftIcon={<CalendarDaysIcon className="h-5 w-5" />}
-        />
-      </FormField>
+        {checkIn.enableDetection && (
+          <div className="flex w-full items-center justify-between gap-4">
+            <div className="flex-1">
+              <label
+                htmlFor="auto-checkin-enabled"
+                className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
+              >
+                {t("form.autoCheckInEnabled")}
+              </label>
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {t("form.autoCheckInEnabledDesc")}
+              </p>
+            </div>
+            <Switch
+              checked={checkIn.autoCheckInEnabled !== false}
+              onChange={(autoCheckInEnabled) =>
+                onCheckInChange({ ...checkIn, autoCheckInEnabled })
+              }
+              id="auto-checkin-enabled"
+              className={`${
+                checkIn.autoCheckInEnabled !== false
+                  ? "bg-green-600"
+                  : "bg-gray-200"
+              } focus:ring-green-500`}
+            />
+          </div>
+        )}
 
-      {/* Open Redeem with Check-in Toggle - Only shown when custom check-in URL is set */}
-      {checkIn.customCheckIn?.url && (
-        <div className="flex w-full items-center justify-between">
-          <label
-            htmlFor="open-redeem-with-checkin"
-            className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
-          >
-            {t("form.openRedeemWithCheckIn")}
-          </label>
-          <Switch
-            checked={checkIn.customCheckIn?.openRedeemWithCheckIn ?? true}
-            onChange={(openRedeemWithCheckIn) =>
+        <FormField
+          label={t("form.customCheckInUrl")}
+          description={t("form.customCheckInDesc")}
+        >
+          <Input
+            type="url"
+            id="custom-checkin-url"
+            value={checkIn.customCheckIn?.url ?? ""}
+            onChange={(e) =>
+              onCheckInChange({
+                ...checkIn,
+                customCheckIn: {
+                  ...(checkIn.customCheckIn ?? {
+                    openRedeemWithCheckIn: true,
+                  }),
+                  url: e.target.value,
+                },
+              })
+            }
+            placeholder="https://cdk.example.com/"
+            leftIcon={<CalendarDaysIcon className="h-5 w-5" />}
+          />
+        </FormField>
+
+        {checkIn.customCheckIn?.url && (
+          <div className="flex w-full items-center justify-between gap-4">
+            <label
+              htmlFor="open-redeem-with-checkin"
+              className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
+            >
+              {t("form.openRedeemWithCheckIn")}
+            </label>
+            <Switch
+              checked={checkIn.customCheckIn?.openRedeemWithCheckIn ?? true}
+              onChange={(openRedeemWithCheckIn) =>
+                onCheckInChange({
+                  ...checkIn,
+                  customCheckIn: {
+                    ...(checkIn.customCheckIn ?? { url: "" }),
+                    openRedeemWithCheckIn,
+                  },
+                })
+              }
+              id="open-redeem-with-checkin"
+              className={`${
+                checkIn.customCheckIn?.openRedeemWithCheckIn ?? true
+                  ? "bg-green-600"
+                  : "bg-gray-200"
+              } focus:ring-green-500`}
+            />
+          </div>
+        )}
+
+        <FormField
+          label={t("form.customRedeemUrl")}
+          description={t("form.customRedeemUrlDesc")}
+        >
+          <Input
+            type="text"
+            id="custom-redeem-url"
+            value={checkIn.customCheckIn?.redeemUrl ?? ""}
+            onChange={(e) =>
               onCheckInChange({
                 ...checkIn,
                 customCheckIn: {
                   ...(checkIn.customCheckIn ?? { url: "" }),
-                  openRedeemWithCheckIn,
+                  redeemUrl: e.target.value,
                 },
               })
             }
-            id="open-redeem-with-checkin"
+            placeholder="https://example.com/console/topup"
+            leftIcon={<TicketIcon className="h-5 w-5" />}
+          />
+        </FormField>
+      </AccountFormSection>
+
+      <AccountFormSection
+        title={t("sections.balanceAndStats.title")}
+        defaultOpen={ACCOUNT_FORM_MOBILE_DEFAULT_OPEN.balance}
+        testId={ACCOUNT_MANAGEMENT_TEST_IDS.accountFormSectionBalance}
+      >
+        <FormField
+          label={t("form.exchangeRate")}
+          description={t("form.exchangeRateDesc")}
+          error={
+            !isValidExchangeRate(exchangeRate) && exchangeRate
+              ? t("form.validRateError")
+              : undefined
+          }
+          required
+        >
+          <Input
+            type="number"
+            step="any"
+            min="0"
+            value={exchangeRate}
+            onChange={(e) => onExchangeRateChange(e.target.value)}
+            placeholder={t("form.exchangeRatePlaceholder")}
+            leftIcon={<CurrencyDollarIcon className="h-5 w-5" />}
+            rightIcon={
+              <span className="dark:text-dark-text-secondary text-sm text-gray-500">
+                CNY
+              </span>
+            }
+            variant={
+              !isValidExchangeRate(exchangeRate) && exchangeRate
+                ? "error"
+                : "default"
+            }
+            required
+          />
+        </FormField>
+
+        <FormField
+          label={t("form.manualBalanceUsd")}
+          description={t("form.manualBalanceUsdDesc")}
+          error={
+            isManualBalanceUsdInvalid
+              ? t("form.manualBalanceUsdError")
+              : undefined
+          }
+        >
+          <Input
+            type="number"
+            step="any"
+            min="0"
+            value={manualBalanceUsd}
+            onChange={(e) => onManualBalanceUsdChange(e.target.value)}
+            placeholder={t("form.manualBalanceUsdPlaceholder")}
+            leftIcon={<CurrencyDollarIcon className="h-5 w-5" />}
+            rightIcon={
+              <span className="dark:text-dark-text-secondary text-sm text-gray-500">
+                USD
+              </span>
+            }
+            variant={isManualBalanceUsdInvalid ? "error" : "default"}
+          />
+        </FormField>
+
+        <div className="flex w-full items-center justify-between gap-4">
+          <div className="flex-1">
+            <label
+              htmlFor="exclude-from-total-balance"
+              className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
+            >
+              {t("form.excludeFromTotalBalance")}
+            </label>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {t("form.excludeFromTotalBalanceDesc")}
+            </p>
+          </div>
+          <Switch
+            checked={excludeFromTotalBalance}
+            onChange={onExcludeFromTotalBalanceChange}
+            id="exclude-from-total-balance"
             className={`${
-              checkIn.customCheckIn?.openRedeemWithCheckIn ?? true
-                ? "bg-green-600"
-                : "bg-gray-200"
+              excludeFromTotalBalance ? "bg-green-600" : "bg-gray-200"
             } focus:ring-green-500`}
           />
         </div>
-      )}
-
-      {/* Custom Redeem Url */}
-      <FormField
-        label={t("form.customRedeemUrl")}
-        description={t("form.customRedeemUrlDesc")}
-      >
-        <Input
-          type="text"
-          id="custom-redeem-url"
-          value={checkIn.customCheckIn?.redeemUrl ?? ""}
-          onChange={(e) =>
-            onCheckInChange({
-              ...checkIn,
-              customCheckIn: {
-                ...(checkIn.customCheckIn ?? { url: "" }),
-                redeemUrl: e.target.value,
-              },
-            })
-          }
-          placeholder="https://example.com/console/topup"
-          leftIcon={<TicketIcon className="h-5 w-5" />}
-        />
-      </FormField>
-
-      {/* 标签 */}
-      <FormField label={t("form.tags")} description={t("form.tagsDescription")}>
-        <TagPicker
-          tags={tags}
-          tagCountsById={tagCountsById}
-          selectedTagIds={tagIds}
-          onSelectedTagIdsChange={onSelectedTagIdsChange}
-          onCreateTag={createTag}
-          onRenameTag={renameTag}
-          onDeleteTag={deleteTag}
-          placeholder={t("form.tagsPlaceholder")}
-        />
-      </FormField>
-
-      {/* 备注 */}
-      <FormField label={t("form.notes")}>
-        <div className="relative">
-          <Textarea
-            value={notes}
-            onChange={(e) => onNotesChange(e.target.value)}
-            placeholder={t("form.notesPlaceholder")}
-            rows={2}
-          />
-        </div>
-      </FormField>
-    </>
+      </AccountFormSection>
+    </div>
   )
 }

--- a/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
@@ -15,7 +15,6 @@ import { useTranslation } from "react-i18next"
 import {
   Alert,
   Button,
-  CardDescription,
   FormField,
   IconButton,
   Input,
@@ -184,7 +183,11 @@ export default function AccountForm({
       >
         <FormField
           label={t("siteInfo.authMethod")}
-          description={isSub2Api ? t("siteInfo.sub2apiAuthOnly") : undefined}
+          description={
+            isSub2Api
+              ? t("siteInfo.sub2apiAuthOnly")
+              : t("siteInfo.cookieWarning")
+          }
         >
           <Select
             value={authType}
@@ -215,11 +218,6 @@ export default function AccountForm({
               )}
             </SelectContent>
           </Select>
-          {!isSub2Api && (
-            <CardDescription className="mt-2">
-              {t("siteInfo.cookieWarning")}
-            </CardDescription>
-          )}
         </FormField>
 
         <FormField label={t("form.username")} required>
@@ -487,6 +485,8 @@ export default function AccountForm({
               onCheckInChange({
                 ...checkIn,
                 enableDetection,
+                // When detection turns on, default auto check-in to true unless
+                // the user has explicitly disabled it with false.
                 autoCheckInEnabled:
                   enableDetection && checkIn.autoCheckInEnabled !== false
                     ? checkIn.autoCheckInEnabled ?? true

--- a/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
@@ -9,6 +9,7 @@ import {
   TicketIcon,
   UserIcon,
 } from "@heroicons/react/24/outline"
+import { Cookie } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -200,20 +201,21 @@ export default function AccountForm({
               data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger}
               data-auth-type={authType}
             >
-              <div className="flex items-center gap-2">
-                <KeyIcon className="text-muted-foreground h-5 w-5" />
-                <SelectValue
-                  placeholder={t("siteInfo.authMethodPlaceholder")}
-                />
-              </div>
+              <SelectValue placeholder={t("siteInfo.authMethodPlaceholder")} />
             </SelectTrigger>
             <SelectContent align="end" className="min-w-48">
               <SelectItem value={AuthTypeEnum.AccessToken}>
-                {t("siteInfo.authType.accessToken")}
+                <div className="flex items-center gap-2">
+                  <KeyIcon className="h-4 w-4" />
+                  <span>{t("siteInfo.authType.accessToken")}</span>
+                </div>
               </SelectItem>
               {!isSub2Api && (
                 <SelectItem value={AuthTypeEnum.Cookie}>
-                  {t("siteInfo.authType.cookieAuth")}
+                  <div className="flex items-center gap-2">
+                    <Cookie className="h-4 w-4" />
+                    <span>{t("siteInfo.authType.cookieAuth")}</span>
+                  </div>
                 </SelectItem>
               )}
             </SelectContent>

--- a/src/features/AccountManagement/components/AccountDialog/AccountFormSection.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountFormSection.tsx
@@ -34,7 +34,7 @@ export function AccountFormSection({
   if (isSmallScreen) {
     return (
       <div
-        data-testid={`${testId}-container`}
+        data-testid={testId}
         data-default-open={defaultOpen ? "true" : "false"}
         data-layout="mobile-collapsible"
       >
@@ -56,9 +56,7 @@ export function AccountFormSection({
           buttonClassName="rounded-md px-0 py-0 text-left hover:bg-transparent dark:hover:bg-transparent"
           panelClassName="mt-3 border-0 bg-transparent p-0"
         >
-          <div className="space-y-4" data-testid={testId}>
-            {children}
-          </div>
+          <div className="space-y-4">{children}</div>
         </CollapsibleSection>
       </div>
     )
@@ -66,7 +64,7 @@ export function AccountFormSection({
 
   return (
     <div
-      data-testid={`${testId}-container`}
+      data-testid={testId}
       data-default-open={defaultOpen ? "true" : "false"}
       data-layout="desktop-card"
     >
@@ -74,7 +72,6 @@ export function AccountFormSection({
         variant="default"
         padding="none"
         className="overflow-hidden shadow-sm"
-        data-testid={testId}
       >
         <CardHeader padding="sm">
           <CardTitle className="text-sm font-medium">{title}</CardTitle>

--- a/src/features/AccountManagement/components/AccountDialog/AccountFormSection.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountFormSection.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from "react"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  CollapsibleSection,
+} from "~/components/ui"
+import { useIsSmallScreen } from "~/hooks/useMediaQuery"
+
+interface AccountFormSectionProps {
+  title: string
+  description?: string
+  defaultOpen?: boolean
+  testId: string
+  children: ReactNode
+}
+
+/**
+ * Responsive section wrapper for the account form.
+ * Desktop uses static cards while mobile uses collapsible panels.
+ */
+export function AccountFormSection({
+  title,
+  description,
+  defaultOpen = false,
+  testId,
+  children,
+}: AccountFormSectionProps) {
+  const isSmallScreen = useIsSmallScreen()
+
+  if (isSmallScreen) {
+    return (
+      <div
+        data-testid={`${testId}-container`}
+        data-default-open={defaultOpen ? "true" : "false"}
+        data-layout="mobile-collapsible"
+      >
+        <CollapsibleSection
+          title={
+            <div className="min-w-0">
+              <div className="dark:text-dark-text-primary truncate text-sm font-medium text-gray-900">
+                {title}
+              </div>
+              {description && (
+                <div className="dark:text-dark-text-secondary mt-1 text-xs text-gray-500">
+                  {description}
+                </div>
+              )}
+            </div>
+          }
+          defaultOpen={defaultOpen}
+          className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary rounded-lg border border-gray-200 bg-white px-3 py-2 shadow-sm"
+          buttonClassName="rounded-md px-0 py-0 text-left hover:bg-transparent dark:hover:bg-transparent"
+          panelClassName="mt-3 border-0 bg-transparent p-0"
+        >
+          <div className="space-y-4" data-testid={testId}>
+            {children}
+          </div>
+        </CollapsibleSection>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-testid={`${testId}-container`}
+      data-default-open={defaultOpen ? "true" : "false"}
+      data-layout="desktop-card"
+    >
+      <Card
+        variant="default"
+        padding="none"
+        className="overflow-hidden shadow-sm"
+        data-testid={testId}
+      >
+        <CardHeader padding="sm">
+          <CardTitle className="text-sm font-medium">{title}</CardTitle>
+          {description && <CardDescription>{description}</CardDescription>}
+        </CardHeader>
+        <CardContent padding="sm" spacing="sm">
+          {children}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -7,18 +7,10 @@ import {
 import { useTranslation } from "react-i18next"
 
 import Tooltip from "~/components/Tooltip"
-import {
-  Button,
-  Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/ui"
+import { Button, Input } from "~/components/ui"
 import { SUB2API } from "~/constants/siteType"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
-import { AuthTypeEnum, type DisplaySiteData } from "~/types"
+import type { DisplaySiteData } from "~/types"
 
 interface SiteInfoInputProps {
   url: string
@@ -26,8 +18,6 @@ interface SiteInfoInputProps {
   isDetected: boolean
   onClearUrl: () => void
   siteType?: string
-  authType: AuthTypeEnum
-  onAuthTypeChange: (authType: AuthTypeEnum) => void
   // Props for "add" mode
   currentTabUrl?: string | null
   isCurrentSiteAdded?: boolean
@@ -58,8 +48,6 @@ export default function SiteInfoInput({
   isDetected,
   onClearUrl,
   siteType,
-  authType,
-  onAuthTypeChange,
   currentTabUrl,
   isCurrentSiteAdded,
   detectedAccount,
@@ -77,66 +65,24 @@ export default function SiteInfoInput({
 
   return (
     <div className="space-y-2">
-      <div className="flex justify-between">
-        <label
-          htmlFor="site-url"
-          className="dark:text-dark-text-secondary block text-sm font-medium text-gray-700"
-        >
-          {t("siteInfo.siteUrl")}
-        </label>
-        <label
-          htmlFor="auth-type"
-          className="dark:text-dark-text-secondary block text-sm font-medium text-gray-700"
-        >
-          {t("siteInfo.authMethod")}
-        </label>
-      </div>
-      <div className="flex items-center gap-2">
-        <div className="relative grow">
-          <Input
-            id="site-url"
-            type="text"
-            value={url}
-            onChange={(e) => onUrlChange(e.target.value)}
-            placeholder="https://example.com"
-            disabled={isDetected}
-            data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput}
-            onClear={onClearUrl}
-            clearButtonLabel={t("common:actions.clear")}
-          />
-        </div>
-        <Tooltip
-          content={
-            isSub2Api
-              ? t("siteInfo.sub2apiAuthOnly")
-              : t("siteInfo.cookieWarning")
-          }
-        >
-          <Select
-            value={authType}
-            onValueChange={(value) => onAuthTypeChange(value as AuthTypeEnum)}
-            disabled={isDetected || isSub2Api}
-          >
-            <SelectTrigger
-              id="auth-type"
-              className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary dark:text-dark-text-primary w-full"
-              data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger}
-              data-auth-type={authType}
-            >
-              <SelectValue placeholder={t("siteInfo.authMethodPlaceholder")} />
-            </SelectTrigger>
-            <SelectContent align="end" className="min-w-48">
-              <SelectItem value={AuthTypeEnum.AccessToken}>
-                {t("siteInfo.authType.accessToken")}
-              </SelectItem>
-              {!isSub2Api && (
-                <SelectItem value={AuthTypeEnum.Cookie}>
-                  {t("siteInfo.authType.cookieAuth")}
-                </SelectItem>
-              )}
-            </SelectContent>
-          </Select>
-        </Tooltip>
+      <label
+        htmlFor="site-url"
+        className="dark:text-dark-text-secondary block text-sm font-medium text-gray-700"
+      >
+        {t("siteInfo.siteUrl")}
+      </label>
+      <div className="relative grow">
+        <Input
+          id="site-url"
+          type="text"
+          value={url}
+          onChange={(e) => onUrlChange(e.target.value)}
+          placeholder="https://example.com"
+          disabled={isDetected}
+          data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput}
+          onClear={onClearUrl}
+          clearButtonLabel={t("common:actions.clear")}
+        />
       </div>
       <div className="flex flex-col justify-between gap-y-2 text-xs">
         {isSub2Api && (

--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -22,15 +22,12 @@ import { SUB2API } from "~/constants/siteType"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import { AuthTypeEnum, type DisplaySiteData } from "~/types"
 
-interface SiteInfoInputProps {
+interface SiteInfoInputBaseProps {
   url: string
   onUrlChange: (url: string) => void
   isDetected: boolean
   onClearUrl: () => void
   siteType?: string
-  authType?: AuthTypeEnum
-  onAuthTypeChange?: (value: AuthTypeEnum) => void
-  showAuthTypeSelector?: boolean
   // Props for "add" mode
   currentTabUrl?: string | null
   isCurrentSiteAdded?: boolean
@@ -38,6 +35,20 @@ interface SiteInfoInputProps {
   onUseCurrentTab?: () => void
   onEditAccount?: (account: DisplaySiteData) => void
 }
+
+type SiteInfoInputWithAuthSelectorProps = SiteInfoInputBaseProps & {
+  showAuthTypeSelector: true
+  authType: AuthTypeEnum
+  onAuthTypeChange: (value: AuthTypeEnum) => void
+}
+
+type SiteInfoInputWithoutAuthSelectorProps = SiteInfoInputBaseProps & {
+  showAuthTypeSelector?: false
+}
+
+type SiteInfoInputProps =
+  | SiteInfoInputWithAuthSelectorProps
+  | SiteInfoInputWithoutAuthSelectorProps
 
 /**
  * Site information section displaying the URL input with contextual helpers
@@ -48,34 +59,29 @@ interface SiteInfoInputProps {
  * @param props.isDetected Whether the site info was auto-detected (locks inputs when true).
  * @param props.onClearUrl Clears the URL field.
  * @param props.siteType Detected or selected site type, used for contextual hints.
- * @param props.authType Selected authentication method for the add-mode entry flow.
- * @param props.onAuthTypeChange Handler updating the selected authentication method.
  * @param props.showAuthTypeSelector Whether to show the auth selector in the add-mode entry flow.
+ * When true, authType and onAuthTypeChange are required.
  * @param props.currentTabUrl URL detected from the active browser tab.
  * @param props.isCurrentSiteAdded Indicates if the current site already exists.
  * @param props.detectedAccount Account info detected from the site.
  * @param props.onUseCurrentTab Handler to reuse the current tab URL.
  * @param props.onEditAccount Handler to edit the detected account entry.
  */
-export default function SiteInfoInput({
-  url,
-  onUrlChange,
-  isDetected,
-  onClearUrl,
-  siteType,
-  authType,
-  onAuthTypeChange,
-  showAuthTypeSelector = false,
-  currentTabUrl,
-  isCurrentSiteAdded,
-  detectedAccount,
-  onUseCurrentTab,
-  onEditAccount,
-}: SiteInfoInputProps) {
+export default function SiteInfoInput(props: SiteInfoInputProps) {
+  const {
+    url,
+    onUrlChange,
+    isDetected,
+    onClearUrl,
+    siteType,
+    currentTabUrl,
+    isCurrentSiteAdded,
+    detectedAccount,
+    onUseCurrentTab,
+    onEditAccount,
+  } = props
   const { t } = useTranslation(["accountDialog", "common"])
   const isSub2Api = siteType === SUB2API
-  const shouldShowEntryAuthSelector =
-    !isDetected && showAuthTypeSelector && authType && onAuthTypeChange
 
   const handleEditClick = () => {
     if (detectedAccount && onEditAccount) {
@@ -85,7 +91,7 @@ export default function SiteInfoInput({
 
   return (
     <div className="space-y-2">
-      {shouldShowEntryAuthSelector ? (
+      {!isDetected && props.showAuthTypeSelector === true ? (
         <>
           <div className="flex justify-between gap-2">
             <label
@@ -120,9 +126,9 @@ export default function SiteInfoInput({
               }
             >
               <Select
-                value={authType}
+                value={props.authType}
                 onValueChange={(value) =>
-                  onAuthTypeChange(value as AuthTypeEnum)
+                  props.onAuthTypeChange(value as AuthTypeEnum)
                 }
                 disabled={isSub2Api}
               >
@@ -130,7 +136,7 @@ export default function SiteInfoInput({
                   className="w-full"
                   aria-label={t("siteInfo.authMethod")}
                   data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger}
-                  data-auth-type={authType}
+                  data-auth-type={props.authType}
                 >
                   <SelectValue
                     placeholder={t("siteInfo.authMethodPlaceholder")}

--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -2,15 +2,25 @@ import {
   ExclamationTriangleIcon,
   GlobeAltIcon,
   InformationCircleIcon,
+  KeyIcon,
   PencilIcon,
 } from "@heroicons/react/24/outline"
+import { Cookie } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import Tooltip from "~/components/Tooltip"
-import { Button, Input } from "~/components/ui"
+import {
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui"
 import { SUB2API } from "~/constants/siteType"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
-import type { DisplaySiteData } from "~/types"
+import { AuthTypeEnum, type DisplaySiteData } from "~/types"
 
 interface SiteInfoInputProps {
   url: string
@@ -18,6 +28,9 @@ interface SiteInfoInputProps {
   isDetected: boolean
   onClearUrl: () => void
   siteType?: string
+  authType?: AuthTypeEnum
+  onAuthTypeChange?: (value: AuthTypeEnum) => void
+  showAuthTypeSelector?: boolean
   // Props for "add" mode
   currentTabUrl?: string | null
   isCurrentSiteAdded?: boolean
@@ -35,6 +48,9 @@ interface SiteInfoInputProps {
  * @param props.isDetected Whether the site info was auto-detected (locks inputs when true).
  * @param props.onClearUrl Clears the URL field.
  * @param props.siteType Detected or selected site type, used for contextual hints.
+ * @param props.authType Selected authentication method for the add-mode entry flow.
+ * @param props.onAuthTypeChange Handler updating the selected authentication method.
+ * @param props.showAuthTypeSelector Whether to show the auth selector in the add-mode entry flow.
  * @param props.currentTabUrl URL detected from the active browser tab.
  * @param props.isCurrentSiteAdded Indicates if the current site already exists.
  * @param props.detectedAccount Account info detected from the site.
@@ -47,6 +63,9 @@ export default function SiteInfoInput({
   isDetected,
   onClearUrl,
   siteType,
+  authType,
+  onAuthTypeChange,
+  showAuthTypeSelector = false,
   currentTabUrl,
   isCurrentSiteAdded,
   detectedAccount,
@@ -55,6 +74,8 @@ export default function SiteInfoInput({
 }: SiteInfoInputProps) {
   const { t } = useTranslation(["accountDialog", "common"])
   const isSub2Api = siteType === SUB2API
+  const shouldShowEntryAuthSelector =
+    !isDetected && showAuthTypeSelector && authType && onAuthTypeChange
 
   const handleEditClick = () => {
     if (detectedAccount && onEditAccount) {
@@ -64,25 +85,100 @@ export default function SiteInfoInput({
 
   return (
     <div className="space-y-2">
-      <label
-        htmlFor="site-url"
-        className="dark:text-dark-text-secondary block text-sm font-medium text-gray-700"
-      >
-        {t("siteInfo.siteUrl")}
-      </label>
-      <div className="relative grow">
-        <Input
-          id="site-url"
-          type="text"
-          value={url}
-          onChange={(e) => onUrlChange(e.target.value)}
-          placeholder="https://example.com"
-          disabled={isDetected}
-          data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput}
-          onClear={onClearUrl}
-          clearButtonLabel={t("common:actions.clear")}
-        />
-      </div>
+      {shouldShowEntryAuthSelector ? (
+        <>
+          <div className="flex justify-between gap-2">
+            <label
+              htmlFor="site-url"
+              className="dark:text-dark-text-secondary block text-sm font-medium text-gray-700"
+            >
+              {t("siteInfo.siteUrl")}
+            </label>
+            <label className="dark:text-dark-text-secondary block text-sm font-medium text-gray-700">
+              {t("siteInfo.authMethod")}
+            </label>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="relative grow">
+              <Input
+                id="site-url"
+                type="text"
+                value={url}
+                onChange={(e) => onUrlChange(e.target.value)}
+                placeholder="https://example.com"
+                disabled={isDetected}
+                data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput}
+                onClear={onClearUrl}
+                clearButtonLabel={t("common:actions.clear")}
+              />
+            </div>
+            <Tooltip
+              content={
+                isSub2Api
+                  ? t("siteInfo.sub2apiAuthOnly")
+                  : t("siteInfo.cookieWarning")
+              }
+            >
+              <Select
+                value={authType}
+                onValueChange={(value) =>
+                  onAuthTypeChange(value as AuthTypeEnum)
+                }
+                disabled={isSub2Api}
+              >
+                <SelectTrigger
+                  className="w-full"
+                  aria-label={t("siteInfo.authMethod")}
+                  data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger}
+                  data-auth-type={authType}
+                >
+                  <SelectValue
+                    placeholder={t("siteInfo.authMethodPlaceholder")}
+                  />
+                </SelectTrigger>
+                <SelectContent align="end" className="min-w-48">
+                  <SelectItem value={AuthTypeEnum.AccessToken}>
+                    <div className="flex items-center gap-2">
+                      <KeyIcon className="h-4 w-4" />
+                      <span>{t("siteInfo.authType.accessToken")}</span>
+                    </div>
+                  </SelectItem>
+                  {!isSub2Api && (
+                    <SelectItem value={AuthTypeEnum.Cookie}>
+                      <div className="flex items-center gap-2">
+                        <Cookie className="h-4 w-4" />
+                        <span>{t("siteInfo.authType.cookieAuth")}</span>
+                      </div>
+                    </SelectItem>
+                  )}
+                </SelectContent>
+              </Select>
+            </Tooltip>
+          </div>
+        </>
+      ) : (
+        <>
+          <label
+            htmlFor="site-url"
+            className="dark:text-dark-text-secondary block text-sm font-medium text-gray-700"
+          >
+            {t("siteInfo.siteUrl")}
+          </label>
+          <div className="relative grow">
+            <Input
+              id="site-url"
+              type="text"
+              value={url}
+              onChange={(e) => onUrlChange(e.target.value)}
+              placeholder="https://example.com"
+              disabled={isDetected}
+              data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput}
+              onClear={onClearUrl}
+              clearButtonLabel={t("common:actions.clear")}
+            />
+          </div>
+        </>
+      )}
       <div className="flex flex-col justify-between gap-y-2 text-xs">
         {isSub2Api && (
           <div className="flex w-full items-start gap-2 rounded-md bg-blue-50 p-2 text-xs text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">

--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -27,15 +27,14 @@ interface SiteInfoInputProps {
 }
 
 /**
- * Site information section displaying URL input and auth selector with contextual helpers.
+ * Site information section displaying the URL input with contextual helpers
+ * such as current-tab reuse, already-added warnings, and the sub2api hint.
  * @param props Component props defining field values, detection state, and callbacks.
  * @param props.url Current site URL value.
  * @param props.onUrlChange Handler updating the site URL.
  * @param props.isDetected Whether the site info was auto-detected (locks inputs when true).
  * @param props.onClearUrl Clears the URL field.
  * @param props.siteType Detected or selected site type, used for contextual hints.
- * @param props.authType Selected authentication method.
- * @param props.onAuthTypeChange Handler updating the authentication method.
  * @param props.currentTabUrl URL detected from the active browser tab.
  * @param props.isCurrentSiteAdded Indicates if the current site already exists.
  * @param props.detectedAccount Account info detected from the site.

--- a/src/features/AccountManagement/components/AccountDialog/accountFormSections.ts
+++ b/src/features/AccountManagement/components/AccountDialog/accountFormSections.ts
@@ -1,0 +1,20 @@
+export const ACCOUNT_FORM_SECTION_IDS = [
+  "site-info",
+  "account-auth",
+  "tags-notes",
+  "check-in",
+  "balance",
+] as const
+
+export type AccountFormSectionId = (typeof ACCOUNT_FORM_SECTION_IDS)[number]
+
+export const ACCOUNT_FORM_MOBILE_DEFAULT_OPEN: Record<
+  AccountFormSectionId,
+  boolean
+> = {
+  "site-info": true,
+  "account-auth": true,
+  "tags-notes": true,
+  "check-in": true,
+  balance: false,
+}

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -136,6 +136,12 @@ export default function AccountDialog({
               isDetected={state.isDetected}
               onClearUrl={handlers.handleClearUrl}
               siteType={state.siteType}
+              authType={state.authType}
+              onAuthTypeChange={setters.setAuthType}
+              showAuthTypeSelector={
+                mode === DIALOG_MODES.ADD &&
+                state.phase === ACCOUNT_DIALOG_PHASES.SITE_INPUT
+              }
               {...(mode === DIALOG_MODES.ADD && {
                 currentTabUrl: state.currentTabUrl,
                 isCurrentSiteAdded: detectedSiteAccounts.length > 0,

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -1,3 +1,5 @@
+import type { ComponentProps } from "react"
+
 import { ThemeAwareToaster } from "~/components/ThemeAwareToaster"
 import { Modal } from "~/components/ui/Dialog/Modal"
 import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
@@ -79,6 +81,40 @@ export default function AccountDialog({
 
   const detectedDisplayAccount =
     displayData.find((acc) => acc.id === detectedAccount?.id) ?? null
+  const showEntryAuthTypeSelector =
+    mode === DIALOG_MODES.ADD &&
+    state.phase === ACCOUNT_DIALOG_PHASES.SITE_INPUT
+  const addModeSiteInfoProps =
+    mode === DIALOG_MODES.ADD
+      ? {
+          currentTabUrl: state.currentTabUrl,
+          isCurrentSiteAdded: detectedSiteAccounts.length > 0,
+          detectedAccount: detectedDisplayAccount,
+          onUseCurrentTab: handlers.handleUseCurrentTabUrl,
+          onEditAccount: openEditAccount,
+        }
+      : {}
+  const siteInfoInputProps: ComponentProps<typeof SiteInfoInput> =
+    showEntryAuthTypeSelector
+      ? {
+          url: state.url,
+          onUrlChange: handlers.handleUrlChange,
+          isDetected: state.isDetected,
+          onClearUrl: handlers.handleClearUrl,
+          siteType: state.siteType,
+          showAuthTypeSelector: true,
+          authType: state.authType,
+          onAuthTypeChange: setters.setAuthType,
+          ...addModeSiteInfoProps,
+        }
+      : {
+          url: state.url,
+          onUrlChange: handlers.handleUrlChange,
+          isDetected: state.isDetected,
+          onClearUrl: handlers.handleClearUrl,
+          siteType: state.siteType,
+          ...addModeSiteInfoProps,
+        }
 
   return (
     <>
@@ -130,26 +166,7 @@ export default function AccountDialog({
               <AutoDetectSlowHintAlert />
             )}
 
-            <SiteInfoInput
-              url={state.url}
-              onUrlChange={handlers.handleUrlChange}
-              isDetected={state.isDetected}
-              onClearUrl={handlers.handleClearUrl}
-              siteType={state.siteType}
-              authType={state.authType}
-              onAuthTypeChange={setters.setAuthType}
-              showAuthTypeSelector={
-                mode === DIALOG_MODES.ADD &&
-                state.phase === ACCOUNT_DIALOG_PHASES.SITE_INPUT
-              }
-              {...(mode === DIALOG_MODES.ADD && {
-                currentTabUrl: state.currentTabUrl,
-                isCurrentSiteAdded: detectedSiteAccounts.length > 0,
-                detectedAccount: detectedDisplayAccount,
-                onUseCurrentTab: handlers.handleUseCurrentTabUrl,
-                onEditAccount: openEditAccount,
-              })}
-            />
+            <SiteInfoInput {...siteInfoInputProps} />
 
             {state.phase === ACCOUNT_DIALOG_PHASES.ACCOUNT_FORM && (
               <AccountForm

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -136,8 +136,6 @@ export default function AccountDialog({
               isDetected={state.isDetected}
               onClearUrl={handlers.handleClearUrl}
               siteType={state.siteType}
-              authType={state.authType}
-              onAuthTypeChange={setters.setAuthType}
               {...(mode === DIALOG_MODES.ADD && {
                 currentTabUrl: state.currentTabUrl,
                 isCurrentSiteAdded: detectedSiteAccounts.length > 0,
@@ -150,6 +148,7 @@ export default function AccountDialog({
             {state.phase === ACCOUNT_DIALOG_PHASES.ACCOUNT_FORM && (
               <AccountForm
                 draft={state.draft}
+                isDetected={state.isDetected}
                 isImportingSub2apiSession={state.isImportingSub2apiSession}
                 isManualBalanceUsdInvalid={state.isManualBalanceUsdInvalid}
                 showAccessToken={state.showAccessToken}
@@ -179,6 +178,7 @@ export default function AccountDialog({
                 deleteTag={deleteTag}
                 onCheckInChange={setters.setCheckIn}
                 onSiteTypeChange={setters.setSiteType}
+                onAuthTypeChange={setters.setAuthType}
                 isImportingCookies={state.isImportingCookies}
                 showCookiePermissionWarning={state.showCookiePermissionWarning}
                 onCookieAuthSessionCookieChange={

--- a/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
+++ b/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
@@ -539,7 +539,7 @@ export default function SiteInfo({
           </div>
         </div>
 
-        <div className="flex min-w-0 items-start gap-1">
+        <div className="mt-0.5 flex min-w-0 items-start gap-1">
           <UserIcon className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
           <Caption className="truncate" title={site.username}>
             {highlights?.username && site.username

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -12,6 +12,13 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   usernameInput: "account-management-username-input",
   userIdInput: "account-management-user-id-input",
   accessTokenInput: "account-management-access-token-input",
+  accountFormSectionSiteInfo:
+    "account-management-account-form-section-site-info",
+  accountFormSectionAuth: "account-management-account-form-section-auth",
+  accountFormSectionTagsNotes:
+    "account-management-account-form-section-tags-notes",
+  accountFormSectionCheckIn: "account-management-account-form-section-check-in",
+  accountFormSectionBalance: "account-management-account-form-section-balance",
   sub2apiRefreshTokenSwitch: "account-management-sub2api-refresh-token-switch",
   sub2apiImportSessionButton:
     "account-management-sub2api-import-session-button",

--- a/src/locales/en/accountDialog.json
+++ b/src/locales/en/accountDialog.json
@@ -112,6 +112,24 @@
     "manualAdd": "Manual Add",
     "reDetect": "Re-detect"
   },
+  "sections": {
+    "accountAuth": {
+      "title": "Account Authentication"
+    },
+    "balanceAndStats": {
+      "title": "Balance & Stats"
+    },
+    "checkInConfig": {
+      "title": "Check-in Settings"
+    },
+    "siteInfo": {
+      "title": "Site Information"
+    },
+    "tagsAndNotes": {
+      "description": "Tags help organize, filter, and quickly identify accounts, while notes add supporting context.",
+      "title": "Tags & Notes"
+    }
+  },
   "siteInfo": {
     "alreadyAdded": "Account(s) already exist for this site",
     "authMethod": "Authentication Method",

--- a/src/locales/ja/accountDialog.json
+++ b/src/locales/ja/accountDialog.json
@@ -111,6 +111,24 @@
     "manualAdd": "手動追加",
     "reDetect": "再検出"
   },
+  "sections": {
+    "accountAuth": {
+      "title": "アカウント認証"
+    },
+    "balanceAndStats": {
+      "title": "残高と統計"
+    },
+    "checkInConfig": {
+      "title": "チェックイン設定"
+    },
+    "siteInfo": {
+      "title": "サイト情報"
+    },
+    "tagsAndNotes": {
+      "description": "タグはアカウントの整理、絞り込み、素早い識別に役立ち、メモは補足情報を残します。",
+      "title": "タグとメモ"
+    }
+  },
   "siteInfo": {
     "alreadyAdded": "このサイトにはすでにアカウントがあります",
     "authMethod": "認証方式",

--- a/src/locales/zh-CN/accountDialog.json
+++ b/src/locales/zh-CN/accountDialog.json
@@ -111,6 +111,24 @@
     "manualAdd": "手动添加",
     "reDetect": "重新识别"
   },
+  "sections": {
+    "accountAuth": {
+      "title": "账号认证"
+    },
+    "balanceAndStats": {
+      "title": "余额与统计"
+    },
+    "checkInConfig": {
+      "title": "签到配置"
+    },
+    "siteInfo": {
+      "title": "站点信息"
+    },
+    "tagsAndNotes": {
+      "description": "标签用于组织、筛选和快速识别账号，备注用于补充上下文。",
+      "title": "标签与备注"
+    }
+  },
   "siteInfo": {
     "alreadyAdded": "该站点已存在账号",
     "authMethod": "认证方式",

--- a/src/locales/zh-TW/accountDialog.json
+++ b/src/locales/zh-TW/accountDialog.json
@@ -111,6 +111,24 @@
     "manualAdd": "手動新增",
     "reDetect": "重新識別"
   },
+  "sections": {
+    "accountAuth": {
+      "title": "帳號認證"
+    },
+    "balanceAndStats": {
+      "title": "餘額與統計"
+    },
+    "checkInConfig": {
+      "title": "簽到設定"
+    },
+    "siteInfo": {
+      "title": "站點資訊"
+    },
+    "tagsAndNotes": {
+      "description": "標籤用於組織、篩選與快速識別帳號，備註則補充上下文。",
+      "title": "標籤與備註"
+    }
+  },
   "siteInfo": {
     "alreadyAdded": "該站點已存在帳號",
     "authMethod": "認證方式",

--- a/tests/features/AccountManagement/components/AccountDialog.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialog.test.tsx
@@ -217,7 +217,7 @@ describe("AccountDialog", () => {
     resetMockState()
   })
 
-  it("hides the form before the dialog reaches the account-form phase", () => {
+  it("hides the form before the dialog reaches the account-form phase", async () => {
     mockState.phase = ACCOUNT_DIALOG_PHASES.SITE_INPUT
     mockState.formSource = ACCOUNT_DIALOG_FORM_SOURCES.MANUAL
 
@@ -231,9 +231,13 @@ describe("AccountDialog", () => {
       />,
     )
 
+    await screen.findByLabelText("accountDialog:siteInfo.siteUrl")
     expect(
       screen.queryByTestId("account-management-site-name-input"),
     ).not.toBeInTheDocument()
+    expect(
+      await screen.findByTestId("account-management-auth-type-trigger"),
+    ).toBeInTheDocument()
   })
 
   it("renders the account form after entering the account-form phase", async () => {
@@ -253,5 +257,25 @@ describe("AccountDialog", () => {
     expect(
       await screen.findByTestId("account-management-site-name-input"),
     ).toBeInTheDocument()
+  })
+
+  it("does not show the entry auth selector in edit mode", async () => {
+    mockState.phase = ACCOUNT_DIALOG_PHASES.SITE_INPUT
+    mockState.formSource = ACCOUNT_DIALOG_FORM_SOURCES.MANUAL
+
+    render(
+      <AccountDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.EDIT}
+        onSuccess={vi.fn()}
+        onError={vi.fn()}
+      />,
+    )
+
+    await screen.findByLabelText("accountDialog:siteInfo.siteUrl")
+    expect(
+      screen.queryByTestId("account-management-auth-type-trigger"),
+    ).not.toBeInTheDocument()
   })
 })

--- a/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
@@ -177,6 +177,28 @@ describe("AccountDialog AccountForm", () => {
     expect(props.onAuthTypeChange).toHaveBeenCalledWith(AuthTypeEnum.Cookie)
   })
 
+  it("disables auth type changes when the account data is detected", async () => {
+    const user = userEvent.setup()
+    const props = createProps()
+    props.isDetected = true
+
+    render(<AccountForm {...props} />)
+
+    const authTypeTrigger = await screen.findByTestId(
+      "account-management-auth-type-trigger",
+    )
+    expect(authTypeTrigger).toBeDisabled()
+
+    await user.click(authTypeTrigger)
+
+    expect(
+      screen.queryByRole("option", {
+        name: "accountDialog:siteInfo.authType.cookieAuth",
+      }),
+    ).not.toBeInTheDocument()
+    expect(props.onAuthTypeChange).not.toHaveBeenCalled()
+  })
+
   it("uses a consistent section subtree on mobile and honors the default-open layout", async () => {
     mediaQueryState.isSmallScreen = true
     const user = userEvent.setup()

--- a/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
@@ -342,6 +342,18 @@ describe("AccountDialog AccountForm", () => {
     )
   })
 
+  it("renders the access token as visible text when showAccessToken is enabled", async () => {
+    const props = createProps()
+    props.showAccessToken = true
+
+    render(<AccountForm {...props} />)
+
+    expect(await screen.findByDisplayValue("secret-token")).toHaveAttribute(
+      "type",
+      "text",
+    )
+  })
+
   it("shows cookie-auth import fallback UI and permission guidance when cookie auth is selected", async () => {
     const user = userEvent.setup()
     const props = createProps()
@@ -376,6 +388,24 @@ describe("AccountDialog AccountForm", () => {
     expect(props.onCookieAuthSessionCookieChange).toHaveBeenLastCalledWith(
       "session=abc; Path=/",
     )
+  })
+
+  it("marks the cookie-auth textarea as required and shows the idle import CTA", async () => {
+    const props = createProps()
+    props.draft.authType = AuthTypeEnum.Cookie
+
+    render(<AccountForm {...props} />)
+
+    expect(
+      await screen.findByRole("button", {
+        name: "accountDialog:form.importCookieAuthSessionCookie",
+      }),
+    ).toBeEnabled()
+    expect(
+      await screen.findByPlaceholderText(
+        "accountDialog:form.cookieAuthSessionCookiePlaceholder",
+      ),
+    ).toBeRequired()
   })
 
   it("renders Sub2API refresh-token controls, visibility toggles, and expiry metadata", async () => {

--- a/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
@@ -1,12 +1,20 @@
 import userEvent from "@testing-library/user-event"
 import type { ComponentProps } from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SUB2API, UNKNOWN_SITE } from "~/constants/siteType"
 import AccountForm from "~/features/AccountManagement/components/AccountDialog/AccountForm"
 import { createEmptyAccountDialogDraft } from "~/features/AccountManagement/components/AccountDialog/models"
 import { AuthTypeEnum, type CheckInConfig } from "~/types"
-import { fireEvent, render, screen } from "~~/tests/test-utils/render"
+import { fireEvent, render, screen, within } from "~~/tests/test-utils/render"
+
+const mediaQueryState = {
+  isSmallScreen: false,
+}
+
+vi.mock("~/hooks/useMediaQuery", () => ({
+  useIsSmallScreen: () => mediaQueryState.isSmallScreen,
+}))
 
 vi.mock("~/features/AccountManagement/components/TagPicker", () => ({
   TagPicker: ({
@@ -32,6 +40,10 @@ vi.mock("~/utils/core/formatters", () => ({
 }))
 
 describe("AccountDialog AccountForm", () => {
+  beforeEach(() => {
+    mediaQueryState.isSmallScreen = false
+  })
+
   const createCheckIn = (
     overrides: Partial<CheckInConfig> = {},
   ): CheckInConfig =>
@@ -62,6 +74,7 @@ describe("AccountDialog AccountForm", () => {
       siteType: UNKNOWN_SITE,
       checkIn: createCheckIn(),
     },
+    isDetected: false,
     isManualBalanceUsdInvalid: false,
     showAccessToken: false,
     isImportingCookies: false,
@@ -89,7 +102,60 @@ describe("AccountDialog AccountForm", () => {
     renameTag: vi.fn(),
     deleteTag: vi.fn(),
     onSiteTypeChange: vi.fn(),
+    onAuthTypeChange: vi.fn(),
     onCheckInChange: vi.fn(),
+  })
+
+  it("renders the desktop sections in the expected order and groups auth fields together", async () => {
+    const props = createProps()
+
+    render(<AccountForm {...props} />)
+
+    const sections = await screen.findAllByTestId(
+      /^account-management-account-form-section-(site-info|auth|tags-notes|check-in|balance)$/,
+    )
+    expect(sections).toHaveLength(5)
+    expect(sections.map((section) => section.dataset.testid)).toEqual([
+      "account-management-account-form-section-site-info",
+      "account-management-account-form-section-auth",
+      "account-management-account-form-section-tags-notes",
+      "account-management-account-form-section-check-in",
+      "account-management-account-form-section-balance",
+    ])
+
+    expect(
+      screen.getByText("accountDialog:sections.siteInfo.title"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("accountDialog:sections.accountAuth.title"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("accountDialog:sections.tagsAndNotes.title"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("accountDialog:sections.checkInConfig.title"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("accountDialog:sections.balanceAndStats.title"),
+    ).toBeInTheDocument()
+
+    const authSection = screen.getByTestId(
+      "account-management-account-form-section-auth",
+    )
+    expect(
+      within(authSection).getByRole("combobox", {
+        name: "accountDialog:siteInfo.authMethod",
+      }),
+    ).toBeInTheDocument()
+    expect(within(authSection).getByDisplayValue("alice")).toBeInTheDocument()
+    expect(
+      within(authSection).getByPlaceholderText(
+        "accountDialog:form.userIdNumber",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(authSection).getByDisplayValue("secret-token"),
+    ).toBeInTheDocument()
   })
 
   it("propagates core field edits, exposes access-token controls, and surfaces validation states", async () => {

--- a/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SUB2API, UNKNOWN_SITE } from "~/constants/siteType"
 import AccountForm from "~/features/AccountManagement/components/AccountDialog/AccountForm"
+import { ACCOUNT_FORM_MOBILE_DEFAULT_OPEN } from "~/features/AccountManagement/components/AccountDialog/accountFormSections"
 import { createEmptyAccountDialogDraft } from "~/features/AccountManagement/components/AccountDialog/models"
 import { AuthTypeEnum, type CheckInConfig } from "~/types"
 import { fireEvent, render, screen, within } from "~~/tests/test-utils/render"
@@ -155,6 +156,84 @@ describe("AccountDialog AccountForm", () => {
     ).toBeInTheDocument()
     expect(
       within(authSection).getByDisplayValue("secret-token"),
+    ).toBeInTheDocument()
+  })
+
+  it("propagates auth type changes from the grouped auth section", async () => {
+    const user = userEvent.setup()
+    const props = createProps()
+
+    render(<AccountForm {...props} />)
+
+    await user.click(
+      await screen.findByTestId("account-management-auth-type-trigger"),
+    )
+    await user.click(
+      await screen.findByRole("option", {
+        name: "accountDialog:siteInfo.authType.cookieAuth",
+      }),
+    )
+
+    expect(props.onAuthTypeChange).toHaveBeenCalledWith(AuthTypeEnum.Cookie)
+  })
+
+  it("uses a consistent section subtree on mobile and honors the default-open layout", async () => {
+    mediaQueryState.isSmallScreen = true
+    const user = userEvent.setup()
+    const props = createProps()
+
+    render(<AccountForm {...props} />)
+
+    const siteInfoSection = await screen.findByTestId(
+      "account-management-account-form-section-site-info",
+    )
+    const authSection = screen.getByTestId(
+      "account-management-account-form-section-auth",
+    )
+    const balanceSection = screen.getByTestId(
+      "account-management-account-form-section-balance",
+    )
+
+    expect(siteInfoSection).toHaveAttribute("data-layout", "mobile-collapsible")
+    expect(siteInfoSection).toHaveAttribute(
+      "data-default-open",
+      String(ACCOUNT_FORM_MOBILE_DEFAULT_OPEN["site-info"]),
+    )
+    expect(authSection).toHaveAttribute(
+      "data-default-open",
+      String(ACCOUNT_FORM_MOBILE_DEFAULT_OPEN["account-auth"]),
+    )
+    expect(balanceSection).toHaveAttribute(
+      "data-default-open",
+      String(ACCOUNT_FORM_MOBILE_DEFAULT_OPEN.balance),
+    )
+
+    expect(
+      within(siteInfoSection).getByText(
+        "accountDialog:sections.siteInfo.title",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(authSection).getByRole("combobox", {
+        name: "accountDialog:siteInfo.authMethod",
+      }),
+    ).toBeInTheDocument()
+    expect(
+      within(balanceSection).queryByPlaceholderText(
+        "accountDialog:form.exchangeRatePlaceholder",
+      ),
+    ).not.toBeInTheDocument()
+
+    await user.click(
+      within(balanceSection).getByRole("button", {
+        name: /accountDialog:sections\.balanceAndStats\.title/i,
+      }),
+    )
+
+    expect(
+      within(balanceSection).getByPlaceholderText(
+        "accountDialog:form.exchangeRatePlaceholder",
+      ),
     ).toBeInTheDocument()
   })
 
@@ -340,6 +419,7 @@ describe("AccountDialog AccountForm", () => {
   it("updates check-in toggles and custom check-in config with the expected fallback defaults", async () => {
     const user = userEvent.setup()
     const props = createProps()
+    const onCheckInChange = vi.mocked(props.onCheckInChange)
 
     const { rerender } = render(<AccountForm {...props} />)
 
@@ -348,16 +428,37 @@ describe("AccountDialog AccountForm", () => {
         name: "accountDialog:form.checkInStatus",
       }),
     )
-    expect(props.onCheckInChange).toHaveBeenCalledWith({
+    expect(onCheckInChange).toHaveBeenCalledWith({
       ...props.draft.checkIn,
       enableDetection: true,
       autoCheckInEnabled: true,
     })
 
+    onCheckInChange.mockClear()
+    const explicitFalseCheckIn = createCheckIn({
+      enableDetection: false,
+      autoCheckInEnabled: false,
+    })
+    props.draft.checkIn = explicitFalseCheckIn
+
+    rerender(<AccountForm {...props} />)
+
+    await user.click(
+      screen.getByRole("switch", {
+        name: "accountDialog:form.checkInStatus",
+      }),
+    )
+    expect(onCheckInChange).toHaveBeenCalledWith({
+      ...explicitFalseCheckIn,
+      enableDetection: true,
+      autoCheckInEnabled: false,
+    })
+
+    onCheckInChange.mockClear()
     fireEvent.change(screen.getByPlaceholderText("https://cdk.example.com/"), {
       target: { value: "https://check.example.com/" },
     })
-    expect(props.onCheckInChange).toHaveBeenLastCalledWith({
+    expect(onCheckInChange).toHaveBeenLastCalledWith({
       ...props.draft.checkIn,
       customCheckIn: {
         openRedeemWithCheckIn: true,
@@ -383,7 +484,7 @@ describe("AccountDialog AccountForm", () => {
         name: "accountDialog:form.autoCheckInEnabled",
       }),
     )
-    expect(props.onCheckInChange).toHaveBeenCalledWith({
+    expect(onCheckInChange).toHaveBeenCalledWith({
       ...nextCheckIn,
       autoCheckInEnabled: true,
     })
@@ -393,7 +494,7 @@ describe("AccountDialog AccountForm", () => {
         name: "accountDialog:form.openRedeemWithCheckIn",
       }),
     )
-    expect(props.onCheckInChange).toHaveBeenCalledWith({
+    expect(onCheckInChange).toHaveBeenCalledWith({
       ...nextCheckIn,
       customCheckIn: {
         ...nextCheckIn.customCheckIn,
@@ -405,11 +506,35 @@ describe("AccountDialog AccountForm", () => {
       screen.getByPlaceholderText("https://example.com/console/topup"),
       { target: { value: "https://redeem.example.com/" } },
     )
-    expect(props.onCheckInChange).toHaveBeenLastCalledWith({
+    expect(onCheckInChange).toHaveBeenLastCalledWith({
       ...nextCheckIn,
       customCheckIn: {
         ...nextCheckIn.customCheckIn,
         redeemUrl: "https://redeem.example.com/",
+      },
+    })
+
+    onCheckInChange.mockClear()
+    const missingRedeemToggleCheckIn = createCheckIn({
+      enableDetection: true,
+      customCheckIn: {
+        url: "https://check.example.com/",
+      },
+    })
+    props.draft.checkIn = missingRedeemToggleCheckIn
+
+    rerender(<AccountForm {...props} />)
+
+    await user.click(
+      screen.getByRole("switch", {
+        name: "accountDialog:form.openRedeemWithCheckIn",
+      }),
+    )
+    expect(onCheckInChange).toHaveBeenCalledWith({
+      ...missingRedeemToggleCheckIn,
+      customCheckIn: {
+        ...missingRedeemToggleCheckIn.customCheckIn,
+        openRedeemWithCheckIn: false,
       },
     })
   })

--- a/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
@@ -8,7 +8,12 @@ import { AuthTypeEnum } from "~/types"
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
 describe("AccountDialog SiteInfoInput", () => {
-  const createProps = (): ComponentProps<typeof SiteInfoInput> => ({
+  type AddModeSiteInfoInputProps = Extract<
+    ComponentProps<typeof SiteInfoInput>,
+    { showAuthTypeSelector: true }
+  >
+
+  const createAddModeProps = (): AddModeSiteInfoInputProps => ({
     url: "https://api.example.com",
     onUrlChange: vi.fn(),
     isDetected: false,
@@ -26,7 +31,7 @@ describe("AccountDialog SiteInfoInput", () => {
 
   it("propagates URL edits, clears the field, and reuses the current tab URL", async () => {
     const user = userEvent.setup()
-    const props = createProps()
+    const props = createAddModeProps()
 
     render(<SiteInfoInput {...props} />)
 
@@ -59,7 +64,7 @@ describe("AccountDialog SiteInfoInput", () => {
 
   it("lets users choose auth type before entering the form", async () => {
     const user = userEvent.setup()
-    const props = createProps()
+    const props = createAddModeProps()
 
     render(<SiteInfoInput {...props} />)
 
@@ -80,7 +85,7 @@ describe("AccountDialog SiteInfoInput", () => {
   })
 
   it("shows the generic already-added warning and disables current-tab reuse when the tab URL is unavailable", async () => {
-    const props = createProps()
+    const props = createAddModeProps()
     props.currentTabUrl = null
     props.isCurrentSiteAdded = true
 
@@ -105,7 +110,7 @@ describe("AccountDialog SiteInfoInput", () => {
   })
 
   it("locks the site fields for detected Sub2API sites and hides the add-mode current-tab helper", async () => {
-    const props = createProps()
+    const props = createAddModeProps()
     props.isDetected = true
     props.siteType = SUB2API
 
@@ -131,7 +136,7 @@ describe("AccountDialog SiteInfoInput", () => {
   })
 
   it("keeps the entry auth selector visible but locked for add-mode Sub2API", async () => {
-    const props = createProps()
+    const props = createAddModeProps()
     props.siteType = SUB2API
 
     render(<SiteInfoInput {...props} />)
@@ -146,7 +151,7 @@ describe("AccountDialog SiteInfoInput", () => {
 
   it("shows the current-login warning and forwards edit requests for the detected account", async () => {
     const user = userEvent.setup()
-    const props = createProps()
+    const props = createAddModeProps()
     const detectedAccount = {
       id: "account-1",
       name: "Existing Account",
@@ -172,5 +177,36 @@ describe("AccountDialog SiteInfoInput", () => {
     )
 
     expect(props.onEditAccount).toHaveBeenCalledWith(detectedAccount)
+  })
+
+  it("renders the plain URL-only layout when the entry auth selector is disabled", async () => {
+    const props: ComponentProps<typeof SiteInfoInput> = {
+      url: "https://api.example.com",
+      onUrlChange: vi.fn(),
+      isDetected: false,
+      onClearUrl: vi.fn(),
+      siteType: "new-api",
+      currentTabUrl: "https://current.example.com",
+      isCurrentSiteAdded: false,
+      detectedAccount: null,
+      onUseCurrentTab: vi.fn(),
+      onEditAccount: vi.fn(),
+    }
+
+    render(<SiteInfoInput {...props} />)
+
+    const urlInput = await screen.findByLabelText(
+      "accountDialog:siteInfo.siteUrl",
+    )
+    fireEvent.change(urlInput, {
+      target: { value: "https://manual.example.com" },
+    })
+
+    expect(props.onUrlChange).toHaveBeenLastCalledWith(
+      "https://manual.example.com",
+    )
+    expect(
+      screen.queryByTestId("account-management-auth-type-trigger"),
+    ).not.toBeInTheDocument()
   })
 })

--- a/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { SUB2API } from "~/constants/siteType"
 import SiteInfoInput from "~/features/AccountManagement/components/AccountDialog/SiteInfoInput"
+import { AuthTypeEnum } from "~/types"
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
 describe("AccountDialog SiteInfoInput", () => {
@@ -13,6 +14,9 @@ describe("AccountDialog SiteInfoInput", () => {
     isDetected: false,
     onClearUrl: vi.fn(),
     siteType: "new-api",
+    authType: AuthTypeEnum.AccessToken,
+    onAuthTypeChange: vi.fn(),
+    showAuthTypeSelector: true,
     currentTabUrl: "https://current.example.com",
     isCurrentSiteAdded: false,
     detectedAccount: null,
@@ -51,6 +55,28 @@ describe("AccountDialog SiteInfoInput", () => {
 
     await user.click(useCurrentButton)
     expect(props.onUseCurrentTab).toHaveBeenCalledTimes(1)
+  })
+
+  it("lets users choose auth type before entering the form", async () => {
+    const user = userEvent.setup()
+    const props = createProps()
+
+    render(<SiteInfoInput {...props} />)
+
+    expect(
+      await screen.findByLabelText("accountDialog:siteInfo.authMethod"),
+    ).toBeEnabled()
+
+    await user.click(
+      await screen.findByTestId("account-management-auth-type-trigger"),
+    )
+    await user.click(
+      await screen.findByRole("option", {
+        name: "accountDialog:siteInfo.authType.cookieAuth",
+      }),
+    )
+
+    expect(props.onAuthTypeChange).toHaveBeenCalledWith(AuthTypeEnum.Cookie)
   })
 
   it("shows the generic already-added warning and disables current-tab reuse when the tab URL is unavailable", async () => {
@@ -99,6 +125,23 @@ describe("AccountDialog SiteInfoInput", () => {
         name: "accountDialog:siteInfo.useCurrent",
       }),
     ).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId("account-management-auth-type-trigger"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps the entry auth selector visible but locked for add-mode Sub2API", async () => {
+    const props = createProps()
+    props.siteType = SUB2API
+
+    render(<SiteInfoInput {...props} />)
+
+    expect(
+      await screen.findByText("accountDialog:siteInfo.sub2apiHint"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText("accountDialog:siteInfo.authMethod"),
+    ).toBeDisabled()
   })
 
   it("shows the current-login warning and forwards edit requests for the detected account", async () => {

--- a/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
@@ -4,7 +4,6 @@ import { describe, expect, it, vi } from "vitest"
 
 import { SUB2API } from "~/constants/siteType"
 import SiteInfoInput from "~/features/AccountManagement/components/AccountDialog/SiteInfoInput"
-import { AuthTypeEnum } from "~/types"
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
 describe("AccountDialog SiteInfoInput", () => {
@@ -14,8 +13,6 @@ describe("AccountDialog SiteInfoInput", () => {
     isDetected: false,
     onClearUrl: vi.fn(),
     siteType: "new-api",
-    authType: AuthTypeEnum.AccessToken,
-    onAuthTypeChange: vi.fn(),
     currentTabUrl: "https://current.example.com",
     isCurrentSiteAdded: false,
     detectedAccount: null,
@@ -23,7 +20,7 @@ describe("AccountDialog SiteInfoInput", () => {
     onEditAccount: vi.fn(),
   })
 
-  it("propagates URL edits, clears the field, changes auth type, and reuses the current tab URL", async () => {
+  it("propagates URL edits, clears the field, and reuses the current tab URL", async () => {
     const user = userEvent.setup()
     const props = createProps()
 
@@ -46,18 +43,6 @@ describe("AccountDialog SiteInfoInput", () => {
       screen.getByRole("button", { name: "common:actions.clear" }),
     )
     expect(props.onClearUrl).toHaveBeenCalledTimes(1)
-
-    await user.click(
-      screen.getByRole("combobox", {
-        name: "accountDialog:siteInfo.authMethod",
-      }),
-    )
-    await user.click(
-      await screen.findByRole("option", {
-        name: "accountDialog:siteInfo.authType.cookieAuth",
-      }),
-    )
-    expect(props.onAuthTypeChange).toHaveBeenCalledWith(AuthTypeEnum.Cookie)
 
     const useCurrentButton = screen.getByRole("button", {
       name: "accountDialog:siteInfo.useCurrent",
@@ -105,11 +90,6 @@ describe("AccountDialog SiteInfoInput", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByLabelText("accountDialog:siteInfo.siteUrl"),
-    ).toBeDisabled()
-    expect(
-      screen.getByRole("combobox", {
-        name: "accountDialog:siteInfo.authMethod",
-      }),
     ).toBeDisabled()
     expect(
       screen.queryByRole("button", { name: "common:actions.clear" }),

--- a/tests/features/AccountManagement/components/accountFormSections.test.ts
+++ b/tests/features/AccountManagement/components/accountFormSections.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ACCOUNT_FORM_MOBILE_DEFAULT_OPEN,
+  ACCOUNT_FORM_SECTION_IDS,
+} from "~/features/AccountManagement/components/AccountDialog/accountFormSections"
+
+describe("accountFormSections config", () => {
+  it("defines the section order used by the account form information architecture", () => {
+    expect(ACCOUNT_FORM_SECTION_IDS).toEqual([
+      "site-info",
+      "account-auth",
+      "tags-notes",
+      "check-in",
+      "balance",
+    ])
+  })
+
+  it("keeps check-in ahead of balance in the mobile default-open strategy", () => {
+    expect(ACCOUNT_FORM_MOBILE_DEFAULT_OPEN).toEqual({
+      "site-info": true,
+      "account-auth": true,
+      "tags-notes": true,
+      "check-in": true,
+      balance: false,
+    })
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account form reorganized into clear sections (Site Info, Authentication, Tags & Notes, Check‑in, Balance) with responsive behavior: collapsible on mobile, card layout on desktop.
  * Authentication selector can be shown/hidden and is disabled when a site/account is auto‑detected; changes propagate within the form.

* **User Experience**
  * Site input supports add-mode auth selector, streamlined URL/current‑tab workflows; mobile default-open behavior tuned.

* **Localization**
  * Added localized titles/descriptions for the new account form sections.

* **Tests**
  * Expanded tests and new test IDs covering section behavior, responsive layouts, auth flows, and check‑in controls.

* **Style**
  * Minor spacing tweak in account list display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->