### PR TITLE
feat: Add scheduled task notification system

### DIFF
--- a/src/constants/runtimeActions.ts
+++ b/src/constants/runtimeActions.ts
@@ -25,6 +25,7 @@ export const RuntimeActionPrefixes = {
   Preferences: "preferences:",
   ReleaseUpdate: "releaseUpdate:",
   RedemptionAssist: "redemptionAssist:",
+  TaskNotifications: "taskNotifications:",
   UsageHistory: "usageHistory:",
   WebdavAutoSync: "webdavAutoSync:",
 } as const
@@ -281,6 +282,11 @@ export const RuntimeActionIds = {
   RedemptionAssistContextMenuTrigger: composeRuntimeAction(
     RuntimeActionPrefixes.RedemptionAssist,
     "contextMenuTrigger",
+  ),
+
+  TaskNotificationsTest: composeRuntimeAction(
+    RuntimeActionPrefixes.TaskNotifications,
+    "test",
   ),
 
   UsageHistoryUpdateSettings: composeRuntimeAction(

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -1452,7 +1452,11 @@ export const UserPreferencesProvider = ({
         setPreferences((prev) =>
           prev
             ? deepOverride(prev, {
-                taskNotifications: updates,
+                taskNotifications: deepOverride(
+                  prev.taskNotifications ??
+                    DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+                  updates,
+                ),
                 lastUpdated: Date.now(),
               })
             : prev,

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -49,6 +49,10 @@ import {
 import type { LogLevel } from "~/types/logging"
 import type { ModelRedirectPreferences } from "~/types/managedSiteModelRedirect"
 import type { SortingPriorityConfig } from "~/types/sorting"
+import {
+  DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+  type TaskNotificationPreferences,
+} from "~/types/taskNotifications"
 import type { ThemeMode } from "~/types/theme"
 import type { WebDAVSettings } from "~/types/webdav"
 import { deepOverride } from "~/utils"
@@ -179,6 +183,7 @@ interface UserPreferencesContextType {
   loggingLevel: LogLevel
   tempWindowFallback: TempWindowFallbackPreferences
   tempWindowFallbackReminder: TempWindowFallbackReminderPreferences
+  taskNotifications: TaskNotificationPreferences
 
   updateActiveTab: (activeTab: DashboardTabType) => Promise<boolean>
   updateDefaultTab: (activeTab: DashboardTabType) => Promise<boolean>
@@ -351,6 +356,9 @@ interface UserPreferencesContextType {
   updateTempWindowFallbackReminder: (
     updates: Partial<TempWindowFallbackReminderPreferences>,
   ) => Promise<boolean>
+  updateTaskNotifications: (
+    updates: Partial<TaskNotificationPreferences>,
+  ) => Promise<boolean>
   resetToDefaults: () => Promise<boolean>
   resetDisplaySettings: () => Promise<boolean>
   resetAutoRefreshConfig: () => Promise<boolean>
@@ -370,6 +378,7 @@ interface UserPreferencesContextType {
   resetWebdavConfig: () => Promise<boolean>
   resetLoggingSettings: () => Promise<boolean>
   resetSortingPriorityConfig: () => Promise<boolean>
+  resetTaskNotifications: () => Promise<boolean>
   loadPreferences: () => Promise<void>
 }
 
@@ -1436,6 +1445,24 @@ export const UserPreferencesProvider = ({
     [],
   )
 
+  const updateTaskNotifications = useCallback(
+    async (updates: Partial<TaskNotificationPreferences>) => {
+      const success = await userPreferences.updateTaskNotifications(updates)
+      if (success) {
+        setPreferences((prev) =>
+          prev
+            ? deepOverride(prev, {
+                taskNotifications: updates,
+                lastUpdated: Date.now(),
+              })
+            : prev,
+        )
+      }
+      return success
+    },
+    [],
+  )
+
   const resetToDefaults = useCallback(async () => {
     const success = await userPreferences.resetToDefaults()
     if (success) {
@@ -1699,6 +1726,21 @@ export const UserPreferencesProvider = ({
     return success
   }, [])
 
+  const resetTaskNotifications = useCallback(async () => {
+    const success = await userPreferences.resetTaskNotifications()
+    if (success) {
+      setPreferences((prev) =>
+        prev
+          ? deepOverride(prev, {
+              taskNotifications: DEFAULT_PREFERENCES.taskNotifications,
+              lastUpdated: Date.now(),
+            })
+          : prev,
+      )
+    }
+    return success
+  }, [])
+
   useEffect(() => {
     if (!preferences) return
 
@@ -1811,6 +1853,8 @@ export const UserPreferencesProvider = ({
     tempWindowFallbackReminder:
       preferences.tempWindowFallbackReminder ??
       (DEFAULT_PREFERENCES.tempWindowFallbackReminder as TempWindowFallbackReminderPreferences),
+    taskNotifications:
+      preferences.taskNotifications ?? DEFAULT_TASK_NOTIFICATION_PREFERENCES,
     updateActiveTab,
     updateDefaultTab,
     updateCurrencyType,
@@ -1867,6 +1911,7 @@ export const UserPreferencesProvider = ({
     updateWebdavAutoSyncSettings,
     updateTempWindowFallback,
     updateTempWindowFallbackReminder,
+    updateTaskNotifications,
     resetToDefaults,
     resetDisplaySettings,
     resetAutoRefreshConfig,
@@ -1886,6 +1931,7 @@ export const UserPreferencesProvider = ({
     resetWebdavConfig,
     resetLoggingSettings,
     resetSortingPriorityConfig,
+    resetTaskNotifications,
     loadPreferences,
   }
 

--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -15,6 +15,7 @@ import { handleUsageHistoryMessage } from "~/services/history/usageHistory/sched
 import { handleLdohSiteLookupMessage } from "~/services/integrations/ldohSiteLookup/background"
 import { handleChannelConfigMessage } from "~/services/managedSites/channelConfigStorage"
 import { handleManagedSiteModelSyncMessage } from "~/services/models/modelSync"
+import { handleTaskNotificationMessage } from "~/services/notifications/taskNotificationService"
 import { handleRedemptionAssistMessage } from "~/services/redemption/redemptionAssist"
 import { handleReleaseUpdateMessage } from "~/services/updates/releaseUpdateService"
 import { handleWebAiApiCheckMessage } from "~/services/verification/webAiApiCheck/background"
@@ -318,6 +319,16 @@ export function setupRuntimeMessageListeners() {
         )
       ) {
         void handleRedemptionAssistMessage(request, sender, sendResponse)
+        return true
+      }
+
+      if (
+        hasRuntimeActionPrefix(
+          request.action,
+          RuntimeActionPrefixes.TaskNotifications,
+        )
+      ) {
+        void handleTaskNotificationMessage(request, sendResponse)
         return true
       }
 

--- a/src/entrypoints/background/servicesInit.ts
+++ b/src/entrypoints/background/servicesInit.ts
@@ -4,6 +4,7 @@ import { dailyBalanceHistoryScheduler } from "~/services/history/dailyBalanceHis
 import { usageHistoryScheduler } from "~/services/history/usageHistory/scheduler"
 import { modelMetadataService } from "~/services/models/modelMetadata"
 import { modelSyncScheduler } from "~/services/models/modelSync"
+import { initializeTaskNotificationService } from "~/services/notifications/taskNotificationService"
 import { redemptionAssistService } from "~/services/redemption/redemptionAssist"
 import { releaseUpdateService } from "~/services/updates/releaseUpdateService"
 import { webdavAutoSyncService } from "~/services/webdav/webdavAutoSyncService"
@@ -57,6 +58,7 @@ export async function initializeServices() {
         dailyBalanceHistoryScheduler.initialize(),
         releaseUpdateService.initialize(),
       ])
+      initializeTaskNotificationService()
 
       await initBackgroundI18n().catch((error) => {
         logger.warn("Background i18n initialization failed", error)

--- a/src/features/BasicSettings/components/dialogs/PermissionOnboardingDialog.tsx
+++ b/src/features/BasicSettings/components/dialogs/PermissionOnboardingDialog.tsx
@@ -47,6 +47,8 @@ function getPermissionTitle(t: TFunction, id: ManifestOptionalPermissions) {
       return t("settings:permissions.items.webRequestBlocking.title")
     case "clipboardRead":
       return t("settings:permissions.items.clipboardRead.title")
+    case "notifications":
+      return t("settings:permissions.items.notifications.title")
   }
 }
 
@@ -70,6 +72,8 @@ function getPermissionDescription(
       return t("settings:permissions.items.webRequestBlocking.description")
     case "clipboardRead":
       return t("settings:permissions.items.clipboardRead.description")
+    case "notifications":
+      return t("settings:permissions.items.notifications.description")
   }
 }
 

--- a/src/features/BasicSettings/components/tabs/General/AppearanceSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/AppearanceSettings.tsx
@@ -1,0 +1,37 @@
+import { LanguageIcon } from "@heroicons/react/24/outline"
+import { useTranslation } from "react-i18next"
+
+import { LanguageSwitcher } from "~/components/LanguageSwitcher"
+import { BodySmall, Card, CardItem, CardList, Heading3 } from "~/components/ui"
+import ThemeToggle from "~/entrypoints/options/components/ThemeToggle"
+
+/**
+ * Settings section for theme and interface language preferences.
+ */
+export default function AppearanceSettings() {
+  const { t } = useTranslation("settings")
+
+  return (
+    <section id="appearance" className="space-y-6">
+      <div className="space-y-1.5">
+        <Heading3>{t("theme.appearance")}</Heading3>
+        <BodySmall>{t("display.description")}</BodySmall>
+      </div>
+
+      <Card padding="none">
+        <CardList>
+          <ThemeToggle />
+          <CardItem
+            id="appearance-language"
+            icon={
+              <LanguageIcon className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+            }
+            title={t("appearanceLanguage.language")}
+            description={t("appearanceLanguage.languageDesc")}
+            rightContent={<LanguageSwitcher />}
+          />
+        </CardList>
+      </Card>
+    </section>
+  )
+}

--- a/src/features/BasicSettings/components/tabs/General/General.search.ts
+++ b/src/features/BasicSettings/components/tabs/General/General.search.ts
@@ -11,7 +11,7 @@ const TASK_NOTIFICATION_BREADCRUMBS = [
   "settings:taskNotifications.title",
 ]
 
-const TASK_NOTIFICATION_CONTROL_ORDER_START = 513
+const TASK_NOTIFICATION_CONTROL_ORDER_START = 509
 
 const TASK_NOTIFICATION_SEARCH_CONTROLS = [
   {
@@ -64,46 +64,46 @@ export const generalSearchSections: OptionsSearchItemDefinition[] = [
     200,
   ),
   buildSectionDefinition(
-    "section:action-click",
-    "general",
-    "action-click",
-    "settings:actionClick.title",
-    201,
-  ),
-  buildSectionDefinition(
-    "section:logging",
-    "general",
-    "logging",
-    "settings:logging.title",
-    202,
-  ),
-  buildSectionDefinition(
-    "section:changelog",
-    "general",
-    "changelog-on-update",
-    "settings:changelogOnUpdate.title",
-    203,
-  ),
-  buildSectionDefinition(
     "section:appearance",
     "general",
     "appearance",
     "settings:theme.appearance",
-    204,
+    201,
     {
       descriptionKey: "settings:display.description",
     },
+  ),
+  buildSectionDefinition(
+    "section:action-click",
+    "general",
+    "action-click",
+    "settings:actionClick.title",
+    202,
   ),
   buildSectionDefinition(
     "section:task-notifications",
     "general",
     "task-notifications",
     "settings:taskNotifications.title",
-    205,
+    203,
     {
       descriptionKey: "settings:taskNotifications.description",
       keywords: ["notification", "scheduled task", "alarm"],
     },
+  ),
+  buildSectionDefinition(
+    "section:changelog",
+    "general",
+    "changelog-on-update",
+    "settings:changelogOnUpdate.title",
+    204,
+  ),
+  buildSectionDefinition(
+    "section:logging",
+    "general",
+    "logging",
+    "settings:logging.title",
+    205,
   ),
   buildSectionDefinition(
     "section:danger",
@@ -230,75 +230,11 @@ export const generalSearchControls: OptionsSearchItemDefinition[] = [
     },
   ),
   buildControlDefinition(
-    "control:logging-enabled",
-    "general",
-    "logging-console-enabled",
-    "settings:logging.consoleEnabled",
-    507,
-    {
-      descriptionKey: "settings:logging.consoleEnabledDesc",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:logging.title",
-      ],
-      keywords: ["log", "console", "debug"],
-    },
-  ),
-  buildControlDefinition(
-    "control:logging-min-level",
-    "general",
-    "logging-min-level",
-    "settings:logging.minLevel",
-    508,
-    {
-      descriptionKey: "settings:logging.minLevelDesc",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:logging.title",
-      ],
-      keywords: ["log", "debug", "warn", "error", "info"],
-    },
-  ),
-  buildControlDefinition(
-    "control:changelog-on-update",
-    "general",
-    "changelog-on-update-toggle",
-    "settings:changelogOnUpdate.toggleLabel",
-    509,
-    {
-      descriptionKey: "settings:changelogOnUpdate.toggleDesc",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:changelogOnUpdate.title",
-      ],
-      keywords: ["changelog", "what's new", "update log"],
-    },
-  ),
-  buildControlDefinition(
-    "control:danger-reset-settings",
-    "general",
-    "danger-reset-settings",
-    "settings:danger.resetSettings",
-    510,
-    {
-      descriptionKey: "settings:danger.resetDesc",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:danger.title",
-      ],
-      keywords: ["danger", "reset", "reset settings", "defaults"],
-    },
-  ),
-  buildControlDefinition(
     "control:task-notifications-enabled",
     "general",
     "task-notifications-enabled",
     "settings:taskNotifications.enable",
-    511,
+    507,
     {
       descriptionKey: "settings:taskNotifications.enableDesc",
       breadcrumbsKeys: TASK_NOTIFICATION_BREADCRUMBS,
@@ -310,7 +246,7 @@ export const generalSearchControls: OptionsSearchItemDefinition[] = [
     "general",
     "task-notifications-permission",
     "settings:taskNotifications.permission.title",
-    512,
+    508,
     {
       descriptionKey: "settings:taskNotifications.permission.description",
       breadcrumbsKeys: TASK_NOTIFICATION_BREADCRUMBS,
@@ -330,5 +266,69 @@ export const generalSearchControls: OptionsSearchItemDefinition[] = [
         keywords: [...definition.keywords],
       },
     ),
+  ),
+  buildControlDefinition(
+    "control:changelog-on-update",
+    "general",
+    "changelog-on-update-toggle",
+    "settings:changelogOnUpdate.toggleLabel",
+    514,
+    {
+      descriptionKey: "settings:changelogOnUpdate.toggleDesc",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:changelogOnUpdate.title",
+      ],
+      keywords: ["changelog", "what's new", "update log"],
+    },
+  ),
+  buildControlDefinition(
+    "control:logging-enabled",
+    "general",
+    "logging-console-enabled",
+    "settings:logging.consoleEnabled",
+    515,
+    {
+      descriptionKey: "settings:logging.consoleEnabledDesc",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:logging.title",
+      ],
+      keywords: ["log", "console", "debug"],
+    },
+  ),
+  buildControlDefinition(
+    "control:logging-min-level",
+    "general",
+    "logging-min-level",
+    "settings:logging.minLevel",
+    516,
+    {
+      descriptionKey: "settings:logging.minLevelDesc",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:logging.title",
+      ],
+      keywords: ["log", "debug", "warn", "error", "info"],
+    },
+  ),
+  buildControlDefinition(
+    "control:danger-reset-settings",
+    "general",
+    "danger-reset-settings",
+    "settings:danger.resetSettings",
+    517,
+    {
+      descriptionKey: "settings:danger.resetDesc",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:danger.title",
+      ],
+      keywords: ["danger", "reset", "reset settings", "defaults"],
+    },
   ),
 ]

--- a/src/features/BasicSettings/components/tabs/General/General.search.ts
+++ b/src/features/BasicSettings/components/tabs/General/General.search.ts
@@ -69,9 +69,6 @@ export const generalSearchSections: OptionsSearchItemDefinition[] = [
     "appearance",
     "settings:theme.appearance",
     201,
-    {
-      descriptionKey: "settings:display.description",
-    },
   ),
   buildSectionDefinition(
     "section:action-click",

--- a/src/features/BasicSettings/components/tabs/General/General.search.ts
+++ b/src/features/BasicSettings/components/tabs/General/General.search.ts
@@ -5,6 +5,56 @@ import {
 } from "~/entrypoints/options/search/registryHelpers"
 import type { OptionsSearchItemDefinition } from "~/entrypoints/options/search/types"
 
+const TASK_NOTIFICATION_BREADCRUMBS = [
+  ...DEFAULT_BREADCRUMBS,
+  "settings:tabs.general",
+  "settings:taskNotifications.title",
+]
+
+const TASK_NOTIFICATION_CONTROL_ORDER_START = 513
+
+const TASK_NOTIFICATION_SEARCH_CONTROLS = [
+  {
+    searchId: "control:task-notifications-auto-checkin",
+    targetId: "task-notifications-autoCheckin",
+    labelKey: "settings:taskNotifications.tasks.autoCheckin",
+    descriptionKey: "settings:taskNotifications.taskDescriptions.autoCheckin",
+    keywords: ["notification", "auto checkin", "check-in"],
+  },
+  {
+    searchId: "control:task-notifications-webdav-auto-sync",
+    targetId: "task-notifications-webdavAutoSync",
+    labelKey: "settings:taskNotifications.tasks.webdavAutoSync",
+    descriptionKey:
+      "settings:taskNotifications.taskDescriptions.webdavAutoSync",
+    keywords: ["notification", "webdav", "auto sync"],
+  },
+  {
+    searchId: "control:task-notifications-managed-site-model-sync",
+    targetId: "task-notifications-managedSiteModelSync",
+    labelKey: "settings:taskNotifications.tasks.managedSiteModelSync",
+    descriptionKey:
+      "settings:taskNotifications.taskDescriptions.managedSiteModelSync",
+    keywords: ["notification", "model sync", "managed site"],
+  },
+  {
+    searchId: "control:task-notifications-usage-history-sync",
+    targetId: "task-notifications-usageHistorySync",
+    labelKey: "settings:taskNotifications.tasks.usageHistorySync",
+    descriptionKey:
+      "settings:taskNotifications.taskDescriptions.usageHistorySync",
+    keywords: ["notification", "usage history", "sync"],
+  },
+  {
+    searchId: "control:task-notifications-balance-history-capture",
+    targetId: "task-notifications-balanceHistoryCapture",
+    labelKey: "settings:taskNotifications.tasks.balanceHistoryCapture",
+    descriptionKey:
+      "settings:taskNotifications.taskDescriptions.balanceHistoryCapture",
+    keywords: ["notification", "balance history", "capture"],
+  },
+] as const
+
 export const generalSearchSections: OptionsSearchItemDefinition[] = [
   buildSectionDefinition(
     "section:display",
@@ -251,11 +301,7 @@ export const generalSearchControls: OptionsSearchItemDefinition[] = [
     511,
     {
       descriptionKey: "settings:taskNotifications.enableDesc",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:taskNotifications.title",
-      ],
+      breadcrumbsKeys: TASK_NOTIFICATION_BREADCRUMBS,
       keywords: ["notification", "scheduled task", "background task"],
     },
   ),
@@ -267,96 +313,22 @@ export const generalSearchControls: OptionsSearchItemDefinition[] = [
     512,
     {
       descriptionKey: "settings:taskNotifications.permission.description",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:taskNotifications.title",
-      ],
+      breadcrumbsKeys: TASK_NOTIFICATION_BREADCRUMBS,
       keywords: ["notification", "permission", "system notification"],
     },
   ),
-  buildControlDefinition(
-    "control:task-notifications-auto-checkin",
-    "general",
-    "task-notifications-autoCheckin",
-    "settings:taskNotifications.tasks.autoCheckin",
-    513,
-    {
-      descriptionKey: "settings:taskNotifications.taskDescriptions.autoCheckin",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:taskNotifications.title",
-      ],
-      keywords: ["notification", "auto checkin", "check-in"],
-    },
-  ),
-  buildControlDefinition(
-    "control:task-notifications-webdav-auto-sync",
-    "general",
-    "task-notifications-webdavAutoSync",
-    "settings:taskNotifications.tasks.webdavAutoSync",
-    514,
-    {
-      descriptionKey:
-        "settings:taskNotifications.taskDescriptions.webdavAutoSync",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:taskNotifications.title",
-      ],
-      keywords: ["notification", "webdav", "auto sync"],
-    },
-  ),
-  buildControlDefinition(
-    "control:task-notifications-managed-site-model-sync",
-    "general",
-    "task-notifications-managedSiteModelSync",
-    "settings:taskNotifications.tasks.managedSiteModelSync",
-    515,
-    {
-      descriptionKey:
-        "settings:taskNotifications.taskDescriptions.managedSiteModelSync",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:taskNotifications.title",
-      ],
-      keywords: ["notification", "model sync", "managed site"],
-    },
-  ),
-  buildControlDefinition(
-    "control:task-notifications-usage-history-sync",
-    "general",
-    "task-notifications-usageHistorySync",
-    "settings:taskNotifications.tasks.usageHistorySync",
-    516,
-    {
-      descriptionKey:
-        "settings:taskNotifications.taskDescriptions.usageHistorySync",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:taskNotifications.title",
-      ],
-      keywords: ["notification", "usage history", "sync"],
-    },
-  ),
-  buildControlDefinition(
-    "control:task-notifications-balance-history-capture",
-    "general",
-    "task-notifications-balanceHistoryCapture",
-    "settings:taskNotifications.tasks.balanceHistoryCapture",
-    517,
-    {
-      descriptionKey:
-        "settings:taskNotifications.taskDescriptions.balanceHistoryCapture",
-      breadcrumbsKeys: [
-        ...DEFAULT_BREADCRUMBS,
-        "settings:tabs.general",
-        "settings:taskNotifications.title",
-      ],
-      keywords: ["notification", "balance history", "capture"],
-    },
+  ...TASK_NOTIFICATION_SEARCH_CONTROLS.map((definition, index) =>
+    buildControlDefinition(
+      definition.searchId,
+      "general",
+      definition.targetId,
+      definition.labelKey,
+      TASK_NOTIFICATION_CONTROL_ORDER_START + index,
+      {
+        descriptionKey: definition.descriptionKey,
+        breadcrumbsKeys: TASK_NOTIFICATION_BREADCRUMBS,
+        keywords: [...definition.keywords],
+      },
+    ),
   ),
 ]

--- a/src/features/BasicSettings/components/tabs/General/General.search.ts
+++ b/src/features/BasicSettings/components/tabs/General/General.search.ts
@@ -45,11 +45,22 @@ export const generalSearchSections: OptionsSearchItemDefinition[] = [
     },
   ),
   buildSectionDefinition(
+    "section:task-notifications",
+    "general",
+    "task-notifications",
+    "settings:taskNotifications.title",
+    205,
+    {
+      descriptionKey: "settings:taskNotifications.description",
+      keywords: ["notification", "scheduled task", "alarm"],
+    },
+  ),
+  buildSectionDefinition(
     "section:danger",
     "general",
     "dangerous-zone",
     "settings:danger.title",
-    205,
+    206,
   ),
 ]
 
@@ -230,6 +241,122 @@ export const generalSearchControls: OptionsSearchItemDefinition[] = [
         "settings:danger.title",
       ],
       keywords: ["danger", "reset", "reset settings", "defaults"],
+    },
+  ),
+  buildControlDefinition(
+    "control:task-notifications-enabled",
+    "general",
+    "task-notifications-enabled",
+    "settings:taskNotifications.enable",
+    511,
+    {
+      descriptionKey: "settings:taskNotifications.enableDesc",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:taskNotifications.title",
+      ],
+      keywords: ["notification", "scheduled task", "background task"],
+    },
+  ),
+  buildControlDefinition(
+    "control:task-notifications-permission",
+    "general",
+    "task-notifications-permission",
+    "settings:taskNotifications.permission.title",
+    512,
+    {
+      descriptionKey: "settings:taskNotifications.permission.description",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:taskNotifications.title",
+      ],
+      keywords: ["notification", "permission", "system notification"],
+    },
+  ),
+  buildControlDefinition(
+    "control:task-notifications-auto-checkin",
+    "general",
+    "task-notifications-autoCheckin",
+    "settings:taskNotifications.tasks.autoCheckin",
+    513,
+    {
+      descriptionKey: "settings:taskNotifications.taskDescriptions.autoCheckin",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:taskNotifications.title",
+      ],
+      keywords: ["notification", "auto checkin", "check-in"],
+    },
+  ),
+  buildControlDefinition(
+    "control:task-notifications-webdav-auto-sync",
+    "general",
+    "task-notifications-webdavAutoSync",
+    "settings:taskNotifications.tasks.webdavAutoSync",
+    514,
+    {
+      descriptionKey:
+        "settings:taskNotifications.taskDescriptions.webdavAutoSync",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:taskNotifications.title",
+      ],
+      keywords: ["notification", "webdav", "auto sync"],
+    },
+  ),
+  buildControlDefinition(
+    "control:task-notifications-managed-site-model-sync",
+    "general",
+    "task-notifications-managedSiteModelSync",
+    "settings:taskNotifications.tasks.managedSiteModelSync",
+    515,
+    {
+      descriptionKey:
+        "settings:taskNotifications.taskDescriptions.managedSiteModelSync",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:taskNotifications.title",
+      ],
+      keywords: ["notification", "model sync", "managed site"],
+    },
+  ),
+  buildControlDefinition(
+    "control:task-notifications-usage-history-sync",
+    "general",
+    "task-notifications-usageHistorySync",
+    "settings:taskNotifications.tasks.usageHistorySync",
+    516,
+    {
+      descriptionKey:
+        "settings:taskNotifications.taskDescriptions.usageHistorySync",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:taskNotifications.title",
+      ],
+      keywords: ["notification", "usage history", "sync"],
+    },
+  ),
+  buildControlDefinition(
+    "control:task-notifications-balance-history-capture",
+    "general",
+    "task-notifications-balanceHistoryCapture",
+    "settings:taskNotifications.tasks.balanceHistoryCapture",
+    517,
+    {
+      descriptionKey:
+        "settings:taskNotifications.taskDescriptions.balanceHistoryCapture",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.general",
+        "settings:taskNotifications.title",
+      ],
+      keywords: ["notification", "balance history", "capture"],
     },
   ),
 ]

