### PR TITLE
feat(accounts): add foreground post-save token workflow for managed-site setup

### DIFF
--- a/docs/superpowers/plans/2026-05-11-aihubmix-account-post-save-workflow.md
+++ b/docs/superpowers/plans/2026-05-11-aihubmix-account-post-save-workflow.md
@@ -1,0 +1,1820 @@
+# AIHubMix Account Post-Save Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make add-account "configure to managed site" run a foreground token-preparation workflow so AIHubMix one-time keys and Sub2API group selection are handled in UI before opening managed-site channel setup.
+
+**Architecture:** Add a focused account token workflow module with constants, result types, and a pure foreground helper. Keep account persistence in `validateAndSaveAccount`, then orchestrate post-save steps in `AccountDialog` using existing `OneTimeApiKeyDialog`, `AddTokenDialog`, and `ChannelDialog` paths. Avoid magic strings by using exported constants for workflow steps, result kinds, error codes, and existing `SITE_TYPES` values.
+
+**Tech Stack:** TypeScript, React, WXT, Vitest, Testing Library, i18next locale JSON, existing account/managed-site service modules.
+
+---
+
+## File Structure
+
+- Create `src/services/accounts/accountPostSaveWorkflow/constants.ts`
+  - Exports workflow step constants, result-kind constants, error-code constants, and derived TypeScript types.
+- Create `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+  - Exports the foreground helper that checks existing keys, creates default keys, preserves AIHubMix full secrets, and returns structured results.
+- Create `src/services/accounts/accountPostSaveWorkflow/index.ts`
+  - Barrel export for the new workflow module.
+- Modify `src/services/accounts/accountOperations.ts`
+  - Add `ValidateAndSaveAccountOptions` and make `validateAndSaveAccount` optionally skip background auto-provisioning.
+- Modify `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+  - Add post-save workflow state, token workflow orchestration, one-time-token state, Sub2API resume callback, and pass ensured tokens to `openWithAccount`.
+- Modify `src/features/AccountManagement/components/AccountDialog/index.tsx`
+  - Render `AddTokenDialog` for foreground Sub2API group selection and `OneTimeApiKeyDialog` for AIHubMix one-time keys.
+- Modify `src/features/AccountManagement/components/AccountDialog/ActionButtons.tsx`
+  - Show phase-specific quick-config loading text using workflow step constants mapped to i18n keys.
+- Modify locale files:
+  - `src/locales/zh-CN/accountDialog.json`
+  - `src/locales/zh-TW/accountDialog.json`
+  - `src/locales/en/accountDialog.json`
+  - `src/locales/ja/accountDialog.json`
+- Test files:
+  - `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+  - `tests/services/accountOperations.validateAndSaveAccount.test.ts`
+  - `tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx`
+  - `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`
+
+---
+
+### Task 1: Add Workflow Constants And Token Helper
+
+**Files:**
+- Create: `src/services/accounts/accountPostSaveWorkflow/constants.ts`
+- Create: `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+- Create: `src/services/accounts/accountPostSaveWorkflow/index.ts`
+- Test: `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+
+- [ ] **Step 1: Write failing tests for the foreground token helper**
+
+Create `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts` with this complete content:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES,
+  ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
+  ensureAccountTokenForPostSaveWorkflow,
+} from "~/services/accounts/accountPostSaveWorkflow"
+import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
+import { buildSiteAccount } from "~~/tests/test-utils/factories"
+
+const { fetchAccountTokensMock, createApiTokenMock, fetchUserGroupsMock } =
+  vi.hoisted(() => ({
+    fetchAccountTokensMock: vi.fn(),
+    createApiTokenMock: vi.fn(),
+    fetchUserGroupsMock: vi.fn(),
+  }))
+
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => ({
+      fetchAccountTokens: (...args: unknown[]) =>
+        fetchAccountTokensMock(...args),
+      createApiToken: (...args: unknown[]) => createApiTokenMock(...args),
+      fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
+    })),
+  }
+})
+
+const buildToken = (overrides: Partial<ApiToken> = {}): ApiToken => ({
+  id: 1,
+  user_id: 7,
+  key: "sk-existing",
+  status: 1,
+  name: "existing",
+  created_time: 1,
+  accessed_time: 1,
+  expired_time: -1,
+  remain_quota: -1,
+  unlimited_quota: true,
+  used_quota: 0,
+  ...overrides,
+})
+
+const buildDisplayAccount = (
+  overrides: Partial<DisplaySiteData> = {},
+): DisplaySiteData =>
+  ({
+    id: "account-id",
+    name: "Account",
+    username: "user",
+    balance: { USD: 0, CNY: 0 },
+    todayConsumption: { USD: 0, CNY: 0 },
+    todayIncome: { USD: 0, CNY: 0 },
+    todayTokens: { upload: 0, download: 0 },
+    health: { status: "healthy" },
+    siteType: SITE_TYPES.NEW_API,
+    baseUrl: "https://api.example.com",
+    token: "access-token",
+    userId: 7,
+    authType: AuthTypeEnum.AccessToken,
+    checkIn: { enableDetection: false },
+    cookieAuthSessionCookie: "",
+    ...overrides,
+  }) as DisplaySiteData
+
+const buildStoredAccount = (
+  displayAccount: DisplaySiteData = buildDisplayAccount(),
+) =>
+  buildSiteAccount({
+    id: displayAccount.id,
+    site_name: displayAccount.name,
+    site_url: displayAccount.baseUrl,
+    site_type: displayAccount.siteType,
+    authType: displayAccount.authType,
+    account_info: {
+      id: displayAccount.userId,
+      access_token: displayAccount.token,
+      username: displayAccount.username,
+      quota: 0,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+    },
+  })
+
+describe("ensureAccountTokenForPostSaveWorkflow", () => {
+  beforeEach(() => {
+    fetchAccountTokensMock.mockReset()
+    createApiTokenMock.mockReset()
+    fetchUserGroupsMock.mockReset()
+  })
+
+  it("returns a ready result when the account already has a token", async () => {
+    const displayAccount = buildDisplayAccount()
+    const account = buildStoredAccount(displayAccount)
+    const existingToken = buildToken({ id: 5, key: "sk-ready" })
+    fetchAccountTokensMock.mockResolvedValueOnce([existingToken])
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: existingToken,
+      created: false,
+    })
+    expect(createApiTokenMock).not.toHaveBeenCalled()
+  })
+
+  it("creates a default token for ordinary accounts without existing tokens", async () => {
+    const displayAccount = buildDisplayAccount()
+    const account = buildStoredAccount(displayAccount)
+    const createdToken = buildToken({ id: 6, key: "sk-created" })
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: false,
+    })
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: displayAccount.baseUrl,
+        accountId: displayAccount.id,
+      }),
+      expect.objectContaining({
+        name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: "",
+      }),
+    )
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("creates an AIHubMix token and marks the full secret as one-time", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+      token: "aihubmix-access-token",
+    })
+    const account = buildStoredAccount(displayAccount)
+    const createdToken = buildToken({
+      id: 7,
+      key: "sk-aihubmix-full-secret",
+      name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+    })
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: true,
+    })
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("blocks AIHubMix when creation does not return a usable full secret", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(true)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+      message: "messages:aihubmix.createRequiresOneTimeKeyDialog",
+    })
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("blocks AIHubMix when creation returns a masked key", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(
+      buildToken({ id: 8, key: "sk-***masked***" }),
+    )
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toMatchObject({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+    })
+  })
+
+  it("creates a Sub2API token directly when one current group exists", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    const createdToken = buildToken({ id: 9, key: "sk-sub2", group: "vip" })
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: false,
+    })
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ group: "vip" }),
+    )
+  })
+
+  it("requires Sub2API group selection when multiple current groups exist", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { ratio: 1 },
+      vip: { ratio: 2 },
+    })
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+    expect(createApiTokenMock).not.toHaveBeenCalled()
+  })
+
+  it("blocks Sub2API when no current group is available", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({})
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+      message: "messages:sub2api.createRequiresAvailableGroup",
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the helper test to verify it fails**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+```
+
+Expected: FAIL because `~/services/accounts/accountPostSaveWorkflow` does not exist.
+
+- [ ] **Step 3: Add workflow constants**
+
+Create `src/services/accounts/accountPostSaveWorkflow/constants.ts`:
+
+```ts
+import type { ApiToken } from "~/types"
+
+export const ACCOUNT_POST_SAVE_WORKFLOW_STEPS = {
+  Idle: "idle",
+  SavingAccount: "saving_account",
+  LoadingSavedAccount: "loading_saved_account",
+  CheckingToken: "checking_token",
+  CreatingToken: "creating_token",
+  WaitingForOneTimeKeyAcknowledgement:
+    "waiting_for_one_time_key_acknowledgement",
+  WaitingForSub2ApiGroupSelection: "waiting_for_sub2api_group_selection",
+  OpeningManagedSiteDialog: "opening_managed_site_dialog",
+  Completed: "completed",
+  Failed: "failed",
+} as const
+
+export type AccountPostSaveWorkflowStep =
+  (typeof ACCOUNT_POST_SAVE_WORKFLOW_STEPS)[keyof typeof ACCOUNT_POST_SAVE_WORKFLOW_STEPS]
+
+export const ENSURE_ACCOUNT_TOKEN_RESULT_KINDS = {
+  Ready: "ready",
+  Created: "created",
+  Sub2ApiSelectionRequired: "sub2api_selection_required",
+  Blocked: "blocked",
+} as const
+
+export type EnsureAccountTokenResultKind =
+  (typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS)[keyof typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS]
+
+export const ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES = {
+  SavedAccountNotFound: "saved_account_not_found",
+  TokenCreationFailed: "token_creation_failed",
+  TokenSecretUnavailable: "token_secret_unavailable",
+  ManagedSiteConfigMissing: "managed_site_config_missing",
+  UserCancelled: "user_cancelled",
+} as const
+
+export type AccountPostSaveWorkflowErrorCode =
+  (typeof ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES)[keyof typeof ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES]
+
+export type EnsureAccountTokenResult =
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready
+      token: ApiToken
+      created: false
+    }
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created
+      token: ApiToken
+      created: true
+      oneTimeSecret: boolean
+    }
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired
+      allowedGroups: string[]
+    }
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked
+      code: AccountPostSaveWorkflowErrorCode
+      message: string
+    }
+```
+
+- [ ] **Step 4: Add the foreground token helper**
+
+Create `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  generateDefaultTokenRequest,
+} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import {
+  resolveSub2ApiQuickCreateResolution,
+} from "~/services/accounts/accountOperations"
+import {
+  hasUsableApiTokenKey,
+  isMaskedApiTokenKey,
+} from "~/services/apiService/common/apiKey"
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import { getApiService } from "~/services/apiService"
+import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
+import { t } from "~/utils/i18n/core"
+
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES,
+  ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
+  type EnsureAccountTokenResult,
+} from "./constants"
+
+const isCreatedApiToken = (value: unknown): value is ApiToken =>
+  !!value &&
+  typeof value === "object" &&
+  typeof (value as Partial<ApiToken>).id === "number" &&
+  typeof (value as Partial<ApiToken>).key === "string"
+
+const hasUsableFullTokenSecret = (token: ApiToken): boolean =>
+  hasUsableApiTokenKey(token.key) && !isMaskedApiTokenKey(token.key)
+
+const buildCreateRequest = (
+  account: SiteAccount,
+): ApiServiceRequest => ({
+  baseUrl: account.site_url,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.account_info.id,
+    accessToken: account.account_info.access_token,
+    cookie: account.cookieAuth?.sessionCookie,
+  },
+})
+
+async function createDefaultToken(params: {
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+  group?: string
+}): Promise<ApiToken | null> {
+  const { account, displaySiteData, group } = params
+  const tokenData = generateDefaultTokenRequest()
+  if (typeof group === "string") {
+    tokenData.group = group
+  }
+
+  const created = await getApiService(displaySiteData.siteType).createApiToken(
+    buildCreateRequest(account),
+    tokenData,
+  )
+
+  return isCreatedApiToken(created) ? created : null
+}
+
+export async function ensureAccountTokenForPostSaveWorkflow(params: {
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+}): Promise<EnsureAccountTokenResult> {
+  const { account, displaySiteData } = params
+  const service = getApiService(displaySiteData.siteType)
+  const tokens = await service.fetchAccountTokens({
+    baseUrl: displaySiteData.baseUrl,
+    accountId: displaySiteData.id,
+    auth: {
+      authType: displaySiteData.authType,
+      userId: displaySiteData.userId,
+      accessToken: displaySiteData.token,
+      cookie: displaySiteData.cookieAuthSessionCookie,
+    },
+  })
+
+  const existingToken = Array.isArray(tokens) ? tokens.at(-1) : undefined
+  if (existingToken) {
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: existingToken,
+      created: false,
+    }
+  }
+
+  if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
+    const resolution = await resolveSub2ApiQuickCreateResolution(displaySiteData)
+
+    if (resolution.kind === "blocked") {
+      return {
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+        code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+        message: resolution.message,
+      }
+    }
+
+    if (resolution.kind === "selection_required") {
+      return {
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+        allowedGroups: resolution.allowedGroups,
+      }
+    }
+
+    const token = await createDefaultToken({
+      account,
+      displaySiteData,
+      group: resolution.group,
+    })
+
+    if (!token) {
+      return {
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+        code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+        message: t("messages:accountOperations.createTokenFailed"),
+      }
+    }
+
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token,
+      created: true,
+      oneTimeSecret: false,
+    }
+  }
+
+  const token = await createDefaultToken({ account, displaySiteData })
+
+  if (!token) {
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code:
+        displaySiteData.siteType === SITE_TYPES.AIHUBMIX
+          ? ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable
+          : ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+      message:
+        displaySiteData.siteType === SITE_TYPES.AIHUBMIX
+          ? t("messages:aihubmix.createRequiresOneTimeKeyDialog")
+          : t("messages:accountOperations.createTokenFailed"),
+    }
+  }
+
+  if (
+    displaySiteData.siteType === SITE_TYPES.AIHUBMIX &&
+    !hasUsableFullTokenSecret(token)
+  ) {
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+      message: t("messages:aihubmix.createRequiresOneTimeKeyDialog"),
+    }
+  }
+
+  return {
+    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+    token,
+    created: true,
+    oneTimeSecret: displaySiteData.siteType === SITE_TYPES.AIHUBMIX,
+  }
+}
+```
+
+- [ ] **Step 5: Add the workflow barrel export**
+
+Create `src/services/accounts/accountPostSaveWorkflow/index.ts`:
+
+```ts
+export * from "./constants"
+export * from "./ensureAccountToken"
+```
+
+- [ ] **Step 6: Run the helper test to verify it passes**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add src/services/accounts/accountPostSaveWorkflow tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+git commit -m "feat(accounts): add post-save token workflow"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 2: Let Save Skip Background Auto-Provisioning
+
+**Files:**
+- Modify: `src/services/accounts/accountOperations.ts`
+- Test: `tests/services/accountOperations.validateAndSaveAccount.test.ts`
+
+- [ ] **Step 1: Add a failing save-option test**
+
+In `tests/services/accountOperations.validateAndSaveAccount.test.ts`, add this test before the final `})` of `describe("accountOperations validateAndSaveAccount", ...)`:
+
+```ts
+  it("skips background auto-provisioning when requested by a foreground workflow", async () => {
+    vi.spyOn(userPreferences, "getPreferences").mockResolvedValueOnce({
+      ...DEFAULT_PREFERENCES,
+      autoProvisionKeyOnAccountAdd: true,
+      showTodayCashflow: false,
+    })
+    fetchAccountDataMock.mockResolvedValueOnce({
+      quota: 12,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+      checkIn: CHECK_IN_DISABLED,
+    })
+
+    const result = await validateAndSaveAccount(
+      "https://api.example.com",
+      "Example",
+      "user",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+      undefined,
+      false,
+      undefined,
+      { skipAutoProvisionKeyOnAccountAdd: true },
+    )
+
+    expect(result.success).toBe(true)
+    expect(ensureDefaultApiTokenForAccountMock).not.toHaveBeenCalled()
+  })
+```
+
+- [ ] **Step 2: Run the save test to verify it fails**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/accountOperations.validateAndSaveAccount.test.ts
+```
+
+Expected: FAIL because `validateAndSaveAccount` does not accept the options argument or ignores it.
+
+- [ ] **Step 3: Add the save options type and condition**
+
+In `src/services/accounts/accountOperations.ts`, add this exported type near `type TagIdsInput`:
+
+```ts
+export interface ValidateAndSaveAccountOptions {
+  skipAutoProvisionKeyOnAccountAdd?: boolean
+}
+```
+
+Change the `validateAndSaveAccount` signature from:
+
+```ts
+  excludeFromTotalBalance = false,
+  sub2apiAuth?: Sub2ApiAuthConfig,
+): Promise<AccountSaveResponse> {
+```
+
+to:
+
+```ts
+  excludeFromTotalBalance = false,
+  sub2apiAuth?: Sub2ApiAuthConfig,
+  options: ValidateAndSaveAccountOptions = {},
+): Promise<AccountSaveResponse> {
+```
+
+Replace both successful-save calls:
+
+```ts
+    void autoProvisionKeyOnAccountAdd(
+      accountId,
+      shouldAutoProvisionKeyOnAccountAdd,
+    )
+```
+
+with:
+
+```ts
+    if (!options.skipAutoProvisionKeyOnAccountAdd) {
+      void autoProvisionKeyOnAccountAdd(
+        accountId,
+        shouldAutoProvisionKeyOnAccountAdd,
+      )
+    }
+```
+
+There is one call in the fresh-data success path and one call in the fallback partial-save path.
+
+- [ ] **Step 4: Run the save test to verify it passes**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/accountOperations.validateAndSaveAccount.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add src/services/accounts/accountOperations.ts tests/services/accountOperations.validateAndSaveAccount.test.ts
+git commit -m "feat(accounts): allow foreground save workflows"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Orchestrate Post-Save Workflow In AccountDialog Hook
+
+**Files:**
+- Modify: `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+- Modify: `tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx`
+
+- [ ] **Step 1: Add failing hook tests for foreground quick-config**
+
+In `tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx`, update the hoisted mocks:
+
+```ts
+const {
+  mockToast,
+  mockValidateAndSaveAccount,
+  mockValidateAndUpdateAccount,
+  mockOpenWithAccount,
+  mockOpenSub2ApiTokenCreationDialog,
+  mockGetManagedSiteConfig,
+  mockOpenSettingsTab,
+  mockEnsureAccountTokenForPostSaveWorkflow,
+} = vi.hoisted(() => ({
+  mockToast: vi.fn(),
+  mockValidateAndSaveAccount: vi.fn(),
+  mockValidateAndUpdateAccount: vi.fn(),
+  mockOpenWithAccount: vi.fn(),
+  mockOpenSub2ApiTokenCreationDialog: vi.fn(),
+  mockGetManagedSiteConfig: vi.fn(),
+  mockOpenSettingsTab: vi.fn().mockResolvedValue(undefined),
+  mockEnsureAccountTokenForPostSaveWorkflow: vi.fn(),
+}))
+```
+
+Add imports:
+
+```ts
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_STEPS,
+  ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
+} from "~/services/accounts/accountPostSaveWorkflow"
+import type { ApiToken, DisplaySiteData } from "~/types"
+```
+
+Add this mock after the existing account operations mock:
+
+```ts
+vi.mock("~/services/accounts/accountPostSaveWorkflow", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/services/accounts/accountPostSaveWorkflow")
+    >()
+
+  return {
+    ...actual,
+    ensureAccountTokenForPostSaveWorkflow:
+      mockEnsureAccountTokenForPostSaveWorkflow,
+  }
+})
+```
+
+Add helpers inside the `describe` block after `renderEditHook`:
+
+```ts
+  const buildDisplayAccount = (
+    overrides: Partial<DisplaySiteData> = {},
+  ): DisplaySiteData =>
+    ({
+      id: "saved-account-id",
+      name: "Saved Account",
+      username: "saved-user",
+      balance: { USD: 0, CNY: 0 },
+      todayConsumption: { USD: 0, CNY: 0 },
+      todayIncome: { USD: 0, CNY: 0 },
+      todayTokens: { upload: 0, download: 0 },
+      health: { status: SiteHealthStatus.Healthy },
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://api.example.com",
+      token: "saved-token",
+      userId: 12,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: { enableDetection: false },
+      cookieAuthSessionCookie: "",
+      ...overrides,
+    }) as DisplaySiteData
+
+  const buildToken = (overrides: Partial<ApiToken> = {}): ApiToken => ({
+    id: 101,
+    user_id: 12,
+    key: "sk-created",
+    status: 1,
+    name: "user group (auto)",
+    created_time: 1,
+    accessed_time: 1,
+    expired_time: -1,
+    remain_quota: -1,
+    unlimited_quota: true,
+    used_quota: 0,
+    ...overrides,
+  })
+```
+
+In `beforeEach`, add:
+
+```ts
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: buildToken(),
+      created: false,
+    })
+```
+
+Add these tests before the existing `"reports a missing saved account during auto-config..."` test:
+
+```ts
+  it("saves new accounts for quick-config with background auto-provisioning skipped and passes the ensured token to ChannelDialog", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Saved Account",
+      site_url: "https://api.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.NEW_API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 12,
+        username: "saved-user",
+        access_token: "saved-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount()
+    const ensuredToken = buildToken({ key: "sk-ready" })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValueOnce({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: ensuredToken,
+      created: false,
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://api.example.com")
+      result.current.setters.setSiteName("Saved Account")
+      result.current.setters.setUsername("saved-user")
+      result.current.setters.setAccessToken("saved-token")
+      result.current.setters.setUserId("12")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.NEW_API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(mockValidateAndSaveAccount).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(Array),
+      expect.any(Object),
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+      "",
+      false,
+      undefined,
+      { skipAutoProvisionKeyOnAccountAdd: true },
+    )
+    expect(mockEnsureAccountTokenForPostSaveWorkflow).toHaveBeenCalledWith({
+      account: savedSiteAccount,
+      displaySiteData: savedDisplayData,
+    })
+    expect(mockOpenWithAccount).toHaveBeenCalledWith(
+      savedDisplayData,
+      ensuredToken,
+      expect.any(Function),
+    )
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+    )
+  })
+
+  it("stores an AIHubMix one-time token and waits before opening ChannelDialog", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "AIHubMix",
+      site_url: "https://console.aihubmix.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.AIHUBMIX,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 13,
+        username: "aihubmix-user",
+        access_token: "aihubmix-access-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+      token: "aihubmix-access-token",
+      userId: 13,
+    })
+    const oneTimeToken = buildToken({
+      id: 202,
+      user_id: 13,
+      key: "sk-aihubmix-full-secret",
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValueOnce({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: oneTimeToken,
+      created: true,
+      oneTimeSecret: true,
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://aihubmix.com")
+      result.current.setters.setSiteName("AIHubMix")
+      result.current.setters.setUsername("aihubmix-user")
+      result.current.setters.setAccessToken("aihubmix-access-token")
+      result.current.setters.setUserId("13")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.AIHUBMIX)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.postSaveOneTimeToken).toEqual(oneTimeToken)
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForOneTimeKeyAcknowledgement,
+    )
+    expect(mockOpenWithAccount).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await result.current.handlers.handlePostSaveOneTimeTokenClose()
+    })
+
+    expect(mockOpenWithAccount).toHaveBeenCalledWith(
+      savedDisplayData,
+      oneTimeToken,
+      expect.any(Function),
+    )
+  })
+
+  it("opens Sub2API token selection and resumes quick-config after token creation", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Sub2API",
+      site_url: "https://sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 14,
+        username: "sub-user",
+        access_token: "jwt-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+      token: "jwt-token",
+      userId: 14,
+    })
+    const createdToken = buildToken({
+      id: 303,
+      user_id: 14,
+      key: "sk-sub2-created",
+      group: "vip",
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValueOnce({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteName("Sub2API")
+      result.current.setters.setUsername("sub-user")
+      result.current.setters.setAccessToken("jwt-token")
+      result.current.setters.setUserId("14")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.postSaveSub2ApiAllowedGroups).toEqual([
+      "default",
+      "vip",
+    ])
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
+    )
+    expect(mockOpenWithAccount).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await result.current.handlers.handlePostSaveSub2ApiTokenCreated(
+        createdToken,
+      )
+    })
+
+    expect(mockOpenWithAccount).toHaveBeenCalledWith(
+      savedDisplayData,
+      createdToken,
+      expect.any(Function),
+    )
+  })
+```
+
+- [ ] **Step 2: Run the hook tests to verify they fail**
+
+Run:
+
+```bash
+pnpm vitest --run tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+```
+
+Expected: FAIL because `useAccountDialog` does not expose the new workflow state or handlers.
+
+- [ ] **Step 3: Import the workflow helper and constants in the hook**
+
+In `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`, add imports:
+
+```ts
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_STEPS,
+  ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
+  ensureAccountTokenForPostSaveWorkflow,
+  type AccountPostSaveWorkflowStep,
+} from "~/services/accounts/accountPostSaveWorkflow"
+import type { ApiToken } from "~/types"
+```
+
+If `ApiToken` is already imported from `~/types`, merge it into the existing type import.
+
+- [ ] **Step 4: Add workflow state and refs**
+
+Near existing `isAutoConfiguring` state, add:
+
+```ts
+  const [accountPostSaveWorkflowStep, setAccountPostSaveWorkflowStep] =
+    useState<AccountPostSaveWorkflowStep>(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
+    )
+  const [postSaveOneTimeToken, setPostSaveOneTimeToken] =
+    useState<ApiToken | null>(null)
+  const [
+    postSaveSub2ApiAllowedGroups,
+    setPostSaveSub2ApiAllowedGroups,
+  ] = useState<string[] | null>(null)
+  const pendingPostSaveChannelRef = useRef<{
+    displaySiteData: DisplaySiteData
+    token?: ApiToken
+  } | null>(null)
+```
+
+In `resetForm`, also reset them:
+
+```ts
+    setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+    setPostSaveOneTimeToken(null)
+    setPostSaveSub2ApiAllowedGroups(null)
+    pendingPostSaveChannelRef.current = null
+```
+
+- [ ] **Step 5: Add a helper that opens ChannelDialog from an ensured token**
+
+Add this callback before `handleAutoConfig`:
+
+```ts
+  const openPostSaveManagedSiteDialog = useCallback(
+    async (displaySiteData: DisplaySiteData, token: ApiToken) => {
+      setAccountPostSaveWorkflowStep(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog,
+      )
+      await openChannelDialog(displaySiteData, token, () => {
+        if (onSuccess && targetAccountRef.current) {
+          onSuccess(targetAccountRef.current)
+        }
+      })
+      setAccountPostSaveWorkflowStep(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+      )
+    },
+    [onSuccess, openChannelDialog],
+  )
+```
+
+- [ ] **Step 6: Add close/resume handlers**
+
+Add these callbacks after `openPostSaveManagedSiteDialog`:
+
+```ts
+  const handlePostSaveOneTimeTokenClose = useCallback(async () => {
+    setPostSaveOneTimeToken(null)
+    const pending = pendingPostSaveChannelRef.current
+    pendingPostSaveChannelRef.current = null
+    if (!pending?.token) {
+      setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+      return
+    }
+
+    await openPostSaveManagedSiteDialog(pending.displaySiteData, pending.token)
+  }, [openPostSaveManagedSiteDialog])
+
+  const handlePostSaveSub2ApiTokenCreated = useCallback(
+    async (createdToken?: ApiToken) => {
+      const pending = pendingPostSaveChannelRef.current
+      setPostSaveSub2ApiAllowedGroups(null)
+
+      if (!pending || !createdToken) {
+        pendingPostSaveChannelRef.current = null
+        setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+        return
+      }
+
+      pendingPostSaveChannelRef.current = null
+      await openPostSaveManagedSiteDialog(
+        pending.displaySiteData,
+        createdToken,
+      )
+    },
+    [openPostSaveManagedSiteDialog],
+  )
+```
+
+- [ ] **Step 7: Update `handleSaveAccount` options and save call**
+
+Change the `handleSaveAccount` options type from:
+
+```ts
+  const handleSaveAccount = async (options?: {
+    skipSub2ApiKeyPrompt?: boolean
+  }) => {
+```
+
+to:
+
+```ts
+  const handleSaveAccount = async (options?: {
+    skipSub2ApiKeyPrompt?: boolean
+    skipAutoProvisionKeyOnAccountAdd?: boolean
+  }) => {
+```
+
+Change the `validateAndSaveAccount(...)` call by adding the new final argument:
+
+```ts
+              sub2apiAuth,
+              {
+                skipAutoProvisionKeyOnAccountAdd:
+                  options?.skipAutoProvisionKeyOnAccountAdd === true,
+              },
+```
+
+Keep `validateAndUpdateAccount` unchanged.
+
+- [ ] **Step 8: Replace the quick-config token path**
+
+In `handleAutoConfig`, replace:
+
+```ts
+        targetAccount = (
+          await handleSaveAccount({ skipSub2ApiKeyPrompt: true })
+        ).accountId
+```
+
+with:
+
+```ts
+        setAccountPostSaveWorkflowStep(
+          ACCOUNT_POST_SAVE_WORKFLOW_STEPS.SavingAccount,
+        )
+        targetAccount = (
+          await handleSaveAccount({
+            skipSub2ApiKeyPrompt: true,
+            skipAutoProvisionKeyOnAccountAdd: true,
+          })
+        ).accountId
+```
+
+After setting `targetAccountRef.current = targetAccount`, add step updates around loading:
+
+```ts
+      setAccountPostSaveWorkflowStep(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.LoadingSavedAccount,
+      )
+```
+
+Replace the final `await openChannelDialog(displaySiteData, null, ...)` block with:
+
+```ts
+      if (typeof targetAccount !== "string") {
+        await openChannelDialog(displaySiteData, null, () => {
+          if (onSuccess && targetAccountRef.current) {
+            onSuccess(targetAccountRef.current)
+          }
+        })
+        setAccountPostSaveWorkflowStep(
+          ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+        )
+        return
+      }
+
+      setAccountPostSaveWorkflowStep(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.CheckingToken,
+      )
+      const ensureResult = await ensureAccountTokenForPostSaveWorkflow({
+        account: siteAccount,
+        displaySiteData,
+      })
+
+      switch (ensureResult.kind) {
+        case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready:
+        case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created:
+          if (
+            ensureResult.kind === ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created &&
+            ensureResult.oneTimeSecret
+          ) {
+            pendingPostSaveChannelRef.current = {
+              displaySiteData,
+              token: ensureResult.token,
+            }
+            setPostSaveOneTimeToken(ensureResult.token)
+            setAccountPostSaveWorkflowStep(
+              ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForOneTimeKeyAcknowledgement,
+            )
+            return
+          }
+
+          await openPostSaveManagedSiteDialog(displaySiteData, ensureResult.token)
+          return
+        case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired:
+          pendingPostSaveChannelRef.current = { displaySiteData }
+          setPostSaveSub2ApiAllowedGroups(ensureResult.allowedGroups)
+          setAccountPostSaveWorkflowStep(
+            ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
+          )
+          return
+        case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked:
+          toast.error(ensureResult.message)
+          setAccountPostSaveWorkflowStep(
+            ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+          )
+          return
+      }
+```
+
+- [ ] **Step 9: Expose workflow state and handlers from the hook**
+
+In the returned `state`, add:
+
+```ts
+      accountPostSaveWorkflowStep,
+      postSaveOneTimeToken,
+      postSaveSub2ApiAllowedGroups,
+```
+
+In the returned `handlers`, add:
+
+```ts
+      handlePostSaveOneTimeTokenClose,
+      handlePostSaveSub2ApiTokenCreated,
+```
+
+- [ ] **Step 10: Run the hook tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+```
+
+Expected: PASS after addressing any TypeScript import collisions.
+
+- [ ] **Step 11: Commit Task 3**
+
+Run:
+
+```bash
+git add src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+git commit -m "feat(accounts): orchestrate post-save quick config"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Render Foreground Dialogs And Loading Copy
+
+**Files:**
+- Modify: `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+- Modify: `src/features/AccountManagement/components/AccountDialog/index.tsx`
+- Modify: `src/features/AccountManagement/components/AccountDialog/ActionButtons.tsx`
+- Modify: `src/locales/zh-CN/accountDialog.json`
+- Modify: `src/locales/zh-TW/accountDialog.json`
+- Modify: `src/locales/en/accountDialog.json`
+- Modify: `src/locales/ja/accountDialog.json`
+- Test: `tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx`
+
+- [ ] **Step 1: Expose the saved Sub2API account from the hook**
+
+In `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`, add state near `postSaveSub2ApiAllowedGroups`:
+
+```ts
+  const [postSaveSub2ApiAccount, setPostSaveSub2ApiAccount] =
+    useState<DisplaySiteData | null>(null)
+```
+
+Reset it in `resetForm`:
+
+```ts
+    setPostSaveSub2ApiAccount(null)
+```
+
+When setting Sub2API selection state in `handleAutoConfig`, add:
+
+```ts
+          setPostSaveSub2ApiAccount(displaySiteData)
+```
+
+In `handlePostSaveSub2ApiTokenCreated`, add this before any return:
+
+```ts
+      setPostSaveSub2ApiAccount(null)
+```
+
+Expose it in returned `state`:
+
+```ts
+      postSaveSub2ApiAccount,
+```
+
+Run the hook test to confirm this state-only addition stays green:
+
+```bash
+pnpm vitest --run tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Render `AddTokenDialog` and `OneTimeApiKeyDialog` in `AccountDialog`**
+
+In `src/features/AccountManagement/components/AccountDialog/index.tsx`, add imports:
+
+```ts
+import { useTranslation } from "react-i18next"
+
+import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
+import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
+import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+```
+
+Inside `AccountDialog`, add:
+
+```ts
+  const { t } = useTranslation("messages")
+```
+
+Before `return`, add:
+
+```ts
+  const postSaveSub2ApiCreatePrefill =
+    state.postSaveSub2ApiAllowedGroups &&
+    state.postSaveSub2ApiAllowedGroups.length > 0
+      ? {
+          modelId: "",
+          defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+          group: state.postSaveSub2ApiAllowedGroups.includes("default")
+            ? "default"
+            : state.postSaveSub2ApiAllowedGroups[0] ?? "default",
+          allowedGroups: state.postSaveSub2ApiAllowedGroups,
+        }
+      : undefined
+```
+
+Before the closing fragment `</>`, after `ManagedSiteConfigPromptDialog`, add this complete block:
+
+```tsx
+      {state.postSaveSub2ApiAccount && postSaveSub2ApiCreatePrefill ? (
+        <AddTokenDialog
+          isOpen={true}
+          onClose={() =>
+            void handlers.handlePostSaveSub2ApiTokenCreated(undefined)
+          }
+          availableAccounts={[state.postSaveSub2ApiAccount]}
+          preSelectedAccountId={state.postSaveSub2ApiAccount.id}
+          createPrefill={postSaveSub2ApiCreatePrefill}
+          prefillNotice={t("sub2api.createRequiresGroupSelection")}
+          onSuccess={handlers.handlePostSaveSub2ApiTokenCreated}
+          showOneTimeKeyDialog={false}
+        />
+      ) : null}
+
+      <OneTimeApiKeyDialog
+        isOpen={!!state.postSaveOneTimeToken}
+        token={state.postSaveOneTimeToken}
+        onClose={handlers.handlePostSaveOneTimeTokenClose}
+      />
+```
+
+- [ ] **Step 3: Add workflow loading label support to `ActionButtons`**
+
+In `src/features/AccountManagement/components/AccountDialog/ActionButtons.tsx`, import:
+
+```ts
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_STEPS,
+  type AccountPostSaveWorkflowStep,
+} from "~/services/accounts/accountPostSaveWorkflow"
+```
+
+Add prop:
+
+```ts
+  accountPostSaveWorkflowStep: AccountPostSaveWorkflowStep
+```
+
+Add it to the destructured props.
+
+Add this mapping inside `ActionButtons` before `return`:
+
+```ts
+  const autoConfigLoadingLabelKeyByStep: Partial<
+    Record<AccountPostSaveWorkflowStep, string>
+  > = {
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.SavingAccount]:
+      "accountDialog:actions.workflow.savingAccount",
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.LoadingSavedAccount]:
+      "accountDialog:actions.workflow.loadingSavedAccount",
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.CheckingToken]:
+      "accountDialog:actions.workflow.checkingToken",
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.CreatingToken]:
+      "accountDialog:actions.workflow.creatingToken",
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForOneTimeKeyAcknowledgement]:
+      "accountDialog:actions.workflow.waitingForOneTimeKey",
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection]:
+      "accountDialog:actions.workflow.waitingForSub2ApiGroup",
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog]:
+      "accountDialog:actions.workflow.openingManagedSiteDialog",
+  }
+  const autoConfigLoadingLabel = t(
+    autoConfigLoadingLabelKeyByStep[accountPostSaveWorkflowStep] ??
+      "accountDialog:actions.configuring",
+  )
+```
+
+Change the loading button text from:
+
+```tsx
+          {isAutoConfiguring
+            ? t("accountDialog:actions.configuring")
+            : t("accountDialog:actions.configToManagedSite", {
+```
+
+to:
+
+```tsx
+          {isAutoConfiguring
+            ? autoConfigLoadingLabel
+            : t("accountDialog:actions.configToManagedSite", {
+```
+
+In `AccountDialog/index.tsx`, pass the new prop to `ActionButtons`:
+
+```tsx
+            accountPostSaveWorkflowStep={state.accountPostSaveWorkflowStep}
+```
+
+- [ ] **Step 4: Add locale keys**
+
+In each `src/locales/*/accountDialog.json`, add an `actions.workflow` object under existing `actions`.
+
+For `src/locales/zh-CN/accountDialog.json`:
+
+```json
+"workflow": {
+  "savingAccount": "正在保存账号...",
+  "loadingSavedAccount": "正在读取已保存账号...",
+  "checkingToken": "正在检查 API 密钥...",
+  "creatingToken": "正在创建默认密钥...",
+  "waitingForOneTimeKey": "请先保存一次性密钥...",
+  "waitingForSub2ApiGroup": "请选择 Sub2API 分组...",
+  "openingManagedSiteDialog": "正在打开渠道配置..."
+}
+```
+
+For `src/locales/zh-TW/accountDialog.json`:
+
+```json
+"workflow": {
+  "savingAccount": "正在儲存帳號...",
+  "loadingSavedAccount": "正在讀取已儲存帳號...",
+  "checkingToken": "正在檢查 API 金鑰...",
+  "creatingToken": "正在建立預設金鑰...",
+  "waitingForOneTimeKey": "請先保存一次性金鑰...",
+  "waitingForSub2ApiGroup": "請選擇 Sub2API 分組...",
+  "openingManagedSiteDialog": "正在開啟渠道配置..."
+}
+```
+
+For `src/locales/en/accountDialog.json`:
+
+```json
+"workflow": {
+  "savingAccount": "Saving account...",
+  "loadingSavedAccount": "Loading saved account...",
+  "checkingToken": "Checking API keys...",
+  "creatingToken": "Creating default key...",
+  "waitingForOneTimeKey": "Save the one-time key first...",
+  "waitingForSub2ApiGroup": "Choose a Sub2API group...",
+  "openingManagedSiteDialog": "Opening channel setup..."
+}
+```
+
+For `src/locales/ja/accountDialog.json`:
+
+```json
+"workflow": {
+  "savingAccount": "アカウントを保存しています...",
+  "loadingSavedAccount": "保存済みアカウントを読み込んでいます...",
+  "checkingToken": "API キーを確認しています...",
+  "creatingToken": "デフォルトキーを作成しています...",
+  "waitingForOneTimeKey": "ワンタイムキーを先に保存してください...",
+  "waitingForSub2ApiGroup": "Sub2API グループを選択してください...",
+  "openingManagedSiteDialog": "チャンネル設定を開いています..."
+}
+```
+
+Use valid JSON commas according to each file's existing structure.
+
+- [ ] **Step 5: Run targeted tests and i18n dry-run**
+
+Run:
+
+```bash
+pnpm vitest --run tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+pnpm run i18n:extract:ci
+```
+
+Expected: both PASS. If `i18n:extract:ci` reports locale updates, inspect the reported keys and adjust source/i18n JSON so it passes without uncommitted extractor changes.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add src/features/AccountManagement/components/AccountDialog src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts src/locales/zh-CN/accountDialog.json src/locales/zh-TW/accountDialog.json src/locales/en/accountDialog.json src/locales/ja/accountDialog.json
+git commit -m "feat(accounts): show post-save quick config prompts"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Lock ChannelDialog No-Recreate Behavior
+
+**Files:**
+- Modify: `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`
+
+- [ ] **Step 1: Add the regression test**
+
+In `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`, add this test near the existing `openWithAccount` tests that use `ensureAccountApiTokenSpy`:
+
+```ts
+  it("does not ensure or create a token when openWithAccount receives a token", async () => {
+    const providedToken = buildApiToken({
+      id: 123,
+      key: "sk-provided-token",
+    })
+    const mockService: Partial<ManagedSiteService> = {
+      messagesKey: "newapi",
+      getConfig: vi.fn(async () => ({
+        baseUrl: "https://managed.example.com",
+        token: "admin-token",
+        userId: "1",
+      })),
+      prepareChannelFormData: vi.fn(
+        async () =>
+          ({
+            name: "Auto channel",
+            type: ChannelType.OpenAI,
+            key: providedToken.key,
+            base_url: "https://upstream.example.com",
+            models: ["gpt-4"],
+            groups: ["default"],
+            priority: 0,
+            weight: 0,
+            status: 1,
+          }) satisfies ChannelFormData,
+      ),
+      searchChannel: vi.fn(async () => ({
+        items: [],
+        total: 0,
+        type_counts: {},
+      })),
+    }
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(buildSiteAccount())
+
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData(),
+        providedToken,
+      )
+    })
+
+    expect(ensureAccountApiTokenSpy).not.toHaveBeenCalled()
+    expect(mockFetchAccountTokens).not.toHaveBeenCalled()
+    expect(mockService.prepareChannelFormData).toHaveBeenCalledWith(
+      expect.anything(),
+      providedToken,
+    )
+    expect(result.current.context.state.isOpen).toBe(true)
+  })
+```
+
+If the local helper names differ, use the existing names from this file. Do not introduce new factories if equivalent helpers already exist.
+
+- [ ] **Step 2: Run the ChannelDialog regression test file**
+
+Run:
+
+```bash
+pnpm vitest --run tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: PASS. This should pass without production changes because `openWithAccount` already skips token ensure when `accountToken` is provided.
+
+- [ ] **Step 3: Commit Task 5**
+
+Run:
+
+```bash
+git add tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+git commit -m "test(accounts): lock provided-token channel setup"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 6: Full Validation And Cleanup
+
+**Files:**
+- Review all files changed by Tasks 1-5.
+
+- [ ] **Step 1: Run all affected tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.validateAndSaveAccount.test.ts tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run staged validation**
+
+Run:
+
+```bash
+pnpm run validate:staged
+```
+
+Expected: PASS. This runs lint-staged and staged i18n checks.
+
+- [ ] **Step 3: Run i18n extract CI**
+
+Run:
+
+```bash
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS with no unexpected locale updates.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --porcelain
+git diff --stat HEAD
+git diff HEAD -- src/services/accounts/accountPostSaveWorkflow src/services/accounts/accountOperations.ts src/features/AccountManagement/components/AccountDialog tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.validateAndSaveAccount.test.ts tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: only task-scoped implementation, tests, and locale changes are present. No generated artifacts, debug logs, unrelated formatting, or accidental docs changes.
+
+- [ ] **Step 5: Commit any validation fixes**
+
+If Steps 1-4 required code or test fixes, first identify the changed files:
+
+```bash
+git status --porcelain
+```
+
+Then stage only the task-scoped files that were fixed, using explicit paths. For example, if validation required changes to the workflow helper and its test, run:
+
+```bash
+git add src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+git commit -m "fix(accounts): stabilize post-save workflow"
+```
+
+Expected: either no commit is needed, or a focused validation-fix commit is created.

--- a/docs/superpowers/specs/2026-05-11-aihubmix-account-post-save-workflow-design.md
+++ b/docs/superpowers/specs/2026-05-11-aihubmix-account-post-save-workflow-design.md
@@ -107,6 +107,7 @@ export type EnsureAccountTokenResult =
   | {
       kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired
       allowedGroups: string[]
+      existingTokenIds: number[]
     }
   | {
       kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked

--- a/docs/superpowers/specs/2026-05-11-aihubmix-account-post-save-workflow-design.md
+++ b/docs/superpowers/specs/2026-05-11-aihubmix-account-post-save-workflow-design.md
@@ -1,0 +1,289 @@
+# AIHubMix Account Post-Save Workflow Design
+
+Date: 2026-05-11
+
+## Purpose
+
+Adding an AIHubMix account should support the same "configure to managed site"
+and default-key flow as other account types without losing the one-time full API
+key returned by AIHubMix. The flow must also keep Sub2API's group-selection
+requirements visible to the user when a key has to be created.
+
+The selected approach is a foreground post-save workflow in `AccountDialog`.
+Saving the account remains the first completed step. After the account is saved,
+the dialog continues with token preparation and managed-site channel setup.
+Failures in the follow-up steps do not roll back the saved account.
+
+## Current Context
+
+- `validateAndSaveAccount` currently saves the account, then starts
+  `autoProvisionKeyOnAccountAdd` as a fire-and-forget background task.
+- `autoProvisionKeyOnAccountAdd` skips AIHubMix and Sub2API because both need
+  foreground handling in some cases.
+- `CopyKeyDialog` already preserves a full token returned from `createApiToken`
+  and shows `OneTimeApiKeyDialog` for one-time secrets.
+- `ChannelDialog` already supports preparing managed-site channel data from an
+  account and a token through `openWithAccount(account, token)`.
+- Sub2API already has `resolveSub2ApiQuickCreateResolution` and a global
+  `AddTokenDialog` path for group selection.
+- AIHubMix key creation can return the only full key value in the create
+  response; later list/detail reads may contain masked keys. Implementation must
+  not rely on reading the full key back later.
+
+## Goals
+
+- Keep the add-account save result independent from follow-up configuration.
+- Make token creation and managed-site preparation visible and resumable in the
+  current UI.
+- Preserve AIHubMix full keys immediately when they are created.
+- Reuse existing Sub2API group-selection UI.
+- Avoid duplicate background and foreground token creation.
+- Avoid magic strings for workflow state, result kinds, error codes, and site
+  type branching.
+
+## Non-Goals
+
+- Do not create managed-site channels silently. Users still review the
+  prefilled `ChannelDialog` before saving.
+- Do not add a generic task-event bus for background workflows.
+- Do not store AIHubMix one-time full keys in persistent storage.
+- Do not change the regular account-save behavior except where needed to skip
+  duplicate background auto-provisioning for this foreground workflow.
+
+## Architecture
+
+### Account Save Boundary
+
+`validateAndSaveAccount` remains responsible for validation, remote account data
+refresh, and storage. It should accept a narrow option that allows callers to
+skip the background `autoProvisionKeyOnAccountAdd` task.
+
+The managed-site quick-config path should call account save with that skip
+option enabled. The ordinary "save account" path can keep the existing
+preference-driven background auto-provisioning behavior.
+
+### Foreground Workflow Owner
+
+`AccountDialog` owns the post-save workflow because it owns the relevant UI
+lifecycle:
+
+1. Save the new account if needed.
+2. Load the saved `DisplaySiteData`.
+3. Ensure a usable API token exists.
+4. Show any required foreground prompt.
+5. Open the managed-site channel dialog with the ensured token.
+
+The implementation should keep this orchestration in a focused hook/helper so
+`useAccountDialog.ts` does not gain another large inline block.
+
+### Token Workflow Helper
+
+Introduce a small token preparation helper for foreground flows. It should
+return structured results instead of relying on thrown message strings for
+expected branches.
+
+Recommended constants:
+
+```ts
+export const ENSURE_ACCOUNT_TOKEN_RESULT_KINDS = {
+  Ready: "ready",
+  Created: "created",
+  Sub2ApiSelectionRequired: "sub2api_selection_required",
+  Blocked: "blocked",
+} as const
+```
+
+Recommended result shape:
+
+```ts
+export type EnsureAccountTokenResult =
+  | { kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready; token: ApiToken; created: false }
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created
+      token: ApiToken
+      created: true
+      oneTimeSecret: boolean
+    }
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired
+      allowedGroups: string[]
+    }
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked
+      code: AccountPostSaveWorkflowErrorCode
+      message: string
+    }
+```
+
+Behavior:
+
+- Existing token: return `Ready`.
+- Non-special account without token: create the default token and return
+  `Created`.
+- AIHubMix without token: create a default token and return `Created` only if
+  `createApiToken` returns a full `ApiToken` with a usable unmasked key. Mark it
+  as `oneTimeSecret: true`.
+- AIHubMix create result without a usable full key: return `Blocked`. Do not
+  export a masked key.
+- Sub2API without token:
+  - no valid groups: return `Blocked`;
+  - one valid group: create the default token with that group and return
+    `Created`;
+  - multiple valid groups: return `Sub2ApiSelectionRequired`.
+
+### Workflow State Constants
+
+Workflow steps should be represented by exported constants and derived types.
+
+```ts
+export const ACCOUNT_POST_SAVE_WORKFLOW_STEPS = {
+  Idle: "idle",
+  SavingAccount: "saving_account",
+  LoadingSavedAccount: "loading_saved_account",
+  CheckingToken: "checking_token",
+  CreatingToken: "creating_token",
+  WaitingForOneTimeKeyAcknowledgement: "waiting_for_one_time_key_acknowledgement",
+  WaitingForSub2ApiGroupSelection: "waiting_for_sub2api_group_selection",
+  OpeningManagedSiteDialog: "opening_managed_site_dialog",
+  Completed: "completed",
+  Failed: "failed",
+} as const
+```
+
+These values should be mapped to i18n keys in one place. Components should not
+render or compare raw step strings directly.
+
+### Error Code Constants
+
+Expected workflow stops should use exported error-code constants.
+
+```ts
+export const ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES = {
+  SavedAccountNotFound: "saved_account_not_found",
+  TokenCreationFailed: "token_creation_failed",
+  TokenSecretUnavailable: "token_secret_unavailable",
+  ManagedSiteConfigMissing: "managed_site_config_missing",
+  UserCancelled: "user_cancelled",
+} as const
+```
+
+UI can decide retry/cancel behavior by error code. User-visible text still comes
+from i18n.
+
+### No Magic String Rule
+
+The implementation must not introduce bare protocol or workflow strings in
+branching logic.
+
+- Use `SITE_TYPES.AIHUBMIX` and `SITE_TYPES.SUB2API` for site checks.
+- Use exported result-kind constants for token workflow branches.
+- Use exported workflow-step constants for UI state.
+- Use exported error-code constants for expected stops.
+- Keep i18n keys centralized in mappings when a set of workflow states needs
+  display text.
+
+## User Flow
+
+### Quick Configure To Managed Site
+
+1. User clicks the "configure to managed site" action in add-account mode.
+2. `AccountDialog` verifies managed-site configuration. If missing, show the
+   existing managed-site configuration prompt and do not save.
+3. The account is saved with background auto-provisioning skipped.
+4. The workflow loads the saved display account.
+5. The token helper checks for an existing token or creates one as needed.
+6. AIHubMix one-time secrets open `OneTimeApiKeyDialog` immediately.
+7. Sub2API multi-group requirements open the existing `AddTokenDialog`.
+8. The workflow calls `openWithAccount(displaySiteData, token, onSuccess)`.
+9. `ChannelDialog` opens with prefilled channel data for user review.
+
+### AIHubMix
+
+When AIHubMix creates a token and returns the full key, the workflow keeps that
+token in React state or a ref only. After `OneTimeApiKeyDialog` is closed, the
+same token is passed to `ChannelDialog`.
+
+If AIHubMix does not return a full usable key, the workflow stops with an
+actionable message. It should not perform a follow-up token-list fetch and use a
+masked key for managed-site export.
+
+### Sub2API
+
+When Sub2API has no token, the workflow resolves available groups:
+
+- one group: create with that group;
+- multiple groups: ask the user through the existing `AddTokenDialog`;
+- no groups: stop with the existing no-valid-group message.
+
+After the user creates a Sub2API token through the dialog, the workflow resumes
+with the created token or by reloading the token list, matching existing
+dialog behavior.
+
+### Cancellation
+
+Canceling one of the follow-up dialogs stops only the follow-up workflow. The
+account and any created token remain. The UI should present this as
+configuration incomplete, not account-save failure.
+
+## Error Handling
+
+- Account save failure: show the existing save failure behavior.
+- Managed-site config missing before save: use the existing configuration
+  prompt and avoid saving.
+- Saved account cannot be loaded: stop with `SavedAccountNotFound`.
+- AIHubMix full secret unavailable: stop with `TokenSecretUnavailable`.
+- Sub2API no valid group: stop with the existing Sub2API blocked message.
+- User cancellation: stop without an error toast; show a lightweight
+  "configuration not completed" message if needed.
+- Unexpected exceptions: show a sanitized operation failure and log sanitized
+  diagnostics.
+
+## Testing Plan
+
+### Token Workflow Tests
+
+Add or extend tests around the token workflow helper:
+
+- returns `Ready` for existing tokens;
+- creates default tokens for ordinary accounts;
+- creates AIHubMix default token and marks it as one-time when the full key is
+  returned;
+- blocks AIHubMix when the create result does not include a usable full key;
+- resolves Sub2API one-group creation with the selected group in the request;
+- returns Sub2API selection-required for multiple groups;
+- blocks Sub2API when no valid groups are available.
+
+### AccountDialog Workflow Tests
+
+Extend `useAccountDialog.saveAndAutoConfig` coverage:
+
+- AIHubMix add + quick configure saves the account, creates a full token, shows
+  the one-time key dialog, then opens `ChannelDialog`.
+- AIHubMix without a full create secret saves the account but does not open
+  `ChannelDialog`.
+- Sub2API multi-group flow opens the group-selection dialog and resumes channel
+  setup after token creation.
+- Quick configure skips background `autoProvisionKeyOnAccountAdd`.
+- Managed-site missing config blocks before account save, preserving existing
+  behavior.
+
+### ChannelDialog Regression Test
+
+Ensure `openWithAccount(account, token)` does not call token creation helpers
+again when a token was already provided by the foreground workflow.
+
+### Validation
+
+Minimum expected validation after implementation:
+
+- related Vitest tests for touched workflow and dialog files;
+- `pnpm run validate:staged`;
+- `pnpm run i18n:extract:ci` if translation keys are added or changed.
+
+## E2E Decision
+
+Do not add Playwright E2E coverage by default. This workflow is primarily hook
+and dialog orchestration with mocked API services, which Vitest can cover more
+directly and deterministically. Reconsider E2E only if implementation changes
+browser-extension runtime messaging, cross-entrypoint behavior, or another
+real-browser boundary not covered by component tests.

--- a/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
+++ b/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
@@ -116,11 +116,6 @@ export function ChannelDialogProvider({
   const sub2apiTokenDialogSessionIdRef = useRef(sub2apiTokenDialog.sessionId)
   const sub2apiTokenOnSuccessRef = useRef(sub2apiTokenDialog.onSuccessCallback)
 
-  useEffect(() => {
-    sub2apiTokenDialogSessionIdRef.current = sub2apiTokenDialog.sessionId
-    sub2apiTokenOnSuccessRef.current = sub2apiTokenDialog.onSuccessCallback
-  }, [sub2apiTokenDialog.sessionId, sub2apiTokenDialog.onSuccessCallback])
-
   const openDialog = useCallback(
     (config: {
       mode?: DialogMode
@@ -179,23 +174,29 @@ export function ChannelDialogProvider({
       notice?: string
       onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
     }) => {
-      setSub2apiTokenDialog((prev) => ({
+      const nextSessionId = sub2apiTokenDialogSessionIdRef.current + 1
+      const nextOnSuccess = config.onSuccess ?? null
+      sub2apiTokenDialogSessionIdRef.current = nextSessionId
+      sub2apiTokenOnSuccessRef.current = nextOnSuccess
+      setSub2apiTokenDialog(() => ({
         isOpen: true,
-        sessionId: prev.sessionId + 1,
+        sessionId: nextSessionId,
         account: config.account,
         allowedGroups: config.allowedGroups,
         notice: config.notice,
-        onSuccessCallback: config.onSuccess ?? null,
+        onSuccessCallback: nextOnSuccess,
       }))
     },
     [],
   )
 
   const closeSub2ApiTokenDialog = useCallback(() => {
+    const nextSessionId = sub2apiTokenDialogSessionIdRef.current + 1
+    sub2apiTokenDialogSessionIdRef.current = nextSessionId
     sub2apiTokenOnSuccessRef.current = null
-    setSub2apiTokenDialog((prev) => ({
+    setSub2apiTokenDialog(() => ({
       isOpen: false,
-      sessionId: prev.sessionId + 1,
+      sessionId: nextSessionId,
       account: null,
       allowedGroups: [],
       notice: undefined,
@@ -205,12 +206,12 @@ export function ChannelDialogProvider({
 
   const handleSub2ApiTokenSuccess = useCallback(
     async (createdToken?: ApiToken) => {
-      const activeSessionId = sub2apiTokenDialogSessionIdRef.current
+      const sessionIdAtInvocation = sub2apiTokenDialog.sessionId
       if (!sub2apiTokenDialog.isOpen) {
         return
       }
 
-      if (activeSessionId !== sub2apiTokenDialog.sessionId) {
+      if (sub2apiTokenDialogSessionIdRef.current !== sessionIdAtInvocation) {
         return
       }
 

--- a/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
+++ b/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
@@ -9,7 +9,7 @@ import React, {
 
 import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
 import type { ManagedSiteChannelAssessmentSignals } from "~/services/managedSites/channelAssessmentSignals"
-import type { DisplaySiteData } from "~/types"
+import type { ApiToken, DisplaySiteData } from "~/types"
 import type { ChannelFormData, ManagedSiteChannel } from "~/types/managedSite"
 
 export interface ChannelDialogAdvisoryWarning {
@@ -44,7 +44,7 @@ interface Sub2ApiTokenDialogState {
   account: DisplaySiteData | null
   allowedGroups: string[]
   notice?: string
-  onSuccessCallback?: (() => void | Promise<void>) | null
+  onSuccessCallback?: ((createdToken?: ApiToken) => void | Promise<void>) | null
 }
 
 interface ChannelDialogContextValue {
@@ -70,10 +70,10 @@ interface ChannelDialogContextValue {
     account: DisplaySiteData
     allowedGroups: string[]
     notice?: string
-    onSuccess?: () => void | Promise<void>
+    onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
   }) => void
   closeSub2ApiTokenDialog: () => void
-  handleSub2ApiTokenSuccess: () => Promise<void>
+  handleSub2ApiTokenSuccess: (createdToken?: ApiToken) => Promise<void>
   requestDuplicateChannelWarning: (options: {
     existingChannelName: string
   }) => Promise<boolean>
@@ -168,7 +168,7 @@ export function ChannelDialogProvider({
       account: DisplaySiteData
       allowedGroups: string[]
       notice?: string
-      onSuccess?: () => void | Promise<void>
+      onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
     }) => {
       setSub2apiTokenDialog({
         isOpen: true,
@@ -197,11 +197,14 @@ export function ChannelDialogProvider({
     sub2apiTokenOnSuccessRef.current = sub2apiTokenDialog.onSuccessCallback
   }, [sub2apiTokenDialog.onSuccessCallback])
 
-  const handleSub2ApiTokenSuccess = useCallback(async () => {
-    const callback = sub2apiTokenOnSuccessRef.current
-    closeSub2ApiTokenDialog()
-    await callback?.()
-  }, [closeSub2ApiTokenDialog])
+  const handleSub2ApiTokenSuccess = useCallback(
+    async (createdToken?: ApiToken) => {
+      const callback = sub2apiTokenOnSuccessRef.current
+      closeSub2ApiTokenDialog()
+      await callback?.(createdToken)
+    },
+    [closeSub2ApiTokenDialog],
+  )
 
   const duplicateWarningResolverRef = useRef<
     ((shouldContinue: boolean) => void) | null

--- a/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
+++ b/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
@@ -170,6 +170,7 @@ export function ChannelDialogProvider({
       notice?: string
       onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
     }) => {
+      sub2apiTokenOnSuccessRef.current = config.onSuccess ?? null
       setSub2apiTokenDialog({
         isOpen: true,
         account: config.account,
@@ -182,6 +183,7 @@ export function ChannelDialogProvider({
   )
 
   const closeSub2ApiTokenDialog = useCallback(() => {
+    sub2apiTokenOnSuccessRef.current = null
     setSub2apiTokenDialog({
       isOpen: false,
       account: null,

--- a/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
+++ b/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
@@ -41,6 +41,7 @@ interface DuplicateChannelWarningState {
 
 interface Sub2ApiTokenDialogState {
   isOpen: boolean
+  sessionId: number
   account: DisplaySiteData | null
   allowedGroups: string[]
   notice?: string
@@ -106,11 +107,19 @@ export function ChannelDialogProvider({
   const [sub2apiTokenDialog, setSub2apiTokenDialog] =
     useState<Sub2ApiTokenDialogState>({
       isOpen: false,
+      sessionId: 0,
       account: null,
       allowedGroups: [],
       notice: undefined,
       onSuccessCallback: null,
     })
+  const sub2apiTokenDialogSessionIdRef = useRef(sub2apiTokenDialog.sessionId)
+  const sub2apiTokenOnSuccessRef = useRef(sub2apiTokenDialog.onSuccessCallback)
+
+  useEffect(() => {
+    sub2apiTokenDialogSessionIdRef.current = sub2apiTokenDialog.sessionId
+    sub2apiTokenOnSuccessRef.current = sub2apiTokenDialog.onSuccessCallback
+  }, [sub2apiTokenDialog.sessionId, sub2apiTokenDialog.onSuccessCallback])
 
   const openDialog = useCallback(
     (config: {
@@ -170,42 +179,50 @@ export function ChannelDialogProvider({
       notice?: string
       onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
     }) => {
-      sub2apiTokenOnSuccessRef.current = config.onSuccess ?? null
-      setSub2apiTokenDialog({
+      setSub2apiTokenDialog((prev) => ({
         isOpen: true,
+        sessionId: prev.sessionId + 1,
         account: config.account,
         allowedGroups: config.allowedGroups,
         notice: config.notice,
         onSuccessCallback: config.onSuccess ?? null,
-      })
+      }))
     },
     [],
   )
 
   const closeSub2ApiTokenDialog = useCallback(() => {
     sub2apiTokenOnSuccessRef.current = null
-    setSub2apiTokenDialog({
+    setSub2apiTokenDialog((prev) => ({
       isOpen: false,
+      sessionId: prev.sessionId + 1,
       account: null,
       allowedGroups: [],
       notice: undefined,
       onSuccessCallback: null,
-    })
+    }))
   }, [])
-
-  const sub2apiTokenOnSuccessRef = useRef(sub2apiTokenDialog.onSuccessCallback)
-
-  useEffect(() => {
-    sub2apiTokenOnSuccessRef.current = sub2apiTokenDialog.onSuccessCallback
-  }, [sub2apiTokenDialog.onSuccessCallback])
 
   const handleSub2ApiTokenSuccess = useCallback(
     async (createdToken?: ApiToken) => {
+      const activeSessionId = sub2apiTokenDialogSessionIdRef.current
+      if (!sub2apiTokenDialog.isOpen) {
+        return
+      }
+
+      if (activeSessionId !== sub2apiTokenDialog.sessionId) {
+        return
+      }
+
       const callback = sub2apiTokenOnSuccessRef.current
       closeSub2ApiTokenDialog()
       await callback?.(createdToken)
     },
-    [closeSub2ApiTokenDialog],
+    [
+      closeSub2ApiTokenDialog,
+      sub2apiTokenDialog.isOpen,
+      sub2apiTokenDialog.sessionId,
+    ],
   )
 
   const duplicateWarningResolverRef = useRef<

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -65,6 +65,7 @@ interface PrefilledDialogDuplicateState {
 
 export interface OpenWithAccountResult {
   opened: boolean
+  deferred?: boolean
 }
 
 /**
@@ -434,7 +435,7 @@ export function useChannelDialog() {
                 )
               },
             })
-            return { opened: false }
+            return { opened: false, deferred: true }
           }
 
           apiToken = await ensureAccountApiToken(siteAccount, displaySiteData, {

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -389,7 +389,7 @@ export function useChannelDialog() {
       }
 
       if (!apiToken) {
-        if (displaySiteData.siteType === "sub2api") {
+        if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
           const resolution =
             await resolveSub2ApiQuickCreateResolution(displaySiteData)
           if (!shouldContinue()) {

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -62,6 +62,10 @@ interface PrefilledDialogDuplicateState {
   advisoryWarning: ChannelDialogAdvisoryWarning | null
 }
 
+export interface OpenWithAccountResult {
+  opened: boolean
+}
+
 /**
  * Narrows a display account union to a persisted site account record.
  */
@@ -306,7 +310,7 @@ export function useChannelDialog() {
     accountToken: AccountToken | ApiToken | null,
     onSuccess?: (result: any) => void,
     options?: PrefilledChannelOpenOptions,
-  ) => {
+  ): Promise<OpenWithAccountResult> => {
     const toastId = toast.loading(
       t("messages:accountOperations.checkingApiKeys"),
     )
@@ -340,7 +344,7 @@ export function useChannelDialog() {
             id: toastId,
           },
         )
-        return
+        return { opened: false }
       }
 
       let apiToken = accountToken
@@ -363,7 +367,7 @@ export function useChannelDialog() {
 
           if (resolution.kind === "blocked") {
             toast.error(resolution.message, { id: toastId })
-            return
+            return { opened: false }
           }
 
           if (resolution.kind === "selection_required") {
@@ -381,7 +385,7 @@ export function useChannelDialog() {
                 )
               },
             })
-            return
+            return { opened: false }
           }
 
           apiToken = await ensureAccountApiToken(siteAccount, displaySiteData, {
@@ -429,7 +433,7 @@ export function useChannelDialog() {
           existingChannelName: duplicateState.existingChannelName,
         })
         if (!shouldContinue) {
-          return
+          return { opened: false }
         }
       } else {
         toast.dismiss(toastId)
@@ -449,6 +453,7 @@ export function useChannelDialog() {
           }
         },
       })
+      return { opened: true }
     } catch (error) {
       const diagnostic = toSanitizedErrorSummary(error, secretsToRedact)
       toast.error(
@@ -461,6 +466,7 @@ export function useChannelDialog() {
         accountId: displaySiteData?.id,
         diagnostic,
       })
+      return { opened: false }
     }
   }
 

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -56,6 +56,7 @@ const logger = createLogger("ChannelDialogHook")
 
 interface PrefilledChannelOpenOptions {
   managedSiteStatus?: ManagedSiteTokenChannelStatus
+  shouldContinue?: () => boolean
 }
 
 interface PrefilledDialogDuplicateState {
@@ -327,6 +328,11 @@ export function useChannelDialog() {
     )
     let displaySiteData: DisplaySiteData | null = null
     let secretsToRedact: string[] = []
+    const shouldContinue = () => options?.shouldContinue?.() ?? true
+    const cancelOpen = (): OpenWithAccountResult => {
+      toast.dismiss(toastId)
+      return { opened: false }
+    }
 
     try {
       // Get full account if needed
@@ -386,6 +392,9 @@ export function useChannelDialog() {
         if (displaySiteData.siteType === "sub2api") {
           const resolution =
             await resolveSub2ApiQuickCreateResolution(displaySiteData)
+          if (!shouldContinue()) {
+            return cancelOpen()
+          }
 
           if (resolution.kind === "blocked") {
             toast.error(resolution.message, { id: toastId })
@@ -393,12 +402,19 @@ export function useChannelDialog() {
           }
 
           if (resolution.kind === "selection_required") {
+            if (!shouldContinue()) {
+              return cancelOpen()
+            }
             toast.dismiss(toastId)
             openSub2ApiTokenDialog({
               account: displaySiteData,
               allowedGroups: resolution.allowedGroups,
               notice: t("messages:sub2api.createRequiresGroupSelection"),
               onSuccess: async (createdToken?: ApiToken) => {
+                if (!shouldContinue()) {
+                  return
+                }
+
                 if (createdToken) {
                   await openWithAccount(
                     displaySiteData!,
@@ -409,12 +425,19 @@ export function useChannelDialog() {
                   return
                 }
 
+                if (!shouldContinue()) {
+                  return
+                }
+
                 const refetchedTokens =
                   accountApiService && accountApiRequest
                     ? await accountApiService.fetchAccountTokens(
                         accountApiRequest,
                       )
                     : null
+                if (!shouldContinue()) {
+                  return
+                }
                 const recoveredToken = Array.isArray(refetchedTokens)
                   ? selectSingleNewApiTokenByIdDiff({
                       existingTokenIds,
@@ -451,6 +474,9 @@ export function useChannelDialog() {
           )
         }
       }
+      if (!shouldContinue()) {
+        return cancelOpen()
+      }
 
       const resolvedToken = await resolveDisplayAccountTokenForSecret(
         displaySiteData,
@@ -467,6 +493,9 @@ export function useChannelDialog() {
         displaySiteData,
         resolvedToken,
       )
+      if (!shouldContinue()) {
+        return cancelOpen()
+      }
 
       const duplicateState = await resolvePrefilledDialogDuplicateState({
         service,
@@ -476,6 +505,9 @@ export function useChannelDialog() {
         key: formData.key,
         managedSiteStatus: options?.managedSiteStatus,
       })
+      if (!shouldContinue()) {
+        return cancelOpen()
+      }
 
       if (duplicateState.existingChannelName) {
         toast.dismiss(toastId)
@@ -487,6 +519,9 @@ export function useChannelDialog() {
         }
       } else {
         toast.dismiss(toastId)
+      }
+      if (!shouldContinue()) {
+        return cancelOpen()
       }
 
       // Open dialog

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -13,6 +13,7 @@ import {
   ensureAccountApiToken,
   resolveSub2ApiQuickCreateResolution,
 } from "~/services/accounts/accountOperations"
+import { selectSingleNewApiTokenByIdDiff } from "~/services/accounts/accountPostSaveWorkflow"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import {
   createDisplayAccountApiContext,
@@ -76,6 +77,15 @@ function isSiteAccount(
 }
 
 /**
+ *
+ */
+function getApiTokenIds(tokens: ApiToken[]): number[] {
+  return tokens
+    .map((token) => token?.id)
+    .filter((tokenId): tokenId is number => typeof tokenId === "number")
+}
+
+/**
  * Exposes helpers for opening channel dialogs from account data,
  * raw credentials, or custom initial values.
  */
@@ -88,7 +98,7 @@ export function useChannelDialog() {
     account: DisplaySiteData,
     options?: {
       notice?: string
-      onSuccess?: () => void | Promise<void>
+      onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
     },
   ): Promise<boolean> => {
     const { service, request } = createDisplayAccountApiContext(account)
@@ -348,16 +358,27 @@ export function useChannelDialog() {
       }
 
       let apiToken = accountToken
+      let accountApiService:
+        | ReturnType<typeof createDisplayAccountApiContext>["service"]
+        | null = null
+      let accountApiRequest:
+        | ReturnType<typeof createDisplayAccountApiContext>["request"]
+        | null = null
+      let existingTokenIds: number[] = []
 
       if (!apiToken) {
-        const { service: accountApiService, request: accountApiRequest } =
+        const accountApiContext =
           createDisplayAccountApiContext(displaySiteData)
+        accountApiService = accountApiContext.service
+        accountApiRequest = accountApiContext.request
         const existingTokens =
           await accountApiService.fetchAccountTokens(accountApiRequest)
+        const existingTokenList = Array.isArray(existingTokens)
+          ? existingTokens
+          : []
+        existingTokenIds = getApiTokenIds(existingTokenList)
 
-        apiToken = Array.isArray(existingTokens)
-          ? existingTokens.at(-1) ?? null
-          : null
+        apiToken = existingTokenList.at(-1) ?? null
       }
 
       if (!apiToken) {
@@ -376,10 +397,38 @@ export function useChannelDialog() {
               account: displaySiteData,
               allowedGroups: resolution.allowedGroups,
               notice: t("messages:sub2api.createRequiresGroupSelection"),
-              onSuccess: async () => {
+              onSuccess: async (createdToken?: ApiToken) => {
+                if (createdToken) {
+                  await openWithAccount(
+                    displaySiteData!,
+                    createdToken,
+                    onSuccess,
+                    options,
+                  )
+                  return
+                }
+
+                const refetchedTokens =
+                  accountApiService && accountApiRequest
+                    ? await accountApiService.fetchAccountTokens(
+                        accountApiRequest,
+                      )
+                    : null
+                const recoveredToken = Array.isArray(refetchedTokens)
+                  ? selectSingleNewApiTokenByIdDiff({
+                      existingTokenIds,
+                      tokens: refetchedTokens,
+                    })
+                  : null
+
+                if (!recoveredToken) {
+                  toast.error(t("messages:accountOperations.createTokenFailed"))
+                  return
+                }
+
                 await openWithAccount(
                   displaySiteData!,
-                  null,
+                  recoveredToken,
                   onSuccess,
                   options,
                 )

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -79,7 +79,7 @@ function isSiteAccount(
 }
 
 /**
- *
+ * Extracts numeric token IDs from potentially sparse token lists.
  */
 function getApiTokenIds(tokens: ApiToken[]): number[] {
   return tokens
@@ -511,10 +511,10 @@ export function useChannelDialog() {
 
       if (duplicateState.existingChannelName) {
         toast.dismiss(toastId)
-        const shouldContinue = await requestDuplicateChannelWarning({
+        const confirmedDuplicate = await requestDuplicateChannelWarning({
           existingChannelName: duplicateState.existingChannelName,
         })
-        if (!shouldContinue) {
+        if (!confirmedDuplicate) {
           return { opened: false }
         }
       } else {
@@ -608,10 +608,10 @@ export function useChannelDialog() {
 
       if (duplicateState.existingChannelName) {
         toast.dismiss(toastId)
-        const shouldContinue = await requestDuplicateChannelWarning({
+        const confirmedDuplicate = await requestDuplicateChannelWarning({
           existingChannelName: duplicateState.existingChannelName,
         })
-        if (!shouldContinue) {
+        if (!confirmedDuplicate) {
           return
         }
       } else {

--- a/src/features/AccountManagement/components/AccountDialog/ActionButtons.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/ActionButtons.tsx
@@ -10,6 +10,10 @@ import { Button } from "~/components/ui"
 import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_STEPS,
+  type AccountPostSaveWorkflowStep,
+} from "~/services/accounts/accountPostSaveWorkflow"
 import { getManagedSiteLabel } from "~/services/managedSites/utils/managedSite"
 
 import {
@@ -32,6 +36,7 @@ interface ActionButtonsProps {
   onClose: () => void
   onAutoConfig: () => Promise<void>
   isAutoConfiguring: boolean
+  accountPostSaveWorkflowStep: AccountPostSaveWorkflowStep
   formId?: string
 }
 
@@ -52,6 +57,7 @@ export default function ActionButtons({
   onClose,
   onAutoConfig,
   isAutoConfiguring,
+  accountPostSaveWorkflowStep,
   formId,
 }: ActionButtonsProps) {
   const { t } = useTranslation(["accountDialog", "common", "settings"])
@@ -65,6 +71,34 @@ export default function ActionButtons({
         managedSite: managedSiteLabel,
       })
     : t("accountDialog:actions.autoConfigRequiresValidAccount")
+  const autoConfigLoadingLabelByStep: Partial<
+    Record<AccountPostSaveWorkflowStep, string>
+  > = {
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.SavingAccount]: t(
+      "accountDialog:actions.workflow.savingAccount",
+    ),
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.LoadingSavedAccount]: t(
+      "accountDialog:actions.workflow.loadingSavedAccount",
+    ),
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.CheckingToken]: t(
+      "accountDialog:actions.workflow.checkingToken",
+    ),
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.CreatingToken]: t(
+      "accountDialog:actions.workflow.creatingToken",
+    ),
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForOneTimeKeyAcknowledgement]: t(
+      "accountDialog:actions.workflow.waitingForOneTimeKey",
+    ),
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection]: t(
+      "accountDialog:actions.workflow.waitingForSub2ApiGroup",
+    ),
+    [ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog]: t(
+      "accountDialog:actions.workflow.openingManagedSiteDialog",
+    ),
+  }
+  const autoConfigLoadingLabel =
+    autoConfigLoadingLabelByStep[accountPostSaveWorkflowStep] ??
+    t("accountDialog:actions.configuring")
 
   if (isPreForm) {
     return (
@@ -145,7 +179,7 @@ export default function ActionButtons({
           }
         >
           {isAutoConfiguring
-            ? t("accountDialog:actions.configuring")
+            ? autoConfigLoadingLabel
             : t("accountDialog:actions.configToManagedSite", {
                 managedSite: managedSiteLabel,
               })}

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -1291,10 +1291,12 @@ export function useAccountDialog({
       displaySiteData: DisplaySiteData,
       token: ApiToken,
       runId = postSaveAutoConfigRunRef.current,
+      targetAccount = targetAccountRef.current,
     ) => {
       if (postSaveAutoConfigRunRef.current !== runId) {
         return
       }
+      const isCurrentRun = () => postSaveAutoConfigRunRef.current === runId
 
       setAccountPostSaveWorkflowStep(
         ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog,
@@ -1304,12 +1306,13 @@ export function useAccountDialog({
           displaySiteData,
           token,
           () => {
-            if (onSuccess && targetAccountRef.current) {
-              onSuccess(targetAccountRef.current)
+            if (onSuccess && targetAccount && isCurrentRun()) {
+              onSuccess(targetAccount)
             }
           },
+          { shouldContinue: isCurrentRun },
         )
-        if (postSaveAutoConfigRunRef.current !== runId) {
+        if (!isCurrentRun()) {
           return
         }
         if (!openResult.opened) {
@@ -1322,7 +1325,7 @@ export function useAccountDialog({
           ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
         )
       } catch (error) {
-        if (postSaveAutoConfigRunRef.current !== runId) {
+        if (!isCurrentRun()) {
           return
         }
         setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed)
@@ -1333,7 +1336,7 @@ export function useAccountDialog({
         )
         logger.error("Failed to open post-save managed-site dialog", {
           error: getErrorMessage(error),
-          accountId: targetAccountRef.current,
+          accountId: targetAccount,
           siteType: displaySiteData.siteType,
         })
       }
@@ -1561,6 +1564,7 @@ export function useAccountDialog({
         return
       }
       targetAccountRef.current = targetAccount
+      const intendedTargetAccount = targetAccount
       let displaySiteData
 
       if (typeof targetAccount === "string") {
@@ -1601,10 +1605,11 @@ export function useAccountDialog({
           displaySiteData,
           null,
           () => {
-            if (onSuccess && targetAccountRef.current) {
-              onSuccess(targetAccountRef.current)
+            if (onSuccess && intendedTargetAccount && isCurrentRun()) {
+              onSuccess(intendedTargetAccount)
             }
           },
+          { shouldContinue: isCurrentRun },
         )
         if (!isCurrentRun()) {
           return
@@ -1657,6 +1662,7 @@ export function useAccountDialog({
             displaySiteData,
             ensureResult.token,
             runId,
+            intendedTargetAccount,
           )
           return
         case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired:

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -20,6 +20,12 @@ import {
   validateAndSaveAccount,
   validateAndUpdateAccount,
 } from "~/services/accounts/accountOperations"
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_STEPS,
+  ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
+  ensureAccountTokenForPostSaveWorkflow,
+  type AccountPostSaveWorkflowStep,
+} from "~/services/accounts/accountPostSaveWorkflow"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import {
   analyzeAutoDetectError,
@@ -33,8 +39,10 @@ import {
 } from "~/services/managedSites/utils/managedSite"
 import {
   AuthTypeEnum,
+  type ApiToken,
   type CheckInConfig,
   type DisplaySiteData,
+  type SiteAccount,
   type Sub2ApiAuthConfig,
 } from "~/types"
 import { deepOverride } from "~/utils"
@@ -135,6 +143,12 @@ export function useAccountDialog({
     useState(false)
   const [isImportingSub2apiSession, setIsImportingSub2apiSession] =
     useState(false)
+  const [accountPostSaveWorkflowStep, setAccountPostSaveWorkflowStep] =
+    useState<AccountPostSaveWorkflowStep>(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+  const [postSaveOneTimeToken, setPostSaveOneTimeToken] =
+    useState<ApiToken | null>(null)
+  const [postSaveSub2ApiAllowedGroups, setPostSaveSub2ApiAllowedGroups] =
+    useState<string[] | null>(null)
 
   const [duplicateAccountWarning, setDuplicateAccountWarning] = useState<{
     isOpen: boolean
@@ -447,6 +461,10 @@ export function useAccountDialog({
   // useRef 保存跨渲染引用
   const newAccountRef = useRef<any>(null)
   const targetAccountRef = useRef<any>(null)
+  const pendingPostSaveChannelRef = useRef<{
+    displaySiteData: DisplaySiteData
+    token?: ApiToken
+  } | null>(null)
   const detectSlowHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
@@ -470,6 +488,10 @@ export function useAccountDialog({
     setIsImportingCookies(false)
     setShowCookiePermissionWarning(false)
     setIsImportingSub2apiSession(false)
+    setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+    setPostSaveOneTimeToken(null)
+    setPostSaveSub2ApiAllowedGroups(null)
+    pendingPostSaveChannelRef.current = null
     targetAccountRef.current = null
   }, [mode])
 
@@ -1061,6 +1083,7 @@ export function useAccountDialog({
 
   const handleSaveAccount = async (options?: {
     skipSub2ApiKeyPrompt?: boolean
+    skipAutoProvisionKeyOnAccountAdd?: boolean
   }) => {
     try {
       setIsSaving(true)
@@ -1094,6 +1117,10 @@ export function useAccountDialog({
               manualBalanceUsd,
               excludeFromTotalBalance,
               sub2apiAuth,
+              {
+                skipAutoProvisionKeyOnAccountAdd:
+                  options?.skipAutoProvisionKeyOnAccountAdd === true,
+              },
             )
           : await validateAndUpdateAccount(
               account!.id,
@@ -1223,6 +1250,50 @@ export function useAccountDialog({
     }
   }
 
+  const openPostSaveManagedSiteDialog = useCallback(
+    async (displaySiteData: DisplaySiteData, token: ApiToken) => {
+      setAccountPostSaveWorkflowStep(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog,
+      )
+      await openChannelDialog(displaySiteData, token, () => {
+        if (onSuccess && targetAccountRef.current) {
+          onSuccess(targetAccountRef.current)
+        }
+      })
+      setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed)
+    },
+    [onSuccess, openChannelDialog],
+  )
+
+  const handlePostSaveOneTimeTokenClose = useCallback(async () => {
+    setPostSaveOneTimeToken(null)
+    const pending = pendingPostSaveChannelRef.current
+    pendingPostSaveChannelRef.current = null
+    if (!pending?.token) {
+      setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+      return
+    }
+
+    await openPostSaveManagedSiteDialog(pending.displaySiteData, pending.token)
+  }, [openPostSaveManagedSiteDialog])
+
+  const handlePostSaveSub2ApiTokenCreated = useCallback(
+    async (createdToken?: ApiToken) => {
+      const pending = pendingPostSaveChannelRef.current
+      setPostSaveSub2ApiAllowedGroups(null)
+
+      if (!pending || !createdToken) {
+        pendingPostSaveChannelRef.current = null
+        setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+        return
+      }
+
+      pendingPostSaveChannelRef.current = null
+      await openPostSaveManagedSiteDialog(pending.displaySiteData, createdToken)
+    },
+    [openPostSaveManagedSiteDialog],
+  )
+
   const handleAutoConfig = async () => {
     try {
       const isManagedSiteReady = await ensureManagedSiteAutoConfigReady()
@@ -1249,13 +1320,23 @@ export function useAccountDialog({
     try {
       let targetAccount: DisplaySiteData | null | string | undefined =
         account || newAccountRef.current
+      let savedSiteAccount: SiteAccount | null = null
       // 如果是新增（account 不存在），就先保存
       if (!targetAccount) {
+        setAccountPostSaveWorkflowStep(
+          ACCOUNT_POST_SAVE_WORKFLOW_STEPS.SavingAccount,
+        )
         targetAccount = (
-          await handleSaveAccount({ skipSub2ApiKeyPrompt: true })
+          await handleSaveAccount({
+            skipSub2ApiKeyPrompt: true,
+            skipAutoProvisionKeyOnAccountAdd: true,
+          })
         ).accountId
         if (!targetAccount) {
           toast.error(t("messages.saveAccountFailed"))
+          setAccountPostSaveWorkflowStep(
+            ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+          )
           return
         }
         // 缓存到 ref，避免重复保存
@@ -1267,12 +1348,19 @@ export function useAccountDialog({
       let displaySiteData
 
       if (typeof targetAccount === "string") {
+        setAccountPostSaveWorkflowStep(
+          ACCOUNT_POST_SAVE_WORKFLOW_STEPS.LoadingSavedAccount,
+        )
         // 获取账户详细信息
         const siteAccount = await accountStorage.getAccountById(targetAccount)
         if (!siteAccount) {
           toast.error(t("messages:toast.error.findAccountDetailsFailed"))
+          setAccountPostSaveWorkflowStep(
+            ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+          )
           return
         }
+        savedSiteAccount = siteAccount
         displaySiteData =
           (await accountStorage.getDisplayDataById(siteAccount.id)) ??
           accountStorage.convertToDisplayData(siteAccount)
@@ -1283,17 +1371,70 @@ export function useAccountDialog({
       // The current runtime path opens the channel dialog with prefilled data
       // so users can review it before creation. The direct auto-import helpers
       // are kept only as deprecated compatibility shims.
-      await openChannelDialog(displaySiteData, null, () => {
-        if (onSuccess && targetAccountRef.current) {
-          onSuccess(targetAccountRef.current)
-        }
+      if (!savedSiteAccount) {
+        await openChannelDialog(displaySiteData, null, () => {
+          if (onSuccess && targetAccountRef.current) {
+            onSuccess(targetAccountRef.current)
+          }
+        })
+        setAccountPostSaveWorkflowStep(
+          ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+        )
+        return
+      }
+
+      setAccountPostSaveWorkflowStep(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.CheckingToken,
+      )
+      const ensureResult = await ensureAccountTokenForPostSaveWorkflow({
+        account: savedSiteAccount,
+        displaySiteData,
       })
+
+      switch (ensureResult.kind) {
+        case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready:
+        case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created:
+          if (
+            ensureResult.kind === ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created &&
+            ensureResult.oneTimeSecret
+          ) {
+            pendingPostSaveChannelRef.current = {
+              displaySiteData,
+              token: ensureResult.token,
+            }
+            setPostSaveOneTimeToken(ensureResult.token)
+            setAccountPostSaveWorkflowStep(
+              ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForOneTimeKeyAcknowledgement,
+            )
+            return
+          }
+
+          await openPostSaveManagedSiteDialog(
+            displaySiteData,
+            ensureResult.token,
+          )
+          return
+        case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired:
+          pendingPostSaveChannelRef.current = { displaySiteData }
+          setPostSaveSub2ApiAllowedGroups(ensureResult.allowedGroups)
+          setAccountPostSaveWorkflowStep(
+            ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
+          )
+          return
+        case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked:
+          toast.error(ensureResult.message)
+          setAccountPostSaveWorkflowStep(
+            ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+          )
+          return
+      }
     } catch (error) {
       toast.error(
         t("messages.newApiConfigFailed", {
           error: getErrorMessage(error),
         }),
       )
+      setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed)
       logger.error("Auto configuration failed", { error })
     } finally {
       setIsAutoConfiguring(false)
@@ -1395,6 +1536,9 @@ export function useAccountDialog({
       isImportingCookies,
       showCookiePermissionWarning,
       isImportingSub2apiSession,
+      accountPostSaveWorkflowStep,
+      postSaveOneTimeToken,
+      postSaveSub2ApiAllowedGroups,
       duplicateAccountWarning,
       managedSiteConfigPrompt,
     },
@@ -1448,6 +1592,8 @@ export function useAccountDialog({
       handleDuplicateAccountWarningContinue,
       handleManagedSiteConfigPromptClose,
       handleOpenManagedSiteSettings,
+      handlePostSaveOneTimeTokenClose,
+      handlePostSaveSub2ApiTokenCreated,
     },
   }
 }

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -1375,6 +1375,9 @@ export function useAccountDialog({
           pending.displaySiteData,
         )
         const fetchedTokens = await service.fetchAccountTokens(request)
+        if (postSaveAutoConfigRunRef.current !== runId) {
+          return
+        }
         const latestToken = Array.isArray(fetchedTokens)
           ? selectSingleNewApiTokenByIdDiff({
               existingTokenIds: pending.existingTokenIds ?? [],
@@ -1383,6 +1386,9 @@ export function useAccountDialog({
           : null
 
         if (!latestToken) {
+          if (postSaveAutoConfigRunRef.current !== runId) {
+            return
+          }
           setAccountPostSaveWorkflowStep(
             ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
           )
@@ -1390,12 +1396,18 @@ export function useAccountDialog({
           return
         }
 
+        if (postSaveAutoConfigRunRef.current !== runId) {
+          return
+        }
         await openPostSaveManagedSiteDialog(
           pending.displaySiteData,
           latestToken,
           runId,
         )
       } catch (error) {
+        if (postSaveAutoConfigRunRef.current !== runId) {
+          return
+        }
         setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed)
         toast.error(
           t("messages.newApiConfigFailed", {

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -1261,14 +1261,30 @@ export function useAccountDialog({
       setAccountPostSaveWorkflowStep(
         ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog,
       )
-      await openChannelDialog(displaySiteData, token, () => {
-        if (onSuccess && targetAccountRef.current) {
-          onSuccess(targetAccountRef.current)
-        }
-      })
-      setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed)
+      try {
+        await openChannelDialog(displaySiteData, token, () => {
+          if (onSuccess && targetAccountRef.current) {
+            onSuccess(targetAccountRef.current)
+          }
+        })
+        setAccountPostSaveWorkflowStep(
+          ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+        )
+      } catch (error) {
+        setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed)
+        toast.error(
+          t("messages.newApiConfigFailed", {
+            error: getErrorMessage(error),
+          }),
+        )
+        logger.error("Failed to open post-save managed-site dialog", {
+          error: getErrorMessage(error),
+          accountId: targetAccountRef.current,
+          siteType: displaySiteData.siteType,
+        })
+      }
     },
-    [onSuccess, openChannelDialog],
+    [onSuccess, openChannelDialog, t],
   )
 
   const handlePostSaveOneTimeTokenClose = useCallback(async () => {

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -472,6 +472,13 @@ export function useAccountDialog({
   const { openWithAccount: openChannelDialog, openSub2ApiTokenCreationDialog } =
     useChannelDialog()
 
+  const clearPostSaveWorkflowState = useCallback(() => {
+    setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+    setPostSaveOneTimeToken(null)
+    setPostSaveSub2ApiAllowedGroups(null)
+    pendingPostSaveChannelRef.current = null
+  }, [])
+
   const resetForm = useCallback(() => {
     newAccountRef.current = null
     duplicateAccountWarningAcknowledgedSiteUrlRef.current = null
@@ -488,12 +495,9 @@ export function useAccountDialog({
     setIsImportingCookies(false)
     setShowCookiePermissionWarning(false)
     setIsImportingSub2apiSession(false)
-    setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
-    setPostSaveOneTimeToken(null)
-    setPostSaveSub2ApiAllowedGroups(null)
-    pendingPostSaveChannelRef.current = null
+    clearPostSaveWorkflowState()
     targetAccountRef.current = null
-  }, [mode])
+  }, [clearPostSaveWorkflowState, mode])
 
   const loadAccountData = useCallback(
     async (accountId: string) => {
@@ -709,6 +713,7 @@ export function useAccountDialog({
   const handleClose = useCallback(() => {
     handleDuplicateAccountWarningCancel()
     cancelPendingDuplicateAccountWarning()
+    clearPostSaveWorkflowState()
     setManagedSiteConfigPrompt((prev) =>
       prev.isOpen ? { ...prev, isOpen: false } : prev,
     )
@@ -716,6 +721,7 @@ export function useAccountDialog({
     onClose()
   }, [
     cancelPendingDuplicateAccountWarning,
+    clearPostSaveWorkflowState,
     handleDuplicateAccountWarningCancel,
     onClose,
   ])

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -153,6 +153,8 @@ export function useAccountDialog({
     useState<string[] | null>(null)
   const [postSaveSub2ApiAccount, setPostSaveSub2ApiAccount] =
     useState<DisplaySiteData | null>(null)
+  const [postSaveSub2ApiDialogSessionId, setPostSaveSub2ApiDialogSessionId] =
+    useState<number | null>(null)
 
   const [duplicateAccountWarning, setDuplicateAccountWarning] = useState<{
     isOpen: boolean
@@ -471,6 +473,8 @@ export function useAccountDialog({
     existingTokenIds?: number[]
   } | null>(null)
   const postSaveAutoConfigRunRef = useRef(0)
+  const nextPostSaveSub2ApiDialogSessionIdRef = useRef(0)
+  const activePostSaveSub2ApiDialogSessionIdRef = useRef<number | null>(null)
   const detectSlowHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
@@ -482,14 +486,28 @@ export function useAccountDialog({
     postSaveAutoConfigRunRef.current += 1
   }, [])
 
+  const openPostSaveSub2ApiDialogSession = useCallback(() => {
+    const nextSessionId = nextPostSaveSub2ApiDialogSessionIdRef.current + 1
+    nextPostSaveSub2ApiDialogSessionIdRef.current = nextSessionId
+    activePostSaveSub2ApiDialogSessionIdRef.current = nextSessionId
+    setPostSaveSub2ApiDialogSessionId(nextSessionId)
+    return nextSessionId
+  }, [])
+
+  const invalidatePostSaveSub2ApiDialogSession = useCallback(() => {
+    activePostSaveSub2ApiDialogSessionIdRef.current = null
+    setPostSaveSub2ApiDialogSessionId(null)
+  }, [])
+
   const clearPostSaveWorkflowState = useCallback(() => {
     invalidatePostSaveAutoConfigRun()
+    invalidatePostSaveSub2ApiDialogSession()
     setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
     setPostSaveOneTimeToken(null)
     setPostSaveSub2ApiAllowedGroups(null)
     setPostSaveSub2ApiAccount(null)
     pendingPostSaveChannelRef.current = null
-  }, [invalidatePostSaveAutoConfigRun])
+  }, [invalidatePostSaveAutoConfigRun, invalidatePostSaveSub2ApiDialogSession])
 
   const resetForm = useCallback(() => {
     newAccountRef.current = null
@@ -1340,15 +1358,40 @@ export function useAccountDialog({
     )
   }, [openPostSaveManagedSiteDialog])
 
-  const handlePostSaveSub2ApiTokenDialogClose = useCallback(() => {
-    pendingPostSaveChannelRef.current = null
-    setPostSaveSub2ApiAllowedGroups(null)
-    setPostSaveSub2ApiAccount(null)
-    setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
-  }, [])
+  const handlePostSaveSub2ApiTokenDialogCloseForSession = useCallback(
+    (sessionId: number | null) => {
+      if (
+        sessionId === null ||
+        activePostSaveSub2ApiDialogSessionIdRef.current !== sessionId
+      ) {
+        return
+      }
 
-  const handlePostSaveSub2ApiTokenCreated = useCallback(
-    async (createdToken?: ApiToken) => {
+      invalidatePostSaveSub2ApiDialogSession()
+      pendingPostSaveChannelRef.current = null
+      setPostSaveSub2ApiAllowedGroups(null)
+      setPostSaveSub2ApiAccount(null)
+      setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+    },
+    [invalidatePostSaveSub2ApiDialogSession],
+  )
+
+  const handlePostSaveSub2ApiTokenDialogClose = useCallback(() => {
+    handlePostSaveSub2ApiTokenDialogCloseForSession(
+      activePostSaveSub2ApiDialogSessionIdRef.current,
+    )
+  }, [handlePostSaveSub2ApiTokenDialogCloseForSession])
+
+  const handlePostSaveSub2ApiTokenCreatedForSession = useCallback(
+    async (sessionId: number | null, createdToken?: ApiToken) => {
+      if (
+        sessionId === null ||
+        activePostSaveSub2ApiDialogSessionIdRef.current !== sessionId
+      ) {
+        return
+      }
+
+      invalidatePostSaveSub2ApiDialogSession()
       const runId = postSaveAutoConfigRunRef.current
       const pending = pendingPostSaveChannelRef.current
       setPostSaveSub2ApiAllowedGroups(null)
@@ -1420,7 +1463,35 @@ export function useAccountDialog({
         })
       }
     },
-    [openPostSaveManagedSiteDialog, t],
+    [invalidatePostSaveSub2ApiDialogSession, openPostSaveManagedSiteDialog, t],
+  )
+
+  const handlePostSaveSub2ApiTokenCreated = useCallback(
+    async (createdToken?: ApiToken) => {
+      await handlePostSaveSub2ApiTokenCreatedForSession(
+        activePostSaveSub2ApiDialogSessionIdRef.current,
+        createdToken,
+      )
+    },
+    [handlePostSaveSub2ApiTokenCreatedForSession],
+  )
+
+  const getPostSaveSub2ApiDialogHandlers = useCallback(
+    (sessionId: number | null) => ({
+      onClose: () => {
+        handlePostSaveSub2ApiTokenDialogCloseForSession(sessionId)
+      },
+      onSuccess: async (createdToken?: ApiToken) => {
+        await handlePostSaveSub2ApiTokenCreatedForSession(
+          sessionId,
+          createdToken,
+        )
+      },
+    }),
+    [
+      handlePostSaveSub2ApiTokenCreatedForSession,
+      handlePostSaveSub2ApiTokenDialogCloseForSession,
+    ],
   )
 
   const handleAutoConfig = async () => {
@@ -1589,6 +1660,7 @@ export function useAccountDialog({
           )
           return
         case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired:
+          openPostSaveSub2ApiDialogSession()
           pendingPostSaveChannelRef.current = {
             displaySiteData,
             existingTokenIds: ensureResult.existingTokenIds,
@@ -1723,6 +1795,7 @@ export function useAccountDialog({
       postSaveOneTimeToken,
       postSaveSub2ApiAllowedGroups,
       postSaveSub2ApiAccount,
+      postSaveSub2ApiDialogSessionId,
       duplicateAccountWarning,
       managedSiteConfigPrompt,
     },
@@ -1779,6 +1852,7 @@ export function useAccountDialog({
       handlePostSaveOneTimeTokenClose,
       handlePostSaveSub2ApiTokenDialogClose,
       handlePostSaveSub2ApiTokenCreated,
+      getPostSaveSub2ApiDialogHandlers,
     },
   }
 }

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -149,6 +149,8 @@ export function useAccountDialog({
     useState<ApiToken | null>(null)
   const [postSaveSub2ApiAllowedGroups, setPostSaveSub2ApiAllowedGroups] =
     useState<string[] | null>(null)
+  const [postSaveSub2ApiAccount, setPostSaveSub2ApiAccount] =
+    useState<DisplaySiteData | null>(null)
 
   const [duplicateAccountWarning, setDuplicateAccountWarning] = useState<{
     isOpen: boolean
@@ -482,6 +484,7 @@ export function useAccountDialog({
     setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
     setPostSaveOneTimeToken(null)
     setPostSaveSub2ApiAllowedGroups(null)
+    setPostSaveSub2ApiAccount(null)
     pendingPostSaveChannelRef.current = null
   }, [invalidatePostSaveAutoConfigRun])
 
@@ -1329,6 +1332,7 @@ export function useAccountDialog({
       const runId = postSaveAutoConfigRunRef.current
       const pending = pendingPostSaveChannelRef.current
       setPostSaveSub2ApiAllowedGroups(null)
+      setPostSaveSub2ApiAccount(null)
 
       if (!pending || !createdToken) {
         pendingPostSaveChannelRef.current = null
@@ -1497,6 +1501,7 @@ export function useAccountDialog({
           return
         case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired:
           pendingPostSaveChannelRef.current = { displaySiteData }
+          setPostSaveSub2ApiAccount(displaySiteData)
           setPostSaveSub2ApiAllowedGroups(ensureResult.allowedGroups)
           setAccountPostSaveWorkflowStep(
             ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
@@ -1625,6 +1630,7 @@ export function useAccountDialog({
       accountPostSaveWorkflowStep,
       postSaveOneTimeToken,
       postSaveSub2ApiAllowedGroups,
+      postSaveSub2ApiAccount,
       duplicateAccountWarning,
       managedSiteConfigPrompt,
     },

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -1279,12 +1279,22 @@ export function useAccountDialog({
         ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog,
       )
       try {
-        await openChannelDialog(displaySiteData, token, () => {
-          if (onSuccess && targetAccountRef.current) {
-            onSuccess(targetAccountRef.current)
-          }
-        })
+        const openResult = await openChannelDialog(
+          displaySiteData,
+          token,
+          () => {
+            if (onSuccess && targetAccountRef.current) {
+              onSuccess(targetAccountRef.current)
+            }
+          },
+        )
         if (postSaveAutoConfigRunRef.current !== runId) {
+          return
+        }
+        if (!openResult.opened) {
+          setAccountPostSaveWorkflowStep(
+            ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+          )
           return
         }
         setAccountPostSaveWorkflowStep(
@@ -1450,12 +1460,25 @@ export function useAccountDialog({
       // so users can review it before creation. The direct auto-import helpers
       // are kept only as deprecated compatibility shims.
       if (!savedSiteAccount) {
-        await openChannelDialog(displaySiteData, null, () => {
-          if (onSuccess && targetAccountRef.current) {
-            onSuccess(targetAccountRef.current)
-          }
-        })
+        setAccountPostSaveWorkflowStep(
+          ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog,
+        )
+        const openResult = await openChannelDialog(
+          displaySiteData,
+          null,
+          () => {
+            if (onSuccess && targetAccountRef.current) {
+              onSuccess(targetAccountRef.current)
+            }
+          },
+        )
         if (!isCurrentRun()) {
+          return
+        }
+        if (!openResult.opened) {
+          setAccountPostSaveWorkflowStep(
+            ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+          )
           return
         }
         setAccountPostSaveWorkflowStep(

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -1316,6 +1316,9 @@ export function useAccountDialog({
           return
         }
         if (!openResult.opened) {
+          if (openResult.deferred) {
+            return
+          }
           setAccountPostSaveWorkflowStep(
             ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
           )

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -24,6 +24,7 @@ import {
   ACCOUNT_POST_SAVE_WORKFLOW_STEPS,
   ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
   ensureAccountTokenForPostSaveWorkflow,
+  selectSingleNewApiTokenByIdDiff,
   type AccountPostSaveWorkflowStep,
 } from "~/services/accounts/accountPostSaveWorkflow"
 import { accountStorage } from "~/services/accounts/accountStorage"
@@ -467,6 +468,7 @@ export function useAccountDialog({
   const pendingPostSaveChannelRef = useRef<{
     displaySiteData: DisplaySiteData
     token?: ApiToken
+    existingTokenIds?: number[]
   } | null>(null)
   const postSaveAutoConfigRunRef = useRef(0)
   const detectSlowHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -1374,7 +1376,10 @@ export function useAccountDialog({
         )
         const fetchedTokens = await service.fetchAccountTokens(request)
         const latestToken = Array.isArray(fetchedTokens)
-          ? fetchedTokens.at(-1) ?? null
+          ? selectSingleNewApiTokenByIdDiff({
+              existingTokenIds: pending.existingTokenIds ?? [],
+              tokens: fetchedTokens,
+            })
           : null
 
         if (!latestToken) {
@@ -1569,7 +1574,10 @@ export function useAccountDialog({
           )
           return
         case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired:
-          pendingPostSaveChannelRef.current = { displaySiteData }
+          pendingPostSaveChannelRef.current = {
+            displaySiteData,
+            existingTokenIds: ensureResult.existingTokenIds,
+          }
           setPostSaveSub2ApiAccount(displaySiteData)
           setPostSaveSub2ApiAllowedGroups(ensureResult.allowedGroups)
           setAccountPostSaveWorkflowStep(

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -465,6 +465,7 @@ export function useAccountDialog({
     displaySiteData: DisplaySiteData
     token?: ApiToken
   } | null>(null)
+  const postSaveAutoConfigRunRef = useRef(0)
   const detectSlowHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
@@ -472,12 +473,17 @@ export function useAccountDialog({
   const { openWithAccount: openChannelDialog, openSub2ApiTokenCreationDialog } =
     useChannelDialog()
 
+  const invalidatePostSaveAutoConfigRun = useCallback(() => {
+    postSaveAutoConfigRunRef.current += 1
+  }, [])
+
   const clearPostSaveWorkflowState = useCallback(() => {
+    invalidatePostSaveAutoConfigRun()
     setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
     setPostSaveOneTimeToken(null)
     setPostSaveSub2ApiAllowedGroups(null)
     pendingPostSaveChannelRef.current = null
-  }, [])
+  }, [invalidatePostSaveAutoConfigRun])
 
   const resetForm = useCallback(() => {
     newAccountRef.current = null
@@ -1257,7 +1263,15 @@ export function useAccountDialog({
   }
 
   const openPostSaveManagedSiteDialog = useCallback(
-    async (displaySiteData: DisplaySiteData, token: ApiToken) => {
+    async (
+      displaySiteData: DisplaySiteData,
+      token: ApiToken,
+      runId = postSaveAutoConfigRunRef.current,
+    ) => {
+      if (postSaveAutoConfigRunRef.current !== runId) {
+        return
+      }
+
       setAccountPostSaveWorkflowStep(
         ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog,
       )
@@ -1267,10 +1281,16 @@ export function useAccountDialog({
             onSuccess(targetAccountRef.current)
           }
         })
+        if (postSaveAutoConfigRunRef.current !== runId) {
+          return
+        }
         setAccountPostSaveWorkflowStep(
           ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
         )
       } catch (error) {
+        if (postSaveAutoConfigRunRef.current !== runId) {
+          return
+        }
         setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed)
         toast.error(
           t("messages.newApiConfigFailed", {
@@ -1288,6 +1308,7 @@ export function useAccountDialog({
   )
 
   const handlePostSaveOneTimeTokenClose = useCallback(async () => {
+    const runId = postSaveAutoConfigRunRef.current
     setPostSaveOneTimeToken(null)
     const pending = pendingPostSaveChannelRef.current
     pendingPostSaveChannelRef.current = null
@@ -1296,11 +1317,16 @@ export function useAccountDialog({
       return
     }
 
-    await openPostSaveManagedSiteDialog(pending.displaySiteData, pending.token)
+    await openPostSaveManagedSiteDialog(
+      pending.displaySiteData,
+      pending.token,
+      runId,
+    )
   }, [openPostSaveManagedSiteDialog])
 
   const handlePostSaveSub2ApiTokenCreated = useCallback(
     async (createdToken?: ApiToken) => {
+      const runId = postSaveAutoConfigRunRef.current
       const pending = pendingPostSaveChannelRef.current
       setPostSaveSub2ApiAllowedGroups(null)
 
@@ -1311,18 +1337,32 @@ export function useAccountDialog({
       }
 
       pendingPostSaveChannelRef.current = null
-      await openPostSaveManagedSiteDialog(pending.displaySiteData, createdToken)
+      await openPostSaveManagedSiteDialog(
+        pending.displaySiteData,
+        createdToken,
+        runId,
+      )
     },
     [openPostSaveManagedSiteDialog],
   )
 
   const handleAutoConfig = async () => {
+    const runId = postSaveAutoConfigRunRef.current + 1
+    postSaveAutoConfigRunRef.current = runId
+    const isCurrentRun = () => postSaveAutoConfigRunRef.current === runId
+
     try {
       const isManagedSiteReady = await ensureManagedSiteAutoConfigReady()
+      if (!isCurrentRun()) {
+        return
+      }
       if (!isManagedSiteReady) {
         return
       }
     } catch (error) {
+      if (!isCurrentRun()) {
+        return
+      }
       toast.error(
         t("messages.operationFailed", {
           error: getErrorMessage(error),
@@ -1354,6 +1394,9 @@ export function useAccountDialog({
             skipAutoProvisionKeyOnAccountAdd: true,
           })
         ).accountId
+        if (!isCurrentRun()) {
+          return
+        }
         if (!targetAccount) {
           toast.error(t("messages.saveAccountFailed"))
           setAccountPostSaveWorkflowStep(
@@ -1366,6 +1409,9 @@ export function useAccountDialog({
       }
 
       // 缓存目标账户
+      if (!isCurrentRun()) {
+        return
+      }
       targetAccountRef.current = targetAccount
       let displaySiteData
 
@@ -1375,6 +1421,9 @@ export function useAccountDialog({
         )
         // 获取账户详细信息
         const siteAccount = await accountStorage.getAccountById(targetAccount)
+        if (!isCurrentRun()) {
+          return
+        }
         if (!siteAccount) {
           toast.error(t("messages:toast.error.findAccountDetailsFailed"))
           setAccountPostSaveWorkflowStep(
@@ -1386,6 +1435,9 @@ export function useAccountDialog({
         displaySiteData =
           (await accountStorage.getDisplayDataById(siteAccount.id)) ??
           accountStorage.convertToDisplayData(siteAccount)
+        if (!isCurrentRun()) {
+          return
+        }
       } else {
         displaySiteData = targetAccount
       }
@@ -1399,6 +1451,9 @@ export function useAccountDialog({
             onSuccess(targetAccountRef.current)
           }
         })
+        if (!isCurrentRun()) {
+          return
+        }
         setAccountPostSaveWorkflowStep(
           ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
         )
@@ -1412,6 +1467,9 @@ export function useAccountDialog({
         account: savedSiteAccount,
         displaySiteData,
       })
+      if (!isCurrentRun()) {
+        return
+      }
 
       switch (ensureResult.kind) {
         case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready:
@@ -1434,6 +1492,7 @@ export function useAccountDialog({
           await openPostSaveManagedSiteDialog(
             displaySiteData,
             ensureResult.token,
+            runId,
           )
           return
         case ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired:
@@ -1451,6 +1510,9 @@ export function useAccountDialog({
           return
       }
     } catch (error) {
+      if (!isCurrentRun()) {
+        return
+      }
       toast.error(
         t("messages.newApiConfigFailed", {
           error: getErrorMessage(error),
@@ -1459,7 +1521,9 @@ export function useAccountDialog({
       setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed)
       logger.error("Auto configuration failed", { error })
     } finally {
-      setIsAutoConfiguring(false)
+      if (isCurrentRun()) {
+        setIsAutoConfiguring(false)
+      }
     }
   }
 

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -27,6 +27,7 @@ import {
   type AccountPostSaveWorkflowStep,
 } from "~/services/accounts/accountPostSaveWorkflow"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { createDisplayAccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
 import {
   analyzeAutoDetectError,
   AutoDetectError,
@@ -1337,6 +1338,13 @@ export function useAccountDialog({
     )
   }, [openPostSaveManagedSiteDialog])
 
+  const handlePostSaveSub2ApiTokenDialogClose = useCallback(() => {
+    pendingPostSaveChannelRef.current = null
+    setPostSaveSub2ApiAllowedGroups(null)
+    setPostSaveSub2ApiAccount(null)
+    setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
+  }, [])
+
   const handlePostSaveSub2ApiTokenCreated = useCallback(
     async (createdToken?: ApiToken) => {
       const runId = postSaveAutoConfigRunRef.current
@@ -1344,20 +1352,58 @@ export function useAccountDialog({
       setPostSaveSub2ApiAllowedGroups(null)
       setPostSaveSub2ApiAccount(null)
 
-      if (!pending || !createdToken) {
+      if (!pending) {
         pendingPostSaveChannelRef.current = null
         setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle)
         return
       }
 
       pendingPostSaveChannelRef.current = null
-      await openPostSaveManagedSiteDialog(
-        pending.displaySiteData,
-        createdToken,
-        runId,
-      )
+      if (createdToken) {
+        await openPostSaveManagedSiteDialog(
+          pending.displaySiteData,
+          createdToken,
+          runId,
+        )
+        return
+      }
+
+      try {
+        const { service, request } = createDisplayAccountApiContext(
+          pending.displaySiteData,
+        )
+        const fetchedTokens = await service.fetchAccountTokens(request)
+        const latestToken = Array.isArray(fetchedTokens)
+          ? fetchedTokens.at(-1) ?? null
+          : null
+
+        if (!latestToken) {
+          setAccountPostSaveWorkflowStep(
+            ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+          )
+          toast.error(t("messages:accountOperations.createTokenFailed"))
+          return
+        }
+
+        await openPostSaveManagedSiteDialog(
+          pending.displaySiteData,
+          latestToken,
+          runId,
+        )
+      } catch (error) {
+        setAccountPostSaveWorkflowStep(ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed)
+        toast.error(
+          t("messages.newApiConfigFailed", {
+            error: getErrorMessage(error),
+          }),
+        )
+        logger.error("Failed to resolve latest Sub2API token after create", {
+          accountId: pending.displaySiteData.id,
+          error: getErrorMessage(error),
+        })
+      }
     },
-    [openPostSaveManagedSiteDialog],
+    [openPostSaveManagedSiteDialog, t],
   )
 
   const handleAutoConfig = async () => {
@@ -1708,6 +1754,7 @@ export function useAccountDialog({
       handleManagedSiteConfigPromptClose,
       handleOpenManagedSiteSettings,
       handlePostSaveOneTimeTokenClose,
+      handlePostSaveSub2ApiTokenDialogClose,
       handlePostSaveSub2ApiTokenCreated,
     },
   }

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -1539,6 +1539,9 @@ export function useAccountDialog({
           return
         }
         if (!openResult.opened) {
+          if (openResult.deferred) {
+            return
+          }
           setAccountPostSaveWorkflowStep(
             ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
           )

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps } from "react"
+import { useTranslation } from "react-i18next"
 
 import { ThemeAwareToaster } from "~/components/ThemeAwareToaster"
 import { Modal } from "~/components/ui/Dialog/Modal"
@@ -6,6 +7,9 @@ import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
 import { useAccountDataContext } from "~/features/AccountManagement/hooks/AccountDataContext"
 import { useDialogStateContext } from "~/features/AccountManagement/hooks/DialogStateContext"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
+import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
+import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import type { DisplaySiteData } from "~/types"
 
 import AccountForm from "./AccountForm"
@@ -47,6 +51,7 @@ export default function AccountDialog({
   onSuccess,
   onError,
 }: AccountDialogProps) {
+  const { t } = useTranslation("messages")
   const {
     displayData,
     detectedSiteAccounts,
@@ -116,6 +121,19 @@ export default function AccountDialog({
           ...addModeSiteInfoProps,
         }
 
+  const postSaveSub2ApiCreatePrefill =
+    state.postSaveSub2ApiAllowedGroups &&
+    state.postSaveSub2ApiAllowedGroups.length > 0
+      ? {
+          modelId: "",
+          defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+          group: state.postSaveSub2ApiAllowedGroups.includes("default")
+            ? "default"
+            : state.postSaveSub2ApiAllowedGroups[0] ?? "default",
+          allowedGroups: state.postSaveSub2ApiAllowedGroups,
+        }
+      : undefined
+
   return (
     <>
       <Modal
@@ -143,6 +161,7 @@ export default function AccountDialog({
             isSaving={state.isSaving}
             onAutoConfig={handlers.handleAutoConfig}
             isAutoConfiguring={state.isAutoConfiguring}
+            accountPostSaveWorkflowStep={state.accountPostSaveWorkflowStep}
             // ensure submit button in footer can submit the form by linking via form id
             formId="account-form"
           />
@@ -241,6 +260,27 @@ export default function AccountDialog({
         missingMessage={state.managedSiteConfigPrompt.missingMessage}
         onClose={handlers.handleManagedSiteConfigPromptClose}
         onOpenSettings={handlers.handleOpenManagedSiteSettings}
+      />
+
+      {state.postSaveSub2ApiAccount && postSaveSub2ApiCreatePrefill ? (
+        <AddTokenDialog
+          isOpen={true}
+          onClose={() =>
+            void handlers.handlePostSaveSub2ApiTokenCreated(undefined)
+          }
+          availableAccounts={[state.postSaveSub2ApiAccount]}
+          preSelectedAccountId={state.postSaveSub2ApiAccount.id}
+          createPrefill={postSaveSub2ApiCreatePrefill}
+          prefillNotice={t("sub2api.createRequiresGroupSelection")}
+          onSuccess={handlers.handlePostSaveSub2ApiTokenCreated}
+          showOneTimeKeyDialog={false}
+        />
+      ) : null}
+
+      <OneTimeApiKeyDialog
+        isOpen={!!state.postSaveOneTimeToken}
+        token={state.postSaveOneTimeToken}
+        onClose={handlers.handlePostSaveOneTimeTokenClose}
       />
     </>
   )

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -133,6 +133,17 @@ export default function AccountDialog({
           allowedGroups: state.postSaveSub2ApiAllowedGroups,
         }
       : undefined
+  const postSaveSub2ApiDialogSessionId =
+    typeof state.postSaveSub2ApiDialogSessionId === "number"
+      ? state.postSaveSub2ApiDialogSessionId
+      : null
+  const postSaveSub2ApiDialogHandlers =
+    postSaveSub2ApiDialogSessionId !== null &&
+    typeof handlers.getPostSaveSub2ApiDialogHandlers === "function"
+      ? handlers.getPostSaveSub2ApiDialogHandlers(
+          postSaveSub2ApiDialogSessionId,
+        )
+      : null
 
   return (
     <>
@@ -265,12 +276,18 @@ export default function AccountDialog({
       {state.postSaveSub2ApiAccount && postSaveSub2ApiCreatePrefill ? (
         <AddTokenDialog
           isOpen={true}
-          onClose={handlers.handlePostSaveSub2ApiTokenDialogClose}
+          onClose={
+            postSaveSub2ApiDialogHandlers?.onClose ??
+            handlers.handlePostSaveSub2ApiTokenDialogClose
+          }
           availableAccounts={[state.postSaveSub2ApiAccount]}
           preSelectedAccountId={state.postSaveSub2ApiAccount.id}
           createPrefill={postSaveSub2ApiCreatePrefill}
           prefillNotice={t("sub2api.createRequiresGroupSelection")}
-          onSuccess={handlers.handlePostSaveSub2ApiTokenCreated}
+          onSuccess={
+            postSaveSub2ApiDialogHandlers?.onSuccess ??
+            handlers.handlePostSaveSub2ApiTokenCreated
+          }
           showOneTimeKeyDialog={false}
         />
       ) : null}

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -265,9 +265,7 @@ export default function AccountDialog({
       {state.postSaveSub2ApiAccount && postSaveSub2ApiCreatePrefill ? (
         <AddTokenDialog
           isOpen={true}
-          onClose={() =>
-            void handlers.handlePostSaveSub2ApiTokenCreated(undefined)
-          }
+          onClose={handlers.handlePostSaveSub2ApiTokenDialogClose}
           availableAccounts={[state.postSaveSub2ApiAccount]}
           preSelectedAccountId={state.postSaveSub2ApiAccount.id}
           createPrefill={postSaveSub2ApiCreatePrefill}

--- a/src/locales/en/accountDialog.json
+++ b/src/locales/en/accountDialog.json
@@ -9,7 +9,16 @@
     "helpDocument": "Help Document",
     "reloadCurrentPage": "Reload current page",
     "saveAccount": "Save Account",
-    "saveChanges": "Save Changes"
+    "saveChanges": "Save Changes",
+    "workflow": {
+      "checkingToken": "Checking API keys...",
+      "creatingToken": "Creating default key...",
+      "loadingSavedAccount": "Loading saved account...",
+      "openingManagedSiteDialog": "Opening channel setup...",
+      "savingAccount": "Saving account...",
+      "waitingForOneTimeKey": "Save the one-time key first...",
+      "waitingForSub2ApiGroup": "Choose a Sub2API group..."
+    }
   },
   "form": {
     "accessToken": "Access Token",

--- a/src/locales/ja/accountDialog.json
+++ b/src/locales/ja/accountDialog.json
@@ -9,7 +9,16 @@
     "helpDocument": "ヘルプドキュメント",
     "reloadCurrentPage": "現在のページを再読み込み",
     "saveAccount": "アカウントを保存",
-    "saveChanges": "変更を保存"
+    "saveChanges": "変更を保存",
+    "workflow": {
+      "checkingToken": "API キーを確認しています...",
+      "creatingToken": "デフォルトキーを作成しています...",
+      "loadingSavedAccount": "保存済みアカウントを読み込んでいます...",
+      "openingManagedSiteDialog": "チャンネル設定を開いています...",
+      "savingAccount": "アカウントを保存しています...",
+      "waitingForOneTimeKey": "ワンタイムキーを先に保存してください...",
+      "waitingForSub2ApiGroup": "Sub2API グループを選択してください..."
+    }
   },
   "form": {
     "accessToken": "Access Token",

--- a/src/locales/zh-CN/accountDialog.json
+++ b/src/locales/zh-CN/accountDialog.json
@@ -9,7 +9,16 @@
     "helpDocument": "帮助文档",
     "reloadCurrentPage": "刷新当前页面",
     "saveAccount": "保存账号",
-    "saveChanges": "保存更改"
+    "saveChanges": "保存更改",
+    "workflow": {
+      "checkingToken": "正在检查 API 密钥...",
+      "creatingToken": "正在创建默认密钥...",
+      "loadingSavedAccount": "正在读取已保存账号...",
+      "openingManagedSiteDialog": "正在打开渠道配置...",
+      "savingAccount": "正在保存账号...",
+      "waitingForOneTimeKey": "请先保存一次性密钥...",
+      "waitingForSub2ApiGroup": "请选择 Sub2API 分组..."
+    }
   },
   "form": {
     "accessToken": "访问令牌",

--- a/src/locales/zh-TW/accountDialog.json
+++ b/src/locales/zh-TW/accountDialog.json
@@ -9,7 +9,16 @@
     "helpDocument": "幫助文件",
     "reloadCurrentPage": "重新整理當前頁面",
     "saveAccount": "儲存帳號",
-    "saveChanges": "儲存更改"
+    "saveChanges": "儲存更改",
+    "workflow": {
+      "checkingToken": "正在檢查 API 金鑰...",
+      "creatingToken": "正在建立預設金鑰...",
+      "loadingSavedAccount": "正在讀取已儲存帳號...",
+      "openingManagedSiteDialog": "正在開啟渠道配置...",
+      "savingAccount": "正在儲存帳號...",
+      "waitingForOneTimeKey": "請先保存一次性金鑰...",
+      "waitingForSub2ApiGroup": "請選擇 Sub2API 分組..."
+    }
   },
   "form": {
     "accessToken": "訪問令牌",

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -369,6 +369,10 @@ export function isValidAccount({
 
 type TagIdsInput = string[] | undefined
 
+export interface ValidateAndSaveAccountOptions {
+  skipAutoProvisionKeyOnAccountAdd?: boolean
+}
+
 /**
  * Normalizes a tag id list originating from UI widgets into a de-duped string
  * array, trimming whitespace and discarding empty values.
@@ -534,6 +538,7 @@ export async function validateAndSaveAccount(
   manualBalanceUsd?: string,
   excludeFromTotalBalance = false,
   sub2apiAuth?: Sub2ApiAuthConfig,
+  options: ValidateAndSaveAccountOptions = {},
 ): Promise<AccountSaveResponse> {
   const sessionCookieHeader =
     authType === AuthTypeEnum.Cookie
@@ -670,10 +675,12 @@ export async function validateAndSaveAccount(
       siteType: normalizedSiteType,
     })
 
-    void autoProvisionKeyOnAccountAdd(
-      accountId,
-      shouldAutoProvisionKeyOnAccountAdd,
-    )
+    if (!options.skipAutoProvisionKeyOnAccountAdd) {
+      void autoProvisionKeyOnAccountAdd(
+        accountId,
+        shouldAutoProvisionKeyOnAccountAdd,
+      )
+    }
 
     return {
       success: true,
@@ -735,10 +742,12 @@ export async function validateAndSaveAccount(
         siteType,
       })
 
-      void autoProvisionKeyOnAccountAdd(
-        accountId,
-        shouldAutoProvisionKeyOnAccountAdd,
-      )
+      if (!options.skipAutoProvisionKeyOnAccountAdd) {
+        void autoProvisionKeyOnAccountAdd(
+          accountId,
+          shouldAutoProvisionKeyOnAccountAdd,
+        )
+      }
 
       return {
         success: true,

--- a/src/services/accounts/accountPostSaveWorkflow/constants.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/constants.ts
@@ -24,9 +24,6 @@ export const ENSURE_ACCOUNT_TOKEN_RESULT_KINDS = {
   Blocked: "blocked",
 } as const
 
-export type EnsureAccountTokenResultKind =
-  (typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS)[keyof typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS]
-
 export const ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES = {
   SavedAccountNotFound: "saved_account_not_found",
   TokenCreationFailed: "token_creation_failed",

--- a/src/services/accounts/accountPostSaveWorkflow/constants.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/constants.ts
@@ -53,6 +53,7 @@ export type EnsureAccountTokenResult =
   | {
       kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired
       allowedGroups: string[]
+      existingTokenIds: number[]
     }
   | {
       kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked

--- a/src/services/accounts/accountPostSaveWorkflow/constants.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/constants.ts
@@ -1,0 +1,61 @@
+import type { ApiToken } from "~/types"
+
+export const ACCOUNT_POST_SAVE_WORKFLOW_STEPS = {
+  Idle: "idle",
+  SavingAccount: "saving_account",
+  LoadingSavedAccount: "loading_saved_account",
+  CheckingToken: "checking_token",
+  CreatingToken: "creating_token",
+  WaitingForOneTimeKeyAcknowledgement:
+    "waiting_for_one_time_key_acknowledgement",
+  WaitingForSub2ApiGroupSelection: "waiting_for_sub2api_group_selection",
+  OpeningManagedSiteDialog: "opening_managed_site_dialog",
+  Completed: "completed",
+  Failed: "failed",
+} as const
+
+export type AccountPostSaveWorkflowStep =
+  (typeof ACCOUNT_POST_SAVE_WORKFLOW_STEPS)[keyof typeof ACCOUNT_POST_SAVE_WORKFLOW_STEPS]
+
+export const ENSURE_ACCOUNT_TOKEN_RESULT_KINDS = {
+  Ready: "ready",
+  Created: "created",
+  Sub2ApiSelectionRequired: "sub2api_selection_required",
+  Blocked: "blocked",
+} as const
+
+export type EnsureAccountTokenResultKind =
+  (typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS)[keyof typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS]
+
+export const ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES = {
+  SavedAccountNotFound: "saved_account_not_found",
+  TokenCreationFailed: "token_creation_failed",
+  TokenSecretUnavailable: "token_secret_unavailable",
+  ManagedSiteConfigMissing: "managed_site_config_missing",
+  UserCancelled: "user_cancelled",
+} as const
+
+export type AccountPostSaveWorkflowErrorCode =
+  (typeof ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES)[keyof typeof ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES]
+
+export type EnsureAccountTokenResult =
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready
+      token: ApiToken
+      created: false
+    }
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created
+      token: ApiToken
+      created: true
+      oneTimeSecret: boolean
+    }
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired
+      allowedGroups: string[]
+    }
+  | {
+      kind: typeof ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked
+      code: AccountPostSaveWorkflowErrorCode
+      message: string
+    }

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -1,0 +1,164 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import { resolveSub2ApiQuickCreateResolution } from "~/services/accounts/accountOperations"
+import { getApiService } from "~/services/apiService"
+import {
+  hasUsableApiTokenKey,
+  isMaskedApiTokenKey,
+} from "~/services/apiService/common/apiKey"
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
+import { t } from "~/utils/i18n/core"
+
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES,
+  ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
+  type EnsureAccountTokenResult,
+} from "./constants"
+
+const isCreatedApiToken = (value: unknown): value is ApiToken =>
+  !!value &&
+  typeof value === "object" &&
+  typeof (value as Partial<ApiToken>).id === "number" &&
+  typeof (value as Partial<ApiToken>).key === "string"
+
+const hasUsableFullTokenSecret = (token: ApiToken): boolean =>
+  hasUsableApiTokenKey(token.key) && !isMaskedApiTokenKey(token.key)
+
+const buildCreateRequest = (account: SiteAccount): ApiServiceRequest => ({
+  baseUrl: account.site_url,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.account_info.id,
+    accessToken: account.account_info.access_token,
+    cookie: account.cookieAuth?.sessionCookie,
+  },
+})
+
+/**
+ *
+ */
+async function createDefaultToken(params: {
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+  group?: string
+}): Promise<ApiToken | null> {
+  const { account, displaySiteData, group } = params
+  const tokenData = generateDefaultTokenRequest()
+  if (typeof group === "string") {
+    tokenData.group = group
+  }
+
+  const created = await getApiService(displaySiteData.siteType).createApiToken(
+    buildCreateRequest(account),
+    tokenData,
+  )
+
+  return isCreatedApiToken(created) ? created : null
+}
+
+/**
+ *
+ */
+export async function ensureAccountTokenForPostSaveWorkflow(params: {
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+}): Promise<EnsureAccountTokenResult> {
+  const { account, displaySiteData } = params
+  const service = getApiService(displaySiteData.siteType)
+  const tokens = await service.fetchAccountTokens({
+    baseUrl: displaySiteData.baseUrl,
+    accountId: displaySiteData.id,
+    auth: {
+      authType: displaySiteData.authType,
+      userId: displaySiteData.userId,
+      accessToken: displaySiteData.token,
+      cookie: displaySiteData.cookieAuthSessionCookie,
+    },
+  })
+
+  const existingToken = Array.isArray(tokens) ? tokens.at(-1) : undefined
+  if (existingToken) {
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: existingToken,
+      created: false,
+    }
+  }
+
+  if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
+    const resolution =
+      await resolveSub2ApiQuickCreateResolution(displaySiteData)
+
+    if (resolution.kind === "blocked") {
+      return {
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+        code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+        message: resolution.message,
+      }
+    }
+
+    if (resolution.kind === "selection_required") {
+      return {
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+        allowedGroups: resolution.allowedGroups,
+      }
+    }
+
+    const token = await createDefaultToken({
+      account,
+      displaySiteData,
+      group: resolution.group,
+    })
+
+    if (!token) {
+      return {
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+        code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+        message: t("messages:accountOperations.createTokenFailed"),
+      }
+    }
+
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token,
+      created: true,
+      oneTimeSecret: false,
+    }
+  }
+
+  const token = await createDefaultToken({ account, displaySiteData })
+
+  if (!token) {
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code:
+        displaySiteData.siteType === SITE_TYPES.AIHUBMIX
+          ? ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable
+          : ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+      message:
+        displaySiteData.siteType === SITE_TYPES.AIHUBMIX
+          ? t("messages:aihubmix.createRequiresOneTimeKeyDialog")
+          : t("messages:accountOperations.createTokenFailed"),
+    }
+  }
+
+  if (
+    displaySiteData.siteType === SITE_TYPES.AIHUBMIX &&
+    !hasUsableFullTokenSecret(token)
+  ) {
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+      message: t("messages:aihubmix.createRequiresOneTimeKeyDialog"),
+    }
+  }
+
+  return {
+    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+    token,
+    created: true,
+    oneTimeSecret: displaySiteData.siteType === SITE_TYPES.AIHUBMIX,
+  }
+}

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -25,6 +25,24 @@ const isCreatedApiToken = (value: unknown): value is ApiToken =>
 const hasUsableFullTokenSecret = (token: ApiToken): boolean =>
   hasUsableApiTokenKey(token.key) && !isMaskedApiTokenKey(token.key)
 
+const getTokenIds = (tokens: ApiToken[]): number[] =>
+  tokens.map((token) => token.id)
+
+/**
+ *
+ */
+export function selectSingleNewApiTokenByIdDiff(params: {
+  existingTokenIds: number[]
+  tokens: ApiToken[]
+}): ApiToken | null {
+  const existingTokenIdSet = new Set(params.existingTokenIds)
+  const newTokens = params.tokens.filter(
+    (token) => !existingTokenIdSet.has(token.id),
+  )
+
+  return newTokens.length === 1 ? newTokens[0] : null
+}
+
 const buildCreateRequest = (account: SiteAccount): ApiServiceRequest => ({
   baseUrl: account.site_url,
   accountId: account.id,
@@ -49,12 +67,16 @@ const buildDisplayAccountRequest = (
   },
 })
 
+/**
+ *
+ */
 async function createDefaultToken(params: {
   account: SiteAccount
   displaySiteData: DisplaySiteData
   group?: string
+  existingTokenIds: number[]
 }): Promise<ApiToken | null> {
-  const { account, displaySiteData, group } = params
+  const { account, displaySiteData, group, existingTokenIds } = params
   const service = getApiService(displaySiteData.siteType)
   const tokenData = generateDefaultTokenRequest()
   if (typeof group === "string") {
@@ -82,9 +104,17 @@ async function createDefaultToken(params: {
     buildDisplayAccountRequest(displaySiteData),
   )
 
-  return Array.isArray(updatedTokens) ? updatedTokens.at(-1) ?? null : null
+  return Array.isArray(updatedTokens)
+    ? selectSingleNewApiTokenByIdDiff({
+        existingTokenIds,
+        tokens: updatedTokens,
+      })
+    : null
 }
 
+/**
+ *
+ */
 export async function ensureAccountTokenForPostSaveWorkflow(params: {
   account: SiteAccount
   displaySiteData: DisplaySiteData
@@ -94,8 +124,10 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
   const tokens = await service.fetchAccountTokens(
     buildDisplayAccountRequest(displaySiteData),
   )
+  const existingTokens = Array.isArray(tokens) ? tokens : []
+  const existingTokenIds = getTokenIds(existingTokens)
 
-  const existingToken = Array.isArray(tokens) ? tokens.at(-1) : undefined
+  const existingToken = existingTokens.at(-1)
   if (existingToken) {
     if (
       displaySiteData.siteType === SITE_TYPES.AIHUBMIX &&
@@ -131,6 +163,7 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
       return {
         kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
         allowedGroups: resolution.allowedGroups,
+        existingTokenIds,
       }
     }
 
@@ -138,6 +171,7 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
       account,
       displaySiteData,
       group: resolution.group,
+      existingTokenIds,
     })
 
     if (!token) {
@@ -156,7 +190,11 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
     }
   }
 
-  const token = await createDefaultToken({ account, displaySiteData })
+  const token = await createDefaultToken({
+    account,
+    displaySiteData,
+    existingTokenIds,
+  })
 
   if (!token) {
     return {

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -49,9 +49,6 @@ const buildDisplayAccountRequest = (
   },
 })
 
-/**
- *
- */
 async function createDefaultToken(params: {
   account: SiteAccount
   displaySiteData: DisplaySiteData
@@ -88,9 +85,6 @@ async function createDefaultToken(params: {
   return Array.isArray(updatedTokens) ? updatedTokens.at(-1) ?? null : null
 }
 
-/**
- *
- */
 export async function ensureAccountTokenForPostSaveWorkflow(params: {
   account: SiteAccount
   displaySiteData: DisplaySiteData

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -36,6 +36,19 @@ const buildCreateRequest = (account: SiteAccount): ApiServiceRequest => ({
   },
 })
 
+const buildDisplayAccountRequest = (
+  displaySiteData: DisplaySiteData,
+): ApiServiceRequest => ({
+  baseUrl: displaySiteData.baseUrl,
+  accountId: displaySiteData.id,
+  auth: {
+    authType: displaySiteData.authType,
+    userId: displaySiteData.userId,
+    accessToken: displaySiteData.token,
+    cookie: displaySiteData.cookieAuthSessionCookie,
+  },
+})
+
 /**
  *
  */
@@ -45,17 +58,34 @@ async function createDefaultToken(params: {
   group?: string
 }): Promise<ApiToken | null> {
   const { account, displaySiteData, group } = params
+  const service = getApiService(displaySiteData.siteType)
   const tokenData = generateDefaultTokenRequest()
   if (typeof group === "string") {
     tokenData.group = group
   }
 
-  const created = await getApiService(displaySiteData.siteType).createApiToken(
+  const created = await service.createApiToken(
     buildCreateRequest(account),
     tokenData,
   )
 
-  return isCreatedApiToken(created) ? created : null
+  if (!created) {
+    return null
+  }
+
+  if (isCreatedApiToken(created)) {
+    return created
+  }
+
+  if (displaySiteData.siteType === SITE_TYPES.AIHUBMIX) {
+    return null
+  }
+
+  const updatedTokens = await service.fetchAccountTokens(
+    buildDisplayAccountRequest(displaySiteData),
+  )
+
+  return Array.isArray(updatedTokens) ? updatedTokens.at(-1) ?? null : null
 }
 
 /**
@@ -67,16 +97,9 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
 }): Promise<EnsureAccountTokenResult> {
   const { account, displaySiteData } = params
   const service = getApiService(displaySiteData.siteType)
-  const tokens = await service.fetchAccountTokens({
-    baseUrl: displaySiteData.baseUrl,
-    accountId: displaySiteData.id,
-    auth: {
-      authType: displaySiteData.authType,
-      userId: displaySiteData.userId,
-      accessToken: displaySiteData.token,
-      cookie: displaySiteData.cookieAuthSessionCookie,
-    },
-  })
+  const tokens = await service.fetchAccountTokens(
+    buildDisplayAccountRequest(displaySiteData),
+  )
 
   const existingToken = Array.isArray(tokens) ? tokens.at(-1) : undefined
   if (existingToken) {

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -103,6 +103,17 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
 
   const existingToken = Array.isArray(tokens) ? tokens.at(-1) : undefined
   if (existingToken) {
+    if (
+      displaySiteData.siteType === SITE_TYPES.AIHUBMIX &&
+      !hasUsableFullTokenSecret(existingToken)
+    ) {
+      return {
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+        code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+        message: t("messages:aihubmix.createRequiresOneTimeKeyDialog"),
+      }
+    }
+
     return {
       kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
       token: existingToken,

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -25,6 +25,14 @@ const isCreatedApiToken = (value: unknown): value is ApiToken =>
 const hasUsableFullTokenSecret = (token: ApiToken): boolean =>
   hasUsableApiTokenKey(token.key) && !isMaskedApiTokenKey(token.key)
 
+const isApiTokenWithValidId = (value: unknown): value is ApiToken =>
+  !!value &&
+  typeof value === "object" &&
+  typeof (value as Partial<ApiToken>).id === "number"
+
+const sanitizeApiTokens = (tokens: unknown): ApiToken[] =>
+  Array.isArray(tokens) ? tokens.filter(isApiTokenWithValidId) : []
+
 const getTokenIds = (tokens: ApiToken[]): number[] =>
   tokens.map((token) => token.id)
 
@@ -33,10 +41,10 @@ const getTokenIds = (tokens: ApiToken[]): number[] =>
  */
 export function selectSingleNewApiTokenByIdDiff(params: {
   existingTokenIds: number[]
-  tokens: ApiToken[]
+  tokens: unknown[]
 }): ApiToken | null {
   const existingTokenIdSet = new Set(params.existingTokenIds)
-  const newTokens = params.tokens.filter(
+  const newTokens = sanitizeApiTokens(params.tokens).filter(
     (token) => !existingTokenIdSet.has(token.id),
   )
 
@@ -104,10 +112,12 @@ async function createDefaultToken(params: {
     buildDisplayAccountRequest(displaySiteData),
   )
 
-  return Array.isArray(updatedTokens)
+  const sanitizedUpdatedTokens = sanitizeApiTokens(updatedTokens)
+
+  return sanitizedUpdatedTokens.length > 0
     ? selectSingleNewApiTokenByIdDiff({
         existingTokenIds,
-        tokens: updatedTokens,
+        tokens: sanitizedUpdatedTokens,
       })
     : null
 }
@@ -124,7 +134,7 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
   const tokens = await service.fetchAccountTokens(
     buildDisplayAccountRequest(displaySiteData),
   )
-  const existingTokens = Array.isArray(tokens) ? tokens : []
+  const existingTokens = sanitizeApiTokens(tokens)
   const existingTokenIds = getTokenIds(existingTokens)
 
   const existingToken = existingTokens.at(-1)

--- a/src/services/accounts/accountPostSaveWorkflow/index.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/index.ts
@@ -1,0 +1,2 @@
+export * from "./constants"
+export * from "./ensureAccountToken"

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -777,6 +777,134 @@ describe("useChannelDialog", () => {
     expect(mockFetchAccountTokens).toHaveBeenCalledTimes(2)
   })
 
+  it("resumes Sub2API channel opening with the single new refetched token when AddTokenDialog does not return one", async () => {
+    const existingToken = buildApiToken({
+      id: 3,
+      key: "sk-existing-3",
+      name: "Existing token",
+    })
+    const createdToken = buildApiToken({
+      id: 11,
+      key: "sk-created-11",
+      name: "Created token",
+    })
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: "sub2api" }),
+    )
+    mockFetchAccountTokens
+      .mockResolvedValueOnce([existingToken, undefined] as ApiToken[])
+      .mockResolvedValueOnce([createdToken, existingToken])
+    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: "sub2api" }),
+        null,
+      )
+    })
+
+    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+
+    await act(async () => {
+      await result.current.context.handleSub2ApiTokenSuccess()
+    })
+
+    expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "account-id",
+      }),
+      expect.objectContaining({
+        id: createdToken.id,
+        key: createdToken.key,
+      }),
+    )
+    expect(result.current.context.state).toMatchObject({
+      isOpen: true,
+      initialValues: {
+        key: createdToken.key,
+      },
+    })
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when Sub2API token refetch cannot identify a single new token after dialog success", async () => {
+    const existingToken = buildApiToken({
+      id: 3,
+      key: "sk-existing-3",
+      name: "Existing token",
+    })
+    const ambiguousTokenA = buildApiToken({
+      id: 11,
+      key: "sk-created-11",
+      name: "Created token A",
+    })
+    const ambiguousTokenB = buildApiToken({
+      id: 12,
+      key: "sk-created-12",
+      name: "Created token B",
+    })
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: "sub2api" }),
+    )
+    mockFetchAccountTokens
+      .mockResolvedValueOnce([existingToken, undefined] as ApiToken[])
+      .mockResolvedValueOnce([existingToken, ambiguousTokenA, ambiguousTokenB])
+    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: "sub2api" }),
+        null,
+      )
+    })
+
+    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+
+    await act(async () => {
+      await result.current.context.handleSub2ApiTokenSuccess()
+    })
+
+    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(mockToastError).toHaveBeenCalledWith(
+      "messages:accountOperations.createTokenFailed",
+    )
+  })
+
   it("does not open the Sub2API quick-create dialog when tokens already exist", async () => {
     mockFetchAccountTokens.mockResolvedValueOnce([buildApiToken()])
 

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -407,6 +407,45 @@ describe("useChannelDialog", () => {
     expect(mockToastDismiss).toHaveBeenCalledWith("toast-id")
   })
 
+  it("does not ensure or create a token when openWithAccount receives a token", async () => {
+    const providedToken = buildApiToken({
+      id: 123,
+      key: "sk-provided-token",
+    })
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(buildSiteAccount())
+
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData(),
+        providedToken,
+      )
+    })
+
+    expect(ensureAccountApiTokenSpy).not.toHaveBeenCalled()
+    expect(mockFetchAccountTokens).not.toHaveBeenCalled()
+    expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "account-id",
+      }),
+      providedToken,
+    )
+    expect(result.current.context.state.isOpen).toBe(true)
+  })
+
   it("opens ChannelDialog when New API exact duplicate verification is unavailable", async () => {
     const hiddenKeyChannel = buildManagedSiteChannel({
       id: 22,

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -901,6 +901,84 @@ describe("useChannelDialog", () => {
     expect(mockToastError).not.toHaveBeenCalled()
   })
 
+  it("ignores late Sub2API token success from session A after session B opens", async () => {
+    const createdToken = buildApiToken({
+      id: 21,
+      key: "sk-created-21",
+      name: "Created token",
+    })
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: "sub2api" }),
+    )
+    mockFetchAccountTokens.mockResolvedValueOnce([]).mockResolvedValueOnce([])
+    resolveSub2ApiQuickCreateResolutionSpy
+      .mockResolvedValueOnce({
+        kind: "selection_required",
+        allowedGroups: ["default", "vip"],
+      })
+      .mockResolvedValueOnce({
+        kind: "selection_required",
+        allowedGroups: ["default", "vip"],
+      })
+
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openSub2ApiTokenCreationDialog(
+        buildDisplaySiteData({ siteType: "sub2api" }),
+        {
+          onSuccess: vi.fn(),
+        },
+      )
+    })
+
+    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+
+    const sessionASuccessHandler =
+      result.current.context.handleSub2ApiTokenSuccess
+
+    act(() => {
+      result.current.context.closeSub2ApiTokenDialog()
+    })
+
+    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(false)
+
+    let openResult: Awaited<
+      ReturnType<typeof result.current.dialog.openWithAccount>
+    > | null = null
+    await act(async () => {
+      openResult = await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: "sub2api" }),
+        null,
+      )
+    })
+
+    expect(openResult).toEqual({ opened: false, deferred: true })
+    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+    expect(result.current.context.state.isOpen).toBe(false)
+
+    await act(async () => {
+      await sessionASuccessHandler(createdToken)
+    })
+
+    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
+    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
   it("fails closed when Sub2API token refetch cannot identify a single new token after dialog success", async () => {
     const existingToken = buildApiToken({
       id: 3,

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -901,81 +901,61 @@ describe("useChannelDialog", () => {
     expect(mockToastError).not.toHaveBeenCalled()
   })
 
-  it("ignores late Sub2API token success from session A after session B opens", async () => {
+  it("ignores stale Sub2API token success from session A immediately after session B opens", async () => {
     const createdToken = buildApiToken({
       id: 21,
       key: "sk-created-21",
       name: "Created token",
     })
-    const prepareChannelFormDataMock = vi.fn(
-      async (_account: DisplaySiteData, token: ApiToken) =>
-        buildPreparedFormData({
-          key: token.key,
-        }),
-    )
-    const mockService = buildManagedSiteServiceMock({
-      prepareChannelFormData: prepareChannelFormDataMock,
+    const sessionAOnSuccess = vi.fn()
+    const sessionBOnSuccess = vi.fn()
+    const sessionAAccount = buildDisplaySiteData({
+      id: "account-a",
+      name: "Account A",
+      siteType: "sub2api",
     })
-    getManagedSiteServiceSpy.mockResolvedValue(
-      mockService as ManagedSiteService,
-    )
-    getAccountByIdSpy.mockResolvedValue(
-      buildSiteAccount({ site_type: "sub2api" }),
-    )
-    mockFetchAccountTokens.mockResolvedValueOnce([]).mockResolvedValueOnce([])
-    resolveSub2ApiQuickCreateResolutionSpy
-      .mockResolvedValueOnce({
-        kind: "selection_required",
-        allowedGroups: ["default", "vip"],
-      })
-      .mockResolvedValueOnce({
-        kind: "selection_required",
-        allowedGroups: ["default", "vip"],
-      })
-
+    const sessionBAccount = buildDisplaySiteData({
+      id: "account-b",
+      name: "Account B",
+      siteType: "sub2api",
+    })
     const { result } = await renderChannelDialogHook()
 
-    await act(async () => {
-      await result.current.dialog.openSub2ApiTokenCreationDialog(
-        buildDisplaySiteData({ siteType: "sub2api" }),
-        {
-          onSuccess: vi.fn(),
-        },
-      )
+    act(() => {
+      result.current.context.openSub2ApiTokenDialog({
+        account: sessionAAccount,
+        allowedGroups: ["default"],
+        onSuccess: sessionAOnSuccess,
+      })
     })
 
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+    expect(result.current.context.sub2apiTokenDialog).toMatchObject({
+      isOpen: true,
+      account: sessionAAccount,
+      allowedGroups: ["default"],
+    })
 
     const sessionASuccessHandler =
       result.current.context.handleSub2ApiTokenSuccess
 
     act(() => {
       result.current.context.closeSub2ApiTokenDialog()
+      result.current.context.openSub2ApiTokenDialog({
+        account: sessionBAccount,
+        allowedGroups: ["vip"],
+        onSuccess: sessionBOnSuccess,
+      })
+      void sessionASuccessHandler(createdToken)
     })
 
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(false)
-
-    let openResult: Awaited<
-      ReturnType<typeof result.current.dialog.openWithAccount>
-    > | null = null
-    await act(async () => {
-      openResult = await result.current.dialog.openWithAccount(
-        buildDisplaySiteData({ siteType: "sub2api" }),
-        null,
-      )
+    expect(result.current.context.sub2apiTokenDialog).toMatchObject({
+      isOpen: true,
+      account: sessionBAccount,
+      allowedGroups: ["vip"],
     })
-
-    expect(openResult).toEqual({ opened: false, deferred: true })
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
     expect(result.current.context.state.isOpen).toBe(false)
-
-    await act(async () => {
-      await sessionASuccessHandler(createdToken)
-    })
-
-    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
-    expect(result.current.context.state.isOpen).toBe(false)
+    expect(sessionAOnSuccess).not.toHaveBeenCalled()
+    expect(sessionBOnSuccess).not.toHaveBeenCalled()
     expect(mockToastError).not.toHaveBeenCalled()
   })
 

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -938,14 +938,14 @@ describe("useChannelDialog", () => {
     const sessionASuccessHandler =
       result.current.context.handleSub2ApiTokenSuccess
 
-    act(() => {
+    await act(async () => {
       result.current.context.closeSub2ApiTokenDialog()
       result.current.context.openSub2ApiTokenDialog({
         account: sessionBAccount,
         allowedGroups: ["vip"],
         onSuccess: sessionBOnSuccess,
       })
-      void sessionASuccessHandler(createdToken)
+      await sessionASuccessHandler(createdToken)
     })
 
     expect(result.current.context.sub2apiTokenDialog).toMatchObject({

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -323,11 +323,13 @@ describe("useChannelDialog", () => {
       })
     })
 
+    let openResult: Awaited<typeof openPromise> | undefined
     await act(async () => {
       result.current.context.resolveDuplicateChannelWarning(false)
-      await openPromise
+      openResult = await openPromise
     })
 
+    expect(openResult).toEqual({ opened: false })
     expect(result.current.context.state.isOpen).toBe(false)
     expect(mockToastError).not.toHaveBeenCalled()
     expect(mockToastDismiss).toHaveBeenCalledWith("toast-id")
@@ -387,11 +389,13 @@ describe("useChannelDialog", () => {
       })
     })
 
+    let openResult: Awaited<typeof openPromise> | undefined
     await act(async () => {
       result.current.context.resolveDuplicateChannelWarning(true)
-      await openPromise
+      openResult = await openPromise
     })
 
+    expect(openResult).toEqual({ opened: true })
     expect(result.current.context.state).toMatchObject({
       isOpen: true,
       mode: DIALOG_MODES.ADD,

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -1357,6 +1357,56 @@ describe("useChannelDialog", () => {
     expect(result.current.context.state.isOpen).toBe(false)
   })
 
+  it("returns closed without opening when the caller continuation guard cancels before dialog open", async () => {
+    let releasePrepare: (() => void) | undefined
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) => {
+        await new Promise<void>((resolve) => {
+          releasePrepare = resolve
+        })
+
+        return buildPreparedFormData({
+          key: token.key,
+        })
+      },
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+
+    let shouldContinue = true
+    const { result } = await renderChannelDialogHook()
+
+    const openPromise = result.current.dialog.openWithAccount(
+      buildDisplaySiteData(),
+      buildApiToken(),
+      undefined,
+      {
+        shouldContinue: () => shouldContinue,
+      },
+    )
+
+    await waitFor(() => {
+      expect(prepareChannelFormDataMock).toHaveBeenCalledTimes(1)
+    })
+
+    shouldContinue = false
+
+    let openResult: Awaited<typeof openPromise> | undefined
+    await act(async () => {
+      releasePrepare?.()
+      openResult = await openPromise
+    })
+
+    expect(openResult).toEqual({ opened: false })
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(mockToastDismiss).toHaveBeenCalledWith("toast-id")
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
   it("shows a duplicate warning when opening from raw credentials and aborts on cancel", async () => {
     const existingChannel = buildManagedSiteChannel({
       key: "sk-credential",

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -844,6 +844,63 @@ describe("useChannelDialog", () => {
     expect(mockToastError).not.toHaveBeenCalled()
   })
 
+  it("ignores late Sub2API token success after the dialog was closed", async () => {
+    const createdToken = buildApiToken({
+      id: 11,
+      key: "sk-created-11",
+      name: "Created token",
+    })
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: "sub2api" }),
+    )
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = await renderChannelDialogHook()
+
+    let openResult: Awaited<
+      ReturnType<typeof result.current.dialog.openWithAccount>
+    > | null = null
+    await act(async () => {
+      openResult = await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: "sub2api" }),
+        null,
+      )
+    })
+
+    expect(openResult).toEqual({ opened: false, deferred: true })
+    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+
+    act(() => {
+      result.current.context.closeSub2ApiTokenDialog()
+    })
+
+    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(false)
+
+    await act(async () => {
+      await result.current.context.handleSub2ApiTokenSuccess(createdToken)
+    })
+
+    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
   it("fails closed when Sub2API token refetch cannot identify a single new token after dialog success", async () => {
     const existingToken = buildApiToken({
       id: 3,

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -1020,6 +1020,211 @@ describe("useChannelDialog", () => {
     )
   })
 
+  it("fails closed when Sub2API token refetch returns a non-array after dialog success", async () => {
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
+    )
+    mockFetchAccountTokens.mockResolvedValueOnce([]).mockResolvedValueOnce(null)
+    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: SITE_TYPES.SUB2API }),
+        null,
+      )
+    })
+
+    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+
+    await act(async () => {
+      await result.current.context.handleSub2ApiTokenSuccess()
+    })
+
+    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(mockToastError).toHaveBeenCalledWith(
+      "messages:accountOperations.createTokenFailed",
+    )
+  })
+
+  it("cancels deferred Sub2API resume before using a returned created token", async () => {
+    const createdToken = buildApiToken({
+      id: 11,
+      key: "sk-created-11",
+      name: "Created token",
+    })
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
+    )
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+    })
+
+    let shouldContinue = true
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: SITE_TYPES.SUB2API }),
+        null,
+        undefined,
+        { shouldContinue: () => shouldContinue },
+      )
+    })
+
+    shouldContinue = false
+
+    await act(async () => {
+      await result.current.context.handleSub2ApiTokenSuccess(createdToken)
+    })
+
+    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
+    expect(mockFetchAccountTokens).toHaveBeenCalledTimes(1)
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it("cancels deferred Sub2API resume before refetching tokens", async () => {
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
+    )
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+    })
+
+    let shouldContinueCalls = 0
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: SITE_TYPES.SUB2API }),
+        null,
+        undefined,
+        {
+          shouldContinue: () => {
+            shouldContinueCalls += 1
+            return shouldContinueCalls < 4
+          },
+        },
+      )
+    })
+
+    await act(async () => {
+      await result.current.context.handleSub2ApiTokenSuccess()
+    })
+
+    expect(mockFetchAccountTokens).toHaveBeenCalledTimes(1)
+    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it("cancels deferred Sub2API resume after refetching tokens but before recovery", async () => {
+    const existingToken = buildApiToken({
+      id: 3,
+      key: "sk-existing-3",
+      name: "Existing token",
+    })
+    const createdToken = buildApiToken({
+      id: 11,
+      key: "sk-created-11",
+      name: "Created token",
+    })
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
+    )
+    mockFetchAccountTokens
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([createdToken, existingToken])
+    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+    })
+
+    let shouldContinueCalls = 0
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: SITE_TYPES.SUB2API }),
+        null,
+        undefined,
+        {
+          shouldContinue: () => {
+            shouldContinueCalls += 1
+            return shouldContinueCalls < 5
+          },
+        },
+      )
+    })
+
+    await act(async () => {
+      await result.current.context.handleSub2ApiTokenSuccess()
+    })
+
+    expect(mockFetchAccountTokens).toHaveBeenCalledTimes(2)
+    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
   it("does not open the Sub2API quick-create dialog when tokens already exist", async () => {
     mockFetchAccountTokens.mockResolvedValueOnce([buildApiToken()])
 

--- a/tests/features/AccountManagement/components/AccountDialog.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialog.test.tsx
@@ -8,6 +8,7 @@ import {
   createEmptyAccountDialogDraft,
 } from "~/features/AccountManagement/components/AccountDialog/models"
 import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import { ACCOUNT_POST_SAVE_WORKFLOW_STEPS } from "~/services/accounts/accountPostSaveWorkflow"
 import { AuthTypeEnum } from "~/types"
 import { render, screen } from "~~/tests/test-utils/render"
 
@@ -94,7 +95,6 @@ const {
       managedSiteLabel: "",
       missingMessage: "",
     },
-    accountPostSaveWorkflowStep: "idle",
     postSaveOneTimeToken: null,
     postSaveSub2ApiAllowedGroups: null,
     postSaveSub2ApiAccount: null,
@@ -189,7 +189,7 @@ function resetMockState() {
       managedSiteLabel: "",
       missingMessage: "",
     },
-    accountPostSaveWorkflowStep: "idle",
+    accountPostSaveWorkflowStep: ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
     postSaveOneTimeToken: null,
     postSaveSub2ApiAllowedGroups: null,
     postSaveSub2ApiAccount: null,
@@ -269,7 +269,17 @@ vi.mock(
 
 describe("AccountDialog", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
+    vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
     resetMockState()
   })
 

--- a/tests/features/AccountManagement/components/AccountDialog.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialog.test.tsx
@@ -7,6 +7,7 @@ import {
   ACCOUNT_DIALOG_PHASES,
   createEmptyAccountDialogDraft,
 } from "~/features/AccountManagement/components/AccountDialog/models"
+import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import { AuthTypeEnum } from "~/types"
 import { render, screen } from "~~/tests/test-utils/render"
 
@@ -93,7 +94,12 @@ const {
       managedSiteLabel: "",
       missingMessage: "",
     },
-  },
+    accountPostSaveWorkflowStep: "idle",
+    postSaveOneTimeToken: null,
+    postSaveSub2ApiAllowedGroups: null,
+    postSaveSub2ApiAccount: null,
+    postSaveSub2ApiDialogSessionId: null,
+  } as any,
   mockSetters: {
     setSiteName: vi.fn(),
     setUsername: vi.fn(),
@@ -128,6 +134,10 @@ const {
     handleDuplicateAccountWarningContinue: vi.fn(),
     handleManagedSiteConfigPromptClose: vi.fn(),
     handleOpenManagedSiteSettings: vi.fn(),
+    handlePostSaveOneTimeTokenClose: vi.fn(),
+    handlePostSaveSub2ApiTokenDialogClose: vi.fn(),
+    handlePostSaveSub2ApiTokenCreated: vi.fn(),
+    getPostSaveSub2ApiDialogHandlers: vi.fn(),
   },
   mockCreateTag: vi.fn(),
   mockRenameTag: vi.fn(),
@@ -179,8 +189,53 @@ function resetMockState() {
       managedSiteLabel: "",
       missingMessage: "",
     },
+    accountPostSaveWorkflowStep: "idle",
+    postSaveOneTimeToken: null,
+    postSaveSub2ApiAllowedGroups: null,
+    postSaveSub2ApiAccount: null,
+    postSaveSub2ApiDialogSessionId: null,
   })
 }
+
+vi.mock("~/features/KeyManagement/components/AddTokenDialog", () => ({
+  default: (props: {
+    isOpen: boolean
+    preSelectedAccountId?: string
+    createPrefill?: Record<string, unknown>
+    prefillNotice?: string
+    showOneTimeKeyDialog?: boolean
+  }) => (
+    <div data-testid="post-save-add-token-dialog">
+      <div data-testid="post-save-add-token-open">{String(props.isOpen)}</div>
+      <div data-testid="post-save-add-token-account">
+        {props.preSelectedAccountId}
+      </div>
+      <div data-testid="post-save-add-token-prefill">
+        {JSON.stringify(props.createPrefill)}
+      </div>
+      <div data-testid="post-save-add-token-notice">{props.prefillNotice}</div>
+      <div data-testid="post-save-add-token-one-time">
+        {String(props.showOneTimeKeyDialog)}
+      </div>
+    </div>
+  ),
+}))
+
+vi.mock("~/features/KeyManagement/components/OneTimeApiKeyDialog", () => ({
+  OneTimeApiKeyDialog: (props: {
+    isOpen: boolean
+    token: { key?: string } | null
+  }) => (
+    <div data-testid="post-save-one-time-key-dialog">
+      <div data-testid="post-save-one-time-key-open">
+        {String(props.isOpen)}
+      </div>
+      <div data-testid="post-save-one-time-key-value">
+        {props.token?.key ?? ""}
+      </div>
+    </div>
+  ),
+}))
 
 vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
   useAccountDataContext: () => ({
@@ -214,6 +269,7 @@ vi.mock(
 
 describe("AccountDialog", () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     resetMockState()
   })
 
@@ -277,5 +333,104 @@ describe("AccountDialog", () => {
     expect(
       screen.queryByTestId("account-management-auth-type-trigger"),
     ).not.toBeInTheDocument()
+  })
+
+  it("renders the post-save Sub2API token dialog with default-token prefill", async () => {
+    mockState.postSaveSub2ApiAccount = {
+      id: "sub2-account-id",
+      name: "Sub2API",
+    }
+    mockState.postSaveSub2ApiAllowedGroups = ["vip", "default"]
+    mockState.postSaveSub2ApiDialogSessionId = 42
+    mockHandlers.getPostSaveSub2ApiDialogHandlers.mockReturnValue({
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    render(
+      <AccountDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.ADD}
+        onSuccess={vi.fn()}
+        onError={vi.fn()}
+      />,
+    )
+
+    expect(
+      await screen.findByTestId("post-save-add-token-dialog"),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("post-save-add-token-account")).toHaveTextContent(
+      "sub2-account-id",
+    )
+    expect(screen.getByTestId("post-save-add-token-prefill")).toHaveTextContent(
+      JSON.stringify({
+        modelId: "",
+        defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: "default",
+        allowedGroups: ["vip", "default"],
+      }),
+    )
+    expect(screen.getByTestId("post-save-add-token-notice")).toHaveTextContent(
+      "messages:sub2api.createRequiresGroupSelection",
+    )
+    expect(
+      screen.getByTestId("post-save-add-token-one-time"),
+    ).toHaveTextContent("false")
+    expect(mockHandlers.getPostSaveSub2ApiDialogHandlers).toHaveBeenCalledWith(
+      42,
+    )
+  })
+
+  it("prefills the first allowed Sub2API group when default is unavailable", async () => {
+    mockState.postSaveSub2ApiAccount = {
+      id: "sub2-account-id",
+      name: "Sub2API",
+    }
+    mockState.postSaveSub2ApiAllowedGroups = ["vip", "paid"]
+
+    render(
+      <AccountDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.ADD}
+        onSuccess={vi.fn()}
+        onError={vi.fn()}
+      />,
+    )
+
+    expect(
+      await screen.findByTestId("post-save-add-token-prefill"),
+    ).toHaveTextContent(
+      JSON.stringify({
+        modelId: "",
+        defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: "vip",
+        allowedGroups: ["vip", "paid"],
+      }),
+    )
+  })
+
+  it("renders the post-save one-time key dialog only when a token is pending", async () => {
+    mockState.postSaveOneTimeToken = {
+      key: "sk-one-time",
+    }
+
+    render(
+      <AccountDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.ADD}
+        onSuccess={vi.fn()}
+        onError={vi.fn()}
+      />,
+    )
+
+    expect(
+      await screen.findByTestId("post-save-one-time-key-open"),
+    ).toHaveTextContent("true")
+    expect(
+      screen.getByTestId("post-save-one-time-key-value"),
+    ).toHaveTextContent("sk-one-time")
   })
 })

--- a/tests/features/AccountManagement/components/AccountDialogActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogActionButtons.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { DIALOG_MODES } from "~/constants/dialogModes"
 import ActionButtons from "~/features/AccountManagement/components/AccountDialog/ActionButtons"
+import { ACCOUNT_POST_SAVE_WORKFLOW_STEPS } from "~/services/accounts/accountPostSaveWorkflow"
 import { render, screen } from "~~/tests/test-utils/render"
 
 describe("AccountDialog ActionButtons", () => {
@@ -20,6 +21,7 @@ describe("AccountDialog ActionButtons", () => {
     onClose: vi.fn(),
     onAutoConfig: vi.fn().mockResolvedValue(undefined),
     isAutoConfiguring: false,
+    accountPostSaveWorkflowStep: ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
     formId: "account-form",
   })
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -1444,6 +1444,144 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
   })
 
+  it("ignores stale boolean Sub2API token recovery results after the dialog closes", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Sub2API",
+      site_url: "https://sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 14,
+        username: "sub-user",
+        access_token: "sub-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+      token: "sub-token",
+      userId: 14,
+    })
+    const existingToken = buildToken({
+      id: 88,
+      key: "sk-sub2-existing",
+      group: "default",
+    })
+
+    let resolveFetchAccountTokens: ((value: ApiToken[]) => void) | null = null
+    const fetchAccountTokens = vi.fn(
+      () =>
+        new Promise<ApiToken[]>((resolve) => {
+          resolveFetchAccountTokens = resolve
+        }),
+    )
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    vi.spyOn(
+      apiServiceRequest,
+      "createDisplayAccountApiContext",
+    ).mockReturnValue({
+      service: {
+        fetchAccountTokens,
+      } as any,
+      request: { accountId: savedDisplayData.id } as any,
+    })
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+      existingTokenIds: [existingToken.id],
+    })
+
+    const onClose = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) =>
+        useAccountDialog({
+          mode: DIALOG_MODES.ADD,
+          isOpen,
+          onClose,
+          onSuccess: vi.fn(),
+        }),
+      {
+        initialProps: { isOpen: true },
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteName("Sub2API")
+      result.current.setters.setUsername("sub-user")
+      result.current.setters.setAccessToken("sub-token")
+      result.current.setters.setUserId("14")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
+    )
+
+    let recoverPromise: Promise<void> | undefined
+    await act(async () => {
+      recoverPromise =
+        result.current.handlers.handlePostSaveSub2ApiTokenCreated()
+    })
+
+    await waitFor(() => {
+      expect(fetchAccountTokens).toHaveBeenCalledWith({
+        accountId: savedDisplayData.id,
+      })
+    })
+
+    await act(async () => {
+      result.current.handlers.handleClose()
+    })
+
+    rerender({ isOpen: false })
+    rerender({ isOpen: true })
+
+    await waitFor(() => {
+      expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
+      )
+      expect(result.current.state.postSaveSub2ApiAllowedGroups).toBeNull()
+      expect(result.current.state.postSaveSub2ApiAccount).toBeNull()
+    })
+
+    await act(async () => {
+      resolveFetchAccountTokens?.([existingToken])
+      await recoverPromise
+    })
+
+    expect(mockOpenWithAccount).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "messages:accountOperations.createTokenFailed",
+    )
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "accountDialog:messages.newApiConfigFailed",
+    )
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
+    )
+  })
+
   it("marks the Sub2API paused workflow as failed when opening quick-config rejects after token creation", async () => {
     const savedSiteAccount = buildSiteAccount({
       id: "saved-account-id",

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -964,6 +964,91 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
   })
 
+  it("marks the AIHubMix paused workflow as failed when opening quick-config rejects after token acknowledgement", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "AIHubMix",
+      site_url: "https://aihubmix.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.AIHUBMIX,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 13,
+        username: "aihubmix-user",
+        access_token: "aihubmix-access-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "AIHubMix",
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+      token: "aihubmix-access-token",
+      userId: 13,
+    })
+    const oneTimeToken = buildToken({
+      id: 102,
+      key: "sk-aihubmix-one-time",
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: oneTimeToken,
+      created: true,
+      oneTimeSecret: true,
+    })
+    mockOpenWithAccount.mockRejectedValueOnce(
+      new Error("channel dialog failed"),
+    )
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://aihubmix.com")
+      result.current.setters.setSiteName("AIHubMix")
+      result.current.setters.setUsername("aihubmix-user")
+      result.current.setters.setAccessToken("aihubmix-access-token")
+      result.current.setters.setUserId("13")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.AIHUBMIX)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForOneTimeKeyAcknowledgement,
+    )
+
+    await expect(
+      act(async () => {
+        await result.current.handlers.handlePostSaveOneTimeTokenClose()
+      }),
+    ).resolves.toBeUndefined()
+
+    await waitFor(() => {
+      expect(result.current.state.postSaveOneTimeToken).toBeNull()
+      expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+      )
+      expect(toast.error).toHaveBeenCalledWith(
+        "accountDialog:messages.newApiConfigFailed",
+      )
+    })
+  })
+
   it("waits for Sub2API group token creation before opening quick-config", async () => {
     const savedSiteAccount = buildSiteAccount({
       id: "saved-account-id",
@@ -1048,6 +1133,92 @@ describe("useAccountDialog save and auto-config flows", () => {
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
     )
+  })
+
+  it("marks the Sub2API paused workflow as failed when opening quick-config rejects after token creation", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Sub2API",
+      site_url: "https://sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 14,
+        username: "sub-user",
+        access_token: "sub-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+      token: "sub-token",
+      userId: 14,
+    })
+    const createdToken = buildToken({
+      id: 103,
+      key: "sk-sub2-created",
+      group: "vip",
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+    mockOpenWithAccount.mockRejectedValueOnce(
+      new Error("channel dialog failed"),
+    )
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteName("Sub2API")
+      result.current.setters.setUsername("sub-user")
+      result.current.setters.setAccessToken("sub-token")
+      result.current.setters.setUserId("14")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
+    )
+
+    await expect(
+      act(async () => {
+        await result.current.handlers.handlePostSaveSub2ApiTokenCreated(
+          createdToken,
+        )
+      }),
+    ).resolves.toBeUndefined()
+
+    await waitFor(() => {
+      expect(result.current.state.postSaveSub2ApiAllowedGroups).toBeNull()
+      expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+      )
+      expect(toast.error).toHaveBeenCalledWith(
+        "accountDialog:messages.newApiConfigFailed",
+      )
+    })
   })
 
   it("clears Sub2API post-save workflow state when the dialog closes during group selection", async () => {

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -152,6 +152,7 @@ describe("useAccountDialog save and auto-config flows", () => {
       token: buildToken({ id: 99, key: "sk-default-ensured" }),
       created: false,
     })
+    mockOpenWithAccount.mockResolvedValue({ opened: true })
   })
 
   const renderAddHook = (options?: { onSuccess?: ReturnType<typeof vi.fn> }) =>
@@ -1430,6 +1431,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         onCompleted?: () => void,
       ) => {
         onCompleted?.()
+        return { opened: true }
       },
     )
 
@@ -1453,6 +1455,36 @@ describe("useAccountDialog save and auto-config flows", () => {
       expect.any(Function),
     )
     expect(onSuccess).toHaveBeenCalledWith(existingAccount)
+  })
+
+  it("does not mark direct auto-config complete when the channel dialog does not open", async () => {
+    const onSuccess = vi.fn()
+    const existingAccount = {
+      id: "existing-display-id",
+      siteUrl: "https://edit.example.com",
+      siteName: "Edit Example",
+    } as any
+
+    mockOpenWithAccount.mockResolvedValueOnce({ opened: false })
+
+    const { result } = renderEditHook({
+      account: existingAccount,
+      onSuccess,
+    })
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+    )
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
   })
 
   it("falls back to converted display data during auto-config when persisted display data is unavailable", async () => {
@@ -1753,6 +1785,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         onCompleted?: () => void,
       ) => {
         onCompleted?.()
+        return { opened: true }
       },
     )
 
@@ -1864,6 +1897,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         onCompleted?: () => void,
       ) => {
         onCompleted?.()
+        return { opened: true }
       },
     )
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -1811,6 +1811,216 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
   })
 
+  it("ignores stale AccountDialog-owned Sub2API dialog success after close and reopen", async () => {
+    const firstSavedSiteAccount = buildSiteAccount({
+      id: "first-account-id",
+      site_name: "First Sub2API",
+      site_url: "https://first-sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 21,
+        username: "first-user",
+        access_token: "first-token",
+      },
+    }) as SiteAccount
+    const secondSavedSiteAccount = buildSiteAccount({
+      id: "second-account-id",
+      site_name: "Second Sub2API",
+      site_url: "https://second-sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 22,
+        username: "second-user",
+        access_token: "second-token",
+      },
+    }) as SiteAccount
+    const firstDisplayData = buildDisplayAccount({
+      id: "first-account-id",
+      name: "First Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://first-sub2.example.com",
+      token: "first-token",
+      userId: 21,
+    })
+    const secondDisplayData = buildDisplayAccount({
+      id: "second-account-id",
+      name: "Second Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://second-sub2.example.com",
+      token: "second-token",
+      userId: 22,
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockImplementation(
+      async (accountId) => {
+        if (accountId === "first-account-id") {
+          return firstSavedSiteAccount
+        }
+        if (accountId === "second-account-id") {
+          return secondSavedSiteAccount
+        }
+        return null
+      },
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockImplementation(
+      async (accountId) => {
+        if (accountId === "first-account-id") {
+          return firstDisplayData
+        }
+        if (accountId === "second-account-id") {
+          return secondDisplayData
+        }
+        return null
+      },
+    )
+    mockValidateAndSaveAccount
+      .mockResolvedValueOnce({
+        success: true,
+        accountId: "first-account-id",
+        message: "Saved successfully",
+        feedbackLevel: "success",
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        accountId: "second-account-id",
+        message: "Saved successfully",
+        feedbackLevel: "success",
+      })
+    mockEnsureAccountTokenForPostSaveWorkflow
+      .mockResolvedValueOnce({
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+        allowedGroups: ["default", "vip"],
+      })
+      .mockResolvedValueOnce({
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+        allowedGroups: ["default", "vip"],
+      })
+
+    let resolveOpenWithAccount:
+      | ((value: Awaited<ReturnType<typeof mockOpenWithAccount>>) => void)
+      | null = null
+    mockOpenWithAccount.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveOpenWithAccount = resolve
+        }),
+    )
+
+    const onClose = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) =>
+        useAccountDialog({
+          mode: DIALOG_MODES.ADD,
+          isOpen,
+          onClose,
+          onSuccess: vi.fn(),
+        }),
+      {
+        initialProps: { isOpen: true },
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://first-sub2.example.com")
+      result.current.setters.setSiteName("First Sub2API")
+      result.current.setters.setUsername("first-user")
+      result.current.setters.setAccessToken("first-token")
+      result.current.setters.setUserId("21")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    const firstSessionId = result.current.state.postSaveSub2ApiDialogSessionId
+    expect(firstSessionId).not.toBeNull()
+    const firstDialogHandlers =
+      result.current.handlers.getPostSaveSub2ApiDialogHandlers(firstSessionId)
+
+    await act(async () => {
+      result.current.handlers.handleClose()
+    })
+
+    rerender({ isOpen: false })
+    rerender({ isOpen: true })
+
+    await waitFor(() => {
+      expect(result.current.state.url).toBe("")
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://second-sub2.example.com")
+      result.current.setters.setSiteName("Second Sub2API")
+      result.current.setters.setUsername("second-user")
+      result.current.setters.setAccessToken("second-token")
+      result.current.setters.setUserId("22")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    const secondSessionId = result.current.state.postSaveSub2ApiDialogSessionId
+    expect(secondSessionId).not.toBeNull()
+    expect(secondSessionId).not.toBe(firstSessionId)
+    const secondDialogHandlers =
+      result.current.handlers.getPostSaveSub2ApiDialogHandlers(secondSessionId)
+
+    const staleToken = buildToken({
+      id: 201,
+      key: "sk-stale-sub2",
+      group: "default",
+    })
+    await act(async () => {
+      await firstDialogHandlers.onSuccess(staleToken)
+    })
+
+    expect(mockOpenWithAccount).not.toHaveBeenCalled()
+
+    const currentToken = buildToken({
+      id: 202,
+      key: "sk-current-sub2",
+      group: "vip",
+    })
+    let resumePromise: Promise<void> | undefined
+    await act(async () => {
+      resumePromise = secondDialogHandlers.onSuccess(currentToken)
+      secondDialogHandlers.onClose()
+    })
+
+    expect(mockOpenWithAccount).toHaveBeenCalledTimes(1)
+    expect(mockOpenWithAccount).toHaveBeenCalledWith(
+      secondDisplayData,
+      currentToken,
+      expect.any(Function),
+    )
+
+    await act(async () => {
+      resolveOpenWithAccount?.({ opened: true })
+      await resumePromise
+    })
+
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+    )
+  })
+
   it("opens channel auto-config directly for an existing edit-mode account without saving again", async () => {
     const onSuccess = vi.fn()
     const existingAccount = {

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -802,6 +802,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       savedDisplayData,
       ensuredToken,
       expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
     )
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
@@ -884,6 +887,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       savedDisplayData,
       oneTimeToken,
       expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
     )
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
@@ -1252,6 +1258,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       savedDisplayData,
       createdToken,
       expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
     )
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
@@ -1351,6 +1360,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       savedDisplayData,
       createdToken,
       expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
     )
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
@@ -2009,6 +2021,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       secondDisplayData,
       currentToken,
       expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
     )
 
     await act(async () => {
@@ -2058,6 +2073,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       existingAccount,
       null,
       expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
     )
     expect(onSuccess).toHaveBeenCalledWith(existingAccount)
   })
@@ -2181,6 +2199,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       fallbackDisplayData,
       ensuredToken,
       expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
     )
     expect(mockOpenSub2ApiTokenCreationDialog).not.toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalledWith(
@@ -2307,6 +2328,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       savedDisplayData,
       ensuredToken,
       expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
     )
     expect(mockOpenSub2ApiTokenCreationDialog).not.toHaveBeenCalled()
   })
@@ -2609,6 +2633,204 @@ describe("useAccountDialog save and auto-config flows", () => {
       accountStorage.convertToDisplayData(secondSavedSiteAccount),
       secondEnsuredToken,
       expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
     )
+  })
+
+  it("cancels a stale channel-open continuation after close and does not retarget success to a reopened account", async () => {
+    const firstSavedSiteAccount = buildSiteAccount({
+      id: "first-account-id",
+      site_name: "First Example",
+      site_url: "https://first.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: "new-api",
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 31,
+        username: "first-user",
+        access_token: "first-token",
+      },
+    }) as SiteAccount
+    const secondSavedSiteAccount = buildSiteAccount({
+      id: "second-account-id",
+      site_name: "Second Example",
+      site_url: "https://second.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: "new-api",
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 32,
+        username: "second-user",
+        access_token: "second-token",
+      },
+    }) as SiteAccount
+
+    vi.spyOn(accountStorage, "getAccountById").mockImplementation(
+      async (accountId) => {
+        if (accountId === "first-account-id") return firstSavedSiteAccount
+        if (accountId === "second-account-id") return secondSavedSiteAccount
+        return null
+      },
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockImplementation(
+      async (accountId) => {
+        if (accountId === "first-account-id") {
+          return accountStorage.convertToDisplayData(firstSavedSiteAccount)
+        }
+        if (accountId === "second-account-id") {
+          return accountStorage.convertToDisplayData(secondSavedSiteAccount)
+        }
+        return null
+      },
+    )
+
+    mockValidateAndSaveAccount
+      .mockResolvedValueOnce({
+        success: true,
+        accountId: "first-account-id",
+        message: "Saved successfully",
+        feedbackLevel: "success",
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        accountId: "second-account-id",
+        message: "Saved successfully",
+        feedbackLevel: "success",
+      })
+
+    const firstEnsuredToken = buildToken({ id: 301, key: "sk-first-ensured" })
+    const secondEnsuredToken = buildToken({
+      id: 302,
+      key: "sk-second-ensured",
+    })
+    mockEnsureAccountTokenForPostSaveWorkflow
+      .mockResolvedValueOnce({
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+        token: firstEnsuredToken,
+        created: false,
+      })
+      .mockResolvedValueOnce({
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+        token: secondEnsuredToken,
+        created: false,
+      })
+
+    let firstShouldContinue: (() => boolean) | undefined
+    let firstOnCompleted: (() => void) | undefined
+    mockOpenWithAccount
+      .mockImplementationOnce(
+        async (
+          _displaySiteData: any,
+          _channelId: any,
+          onCompleted?: () => void,
+          options?: { shouldContinue?: () => boolean },
+        ) => {
+          firstOnCompleted = onCompleted
+          firstShouldContinue = options?.shouldContinue
+          return new Promise(() => {})
+        },
+      )
+      .mockImplementationOnce(
+        async (
+          _displaySiteData: any,
+          _channelId: any,
+          onCompleted?: () => void,
+        ) => {
+          onCompleted?.()
+          return { opened: true }
+        },
+      )
+
+    const onClose = vi.fn()
+    const onSuccess = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) =>
+        useAccountDialog({
+          mode: DIALOG_MODES.ADD,
+          isOpen,
+          onClose,
+          onSuccess,
+        }),
+      {
+        initialProps: { isOpen: true },
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://first.example.com")
+      result.current.setters.setSiteName("First Example")
+      result.current.setters.setUsername("first-user")
+      result.current.setters.setAccessToken("first-token")
+      result.current.setters.setUserId("31")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType("new-api")
+    })
+
+    await act(async () => {
+      void result.current.handlers.handleAutoConfig()
+    })
+
+    await waitFor(() => {
+      expect(mockOpenWithAccount).toHaveBeenCalledTimes(1)
+    })
+
+    expect(firstShouldContinue?.()).toBe(true)
+
+    await act(async () => {
+      result.current.handlers.handleClose()
+    })
+
+    expect(firstShouldContinue?.()).toBe(false)
+
+    rerender({ isOpen: false })
+    rerender({ isOpen: true })
+
+    await waitFor(() => {
+      expect(result.current.state.url).toBe("")
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://second.example.com")
+      result.current.setters.setSiteName("Second Example")
+      result.current.setters.setUsername("second-user")
+      result.current.setters.setAccessToken("second-token")
+      result.current.setters.setUserId("32")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType("new-api")
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(mockOpenWithAccount).toHaveBeenCalledTimes(2)
+    expect(mockOpenWithAccount).toHaveBeenNthCalledWith(
+      2,
+      accountStorage.convertToDisplayData(secondSavedSiteAccount),
+      secondEnsuredToken,
+      expect.any(Function),
+      expect.objectContaining({
+        shouldContinue: expect.any(Function),
+      }),
+    )
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onSuccess).toHaveBeenCalledWith("second-account-id")
+
+    await act(async () => {
+      firstOnCompleted?.()
+    })
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onSuccess).not.toHaveBeenCalledWith("first-account-id")
   })
 })

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -1882,6 +1882,40 @@ describe("useAccountDialog save and auto-config flows", () => {
     expect(toast.success).not.toHaveBeenCalled()
   })
 
+  it("keeps direct auto-config waiting when channel opening is deferred by a prerequisite dialog", async () => {
+    const onSuccess = vi.fn()
+    const existingAccount = {
+      id: "existing-display-id",
+      siteUrl: "https://edit.example.com",
+      siteName: "Edit Example",
+    } as any
+
+    mockOpenWithAccount.mockResolvedValueOnce({
+      opened: false,
+      deferred: true,
+    })
+
+    const { result } = renderEditHook({
+      account: existingAccount,
+      onSuccess,
+    })
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.OpeningManagedSiteDialog,
+    )
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
   it("falls back to converted display data during auto-config when persisted display data is unavailable", async () => {
     const savedSiteAccount = buildSiteAccount({
       id: "saved-account-id",

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -888,6 +888,82 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
   })
 
+  it("clears AIHubMix post-save workflow state when the dialog closes during one-time token acknowledgement", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "AIHubMix",
+      site_url: "https://aihubmix.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.AIHUBMIX,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 13,
+        username: "aihubmix-user",
+        access_token: "aihubmix-access-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "AIHubMix",
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+      token: "aihubmix-access-token",
+      userId: 13,
+    })
+    const oneTimeToken = buildToken({
+      id: 102,
+      key: "sk-aihubmix-one-time",
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: oneTimeToken,
+      created: true,
+      oneTimeSecret: true,
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://aihubmix.com")
+      result.current.setters.setSiteName("AIHubMix")
+      result.current.setters.setUsername("aihubmix-user")
+      result.current.setters.setAccessToken("aihubmix-access-token")
+      result.current.setters.setUserId("13")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.AIHUBMIX)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.postSaveOneTimeToken).toBe(oneTimeToken)
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForOneTimeKeyAcknowledgement,
+    )
+
+    await act(async () => {
+      result.current.handlers.handleClose()
+    })
+
+    expect(result.current.state.postSaveOneTimeToken).toBeNull()
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
+    )
+  })
+
   it("waits for Sub2API group token creation before opening quick-config", async () => {
     const savedSiteAccount = buildSiteAccount({
       id: "saved-account-id",
@@ -971,6 +1047,79 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+    )
+  })
+
+  it("clears Sub2API post-save workflow state when the dialog closes during group selection", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Sub2API",
+      site_url: "https://sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 14,
+        username: "sub-user",
+        access_token: "sub-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+      token: "sub-token",
+      userId: 14,
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteName("Sub2API")
+      result.current.setters.setUsername("sub-user")
+      result.current.setters.setAccessToken("sub-token")
+      result.current.setters.setUserId("14")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.postSaveSub2ApiAllowedGroups).toEqual([
+      "default",
+      "vip",
+    ])
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
+    )
+
+    await act(async () => {
+      result.current.handlers.handleClose()
+    })
+
+    expect(result.current.state.postSaveSub2ApiAllowedGroups).toBeNull()
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
     )
   })
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -1258,7 +1258,7 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
   })
 
-  it("resumes paused Sub2API quick-config after boolean token creation by refetching the latest token", async () => {
+  it("resumes paused Sub2API quick-config after boolean token creation by selecting the newly added token id", async () => {
     const savedSiteAccount = buildSiteAccount({
       id: "saved-account-id",
       site_name: "Sub2API",
@@ -1281,12 +1281,19 @@ describe("useAccountDialog save and auto-config flows", () => {
       token: "sub-token",
       userId: 14,
     })
-    const fetchedLatestToken = buildToken({
+    const existingToken = buildToken({
+      id: 88,
+      key: "sk-sub2-existing",
+      group: "default",
+    })
+    const createdToken = buildToken({
       id: 104,
       key: "sk-sub2-refetched",
       group: "vip",
     })
-    const fetchAccountTokens = vi.fn().mockResolvedValue([fetchedLatestToken])
+    const fetchAccountTokens = vi
+      .fn()
+      .mockResolvedValue([createdToken, existingToken])
 
     vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
       savedSiteAccount,
@@ -1306,6 +1313,7 @@ describe("useAccountDialog save and auto-config flows", () => {
     mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
       kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
       allowedGroups: ["default", "vip"],
+      existingTokenIds: [existingToken.id],
     })
 
     const { result } = renderAddHook()
@@ -1341,11 +1349,98 @@ describe("useAccountDialog save and auto-config flows", () => {
     })
     expect(mockOpenWithAccount).toHaveBeenCalledWith(
       savedDisplayData,
-      fetchedLatestToken,
+      createdToken,
       expect.any(Function),
     )
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+    )
+  })
+
+  it("fails closed when boolean Sub2API token creation refetch does not identify exactly one new token", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Sub2API",
+      site_url: "https://sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 14,
+        username: "sub-user",
+        access_token: "sub-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+      token: "sub-token",
+      userId: 14,
+    })
+    const existingToken = buildToken({
+      id: 88,
+      key: "sk-sub2-existing",
+      group: "default",
+    })
+    const fetchAccountTokens = vi
+      .fn()
+      .mockResolvedValueOnce([existingToken])
+      .mockResolvedValueOnce([existingToken])
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    vi.spyOn(
+      apiServiceRequest,
+      "createDisplayAccountApiContext",
+    ).mockReturnValue({
+      service: {
+        fetchAccountTokens,
+      } as any,
+      request: { accountId: savedDisplayData.id } as any,
+    })
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+      existingTokenIds: [existingToken.id],
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteName("Sub2API")
+      result.current.setters.setUsername("sub-user")
+      result.current.setters.setAccessToken("sub-token")
+      result.current.setters.setUserId("14")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    await act(async () => {
+      await result.current.handlers.handlePostSaveSub2ApiTokenCreated()
+    })
+
+    expect(mockOpenWithAccount).not.toHaveBeenCalled()
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
+    )
+    expect(toast.error).toHaveBeenCalledWith(
+      "messages:accountOperations.createTokenFailed",
     )
   })
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -5,8 +5,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DIALOG_MODES } from "~/constants/dialogModes"
 import { SITE_TYPES } from "~/constants/siteType"
 import { useAccountDialog } from "~/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog"
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_STEPS,
+  ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
+} from "~/services/accounts/accountPostSaveWorkflow"
 import { accountStorage } from "~/services/accounts/accountStorage"
-import { AuthTypeEnum, SiteAccount, SiteHealthStatus } from "~/types"
+import {
+  AuthTypeEnum,
+  SiteAccount,
+  SiteHealthStatus,
+  type ApiToken,
+  type DisplaySiteData,
+} from "~/types"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
@@ -14,6 +24,7 @@ const {
   mockToast,
   mockValidateAndSaveAccount,
   mockValidateAndUpdateAccount,
+  mockEnsureAccountTokenForPostSaveWorkflow,
   mockOpenWithAccount,
   mockOpenSub2ApiTokenCreationDialog,
   mockGetManagedSiteConfig,
@@ -22,6 +33,7 @@ const {
   mockToast: vi.fn(),
   mockValidateAndSaveAccount: vi.fn(),
   mockValidateAndUpdateAccount: vi.fn(),
+  mockEnsureAccountTokenForPostSaveWorkflow: vi.fn(),
   mockOpenWithAccount: vi.fn(),
   mockOpenSub2ApiTokenCreationDialog: vi.fn(),
   mockGetManagedSiteConfig: vi.fn(),
@@ -62,6 +74,22 @@ vi.mock("~/services/accounts/accountOperations", async (importOriginal) => {
     validateAndUpdateAccount: mockValidateAndUpdateAccount,
   }
 })
+
+vi.mock(
+  "~/services/accounts/accountPostSaveWorkflow",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/accounts/accountPostSaveWorkflow")
+      >()
+
+    return {
+      ...actual,
+      ensureAccountTokenForPostSaveWorkflow:
+        mockEnsureAccountTokenForPostSaveWorkflow,
+    }
+  },
+)
 
 vi.mock(
   "~/services/managedSites/managedSiteService",
@@ -119,6 +147,11 @@ describe("useAccountDialog save and auto-config flows", () => {
       success: true,
       feedbackLevel: "success",
     })
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: buildToken({ id: 99, key: "sk-default-ensured" }),
+      created: false,
+    })
   })
 
   const renderAddHook = (options?: { onSuccess?: ReturnType<typeof vi.fn> }) =>
@@ -153,6 +186,43 @@ describe("useAccountDialog save and auto-config flows", () => {
       }),
     )
   }
+
+  const buildDisplayAccount = (
+    overrides: Partial<DisplaySiteData> = {},
+  ): DisplaySiteData =>
+    ({
+      id: "saved-account-id",
+      name: "Saved Example",
+      username: "saved-user",
+      balance: { USD: 0, CNY: 0 },
+      todayConsumption: { USD: 0, CNY: 0 },
+      todayIncome: { USD: 0, CNY: 0 },
+      todayTokens: { upload: 0, download: 0 },
+      health: { status: SiteHealthStatus.Healthy },
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://api.example.com",
+      token: "saved-token",
+      userId: 12,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: { enableDetection: false },
+      cookieAuthSessionCookie: "",
+      ...overrides,
+    }) as DisplaySiteData
+
+  const buildToken = (overrides: Partial<ApiToken> = {}): ApiToken => ({
+    id: 1,
+    user_id: 12,
+    key: "sk-ensured",
+    status: 1,
+    name: "ensured",
+    created_time: 1,
+    accessed_time: 1,
+    expired_time: -1,
+    remain_quota: -1,
+    unlimited_quota: true,
+    used_quota: 0,
+    ...overrides,
+  })
 
   it("shows managed-site setup guidance before saving when auto-config prerequisites are missing", async () => {
     mockGetManagedSiteConfig.mockResolvedValue(null)
@@ -252,6 +322,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         refreshToken: "refresh-token",
         tokenExpiresAt: 123456789,
       },
+      { skipAutoProvisionKeyOnAccountAdd: false },
     )
     expect(mockOpenSub2ApiTokenCreationDialog).toHaveBeenCalledWith(
       savedDisplayData,
@@ -298,6 +369,7 @@ describe("useAccountDialog save and auto-config flows", () => {
       "",
       false,
       undefined,
+      { skipAutoProvisionKeyOnAccountAdd: false },
     )
   })
 
@@ -651,6 +723,257 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
   })
 
+  it("new-account quick-config saves without background key provisioning and opens with the ensured token", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Example",
+      site_url: "https://api.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.NEW_API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 12,
+        username: "saved-user",
+        access_token: "saved-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount()
+    const ensuredToken = buildToken({ id: 101, key: "sk-ready" })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: ensuredToken,
+      created: false,
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://api.example.com")
+      result.current.setters.setSiteName("Example")
+      result.current.setters.setUsername("saved-user")
+      result.current.setters.setAccessToken("saved-token")
+      result.current.setters.setUserId("12")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.NEW_API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(mockValidateAndSaveAccount).toHaveBeenCalledWith(
+      "https://api.example.com",
+      "Example",
+      "saved-user",
+      "saved-token",
+      "12",
+      "7",
+      "",
+      [],
+      expect.any(Object),
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+      "",
+      false,
+      undefined,
+      { skipAutoProvisionKeyOnAccountAdd: true },
+    )
+    expect(mockEnsureAccountTokenForPostSaveWorkflow).toHaveBeenCalledWith({
+      account: savedSiteAccount,
+      displaySiteData: savedDisplayData,
+    })
+    expect(mockOpenWithAccount).toHaveBeenCalledWith(
+      savedDisplayData,
+      ensuredToken,
+      expect.any(Function),
+    )
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+    )
+  })
+
+  it("waits for AIHubMix one-time token acknowledgement before opening quick-config", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "AIHubMix",
+      site_url: "https://aihubmix.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.AIHUBMIX,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 13,
+        username: "aihubmix-user",
+        access_token: "aihubmix-access-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "AIHubMix",
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+      token: "aihubmix-access-token",
+      userId: 13,
+    })
+    const oneTimeToken = buildToken({
+      id: 102,
+      key: "sk-aihubmix-one-time",
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: oneTimeToken,
+      created: true,
+      oneTimeSecret: true,
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://aihubmix.com")
+      result.current.setters.setSiteName("AIHubMix")
+      result.current.setters.setUsername("aihubmix-user")
+      result.current.setters.setAccessToken("aihubmix-access-token")
+      result.current.setters.setUserId("13")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.AIHUBMIX)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.postSaveOneTimeToken).toBe(oneTimeToken)
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForOneTimeKeyAcknowledgement,
+    )
+    expect(mockOpenWithAccount).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await result.current.handlers.handlePostSaveOneTimeTokenClose()
+    })
+
+    expect(result.current.state.postSaveOneTimeToken).toBeNull()
+    expect(mockOpenWithAccount).toHaveBeenCalledWith(
+      savedDisplayData,
+      oneTimeToken,
+      expect.any(Function),
+    )
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+    )
+  })
+
+  it("waits for Sub2API group token creation before opening quick-config", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Sub2API",
+      site_url: "https://sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 14,
+        username: "sub-user",
+        access_token: "sub-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+      token: "sub-token",
+      userId: 14,
+    })
+    const createdToken = buildToken({
+      id: 103,
+      key: "sk-sub2-created",
+      group: "vip",
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteName("Sub2API")
+      result.current.setters.setUsername("sub-user")
+      result.current.setters.setAccessToken("sub-token")
+      result.current.setters.setUserId("14")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.postSaveSub2ApiAllowedGroups).toEqual([
+      "default",
+      "vip",
+    ])
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
+    )
+    expect(mockOpenWithAccount).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await result.current.handlers.handlePostSaveSub2ApiTokenCreated(
+        createdToken,
+      )
+    })
+
+    expect(result.current.state.postSaveSub2ApiAllowedGroups).toBeNull()
+    expect(mockOpenWithAccount).toHaveBeenCalledWith(
+      savedDisplayData,
+      createdToken,
+      expect.any(Function),
+    )
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+    )
+  })
+
   it("opens channel auto-config directly for an existing edit-mode account without saving again", async () => {
     const onSuccess = vi.fn()
     const existingAccount = {
@@ -715,6 +1038,12 @@ describe("useAccountDialog save and auto-config flows", () => {
 
     const fallbackDisplayData =
       accountStorage.convertToDisplayData(savedSiteAccount)
+    const ensuredToken = buildToken({ id: 104, key: "sk-fallback-ensured" })
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: ensuredToken,
+      created: false,
+    })
 
     const { result } = renderAddHook()
 
@@ -738,7 +1067,7 @@ describe("useAccountDialog save and auto-config flows", () => {
 
     expect(mockOpenWithAccount).toHaveBeenCalledWith(
       fallbackDisplayData,
-      null,
+      ensuredToken,
       expect.any(Function),
     )
     expect(mockOpenSub2ApiTokenCreationDialog).not.toHaveBeenCalled()
@@ -835,6 +1164,12 @@ describe("useAccountDialog save and auto-config flows", () => {
     vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
       savedDisplayData,
     )
+    const ensuredToken = buildToken({ id: 105, key: "sk-sub2-ensured" })
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: ensuredToken,
+      created: false,
+    })
 
     const { result } = renderAddHook()
 
@@ -858,7 +1193,7 @@ describe("useAccountDialog save and auto-config flows", () => {
 
     expect(mockOpenWithAccount).toHaveBeenCalledWith(
       savedDisplayData,
-      null,
+      ensuredToken,
       expect.any(Function),
     )
     expect(mockOpenSub2ApiTokenCreationDialog).not.toHaveBeenCalled()
@@ -1068,6 +1403,19 @@ describe("useAccountDialog save and auto-config flows", () => {
         message: "Saved successfully",
         feedbackLevel: "success",
       })
+    const firstEnsuredToken = buildToken({ id: 106, key: "sk-first-ensured" })
+    const secondEnsuredToken = buildToken({ id: 107, key: "sk-second-ensured" })
+    mockEnsureAccountTokenForPostSaveWorkflow
+      .mockResolvedValueOnce({
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+        token: firstEnsuredToken,
+        created: false,
+      })
+      .mockResolvedValueOnce({
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+        token: secondEnsuredToken,
+        created: false,
+      })
     mockOpenWithAccount.mockImplementation(
       async (
         _displaySiteData: any,
@@ -1145,7 +1493,7 @@ describe("useAccountDialog save and auto-config flows", () => {
     expect(getDisplayDataByIdSpy).toHaveBeenCalledWith("second-account-id")
     expect(mockOpenWithAccount).toHaveBeenLastCalledWith(
       accountStorage.convertToDisplayData(secondSavedSiteAccount),
-      null,
+      secondEnsuredToken,
       expect.any(Function),
     )
   })

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -10,6 +10,7 @@ import {
   ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
 } from "~/services/accounts/accountPostSaveWorkflow"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import * as apiServiceRequest from "~/services/accounts/utils/apiServiceRequest"
 import {
   AuthTypeEnum,
   SiteAccount,
@@ -1257,6 +1258,97 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
   })
 
+  it("resumes paused Sub2API quick-config after boolean token creation by refetching the latest token", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Sub2API",
+      site_url: "https://sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 14,
+        username: "sub-user",
+        access_token: "sub-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+      token: "sub-token",
+      userId: 14,
+    })
+    const fetchedLatestToken = buildToken({
+      id: 104,
+      key: "sk-sub2-refetched",
+      group: "vip",
+    })
+    const fetchAccountTokens = vi.fn().mockResolvedValue([fetchedLatestToken])
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    vi.spyOn(
+      apiServiceRequest,
+      "createDisplayAccountApiContext",
+    ).mockReturnValue({
+      service: {
+        fetchAccountTokens,
+      } as any,
+      request: { accountId: savedDisplayData.id } as any,
+    })
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteName("Sub2API")
+      result.current.setters.setUsername("sub-user")
+      result.current.setters.setAccessToken("sub-token")
+      result.current.setters.setUserId("14")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
+    )
+
+    await act(async () => {
+      await result.current.handlers.handlePostSaveSub2ApiTokenCreated()
+    })
+
+    expect(fetchAccountTokens).toHaveBeenCalledWith({
+      accountId: savedDisplayData.id,
+    })
+    expect(mockOpenWithAccount).toHaveBeenCalledWith(
+      savedDisplayData,
+      fetchedLatestToken,
+      expect.any(Function),
+    )
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Completed,
+    )
+  })
+
   it("marks the Sub2API paused workflow as failed when opening quick-config rejects after token creation", async () => {
     const savedSiteAccount = buildSiteAccount({
       id: "saved-account-id",
@@ -1410,6 +1502,76 @@ describe("useAccountDialog save and auto-config flows", () => {
       result.current.handlers.handleClose()
     })
 
+    expect(result.current.state.postSaveSub2ApiAllowedGroups).toBeNull()
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
+    )
+  })
+
+  it("returns Sub2API group selection to idle when the token dialog closes without creating a token", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "Sub2API",
+      site_url: "https://sub2.example.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.SUB2API,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 14,
+        username: "sub-user",
+        access_token: "sub-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+      token: "sub-token",
+      userId: 14,
+    })
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteName("Sub2API")
+      result.current.setters.setUsername("sub-user")
+      result.current.setters.setAccessToken("sub-token")
+      result.current.setters.setUserId("14")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleAutoConfig()
+    })
+
+    expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+      ACCOUNT_POST_SAVE_WORKFLOW_STEPS.WaitingForSub2ApiGroupSelection,
+    )
+
+    await act(async () => {
+      await result.current.handlers.handlePostSaveSub2ApiTokenDialogClose()
+    })
+
+    expect(mockOpenWithAccount).not.toHaveBeenCalled()
     expect(result.current.state.postSaveSub2ApiAllowedGroups).toBeNull()
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -964,6 +964,127 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
   })
 
+  it("does not restore AIHubMix paused post-save state when a pending token check resolves after close and reopen", async () => {
+    const savedSiteAccount = buildSiteAccount({
+      id: "saved-account-id",
+      site_name: "AIHubMix",
+      site_url: "https://aihubmix.com",
+      health: { status: SiteHealthStatus.Healthy },
+      site_type: SITE_TYPES.AIHUBMIX,
+      exchange_rate: 7,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        ...buildSiteAccount().account_info,
+        id: 13,
+        username: "aihubmix-user",
+        access_token: "aihubmix-access-token",
+      },
+    }) as SiteAccount
+    const savedDisplayData = buildDisplayAccount({
+      name: "AIHubMix",
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+      token: "aihubmix-access-token",
+      userId: 13,
+    })
+    const oneTimeToken = buildToken({
+      id: 108,
+      key: "sk-aihubmix-stale-one-time",
+    })
+
+    let resolveEnsureAccountToken:
+      | ((
+          value: Awaited<
+            ReturnType<typeof mockEnsureAccountTokenForPostSaveWorkflow>
+          >,
+        ) => void)
+      | null = null
+
+    vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
+      savedSiteAccount,
+    )
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
+      savedDisplayData,
+    )
+    mockEnsureAccountTokenForPostSaveWorkflow.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveEnsureAccountToken = resolve
+        }),
+    )
+
+    const onClose = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) =>
+        useAccountDialog({
+          mode: DIALOG_MODES.ADD,
+          isOpen,
+          onClose,
+          onSuccess: vi.fn(),
+        }),
+      {
+        initialProps: { isOpen: true },
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://aihubmix.com")
+      result.current.setters.setSiteName("AIHubMix")
+      result.current.setters.setUsername("aihubmix-user")
+      result.current.setters.setAccessToken("aihubmix-access-token")
+      result.current.setters.setUserId("13")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType(SITE_TYPES.AIHUBMIX)
+    })
+
+    let autoConfigPromise: Promise<void> | undefined
+
+    await act(async () => {
+      autoConfigPromise = result.current.handlers.handleAutoConfig()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.CheckingToken,
+      )
+    })
+
+    await act(async () => {
+      result.current.handlers.handleClose()
+    })
+
+    rerender({ isOpen: false })
+    rerender({ isOpen: true })
+
+    await waitFor(() => {
+      expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
+      )
+      expect(result.current.state.postSaveOneTimeToken).toBeNull()
+    })
+
+    await act(async () => {
+      resolveEnsureAccountToken?.({
+        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+        token: oneTimeToken,
+        created: true,
+        oneTimeSecret: true,
+      })
+      await autoConfigPromise
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.accountPostSaveWorkflowStep).toBe(
+        ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Idle,
+      )
+      expect(result.current.state.postSaveOneTimeToken).toBeNull()
+    })
+  })
+
   it("marks the AIHubMix paused workflow as failed when opening quick-config rejects after token acknowledgement", async () => {
     const savedSiteAccount = buildSiteAccount({
       id: "saved-account-id",

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -63,6 +63,12 @@ const CHECK_IN_DISABLED: CheckInConfig = {
   },
 }
 
+const flushMicrotasks = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 describe("accountOperations validateAndSaveAccount", () => {
   beforeEach(async () => {
     vi.clearAllMocks()
@@ -432,7 +438,7 @@ describe("accountOperations validateAndSaveAccount", () => {
     expect(fetchAccountDataMock).not.toHaveBeenCalled()
   })
 
-  it("skips background auto-provisioning when requested by a foreground workflow", async () => {
+  it("skips background auto-provisioning after refreshed save when requested by a foreground workflow", async () => {
     vi.spyOn(userPreferences, "getPreferences").mockResolvedValueOnce({
       ...DEFAULT_PREFERENCES,
       autoProvisionKeyOnAccountAdd: true,
@@ -468,6 +474,93 @@ describe("accountOperations validateAndSaveAccount", () => {
     )
 
     expect(result.success).toBe(true)
+    await flushMicrotasks()
     expect(ensureDefaultApiTokenForAccountMock).not.toHaveBeenCalled()
+  })
+
+  it("skips background auto-provisioning after fallback save when requested by a foreground workflow", async () => {
+    vi.spyOn(userPreferences, "getPreferences").mockResolvedValueOnce({
+      ...DEFAULT_PREFERENCES,
+      autoProvisionKeyOnAccountAdd: true,
+      showTodayCashflow: false,
+    })
+    fetchAccountDataMock.mockRejectedValueOnce(new Error("quota fetch failed"))
+
+    const result = await validateAndSaveAccount(
+      "https://api.example.com",
+      "Example",
+      "user",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+      undefined,
+      false,
+      undefined,
+      { skipAutoProvisionKeyOnAccountAdd: true },
+    )
+
+    expect(result).toMatchObject({
+      success: true,
+      message: "messages:warnings.accountSavedWithoutDataRefresh",
+      feedbackLevel: "warning",
+    })
+    await flushMicrotasks()
+    expect(ensureDefaultApiTokenForAccountMock).not.toHaveBeenCalled()
+  })
+
+  it("runs background auto-provisioning after save when preference is enabled", async () => {
+    vi.spyOn(userPreferences, "getPreferences").mockResolvedValueOnce({
+      ...DEFAULT_PREFERENCES,
+      autoProvisionKeyOnAccountAdd: true,
+      showTodayCashflow: false,
+    })
+    fetchAccountDataMock.mockResolvedValueOnce({
+      quota: 12,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+      checkIn: CHECK_IN_DISABLED,
+    })
+    ensureDefaultApiTokenForAccountMock.mockResolvedValueOnce({
+      created: true,
+    })
+
+    const result = await validateAndSaveAccount(
+      "https://api.example.com",
+      "Example",
+      "user",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result.success).toBe(true)
+    await flushMicrotasks()
+    expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledTimes(1)
+    expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({
+          site_name: "Example",
+        }),
+        displaySiteData: expect.objectContaining({
+          name: "Example",
+          baseUrl: "https://api.example.com",
+        }),
+      }),
+    )
   })
 })

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -431,4 +431,43 @@ describe("accountOperations validateAndSaveAccount", () => {
     })
     expect(fetchAccountDataMock).not.toHaveBeenCalled()
   })
+
+  it("skips background auto-provisioning when requested by a foreground workflow", async () => {
+    vi.spyOn(userPreferences, "getPreferences").mockResolvedValueOnce({
+      ...DEFAULT_PREFERENCES,
+      autoProvisionKeyOnAccountAdd: true,
+      showTodayCashflow: false,
+    })
+    fetchAccountDataMock.mockResolvedValueOnce({
+      quota: 12,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+      checkIn: CHECK_IN_DISABLED,
+    })
+
+    const result = await validateAndSaveAccount(
+      "https://api.example.com",
+      "Example",
+      "user",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+      undefined,
+      false,
+      undefined,
+      { skipAutoProvisionKeyOnAccountAdd: true },
+    )
+
+    expect(result.success).toBe(true)
+    expect(ensureDefaultApiTokenForAccountMock).not.toHaveBeenCalled()
+  })
 })

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -120,7 +120,8 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     const account = buildStoredAccount(displayAccount)
     const createdToken = buildToken({ id: 6, key: "sk-created" })
     fetchAccountTokensMock.mockResolvedValueOnce([])
-    createApiTokenMock.mockResolvedValueOnce(createdToken)
+    createApiTokenMock.mockResolvedValueOnce(true)
+    fetchAccountTokensMock.mockResolvedValueOnce([createdToken])
 
     await expect(
       ensureAccountTokenForPostSaveWorkflow({
@@ -143,7 +144,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
         group: "",
       }),
     )
-    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
   })
 
   it("creates an AIHubMix token and marks the full secret as one-time", async () => {
@@ -228,7 +229,8 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     const createdToken = buildToken({ id: 9, key: "sk-sub2", group: "vip" })
     fetchAccountTokensMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
-    createApiTokenMock.mockResolvedValueOnce(createdToken)
+    createApiTokenMock.mockResolvedValueOnce(true)
+    fetchAccountTokensMock.mockResolvedValueOnce([createdToken])
 
     await expect(
       ensureAccountTokenForPostSaveWorkflow({
@@ -245,6 +247,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       expect.anything(),
       expect.objectContaining({ group: "vip" }),
     )
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
   })
 
   it("requires Sub2API group selection when multiple current groups exist", async () => {

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES,
+  ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
+  ensureAccountTokenForPostSaveWorkflow,
+} from "~/services/accounts/accountPostSaveWorkflow"
+import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
+import { buildSiteAccount } from "~~/tests/test-utils/factories"
+
+const { fetchAccountTokensMock, createApiTokenMock, fetchUserGroupsMock } =
+  vi.hoisted(() => ({
+    fetchAccountTokensMock: vi.fn(),
+    createApiTokenMock: vi.fn(),
+    fetchUserGroupsMock: vi.fn(),
+  }))
+
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => ({
+      fetchAccountTokens: (...args: unknown[]) =>
+        fetchAccountTokensMock(...args),
+      createApiToken: (...args: unknown[]) => createApiTokenMock(...args),
+      fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
+    })),
+  }
+})
+
+const buildToken = (overrides: Partial<ApiToken> = {}): ApiToken => ({
+  id: 1,
+  user_id: 7,
+  key: "sk-existing",
+  status: 1,
+  name: "existing",
+  created_time: 1,
+  accessed_time: 1,
+  expired_time: -1,
+  remain_quota: -1,
+  unlimited_quota: true,
+  used_quota: 0,
+  ...overrides,
+})
+
+const buildDisplayAccount = (
+  overrides: Partial<DisplaySiteData> = {},
+): DisplaySiteData =>
+  ({
+    id: "account-id",
+    name: "Account",
+    username: "user",
+    balance: { USD: 0, CNY: 0 },
+    todayConsumption: { USD: 0, CNY: 0 },
+    todayIncome: { USD: 0, CNY: 0 },
+    todayTokens: { upload: 0, download: 0 },
+    health: { status: "healthy" },
+    siteType: SITE_TYPES.NEW_API,
+    baseUrl: "https://api.example.com",
+    token: "access-token",
+    userId: 7,
+    authType: AuthTypeEnum.AccessToken,
+    checkIn: { enableDetection: false },
+    cookieAuthSessionCookie: "",
+    ...overrides,
+  }) as DisplaySiteData
+
+const buildStoredAccount = (
+  displayAccount: DisplaySiteData = buildDisplayAccount(),
+) =>
+  buildSiteAccount({
+    id: displayAccount.id,
+    site_name: displayAccount.name,
+    site_url: displayAccount.baseUrl,
+    site_type: displayAccount.siteType,
+    authType: displayAccount.authType,
+    account_info: {
+      id: displayAccount.userId,
+      access_token: displayAccount.token,
+      username: displayAccount.username,
+      quota: 0,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+    },
+  })
+
+describe("ensureAccountTokenForPostSaveWorkflow", () => {
+  beforeEach(() => {
+    fetchAccountTokensMock.mockReset()
+    createApiTokenMock.mockReset()
+    fetchUserGroupsMock.mockReset()
+  })
+
+  it("returns a ready result when the account already has a token", async () => {
+    const displayAccount = buildDisplayAccount()
+    const account = buildStoredAccount(displayAccount)
+    const existingToken = buildToken({ id: 5, key: "sk-ready" })
+    fetchAccountTokensMock.mockResolvedValueOnce([existingToken])
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: existingToken,
+      created: false,
+    })
+    expect(createApiTokenMock).not.toHaveBeenCalled()
+  })
+
+  it("creates a default token for ordinary accounts without existing tokens", async () => {
+    const displayAccount = buildDisplayAccount()
+    const account = buildStoredAccount(displayAccount)
+    const createdToken = buildToken({ id: 6, key: "sk-created" })
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: false,
+    })
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: displayAccount.baseUrl,
+        accountId: displayAccount.id,
+      }),
+      expect.objectContaining({
+        name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: "",
+      }),
+    )
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("creates an AIHubMix token and marks the full secret as one-time", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+      token: "aihubmix-access-token",
+    })
+    const account = buildStoredAccount(displayAccount)
+    const createdToken = buildToken({
+      id: 7,
+      key: "sk-aihubmix-full-secret",
+      name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+    })
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: true,
+    })
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("blocks AIHubMix when creation does not return a usable full secret", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(true)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+      message: "messages:aihubmix.createRequiresOneTimeKeyDialog",
+    })
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("blocks AIHubMix when creation returns a masked key", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(
+      buildToken({ id: 8, key: "sk-***masked***" }),
+    )
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toMatchObject({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+    })
+  })
+
+  it("creates a Sub2API token directly when one current group exists", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    const createdToken = buildToken({ id: 9, key: "sk-sub2", group: "vip" })
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: false,
+    })
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ group: "vip" }),
+    )
+  })
+
+  it("requires Sub2API group selection when multiple current groups exist", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { ratio: 1 },
+      vip: { ratio: 2 },
+    })
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+    expect(createApiTokenMock).not.toHaveBeenCalled()
+  })
+
+  it("blocks Sub2API when no current group is available", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({})
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+      message: "messages:sub2api.createRequiresAvailableGroup",
+    })
+  })
+})

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -176,6 +176,32 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
   })
 
+  it("returns ready for an existing AIHubMix token with a full secret", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    const existingToken = buildToken({
+      id: 8,
+      key: "sk-aihubmix-existing-full-secret",
+    })
+    fetchAccountTokensMock.mockResolvedValueOnce([existingToken])
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: existingToken,
+      created: false,
+    })
+    expect(createApiTokenMock).not.toHaveBeenCalled()
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
   it("blocks AIHubMix when an existing inventory token has a masked key", async () => {
     const displayAccount = buildDisplayAccount({
       siteType: SITE_TYPES.AIHUBMIX,

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -132,6 +132,22 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     ).toBeNull()
   })
 
+  it("ignores malformed token entries when selecting a token by id diff", () => {
+    const createdToken = buildToken({ id: 11, key: "sk-created-11" })
+
+    expect(
+      selectSingleNewApiTokenByIdDiff({
+        existingTokenIds: [3],
+        tokens: [
+          null,
+          { id: "bad-token-id", key: "sk-invalid" },
+          buildToken({ id: 3 }),
+          createdToken,
+        ],
+      }),
+    ).toEqual(createdToken)
+  })
+
   it("returns a ready result when the account already has a token", async () => {
     const displayAccount = buildDisplayAccount()
     const account = buildStoredAccount(displayAccount)

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -219,6 +219,25 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
   })
 
+  it("blocks ordinary token creation when the create request returns a falsy result", async () => {
+    const displayAccount = buildDisplayAccount()
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(false)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+      message: "messages:accountOperations.createTokenFailed",
+    })
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
   it("creates an AIHubMix token and marks the full secret as one-time", async () => {
     const displayAccount = buildDisplayAccount({
       siteType: SITE_TYPES.AIHUBMIX,

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -176,6 +176,30 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
   })
 
+  it("blocks AIHubMix when an existing inventory token has a masked key", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.AIHUBMIX,
+      baseUrl: "https://aihubmix.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([
+      buildToken({ id: 8, key: "sk-***masked***" }),
+    ])
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+      message: "messages:aihubmix.createRequiresOneTimeKeyDialog",
+    })
+    expect(createApiTokenMock).not.toHaveBeenCalled()
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
   it("blocks AIHubMix when creation does not return a usable full secret", async () => {
     const displayAccount = buildDisplayAccount({
       siteType: SITE_TYPES.AIHUBMIX,

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -6,6 +6,7 @@ import {
   ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES,
   ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
   ensureAccountTokenForPostSaveWorkflow,
+  selectSingleNewApiTokenByIdDiff,
 } from "~/services/accounts/accountPostSaveWorkflow"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
@@ -94,6 +95,41 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     fetchAccountTokensMock.mockReset()
     createApiTokenMock.mockReset()
     fetchUserGroupsMock.mockReset()
+  })
+
+  it("selects the single newly created token by id diff even when it is not the last refetched token", () => {
+    const existingTokens = [
+      buildToken({ id: 3, key: "sk-existing-3" }),
+      buildToken({ id: 8, key: "sk-existing-8" }),
+    ]
+    const createdToken = buildToken({ id: 11, key: "sk-created-11" })
+
+    expect(
+      selectSingleNewApiTokenByIdDiff({
+        existingTokenIds: existingTokens.map((token) => token.id),
+        tokens: [createdToken, existingTokens[1], existingTokens[0]],
+      }),
+    ).toEqual(createdToken)
+  })
+
+  it("returns null when token id diff is ambiguous or empty", () => {
+    const existingTokenIds = [3, 8]
+    const createdTokenA = buildToken({ id: 11, key: "sk-created-11" })
+    const createdTokenB = buildToken({ id: 12, key: "sk-created-12" })
+
+    expect(
+      selectSingleNewApiTokenByIdDiff({
+        existingTokenIds,
+        tokens: [buildToken({ id: 3 }), buildToken({ id: 8 })],
+      }),
+    ).toBeNull()
+
+    expect(
+      selectSingleNewApiTokenByIdDiff({
+        existingTokenIds,
+        tokens: [createdTokenA, createdTokenB, buildToken({ id: 8 })],
+      }),
+    ).toBeNull()
   })
 
   it("returns a ready result when the account already has a token", async () => {
@@ -320,6 +356,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     ).resolves.toEqual({
       kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
       allowedGroups: ["default", "vip"],
+      existingTokenIds: [],
     })
     expect(createApiTokenMock).not.toHaveBeenCalled()
   })

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -199,6 +199,26 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
   })
 
+  it("blocks ordinary token creation when create succeeds but refetch cannot identify the new token", async () => {
+    const displayAccount = buildDisplayAccount()
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(true)
+    fetchAccountTokensMock.mockResolvedValueOnce([null])
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+      message: "messages:accountOperations.createTokenFailed",
+    })
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
+  })
+
   it("creates an AIHubMix token and marks the full secret as one-time", async () => {
     const displayAccount = buildDisplayAccount({
       siteType: SITE_TYPES.AIHUBMIX,
@@ -396,5 +416,29 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
       message: "messages:sub2api.createRequiresAvailableGroup",
     })
+  })
+
+  it("blocks Sub2API when single-group token creation cannot recover the created token", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
+    createApiTokenMock.mockResolvedValueOnce(true)
+    fetchAccountTokensMock.mockResolvedValueOnce(null)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+      message: "messages:accountOperations.createTokenFailed",
+    })
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post-save account workflow to ensure API tokens, handle one-time-key acknowledgement and group-selection, then continue into managed-site setup; option to skip background auto-provisioning and clearer open-result outcomes.

* **UI / Reliability**
  * Token and dialog flows are session-aware and more resilient to stale callbacks, cancellation, and duplicate-warning branches.

* **Localization**
  * Added workflow status messages in English, Japanese, Simplified Chinese, and Traditional Chinese.

* **Documentation & Tests**
  * New design docs and extensive unit/integration tests covering workflow, token scenarios, and dialog/session behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/812)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->