### PR TITLE
fix(tokens): align optional sk-prefix display and copy behavior

### DIFF
--- a/docs/superpowers/specs/managed-site-key-prefix-compatibility.md
+++ b/docs/superpowers/specs/managed-site-key-prefix-compatibility.md
@@ -1,0 +1,117 @@
+# Site Key Prefix Compatibility Evidence
+
+Date: 2026-05-18
+
+## Decision
+
+Treat `sk-` as an optional identity prefix only for One API/New API compatible
+site types or for backends with source-confirmed matching token authentication.
+Do not apply this rule globally to arbitrary API keys, API credential profiles,
+provider keys, or unconfirmed channel keys.
+
+In this codebase, channel matching defaults to exact key comparison. One API,
+New API, AnyRouter, Veloera, OneHub, DoneHub, `v-api`, VoAPI, Super-API,
+Rix-Api, Neo-API, and WONG公益站 may use optional `sk-` prefix comparison
+because they are source-confirmed, documented in `AGENTS.md` as One API/New API
+family compatibility buckets, or site-specific compatible deployments whose
+tokens are observed to use `sk-` keys. Among current managed-site providers,
+this rule is exercised by New API, Veloera, and DoneHub.
+
+## Source Review Summary
+
+| Gateway | Upstream source reviewed | Optional `sk-` auth prefix with bare stored key | Confidence | Notes |
+| --- | --- | --- | --- | --- |
+| New API | Previously known from New API source behavior and local adapter evidence | Yes | High | Token auth accepts optional `sk-`; key inventory may be bare or masked. |
+| One API | `songquanpeng/one-api` | Yes | High | `middleware/auth.go` strips `Bearer ` and `sk-` before token validation; token create/model paths store bare keys. |
+| AnyRouter | Local adapter plus observed deployment behavior | Yes by compatible deployment behavior | Medium | Adapter reuses common One/New API account helpers with AnyRouter-specific check-in overrides; user-confirmed keys use `sk-`. |
+| Veloera | `AGENTS.md` compatibility relationship | Yes by New API-family compatibility | Medium-high | Documented as downstream of New API and implemented with dedicated New API-family adapter overrides in this repo. |
+| OneHub | `MartialBE/one-hub` | Yes | High | `middleware/auth.go` strips `Bearer ` and `sk-`; token model/create paths return stored key values. |
+| DoneHub | `deanxv/done-hub` | Yes | High | `middleware/auth.go` strips `Bearer ` and `sk-`; generated token keys are stored bare and token responses do not add `sk-`. |
+| v-api | `AGENTS.md` compatibility relationship | Yes by One API/New API-family compatibility | Medium | Documented as based on One API with some New API functionality. Exact deployment depth can vary. |
+| VoAPI | `AGENTS.md` compatibility relationship | Yes for older compatible deployments | Medium | Older VoAPI support is treated as New API-family compatibility; newer VoAPI may be incompatible without target verification. |
+| Super-API | `AGENTS.md` compatibility relationship | Yes by New API-family compatibility | Medium | Documented as a New API-family variant or compatibility bucket; deployment modifications can vary. |
+| Rix-Api | `AGENTS.md` compatibility relationship | Yes by New API-family compatibility | Medium-low | Treated as a New API-family compatibility bucket in this repo; no single upstream is assumed. |
+| Neo-API | `AGENTS.md` compatibility relationship | Yes by New API-family compatibility | Medium-low | Treated as a New API-family compatibility bucket in this repo; no single upstream is assumed. |
+| WONG公益站 | Local adapter plus observed deployment behavior | Yes by compatible deployment behavior | Medium | Adapter reuses common One/New API account helpers with WONG-specific check-in and token-key reveal overrides; user-confirmed keys use `sk-`. |
+| Sub2API | `Wei-Shaw/sub2api` at `1d78dde8c414932a365c43985477d52eab044fbd` | No | High | Auth middlewares pass the full key to `GetByKey`; repository uses exact `apikey.KeyEQ(key)`. Random keys may be generated with `sk-`, but that prefix is part of the key. |
+| Octopus | `bestruirui/octopus` `dev` branch | No | High | Channel keys are stored, listed, and forwarded as-is. `sk-octopus-*` is a strict Octopus public API key format, not a channel key equivalence rule. |
+| AxonHub | `looplj/axonhub` `unstable` branch | No evidence found | Medium-high | Reviewed header extraction and channel credential structs. Header code strips transport prefixes such as `Bearer `, not a business-key `sk-` prefix. |
+| Claude Code Hub | `ding113/claude-code-hub` provider management files | No evidence found for provider keys | Medium | Provider key management uses masked display plus reveal. The review covered provider management paths, not every possible client auth path. |
+| AIHubMix | Closed source | Not source-confirmed | Not applicable | AIHubMix is closed source; observed keys are already `sk-` prefixed, so no optional-prefix normalization is justified from source evidence. |
+
+## Reviewed Upstream Files
+
+Repository compatibility policy:
+
+- AGENTS.md: Veloera is downstream of New API; `v-api` is a One API
+  derivative/New API-compatible bucket; older VoAPI, Super-API, Rix-Api, and
+  Neo-API are treated as New API-family variants or compatibility buckets.
+
+One API:
+
+- https://github.com/songquanpeng/one-api/blob/main/middleware/auth.go
+- https://github.com/songquanpeng/one-api/blob/main/controller/token.go
+- https://github.com/songquanpeng/one-api/blob/main/model/token.go
+
+OneHub:
+
+- https://github.com/MartialBE/one-hub/blob/main/middleware/auth.go
+- https://github.com/MartialBE/one-hub/blob/main/controller/token.go
+- https://github.com/MartialBE/one-hub/blob/main/model/token.go
+
+DoneHub:
+
+- https://github.com/deanxv/done-hub/blob/main/middleware/auth.go
+- https://github.com/deanxv/done-hub/blob/main/model/token.go
+- https://github.com/deanxv/done-hub/blob/main/common/user-token.go
+- https://github.com/deanxv/done-hub/blob/main/controller/token.go
+- https://github.com/deanxv/done-hub/blob/main/model/channel.go
+- https://github.com/deanxv/done-hub/blob/main/controller/channel.go
+
+Sub2API:
+
+- https://github.com/Wei-Shaw/sub2api/blob/1d78dde8c414932a365c43985477d52eab044fbd/backend/internal/server/middleware/api_key_auth.go
+- https://github.com/Wei-Shaw/sub2api/blob/1d78dde8c414932a365c43985477d52eab044fbd/backend/internal/server/middleware/api_key_auth_google.go
+- https://github.com/Wei-Shaw/sub2api/blob/1d78dde8c414932a365c43985477d52eab044fbd/backend/internal/service/api_key_service.go
+- https://github.com/Wei-Shaw/sub2api/blob/1d78dde8c414932a365c43985477d52eab044fbd/backend/internal/repository/api_key_repo.go
+
+Octopus:
+
+- https://github.com/bestruirui/octopus/blob/dev/internal/model/channel.go
+- https://github.com/bestruirui/octopus/blob/dev/internal/op/channel.go
+- https://github.com/bestruirui/octopus/blob/dev/internal/helper/fetch.go
+- https://github.com/bestruirui/octopus/blob/dev/internal/server/middleware/auth.go
+- https://github.com/bestruirui/octopus/blob/dev/README.md
+
+AxonHub:
+
+- https://github.com/looplj/axonhub/blob/unstable/internal/server/middleware/header.go
+- https://github.com/looplj/axonhub/blob/unstable/internal/objects/channel.go
+
+Claude Code Hub:
+
+- https://github.com/ding113/claude-code-hub/blob/main/src/actions/providers.ts
+- https://github.com/ding113/claude-code-hub/blob/main/src/app/api/v1/resources/providers/handlers.ts
+
+## Implementation Rules
+
+- Preserve backend-provided key values for storage, display, copy, and request
+  payloads unless a provider-specific adapter has an explicit reason to
+  transform them.
+- Use optional `sk-` prefix comparison only in identity checks for confirmed
+  compatible backends, documented compatibility buckets, and site-specific
+  compatible deployments with observed `sk-` token behavior: One API, New API,
+  AnyRouter, Veloera, OneHub, DoneHub, `v-api`, VoAPI, Super-API, Rix-Api,
+  Neo-API, and WONG公益站.
+- Use exact key comparison for Sub2API, Octopus, AxonHub, Claude Code Hub,
+  AIHubMix, and source-unknown API credentials.
+- Do not strip One API `-channelId` or OneHub `#channelId` suffixes in this
+  codebase unless implementing a dedicated parser for those upstream routing
+  syntaxes; those suffixes can change routing semantics.
+
+## Verification
+
+An independent re-review of the upstream files above reached the same gateway
+classification. The only caveat was Claude Code Hub: the conclusion is scoped
+to provider key management paths because the review did not exhaustively cover
+all client authentication and proxy forwarding paths.