--- a/src/features/BasicSettings/components/tabs/General/GeneralTab.tsx
+++ b/src/features/BasicSettings/components/tabs/General/GeneralTab.tsx
@@ -1,11 +1,5 @@
-import { LanguageIcon } from "@heroicons/react/24/outline"
-import { useTranslation } from "react-i18next"
-
-import { LanguageSwitcher } from "~/components/LanguageSwitcher"
-import { BodySmall, Card, CardItem, CardList, Heading3 } from "~/components/ui"
-import ThemeToggle from "~/entrypoints/options/components/ThemeToggle"
-
 import ActionClickBehaviorSettings from "./ActionClickBehaviorSettings"
+import AppearanceSettings from "./AppearanceSettings"
 import ChangelogOnUpdateSettings from "./ChangelogOnUpdateSettings"
 import DisplaySettings from "./DisplaySettings"
 import LoggingSettings from "./LoggingSettings"
@@ -13,42 +7,18 @@ import ResetSettingsSection from "./ResetSettingsSection"
 import TaskNotificationSettings from "./TaskNotificationSettings"
 
 /**
- * General Basic Settings tab for display preferences, theme/language, and dangerous zone.
+ * General Basic Settings tab for everyday UI preferences, behavior, notifications,
+ * maintenance preferences, diagnostics, and reset actions.
  */
 export default function GeneralTab() {
-  const { t } = useTranslation("settings")
-
   return (
     <div className="space-y-6">
       <DisplaySettings />
+      <AppearanceSettings />
       <ActionClickBehaviorSettings />
-      <LoggingSettings />
-      <ChangelogOnUpdateSettings />
       <TaskNotificationSettings />
-
-      {/* Appearance & Language Section */}
-      <section id="appearance" className="space-y-6">
-        <div className="space-y-1.5">
-          <Heading3>{t("theme.appearance")}</Heading3>
-          <BodySmall>{t("display.description")}</BodySmall>
-        </div>
-
-        <Card padding="none">
-          <CardList>
-            <ThemeToggle />
-            <CardItem
-              id="appearance-language"
-              icon={
-                <LanguageIcon className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-              }
-              title={t("appearanceLanguage.language")}
-              description={t("appearanceLanguage.languageDesc")}
-              rightContent={<LanguageSwitcher />}
-            />
-          </CardList>
-        </Card>
-      </section>
-
+      <ChangelogOnUpdateSettings />
+      <LoggingSettings />
       <section id="dangerous-zone">
         <ResetSettingsSection />
       </section>

--- a/src/features/BasicSettings/components/tabs/General/GeneralTab.tsx
+++ b/src/features/BasicSettings/components/tabs/General/GeneralTab.tsx
@@ -10,6 +10,7 @@ import ChangelogOnUpdateSettings from "./ChangelogOnUpdateSettings"
 import DisplaySettings from "./DisplaySettings"
 import LoggingSettings from "./LoggingSettings"
 import ResetSettingsSection from "./ResetSettingsSection"
+import TaskNotificationSettings from "./TaskNotificationSettings"
 
 /**
  * General Basic Settings tab for display preferences, theme/language, and dangerous zone.
@@ -23,6 +24,7 @@ export default function GeneralTab() {
       <ActionClickBehaviorSettings />
       <LoggingSettings />
       <ChangelogOnUpdateSettings />
+      <TaskNotificationSettings />
 
       {/* Appearance & Language Section */}
       <section id="appearance" className="space-y-6">

--- a/src/features/BasicSettings/components/tabs/General/TaskNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/TaskNotificationSettings.tsx
@@ -34,25 +34,15 @@ const logger = createLogger("TaskNotificationSettings")
 const TASK_NOTIFICATION_ITEMS: Array<{
   task: TaskNotificationTask
 }> = [
-  {
-    task: TASK_NOTIFICATION_TASKS.AutoCheckin,
-  },
-  {
-    task: TASK_NOTIFICATION_TASKS.WebdavAutoSync,
-  },
-  {
-    task: TASK_NOTIFICATION_TASKS.ManagedSiteModelSync,
-  },
-  {
-    task: TASK_NOTIFICATION_TASKS.UsageHistorySync,
-  },
-  {
-    task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
-  },
+  { task: TASK_NOTIFICATION_TASKS.AutoCheckin },
+  { task: TASK_NOTIFICATION_TASKS.WebdavAutoSync },
+  { task: TASK_NOTIFICATION_TASKS.ManagedSiteModelSync },
+  { task: TASK_NOTIFICATION_TASKS.UsageHistorySync },
+  { task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture },
 ]
 
 /**
- *
+ * Resolves the localized label for a task notification option.
  */
 function getTaskLabel(t: TFunction<"settings">, task: TaskNotificationTask) {
   switch (task) {
@@ -70,7 +60,7 @@ function getTaskLabel(t: TFunction<"settings">, task: TaskNotificationTask) {
 }
 
 /**
- *
+ * Resolves the localized description for a task notification option.
  */
 function getTaskDescription(
   t: TFunction<"settings">,

--- a/src/features/BasicSettings/components/tabs/General/TaskNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/TaskNotificationSettings.tsx
@@ -1,0 +1,263 @@
+import { BellIcon } from "@heroicons/react/24/outline"
+import type { TFunction } from "i18next"
+import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { SettingSection } from "~/components/SettingSection"
+import {
+  Badge,
+  Button,
+  Card,
+  CardItem,
+  CardList,
+  Switch,
+} from "~/components/ui"
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import {
+  hasPermission,
+  onOptionalPermissionsChanged,
+  OPTIONAL_PERMISSION_IDS,
+  requestPermission,
+} from "~/services/permissions/permissionManager"
+import {
+  TASK_NOTIFICATION_TASKS,
+  type TaskNotificationTask,
+} from "~/types/taskNotifications"
+import { sendRuntimeMessage } from "~/utils/browser/browserApi"
+import { getErrorMessage } from "~/utils/core/error"
+import { createLogger } from "~/utils/core/logger"
+import { showResultToast, showUpdateToast } from "~/utils/core/toastHelpers"
+
+const logger = createLogger("TaskNotificationSettings")
+
+const TASK_NOTIFICATION_ITEMS: Array<{
+  task: TaskNotificationTask
+}> = [
+  {
+    task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+  },
+  {
+    task: TASK_NOTIFICATION_TASKS.WebdavAutoSync,
+  },
+  {
+    task: TASK_NOTIFICATION_TASKS.ManagedSiteModelSync,
+  },
+  {
+    task: TASK_NOTIFICATION_TASKS.UsageHistorySync,
+  },
+  {
+    task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
+  },
+]
+
+/**
+ *
+ */
+function getTaskLabel(t: TFunction<"settings">, task: TaskNotificationTask) {
+  switch (task) {
+    case TASK_NOTIFICATION_TASKS.AutoCheckin:
+      return t("taskNotifications.tasks.autoCheckin")
+    case TASK_NOTIFICATION_TASKS.WebdavAutoSync:
+      return t("taskNotifications.tasks.webdavAutoSync")
+    case TASK_NOTIFICATION_TASKS.ManagedSiteModelSync:
+      return t("taskNotifications.tasks.managedSiteModelSync")
+    case TASK_NOTIFICATION_TASKS.UsageHistorySync:
+      return t("taskNotifications.tasks.usageHistorySync")
+    case TASK_NOTIFICATION_TASKS.BalanceHistoryCapture:
+      return t("taskNotifications.tasks.balanceHistoryCapture")
+  }
+}
+
+/**
+ *
+ */
+function getTaskDescription(
+  t: TFunction<"settings">,
+  task: TaskNotificationTask,
+) {
+  switch (task) {
+    case TASK_NOTIFICATION_TASKS.AutoCheckin:
+      return t("taskNotifications.taskDescriptions.autoCheckin")
+    case TASK_NOTIFICATION_TASKS.WebdavAutoSync:
+      return t("taskNotifications.taskDescriptions.webdavAutoSync")
+    case TASK_NOTIFICATION_TASKS.ManagedSiteModelSync:
+      return t("taskNotifications.taskDescriptions.managedSiteModelSync")
+    case TASK_NOTIFICATION_TASKS.UsageHistorySync:
+      return t("taskNotifications.taskDescriptions.usageHistorySync")
+    case TASK_NOTIFICATION_TASKS.BalanceHistoryCapture:
+      return t("taskNotifications.taskDescriptions.balanceHistoryCapture")
+  }
+}
+
+/**
+ * General settings section for background scheduled-task system notifications.
+ */
+export default function TaskNotificationSettings() {
+  const { t } = useTranslation("settings")
+  const { taskNotifications, updateTaskNotifications } =
+    useUserPreferencesContext()
+  const [permissionGranted, setPermissionGranted] = useState<boolean | null>(
+    null,
+  )
+  const [isRequestingPermission, setIsRequestingPermission] = useState(false)
+  const [isSendingTest, setIsSendingTest] = useState(false)
+
+  const refreshPermissionStatus = useCallback(async () => {
+    const granted = await hasPermission(OPTIONAL_PERMISSION_IDS.Notifications)
+    setPermissionGranted(granted)
+  }, [])
+
+  useEffect(() => {
+    void refreshPermissionStatus()
+    const unsubscribe = onOptionalPermissionsChanged(() => {
+      void refreshPermissionStatus()
+    })
+    return unsubscribe
+  }, [refreshPermissionStatus])
+
+  const handleGlobalToggle = async (enabled: boolean) => {
+    const success = await updateTaskNotifications({ enabled })
+    showUpdateToast(success, t("taskNotifications.enable"))
+  }
+
+  const handleTaskToggle = async (
+    task: TaskNotificationTask,
+    enabled: boolean,
+  ) => {
+    const success = await updateTaskNotifications({
+      tasks: {
+        ...taskNotifications.tasks,
+        [task]: enabled,
+      },
+    })
+    showUpdateToast(success, t("taskNotifications.tasksLabel"))
+  }
+
+  const handleRequestPermission = async () => {
+    setIsRequestingPermission(true)
+    try {
+      const success = await requestPermission(
+        OPTIONAL_PERMISSION_IDS.Notifications,
+      )
+      await refreshPermissionStatus()
+      showResultToast(
+        success,
+        t("taskNotifications.permission.requestSuccess"),
+        t("taskNotifications.permission.requestFailed"),
+      )
+    } finally {
+      setIsRequestingPermission(false)
+    }
+  }
+
+  const handleSendTest = async () => {
+    setIsSendingTest(true)
+    try {
+      const response = await sendRuntimeMessage({
+        action: RuntimeActionIds.TaskNotificationsTest,
+      })
+      showResultToast({
+        success: response?.success === true,
+        message: response?.error,
+        successFallback: t("taskNotifications.test.sent"),
+        errorFallback: t("taskNotifications.test.failed"),
+      })
+    } catch (error) {
+      logger.warn("Failed to send test task notification", error)
+      showResultToast({
+        success: false,
+        message: getErrorMessage(error),
+        errorFallback: t("taskNotifications.test.failed"),
+      })
+    } finally {
+      setIsSendingTest(false)
+    }
+  }
+
+  const statusText =
+    permissionGranted === null
+      ? t("permissions.status.checking")
+      : permissionGranted
+        ? t("permissions.status.granted")
+        : t("permissions.status.denied")
+
+  return (
+    <SettingSection
+      id="task-notifications"
+      title={t("taskNotifications.title")}
+      description={t("taskNotifications.description")}
+    >
+      <Card padding="none">
+        <CardList>
+          <CardItem
+            id="task-notifications-enabled"
+            icon={
+              <BellIcon className="h-5 w-5 text-teal-600 dark:text-teal-400" />
+            }
+            title={t("taskNotifications.enable")}
+            description={t("taskNotifications.enableDesc")}
+            rightContent={
+              <Switch
+                checked={taskNotifications.enabled}
+                onChange={handleGlobalToggle}
+              />
+            }
+          />
+
+          <CardItem
+            id="task-notifications-permission"
+            title={t("taskNotifications.permission.title")}
+            description={t("taskNotifications.permission.description")}
+            rightContent={
+              <div className="flex flex-col gap-2 sm:items-end">
+                <Badge variant={permissionGranted ? "success" : "secondary"}>
+                  {statusText}
+                </Badge>
+                {!permissionGranted && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    loading={isRequestingPermission}
+                    onClick={() => void handleRequestPermission()}
+                  >
+                    {t("taskNotifications.permission.request")}
+                  </Button>
+                )}
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  loading={isSendingTest}
+                  disabled={!permissionGranted || isSendingTest}
+                  onClick={() => void handleSendTest()}
+                >
+                  {t("taskNotifications.test.action")}
+                </Button>
+              </div>
+            }
+          />
+
+          {TASK_NOTIFICATION_ITEMS.map((item) => (
+            <CardItem
+              key={item.task}
+              id={`task-notifications-${item.task}`}
+              title={getTaskLabel(t, item.task)}
+              description={getTaskDescription(t, item.task)}
+              rightContent={
+                <Switch
+                  checked={taskNotifications.tasks[item.task]}
+                  disabled={!taskNotifications.enabled}
+                  onChange={(enabled) =>
+                    void handleTaskToggle(item.task, enabled)
+                  }
+                />
+              }
+            />
+          ))}
+        </CardList>
+      </Card>
+    </SettingSection>
+  )
+}

--- a/src/features/BasicSettings/components/tabs/Permissions/PermissionList.tsx
+++ b/src/features/BasicSettings/components/tabs/Permissions/PermissionList.tsx
@@ -1,4 +1,5 @@
 import {
+  Bell,
   ClipboardCheck,
   Cookie,
   Network,
@@ -21,6 +22,7 @@ export const permissionIconMap: Partial<
   webRequest: <Network className="h-5 w-5 text-blue-500" />,
   webRequestBlocking: <ShieldAlert className="h-5 w-5 text-purple-500" />,
   clipboardRead: <ClipboardCheck className="h-5 w-5 text-indigo-500" />,
+  notifications: <Bell className="h-5 w-5 text-teal-500" />,
 }
 
 export interface PermissionListItem {

--- a/src/features/BasicSettings/components/tabs/Permissions/PermissionSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Permissions/PermissionSettings.tsx
@@ -50,6 +50,8 @@ function getPermissionTitle(t: TFunction, id: ManifestOptionalPermissions) {
       return t("settings:permissions.items.webRequestBlocking.title")
     case "clipboardRead":
       return t("settings:permissions.items.clipboardRead.title")
+    case "notifications":
+      return t("settings:permissions.items.notifications.title")
   }
 }
 
@@ -73,6 +75,8 @@ function getPermissionDescription(
       return t("settings:permissions.items.webRequestBlocking.description")
     case "clipboardRead":
       return t("settings:permissions.items.clipboardRead.description")
+    case "notifications":
+      return t("settings:permissions.items.notifications.description")
   }
 }
 

--- a/src/features/BasicSettings/components/tabs/Permissions/Permissions.search.ts
+++ b/src/features/BasicSettings/components/tabs/Permissions/Permissions.search.ts
@@ -123,4 +123,21 @@ export const permissionsSearchControls: OptionsSearchItemDefinition[] = [
       isVisible: (context) => context.hasOptionalPermissions,
     },
   ),
+  buildControlDefinition(
+    "control:permissions-notifications",
+    "permissions",
+    "notifications",
+    "settings:permissions.items.notifications.title",
+    706,
+    {
+      descriptionKey: "settings:permissions.items.notifications.description",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.permissions",
+        "settings:permissions.title",
+      ],
+      keywords: ["permission", "notification", "system notification"],
+      isVisible: (context) => context.hasOptionalPermissions,
+    },
+  ),
 ]

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -324,6 +324,10 @@
         "description": "Allow applying request header rules by pressing Tab during the temporary window shield, attaching the correct cookies for different accounts, and avoiding data anomalies under multiple accounts.",
         "title": "Declarative Net Request"
       },
+      "notifications": {
+        "description": "Allow background scheduled tasks to send system notifications after they finish.",
+        "title": "System Notifications"
+      },
       "webRequest": {
         "description": "Lets the extension observe outgoing requests only when temp-window bypass or auto-refresh needs to add required headers.",
         "title": "Web Request"
@@ -489,6 +493,53 @@
     "scrollRight": "Scroll tabs right",
     "select": "Select a tab",
     "webAiApiCheck": "AI API Test"
+  },
+  "taskNotifications": {
+    "description": "Control whether background scheduled tasks send system notifications after they finish. Tasks continue running normally when notification permission is not granted.",
+    "enable": "Enable task notifications",
+    "enableDesc": "When enabled, selected tasks send success, partial success, or failure notifications after scheduled runs finish.",
+    "notification": {
+      "body": {
+        "failure": "{{task}} failed.",
+        "partialSuccess": "{{task}} partially completed.",
+        "success": "{{task}} completed successfully."
+      },
+      "counts": "Total {{total}}, success {{success}}, failed {{failed}}, skipped {{skipped}}.",
+      "title": {
+        "failure": "{{task}} failed",
+        "partialSuccess": "{{task}} partially succeeded",
+        "success": "{{task}} completed"
+      }
+    },
+    "permission": {
+      "description": "System notifications require the browser's optional notifications permission. You can also revoke it from Permissions.",
+      "request": "Grant notification permission",
+      "requestFailed": "Notification permission was not granted",
+      "requestSuccess": "Notification permission granted",
+      "title": "Notification permission"
+    },
+    "taskDescriptions": {
+      "autoCheckin": "Notify after daily automatic check-in and automatic retry runs finish.",
+      "balanceHistoryCapture": "Notify after the end-of-day balance history capture finishes.",
+      "managedSiteModelSync": "Notify after scheduled managed-site model sync finishes.",
+      "usageHistorySync": "Notify after scheduled usage history sync finishes.",
+      "webdavAutoSync": "Notify after scheduled WebDAV automatic sync finishes."
+    },
+    "tasks": {
+      "autoCheckin": "Auto check-in",
+      "balanceHistoryCapture": "End-of-day balance capture",
+      "managedSiteModelSync": "Model sync",
+      "usageHistorySync": "Usage history sync",
+      "webdavAutoSync": "WebDAV auto sync"
+    },
+    "tasksLabel": "Task notifications",
+    "test": {
+      "action": "Send test notification",
+      "failed": "Failed to send the test notification. Check notification permission.",
+      "message": "This is an All API Hub task notification test.",
+      "sent": "Test notification sent"
+    },
+    "title": "Notifications"
   },
   "theme": {
     "appearance": "Appearance",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -324,6 +324,10 @@
         "description": "一時ウィンドウでの保護回避中に Tab キーでリクエストヘッダールールを適用し、アカウントごとに正しい Cookie を付与して複数アカウント時のデータ異常を防ぎます。",
         "title": "宣言的ネットワークリクエスト"
       },
