### PR TITLE
feat(bookmark): Add current page autofill to bookmark dialog

### DIFF
--- a/src/features/SiteBookmarks/components/BookmarkDialog.tsx
+++ b/src/features/SiteBookmarks/components/BookmarkDialog.tsx
@@ -249,11 +249,13 @@ export default function BookmarkDialog({
               </div>
               <div className="mt-1 truncate font-medium">
                 {currentPage?.title ||
-                  t("bookmark:dialog.currentPageUnavailable")}
+                  (!isCurrentPageLoading &&
+                    t("bookmark:dialog.currentPageUnavailable"))}
               </div>
               <div className="truncate opacity-80">
                 {currentPage?.url ||
-                  t("bookmark:dialog.currentPageUnavailable")}
+                  (!isCurrentPageLoading &&
+                    t("bookmark:dialog.currentPageUnavailable"))}
               </div>
             </div>
             <Button

--- a/src/features/SiteBookmarks/components/BookmarkDialog.tsx
+++ b/src/features/SiteBookmarks/components/BookmarkDialog.tsx
@@ -1,3 +1,7 @@
+import {
+  GlobeAltIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/24/outline"
 import { useEffect, useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -5,9 +9,12 @@ import { useTranslation } from "react-i18next"
 import { Button, FormField, Input, Modal, Textarea } from "~/components/ui"
 import { TagPicker } from "~/features/AccountManagement/components/TagPicker"
 import { useAccountDataContext } from "~/features/AccountManagement/hooks/AccountDataContext"
+import { getSiteName } from "~/services/accounts/accountOperations"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import type { SiteBookmark } from "~/types"
+import { getActiveTab } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
+import { createLogger } from "~/utils/core/logger"
 
 export type BookmarkDialogMode = "add" | "edit"
 
@@ -17,6 +24,8 @@ interface BookmarkDialogProps {
   bookmark: SiteBookmark | null
   onClose: () => void
 }
+
+const logger = createLogger("BookmarkDialog")
 
 /**
  * BookmarkDialog provides Add/Edit UI for SiteBookmark entries.
@@ -47,6 +56,11 @@ export default function BookmarkDialog({
   const [tagIds, setTagIds] = useState<string[]>(initial.tagIds)
   const [errors, setErrors] = useState<{ name?: string; url?: string }>({})
   const [isWorking, setIsWorking] = useState(false)
+  const [currentPage, setCurrentPage] = useState<{
+    title: string
+    url: string
+  } | null>(null)
+  const [isCurrentPageLoading, setIsCurrentPageLoading] = useState(false)
 
   useEffect(() => {
     if (!isOpen) return
@@ -58,10 +72,82 @@ export default function BookmarkDialog({
     setIsWorking(false)
   }, [initial, isOpen])
 
+  useEffect(() => {
+    if (!isOpen || mode !== "add") {
+      setCurrentPage(null)
+      setIsCurrentPageLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    const loadCurrentPage = async () => {
+      setIsCurrentPageLoading(true)
+
+      try {
+        const tab = await getActiveTab()
+        const rawUrl = typeof tab?.url === "string" ? tab.url.trim() : ""
+        if (!rawUrl) {
+          if (!cancelled) {
+            setCurrentPage(null)
+          }
+          return
+        }
+
+        const parsedUrl = new URL(rawUrl)
+        if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+          if (!cancelled) {
+            setCurrentPage(null)
+          }
+          return
+        }
+
+        const resolvedTitle = tab ? await getSiteName(tab) : ""
+        if (cancelled) {
+          return
+        }
+
+        setCurrentPage({
+          title: resolvedTitle.trim() || parsedUrl.hostname,
+          url: parsedUrl.toString(),
+        })
+      } catch (error) {
+        if (!cancelled) {
+          setCurrentPage(null)
+        }
+        logger.warn("Failed to resolve current page for bookmark autofill", {
+          error: getErrorMessage(error),
+        })
+      } finally {
+        if (!cancelled) {
+          setIsCurrentPageLoading(false)
+        }
+      }
+    }
+
+    void loadCurrentPage()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, mode])
+
   const title =
     mode === "add"
       ? t("bookmark:dialog.titleAdd")
       : t("bookmark:dialog.titleEdit")
+
+  const handleUseCurrentPage = () => {
+    if (!currentPage) return
+
+    setName(currentPage.title)
+    setUrl(currentPage.url)
+    setErrors((prev) => ({
+      ...prev,
+      name: undefined,
+      url: undefined,
+    }))
+  }
 
   const validate = () => {
     const nextErrors: { name?: string; url?: string } = {}
@@ -153,6 +239,38 @@ export default function BookmarkDialog({
         </div>
       }
     >
+      {mode === "add" && (
+        <div className="rounded-md bg-blue-50 p-3 text-xs text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1 font-medium">
+                <InformationCircleIcon className="h-4 w-4 shrink-0" />
+                <span>{t("bookmark:dialog.currentPageLabel")}</span>
+              </div>
+              <div className="mt-1 truncate font-medium">
+                {currentPage?.title ||
+                  t("bookmark:dialog.currentPageUnavailable")}
+              </div>
+              <div className="truncate opacity-80">
+                {currentPage?.url ||
+                  t("bookmark:dialog.currentPageUnavailable")}
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="link"
+              size="sm"
+              leftIcon={<GlobeAltIcon className="h-4 w-4" />}
+              onClick={handleUseCurrentPage}
+              loading={isCurrentPageLoading}
+              disabled={!currentPage || isWorking || isCurrentPageLoading}
+            >
+              {t("bookmark:dialog.useCurrentPage")}
+            </Button>
+          </div>
+        </div>
+      )}
+
       <FormField
         label={t("bookmark:form.nameLabel")}
         required={true}

--- a/src/locales/en/bookmark.json
+++ b/src/locales/en/bookmark.json
@@ -13,9 +13,12 @@
   },
   "description": "Save quick links (console/docs/admin pages) without creating full accounts.",
   "dialog": {
+    "currentPageLabel": "Current page",
+    "currentPageUnavailable": "Current page unavailable",
     "description": "Bookmarks can be any link, such as to a site console, documentation, or an administration page. This is useful for situations where a full account cannot be created.",
     "titleAdd": "Add Bookmark",
-    "titleEdit": "Edit Bookmark"
+    "titleEdit": "Edit Bookmark",
+    "useCurrentPage": "Use current page"
   },
   "emptyState": "No bookmarks yet",
   "filter": {

--- a/src/locales/ja/bookmark.json
+++ b/src/locales/ja/bookmark.json
@@ -13,9 +13,12 @@
   },
   "description": "完全なアカウントを作成しなくても、よく使うリンク（コンソール / ドキュメント / 管理ページ）を保存できます。",
   "dialog": {
+    "currentPageLabel": "現在のページ",
+    "currentPageUnavailable": "現在のページを取得できません",
     "description": "ブックマークには、サイトのコンソール、ドキュメント、管理ページなど、任意のリンクを登録できます。完全なアカウントを作成できない場面で便利です。",
     "titleAdd": "ブックマークを追加",
-    "titleEdit": "ブックマークを編集"
+    "titleEdit": "ブックマークを編集",
+    "useCurrentPage": "現在のページを使う"
   },
   "emptyState": "まだブックマークがありません",
   "filter": {

--- a/src/locales/zh-CN/bookmark.json
+++ b/src/locales/zh-CN/bookmark.json
@@ -13,9 +13,12 @@
   },
   "description": "保存站点控制台/文档/管理页等快捷链接，无需创建完整账号。",
   "dialog": {
+    "currentPageLabel": "当前页面",
+    "currentPageUnavailable": "暂时无法读取当前页面",
     "description": "书签可以是任何链接，例如站点控制台、文档、管理页等。适用于无法创建完整账号的情况。",
     "titleAdd": "添加书签",
-    "titleEdit": "编辑书签"
+    "titleEdit": "编辑书签",
+    "useCurrentPage": "填充当前页面"
   },
   "emptyState": "暂无书签",
   "filter": {

--- a/src/locales/zh-TW/bookmark.json
+++ b/src/locales/zh-TW/bookmark.json
@@ -13,9 +13,12 @@
   },
   "description": "儲存站點控制台/文件/管理頁等快捷連結，無需建立完整帳號。",
   "dialog": {
+    "currentPageLabel": "目前頁面",
+    "currentPageUnavailable": "暫時無法讀取目前頁面",
     "description": "書籤可以是任何連結，例如站點控制台、文件、管理頁等。適用於無法建立完整帳號的情況。",
     "titleAdd": "新增書籤",
-    "titleEdit": "編輯書籤"
+    "titleEdit": "編輯書籤",
+    "useCurrentPage": "填入目前頁面"
   },
   "emptyState": "暫無書籤",
   "filter": {

--- a/tests/features/SiteBookmarks/components/BookmarkDialog.test.tsx
+++ b/tests/features/SiteBookmarks/components/BookmarkDialog.test.tsx
@@ -79,6 +79,16 @@ beforeEach(() => {
   loadAccountDataMock.mockReset()
 })
 
+const renderAddDialog = () =>
+  render(
+    <BookmarkDialog
+      isOpen={true}
+      mode="add"
+      bookmark={null}
+      onClose={vi.fn()}
+    />,
+  )
+
 describe("BookmarkDialog", () => {
   it("validates required fields before submitting", async () => {
     const onClose = vi.fn()
@@ -151,14 +161,7 @@ describe("BookmarkDialog", () => {
   })
 
   it("fills name and url from the current page helper in add mode", async () => {
-    render(
-      <BookmarkDialog
-        isOpen={true}
-        mode="add"
-        bookmark={null}
-        onClose={vi.fn()}
-      />,
-    )
+    renderAddDialog()
 
     fireEvent.click(
       await screen.findByRole("button", {
@@ -175,6 +178,140 @@ describe("BookmarkDialog", () => {
     expect(screen.getByDisplayValue("Current Admin")).toBeInTheDocument()
     expect(getActiveTabMock).toHaveBeenCalledTimes(1)
     expect(getSiteNameMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not show unavailable text while current page data is still loading", async () => {
+    let resolveTab:
+      | ((value: { title: string; url: string }) => void)
+      | undefined
+
+    getActiveTabMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTab = resolve
+      }),
+    )
+
+    renderAddDialog()
+
+    await waitFor(() => {
+      expect(getActiveTabMock).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      screen.queryByText("bookmark:dialog.currentPageUnavailable"),
+    ).not.toBeInTheDocument()
+
+    resolveTab?.({
+      title: "Current Admin",
+      url: "https://example.com/console",
+    })
+
+    await waitFor(() => {
+      const useCurrentPageButton = screen.getByRole("button", {
+        name: "bookmark:dialog.useCurrentPage",
+      })
+      expect(useCurrentPageButton).not.toBeDisabled()
+    })
+  })
+
+  it("disables current page helper when no active tab url is available", async () => {
+    getActiveTabMock.mockResolvedValue(null)
+
+    renderAddDialog()
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "bookmark:dialog.useCurrentPage",
+        }),
+      ).toBeDisabled()
+    })
+
+    expect(getSiteNameMock).not.toHaveBeenCalled()
+    expect(
+      screen.getAllByText("bookmark:dialog.currentPageUnavailable"),
+    ).toHaveLength(2)
+  })
+
+  it("disables current page helper for non-http urls", async () => {
+    getActiveTabMock.mockResolvedValue({
+      title: "Extension Page",
+      url: "chrome-extension://abc/options.html",
+    })
+
+    renderAddDialog()
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "bookmark:dialog.useCurrentPage",
+        }),
+      ).toBeDisabled()
+    })
+
+    expect(getSiteNameMock).not.toHaveBeenCalled()
+    expect(
+      screen.getAllByText("bookmark:dialog.currentPageUnavailable"),
+    ).toHaveLength(2)
+  })
+
+  it("keeps the dialog usable when current page lookup fails", async () => {
+    getActiveTabMock.mockRejectedValue(new Error("permission denied"))
+
+    renderAddDialog()
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "bookmark:dialog.useCurrentPage",
+        }),
+      ).toBeDisabled()
+    })
+
+    fireEvent.change(
+      await screen.findByPlaceholderText("bookmark:form.namePlaceholder"),
+      { target: { value: "Docs" } },
+    )
+    fireEvent.change(
+      await screen.findByPlaceholderText("bookmark:form.urlPlaceholder"),
+      { target: { value: "https://example.com/docs" } },
+    )
+    fireEvent.click(
+      await screen.findByRole("button", { name: "bookmark:actions.add" }),
+    )
+
+    await waitFor(() => {
+      expect(addBookmarkMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Docs",
+          url: "https://example.com/docs",
+        }),
+      )
+    })
+
+    expect(getSiteNameMock).not.toHaveBeenCalled()
+    expect(
+      screen.queryByText("bookmark:validation.nameRequired"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("disables current page helper when site name resolution fails", async () => {
+    getSiteNameMock.mockRejectedValue(new Error("tab title blocked"))
+
+    renderAddDialog()
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "bookmark:dialog.useCurrentPage",
+        }),
+      ).toBeDisabled()
+    })
+
+    expect(getActiveTabMock).toHaveBeenCalledTimes(1)
+    expect(getSiteNameMock).toHaveBeenCalledTimes(1)
+    expect(
+      screen.getAllByText("bookmark:dialog.currentPageUnavailable"),
+    ).toHaveLength(2)
   })
 
   it("does not show current page helper in edit mode", async () => {

--- a/tests/features/SiteBookmarks/components/BookmarkDialog.test.tsx
+++ b/tests/features/SiteBookmarks/components/BookmarkDialog.test.tsx
@@ -8,11 +8,15 @@ const loadAccountDataMock = vi.fn()
 
 const {
   addBookmarkMock,
+  getActiveTabMock,
+  getSiteNameMock,
   updateBookmarkMock,
   toastSuccessMock,
   toastErrorMock,
 } = vi.hoisted(() => ({
   addBookmarkMock: vi.fn().mockResolvedValue("bookmark-1"),
+  getActiveTabMock: vi.fn(),
+  getSiteNameMock: vi.fn(),
   updateBookmarkMock: vi.fn().mockResolvedValue(true),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
@@ -32,6 +36,19 @@ vi.mock("react-hot-toast", () => ({
   },
 }))
 
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/utils/browser/browserApi")>()
+  return {
+    ...actual,
+    getActiveTab: getActiveTabMock,
+  }
+})
+
+vi.mock("~/services/accounts/accountOperations", () => ({
+  getSiteName: getSiteNameMock,
+}))
+
 vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
   useAccountDataContext: () => ({
     tags: [],
@@ -49,6 +66,13 @@ vi.mock("~/features/AccountManagement/components/TagPicker", () => ({
 beforeEach(() => {
   vi.useRealTimers()
   addBookmarkMock.mockClear()
+  getActiveTabMock.mockReset()
+  getActiveTabMock.mockResolvedValue({
+    title: "Current Admin",
+    url: "https://example.com/console",
+  })
+  getSiteNameMock.mockReset()
+  getSiteNameMock.mockResolvedValue("Current Admin")
   updateBookmarkMock.mockClear()
   toastSuccessMock.mockClear()
   toastErrorMock.mockClear()
@@ -124,6 +148,61 @@ describe("BookmarkDialog", () => {
       "messages:toast.success.bookmarkAdded",
     )
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("fills name and url from the current page helper in add mode", async () => {
+    render(
+      <BookmarkDialog
+        isOpen={true}
+        mode="add"
+        bookmark={null}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "bookmark:dialog.useCurrentPage",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("https://example.com/console"),
+      ).toBeInTheDocument()
+    })
+
+    expect(screen.getByDisplayValue("Current Admin")).toBeInTheDocument()
+    expect(getActiveTabMock).toHaveBeenCalledTimes(1)
+    expect(getSiteNameMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not show current page helper in edit mode", async () => {
+    const bookmark: SiteBookmark = {
+      id: "b1",
+      name: "Existing",
+      url: "https://example.com/existing",
+      tagIds: [],
+      notes: "",
+      created_at: 0,
+      updated_at: 0,
+    }
+
+    render(
+      <BookmarkDialog
+        isOpen={true}
+        mode="edit"
+        bookmark={bookmark}
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.queryByRole("button", {
+        name: "bookmark:dialog.useCurrentPage",
+      }),
+    ).not.toBeInTheDocument()
+    expect(getActiveTabMock).not.toHaveBeenCalled()
   })
 
   it("updates a bookmark in edit mode", async () => {


### PR DESCRIPTION
Resolves #794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Use Current Page" feature to the bookmark dialog, enabling quick bookmarking of the currently active browser page with automatically extracted title and URL information.
  * Includes built-in validation for supported web protocols and gracefully handles unavailable page data.
  * Added localization support for English, Japanese, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->