### PR TITLE
test(e2e): ensure extension build freshness before Playwright runs

### DIFF
--- a/e2e/accountToApiProfileJourney.spec.ts
+++ b/e2e/accountToApiProfileJourney.spec.ts
@@ -205,6 +205,9 @@ test("adds an account, creates a reusable API profile from its key, and verifies
   installExtensionPageGuards(keysPage)
   await waitForExtensionRoot(keysPage)
   await expect(keysPage).toHaveURL(new RegExp(`accountId=${accountId}#keys$`))
+  await expect(
+    keysPage.getByTestId(getKeyManagementTokenRowTestId(42)),
+  ).toBeVisible()
 
   await keysPage.getByTestId(KEY_MANAGEMENT_TEST_IDS.addTokenButton).click()
   await expect(keysPage.locator("#tokenName")).toBeVisible()

--- a/e2e/e2e-build-inputs.json
+++ b/e2e/e2e-build-inputs.json
@@ -1,0 +1,16 @@
+[
+  "src",
+  "public",
+  "e2e/utils/e2eBuildMetadata.ts",
+  "e2e/utils/extension.ts",
+  "scripts/e2e-build.mjs",
+  "e2e/e2e-build-inputs.json",
+  "package.json",
+  "pnpm-lock.yaml",
+  "tsconfig.json",
+  "wxt.config.ts",
+  "postcss.config.js",
+  "tailwind.config.js",
+  ".env",
+  ".env.local"
+]

--- a/e2e/setup/build.setup.ts
+++ b/e2e/setup/build.setup.ts
@@ -1,0 +1,20 @@
+import { execFileSync } from "node:child_process"
+import path from "node:path"
+import { test as setup } from "@playwright/test"
+
+import { isE2eBuildCurrent } from "~~/e2e/utils/e2eBuildMetadata"
+
+setup("build extension for e2e", async () => {
+  if (process.env.AAH_SKIP_E2E_BUILD === "1") {
+    setup.skip(true, "AAH_SKIP_E2E_BUILD=1")
+  }
+
+  if (await isE2eBuildCurrent(path.resolve(".output", "chrome-mv3-test"))) {
+    return
+  }
+
+  execFileSync(process.execPath, [path.join("scripts", "e2e-build.mjs")], {
+    cwd: process.cwd(),
+    stdio: "inherit",
+  })
+})

--- a/e2e/setup/build.setup.ts
+++ b/e2e/setup/build.setup.ts
@@ -1,20 +1,32 @@
 import { execFileSync } from "node:child_process"
 import path from "node:path"
+import { fileURLToPath } from "node:url"
 import { test as setup } from "@playwright/test"
 
 import { isE2eBuildCurrent } from "~~/e2e/utils/e2eBuildMetadata"
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+)
+const extensionDir = path.join(rootDir, ".output", "chrome-mv3-test")
 
 setup("build extension for e2e", async () => {
   if (process.env.AAH_SKIP_E2E_BUILD === "1") {
     setup.skip(true, "AAH_SKIP_E2E_BUILD=1")
   }
 
-  if (await isE2eBuildCurrent(path.resolve(".output", "chrome-mv3-test"))) {
+  if (await isE2eBuildCurrent(extensionDir, { cwd: rootDir })) {
     return
   }
 
-  execFileSync(process.execPath, [path.join("scripts", "e2e-build.mjs")], {
-    cwd: process.cwd(),
-    stdio: "inherit",
-  })
+  execFileSync(
+    process.execPath,
+    [path.join(rootDir, "scripts", "e2e-build.mjs")],
+    {
+      cwd: rootDir,
+      stdio: "inherit",
+    },
+  )
 })

--- a/e2e/utils/e2eBuildMetadata.ts
+++ b/e2e/utils/e2eBuildMetadata.ts
@@ -169,9 +169,12 @@ async function readE2eBuildMetadata(
       parsed.version !== 1 ||
       typeof parsed.gitHead !== "string" ||
       typeof parsed.inputHash !== "string" ||
-      !Array.isArray(parsed.inputPaths)
+      !Array.isArray(parsed.inputPaths) ||
+      parsed.inputPaths.some((item) => typeof item !== "string")
     ) {
-      throw new Error("metadata is missing required fields")
+      throw new Error(
+        "metadata is missing required fields or inputPaths must contain only strings",
+      )
     }
 
     return parsed as E2eBuildMetadata

--- a/e2e/utils/e2eBuildMetadata.ts
+++ b/e2e/utils/e2eBuildMetadata.ts
@@ -1,0 +1,274 @@
+import { execFile } from "node:child_process"
+import crypto from "node:crypto"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+const E2E_BUILD_METADATA_FILE = ".aah-e2e-build.json"
+
+const IGNORED_DIRECTORY_NAMES = new Set(["node_modules", ".git", ".output"])
+
+type E2eBuildMetadata = {
+  version: 1
+  gitHead: string
+  inputHash: string
+  inputPaths: string[]
+  builtAt: string
+}
+
+type E2eBuildMetadataSnapshot = Pick<
+  E2eBuildMetadata,
+  "gitHead" | "inputHash" | "inputPaths"
+>
+
+type E2eBuildMetadataOptions = {
+  cwd?: string
+  inputPaths?: readonly string[]
+}
+
+export async function createE2eBuildMetadata(
+  options: E2eBuildMetadataOptions = {},
+): Promise<E2eBuildMetadata> {
+  const snapshot = await createE2eBuildMetadataSnapshot(options)
+
+  return {
+    version: 1,
+    ...snapshot,
+    builtAt: new Date().toISOString(),
+  }
+}
+
+async function createE2eBuildMetadataSnapshot(
+  options: E2eBuildMetadataOptions = {},
+): Promise<E2eBuildMetadataSnapshot> {
+  const cwd = options.cwd ?? process.cwd()
+  const inputPaths = [
+    ...(options.inputPaths ?? (await readDefaultInputPaths(cwd))),
+  ]
+  const [gitHead, inputHash] = await Promise.all([
+    getGitHead(cwd),
+    createInputHash(cwd, inputPaths),
+  ])
+
+  return {
+    gitHead,
+    inputHash,
+    inputPaths,
+  }
+}
+
+export async function writeE2eBuildMetadata(
+  extensionDir: string,
+  metadata: E2eBuildMetadata,
+) {
+  await fs.mkdir(extensionDir, { recursive: true })
+  await fs.writeFile(
+    getE2eBuildMetadataPath(extensionDir),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+    "utf8",
+  )
+}
+
+export async function assertE2eBuildMetadataCurrent(
+  extensionDir: string,
+  options: E2eBuildMetadataOptions = {},
+) {
+  const metadataPath = getE2eBuildMetadataPath(extensionDir)
+  const metadata = await readE2eBuildMetadata(metadataPath)
+  const current = await createE2eBuildMetadataSnapshot({
+    cwd: options.cwd,
+    inputPaths: metadata.inputPaths,
+  })
+
+  const mismatches = getE2eBuildMetadataMismatches(metadata, current)
+  if (mismatches.length > 0) {
+    throw new Error(
+      [
+        `Stale E2E extension build at '${extensionDir}'.`,
+        ...mismatches,
+        "Run 'pnpm build:e2e' before running E2E tests.",
+      ].join(" "),
+    )
+  }
+}
+
+export async function isE2eBuildCurrent(
+  extensionDir: string,
+  options: E2eBuildMetadataOptions = {},
+) {
+  try {
+    await fs.access(path.join(extensionDir, "manifest.json"))
+    return await isE2eBuildMetadataCurrent(extensionDir, options)
+  } catch {
+    return false
+  }
+}
+
+export async function isE2eBuildMetadataCurrent(
+  extensionDir: string,
+  options: E2eBuildMetadataOptions = {},
+) {
+  try {
+    const metadataPath = getE2eBuildMetadataPath(extensionDir)
+    const metadata = await readE2eBuildMetadata(metadataPath)
+    const current = await createE2eBuildMetadataSnapshot({
+      cwd: options.cwd,
+      inputPaths: metadata.inputPaths,
+    })
+
+    return getE2eBuildMetadataMismatches(metadata, current).length === 0
+  } catch {
+    return false
+  }
+}
+
+export function getE2eBuildMetadataMismatches(
+  metadata: E2eBuildMetadata,
+  current: E2eBuildMetadataSnapshot,
+) {
+  const mismatches: string[] = []
+
+  if (metadata.gitHead !== current.gitHead) {
+    mismatches.push(
+      `Built from git HEAD ${metadata.gitHead}, current HEAD is ${current.gitHead}.`,
+    )
+  }
+
+  if (metadata.inputHash !== current.inputHash) {
+    mismatches.push("Build inputs have changed since the extension was built.")
+  }
+
+  return mismatches
+}
+
+function getE2eBuildMetadataPath(extensionDir: string) {
+  return path.join(extensionDir, E2E_BUILD_METADATA_FILE)
+}
+
+async function readE2eBuildMetadata(
+  metadataPath: string,
+): Promise<E2eBuildMetadata> {
+  let raw: string
+
+  try {
+    raw = await fs.readFile(metadataPath, "utf8")
+  } catch {
+    throw new Error(
+      [
+        `Missing E2E build metadata at '${metadataPath}'.`,
+        "Run 'pnpm build:e2e' before running E2E tests.",
+      ].join(" "),
+    )
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<E2eBuildMetadata>
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.gitHead !== "string" ||
+      typeof parsed.inputHash !== "string" ||
+      !Array.isArray(parsed.inputPaths)
+    ) {
+      throw new Error("metadata is missing required fields")
+    }
+
+    return parsed as E2eBuildMetadata
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Invalid E2E build metadata at '${metadataPath}': ${message}`,
+    )
+  }
+}
+
+async function getGitHead(cwd: string) {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd,
+    })
+    return stdout.trim()
+  } catch {
+    return "unknown"
+  }
+}
+
+async function readDefaultInputPaths(cwd: string) {
+  const raw = await fs.readFile(
+    path.resolve(cwd, "e2e", "e2e-build-inputs.json"),
+    "utf8",
+  )
+  const parsed = JSON.parse(raw) as unknown
+
+  if (
+    !Array.isArray(parsed) ||
+    parsed.some((item) => typeof item !== "string")
+  ) {
+    throw new Error("e2e/e2e-build-inputs.json must be an array of strings")
+  }
+
+  return parsed as string[]
+}
+
+async function createInputHash(cwd: string, inputPaths: readonly string[]) {
+  const hash = crypto.createHash("sha256")
+  const files = await collectExistingFiles(cwd, inputPaths)
+
+  for (const filePath of files) {
+    const relativePath = path.relative(cwd, filePath).replaceAll(path.sep, "/")
+    const fileContents = await fs.readFile(filePath)
+    hash.update(relativePath)
+    hash.update("\0")
+    hash.update(fileContents)
+    hash.update("\0")
+  }
+
+  return hash.digest("hex")
+}
+
+async function collectExistingFiles(
+  cwd: string,
+  inputPaths: readonly string[],
+) {
+  const files: string[] = []
+
+  for (const inputPath of inputPaths) {
+    const absolutePath = path.resolve(cwd, inputPath)
+    let stat
+
+    try {
+      stat = await fs.stat(absolutePath)
+    } catch {
+      continue
+    }
+
+    if (stat.isDirectory()) {
+      files.push(...(await collectDirectoryFiles(absolutePath)))
+    } else if (stat.isFile()) {
+      files.push(absolutePath)
+    }
+  }
+
+  return files.sort()
+}
+
+async function collectDirectoryFiles(directoryPath: string): Promise<string[]> {
+  const entries = await fs.readdir(directoryPath, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+      continue
+    }
+
+    const entryPath = path.join(directoryPath, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await collectDirectoryFiles(entryPath)))
+    } else if (entry.isFile()) {
+      files.push(entryPath)
+    }
+  }
+
+  return files
+}

--- a/e2e/utils/extension.ts
+++ b/e2e/utils/extension.ts
@@ -2,12 +2,20 @@ import fs from "node:fs/promises"
 import path from "node:path"
 import type { BrowserContext } from "@playwright/test"
 
+import { assertE2eBuildMetadataCurrent } from "~~/e2e/utils/e2eBuildMetadata"
+
+const verifiedExtensionDirs = new Set<string>()
+
 /**
  * Ensures the built MV3 extension output exists before running E2E.
  */
 export async function assertBuiltExtensionExists(
   extensionDir: string,
 ): Promise<void> {
+  if (verifiedExtensionDirs.has(extensionDir)) {
+    return
+  }
+
   const manifestPath = path.join(extensionDir, "manifest.json")
 
   try {
@@ -20,6 +28,9 @@ export async function assertBuiltExtensionExists(
       ].join(" "),
     )
   }
+
+  await assertE2eBuildMetadataCurrent(extensionDir)
+  verifiedExtensionDirs.add(extensionDir)
 }
 
 /**

--- a/knip.ts
+++ b/knip.ts
@@ -21,6 +21,9 @@ const config: KnipConfig = {
     "tests/setup.ts",
     "tests/setup.node.ts",
     "tests/setup.shared.ts",
+    // Playwright runs this through the build dependency project in
+    // playwright.config.ts, which Knip does not discover as a static import.
+    "e2e/setup/build.setup.ts",
   ],
   project: [
     "src/**/*.{ts,tsx}",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:firefox": "wxt -b firefox",
     "dev:mobile:firefox": "node scripts/android-dev.js",
     "build": "wxt build",
-    "build:e2e": "wxt build --mode test",
+    "build:e2e": "node scripts/e2e-build.mjs",
     "build:firefox": "wxt build -b firefox",
     "build:safari": "wxt build -b safari",
     "build:all": "pnpm run build && pnpm run build:firefox && pnpm run build:safari",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
   testDir: "./e2e",
   projects: [
     {
+      name: "build",
+      testMatch: /setup\/build\.setup\.ts/u,
+    },
+    {
       name: "chromium",
+      dependencies: ["build"],
       use: {
         browserName: "chromium",
       },

--- a/scripts/e2e-build.mjs
+++ b/scripts/e2e-build.mjs
@@ -1,0 +1,135 @@
+import { spawnSync } from "node:child_process"
+import crypto from "node:crypto"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const extensionDir = path.join(rootDir, ".output", "chrome-mv3-test")
+const metadataPath = path.join(extensionDir, ".aah-e2e-build.json")
+const inputPaths = JSON.parse(
+  fs.readFileSync(path.join(rootDir, "e2e", "e2e-build-inputs.json"), "utf8"),
+)
+
+run(process.execPath, [
+  path.join(rootDir, "node_modules", "wxt", "bin", "wxt.mjs"),
+  "build",
+  "--mode",
+  "test",
+])
+
+fs.mkdirSync(extensionDir, { recursive: true })
+fs.writeFileSync(
+  metadataPath,
+  `${JSON.stringify(
+    {
+      version: 1,
+      gitHead: getGitHead(),
+      inputHash: createInputHash(),
+      inputPaths,
+      builtAt: new Date().toISOString(),
+    },
+    null,
+    2,
+  )}\n`,
+  "utf8",
+)
+
+/**
+ *
+ * @param command
+ * @param args
+ */
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: rootDir,
+    stdio: "inherit",
+  })
+
+  if (result.status !== 0) {
+    if (result.error) {
+      console.error(result.error)
+    }
+    process.exit(result.status ?? 1)
+  }
+}
+
+/**
+ *
+ */
+function getGitHead() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: rootDir,
+    encoding: "utf8",
+  })
+
+  return result.status === 0 ? result.stdout.trim() : "unknown"
+}
+
+/**
+ *
+ */
+function createInputHash() {
+  const hash = crypto.createHash("sha256")
+  const files = collectExistingFiles(inputPaths)
+
+  for (const filePath of files) {
+    const relativePath = path
+      .relative(rootDir, filePath)
+      .replaceAll(path.sep, "/")
+    hash.update(relativePath)
+    hash.update("\0")
+    hash.update(fs.readFileSync(filePath))
+    hash.update("\0")
+  }
+
+  return hash.digest("hex")
+}
+
+/**
+ *
+ * @param pathsToCollect
+ */
+function collectExistingFiles(pathsToCollect) {
+  const files = []
+
+  for (const inputPath of pathsToCollect) {
+    const absolutePath = path.resolve(rootDir, inputPath)
+
+    if (!fs.existsSync(absolutePath)) {
+      continue
+    }
+
+    const stat = fs.statSync(absolutePath)
+    if (stat.isDirectory()) {
+      files.push(...collectDirectoryFiles(absolutePath))
+    } else if (stat.isFile()) {
+      files.push(absolutePath)
+    }
+  }
+
+  return files.sort()
+}
+
+/**
+ *
+ * @param directoryPath
+ */
+function collectDirectoryFiles(directoryPath) {
+  const files = []
+
+  for (const entry of fs.readdirSync(directoryPath, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") || entry.name === "node_modules") {
+      continue
+    }
+
+    const entryPath = path.join(directoryPath, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...collectDirectoryFiles(entryPath))
+    } else if (entry.isFile()) {
+      files.push(entryPath)
+    }
+  }
+
+  return files
+}

--- a/scripts/e2e-build.mjs
+++ b/scripts/e2e-build.mjs
@@ -11,6 +11,13 @@ const inputPaths = JSON.parse(
   fs.readFileSync(path.join(rootDir, "e2e", "e2e-build-inputs.json"), "utf8"),
 )
 
+if (
+  !Array.isArray(inputPaths) ||
+  inputPaths.some((inputPath) => typeof inputPath !== "string")
+) {
+  throw new Error("e2e/e2e-build-inputs.json must be an array of strings")
+}
+
 run(process.execPath, [
   path.join(rootDir, "node_modules", "wxt", "bin", "wxt.mjs"),
   "build",
@@ -36,9 +43,9 @@ fs.writeFileSync(
 )
 
 /**
- *
- * @param command
- * @param args
+ * Runs a child process and exits with the same status when it fails.
+ * @param command Executable path or command name to run.
+ * @param args Command-line arguments passed to the executable.
  */
 function run(command, args) {
   const result = spawnSync(command, args, {
@@ -55,7 +62,8 @@ function run(command, args) {
 }
 
 /**
- *
+ * Reads the current Git commit hash for the repository.
+ * @returns The current HEAD hash, or "unknown" outside a Git checkout.
  */
 function getGitHead() {
   const result = spawnSync("git", ["rev-parse", "HEAD"], {
@@ -67,7 +75,8 @@ function getGitHead() {
 }
 
 /**
- *
+ * Hashes all existing E2E build inputs in deterministic path order.
+ * @returns SHA-256 digest for the files that feed the test extension build.
  */
 function createInputHash() {
   const hash = crypto.createHash("sha256")
@@ -87,8 +96,9 @@ function createInputHash() {
 }
 
 /**
- *
- * @param pathsToCollect
+ * Collects existing files under the configured input paths.
+ * @param pathsToCollect Repo-relative files or directories to include.
+ * @returns Sorted absolute file paths.
  */
 function collectExistingFiles(pathsToCollect) {
   const files = []
@@ -112,8 +122,9 @@ function collectExistingFiles(pathsToCollect) {
 }
 
 /**
- *
- * @param directoryPath
+ * Recursively collects files from a directory, ignoring generated dependencies.
+ * @param directoryPath Absolute directory path to scan.
+ * @returns Absolute file paths under the directory.
  */
 function collectDirectoryFiles(directoryPath) {
   const files = []

--- a/tests/utils/e2eBuildMetadata.test.ts
+++ b/tests/utils/e2eBuildMetadata.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  assertE2eBuildMetadataCurrent,
+  createE2eBuildMetadata,
+  getE2eBuildMetadataMismatches,
+  isE2eBuildMetadataCurrent,
+  writeE2eBuildMetadata,
+} from "~~/e2e/utils/e2eBuildMetadata"
+
+const tempDirs: string[] = []
+
+async function createTempDir() {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "aah-e2e-build-"))
+  tempDirs.push(tempDir)
+  return tempDir
+}
+
+describe("E2E build metadata", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((tempDir) => fs.rm(tempDir, { recursive: true, force: true })),
+    )
+  })
+
+  it("accepts metadata that matches the current build inputs", async () => {
+    const cwd = await createTempDir()
+    const extensionDir = path.join(cwd, ".output", "chrome-mv3-test")
+    await fs.writeFile(path.join(cwd, "source.txt"), "initial\n")
+
+    const metadata = await createE2eBuildMetadata({
+      cwd,
+      inputPaths: ["source.txt"],
+    })
+    await writeE2eBuildMetadata(extensionDir, metadata)
+
+    await expect(
+      assertE2eBuildMetadataCurrent(extensionDir, {
+        cwd,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it("rejects a missing metadata file", async () => {
+    const cwd = await createTempDir()
+    const extensionDir = path.join(cwd, ".output", "chrome-mv3-test")
+
+    await expect(
+      assertE2eBuildMetadataCurrent(extensionDir, { cwd }),
+    ).rejects.toThrow("Missing E2E build metadata")
+  })
+
+  it("rejects metadata when tracked build inputs changed", async () => {
+    const cwd = await createTempDir()
+    const extensionDir = path.join(cwd, ".output", "chrome-mv3-test")
+    await fs.writeFile(path.join(cwd, "source.txt"), "initial\n")
+
+    const metadata = await createE2eBuildMetadata({
+      cwd,
+      inputPaths: ["source.txt"],
+    })
+    await writeE2eBuildMetadata(extensionDir, metadata)
+    await fs.writeFile(path.join(cwd, "source.txt"), "changed\n")
+
+    await expect(
+      assertE2eBuildMetadataCurrent(extensionDir, {
+        cwd,
+      }),
+    ).rejects.toThrow("Build inputs have changed")
+  })
+
+  it("returns false when checking stale metadata without throwing", async () => {
+    const cwd = await createTempDir()
+    const extensionDir = path.join(cwd, ".output", "chrome-mv3-test")
+    await fs.writeFile(path.join(cwd, "source.txt"), "initial\n")
+
+    const metadata = await createE2eBuildMetadata({
+      cwd,
+      inputPaths: ["source.txt"],
+    })
+    await writeE2eBuildMetadata(extensionDir, metadata)
+    await fs.writeFile(path.join(cwd, "source.txt"), "changed\n")
+
+    await expect(
+      isE2eBuildMetadataCurrent(extensionDir, {
+        cwd,
+      }),
+    ).resolves.toBe(false)
+  })
+
+  it("reports commit mismatches separately from input hash mismatches", () => {
+    expect(
+      getE2eBuildMetadataMismatches(
+        {
+          version: 1,
+          gitHead: "old-head",
+          inputHash: "same-hash",
+          inputPaths: ["src"],
+          builtAt: "2026-05-18T00:00:00.000Z",
+        },
+        {
+          gitHead: "new-head",
+          inputHash: "same-hash",
+          inputPaths: ["src"],
+        },
+      ),
+    ).toEqual(["Built from git HEAD old-head, current HEAD is new-head."])
+  })
+})

--- a/tests/utils/e2eBuildMetadata.test.ts
+++ b/tests/utils/e2eBuildMetadata.test.ts
@@ -74,6 +74,24 @@ describe("E2E build metadata", () => {
     ).rejects.toThrow("Build inputs have changed")
   })
 
+  it("rejects metadata with non-string input paths", async () => {
+    const cwd = await createTempDir()
+    const extensionDir = path.join(cwd, ".output", "chrome-mv3-test")
+    await writeE2eBuildMetadata(extensionDir, {
+      version: 1,
+      gitHead: "head",
+      inputHash: "hash",
+      inputPaths: ["source.txt", 42] as string[],
+      builtAt: "2026-05-18T00:00:00.000Z",
+    })
+
+    await expect(
+      assertE2eBuildMetadataCurrent(extensionDir, {
+        cwd,
+      }),
+    ).rejects.toThrow("inputPaths must contain only strings")
+  })
+
   it("returns false when checking stale metadata without throwing", async () => {
     const cwd = await createTempDir()
     const extensionDir = path.join(cwd, ".output", "chrome-mv3-test")
@@ -110,5 +128,65 @@ describe("E2E build metadata", () => {
         },
       ),
     ).toEqual(["Built from git HEAD old-head, current HEAD is new-head."])
+  })
+
+  it("reports input hash mismatches with matching commit metadata", () => {
+    expect(
+      getE2eBuildMetadataMismatches(
+        {
+          version: 1,
+          gitHead: "same-head",
+          inputHash: "old-hash",
+          inputPaths: ["src"],
+          builtAt: "2026-05-18T00:00:00.000Z",
+        },
+        {
+          gitHead: "same-head",
+          inputHash: "new-hash",
+          inputPaths: ["src"],
+        },
+      ),
+    ).toEqual(["Build inputs have changed since the extension was built."])
+  })
+
+  it("reports commit and input hash mismatches together", () => {
+    expect(
+      getE2eBuildMetadataMismatches(
+        {
+          version: 1,
+          gitHead: "old-head",
+          inputHash: "old-hash",
+          inputPaths: ["src"],
+          builtAt: "2026-05-18T00:00:00.000Z",
+        },
+        {
+          gitHead: "new-head",
+          inputHash: "new-hash",
+          inputPaths: ["src"],
+        },
+      ),
+    ).toEqual([
+      "Built from git HEAD old-head, current HEAD is new-head.",
+      "Build inputs have changed since the extension was built.",
+    ])
+  })
+
+  it("returns no mismatches for current metadata", () => {
+    expect(
+      getE2eBuildMetadataMismatches(
+        {
+          version: 1,
+          gitHead: "same-head",
+          inputHash: "same-hash",
+          inputPaths: ["src"],
+          builtAt: "2026-05-18T00:00:00.000Z",
+        },
+        {
+          gitHead: "same-head",
+          inputHash: "same-hash",
+          inputPaths: ["src"],
+        },
+      ),
+    ).toEqual([])
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reproducible E2E build metadata and conditional skip logic to avoid unnecessary rebuilds.

* **Tests**
  * Added unit tests for build-metadata validation and updated E2E tests to assert a specific token is visible before proceeding.

* **Chores**
  * Integrated the new metadata-driven build into the E2E build workflow and test runner ordering; updated the E2E build script and inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->