### PR TITLE
fix: Prevent content API check UI from triggering page shortcuts

### DIFF
--- a/src/entrypoints/content/shared/ContentReactRoot.tsx
+++ b/src/entrypoints/content/shared/ContentReactRoot.tsx
@@ -15,6 +15,12 @@ import { RedemptionToaster } from "../redemptionAssist/components/RedemptionToas
  */
 const logger = createLogger("ContentReactRoot")
 
+const stopHostPageKeyboardShortcuts = (
+  event: React.KeyboardEvent<HTMLDivElement>,
+) => {
+  event.stopPropagation()
+}
+
 export const ContentReactRoot: React.FC = () => {
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light")
 
@@ -65,7 +71,12 @@ export const ContentReactRoot: React.FC = () => {
     resolvedTheme === "dark" ? "dark text-foreground bg-background" : ""
 
   return (
-    <div className={wrapperClassName}>
+    <div
+      className={wrapperClassName}
+      onKeyDown={stopHostPageKeyboardShortcuts}
+      onKeyPress={stopHostPageKeyboardShortcuts}
+      onKeyUp={stopHostPageKeyboardShortcuts}
+    >
       <ApiCheckModalHost />
       <RedemptionToaster />
     </div>

--- a/src/entrypoints/content/shared/ContentReactRoot.tsx
+++ b/src/entrypoints/content/shared/ContentReactRoot.tsx
@@ -74,7 +74,6 @@ export const ContentReactRoot: React.FC = () => {
     <div
       className={wrapperClassName}
       onKeyDown={stopHostPageKeyboardShortcuts}
-      onKeyPress={stopHostPageKeyboardShortcuts}
       onKeyUp={stopHostPageKeyboardShortcuts}
     >
       <ApiCheckModalHost />

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
@@ -1,5 +1,12 @@
 import { XMarkIcon } from "@heroicons/react/24/outline"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react"
 import toast from "react-hot-toast/headless"
 import { useTranslation } from "react-i18next"
 
@@ -65,6 +72,14 @@ const contentApiCheckAnalyticsScope = {
   surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.ContentApiCheckModal,
   entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Content,
 } as const
+
+const stopHostPageKeyboardShortcuts = (
+  event: ReactKeyboardEvent<HTMLElement>,
+) => {
+  event.stopPropagation()
+}
+
+const KEYBOARD_EVENTS_TO_CONTAIN = ["keydown", "keypress", "keyup"] as const
 
 /**
  * Classifies the modal opening source without carrying page content.
@@ -141,6 +156,9 @@ export function ApiCheckModalHost() {
   const lastAutoFetchKeyRef = useRef<string | null>(null)
   const fetchModelsRequestIdRef = useRef(0)
   const hasSignaledHostReadyRef = useRef(false)
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const backdropRef = useRef<HTMLDivElement | null>(null)
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
 
   /**
    * Radix popovers (used by `SearchableSelect`) portal to `document.body` by default.
@@ -200,6 +218,63 @@ export function ApiCheckModalHost() {
     setFetchModelsError(null)
     setValidationError(null)
   }, [apiType])
+
+  useEffect(() => {
+    if (!isOpen) return
+    dialogRef.current?.focus({ preventScroll: true })
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const stopKeyboardShortcut = (event: KeyboardEvent) => {
+      const target = event.target
+      if (target instanceof Node && dialogRef.current?.contains(target)) {
+        event.stopImmediatePropagation()
+      }
+    }
+    const stopWheel = (event: WheelEvent) => {
+      event.stopPropagation()
+    }
+    const stopBackgroundWheel = (event: WheelEvent) => {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    const documentElement = document.documentElement
+    const body = document.body
+    const previousDocumentOverflow = documentElement.style.overflow
+    const previousBodyOverflow = body.style.overflow
+
+    const dialog = dialogRef.current
+    const backdrop = backdropRef.current
+    const scrollContainer = scrollContainerRef.current
+
+    KEYBOARD_EVENTS_TO_CONTAIN.forEach((eventName) => {
+      document.addEventListener(eventName, stopKeyboardShortcut, {
+        capture: true,
+      })
+    })
+    documentElement.style.overflow = "hidden"
+    body.style.overflow = "hidden"
+    dialog?.addEventListener("wheel", stopBackgroundWheel, { passive: false })
+    backdrop?.addEventListener("wheel", stopBackgroundWheel, {
+      passive: false,
+    })
+    scrollContainer?.addEventListener("wheel", stopWheel, { passive: false })
+
+    return () => {
+      KEYBOARD_EVENTS_TO_CONTAIN.forEach((eventName) => {
+        document.removeEventListener(eventName, stopKeyboardShortcut, {
+          capture: true,
+        })
+      })
+      documentElement.style.overflow = previousDocumentOverflow
+      body.style.overflow = previousBodyOverflow
+      dialog?.removeEventListener("wheel", stopBackgroundWheel)
+      backdrop?.removeEventListener("wheel", stopBackgroundWheel)
+      scrollContainer?.removeEventListener("wheel", stopWheel)
+    }
+  }, [isOpen])
 
   useEffect(() => {
     const handleOpen = (event: Event) => {
@@ -743,15 +818,29 @@ export function ApiCheckModalHost() {
         className="pointer-events-auto"
       />
       <div
+        ref={backdropRef}
         className="pointer-events-auto absolute inset-0 bg-black/40"
         onClick={close}
       />
 
       <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-3">
-        <div className="border-border bg-background pointer-events-auto max-h-[90vh] w-full max-w-[860px] overflow-hidden rounded-lg border shadow-xl">
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="api-check-modal-title"
+          tabIndex={-1}
+          className="border-border bg-background pointer-events-auto max-h-[90vh] w-full max-w-[860px] overflow-hidden rounded-lg border shadow-xl"
+          onKeyDown={stopHostPageKeyboardShortcuts}
+          onKeyPress={stopHostPageKeyboardShortcuts}
+          onKeyUp={stopHostPageKeyboardShortcuts}
+        >
           <div className="border-border flex items-start justify-between gap-3 border-b p-4">
             <div className="min-w-0">
-              <div className="text-foreground text-base font-semibold">
+              <div
+                id="api-check-modal-title"
+                className="text-foreground text-base font-semibold"
+              >
                 {t("webAiApiCheck:modal.title")}
               </div>
               <div className="text-muted-foreground truncate text-xs">
@@ -769,7 +858,10 @@ export function ApiCheckModalHost() {
             </IconButton>
           </div>
 
-          <div className="max-h-[calc(90vh-64px)] overflow-y-auto p-4">
+          <div
+            ref={scrollContainerRef}
+            className="max-h-[calc(90vh-64px)] overflow-y-auto overscroll-contain p-4"
+          >
             <div className="space-y-4">
               <div className="space-y-2">
                 <div className="text-foreground text-sm font-medium">

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
@@ -79,7 +79,7 @@ const stopHostPageKeyboardShortcuts = (
   event.stopPropagation()
 }
 
-const KEYBOARD_EVENTS_TO_CONTAIN = ["keydown", "keypress", "keyup"] as const
+const KEYBOARD_EVENTS_TO_CONTAIN = ["keydown", "keyup"] as const
 
 /**
  * Classifies the modal opening source without carrying page content.
@@ -832,7 +832,6 @@ export function ApiCheckModalHost() {
           tabIndex={-1}
           className="border-border bg-background pointer-events-auto max-h-[90vh] w-full max-w-[860px] overflow-hidden rounded-lg border shadow-xl"
           onKeyDown={stopHostPageKeyboardShortcuts}
-          onKeyPress={stopHostPageKeyboardShortcuts}
           onKeyUp={stopHostPageKeyboardShortcuts}
         >
           <div className="border-border flex items-start justify-between gap-3 border-b p-4">

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -249,20 +249,28 @@ describe("ApiCheckModalHost", () => {
 
   it("locks host page scrolling while open and restores previous overflow styles after close", async () => {
     const user = userEvent.setup()
+    const previousHtmlOverflow = document.documentElement.style.overflow
+    const previousBodyOverflow = document.body.style.overflow
+
     document.documentElement.style.overflow = "visible"
     document.body.style.overflow = "auto"
 
-    await openModal()
+    try {
+      await openModal()
 
-    expect(document.documentElement.style.overflow).toBe("hidden")
-    expect(document.body.style.overflow).toBe("hidden")
+      expect(document.documentElement.style.overflow).toBe("hidden")
+      expect(document.body.style.overflow).toBe("hidden")
 
-    await user.click(
-      screen.getByRole("button", { name: "common:actions.close" }),
-    )
+      await user.click(
+        screen.getByRole("button", { name: "common:actions.close" }),
+      )
 
-    expect(document.documentElement.style.overflow).toBe("visible")
-    expect(document.body.style.overflow).toBe("auto")
+      expect(document.documentElement.style.overflow).toBe("visible")
+      expect(document.body.style.overflow).toBe("auto")
+    } finally {
+      document.documentElement.style.overflow = previousHtmlOverflow
+      document.body.style.overflow = previousBodyOverflow
+    }
   })
 
   it("dispatches a dismissed close event when closed before any fetch or probe result", async () => {

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -134,6 +134,83 @@ describe("ApiCheckModalHost", () => {
     expect(apiKeyInput.value).toBe("")
   })
 
+  it("focuses the modal when opened so page shortcuts no longer use the previously focused page element", async () => {
+    const pageInput = document.createElement("input")
+    pageInput.setAttribute("aria-label", "Host page input")
+    document.body.appendChild(pageInput)
+    pageInput.focus()
+
+    await openModal()
+
+    const dialog = await screen.findByRole("dialog")
+
+    expect(dialog).toHaveFocus()
+    expect(document.activeElement).not.toBe(pageInput)
+
+    pageInput.remove()
+  })
+
+  it("contains keyboard and wheel events inside the open modal", async () => {
+    await openModal()
+
+    const dialog = await screen.findByRole("dialog")
+    const hostPageKeyDown = vi.fn()
+    const hostPageWheel = vi.fn()
+    window.addEventListener("keydown", hostPageKeyDown)
+    window.addEventListener("wheel", hostPageWheel)
+
+    dialog.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "j", bubbles: true }),
+    )
+    const wheelEvent = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 100,
+    })
+    dialog.dispatchEvent(wheelEvent)
+
+    expect(hostPageKeyDown).not.toHaveBeenCalled()
+    expect(hostPageWheel).not.toHaveBeenCalled()
+    expect(wheelEvent.defaultPrevented).toBe(true)
+
+    window.removeEventListener("keydown", hostPageKeyDown)
+    window.removeEventListener("wheel", hostPageWheel)
+  })
+
+  it("blocks host page capture-phase shortcuts while the modal itself is focused", async () => {
+    await openModal()
+
+    const dialog = await screen.findByRole("dialog")
+    const hostPageCaptureShortcut = vi.fn()
+    document.addEventListener("keydown", hostPageCaptureShortcut, true)
+
+    dialog.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "k", bubbles: true }),
+    )
+
+    expect(hostPageCaptureShortcut).not.toHaveBeenCalled()
+
+    document.removeEventListener("keydown", hostPageCaptureShortcut, true)
+  })
+
+  it("locks host page scrolling while open and restores previous overflow styles after close", async () => {
+    const user = userEvent.setup()
+    document.documentElement.style.overflow = "visible"
+    document.body.style.overflow = "auto"
+
+    await openModal()
+
+    expect(document.documentElement.style.overflow).toBe("hidden")
+    expect(document.body.style.overflow).toBe("hidden")
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.close" }),
+    )
+
+    expect(document.documentElement.style.overflow).toBe("visible")
+    expect(document.body.style.overflow).toBe("auto")
+  })
+
   it("dispatches a dismissed close event when closed before any fetch or probe result", async () => {
     const user = userEvent.setup()
     const closedDetailPromise = new Promise<any>((resolve) => {

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -155,12 +155,17 @@ describe("ApiCheckModalHost", () => {
 
     const dialog = await screen.findByRole("dialog")
     const hostPageKeyDown = vi.fn()
+    const hostPageKeyUp = vi.fn()
     const hostPageWheel = vi.fn()
     window.addEventListener("keydown", hostPageKeyDown)
+    window.addEventListener("keyup", hostPageKeyUp)
     window.addEventListener("wheel", hostPageWheel)
 
     dialog.dispatchEvent(
       new KeyboardEvent("keydown", { key: "j", bubbles: true }),
+    )
+    dialog.dispatchEvent(
+      new KeyboardEvent("keyup", { key: "j", bubbles: true }),
     )
     const wheelEvent = new WheelEvent("wheel", {
       bubbles: true,
@@ -170,11 +175,35 @@ describe("ApiCheckModalHost", () => {
     dialog.dispatchEvent(wheelEvent)
 
     expect(hostPageKeyDown).not.toHaveBeenCalled()
+    expect(hostPageKeyUp).not.toHaveBeenCalled()
     expect(hostPageWheel).not.toHaveBeenCalled()
     expect(wheelEvent.defaultPrevented).toBe(true)
 
     window.removeEventListener("keydown", hostPageKeyDown)
+    window.removeEventListener("keyup", hostPageKeyUp)
     window.removeEventListener("wheel", hostPageWheel)
+  })
+
+  it("allows modal fields to receive keyboard input while host page shortcuts are blocked", async () => {
+    const user = userEvent.setup()
+    await openModal()
+
+    const hostPageKeyDown = vi.fn()
+    const hostPageKeyUp = vi.fn()
+    window.addEventListener("keydown", hostPageKeyDown)
+    window.addEventListener("keyup", hostPageKeyUp)
+
+    const baseUrlInput = screen.getByPlaceholderText(
+      "https://example.com/api",
+    ) as HTMLInputElement
+    await user.type(baseUrlInput, "https://api.example.com")
+
+    expect(baseUrlInput.value).toBe("https://api.example.com")
+    expect(hostPageKeyDown).not.toHaveBeenCalled()
+    expect(hostPageKeyUp).not.toHaveBeenCalled()
+
+    window.removeEventListener("keydown", hostPageKeyDown)
+    window.removeEventListener("keyup", hostPageKeyUp)
   })
 
   it("blocks host page capture-phase shortcuts while the modal itself is focused", async () => {
@@ -191,6 +220,31 @@ describe("ApiCheckModalHost", () => {
     expect(hostPageCaptureShortcut).not.toHaveBeenCalled()
 
     document.removeEventListener("keydown", hostPageCaptureShortcut, true)
+  })
+
+  it("allows wheel events inside the scrollable modal body without scrolling the host page", async () => {
+    await openModal()
+
+    const sourceTextInput = screen.getByPlaceholderText(
+      "webAiApiCheck:modal.sourceText.placeholder",
+    )
+    const scrollContainer = sourceTextInput.closest(".overflow-y-auto")
+    expect(scrollContainer).not.toBeNull()
+
+    const hostPageWheel = vi.fn()
+    window.addEventListener("wheel", hostPageWheel)
+
+    const wheelEvent = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 100,
+    })
+    scrollContainer?.dispatchEvent(wheelEvent)
+
+    expect(hostPageWheel).not.toHaveBeenCalled()
+    expect(wheelEvent.defaultPrevented).toBe(false)
+
+    window.removeEventListener("wheel", hostPageWheel)
   })
 
   it("locks host page scrolling while open and restores previous overflow styles after close", async () => {

--- a/tests/entrypoints/content/shared/ContentReactRoot.test.tsx
+++ b/tests/entrypoints/content/shared/ContentReactRoot.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 type MatchMediaListener = (event: MediaQueryListEvent) => void
@@ -26,7 +27,9 @@ vi.mock("~/utils/core/logger", () => ({
 vi.mock(
   "~/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost",
   () => ({
-    ApiCheckModalHost: () => <div data-testid="api-check-modal-host" />,
+    ApiCheckModalHost: () => (
+      <input aria-label="API credential" data-testid="api-check-modal-host" />
+    ),
   }),
 )
 
@@ -169,5 +172,43 @@ describe("ContentReactRoot", () => {
     })
 
     expect(container.firstChild).not.toHaveClass("dark")
+  })
+
+  it("stops content UI keyboard events from reaching host page shortcut listeners", async () => {
+    const user = userEvent.setup()
+    const media = createMatchMediaController(false)
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => media.queryList),
+    )
+    getPreferencesMock.mockResolvedValue({ themeMode: "light" })
+    const hostPageKeyDown = vi.fn()
+    const hostPageKeyPress = vi.fn()
+    const hostPageKeyUp = vi.fn()
+    window.addEventListener("keydown", hostPageKeyDown)
+    window.addEventListener("keypress", hostPageKeyPress)
+    window.addEventListener("keyup", hostPageKeyUp)
+
+    const { ContentReactRoot } = await import(
+      "~/entrypoints/content/shared/ContentReactRoot"
+    )
+
+    render(<ContentReactRoot />)
+
+    const input = screen.getByRole("textbox", {
+      name: "API credential",
+    }) as HTMLInputElement
+
+    input.focus()
+    await user.keyboard("a")
+
+    expect(input.value).toBe("a")
+    expect(hostPageKeyDown).not.toHaveBeenCalled()
+    expect(hostPageKeyPress).not.toHaveBeenCalled()
+    expect(hostPageKeyUp).not.toHaveBeenCalled()
+
+    window.removeEventListener("keydown", hostPageKeyDown)
+    window.removeEventListener("keypress", hostPageKeyPress)
+    window.removeEventListener("keyup", hostPageKeyUp)
   })
 })

--- a/tests/entrypoints/content/shared/ContentReactRoot.test.tsx
+++ b/tests/entrypoints/content/shared/ContentReactRoot.test.tsx
@@ -183,10 +183,8 @@ describe("ContentReactRoot", () => {
     )
     getPreferencesMock.mockResolvedValue({ themeMode: "light" })
     const hostPageKeyDown = vi.fn()
-    const hostPageKeyPress = vi.fn()
     const hostPageKeyUp = vi.fn()
     window.addEventListener("keydown", hostPageKeyDown)
-    window.addEventListener("keypress", hostPageKeyPress)
     window.addEventListener("keyup", hostPageKeyUp)
 
     const { ContentReactRoot } = await import(
@@ -204,11 +202,9 @@ describe("ContentReactRoot", () => {
 
     expect(input.value).toBe("a")
     expect(hostPageKeyDown).not.toHaveBeenCalled()
-    expect(hostPageKeyPress).not.toHaveBeenCalled()
     expect(hostPageKeyUp).not.toHaveBeenCalled()
 
     window.removeEventListener("keydown", hostPageKeyDown)
-    window.removeEventListener("keypress", hostPageKeyPress)
     window.removeEventListener("keyup", hostPageKeyUp)
   })
 })

--- a/tests/entrypoints/options/pages/UsageAnalytics/UsageAnalyticsCharts.test.tsx
+++ b/tests/entrypoints/options/pages/UsageAnalytics/UsageAnalyticsCharts.test.tsx
@@ -299,10 +299,11 @@ describe("UsageAnalytics charts", () => {
     render(<UsageAnalytics />)
     await screen.findByText("usageAnalytics:charts.dailyOverview.title")
 
-    const dailyInstance = echartsInstances[0]
+    let dailyInstance: (typeof echartsInstances)[number] | undefined
     let legendSelectHandler: ((event: unknown) => void) | undefined
 
     await waitFor(() => {
+      dailyInstance = echartsInstances[0]
       legendSelectHandler = dailyInstance?.on.mock.calls.find(
         ([eventName]) => eventName === "legendselectchanged",
       )?.[1] as ((event: unknown) => void) | undefined


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Isolated keyboard handling in the React root to prevent host-page shortcuts from firing while interacting with in-app UI.
  * Modal improvements: keyboard isolation, auto-focus, and prevention of background scrolling while open.
  * Contained scroll/wheel events inside modals to avoid affecting the host page.

* **Tests**
  * Added/extended tests covering modal accessibility, focus behavior, keyboard/wheel event isolation, and scroll-lock behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->