### PR TITLE
fix(aihubmix): canonicalize account URLs

### DIFF
--- a/src/constants/siteType.ts
+++ b/src/constants/siteType.ts
@@ -24,6 +24,11 @@ export const SITE_TYPES = {
 
 export const AIHUBMIX_API_ORIGIN = "https://aihubmix.com"
 export const AIHUBMIX_WEB_ORIGIN = "https://console.aihubmix.com"
+export const AIHUBMIX_HOSTNAMES = [
+  "aihubmix.com",
+  "www.aihubmix.com",
+  "console.aihubmix.com",
+] as const
 
 export const ACCOUNT_SITE_TYPES = [
   SITE_TYPES.ONE_API,
@@ -103,7 +108,7 @@ export const ACCOUNT_SITE_DOMAIN_RULES = [
     name: SITE_TYPES.AIHUBMIX,
     // Domain-first detection avoids treating AIHubMix as a generic
     // One-API/New-API compatible site based on page title or fallback probes.
-    hostnames: ["aihubmix.com", "www.aihubmix.com", "console.aihubmix.com"],
+    hostnames: AIHUBMIX_HOSTNAMES,
   },
 ] as const
 

--- a/src/constants/siteType.ts
+++ b/src/constants/siteType.ts
@@ -22,6 +22,9 @@ export const SITE_TYPES = {
   UNKNOWN: "unknown",
 } as const
 
+export const AIHUBMIX_API_ORIGIN = "https://aihubmix.com"
+export const AIHUBMIX_WEB_ORIGIN = "https://console.aihubmix.com"
+
 export const ACCOUNT_SITE_TYPES = [
   SITE_TYPES.ONE_API,
   SITE_TYPES.NEW_API,
@@ -169,6 +172,12 @@ const SITE_ROUTE_CONFIGS: Partial<
     usagePath: "/usage",
     redeemPath: "/redeem",
     siteAnnouncementsPath: "/dashboard",
+  },
+  [SITE_TYPES.AIHUBMIX]: {
+    usagePath: "/statistics",
+    redeemPath: "/topup",
+    checkInPath: "/",
+    adminCredentialsPath: "/",
   },
   Default: {
     usagePath: DEFAULT_USAGE_PATH,

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -25,6 +25,7 @@ import {
   analyzeAutoDetectError,
   AutoDetectError,
 } from "~/services/accounts/utils/autoDetectUtils"
+import { normalizeAccountSiteUrlForOriginKey } from "~/services/accounts/utils/siteUrlNormalization"
 import { getManagedSiteServiceForType } from "~/services/managedSites/managedSiteService"
 import {
   getManagedSiteConfigMissingMessage,
@@ -47,10 +48,7 @@ import {
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { showWarningToast } from "~/utils/core/toastHelpers"
-import {
-  normalizeUrlForOriginKey,
-  tryParseOrigin,
-} from "~/utils/core/urlParsing"
+import { tryParseOrigin } from "~/utils/core/urlParsing"
 import { openSettingsTab } from "~/utils/navigation"
 
 import {
@@ -355,7 +353,10 @@ export function useAccountDialog({
     }
 
     const baseUrl = url.trim()
-    const normalizedBaseUrl = normalizeSiteUrlForDuplicateCheck(baseUrl)
+    const normalizedBaseUrl = normalizeSiteUrlForDuplicateCheck({
+      value: baseUrl,
+      siteType,
+    })
     const currentUserId = userId.trim()
 
     if (!baseUrl) {
@@ -372,7 +373,10 @@ export function useAccountDialog({
     const accounts = await accountStorage.getAllAccounts()
     const existingSiteAccounts = accounts.filter(
       (acc) =>
-        normalizeSiteUrlForDuplicateCheck(acc.site_url) === normalizedBaseUrl,
+        normalizeSiteUrlForDuplicateCheck({
+          value: acc.site_url,
+          siteType: acc.site_type,
+        }) === normalizedBaseUrl,
     )
 
     if (existingSiteAccounts.length === 0) {
@@ -405,6 +409,7 @@ export function useAccountDialog({
   }, [
     mode,
     requestDuplicateAccountAddConfirmation,
+    siteType,
     url,
     userId,
     warnOnDuplicateAccountAdd,
@@ -1450,8 +1455,14 @@ export function useAccountDialog({
 /**
  * Normalizes user-supplied site URLs for duplicate-account checks.
  */
-function normalizeSiteUrlForDuplicateCheck(value: string): string {
-  return normalizeUrlForOriginKey(value, { lowerCase: true })
+function normalizeSiteUrlForDuplicateCheck(params: {
+  value: string
+  siteType?: AccountSiteType | string
+}): string {
+  return normalizeAccountSiteUrlForOriginKey({
+    url: params.value,
+    siteType: params.siteType,
+  })
 }
 
 /**

--- a/src/services/accounts/accountDedupe.ts
+++ b/src/services/accounts/accountDedupe.ts
@@ -1,3 +1,8 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  isAIHubMixSiteUrl,
+  normalizeAccountSiteUrlForOriginKey,
+} from "~/services/accounts/utils/siteUrlNormalization"
 import type { SiteAccount } from "~/types"
 import { sanitizeOriginUrl } from "~/utils/core/url"
 
@@ -158,7 +163,14 @@ export function scanDuplicateAccounts(input: {
   >()
 
   for (const account of input.accounts) {
-    const origin = sanitizeOriginUrl(account.site_url)
+    const origin =
+      account.site_type === SITE_TYPES.AIHUBMIX ||
+      isAIHubMixSiteUrl(account.site_url)
+        ? normalizeAccountSiteUrlForOriginKey({
+            url: account.site_url,
+            siteType: account.site_type,
+          })
+        : sanitizeOriginUrl(account.site_url)
     const userId = coerceFiniteUserId(account.account_info?.id)
 
     if (!origin || userId === undefined) {

--- a/src/services/accounts/accountDefaults.ts
+++ b/src/services/accounts/accountDefaults.ts
@@ -1,5 +1,6 @@
 import { isAccountSiteType, SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
+import { normalizeAccountSiteUrlForStorage } from "~/services/accounts/utils/siteUrlNormalization"
 import {
   AuthTypeEnum,
   SiteHealthStatus,
@@ -219,10 +220,15 @@ export function normalizeSiteAccount(raw: SiteAccount): SiteAccount {
     ...merged,
     id: coerceString(merged.id, ""),
     site_name: coerceString(merged.site_name, ""),
-    site_url: coerceString(merged.site_url, ""),
     site_type: isAccountSiteType(merged.site_type)
       ? merged.site_type
       : SITE_TYPES.UNKNOWN,
+    site_url: normalizeAccountSiteUrlForStorage({
+      siteType: isAccountSiteType(merged.site_type)
+        ? merged.site_type
+        : SITE_TYPES.UNKNOWN,
+      url: coerceString(merged.site_url, ""),
+    }),
     exchange_rate: coerceNumber(
       merged.exchange_rate,
       UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -22,6 +22,7 @@ import {
   analyzeAutoDetectError,
   getAutoDetectErrorByCode,
 } from "~/services/accounts/utils/autoDetectUtils"
+import { normalizeAccountSiteUrlForStorage } from "~/services/accounts/utils/siteUrlNormalization"
 import { getApiService } from "~/services/apiService"
 import {
   DEFAULT_PREFERENCES,
@@ -591,18 +592,23 @@ export async function validateAndSaveAccount(
     normalizedSiteType,
     sub2apiAuth,
   )
+  const requestBaseUrl = url.trim()
+  const storageSiteUrl = normalizeAccountSiteUrlForStorage({
+    siteType: normalizedSiteType,
+    url,
+  })
 
   try {
     // 获取账号余额和今日使用情况
     logger.debug("Fetching account data for new account", {
-      baseUrl: url.trim(),
+      baseUrl: requestBaseUrl,
       siteType: normalizedSiteType,
       authType,
       userId: parsedUserId,
     })
     const freshAccountData = await withTimeout(
       getApiService(normalizedSiteType).fetchAccountData({
-        baseUrl: url.trim(),
+        baseUrl: requestBaseUrl,
         checkIn: checkInConfig,
         accountId: undefined, // New account, no ID yet
         includeTodayCashflow,
@@ -627,7 +633,7 @@ export async function validateAndSaveAccount(
 
     const accountData: Omit<SiteAccount, "id" | "created_at" | "updated_at"> = {
       site_name: siteName.trim(),
-      site_url: url.trim(),
+      site_url: storageSiteUrl,
       health: { status: SiteHealthStatus.Healthy }, // 成功获取数据说明状态正常
       site_type: normalizedSiteType,
       authType: authType,
@@ -687,7 +693,7 @@ export async function validateAndSaveAccount(
       "id" | "created_at" | "updated_at"
     > = {
       site_name: siteName.trim(),
-      site_url: url.trim(),
+      site_url: storageSiteUrl,
       site_type: normalizedSiteType,
       authType: authType,
       disabled: false,
@@ -834,12 +840,17 @@ export async function validateAndUpdateAccount(
     normalizedSiteType,
     sub2apiAuth,
   )
+  const requestBaseUrl = url.trim()
+  const storageSiteUrl = normalizeAccountSiteUrlForStorage({
+    siteType: normalizedSiteType,
+    url,
+  })
 
   try {
     // 获取账号余额和今日使用情况
     logger.debug("Fetching account data for update", {
       accountId,
-      baseUrl: url.trim(),
+      baseUrl: requestBaseUrl,
       siteType: normalizedSiteType,
       authType,
       userId: parsedUserId,
@@ -849,7 +860,7 @@ export async function validateAndUpdateAccount(
     const freshAccountData = await getApiService(
       normalizedSiteType,
     ).fetchAccountData({
-      baseUrl: url.trim(),
+      baseUrl: requestBaseUrl,
       checkIn: checkInConfig,
       accountId,
       includeTodayCashflow,
@@ -868,7 +879,7 @@ export async function validateAndUpdateAccount(
 
     const updateData: Partial<Omit<SiteAccount, "id" | "created_at">> = {
       site_name: siteName.trim(),
-      site_url: url.trim(),
+      site_url: storageSiteUrl,
       health: { status: SiteHealthStatus.Healthy }, // 成功获取数据说明状态正常
       site_type: normalizedSiteType,
       authType: authType,
@@ -928,7 +939,7 @@ export async function validateAndUpdateAccount(
 
     const partialUpdateData = {
       site_name: siteName.trim(),
-      site_url: url.trim(),
+      site_url: storageSiteUrl,
       site_type: normalizedSiteType,
       authType: authType,
       excludeFromTotalBalance: excludeFromTotalBalance === true,

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -46,6 +46,10 @@ import {
   migrateAccountsConfig,
   needsConfigMigration,
 } from "./migrations/accountDataMigration"
+import {
+  isAIHubMixSiteUrl,
+  normalizeAccountSiteUrlForOriginKey,
+} from "./utils/siteUrlNormalization"
 
 // Re-export for backward compatibility across the codebase.
 export { ACCOUNT_STORAGE_KEYS }
@@ -253,11 +257,29 @@ class AccountStorageService {
         userId,
       })
       const accounts = await this.getAllAccounts()
-      const account = accounts.find(
-        (acc) =>
-          acc.site_url === baseUrl &&
-          String(acc.account_info.id) === String(userId),
-      )
+      const requestedOriginKey = isAIHubMixSiteUrl(baseUrl)
+        ? normalizeAccountSiteUrlForOriginKey({ url: baseUrl })
+        : null
+      const account = accounts.find((acc) => {
+        if (String(acc.account_info.id) !== String(userId)) {
+          return false
+        }
+
+        if (acc.site_url === baseUrl) {
+          return true
+        }
+
+        if (!requestedOriginKey || !isAIHubMixSiteUrl(acc.site_url)) {
+          return false
+        }
+
+        return (
+          normalizeAccountSiteUrlForOriginKey({
+            url: acc.site_url,
+            siteType: acc.site_type,
+          }) === requestedOriginKey
+        )
+      })
 
       if (account && needsConfigMigration(account)) {
         logger.debug("Migrating account on fetch", {

--- a/src/services/accounts/utils/siteUrlNormalization.ts
+++ b/src/services/accounts/utils/siteUrlNormalization.ts
@@ -1,15 +1,12 @@
 import {
+  AIHUBMIX_HOSTNAMES,
   AIHUBMIX_WEB_ORIGIN,
   SITE_TYPES,
   type AccountSiteType,
 } from "~/constants/siteType"
 import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
 
-const AIHUBMIX_HOSTNAMES = new Set([
-  "aihubmix.com",
-  "www.aihubmix.com",
-  "console.aihubmix.com",
-])
+const AIHUBMIX_HOSTNAME_SET: ReadonlySet<string> = new Set(AIHUBMIX_HOSTNAMES)
 
 const parseHttpUrl = (value: string): URL | null => {
   const trimmed = value.trim()
@@ -34,7 +31,9 @@ const parseHttpUrl = (value: string): URL | null => {
  */
 export function isAIHubMixSiteUrl(value: string): boolean {
   const parsed = parseHttpUrl(value)
-  return parsed ? AIHUBMIX_HOSTNAMES.has(parsed.hostname.toLowerCase()) : false
+  return parsed
+    ? AIHUBMIX_HOSTNAME_SET.has(parsed.hostname.toLowerCase())
+    : false
 }
 
 /**

--- a/src/services/accounts/utils/siteUrlNormalization.ts
+++ b/src/services/accounts/utils/siteUrlNormalization.ts
@@ -1,0 +1,72 @@
+import {
+  AIHUBMIX_WEB_ORIGIN,
+  SITE_TYPES,
+  type AccountSiteType,
+} from "~/constants/siteType"
+import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
+
+const AIHUBMIX_HOSTNAMES = new Set([
+  "aihubmix.com",
+  "www.aihubmix.com",
+  "console.aihubmix.com",
+])
+
+const parseHttpUrl = (value: string): URL | null => {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const candidate = /^https?:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`
+
+  try {
+    const parsed = new URL(candidate)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? parsed
+      : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Checks whether a user-supplied URL points at one of AIHubMix's supported hosts.
+ */
+export function isAIHubMixSiteUrl(value: string): boolean {
+  const parsed = parseHttpUrl(value)
+  return parsed ? AIHUBMIX_HOSTNAMES.has(parsed.hostname.toLowerCase()) : false
+}
+
+/**
+ * Canonicalizes the URL persisted for account UI navigation.
+ *
+ * AIHubMix API calls are pinned to `https://aihubmix.com`, while the user-facing
+ * console pages live under `https://console.aihubmix.com`.
+ */
+export function normalizeAccountSiteUrlForStorage(params: {
+  siteType: AccountSiteType | string
+  url: string
+}): string {
+  if (params.siteType === SITE_TYPES.AIHUBMIX) {
+    return AIHUBMIX_WEB_ORIGIN
+  }
+
+  return params.url.trim()
+}
+
+/**
+ * Produces a stable origin key for duplicate-account scans and warnings.
+ */
+export function normalizeAccountSiteUrlForOriginKey(params: {
+  siteType?: AccountSiteType | string
+  url: string
+}): string {
+  if (
+    params.siteType === SITE_TYPES.AIHUBMIX ||
+    isAIHubMixSiteUrl(params.url)
+  ) {
+    return AIHUBMIX_WEB_ORIGIN.toLowerCase()
+  }
+
+  return normalizeUrlForOriginKey(params.url, { lowerCase: true })
+}

--- a/src/services/apiService/aihubmix/index.ts
+++ b/src/services/apiService/aihubmix/index.ts
@@ -1,3 +1,4 @@
+import { AIHUBMIX_API_ORIGIN } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { determineHealthStatus } from "~/services/apiService/common"
 import {
@@ -31,7 +32,6 @@ import { t } from "~/utils/i18n/core"
 const logger = createLogger("ApiService.AIHubMix")
 // AIHubMix console traffic is pinned to the main origin even when detection
 // starts from console.aihubmix.com.
-const AIHUBMIX_API_ORIGIN = "https://aihubmix.com"
 const AIHUBMIX_API_USER_SELF_ENDPOINT = "/api/user/self"
 // These `/call/usr/*` routes are web-session endpoints used only while
 // importing an account from the logged-in browser session.

--- a/tests/constants/siteType.test.ts
+++ b/tests/constants/siteType.test.ts
@@ -41,9 +41,9 @@ describe("siteType constants", () => {
 
   it("returns default routes for AIHubMix account pages", () => {
     expect(getAccountSiteApiRouter(SITE_TYPES.AIHUBMIX)).toMatchObject({
-      usagePath: "/console/log",
-      checkInPath: "/console/personal",
-      redeemPath: "/console/topup",
+      usagePath: "/statistics",
+      checkInPath: "/",
+      redeemPath: "/topup",
       siteAnnouncementsPath: "/",
     })
   })

--- a/tests/constants/siteType.test.ts
+++ b/tests/constants/siteType.test.ts
@@ -44,6 +44,7 @@ describe("siteType constants", () => {
       usagePath: "/statistics",
       checkInPath: "/",
       redeemPath: "/topup",
+      adminCredentialsPath: "/",
       siteAnnouncementsPath: "/",
     })
   })

--- a/tests/features/AccountManagement/hooks/useAccountDialog.duplicateAccountWarning.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.duplicateAccountWarning.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { DIALOG_MODES } from "~/constants/dialogModes"
+import { SITE_TYPES } from "~/constants/siteType"
 import { useAccountDialog } from "~/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { userPreferences } from "~/services/preferences/userPreferences"
@@ -237,6 +238,43 @@ describe("useAccountDialog duplicate account warning", () => {
 
     expect(result.current.state.duplicateAccountWarning.isOpen).toBe(false)
     expect(result.current.state.showManualForm).toBe(true)
+  })
+
+  it("warns for AIHubMix duplicates across main and console hostnames", async () => {
+    await accountStorage.addAccount(
+      buildSiteAccount({
+        site_name: "AIHubMix Existing",
+        site_url: "https://aihubmix.com",
+        site_type: SITE_TYPES.AIHUBMIX,
+        account_info: {
+          ...defaultAccountInfo,
+          id: 11,
+          username: "aihubmix-user",
+        },
+      }),
+    )
+
+    const { result } = await renderDuplicateWarningHook()
+
+    await act(async () => {
+      result.current.setters.setUrl(
+        "https://console.aihubmix.com/statistics?tab=detail",
+      )
+      result.current.setters.setSiteType(SITE_TYPES.AIHUBMIX)
+      result.current.setters.setUserId("11")
+    })
+
+    act(() => {
+      void result.current.handlers.handleShowManualForm()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.duplicateAccountWarning.isOpen).toBe(true)
+    })
+    expect(result.current.state.duplicateAccountWarning.siteUrl).toBe(
+      "https://console.aihubmix.com",
+    )
+    expect(result.current.state.duplicateAccountWarning.existingUserId).toBe(11)
   })
 
   it("skips duplicate warning in edit mode", async () => {

--- a/tests/services/accountDedupe.test.ts
+++ b/tests/services/accountDedupe.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import { scanDuplicateAccounts } from "~/services/accounts/accountDedupe"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
 
@@ -59,6 +60,33 @@ describe("scanDuplicateAccounts", () => {
     expect(result.groups).toHaveLength(1)
     expect(result.groups[0].key).toEqual({
       origin: "https://api.example.com",
+      userId: 1,
+    })
+  })
+
+  it("groups AIHubMix accounts across main and console hostnames", () => {
+    const main = buildSiteAccount({
+      id: "acc-1",
+      site_url: "https://aihubmix.com",
+      site_type: SITE_TYPES.AIHUBMIX,
+      account_info: { id: 1 } as any,
+    })
+    const console = buildSiteAccount({
+      id: "acc-2",
+      site_url: "https://console.aihubmix.com/statistics?tab=detail",
+      site_type: SITE_TYPES.AIHUBMIX,
+      account_info: { id: 1 } as any,
+    })
+
+    const result = scanDuplicateAccounts({
+      accounts: [main, console],
+      pinnedAccountIds: [],
+      strategy: "keepPinned",
+    })
+
+    expect(result.groups).toHaveLength(1)
+    expect(result.groups[0].key).toEqual({
+      origin: "https://console.aihubmix.com",
       userId: 1,
     })
   })

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -4,6 +4,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 import {
   MANUAL_ADD_ACCOUNT_DATA_FETCH_TIMEOUT_MS,
   validateAndSaveAccount,
+  validateAndUpdateAccount,
 } from "~/services/accounts/accountOperations"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import {
@@ -163,6 +164,70 @@ describe("accountOperations validateAndSaveAccount", () => {
     expect(result.success).toBe(true)
 
     const saved = await accountStorage.getAccountById(result.accountId!)
+    expect(saved?.site_url).toBe("https://console.aihubmix.com")
+    expect(fetchAccountDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://aihubmix.com/statistics?tab=detail",
+      }),
+    )
+  })
+
+  it("updates AIHubMix accounts with the canonical console origin", async () => {
+    const accountId = await accountStorage.addAccount({
+      site_name: "AIHubMix",
+      site_url: "https://aihubmix.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.AIHUBMIX,
+      exchange_rate: 7,
+      account_info: {
+        id: 11,
+        access_token: "old-access-token",
+        username: "aihubmix-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+      last_sync_time: 0,
+      notes: "",
+      tagIds: [],
+      disabled: false,
+      excludeFromTotalBalance: false,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: CHECK_IN_DISABLED,
+    })
+
+    fetchAccountDataMock.mockResolvedValueOnce({
+      quota: 100,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+      checkIn: CHECK_IN_DISABLED,
+    })
+
+    const result = await validateAndUpdateAccount(
+      accountId,
+      "https://aihubmix.com/statistics?tab=detail",
+      "AIHubMix",
+      "aihubmix-user",
+      "access-token",
+      "11",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.AIHUBMIX,
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result.success).toBe(true)
+
+    const saved = await accountStorage.getAccountById(accountId)
     expect(saved?.site_url).toBe("https://console.aihubmix.com")
     expect(fetchAccountDataMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -134,6 +134,43 @@ describe("accountOperations validateAndSaveAccount", () => {
     expect(ensureDefaultApiTokenForAccountMock).not.toHaveBeenCalled()
   })
 
+  it("stores AIHubMix accounts with the canonical console origin", async () => {
+    fetchAccountDataMock.mockResolvedValueOnce({
+      quota: 100,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+      checkIn: CHECK_IN_DISABLED,
+    })
+
+    const result = await validateAndSaveAccount(
+      "https://aihubmix.com/statistics?tab=detail",
+      "AIHubMix",
+      "aihubmix-user",
+      "access-token",
+      "11",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.AIHUBMIX,
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result.success).toBe(true)
+
+    const saved = await accountStorage.getAccountById(result.accountId!)
+    expect(saved?.site_url).toBe("https://console.aihubmix.com")
+    expect(fetchAccountDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://aihubmix.com/statistics?tab=detail",
+      }),
+    )
+  })
+
   it("saves a warning-only Sub2API account when remote data refresh fails", async () => {
     fetchAccountDataMock.mockRejectedValueOnce(new Error("quota fetch failed"))
 

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -1025,6 +1025,35 @@ describe("accountStorage core behaviors", () => {
     expect(missing).toBeNull()
   })
 
+  it("getAccountByBaseUrlAndUserId should match AIHubMix canonical web origins", async () => {
+    seedStorage([
+      createAccount({
+        id: "aihubmix-target",
+        site_url: "https://aihubmix.com",
+        site_type: SITE_TYPES.AIHUBMIX,
+        account_info: {
+          id: 123,
+          access_token: "token",
+          username: "aihubmix-user",
+          quota: 100,
+          today_prompt_tokens: 0,
+          today_completion_tokens: 0,
+          today_quota_consumption: 0,
+          today_requests_count: 0,
+          today_income: 0,
+        },
+      }),
+    ])
+
+    const found = await accountStorage.getAccountByBaseUrlAndUserId(
+      "https://console.aihubmix.com/statistics?tab=detail",
+      "123",
+    )
+
+    expect(found?.id).toBe("aihubmix-target")
+    expect(found?.site_url).toBe("https://console.aihubmix.com")
+  })
+
   it("deleteAccount should remove account data and pinned references", async () => {
     const account = createAccount({ id: "to-delete" })
     seedStorage([account], ["to-delete"])

--- a/tests/services/accounts/accountDefaults.test.ts
+++ b/tests/services/accounts/accountDefaults.test.ts
@@ -146,6 +146,17 @@ describe("accountDefaults", () => {
       expect(normalized.notes).toBe("hello")
     })
 
+    it("canonicalizes AIHubMix accounts to the console web origin", () => {
+      const normalized = normalizeSiteAccount(
+        createSiteAccount({
+          site_type: SITE_TYPES.AIHUBMIX,
+          site_url: "https://aihubmix.com/statistics?tab=detail",
+        }),
+      )
+
+      expect(normalized.site_url).toBe("https://console.aihubmix.com")
+    })
+
     it("coerces invalid persisted values to stable defaults", () => {
       const normalized = normalizeSiteAccount({
         ...createSiteAccount(),

--- a/tests/services/accounts/siteUrlNormalization.test.ts
+++ b/tests/services/accounts/siteUrlNormalization.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  isAIHubMixSiteUrl,
+  normalizeAccountSiteUrlForOriginKey,
+  normalizeAccountSiteUrlForStorage,
+} from "~/services/accounts/utils/siteUrlNormalization"
+
+describe("siteUrlNormalization", () => {
+  it("recognizes supported AIHubMix hostnames", () => {
+    expect(isAIHubMixSiteUrl("aihubmix.com")).toBe(true)
+    expect(isAIHubMixSiteUrl("https://www.aihubmix.com/statistics")).toBe(true)
+    expect(isAIHubMixSiteUrl("https://console.aihubmix.com")).toBe(true)
+  })
+
+  it("rejects invalid and unsupported URLs", () => {
+    expect(isAIHubMixSiteUrl("https://[invalid-url")).toBe(false)
+    expect(isAIHubMixSiteUrl("https://example.com")).toBe(false)
+  })
+
+  it("canonicalizes AIHubMix storage and origin keys", () => {
+    expect(
+      normalizeAccountSiteUrlForStorage({
+        siteType: SITE_TYPES.AIHUBMIX,
+        url: "https://aihubmix.com/statistics",
+      }),
+    ).toBe("https://console.aihubmix.com")
+    expect(
+      normalizeAccountSiteUrlForOriginKey({
+        url: "https://aihubmix.com/statistics",
+      }),
+    ).toBe("https://console.aihubmix.com")
+  })
+
+  it("preserves non-AIHubMix storage URLs and origin keys", () => {
+    expect(
+      normalizeAccountSiteUrlForStorage({
+        siteType: SITE_TYPES.NEW_API,
+        url: " https://example.com/path ",
+      }),
+    ).toBe("https://example.com/path")
+    expect(
+      normalizeAccountSiteUrlForOriginKey({
+        siteType: SITE_TYPES.NEW_API,
+        url: "https://example.com/path?tab=1",
+      }),
+    ).toBe("https://example.com")
+  })
+})


### PR DESCRIPTION
Resolves #631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AIHubMix site type with default routes and origins; app now treats AIHubMix host variants as a single site.

* **Bug Fixes**
  * Improved duplicate-account detection across AIHubMix hostnames.
  * Persisted account URLs are now canonicalized for reliable lookups and updates.

* **Tests**
  * Added unit and integration tests covering AIHubMix normalization, dedupe, storage, and account workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/811)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->