+      "notifications": {
+        "description": "バックグラウンドのスケジュールタスク完了後にシステム通知を送信できるようにします。",
+        "title": "システム通知"
+      },
       "webRequest": {
         "description": "一時ウィンドウによる回避や自動更新で必要なヘッダーを追加する必要がある場合にのみ、拡張機能が送信リクエストを監視できるようにします。",
         "title": "Web リクエスト"
@@ -489,6 +493,53 @@
     "scrollRight": "タブを右へスクロール",
     "select": "タブを選択",
     "webAiApiCheck": "AI API テスト"
+  },
+  "taskNotifications": {
+    "description": "バックグラウンドのスケジュールタスク完了後にシステム通知を送るかどうかを制御します。通知権限が未許可でもタスクは通常どおり実行されます。",
+    "enable": "タスク通知を有効化",
+    "enableDesc": "有効にすると、選択したタスクがスケジュール実行を終えた後に成功、部分成功、失敗の通知を送ります。",
+    "notification": {
+      "body": {
+        "failure": "{{task}} が失敗しました。",
+        "partialSuccess": "{{task}} が一部完了しました。",
+        "success": "{{task}} が正常に完了しました。"
+      },
+      "counts": "合計 {{total}}、成功 {{success}}、失敗 {{failed}}、スキップ {{skipped}}。",
+      "title": {
+        "failure": "{{task}} が失敗しました",
+        "partialSuccess": "{{task}} が一部成功しました",
+        "success": "{{task}} が完了しました"
+      }
+    },
+    "permission": {
+      "description": "システム通知にはブラウザの任意 notifications 権限が必要です。権限ページから取り消すこともできます。",
+      "request": "通知権限を許可",
+      "requestFailed": "通知権限は許可されませんでした",
+      "requestSuccess": "通知権限を許可しました",
+      "title": "通知権限"
+    },
+    "taskDescriptions": {
+      "autoCheckin": "毎日の自動チェックインと自動リトライの完了後に通知します。",
+      "balanceHistoryCapture": "日末の残高履歴自動キャプチャ完了後に通知します。",
+      "managedSiteModelSync": "管理サイトのモデル定期同期完了後に通知します。",
+      "usageHistorySync": "利用履歴の定期同期完了後に通知します。",
+      "webdavAutoSync": "WebDAV の定期自動同期完了後に通知します。"
+    },
+    "tasks": {
+      "autoCheckin": "自動チェックイン",
+      "balanceHistoryCapture": "日末残高キャプチャ",
+      "managedSiteModelSync": "モデル同期",
+      "usageHistorySync": "利用履歴同期",
+      "webdavAutoSync": "WebDAV 自動同期"
+    },
+    "tasksLabel": "タスク通知",
+    "test": {
+      "action": "テスト通知を送信",
+      "failed": "テスト通知を送信できませんでした。通知権限を確認してください。",
+      "message": "これは All API Hub のタスク通知テストです。",
+      "sent": "テスト通知を送信しました"
+    },
+    "title": "通知"
   },
   "theme": {
     "appearance": "外観",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -324,6 +324,10 @@
         "description": "允许在临时窗口过盾期间按 Tab 应用请求头规则，为不同账号附加正确的 Cookie，避免多账号下的数据异常问题。",
         "title": "声明式网络请求"
       },
+      "notifications": {
+        "description": "允许后台定时任务完成后发送系统通知。",
+        "title": "系统通知"
+      },
       "webRequest": {
         "description": "仅在临时窗口过盾或自动刷新需要时，监听请求并追加必要的请求头。",
         "title": "网络请求"
@@ -489,6 +493,53 @@
     "scrollRight": "向右滚动标签",
     "select": "选择一个分组",
     "webAiApiCheck": "AI API 测试"
+  },
+  "taskNotifications": {
+    "description": "控制后台定时任务完成后是否发送系统通知。通知权限未授予时，任务仍会照常运行。",
+    "enable": "启用任务通知",
+    "enableDesc": "开启后，已勾选任务在定时运行完成时会发送成功、部分成功或失败通知。",
+    "notification": {
+      "body": {
+        "failure": "{{task}}运行失败。",
+        "partialSuccess": "{{task}}部分完成。",
+        "success": "{{task}}已成功完成。"
+      },
+      "counts": "总计 {{total}}，成功 {{success}}，失败 {{failed}}，跳过 {{skipped}}。",
+      "title": {
+        "failure": "{{task}}失败",
+        "partialSuccess": "{{task}}部分成功",
+        "success": "{{task}}完成"
+      }
+    },
+    "permission": {
+      "description": "系统通知需要浏览器授予 notifications 可选权限。你也可以在权限管理页撤销。",
+      "request": "授权通知权限",
+      "requestFailed": "未能授予通知权限",
+      "requestSuccess": "通知权限已授予",
+      "title": "通知权限"
+    },
+    "taskDescriptions": {
+      "autoCheckin": "每日自动签到和自动重试完成后通知。",
+      "balanceHistoryCapture": "余额历史日终自动捕获完成后通知。",
+      "managedSiteModelSync": "自建站点模型定时同步完成后通知。",
+      "usageHistorySync": "用量历史定时同步完成后通知。",
+      "webdavAutoSync": "WebDAV 定时自动同步完成后通知。"
+    },
+    "tasks": {
+      "autoCheckin": "自动签到",
+      "balanceHistoryCapture": "余额历史日终捕获",
+      "managedSiteModelSync": "模型同步",
+      "usageHistorySync": "用量历史同步",
+      "webdavAutoSync": "WebDAV 自动同步"
+    },
+    "tasksLabel": "任务通知",
+    "test": {
+      "action": "发送测试通知",
+      "failed": "测试通知发送失败，请确认已授予通知权限。",
+      "message": "这是一条 All API Hub 任务通知测试。",
+      "sent": "测试通知已发送"
+    },
+    "title": "通知"
   },
   "theme": {
     "appearance": "外观",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -324,6 +324,10 @@
         "description": "允許在臨時視窗過盾期間按 Tab 應用請求頭規則，為不同帳號附加正確的 Cookie，避免多帳號下的資料異常問題。",
         "title": "宣告式網路請求"
       },
