### PR TITLE
feat(webhook): add URL templating and save-before-test

### DIFF
--- a/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
@@ -357,7 +357,7 @@ export default function TaskNotificationSettings() {
     )
   }
 
-  const handleNtfyConfigSave = async () => {
+  const handleNtfyConfigSave = async (): Promise<boolean> => {
     const nextNtfy = {
       ...channels[TASK_NOTIFICATION_CHANNELS.Ntfy],
       topicUrl: ntfyDraft.topicUrl.trim(),
@@ -368,10 +368,10 @@ export default function TaskNotificationSettings() {
       nextNtfy.topicUrl === currentNtfy.topicUrl &&
       nextNtfy.accessToken === currentNtfy.accessToken
     ) {
-      return
+      return true
     }
 
-    await handleChannelUpdate(
+    return await handleChannelUpdate(
       {
         ...channels,
         [TASK_NOTIFICATION_CHANNELS.Ntfy]: nextNtfy,
@@ -380,7 +380,7 @@ export default function TaskNotificationSettings() {
     )
   }
 
-  const handleTelegramConfigSave = async () => {
+  const handleTelegramConfigSave = async (): Promise<boolean> => {
     const nextTelegram = {
       ...channels[TASK_NOTIFICATION_CHANNELS.Telegram],
       botToken: telegramDraft.botToken.trim(),
@@ -391,10 +391,10 @@ export default function TaskNotificationSettings() {
       nextTelegram.botToken === currentTelegram.botToken &&
       nextTelegram.chatId === currentTelegram.chatId
     ) {
-      return
+      return true
     }
 
-    await handleChannelUpdate(
+    return await handleChannelUpdate(
       {
         ...channels,
         [TASK_NOTIFICATION_CHANNELS.Telegram]: nextTelegram,
@@ -403,7 +403,7 @@ export default function TaskNotificationSettings() {
     )
   }
 
-  const handleFeishuConfigSave = async () => {
+  const handleFeishuConfigSave = async (): Promise<boolean> => {
     const nextFeishu = {
       ...channels[TASK_NOTIFICATION_CHANNELS.Feishu],
       webhookKey: feishuDraft.webhookKey.trim(),
@@ -412,10 +412,10 @@ export default function TaskNotificationSettings() {
       nextFeishu.webhookKey ===
       channels[TASK_NOTIFICATION_CHANNELS.Feishu].webhookKey
     ) {
-      return
+      return true
     }
 
-    await handleChannelUpdate(
+    return await handleChannelUpdate(
       {
         ...channels,
         [TASK_NOTIFICATION_CHANNELS.Feishu]: nextFeishu,
@@ -424,7 +424,7 @@ export default function TaskNotificationSettings() {
     )
   }
 
-  const handleDingtalkConfigSave = async () => {
+  const handleDingtalkConfigSave = async (): Promise<boolean> => {
     const nextDingtalk = {
       ...channels[TASK_NOTIFICATION_CHANNELS.Dingtalk],
       webhookKey: dingtalkDraft.webhookKey.trim(),
@@ -435,10 +435,10 @@ export default function TaskNotificationSettings() {
       nextDingtalk.webhookKey === currentDingtalk.webhookKey &&
       nextDingtalk.secret === currentDingtalk.secret
     ) {
-      return
+      return true
     }
 
-    await handleChannelUpdate(
+    return await handleChannelUpdate(
       {
         ...channels,
         [TASK_NOTIFICATION_CHANNELS.Dingtalk]: nextDingtalk,
@@ -447,7 +447,7 @@ export default function TaskNotificationSettings() {
     )
   }
 
-  const handleWecomConfigSave = async () => {
+  const handleWecomConfigSave = async (): Promise<boolean> => {
     const nextWecom = {
       ...channels[TASK_NOTIFICATION_CHANNELS.Wecom],
       webhookKey: wecomDraft.webhookKey.trim(),
@@ -456,10 +456,10 @@ export default function TaskNotificationSettings() {
       nextWecom.webhookKey ===
       channels[TASK_NOTIFICATION_CHANNELS.Wecom].webhookKey
     ) {
-      return
+      return true
     }
 
-    await handleChannelUpdate(
+    return await handleChannelUpdate(
       {
         ...channels,
         [TASK_NOTIFICATION_CHANNELS.Wecom]: nextWecom,
@@ -468,16 +468,16 @@ export default function TaskNotificationSettings() {
     )
   }
 
-  const handleWebhookConfigSave = async () => {
+  const handleWebhookConfigSave = async (): Promise<boolean> => {
     const nextWebhook = {
       ...channels[TASK_NOTIFICATION_CHANNELS.Webhook],
       url: webhookDraft.url.trim(),
     }
     if (nextWebhook.url === channels[TASK_NOTIFICATION_CHANNELS.Webhook].url) {
-      return
+      return true
     }
 
-    await handleChannelUpdate(
+    return await handleChannelUpdate(
       {
         ...channels,
         [TASK_NOTIFICATION_CHANNELS.Webhook]: nextWebhook,
@@ -508,28 +508,22 @@ export default function TaskNotificationSettings() {
 
   const saveChannelDraftBeforeTest = async (
     channel: TaskNotificationChannel,
-  ) => {
+  ): Promise<boolean> => {
     switch (channel) {
       case TASK_NOTIFICATION_CHANNELS.Telegram:
-        await handleTelegramConfigSave()
-        return
+        return await handleTelegramConfigSave()
       case TASK_NOTIFICATION_CHANNELS.Feishu:
-        await handleFeishuConfigSave()
-        return
+        return await handleFeishuConfigSave()
       case TASK_NOTIFICATION_CHANNELS.Dingtalk:
-        await handleDingtalkConfigSave()
-        return
+        return await handleDingtalkConfigSave()
       case TASK_NOTIFICATION_CHANNELS.Wecom:
-        await handleWecomConfigSave()
-        return
+        return await handleWecomConfigSave()
       case TASK_NOTIFICATION_CHANNELS.Ntfy:
-        await handleNtfyConfigSave()
-        return
+        return await handleNtfyConfigSave()
       case TASK_NOTIFICATION_CHANNELS.Webhook:
-        await handleWebhookConfigSave()
-        return
+        return await handleWebhookConfigSave()
       case TASK_NOTIFICATION_CHANNELS.Browser:
-        return
+        return true
     }
   }
 
@@ -553,7 +547,11 @@ export default function TaskNotificationSettings() {
   const handleSendTest = async (channel: TaskNotificationChannel) => {
     setTestingChannel(channel)
     try {
-      await saveChannelDraftBeforeTest(channel)
+      const saved = await saveChannelDraftBeforeTest(channel)
+      if (!saved) {
+        throw new Error(t("messages.saveSettingsFailed"))
+      }
+
       const response = await sendRuntimeMessage({
         action: RuntimeActionIds.TaskNotificationsTest,
         channel,

--- a/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
@@ -506,6 +506,33 @@ export default function TaskNotificationSettings() {
     showUpdateToast(success, t("taskNotifications.siteAnnouncements.enable"))
   }
 
+  const saveChannelDraftBeforeTest = async (
+    channel: TaskNotificationChannel,
+  ) => {
+    switch (channel) {
+      case TASK_NOTIFICATION_CHANNELS.Telegram:
+        await handleTelegramConfigSave()
+        return
+      case TASK_NOTIFICATION_CHANNELS.Feishu:
+        await handleFeishuConfigSave()
+        return
+      case TASK_NOTIFICATION_CHANNELS.Dingtalk:
+        await handleDingtalkConfigSave()
+        return
+      case TASK_NOTIFICATION_CHANNELS.Wecom:
+        await handleWecomConfigSave()
+        return
+      case TASK_NOTIFICATION_CHANNELS.Ntfy:
+        await handleNtfyConfigSave()
+        return
+      case TASK_NOTIFICATION_CHANNELS.Webhook:
+        await handleWebhookConfigSave()
+        return
+      case TASK_NOTIFICATION_CHANNELS.Browser:
+        return
+    }
+  }
+
   const handleRequestPermission = async () => {
     setIsRequestingPermission(true)
     try {
@@ -526,6 +553,7 @@ export default function TaskNotificationSettings() {
   const handleSendTest = async (channel: TaskNotificationChannel) => {
     setTestingChannel(channel)
     try {
+      await saveChannelDraftBeforeTest(channel)
       const response = await sendRuntimeMessage({
         action: RuntimeActionIds.TaskNotificationsTest,
         channel,
@@ -1123,6 +1151,9 @@ export default function TaskNotificationSettings() {
                   }
                   onBlur={() => void handleWebhookConfigSave()}
                 />
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {t("taskNotifications.channels.webhook.urlDescription")}
+                </p>
               </FormField>
             </NotificationSettingItem>
           </CardList>

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -549,10 +549,11 @@
         "title": "Telegram Bot"
       },
       "webhook": {
-        "description": "Send JSON notifications to a custom HTTP(S) webhook for self-hosted services or compatible third-party platforms.",
+        "description": "Send JSON notifications to a custom HTTP(S) webhook. The URL supports template variables for services such as Bark that put notification text in the path.",
         "title": "Generic webhook",
         "url": "Webhook URL",
-        "urlPlaceholder": "https://example.com/webhook"
+        "urlDescription": "Use {title}, {message}, {task}, {status}, {total}, {success}, {failed}, or {skipped} in the URL. Values are URL-encoded before sending. For Bark, use https://api.day.app/your-key/{title}/{message}.",
+        "urlPlaceholder": "https://api.day.app/your-key/{title}/{message}"
       },
       "wecom": {
         "description": "Send task notifications through WeCom group message push. Pasting the full webhook URL from WeCom is recommended, and the key value is still supported.",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -549,10 +549,11 @@
         "title": "Telegram Bot"
       },
       "webhook": {
-        "description": "自ホストサービスや互換性のあるサードパーティ向けに、カスタム HTTP(S) Webhook へ JSON 通知を送信します。",
+        "description": "カスタム HTTP(S) Webhook へ JSON 通知を送信します。URL ではテンプレート変数を利用でき、通知本文をパスに含める Bark などのサービスに使えます。",
         "title": "汎用 Webhook",
         "url": "Webhook URL",
-        "urlPlaceholder": "https://example.com/webhook"
+        "urlDescription": "URL では {title}、{message}、{task}、{status}、{total}、{success}、{failed}、{skipped} を使用できます。値は送信前に URL エンコードされます。Bark では https://api.day.app/your-key/{title}/{message} を指定できます。",
+        "urlPlaceholder": "https://api.day.app/your-key/{title}/{message}"
       },
       "wecom": {
         "description": "WeCom グループのメッセージプッシュでタスク通知を送信します。WeCom が提供する Webhook URL 全体を貼り付ける方法を推奨します。key だけの入力にも対応しています。",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -549,10 +549,11 @@
         "title": "Telegram Bot"
       },
       "webhook": {
-        "description": "向自定义 HTTP(S) Webhook 发送 JSON 通知，可用于自建服务或兼容的第三方平台。",
+        "description": "向自定义 HTTP(S) Webhook 发送 JSON 通知。URL 支持模板变量，可用于 Bark 等把通知内容放在路径中的服务。",
         "title": "通用 Webhook",
         "url": "Webhook URL",
-        "urlPlaceholder": "https://example.com/webhook"
+        "urlDescription": "URL 中可使用 {title}、{message}、{task}、{status}、{total}、{success}、{failed}、{skipped}，发送前会按 URL 片段自动编码。例如 Bark 可填写 https://api.day.app/your-key/{title}/{message}。",
+        "urlPlaceholder": "https://api.day.app/your-key/{title}/{message}"
       },
       "wecom": {
         "description": "通过企业微信群消息推送发送任务通知。推荐直接粘贴企业微信提供的完整 Webhook URL，也兼容只填写 key。",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -549,10 +549,11 @@
         "title": "Telegram Bot"
       },
       "webhook": {
-        "description": "向自訂 HTTP(S) Webhook 傳送 JSON 通知，可用於自建服務或相容的第三方平台。",
+        "description": "向自訂 HTTP(S) Webhook 傳送 JSON 通知。URL 支援範本變數，可用於 Bark 等把通知內容放在路徑中的服務。",
         "title": "通用 Webhook",
         "url": "Webhook URL",
-        "urlPlaceholder": "https://example.com/webhook"
+        "urlDescription": "URL 中可使用 {title}、{message}、{task}、{status}、{total}、{success}、{failed}、{skipped}，傳送前會按 URL 片段自動編碼。例如 Bark 可填寫 https://api.day.app/your-key/{title}/{message}。",
+        "urlPlaceholder": "https://api.day.app/your-key/{title}/{message}"
       },
       "wecom": {
         "description": "透過企業微信群消息推送傳送任務通知。建議直接貼上企業微信提供的完整 Webhook URL，也相容只填寫 key。",

--- a/src/services/notifications/taskNotificationService.ts
+++ b/src/services/notifications/taskNotificationService.ts
@@ -726,7 +726,7 @@ async function sendNtfyNotification(
 }
 
 /**
- *
+ * Formats optional task result counts for URL template substitution.
  */
 function formatWebhookTemplateCount(value: number | undefined): string {
   return typeof value === "number" && Number.isFinite(value)
@@ -735,7 +735,7 @@ function formatWebhookTemplateCount(value: number | undefined): string {
 }
 
 /**
- *
+ * Replaces supported webhook URL placeholders with encoded notification values.
  */
 function renderWebhookUrlTemplate(
   template: string,

--- a/src/services/notifications/taskNotificationService.ts
+++ b/src/services/notifications/taskNotificationService.ts
@@ -103,6 +103,8 @@ const WECOM_BOT_WEBHOOK_PREFIX =
   "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key="
 const NTFY_DEFAULT_SERVER_URL = "https://ntfy.sh"
 const ASCII_HEADER_VALUE_PATTERN = /^[\x20-\x7e]*$/
+const WEBHOOK_URL_TEMPLATE_PATTERN =
+  /(?:\{|%7b)(title|message|task|status|total|success|failed|skipped)(?:\}|%7d)/gi
 
 const TASK_LABEL_KEYS: Record<TaskNotificationTask, string> = {
   [TASK_NOTIFICATION_TASKS.AutoCheckin]:
@@ -724,6 +726,40 @@ async function sendNtfyNotification(
 }
 
 /**
+ *
+ */
+function formatWebhookTemplateCount(value: number | undefined): string {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value.toString()
+    : ""
+}
+
+/**
+ *
+ */
+function renderWebhookUrlTemplate(
+  template: string,
+  payload: TaskNotificationPayload,
+  content: TaskNotificationContent,
+): string {
+  const values = {
+    title: content.title,
+    message: content.message,
+    task: payload.task,
+    status: payload.status,
+    total: formatWebhookTemplateCount(payload.counts?.total),
+    success: formatWebhookTemplateCount(payload.counts?.success),
+    failed: formatWebhookTemplateCount(payload.counts?.failed),
+    skipped: formatWebhookTemplateCount(payload.counts?.skipped),
+  }
+
+  return template.replace(WEBHOOK_URL_TEMPLATE_PATTERN, (_, key: string) => {
+    const normalizedKey = key.toLowerCase() as keyof typeof values
+    return encodeURIComponent(values[normalizedKey])
+  })
+}
+
+/**
  * Sends a JSON payload to a user-provided webhook endpoint.
  */
 async function sendWebhookNotification(
@@ -736,7 +772,7 @@ async function sendWebhookNotification(
     throw new Error(t("settings:taskNotifications.test.webhookMissingConfig"))
   }
 
-  const parsedUrl = new URL(url)
+  const parsedUrl = new URL(renderWebhookUrlTemplate(url, payload, content))
   if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
     logger.warn("Webhook task notification skipped: unsupported URL protocol", {
       task: payload.task,

--- a/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
@@ -812,6 +812,66 @@ describe("TaskNotificationSettings", () => {
     ).toBeLessThan(sendRuntimeMessageMock.mock.invocationCallOrder[0])
   })
 
+  it("does not send a webhook test notification when saving the draft fails", async () => {
+    updateTaskNotificationsMock.mockResolvedValueOnce(false)
+    taskNotificationsMock.current = {
+      ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+      channels: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.channels,
+        [TASK_NOTIFICATION_CHANNELS.Webhook]: {
+          enabled: true,
+          url: "https://hooks.example.com/old",
+        },
+      },
+    }
+
+    render(<TaskNotificationSettings />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    await screen.findByText("settings:taskNotifications.channels.webhook.title")
+    const webhookChannel = document.getElementById(
+      SETTINGS_ANCHORS.TASK_NOTIFICATIONS_CHANNEL_WEBHOOK,
+    )
+    if (!webhookChannel) {
+      throw new Error("Expected webhook channel settings row")
+    }
+
+    fireEvent.change(
+      within(webhookChannel).getByLabelText(
+        "settings:taskNotifications.channels.webhook.url",
+      ),
+      {
+        target: {
+          value: "https://hooks.example.com/next",
+        },
+      },
+    )
+    fireEvent.click(
+      within(webhookChannel).getByRole("button", {
+        name: "settings:taskNotifications.test.action",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(updateTaskNotificationsMock).toHaveBeenCalledWith({
+        channels: expect.objectContaining({
+          [TASK_NOTIFICATION_CHANNELS.Webhook]: expect.objectContaining({
+            url: "https://hooks.example.com/next",
+          }),
+        }),
+      })
+      expect(showResultToastMock).toHaveBeenCalledWith({
+        success: false,
+        message: "settings:messages.saveSettingsFailed",
+        errorFallback: "settings:taskNotifications.test.failed",
+      })
+    })
+
+    expect(sendRuntimeMessageMock).not.toHaveBeenCalled()
+  })
+
   it("does not save unchanged third-party channel drafts", async () => {
     taskNotificationsMock.current = {
       ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,

--- a/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
@@ -438,6 +438,12 @@ describe("TaskNotificationSettings", () => {
         channel: TASK_NOTIFICATION_CHANNELS.Webhook,
       })
     })
+
+    expect(
+      within(webhookChannel).getByText(
+        "settings:taskNotifications.channels.webhook.urlDescription",
+      ),
+    ).toBeInTheDocument()
   })
 
   it("updates channel switches and saves trimmed third-party channel drafts", async () => {
@@ -744,6 +750,66 @@ describe("TaskNotificationSettings", () => {
         }),
       })
     })
+  })
+
+  it("saves the current webhook draft before sending a test notification", async () => {
+    taskNotificationsMock.current = {
+      ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+      channels: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.channels,
+        [TASK_NOTIFICATION_CHANNELS.Webhook]: {
+          enabled: true,
+          url: "https://hooks.example.com/old",
+        },
+      },
+    }
+
+    render(<TaskNotificationSettings />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    await screen.findByText("settings:taskNotifications.channels.webhook.title")
+    const webhookChannel = document.getElementById(
+      SETTINGS_ANCHORS.TASK_NOTIFICATIONS_CHANNEL_WEBHOOK,
+    )
+    if (!webhookChannel) {
+      throw new Error("Expected webhook channel settings row")
+    }
+
+    fireEvent.change(
+      within(webhookChannel).getByLabelText(
+        "settings:taskNotifications.channels.webhook.url",
+      ),
+      {
+        target: {
+          value: "  https://api.day.app/key/{title}/{message} and {status}  ",
+        },
+      },
+    )
+    fireEvent.click(
+      within(webhookChannel).getByRole("button", {
+        name: "settings:taskNotifications.test.action",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(updateTaskNotificationsMock).toHaveBeenCalledWith({
+        channels: expect.objectContaining({
+          [TASK_NOTIFICATION_CHANNELS.Webhook]: expect.objectContaining({
+            url: "https://api.day.app/key/{title}/{message} and {status}",
+          }),
+        }),
+      })
+      expect(sendRuntimeMessageMock).toHaveBeenCalledWith({
+        action: RuntimeActionIds.TaskNotificationsTest,
+        channel: TASK_NOTIFICATION_CHANNELS.Webhook,
+      })
+    })
+
+    expect(
+      updateTaskNotificationsMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(sendRuntimeMessageMock.mock.invocationCallOrder[0])
   })
 
   it("does not save unchanged third-party channel drafts", async () => {

--- a/tests/services/notifications/taskNotificationService.test.ts
+++ b/tests/services/notifications/taskNotificationService.test.ts
@@ -452,6 +452,80 @@ describe("taskNotificationService", () => {
     )
   })
 
+  it("renders generic webhook URL templates for Bark-style endpoints", async () => {
+    getPreferencesMock.mockResolvedValueOnce({
+      taskNotifications: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+        channels: {
+          ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.channels,
+          [TASK_NOTIFICATION_CHANNELS.Browser]: {
+            enabled: false,
+          },
+          [TASK_NOTIFICATION_CHANNELS.Webhook]: {
+            enabled: true,
+            url: "https://api.day.app/device-key/{title}/{message}?group={task}&status={status}&total={total}&success={success}&failed={failed}&skipped={skipped}",
+          },
+        },
+      },
+    })
+
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.WebdavAutoSync,
+        status: TASK_NOTIFICATION_STATUSES.PartialSuccess,
+        counts: {
+          total: 4,
+          success: 2,
+          failed: 1,
+        },
+        title: "All API Hub 测试通知",
+        message: "同步完成 2/4",
+      }),
+    ).resolves.toBe(true)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.day.app/device-key/All%20API%20Hub%20%E6%B5%8B%E8%AF%95%E9%80%9A%E7%9F%A5/%E5%90%8C%E6%AD%A5%E5%AE%8C%E6%88%90%202%2F4%20total%204%20success%202%20failed%201%20skipped%200?group=webdavAutoSync&status=partial_success&total=4&success=2&failed=1&skipped=",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"status":"partial_success"'),
+      }),
+    )
+  })
+
+  it("renders URL-encoded generic webhook placeholders", async () => {
+    getPreferencesMock.mockResolvedValueOnce({
+      taskNotifications: {
+        ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+        channels: {
+          ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.channels,
+          [TASK_NOTIFICATION_CHANNELS.Browser]: {
+            enabled: false,
+          },
+          [TASK_NOTIFICATION_CHANNELS.Webhook]: {
+            enabled: true,
+            url: "https://api.day.app/device-key/%7Btitle%7D/%7Bmessage%7D%20and%20%7Bstatus%7D",
+          },
+        },
+      },
+    })
+
+    await expect(
+      notifyTaskResult({
+        task: TASK_NOTIFICATION_TASKS.AutoCheckin,
+        status: TASK_NOTIFICATION_STATUSES.Success,
+        title: "All API Hub test",
+        message: "Webhook template",
+      }),
+    ).resolves.toBe(true)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.day.app/device-key/All%20API%20Hub%20test/Webhook%20template%20and%20success",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    )
+  })
+
   it("sends Feishu custom bot notifications", async () => {
     getPreferencesMock.mockResolvedValueOnce({
       taskNotifications: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook notifications support template variables in URLs (title, message, task, status, counts) with automatic URL encoding.

* **Bug Fixes**
  * Channel draft configuration is persisted before sending test notifications; failed saves prevent test sends and surface an error toast.

* **Documentation**
  * Webhook URL guidance added in the UI and updated across locales, including a Bark-style example.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/804)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->