### PR TITLE
feat(claude-code-hub): support provider channel lookup and key reveal

### DIFF
--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -231,7 +231,8 @@ export default function ManagedSiteChannels({
   const isNewApiManagedSite = managedSiteType === SITE_TYPES.NEW_API
   const supportsDetailBackedRealKeyLoading =
     managedSiteType === SITE_TYPES.DONE_HUB ||
-    managedSiteType === SITE_TYPES.VELOERA
+    managedSiteType === SITE_TYPES.VELOERA ||
+    managedSiteType === SITE_TYPES.CLAUDE_CODE_HUB
   const isConfigMissing = !hasValidManagedSiteConfig(
     preferences,
     managedSiteType,

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -112,7 +112,7 @@
     },
     "title": "Claude Code Hub Integration Settings",
     "unsupported": {
-      "description": "Channel migration, model sync, model redirect, and full key reveal are not available for Claude Code Hub in this version.",
+      "description": "Model sync and model redirect are not available for Claude Code Hub in this version.",
       "title": "Unsupported channel actions"
     },
     "validation": {

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -112,7 +112,7 @@
     },
     "title": "Claude Code Hub 統合設定",
     "unsupported": {
-      "description": "このバージョンでは、Claude Code Hub のチャネル移行、モデル同期、モデルリダイレクト、完全なキー表示は利用できません。",
+      "description": "このバージョンでは、Claude Code Hub のモデル同期とモデルリダイレクトは利用できません。",
       "title": "未対応のチャネル操作"
     },
     "validation": {

--- a/src/locales/vi/settings.json
+++ b/src/locales/vi/settings.json
@@ -112,7 +112,7 @@
     },
     "title": "Cài đặt tích hợp Claude Code Hub",
     "unsupported": {
-      "description": "Phiên bản hiện tại chưa hỗ trợ di chuyển kênh, đồng bộ mô hình, chuyển hướng mô hình và xem đầy đủ key của Claude Code Hub.",
+      "description": "Phiên bản hiện tại chưa hỗ trợ đồng bộ mô hình và chuyển hướng mô hình của Claude Code Hub.",
       "title": "Thao tác kênh chưa được hỗ trợ"
     },
     "validation": {

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -112,7 +112,7 @@
     },
     "title": "Claude Code Hub 集成设置",
     "unsupported": {
-      "description": "当前版本暂不支持 Claude Code Hub 的渠道迁移、模型同步、模型重定向和完整密钥查看。",
+      "description": "当前版本暂不支持 Claude Code Hub 的模型同步和模型重定向。",
       "title": "不支持的渠道操作"
     },
     "validation": {

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -112,7 +112,7 @@
     },
     "title": "Claude Code Hub 整合設定",
     "unsupported": {
-      "description": "目前版本暫不支援 Claude Code Hub 的渠道遷移、模型同步、模型重定向和完整金鑰查看。",
+      "description": "目前版本暫不支援 Claude Code Hub 的模型同步和模型重定向。",
       "title": "不支援的渠道操作"
     },
     "validation": {

--- a/src/services/apiService/claudeCodeHub/index.ts
+++ b/src/services/apiService/claudeCodeHub/index.ts
@@ -115,6 +115,47 @@ async function parseActionResponse<T>(
 }
 
 /**
+ * Parses a Claude Code Hub v1 JSON response and normalizes problem+json errors.
+ */
+async function parseV1JsonResponse<T>(
+  response: Response,
+  config: ClaudeCodeHubConfig,
+  extraSecrets: Array<string | undefined | null>,
+): Promise<T> {
+  let parsed: unknown
+  try {
+    parsed = await response.json()
+  } catch {
+    throw new ClaudeCodeHubApiError(
+      `Claude Code Hub returned a non-JSON response (${response.status})`,
+      response.status,
+    )
+  }
+
+  if (!response.ok) {
+    const fallbackMessage =
+      response.statusText ||
+      `Claude Code Hub request failed (${response.status})`
+    const problem =
+      parsed && typeof parsed === "object"
+        ? (parsed as { detail?: unknown; error?: unknown; title?: unknown })
+        : undefined
+    const message =
+      getErrorMessage(
+        problem?.detail ?? problem?.error ?? problem?.title,
+        fallbackMessage,
+      ) || fallbackMessage
+
+    throw new ClaudeCodeHubApiError(
+      redactClaudeCodeHubSecrets(message, [config.adminToken, ...extraSecrets]),
+      response.status,
+    )
+  }
+
+  return parsed as T
+}
+
+/**
  * Calls a Claude Code Hub provider action endpoint and normalizes failures.
  */
 function createTimeoutAbortSignal(timeoutMs: number): ActionSignalHandle {
@@ -306,6 +347,59 @@ export async function listProviders(
 }
 
 /**
+ * Searches Claude Code Hub providers through the admin v1 provider list API.
+ *
+ * Upstream contract: ding113/claude-code-hub
+ * `src/app/api/v1/resources/providers/router.ts` registers
+ * `GET /api/v1/providers` with optional `q` search text and returns
+ * `{ items: ProviderSummary[] }`.
+ */
+export async function searchProviders(
+  config: ClaudeCodeHubConfig,
+  keyword: string,
+  options?: {
+    signal?: AbortSignal
+    timeoutMs?: number
+  },
+): Promise<ClaudeCodeHubProviderDisplay[]> {
+  const baseUrl = normalizeClaudeCodeHubBaseUrl(config.baseUrl)
+  const searchParams = new URLSearchParams()
+  const trimmedKeyword = keyword.trim()
+  if (trimmedKeyword) {
+    searchParams.set("q", trimmedKeyword)
+  }
+
+  const query = searchParams.toString()
+  const actionSignal = buildActionSignal(options)
+  let response: Response | undefined
+
+  try {
+    response = await fetch(
+      `${baseUrl}/api/v1/providers${query ? `?${query}` : ""}`,
+      {
+        method: "GET",
+        signal: actionSignal.signal,
+        headers: {
+          Authorization: `Bearer ${config.adminToken}`,
+        },
+      },
+    )
+    const data = await parseV1JsonResponse<unknown>(response, config, [])
+    return extractProviderList(data)
+  } catch (error) {
+    if (error instanceof ClaudeCodeHubApiError) {
+      throw error
+    }
+    throw new ClaudeCodeHubApiError(
+      normalizeActionError(error, config),
+      response?.status,
+    )
+  } finally {
+    actionSignal.cleanup()
+  }
+}
+
+/**
  * Validates Claude Code Hub credentials by performing a provider list request.
  */
 export async function validateClaudeCodeHubConfig(
@@ -335,6 +429,63 @@ export async function createProvider(
     signal: options?.signal,
     timeoutMs: options?.timeoutMs,
   })
+}
+
+/**
+ * Fetches the real provider key through Claude Code Hub's admin v1 API.
+ *
+ * Upstream contract: ding113/claude-code-hub
+ * `src/app/api/v1/resources/providers/router.ts` registers
+ * `GET /api/v1/providers/{id}/key:reveal` and returns `{ key: string }`.
+ */
+export async function getUnmaskedProviderKey(
+  config: ClaudeCodeHubConfig,
+  providerId: number,
+  options?: {
+    signal?: AbortSignal
+    timeoutMs?: number
+  },
+): Promise<string> {
+  const baseUrl = normalizeClaudeCodeHubBaseUrl(config.baseUrl)
+  let response: Response | undefined
+  const actionSignal = buildActionSignal(options)
+
+  try {
+    response = await fetch(
+      `${baseUrl}/api/v1/providers/${providerId}/key:reveal`,
+      {
+        method: "GET",
+        signal: actionSignal.signal,
+        headers: {
+          Authorization: `Bearer ${config.adminToken}`,
+        },
+      },
+    )
+    const data = await parseV1JsonResponse<unknown>(response, config, [])
+
+    const key =
+      data && typeof data === "object"
+        ? (data as { key?: unknown }).key
+        : undefined
+    if (typeof key !== "string" || !key.trim()) {
+      throw new ClaudeCodeHubApiError(
+        "Claude Code Hub returned an invalid provider key response",
+        response.status,
+      )
+    }
+
+    return key
+  } catch (error) {
+    if (error instanceof ClaudeCodeHubApiError) {
+      throw error
+    }
+    throw new ClaudeCodeHubApiError(
+      normalizeActionError(error, config),
+      response?.status,
+    )
+  } finally {
+    actionSignal.cleanup()
+  }
 }
 
 /**

--- a/src/services/managedSites/managedSiteService.ts
+++ b/src/services/managedSites/managedSiteService.ts
@@ -209,6 +209,7 @@ export function getManagedSiteServiceForType(
       prepareChannelFormData: claudeCodeHubService.prepareChannelFormData,
       buildChannelPayload: claudeCodeHubService.buildChannelPayload,
       findMatchingChannel: claudeCodeHubService.findMatchingChannel,
+      fetchChannelSecretKey: claudeCodeHubService.fetchChannelSecretKey,
       autoConfigToManagedSite: claudeCodeHubService.autoConfigToClaudeCodeHub,
     }
   }

--- a/src/services/managedSites/providers/claudeCodeHub.ts
+++ b/src/services/managedSites/providers/claudeCodeHub.ts
@@ -11,7 +11,10 @@ import { normalizeAccountForManagedChannel } from "~/services/accounts/utils/sit
 import * as claudeCodeHubApi from "~/services/apiService/claudeCodeHub"
 import type { ApiResponse } from "~/services/apiService/common/type"
 import type { ManagedSiteConfig } from "~/services/managedSites/managedSiteService"
-import { findManagedSiteChannelByComparableInputs } from "~/services/managedSites/utils/channelMatching"
+import {
+  findManagedSiteChannelByComparableInputs,
+  findManagedSiteChannelsByBaseUrlAndModels,
+} from "~/services/managedSites/utils/channelMatching"
 import { fetchManagedSiteAvailableModels } from "~/services/managedSites/utils/fetchManagedSiteAvailableModels"
 import { fetchTokenScopedModels } from "~/services/managedSites/utils/fetchTokenScopedModels"
 import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/managedSite"
@@ -291,7 +294,7 @@ async function hydrateComparableChannelKey(
       channel.id,
     )
     if (!hasUsableManagedSiteChannelKey(key)) {
-      return null
+      throw new Error("Claude Code Hub returned an unusable provider key")
     }
     return {
       ...channel,
@@ -621,14 +624,34 @@ export async function findMatchingChannel(
     if (!config || !hasUsableManagedSiteChannelKey(key)) return null
 
     const channels = await listClaudeCodeHubChannels(config)
-    const comparableChannels = (
-      await Promise.all(
-        channels.items.map((channel) =>
-          hydrateComparableChannelKey(config, channel),
-        ),
-      )
-    ).filter((channel): channel is ManagedSiteChannel => channel !== null)
+    const exactMatch = findManagedSiteChannelByComparableInputs({
+      channels: channels.items,
+      accountBaseUrl,
+      models,
+      key,
+    })
 
+    if (exactMatch) {
+      return exactMatch
+    }
+
+    const narrowedCandidates = findManagedSiteChannelsByBaseUrlAndModels({
+      channels: channels.items,
+      accountBaseUrl,
+      models,
+    }).filter((channel) => !hasUsableManagedSiteChannelKey(channel.key))
+
+    if (narrowedCandidates.length === 0) {
+      return null
+    }
+
+    const comparableChannels = []
+    for (const channel of narrowedCandidates) {
+      const hydratedChannel = await hydrateComparableChannelKey(config, channel)
+      if (hydratedChannel) {
+        comparableChannels.push(hydratedChannel)
+      }
+    }
     return findManagedSiteChannelByComparableInputs({
       channels: comparableChannels,
       accountBaseUrl,

--- a/src/services/managedSites/providers/claudeCodeHub.ts
+++ b/src/services/managedSites/providers/claudeCodeHub.ts
@@ -232,29 +232,6 @@ export function providerToManagedSiteChannel(
 }
 
 /**
- * Filters provider channels with a case-insensitive keyword match.
- */
-function providerMatchesKeyword(
-  channel: ManagedSiteChannel,
-  keyword: string,
-): boolean {
-  const normalizedKeyword = keyword.trim().toLowerCase()
-  if (!normalizedKeyword) return true
-
-  const searchable = [
-    channel.name,
-    String(channel.type),
-    channel.base_url,
-    channel.models,
-    channel.group,
-  ]
-    .join(" ")
-    .toLowerCase()
-
-  return searchable.includes(normalizedKeyword)
-}
-
-/**
  * Lists Claude Code Hub providers and derives managed-site type counts.
  */
 async function listClaudeCodeHubChannels(
@@ -272,6 +249,60 @@ async function listClaudeCodeHubChannels(
     items,
     total: items.length,
     type_counts: typeCounts,
+  }
+}
+
+/**
+ * Searches Claude Code Hub providers through the upstream admin search API.
+ */
+async function searchClaudeCodeHubChannels(
+  config: ClaudeCodeHubConfig,
+  keyword: string,
+): Promise<ManagedSiteChannelListData> {
+  const providers = await claudeCodeHubApi.searchProviders(config, keyword)
+  const items = providers.map(providerToManagedSiteChannel)
+  const typeCounts = items.reduce<Record<string, number>>((acc, item) => {
+    const type = String(item.type)
+    acc[type] = (acc[type] ?? 0) + 1
+    return acc
+  }, {})
+
+  return {
+    items,
+    total: items.length,
+    type_counts: typeCounts,
+  }
+}
+
+/**
+ * Resolves a real provider key when list data only contains a masked key.
+ */
+async function hydrateComparableChannelKey(
+  config: ClaudeCodeHubConfig,
+  channel: ManagedSiteChannel,
+): Promise<ManagedSiteChannel | null> {
+  if (hasUsableManagedSiteChannelKey(channel.key)) {
+    return channel
+  }
+
+  try {
+    const key = await claudeCodeHubApi.getUnmaskedProviderKey(
+      config,
+      channel.id,
+    )
+    if (!hasUsableManagedSiteChannelKey(key)) {
+      return null
+    }
+    return {
+      ...channel,
+      key: key.trim(),
+    }
+  } catch (error) {
+    logger.warn("Failed to hydrate Claude Code Hub provider key", {
+      channelId: channel.id,
+      error: getErrorMessage(error),
+    })
+    return null
   }
 }
 
@@ -347,7 +378,7 @@ export function buildClaudeCodeHubUpdatePayloadFromChannelData(
 }
 
 /**
- * Searches Claude Code Hub channels by keyword within the local provider cache.
+ * Searches Claude Code Hub channels by keyword through the provider search API.
  */
 export async function searchChannel(
   _baseUrl: string,
@@ -359,16 +390,7 @@ export async function searchChannel(
     const config = await getFullClaudeCodeHubConfig()
     if (!config) return null
 
-    const allChannels = await listClaudeCodeHubChannels(config)
-    const items = allChannels.items.filter((channel) =>
-      providerMatchesKeyword(channel, keyword),
-    )
-
-    return {
-      items,
-      total: items.length,
-      type_counts: allChannels.type_counts,
-    }
+    return await searchClaudeCodeHubChannels(config, keyword)
   } catch (error) {
     logger.error("Failed to search Claude Code Hub providers", error)
     return null
@@ -491,6 +513,23 @@ export async function deleteChannel(
 }
 
 /**
+ * Fetches the real Claude Code Hub provider key for edit, comparison, and export flows.
+ */
+export async function fetchChannelSecretKey(
+  _baseUrl: string,
+  _adminToken: string,
+  _userId: number | string,
+  channelId: number,
+): Promise<string> {
+  const config = await getFullClaudeCodeHubConfig()
+  if (!config) {
+    throw new Error(t("messages:claudecodehub.configMissing"))
+  }
+
+  return await claudeCodeHubApi.getUnmaskedProviderKey(config, channelId)
+}
+
+/**
  * Fetches available models for a managed-site account token pair.
  */
 export async function fetchAvailableModels(
@@ -582,9 +621,14 @@ export async function findMatchingChannel(
     if (!config || !hasUsableManagedSiteChannelKey(key)) return null
 
     const channels = await listClaudeCodeHubChannels(config)
-    const comparableChannels = channels.items.filter((channel) =>
-      hasUsableManagedSiteChannelKey(channel.key),
-    )
+    const comparableChannels = (
+      await Promise.all(
+        channels.items.map((channel) =>
+          hydrateComparableChannelKey(config, channel),
+        ),
+      )
+    ).filter((channel): channel is ManagedSiteChannel => channel !== null)
+
     return findManagedSiteChannelByComparableInputs({
       channels: comparableChannels,
       accountBaseUrl,

--- a/src/services/managedSites/utils/managedSite.ts
+++ b/src/services/managedSites/utils/managedSite.ts
@@ -283,9 +283,7 @@ export function getManagedSiteType(prefs: UserPreferences): ManagedSiteType {
 export function supportsManagedSiteBaseUrlChannelLookup(
   siteType: ManagedSiteType,
 ): boolean {
-  return (
-    siteType !== SITE_TYPES.VELOERA && siteType !== SITE_TYPES.CLAUDE_CODE_HUB
-  )
+  return siteType !== SITE_TYPES.VELOERA
 }
 
 /**

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -2068,6 +2068,7 @@ describe("ManagedSiteChannels", () => {
   it.each([
     [SITE_TYPES.DONE_HUB, "donehub"],
     [SITE_TYPES.VELOERA, "veloera"],
+    [SITE_TYPES.CLAUDE_CODE_HUB, "claudecodehub"],
   ])(
     "loads the real channel key from the edit dialog for %s",
     async (managedSiteType, messagesKey) => {

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -2429,10 +2429,10 @@ describe("ManagedSiteChannels", () => {
     )
     const editDialog = await screen.findByRole("dialog")
     expect(
-      within(editDialog).queryByRole("button", {
+      within(editDialog).getByRole("button", {
         name: "channelDialog:actions.loadRealKey",
       }),
-    ).not.toBeInTheDocument()
+    ).toBeInTheDocument()
 
     await user.click(
       within(editDialog).getByText("common:actions.cancel", {

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -2054,17 +2054,6 @@ describe("AccountActionButtons", () => {
       },
       "Veloera Site",
     ],
-    [
-      "Claude Code Hub",
-      {
-        managedSiteType: SITE_TYPES.CLAUDE_CODE_HUB,
-        claudeCodeHub: {
-          baseUrl: "https://cch-admin.example",
-          adminToken: "cch-admin-token",
-        },
-      },
-      "Claude Code Hub Site",
-    ],
   ])(
     "shows a disabled locate action with visible unsupported guidance for %s",
     async (_label, preferences, siteName) => {
@@ -2116,6 +2105,48 @@ describe("AccountActionButtons", () => {
       expect(openManagedSiteChannelsPageMock).not.toHaveBeenCalled()
     },
   )
+
+  it("shows an actionable locate action for Claude Code Hub", async () => {
+    userPreferencesContextValue.preferences = {
+      managedSiteType: SITE_TYPES.CLAUDE_CODE_HUB,
+      claudeCodeHub: {
+        baseUrl: "https://cch-admin.example",
+        adminToken: "cch-admin-token",
+      },
+    } as Partial<UserPreferences>
+
+    const user = userEvent.setup()
+
+    render(
+      <AccountActionButtons
+        site={buildDisplaySiteData({
+          id: "acc-8d",
+          disabled: false,
+          name: "Claude Code Hub Site",
+          baseUrl: "https://api.example.com/v1/",
+        })}
+        onCopyKey={vi.fn()}
+        onDeleteAccount={vi.fn()}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.more" }),
+    )
+
+    const menu = await screen.findByRole("menu")
+    const label = await within(menu).findByText(
+      "account:actions.locateManagedSiteChannel",
+    )
+    const button = label.closest("button")
+    expect(button).not.toBeNull()
+    expect(button!).toBeEnabled()
+    expect(
+      within(menu).queryByText(
+        "account:actions.locateManagedSiteChannelUnsupportedHint",
+      ),
+    ).toBeNull()
+  })
 
   it("hides the locate action when managed site config is missing", async () => {
     hasValidManagedSiteConfigMock.mockReturnValue(false)

--- a/tests/services/apiService/claudeCodeHub/index.test.ts
+++ b/tests/services/apiService/claudeCodeHub/index.test.ts
@@ -141,6 +141,20 @@ describe("Claude Code Hub action API adapter", () => {
     expect(capturedAuthorization).toBe("Bearer admin-secret")
   })
 
+  it("throws when the provider v1 reveal API omits a usable string key", async () => {
+    server.use(
+      http.get(`${PROVIDER_V1_BASE}/42/key:reveal`, () =>
+        HttpResponse.json({
+          key: null,
+        }),
+      ),
+    )
+
+    await expect(getUnmaskedProviderKey(config, 42)).rejects.toThrow(
+      "invalid provider key response",
+    )
+  })
+
   it("searches providers through the provider v1 list API", async () => {
     let capturedAuthorization: string | null = null
     let capturedQuery: string | null = null
@@ -171,6 +185,25 @@ describe("Claude Code Hub action API adapter", () => {
     ])
     expect(capturedAuthorization).toBe("Bearer admin-secret")
     expect(capturedQuery).toBe("search match")
+  })
+
+  it("throws redacted errors for provider v1 search failures", async () => {
+    server.use(
+      http.get(PROVIDER_V1_BASE, () =>
+        HttpResponse.json(
+          {
+            type: "about:blank",
+            title: "Provider search failed",
+            detail: "bad token admin-secret while searching",
+          },
+          { status: 500 },
+        ),
+      ),
+    )
+
+    await expect(searchProviders(config, "search match")).rejects.toThrow(
+      "bad token [REDACTED] while searching",
+    )
   })
 
   it("throws redacted errors for provider v1 reveal failures", async () => {

--- a/tests/services/apiService/claudeCodeHub/index.test.ts
+++ b/tests/services/apiService/claudeCodeHub/index.test.ts
@@ -5,9 +5,11 @@ import {
   ClaudeCodeHubApiError,
   createProvider,
   deleteProvider,
+  getUnmaskedProviderKey,
   listProviders,
   normalizeClaudeCodeHubBaseUrl,
   redactClaudeCodeHubSecrets,
+  searchProviders,
   updateProvider,
   validateClaudeCodeHubConfig,
 } from "~/services/apiService/claudeCodeHub"
@@ -19,6 +21,7 @@ const config = {
 }
 
 const PROVIDER_ACTION_BASE = "https://cch.example.com/api/actions/providers"
+const PROVIDER_V1_BASE = "https://cch.example.com/api/v1/providers"
 
 function restoreAbortSignalStatic(
   key: "any" | "timeout",
@@ -118,6 +121,75 @@ describe("Claude Code Hub action API adapter", () => {
         providerId: 12,
       },
     ])
+  })
+
+  it("fetches an unmasked provider key from the provider v1 reveal API", async () => {
+    let capturedAuthorization: string | null = null
+
+    server.use(
+      http.get(`${PROVIDER_V1_BASE}/42/key:reveal`, ({ request }) => {
+        capturedAuthorization = request.headers.get("authorization")
+        return HttpResponse.json({
+          key: "sk-real-provider-key",
+        })
+      }),
+    )
+
+    await expect(getUnmaskedProviderKey(config, 42)).resolves.toBe(
+      "sk-real-provider-key",
+    )
+    expect(capturedAuthorization).toBe("Bearer admin-secret")
+  })
+
+  it("searches providers through the provider v1 list API", async () => {
+    let capturedAuthorization: string | null = null
+    let capturedQuery: string | null = null
+
+    server.use(
+      http.get(PROVIDER_V1_BASE, ({ request }) => {
+        const url = new URL(request.url)
+        capturedAuthorization = request.headers.get("authorization")
+        capturedQuery = url.searchParams.get("q")
+        return HttpResponse.json({
+          items: [
+            {
+              id: 9,
+              name: "Search Match",
+              url: "https://search.example.com",
+            },
+          ],
+        })
+      }),
+    )
+
+    await expect(searchProviders(config, "search match")).resolves.toEqual([
+      {
+        id: 9,
+        name: "Search Match",
+        url: "https://search.example.com",
+      },
+    ])
+    expect(capturedAuthorization).toBe("Bearer admin-secret")
+    expect(capturedQuery).toBe("search match")
+  })
+
+  it("throws redacted errors for provider v1 reveal failures", async () => {
+    server.use(
+      http.get(`${PROVIDER_V1_BASE}/42/key:reveal`, () =>
+        HttpResponse.json(
+          {
+            type: "about:blank",
+            title: "Admin access required",
+            detail: "bad token admin-secret",
+          },
+          { status: 403 },
+        ),
+      ),
+    )
+
+    await expect(getUnmaskedProviderKey(config, 42)).rejects.toThrow(
+      "bad token [REDACTED]",
+    )
   })
 
   it("supports provider arrays wrapped in an inner data field", async () => {

--- a/tests/services/managedSiteService/managedSiteService.test.ts
+++ b/tests/services/managedSiteService/managedSiteService.test.ts
@@ -124,6 +124,7 @@ vi.mock("~/services/managedSites/providers/claudeCodeHub", () => ({
   prepareChannelFormData: vi.fn(),
   buildChannelPayload: vi.fn(),
   findMatchingChannel: vi.fn(),
+  fetchChannelSecretKey: vi.fn(),
   autoConfigToClaudeCodeHub: vi.fn(),
 }))
 
@@ -283,7 +284,7 @@ describe("managedSiteService", () => {
     })
   })
 
-  it("routes to Claude Code Hub service without key reveal support", async () => {
+  it("routes to Claude Code Hub service with key reveal support", async () => {
     const { getManagedSiteServiceForType } = await import(
       "~/services/managedSites/managedSiteService"
     )
@@ -291,7 +292,7 @@ describe("managedSiteService", () => {
     const service = getManagedSiteServiceForType(SITE_TYPES.CLAUDE_CODE_HUB)
     expect(service.siteType).toBe(SITE_TYPES.CLAUDE_CODE_HUB)
     expect(service.messagesKey).toBe("claudecodehub")
-    expect(service.fetchChannelSecretKey).toBeUndefined()
+    expect(service.fetchChannelSecretKey).toEqual(expect.any(Function))
 
     const config = await service.getConfig()
     expect(config).toEqual({

--- a/tests/services/managedSites/managedSite.test.ts
+++ b/tests/services/managedSites/managedSite.test.ts
@@ -14,14 +14,14 @@ describe("supportsManagedSiteBaseUrlChannelLookup", () => {
     expect(supportsManagedSiteBaseUrlChannelLookup(SITE_TYPES.OCTOPUS)).toBe(
       true,
     )
+    expect(
+      supportsManagedSiteBaseUrlChannelLookup(SITE_TYPES.CLAUDE_CODE_HUB),
+    ).toBe(true)
   })
 
   it("returns false for backends without reliable base-url lookup", () => {
     expect(supportsManagedSiteBaseUrlChannelLookup(SITE_TYPES.VELOERA)).toBe(
       false,
     )
-    expect(
-      supportsManagedSiteBaseUrlChannelLookup(SITE_TYPES.CLAUDE_CODE_HUB),
-    ).toBe(false)
   })
 })

--- a/tests/services/managedSites/managedSiteUtils.test.ts
+++ b/tests/services/managedSites/managedSiteUtils.test.ts
@@ -353,7 +353,7 @@ describe("managedSite utils", () => {
     )
     expect(
       supportsManagedSiteBaseUrlChannelLookup(SITE_TYPES.CLAUDE_CODE_HUB),
-    ).toBe(false)
+    ).toBe(true)
     expect(supportsManagedSiteBaseUrlChannelLookup(SITE_TYPES.NEW_API)).toBe(
       true,
     )

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -70,10 +70,17 @@ vi.mock("~/services/preferences/userPreferences", () => ({
   },
 }))
 
-vi.mock("~/services/managedSites/utils/channelMatching", () => ({
-  findManagedSiteChannelByComparableInputs: (...args: unknown[]) =>
-    mockFindManagedSiteChannelByComparableInputs(...args),
-}))
+vi.mock(
+  "~/services/managedSites/utils/channelMatching",
+  async (importActual) => {
+    const actual = (await importActual()) as any
+    return {
+      ...actual,
+      findManagedSiteChannelByComparableInputs: (...args: unknown[]) =>
+        mockFindManagedSiteChannelByComparableInputs(...args),
+    }
+  },
+)
 
 vi.mock("~/services/accounts/accountStorage", () => ({
   accountStorage: {
@@ -465,6 +472,20 @@ describe("Claude Code Hub managed-site provider", () => {
     )
   })
 
+  it("surfaces provider key reveal failures from edit flows", async () => {
+    mockGetPreferences.mockResolvedValue({
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+    })
+    mockGetUnmaskedProviderKey.mockRejectedValueOnce(new Error("reveal failed"))
+
+    await expect(fetchChannelSecretKey("", "", "", 42)).rejects.toThrow(
+      "reveal failed",
+    )
+  })
+
   it("hydrates masked provider keys before matching duplicate Claude Code Hub channels", async () => {
     mockGetPreferences.mockResolvedValue({
       claudeCodeHub: {
@@ -483,10 +504,12 @@ describe("Claude Code Hub managed-site provider", () => {
       },
     ])
     mockGetUnmaskedProviderKey.mockResolvedValueOnce("sk-real-key")
-    mockFindManagedSiteChannelByComparableInputs.mockResolvedValueOnce({
-      id: 31,
-      name: "Masked Provider",
-    })
+    mockFindManagedSiteChannelByComparableInputs
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({
+        id: 31,
+        name: "Masked Provider",
+      })
 
     await expect(
       findMatchingChannel(
@@ -515,6 +538,112 @@ describe("Claude Code Hub managed-site provider", () => {
           key: "sk-real-key",
         }),
       ],
+      accountBaseUrl: "https://api.example.com",
+      models: ["gpt-4o"],
+      key: "sk-real-key",
+    })
+  })
+
+  it("hydrates only narrowed Claude Code Hub duplicate candidates", async () => {
+    mockGetPreferences.mockResolvedValue({
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+    })
+    mockListProviders.mockResolvedValue([
+      {
+        id: 31,
+        name: "Matching Masked Provider",
+        providerType: "openai-compatible",
+        url: "https://api.example.com",
+        maskedKey: "sk-***",
+        allowedModels: ["gpt-4o"],
+      },
+      {
+        id: 32,
+        name: "Different URL Provider",
+        providerType: "openai-compatible",
+        url: "https://other.example.com",
+        maskedKey: "sk-***",
+        allowedModels: ["gpt-4o"],
+      },
+      {
+        id: 33,
+        name: "Different Models Provider",
+        providerType: "openai-compatible",
+        url: "https://api.example.com",
+        maskedKey: "sk-***",
+        allowedModels: ["claude-sonnet"],
+      },
+    ])
+    mockGetUnmaskedProviderKey.mockResolvedValueOnce("sk-real-key")
+    mockFindManagedSiteChannelByComparableInputs
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({
+        id: 31,
+        name: "Matching Masked Provider",
+      })
+
+    await expect(
+      findMatchingChannel(
+        "",
+        "",
+        "",
+        "https://api.example.com",
+        ["gpt-4o"],
+        "sk-real-key",
+      ),
+    ).resolves.toEqual({
+      id: 31,
+      name: "Matching Masked Provider",
+    })
+    expect(mockGetUnmaskedProviderKey).toHaveBeenCalledTimes(1)
+    expect(mockGetUnmaskedProviderKey).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+      31,
+    )
+  })
+
+  it("skips Claude Code Hub duplicate key candidates when key hydration fails", async () => {
+    mockGetPreferences.mockResolvedValue({
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+    })
+    mockListProviders.mockResolvedValue([
+      {
+        id: 31,
+        name: "Masked Provider",
+        providerType: "openai-compatible",
+        url: "https://api.example.com",
+        maskedKey: "sk-***",
+        allowedModels: ["gpt-4o"],
+      },
+    ])
+    mockGetUnmaskedProviderKey.mockRejectedValueOnce(new Error("reveal failed"))
+    mockFindManagedSiteChannelByComparableInputs
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null)
+
+    await expect(
+      findMatchingChannel(
+        "",
+        "",
+        "",
+        "https://api.example.com",
+        ["gpt-4o"],
+        "sk-real-key",
+      ),
+    ).resolves.toBeNull()
+    expect(
+      mockFindManagedSiteChannelByComparableInputs,
+    ).toHaveBeenLastCalledWith({
+      channels: [],
       accountBaseUrl: "https://api.example.com",
       models: ["gpt-4o"],
       key: "sk-real-key",
@@ -631,7 +760,7 @@ describe("Claude Code Hub managed-site provider", () => {
         allowedModels: ["gpt-4o"],
       },
     ])
-    mockFindManagedSiteChannelByComparableInputs.mockResolvedValueOnce({
+    mockFindManagedSiteChannelByComparableInputs.mockReturnValueOnce({
       id: 31,
       name: "Comparable Provider",
     })
@@ -654,6 +783,10 @@ describe("Claude Code Hub managed-site provider", () => {
         expect.objectContaining({
           id: 31,
           key: "sk-real-key",
+        }),
+        expect.objectContaining({
+          id: 32,
+          key: "sk-***",
         }),
       ],
       accountBaseUrl: "https://api.example.com",
@@ -696,7 +829,7 @@ describe("Claude Code Hub managed-site provider", () => {
       fetchFailed: false,
     })
     mockListProviders.mockResolvedValue([])
-    mockFindManagedSiteChannelByComparableInputs.mockResolvedValueOnce(null)
+    mockFindManagedSiteChannelByComparableInputs.mockReturnValueOnce(null)
     mockCreateProvider.mockResolvedValue({ ok: true })
 
     await expect(
@@ -714,7 +847,7 @@ describe("Claude Code Hub managed-site provider", () => {
       { id: "toast-id" },
     )
 
-    mockFindManagedSiteChannelByComparableInputs.mockResolvedValueOnce({
+    mockFindManagedSiteChannelByComparableInputs.mockReturnValueOnce({
       name: "Existing Provider",
     })
     await expect(

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -14,6 +14,7 @@ import {
   createChannel,
   deleteChannel,
   fetchAvailableModels,
+  fetchChannelSecretKey,
   findMatchingChannel,
   prepareChannelFormData,
   providerToManagedSiteChannel,
@@ -25,9 +26,11 @@ import { CHANNEL_STATUS } from "~/types/managedSite"
 const mockFetchTokenScopedModels = vi.fn()
 const mockFetchManagedSiteAvailableModels = vi.fn()
 const mockListProviders = vi.fn()
+const mockSearchProviders = vi.fn()
 const mockCreateProvider = vi.fn()
 const mockUpdateProvider = vi.fn()
 const mockDeleteProvider = vi.fn()
+const mockGetUnmaskedProviderKey = vi.fn()
 const mockGetPreferences = vi.fn()
 const mockFindManagedSiteChannelByComparableInputs = vi.fn()
 const mockConvertToDisplayData = vi.fn()
@@ -51,9 +54,12 @@ vi.mock(
 
 vi.mock("~/services/apiService/claudeCodeHub", () => ({
   listProviders: (...args: unknown[]) => mockListProviders(...args),
+  searchProviders: (...args: unknown[]) => mockSearchProviders(...args),
   createProvider: (...args: unknown[]) => mockCreateProvider(...args),
   updateProvider: (...args: unknown[]) => mockUpdateProvider(...args),
   deleteProvider: (...args: unknown[]) => mockDeleteProvider(...args),
+  getUnmaskedProviderKey: (...args: unknown[]) =>
+    mockGetUnmaskedProviderKey(...args),
   validateClaudeCodeHubConfig: vi.fn(),
   normalizeClaudeCodeHubBaseUrl: vi.fn(),
 }))
@@ -98,9 +104,11 @@ describe("Claude Code Hub managed-site provider", () => {
     mockFetchTokenScopedModels.mockReset()
     mockFetchManagedSiteAvailableModels.mockReset()
     mockListProviders.mockReset()
+    mockSearchProviders.mockReset()
     mockCreateProvider.mockReset()
     mockUpdateProvider.mockReset()
     mockDeleteProvider.mockReset()
+    mockGetUnmaskedProviderKey.mockReset()
     mockGetPreferences.mockReset()
     mockFindManagedSiteChannelByComparableInputs.mockReset()
     mockConvertToDisplayData.mockReset()
@@ -347,7 +355,7 @@ describe("Claude Code Hub managed-site provider", () => {
         adminToken: "admin-token",
       },
     })
-    mockListProviders.mockResolvedValue([
+    mockSearchProviders.mockResolvedValue([
       {
         id: 21,
         name: "Provider Alpha",
@@ -356,15 +364,6 @@ describe("Claude Code Hub managed-site provider", () => {
         key: "sk-real-key",
         allowedModels: ["gpt-4o"],
         groupTag: "team-a",
-      },
-      {
-        id: 22,
-        name: "Provider Beta",
-        providerType: "gemini",
-        url: "https://beta.example.com",
-        key: "sk-other-key",
-        allowedModels: ["gemini-2.5-pro"],
-        groupTag: "team-b",
       },
     ])
     mockCreateProvider.mockResolvedValue({ ok: true })
@@ -381,9 +380,16 @@ describe("Claude Code Hub managed-site provider", () => {
       ],
       type_counts: {
         codex: 1,
-        gemini: 1,
       },
     })
+    expect(mockSearchProviders).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+      "alpha",
+    )
+    expect(mockListProviders).not.toHaveBeenCalled()
 
     await expect(
       createChannel("", "", "", {
@@ -438,6 +444,83 @@ describe("Claude Code Hub managed-site provider", () => {
     })
   })
 
+  it("fetches real provider keys through the Claude Code Hub provider API", async () => {
+    mockGetPreferences.mockResolvedValue({
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+    })
+    mockGetUnmaskedProviderKey.mockResolvedValueOnce("sk-real-provider-key")
+
+    await expect(fetchChannelSecretKey("", "", "", 42)).resolves.toBe(
+      "sk-real-provider-key",
+    )
+    expect(mockGetUnmaskedProviderKey).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+      42,
+    )
+  })
+
+  it("hydrates masked provider keys before matching duplicate Claude Code Hub channels", async () => {
+    mockGetPreferences.mockResolvedValue({
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+    })
+    mockListProviders.mockResolvedValue([
+      {
+        id: 31,
+        name: "Masked Provider",
+        providerType: "openai-compatible",
+        url: "https://api.example.com",
+        maskedKey: "sk-***",
+        allowedModels: ["gpt-4o"],
+      },
+    ])
+    mockGetUnmaskedProviderKey.mockResolvedValueOnce("sk-real-key")
+    mockFindManagedSiteChannelByComparableInputs.mockResolvedValueOnce({
+      id: 31,
+      name: "Masked Provider",
+    })
+
+    await expect(
+      findMatchingChannel(
+        "",
+        "",
+        "",
+        "https://api.example.com",
+        ["gpt-4o"],
+        "sk-real-key",
+      ),
+    ).resolves.toEqual({
+      id: 31,
+      name: "Masked Provider",
+    })
+    expect(mockGetUnmaskedProviderKey).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+      31,
+    )
+    expect(mockFindManagedSiteChannelByComparableInputs).toHaveBeenCalledWith({
+      channels: [
+        expect.objectContaining({
+          id: 31,
+          key: "sk-real-key",
+        }),
+      ],
+      accountBaseUrl: "https://api.example.com",
+      models: ["gpt-4o"],
+      key: "sk-real-key",
+    })
+  })
+
   it("surfaces config and API failures for CRUD-style operations", async () => {
     mockGetPreferences.mockResolvedValueOnce({})
 
@@ -464,7 +547,7 @@ describe("Claude Code Hub managed-site provider", () => {
     })
     mockUpdateProvider.mockRejectedValueOnce(new Error("update failed"))
     mockDeleteProvider.mockRejectedValueOnce(new Error("delete failed"))
-    mockListProviders.mockRejectedValueOnce(new Error("search failed"))
+    mockSearchProviders.mockRejectedValueOnce(new Error("search failed"))
 
     await expect(searchChannel("", "", "", "alpha")).resolves.toBeNull()
     await expect(

--- a/tests/services/managedSites/tokenChannelStatus.test.ts
+++ b/tests/services/managedSites/tokenChannelStatus.test.ts
@@ -658,6 +658,45 @@ describe("getManagedSiteTokenChannelStatus", () => {
     expect(prepareChannelFormData).not.toHaveBeenCalled()
   })
 
+  it("checks Claude Code Hub token channel status through base URL search", async () => {
+    const account = buildDisplaySiteData({ baseUrl: "https://api.example.com" })
+    const token = buildApiToken({ key: "test-token-key" })
+    const searchChannel = vi.fn().mockResolvedValue({
+      items: [
+        buildManagedSiteChannel({
+          id: 42,
+          name: "Claude Code Hub Provider",
+          base_url: "https://api.example.com",
+          key: "test-token-key",
+          models: "gpt-4o",
+        }),
+      ],
+      total: 1,
+      type_counts: {},
+    })
+    const service = createManagedSiteServiceStub({
+      siteType: SITE_TYPES.CLAUDE_CODE_HUB,
+      messagesKey: "claudecodehub",
+      searchChannel,
+    })
+
+    const result = await getManagedSiteTokenChannelStatus({
+      account,
+      token,
+      service,
+    })
+
+    expect(supportsManagedSiteBaseUrlChannelLookup(service.siteType)).toBe(true)
+    expect(result).toMatchObject({
+      status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.ADDED,
+      matchedChannel: {
+        id: 42,
+        name: "Claude Code Hub Provider",
+      },
+    })
+    expect(searchChannel).toHaveBeenCalled()
+  })
+
   it("returns backend-search-failed without assessment when the backend search cannot complete", async () => {
     const account = buildDisplaySiteData({ baseUrl: "https://api.example.com" })
     const token = buildApiToken({ key: "test-token-key" })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code Hub managed sites now support loading real provider keys in the edit dialog.
  * Added provider search and unmasked key reveal capabilities for Claude Code Hub.

* **Documentation**
  * Updated localized settings text to state that only model sync and model redirect are unsupported for Claude Code Hub.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->