--- a/e2e/accountOnboardingCommonFlows.spec.ts
+++ b/e2e/accountOnboardingCommonFlows.spec.ts
@@ -230,7 +230,7 @@ async function stubAIHubMixRoutes(context: BrowserContext) {
             id: 501,
             user_id: 808,
             name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-            full_key: "aihubmix-created-one-time-key",
+            full_key: "sk-aihubmix-created-one-time-key",
             status: 1,
             unlimited_quota: true,
             remain_quota: -1,

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -9,6 +9,7 @@ import {
   createDisplayAccountApiContext,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -209,7 +210,9 @@ export function useCopyKeyDialog(
             )
             return [...withoutCreated, createdToken]
           })
-          setOneTimeToken(createdToken)
+          setOneTimeToken(
+            formatOptionalSkPrefixSiteToken(createdToken, account.siteType),
+          )
           await copyKey(createdToken)
           return
         }

--- a/src/features/KeyManagement/components/AddTokenDialog/index.tsx
+++ b/src/features/KeyManagement/components/AddTokenDialog/index.tsx
@@ -6,6 +6,7 @@ import { Alert } from "~/components/ui"
 import { Modal } from "~/components/ui/Dialog/Modal"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { createDisplayAccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
+import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
@@ -172,9 +173,15 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
       } else {
         const created = await service.createApiToken(request, tokenData)
         const createdToken = isCreatedApiToken(created) ? created : undefined
+        const displayCreatedToken = createdToken
+          ? formatOptionalSkPrefixSiteToken(
+              createdToken,
+              currentAccount.siteType,
+            )
+          : undefined
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
         if (createdToken && showOneTimeKeyDialog) {
-          setOneTimeToken(createdToken)
+          setOneTimeToken(displayCreatedToken ?? createdToken)
         } else {
           toast.success(t("dialog.createSuccess"))
         }

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -9,6 +9,7 @@ import {
   createDisplayAccountApiContext,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { formatOptionalSkPrefixSiteTokenAuthKey } from "~/services/apiService/common/apiKey"
 import { getManagedSiteTokenChannelStatus } from "~/services/managedSites/tokenChannelStatus"
 import { supportsManagedSiteBaseUrlChannelLookup } from "~/services/managedSites/utils/managedSite"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
@@ -1224,9 +1225,13 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
   const getVisibleTokenKey = useCallback(
     (token: Pick<AccountToken, "accountId" | "id" | "key">) => {
       const tokenIdentityKey = buildTokenIdentityKey(token.accountId, token.id)
-      return resolvedVisibleKeys[tokenIdentityKey] ?? token.key
+      const account = accountById.get(token.accountId)
+      return formatOptionalSkPrefixSiteTokenAuthKey(
+        resolvedVisibleKeys[tokenIdentityKey] ?? token.key,
+        account?.siteType,
+      )
     },
-    [resolvedVisibleKeys],
+    [accountById, resolvedVisibleKeys],
   )
 
   const toggleKeyVisibility = async (

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -10,6 +10,7 @@ import {
   InvalidTokenPayloadError,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import { isTokenCompatibleWithModel } from "~/services/models/utils/tokenModelCompatibility"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
@@ -204,7 +205,9 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
           })
           if (isTokenCompatibleWithModel(createdToken, modelContext)) {
             setSelectedTokenId(createdToken.id)
-            setOneTimeToken(createdToken)
+            setOneTimeToken(
+              formatOptionalSkPrefixSiteToken(createdToken, account.siteType),
+            )
             toast.success(t("modelList:keyDialog.createSuccess"))
             return "success" as const
           } else {

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -1,4 +1,5 @@
 import { getApiService } from "~/services/apiService"
+import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import type { ApiServiceRequest } from "~/services/apiService/common/type"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { createLogger } from "~/utils/core/logger"
@@ -131,15 +132,10 @@ export async function resolveDisplayAccountTokenForSecret<
 ): Promise<TToken> {
   const { service, request } = createDisplayAccountApiContext(account)
   const resolvedKey = await service.resolveApiTokenKey(request, token)
-
-  if (resolvedKey === token.key) {
-    return token
-  }
-
-  return {
-    ...token,
-    key: resolvedKey,
-  }
+  return formatOptionalSkPrefixSiteToken(
+    resolvedKey === token.key ? token : { ...token, key: resolvedKey },
+    account.siteType,
+  )
 }
 
 /**

--- a/src/services/apiService/common/apiKey.ts
+++ b/src/services/apiService/common/apiKey.ts
@@ -1,23 +1,23 @@
 import type { ApiToken } from "~/types"
 
 /**
- * Ensures API keys are consistently represented with an `sk-` prefix.
+ * Normalizes a raw token key string without changing the backend-provided
+ * token shape.
  *
- * The application treats upstream API tokens as OpenAI-style keys. Normalizing
- * them at ingestion time keeps UI and integrations free from scattered `sk-`
- * prefix handling.
+ * Do not synthesize an `sk-` prefix here. Some backends store and return raw
+ * keys, and upstream `new-api` accepts an optional `sk-` prefix at auth time
+ * while persisting the underlying key without it
+ * (`controller/token.go:GetTokenUsage` trims `sk-` before lookup).
  */
-function ensureSkPrefixedKey(key: string): string {
-  const trimmed = key.trim()
-  if (!trimmed) return trimmed
-  return /^sk-/i.test(trimmed) ? trimmed : `sk-${trimmed}`
+function normalizeApiTokenKeyText(key: string): string {
+  return key.trim()
 }
 
 /**
- * Normalizes a raw token key string into the extension's canonical `sk-*` shape.
+ * Normalizes a raw token key string by trimming surrounding whitespace only.
  */
 export function normalizeApiTokenKeyValue(key: string): string {
-  return ensureSkPrefixedKey(key)
+  return normalizeApiTokenKeyText(key)
 }
 
 /**
@@ -41,7 +41,7 @@ export function hasUsableApiTokenKey(key: string): boolean {
 }
 
 /**
- * Normalizes an ApiToken so callers can safely assume `token.key` includes `sk-`.
+ * Normalizes an ApiToken so callers can rely on a trimmed key value.
  */
 export function normalizeApiTokenKey(token: ApiToken): ApiToken {
   if (!token || typeof token.key !== "string") return token

--- a/src/services/apiService/common/apiKey.ts
+++ b/src/services/apiService/common/apiKey.ts
@@ -1,4 +1,20 @@
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 import type { ApiToken } from "~/types"
+
+const OPTIONAL_SK_PREFIX_SITE_TYPES = new Set<string>([
+  SITE_TYPES.ONE_API,
+  SITE_TYPES.NEW_API,
+  SITE_TYPES.ANYROUTER,
+  SITE_TYPES.VELOERA,
+  SITE_TYPES.ONE_HUB,
+  SITE_TYPES.DONE_HUB,
+  SITE_TYPES.V_API,
+  SITE_TYPES.VO_API,
+  SITE_TYPES.SUPER_API,
+  SITE_TYPES.RIX_API,
+  SITE_TYPES.NEO_API,
+  SITE_TYPES.WONG_GONGYI,
+])
 
 /**
  * Normalizes a raw token key string without changing the backend-provided
@@ -18,6 +34,82 @@ function normalizeApiTokenKeyText(key: string): string {
  */
 export function normalizeApiTokenKeyValue(key: string): string {
   return normalizeApiTokenKeyText(key)
+}
+
+/**
+ * Returns true for One/New API-family site types whose token identity accepts
+ * either raw keys or a single `sk-` prefix, while user-facing auth/export
+ * values should be OpenAI-compatible `sk-...` keys.
+ */
+export function hasOptionalSkPrefixSiteTokenSemantics(
+  siteType?: AccountSiteType | string,
+): boolean {
+  return siteType ? OPTIONAL_SK_PREFIX_SITE_TYPES.has(siteType) : false
+}
+
+/**
+ * Formats a token key for auth/display/export boundaries for compatible site
+ * types without changing the backend-provided raw key stored in inventory.
+ */
+export function formatOptionalSkPrefixSiteTokenAuthKey(
+  key: string,
+  siteType?: AccountSiteType | string,
+): string {
+  const normalizedKey = normalizeApiTokenKeyValue(key)
+  if (!normalizedKey) return ""
+
+  if (
+    hasOptionalSkPrefixSiteTokenSemantics(siteType) &&
+    !normalizedKey.startsWith("sk-")
+  ) {
+    return `sk-${normalizedKey}`
+  }
+
+  return normalizedKey
+}
+
+/**
+ * Formats token identity when the caller already selected optional-`sk-`
+ * comparison semantics.
+ */
+export function formatOptionalSkPrefixTokenComparableKey(key: string): string {
+  const normalizedKey = normalizeApiTokenKeyValue(key)
+  return normalizedKey.startsWith("sk-")
+    ? normalizedKey.slice(3)
+    : normalizedKey
+}
+
+/**
+ * Formats token identity for compatible site-type comparisons where one
+ * leading `sk-` prefix is optional.
+ */
+export function formatOptionalSkPrefixSiteTokenComparableKey(
+  key: string,
+  siteType?: AccountSiteType | string,
+): string {
+  const normalizedKey = normalizeApiTokenKeyValue(key)
+  if (
+    hasOptionalSkPrefixSiteTokenSemantics(siteType) &&
+    normalizedKey.startsWith("sk-")
+  ) {
+    return formatOptionalSkPrefixTokenComparableKey(normalizedKey)
+  }
+  return normalizedKey
+}
+
+/**
+ * Returns a transient token clone with an auth/display key for compatible site
+ * types, preserving the caller's original token object when no change is
+ * needed.
+ */
+export function formatOptionalSkPrefixSiteToken<TToken extends ApiToken>(
+  token: TToken,
+  siteType?: AccountSiteType | string,
+): TToken {
+  if (!token || typeof token.key !== "string") return token
+
+  const authKey = formatOptionalSkPrefixSiteTokenAuthKey(token.key, siteType)
+  return authKey === token.key ? token : { ...token, key: authKey }
 }
 
 /**

--- a/src/services/apiService/common/index.ts
+++ b/src/services/apiService/common/index.ts
@@ -89,6 +89,14 @@ export {
   resolveApiTokenKey,
 } from "~/services/apiService/common/tokenKeyResolver"
 
+export {
+  formatOptionalSkPrefixSiteToken,
+  formatOptionalSkPrefixSiteTokenAuthKey,
+  formatOptionalSkPrefixSiteTokenComparableKey,
+  formatOptionalSkPrefixTokenComparableKey,
+  hasOptionalSkPrefixSiteTokenSemantics,
+} from "~/services/apiService/common/apiKey"
+
 /**
  * 搜索指定关键词的渠道。
  * @param request ApiServiceRequest（包含 baseUrl + 认证信息）。

--- a/src/services/managedSites/channelMatchResolver.ts
+++ b/src/services/managedSites/channelMatchResolver.ts
@@ -13,6 +13,7 @@ import type {
 import {
   findManagedSiteChannelsByBaseUrl,
   findManagedSiteChannelsByBaseUrlAndModels,
+  getManagedSiteChannelKeyComparisonMode,
   inspectManagedSiteChannelKeyMatch,
   inspectManagedSiteChannelModelsMatch,
   normalizeManagedSiteChannelBaseUrl,
@@ -21,7 +22,10 @@ import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/ma
 
 export type ManagedSiteChannelMatchService = Pick<
   ManagedSiteService,
-  "searchChannel" | "hydrateComparableChannelKeys" | "fetchChannelSecretKey"
+  | "siteType"
+  | "searchChannel"
+  | "hydrateComparableChannelKeys"
+  | "fetchChannelSecretKey"
 >
 
 interface ResolveManagedSiteChannelMatchParams {
@@ -107,6 +111,9 @@ export async function resolveManagedSiteChannelMatch(
     params.accountBaseUrl,
   )
   let unresolvedReason: ManagedSiteChannelMatchUnresolvedReason | undefined
+  const keyComparisonMode = getManagedSiteChannelKeyComparisonMode(
+    service.siteType,
+  )
 
   const searchResults = await service.searchChannel(
     managedConfig.baseUrl,
@@ -128,6 +135,7 @@ export async function resolveManagedSiteChannelMatch(
         channels: [],
         accountBaseUrl: searchBaseUrl,
         key,
+        keyComparisonMode,
       }),
       models: inspectManagedSiteChannelModelsMatch({
         channels: [],
@@ -156,6 +164,7 @@ export async function resolveManagedSiteChannelMatch(
     channels,
     accountBaseUrl: searchBaseUrl,
     key,
+    keyComparisonMode,
   })
   let modelsAssessment = inspectManagedSiteChannelModelsMatch({
     channels,
@@ -214,6 +223,7 @@ export async function resolveManagedSiteChannelMatch(
       channels: channelsWithResolvedKeys,
       accountBaseUrl: searchBaseUrl,
       key,
+      keyComparisonMode,
     })
     modelsAssessment = inspectManagedSiteChannelModelsMatch({
       channels: channelsWithResolvedKeys,

--- a/src/services/managedSites/providers/axonHub.ts
+++ b/src/services/managedSites/providers/axonHub.ts
@@ -5,6 +5,7 @@ import {
   AXON_HUB_CHANNEL_TYPE,
   DEFAULT_AXON_HUB_CHANNEL_FIELDS,
 } from "~/constants/axonHub"
+import { SITE_TYPES } from "~/constants/siteType"
 import { ensureAccountApiToken } from "~/services/accounts/accountOperations"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { normalizeAccountForManagedChannel } from "~/services/accounts/utils/siteUrlNormalization"
@@ -45,6 +46,7 @@ import { t } from "~/utils/i18n/core"
 const logger = createLogger("AxonHubService")
 
 const axonHubImportDuplicateService = {
+  siteType: SITE_TYPES.AXON_HUB,
   searchChannel,
 }
 

--- a/src/services/managedSites/providers/claudeCodeHub.ts
+++ b/src/services/managedSites/providers/claudeCodeHub.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_CLAUDE_CODE_HUB_CHANNEL_FIELDS,
   isClaudeCodeHubProviderType,
 } from "~/constants/claudeCodeHub"
+import { SITE_TYPES } from "~/constants/siteType"
 import { ensureAccountApiToken } from "~/services/accounts/accountOperations"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { normalizeAccountForManagedChannel } from "~/services/accounts/utils/siteUrlNormalization"
@@ -55,6 +56,7 @@ const logger = createLogger("ClaudeCodeHubService")
 const DEFAULT_GROUP_TAG = "default"
 
 const claudeCodeHubImportDuplicateService = {
+  siteType: SITE_TYPES.CLAUDE_CODE_HUB,
   searchChannel,
   hydrateComparableChannelKeys,
   fetchChannelSecretKey,

--- a/src/services/managedSites/providers/doneHubService.ts
+++ b/src/services/managedSites/providers/doneHubService.ts
@@ -47,6 +47,7 @@ import { resolveDefaultChannelGroups } from "./defaultChannelGroups"
 const logger = createLogger("DoneHubService")
 
 const doneHubImportDuplicateService = {
+  siteType: SITE_TYPES.DONE_HUB,
   searchChannel,
   hydrateComparableChannelKeys,
   fetchChannelSecretKey,

--- a/src/services/managedSites/providers/newApi.ts
+++ b/src/services/managedSites/providers/newApi.ts
@@ -51,6 +51,7 @@ import { resolveDefaultChannelGroups } from "./defaultChannelGroups"
 const logger = createLogger("NewApiService")
 
 const newApiImportDuplicateService = {
+  siteType: SITE_TYPES.NEW_API,
   searchChannel,
   hydrateComparableChannelKeys,
   fetchChannelSecretKey,

--- a/src/services/managedSites/providers/octopus.ts
+++ b/src/services/managedSites/providers/octopus.ts
@@ -6,6 +6,7 @@ import toast from "react-hot-toast"
 
 import { ChannelType } from "~/constants"
 import { DEFAULT_OCTOPUS_CHANNEL_FIELDS } from "~/constants/octopus"
+import { SITE_TYPES } from "~/constants/siteType"
 import { ensureAccountApiToken } from "~/services/accounts/accountOperations"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { normalizeAccountForManagedChannel } from "~/services/accounts/utils/siteUrlNormalization"
@@ -48,6 +49,7 @@ import { t } from "~/utils/i18n/core"
 const logger = createLogger("OctopusService")
 
 const octopusImportDuplicateService = {
+  siteType: SITE_TYPES.OCTOPUS,
   searchChannel,
 }
 

--- a/src/services/managedSites/providers/veloera.ts
+++ b/src/services/managedSites/providers/veloera.ts
@@ -46,6 +46,7 @@ import { resolveDefaultChannelGroups } from "./defaultChannelGroups"
 const logger = createLogger("VeloeraService")
 
 const veloeraImportDuplicateService = {
+  siteType: SITE_TYPES.VELOERA,
   searchChannel,
   hydrateComparableChannelKeys,
   fetchChannelSecretKey,

--- a/src/services/managedSites/utils/channelMatching.ts
+++ b/src/services/managedSites/utils/channelMatching.ts
@@ -1,4 +1,9 @@
 import {
+  SITE_TYPES,
+  type AccountSiteType,
+  type ManagedSiteType,
+} from "~/constants/siteType"
+import {
   MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS,
   MANAGED_SITE_CHANNEL_MATCH_LEVELS,
   MANAGED_SITE_CHANNEL_MATCH_REASONS,
@@ -18,6 +23,7 @@ interface FindManagedSiteChannelByComparableInputsParams {
   accountBaseUrl: string
   models: string[]
   key?: string
+  keyComparisonMode?: ManagedSiteChannelKeyComparisonMode
 }
 
 interface FindManagedSiteChannelsByBaseUrlParams {
@@ -42,6 +48,7 @@ interface InspectManagedSiteChannelKeyMatchParams {
   accountBaseUrl: string
   key?: string
   exactChannel?: ManagedSiteChannel | null
+  keyComparisonMode?: ManagedSiteChannelKeyComparisonMode
 }
 
 interface InspectManagedSiteChannelModelsMatchParams {
@@ -73,10 +80,63 @@ const MODEL_MATCH_REASON_PRIORITY: Record<
 const toNormalizedModelList = (models: string[] | string): string[] =>
   normalizeList(Array.isArray(models) ? models : parseDelimitedList(models))
 
-const toChannelKeyCandidates = (channel: ManagedSiteChannel): string[] =>
+export const MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES = {
+  EXACT: "exact",
+  OPTIONAL_SK_PREFIX: "optional-sk-prefix",
+} as const
+
+export type ManagedSiteChannelKeyComparisonMode =
+  (typeof MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES)[keyof typeof MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES]
+
+const OPTIONAL_SK_PREFIX_SITE_TYPES = new Set<string>([
+  SITE_TYPES.ONE_API,
+  SITE_TYPES.NEW_API,
+  SITE_TYPES.ANYROUTER,
+  SITE_TYPES.VELOERA,
+  SITE_TYPES.ONE_HUB,
+  SITE_TYPES.DONE_HUB,
+  SITE_TYPES.V_API,
+  SITE_TYPES.VO_API,
+  SITE_TYPES.SUPER_API,
+  SITE_TYPES.RIX_API,
+  SITE_TYPES.NEO_API,
+  SITE_TYPES.WONG_GONGYI,
+])
+
+/**
+ * Selects channel-key identity comparison semantics from source-confirmed
+ * upstream behavior plus the One/New API compatibility buckets documented in
+ * AGENTS.md.
+ */
+export function getManagedSiteChannelKeyComparisonMode(
+  siteType?: AccountSiteType | ManagedSiteType | string,
+): ManagedSiteChannelKeyComparisonMode {
+  return siteType && OPTIONAL_SK_PREFIX_SITE_TYPES.has(siteType)
+    ? MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX
+    : MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT
+}
+
+const toComparableChannelKey = (
+  key: string,
+  mode: ManagedSiteChannelKeyComparisonMode,
+): string => {
+  const trimmed = key.trim()
+  if (
+    mode === MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX &&
+    trimmed.startsWith("sk-")
+  ) {
+    return trimmed.slice(3)
+  }
+  return trimmed
+}
+
+const toChannelKeyCandidates = (
+  channel: ManagedSiteChannel,
+  mode: ManagedSiteChannelKeyComparisonMode,
+): string[] =>
   (channel.key ?? "")
     .split(/[\n,]/)
-    .map((item) => item.trim())
+    .map((key) => toComparableChannelKey(key, mode))
     .filter(Boolean)
 
 const isSubset = (subset: string[], superset: string[]) =>
@@ -175,7 +235,12 @@ export function findManagedSiteChannelByComparableInputs(
   params: FindManagedSiteChannelByComparableInputsParams,
 ): ManagedSiteChannel | null {
   const { channels, accountBaseUrl, models, key } = params
-  const normalizedDesiredKey = (key ?? "").trim()
+  const keyComparisonMode =
+    params.keyComparisonMode ?? MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT
+  const normalizedDesiredKey = toComparableChannelKey(
+    key ?? "",
+    keyComparisonMode,
+  )
   const shouldMatchKey = normalizedDesiredKey.length > 0
   const comparableChannels = findManagedSiteChannelsByBaseUrlAndModels({
     channels,
@@ -189,12 +254,9 @@ export function findManagedSiteChannelByComparableInputs(
         return true
       }
 
-      const candidates = (channel.key ?? "")
-        .split(/[\n,]/)
-        .map((item) => item.trim())
-        .filter(Boolean)
-
-      return candidates.includes(normalizedDesiredKey)
+      return toChannelKeyCandidates(channel, keyComparisonMode).includes(
+        normalizedDesiredKey,
+      )
     }) ?? null
   )
 }
@@ -206,7 +268,12 @@ export function findManagedSiteChannelByComparableInputs(
 export function inspectManagedSiteChannelKeyMatch(
   params: InspectManagedSiteChannelKeyMatchParams,
 ): ManagedSiteChannelKeyAssessment {
-  const normalizedDesiredKey = (params.key ?? "").trim()
+  const keyComparisonMode =
+    params.keyComparisonMode ?? MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT
+  const normalizedDesiredKey = toComparableChannelKey(
+    params.key ?? "",
+    keyComparisonMode,
+  )
 
   if (!normalizedDesiredKey) {
     return {
@@ -242,7 +309,9 @@ export function inspectManagedSiteChannelKeyMatch(
 
   const matchedChannel =
     urlBucket.find((channel) =>
-      toChannelKeyCandidates(channel).includes(normalizedDesiredKey),
+      toChannelKeyCandidates(channel, keyComparisonMode).includes(
+        normalizedDesiredKey,
+      ),
     ) ?? null
 
   if (matchedChannel) {
@@ -255,7 +324,7 @@ export function inspectManagedSiteChannelKeyMatch(
   }
 
   const hasComparableChannelKey = urlBucket.some(
-    (channel) => toChannelKeyCandidates(channel).length > 0,
+    (channel) => toChannelKeyCandidates(channel, keyComparisonMode).length > 0,
   )
 
   if (!hasComparableChannelKey) {

--- a/src/services/managedSites/utils/channelMatching.ts
+++ b/src/services/managedSites/utils/channelMatching.ts
@@ -1,8 +1,11 @@
 import {
-  SITE_TYPES,
   type AccountSiteType,
   type ManagedSiteType,
 } from "~/constants/siteType"
+import {
+  formatOptionalSkPrefixTokenComparableKey,
+  hasOptionalSkPrefixSiteTokenSemantics,
+} from "~/services/apiService/common/apiKey"
 import {
   MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS,
   MANAGED_SITE_CHANNEL_MATCH_LEVELS,
@@ -85,23 +88,8 @@ export const MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES = {
   OPTIONAL_SK_PREFIX: "optional-sk-prefix",
 } as const
 
-export type ManagedSiteChannelKeyComparisonMode =
+type ManagedSiteChannelKeyComparisonMode =
   (typeof MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES)[keyof typeof MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES]
-
-const OPTIONAL_SK_PREFIX_SITE_TYPES = new Set<string>([
-  SITE_TYPES.ONE_API,
-  SITE_TYPES.NEW_API,
-  SITE_TYPES.ANYROUTER,
-  SITE_TYPES.VELOERA,
-  SITE_TYPES.ONE_HUB,
-  SITE_TYPES.DONE_HUB,
-  SITE_TYPES.V_API,
-  SITE_TYPES.VO_API,
-  SITE_TYPES.SUPER_API,
-  SITE_TYPES.RIX_API,
-  SITE_TYPES.NEO_API,
-  SITE_TYPES.WONG_GONGYI,
-])
 
 /**
  * Selects channel-key identity comparison semantics from source-confirmed
@@ -111,7 +99,7 @@ const OPTIONAL_SK_PREFIX_SITE_TYPES = new Set<string>([
 export function getManagedSiteChannelKeyComparisonMode(
   siteType?: AccountSiteType | ManagedSiteType | string,
 ): ManagedSiteChannelKeyComparisonMode {
-  return siteType && OPTIONAL_SK_PREFIX_SITE_TYPES.has(siteType)
+  return hasOptionalSkPrefixSiteTokenSemantics(siteType)
     ? MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX
     : MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT
 }
@@ -125,7 +113,7 @@ const toComparableChannelKey = (
     mode === MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX &&
     trimmed.startsWith("sk-")
   ) {
-    return trimmed.slice(3)
+    return formatOptionalSkPrefixTokenComparableKey(trimmed)
   }
   return trimmed
 }

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -1540,13 +1540,13 @@ describe("useChannelDialog", () => {
         id: "account-id",
       }),
       expect.objectContaining({
-        key: "ensured-token",
+        key: "sk-ensured-token",
       }),
     )
     expect(result.current.context.state).toMatchObject({
       isOpen: true,
       initialValues: {
-        key: "ensured-token",
+        key: "sk-ensured-token",
       },
     })
 

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -307,6 +307,48 @@ describe("ModelKeyDialog", () => {
     )
   })
 
+  it("formats optional-prefix compatible created keys before showing the one-time dialog", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce({
+      ...TOKEN,
+      id: 8,
+      key: "created-full-secret",
+      name: "model-key",
+    })
+
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+
+    render(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{ ...ACCOUNT, siteType: "Veloera" }}
+        modelId="gpt-4"
+        modelEnableGroups={["default"]}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "modelList:keyDialog.createKey",
+      }),
+    )
+
+    expect(
+      await screen.findByText("keyManagement:oneTimeKey.title"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText("keyManagement:oneTimeKey.keyLabel"),
+    ).toHaveValue("sk-created-full-secret")
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("sk-created-full-secret")
+    })
+  })
+
   it("shows a compatibility error when default create returns an incompatible full token", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     createApiTokenMock.mockResolvedValueOnce({

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -109,6 +109,39 @@ describe("fetchDisplayAccountTokens", () => {
     expect(result).not.toBe(token)
   })
 
+  it("returns a transient sk-prefixed secret for optional-prefix compatible account types", async () => {
+    const token = { id: 1, key: "plain-secret", status: 1, name: "Plain" }
+    const resolveApiTokenKey = vi.fn().mockResolvedValue("plain-secret")
+    vi.mocked(getApiService).mockReturnValue({ resolveApiTokenKey } as any)
+
+    const result = await resolveDisplayAccountTokenForSecret(
+      { ...ACCOUNT, siteType: "Veloera" } as any,
+      token as any,
+    )
+
+    expect(result).toEqual({
+      id: 1,
+      key: "sk-plain-secret",
+      status: 1,
+      name: "Plain",
+    })
+    expect(result).not.toBe(token)
+    expect(token.key).toBe("plain-secret")
+  })
+
+  it("does not synthesize sk-prefixes for non-compatible account types", async () => {
+    const token = { id: 1, key: "plain-secret", status: 1, name: "Plain" }
+    const resolveApiTokenKey = vi.fn().mockResolvedValue("plain-secret")
+    vi.mocked(getApiService).mockReturnValue({ resolveApiTokenKey } as any)
+
+    const result = await resolveDisplayAccountTokenForSecret(
+      { ...ACCOUNT, siteType: "sub2api" } as any,
+      token as any,
+    )
+
+    expect(result).toBe(token)
+  })
+
   it("only allows token management for enabled accounts with complete auth context", () => {
     expect(canManageDisplayAccountTokens(null)).toBe(false)
     expect(

--- a/tests/services/apiService/aihubmix/index.test.ts
+++ b/tests/services/apiService/aihubmix/index.test.ts
@@ -122,7 +122,7 @@ describe("apiService AIHubMix", () => {
       expect.objectContaining({
         id: 0,
         user_id: 0,
-        key: "sk-direct-key",
+        key: "direct-key",
         status: 1,
         name: "",
         created_time: 0,
@@ -521,7 +521,7 @@ describe("apiService AIHubMix", () => {
     expect(tokens).toEqual([
       expect.objectContaining({
         id: 1,
-        key: "sk-plain-key",
+        key: "plain-key",
         name: "test-key",
         remain_quota: 500000,
         used_quota: 1000,
@@ -620,7 +620,7 @@ describe("apiService AIHubMix", () => {
     expect(tokens).toEqual([
       expect.objectContaining({
         id: 9,
-        key: "sk-searched-key",
+        key: "searched-key",
         name: "search match",
       }),
     ])
@@ -832,7 +832,7 @@ describe("apiService AIHubMix", () => {
 
     await expect(fetchTokenById(baseRequest, 12)).resolves.toMatchObject({
       id: 12,
-      key: "sk-detail-key",
+      key: "detail-key",
     })
     await expect(createApiToken(baseRequest, tokenRequest)).resolves.toEqual(
       expect.objectContaining({
@@ -1029,7 +1029,7 @@ describe("apiService AIHubMix", () => {
         id: 12,
         key: "plain-key",
       } as any),
-    ).resolves.toBe("sk-plain-key")
+    ).resolves.toBe("plain-key")
     expect(revealCalled).toBe(false)
     expect(detailCalled).toBe(false)
   })

--- a/tests/services/apiService/common/tokenApi.test.ts
+++ b/tests/services/apiService/common/tokenApi.test.ts
@@ -4,7 +4,10 @@ import { SITE_TYPES } from "~/constants/siteType"
 import {
   fetchAccountTokens,
   fetchTokenById,
+  formatOptionalSkPrefixSiteToken,
   formatOptionalSkPrefixSiteTokenAuthKey,
+  formatOptionalSkPrefixSiteTokenComparableKey,
+  formatOptionalSkPrefixTokenComparableKey,
   hasOptionalSkPrefixSiteTokenSemantics,
   resolveApiTokenKey,
 } from "~/services/apiService/common"
@@ -83,6 +86,38 @@ describe("apiService common token APIs", () => {
     expect(
       formatOptionalSkPrefixSiteTokenAuthKey("   ", SITE_TYPES.NEW_API),
     ).toBe("")
+  })
+
+  it("formats comparable keys for optional sk-prefix semantics", () => {
+    expect(formatOptionalSkPrefixTokenComparableKey(" sk-abc ")).toBe("abc")
+    expect(
+      formatOptionalSkPrefixSiteTokenComparableKey(
+        "sk-abc",
+        SITE_TYPES.NEW_API,
+      ),
+    ).toBe("abc")
+    expect(
+      formatOptionalSkPrefixSiteTokenComparableKey(
+        "sk-abc",
+        SITE_TYPES.SUB2API,
+      ),
+    ).toBe("sk-abc")
+  })
+
+  it("formats token auth keys by site type and preserves identity when unchanged", () => {
+    const token = { id: 1, key: "plain-key" } as any
+    const formatted = formatOptionalSkPrefixSiteToken(token, SITE_TYPES.NEW_API)
+
+    expect(formatted.key).toBe("sk-plain-key")
+    expect(formatted).not.toBe(token)
+
+    const alreadyPrefixed = { id: 2, key: "sk-ready" } as any
+    const unchanged = formatOptionalSkPrefixSiteToken(
+      alreadyPrefixed,
+      SITE_TYPES.NEW_API,
+    )
+
+    expect(unchanged).toBe(alreadyPrefixed)
   })
 
   it("fetchAccountTokens trims token.key without forcing an sk- prefix (array response)", async () => {

--- a/tests/services/apiService/common/tokenApi.test.ts
+++ b/tests/services/apiService/common/tokenApi.test.ts
@@ -5,6 +5,7 @@ import {
   fetchTokenById,
   resolveApiTokenKey,
 } from "~/services/apiService/common"
+import { normalizeApiTokenKeyValue } from "~/services/apiService/common/apiKey"
 import {
   fetchTokenSecretKeyById,
   fetchTokenSecretKeyByIdWithMethod,
@@ -45,7 +46,12 @@ describe("apiService common token APIs", () => {
     mockFetchApi.mockReset()
   })
 
-  it("fetchAccountTokens normalizes token.key with sk- prefix (array response)", async () => {
+  it("normalizeApiTokenKeyValue trims whitespace without adding sk- prefixes", () => {
+    expect(normalizeApiTokenKeyValue("  plain-key  ")).toBe("plain-key")
+    expect(normalizeApiTokenKeyValue("sk-already")).toBe("sk-already")
+  })
+
+  it("fetchAccountTokens trims token.key without forcing an sk- prefix (array response)", async () => {
     mockedFetchApiData.mockResolvedValueOnce([
       { id: 1, key: "plain-key" },
       { id: 2, key: "sk-already" },
@@ -70,13 +76,13 @@ describe("apiService common token APIs", () => {
     expect(endpoint).toContain("size=100")
 
     expect(result.map((token: any) => token.key)).toEqual([
-      "sk-plain-key",
+      "plain-key",
       "sk-already",
       "sk-trim",
     ])
   })
 
-  it("fetchAccountTokens normalizes token.key with sk- prefix (paginated response)", async () => {
+  it("fetchAccountTokens trims token.key without forcing an sk- prefix (paginated response)", async () => {
     mockedFetchApiData.mockResolvedValueOnce({
       items: [{ id: 1, key: "plain" }],
     })
@@ -91,10 +97,10 @@ describe("apiService common token APIs", () => {
     }
 
     const result = await fetchAccountTokens(request as any)
-    expect(result.map((token: any) => token.key)).toEqual(["sk-plain"])
+    expect(result.map((token: any) => token.key)).toEqual(["plain"])
   })
 
-  it("fetchTokenById normalizes token.key with sk- prefix", async () => {
+  it("fetchTokenById trims token.key without forcing an sk- prefix", async () => {
     mockedFetchApiData.mockResolvedValueOnce({ id: 99, key: "abc" })
 
     const request = {
@@ -111,7 +117,7 @@ describe("apiService common token APIs", () => {
     expect(mockedFetchApiData).toHaveBeenCalledWith(request, {
       endpoint: "/api/token/99",
     })
-    expect((result as any).key).toBe("sk-abc")
+    expect((result as any).key).toBe("abc")
   })
 
   it("resolveApiTokenKey fetches the explicit secret when inventory key is masked", async () => {
@@ -141,7 +147,7 @@ describe("apiService common token APIs", () => {
         method: "POST",
       },
     })
-    expect(result).toBe("sk-resolved-secret")
+    expect(result).toBe("resolved-secret")
   })
 
   it("fetchTokenSecretKeyByIdWithMethod uses the caller-provided HTTP method", async () => {
@@ -159,7 +165,7 @@ describe("apiService common token APIs", () => {
 
     await expect(
       fetchTokenSecretKeyByIdWithMethod(request as any, 70, "GET"),
-    ).resolves.toBe("sk-resolved-via-get")
+    ).resolves.toBe("resolved-via-get")
 
     expect(mockedFetchApiData).toHaveBeenCalledWith(request, {
       endpoint: "/api/token/70/key",
@@ -221,15 +227,15 @@ describe("apiService common token APIs", () => {
     ])
 
     expect(mockedFetchApiData).toHaveBeenCalledTimes(1)
-    expect(first).toBe("sk-deduped-secret")
-    expect(second).toBe("sk-deduped-secret")
+    expect(first).toBe("deduped-secret")
+    expect(second).toBe("deduped-secret")
   })
 
   it("resolveApiTokenKeyWithFetcher reuses the shared dedupe/cache path for custom site fetchers", async () => {
     const fetchSecretKey = vi.fn().mockImplementationOnce(
       () =>
         new Promise((resolve) => {
-          setTimeout(() => resolve("sk-custom-secret"), 0)
+          setTimeout(() => resolve("custom-secret"), 0)
         }),
     )
 
@@ -263,8 +269,8 @@ describe("apiService common token APIs", () => {
 
     expect(fetchSecretKey).toHaveBeenCalledTimes(1)
     expect(fetchSecretKey).toHaveBeenCalledWith(request, 71)
-    expect(first).toBe("sk-custom-secret")
-    expect(second).toBe("sk-custom-secret")
+    expect(first).toBe("custom-secret")
+    expect(second).toBe("custom-secret")
   })
 
   it("resolveApiTokenKey returns an empty normalized key without fetching", async () => {
@@ -309,7 +315,7 @@ describe("apiService common token APIs", () => {
       } as any,
     )
 
-    expect(result).toBe("sk-plain-secret")
+    expect(result).toBe("plain-secret")
     expect(mockedFetchApiData).not.toHaveBeenCalled()
   })
 
@@ -394,13 +400,13 @@ describe("apiService common token APIs", () => {
 
     await expect(
       resolveApiTokenKey(request as any, token as any),
-    ).resolves.toBe("sk-first-secret")
+    ).resolves.toBe("first-secret")
 
     invalidateResolvedApiTokenKeyCache(request as any)
 
     await expect(
       resolveApiTokenKey(request as any, token as any),
-    ).resolves.toBe("sk-second-secret")
+    ).resolves.toBe("second-secret")
     expect(mockedFetchApiData).toHaveBeenCalledTimes(2)
   })
 
@@ -425,7 +431,7 @@ describe("apiService common token APIs", () => {
 
     await expect(
       resolveApiTokenKey(request as any, token as any),
-    ).resolves.toBe("sk-first-secret")
+    ).resolves.toBe("first-secret")
 
     syncResolvedApiTokenKeyCache(
       request as any,
@@ -439,7 +445,7 @@ describe("apiService common token APIs", () => {
 
     await expect(
       resolveApiTokenKey(request as any, token as any),
-    ).resolves.toBe("sk-refetched-secret")
+    ).resolves.toBe("refetched-secret")
     expect(mockedFetchApiData).toHaveBeenCalledTimes(2)
   })
 
@@ -477,19 +483,19 @@ describe("apiService common token APIs", () => {
 
     await expect(
       resolveApiTokenKey(scopedRequest as any, scopedToken as any),
-    ).resolves.toBe("sk-scoped-secret")
+    ).resolves.toBe("scoped-secret")
     await expect(
       resolveApiTokenKey(otherRequest as any, otherToken as any),
-    ).resolves.toBe("sk-other-secret")
+    ).resolves.toBe("other-secret")
 
     invalidateResolvedApiTokenKeyCache(scopedRequest as any)
 
     await expect(
       resolveApiTokenKey(scopedRequest as any, scopedToken as any),
-    ).resolves.toBe("sk-refetched-scoped-secret")
+    ).resolves.toBe("refetched-scoped-secret")
     await expect(
       resolveApiTokenKey(otherRequest as any, otherToken as any),
-    ).resolves.toBe("sk-other-secret")
+    ).resolves.toBe("other-secret")
 
     expect(mockedFetchApiData).toHaveBeenCalledTimes(3)
   })
@@ -514,7 +520,7 @@ describe("apiService common token APIs", () => {
 
     await expect(
       resolveApiTokenKey(request as any, token as any),
-    ).resolves.toBe("sk-stable-secret")
+    ).resolves.toBe("stable-secret")
 
     syncResolvedApiTokenKeyCache(
       request as any,
@@ -532,7 +538,7 @@ describe("apiService common token APIs", () => {
 
     await expect(
       resolveApiTokenKey(request as any, token as any),
-    ).resolves.toBe("sk-refetched-secret")
+    ).resolves.toBe("refetched-secret")
 
     expect(mockedFetchApiData).toHaveBeenCalledTimes(2)
   })
@@ -561,7 +567,7 @@ describe("apiService common token APIs", () => {
     ).rejects.toThrow("temporary failure")
     await expect(
       resolveApiTokenKey(request as any, token as any),
-    ).resolves.toBe("sk-retry-secret")
+    ).resolves.toBe("retry-secret")
 
     expect(mockedFetchApiData).toHaveBeenCalledTimes(2)
   })

--- a/tests/services/apiService/common/tokenApi.test.ts
+++ b/tests/services/apiService/common/tokenApi.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import {
   fetchAccountTokens,
   fetchTokenById,
+  formatOptionalSkPrefixSiteTokenAuthKey,
+  hasOptionalSkPrefixSiteTokenSemantics,
   resolveApiTokenKey,
 } from "~/services/apiService/common"
 import { normalizeApiTokenKeyValue } from "~/services/apiService/common/apiKey"
@@ -49,6 +52,37 @@ describe("apiService common token APIs", () => {
   it("normalizeApiTokenKeyValue trims whitespace without adding sk- prefixes", () => {
     expect(normalizeApiTokenKeyValue("  plain-key  ")).toBe("plain-key")
     expect(normalizeApiTokenKeyValue("sk-already")).toBe("sk-already")
+  })
+
+  it("formats auth/display keys for optional sk-prefix compatible site types only", () => {
+    expect(hasOptionalSkPrefixSiteTokenSemantics(SITE_TYPES.NEW_API)).toBe(true)
+    expect(hasOptionalSkPrefixSiteTokenSemantics(SITE_TYPES.VELOERA)).toBe(true)
+    expect(hasOptionalSkPrefixSiteTokenSemantics(SITE_TYPES.ONE_HUB)).toBe(true)
+    expect(hasOptionalSkPrefixSiteTokenSemantics(SITE_TYPES.DONE_HUB)).toBe(
+      true,
+    )
+    expect(hasOptionalSkPrefixSiteTokenSemantics(SITE_TYPES.ANYROUTER)).toBe(
+      true,
+    )
+    expect(hasOptionalSkPrefixSiteTokenSemantics(SITE_TYPES.SUB2API)).toBe(
+      false,
+    )
+    expect(hasOptionalSkPrefixSiteTokenSemantics(SITE_TYPES.AIHUBMIX)).toBe(
+      false,
+    )
+
+    expect(
+      formatOptionalSkPrefixSiteTokenAuthKey(" plain-key ", SITE_TYPES.VELOERA),
+    ).toBe("sk-plain-key")
+    expect(
+      formatOptionalSkPrefixSiteTokenAuthKey("sk-already", SITE_TYPES.DONE_HUB),
+    ).toBe("sk-already")
+    expect(
+      formatOptionalSkPrefixSiteTokenAuthKey("plain-key", SITE_TYPES.SUB2API),
+    ).toBe("plain-key")
+    expect(
+      formatOptionalSkPrefixSiteTokenAuthKey("   ", SITE_TYPES.NEW_API),
+    ).toBe("")
   })
 
   it("fetchAccountTokens trims token.key without forcing an sk- prefix (array response)", async () => {

--- a/tests/services/apiService/oneHub/index.test.ts
+++ b/tests/services/apiService/oneHub/index.test.ts
@@ -113,7 +113,7 @@ describe("OneHub API service", () => {
     expect(result).toEqual(tokens)
   })
 
-  it("fetchAccountTokens should normalize token.key with sk- prefix", async () => {
+  it("fetchAccountTokens should trim token.key without synthesizing an sk- prefix", async () => {
     mockedFetchApiData.mockResolvedValueOnce([
       { id: 1, key: "plain" },
       { id: 2, key: "sk-already" },
@@ -122,7 +122,7 @@ describe("OneHub API service", () => {
 
     const result = await fetchAccountTokens(baseRequest as any)
     expect(result.map((token: any) => token.key)).toEqual([
-      "sk-plain",
+      "plain",
       "sk-already",
       "sk-trim",
     ])

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -325,7 +325,7 @@ describe("apiService sub2api parsing", () => {
     expect(token).toMatchObject({
       id: 7,
       user_id: 42,
-      key: "sk-sub2api-token",
+      key: "sub2api-token",
       status: 1,
       name: "Primary Key",
       remain_quota: 0,
@@ -869,7 +869,7 @@ describe("apiService sub2api refreshAccountData", () => {
     ).toBe("resynced-jwt")
     expect(tokens).toHaveLength(1)
     expect(tokens[0]).toMatchObject({
-      key: "sk-sub2api-token",
+      key: "sub2api-token",
       group: "default",
     })
   })

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -95,7 +95,7 @@ describe("apiService sub2api key management parsing", () => {
 
     expect(token.id).toBe(7)
     expect(token.user_id).toBe(5)
-    expect(token.key).toBe("sk-test-key")
+    expect(token.key).toBe("test-key")
     expect(token.status).toBe(0)
     expect(token.remain_quota).toBe(Math.round(1.25 * 500000))
     expect(token.used_quota).toBe(Math.round(1.25 * 500000))
@@ -531,7 +531,7 @@ describe("apiService sub2api key management service", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(tokens).toHaveLength(1)
-    expect(tokens[0].key).toBe("sk-retried-key")
+    expect(tokens[0].key).toBe("retried-key")
     expect(updateAccountMock).toHaveBeenCalledWith(
       "acc-1",
       expect.objectContaining({

--- a/tests/services/apiService/wong/index.test.ts
+++ b/tests/services/apiService/wong/index.test.ts
@@ -286,7 +286,7 @@ describe("apiService wong", () => {
         id: 7,
         key: "sk-abcd************wxyz",
       } as any),
-    ).resolves.toBe("sk-resolved-secret")
+    ).resolves.toBe("resolved-secret")
 
     expect(mockFetchApiData).toHaveBeenCalledWith(baseRequest, {
       endpoint: "/api/token/7/key",

--- a/tests/services/managedSites/channelMatchResolver.test.ts
+++ b/tests/services/managedSites/channelMatchResolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import {
   getManagedSiteChannelExactMatch,
   MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS,
@@ -80,6 +81,98 @@ describe("resolveManagedSiteChannelMatch", () => {
     expect(result.models.reason).toBe(
       MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.EXACT,
     )
+  })
+
+  it("matches optional sk- prefixes for New API compatible managed sites", async () => {
+    const channel = buildManagedSiteChannel({
+      id: 61,
+      key: "stored-key",
+      base_url: "https://api.example.com/v1",
+      models: "gpt-4o",
+    })
+    const service = createManagedSiteServiceStub({
+      siteType: SITE_TYPES.NEW_API,
+      searchChannel: vi.fn().mockResolvedValue({
+        items: [channel],
+      }),
+    })
+
+    const result = await resolveManagedSiteChannelMatch({
+      service,
+      managedConfig,
+      accountBaseUrl: "https://api.example.com/v1",
+      models: ["gpt-4o"],
+      key: "sk-stored-key",
+    })
+
+    expect(result.key).toEqual({
+      comparable: true,
+      matched: true,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED,
+      channel,
+    })
+  })
+
+  it("matches optional sk- prefixes for DoneHub managed sites", async () => {
+    const channel = buildManagedSiteChannel({
+      id: 63,
+      key: "stored-key",
+      base_url: "https://api.example.com/v1",
+      models: "gpt-4o",
+    })
+    const service = createManagedSiteServiceStub({
+      siteType: SITE_TYPES.DONE_HUB,
+      searchChannel: vi.fn().mockResolvedValue({
+        items: [channel],
+      }),
+    })
+
+    const result = await resolveManagedSiteChannelMatch({
+      service,
+      managedConfig,
+      accountBaseUrl: "https://api.example.com/v1",
+      models: ["gpt-4o"],
+      key: "sk-stored-key",
+    })
+
+    expect(result.key).toEqual({
+      comparable: true,
+      matched: true,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED,
+      channel,
+    })
+  })
+
+  it("keeps non-compatible managed-site key matching exact", async () => {
+    const service = createManagedSiteServiceStub({
+      siteType: SITE_TYPES.OCTOPUS,
+      searchChannel: vi.fn().mockResolvedValue({
+        items: [
+          buildManagedSiteChannel({
+            id: 62,
+            key: "stored-key",
+            base_url: "https://api.example.com/v1",
+            models: "gpt-4o",
+          }),
+        ],
+      }),
+    })
+
+    const result = await resolveManagedSiteChannelMatch({
+      service,
+      managedConfig,
+      accountBaseUrl: "https://api.example.com/v1",
+      models: ["gpt-4o"],
+      key: "sk-stored-key",
+    })
+
+    expect(result.key).toEqual({
+      comparable: true,
+      matched: false,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.NO_MATCH,
+      channel: null,
+    })
+    expect(getManagedSiteChannelExactMatch(result)).toBeNull()
   })
 
   it("hydrates narrowed comparable candidates instead of calling provider duplicate search", async () => {

--- a/tests/services/managedSites/channelMatching.test.ts
+++ b/tests/services/managedSites/channelMatching.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import {
   MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS,
   MANAGED_SITE_CHANNEL_MATCH_LEVELS,
@@ -12,12 +13,71 @@ import {
   findManagedSiteChannelByComparableInputs,
   findManagedSiteChannelsByBaseUrl,
   findManagedSiteChannelsByBaseUrlAndModels,
+  getManagedSiteChannelKeyComparisonMode,
   inspectManagedSiteChannelKeyMatch,
   inspectManagedSiteChannelModelsMatch,
+  MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES,
 } from "~/services/managedSites/utils/channelMatching"
 import { buildManagedSiteChannel } from "~~/tests/test-utils/factories"
 
 describe("channelMatching", () => {
+  it("uses optional sk- prefix comparison for One/New API compatible gateways", () => {
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.ONE_API)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.NEW_API)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.ANYROUTER)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.VELOERA)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.ONE_HUB)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.DONE_HUB)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.V_API)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.VO_API)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.SUPER_API)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.RIX_API)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.NEO_API)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.WONG_GONGYI)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+    )
+  })
+
+  it("keeps non-compatible and source-unknown gateways on exact key comparison", () => {
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.SUB2API)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.OCTOPUS)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT,
+    )
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.AXON_HUB)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT,
+    )
+    expect(
+      getManagedSiteChannelKeyComparisonMode(SITE_TYPES.CLAUDE_CODE_HUB),
+    ).toBe(MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT)
+    expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.AIHUBMIX)).toBe(
+      MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT,
+    )
+  })
+
   it("normalizes OpenAI-family base URLs before filtering the URL bucket", () => {
     const matchingChannel = buildManagedSiteChannel({
       id: 0,
@@ -88,6 +148,76 @@ describe("channelMatching", () => {
     ).toBe(keyedComparableChannel)
   })
 
+  it("compares channel keys exactly by default", () => {
+    const channelWithoutPrefix = buildManagedSiteChannel({
+      id: 1_21,
+      base_url: "https://api.example.com",
+      models: "gpt-4",
+      key: "stored-key",
+    })
+    const channelWithPrefix = buildManagedSiteChannel({
+      id: 1_22,
+      base_url: "https://api.example.com",
+      models: "gpt-4",
+      key: "sk-stored-key",
+    })
+
+    expect(
+      findManagedSiteChannelByComparableInputs({
+        channels: [channelWithoutPrefix],
+        accountBaseUrl: "https://api.example.com",
+        models: ["gpt-4"],
+        key: "sk-stored-key",
+      }),
+    ).toBeNull()
+
+    expect(
+      findManagedSiteChannelByComparableInputs({
+        channels: [channelWithPrefix],
+        accountBaseUrl: "https://api.example.com",
+        models: ["gpt-4"],
+        key: "stored-key",
+      }),
+    ).toBeNull()
+  })
+
+  it("treats an optional sk- prefix as equivalent when that comparison mode is enabled", () => {
+    const channelWithoutPrefix = buildManagedSiteChannel({
+      id: 1_23,
+      base_url: "https://api.example.com",
+      models: "gpt-4",
+      key: "stored-key",
+    })
+    const channelWithPrefix = buildManagedSiteChannel({
+      id: 1_24,
+      base_url: "https://api.example.com",
+      models: "gpt-4",
+      key: "sk-stored-key",
+    })
+
+    expect(
+      findManagedSiteChannelByComparableInputs({
+        channels: [channelWithoutPrefix],
+        accountBaseUrl: "https://api.example.com",
+        models: ["gpt-4"],
+        key: "sk-stored-key",
+        keyComparisonMode:
+          MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+      }),
+    ).toBe(channelWithoutPrefix)
+
+    expect(
+      findManagedSiteChannelByComparableInputs({
+        channels: [channelWithPrefix],
+        accountBaseUrl: "https://api.example.com",
+        models: ["gpt-4"],
+        key: "stored-key",
+        keyComparisonMode:
+          MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+      }),
+    ).toBe(channelWithPrefix)
+  })
+
   it("reports key comparison as unavailable when no key is provided", () => {
     const result = inspectManagedSiteChannelKeyMatch({
       channels: [],
@@ -138,6 +268,50 @@ describe("channelMatching", () => {
       reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.EXACT,
       channel: exactChannel,
       similarityScore: 1,
+    })
+  })
+
+  it("matches managed-site channel keys exactly by default", () => {
+    const channel = buildManagedSiteChannel({
+      id: 1_31,
+      base_url: "https://api.example.com",
+      key: "stored-key",
+    })
+
+    expect(
+      inspectManagedSiteChannelKeyMatch({
+        channels: [channel],
+        accountBaseUrl: "https://api.example.com",
+        key: "sk-stored-key",
+      }),
+    ).toEqual({
+      comparable: true,
+      matched: false,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.NO_MATCH,
+      channel: null,
+    })
+  })
+
+  it("matches managed-site channel keys regardless of optional sk- prefix when enabled", () => {
+    const channel = buildManagedSiteChannel({
+      id: 1_32,
+      base_url: "https://api.example.com",
+      key: "stored-key",
+    })
+
+    expect(
+      inspectManagedSiteChannelKeyMatch({
+        channels: [channel],
+        accountBaseUrl: "https://api.example.com",
+        key: "sk-stored-key",
+        keyComparisonMode:
+          MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+      }),
+    ).toEqual({
+      comparable: true,
+      matched: true,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED,
+      channel,
     })
   })
 

--- a/tests/services/managedSites/channelMatching.test.ts
+++ b/tests/services/managedSites/channelMatching.test.ts
@@ -76,6 +76,9 @@ describe("channelMatching", () => {
     expect(getManagedSiteChannelKeyComparisonMode(SITE_TYPES.AIHUBMIX)).toBe(
       MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT,
     )
+    expect(
+      getManagedSiteChannelKeyComparisonMode("unknown-site-type" as any),
+    ).toBe(MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT)
   })
 
   it("normalizes OpenAI-family base URLs before filtering the URL bucket", () => {

--- a/tests/services/managedSites/importDuplicateResolution.test.ts
+++ b/tests/services/managedSites/importDuplicateResolution.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import {
   MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS,
   MatchResolutionUnresolvedError,
 } from "~/services/managedSites/channelMatch"
+import type { ManagedSiteChannelMatchService } from "~/services/managedSites/channelMatchResolver"
 import { resolveManagedSiteImportDuplicate } from "~/services/managedSites/importDuplicateResolution"
 import { CHANNEL_STATUS } from "~/types/managedSite"
 
@@ -25,9 +27,17 @@ const formData = {
   status: CHANNEL_STATUS.Enable,
 }
 
+const createService = (
+  overrides: Omit<ManagedSiteChannelMatchService, "siteType"> &
+    Partial<Pick<ManagedSiteChannelMatchService, "siteType">>,
+): ManagedSiteChannelMatchService => ({
+  siteType: SITE_TYPES.NEW_API,
+  ...overrides,
+})
+
 describe("resolveManagedSiteImportDuplicate", () => {
   it("defaults unresolved exact-model hidden-key duplicates to verification required", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [
           {
@@ -39,7 +49,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
           },
         ],
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -55,7 +65,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
   })
 
   it("preserves provider unresolved reasons for exact-model hidden-key duplicates", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [
           {
@@ -72,7 +82,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
           MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS.KEY_RESOLUTION_FAILED,
         )
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -88,7 +98,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
   })
 
   it("returns null when hidden-key comparison is unavailable without an exact model match", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [
           {
@@ -100,7 +110,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
           },
         ],
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -112,11 +122,11 @@ describe("resolveManagedSiteImportDuplicate", () => {
   })
 
   it("returns null when search finds no duplicate candidates", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [],
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -129,9 +139,9 @@ describe("resolveManagedSiteImportDuplicate", () => {
 
   it("propagates search failures from duplicate lookup", async () => {
     const searchError = new Error("API unavailable")
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockRejectedValue(searchError),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -143,7 +153,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
   })
 
   it("prefers the exact key and model duplicate from multiple candidates", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [
           {
@@ -162,7 +172,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
           },
         ],
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -177,7 +187,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
   })
 
   it("ignores malformed candidates that cannot match comparable import inputs", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [
           {
@@ -194,7 +204,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
           },
         ],
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -206,7 +216,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
   })
 
   it("matches duplicate candidates with the same multiple-model set", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [
           {
@@ -218,7 +228,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
           },
         ],
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -236,7 +246,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
   })
 
   it("returns null when import form data has no models to compare", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [
           {
@@ -248,7 +258,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
           },
         ],
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -263,7 +273,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
   })
 
   it("returns exact duplicate channels", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [
           {
@@ -275,7 +285,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
           },
         ],
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({
@@ -290,7 +300,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
   })
 
   it("passes through non-hidden-key non-matches", async () => {
-    const service = {
+    const service = createService({
       searchChannel: vi.fn().mockResolvedValue({
         items: [
           {
@@ -302,7 +312,7 @@ describe("resolveManagedSiteImportDuplicate", () => {
           },
         ],
       }),
-    }
+    })
 
     await expect(
       resolveManagedSiteImportDuplicate({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added spec describing when an optional "sk-" API key prefix is allowed and how it should be handled for managed sites/backends.

* **New Features**
  * UI now shows and copies token keys according to site-specific prefix rules (one-time key dialogs, account/key views).
  * Channel matching for managed sites now considers site-aware key comparison modes.

* **Tests**
  * Added/updated tests covering token formatting, display, copy behavior, and channel-key matching across site types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->