+      "notifications": {
+        "description": "允許後臺定時任務完成後傳送系統通知。",
+        "title": "系統通知"
+      },
       "webRequest": {
         "description": "僅在臨時視窗過盾或自動重新整理需要時，監聽請求並追加必要的請求頭。",
         "title": "網路請求"
@@ -489,6 +493,53 @@
     "scrollRight": "向右滾動標籤",
     "select": "選擇一個分組",
     "webAiApiCheck": "AI API 測試"
+  },
+  "taskNotifications": {
+    "description": "控制後臺定時任務完成後是否傳送系統通知。通知權限未授予時，任務仍會照常執行。",
+    "enable": "啟用任務通知",
+    "enableDesc": "開啟後，已勾選任務在定時執行完成時會傳送成功、部分成功或失敗通知。",
+    "notification": {
+      "body": {
+        "failure": "{{task}}執行失敗。",
+        "partialSuccess": "{{task}}部分完成。",
+        "success": "{{task}}已成功完成。"
+      },
+      "counts": "總計 {{total}}，成功 {{success}}，失敗 {{failed}}，跳過 {{skipped}}。",
+      "title": {
+        "failure": "{{task}}失敗",
+        "partialSuccess": "{{task}}部分成功",
+        "success": "{{task}}完成"
+      }
+    },
+    "permission": {
+      "description": "系統通知需要瀏覽器授予 notifications 可選權限。你也可以在權限管理頁撤銷。",
+      "request": "授權通知權限",
+      "requestFailed": "未能授予通知權限",
+      "requestSuccess": "通知權限已授予",
+      "title": "通知權限"
+    },
+    "taskDescriptions": {
+      "autoCheckin": "每日自動簽到和自動重試完成後通知。",
+      "balanceHistoryCapture": "餘額歷史日終自動捕獲完成後通知。",
+      "managedSiteModelSync": "自建站點模型定時同步完成後通知。",
+      "usageHistorySync": "用量歷史定時同步完成後通知。",
+      "webdavAutoSync": "WebDAV 定時自動同步完成後通知。"
+    },
+    "tasks": {
+      "autoCheckin": "自動簽到",
+      "balanceHistoryCapture": "餘額歷史日終捕獲",
+      "managedSiteModelSync": "模型同步",
+      "usageHistorySync": "用量歷史同步",
+      "webdavAutoSync": "WebDAV 自動同步"
+    },
+    "tasksLabel": "任務通知",
+    "test": {
+      "action": "傳送測試通知",
+      "failed": "測試通知傳送失敗，請確認已授予通知權限。",
+      "message": "這是一條 All API Hub 任務通知測試。",
+      "sent": "測試通知已傳送"
+    },
+    "title": "通知"
   },
   "theme": {
     "appearance": "外觀",

--- a/src/services/checkin/autoCheckin/scheduler.ts
+++ b/src/services/checkin/autoCheckin/scheduler.ts
@@ -2,6 +2,7 @@ import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { buildAccountDisplayNameMap } from "~/services/accounts/utils/accountDisplayName"
 import { withExtensionStorageWriteLock } from "~/services/core/storageWriteLock"
+import { notifyTaskResult } from "~/services/notifications/taskNotificationService"
 import {
   DEFAULT_PREFERENCES,
   userPreferences,
@@ -27,6 +28,7 @@ import {
   type CheckinAccountResult,
   type CheckinResultStatus,
 } from "~/types/autoCheckin"
+import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
 import {
   clearAlarm,
   createAlarm,
@@ -246,6 +248,37 @@ class AutoCheckinScheduler {
         error: errorMessage,
       })
     }
+  }
+
+  private getTaskNotificationStatus(successCount: number, failedCount: number) {
+    if (failedCount > 0 && successCount > 0) {
+      return "partial_success" as const
+    }
+    if (failedCount > 0) {
+      return "failure" as const
+    }
+    return "success" as const
+  }
+
+  private async notifyScheduledRunResult(params: {
+    successCount: number
+    failedCount: number
+    skippedCount: number
+    total: number
+  }) {
+    await notifyTaskResult({
+      task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+      status: this.getTaskNotificationStatus(
+        params.successCount,
+        params.failedCount,
+      ),
+      counts: {
+        success: params.successCount,
+        failed: params.failedCount,
+        skipped: params.skippedCount,
+        total: params.total,
+      },
+    })
   }
 
   /**
@@ -1974,6 +2007,15 @@ class AutoCheckinScheduler {
         })
       }
 
+      if (isDailyRun) {
+        await this.notifyScheduledRunResult({
+          successCount,
+          failedCount,
+          skippedCount,
+          total: runnableAccounts.length + skippedCount,
+        })
+      }
+
       const duration = Date.now() - startTime
       logger.info("Execution completed", {
         durationMs: duration,
@@ -2012,6 +2054,13 @@ class AutoCheckinScheduler {
         await this.notifyUiRunCompleted({
           runKind: runType,
           updatedAccountIds: [],
+        })
+      }
+
+      if (isDailyRun) {
+        await notifyTaskResult({
+          task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+          status: "failure",
         })
       }
     }
@@ -2191,6 +2240,28 @@ class AutoCheckinScheduler {
         runKind: "retry",
         updatedAccountIds,
         summary,
+      })
+    }
+
+    const retryResults = Object.values(updates)
+    const retrySuccessCount = retryResults.filter(
+      (result) =>
+        result.status === CHECKIN_RESULT_STATUS.SUCCESS ||
+        result.status === CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
+    ).length
+    const retryFailedCount = retryResults.filter(
+      (result) => result.status === CHECKIN_RESULT_STATUS.FAILED,
+    ).length
+    const retrySkippedCount = retryResults.filter(
+      (result) => result.status === CHECKIN_RESULT_STATUS.SKIPPED,
+    ).length
+
+    if (retryResults.length > 0) {
+      await this.notifyScheduledRunResult({
+        successCount: retrySuccessCount,
+        failedCount: retryFailedCount,
+        skippedCount: retrySkippedCount,
+        total: retryResults.length,
       })
     }
   }

--- a/src/services/checkin/autoCheckin/scheduler.ts
+++ b/src/services/checkin/autoCheckin/scheduler.ts
@@ -28,7 +28,11 @@ import {
   type CheckinAccountResult,
   type CheckinResultStatus,
 } from "~/types/autoCheckin"
-import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
+import {
+  getTaskNotificationStatusFromCounts,
+  TASK_NOTIFICATION_STATUSES,
+  TASK_NOTIFICATION_TASKS,
+} from "~/types/taskNotifications"
 import {
   clearAlarm,
   createAlarm,
@@ -251,13 +255,10 @@ class AutoCheckinScheduler {
   }
 
   private getTaskNotificationStatus(successCount: number, failedCount: number) {
-    if (failedCount > 0 && successCount > 0) {
-      return "partial_success" as const
-    }
-    if (failedCount > 0) {
-      return "failure" as const
-    }
-    return "success" as const
+    return getTaskNotificationStatusFromCounts({
+      successCount,
+      failedCount,
+    })
   }
 
   private async notifyScheduledRunResult(params: {
@@ -2060,7 +2061,7 @@ class AutoCheckinScheduler {
       if (isDailyRun) {
         await notifyTaskResult({
           task: TASK_NOTIFICATION_TASKS.AutoCheckin,
-          status: "failure",
+          status: TASK_NOTIFICATION_STATUSES.Failure,
         })
       }
     }

--- a/src/services/history/dailyBalanceHistory/scheduler.ts
+++ b/src/services/history/dailyBalanceHistory/scheduler.ts
@@ -27,6 +27,7 @@ import { dailyBalanceHistoryStorage } from "./storage"
 import { clampBalanceHistoryRetentionDays } from "./utils"
 
 const logger = createLogger("DailyBalanceHistoryScheduler")
+const BALANCE_HISTORY_ALARM_TRIGGER: DailyBalanceHistoryCaptureSource = "alarm"
 
 const END_OF_DAY_CAPTURE_TIME = {
   hour: 23,
@@ -73,7 +74,9 @@ class DailyBalanceHistoryScheduler {
       }
 
       // Await to keep the MV3 service worker alive for the duration of the capture run.
-      const result = await this.runEndOfDayCapture({ trigger: "alarm" })
+      const result = await this.runEndOfDayCapture({
+        trigger: BALANCE_HISTORY_ALARM_TRIGGER,
+      })
       if (!result?.started || !result.totals) {
         return
       }
@@ -277,12 +280,16 @@ class DailyBalanceHistoryScheduler {
       }
     } catch (error) {
       logger.error("End-of-day capture run failed", error)
-      if (params.trigger === "alarm") {
-        await notifyTaskResult({
-          task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
-          status: TASK_NOTIFICATION_STATUSES.Failure,
-          message: getErrorMessage(error),
-        })
+      if (params.trigger === BALANCE_HISTORY_ALARM_TRIGGER) {
+        try {
+          await notifyTaskResult({
+            task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
+            status: TASK_NOTIFICATION_STATUSES.Failure,
+            message: getErrorMessage(error),
+          })
+        } catch (notifyError) {
+          logger.error("Failed to send task notification", notifyError)
+        }
       }
       return null
     } finally {

--- a/src/services/history/dailyBalanceHistory/scheduler.ts
+++ b/src/services/history/dailyBalanceHistory/scheduler.ts
@@ -93,6 +93,7 @@ class DailyBalanceHistoryScheduler {
           total: totals.success + totals.failed,
           success: totals.success,
           failed: totals.failed,
+          skipped: 0,
         },
       })
     })

--- a/src/services/history/dailyBalanceHistory/scheduler.ts
+++ b/src/services/history/dailyBalanceHistory/scheduler.ts
@@ -1,11 +1,13 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { notifyTaskResult } from "~/services/notifications/taskNotificationService"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import {
   DEFAULT_BALANCE_HISTORY_PREFERENCES,
   type BalanceHistoryPreferences,
   type DailyBalanceHistoryCaptureSource,
 } from "~/types/dailyBalanceHistory"
+import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
 import {
   clearAlarm,
   createAlarm,
@@ -67,7 +69,30 @@ class DailyBalanceHistoryScheduler {
       }
 
       // Await to keep the MV3 service worker alive for the duration of the capture run.
-      await this.runEndOfDayCapture({ trigger: "alarm" })
+      const result = await this.runEndOfDayCapture({ trigger: "alarm" })
+      if (!result?.started || !result.totals) {
+        return
+      }
+
+      const totals = result.totals
+      if (totals.success + totals.failed === 0) {
+        return
+      }
+
+      await notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
+        status:
+          totals.failed > 0 && totals.success > 0
+            ? "partial_success"
+            : totals.failed > 0
+              ? "failure"
+              : "success",
+        counts: {
+          total: totals.success + totals.failed,
+          success: totals.success,
+          failed: totals.failed,
+        },
+      })
     })
 
     await this.applyScheduleFromPreferences({ preserveExisting: true })
@@ -249,6 +274,13 @@ class DailyBalanceHistoryScheduler {
       }
     } catch (error) {
       logger.error("End-of-day capture run failed", error)
+      if (params.trigger === "alarm") {
+        await notifyTaskResult({
+          task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
+          status: "failure",
+          message: getErrorMessage(error),
+        })
+      }
       return null
     } finally {
       this.isRunning = false

--- a/src/services/history/dailyBalanceHistory/scheduler.ts
+++ b/src/services/history/dailyBalanceHistory/scheduler.ts
@@ -7,7 +7,11 @@ import {
   type BalanceHistoryPreferences,
   type DailyBalanceHistoryCaptureSource,
 } from "~/types/dailyBalanceHistory"
-import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
+import {
+  getTaskNotificationStatusFromCounts,
+  TASK_NOTIFICATION_STATUSES,
+  TASK_NOTIFICATION_TASKS,
+} from "~/types/taskNotifications"
 import {
   clearAlarm,
   createAlarm,
@@ -81,12 +85,10 @@ class DailyBalanceHistoryScheduler {
 
       await notifyTaskResult({
         task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
-        status:
-          totals.failed > 0 && totals.success > 0
-            ? "partial_success"
-            : totals.failed > 0
-              ? "failure"
-              : "success",
+        status: getTaskNotificationStatusFromCounts({
+          successCount: totals.success,
+          failedCount: totals.failed,
+        }),
         counts: {
           total: totals.success + totals.failed,
           success: totals.success,
@@ -277,7 +279,7 @@ class DailyBalanceHistoryScheduler {
       if (params.trigger === "alarm") {
         await notifyTaskResult({
           task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
-          status: "failure",
+          status: TASK_NOTIFICATION_STATUSES.Failure,
           message: getErrorMessage(error),
         })
       }

--- a/src/services/history/usageHistory/scheduler.ts
+++ b/src/services/history/usageHistory/scheduler.ts
@@ -1,6 +1,8 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { notifyTaskResult } from "~/services/notifications/taskNotificationService"
 import { userPreferences } from "~/services/preferences/userPreferences"
+import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
 import type { UsageHistoryPreferences } from "~/types/usageHistory"
 import {
   DEFAULT_USAGE_HISTORY_PREFERENCES,
@@ -69,9 +71,14 @@ class UsageHistoryScheduler {
       }
 
       // Await to keep the MV3 service worker alive while the sync runs.
-      await this.runSync({
+      const result = await this.runSync({
         trigger: "alarm",
       })
+      if (!result) {
+        return
+      }
+
+      await this.notifyAlarmResult(result)
     })
 
     await this.applyScheduleFromPreferences()
@@ -245,10 +252,42 @@ class UsageHistoryScheduler {
       return { totals, perAccount }
     } catch (error) {
       logger.error("Sync run failed", error)
+      if (params.trigger === "alarm") {
+        await notifyTaskResult({
+          task: TASK_NOTIFICATION_TASKS.UsageHistorySync,
+          status: "failure",
+          message: getErrorMessage(error),
+        })
+      }
       return null
     } finally {
       this.isRunning = false
     }
+  }
+
+  private async notifyAlarmResult(
+    result: UsageHistoryBatchSyncResult,
+  ): Promise<void> {
+    const processedCount = result.totals.success + result.totals.error
+    if (processedCount === 0) {
+      return
+    }
+
+    await notifyTaskResult({
+      task: TASK_NOTIFICATION_TASKS.UsageHistorySync,
+      status:
+        result.totals.error > 0 && result.totals.success > 0
+          ? "partial_success"
+          : result.totals.error > 0
+            ? "failure"
+            : "success",
+      counts: {
+        total: result.perAccount.length,
+        success: result.totals.success,
+        failed: result.totals.error,
+        skipped: result.totals.skipped + result.totals.unsupported,
+      },
+    })
   }
 }
 

--- a/src/services/history/usageHistory/scheduler.ts
+++ b/src/services/history/usageHistory/scheduler.ts
@@ -2,7 +2,11 @@ import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { notifyTaskResult } from "~/services/notifications/taskNotificationService"
 import { userPreferences } from "~/services/preferences/userPreferences"
-import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
+import {
+  getTaskNotificationStatusFromCounts,
+  TASK_NOTIFICATION_STATUSES,
+  TASK_NOTIFICATION_TASKS,
+} from "~/types/taskNotifications"
 import type { UsageHistoryPreferences } from "~/types/usageHistory"
 import {
   DEFAULT_USAGE_HISTORY_PREFERENCES,
@@ -255,7 +259,7 @@ class UsageHistoryScheduler {
       if (params.trigger === "alarm") {
         await notifyTaskResult({
           task: TASK_NOTIFICATION_TASKS.UsageHistorySync,
-          status: "failure",
+          status: TASK_NOTIFICATION_STATUSES.Failure,
           message: getErrorMessage(error),
         })
       }
@@ -275,12 +279,10 @@ class UsageHistoryScheduler {
 
     await notifyTaskResult({
       task: TASK_NOTIFICATION_TASKS.UsageHistorySync,
-      status:
-        result.totals.error > 0 && result.totals.success > 0
-          ? "partial_success"
-          : result.totals.error > 0
-            ? "failure"
-            : "success",
+      status: getTaskNotificationStatusFromCounts({
+        successCount: result.totals.success,
+        failedCount: result.totals.error,
+      }),
       counts: {
         total: result.perAccount.length,
         success: result.totals.success,

--- a/src/services/models/modelSync/scheduler.ts
+++ b/src/services/models/modelSync/scheduler.ts
@@ -26,7 +26,11 @@ import {
   ExecutionResult,
 } from "~/types/managedSiteModelSync"
 import type { OctopusConfig } from "~/types/octopusConfig"
-import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
+import {
+  getTaskNotificationStatusFromCounts,
+  TASK_NOTIFICATION_STATUSES,
+  TASK_NOTIFICATION_TASKS,
+} from "~/types/taskNotifications"
 import {
   clearAlarm,
   createAlarm,
@@ -121,13 +125,10 @@ class ModelSyncScheduler {
               const result = await this.executeSync()
               await notifyTaskResult({
                 task: TASK_NOTIFICATION_TASKS.ManagedSiteModelSync,
-                status:
-                  result.statistics.failureCount > 0 &&
-                  result.statistics.successCount > 0
-                    ? "partial_success"
-                    : result.statistics.failureCount > 0
-                      ? "failure"
-                      : "success",
+                status: getTaskNotificationStatusFromCounts({
+                  successCount: result.statistics.successCount,
+                  failedCount: result.statistics.failureCount,
+                }),
                 counts: {
                   total: result.statistics.total,
                   success: result.statistics.successCount,
@@ -138,7 +139,7 @@ class ModelSyncScheduler {
               logger.error("Scheduled execution failed", error)
               await notifyTaskResult({
                 task: TASK_NOTIFICATION_TASKS.ManagedSiteModelSync,
-                status: "failure",
+                status: TASK_NOTIFICATION_STATUSES.Failure,
                 message: getErrorMessage(error),
               })
             }

--- a/src/services/models/modelSync/scheduler.ts
+++ b/src/services/models/modelSync/scheduler.ts
@@ -11,6 +11,7 @@ import {
   ManagedSiteMessagesKey,
 } from "~/services/managedSites/utils/managedSite"
 import { ModelRedirectService } from "~/services/models/modelRedirect"
+import { notifyTaskResult } from "~/services/notifications/taskNotificationService"
 import type { ChannelModelFilterRule } from "~/types/channelModelFilters"
 import type {
   ManagedSiteChannel,
@@ -25,6 +26,7 @@ import {
   ExecutionResult,
 } from "~/types/managedSiteModelSync"
 import type { OctopusConfig } from "~/types/octopusConfig"
+import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
 import {
   clearAlarm,
   createAlarm,
@@ -116,9 +118,29 @@ class ModelSyncScheduler {
           if (alarm.name === ModelSyncScheduler.ALARM_NAME) {
             try {
               // Await to keep the MV3 service worker alive while the sync runs.
-              await this.executeSync()
+              const result = await this.executeSync()
+              await notifyTaskResult({
+                task: TASK_NOTIFICATION_TASKS.ManagedSiteModelSync,
+                status:
+                  result.statistics.failureCount > 0 &&
+                  result.statistics.successCount > 0
+                    ? "partial_success"
+                    : result.statistics.failureCount > 0
+                      ? "failure"
+                      : "success",
+                counts: {
+                  total: result.statistics.total,
+                  success: result.statistics.successCount,
+                  failed: result.statistics.failureCount,
+                },
+              })
             } catch (error) {
               logger.error("Scheduled execution failed", error)
+              await notifyTaskResult({
+                task: TASK_NOTIFICATION_TASKS.ManagedSiteModelSync,
+                status: "failure",
+                message: getErrorMessage(error),
+              })
             }
           }
         })

--- a/src/services/notifications/taskNotificationService.ts
+++ b/src/services/notifications/taskNotificationService.ts
@@ -42,27 +42,26 @@ interface TaskNotificationPayload {
   message?: string
 }
 
+interface TaskNotificationMessageRequest {
+  action: string
+}
+
+interface TaskNotificationMessageResponse {
+  success: boolean
+  error?: string
+}
+
 const TASK_LABEL_KEYS: Record<TaskNotificationTask, string> = {
-  autoCheckin: "settings:taskNotifications.tasks.autoCheckin",
-  webdavAutoSync: "settings:taskNotifications.tasks.webdavAutoSync",
-  managedSiteModelSync: "settings:taskNotifications.tasks.managedSiteModelSync",
-  usageHistorySync: "settings:taskNotifications.tasks.usageHistorySync",
-  balanceHistoryCapture:
+  [TASK_NOTIFICATION_TASKS.AutoCheckin]:
+    "settings:taskNotifications.tasks.autoCheckin",
+  [TASK_NOTIFICATION_TASKS.WebdavAutoSync]:
+    "settings:taskNotifications.tasks.webdavAutoSync",
+  [TASK_NOTIFICATION_TASKS.ManagedSiteModelSync]:
+    "settings:taskNotifications.tasks.managedSiteModelSync",
+  [TASK_NOTIFICATION_TASKS.UsageHistorySync]:
+    "settings:taskNotifications.tasks.usageHistorySync",
+  [TASK_NOTIFICATION_TASKS.BalanceHistoryCapture]:
     "settings:taskNotifications.tasks.balanceHistoryCapture",
-}
-
-const STATUS_TITLE_KEYS: Record<TaskNotificationStatus, string> = {
-  success: "settings:taskNotifications.notification.title.success",
-  partial_success:
-    "settings:taskNotifications.notification.title.partialSuccess",
-  failure: "settings:taskNotifications.notification.title.failure",
-}
-
-const STATUS_BODY_KEYS: Record<TaskNotificationStatus, string> = {
-  success: "settings:taskNotifications.notification.body.success",
-  partial_success:
-    "settings:taskNotifications.notification.body.partialSuccess",
-  failure: "settings:taskNotifications.notification.body.failure",
 }
 
 const TASK_NAVIGATION_TARGETS: Record<
@@ -72,21 +71,21 @@ const TASK_NAVIGATION_TARGETS: Record<
     searchParams?: Record<string, string | undefined>
   }
 > = {
-  autoCheckin: {
+  [TASK_NOTIFICATION_TASKS.AutoCheckin]: {
     menuItemId: MENU_ITEM_IDS.AUTO_CHECKIN,
   },
-  webdavAutoSync: {
+  [TASK_NOTIFICATION_TASKS.WebdavAutoSync]: {
     menuItemId: MENU_ITEM_IDS.BASIC,
     searchParams: { tab: "dataBackup", anchor: "webdav-auto-sync" },
   },
-  managedSiteModelSync: {
+  [TASK_NOTIFICATION_TASKS.ManagedSiteModelSync]: {
     menuItemId: MENU_ITEM_IDS.MANAGED_SITE_MODEL_SYNC,
   },
-  usageHistorySync: {
+  [TASK_NOTIFICATION_TASKS.UsageHistorySync]: {
     menuItemId: MENU_ITEM_IDS.BASIC,
     searchParams: { tab: "accountUsage" },
   },
-  balanceHistoryCapture: {
+  [TASK_NOTIFICATION_TASKS.BalanceHistoryCapture]: {
     menuItemId: MENU_ITEM_IDS.BASIC,
     searchParams: { tab: "balanceHistory" },
   },
@@ -119,15 +118,66 @@ function formatCounts(counts: TaskNotificationCounts | undefined) {
 }
 
 /**
+ * Resolves the localized task label used inside notification copy.
+ */
+function getTaskLabel(task: TaskNotificationTask): string {
+  return t(TASK_LABEL_KEYS[task])
+}
+
+/**
+ * Resolves the localized notification title for the given status.
+ */
+function getNotificationTitle(
+  status: TaskNotificationStatus,
+  taskName: string,
+): string {
+  switch (status) {
+    case TASK_NOTIFICATION_STATUSES.Success:
+      return t("settings:taskNotifications.notification.title.success", {
+        task: taskName,
+      })
+    case TASK_NOTIFICATION_STATUSES.PartialSuccess:
+      return t("settings:taskNotifications.notification.title.partialSuccess", {
+        task: taskName,
+      })
+    case TASK_NOTIFICATION_STATUSES.Failure:
+      return t("settings:taskNotifications.notification.title.failure", {
+        task: taskName,
+      })
+  }
+}
+
+/**
+ * Resolves the localized fallback body for the given status.
+ */
+function getNotificationBody(
+  status: TaskNotificationStatus,
+  taskName: string,
+): string {
+  switch (status) {
+    case TASK_NOTIFICATION_STATUSES.Success:
+      return t("settings:taskNotifications.notification.body.success", {
+        task: taskName,
+      })
+    case TASK_NOTIFICATION_STATUSES.PartialSuccess:
+      return t("settings:taskNotifications.notification.body.partialSuccess", {
+        task: taskName,
+      })
+    case TASK_NOTIFICATION_STATUSES.Failure:
+      return t("settings:taskNotifications.notification.body.failure", {
+        task: taskName,
+      })
+  }
+}
+
+/**
  * Builds the localized title and message for a task notification payload.
  */
 function buildNotificationContent(payload: TaskNotificationPayload) {
-  const taskName = t(TASK_LABEL_KEYS[payload.task])
-  const title = t(STATUS_TITLE_KEYS[payload.status], { task: taskName })
+  const taskName = getTaskLabel(payload.task)
+  const title = getNotificationTitle(payload.status, taskName)
   const counts = formatCounts(payload.counts)
-  const fallbackMessage = t(STATUS_BODY_KEYS[payload.status], {
-    task: taskName,
-  })
+  const fallbackMessage = getNotificationBody(payload.status, taskName)
   const message = payload.message?.trim() || fallbackMessage
 
   return {
@@ -241,11 +291,18 @@ export function initializeTaskNotificationService(): void {
 }
 
 /**
+ * Test-only reset for the module-scoped click subscription guard.
+ */
+export function __resetTaskNotificationServiceForTesting(): void {
+  unsubscribeNotificationClicked = null
+}
+
+/**
  * Handles runtime requests that trigger a test task notification.
  */
 export async function handleTaskNotificationMessage(
-  request: any,
-  sendResponse: (response: any) => void,
+  request: TaskNotificationMessageRequest,
+  sendResponse: (response: TaskNotificationMessageResponse) => void,
 ): Promise<void> {
   if (request.action !== RuntimeActionIds.TaskNotificationsTest) {
     sendResponse({ success: false, error: "Unknown action" })

--- a/src/services/notifications/taskNotificationService.ts
+++ b/src/services/notifications/taskNotificationService.ts
@@ -1,0 +1,298 @@
+import iconUrl from "~/assets/icon.png"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import {
+  hasPermission,
+  OPTIONAL_PERMISSION_IDS,
+} from "~/services/permissions/permissionManager"
+import { userPreferences } from "~/services/preferences/userPreferences"
+import {
+  DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+  TASK_NOTIFICATION_TASKS,
+  type TaskNotificationStatus,
+  type TaskNotificationTask,
+} from "~/types/taskNotifications"
+import {
+  clearNotification,
+  createNotification,
+  hasNotificationsAPI,
+  onNotificationClicked,
+} from "~/utils/browser/browserApi"
+import { getErrorMessage } from "~/utils/core/error"
+import { createLogger } from "~/utils/core/logger"
+import { t } from "~/utils/i18n/core"
+import { openOrFocusOptionsMenuItem } from "~/utils/navigation"
+
+const logger = createLogger("TaskNotificationService")
+
+export interface TaskNotificationCounts {
+  total?: number
+  success?: number
+  failed?: number
+  skipped?: number
+}
+
+export interface TaskNotificationPayload {
+  task: TaskNotificationTask
+  status: TaskNotificationStatus
+  counts?: TaskNotificationCounts
+  message?: string
+}
+
+const TASK_NOTIFICATION_ID_PREFIX = "all-api-hub:task:"
+
+const TASK_LABEL_KEYS: Record<TaskNotificationTask, string> = {
+  autoCheckin: "settings:taskNotifications.tasks.autoCheckin",
+  webdavAutoSync: "settings:taskNotifications.tasks.webdavAutoSync",
+  managedSiteModelSync: "settings:taskNotifications.tasks.managedSiteModelSync",
+  usageHistorySync: "settings:taskNotifications.tasks.usageHistorySync",
+  balanceHistoryCapture:
+    "settings:taskNotifications.tasks.balanceHistoryCapture",
+}
+
+const STATUS_TITLE_KEYS: Record<TaskNotificationStatus, string> = {
+  success: "settings:taskNotifications.notification.title.success",
+  partial_success:
+    "settings:taskNotifications.notification.title.partialSuccess",
+  failure: "settings:taskNotifications.notification.title.failure",
+}
+
+const STATUS_BODY_KEYS: Record<TaskNotificationStatus, string> = {
+  success: "settings:taskNotifications.notification.body.success",
+  partial_success:
+    "settings:taskNotifications.notification.body.partialSuccess",
+  failure: "settings:taskNotifications.notification.body.failure",
+}
+
+const TASK_NAVIGATION_TARGETS: Record<
+  TaskNotificationTask,
+  {
+    menuItemId: Parameters<typeof openOrFocusOptionsMenuItem>[0]
+    searchParams?: Record<string, string | undefined>
+  }
+> = {
+  autoCheckin: {
+    menuItemId: MENU_ITEM_IDS.AUTO_CHECKIN,
+  },
+  webdavAutoSync: {
+    menuItemId: MENU_ITEM_IDS.BASIC,
+    searchParams: { tab: "dataBackup", anchor: "webdav-auto-sync" },
+  },
+  managedSiteModelSync: {
+    menuItemId: MENU_ITEM_IDS.MANAGED_SITE_MODEL_SYNC,
+  },
+  usageHistorySync: {
+    menuItemId: MENU_ITEM_IDS.BASIC,
+    searchParams: { tab: "accountUsage" },
+  },
+  balanceHistoryCapture: {
+    menuItemId: MENU_ITEM_IDS.BASIC,
+    searchParams: { tab: "balanceHistory" },
+  },
+}
+
+let unsubscribeNotificationClicked: (() => void) | null = null
+
+/**
+ *
+ */
+function getNotificationId(task: TaskNotificationTask): string {
+  return `${TASK_NOTIFICATION_ID_PREFIX}${task}`
+}
+
+/**
+ *
+ */
+function isTaskNotificationId(
+  notificationId: string,
+): notificationId is `${typeof TASK_NOTIFICATION_ID_PREFIX}${TaskNotificationTask}` {
+  return notificationId.startsWith(TASK_NOTIFICATION_ID_PREFIX)
+}
+
+/**
+ *
+ */
+function getTaskFromNotificationId(
+  notificationId: string,
+): TaskNotificationTask | null {
+  if (!isTaskNotificationId(notificationId)) {
+    return null
+  }
+
+  const task = notificationId.slice(TASK_NOTIFICATION_ID_PREFIX.length)
+  return Object.values(TASK_NOTIFICATION_TASKS).includes(
+    task as TaskNotificationTask,
+  )
+    ? (task as TaskNotificationTask)
+    : null
+}
+
+/**
+ *
+ */
+function formatCounts(counts: TaskNotificationCounts | undefined) {
+  if (!counts) {
+    return null
+  }
+
+  const hasAnyCount = Object.values(counts).some(
+    (value) => typeof value === "number" && Number.isFinite(value),
+  )
+
+  if (!hasAnyCount) {
+    return null
+  }
+
+  return t("settings:taskNotifications.notification.counts", {
+    total: counts.total ?? 0,
+    success: counts.success ?? 0,
+    failed: counts.failed ?? 0,
+    skipped: counts.skipped ?? 0,
+  })
+}
+
+/**
+ *
+ */
+function buildNotificationContent(payload: TaskNotificationPayload) {
+  const taskName = t(TASK_LABEL_KEYS[payload.task])
+  const title = t(STATUS_TITLE_KEYS[payload.status], { task: taskName })
+  const counts = formatCounts(payload.counts)
+  const fallbackMessage = t(STATUS_BODY_KEYS[payload.status], {
+    task: taskName,
+  })
+  const message = payload.message?.trim() || fallbackMessage
+
+  return {
+    title,
+    message: counts ? `${message} ${counts}` : message,
+  }
+}
+
+/**
+ *
+ */
+async function shouldNotify(
+  payload: TaskNotificationPayload,
+): Promise<boolean> {
+  const prefs = await userPreferences.getPreferences()
+  const taskNotifications =
+    prefs.taskNotifications ?? DEFAULT_TASK_NOTIFICATION_PREFERENCES
+
+  if (!taskNotifications.enabled || !taskNotifications.tasks[payload.task]) {
+    return false
+  }
+
+  if (!hasNotificationsAPI()) {
+    logger.warn("Task notification skipped: notifications API unavailable", {
+      task: payload.task,
+      status: payload.status,
+    })
+    return false
+  }
+
+  const granted = await hasPermission(OPTIONAL_PERMISSION_IDS.Notifications)
+  if (!granted) {
+    logger.debug("Task notification skipped: permission not granted", {
+      task: payload.task,
+      status: payload.status,
+    })
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Sends a best-effort system notification for a scheduled task result.
+ *
+ * Notification failures are deliberately swallowed so the background task result
+ * remains independent from user-facing delivery.
+ */
+export async function notifyTaskResult(
+  payload: TaskNotificationPayload,
+): Promise<boolean> {
+  try {
+    if (!(await shouldNotify(payload))) {
+      return false
+    }
+
+    const content = buildNotificationContent(payload)
+    const createdId = await createNotification(
+      getNotificationId(payload.task),
+      {
+        type: "basic",
+        iconUrl,
+        title: content.title,
+        message: content.message,
+        isClickable: true,
+      },
+    )
+
+    return createdId !== null
+  } catch (error) {
+    logger.warn("Task notification failed", {
+      task: payload.task,
+      status: payload.status,
+      error: getErrorMessage(error),
+    })
+    return false
+  }
+}
+
+/**
+ *
+ */
+async function handleNotificationClick(notificationId: string): Promise<void> {
+  const task = getTaskFromNotificationId(notificationId)
+  if (!task) {
+    return
+  }
+
+  const target = TASK_NAVIGATION_TARGETS[task]
+  await openOrFocusOptionsMenuItem(target.menuItemId, target.searchParams)
+  await clearNotification(notificationId)
+}
+
+/**
+ * Registers the notification click listener. Idempotent across background
+ * service initialization attempts.
+ */
+export function initializeTaskNotificationService(): void {
+  if (unsubscribeNotificationClicked) {
+    return
+  }
+
+  unsubscribeNotificationClicked = onNotificationClicked((notificationId) => {
+    void handleNotificationClick(notificationId).catch((error) => {
+      logger.warn("Failed to handle task notification click", {
+        notificationId,
+        error: getErrorMessage(error),
+      })
+    })
+  })
+}
+
+/**
+ *
+ */
+export async function handleTaskNotificationMessage(
+  request: any,
+  sendResponse: (response: any) => void,
+): Promise<void> {
+  if (request.action !== RuntimeActionIds.TaskNotificationsTest) {
+    sendResponse({ success: false, error: "Unknown action" })
+    return
+  }
+
+  const success = await notifyTaskResult({
+    task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+    status: "success",
+    message: t("settings:taskNotifications.test.message"),
+  })
+
+  sendResponse({
+    success,
+    error: success ? undefined : t("settings:taskNotifications.test.failed"),
+  })
+}

--- a/src/services/notifications/taskNotificationService.ts
+++ b/src/services/notifications/taskNotificationService.ts
@@ -28,14 +28,14 @@ import { openOrFocusOptionsMenuItem } from "~/utils/navigation"
 
 const logger = createLogger("TaskNotificationService")
 
-export interface TaskNotificationCounts {
+interface TaskNotificationCounts {
   total?: number
   success?: number
   failed?: number
   skipped?: number
 }
 
-export interface TaskNotificationPayload {
+interface TaskNotificationPayload {
   task: TaskNotificationTask
   status: TaskNotificationStatus
   counts?: TaskNotificationCounts

--- a/src/services/notifications/taskNotificationService.ts
+++ b/src/services/notifications/taskNotificationService.ts
@@ -8,6 +8,9 @@ import {
 import { userPreferences } from "~/services/preferences/userPreferences"
 import {
   DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+  getTaskNotificationId,
+  parseTaskNotificationId,
+  TASK_NOTIFICATION_STATUSES,
   TASK_NOTIFICATION_TASKS,
   type TaskNotificationStatus,
   type TaskNotificationTask,
@@ -38,8 +41,6 @@ export interface TaskNotificationPayload {
   counts?: TaskNotificationCounts
   message?: string
 }
-
-const TASK_NOTIFICATION_ID_PREFIX = "all-api-hub:task:"
 
 const TASK_LABEL_KEYS: Record<TaskNotificationTask, string> = {
   autoCheckin: "settings:taskNotifications.tasks.autoCheckin",
@@ -94,41 +95,7 @@ const TASK_NAVIGATION_TARGETS: Record<
 let unsubscribeNotificationClicked: (() => void) | null = null
 
 /**
- *
- */
-function getNotificationId(task: TaskNotificationTask): string {
-  return `${TASK_NOTIFICATION_ID_PREFIX}${task}`
-}
-
-/**
- *
- */
-function isTaskNotificationId(
-  notificationId: string,
-): notificationId is `${typeof TASK_NOTIFICATION_ID_PREFIX}${TaskNotificationTask}` {
-  return notificationId.startsWith(TASK_NOTIFICATION_ID_PREFIX)
-}
-
-/**
- *
- */
-function getTaskFromNotificationId(
-  notificationId: string,
-): TaskNotificationTask | null {
-  if (!isTaskNotificationId(notificationId)) {
-    return null
-  }
-
-  const task = notificationId.slice(TASK_NOTIFICATION_ID_PREFIX.length)
-  return Object.values(TASK_NOTIFICATION_TASKS).includes(
-    task as TaskNotificationTask,
-  )
-    ? (task as TaskNotificationTask)
-    : null
-}
-
-/**
- *
+ * Formats task execution counts for inclusion in notification copy.
  */
 function formatCounts(counts: TaskNotificationCounts | undefined) {
   if (!counts) {
@@ -152,7 +119,7 @@ function formatCounts(counts: TaskNotificationCounts | undefined) {
 }
 
 /**
- *
+ * Builds the localized title and message for a task notification payload.
  */
 function buildNotificationContent(payload: TaskNotificationPayload) {
   const taskName = t(TASK_LABEL_KEYS[payload.task])
@@ -170,7 +137,7 @@ function buildNotificationContent(payload: TaskNotificationPayload) {
 }
 
 /**
- *
+ * Checks user preferences and browser capabilities before sending a notification.
  */
 async function shouldNotify(
   payload: TaskNotificationPayload,
@@ -219,7 +186,7 @@ export async function notifyTaskResult(
 
     const content = buildNotificationContent(payload)
     const createdId = await createNotification(
-      getNotificationId(payload.task),
+      getTaskNotificationId(payload.task),
       {
         type: "basic",
         iconUrl,
@@ -241,10 +208,10 @@ export async function notifyTaskResult(
 }
 
 /**
- *
+ * Handles task-notification clicks by opening the related settings destination.
  */
 async function handleNotificationClick(notificationId: string): Promise<void> {
-  const task = getTaskFromNotificationId(notificationId)
+  const task = parseTaskNotificationId(notificationId)
   if (!task) {
     return
   }
@@ -274,7 +241,7 @@ export function initializeTaskNotificationService(): void {
 }
 
 /**
- *
+ * Handles runtime requests that trigger a test task notification.
  */
 export async function handleTaskNotificationMessage(
   request: any,
@@ -287,7 +254,7 @@ export async function handleTaskNotificationMessage(
 
   const success = await notifyTaskResult({
     task: TASK_NOTIFICATION_TASKS.AutoCheckin,
-    status: "success",
+    status: TASK_NOTIFICATION_STATUSES.Success,
     message: t("settings:taskNotifications.test.message"),
   })
 

--- a/src/services/permissions/permissionManager.ts
+++ b/src/services/permissions/permissionManager.ts
@@ -13,6 +13,7 @@ export const OPTIONAL_PERMISSION_IDS = {
   WebRequest: "webRequest",
   WebRequestBlocking: "webRequestBlocking",
   ClipboardRead: "clipboardRead",
+  Notifications: "notifications",
 } as const
 
 export type ManifestOptionalPermissions =

--- a/src/services/preferences/migrations/preferencesMigration.ts
+++ b/src/services/preferences/migrations/preferencesMigration.ts
@@ -18,6 +18,7 @@ import {
   type BalanceHistoryPreferences,
 } from "~/types/dailyBalanceHistory"
 import { DEFAULT_OCTOPUS_CONFIG } from "~/types/octopusConfig"
+import { DEFAULT_TASK_NOTIFICATION_PREFERENCES } from "~/types/taskNotifications"
 import {
   DEFAULT_WEBDAV_SETTINGS,
   resolveWebdavSyncDataSelection,
@@ -32,7 +33,7 @@ import { migrateSortingConfig } from "./sortingConfigMigration"
 const logger = createLogger("PreferencesMigration")
 
 // Current version of the preferences schema
-export const CURRENT_PREFERENCES_VERSION = 18
+export const CURRENT_PREFERENCES_VERSION = 19
 
 /**
  * Migration function type
@@ -404,6 +405,30 @@ const migrations: Record<number, PreferencesMigrationFunction> = {
       ...prefs,
       sortingPriorityConfig: migratedSortingConfig,
       preferencesVersion: 18,
+    }
+  },
+
+  // Version 18 -> 19: Introduce scheduled task notification preferences
+  19: (prefs: UserPreferences): UserPreferences => {
+    logger.debug("Migrating preferences from v18 to v19 (task notifications)")
+
+    const stored = (prefs as any).taskNotifications
+    const storedTasks =
+      stored && typeof stored === "object" ? stored.tasks : undefined
+
+    return {
+      ...prefs,
+      taskNotifications: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+        ...(stored && typeof stored === "object" ? stored : {}),
+        tasks: {
+          ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+          ...(storedTasks && typeof storedTasks === "object"
+            ? storedTasks
+            : {}),
+        },
+      },
+      preferencesVersion: 19,
     }
   },
 }

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -1216,6 +1216,9 @@ class UserPreferencesService {
     })
   }
 
+  /**
+   * Update task-notification preferences.
+   */
   async updateTaskNotifications(
     updates: Partial<TaskNotificationPreferences>,
   ): Promise<boolean> {
@@ -1224,6 +1227,9 @@ class UserPreferencesService {
     })
   }
 
+  /**
+   * Reset task-notification preferences.
+   */
   async resetTaskNotifications(): Promise<boolean> {
     return this.savePreferences({
       taskNotifications: DEFAULT_PREFERENCES.taskNotifications,

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -78,6 +78,10 @@ import {
 import { DEFAULT_NEW_API_CONFIG, NewApiConfig } from "~/types/newApiConfig"
 import { DEFAULT_OCTOPUS_CONFIG, OctopusConfig } from "~/types/octopusConfig"
 import type { SortingPriorityConfig } from "~/types/sorting"
+import {
+  DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+  type TaskNotificationPreferences,
+} from "~/types/taskNotifications"
 import type { ThemeMode } from "~/types/theme"
 import {
   DEFAULT_USAGE_HISTORY_PREFERENCES,
@@ -373,6 +377,12 @@ export interface UserPreferences {
   tempWindowFallbackReminder?: TempWindowFallbackReminderPreferences
 
   /**
+   * Controls best-effort system notifications emitted by background scheduled
+   * jobs. Browser notification permission is still requested separately.
+   */
+  taskNotifications?: TaskNotificationPreferences
+
+  /**
    * 最后更新时间
    */
   lastUpdated: number
@@ -546,6 +556,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   tempWindowFallbackReminder: {
     dismissed: false,
   },
+  taskNotifications: DEFAULT_TASK_NOTIFICATION_PREFERENCES,
 }
 
 /**
@@ -1202,6 +1213,20 @@ class UserPreferencesService {
   async resetWebdavConfig(): Promise<boolean> {
     return this.savePreferences({
       webdav: DEFAULT_PREFERENCES.webdav,
+    })
+  }
+
+  async updateTaskNotifications(
+    updates: Partial<TaskNotificationPreferences>,
+  ): Promise<boolean> {
+    return this.savePreferences({
+      taskNotifications: updates,
+    })
+  }
+
+  async resetTaskNotifications(): Promise<boolean> {
+    return this.savePreferences({
+      taskNotifications: DEFAULT_PREFERENCES.taskNotifications,
     })
   }
 }

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -8,6 +8,7 @@ import {
   normalizeBackupForMerge,
   type BackupFullV2,
 } from "~/services/importExport/importExportService"
+import { notifyTaskResult } from "~/services/notifications/taskNotificationService"
 import {
   getSharedPreferencesLastUpdated,
   restoreWebdavLocalOnlyPreferences,
@@ -24,6 +25,7 @@ import {
   type ApiCredentialProfilesConfig,
 } from "~/types/apiCredentialProfiles"
 import type { ChannelConfigMap } from "~/types/channelConfig"
+import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
 import {
   isWebdavSyncDataSelectionEmpty,
   resolveWebdavSyncDataSelection,
@@ -285,11 +287,20 @@ class WebdavAutoSyncService {
       this.notifyFrontend("sync_completed", {
         timestamp: this.lastSyncTime,
       })
+      await notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.WebdavAutoSync,
+        status: "success",
+      })
     } catch (error) {
       logger.error("后台同步失败", error)
       this.lastSyncStatus = "error"
       this.lastSyncError = getErrorMessage(error)
       this.notifyFrontend("sync_error", { error: getErrorMessage(error) })
+      await notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.WebdavAutoSync,
+        status: "failure",
+        message: getErrorMessage(error),
+      })
     } finally {
       this.isSyncing = false
     }

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -25,7 +25,10 @@ import {
   type ApiCredentialProfilesConfig,
 } from "~/types/apiCredentialProfiles"
 import type { ChannelConfigMap } from "~/types/channelConfig"
-import { TASK_NOTIFICATION_TASKS } from "~/types/taskNotifications"
+import {
+  TASK_NOTIFICATION_STATUSES,
+  TASK_NOTIFICATION_TASKS,
+} from "~/types/taskNotifications"
 import {
   isWebdavSyncDataSelectionEmpty,
   resolveWebdavSyncDataSelection,
@@ -289,7 +292,7 @@ class WebdavAutoSyncService {
       })
       await notifyTaskResult({
         task: TASK_NOTIFICATION_TASKS.WebdavAutoSync,
-        status: "success",
+        status: TASK_NOTIFICATION_STATUSES.Success,
       })
     } catch (error) {
       logger.error("后台同步失败", error)
@@ -298,7 +301,7 @@ class WebdavAutoSyncService {
       this.notifyFrontend("sync_error", { error: getErrorMessage(error) })
       await notifyTaskResult({
         task: TASK_NOTIFICATION_TASKS.WebdavAutoSync,
-        status: "failure",
+        status: TASK_NOTIFICATION_STATUSES.Failure,
         message: getErrorMessage(error),
       })
     } finally {

--- a/src/types/taskNotifications.ts
+++ b/src/types/taskNotifications.ts
@@ -9,7 +9,14 @@ export const TASK_NOTIFICATION_TASKS = {
 export type TaskNotificationTask =
   (typeof TASK_NOTIFICATION_TASKS)[keyof typeof TASK_NOTIFICATION_TASKS]
 
-export type TaskNotificationStatus = "success" | "partial_success" | "failure"
+export const TASK_NOTIFICATION_STATUSES = {
+  Success: "success",
+  PartialSuccess: "partial_success",
+  Failure: "failure",
+} as const
+
+export type TaskNotificationStatus =
+  (typeof TASK_NOTIFICATION_STATUSES)[keyof typeof TASK_NOTIFICATION_STATUSES]
 
 export type TaskNotificationTaskPreferences = Record<
   TaskNotificationTask,
@@ -21,17 +28,64 @@ export interface TaskNotificationPreferences {
   tasks: TaskNotificationTaskPreferences
 }
 
+export const TASK_NOTIFICATION_TASK_ORDER = [
+  TASK_NOTIFICATION_TASKS.AutoCheckin,
+  TASK_NOTIFICATION_TASKS.WebdavAutoSync,
+  TASK_NOTIFICATION_TASKS.ManagedSiteModelSync,
+  TASK_NOTIFICATION_TASKS.UsageHistorySync,
+  TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
+] as const satisfies readonly TaskNotificationTask[]
+
+export const TASK_NOTIFICATION_ID_PREFIX = "all-api-hub:task:" as const
+
 export const DEFAULT_TASK_NOTIFICATION_TASK_PREFERENCES: TaskNotificationTaskPreferences =
-  {
-    autoCheckin: true,
-    webdavAutoSync: true,
-    managedSiteModelSync: true,
-    usageHistorySync: true,
-    balanceHistoryCapture: true,
-  }
+  Object.fromEntries(
+    TASK_NOTIFICATION_TASK_ORDER.map((task) => [task, true]),
+  ) as TaskNotificationTaskPreferences
 
 export const DEFAULT_TASK_NOTIFICATION_PREFERENCES: TaskNotificationPreferences =
   {
     enabled: true,
     tasks: DEFAULT_TASK_NOTIFICATION_TASK_PREFERENCES,
   }
+
+/**
+ * Builds the stable browser notification id for a task notification.
+ */
+export function getTaskNotificationId(task: TaskNotificationTask): string {
+  return `${TASK_NOTIFICATION_ID_PREFIX}${task}`
+}
+
+/**
+ * Parses a task notification id back into its task key when it matches the known format.
+ */
+export function parseTaskNotificationId(
+  notificationId: string,
+): TaskNotificationTask | null {
+  if (!notificationId.startsWith(TASK_NOTIFICATION_ID_PREFIX)) {
+    return null
+  }
+
+  const task = notificationId.slice(TASK_NOTIFICATION_ID_PREFIX.length)
+  return TASK_NOTIFICATION_TASK_ORDER.includes(task as TaskNotificationTask)
+    ? (task as TaskNotificationTask)
+    : null
+}
+
+/**
+ * Derives an overall notification status from per-run success and failure counts.
+ */
+export function getTaskNotificationStatusFromCounts(params: {
+  successCount: number
+  failedCount: number
+}): TaskNotificationStatus {
+  if (params.failedCount > 0 && params.successCount > 0) {
+    return TASK_NOTIFICATION_STATUSES.PartialSuccess
+  }
+
+  if (params.failedCount > 0) {
+    return TASK_NOTIFICATION_STATUSES.Failure
+  }
+
+  return TASK_NOTIFICATION_STATUSES.Success
+}

--- a/src/types/taskNotifications.ts
+++ b/src/types/taskNotifications.ts
@@ -28,7 +28,7 @@ export interface TaskNotificationPreferences {
   tasks: TaskNotificationTaskPreferences
 }
 
-export const TASK_NOTIFICATION_TASK_ORDER = [
+const TASK_NOTIFICATION_TASK_ORDER = [
   TASK_NOTIFICATION_TASKS.AutoCheckin,
   TASK_NOTIFICATION_TASKS.WebdavAutoSync,
   TASK_NOTIFICATION_TASKS.ManagedSiteModelSync,
@@ -36,9 +36,9 @@ export const TASK_NOTIFICATION_TASK_ORDER = [
   TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
 ] as const satisfies readonly TaskNotificationTask[]
 
-export const TASK_NOTIFICATION_ID_PREFIX = "all-api-hub:task:" as const
+const TASK_NOTIFICATION_ID_PREFIX = "all-api-hub:task:" as const
 
-export const DEFAULT_TASK_NOTIFICATION_TASK_PREFERENCES: TaskNotificationTaskPreferences =
+const DEFAULT_TASK_NOTIFICATION_TASK_PREFERENCES: TaskNotificationTaskPreferences =
   Object.fromEntries(
     TASK_NOTIFICATION_TASK_ORDER.map((task) => [task, true]),
   ) as TaskNotificationTaskPreferences

--- a/src/types/taskNotifications.ts
+++ b/src/types/taskNotifications.ts
@@ -1,0 +1,37 @@
+export const TASK_NOTIFICATION_TASKS = {
+  AutoCheckin: "autoCheckin",
+  WebdavAutoSync: "webdavAutoSync",
+  ManagedSiteModelSync: "managedSiteModelSync",
+  UsageHistorySync: "usageHistorySync",
+  BalanceHistoryCapture: "balanceHistoryCapture",
+} as const
+
+export type TaskNotificationTask =
+  (typeof TASK_NOTIFICATION_TASKS)[keyof typeof TASK_NOTIFICATION_TASKS]
+
+export type TaskNotificationStatus = "success" | "partial_success" | "failure"
+
+export type TaskNotificationTaskPreferences = Record<
+  TaskNotificationTask,
+  boolean
+>
+
+export interface TaskNotificationPreferences {
+  enabled: boolean
+  tasks: TaskNotificationTaskPreferences
+}
+
+export const DEFAULT_TASK_NOTIFICATION_TASK_PREFERENCES: TaskNotificationTaskPreferences =
+  {
+    autoCheckin: true,
+    webdavAutoSync: true,
+    managedSiteModelSync: true,
+    usageHistorySync: true,
+    balanceHistoryCapture: true,
+  }
+
+export const DEFAULT_TASK_NOTIFICATION_PREFERENCES: TaskNotificationPreferences =
+  {
+    enabled: true,
+    tasks: DEFAULT_TASK_NOTIFICATION_TASK_PREFERENCES,
+  }

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -815,6 +815,77 @@ export function onAlarm(
 }
 
 /**
+ * Check whether the notifications API is available in this runtime.
+ */
+export function hasNotificationsAPI(): boolean {
+  return !!browser.notifications
+}
+
+/**
+ * Creates or replaces a browser notification. Returns the created id, or null
+ * when notifications are unavailable or creation fails.
+ */
+export async function createNotification(
+  notificationId: string,
+  options: browser.notifications.CreateNotificationOptions,
+): Promise<string | null> {
+  if (!hasNotificationsAPI()) {
+    logger.warn("Notifications API not supported")
+    return null
+  }
+
+  try {
+    return await browser.notifications.create(notificationId, options)
+  } catch (error) {
+    logger.warn("notifications.create failed", {
+      notificationId,
+      error: getErrorMessage(error),
+    })
+    return null
+  }
+}
+
+/**
+ * Clears a browser notification. Returns false when unsupported or clearing
+ * fails.
+ */
+export async function clearNotification(
+  notificationId: string,
+): Promise<boolean> {
+  if (!hasNotificationsAPI()) {
+    logger.warn("Notifications API not supported")
+    return false
+  }
+
+  try {
+    return (await browser.notifications.clear(notificationId)) || false
+  } catch (error) {
+    logger.warn("notifications.clear failed", {
+      notificationId,
+      error: getErrorMessage(error),
+    })
+    return false
+  }
+}
+
+/**
+ * Subscribes to notification click events and returns an unsubscribe callback.
+ */
+export function onNotificationClicked(
+  callback: (notificationId: string) => void | Promise<void>,
+): () => void {
+  if (!hasNotificationsAPI()) {
+    logger.warn("Notifications API not supported")
+    return () => {}
+  }
+
+  browser.notifications.onClicked.addListener(callback)
+  return () => {
+    browser.notifications.onClicked.removeListener(callback)
+  }
+}
+
+/**
  * 获取当前扩展的 manifest 版本
  */
 export function getManifest(): browser._manifest.WebExtensionManifest {

--- a/src/utils/core/url.ts
+++ b/src/utils/core/url.ts
@@ -41,6 +41,10 @@ function scrollToAnchorWhenAvailable(
   } = options
 
   const tryScroll = (remainingWaitMs: number) => {
+    if (typeof document === "undefined" || typeof window === "undefined") {
+      return
+    }
+
     const element = document.getElementById(anchor)
     if (element) {
       element.scrollIntoView({ behavior: "smooth", block: "start" })

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -384,6 +384,20 @@ describe("UserPreferencesContext", () => {
     expect((latestContext as any)?.showTodayCashflow).toBe(false)
   })
 
+  it("falls back to default task notification preferences when they are missing", async () => {
+    const preferences = clonePreferences()
+    delete (preferences as Partial<UserPreferences>).taskNotifications
+
+    const context = await renderProvider(preferences)
+
+    expect(context.taskNotifications).toEqual(
+      DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+    )
+    expect(
+      (latestContext as any)?.preferences.taskNotifications,
+    ).toBeUndefined()
+  })
+
   it("updates scalar, nested, and runtime-backed preferences through the provider", async () => {
     const context = await renderProvider()
 

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -398,6 +398,30 @@ describe("UserPreferencesContext", () => {
     ).toBeUndefined()
   })
 
+  it("hydrates missing task notification preferences before applying local updates", async () => {
+    const preferences = clonePreferences()
+    delete (preferences as Partial<UserPreferences>).taskNotifications
+
+    const context = await renderProvider(preferences)
+
+    await act(async () => {
+      await context.updateTaskNotifications({
+        tasks: {
+          ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+          autoCheckin: false,
+        },
+      })
+    })
+
+    expect((latestContext as any)?.preferences.taskNotifications).toEqual({
+      ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+      tasks: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+        autoCheckin: false,
+      },
+    })
+  })
+
   it("updates scalar, nested, and runtime-backed preferences through the provider", async () => {
     const context = await renderProvider()
 
@@ -1773,6 +1797,82 @@ describe("UserPreferencesContext", () => {
       error: "Invalid response from background",
     })
     expect((latestContext as any)?.preferences.webdav.autoSync).toBe(true)
+  })
+
+  it("keeps the visible task notification state stable while an update succeeds during a deferred reload", async () => {
+    const initialPreferences = clonePreferences()
+    initialPreferences.taskNotifications = {
+      ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+      enabled: true,
+    }
+    const deferredPreferences = createDeferred<UserPreferences>()
+    mockedUserPreferences.getPreferences
+      .mockResolvedValueOnce(initialPreferences)
+      .mockReturnValueOnce(deferredPreferences.promise)
+    mockedUserPreferences.updateTaskNotifications.mockResolvedValueOnce(true)
+
+    const context = await renderProvider(initialPreferences)
+
+    await act(async () => {
+      void context.loadPreferences()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-state")).toHaveTextContent("true")
+    })
+
+    await act(async () => {
+      expect(
+        await context.updateTaskNotifications({
+          enabled: false,
+        }),
+      ).toBe(true)
+    })
+
+    expect((latestContext as any)?.preferences.taskNotifications.enabled).toBe(
+      false,
+    )
+
+    await act(async () => {
+      deferredPreferences.resolve(initialPreferences)
+      await deferredPreferences.promise
+    })
+  })
+
+  it("keeps the visible task notification state stable while a reset succeeds during a deferred reload", async () => {
+    const initialPreferences = clonePreferences()
+    initialPreferences.taskNotifications = {
+      ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+      enabled: false,
+    }
+    const deferredPreferences = createDeferred<UserPreferences>()
+    mockedUserPreferences.getPreferences
+      .mockResolvedValueOnce(initialPreferences)
+      .mockReturnValueOnce(deferredPreferences.promise)
+    mockedUserPreferences.resetTaskNotifications.mockResolvedValueOnce(true)
+
+    const context = await renderProvider(initialPreferences)
+
+    await act(async () => {
+      void context.loadPreferences()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-state")).toHaveTextContent("true")
+    })
+
+    await act(async () => {
+      expect(await context.resetTaskNotifications()).toBe(true)
+    })
+
+    expect((latestContext as any)?.preferences.taskNotifications).toEqual(
+      DEFAULT_PREFERENCES.taskNotifications,
+    )
+
+    await act(async () => {
+      deferredPreferences.resolve(initialPreferences)
+      await deferredPreferences.promise
+    })
   })
 
   it("hydrates the provider from the saved WebDAV snapshot returned by background updates", async () => {

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -29,6 +29,7 @@ import { DEFAULT_BALANCE_HISTORY_PREFERENCES } from "~/types/dailyBalanceHistory
 import { DEFAULT_DONE_HUB_CONFIG } from "~/types/doneHubConfig"
 import { DEFAULT_OCTOPUS_CONFIG } from "~/types/octopusConfig"
 import { SortingCriteriaType } from "~/types/sorting"
+import { DEFAULT_TASK_NOTIFICATION_PREFERENCES } from "~/types/taskNotifications"
 import { deepOverride } from "~/utils"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import {
@@ -82,6 +83,7 @@ vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
       updateWarnOnDuplicateAccountAdd: vi.fn(),
       updateManagedSiteType: vi.fn(),
       updateLoggingPreferences: vi.fn(),
+      updateTaskNotifications: vi.fn(),
       resetToDefaults: vi.fn(),
       resetDisplaySettings: vi.fn(),
       resetAutoRefreshConfig: vi.fn(),
@@ -100,6 +102,7 @@ vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
       resetModelRedirectConfig: vi.fn(),
       resetWebdavConfig: vi.fn(),
       resetSortingPriorityConfig: vi.fn(),
+      resetTaskNotifications: vi.fn(),
     },
   }
 })
@@ -222,6 +225,9 @@ describe("UserPreferencesContext", () => {
     mockedUserPreferences.updateLoggingPreferences.mockImplementation(
       async (updates) => applyPersistedUpdate({ logging: updates }),
     )
+    mockedUserPreferences.updateTaskNotifications.mockImplementation(
+      async (updates) => applyPersistedUpdate({ taskNotifications: updates }),
+    )
     mockedUserPreferences.resetToDefaults.mockResolvedValue(true)
     mockedUserPreferences.resetDisplaySettings.mockImplementation(async () =>
       applyPersistedUpdate({
@@ -312,6 +318,11 @@ describe("UserPreferencesContext", () => {
       }),
     )
     mockedUserPreferences.resetSortingPriorityConfig.mockResolvedValue(true)
+    mockedUserPreferences.resetTaskNotifications.mockImplementation(async () =>
+      applyPersistedUpdate({
+        taskNotifications: DEFAULT_PREFERENCES.taskNotifications,
+      }),
+    )
     mockedSendRuntimeMessage.mockResolvedValue(undefined)
   })
 
@@ -457,6 +468,13 @@ describe("UserPreferencesContext", () => {
       await context.updateTempWindowFallbackReminder({
         dismissed: true,
       })
+      await context.updateTaskNotifications({
+        enabled: false,
+        tasks: {
+          ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+          autoCheckin: false,
+        },
+      })
       await context.updateCliProxyBaseUrl("https://cli.example")
       await context.updateCliProxyManagementKey("cli-key")
       await context.updateClaudeCodeRouterBaseUrl("https://ccr.example")
@@ -594,6 +612,13 @@ describe("UserPreferencesContext", () => {
     expect(
       (latestContext as any)?.preferences.tempWindowFallbackReminder.dismissed,
     ).toBe(true)
+    expect((latestContext as any)?.preferences.taskNotifications).toEqual({
+      enabled: false,
+      tasks: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+        autoCheckin: false,
+      },
+    })
 
     expect(mockedSendRuntimeMessage).toHaveBeenCalledWith({
       action: RuntimeActionIds.PreferencesUpdateActionClickBehavior,
@@ -922,6 +947,7 @@ describe("UserPreferencesContext", () => {
       await context.resetWebdavConfig()
       await context.resetLoggingSettings()
       await context.resetSortingPriorityConfig()
+      await context.resetTaskNotifications()
     })
 
     expect((latestContext as any)?.preferences.currencyType).toBe(
@@ -974,6 +1000,9 @@ describe("UserPreferencesContext", () => {
     )
     expect((latestContext as any)?.preferences.sortingPriorityConfig).toBe(
       undefined,
+    )
+    expect((latestContext as any)?.preferences.taskNotifications).toEqual(
+      DEFAULT_PREFERENCES.taskNotifications,
     )
 
     expect(mockedSendRuntimeMessage).toHaveBeenCalledWith({
@@ -1319,6 +1348,7 @@ describe("UserPreferencesContext", () => {
     mockedUserPreferences.resetWebdavConfig.mockResolvedValue(false)
     mockedUserPreferences.updateLoggingPreferences.mockResolvedValue(false)
     mockedUserPreferences.resetSortingPriorityConfig.mockResolvedValue(false)
+    mockedUserPreferences.resetTaskNotifications.mockResolvedValue(false)
 
     const context = await renderProvider(preferences)
 
@@ -1341,6 +1371,7 @@ describe("UserPreferencesContext", () => {
       expect(await context.resetWebdavConfig()).toBe(false)
       expect(await context.resetLoggingSettings()).toBe(false)
       expect(await context.resetSortingPriorityConfig()).toBe(false)
+      expect(await context.resetTaskNotifications()).toBe(false)
     })
 
     expect((latestContext as any)?.preferences).toEqual(preferences)

--- a/tests/entrypoints/background/runtimeMessages.more.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.more.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   handleUsageHistoryMessage: vi.fn(),
   handleWebdavAutoSyncMessage: vi.fn(),
   handleDailyBalanceHistoryMessage: vi.fn(),
+  handleTaskNotificationMessage: vi.fn(),
   handleLdohSiteLookupMessage: vi.fn(),
   handleWebAiApiCheckMessage: vi.fn(),
   handleAccountKeyRepairMessage: vi.fn(),
@@ -111,6 +112,10 @@ vi.mock("~/services/history/dailyBalanceHistory/scheduler", () => ({
 
 vi.mock("~/services/webdav/webdavAutoSyncService", () => ({
   handleWebdavAutoSyncMessage: mocks.handleWebdavAutoSyncMessage,
+}))
+
+vi.mock("~/services/notifications/taskNotificationService", () => ({
+  handleTaskNotificationMessage: mocks.handleTaskNotificationMessage,
 }))
 
 vi.mock("~/services/integrations/ldohSiteLookup/background", () => ({
@@ -362,6 +367,10 @@ describe("setupRuntimeMessageListeners additional routing", () => {
       {
         request: { action: RuntimeActionIds.LdohSiteLookupRefreshSites },
         expected: mocks.handleLdohSiteLookupMessage,
+      },
+      {
+        request: { action: RuntimeActionIds.TaskNotificationsTest },
+        expected: mocks.handleTaskNotificationMessage,
       },
     ]
 

--- a/tests/entrypoints/options/PermissionSettings.test.tsx
+++ b/tests/entrypoints/options/PermissionSettings.test.tsx
@@ -120,7 +120,10 @@ describe("PermissionSettings", () => {
       "settings:permissions.messages.revoked",
       "settings:permissions.messages.revokeFailed",
     )
-    expect(hasPermissionMock).toHaveBeenCalledTimes(6)
+    expect(hasPermissionMock).toHaveBeenCalledWith("cookies")
+    expect(hasPermissionMock).toHaveBeenCalledWith("clipboardRead")
+    expect(hasPermissionMock).toHaveBeenCalledWith("notifications")
+    expect(hasPermissionMock.mock.calls.length).toBeGreaterThanOrEqual(3)
   })
 
   it("reloads statuses on external permission change and unsubscribes on cleanup", async () => {
@@ -141,7 +144,9 @@ describe("PermissionSettings", () => {
     })
 
     await waitFor(() => {
-      expect(hasPermissionMock).toHaveBeenCalledTimes(6)
+      expect(hasPermissionMock).toHaveBeenCalledWith("cookies")
+      expect(hasPermissionMock).toHaveBeenCalledWith("clipboardRead")
+      expect(hasPermissionMock).toHaveBeenCalledWith("notifications")
     })
 
     unmount()
@@ -156,6 +161,7 @@ describe("PermissionSettings", () => {
       withThemeProvider: false,
     })
 
+    await screen.findByText("settings:permissions.items.clipboardRead.title")
     const clipboardRow = document.getElementById("clipboardRead")
     if (!clipboardRow) {
       throw new Error("Expected clipboard permission row")

--- a/tests/entrypoints/options/PermissionSettings.test.tsx
+++ b/tests/entrypoints/options/PermissionSettings.test.tsx
@@ -2,7 +2,7 @@ import { act, cleanup, fireEvent } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import PermissionSettings from "~/features/BasicSettings/components/tabs/Permissions/PermissionSettings"
-import { render, screen, waitFor } from "~~/tests/test-utils/render"
+import { render, screen, waitFor, within } from "~~/tests/test-utils/render"
 
 const {
   changedListenerRef,
@@ -25,8 +25,12 @@ const {
 }))
 
 vi.mock("~/services/permissions/permissionManager", () => ({
-  OPTIONAL_PERMISSIONS: ["cookies", "clipboardRead"],
-  OPTIONAL_PERMISSION_DEFINITIONS: [{ id: "cookies" }, { id: "clipboardRead" }],
+  OPTIONAL_PERMISSIONS: ["cookies", "clipboardRead", "notifications"],
+  OPTIONAL_PERMISSION_DEFINITIONS: [
+    { id: "cookies" },
+    { id: "clipboardRead" },
+    { id: "notifications" },
+  ],
   hasPermission: (id: string) => hasPermissionMock(id),
   onOptionalPermissionsChanged: (listener: () => void) =>
     onOptionalPermissionsChangedMock(listener),
@@ -41,7 +45,9 @@ vi.mock("~/utils/core/toastHelpers", () => ({
 describe("PermissionSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    hasPermissionMock.mockImplementation(async (id: string) => id === "cookies")
+    hasPermissionMock.mockImplementation(
+      async (id: string) => id === "cookies" || id === "notifications",
+    )
     requestPermissionMock.mockResolvedValue(true)
     removePermissionMock.mockResolvedValue(false)
     onOptionalPermissionsChangedMock.mockImplementation((listener) => {
@@ -61,18 +67,38 @@ describe("PermissionSettings", () => {
     })
 
     expect(
-      await screen.findByText("settings:permissions.status.granted"),
-    ).toBeInTheDocument()
+      await screen.findAllByText("settings:permissions.status.granted"),
+    ).toHaveLength(2)
     expect(
-      screen.getByText("settings:permissions.status.denied"),
+      screen.getAllByText("settings:permissions.status.denied"),
+    ).toHaveLength(1)
+    expect(
+      screen.getByText("settings:permissions.items.notifications.title"),
     ).toBeInTheDocument()
 
-    const actionButtons = await screen.findAllByRole("button", {
-      name: /settings:permissions\.actions\.(allow|remove)/,
-    })
+    const cookiesRow = document.getElementById("cookies")
+    const clipboardRow = document.getElementById("clipboardRead")
+    const notificationsRow = document.getElementById("notifications")
 
-    fireEvent.click(actionButtons[0])
-    fireEvent.click(actionButtons[1])
+    if (!cookiesRow || !clipboardRow || !notificationsRow) {
+      throw new Error("Expected permission rows to be rendered")
+    }
+
+    fireEvent.click(
+      within(cookiesRow).getByRole("button", {
+        name: "settings:permissions.actions.remove",
+      }),
+    )
+    fireEvent.click(
+      within(clipboardRow).getByRole("button", {
+        name: "settings:permissions.actions.allow",
+      }),
+    )
+    fireEvent.click(
+      within(notificationsRow).getByRole("button", {
+        name: "settings:permissions.actions.remove",
+      }),
+    )
     fireEvent.click(
       screen.getByRole("button", {
         name: "settings:permissions.actions.refresh",
@@ -83,6 +109,7 @@ describe("PermissionSettings", () => {
       expect(removePermissionMock).toHaveBeenCalledWith("cookies")
     })
     expect(requestPermissionMock).toHaveBeenCalledWith("clipboardRead")
+    expect(removePermissionMock).toHaveBeenCalledWith("notifications")
     expect(showResultToastMock).toHaveBeenCalledWith(
       true,
       "settings:permissions.messages.granted",
@@ -93,7 +120,7 @@ describe("PermissionSettings", () => {
       "settings:permissions.messages.revoked",
       "settings:permissions.messages.revokeFailed",
     )
-    expect(hasPermissionMock).toHaveBeenCalledTimes(4)
+    expect(hasPermissionMock).toHaveBeenCalledTimes(6)
   })
 
   it("reloads statuses on external permission change and unsubscribes on cleanup", async () => {
@@ -102,7 +129,7 @@ describe("PermissionSettings", () => {
       withThemeProvider: false,
     })
 
-    await screen.findByText("settings:permissions.status.granted")
+    await screen.findAllByText("settings:permissions.status.granted")
 
     hasPermissionMock.mockResolvedValue(false)
     const listener = changedListenerRef.current
@@ -114,10 +141,46 @@ describe("PermissionSettings", () => {
     })
 
     await waitFor(() => {
-      expect(hasPermissionMock).toHaveBeenCalledTimes(4)
+      expect(hasPermissionMock).toHaveBeenCalledTimes(6)
     })
 
     unmount()
     expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows an error toast when requesting a permission throws", async () => {
+    requestPermissionMock.mockRejectedValueOnce(new Error("request failed"))
+
+    render(<PermissionSettings />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    const clipboardRow = document.getElementById("clipboardRead")
+    if (!clipboardRow) {
+      throw new Error("Expected clipboard permission row")
+    }
+
+    const allowButton = await within(clipboardRow).findByRole("button", {
+      name: "settings:permissions.actions.allow",
+    })
+
+    await waitFor(() => {
+      expect(allowButton).toBeEnabled()
+    })
+
+    fireEvent.click(
+      within(clipboardRow).getByRole("button", {
+        name: "settings:permissions.actions.allow",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(showResultToastMock).toHaveBeenCalledWith(
+        false,
+        "settings:permissions.messages.granted",
+        "settings:permissions.messages.grantFailed",
+      )
+    })
   })
 })

--- a/tests/features/BasicSettings/General.search.test.ts
+++ b/tests/features/BasicSettings/General.search.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  generalSearchControls,
+  generalSearchSections,
+} from "~/features/BasicSettings/components/tabs/General/General.search"
+
+describe("general settings search definitions", () => {
+  it("keeps section search order aligned with the rendered general settings order", () => {
+    expect(generalSearchSections.map((section) => section.id)).toEqual([
+      "section:display",
+      "section:appearance",
+      "section:action-click",
+      "section:task-notifications",
+      "section:changelog",
+      "section:logging",
+      "section:danger",
+    ])
+  })
+
+  it("keeps task notification controls before lower-frequency maintenance controls", () => {
+    const orderedControlIds = generalSearchControls.map((control) => control.id)
+
+    expect(
+      orderedControlIds.indexOf("control:task-notifications-enabled"),
+    ).toBeLessThan(orderedControlIds.indexOf("control:changelog-on-update"))
+    expect(
+      orderedControlIds.indexOf("control:changelog-on-update"),
+    ).toBeLessThan(orderedControlIds.indexOf("control:logging-enabled"))
+    expect(orderedControlIds.indexOf("control:logging-enabled")).toBeLessThan(
+      orderedControlIds.indexOf("control:danger-reset-settings"),
+    )
+  })
+})

--- a/tests/features/BasicSettings/General.search.test.ts
+++ b/tests/features/BasicSettings/General.search.test.ts
@@ -20,15 +20,24 @@ describe("general settings search definitions", () => {
 
   it("keeps task notification controls before lower-frequency maintenance controls", () => {
     const orderedControlIds = generalSearchControls.map((control) => control.id)
-
-    expect(
-      orderedControlIds.indexOf("control:task-notifications-enabled"),
-    ).toBeLessThan(orderedControlIds.indexOf("control:changelog-on-update"))
-    expect(
-      orderedControlIds.indexOf("control:changelog-on-update"),
-    ).toBeLessThan(orderedControlIds.indexOf("control:logging-enabled"))
-    expect(orderedControlIds.indexOf("control:logging-enabled")).toBeLessThan(
-      orderedControlIds.indexOf("control:danger-reset-settings"),
+    const taskNotificationsIndex = orderedControlIds.indexOf(
+      "control:task-notifications-enabled",
     )
+    const changelogIndex = orderedControlIds.indexOf(
+      "control:changelog-on-update",
+    )
+    const loggingIndex = orderedControlIds.indexOf("control:logging-enabled")
+    const dangerResetIndex = orderedControlIds.indexOf(
+      "control:danger-reset-settings",
+    )
+
+    expect(taskNotificationsIndex).toBeGreaterThanOrEqual(0)
+    expect(changelogIndex).toBeGreaterThanOrEqual(0)
+    expect(loggingIndex).toBeGreaterThanOrEqual(0)
+    expect(dangerResetIndex).toBeGreaterThanOrEqual(0)
+
+    expect(taskNotificationsIndex).toBeLessThan(changelogIndex)
+    expect(changelogIndex).toBeLessThan(loggingIndex)
+    expect(loggingIndex).toBeLessThan(dangerResetIndex)
   })
 })

--- a/tests/features/BasicSettings/GeneralTab.order.test.tsx
+++ b/tests/features/BasicSettings/GeneralTab.order.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import GeneralTab from "~/features/BasicSettings/components/tabs/General/GeneralTab"
+
+vi.mock(
+  "~/features/BasicSettings/components/tabs/General/DisplaySettings",
+  () => ({
+    default: () => <section data-testid="display-settings" />,
+  }),
+)
+
+vi.mock(
+  "~/features/BasicSettings/components/tabs/General/AppearanceSettings",
+  () => ({
+    default: () => <section data-testid="appearance-settings" />,
+  }),
+)
+
+vi.mock(
+  "~/features/BasicSettings/components/tabs/General/ActionClickBehaviorSettings",
+  () => ({
+    default: () => <section data-testid="action-click-settings" />,
+  }),
+)
+
+vi.mock(
+  "~/features/BasicSettings/components/tabs/General/TaskNotificationSettings",
+  () => ({
+    default: () => <section data-testid="task-notification-settings" />,
+  }),
+)
+
+vi.mock(
+  "~/features/BasicSettings/components/tabs/General/ChangelogOnUpdateSettings",
+  () => ({
+    default: () => <section data-testid="changelog-settings" />,
+  }),
+)
+
+vi.mock(
+  "~/features/BasicSettings/components/tabs/General/LoggingSettings",
+  () => ({
+    default: () => <section data-testid="logging-settings" />,
+  }),
+)
+
+vi.mock(
+  "~/features/BasicSettings/components/tabs/General/ResetSettingsSection",
+  () => ({
+    default: () => <section data-testid="reset-settings" />,
+  }),
+)
+
+describe("GeneralTab", () => {
+  it("orders common settings before maintenance, diagnostics, and reset actions", () => {
+    render(<GeneralTab />)
+
+    const sectionTestIds = [
+      "display-settings",
+      "appearance-settings",
+      "action-click-settings",
+      "task-notification-settings",
+      "changelog-settings",
+      "logging-settings",
+      "reset-settings",
+    ]
+
+    const sections = sectionTestIds.map((testId) => screen.getByTestId(testId))
+
+    for (let index = 0; index < sections.length - 1; index += 1) {
+      expect(
+        sections[index].compareDocumentPosition(sections[index + 1]) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy()
+    }
+  })
+})

--- a/tests/features/BasicSettings/PermissionOnboardingDialog.languageSelection.test.tsx
+++ b/tests/features/BasicSettings/PermissionOnboardingDialog.languageSelection.test.tsx
@@ -34,6 +34,7 @@ vi.mock("~/services/permissions/permissionManager", () => {
     "webRequest",
     "webRequestBlocking",
     "clipboardRead",
+    "notifications",
   ] as const
 
   return {
@@ -367,6 +368,7 @@ describe("PermissionOnboardingDialog language selection", () => {
       webRequest: false,
       webRequestBlocking: false,
       clipboardRead: false,
+      notifications: false,
     }
 
     permissionMocks.hasPermission.mockImplementation(
@@ -387,22 +389,23 @@ describe("PermissionOnboardingDialog language selection", () => {
       ).toHaveLength(1)
       expect(
         screen.getAllByText(i18n.t("permissions.status.denied")),
-      ).toHaveLength(4)
+      ).toHaveLength(5)
     })
 
     permissionStates.cookies = false
     permissionStates.declarativeNetRequestWithHostAccess = true
     permissionStates.clipboardRead = true
+    permissionStates.notifications = true
 
     await act(async () => {
       permissionChangeHandler?.()
     })
 
     await waitFor(() => {
-      expect(permissionMocks.hasPermission).toHaveBeenCalledTimes(10)
+      expect(permissionMocks.hasPermission).toHaveBeenCalledTimes(12)
       expect(
         screen.getAllByText(i18n.t("permissions.status.granted")),
-      ).toHaveLength(2)
+      ).toHaveLength(3)
       expect(
         screen.getAllByText(i18n.t("permissions.status.denied")),
       ).toHaveLength(3)
@@ -429,6 +432,7 @@ describe("PermissionOnboardingDialog language selection", () => {
         "webRequest",
         "webRequestBlocking",
         "clipboardRead",
+        "notifications",
       ])
     })
 
@@ -542,5 +546,18 @@ describe("PermissionOnboardingDialog language selection", () => {
     )
 
     openSpy.mockRestore()
+  })
+
+  it("renders the notifications permission item in the onboarding list", async () => {
+    const i18n = await createSettingsI18n("en")
+
+    renderWithI18n(<PermissionOnboardingDialog open onClose={vi.fn()} />, i18n)
+
+    expect(
+      await screen.findByText(i18n.t("permissions.items.notifications.title")),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(i18n.t("permissions.items.notifications.description")),
+    ).toBeInTheDocument()
   })
 })

--- a/tests/features/BasicSettings/PermissionOnboardingDialog.languageSelection.test.tsx
+++ b/tests/features/BasicSettings/PermissionOnboardingDialog.languageSelection.test.tsx
@@ -99,6 +99,13 @@ vi.mock(
   }),
 )
 
+vi.mock(
+  "~/features/BasicSettings/components/tabs/General/TaskNotificationSettings",
+  () => ({
+    default: () => <div data-testid="task-notification-settings" />,
+  }),
+)
+
 vi.mock("~/entrypoints/options/components/ThemeToggle", () => ({
   default: () => <div data-testid="theme-toggle" />,
 }))

--- a/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import TaskNotificationSettings from "~/features/BasicSettings/components/tabs/General/TaskNotificationSettings"
+import { DEFAULT_TASK_NOTIFICATION_PREFERENCES } from "~/types/taskNotifications"
+import { render, screen, waitFor } from "~~/tests/test-utils/render"
+
+const {
+  hasPermissionMock,
+  onOptionalPermissionsChangedMock,
+  requestPermissionMock,
+  sendRuntimeMessageMock,
+  showResultToastMock,
+  showUpdateToastMock,
+  updateTaskNotificationsMock,
+} = vi.hoisted(() => ({
+  hasPermissionMock: vi.fn(),
+  onOptionalPermissionsChangedMock: vi.fn(),
+  requestPermissionMock: vi.fn(),
+  sendRuntimeMessageMock: vi.fn(),
+  showResultToastMock: vi.fn(),
+  showUpdateToastMock: vi.fn(),
+  updateTaskNotificationsMock: vi.fn(),
+}))
+
+vi.mock("~/contexts/UserPreferencesContext", () => ({
+  useUserPreferencesContext: () => ({
+    taskNotifications: DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+    updateTaskNotifications: updateTaskNotificationsMock,
+  }),
+}))
+
+vi.mock("~/services/permissions/permissionManager", () => ({
+  OPTIONAL_PERMISSION_IDS: {
+    Notifications: "notifications",
+  },
+  hasPermission: hasPermissionMock,
+  onOptionalPermissionsChanged: onOptionalPermissionsChangedMock,
+  requestPermission: requestPermissionMock,
+}))
+
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/utils/browser/browserApi")>()
+
+  return {
+    ...actual,
+    sendRuntimeMessage: sendRuntimeMessageMock,
+  }
+})
+
+vi.mock("~/utils/core/toastHelpers", () => ({
+  showResultToast: (...args: unknown[]) => showResultToastMock(...args),
+  showUpdateToast: (...args: unknown[]) => showUpdateToastMock(...args),
+}))
+
+describe("TaskNotificationSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hasPermissionMock.mockResolvedValue(false)
+    onOptionalPermissionsChangedMock.mockReturnValue(() => {})
+    requestPermissionMock.mockResolvedValue(true)
+    sendRuntimeMessageMock.mockResolvedValue({ success: true })
+    updateTaskNotificationsMock.mockResolvedValue(true)
+  })
+
+  it("renders permission controls and requests notification permission", async () => {
+    render(<TaskNotificationSettings />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    expect(
+      await screen.findByText("settings:taskNotifications.permission.request"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "settings:taskNotifications.test.action",
+      }),
+    ).toBeDisabled()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "settings:taskNotifications.permission.request",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(requestPermissionMock).toHaveBeenCalledWith("notifications")
+    })
+
+    expect(showResultToastMock).toHaveBeenCalledWith(
+      true,
+      "settings:taskNotifications.permission.requestSuccess",
+      "settings:taskNotifications.permission.requestFailed",
+    )
+  })
+
+  it("sends a test notification and reports runtime failures", async () => {
+    hasPermissionMock.mockResolvedValue(true)
+    sendRuntimeMessageMock
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error("runtime failed"))
+
+    render(<TaskNotificationSettings />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    const testButton = await screen.findByRole("button", {
+      name: "settings:taskNotifications.test.action",
+    })
+
+    fireEvent.click(testButton)
+
+    await waitFor(() => {
+      expect(sendRuntimeMessageMock).toHaveBeenCalledWith({
+        action: "taskNotifications:test",
+      })
+    })
+
+    expect(showResultToastMock).toHaveBeenCalledWith({
+      success: true,
+      message: undefined,
+      successFallback: "settings:taskNotifications.test.sent",
+      errorFallback: "settings:taskNotifications.test.failed",
+    })
+
+    fireEvent.click(testButton)
+
+    await waitFor(() => {
+      expect(showResultToastMock).toHaveBeenCalledWith({
+        success: false,
+        message: "runtime failed",
+        errorFallback: "settings:taskNotifications.test.failed",
+      })
+    })
+  })
+})

--- a/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import TaskNotificationSettings from "~/features/BasicSettings/components/tabs/General/TaskNotificationSettings"
+import { OPTIONAL_PERMISSION_IDS } from "~/services/permissions/permissionManager"
 import {
   DEFAULT_TASK_NOTIFICATION_PREFERENCES,
   TASK_NOTIFICATION_TASKS,
@@ -90,7 +91,9 @@ describe("TaskNotificationSettings", () => {
     )
 
     await waitFor(() => {
-      expect(requestPermissionMock).toHaveBeenCalledWith("notifications")
+      expect(requestPermissionMock).toHaveBeenCalledWith(
+        OPTIONAL_PERMISSION_IDS.Notifications,
+      )
     })
 
     expect(showResultToastMock).toHaveBeenCalledWith(
@@ -177,10 +180,24 @@ describe("TaskNotificationSettings", () => {
       withThemeProvider: false,
     })
 
-    const switches = await screen.findAllByRole("switch")
+    const globalTaskNotifications = (
+      await screen.findByText("settings:taskNotifications.enable")
+    ).closest('[id="task-notifications-enabled"]')
+    const globalSwitch = globalTaskNotifications?.querySelector(
+      '[role="switch"]',
+    ) as HTMLElement | null
+    const autoCheckinTask = screen
+      .getByText("settings:taskNotifications.tasks.autoCheckin")
+      .closest('[id="task-notifications-autoCheckin"]')
+    const autoCheckinSwitch = autoCheckinTask?.querySelector(
+      '[role="switch"]',
+    ) as HTMLElement | null
 
-    fireEvent.click(switches[0]!)
-    fireEvent.click(switches[1]!)
+    expect(globalSwitch).not.toBeNull()
+    expect(autoCheckinSwitch).not.toBeNull()
+
+    fireEvent.click(globalSwitch!)
+    fireEvent.click(autoCheckinSwitch!)
 
     await waitFor(() => {
       expect(updateTaskNotificationsMock).toHaveBeenCalledWith({

--- a/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
@@ -1,8 +1,12 @@
 import { fireEvent } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { RuntimeActionIds } from "~/constants/runtimeActions"
 import TaskNotificationSettings from "~/features/BasicSettings/components/tabs/General/TaskNotificationSettings"
-import { DEFAULT_TASK_NOTIFICATION_PREFERENCES } from "~/types/taskNotifications"
+import {
+  DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+  TASK_NOTIFICATION_TASKS,
+} from "~/types/taskNotifications"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
@@ -115,7 +119,7 @@ describe("TaskNotificationSettings", () => {
 
     await waitFor(() => {
       expect(sendRuntimeMessageMock).toHaveBeenCalledWith({
-        action: "taskNotifications:test",
+        action: RuntimeActionIds.TaskNotificationsTest,
       })
     })
 
@@ -135,5 +139,40 @@ describe("TaskNotificationSettings", () => {
         errorFallback: "settings:taskNotifications.test.failed",
       })
     })
+  })
+
+  it("updates the global switch and per-task switch through the preferences context", async () => {
+    hasPermissionMock.mockResolvedValue(true)
+
+    render(<TaskNotificationSettings />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    const switches = await screen.findAllByRole("switch")
+
+    fireEvent.click(switches[0]!)
+    fireEvent.click(switches[1]!)
+
+    await waitFor(() => {
+      expect(updateTaskNotificationsMock).toHaveBeenCalledWith({
+        enabled: false,
+      })
+    })
+
+    expect(updateTaskNotificationsMock).toHaveBeenCalledWith({
+      tasks: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+        [TASK_NOTIFICATION_TASKS.AutoCheckin]: false,
+      },
+    })
+    expect(showUpdateToastMock).toHaveBeenCalledWith(
+      true,
+      "settings:taskNotifications.enable",
+    )
+    expect(showUpdateToastMock).toHaveBeenCalledWith(
+      true,
+      "settings:taskNotifications.tasksLabel",
+    )
   })
 })

--- a/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react"
+import { act, fireEvent } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
@@ -98,6 +98,34 @@ describe("TaskNotificationSettings", () => {
       "settings:taskNotifications.permission.requestSuccess",
       "settings:taskNotifications.permission.requestFailed",
     )
+  })
+
+  it("refreshes permission status when optional permissions change", async () => {
+    let permissionsChangedHandler: (() => void | Promise<void>) | undefined
+    hasPermissionMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    onOptionalPermissionsChangedMock.mockImplementation((handler) => {
+      permissionsChangedHandler = handler
+      return () => {}
+    })
+
+    render(<TaskNotificationSettings />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    expect(
+      await screen.findByText("settings:taskNotifications.permission.request"),
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      await permissionsChangedHandler?.()
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("settings:taskNotifications.permission.request"),
+      ).not.toBeInTheDocument()
+    })
   })
 
   it("sends a test notification and reports runtime failures", async () => {

--- a/tests/services/configMigration/preferences/preferencesMigration.test.ts
+++ b/tests/services/configMigration/preferences/preferencesMigration.test.ts
@@ -1007,6 +1007,20 @@ describe("preferencesMigration", () => {
       })
     })
 
+    it("falls back to defaults when stored taskNotifications is a non-object during v18 to v19 migration", () => {
+      const prefs = createV0Preferences({
+        preferencesVersion: 18,
+        taskNotifications: "invalid" as any,
+      })
+
+      const result = migratePreferences(prefs)
+
+      expect(result.preferencesVersion).toBe(CURRENT_PREFERENCES_VERSION)
+      expect(result.taskNotifications).toEqual(
+        DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+      )
+    })
+
     it("removes all deprecated fields after full migration", () => {
       const prefs = createV0Preferences({
         // All deprecated fields

--- a/tests/services/configMigration/preferences/preferencesMigration.test.ts
+++ b/tests/services/configMigration/preferences/preferencesMigration.test.ts
@@ -25,6 +25,7 @@ import type {
 import { DEFAULT_BALANCE_HISTORY_PREFERENCES } from "~/types/dailyBalanceHistory"
 import { DEFAULT_NEW_API_CONFIG } from "~/types/newApiConfig"
 import { SortingCriteriaType } from "~/types/sorting"
+import { DEFAULT_TASK_NOTIFICATION_PREFERENCES } from "~/types/taskNotifications"
 import { DEFAULT_VELOERA_CONFIG } from "~/types/veloeraConfig"
 import { DEFAULT_WEBDAV_SETTINGS, WEBDAV_SYNC_STRATEGIES } from "~/types/webdav"
 import { buildUserPreferences } from "~~/tests/test-utils/factories"
@@ -944,6 +945,66 @@ describe("preferencesMigration", () => {
       expect(ids?.indexOf(SortingCriteriaType.HEALTH_STATUS)).toBe(7)
       expect(ids?.indexOf(SortingCriteriaType.CUSTOM_CHECK_IN_URL)).toBe(8)
       expect(ids?.indexOf(SortingCriteriaType.CUSTOM_REDEEM_URL)).toBe(9)
+    })
+
+    it("initializes task notification preferences during v18 to v19 migration", () => {
+      const prefs = createV0Preferences({
+        preferencesVersion: 18,
+      })
+      delete (prefs as any).taskNotifications
+
+      const result = migratePreferences(prefs)
+
+      expect(result.preferencesVersion).toBe(CURRENT_PREFERENCES_VERSION)
+      expect(result.taskNotifications).toEqual(
+        DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+      )
+    })
+
+    it("preserves existing task notification preferences during v18 to v19 migration", () => {
+      const prefs = createV0Preferences({
+        preferencesVersion: 18,
+        taskNotifications: {
+          enabled: false,
+          tasks: {
+            ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+            webdavAutoSync: false,
+          },
+        },
+      })
+
+      const result = migratePreferences(prefs)
+
+      expect(result.preferencesVersion).toBe(CURRENT_PREFERENCES_VERSION)
+      expect(result.taskNotifications).toEqual({
+        enabled: false,
+        tasks: {
+          ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+          webdavAutoSync: false,
+        },
+      })
+    })
+
+    it("backfills missing task notification task switches during v18 to v19 migration", () => {
+      const prefs = createV0Preferences({
+        preferencesVersion: 18,
+        taskNotifications: {
+          enabled: true,
+          tasks: {
+            autoCheckin: false,
+          } as any,
+        },
+      })
+
+      const result = migratePreferences(prefs)
+
+      expect(result.taskNotifications).toEqual({
+        enabled: true,
+        tasks: {
+          ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+          autoCheckin: false,
+        },
+      })
     })
 
     it("removes all deprecated fields after full migration", () => {

--- a/tests/services/dailyBalanceHistory/scheduler.test.ts
+++ b/tests/services/dailyBalanceHistory/scheduler.test.ts
@@ -290,6 +290,17 @@ describe("dailyBalanceHistoryScheduler", () => {
     })
   })
 
+  it("swallows notification delivery failures for alarm-triggered capture errors", async () => {
+    mockGetPreferences.mockRejectedValueOnce(new Error("prefs failed"))
+    mockNotifyTaskResult.mockRejectedValueOnce(new Error("notify failed"))
+
+    await expect(
+      dailyBalanceHistoryScheduler.runEndOfDayCapture({
+        trigger: "alarm",
+      }),
+    ).resolves.toBeNull()
+  })
+
   it("routes runtime messages to the correct handlers", async () => {
     const updateResponse = vi.fn()
     await handleDailyBalanceHistoryMessage(

--- a/tests/services/dailyBalanceHistory/scheduler.test.ts
+++ b/tests/services/dailyBalanceHistory/scheduler.test.ts
@@ -7,6 +7,10 @@ import {
   handleDailyBalanceHistoryMessage,
 } from "~/services/history/dailyBalanceHistory/scheduler"
 import { DEFAULT_BALANCE_HISTORY_PREFERENCES } from "~/types/dailyBalanceHistory"
+import {
+  TASK_NOTIFICATION_STATUSES,
+  TASK_NOTIFICATION_TASKS,
+} from "~/types/taskNotifications"
 
 const {
   mockGetPreferences,
@@ -20,6 +24,7 @@ const {
   mockGetAlarm,
   mockHasAlarmsAPI,
   mockOnAlarm,
+  mockNotifyTaskResult,
 } = vi.hoisted(() => ({
   mockGetPreferences: vi.fn(),
   mockSavePreferences: vi.fn(),
@@ -32,6 +37,7 @@ const {
   mockGetAlarm: vi.fn(),
   mockHasAlarmsAPI: vi.fn(),
   mockOnAlarm: vi.fn(),
+  mockNotifyTaskResult: vi.fn(),
 }))
 
 vi.mock("~/services/preferences/userPreferences", () => ({
@@ -68,6 +74,10 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
+vi.mock("~/services/notifications/taskNotificationService", () => ({
+  notifyTaskResult: mockNotifyTaskResult,
+}))
+
 describe("dailyBalanceHistoryScheduler", () => {
   const getExpectedEndOfDayCaptureTime = () => {
     const expected = new Date()
@@ -103,6 +113,7 @@ describe("dailyBalanceHistoryScheduler", () => {
     mockGetAlarm.mockResolvedValue(undefined)
     mockCreateAlarm.mockResolvedValue(undefined)
     mockClearAlarm.mockResolvedValue(true)
+    mockNotifyTaskResult.mockResolvedValue(true)
   })
 
   it("initializes once, registers the alarm listener, and schedules the next capture", async () => {
@@ -328,5 +339,40 @@ describe("dailyBalanceHistoryScheduler", () => {
       success: false,
       error: "Unknown action",
     })
+  })
+
+  it("notifies successful alarm captures when at least one account was processed", async () => {
+    let alarmHandler: ((alarm: { name: string }) => Promise<void>) | undefined
+    mockOnAlarm.mockImplementation((handler) => {
+      alarmHandler = handler
+    })
+    mockGetEnabledAccounts.mockResolvedValue([{ id: "a" }])
+    mockRefreshAccount.mockResolvedValue({ refreshed: true })
+
+    await dailyBalanceHistoryScheduler.initialize()
+    await alarmHandler?.({ name: DAILY_BALANCE_HISTORY_ALARM_NAME })
+
+    expect(mockNotifyTaskResult).toHaveBeenCalledWith({
+      task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
+      status: TASK_NOTIFICATION_STATUSES.Success,
+      counts: {
+        total: 1,
+        success: 1,
+        failed: 0,
+      },
+    })
+  })
+
+  it("skips alarm notifications when the capture did not process any accounts", async () => {
+    let alarmHandler: ((alarm: { name: string }) => Promise<void>) | undefined
+    mockOnAlarm.mockImplementation((handler) => {
+      alarmHandler = handler
+    })
+    mockGetEnabledAccounts.mockResolvedValue([])
+
+    await dailyBalanceHistoryScheduler.initialize()
+    await alarmHandler?.({ name: DAILY_BALANCE_HISTORY_ALARM_NAME })
+
+    expect(mockNotifyTaskResult).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/dailyBalanceHistory/scheduler.test.ts
+++ b/tests/services/dailyBalanceHistory/scheduler.test.ts
@@ -359,6 +359,7 @@ describe("dailyBalanceHistoryScheduler", () => {
         total: 1,
         success: 1,
         failed: 0,
+        skipped: 0,
       },
     })
   })
@@ -374,5 +375,28 @@ describe("dailyBalanceHistoryScheduler", () => {
     await alarmHandler?.({ name: DAILY_BALANCE_HISTORY_ALARM_NAME })
 
     expect(mockNotifyTaskResult).not.toHaveBeenCalled()
+  })
+
+  it("notifies alarm failures when the capture run throws", async () => {
+    let alarmHandler: ((alarm: { name: string }) => Promise<void>) | undefined
+    mockOnAlarm.mockImplementation((handler) => {
+      alarmHandler = handler
+    })
+    mockGetEnabledAccounts.mockResolvedValue([{ id: "a" }])
+    mockRefreshAccount.mockRejectedValue(new Error("refresh failed"))
+
+    await dailyBalanceHistoryScheduler.initialize()
+    await alarmHandler?.({ name: DAILY_BALANCE_HISTORY_ALARM_NAME })
+
+    expect(mockNotifyTaskResult).toHaveBeenCalledWith({
+      task: TASK_NOTIFICATION_TASKS.BalanceHistoryCapture,
+      status: TASK_NOTIFICATION_STATUSES.Failure,
+      counts: {
+        total: 1,
+        success: 0,
+        failed: 1,
+        skipped: 0,
+      },
+    })
   })
 })

--- a/tests/services/modelSync/scheduler.lifecycle.test.ts
+++ b/tests/services/modelSync/scheduler.lifecycle.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   generateModelMappingForChannel: vi.fn(),
   applyModelMappingToChannel: vi.fn(),
   octopusChannelToManagedSite: vi.fn(),
+  notifyTaskResult: vi.fn(),
 }))
 
 vi.mock("~/utils/core/error", () => ({
@@ -104,6 +105,10 @@ vi.mock("~/services/models/modelRedirect", () => ({
   },
 }))
 
+vi.mock("~/services/notifications/taskNotificationService", () => ({
+  notifyTaskResult: mocks.notifyTaskResult,
+}))
+
 vi.mock("~/services/apiService/octopus", () => ({
   listChannels: mocks.octopusListChannels,
 }))
@@ -140,6 +145,7 @@ describe("modelSyncScheduler lifecycle and edge flows", () => {
       name: `mapped-${channel.name}`,
     }))
     mocks.sendRuntimeMessage.mockResolvedValue(undefined)
+    mocks.notifyTaskResult.mockResolvedValue(true)
 
     mocks.getPreferences.mockResolvedValue({
       managedSiteType: NEW_API,
@@ -183,6 +189,41 @@ describe("modelSyncScheduler lifecycle and edge flows", () => {
 
     await alarmHandler?.({ name: "managedSiteModelSync" })
     expect(executeSpy).toHaveBeenCalledTimes(1)
+    expect(mocks.notifyTaskResult).toHaveBeenCalledWith({
+      task: "managedSiteModelSync",
+      status: "failure",
+      message: "scheduled sync failed",
+    })
+  })
+
+  it("notifies scheduled sync success counts after the alarm handler runs", async () => {
+    let alarmHandler: ((alarm: { name: string }) => Promise<void>) | undefined
+    mocks.onAlarm.mockImplementation((handler) => {
+      alarmHandler = handler
+    })
+
+    vi.spyOn(modelSyncScheduler, "setupAlarm").mockResolvedValue(undefined)
+    vi.spyOn(modelSyncScheduler, "executeSync").mockResolvedValue({
+      items: [],
+      statistics: {
+        total: 3,
+        successCount: 2,
+        failureCount: 1,
+      },
+    } as any)
+
+    await modelSyncScheduler.initialize()
+    await alarmHandler?.({ name: "managedSiteModelSync" })
+
+    expect(mocks.notifyTaskResult).toHaveBeenCalledWith({
+      task: "managedSiteModelSync",
+      status: "partial_success",
+      counts: {
+        total: 3,
+        success: 2,
+        failed: 1,
+      },
+    })
   })
 
   it("lists Octopus channels through the Octopus adapter and validates config", async () => {

--- a/tests/services/notifications/taskNotificationService.test.ts
+++ b/tests/services/notifications/taskNotificationService.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import {
+  __resetTaskNotificationServiceForTesting,
   handleTaskNotificationMessage,
   initializeTaskNotificationService,
   notifyTaskResult,
@@ -79,6 +80,7 @@ vi.mock("~/utils/i18n/core", () => ({
 describe("taskNotificationService", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    __resetTaskNotificationServiceForTesting()
     getPreferencesMock.mockResolvedValue({
       taskNotifications: DEFAULT_TASK_NOTIFICATION_PREFERENCES,
     })
@@ -264,6 +266,42 @@ describe("taskNotificationService", () => {
       success: false,
       error: "Unknown action",
     })
+  })
+
+  it("ignores invalid notification ids when handling clicks", async () => {
+    initializeTaskNotificationService()
+    const handler = onNotificationClickedMock.mock.calls[0]?.[0] as
+      | ((notificationId: string) => void | Promise<void>)
+      | undefined
+
+    if (!handler) {
+      throw new Error("Expected notification click handler to be registered")
+    }
+
+    await handler("all-api-hub:task:unknown")
+
+    expect(openOrFocusOptionsMenuItemMock).not.toHaveBeenCalled()
+    expect(clearNotificationMock).not.toHaveBeenCalled()
+  })
+
+  it("swallows notification click handler failures", async () => {
+    openOrFocusOptionsMenuItemMock.mockRejectedValueOnce(
+      new Error("open failed"),
+    )
+
+    initializeTaskNotificationService()
+    const handler = onNotificationClickedMock.mock.calls[0]?.[0] as
+      | ((notificationId: string) => void | Promise<void>)
+      | undefined
+
+    if (!handler) {
+      throw new Error("Expected notification click handler to be registered")
+    }
+
+    await handler(getTaskNotificationId(TASK_NOTIFICATION_TASKS.AutoCheckin))
+    await Promise.resolve()
+
+    expect(clearNotificationMock).not.toHaveBeenCalled()
   })
 
   it("parses only valid notification ids and derives failure status", () => {

--- a/tests/services/notifications/taskNotificationService.test.ts
+++ b/tests/services/notifications/taskNotificationService.test.ts
@@ -63,8 +63,14 @@ vi.mock("~/utils/navigation", () => ({
   openOrFocusOptionsMenuItem: openOrFocusOptionsMenuItemMock,
 }))
 
+const translationCalls: Array<{
+  key: string
+  options?: Record<string, unknown>
+}> = []
+
 vi.mock("~/utils/i18n/core", () => ({
   t: vi.fn((key: string, options?: Record<string, unknown>) => {
+    translationCalls.push({ key, options })
     if (key.endsWith(".counts")) {
       return `total ${options?.total} success ${options?.success} failed ${options?.failed} skipped ${options?.skipped}`
     }
@@ -80,6 +86,7 @@ vi.mock("~/utils/i18n/core", () => ({
 describe("taskNotificationService", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    translationCalls.length = 0
     __resetTaskNotificationServiceForTesting()
     getPreferencesMock.mockResolvedValue({
       taskNotifications: DEFAULT_TASK_NOTIFICATION_PREFERENCES,
@@ -199,6 +206,32 @@ describe("taskNotificationService", () => {
     )
   })
 
+  it("omits counts text when no finite counts are provided", async () => {
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+        status: TASK_NOTIFICATION_STATUSES.Success,
+        counts: {
+          total: Number.NaN,
+          success: Number.POSITIVE_INFINITY,
+        },
+      }),
+    ).resolves.toBe(true)
+
+    expect(
+      translationCalls.some(
+        ({ key }) => key === "settings:taskNotifications.notification.counts",
+      ),
+    ).toBe(false)
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      getTaskNotificationId(TASK_NOTIFICATION_TASKS.AutoCheckin),
+      expect.objectContaining({
+        message:
+          "settings:taskNotifications.notification.body.success:settings:taskNotifications.tasks.autoCheckin",
+      }),
+    )
+  })
+
   it("falls back to the localized body when the custom message is blank", async () => {
     await expect(
       notifyTaskResult({
@@ -215,6 +248,19 @@ describe("taskNotificationService", () => {
           "settings:taskNotifications.notification.body.success:settings:taskNotifications.tasks.autoCheckin",
       }),
     )
+  })
+
+  it("returns false when loading preferences throws", async () => {
+    getPreferencesMock.mockRejectedValueOnce(new Error("prefs failed"))
+
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+        status: TASK_NOTIFICATION_STATUSES.Success,
+      }),
+    ).resolves.toBe(false)
+
+    expect(createNotificationMock).not.toHaveBeenCalled()
   })
 
   it("opens the mapped settings page when a task notification is clicked", async () => {
@@ -269,6 +315,7 @@ describe("taskNotificationService", () => {
   })
 
   it("ignores invalid notification ids when handling clicks", async () => {
+    onNotificationClickedMock.mockReturnValueOnce(undefined)
     initializeTaskNotificationService()
     const handler = onNotificationClickedMock.mock.calls[0]?.[0] as
       | ((notificationId: string) => void | Promise<void>)
@@ -302,6 +349,13 @@ describe("taskNotificationService", () => {
     await Promise.resolve()
 
     expect(clearNotificationMock).not.toHaveBeenCalled()
+  })
+
+  it("does not register the click listener twice", () => {
+    initializeTaskNotificationService()
+    initializeTaskNotificationService()
+
+    expect(onNotificationClickedMock).toHaveBeenCalledTimes(1)
   })
 
   it("parses only valid notification ids and derives failure status", () => {

--- a/tests/services/notifications/taskNotificationService.test.ts
+++ b/tests/services/notifications/taskNotificationService.test.ts
@@ -9,6 +9,8 @@ import {
 } from "~/services/notifications/taskNotificationService"
 import {
   DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+  getTaskNotificationId,
+  TASK_NOTIFICATION_STATUSES,
   TASK_NOTIFICATION_TASKS,
 } from "~/types/taskNotifications"
 
@@ -80,7 +82,9 @@ describe("taskNotificationService", () => {
     })
     hasNotificationsAPIMock.mockReturnValue(true)
     hasPermissionMock.mockResolvedValue(true)
-    createNotificationMock.mockResolvedValue("all-api-hub:task:autoCheckin")
+    createNotificationMock.mockResolvedValue(
+      getTaskNotificationId(TASK_NOTIFICATION_TASKS.AutoCheckin),
+    )
     clearNotificationMock.mockResolvedValue(true)
     onNotificationClickedMock.mockReturnValue(vi.fn())
     openOrFocusOptionsMenuItemMock.mockResolvedValue(undefined)
@@ -97,7 +101,7 @@ describe("taskNotificationService", () => {
     await expect(
       notifyTaskResult({
         task: TASK_NOTIFICATION_TASKS.AutoCheckin,
-        status: "success",
+        status: TASK_NOTIFICATION_STATUSES.Success,
       }),
     ).resolves.toBe(false)
 
@@ -118,7 +122,7 @@ describe("taskNotificationService", () => {
     await expect(
       notifyTaskResult({
         task: TASK_NOTIFICATION_TASKS.WebdavAutoSync,
-        status: "failure",
+        status: TASK_NOTIFICATION_STATUSES.Failure,
       }),
     ).resolves.toBe(false)
 
@@ -131,7 +135,7 @@ describe("taskNotificationService", () => {
     await expect(
       notifyTaskResult({
         task: TASK_NOTIFICATION_TASKS.AutoCheckin,
-        status: "success",
+        status: TASK_NOTIFICATION_STATUSES.Success,
       }),
     ).resolves.toBe(false)
 
@@ -145,7 +149,7 @@ describe("taskNotificationService", () => {
     await expect(
       notifyTaskResult({
         task: TASK_NOTIFICATION_TASKS.AutoCheckin,
-        status: "success",
+        status: TASK_NOTIFICATION_STATUSES.Success,
       }),
     ).resolves.toBe(false)
 
@@ -159,7 +163,7 @@ describe("taskNotificationService", () => {
     await expect(
       notifyTaskResult({
         task: TASK_NOTIFICATION_TASKS.AutoCheckin,
-        status: "failure",
+        status: TASK_NOTIFICATION_STATUSES.Failure,
       }),
     ).resolves.toBe(false)
   })
@@ -168,7 +172,7 @@ describe("taskNotificationService", () => {
     await expect(
       notifyTaskResult({
         task: TASK_NOTIFICATION_TASKS.AutoCheckin,
-        status: "partial_success",
+        status: TASK_NOTIFICATION_STATUSES.PartialSuccess,
         counts: {
           total: 3,
           success: 2,
@@ -178,7 +182,7 @@ describe("taskNotificationService", () => {
     ).resolves.toBe(true)
 
     expect(createNotificationMock).toHaveBeenCalledWith(
-      "all-api-hub:task:autoCheckin",
+      getTaskNotificationId(TASK_NOTIFICATION_TASKS.AutoCheckin),
       expect.objectContaining({
         type: "basic",
         iconUrl: "icon.png",
@@ -202,14 +206,14 @@ describe("taskNotificationService", () => {
       throw new Error("Expected notification click handler to be registered")
     }
 
-    await handler("all-api-hub:task:webdavAutoSync")
+    await handler(getTaskNotificationId(TASK_NOTIFICATION_TASKS.WebdavAutoSync))
 
     expect(openOrFocusOptionsMenuItemMock).toHaveBeenCalledWith(
       MENU_ITEM_IDS.BASIC,
       { tab: "dataBackup", anchor: "webdav-auto-sync" },
     )
     expect(clearNotificationMock).toHaveBeenCalledWith(
-      "all-api-hub:task:webdavAutoSync",
+      getTaskNotificationId(TASK_NOTIFICATION_TASKS.WebdavAutoSync),
     )
   })
 

--- a/tests/services/notifications/taskNotificationService.test.ts
+++ b/tests/services/notifications/taskNotificationService.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import {
+  handleTaskNotificationMessage,
+  initializeTaskNotificationService,
+  notifyTaskResult,
+} from "~/services/notifications/taskNotificationService"
+import {
+  DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+  TASK_NOTIFICATION_TASKS,
+} from "~/types/taskNotifications"
+
+const {
+  clearNotificationMock,
+  createNotificationMock,
+  getPreferencesMock,
+  hasNotificationsAPIMock,
+  hasPermissionMock,
+  onNotificationClickedMock,
+  openOrFocusOptionsMenuItemMock,
+} = vi.hoisted(() => ({
+  clearNotificationMock: vi.fn(),
+  createNotificationMock: vi.fn(),
+  getPreferencesMock: vi.fn(),
+  hasNotificationsAPIMock: vi.fn(),
+  hasPermissionMock: vi.fn(),
+  onNotificationClickedMock: vi.fn(),
+  openOrFocusOptionsMenuItemMock: vi.fn(),
+}))
+
+vi.mock("~/assets/icon.png", () => ({
+  default: "icon.png",
+}))
+
+vi.mock("~/services/preferences/userPreferences", () => ({
+  userPreferences: {
+    getPreferences: getPreferencesMock,
+  },
+}))
+
+vi.mock("~/services/permissions/permissionManager", () => ({
+  OPTIONAL_PERMISSION_IDS: {
+    Notifications: "notifications",
+  },
+  hasPermission: hasPermissionMock,
+}))
+
+vi.mock("~/utils/browser/browserApi", () => ({
+  clearNotification: clearNotificationMock,
+  createNotification: createNotificationMock,
+  hasNotificationsAPI: hasNotificationsAPIMock,
+  onNotificationClicked: onNotificationClickedMock,
+}))
+
+vi.mock("~/utils/navigation", () => ({
+  openOrFocusOptionsMenuItem: openOrFocusOptionsMenuItemMock,
+}))
+
+vi.mock("~/utils/i18n/core", () => ({
+  t: vi.fn((key: string, options?: Record<string, unknown>) => {
+    if (key.endsWith(".counts")) {
+      return `total ${options?.total} success ${options?.success} failed ${options?.failed} skipped ${options?.skipped}`
+    }
+
+    if (typeof options?.task === "string") {
+      return `${key}:${options.task}`
+    }
+
+    return key
+  }),
+}))
+
+describe("taskNotificationService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPreferencesMock.mockResolvedValue({
+      taskNotifications: DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+    })
+    hasNotificationsAPIMock.mockReturnValue(true)
+    hasPermissionMock.mockResolvedValue(true)
+    createNotificationMock.mockResolvedValue("all-api-hub:task:autoCheckin")
+    clearNotificationMock.mockResolvedValue(true)
+    onNotificationClickedMock.mockReturnValue(vi.fn())
+    openOrFocusOptionsMenuItemMock.mockResolvedValue(undefined)
+  })
+
+  it("skips notifications when the global switch is disabled", async () => {
+    getPreferencesMock.mockResolvedValueOnce({
+      taskNotifications: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+        enabled: false,
+      },
+    })
+
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+        status: "success",
+      }),
+    ).resolves.toBe(false)
+
+    expect(createNotificationMock).not.toHaveBeenCalled()
+  })
+
+  it("skips only the disabled task switch", async () => {
+    getPreferencesMock.mockResolvedValueOnce({
+      taskNotifications: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+        tasks: {
+          ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+          webdavAutoSync: false,
+        },
+      },
+    })
+
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.WebdavAutoSync,
+        status: "failure",
+      }),
+    ).resolves.toBe(false)
+
+    expect(createNotificationMock).not.toHaveBeenCalled()
+  })
+
+  it("skips cleanly when permission is not granted", async () => {
+    hasPermissionMock.mockResolvedValueOnce(false)
+
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+        status: "success",
+      }),
+    ).resolves.toBe(false)
+
+    expect(hasPermissionMock).toHaveBeenCalledWith("notifications")
+    expect(createNotificationMock).not.toHaveBeenCalled()
+  })
+
+  it("does not throw when the notifications API is unavailable", async () => {
+    hasNotificationsAPIMock.mockReturnValueOnce(false)
+
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+        status: "success",
+      }),
+    ).resolves.toBe(false)
+
+    expect(hasPermissionMock).not.toHaveBeenCalled()
+    expect(createNotificationMock).not.toHaveBeenCalled()
+  })
+
+  it("returns false without throwing when notification creation fails", async () => {
+    createNotificationMock.mockResolvedValueOnce(null)
+
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+        status: "failure",
+      }),
+    ).resolves.toBe(false)
+  })
+
+  it("creates localized task result notifications with stable task IDs", async () => {
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+        status: "partial_success",
+        counts: {
+          total: 3,
+          success: 2,
+          failed: 1,
+        },
+      }),
+    ).resolves.toBe(true)
+
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      "all-api-hub:task:autoCheckin",
+      expect.objectContaining({
+        type: "basic",
+        iconUrl: "icon.png",
+        isClickable: true,
+        title:
+          "settings:taskNotifications.notification.title.partialSuccess:settings:taskNotifications.tasks.autoCheckin",
+        message:
+          "settings:taskNotifications.notification.body.partialSuccess:settings:taskNotifications.tasks.autoCheckin total 3 success 2 failed 1 skipped 0",
+      }),
+    )
+  })
+
+  it("opens the mapped settings page when a task notification is clicked", async () => {
+    onNotificationClickedMock.mockReturnValueOnce(vi.fn())
+
+    initializeTaskNotificationService()
+    const handler = onNotificationClickedMock.mock.calls[0]?.[0] as
+      | ((notificationId: string) => void | Promise<void>)
+      | undefined
+    if (!handler) {
+      throw new Error("Expected notification click handler to be registered")
+    }
+
+    await handler("all-api-hub:task:webdavAutoSync")
+
+    expect(openOrFocusOptionsMenuItemMock).toHaveBeenCalledWith(
+      MENU_ITEM_IDS.BASIC,
+      { tab: "dataBackup", anchor: "webdav-auto-sync" },
+    )
+    expect(clearNotificationMock).toHaveBeenCalledWith(
+      "all-api-hub:task:webdavAutoSync",
+    )
+  })
+
+  it("handles test notification runtime messages", async () => {
+    const sendResponse = vi.fn()
+
+    await handleTaskNotificationMessage(
+      { action: RuntimeActionIds.TaskNotificationsTest },
+      sendResponse,
+    )
+
+    expect(createNotificationMock).toHaveBeenCalled()
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      error: undefined,
+    })
+  })
+})

--- a/tests/services/notifications/taskNotificationService.test.ts
+++ b/tests/services/notifications/taskNotificationService.test.ts
@@ -10,6 +10,8 @@ import {
 import {
   DEFAULT_TASK_NOTIFICATION_PREFERENCES,
   getTaskNotificationId,
+  getTaskNotificationStatusFromCounts,
+  parseTaskNotificationId,
   TASK_NOTIFICATION_STATUSES,
   TASK_NOTIFICATION_TASKS,
 } from "~/types/taskNotifications"
@@ -195,6 +197,24 @@ describe("taskNotificationService", () => {
     )
   })
 
+  it("falls back to the localized body when the custom message is blank", async () => {
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+        status: TASK_NOTIFICATION_STATUSES.Success,
+        message: "   ",
+      }),
+    ).resolves.toBe(true)
+
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      getTaskNotificationId(TASK_NOTIFICATION_TASKS.AutoCheckin),
+      expect.objectContaining({
+        message:
+          "settings:taskNotifications.notification.body.success:settings:taskNotifications.tasks.autoCheckin",
+      }),
+    )
+  })
+
   it("opens the mapped settings page when a task notification is clicked", async () => {
     onNotificationClickedMock.mockReturnValueOnce(vi.fn())
 
@@ -230,5 +250,30 @@ describe("taskNotificationService", () => {
       success: true,
       error: undefined,
     })
+  })
+
+  it("rejects unknown runtime actions", async () => {
+    const sendResponse = vi.fn()
+
+    await handleTaskNotificationMessage(
+      { action: "taskNotifications:unknown" },
+      sendResponse,
+    )
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "Unknown action",
+    })
+  })
+
+  it("parses only valid notification ids and derives failure status", () => {
+    expect(parseTaskNotificationId("all-api-hub:task:unknown")).toBeNull()
+    expect(parseTaskNotificationId("wrong-prefix:autoCheckin")).toBeNull()
+    expect(
+      getTaskNotificationStatusFromCounts({
+        successCount: 0,
+        failedCount: 2,
+      }),
+    ).toBe(TASK_NOTIFICATION_STATUSES.Failure)
   })
 })

--- a/tests/services/permissions/permissionManager.test.ts
+++ b/tests/services/permissions/permissionManager.test.ts
@@ -34,7 +34,12 @@ const {
 vi.mock("~/utils/browser/browserApi", () => ({
   containsPermissions: containsPermissionsMock,
   getManifest: vi.fn(() => ({
-    optional_permissions: ["cookies", "webRequest", "clipboardRead"],
+    optional_permissions: [
+      "cookies",
+      "webRequest",
+      "clipboardRead",
+      "notifications",
+    ],
   })),
   onPermissionsAdded: vi.fn((callback: (permissions: any) => void) => {
     permissionsAddedCallbacks.push(callback)
@@ -60,6 +65,7 @@ describe("permissionManager", () => {
       "cookies",
       "webRequest",
       "clipboardRead",
+      "notifications",
     ])
     expect(COOKIE_INTERCEPTOR_PERMISSIONS).toEqual([
       OPTIONAL_PERMISSION_IDS.Cookies,

--- a/tests/services/usageHistory/scheduler.test.ts
+++ b/tests/services/usageHistory/scheduler.test.ts
@@ -13,6 +13,10 @@ import {
   userPreferences,
 } from "~/services/preferences/userPreferences"
 import {
+  TASK_NOTIFICATION_STATUSES,
+  TASK_NOTIFICATION_TASKS,
+} from "~/types/taskNotifications"
+import {
   DEFAULT_USAGE_HISTORY_PREFERENCES,
   USAGE_HISTORY_SCHEDULE_MODE,
 } from "~/types/usageHistory"
@@ -26,6 +30,7 @@ import {
 const registeredAlarmListeners: Array<
   (alarm: { name: string }) => Promise<void> | void
 > = []
+const notifyTaskResultMock = vi.fn()
 
 vi.mock("~/services/accounts/accountStorage", () => ({
   accountStorage: {
@@ -74,6 +79,10 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
+vi.mock("~/services/notifications/taskNotificationService", () => ({
+  notifyTaskResult: (...args: unknown[]) => notifyTaskResultMock(...args),
+}))
+
 const createUsageHistoryConfig = (overrides = {}) => ({
   ...DEFAULT_USAGE_HISTORY_PREFERENCES,
   enabled: true,
@@ -112,6 +121,8 @@ describe("usageHistoryScheduler", () => {
       } as any
     })
     vi.mocked(usageHistoryStorage.pruneAllAccounts).mockResolvedValue(true)
+    notifyTaskResultMock.mockReset()
+    notifyTaskResultMock.mockResolvedValue(true)
   })
 
   it("initializes once, schedules the alarm, and only syncs for the matching alarm name", async () => {
@@ -274,6 +285,21 @@ describe("usageHistoryScheduler", () => {
     await registeredAlarmListeners[0]?.({ name: "usageHistorySync" })
 
     expect(syncUsageHistoryForAccount).not.toHaveBeenCalled()
+  })
+
+  it("notifies failures from alarm-triggered sync exceptions", async () => {
+    vi.mocked(syncUsageHistoryForAccount).mockRejectedValueOnce(
+      new Error("sync failed"),
+    )
+
+    await usageHistoryScheduler.initialize()
+    await registeredAlarmListeners[0]?.({ name: "usageHistorySync" })
+
+    expect(notifyTaskResultMock).toHaveBeenCalledWith({
+      task: TASK_NOTIFICATION_TASKS.UsageHistorySync,
+      status: TASK_NOTIFICATION_STATUSES.Failure,
+      message: "sync failed",
+    })
   })
 
   it("runs manual sync for explicit account ids, filtering missing and disabled accounts", async () => {

--- a/tests/services/userPreferences.settingsHelpers.test.ts
+++ b/tests/services/userPreferences.settingsHelpers.test.ts
@@ -9,6 +9,7 @@ import {
   userPreferences,
 } from "~/services/preferences/userPreferences"
 import { AUTO_CHECKIN_SCHEDULE_MODE } from "~/types/autoCheckin"
+import { DEFAULT_TASK_NOTIFICATION_PREFERENCES } from "~/types/taskNotifications"
 import { WEBDAV_SYNC_STRATEGIES } from "~/types/webdav"
 
 describe("userPreferences settings helpers", () => {
@@ -90,6 +91,39 @@ describe("userPreferences settings helpers", () => {
     )) as any
     expect(storedAfter.language).toBe("ja")
     expect(storedAfter.webdav).toEqual(preferences.webdav)
+  })
+
+  it("persists and resets task notification preferences", async () => {
+    await storage.set(
+      USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
+      structuredClone(DEFAULT_PREFERENCES),
+    )
+
+    expect(
+      await userPreferences.updateTaskNotifications({
+        enabled: false,
+        tasks: {
+          ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+          usageHistorySync: false,
+        },
+      }),
+    ).toBe(true)
+
+    let preferences = await userPreferences.getPreferences()
+    expect(preferences.taskNotifications).toEqual({
+      enabled: false,
+      tasks: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
+        usageHistorySync: false,
+      },
+    })
+
+    expect(await userPreferences.resetTaskNotifications()).toBe(true)
+
+    preferences = await userPreferences.getPreferences()
+    expect(preferences.taskNotifications).toEqual(
+      DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+    )
   })
 
   it("restores grouped reset helpers back to their default snapshots", async () => {

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -234,6 +234,15 @@ describe("browserApi notification helpers", () => {
     await expect(clearNotification("test")).resolves.toBe(false)
   })
 
+  it("returns a safe no-op cleanup when notification click events are unavailable", () => {
+    ;(globalThis as any).browser = {}
+
+    const cleanup = onNotificationClicked(vi.fn())
+
+    expect(typeof cleanup).toBe("function")
+    cleanup()
+  })
+
   it("creates, clears, and subscribes to notification clicks when supported", async () => {
     const addListener = vi.fn()
     const removeListener = vi.fn()

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -6,8 +6,10 @@ import {
   checkPermissionViaMessage,
   classifyRecoverableWindowCreationFailure,
   clearAlarm,
+  clearNotification,
   containsPermissions,
   createAlarm,
+  createNotification,
   createWindow,
   focusTab,
   getActionApi,
@@ -21,10 +23,12 @@ import {
   getManifest,
   getManifestVersion,
   hasAlarmsAPI,
+  hasNotificationsAPI,
   isAllowedIncognitoAccess,
   isMessageReceiverUnavailableError,
   onAlarm,
   onInstalled,
+  onNotificationClicked,
   onPermissionsAdded,
   onPermissionsRemoved,
   onRuntimeMessage,
@@ -195,6 +199,95 @@ describe("browserApi alarms helpers", () => {
   afterAll(() => {
     ;(globalThis as any).browser = originalBrowser
     ;(globalThis as any).chrome = originalChrome
+  })
+})
+
+describe("browserApi notification helpers", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    ;(globalThis as any).browser = undefined
+  })
+
+  afterAll(() => {
+    ;(globalThis as any).browser = originalBrowser
+    ;(globalThis as any).chrome = originalChrome
+  })
+
+  it("reports notification API support from browser.notifications", () => {
+    ;(globalThis as any).browser = {}
+    expect(hasNotificationsAPI()).toBe(false)
+    ;(globalThis as any).browser = { notifications: {} }
+    expect(hasNotificationsAPI()).toBe(true)
+  })
+
+  it("returns null or false when notifications are unavailable", async () => {
+    ;(globalThis as any).browser = {}
+
+    await expect(
+      createNotification("test", {
+        type: "basic",
+        title: "Title",
+        message: "Message",
+        iconUrl: "icon.png",
+      }),
+    ).resolves.toBeNull()
+    await expect(clearNotification("test")).resolves.toBe(false)
+  })
+
+  it("creates, clears, and subscribes to notification clicks when supported", async () => {
+    const addListener = vi.fn()
+    const removeListener = vi.fn()
+    ;(globalThis as any).browser = {
+      notifications: {
+        create: vi.fn().mockResolvedValue("test"),
+        clear: vi.fn().mockResolvedValue(true),
+        onClicked: {
+          addListener,
+          removeListener,
+        },
+      },
+    }
+
+    const options = {
+      type: "basic" as const,
+      title: "Title",
+      message: "Message",
+      iconUrl: "icon.png",
+    }
+    const callback = vi.fn()
+    const cleanup = onNotificationClicked(callback)
+
+    await expect(createNotification("test", options)).resolves.toBe("test")
+    await expect(clearNotification("test")).resolves.toBe(true)
+    expect(
+      (globalThis as any).browser.notifications.create,
+    ).toHaveBeenCalledWith("test", options)
+    expect(
+      (globalThis as any).browser.notifications.clear,
+    ).toHaveBeenCalledWith("test")
+    expect(addListener).toHaveBeenCalledWith(callback)
+
+    cleanup()
+    expect(removeListener).toHaveBeenCalledWith(callback)
+  })
+
+  it("swallows notification create and clear failures", async () => {
+    ;(globalThis as any).browser = {
+      notifications: {
+        create: vi.fn().mockRejectedValue(new Error("create failed")),
+        clear: vi.fn().mockRejectedValue(new Error("clear failed")),
+      },
+    }
+
+    await expect(
+      createNotification("test", {
+        type: "basic",
+        title: "Title",
+        message: "Message",
+        iconUrl: "icon.png",
+      }),
+    ).resolves.toBeNull()
+    await expect(clearNotification("test")).resolves.toBe(false)
   })
 })
 

--- a/tests/utils/url.test.ts
+++ b/tests/utils/url.test.ts
@@ -449,6 +449,7 @@ describe("navigateToAnchor", () => {
   })
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     vi.useRealTimers()
   })
 
@@ -531,6 +532,19 @@ describe("navigateToAnchor", () => {
     }).not.toThrow()
 
     await vi.runAllTimersAsync()
+  })
+
+  it("should stop retrying if the document is no longer available", async () => {
+    ;(document.getElementById as any).mockReturnValue(null)
+
+    navigateToAnchor("non-existent")
+    await vi.advanceTimersByTimeAsync(100)
+
+    vi.stubGlobal("document", undefined)
+
+    await vi.runAllTimersAsync()
+
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it("should not update tab if tab parameter is undefined", async () => {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
               "webRequest",
               "webRequestBlocking",
               "clipboardRead",
+              "notifications",
             ],
           }
         : {
@@ -49,6 +50,7 @@ export default defineConfig({
               "cookies",
               "declarativeNetRequestWithHostAccess",
               "clipboardRead",
+              "notifications",
             ],
           }),
       // ensure can get site cookies, please refer to https://stackoverflow.com/a/70070106/22460724


### PR DESCRIPTION
This PR implements a scheduled task notification system and includes associated refactorings.

**Feature**
- Adds task notification preferences and migration.
- Implements notification service and browser API helpers.
- Adds UI for notification permissions and settings.
- Integrates notifications with background schedulers.
- Adds test coverage for new features.

**Refactoring**
- Extracts constants and utility functions for task notifications.
- Reorders general settings tab sections.
- Makes internal constants private.

Related content: #740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task notification system: global enable/disable, per‑task toggles, Send test action, permission request UI, background scheduled-task notifications, click-to-open settings handling, and Notifications API support.

* **Chores**
  * Preferences migration bumped to v19 to add task notification defaults and new preference APIs.

* **Search**
  * General settings search now includes a Task Notifications section and controls.

* **Localization**
  * New task notification strings added for en, ja, zh-CN, zh-TW.

* **Tests**
  * Extensive tests added/updated for preferences, permissions, notifications, schedulers, and search ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->