### PR TITLE
refactor(managed-sites): pass explicit runtime configs through service adapters

### DIFF
--- a/docs/superpowers/plans/2026-05-19-managed-site-runtime-config.md
+++ b/docs/superpowers/plans/2026-05-19-managed-site-runtime-config.md
@@ -800,7 +800,7 @@ Then update calls:
 ```ts
 const searchResults = await service.searchChannel(
   managedConfig,
-  searchBaseUrl,
+  keyword,
 )
 ```
 

--- a/docs/superpowers/plans/2026-05-19-managed-site-runtime-config.md
+++ b/docs/superpowers/plans/2026-05-19-managed-site-runtime-config.md
@@ -1,0 +1,1349 @@
+# Managed Site Runtime Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the shallow managed-site `baseUrl/token/userId` operation Interface with explicit site-specific runtime configs passed from the business layer into each Adapter.
+
+**Architecture:** Add a runtime config resolver Module that is the only managed-site operation path allowed to read `userPreferences`. `ManagedSiteService` becomes a registry for site-specific Adapters whose operation functions accept explicit full config objects. Business-layer flows resolve config once and pass that config through channel matching, import duplicate resolution, token batch export, and channel migration.
+
+**Tech Stack:** TypeScript, Vitest, WXT extension services, existing managed-site provider modules.
+
+---
+
+## File Structure
+
+- Create `src/services/managedSites/runtimeConfig.ts`
+  - Owns the managed-site runtime config union, explicit config resolution from a `UserPreferences` snapshot, async current/explicit config loaders, and shared compatibility conversion helpers.
+- Create `tests/services/managedSites/runtimeConfig.test.ts`
+  - Tests complete and incomplete config resolution for every managed-site type.
+- Modify `src/services/managedSites/managedSiteService.ts`
+  - Replaces operation signatures with config-object signatures.
+  - Wires `getConfig()` to `runtimeConfig.ts`.
+  - Keeps service selection and `messagesKey` behavior unchanged.
+- Modify `tests/services/managedSiteService/managedSiteService.test.ts`
+  - Updates mocks and expectations for runtime configs instead of `{ baseUrl, token, userId }`.
+- Modify provider modules:
+  - `src/services/managedSites/providers/newApi.ts`
+  - `src/services/managedSites/providers/doneHubService.ts`
+  - `src/services/managedSites/providers/veloera.ts`
+  - `src/services/managedSites/providers/octopus.ts`
+  - `src/services/managedSites/providers/axonHub.ts`
+  - `src/services/managedSites/providers/claudeCodeHub.ts`
+- Modify provider tests:
+  - `tests/services/newApiService/newApiService.test.ts`
+  - `tests/services/doneHubService/doneHubService.test.ts`
+  - `tests/services/doneHubService/doneHubService.more.test.ts`
+  - `tests/services/veloeraService/veloeraService.test.ts`
+  - `tests/services/veloeraService/veloeraService.more.test.ts`
+  - `tests/services/octopusService/octopusService.more.test.ts`
+  - `tests/services/managedSites/providers/axonHub.test.ts`
+  - `tests/services/managedSites/providers/claudeCodeHub.test.ts`
+- Modify shared managed-site flows:
+  - `src/services/managedSites/channelMatchResolver.ts`
+  - `src/services/managedSites/importDuplicateResolution.ts`
+  - `src/services/managedSites/channelMigration.ts`
+  - `src/services/managedSites/tokenBatchExport.ts`
+  - `src/services/managedSites/tokenChannelStatus.ts` if compile reveals it still consumes the old operation Interface.
+- Modify shared flow tests:
+  - `tests/services/managedSites/channelMatchResolver.test.ts`
+  - `tests/services/managedSites/importDuplicateResolution.test.ts`
+  - `tests/services/managedSites/channelMigration.test.ts`
+  - `tests/services/managedSites/tokenBatchExport.test.ts`
+  - `tests/services/managedSites/tokenChannelStatus.test.ts` if touched by implementation.
+
+---
+
+### Task 1: Add Runtime Config Resolver
+
+**Files:**
+
+- Create: `src/services/managedSites/runtimeConfig.ts`
+- Test: `tests/services/managedSites/runtimeConfig.test.ts`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Create `tests/services/managedSites/runtimeConfig.test.ts` with these tests:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  getManagedSiteLegacyAdminConfig,
+  resolveManagedSiteRuntimeConfigForType,
+} from "~/services/managedSites/runtimeConfig"
+import { buildUserPreferences } from "~~/tests/test-utils/factories"
+
+describe("managed-site runtime config resolver", () => {
+  it("resolves full runtime configs for every managed-site type", () => {
+    const prefs = buildUserPreferences({
+      newApi: {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "new-token",
+        userId: "1",
+      },
+      doneHub: {
+        baseUrl: "https://donehub.example.com",
+        adminToken: "done-token",
+        userId: "2",
+      },
+      veloera: {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "3",
+      },
+      octopus: {
+        baseUrl: "https://octopus.example.com",
+        username: "octo-admin",
+        password: "octo-password",
+      },
+      axonHub: {
+        baseUrl: "https://axonhub.example.com",
+        email: "admin@example.com",
+        password: "axon-password",
+      },
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "cch-token",
+      },
+    })
+
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.NEW_API),
+    ).toEqual({
+      siteType: SITE_TYPES.NEW_API,
+      config: prefs.newApi,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.DONE_HUB),
+    ).toEqual({
+      siteType: SITE_TYPES.DONE_HUB,
+      config: prefs.doneHub,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.VELOERA),
+    ).toEqual({
+      siteType: SITE_TYPES.VELOERA,
+      config: prefs.veloera,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.OCTOPUS),
+    ).toEqual({
+      siteType: SITE_TYPES.OCTOPUS,
+      config: prefs.octopus,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.AXON_HUB),
+    ).toEqual({
+      siteType: SITE_TYPES.AXON_HUB,
+      config: prefs.axonHub,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(
+        prefs,
+        SITE_TYPES.CLAUDE_CODE_HUB,
+      ),
+    ).toEqual({
+      siteType: SITE_TYPES.CLAUDE_CODE_HUB,
+      config: prefs.claudeCodeHub,
+    })
+  })
+
+  it("returns null for incomplete configs", () => {
+    const prefs = buildUserPreferences({
+      newApi: {
+        baseUrl: "",
+        adminToken: "new-token",
+        userId: "1",
+      },
+      octopus: {
+        baseUrl: "https://octopus.example.com",
+        username: "",
+        password: "octo-password",
+      },
+      axonHub: {
+        baseUrl: "https://axonhub.example.com",
+        email: "admin@example.com",
+        password: "",
+      },
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "",
+      },
+    })
+
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.NEW_API),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.OCTOPUS),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.AXON_HUB),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(
+        prefs,
+        SITE_TYPES.CLAUDE_CODE_HUB,
+      ),
+    ).toBeNull()
+  })
+
+  it("converts full runtime configs to the legacy admin shape for compatibility consumers", () => {
+    const prefs = buildUserPreferences({
+      newApi: {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "new-token",
+        userId: "1",
+      },
+      octopus: {
+        baseUrl: "https://octopus.example.com",
+        username: "octo-admin",
+        password: "octo-password",
+      },
+      axonHub: {
+        baseUrl: "https://axonhub.example.com",
+        email: "admin@example.com",
+        password: "axon-password",
+      },
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "cch-token",
+      },
+    })
+
+    expect(
+      getManagedSiteLegacyAdminConfig(
+        resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.NEW_API)!,
+      ),
+    ).toEqual({
+      baseUrl: "https://new-api.example.com",
+      adminToken: "new-token",
+      userId: "1",
+    })
+    expect(
+      getManagedSiteLegacyAdminConfig(
+        resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.OCTOPUS)!,
+      ),
+    ).toEqual({
+      baseUrl: "https://octopus.example.com",
+      adminToken: "",
+      userId: "octo-admin",
+    })
+    expect(
+      getManagedSiteLegacyAdminConfig(
+        resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.AXON_HUB)!,
+      ),
+    ).toEqual({
+      baseUrl: "https://axonhub.example.com",
+      adminToken: "axon-password",
+      userId: "admin@example.com",
+    })
+    expect(
+      getManagedSiteLegacyAdminConfig(
+        resolveManagedSiteRuntimeConfigForType(
+          prefs,
+          SITE_TYPES.CLAUDE_CODE_HUB,
+        )!,
+      ),
+    ).toEqual({
+      baseUrl: "https://cch.example.com",
+      adminToken: "cch-token",
+      userId: "admin",
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/runtimeConfig.test.ts
+```
+
+Expected: FAIL because `~/services/managedSites/runtimeConfig` does not exist.
+
+- [ ] **Step 3: Implement the resolver Module**
+
+Create `src/services/managedSites/runtimeConfig.ts`:
+
+```ts
+import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import {
+  userPreferences,
+  type UserPreferences,
+} from "~/services/preferences/userPreferences"
+import type { AxonHubConfig } from "~/types/axonHubConfig"
+import type { ClaudeCodeHubConfig } from "~/types/claudeCodeHubConfig"
+import type { DoneHubConfig } from "~/types/doneHubConfig"
+import type { NewApiConfig } from "~/types/newApiConfig"
+import type { OctopusConfig } from "~/types/octopusConfig"
+import type { VeloeraConfig } from "~/types/veloeraConfig"
+
+export interface ManagedSiteLegacyAdminConfig {
+  baseUrl: string
+  adminToken: string
+  userId: string
+}
+
+export type ManagedSiteRuntimeConfig =
+  | { siteType: typeof SITE_TYPES.NEW_API; config: NewApiConfig }
+  | { siteType: typeof SITE_TYPES.DONE_HUB; config: DoneHubConfig }
+  | { siteType: typeof SITE_TYPES.VELOERA; config: VeloeraConfig }
+  | { siteType: typeof SITE_TYPES.OCTOPUS; config: OctopusConfig }
+  | { siteType: typeof SITE_TYPES.AXON_HUB; config: AxonHubConfig }
+  | {
+      siteType: typeof SITE_TYPES.CLAUDE_CODE_HUB
+      config: ClaudeCodeHubConfig
+    }
+
+export type ManagedSiteRuntimeConfigValue = ManagedSiteRuntimeConfig["config"]
+
+const hasText = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+function resolveAccessTokenConfig(
+  config: NewApiConfig | DoneHubConfig | VeloeraConfig | undefined,
+) {
+  if (!config) return null
+  if (!hasText(config.baseUrl) || !hasText(config.adminToken)) return null
+  if (!hasText(config.userId)) return null
+  return config
+}
+
+export function resolveManagedSiteRuntimeConfigForType(
+  preferences: UserPreferences,
+  siteType: ManagedSiteType,
+): ManagedSiteRuntimeConfig | null {
+  if (siteType === SITE_TYPES.OCTOPUS) {
+    const config = preferences.octopus
+    if (
+      !config ||
+      !hasText(config.baseUrl) ||
+      !hasText(config.username) ||
+      !hasText(config.password)
+    ) {
+      return null
+    }
+    return { siteType, config }
+  }
+
+  if (siteType === SITE_TYPES.AXON_HUB) {
+    const config = preferences.axonHub
+    if (
+      !config ||
+      !hasText(config.baseUrl) ||
+      !hasText(config.email) ||
+      !hasText(config.password)
+    ) {
+      return null
+    }
+    return { siteType, config }
+  }
+
+  if (siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
+    const config = preferences.claudeCodeHub
+    if (!config || !hasText(config.baseUrl) || !hasText(config.adminToken)) {
+      return null
+    }
+    return { siteType, config }
+  }
+
+  if (siteType === SITE_TYPES.DONE_HUB) {
+    const config = resolveAccessTokenConfig(preferences.doneHub)
+    return config ? { siteType, config } : null
+  }
+
+  if (siteType === SITE_TYPES.VELOERA) {
+    const config = resolveAccessTokenConfig(preferences.veloera)
+    return config ? { siteType, config } : null
+  }
+
+  const config = resolveAccessTokenConfig(preferences.newApi)
+  return config ? { siteType: SITE_TYPES.NEW_API, config } : null
+}
+
+export function resolveCurrentManagedSiteRuntimeConfig(
+  preferences: UserPreferences,
+): ManagedSiteRuntimeConfig | null {
+  return resolveManagedSiteRuntimeConfigForType(
+    preferences,
+    preferences.managedSiteType || SITE_TYPES.NEW_API,
+  )
+}
+
+export async function getCurrentManagedSiteRuntimeConfig(): Promise<ManagedSiteRuntimeConfig | null> {
+  try {
+    const preferences = await userPreferences.getPreferences()
+    return resolveCurrentManagedSiteRuntimeConfig(preferences)
+  } catch {
+    return null
+  }
+}
+
+export async function getManagedSiteRuntimeConfigForType(
+  siteType: ManagedSiteType,
+): Promise<ManagedSiteRuntimeConfig | null> {
+  try {
+    const preferences = await userPreferences.getPreferences()
+    return resolveManagedSiteRuntimeConfigForType(preferences, siteType)
+  } catch {
+    return null
+  }
+}
+
+export function getManagedSiteLegacyAdminConfig(
+  runtimeConfig: ManagedSiteRuntimeConfig,
+): ManagedSiteLegacyAdminConfig {
+  if (runtimeConfig.siteType === SITE_TYPES.OCTOPUS) {
+    return {
+      baseUrl: runtimeConfig.config.baseUrl,
+      adminToken: "",
+      userId: runtimeConfig.config.username,
+    }
+  }
+
+  if (runtimeConfig.siteType === SITE_TYPES.AXON_HUB) {
+    return {
+      baseUrl: runtimeConfig.config.baseUrl,
+      adminToken: runtimeConfig.config.password,
+      userId: runtimeConfig.config.email,
+    }
+  }
+
+  if (runtimeConfig.siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
+    return {
+      baseUrl: runtimeConfig.config.baseUrl,
+      adminToken: runtimeConfig.config.adminToken,
+      userId: "admin",
+    }
+  }
+
+  return {
+    baseUrl: runtimeConfig.config.baseUrl,
+    adminToken: runtimeConfig.config.adminToken,
+    userId: runtimeConfig.config.userId,
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/runtimeConfig.test.ts
+```
+
+Expected: PASS.
+
+---
+
+### Task 2: Wire ManagedSiteService to Runtime Configs
+
+**Files:**
+
+- Modify: `src/services/managedSites/managedSiteService.ts`
+- Modify: `src/services/managedSites/utils/managedSite.ts`
+- Test: `tests/services/managedSiteService/managedSiteService.test.ts`
+- Test: `tests/services/managedSites/runtimeConfig.test.ts`
+
+- [ ] **Step 1: Update service tests for full configs**
+
+In `tests/services/managedSiteService/managedSiteService.test.ts`, update provider mocks so `getConfig()` returns full config objects:
+
+```ts
+vi.mock("~/services/managedSites/providers/axonHub", () => ({
+  checkValidAxonHubConfig: vi.fn(async () => true),
+  searchChannel: vi.fn(),
+  createChannel: vi.fn(),
+  updateChannel: vi.fn(),
+  deleteChannel: vi.fn(),
+  fetchAvailableModels: vi.fn(),
+  buildChannelName: vi.fn(),
+  prepareChannelFormData: vi.fn(),
+  buildChannelPayload: vi.fn(),
+  autoConfigToAxonHub: vi.fn(),
+}))
+```
+
+Then update config expectations to full runtime configs after importing the service:
+
+```ts
+mockGetPreferences.mockResolvedValueOnce({
+  managedSiteType: SITE_TYPES.AXON_HUB,
+  axonHub: {
+    baseUrl: "https://axonhub.example.com",
+    email: "admin@example.com",
+    password: "secret",
+  },
+})
+
+const service = getManagedSiteServiceForType(SITE_TYPES.AXON_HUB)
+await expect(service.getConfig()).resolves.toEqual({
+  baseUrl: "https://axonhub.example.com",
+  email: "admin@example.com",
+  password: "secret",
+})
+```
+
+Add one assertion for explicit service routing:
+
+```ts
+mockGetPreferences.mockResolvedValueOnce({
+  managedSiteType: SITE_TYPES.NEW_API,
+  claudeCodeHub: {
+    baseUrl: "https://cch.example.com",
+    adminToken: "cch-token",
+  },
+})
+
+const service = getManagedSiteServiceForType(SITE_TYPES.CLAUDE_CODE_HUB)
+await expect(service.getConfig()).resolves.toEqual({
+  baseUrl: "https://cch.example.com",
+  adminToken: "cch-token",
+})
+```
+
+- [ ] **Step 2: Run service tests to verify failure**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSiteService/managedSiteService.test.ts
+```
+
+Expected: FAIL because `ManagedSiteService.getConfig()` still delegates to provider-local config functions and operation signatures still use `baseUrl/token/userId`.
+
+- [ ] **Step 3: Update `ManagedSiteService` types and registry**
+
+In `src/services/managedSites/managedSiteService.ts`:
+
+1. Import runtime config types and resolver:
+
+```ts
+import {
+  getManagedSiteRuntimeConfigForType,
+  getCurrentManagedSiteRuntimeConfig,
+  type ManagedSiteRuntimeConfigValue,
+} from "~/services/managedSites/runtimeConfig"
+```
+
+2. Replace `ManagedSiteConfig` with an alias for compatibility:
+
+```ts
+export type ManagedSiteConfig = ManagedSiteRuntimeConfigValue
+```
+
+3. Update `ManagedSiteService` operation signatures:
+
+```ts
+export interface ManagedSiteService {
+  siteType: ManagedSiteType
+  messagesKey: ManagedSiteMessagesKey
+
+  searchChannel(
+    config: ManagedSiteRuntimeConfigValue,
+    keyword: string,
+  ): Promise<ManagedSiteChannelListData | null>
+
+  createChannel(
+    config: ManagedSiteRuntimeConfigValue,
+    channelData: CreateChannelPayload,
+  ): Promise<ApiResponse<unknown>>
+
+  updateChannel(
+    config: ManagedSiteRuntimeConfigValue,
+    channelData: UpdateChannelPayload,
+  ): Promise<ApiResponse<unknown>>
+
+  deleteChannel(
+    config: ManagedSiteRuntimeConfigValue,
+    channelId: number,
+  ): Promise<ApiResponse<unknown>>
+
+  checkValidConfig(): Promise<boolean>
+  getConfig(): Promise<ManagedSiteRuntimeConfigValue | null>
+
+  fetchAvailableModels(
+    account: DisplaySiteData,
+    token: ApiToken,
+  ): Promise<string[]>
+
+  buildChannelName(account: DisplaySiteData, token: ApiToken): string
+
+  prepareChannelFormData(
+    account: DisplaySiteData,
+    token: ApiToken | AccountToken,
+  ): Promise<ChannelFormData>
+
+  buildChannelPayload(
+    formData: ChannelFormData,
+    mode?: ChannelMode,
+  ): CreateChannelPayload
+
+  hydrateComparableChannelKeys?(
+    config: ManagedSiteRuntimeConfigValue,
+    candidates: ManagedSiteChannel[],
+  ): Promise<ManagedSiteChannel[]>
+
+  fetchChannelSecretKey?(
+    config: ManagedSiteRuntimeConfigValue,
+    channelId: number,
+  ): Promise<string>
+
+  autoConfigToManagedSite(
+    account: SiteAccount,
+    toastId?: string,
+  ): Promise<unknown>
+}
+```
+
+4. Add helper:
+
+```ts
+const getConfigForServiceType = async (siteType: ManagedSiteType) => {
+  const runtimeConfig = await getManagedSiteRuntimeConfigForType(siteType)
+  return runtimeConfig?.config ?? null
+}
+```
+
+5. Replace each provider's `getConfig` wiring:
+
+```ts
+getConfig: () => getConfigForServiceType(siteType),
+```
+
+For `getManagedSiteService()`, continue using preferences only to select the current site type:
+
+```ts
+export async function getManagedSiteService(): Promise<ManagedSiteService> {
+  const runtimeConfig = await getCurrentManagedSiteRuntimeConfig()
+  const siteType = runtimeConfig?.siteType ?? SITE_TYPES.NEW_API
+  return getManagedSiteServiceForType(siteType)
+}
+```
+
+- [ ] **Step 4: Move legacy admin config helpers to the resolver**
+
+In `src/services/managedSites/utils/managedSite.ts`, import and reuse:
+
+```ts
+import {
+  getManagedSiteLegacyAdminConfig,
+  resolveManagedSiteRuntimeConfigForType,
+} from "~/services/managedSites/runtimeConfig"
+```
+
+Rewrite `getManagedSiteAdminConfigForType`:
+
+```ts
+export function getManagedSiteAdminConfigForType(
+  preferences: UserPreferences,
+  siteType: ManagedSiteType,
+): ManagedSiteAdminConfig | null {
+  const runtimeConfig = resolveManagedSiteRuntimeConfigForType(
+    preferences,
+    siteType,
+  )
+  return runtimeConfig ? getManagedSiteLegacyAdminConfig(runtimeConfig) : null
+}
+```
+
+Keep label/message helpers in `managedSite.ts`.
+
+- [ ] **Step 5: Run service and resolver tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/runtimeConfig.test.ts tests/services/managedSiteService/managedSiteService.test.ts
+```
+
+Expected: PASS.
+
+---
+
+### Task 3: Convert New API-Family Providers to Config Objects
+
+**Files:**
+
+- Modify: `src/services/managedSites/providers/newApi.ts`
+- Modify: `src/services/managedSites/providers/doneHubService.ts`
+- Modify: `src/services/managedSites/providers/veloera.ts`
+- Test: `tests/services/newApiService/newApiService.test.ts`
+- Test: `tests/services/doneHubService/doneHubService.test.ts`
+- Test: `tests/services/veloeraService/veloeraService.test.ts`
+- Test: `tests/services/managedSites/channelMatchResolver.test.ts`
+
+- [ ] **Step 1: Update one provider test to require config-object operations**
+
+In the most focused New API/DoneHub/Veloera tests, add assertions following this shape:
+
+```ts
+const config = {
+  baseUrl: "https://donehub.example.com",
+  adminToken: "done-token",
+  userId: "9",
+}
+
+await provider.searchChannel(config, "alpha")
+
+expect(mockSearchChannel).toHaveBeenCalledWith(
+  {
+    baseUrl: "https://donehub.example.com",
+    auth: {
+      authType: AuthTypeEnum.AccessToken,
+      accessToken: "done-token",
+      userId: "9",
+    },
+  },
+  "alpha",
+)
+```
+
+For key hydration in `tests/services/managedSites/channelMatchResolver.test.ts`, update the service stub:
+
+```ts
+hydrateComparableChannelKeys: vi.fn(async (_config, candidates) => candidates)
+```
+
+And update expectations:
+
+```ts
+expect(hydrateComparableChannelKeys).toHaveBeenCalledWith(
+  managedConfig,
+  [expect.objectContaining({ id: 7 })],
+)
+```
+
+- [ ] **Step 2: Run related tests to verify failure**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/channelMatchResolver.test.ts tests/services/doneHubService/doneHubService.test.ts tests/services/veloeraService/veloeraService.test.ts
+```
+
+Expected: FAIL because providers and channel match resolver still call the old signatures.
+
+- [ ] **Step 3: Convert provider function signatures**
+
+For `newApi.ts`, `doneHubService.ts`, and `veloera.ts`, replace operation signatures:
+
+```ts
+export async function searchChannel(
+  config: NewApiConfig,
+  keyword: string,
+): Promise<ManagedSiteChannelListData | null> {
+  return await getApiService(SITE_TYPES.NEW_API).searchChannel(
+    {
+      baseUrl: config.baseUrl,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: config.adminToken,
+        userId: config.userId,
+      },
+    },
+    keyword,
+  )
+}
+```
+
+Apply the same pattern for:
+
+- `createChannel(config, channelData)`
+- `updateChannel(config, channelData)`
+- `deleteChannel(config, channelId)`
+- `fetchChannelSecretKey(config, channelId)`
+- `hydrateComparableChannelKeys(config, candidates)`
+
+Use the correct config type per provider:
+
+- New API: `NewApiConfig`
+- DoneHub: `DoneHubConfig`
+- Veloera: `VeloeraConfig`
+
+For New API session-backed key reveal, replace:
+
+```ts
+const sessionConfig = await getNewApiManagedSessionConfig(baseUrl, userId)
+```
+
+with:
+
+```ts
+const sessionConfig = await getNewApiManagedSessionConfig(
+  config.baseUrl,
+  config.userId,
+)
+```
+
+- [ ] **Step 4: Update channel match resolver**
+
+In `src/services/managedSites/channelMatchResolver.ts`, change the params field:
+
+```ts
+managedConfig: ManagedSiteConfig
+```
+
+to:
+
+```ts
+managedConfig: ManagedSiteRuntimeConfigValue
+```
+
+Then update calls:
+
+```ts
+const searchResults = await service.searchChannel(
+  managedConfig,
+  searchBaseUrl,
+)
+```
+
+```ts
+return await params.service.fetchChannelSecretKey!(
+  params.managedConfig,
+  params.channelId,
+)
+```
+
+```ts
+const hydratedCandidates = await service.hydrateComparableChannelKeys(
+  managedConfig,
+  recoverableCandidates,
+)
+```
+
+- [ ] **Step 5: Run related tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/channelMatchResolver.test.ts tests/services/doneHubService/doneHubService.test.ts tests/services/veloeraService/veloeraService.test.ts
+```
+
+Expected: PASS for converted call paths.
+
+---
+
+### Task 4: Convert Octopus, AxonHub, and Claude Code Hub Providers
+
+**Files:**
+
+- Modify: `src/services/managedSites/providers/octopus.ts`
+- Modify: `src/services/managedSites/providers/axonHub.ts`
+- Modify: `src/services/managedSites/providers/claudeCodeHub.ts`
+- Test: `tests/services/octopusService/octopusService.more.test.ts`
+- Test: `tests/services/managedSites/providers/axonHub.test.ts`
+- Test: `tests/services/managedSites/providers/claudeCodeHub.test.ts`
+
+- [ ] **Step 1: Update provider tests to prove operations use passed config**
+
+For `tests/services/managedSites/providers/claudeCodeHub.test.ts`, rewrite the CRUD test from “stored admin config” to “passed admin config”:
+
+```ts
+const config = {
+  baseUrl: "https://passed-cch.example.com",
+  adminToken: "passed-admin-token",
+}
+
+mockGetPreferences.mockResolvedValue({
+  claudeCodeHub: {
+    baseUrl: "https://stored-cch.example.com",
+    adminToken: "stored-token",
+  },
+})
+
+await searchChannel(config, "alpha")
+
+expect(mockSearchProviders).toHaveBeenCalledWith(config, "alpha")
+expect(mockSearchProviders).not.toHaveBeenCalledWith(
+  {
+    baseUrl: "https://stored-cch.example.com",
+    adminToken: "stored-token",
+  },
+  "alpha",
+)
+```
+
+Apply the same proof for:
+
+- `createChannel(config, payload)`
+- `updateChannel(config, payload)`
+- `deleteChannel(config, channelId)`
+- `fetchChannelSecretKey(config, channelId)`
+- `hydrateComparableChannelKeys(config, candidates)`
+
+For `tests/services/managedSites/providers/axonHub.test.ts`, assert:
+
+```ts
+const passedConfig = {
+  baseUrl: "https://passed-axonhub.example.com",
+  email: "passed-admin@example.com",
+  password: "passed-password",
+}
+
+await provider.searchChannel(passedConfig, "alpha")
+expect(mockSearchChannels).toHaveBeenCalledWith(passedConfig, "alpha")
+```
+
+For Octopus, assert `octopusApi.searchChannels`, `createChannel`,
+`updateChannel`, and `deleteChannel` receive the passed `OctopusConfig`.
+
+- [ ] **Step 2: Run provider tests to verify failure**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/providers/claudeCodeHub.test.ts tests/services/managedSites/providers/axonHub.test.ts tests/services/octopusService/octopusService.more.test.ts
+```
+
+Expected: FAIL because operations still call `getFull...Config()`.
+
+- [ ] **Step 3: Convert operation signatures and remove operation-level preference reads**
+
+In each provider:
+
+1. Keep `checkValid...Config()` and legacy import helpers reading config through service/resolver.
+2. Change operation functions to accept explicit config:
+
+```ts
+export async function searchChannel(
+  config: ClaudeCodeHubConfig,
+  keyword: string,
+): Promise<ManagedSiteChannelListData | null> {
+  try {
+    return await searchClaudeCodeHubChannels(config, keyword)
+  } catch (error) {
+    logger.error("Failed to search Claude Code Hub providers", error)
+    return null
+  }
+}
+```
+
+```ts
+export async function createChannel(
+  config: ClaudeCodeHubConfig,
+  channelData: CreateChannelPayload,
+): Promise<ApiResponse<unknown>> {
+  try {
+    const created = await claudeCodeHubApi.createProvider(
+      config,
+      buildClaudeCodeHubCreatePayloadFromFormData(/* existing mapping */),
+    )
+    return { success: true, data: created, message: "success" }
+  } catch (error) {
+    return {
+      success: false,
+      data: null,
+      message:
+        getErrorMessage(error) || t("messages:claudecodehub.importFailed"),
+    }
+  }
+}
+```
+
+3. Delete `getFullClaudeCodeHubConfig()` from operation paths. If a legacy import helper still needs it, replace it with:
+
+```ts
+const service = getManagedSiteServiceForType(SITE_TYPES.CLAUDE_CODE_HUB)
+const config = (await service.getConfig()) as ClaudeCodeHubConfig | null
+```
+
+If that import would create a circular dependency, import `getManagedSiteRuntimeConfigForType` from `runtimeConfig.ts` instead:
+
+```ts
+const runtimeConfig = await getManagedSiteRuntimeConfigForType(
+  SITE_TYPES.CLAUDE_CODE_HUB,
+)
+const config =
+  runtimeConfig?.siteType === SITE_TYPES.CLAUDE_CODE_HUB
+    ? runtimeConfig.config
+    : null
+```
+
+4. Apply equivalent conversions for AxonHub and Octopus:
+
+```ts
+export async function updateChannel(
+  config: AxonHubConfig,
+  channelData: UpdateChannelPayload & { status?: number },
+): Promise<ApiResponse<unknown>> {
+  // existing body, but remove getFullAxonHubConfig()
+}
+```
+
+```ts
+export async function deleteChannel(
+  config: OctopusConfig,
+  channelId: number,
+): Promise<ApiResponse<unknown>> {
+  // existing body, but remove getFullOctopusConfig()
+}
+```
+
+- [ ] **Step 4: Run provider tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/providers/claudeCodeHub.test.ts tests/services/managedSites/providers/axonHub.test.ts tests/services/octopusService/octopusService.more.test.ts
+```
+
+Expected: PASS.
+
+---
+
+### Task 5: Update Business-Layer Flows
+
+**Files:**
+
+- Modify: `src/services/managedSites/importDuplicateResolution.ts`
+- Modify: `src/services/managedSites/tokenBatchExport.ts`
+- Modify: `src/services/managedSites/channelMigration.ts`
+- Modify: `src/services/managedSites/tokenChannelStatus.ts` if compile reports old signature use.
+- Test: `tests/services/managedSites/importDuplicateResolution.test.ts`
+- Test: `tests/services/managedSites/tokenBatchExport.test.ts`
+- Test: `tests/services/managedSites/channelMigration.test.ts`
+- Test: `tests/services/managedSites/tokenChannelStatus.test.ts` if touched.
+
+- [ ] **Step 1: Update tests to expect config-object calls**
+
+In `tests/services/managedSites/tokenBatchExport.test.ts`, change service mock config:
+
+```ts
+const managedConfig = {
+  baseUrl: "https://target.example.com",
+  adminToken: "admin-token",
+  userId: "1",
+}
+
+getConfig: vi.fn().mockResolvedValue(managedConfig)
+```
+
+Then assert execution calls:
+
+```ts
+expect(service.createChannel).toHaveBeenCalledWith(
+  managedConfig,
+  expect.objectContaining({
+    channel: expect.objectContaining({
+      key: "token-secret",
+    }),
+  }),
+)
+```
+
+In `tests/services/managedSites/channelMigration.test.ts`, update expectations:
+
+```ts
+expect(mockDoneHubFetchChannelSecretKey).toHaveBeenCalledWith(
+  {
+    baseUrl: "https://donehub.example.com",
+    adminToken: "donehub-token",
+    userId: "9",
+  },
+  21,
+)
+```
+
+```ts
+expect(mockAxonHubCreateChannel).toHaveBeenNthCalledWith(
+  1,
+  {
+    baseUrl: "https://axonhub.example.com",
+    email: "admin@example.com",
+    password: "secret",
+  },
+  expect.objectContaining({
+    channel: expect.objectContaining({
+      type: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
+    }),
+  }),
+)
+```
+
+- [ ] **Step 2: Run shared flow tests to verify failure**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/importDuplicateResolution.test.ts tests/services/managedSites/tokenBatchExport.test.ts tests/services/managedSites/channelMigration.test.ts
+```
+
+Expected: FAIL because these flows still pass `baseUrl/token/userId` into service operations.
+
+- [ ] **Step 3: Update duplicate resolution**
+
+In `src/services/managedSites/importDuplicateResolution.ts`, change the input type from legacy admin config to runtime config:
+
+```ts
+managedConfig: ManagedSiteRuntimeConfigValue
+```
+
+Update calls:
+
+```ts
+const resolution = await resolveManagedSiteChannelMatch({
+  service,
+  managedConfig,
+  accountBaseUrl: formData.base_url,
+  models: normalizeList(formData.models ?? []),
+  key: formData.key,
+  resolveHiddenKeys: true,
+})
+```
+
+Do not decompose config into `baseUrl/token/userId`.
+
+- [ ] **Step 4: Update token batch export**
+
+In `src/services/managedSites/tokenBatchExport.ts`:
+
+1. Keep `const managedConfig = await service.getConfig()`.
+2. Pass `managedConfig` directly into `resolveManagedSiteChannelMatch`.
+3. Pass `managedConfig` directly into create:
+
+```ts
+const response = await service.createChannel(managedConfig, payload)
+```
+
+4. Update `collectSecrets` to avoid assuming `managedConfig.token` exists:
+
+```ts
+const collectManagedConfigSecrets = (managedConfig: ManagedSiteConfig) => {
+  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
+  if ("password" in managedConfig) return [managedConfig.password]
+  return []
+}
+
+const collectSecrets = (
+  account: DisplaySiteData,
+  token: AccountToken,
+  managedConfig: ManagedSiteConfig,
+) =>
+  [
+    token.key,
+    account.token,
+    account.cookieAuthSessionCookie,
+    ...collectManagedConfigSecrets(managedConfig),
+  ].filter(Boolean) as string[]
+```
+
+- [ ] **Step 5: Update channel migration**
+
+In `src/services/managedSites/channelMigration.ts`:
+
+1. Use `resolveManagedSiteRuntimeConfigForType(preferences, sourceSiteType)` for source key resolution when a source config is needed.
+2. Pass the full source config into `fetchChannelSecretKey`:
+
+```ts
+const sourceRuntimeConfig = resolveManagedSiteRuntimeConfigForType(
+  preferences,
+  sourceSiteType,
+)
+
+if (!sourceRuntimeConfig) {
+  return {
+    key: null,
+    blockingReasonCode:
+      MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+    blockingMessage: "Source managed-site configuration is missing.",
+  }
+}
+
+const key = await sourceService.fetchChannelSecretKey(
+  sourceRuntimeConfig.config,
+  channel.id,
+)
+```
+
+3. During execution, pass target config directly:
+
+```ts
+const targetConfig = await targetService.getConfig()
+...
+const response = await targetService.createChannel(targetConfig, payload)
+```
+
+- [ ] **Step 6: Run shared flow tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/importDuplicateResolution.test.ts tests/services/managedSites/tokenBatchExport.test.ts tests/services/managedSites/channelMigration.test.ts
+```
+
+Expected: PASS.
+
+---
+
+### Task 6: Remove Remaining Old Operation Signature Uses
+
+**Files:**
+
+- Search and modify any file under `src/services/managedSites/**` still calling service operations with `baseUrl/token/userId`.
+- Search and modify any tests under `tests/services/**` still expecting the old operation Interface.
+
+- [ ] **Step 1: Search for old operation calls**
+
+Run:
+
+```bash
+rg -n "searchChannel\\([^\\n]*baseUrl|createChannel\\([^\\n]*baseUrl|updateChannel\\([^\\n]*baseUrl|deleteChannel\\([^\\n]*baseUrl|fetchChannelSecretKey\\([^\\n]*baseUrl|hydrateComparableChannelKeys\\([^\\n]*baseUrl|managedConfig\\.token|managedConfig\\.userId" src tests
+```
+
+Expected before cleanup: matches in call sites not yet updated or tests still using legacy admin config shape.
+
+- [ ] **Step 2: Replace remaining calls**
+
+For any operation call still shaped like:
+
+```ts
+await service.createChannel(
+  managedConfig.baseUrl,
+  managedConfig.token,
+  managedConfig.userId,
+  payload,
+)
+```
+
+replace with:
+
+```ts
+await service.createChannel(managedConfig, payload)
+```
+
+For any hydration call still shaped like:
+
+```ts
+await service.hydrateComparableChannelKeys(
+  managedConfig.baseUrl,
+  managedConfig.token,
+  managedConfig.userId,
+  candidates,
+)
+```
+
+replace with:
+
+```ts
+await service.hydrateComparableChannelKeys(managedConfig, candidates)
+```
+
+- [ ] **Step 3: Verify the old operation shape is gone**
+
+Run:
+
+```bash
+rg -n "searchChannel\\([^\\n]*baseUrl|createChannel\\([^\\n]*baseUrl|updateChannel\\([^\\n]*baseUrl|deleteChannel\\([^\\n]*baseUrl|fetchChannelSecretKey\\([^\\n]*baseUrl|hydrateComparableChannelKeys\\([^\\n]*baseUrl" src tests
+```
+
+Expected: no matches for service operation calls using old `baseUrl/token/userId` shape. Matches in comments or unrelated backend request objects are acceptable only if they do not call `ManagedSiteService` provider operations.
+
+- [ ] **Step 4: Compile to catch type drift**
+
+Run:
+
+```bash
+pnpm compile
+```
+
+Expected: PASS. If it fails, fix all TypeScript errors caused by the signature migration before continuing.
+
+---
+
+### Task 7: Focused Validation and Commit
+
+**Files:**
+
+- All task-scoped modified files.
+
+- [ ] **Step 1: Run focused related tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/managedSites/runtimeConfig.test.ts tests/services/managedSiteService/managedSiteService.test.ts tests/services/managedSites/channelMatchResolver.test.ts tests/services/managedSites/importDuplicateResolution.test.ts tests/services/managedSites/tokenBatchExport.test.ts tests/services/managedSites/channelMigration.test.ts tests/services/managedSites/providers/claudeCodeHub.test.ts tests/services/managedSites/providers/axonHub.test.ts tests/services/octopusService/octopusService.more.test.ts tests/services/doneHubService/doneHubService.test.ts tests/services/veloeraService/veloeraService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run compile**
+
+Run:
+
+```bash
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run dependency/export validation**
+
+Because this change adds a new service Module and changes exported service types, run:
+
+```bash
+pnpm run validate:push
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff --check
+git status --porcelain=v1
+```
+
+Expected:
+
+- `git diff --check` exits 0.
+- Diff includes only managed-site runtime config implementation, tests, and this plan.
+- Pre-existing untracked files such as `notify.py` and `store-description/` remain untracked and untouched.
+
+- [ ] **Step 5: Stage only task-scoped files**
+
+Run:
+
+```bash
+git add src/services/managedSites/runtimeConfig.ts src/services/managedSites/managedSiteService.ts src/services/managedSites/utils/managedSite.ts src/services/managedSites/providers/newApi.ts src/services/managedSites/providers/doneHubService.ts src/services/managedSites/providers/veloera.ts src/services/managedSites/providers/octopus.ts src/services/managedSites/providers/axonHub.ts src/services/managedSites/providers/claudeCodeHub.ts src/services/managedSites/channelMatchResolver.ts src/services/managedSites/importDuplicateResolution.ts src/services/managedSites/channelMigration.ts src/services/managedSites/tokenBatchExport.ts tests/services/managedSites/runtimeConfig.test.ts tests/services/managedSiteService/managedSiteService.test.ts tests/services/managedSites/channelMatchResolver.test.ts tests/services/managedSites/importDuplicateResolution.test.ts tests/services/managedSites/tokenBatchExport.test.ts tests/services/managedSites/channelMigration.test.ts tests/services/managedSites/providers/claudeCodeHub.test.ts tests/services/managedSites/providers/axonHub.test.ts tests/services/octopusService/octopusService.more.test.ts tests/services/doneHubService/doneHubService.test.ts tests/services/veloeraService/veloeraService.test.ts
+```
+
+If `tokenChannelStatus.ts` or related tests changed during compile fixes, include those exact files in the same task-scoped `git add`.
+
+- [ ] **Step 6: Run staged validation**
+
+Run:
+
+```bash
+pnpm run validate:staged
+```
+
+Expected: PASS and not a no-staged-files skip.
+
+- [ ] **Step 7: Commit implementation**
+
+Run:
+
+```bash
+git commit -m "refactor(managed-sites): pass runtime configs to adapters"
+```
+
+Expected: commit succeeds after hooks pass.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers the resolver Module, the `ManagedSiteService` Interface, all six managed-site providers, shared business-layer flows, tests, and validation.
+- Placeholder scan: No task contains placeholder language or vague implementation instructions.
+- Type consistency: The plan uses `ManagedSiteRuntimeConfig`, `ManagedSiteRuntimeConfigValue`, `ManagedSiteConfig`, and `ManagedSiteLegacyAdminConfig` consistently. `ManagedSiteConfig` remains an alias during implementation to limit call-site churn.
+- E2E decision: No E2E task is included because this is service-layer configuration flow with targeted Vitest coverage and compile validation.

--- a/docs/superpowers/specs/2026-05-19-managed-site-runtime-config-design.md
+++ b/docs/superpowers/specs/2026-05-19-managed-site-runtime-config-design.md
@@ -108,7 +108,7 @@ Pseudo-code:
 type ManagedSiteRuntimeConfig =
   | { siteType: "new-api"; config: NewApiConfig }
   | { siteType: "done-hub"; config: DoneHubConfig }
-  | { siteType: "Veloera"; config: VeloeraConfig }
+  | { siteType: typeof SITE_TYPES.VELOERA; config: VeloeraConfig }
   | { siteType: "octopus"; config: OctopusConfig }
   | { siteType: "axonhub"; config: AxonHubConfig }
   | { siteType: "claude-code-hub"; config: ClaudeCodeHubConfig }

--- a/docs/superpowers/specs/2026-05-19-managed-site-runtime-config-design.md
+++ b/docs/superpowers/specs/2026-05-19-managed-site-runtime-config-design.md
@@ -1,0 +1,321 @@
+# Managed Site Runtime Config Design
+
+Date: 2026-05-19
+
+## Goal
+
+Deepen the managed-site configuration seam so every managed-site Adapter
+operates on an explicit runtime config passed by the business layer, instead
+of re-reading `userPreferences` inside provider operations.
+
+## Problem
+
+The current `ManagedSiteService` Interface exposes operations as:
+
+```ts
+searchChannel(baseUrl, token, userId, keyword)
+createChannel(baseUrl, token, userId, payload)
+updateChannel(baseUrl, token, userId, payload)
+deleteChannel(baseUrl, token, userId, channelId)
+```
+
+This shallow shape matches New API, DoneHub, and Veloera, but it does not
+represent Octopus, AxonHub, or Claude Code Hub accurately:
+
+- Octopus needs `baseUrl`, `username`, and `password`.
+- AxonHub needs `baseUrl`, `email`, and `password`.
+- Claude Code Hub needs `baseUrl` and `adminToken`, with no meaningful
+  managed-site `userId`.
+
+Because the Interface cannot carry the full config, those Adapters currently
+ignore the passed `baseUrl/token/userId` for several operations and call
+`userPreferences.getPreferences()` internally to recover their real config.
+That creates a misleading Interface: callers appear to choose the operation
+target, but some Adapter implementations silently use the currently saved
+global preferences instead.
+
+This reduces Locality. Config validation, config shape knowledge, and operation
+target selection are spread between the business layer and provider Adapter
+implementations. It also makes tests weaker because a test that passes explicit
+operation config may still need to mock global preferences for the Adapter to
+work.
+
+## Current Data Flow
+
+```ts
+const service = await getManagedSiteService()
+const managedConfig = await service.getConfig()
+
+await service.searchChannel(
+  managedConfig.baseUrl,
+  managedConfig.token,
+  managedConfig.userId,
+  keyword,
+)
+```
+
+For New API-family managed sites, the Adapter uses those arguments directly:
+
+```ts
+async function searchChannel(baseUrl, token, userId, keyword) {
+  return getApiService(siteType).searchChannel({
+    baseUrl,
+    auth: { accessToken: token, userId },
+  }, keyword)
+}
+```
+
+For Claude Code Hub, AxonHub, and Octopus, provider operations recover config
+from preferences:
+
+```ts
+async function searchChannel(_baseUrl, _token, _userId, keyword) {
+  const config = await getFullClaudeCodeHubConfig()
+  if (!config) return null
+  return claudeCodeHubApi.searchProviders(config, keyword)
+}
+```
+
+Actual flow:
+
+```ts
+preferences
+  -> service.getConfig()
+  -> { baseUrl, token, userId }
+  -> caller passes args
+  -> adapter may ignore args
+  -> adapter reads preferences again
+  -> backend call
+```
+
+## Target Data Flow
+
+Only the managed-site runtime config resolver reads preferences. Provider
+operation Adapters receive explicit config and do not read preferences.
+
+```ts
+preferences
+  -> managedSiteRuntimeConfigResolver
+  -> { siteType, config }
+  -> business layer passes config
+  -> adapter operation
+  -> backend call
+```
+
+Pseudo-code:
+
+```ts
+type ManagedSiteRuntimeConfig =
+  | { siteType: "new-api"; config: NewApiConfig }
+  | { siteType: "done-hub"; config: DoneHubConfig }
+  | { siteType: "Veloera"; config: VeloeraConfig }
+  | { siteType: "octopus"; config: OctopusConfig }
+  | { siteType: "axonhub"; config: AxonHubConfig }
+  | { siteType: "claude-code-hub"; config: ClaudeCodeHubConfig }
+
+async function getCurrentManagedSiteRuntimeConfig() {
+  const prefs = await userPreferences.getPreferences()
+  return resolveManagedSiteRuntimeConfigForType(
+    prefs,
+    prefs.managedSiteType ?? SITE_TYPES.NEW_API,
+  )
+}
+
+function resolveManagedSiteRuntimeConfigForType(prefs, siteType) {
+  switch (siteType) {
+    case SITE_TYPES.CLAUDE_CODE_HUB:
+      return {
+        siteType,
+        config: requireClaudeCodeHubConfig(prefs.claudeCodeHub),
+      }
+    case SITE_TYPES.AXON_HUB:
+      return {
+        siteType,
+        config: requireAxonHubConfig(prefs.axonHub),
+      }
+    case SITE_TYPES.OCTOPUS:
+      return {
+        siteType,
+        config: requireOctopusConfig(prefs.octopus),
+      }
+    default:
+      return {
+        siteType,
+        config: requireAccessTokenManagedSiteConfig(prefs, siteType),
+      }
+  }
+}
+```
+
+Provider operation Interface:
+
+```ts
+interface ManagedSiteService<TConfig> {
+  siteType: ManagedSiteType
+
+  getConfig(): Promise<TConfig | null>
+
+  searchChannel(
+    config: TConfig,
+    keyword: string,
+  ): Promise<ManagedSiteChannelListData | null>
+
+  createChannel(
+    config: TConfig,
+    payload: CreateChannelPayload,
+  ): Promise<ApiResponse<unknown>>
+
+  updateChannel(
+    config: TConfig,
+    payload: UpdateChannelPayload,
+  ): Promise<ApiResponse<unknown>>
+
+  deleteChannel(
+    config: TConfig,
+    channelId: number,
+  ): Promise<ApiResponse<unknown>>
+
+  fetchChannelSecretKey?(
+    config: TConfig,
+    channelId: number,
+  ): Promise<string>
+
+  hydrateComparableChannelKeys?(
+    config: TConfig,
+    candidates: ManagedSiteChannel[],
+  ): Promise<ManagedSiteChannel[]>
+}
+```
+
+Example Adapter operation:
+
+```ts
+async function searchChannel(
+  config: ClaudeCodeHubConfig,
+  keyword: string,
+): Promise<ManagedSiteChannelListData | null> {
+  const providers = await claudeCodeHubApi.searchProviders(config, keyword)
+  return toManagedSiteChannelList(providers)
+}
+```
+
+## Module Responsibilities
+
+### Runtime Config Resolver Module
+
+This Module owns config shape knowledge and validation for all managed-site
+types. It is the only Module in this flow that reads `userPreferences`.
+
+Responsibilities:
+
+- Resolve the selected managed-site type from preferences.
+- Resolve an explicit managed-site type for migration and cross-site flows.
+- Validate required fields for each site type.
+- Return the full site-specific config object.
+- Return `null` when the config is incomplete or preferences cannot be read.
+
+### Managed Site Service Registry
+
+This Module selects the Adapter for a managed-site type.
+
+Responsibilities:
+
+- Keep `getManagedSiteService()` and `getManagedSiteServiceForType(siteType)`.
+- Wire each service's `getConfig()` to the runtime config resolver.
+- Expose operation functions that accept explicit full config objects.
+
+### Provider Adapters
+
+Provider Adapters translate between the shared managed-site channel model and
+the backend-specific protocol.
+
+Responsibilities:
+
+- Accept explicit full config objects from callers.
+- Use the passed config for search, create, update, delete, key reveal, and key
+  hydration.
+- Convert backend channel/provider data to `ManagedSiteChannel` shapes.
+- Build backend-specific payloads from `ChannelFormData` and managed-site
+  payloads.
+
+Provider Adapters must not call `userPreferences.getPreferences()` inside
+operation functions. Legacy direct-import helpers may read config only through
+the resolver or through `service.getConfig()`.
+
+### Business-Layer Flows
+
+Business-layer flows decide which target config an operation should use.
+
+Impacted flows:
+
+- Token batch export preview and execution.
+- Managed-site channel migration preview and execution.
+- Channel matching and duplicate resolution.
+- Legacy direct-import helpers kept for compatibility.
+
+These flows should resolve runtime config once at the operation boundary and
+pass the explicit config through to Adapter operations.
+
+## Compatibility Strategy
+
+This change is intentionally structural but not user-visible. It should not
+change stored preference keys, backend request paths, payload fields, i18n copy,
+or UI behavior.
+
+Implementation can be progressive:
+
+1. Add the runtime config resolver and tests.
+2. Change `ManagedSiteService` to accept full config objects.
+3. Convert one provider Adapter at a time.
+4. Update business-layer call sites.
+5. Remove operation-level preference reads from provider Adapters.
+
+During migration, compatibility helper types may exist locally, but the final
+state should not preserve the old `baseUrl/token/userId` operation Interface.
+
+## Non-Goals
+
+- Do not change the persisted `UserPreferences` shape.
+- Do not add new managed-site types.
+- Do not change backend protocols or endpoint selection.
+- Do not change account token model-prefill behavior.
+- Do not change optional `sk-` prefix comparison rules.
+- Do not rewrite unrelated managed-site UI state.
+
+## Testing Strategy
+
+Use TDD for executable changes.
+
+Required tests:
+
+- Runtime config resolver returns the full config for every managed-site type.
+- Runtime config resolver returns `null` for incomplete configs.
+- `ManagedSiteService.getConfig()` delegates to the resolver for the selected
+  or explicit site type.
+- Claude Code Hub, AxonHub, and Octopus operation tests prove the passed config
+  is used and provider operations do not depend on mocked `userPreferences`.
+- Channel match, token batch export, and migration tests prove explicit configs
+  flow from the business layer into Adapter operations.
+
+Validation:
+
+- Run focused related Vitest coverage for touched tests.
+- Run `pnpm run validate:staged` after staging only task-scoped files.
+- Use `pnpm run validate:push` if the final implementation changes exports,
+  barrels, or other dependency graph structure.
+
+## E2E Decision
+
+This refactor changes service-layer configuration flow, not browser runtime
+behavior or UI interactions. Targeted Vitest coverage is the right primary
+coverage layer. E2E is not required unless implementation later changes
+entrypoint wiring, extension storage behavior, or user-facing managed-site
+workflows.
+
+## Open Design Constraint
+
+TypeScript cannot easily express a heterogeneous service registry where
+`getManagedSiteServiceForType(siteType)` returns a perfectly narrowed generic
+service for every dynamic `siteType` without added complexity. The implementation
+should prefer a small discriminated runtime config union and straightforward
+call-site narrowing over elaborate generic abstractions.

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -54,6 +54,12 @@ import { createLogger } from "~/utils/core/logger"
  */
 const logger = createLogger("ChannelDialogHook")
 
+const collectManagedConfigSecrets = (managedConfig: ManagedSiteConfig) => {
+  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
+  if ("password" in managedConfig) return [managedConfig.password]
+  return []
+}
+
 interface PrefilledChannelOpenOptions {
   managedSiteStatus?: ManagedSiteTokenChannelStatus
   shouldContinue?: () => boolean
@@ -485,7 +491,7 @@ export function useChannelDialog() {
       secretsToRedact = [
         apiToken.key,
         resolvedToken.key,
-        managedConfig.token,
+        ...collectManagedConfigSecrets(managedConfig),
         displaySiteData.token,
         displaySiteData.cookieAuthSessionCookie,
       ].filter(Boolean) as string[]
@@ -589,9 +595,10 @@ export function useChannelDialog() {
         name: credentials.name,
         apiKey: credentials.apiKey,
       })
-      secretsToRedact = [apiToken.key, managedConfig.token].filter(
-        Boolean,
-      ) as string[]
+      secretsToRedact = [
+        apiToken.key,
+        ...collectManagedConfigSecrets(managedConfig),
+      ].filter(Boolean) as string[]
 
       const formData = await service.prepareChannelFormData(
         displaySiteData,

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -33,6 +33,7 @@ import {
   type ManagedSiteTokenChannelStatus,
 } from "~/services/managedSites/tokenChannelStatus"
 import {
+  collectManagedConfigSecrets,
   getManagedSiteConfigMissingMessage,
   supportsManagedSiteBaseUrlChannelLookup,
 } from "~/services/managedSites/utils/managedSite"
@@ -53,12 +54,6 @@ import { createLogger } from "~/utils/core/logger"
  * Unified logger scoped to channel dialog open helpers.
  */
 const logger = createLogger("ChannelDialogHook")
-
-const collectManagedConfigSecrets = (managedConfig: ManagedSiteConfig) => {
-  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
-  if ("password" in managedConfig) return [managedConfig.password]
-  return []
-}
 
 interface PrefilledChannelOpenOptions {
   managedSiteStatus?: ManagedSiteTokenChannelStatus

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelForm.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelForm.ts
@@ -10,6 +10,7 @@ import { ChannelType, DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
 import { SITE_TYPES } from "~/constants/siteType"
 import { getApiService } from "~/services/apiService"
 import { getManagedSiteService } from "~/services/managedSites/managedSiteService"
+import type { ManagedSiteConfig } from "~/services/managedSites/managedSiteService"
 import {
   getManagedSiteConfigMissingMessage,
   hasUsableManagedSiteChannelKey,
@@ -27,6 +28,13 @@ import { createLogger } from "~/utils/core/logger"
  * Unified logger scoped to channel dialog form state and submissions.
  */
 const logger = createLogger("ChannelFormHook")
+
+const isAccessTokenManagedConfig = (
+  config: ManagedSiteConfig,
+): config is Extract<
+  ManagedSiteConfig,
+  { adminToken: string; userId: string }
+> => "adminToken" in config && "userId" in config
 
 export interface UseChannelFormProps {
   mode: DialogMode
@@ -256,8 +264,10 @@ export function useChannelForm({
         baseUrl: config.baseUrl,
         auth: {
           authType: AuthTypeEnum.AccessToken,
-          userId: config.userId,
-          accessToken: config.token,
+          userId: isAccessTokenManagedConfig(config) ? config.userId : "",
+          accessToken: isAccessTokenManagedConfig(config)
+            ? config.adminToken
+            : "",
         },
       })
 
@@ -408,20 +418,10 @@ export function useChannelForm({
             group: formData.groups.join(","),
           }
         })()
-        response = await service.updateChannel(
-          apiConfig.baseUrl,
-          apiConfig.token,
-          apiConfig.userId,
-          updatePayload,
-        )
+        response = await service.updateChannel(apiConfig, updatePayload)
       } else {
         const payload = service.buildChannelPayload(formData)
-        response = await service.createChannel(
-          apiConfig.baseUrl,
-          apiConfig.token,
-          apiConfig.userId,
-          payload,
-        )
+        response = await service.createChannel(apiConfig, payload)
       }
 
       if (response.success) {

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -42,10 +42,10 @@ import { resolveManagedSiteChannelMatch } from "~/services/managedSites/channelM
 import {
   getManagedSiteService,
   hasValidManagedSiteConfig,
-  type ManagedSiteConfig,
 } from "~/services/managedSites/managedSiteService"
 import { normalizeManagedSiteChannelBaseUrl } from "~/services/managedSites/utils/channelMatching"
 import {
+  collectManagedConfigSecrets,
   getManagedSiteType,
   supportsManagedSiteBaseUrlChannelLookup,
 } from "~/services/managedSites/utils/managedSite"
@@ -207,12 +207,6 @@ const getLocateManagedSiteChannelToastMessage = (
   }
 
   return t("account:actions.channelLocateUnresolved")
-}
-
-const collectManagedConfigSecrets = (managedConfig: ManagedSiteConfig) => {
-  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
-  if ("password" in managedConfig) return [managedConfig.password]
-  return []
 }
 
 /**

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -42,6 +42,7 @@ import { resolveManagedSiteChannelMatch } from "~/services/managedSites/channelM
 import {
   getManagedSiteService,
   hasValidManagedSiteConfig,
+  type ManagedSiteConfig,
 } from "~/services/managedSites/managedSiteService"
 import { normalizeManagedSiteChannelBaseUrl } from "~/services/managedSites/utils/channelMatching"
 import {
@@ -206,6 +207,12 @@ const getLocateManagedSiteChannelToastMessage = (
   }
 
   return t("account:actions.channelLocateUnresolved")
+}
+
+const collectManagedConfigSecrets = (managedConfig: ManagedSiteConfig) => {
+  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
+  if ("password" in managedConfig) return [managedConfig.password]
+  return []
 }
 
 /**
@@ -436,9 +443,11 @@ export default function AccountActionButtons({
         )
       }
 
-      if (managedConfig.token) {
-        secretsToRedact.add(managedConfig.token)
-      }
+      collectManagedConfigSecrets(managedConfig).forEach((secret) => {
+        if (secret) {
+          secretsToRedact.add(secret)
+        }
+      })
 
       const tokensResponse = await getApiService(
         site.siteType,

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -470,9 +470,7 @@ export default function ManagedSiteChannels({
                   }
 
                   const resolvedKey = await service.fetchChannelSecretKey(
-                    config.baseUrl,
-                    config.token,
-                    config.userId,
+                    config,
                     channel.id,
                   )
 
@@ -580,14 +578,7 @@ export default function ManagedSiteChannels({
       }
 
       const results = await Promise.allSettled(
-        pendingDeleteIds.map((id) =>
-          service.deleteChannel(
-            config.baseUrl,
-            config.token,
-            config.userId,
-            id,
-          ),
-        ),
+        pendingDeleteIds.map((id) => service.deleteChannel(config, id)),
       )
 
       const successIds: number[] = []

--- a/src/services/managedSites/channelMatchResolver.ts
+++ b/src/services/managedSites/channelMatchResolver.ts
@@ -6,10 +6,8 @@ import {
   type ManagedSiteChannelMatchInspection,
   type ManagedSiteChannelMatchUnresolvedReason,
 } from "~/services/managedSites/channelMatch"
-import type {
-  ManagedSiteConfig,
-  ManagedSiteService,
-} from "~/services/managedSites/managedSiteService"
+import type { ManagedSiteService } from "~/services/managedSites/managedSiteService"
+import type { ManagedSiteRuntimeConfigValue } from "~/services/managedSites/runtimeConfig"
 import {
   findManagedSiteChannelsByBaseUrl,
   findManagedSiteChannelsByBaseUrlAndModels,
@@ -30,7 +28,7 @@ export type ManagedSiteChannelMatchService = Pick<
 
 interface ResolveManagedSiteChannelMatchParams {
   service: ManagedSiteChannelMatchService
-  managedConfig: ManagedSiteConfig
+  managedConfig: ManagedSiteRuntimeConfigValue
   accountBaseUrl: string
   models: string[]
   key?: string
@@ -71,14 +69,12 @@ const applyResolvedChannelKeys = <T extends { id: number; key?: string }>(
 
 const fetchRecoverableCandidateSecretKey = async (params: {
   service: ManagedSiteChannelMatchService
-  managedConfig: ManagedSiteConfig
+  managedConfig: ManagedSiteRuntimeConfigValue
   channelId: number
 }) => {
   try {
     return await params.service.fetchChannelSecretKey!(
-      params.managedConfig.baseUrl,
-      params.managedConfig.token,
-      params.managedConfig.userId,
+      params.managedConfig,
       params.channelId,
     )
   } catch (error) {
@@ -116,9 +112,7 @@ export async function resolveManagedSiteChannelMatch(
   )
 
   const searchResults = await service.searchChannel(
-    managedConfig.baseUrl,
-    managedConfig.token,
-    managedConfig.userId,
+    managedConfig,
     searchBaseUrl,
   )
 
@@ -359,9 +353,7 @@ export async function resolveManagedSiteChannelMatch(
     if (recoverableCandidates.length > 0) {
       try {
         const hydratedCandidates = await service.hydrateComparableChannelKeys(
-          managedConfig.baseUrl,
-          managedConfig.token,
-          managedConfig.userId,
+          managedConfig,
           recoverableCandidates,
         )
 

--- a/src/services/managedSites/channelMigration.ts
+++ b/src/services/managedSites/channelMigration.ts
@@ -11,10 +11,8 @@ import {
   mapChannelTypeToOctopusOutboundType,
   mapOctopusOutboundTypeToChannelType,
 } from "~/services/managedSites/providers/octopus"
-import {
-  getManagedSiteAdminConfigForType,
-  needsManagedSiteChannelKeyResolution,
-} from "~/services/managedSites/utils/managedSite"
+import { resolveManagedSiteRuntimeConfigForType } from "~/services/managedSites/runtimeConfig"
+import { needsManagedSiteChannelKeyResolution } from "~/services/managedSites/utils/managedSite"
 import type { UserPreferences } from "~/services/preferences/userPreferences"
 import type { ChannelFormData, ManagedSiteChannel } from "~/types/managedSite"
 import {
@@ -499,11 +497,11 @@ const resolveSourceChannelKey = async (params: {
     }
   }
 
-  const sourceConfig = getManagedSiteAdminConfigForType(
+  const sourceRuntimeConfig = resolveManagedSiteRuntimeConfigForType(
     preferences,
     sourceSiteType,
   )
-  if (!sourceConfig) {
+  if (!sourceRuntimeConfig) {
     return {
       key: null,
       blockingReasonCode:
@@ -523,9 +521,7 @@ const resolveSourceChannelKey = async (params: {
 
   try {
     const key = await sourceService.fetchChannelSecretKey(
-      sourceConfig.baseUrl,
-      sourceConfig.adminToken,
-      sourceConfig.userId,
+      sourceRuntimeConfig.config,
       channel.id,
     )
     const resolvedKey = key.trim()
@@ -733,12 +729,7 @@ export async function executeManagedSiteChannelMigration(
 
     try {
       const payload = targetService.buildChannelPayload(item.draft)
-      const response = await targetService.createChannel(
-        targetConfig.baseUrl,
-        targetConfig.token,
-        targetConfig.userId,
-        payload,
-      )
+      const response = await targetService.createChannel(targetConfig, payload)
 
       if (!response.success) {
         failedCount += 1

--- a/src/services/managedSites/managedSiteService.ts
+++ b/src/services/managedSites/managedSiteService.ts
@@ -4,6 +4,7 @@ import {
   getCurrentManagedSiteRuntimeConfig,
   getManagedSiteRuntimeConfigForType,
   type ManagedSiteRuntimeConfigValue,
+  type ManagedSiteRuntimeConfigValueForType,
 } from "~/services/managedSites/runtimeConfig"
 import type { ManagedSiteMessagesKey } from "~/services/managedSites/utils/managedSite"
 import {
@@ -39,32 +40,35 @@ import * as veloeraService from "./providers/veloera"
 
 export type ManagedSiteConfig = ManagedSiteRuntimeConfigValue
 
-export interface ManagedSiteService {
-  siteType: ManagedSiteType
+export interface ManagedSiteService<
+  TConfig extends ManagedSiteConfig = ManagedSiteConfig,
+  TSiteType extends ManagedSiteType = ManagedSiteType,
+> {
+  siteType: TSiteType
   messagesKey: ManagedSiteMessagesKey
 
   searchChannel(
-    config: ManagedSiteRuntimeConfigValue,
+    config: TConfig,
     keyword: string,
   ): Promise<ManagedSiteChannelListData | null>
 
   createChannel(
-    config: ManagedSiteRuntimeConfigValue,
+    config: TConfig,
     channelData: CreateChannelPayload,
   ): Promise<ApiResponse<unknown>>
 
   updateChannel(
-    config: ManagedSiteRuntimeConfigValue,
+    config: TConfig,
     channelData: UpdateChannelPayload,
   ): Promise<ApiResponse<unknown>>
 
   deleteChannel(
-    config: ManagedSiteRuntimeConfigValue,
+    config: TConfig,
     channelId: number,
   ): Promise<ApiResponse<unknown>>
 
   checkValidConfig(): Promise<boolean>
-  getConfig(): Promise<ManagedSiteConfig | null>
+  getConfig(): Promise<TConfig | null>
 
   fetchAvailableModels(
     account: DisplaySiteData,
@@ -84,14 +88,11 @@ export interface ManagedSiteService {
   ): CreateChannelPayload
 
   hydrateComparableChannelKeys?(
-    config: ManagedSiteRuntimeConfigValue,
+    config: TConfig,
     candidates: ManagedSiteChannel[],
   ): Promise<ManagedSiteChannel[]>
 
-  fetchChannelSecretKey?(
-    config: ManagedSiteRuntimeConfigValue,
-    channelId: number,
-  ): Promise<string>
+  fetchChannelSecretKey?(config: TConfig, channelId: number): Promise<string>
 
   /**
    * Legacy direct-import entrypoint kept on the managed-site service contract.
@@ -104,6 +105,9 @@ export interface ManagedSiteService {
     toastId?: string,
   ): Promise<unknown>
 }
+
+export type TypedManagedSiteService<TSiteType extends ManagedSiteType> =
+  ManagedSiteService<ManagedSiteRuntimeConfigValueForType<TSiteType>, TSiteType>
 
 /**
  * Check if preferences contain a valid managed site admin configuration.
@@ -145,6 +149,27 @@ export async function getManagedSiteService(): Promise<ManagedSiteService> {
 /**
  * Resolve the managed site service implementation for an explicit site type.
  */
+export function getManagedSiteServiceForType(
+  siteType: typeof SITE_TYPES.OCTOPUS,
+): TypedManagedSiteService<typeof SITE_TYPES.OCTOPUS>
+export function getManagedSiteServiceForType(
+  siteType: typeof SITE_TYPES.AXON_HUB,
+): TypedManagedSiteService<typeof SITE_TYPES.AXON_HUB>
+export function getManagedSiteServiceForType(
+  siteType: typeof SITE_TYPES.CLAUDE_CODE_HUB,
+): TypedManagedSiteService<typeof SITE_TYPES.CLAUDE_CODE_HUB>
+export function getManagedSiteServiceForType(
+  siteType: typeof SITE_TYPES.VELOERA,
+): TypedManagedSiteService<typeof SITE_TYPES.VELOERA>
+export function getManagedSiteServiceForType(
+  siteType: typeof SITE_TYPES.DONE_HUB,
+): TypedManagedSiteService<typeof SITE_TYPES.DONE_HUB>
+export function getManagedSiteServiceForType(
+  siteType: typeof SITE_TYPES.NEW_API,
+): TypedManagedSiteService<typeof SITE_TYPES.NEW_API>
+export function getManagedSiteServiceForType(
+  siteType: ManagedSiteType,
+): ManagedSiteService
 export function getManagedSiteServiceForType(
   siteType: ManagedSiteType,
 ): ManagedSiteService {

--- a/src/services/managedSites/managedSiteService.ts
+++ b/src/services/managedSites/managedSiteService.ts
@@ -1,10 +1,14 @@
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
 import type { ApiResponse } from "~/services/apiService/common/type"
+import {
+  getCurrentManagedSiteRuntimeConfig,
+  getManagedSiteRuntimeConfigForType,
+  type ManagedSiteRuntimeConfigValue,
+} from "~/services/managedSites/runtimeConfig"
 import type { ManagedSiteMessagesKey } from "~/services/managedSites/utils/managedSite"
 import {
   getManagedSiteAdminConfig,
   getManagedSiteAdminConfigForType,
-  getManagedSiteContext,
   getManagedSiteMessagesKeyFromSiteType,
 } from "~/services/managedSites/utils/managedSite"
 import type {
@@ -33,41 +37,29 @@ import * as newApiService from "./providers/newApi"
 import * as octopusService from "./providers/octopus"
 import * as veloeraService from "./providers/veloera"
 
-export interface ManagedSiteConfig {
-  baseUrl: string
-  token: string
-  userId: string
-}
+export type ManagedSiteConfig = ManagedSiteRuntimeConfigValue
 
 export interface ManagedSiteService {
   siteType: ManagedSiteType
   messagesKey: ManagedSiteMessagesKey
 
   searchChannel(
-    baseUrl: string,
-    accessToken: string,
-    userId: number | string,
+    config: ManagedSiteRuntimeConfigValue,
     keyword: string,
   ): Promise<ManagedSiteChannelListData | null>
 
   createChannel(
-    baseUrl: string,
-    adminToken: string,
-    userId: number | string,
+    config: ManagedSiteRuntimeConfigValue,
     channelData: CreateChannelPayload,
   ): Promise<ApiResponse<unknown>>
 
   updateChannel(
-    baseUrl: string,
-    adminToken: string,
-    userId: number | string,
+    config: ManagedSiteRuntimeConfigValue,
     channelData: UpdateChannelPayload,
   ): Promise<ApiResponse<unknown>>
 
   deleteChannel(
-    baseUrl: string,
-    adminToken: string,
-    userId: number | string,
+    config: ManagedSiteRuntimeConfigValue,
     channelId: number,
   ): Promise<ApiResponse<unknown>>
 
@@ -92,16 +84,12 @@ export interface ManagedSiteService {
   ): CreateChannelPayload
 
   hydrateComparableChannelKeys?(
-    baseUrl: string,
-    adminToken: string,
-    userId: number | string,
+    config: ManagedSiteRuntimeConfigValue,
     candidates: ManagedSiteChannel[],
   ): Promise<ManagedSiteChannel[]>
 
   fetchChannelSecretKey?(
-    baseUrl: string,
-    adminToken: string,
-    userId: number | string,
+    config: ManagedSiteRuntimeConfigValue,
     channelId: number,
   ): Promise<string>
 
@@ -139,10 +127,19 @@ export function hasValidManagedSiteConfig(
  * Resolve the managed site service implementation based on preferences.
  */
 export async function getManagedSiteService(): Promise<ManagedSiteService> {
-  const prefs = await userPreferences.getPreferences()
-  const { siteType } = getManagedSiteContext(prefs)
+  const runtimeConfig = await getCurrentManagedSiteRuntimeConfig()
+  if (runtimeConfig) {
+    return getManagedSiteServiceForType(runtimeConfig.siteType)
+  }
 
-  return getManagedSiteServiceForType(siteType)
+  try {
+    const preferences = await userPreferences.getPreferences()
+    return getManagedSiteServiceForType(
+      preferences.managedSiteType || SITE_TYPES.NEW_API,
+    )
+  } catch {
+    return getManagedSiteServiceForType(SITE_TYPES.NEW_API)
+  }
 }
 
 /**
@@ -153,6 +150,10 @@ export function getManagedSiteServiceForType(
 ): ManagedSiteService {
   const messagesKey: ManagedSiteMessagesKey =
     getManagedSiteMessagesKeyFromSiteType(siteType)
+  const getConfig = async (): Promise<ManagedSiteConfig | null> => {
+    const runtimeConfig = await getManagedSiteRuntimeConfigForType(siteType)
+    return runtimeConfig?.config ?? null
+  }
 
   if (siteType === SITE_TYPES.OCTOPUS) {
     return {
@@ -163,7 +164,7 @@ export function getManagedSiteServiceForType(
       updateChannel: octopusService.updateChannel,
       deleteChannel: octopusService.deleteChannel,
       checkValidConfig: octopusService.checkValidOctopusConfig,
-      getConfig: octopusService.getOctopusConfig,
+      getConfig,
       fetchAvailableModels: octopusService.fetchAvailableModels,
       buildChannelName: octopusService.buildChannelName,
       prepareChannelFormData: octopusService.prepareChannelFormData,
@@ -181,7 +182,7 @@ export function getManagedSiteServiceForType(
       updateChannel: axonHubService.updateChannel,
       deleteChannel: axonHubService.deleteChannel,
       checkValidConfig: axonHubService.checkValidAxonHubConfig,
-      getConfig: axonHubService.getAxonHubConfig,
+      getConfig,
       fetchAvailableModels: axonHubService.fetchAvailableModels,
       buildChannelName: axonHubService.buildChannelName,
       prepareChannelFormData: axonHubService.prepareChannelFormData,
@@ -199,7 +200,7 @@ export function getManagedSiteServiceForType(
       updateChannel: claudeCodeHubService.updateChannel,
       deleteChannel: claudeCodeHubService.deleteChannel,
       checkValidConfig: claudeCodeHubService.checkValidClaudeCodeHubConfig,
-      getConfig: claudeCodeHubService.getClaudeCodeHubConfig,
+      getConfig,
       fetchAvailableModels: claudeCodeHubService.fetchAvailableModels,
       buildChannelName: claudeCodeHubService.buildChannelName,
       prepareChannelFormData: claudeCodeHubService.prepareChannelFormData,
@@ -220,7 +221,7 @@ export function getManagedSiteServiceForType(
       updateChannel: veloeraService.updateChannel,
       deleteChannel: veloeraService.deleteChannel,
       checkValidConfig: veloeraService.checkValidVeloeraConfig,
-      getConfig: veloeraService.getVeloeraConfig,
+      getConfig,
       fetchAvailableModels: veloeraService.fetchAvailableModels,
       buildChannelName: veloeraService.buildChannelName,
       prepareChannelFormData: veloeraService.prepareChannelFormData,
@@ -240,7 +241,7 @@ export function getManagedSiteServiceForType(
       updateChannel: doneHubService.updateChannel,
       deleteChannel: doneHubService.deleteChannel,
       checkValidConfig: doneHubService.checkValidDoneHubConfig,
-      getConfig: doneHubService.getDoneHubConfig,
+      getConfig,
       fetchAvailableModels: doneHubService.fetchAvailableModels,
       buildChannelName: doneHubService.buildChannelName,
       prepareChannelFormData: doneHubService.prepareChannelFormData,
@@ -259,7 +260,7 @@ export function getManagedSiteServiceForType(
     updateChannel: newApiService.updateChannel,
     deleteChannel: newApiService.deleteChannel,
     checkValidConfig: newApiService.checkValidNewApiConfig,
-    getConfig: newApiService.getNewApiConfig,
+    getConfig,
     fetchAvailableModels: newApiService.fetchAvailableModels,
     buildChannelName: newApiService.buildChannelName,
     prepareChannelFormData: newApiService.prepareChannelFormData,

--- a/src/services/managedSites/providers/axonHub.ts
+++ b/src/services/managedSites/providers/axonHub.ts
@@ -64,8 +64,11 @@ function hasValidAxonHubConfig(prefs: UserPreferences | null): boolean {
  */
 export async function checkValidAxonHubConfig(): Promise<boolean> {
   try {
-    const config = await getFullAxonHubConfig()
-    if (!config) return false
+    const prefs = await userPreferences.getPreferences()
+    if (!hasValidAxonHubConfig(prefs) || !prefs.axonHub) {
+      return false
+    }
+    const config = prefs.axonHub
     await axonHubApi.signIn(config)
     return true
   } catch (error) {
@@ -81,28 +84,13 @@ export async function getAxonHubConfig(): Promise<ManagedSiteConfig | null> {
   try {
     const prefs = await userPreferences.getPreferences()
     if (hasValidAxonHubConfig(prefs) && prefs.axonHub) {
-      return {
-        baseUrl: prefs.axonHub.baseUrl,
-        token: prefs.axonHub.password,
-        userId: prefs.axonHub.email,
-      }
+      return prefs.axonHub
     }
     return null
   } catch (error) {
     logger.error("Error getting AxonHub config", error)
     return null
   }
-}
-
-/**
- * Return the full AxonHub credential config used by provider operations.
- */
-async function getFullAxonHubConfig(): Promise<AxonHubConfig | null> {
-  const prefs = await userPreferences.getPreferences()
-  if (hasValidAxonHubConfig(prefs) && prefs.axonHub) {
-    return prefs.axonHub
-  }
-  return null
 }
 
 const getFinalModels = (formData: ChannelFormData) =>
@@ -177,15 +165,10 @@ function buildAxonHubUpdateInputFromPayload(
  * Search AxonHub channels using the current saved admin credentials.
  */
 export async function searchChannel(
-  _baseUrl: string,
-  _accessToken: string,
-  _userId: number | string,
+  config: AxonHubConfig,
   keyword: string,
 ): Promise<ManagedSiteChannelListData | null> {
   try {
-    const config = await getFullAxonHubConfig()
-    if (!config) return null
-
     return await axonHubApi.searchChannels(config, keyword)
   } catch (error) {
     logger.error("Failed to search AxonHub channels", error)
@@ -197,21 +180,10 @@ export async function searchChannel(
  * Create an AxonHub channel through the managed-site service contract.
  */
 export async function createChannel(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: AxonHubConfig,
   channelData: CreateChannelPayload,
 ): Promise<ApiResponse<unknown>> {
   try {
-    const config = await getFullAxonHubConfig()
-    if (!config) {
-      return {
-        success: false,
-        data: null,
-        message: t("messages:axonhub.configMissing"),
-      }
-    }
-
     const channel = channelData.channel
     const input = buildAxonHubInputFromFormData({
       name: channel.name ?? "",
@@ -251,21 +223,10 @@ export async function createChannel(
  * Update an AxonHub channel through the managed-site service contract.
  */
 export async function updateChannel(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: AxonHubConfig,
   channelData: UpdateChannelPayload & { status?: number },
 ): Promise<ApiResponse<unknown>> {
   try {
-    const config = await getFullAxonHubConfig()
-    if (!config) {
-      return {
-        success: false,
-        data: null,
-        message: t("messages:axonhub.configMissing"),
-      }
-    }
-
     const graphqlId = axonHubApi.resolveAxonHubGraphqlId(channelData.id)
     const updated = await axonHubApi.updateAxonHubChannel(
       config,
@@ -295,21 +256,10 @@ export async function updateChannel(
  * Delete an AxonHub channel through the managed-site service contract.
  */
 export async function deleteChannel(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: AxonHubConfig,
   channelId: number,
 ): Promise<ApiResponse<unknown>> {
   try {
-    const config = await getFullAxonHubConfig()
-    if (!config) {
-      return {
-        success: false,
-        data: null,
-        message: t("messages:axonhub.configMissing"),
-      }
-    }
-
     const deleted = await axonHubApi.deleteAxonHubChannel(
       config,
       axonHubApi.resolveAxonHubGraphqlId(channelId),
@@ -411,19 +361,16 @@ export async function importToAxonHub(
   token: ApiToken,
 ): Promise<{ success: boolean; message: string }> {
   try {
-    const config = await getFullAxonHubConfig()
-    if (!config) {
+    const prefs = await userPreferences.getPreferences()
+    if (!hasValidAxonHubConfig(prefs) || !prefs.axonHub) {
       return { success: false, message: t("messages:axonhub.configMissing") }
     }
+    const config = prefs.axonHub
 
     const formData = await prepareChannelFormData(account, token)
     const existingChannel = await resolveManagedSiteImportDuplicate({
       service: axonHubImportDuplicateService,
-      managedConfig: {
-        baseUrl: config.baseUrl,
-        token: config.password,
-        userId: config.email,
-      },
+      managedConfig: config,
       formData,
     })
 
@@ -436,12 +383,7 @@ export async function importToAxonHub(
       }
     }
 
-    const result = await createChannel(
-      config.baseUrl,
-      config.password,
-      config.email,
-      buildChannelPayload(formData),
-    )
+    const result = await createChannel(config, buildChannelPayload(formData))
 
     return result.success
       ? {
@@ -467,11 +409,10 @@ export async function autoConfigToAxonHub(
   toastId?: string,
 ): Promise<{ success: boolean; message: string }> {
   try {
-    const config = await getFullAxonHubConfig()
-    if (!config) {
+    const prefs = await userPreferences.getPreferences()
+    if (!hasValidAxonHubConfig(prefs) || !prefs.axonHub) {
       return { success: false, message: t("messages:axonhub.configMissing") }
     }
-
     const displaySiteData = accountStorage.convertToDisplayData(account)
     const apiToken = await ensureAccountApiToken(
       account,

--- a/src/services/managedSites/providers/claudeCodeHub.ts
+++ b/src/services/managedSites/providers/claudeCodeHub.ts
@@ -72,23 +72,15 @@ function hasValidClaudeCodeHubConfig(prefs: UserPreferences | null): boolean {
 }
 
 /**
- * Loads the stored Claude Code Hub admin config when all required fields exist.
- */
-async function getFullClaudeCodeHubConfig(): Promise<ClaudeCodeHubConfig | null> {
-  const prefs = await userPreferences.getPreferences()
-  if (hasValidClaudeCodeHubConfig(prefs) && prefs.claudeCodeHub) {
-    return prefs.claudeCodeHub
-  }
-  return null
-}
-
-/**
  * Verifies the saved Claude Code Hub config can authenticate successfully.
  */
 export async function checkValidClaudeCodeHubConfig(): Promise<boolean> {
   try {
-    const config = await getFullClaudeCodeHubConfig()
-    if (!config) return false
+    const prefs = await userPreferences.getPreferences()
+    if (!hasValidClaudeCodeHubConfig(prefs) || !prefs.claudeCodeHub) {
+      return false
+    }
+    const config = prefs.claudeCodeHub
     return await claudeCodeHubApi.validateClaudeCodeHubConfig(config)
   } catch (error) {
     logger.warn("Claude Code Hub config validation failed", error)
@@ -103,11 +95,7 @@ export async function getClaudeCodeHubConfig(): Promise<ManagedSiteConfig | null
   try {
     const prefs = await userPreferences.getPreferences()
     if (hasValidClaudeCodeHubConfig(prefs) && prefs.claudeCodeHub) {
-      return {
-        baseUrl: prefs.claudeCodeHub.baseUrl,
-        token: prefs.claudeCodeHub.adminToken,
-        userId: "admin",
-      }
+      return prefs.claudeCodeHub
     }
     return null
   } catch (error) {
@@ -301,18 +289,9 @@ async function hydrateComparableChannelKey(
  * Hydrates Claude Code Hub provider keys for shared channel comparison.
  */
 export async function hydrateComparableChannelKeys(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: ClaudeCodeHubConfig,
   candidates: ManagedSiteChannel[],
 ): Promise<ManagedSiteChannel[]> {
-  const config = await getFullClaudeCodeHubConfig()
-  if (!config) {
-    throw new MatchResolutionUnresolvedError(
-      MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS.KEY_RESOLUTION_FAILED,
-    )
-  }
-
   const hydratedCandidates: ManagedSiteChannel[] = []
 
   for (const candidate of candidates) {
@@ -410,15 +389,10 @@ export function buildClaudeCodeHubUpdatePayloadFromChannelData(
  * Searches Claude Code Hub channels by keyword through the provider search API.
  */
 export async function searchChannel(
-  _baseUrl: string,
-  _accessToken: string,
-  _userId: number | string,
+  config: ClaudeCodeHubConfig,
   keyword: string,
 ): Promise<ManagedSiteChannelListData | null> {
   try {
-    const config = await getFullClaudeCodeHubConfig()
-    if (!config) return null
-
     return await searchClaudeCodeHubChannels(config, keyword)
   } catch (error) {
     logger.error("Failed to search Claude Code Hub providers", error)
@@ -430,21 +404,10 @@ export async function searchChannel(
  * Creates a Claude Code Hub channel from managed-site channel input.
  */
 export async function createChannel(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: ClaudeCodeHubConfig,
   channelData: CreateChannelPayload,
 ): Promise<ApiResponse<unknown>> {
   try {
-    const config = await getFullClaudeCodeHubConfig()
-    if (!config) {
-      return {
-        success: false,
-        data: null,
-        message: t("messages:claudecodehub.configMissing"),
-      }
-    }
-
     const created = await claudeCodeHubApi.createProvider(
       config,
       buildClaudeCodeHubCreatePayloadFromFormData({
@@ -479,21 +442,10 @@ export async function createChannel(
  * Updates a Claude Code Hub channel from managed-site channel input.
  */
 export async function updateChannel(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: ClaudeCodeHubConfig,
   channelData: UpdateChannelPayload & { status?: number },
 ): Promise<ApiResponse<unknown>> {
   try {
-    const config = await getFullClaudeCodeHubConfig()
-    if (!config) {
-      return {
-        success: false,
-        data: null,
-        message: t("messages:claudecodehub.configMissing"),
-      }
-    }
-
     const updated = await claudeCodeHubApi.updateProvider(
       config,
       buildClaudeCodeHubUpdatePayloadFromChannelData(channelData),
@@ -514,21 +466,10 @@ export async function updateChannel(
  * Deletes a Claude Code Hub channel by provider id.
  */
 export async function deleteChannel(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: ClaudeCodeHubConfig,
   channelId: number,
 ): Promise<ApiResponse<unknown>> {
   try {
-    const config = await getFullClaudeCodeHubConfig()
-    if (!config) {
-      return {
-        success: false,
-        data: null,
-        message: t("messages:claudecodehub.configMissing"),
-      }
-    }
-
     const deleted = await claudeCodeHubApi.deleteProvider(config, channelId)
     return { success: true, data: deleted, message: "success" }
   } catch (error) {
@@ -545,16 +486,9 @@ export async function deleteChannel(
  * Fetches the real Claude Code Hub provider key for edit, comparison, and export flows.
  */
 export async function fetchChannelSecretKey(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: ClaudeCodeHubConfig,
   channelId: number,
 ): Promise<string> {
-  const config = await getFullClaudeCodeHubConfig()
-  if (!config) {
-    throw new Error(t("messages:claudecodehub.configMissing"))
-  }
-
   return await claudeCodeHubApi.getUnmaskedProviderKey(config, channelId)
 }
 
@@ -642,22 +576,19 @@ async function importToClaudeCodeHub(
   token: ApiToken,
 ): Promise<{ success: boolean; message: string }> {
   try {
-    const config = await getFullClaudeCodeHubConfig()
-    if (!config) {
+    const prefs = await userPreferences.getPreferences()
+    if (!hasValidClaudeCodeHubConfig(prefs) || !prefs.claudeCodeHub) {
       return {
         success: false,
         message: t("messages:claudecodehub.configMissing"),
       }
     }
+    const config = prefs.claudeCodeHub
 
     const formData = await prepareChannelFormData(account, token)
     const existingChannel = await resolveManagedSiteImportDuplicate({
       service: claudeCodeHubImportDuplicateService,
-      managedConfig: {
-        baseUrl: config.baseUrl,
-        token: config.adminToken,
-        userId: "admin",
-      },
+      managedConfig: config,
       formData,
     })
 
@@ -670,12 +601,7 @@ async function importToClaudeCodeHub(
       }
     }
 
-    const result = await createChannel(
-      config.baseUrl,
-      config.adminToken,
-      "admin",
-      buildChannelPayload(formData),
-    )
+    const result = await createChannel(config, buildChannelPayload(formData))
 
     return result.success
       ? {
@@ -702,14 +628,13 @@ export async function autoConfigToClaudeCodeHub(
   toastId?: string,
 ): Promise<{ success: boolean; message: string }> {
   try {
-    const config = await getFullClaudeCodeHubConfig()
-    if (!config) {
+    const prefs = await userPreferences.getPreferences()
+    if (!hasValidClaudeCodeHubConfig(prefs) || !prefs.claudeCodeHub) {
       return {
         success: false,
         message: t("messages:claudecodehub.configMissing"),
       }
     }
-
     const displaySiteData = accountStorage.convertToDisplayData(account)
     const apiToken = await ensureAccountApiToken(
       account,

--- a/src/services/managedSites/providers/doneHubService.ts
+++ b/src/services/managedSites/providers/doneHubService.ts
@@ -53,6 +53,15 @@ const doneHubImportDuplicateService = {
   fetchChannelSecretKey,
 }
 
+const toDoneHubRequestConfig = (config: DoneHubConfig) => ({
+  baseUrl: config.baseUrl,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: config.adminToken,
+    userId: config.userId,
+  },
+})
+
 const toSafeDoneHubChannelDetailDiagnostic = (error: unknown): string => {
   const message = getErrorMessage(error) || "Unknown error"
 
@@ -73,20 +82,11 @@ const toSafeDoneHubChannelDetailDiagnostic = (error: unknown): string => {
  * Searches channels matching the keyword.
  */
 export async function searchChannel(
-  baseUrl: string,
-  accessToken: string,
-  userId: number | string,
+  config: DoneHubConfig,
   keyword: string,
 ): Promise<ManagedSiteChannelListData | null> {
   return await getApiService(SITE_TYPES.DONE_HUB).searchChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken,
-        userId,
-      },
-    },
+    toDoneHubRequestConfig(config),
     keyword,
   )
 }
@@ -95,20 +95,11 @@ export async function searchChannel(
  * Creates a channel.
  */
 export async function createChannel(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: DoneHubConfig,
   channelData: CreateChannelPayload,
 ) {
   return await getApiService(SITE_TYPES.DONE_HUB).createChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toDoneHubRequestConfig(config),
     channelData,
   )
 }
@@ -117,20 +108,11 @@ export async function createChannel(
  * Updates a channel.
  */
 export async function updateChannel(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: DoneHubConfig,
   channelData: UpdateChannelPayload,
 ) {
   return await getApiService(SITE_TYPES.DONE_HUB).updateChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toDoneHubRequestConfig(config),
     channelData,
   )
 }
@@ -138,21 +120,9 @@ export async function updateChannel(
 /**
  * Deletes a channel.
  */
-export async function deleteChannel(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
-  channelId: number,
-) {
+export async function deleteChannel(config: DoneHubConfig, channelId: number) {
   return await getApiService(SITE_TYPES.DONE_HUB).deleteChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toDoneHubRequestConfig(config),
     channelId,
   )
 }
@@ -161,20 +131,11 @@ export async function deleteChannel(
  * Fetches the full secret key for a Done Hub channel from its detail payload.
  */
 export async function fetchChannelSecretKey(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: DoneHubConfig,
   channelId: number,
 ): Promise<string> {
   const channel = await fetchDoneHubChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toDoneHubRequestConfig(config),
     channelId,
   )
 
@@ -190,9 +151,7 @@ export async function fetchChannelSecretKey(
  * Hydrates Done Hub channel keys from detail payloads for shared comparison.
  */
 export async function hydrateComparableChannelKeys(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: DoneHubConfig,
   candidates: ManagedSiteChannel[],
 ): Promise<ManagedSiteChannel[]> {
   const hydratedCandidates: ManagedSiteChannel[] = []
@@ -205,14 +164,7 @@ export async function hydrateComparableChannelKeys(
 
     try {
       const detail = await fetchDoneHubChannel(
-        {
-          baseUrl,
-          auth: {
-            authType: AuthTypeEnum.AccessToken,
-            accessToken: adminToken,
-            userId,
-          },
-        },
+        toDoneHubRequestConfig(config),
         candidate.id,
       )
       const key = detail.key?.trim()
@@ -416,13 +368,15 @@ async function importToDoneHub(
 
     const formData = await prepareChannelFormData(account, token)
 
+    const managedConfig = {
+      baseUrl: doneHubBaseUrl!,
+      adminToken: doneHubAdminToken!,
+      userId: doneHubUserId!,
+    }
+
     const existingChannel = await resolveManagedSiteImportDuplicate({
       service: doneHubImportDuplicateService,
-      managedConfig: {
-        baseUrl: doneHubBaseUrl!,
-        token: doneHubAdminToken!,
-        userId: doneHubUserId!,
-      },
+      managedConfig,
       formData,
     })
 
@@ -437,12 +391,7 @@ async function importToDoneHub(
 
     const payload = buildChannelPayload(formData)
 
-    const createdChannelResponse = await createChannel(
-      doneHubBaseUrl!,
-      doneHubAdminToken!,
-      doneHubUserId!,
-      payload,
-    )
+    const createdChannelResponse = await createChannel(managedConfig, payload)
 
     if (createdChannelResponse.success) {
       return {

--- a/src/services/managedSites/providers/newApi.ts
+++ b/src/services/managedSites/providers/newApi.ts
@@ -57,80 +57,56 @@ const newApiImportDuplicateService = {
   fetchChannelSecretKey,
 }
 
+const toNewApiRequestConfig = (config: NewApiConfig) => ({
+  baseUrl: config.baseUrl,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: config.adminToken,
+    userId: config.userId,
+  },
+})
+
 /**
  * 搜索指定关键词的渠道
- * @param baseUrl New API 的基础 URL
- * @param accessToken 管理员令牌
- * @param userId 用户 ID
+ * @param config New API runtime config
  * @param keyword 搜索关键词
  */
 export async function searchChannel(
-  baseUrl: string,
-  accessToken: string,
-  userId: number | string,
+  config: NewApiConfig,
   keyword: string,
 ): Promise<ManagedSiteChannelListData | null> {
   return await getApiService(SITE_TYPES.NEW_API).searchChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken,
-        userId,
-      },
-    },
+    toNewApiRequestConfig(config),
     keyword,
   )
 }
 
 /**
  * 创建新渠道
- * @param baseUrl New API 的基础 URL
- * @param adminToken 管理员令牌
- * @param userId 用户 ID
+ * @param config New API runtime config
  * @param channelData 渠道数据
  */
 export async function createChannel(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: NewApiConfig,
   channelData: CreateChannelPayload,
 ) {
   return await getApiService(SITE_TYPES.NEW_API).createChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toNewApiRequestConfig(config),
     channelData,
   )
 }
 
 /**
  * 更新新渠道
- * @param baseUrl New API 的基础 URL
- * @param adminToken 管理员令牌
- * @param userId 用户 ID
+ * @param config New API runtime config
  * @param channelData 渠道数据
  */
 export async function updateChannel(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: NewApiConfig,
   channelData: UpdateChannelPayload,
 ) {
   return await getApiService(SITE_TYPES.NEW_API).updateChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toNewApiRequestConfig(config),
     channelData,
   )
 }
@@ -138,21 +114,9 @@ export async function updateChannel(
 /**
  * 删除渠道
  */
-export async function deleteChannel(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
-  channelId: number,
-) {
+export async function deleteChannel(config: NewApiConfig, channelId: number) {
   return await getApiService(SITE_TYPES.NEW_API).deleteChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toNewApiRequestConfig(config),
     channelId,
   )
 }
@@ -161,12 +125,10 @@ export async function deleteChannel(
  * Reads a single managed-site channel key using the New API verification flow.
  */
 export async function fetchChannelSecretKey(
-  baseUrl: string,
-  _adminToken: string,
-  userId: number | string,
+  config: NewApiConfig,
   channelId: number,
 ): Promise<string> {
-  const sessionConfig = await getNewApiManagedSessionConfig(baseUrl, userId)
+  const sessionConfig = await getNewApiManagedSessionConfig(config)
 
   return await fetchNewApiChannelKey({
     ...sessionConfig,
@@ -178,12 +140,10 @@ export async function fetchChannelSecretKey(
  * Hydrates hidden New API channel keys so the shared resolver can compare them.
  */
 export async function hydrateComparableChannelKeys(
-  baseUrl: string,
-  _adminToken: string,
-  userId: number | string,
+  config: NewApiConfig,
   candidates: ManagedSiteChannel[],
 ): Promise<ManagedSiteChannel[]> {
-  const sessionConfig = await getNewApiManagedSessionConfig(baseUrl, userId)
+  const sessionConfig = await getNewApiManagedSessionConfig(config)
   const hydratedCandidates: ManagedSiteChannel[] = []
 
   for (const candidate of candidates) {
@@ -210,7 +170,7 @@ export async function hydrateComparableChannelKeys(
       }
 
       logger.warn("Failed to hydrate hidden New API channel key", {
-        baseUrl,
+        baseUrl: config.baseUrl,
         channelId: candidate.id,
         error: getErrorMessage(error),
       })
@@ -323,8 +283,7 @@ const sharesNewApiOrigin = (leftBaseUrl: string, rightBaseUrl: string) => {
 }
 
 const getNewApiManagedSessionConfig = async (
-  baseUrl: string,
-  userId: number | string,
+  config: Pick<NewApiConfig, "baseUrl" | "userId">,
 ): Promise<
   Pick<
     NewApiConfig,
@@ -333,11 +292,12 @@ const getNewApiManagedSessionConfig = async (
 > => {
   const loginAssistConfig = await getNewApiLoginAssistConfig()
   const canReuseLoginAssist =
-    loginAssistConfig && sharesNewApiOrigin(loginAssistConfig.baseUrl, baseUrl)
+    loginAssistConfig &&
+    sharesNewApiOrigin(loginAssistConfig.baseUrl, config.baseUrl)
 
   return {
-    baseUrl,
-    userId: userId?.toString() ?? "",
+    baseUrl: config.baseUrl,
+    userId: config.userId?.toString() ?? "",
     username: canReuseLoginAssist ? loginAssistConfig.username ?? "" : "",
     password: canReuseLoginAssist ? loginAssistConfig.password ?? "" : "",
     totpSecret: canReuseLoginAssist ? loginAssistConfig.totpSecret ?? "" : "",
@@ -466,13 +426,15 @@ export async function importToNewApi(
 
     const formData = await prepareChannelFormData(account, token)
 
+    const managedConfig = {
+      baseUrl: newApiBaseUrl!,
+      adminToken: newApiAdminToken!,
+      userId: newApiUserId!,
+    }
+
     const existingChannel = await resolveManagedSiteImportDuplicate({
       service: newApiImportDuplicateService,
-      managedConfig: {
-        baseUrl: newApiBaseUrl!,
-        token: newApiAdminToken!,
-        userId: newApiUserId!,
-      },
+      managedConfig,
       formData,
     })
 
@@ -487,12 +449,7 @@ export async function importToNewApi(
 
     const payload = buildChannelPayload(formData)
 
-    const createdChannelResponse = await createChannel(
-      newApiBaseUrl!,
-      newApiAdminToken!,
-      newApiUserId!,
-      payload,
-    )
+    const createdChannelResponse = await createChannel(managedConfig, payload)
 
     if (createdChannelResponse.success) {
       return {

--- a/src/services/managedSites/providers/octopus.ts
+++ b/src/services/managedSites/providers/octopus.ts
@@ -169,28 +169,13 @@ export async function getOctopusConfig(): Promise<ManagedSiteConfig | null> {
   try {
     const prefs = await userPreferences.getPreferences()
     if (hasValidOctopusConfig(prefs) && prefs.octopus) {
-      return {
-        baseUrl: prefs.octopus.baseUrl,
-        token: "", // Octopus 使用 JWT，token 动态获取
-        userId: prefs.octopus.username,
-      }
+      return prefs.octopus
     }
     return null
   } catch (error) {
     logger.error("Error getting config", error)
     return null
   }
-}
-
-/**
- * 获取完整的 Octopus 配置（包含密码）
- */
-async function getFullOctopusConfig(): Promise<OctopusConfig | null> {
-  const prefs = await userPreferences.getPreferences()
-  if (hasValidOctopusConfig(prefs) && prefs.octopus) {
-    return prefs.octopus
-  }
-  return null
 }
 
 /**
@@ -246,15 +231,10 @@ export function octopusChannelToManagedSite(
  * 搜索渠道
  */
 export async function searchChannel(
-  _baseUrl: string,
-  _accessToken: string,
-  _userId: number | string,
+  config: OctopusConfig,
   keyword: string,
 ): Promise<ManagedSiteChannelListData | null> {
   try {
-    const config = await getFullOctopusConfig()
-    if (!config) return null
-
     const channels = await octopusApi.searchChannels(config, keyword)
     return {
       items: channels.map(octopusChannelToManagedSite),
@@ -271,17 +251,10 @@ export async function searchChannel(
  * 创建渠道
  */
 export async function createChannel(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: OctopusConfig,
   channelData: CreateChannelPayload,
 ): Promise<ApiResponse<unknown>> {
   try {
-    const config = await getFullOctopusConfig()
-    if (!config) {
-      return { success: false, data: null, message: "Octopus config not found" }
-    }
-
     const channel = channelData.channel
     const request: OctopusCreateChannelRequest = {
       name: channel.name || "",
@@ -317,17 +290,10 @@ export async function createChannel(
  * 更新渠道
  */
 export async function updateChannel(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: OctopusConfig,
   channelData: UpdateChannelPayload & { status?: number },
 ): Promise<ApiResponse<unknown>> {
   try {
-    const config = await getFullOctopusConfig()
-    if (!config) {
-      return { success: false, data: null, message: "Octopus config not found" }
-    }
-
     const result = await octopusApi.updateChannel(config, {
       id: channelData.id,
       name: channelData.name,
@@ -364,17 +330,10 @@ export async function updateChannel(
  * 删除渠道
  */
 export async function deleteChannel(
-  _baseUrl: string,
-  _adminToken: string,
-  _userId: number | string,
+  config: OctopusConfig,
   channelId: number,
 ): Promise<ApiResponse<unknown>> {
   try {
-    const config = await getFullOctopusConfig()
-    if (!config) {
-      return { success: false, data: null, message: "Octopus config not found" }
-    }
-
     const result = await octopusApi.deleteChannel(config, channelId)
     return {
       success: result.success,
@@ -477,10 +436,11 @@ export async function autoConfigToOctopus(
   toastId?: string,
 ): Promise<{ success: boolean; message: string }> {
   try {
-    const config = await getFullOctopusConfig()
-    if (!config) {
+    const prefs = await userPreferences.getPreferences()
+    if (!hasValidOctopusConfig(prefs) || !prefs.octopus) {
       return { success: false, message: t("messages:octopus.configMissing") }
     }
+    const config = prefs.octopus
 
     const displaySiteData = accountStorage.convertToDisplayData(account)
 
@@ -498,11 +458,7 @@ export async function autoConfigToOctopus(
 
     const existingChannel = await resolveManagedSiteImportDuplicate({
       service: octopusImportDuplicateService,
-      managedConfig: {
-        baseUrl: config.baseUrl,
-        token: "",
-        userId: config.username,
-      },
+      managedConfig: config,
       formData,
     })
 
@@ -516,7 +472,7 @@ export async function autoConfigToOctopus(
     }
 
     const payload = buildChannelPayload(formData)
-    const result = await createChannel(config.baseUrl, "", "", payload)
+    const result = await createChannel(config, payload)
 
     if (result.success) {
       toast.success(

--- a/src/services/managedSites/providers/veloera.ts
+++ b/src/services/managedSites/providers/veloera.ts
@@ -28,6 +28,7 @@ import type {
   AutoConfigToNewApiResponse,
   ServiceResponse,
 } from "~/types/serviceResponse"
+import type { VeloeraConfig } from "~/types/veloeraConfig"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { normalizeList, parseDelimitedList } from "~/utils/core/string"
@@ -52,24 +53,24 @@ const veloeraImportDuplicateService = {
   fetchChannelSecretKey,
 }
 
+const toVeloeraRequestConfig = (config: VeloeraConfig) => ({
+  baseUrl: config.baseUrl,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: config.adminToken,
+    userId: config.userId,
+  },
+})
+
 /**
  * Searches channels matching the keyword.
  */
 export async function searchChannel(
-  baseUrl: string,
-  accessToken: string,
-  userId: number | string,
+  config: VeloeraConfig,
   keyword: string,
 ): Promise<ManagedSiteChannelListData | null> {
   return await getApiService(SITE_TYPES.VELOERA).searchChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken,
-        userId,
-      },
-    },
+    toVeloeraRequestConfig(config),
     keyword,
   )
 }
@@ -78,20 +79,11 @@ export async function searchChannel(
  * Creates a channel.
  */
 export async function createChannel(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: VeloeraConfig,
   channelData: CreateChannelPayload,
 ) {
   return await getApiService(SITE_TYPES.VELOERA).createChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toVeloeraRequestConfig(config),
     channelData,
   )
 }
@@ -100,20 +92,11 @@ export async function createChannel(
  * Updates a channel.
  */
 export async function updateChannel(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: VeloeraConfig,
   channelData: UpdateChannelPayload,
 ) {
   return await getApiService(SITE_TYPES.VELOERA).updateChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toVeloeraRequestConfig(config),
     channelData,
   )
 }
@@ -121,21 +104,9 @@ export async function updateChannel(
 /**
  * Deletes a channel.
  */
-export async function deleteChannel(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
-  channelId: number,
-) {
+export async function deleteChannel(config: VeloeraConfig, channelId: number) {
   return await getApiService(SITE_TYPES.VELOERA).deleteChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toVeloeraRequestConfig(config),
     channelId,
   )
 }
@@ -144,20 +115,11 @@ export async function deleteChannel(
  * Fetches the full secret key for a Veloera channel from its detail payload.
  */
 export async function fetchChannelSecretKey(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: VeloeraConfig,
   channelId: number,
 ): Promise<string> {
   const channel = await fetchVeloeraChannel(
-    {
-      baseUrl,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        accessToken: adminToken,
-        userId,
-      },
-    },
+    toVeloeraRequestConfig(config),
     channelId,
   )
 
@@ -173,9 +135,7 @@ export async function fetchChannelSecretKey(
  * Hydrates Veloera channel keys from detail payloads for shared comparison.
  */
 export async function hydrateComparableChannelKeys(
-  baseUrl: string,
-  adminToken: string,
-  userId: number | string,
+  config: VeloeraConfig,
   candidates: ManagedSiteChannel[],
 ): Promise<ManagedSiteChannel[]> {
   const hydratedCandidates: ManagedSiteChannel[] = []
@@ -187,12 +147,7 @@ export async function hydrateComparableChannelKeys(
     }
 
     try {
-      const key = await fetchChannelSecretKey(
-        baseUrl,
-        adminToken,
-        userId,
-        candidate.id,
-      )
+      const key = await fetchChannelSecretKey(config, candidate.id)
 
       hydratedCandidates.push({
         ...candidate,
@@ -391,13 +346,15 @@ async function importToVeloera(
 
     const formData = await prepareChannelFormData(account, token)
 
+    const managedConfig = {
+      baseUrl: veloeraBaseUrl!,
+      adminToken: veloeraAdminToken!,
+      userId: veloeraUserId!,
+    }
+
     const existingChannel = await resolveManagedSiteImportDuplicate({
       service: veloeraImportDuplicateService,
-      managedConfig: {
-        baseUrl: veloeraBaseUrl!,
-        token: veloeraAdminToken!,
-        userId: veloeraUserId!,
-      },
+      managedConfig,
       formData,
     })
 
@@ -412,12 +369,7 @@ async function importToVeloera(
 
     const payload = buildChannelPayload(formData)
 
-    const createdChannelResponse = await createChannel(
-      veloeraBaseUrl!,
-      veloeraAdminToken!,
-      veloeraUserId!,
-      payload,
-    )
+    const createdChannelResponse = await createChannel(managedConfig, payload)
 
     if (createdChannelResponse.success) {
       return {

--- a/src/services/managedSites/runtimeConfig.ts
+++ b/src/services/managedSites/runtimeConfig.ts
@@ -1,0 +1,180 @@
+import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import {
+  userPreferences,
+  type UserPreferences,
+} from "~/services/preferences/userPreferences"
+import type { AxonHubConfig } from "~/types/axonHubConfig"
+import type { ClaudeCodeHubConfig } from "~/types/claudeCodeHubConfig"
+import type { DoneHubConfig } from "~/types/doneHubConfig"
+import type { NewApiConfig } from "~/types/newApiConfig"
+import type { OctopusConfig } from "~/types/octopusConfig"
+import type { VeloeraConfig } from "~/types/veloeraConfig"
+
+export interface ManagedSiteLegacyAdminConfig {
+  baseUrl: string
+  adminToken: string
+  userId: string
+}
+
+export type ManagedSiteRuntimeConfig =
+  | { siteType: typeof SITE_TYPES.NEW_API; config: NewApiConfig }
+  | { siteType: typeof SITE_TYPES.DONE_HUB; config: DoneHubConfig }
+  | { siteType: typeof SITE_TYPES.VELOERA; config: VeloeraConfig }
+  | { siteType: typeof SITE_TYPES.OCTOPUS; config: OctopusConfig }
+  | { siteType: typeof SITE_TYPES.AXON_HUB; config: AxonHubConfig }
+  | {
+      siteType: typeof SITE_TYPES.CLAUDE_CODE_HUB
+      config: ClaudeCodeHubConfig
+    }
+
+export type ManagedSiteRuntimeConfigValue = ManagedSiteRuntimeConfig["config"]
+
+const hasText = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+/**
+ * Returns a complete access-token managed-site config when required fields exist.
+ */
+function resolveAccessTokenConfig(
+  config: NewApiConfig | DoneHubConfig | VeloeraConfig | undefined,
+) {
+  if (!config) return null
+  if (!hasText(config.baseUrl) || !hasText(config.adminToken)) return null
+  if (!hasText(config.userId)) return null
+  return config
+}
+
+/**
+ * Resolves the full runtime config for an explicit managed-site type.
+ */
+export function resolveManagedSiteRuntimeConfigForType(
+  preferences: UserPreferences,
+  siteType: ManagedSiteType,
+): ManagedSiteRuntimeConfig | null {
+  if (siteType === SITE_TYPES.OCTOPUS) {
+    const config = preferences.octopus
+    if (
+      !config ||
+      !hasText(config.baseUrl) ||
+      !hasText(config.username) ||
+      !hasText(config.password)
+    ) {
+      return null
+    }
+    return { siteType, config }
+  }
+
+  if (siteType === SITE_TYPES.AXON_HUB) {
+    const config = preferences.axonHub
+    if (
+      !config ||
+      !hasText(config.baseUrl) ||
+      !hasText(config.email) ||
+      !hasText(config.password)
+    ) {
+      return null
+    }
+    return { siteType, config }
+  }
+
+  if (siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
+    const config = preferences.claudeCodeHub
+    if (!config || !hasText(config.baseUrl) || !hasText(config.adminToken)) {
+      return null
+    }
+    return { siteType, config }
+  }
+
+  if (siteType === SITE_TYPES.DONE_HUB) {
+    const config = resolveAccessTokenConfig(preferences.doneHub)
+    return config ? { siteType, config } : null
+  }
+
+  if (siteType === SITE_TYPES.VELOERA) {
+    const config = resolveAccessTokenConfig(preferences.veloera)
+    return config ? { siteType, config } : null
+  }
+
+  if (siteType === SITE_TYPES.NEW_API) {
+    const config = resolveAccessTokenConfig(preferences.newApi)
+    return config ? { siteType, config } : null
+  }
+
+  const exhaustiveSiteType: never = siteType
+  return exhaustiveSiteType
+}
+
+/**
+ * Resolves the runtime config for the currently selected managed-site type.
+ */
+export function resolveCurrentManagedSiteRuntimeConfig(
+  preferences: UserPreferences,
+): ManagedSiteRuntimeConfig | null {
+  return resolveManagedSiteRuntimeConfigForType(
+    preferences,
+    preferences.managedSiteType || SITE_TYPES.NEW_API,
+  )
+}
+
+/**
+ * Loads preferences and resolves the currently selected managed-site runtime config.
+ */
+export async function getCurrentManagedSiteRuntimeConfig(): Promise<ManagedSiteRuntimeConfig | null> {
+  try {
+    const preferences = await userPreferences.getPreferences()
+    return resolveCurrentManagedSiteRuntimeConfig(preferences)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Loads preferences and resolves a runtime config for an explicit site type.
+ */
+export async function getManagedSiteRuntimeConfigForType(
+  siteType: ManagedSiteType,
+): Promise<ManagedSiteRuntimeConfig | null> {
+  try {
+    const preferences = await userPreferences.getPreferences()
+    return resolveManagedSiteRuntimeConfigForType(preferences, siteType)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Converts a runtime config to the legacy admin shape for compatibility callers.
+ */
+export function getManagedSiteLegacyAdminConfig(
+  runtimeConfig: ManagedSiteRuntimeConfig,
+): ManagedSiteLegacyAdminConfig {
+  if (runtimeConfig.siteType === SITE_TYPES.OCTOPUS) {
+    return {
+      baseUrl: runtimeConfig.config.baseUrl,
+      adminToken: "",
+      userId: runtimeConfig.config.username,
+    }
+  }
+
+  if (runtimeConfig.siteType === SITE_TYPES.AXON_HUB) {
+    return {
+      baseUrl: runtimeConfig.config.baseUrl,
+      adminToken: runtimeConfig.config.password,
+      userId: runtimeConfig.config.email,
+    }
+  }
+
+  if (runtimeConfig.siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
+    return {
+      baseUrl: runtimeConfig.config.baseUrl,
+      adminToken: runtimeConfig.config.adminToken,
+      userId: "admin",
+    }
+  }
+
+  return {
+    baseUrl: runtimeConfig.config.baseUrl,
+    adminToken: runtimeConfig.config.adminToken,
+    userId: runtimeConfig.config.userId,
+  }
+}

--- a/src/services/managedSites/runtimeConfig.ts
+++ b/src/services/managedSites/runtimeConfig.ts
@@ -1,4 +1,5 @@
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import { isManagedSiteAdminUserId } from "~/services/managedSites/utils/adminUserId"
 import {
   userPreferences,
   type UserPreferences,
@@ -10,7 +11,7 @@ import type { NewApiConfig } from "~/types/newApiConfig"
 import type { OctopusConfig } from "~/types/octopusConfig"
 import type { VeloeraConfig } from "~/types/veloeraConfig"
 
-export interface ManagedSiteLegacyAdminConfig {
+interface ManagedSiteLegacyAdminConfig {
   baseUrl: string
   adminToken: string
   userId: string
@@ -28,6 +29,11 @@ export type ManagedSiteRuntimeConfig =
     }
 
 export type ManagedSiteRuntimeConfigValue = ManagedSiteRuntimeConfig["config"]
+export type ManagedSiteRuntimeConfigForType<TSiteType extends ManagedSiteType> =
+  Extract<ManagedSiteRuntimeConfig, { siteType: TSiteType }>
+export type ManagedSiteRuntimeConfigValueForType<
+  TSiteType extends ManagedSiteType,
+> = ManagedSiteRuntimeConfigForType<TSiteType>["config"]
 
 const hasText = (value: unknown): value is string =>
   typeof value === "string" && value.trim().length > 0
@@ -40,17 +46,19 @@ function resolveAccessTokenConfig(
 ) {
   if (!config) return null
   if (!hasText(config.baseUrl) || !hasText(config.adminToken)) return null
-  if (!hasText(config.userId)) return null
+  if (!isManagedSiteAdminUserId(config.userId)) return null
   return config
 }
 
 /**
  * Resolves the full runtime config for an explicit managed-site type.
  */
-export function resolveManagedSiteRuntimeConfigForType(
+export function resolveManagedSiteRuntimeConfigForType<
+  TSiteType extends ManagedSiteType,
+>(
   preferences: UserPreferences,
-  siteType: ManagedSiteType,
-): ManagedSiteRuntimeConfig | null {
+  siteType: TSiteType,
+): ManagedSiteRuntimeConfigForType<TSiteType> | null {
   if (siteType === SITE_TYPES.OCTOPUS) {
     const config = preferences.octopus
     if (
@@ -61,7 +69,7 @@ export function resolveManagedSiteRuntimeConfigForType(
     ) {
       return null
     }
-    return { siteType, config }
+    return { siteType, config } as ManagedSiteRuntimeConfigForType<TSiteType>
   }
 
   if (siteType === SITE_TYPES.AXON_HUB) {
@@ -74,7 +82,7 @@ export function resolveManagedSiteRuntimeConfigForType(
     ) {
       return null
     }
-    return { siteType, config }
+    return { siteType, config } as ManagedSiteRuntimeConfigForType<TSiteType>
   }
 
   if (siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
@@ -82,22 +90,28 @@ export function resolveManagedSiteRuntimeConfigForType(
     if (!config || !hasText(config.baseUrl) || !hasText(config.adminToken)) {
       return null
     }
-    return { siteType, config }
+    return { siteType, config } as ManagedSiteRuntimeConfigForType<TSiteType>
   }
 
   if (siteType === SITE_TYPES.DONE_HUB) {
     const config = resolveAccessTokenConfig(preferences.doneHub)
-    return config ? { siteType, config } : null
+    return config
+      ? ({ siteType, config } as ManagedSiteRuntimeConfigForType<TSiteType>)
+      : null
   }
 
   if (siteType === SITE_TYPES.VELOERA) {
     const config = resolveAccessTokenConfig(preferences.veloera)
-    return config ? { siteType, config } : null
+    return config
+      ? ({ siteType, config } as ManagedSiteRuntimeConfigForType<TSiteType>)
+      : null
   }
 
   if (siteType === SITE_TYPES.NEW_API) {
     const config = resolveAccessTokenConfig(preferences.newApi)
-    return config ? { siteType, config } : null
+    return config
+      ? ({ siteType, config } as ManagedSiteRuntimeConfigForType<TSiteType>)
+      : null
   }
 
   const exhaustiveSiteType: never = siteType

--- a/src/services/managedSites/tokenBatchExport.ts
+++ b/src/services/managedSites/tokenBatchExport.ts
@@ -160,8 +160,14 @@ const collectSecrets = (
     token.key,
     account.token,
     account.cookieAuthSessionCookie,
-    managedConfig.token,
+    ...collectManagedConfigSecrets(managedConfig),
   ].filter(Boolean) as string[]
+
+const collectManagedConfigSecrets = (managedConfig: ManagedSiteConfig) => {
+  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
+  if ("password" in managedConfig) return [managedConfig.password]
+  return []
+}
 
 const preparePreviewItem = async (params: {
   input: ManagedSiteTokenBatchExportItemInput
@@ -455,12 +461,7 @@ export async function executeManagedSiteTokenBatchExport(params: {
     async (item): Promise<ManagedSiteTokenBatchExportExecutionItem> => {
       try {
         const payload = service.buildChannelPayload(item.draft!)
-        const response = await service.createChannel(
-          managedConfig.baseUrl,
-          managedConfig.token,
-          managedConfig.userId,
-          payload,
-        )
+        const response = await service.createChannel(managedConfig, payload)
 
         if (!response.success) {
           throw new Error(response.message || "Failed to create channel")

--- a/src/services/managedSites/tokenBatchExport.ts
+++ b/src/services/managedSites/tokenBatchExport.ts
@@ -11,6 +11,7 @@ import {
 } from "~/services/managedSites/managedSiteService"
 import { normalizeManagedSiteChannelBaseUrl } from "~/services/managedSites/utils/channelMatching"
 import {
+  collectManagedConfigSecrets,
   hasUsableManagedSiteChannelKey,
   supportsManagedSiteBaseUrlChannelLookup,
 } from "~/services/managedSites/utils/managedSite"
@@ -162,12 +163,6 @@ const collectSecrets = (
     account.cookieAuthSessionCookie,
     ...collectManagedConfigSecrets(managedConfig),
   ].filter(Boolean) as string[]
-
-const collectManagedConfigSecrets = (managedConfig: ManagedSiteConfig) => {
-  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
-  if ("password" in managedConfig) return [managedConfig.password]
-  return []
-}
 
 const preparePreviewItem = async (params: {
   input: ManagedSiteTokenBatchExportItemInput

--- a/src/services/managedSites/tokenChannelStatus.ts
+++ b/src/services/managedSites/tokenChannelStatus.ts
@@ -19,7 +19,10 @@ import {
 } from "~/services/managedSites/providers/newApiSession"
 import { hasNewApiTotpSecret } from "~/services/managedSites/providers/newApiTotp"
 import { normalizeManagedSiteChannelBaseUrl } from "~/services/managedSites/utils/channelMatching"
-import { supportsManagedSiteBaseUrlChannelLookup } from "~/services/managedSites/utils/managedSite"
+import {
+  collectManagedConfigSecrets,
+  supportsManagedSiteBaseUrlChannelLookup,
+} from "~/services/managedSites/utils/managedSite"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { AccountToken, ApiToken, DisplaySiteData } from "~/types"
 import type { ManagedSiteChannel } from "~/types/managedSite"
@@ -173,12 +176,6 @@ const collectSecrets = (
     token.key,
     ...(managedConfig ? collectManagedConfigSecrets(managedConfig) : []),
   ].filter(Boolean) as string[]
-}
-
-const collectManagedConfigSecrets = (managedConfig: ManagedSiteConfig) => {
-  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
-  if ("password" in managedConfig) return [managedConfig.password]
-  return []
 }
 
 const isNewApiConfig = (config: ManagedSiteConfig): config is NewApiConfig =>

--- a/src/services/managedSites/tokenChannelStatus.ts
+++ b/src/services/managedSites/tokenChannelStatus.ts
@@ -23,6 +23,7 @@ import { supportsManagedSiteBaseUrlChannelLookup } from "~/services/managedSites
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { AccountToken, ApiToken, DisplaySiteData } from "~/types"
 import type { ManagedSiteChannel } from "~/types/managedSite"
+import type { NewApiConfig } from "~/types/newApiConfig"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("ManagedSiteTokenChannelStatus")
@@ -168,15 +169,27 @@ const collectSecrets = (
   token: ApiToken | AccountToken,
   managedConfig: ManagedSiteConfig | null,
 ) => {
-  return [token.key, managedConfig?.token].filter(Boolean) as string[]
+  return [
+    token.key,
+    ...(managedConfig ? collectManagedConfigSecrets(managedConfig) : []),
+  ].filter(Boolean) as string[]
 }
+
+const collectManagedConfigSecrets = (managedConfig: ManagedSiteConfig) => {
+  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
+  if ("password" in managedConfig) return [managedConfig.password]
+  return []
+}
+
+const isNewApiConfig = (config: ManagedSiteConfig): config is NewApiConfig =>
+  "adminToken" in config && "userId" in config
 
 const isExactVerificationUnavailable = (
   resolution: ManagedSiteChannelMatchInspection,
 ) => resolution.url.matched && !resolution.key.comparable
 
 const buildNewApiRecoveryMetadata = async (params: {
-  managedConfig: ManagedSiteConfig
+  managedConfig: NewApiConfig
   assessment?: ManagedSiteTokenChannelAssessment
 }): Promise<ManagedSiteTokenChannelRecovery> => {
   const loginAssistConfig = await getNewApiLoginAssistConfig()
@@ -315,6 +328,7 @@ export async function getManagedSiteTokenChannelStatus(
 
       if (
         service.siteType === SITE_TYPES.NEW_API &&
+        isNewApiConfig(managedConfig) &&
         isExactVerificationUnavailable(resolution)
       ) {
         try {

--- a/src/services/managedSites/utils/managedSite.ts
+++ b/src/services/managedSites/utils/managedSite.ts
@@ -63,6 +63,14 @@ type ManagedSiteConfig =
   | AxonHubConfig
   | ClaudeCodeHubConfig
 
+export const collectManagedConfigSecrets = (
+  managedConfig: ManagedSiteConfig,
+) => {
+  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
+  if ("password" in managedConfig) return [managedConfig.password]
+  return []
+}
+
 /**
  * Extracts the selected managed site type and its corresponding config from a
  * given preferences snapshot.

--- a/src/services/managedSites/utils/managedSite.ts
+++ b/src/services/managedSites/utils/managedSite.ts
@@ -5,23 +5,9 @@ import { hasUsableApiTokenKey } from "~/services/apiService/common/apiKey"
 import {
   getManagedSiteLegacyAdminConfig,
   resolveManagedSiteRuntimeConfigForType,
+  type ManagedSiteRuntimeConfigValue,
 } from "~/services/managedSites/runtimeConfig"
 import type { UserPreferences } from "~/services/preferences/userPreferences"
-import {
-  DEFAULT_AXON_HUB_CONFIG,
-  type AxonHubConfig,
-} from "~/types/axonHubConfig"
-import {
-  DEFAULT_CLAUDE_CODE_HUB_CONFIG,
-  type ClaudeCodeHubConfig,
-} from "~/types/claudeCodeHubConfig"
-import {
-  DEFAULT_DONE_HUB_CONFIG,
-  type DoneHubConfig,
-} from "~/types/doneHubConfig"
-import type { NewApiConfig } from "~/types/newApiConfig"
-import type { OctopusConfig } from "~/types/octopusConfig"
-import type { VeloeraConfig } from "~/types/veloeraConfig"
 
 export type ManagedSiteLabelKey =
   | "settings:managedSite.newApi"
@@ -55,73 +41,12 @@ export interface ManagedSiteTargetOption {
   config: ManagedSiteAdminConfig
 }
 
-type ManagedSiteConfig =
-  | NewApiConfig
-  | DoneHubConfig
-  | VeloeraConfig
-  | OctopusConfig
-  | AxonHubConfig
-  | ClaudeCodeHubConfig
-
 export const collectManagedConfigSecrets = (
-  managedConfig: ManagedSiteConfig,
+  managedConfig: ManagedSiteRuntimeConfigValue,
 ) => {
   if ("adminToken" in managedConfig) return [managedConfig.adminToken]
   if ("password" in managedConfig) return [managedConfig.password]
   return []
-}
-
-/**
- * Extracts the selected managed site type and its corresponding config from a
- * given preferences snapshot.
- */
-function getManagedSiteConfigFromPreferencesForType(
-  preferences: UserPreferences,
-  siteType: ManagedSiteType,
-): {
-  siteType: ManagedSiteType
-  config: ManagedSiteConfig
-} {
-  let config: ManagedSiteConfig
-  if (siteType === SITE_TYPES.AXON_HUB) {
-    config = preferences.axonHub || DEFAULT_AXON_HUB_CONFIG
-  } else if (siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
-    config = preferences.claudeCodeHub || DEFAULT_CLAUDE_CODE_HUB_CONFIG
-  } else if (siteType === SITE_TYPES.OCTOPUS) {
-    config = preferences.octopus || { baseUrl: "", username: "", password: "" }
-  } else if (siteType === SITE_TYPES.DONE_HUB) {
-    config = preferences.doneHub ?? DEFAULT_DONE_HUB_CONFIG
-  } else if (siteType === SITE_TYPES.VELOERA) {
-    config = preferences.veloera
-  } else {
-    config = preferences.newApi
-  }
-  return { siteType, config }
-}
-
-/**
- * Extracts the selected managed site type and its corresponding config from a
- * given preferences snapshot.
- */
-export function getManagedSiteConfigFromPreferences(
-  preferences: UserPreferences,
-): {
-  siteType: ManagedSiteType
-  config: ManagedSiteConfig
-} {
-  const siteType: ManagedSiteType =
-    preferences.managedSiteType || SITE_TYPES.NEW_API
-  return getManagedSiteConfigFromPreferencesForType(preferences, siteType)
-}
-
-/**
- * Convenience wrapper for retrieving the managed site type + config.
- */
-export function getManagedSiteConfig(prefs: UserPreferences): {
-  siteType: ManagedSiteType
-  config: ManagedSiteConfig
-} {
-  return getManagedSiteConfigFromPreferences(prefs)
 }
 
 /**

--- a/src/services/managedSites/utils/managedSite.ts
+++ b/src/services/managedSites/utils/managedSite.ts
@@ -2,6 +2,10 @@ import type { TFunction } from "i18next"
 
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
 import { hasUsableApiTokenKey } from "~/services/apiService/common/apiKey"
+import {
+  getManagedSiteLegacyAdminConfig,
+  resolveManagedSiteRuntimeConfigForType,
+} from "~/services/managedSites/runtimeConfig"
 import type { UserPreferences } from "~/services/preferences/userPreferences"
 import {
   DEFAULT_AXON_HUB_CONFIG,
@@ -197,76 +201,11 @@ export function getManagedSiteAdminConfigForType(
   preferences: UserPreferences,
   siteType: ManagedSiteType,
 ): ManagedSiteAdminConfig | null {
-  const { config } = getManagedSiteConfigFromPreferencesForType(
+  const runtimeConfig = resolveManagedSiteRuntimeConfigForType(
     preferences,
     siteType,
   )
-
-  // Octopus 使用不同的配置结构
-  if (siteType === SITE_TYPES.OCTOPUS) {
-    const octopusConfig = config as OctopusConfig
-    if (
-      !octopusConfig?.baseUrl ||
-      !octopusConfig?.username ||
-      !octopusConfig?.password
-    ) {
-      return null
-    }
-    return {
-      baseUrl: octopusConfig.baseUrl,
-      adminToken: "", // Octopus 使用 JWT，动态获取
-      userId: octopusConfig.username,
-    }
-  }
-
-  if (siteType === SITE_TYPES.AXON_HUB) {
-    const axonHubConfig = config as AxonHubConfig
-    if (
-      !axonHubConfig?.baseUrl ||
-      !axonHubConfig?.email ||
-      !axonHubConfig?.password
-    ) {
-      return null
-    }
-    // AxonHub authenticates with admin email + password and obtains a session
-    // token per request. Keep the shared shape uniform, but treat adminToken as
-    // a password slot here, not a Bearer token, and never log or forward it.
-    return {
-      baseUrl: axonHubConfig.baseUrl,
-      adminToken: axonHubConfig.password,
-      userId: axonHubConfig.email,
-    }
-  }
-
-  if (siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
-    const claudeCodeHubConfig = config as ClaudeCodeHubConfig
-    if (!claudeCodeHubConfig?.baseUrl || !claudeCodeHubConfig?.adminToken) {
-      return null
-    }
-    // Claude Code Hub authenticates with an admin token only and does not
-    // expose a meaningful per-user identifier through this shared contract.
-    return {
-      baseUrl: claudeCodeHubConfig.baseUrl,
-      adminToken: claudeCodeHubConfig.adminToken,
-      userId: "admin",
-    }
-  }
-
-  // New API / Done Hub / Veloera 使用 adminToken
-  const legacyConfig = config as NewApiConfig | DoneHubConfig | VeloeraConfig
-  if (
-    !legacyConfig?.baseUrl ||
-    !legacyConfig?.adminToken ||
-    !legacyConfig?.userId
-  ) {
-    return null
-  }
-
-  return {
-    baseUrl: legacyConfig.baseUrl,
-    adminToken: legacyConfig.adminToken,
-    userId: legacyConfig.userId,
-  }
+  return runtimeConfig ? getManagedSiteLegacyAdminConfig(runtimeConfig) : null
 }
 
 /**

--- a/src/services/managedSites/utils/managedSite.ts
+++ b/src/services/managedSites/utils/managedSite.ts
@@ -44,12 +44,20 @@ export interface ManagedSiteTargetOption {
 export const collectManagedConfigSecrets = (
   managedConfig: ManagedSiteRuntimeConfigValue,
 ): string[] => {
+  const secrets: string[] = []
   if ("token" in managedConfig && typeof managedConfig.token === "string") {
-    return [managedConfig.token]
+    secrets.push(managedConfig.token)
   }
-  if ("adminToken" in managedConfig) return [managedConfig.adminToken]
-  if ("password" in managedConfig) return [managedConfig.password]
-  return []
+  if ("adminToken" in managedConfig) {
+    secrets.push(managedConfig.adminToken)
+  }
+  if (
+    "password" in managedConfig &&
+    typeof managedConfig.password === "string"
+  ) {
+    secrets.push(managedConfig.password)
+  }
+  return secrets
 }
 
 /**

--- a/src/services/managedSites/utils/managedSite.ts
+++ b/src/services/managedSites/utils/managedSite.ts
@@ -43,7 +43,10 @@ export interface ManagedSiteTargetOption {
 
 export const collectManagedConfigSecrets = (
   managedConfig: ManagedSiteRuntimeConfigValue,
-) => {
+): string[] => {
+  if ("token" in managedConfig && typeof managedConfig.token === "string") {
+    return [managedConfig.token]
+  }
   if ("adminToken" in managedConfig) return [managedConfig.adminToken]
   if ("password" in managedConfig) return [managedConfig.password]
   return []

--- a/src/services/models/modelRedirect/ModelRedirectService.ts
+++ b/src/services/models/modelRedirect/ModelRedirectService.ts
@@ -5,10 +5,7 @@
  */
 
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
-import {
-  getManagedSiteAdminConfig,
-  getManagedSiteConfig,
-} from "~/services/managedSites/utils/managedSite"
+import { resolveCurrentManagedSiteRuntimeConfig } from "~/services/managedSites/runtimeConfig"
 import { modelMetadataService } from "~/services/models/modelMetadata"
 import { ModelSyncService } from "~/services/models/modelSync"
 import { toModelTokenKey } from "~/services/models/utils/modelName"
@@ -158,9 +155,9 @@ export class ModelRedirectService {
       }
     }
 
-    const { siteType } = getManagedSiteConfig(resolvedPrefs)
+    const runtimeConfig = resolveCurrentManagedSiteRuntimeConfig(resolvedPrefs)
 
-    if (siteType === SITE_TYPES.OCTOPUS) {
+    if (runtimeConfig?.siteType === SITE_TYPES.OCTOPUS) {
       return {
         ok: false,
         errors: ["Model redirect is not supported for Octopus sites"],
@@ -168,8 +165,7 @@ export class ModelRedirectService {
       }
     }
 
-    const adminConfig = getManagedSiteAdminConfig(resolvedPrefs)
-    if (!adminConfig) {
+    if (!runtimeConfig) {
       return {
         ok: false,
         errors: ["Managed site configuration is missing"],
@@ -179,16 +175,7 @@ export class ModelRedirectService {
 
     return {
       ok: true,
-      service: new ModelSyncService(
-        adminConfig.baseUrl,
-        adminConfig.adminToken,
-        adminConfig.userId,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        siteType,
-      ),
+      service: new ModelSyncService(runtimeConfig),
     }
   }
 

--- a/src/services/models/modelSync/channelModelFilterEvaluator.ts
+++ b/src/services/models/modelSync/channelModelFilterEvaluator.ts
@@ -1,8 +1,9 @@
 import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
 import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
 import { ChannelType } from "~/constants/newApi"
-import type { ManagedSiteType } from "~/constants/siteType"
+import { SITE_TYPES } from "~/constants/siteType"
 import { getManagedSiteServiceForType } from "~/services/managedSites/managedSiteService"
+import type { ManagedSiteRuntimeConfig } from "~/services/managedSites/runtimeConfig"
 import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/managedSite"
 import {
   API_TYPES,
@@ -41,10 +42,7 @@ export class ProbeFilterUnavailableError extends Error {
  */
 export interface ProbeFilterContext {
   channel: ManagedSiteChannel
-  siteType: ManagedSiteType
-  managedSiteBaseUrl: string
-  adminToken: string
-  userId?: string
+  managedConfig: ManagedSiteRuntimeConfig
   cache: Map<string, boolean>
   resolvedKey?: string
   abortSignal?: AbortSignal
@@ -183,6 +181,21 @@ function hashSecret(value: string): string {
 }
 
 /**
+ * Extracts managed-site secrets that must be redacted from probe diagnostics.
+ */
+function getRuntimeConfigSecrets(config: ManagedSiteRuntimeConfig): string[] {
+  if (config.siteType === SITE_TYPES.OCTOPUS) {
+    return [config.config.password]
+  }
+
+  if (config.siteType === SITE_TYPES.AXON_HUB) {
+    return [config.config.password]
+  }
+
+  return [config.config.adminToken]
+}
+
+/**
  * Resolve the usable channel key from the channel row or provider capability.
  */
 async function resolveChannelKey(context: ProbeFilterContext): Promise<string> {
@@ -196,7 +209,7 @@ async function resolveChannelKey(context: ProbeFilterContext): Promise<string> {
     return directKey
   }
 
-  const service = getManagedSiteServiceForType(context.siteType)
+  const service = getManagedSiteServiceForType(context.managedConfig.siteType)
   if (!service.fetchChannelSecretKey) {
     throw new ProbeFilterUnavailableError(
       "provider-unsupported",
@@ -206,9 +219,7 @@ async function resolveChannelKey(context: ProbeFilterContext): Promise<string> {
 
   try {
     const key = await service.fetchChannelSecretKey(
-      context.managedSiteBaseUrl,
-      context.adminToken,
-      context.userId ?? "",
+      context.managedConfig.config,
       context.channel.id,
     )
     if (!hasUsableManagedSiteChannelKey(key)) {
@@ -218,7 +229,7 @@ async function resolveChannelKey(context: ProbeFilterContext): Promise<string> {
     return context.resolvedKey
   } catch (error) {
     const diagnostic = toSanitizedErrorSummary(error, [
-      context.adminToken,
+      ...getRuntimeConfigSecrets(context.managedConfig),
       directKey,
     ])
     logger.warn("Probe filter channel key resolution failed", {

--- a/src/services/models/modelSync/modelSyncService.ts
+++ b/src/services/models/modelSync/modelSyncService.ts
@@ -94,6 +94,8 @@ export class ModelSyncService {
     }
 
     if (siteType === SITE_TYPES.OCTOPUS) {
+      // Octopus model sync is routed through its dedicated scheduler executor;
+      // this fallback shape is retained only for defensive request construction.
       auth.userId = config.username
     } else if (siteType === SITE_TYPES.AXON_HUB) {
       auth.accessToken = config.password

--- a/src/services/models/modelSync/modelSyncService.ts
+++ b/src/services/models/modelSync/modelSyncService.ts
@@ -1,7 +1,9 @@
 import { union } from "lodash-es"
 
-import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import { SITE_TYPES } from "~/constants/siteType"
 import { getApiService } from "~/services/apiService"
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import { type ManagedSiteRuntimeConfig } from "~/services/managedSites/runtimeConfig"
 import { AuthTypeEnum } from "~/types"
 import type { ChannelConfigMap } from "~/types/channelConfig"
 import type { ChannelModelFilterRule } from "~/types/channelModelFilters"
@@ -40,20 +42,15 @@ const logger = createLogger("ManagedSiteModelSync")
  * Handles channel operations for model synchronization
  */
 export class ModelSyncService {
-  private baseUrl: string
-  private token: string
-  private userId?: string
-  private siteType: ManagedSiteType
+  private managedSiteConfig: ManagedSiteRuntimeConfig
   private rateLimiter: RateLimiter | null = null
   private allowedModelSet: Set<string> | null = null
   private channelConfigs: ChannelConfigMap | null = null
   private globalChannelModelFilters: ChannelModelFilterRule[] | null = null
 
   /**
-   * Create a model sync service bound to a specific New API instance.
-   * @param baseUrl New API base URL.
-   * @param token Admin token for channel operations.
-   * @param userId Optional user id for header injection.
+   * Create a model sync service bound to a specific managed-site runtime config.
+   * @param managedSiteConfig Managed-site runtime config object.
    * @param rateLimitConfig Optional RPM/burst limits for upstream calls.
    * @param rateLimitConfig.requestsPerMinute Maximum allowed requests per minute.
    * @param rateLimitConfig.burst Maximum burst size before throttling kicks in.
@@ -62,19 +59,13 @@ export class ModelSyncService {
    * @param globalChannelModelFilters Optional global include/exclude rules.
    */
   constructor(
-    baseUrl: string,
-    token: string,
-    userId?: string,
+    managedSiteConfig: ManagedSiteRuntimeConfig,
     rateLimitConfig?: { requestsPerMinute: number; burst: number },
     allowedModels?: string[],
     channelConfigs?: ChannelConfigMap | null,
     globalChannelModelFilters?: ChannelModelFilterRule[] | null,
-    siteType: ManagedSiteType = SITE_TYPES.NEW_API,
   ) {
-    this.baseUrl = baseUrl
-    this.token = token
-    this.userId = userId
-    this.siteType = siteType
+    this.managedSiteConfig = managedSiteConfig
     if (rateLimitConfig) {
       this.rateLimiter = new RateLimiter(
         rateLimitConfig.requestsPerMinute,
@@ -91,6 +82,33 @@ export class ModelSyncService {
     }
     if (globalChannelModelFilters && globalChannelModelFilters.length > 0) {
       this.globalChannelModelFilters = globalChannelModelFilters
+    }
+  }
+
+  private createApiServiceRequest(): ApiServiceRequest {
+    const { config, siteType } = this.managedSiteConfig
+    const auth = {
+      authType: AuthTypeEnum.AccessToken,
+      accessToken: "",
+      userId: "",
+    }
+
+    if (siteType === SITE_TYPES.OCTOPUS) {
+      auth.userId = config.username
+    } else if (siteType === SITE_TYPES.AXON_HUB) {
+      auth.accessToken = config.password
+      auth.userId = config.email
+    } else if (siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
+      auth.accessToken = config.adminToken
+      auth.userId = "admin"
+    } else {
+      auth.accessToken = config.adminToken
+      auth.userId = config.userId
+    }
+
+    return {
+      baseUrl: config.baseUrl,
+      auth,
     }
   }
 
@@ -146,21 +164,13 @@ export class ModelSyncService {
    */
   async listChannels(): Promise<ManagedSiteChannelListData> {
     try {
-      return await getApiService(this.siteType).listAllChannels(
-        {
-          baseUrl: this.baseUrl,
-          auth: {
-            authType: AuthTypeEnum.AccessToken,
-            accessToken: this.token,
-            userId: this.userId,
-          },
+      return await getApiService(
+        this.managedSiteConfig.siteType,
+      ).listAllChannels(this.createApiServiceRequest(), {
+        beforeRequest: async () => {
+          await this.throttle()
         },
-        {
-          beforeRequest: async () => {
-            await this.throttle()
-          },
-        },
-      )
+      })
     } catch (error) {
       logger.error("Failed to list channels", error)
       throw error
@@ -176,17 +186,9 @@ export class ModelSyncService {
     try {
       await this.throttle()
 
-      return await getApiService(this.siteType).fetchChannelModels(
-        {
-          baseUrl: this.baseUrl,
-          auth: {
-            authType: AuthTypeEnum.AccessToken,
-            accessToken: this.token,
-            userId: this.userId,
-          },
-        },
-        channelId,
-      )
+      return await getApiService(
+        this.managedSiteConfig.siteType,
+      ).fetchChannelModels(this.createApiServiceRequest(), channelId)
     } catch (error: any) {
       logger.error("Failed to fetch models", { channelId, error })
       throw error
@@ -205,15 +207,8 @@ export class ModelSyncService {
     try {
       await this.throttle()
 
-      await getApiService(this.siteType).updateChannelModels(
-        {
-          baseUrl: this.baseUrl,
-          auth: {
-            authType: AuthTypeEnum.AccessToken,
-            accessToken: this.token,
-            userId: this.userId,
-          },
-        },
+      await getApiService(this.managedSiteConfig.siteType).updateChannelModels(
+        this.createApiServiceRequest(),
         channel.id,
         models.join(","),
       )
@@ -239,15 +234,10 @@ export class ModelSyncService {
       ).join(",")
       await this.throttle()
 
-      await getApiService(this.siteType).updateChannelModelMapping(
-        {
-          baseUrl: this.baseUrl,
-          auth: {
-            authType: AuthTypeEnum.AccessToken,
-            accessToken: this.token,
-            userId: this.userId,
-          },
-        },
+      await getApiService(
+        this.managedSiteConfig.siteType,
+      ).updateChannelModelMapping(
+        this.createApiServiceRequest(),
         channel.id,
         updateModels,
         JSON.stringify(modelMapping),
@@ -289,10 +279,7 @@ export class ModelSyncService {
         const probeFilterAbort = this.createProbeFilterAbortSignal()
         const probeContext: ProbeFilterContext = {
           channel,
-          siteType: this.siteType,
-          managedSiteBaseUrl: this.baseUrl,
-          adminToken: this.token,
-          userId: this.userId,
+          managedConfig: this.managedSiteConfig,
           cache: probeFilterCache,
           abortSignal: probeFilterAbort.signal,
         }

--- a/src/services/models/modelSync/scheduler.ts
+++ b/src/services/models/modelSync/scheduler.ts
@@ -2,9 +2,8 @@ import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import * as octopusApi from "~/services/apiService/octopus"
 import { getManagedSiteServiceForType } from "~/services/managedSites/managedSiteService"
+import { resolveCurrentManagedSiteRuntimeConfig } from "~/services/managedSites/runtimeConfig"
 import {
-  getManagedSiteAdminConfig,
-  getManagedSiteConfig,
   getManagedSiteConfigMissingMessage,
   getManagedSiteContext,
   getManagedSiteNoChannelsToSyncMessage,
@@ -37,7 +36,6 @@ import {
   ExecutionProgress,
   ExecutionResult,
 } from "~/types/managedSiteModelSync"
-import type { OctopusConfig } from "~/types/octopusConfig"
 import {
   getTaskNotificationStatusFromCounts,
   TASK_NOTIFICATION_STATUSES,
@@ -178,14 +176,12 @@ class ModelSyncScheduler {
   private async createService(): Promise<ModelSyncService> {
     const userPrefs = await userPreferences.getPreferences()
 
-    const { siteType, messagesKey } = getManagedSiteContext(userPrefs)
-    const managedConfig = getManagedSiteAdminConfig(userPrefs)
+    const { messagesKey } = getManagedSiteContext(userPrefs)
+    const managedConfig = resolveCurrentManagedSiteRuntimeConfig(userPrefs)
 
     if (!managedConfig) {
       throw new Error(getManagedSiteConfigMissingMessage(t, messagesKey))
     }
-
-    const { baseUrl, adminToken, userId } = managedConfig
 
     const config =
       userPrefs.managedSiteModelSync ??
@@ -194,16 +190,13 @@ class ModelSyncScheduler {
     const channelConfigs = await channelConfigStorage.getAllConfigs()
 
     return new ModelSyncService(
-      baseUrl,
-      adminToken,
-      userId,
+      managedConfig,
       config.rateLimit,
       config.allowedModels,
       channelConfigs,
       sanitizeChannelFiltersForStorage(config.globalChannelModelFilters, {
         idPrefix: "global-channel-filter",
       }),
-      siteType,
     )
   }
 
@@ -376,19 +369,23 @@ class ModelSyncScheduler {
 
     // Octopus 使用独立的 API 服务
     if (siteType === SITE_TYPES.OCTOPUS) {
-      const { config } = getManagedSiteConfig(userPrefs)
-      const octopusConfig = config as OctopusConfig
+      const octopusRuntimeConfig =
+        resolveCurrentManagedSiteRuntimeConfig(userPrefs)
 
       // Validate config like createService does
       if (
-        !octopusConfig?.baseUrl ||
-        !octopusConfig?.username ||
-        !octopusConfig?.password
+        !octopusRuntimeConfig ||
+        octopusRuntimeConfig.siteType !== SITE_TYPES.OCTOPUS ||
+        !octopusRuntimeConfig.config.baseUrl ||
+        !octopusRuntimeConfig.config.username ||
+        !octopusRuntimeConfig.config.password
       ) {
         throw new Error(getManagedSiteConfigMissingMessage(t, messagesKey))
       }
 
-      const channels = await octopusApi.listChannels(octopusConfig)
+      const channels = await octopusApi.listChannels(
+        octopusRuntimeConfig.config,
+      )
       return {
         items: channels.map(octopusChannelToManagedSite),
         total: channels.length,
@@ -397,18 +394,13 @@ class ModelSyncScheduler {
     }
 
     if (siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
-      const managedConfig = getManagedSiteAdminConfig(userPrefs)
+      const managedConfig = resolveCurrentManagedSiteRuntimeConfig(userPrefs)
       if (!managedConfig) {
         throw new Error(getManagedSiteConfigMissingMessage(t, messagesKey))
       }
 
       const service = getManagedSiteServiceForType(siteType)
-      const channels = await service.searchChannel(
-        managedConfig.baseUrl,
-        managedConfig.adminToken,
-        managedConfig.userId,
-        "",
-      )
+      const channels = await service.searchChannel(managedConfig.config, "")
 
       return channels ?? { items: [], total: 0, type_counts: {} }
     }
@@ -641,20 +633,23 @@ class ModelSyncScheduler {
     concurrency: number,
     maxRetries: number,
   ): Promise<ExecutionResult> {
-    const { config } = getManagedSiteConfig(prefs)
-    const octopusConfig = config as OctopusConfig
+    const octopusRuntimeConfig = resolveCurrentManagedSiteRuntimeConfig(prefs)
 
     // Validate config like createService does
     if (
-      !octopusConfig?.baseUrl ||
-      !octopusConfig?.username ||
-      !octopusConfig?.password
+      !octopusRuntimeConfig ||
+      octopusRuntimeConfig.siteType !== SITE_TYPES.OCTOPUS ||
+      !octopusRuntimeConfig.config.baseUrl ||
+      !octopusRuntimeConfig.config.username ||
+      !octopusRuntimeConfig.config.password
     ) {
       throw new Error(getManagedSiteConfigMissingMessage(t, messagesKey))
     }
 
     // List channels using Octopus API
-    const octopusChannels = await octopusApi.listChannels(octopusConfig)
+    const octopusChannels = await octopusApi.listChannels(
+      octopusRuntimeConfig.config,
+    )
     const allChannels = octopusChannels.map(octopusChannelToManagedSite)
 
     // Filter channels if specific IDs provided
@@ -682,7 +677,7 @@ class ModelSyncScheduler {
     let result
     try {
       // Execute batch sync using Octopus-specific implementation
-      result = await runOctopusBatch(octopusConfig, channels, {
+      result = await runOctopusBatch(octopusRuntimeConfig.config, channels, {
         concurrency,
         maxRetries,
         onProgress: async (payload) => {

--- a/src/services/models/modelSync/scheduler.ts
+++ b/src/services/models/modelSync/scheduler.ts
@@ -2,7 +2,10 @@ import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import * as octopusApi from "~/services/apiService/octopus"
 import { getManagedSiteServiceForType } from "~/services/managedSites/managedSiteService"
-import { resolveCurrentManagedSiteRuntimeConfig } from "~/services/managedSites/runtimeConfig"
+import {
+  resolveCurrentManagedSiteRuntimeConfig,
+  resolveManagedSiteRuntimeConfigForType,
+} from "~/services/managedSites/runtimeConfig"
 import {
   getManagedSiteConfigMissingMessage,
   getManagedSiteContext,
@@ -394,7 +397,10 @@ class ModelSyncScheduler {
     }
 
     if (siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
-      const managedConfig = resolveCurrentManagedSiteRuntimeConfig(userPrefs)
+      const managedConfig = resolveManagedSiteRuntimeConfigForType(
+        userPrefs,
+        SITE_TYPES.CLAUDE_CODE_HUB,
+      )
       if (!managedConfig) {
         throw new Error(getManagedSiteConfigMissingMessage(t, messagesKey))
       }

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -205,7 +205,7 @@ const buildManagedSiteServiceMock = (
   messagesKey: "newapi",
   getConfig: vi.fn(async () => ({
     baseUrl: "https://managed.example.com",
-    token: "admin-token",
+    adminToken: "admin-token",
     userId: "1",
   })),
   prepareChannelFormData: vi.fn(async () => buildPreparedFormData()),
@@ -215,7 +215,7 @@ const buildManagedSiteServiceMock = (
     type_counts: {},
   })),
   hydrateComparableChannelKeys: vi.fn(
-    async (_baseUrl, _token, _userId, candidates) => candidates,
+    async (_config, candidates) => candidates,
   ),
   ...overrides,
 })
@@ -277,7 +277,7 @@ describe("useChannelDialog", () => {
       messagesKey: "newapi",
       getConfig: vi.fn(async () => ({
         baseUrl: "https://managed.example.com",
-        token: "admin-token",
+        adminToken: "admin-token",
         userId: "1",
       })),
       prepareChannelFormData: vi.fn(
@@ -343,7 +343,7 @@ describe("useChannelDialog", () => {
       messagesKey: "newapi",
       getConfig: vi.fn(async () => ({
         baseUrl: "https://managed.example.com",
-        token: "admin-token",
+        adminToken: "admin-token",
         userId: "1",
       })),
       prepareChannelFormData: vi.fn(
@@ -461,7 +461,7 @@ describe("useChannelDialog", () => {
       messagesKey: "newapi",
       getConfig: vi.fn(async () => ({
         baseUrl: "https://managed.example.com",
-        token: "admin-token",
+        adminToken: "admin-token",
         userId: "1",
       })),
       prepareChannelFormData: vi.fn(
@@ -538,7 +538,7 @@ describe("useChannelDialog", () => {
       messagesKey: "newapi",
       getConfig: vi.fn(async () => ({
         baseUrl: "https://managed.example.com",
-        token: "admin-token",
+        adminToken: "admin-token",
         userId: "1",
       })),
       prepareChannelFormData: vi.fn(
@@ -603,7 +603,7 @@ describe("useChannelDialog", () => {
       messagesKey: "newapi",
       getConfig: vi.fn(async () => ({
         baseUrl: "https://managed.example.com",
-        token: "admin-token",
+        adminToken: "admin-token",
         userId: "1",
       })),
       prepareChannelFormData: vi.fn(
@@ -667,7 +667,7 @@ describe("useChannelDialog", () => {
       messagesKey: "newapi",
       getConfig: vi.fn(async () => ({
         baseUrl: "https://managed.example.com",
-        token: "admin-token",
+        adminToken: "admin-token",
         userId: "1",
       })),
       prepareChannelFormData: vi.fn(),
@@ -714,7 +714,7 @@ describe("useChannelDialog", () => {
       messagesKey: "newapi",
       getConfig: vi.fn(async () => ({
         baseUrl: "https://managed.example.com",
-        token: "admin-token",
+        adminToken: "admin-token",
         userId: "1",
       })),
       prepareChannelFormData: vi.fn(

--- a/tests/components/dialogs/ChannelDialog/ChannelDialog.advisoryWarning.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/ChannelDialog.advisoryWarning.test.tsx
@@ -150,7 +150,7 @@ vi.mock("~/services/managedSites/managedSiteService", () => ({
     messagesKey: "newapi",
     getConfig: vi.fn(async () => ({
       baseUrl: "https://managed.example.com",
-      token: "admin-token",
+      adminToken: "admin-token",
       userId: "1",
     })),
     searchChannel: vi.fn(async () => ({
@@ -291,9 +291,11 @@ describe("ChannelDialog advisory verification action", () => {
     })
 
     expect(fetchChannelSecretKeyMock).toHaveBeenCalledWith(
-      "https://managed.example.com",
-      "admin-token",
-      "1",
+      {
+        baseUrl: "https://managed.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      },
       7,
     )
 

--- a/tests/components/dialogs/ChannelDialog/useChannelForm.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/useChannelForm.test.tsx
@@ -7,12 +7,17 @@ import { DEFAULT_CLAUDE_CODE_HUB_CHANNEL_FIELDS } from "~/constants/claudeCodeHu
 import { DIALOG_MODES } from "~/constants/dialogModes"
 import { ChannelType, DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
 import { SITE_TYPES } from "~/constants/siteType"
+import { getApiService } from "~/services/apiService"
 import { getManagedSiteService } from "~/services/managedSites/managedSiteService"
 import type {
   CreateChannelPayload,
   ManagedSiteChannel,
 } from "~/types/managedSite"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: vi.fn(),
+}))
 
 vi.mock("~/services/managedSites/managedSiteService", () => ({
   getManagedSiteService: vi.fn(),
@@ -73,9 +78,15 @@ describe("useChannelForm", () => {
   const mockBuildChannelPayload = vi.fn()
   const mockCreateChannel = vi.fn()
   const mockUpdateChannel = vi.fn()
+  const mockFetchSiteUserGroups = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getApiService).mockReturnValue({
+      fetchSiteUserGroups: mockFetchSiteUserGroups.mockResolvedValue([
+        "default",
+      ]),
+    } as any)
     vi.mocked(getManagedSiteService).mockResolvedValue({
       siteType: SITE_TYPES.NEW_API,
       checkValidConfig: mockCheckValidConfig.mockResolvedValue(false),
@@ -155,6 +166,41 @@ describe("useChannelForm", () => {
     expect(result.current.formData.groups).not.toBe(
       DEFAULT_CHANNEL_FIELDS.groups,
     )
+  })
+
+  it("loads groups with access-token managed-site auth", async () => {
+    mockCheckValidConfig.mockResolvedValue(true)
+    mockGetConfig.mockResolvedValue({
+      baseUrl: "https://managed.example.com",
+      adminToken: "admin-token",
+      userId: "42",
+    })
+    mockFetchSiteUserGroups.mockResolvedValue(["vip"])
+
+    const { result } = renderHook(() =>
+      useChannelForm({
+        mode: DIALOG_MODES.ADD,
+        channel: null,
+        isOpen: true,
+        onClose: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.availableGroups).toEqual([
+        { label: "vip", value: "vip" },
+        { label: "default", value: "default" },
+      ])
+    })
+
+    expect(mockFetchSiteUserGroups).toHaveBeenCalledWith({
+      baseUrl: "https://managed.example.com",
+      auth: {
+        authType: "access_token",
+        accessToken: "admin-token",
+        userId: "42",
+      },
+    })
   })
 
   it("treats handleSubmit as a no-op in view mode", async () => {

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -413,7 +413,7 @@ describe("ManagedSiteChannels", () => {
       messagesKey,
       getConfig: vi.fn().mockResolvedValue({
         baseUrl: "https://admin.example",
-        token: "t",
+        adminToken: "t",
         userId: "1",
       }),
       fetchChannelSecretKey: options?.fetchChannelSecretKey,
@@ -1505,7 +1505,7 @@ describe("ManagedSiteChannels", () => {
       messagesKey: "newapi",
       getConfig: vi.fn().mockResolvedValue({
         baseUrl: "https://admin.example",
-        token: "t",
+        adminToken: "t",
         userId: "1",
       }),
       deleteChannel,
@@ -1545,9 +1545,11 @@ describe("ManagedSiteChannels", () => {
 
     await waitFor(() => {
       expect(deleteChannel).toHaveBeenCalledWith(
-        "https://admin.example",
-        "t",
-        "1",
+        {
+          baseUrl: "https://admin.example",
+          adminToken: "t",
+          userId: "1",
+        },
         1,
       )
     })
@@ -1587,16 +1589,10 @@ describe("ManagedSiteChannels", () => {
 
     const deleteChannel = vi
       .fn()
-      .mockImplementation(
-        (
-          _baseUrl: string,
-          _token: string,
-          _userId: string,
-          channelId: number,
-        ) =>
-          channelId === 1
-            ? Promise.resolve({ success: true })
-            : Promise.reject(new Error("delete beta failed")),
+      .mockImplementation((_config: unknown, channelId: number) =>
+        channelId === 1
+          ? Promise.resolve({ success: true })
+          : Promise.reject(new Error("delete beta failed")),
       )
 
     vi.mocked(getManagedSiteService).mockResolvedValue({
@@ -1604,7 +1600,7 @@ describe("ManagedSiteChannels", () => {
       messagesKey: "newapi",
       getConfig: vi.fn().mockResolvedValue({
         baseUrl: "https://admin.example",
-        token: "t",
+        adminToken: "t",
         userId: "1",
       }),
       deleteChannel,
@@ -2122,9 +2118,11 @@ describe("ManagedSiteChannels", () => {
 
       await waitFor(() => {
         expect(fetchChannelSecretKey).toHaveBeenCalledWith(
-          "https://admin.example",
-          "t",
-          "1",
+          {
+            baseUrl: "https://admin.example",
+            adminToken: "t",
+            userId: "1",
+          },
           308,
         )
       })

--- a/tests/services/doneHubService/doneHubService.more.test.ts
+++ b/tests/services/doneHubService/doneHubService.more.test.ts
@@ -371,15 +371,19 @@ describe("doneHubService additional flows", () => {
     })
 
     await searchChannel(
-      "https://done-hub.example.com",
-      "done-hub-token",
-      "100",
+      {
+        baseUrl: "https://done-hub.example.com",
+        adminToken: "done-hub-token",
+        userId: "100",
+      },
       "proxy",
     )
     await createChannel(
-      "https://done-hub.example.com",
-      "done-hub-token",
-      "100",
+      {
+        baseUrl: "https://done-hub.example.com",
+        adminToken: "done-hub-token",
+        userId: "100",
+      },
       {
         mode: "single",
         channel: {
@@ -396,9 +400,11 @@ describe("doneHubService additional flows", () => {
       } as any,
     )
     await updateChannel(
-      "https://done-hub.example.com",
-      "done-hub-token",
-      "100",
+      {
+        baseUrl: "https://done-hub.example.com",
+        adminToken: "done-hub-token",
+        userId: "100",
+      },
       {
         id: 7,
         name: "Updated Channel",
@@ -413,9 +419,11 @@ describe("doneHubService additional flows", () => {
       } as any,
     )
     await deleteChannel(
-      "https://done-hub.example.com",
-      "done-hub-token",
-      "100",
+      {
+        baseUrl: "https://done-hub.example.com",
+        adminToken: "done-hub-token",
+        userId: "100",
+      },
       7,
     )
     const models = await fetchAvailableModels(account, token)
@@ -531,9 +539,11 @@ describe("doneHubService additional flows", () => {
 
     await expect(
       fetchChannelSecretKey(
-        "https://done-hub.example.com",
-        "done-hub-token",
-        "100",
+        {
+          baseUrl: "https://done-hub.example.com",
+          adminToken: "done-hub-token",
+          userId: "100",
+        },
         42,
       ),
     ).rejects.toThrow("done_hub_channel_key_missing")
@@ -548,9 +558,11 @@ describe("doneHubService additional flows", () => {
     )
 
     const result = await hydrateComparableChannelKeys(
-      "https://done-hub.example.com",
-      "done-hub-token",
-      "100",
+      {
+        baseUrl: "https://done-hub.example.com",
+        adminToken: "done-hub-token",
+        userId: "100",
+      },
       [
         buildManagedSiteChannel({
           id: undefined as any,
@@ -575,9 +587,11 @@ describe("doneHubService additional flows", () => {
 
     await expect(
       hydrateComparableChannelKeys(
-        "https://done-hub.example.com",
-        "done-hub-token",
-        "100",
+        {
+          baseUrl: "https://done-hub.example.com",
+          adminToken: "done-hub-token",
+          userId: "100",
+        },
         [
           buildManagedSiteChannel({
             id: 22,

--- a/tests/services/doneHubService/doneHubService.test.ts
+++ b/tests/services/doneHubService/doneHubService.test.ts
@@ -21,10 +21,42 @@ describe("doneHubService hydrateComparableChannelKeys", () => {
     mockSearchChannel.mockReset()
   })
 
+  it("searches channels from a runtime config object", async () => {
+    const { searchChannel } = await import(
+      "~/services/managedSites/providers/doneHubService"
+    )
+    const config = {
+      baseUrl: "https://donehub.example.com",
+      adminToken: "done-token",
+      userId: "9",
+    }
+
+    mockSearchChannel.mockResolvedValueOnce({ items: [] })
+
+    await searchChannel(config, "alpha")
+
+    expect(mockSearchChannel).toHaveBeenCalledWith(
+      {
+        baseUrl: config.baseUrl,
+        auth: {
+          authType: "access_token",
+          accessToken: config.adminToken,
+          userId: config.userId,
+        },
+      },
+      "alpha",
+    )
+  })
+
   it("fetches the full channel key from channel detail", async () => {
     const { fetchChannelSecretKey } = await import(
       "~/services/managedSites/providers/doneHubService"
     )
+    const config = {
+      baseUrl: "https://done-hub.example.com",
+      adminToken: "admin-token",
+      userId: "1",
+    }
 
     mockFetchDoneHubChannel.mockResolvedValueOnce(
       buildManagedSiteChannel({
@@ -33,20 +65,15 @@ describe("doneHubService hydrateComparableChannelKeys", () => {
       }),
     )
 
-    const result = await fetchChannelSecretKey(
-      "https://done-hub.example.com",
-      "admin-token",
-      "1",
-      21,
-    )
+    const result = await fetchChannelSecretKey(config, 21)
 
     expect(mockFetchDoneHubChannel).toHaveBeenCalledWith(
       {
-        baseUrl: "https://done-hub.example.com",
+        baseUrl: config.baseUrl,
         auth: {
           authType: "access_token",
-          accessToken: "admin-token",
-          userId: "1",
+          accessToken: config.adminToken,
+          userId: config.userId,
         },
       },
       21,
@@ -58,6 +85,11 @@ describe("doneHubService hydrateComparableChannelKeys", () => {
     const { hydrateComparableChannelKeys } = await import(
       "~/services/managedSites/providers/doneHubService"
     )
+    const config = {
+      baseUrl: "https://donehub.example.com",
+      adminToken: "admin-token",
+      userId: "1",
+    }
 
     mockFetchDoneHubChannel.mockResolvedValueOnce(
       buildManagedSiteChannel({
@@ -69,21 +101,16 @@ describe("doneHubService hydrateComparableChannelKeys", () => {
       }),
     )
 
-    const result = await hydrateComparableChannelKeys(
-      "https://donehub.example.com",
-      "admin-token",
-      1,
-      [
-        buildManagedSiteChannel({
-          id: 20,
-          base_url: "https://candidate.example.com",
-          key: "",
-          name: "Candidate Done Hub Channel",
-          models: "candidate-model",
-        }),
-        buildManagedSiteChannel({ id: 21, key: "sk-visible" }),
-      ],
-    )
+    const result = await hydrateComparableChannelKeys(config, [
+      buildManagedSiteChannel({
+        id: 20,
+        base_url: "https://candidate.example.com",
+        key: "",
+        name: "Candidate Done Hub Channel",
+        models: "candidate-model",
+      }),
+      buildManagedSiteChannel({ id: 21, key: "sk-visible" }),
+    ])
 
     expect(mockFetchDoneHubChannel).toHaveBeenCalledTimes(1)
     expect(mockFetchDoneHubChannel).toHaveBeenCalledWith(expect.any(Object), 20)
@@ -106,6 +133,11 @@ describe("doneHubService hydrateComparableChannelKeys", () => {
     const { MatchResolutionUnresolvedError } = await import(
       "~/services/managedSites/channelMatch"
     )
+    const config = {
+      baseUrl: "https://donehub.example.com",
+      adminToken: "admin-token",
+      userId: "1",
+    }
 
     mockFetchDoneHubChannel.mockResolvedValueOnce(
       buildManagedSiteChannel({
@@ -115,12 +147,9 @@ describe("doneHubService hydrateComparableChannelKeys", () => {
     )
 
     await expect(
-      hydrateComparableChannelKeys(
-        "https://donehub.example.com",
-        "admin-token",
-        1,
-        [buildManagedSiteChannel({ id: 22, key: "" })],
-      ),
+      hydrateComparableChannelKeys(config, [
+        buildManagedSiteChannel({ id: 22, key: "" }),
+      ]),
     ).rejects.toBeInstanceOf(MatchResolutionUnresolvedError)
   })
 })

--- a/tests/services/managedSiteService/managedSiteService.test.ts
+++ b/tests/services/managedSiteService/managedSiteService.test.ts
@@ -35,11 +35,6 @@ vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
 
 vi.mock("~/services/managedSites/providers/newApi", () => ({
   checkValidNewApiConfig: vi.fn(async () => true),
-  getNewApiConfig: vi.fn(async () => ({
-    baseUrl: "n",
-    token: "t",
-    userId: "u",
-  })),
   searchChannel: vi.fn(),
   createChannel: vi.fn(),
   updateChannel: vi.fn(),
@@ -55,11 +50,6 @@ vi.mock("~/services/managedSites/providers/newApi", () => ({
 
 vi.mock("~/services/managedSites/providers/veloera", () => ({
   checkValidVeloeraConfig: vi.fn(async () => true),
-  getVeloeraConfig: vi.fn(async () => ({
-    baseUrl: "v",
-    token: "t",
-    userId: "u",
-  })),
   searchChannel: vi.fn(),
   createChannel: vi.fn(),
   updateChannel: vi.fn(),
@@ -75,11 +65,6 @@ vi.mock("~/services/managedSites/providers/veloera", () => ({
 
 vi.mock("~/services/managedSites/providers/doneHubService", () => ({
   checkValidDoneHubConfig: vi.fn(async () => true),
-  getDoneHubConfig: vi.fn(async () => ({
-    baseUrl: "d",
-    token: "t",
-    userId: "u",
-  })),
   searchChannel: vi.fn(),
   createChannel: vi.fn(),
   updateChannel: vi.fn(),
@@ -95,11 +80,6 @@ vi.mock("~/services/managedSites/providers/doneHubService", () => ({
 
 vi.mock("~/services/managedSites/providers/octopus", () => ({
   checkValidOctopusConfig: vi.fn(async () => true),
-  getOctopusConfig: vi.fn(async () => ({
-    baseUrl: "o",
-    token: "",
-    userId: "admin",
-  })),
   searchChannel: vi.fn(),
   createChannel: vi.fn(),
   updateChannel: vi.fn(),
@@ -113,11 +93,6 @@ vi.mock("~/services/managedSites/providers/octopus", () => ({
 
 vi.mock("~/services/managedSites/providers/axonHub", () => ({
   checkValidAxonHubConfig: vi.fn(async () => true),
-  getAxonHubConfig: vi.fn(async () => ({
-    baseUrl: "a",
-    token: "p",
-    userId: "admin@example.com",
-  })),
   searchChannel: vi.fn(),
   createChannel: vi.fn(),
   updateChannel: vi.fn(),
@@ -131,11 +106,6 @@ vi.mock("~/services/managedSites/providers/axonHub", () => ({
 
 vi.mock("~/services/managedSites/providers/claudeCodeHub", () => ({
   checkValidClaudeCodeHubConfig: vi.fn(async () => true),
-  getClaudeCodeHubConfig: vi.fn(async () => ({
-    baseUrl: "c",
-    token: "t",
-    userId: "admin",
-  })),
   searchChannel: vi.fn(),
   createChannel: vi.fn(),
   updateChannel: vi.fn(),
@@ -233,9 +203,15 @@ describe("managedSiteService", () => {
       "~/services/managedSites/managedSiteService"
     )
 
-    mockGetPreferences.mockResolvedValueOnce({
+    const prefs = {
       managedSiteType: SITE_TYPES.NEW_API,
-    })
+      newApi: {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "admin-token",
+        userId: "admin",
+      },
+    }
+    mockGetPreferences.mockResolvedValueOnce(prefs).mockResolvedValueOnce(prefs)
 
     const service = await getManagedSiteService()
     expect(service.siteType).toBe(SITE_TYPES.NEW_API)
@@ -244,7 +220,11 @@ describe("managedSiteService", () => {
     expect(service.hydrateComparableChannelKeys).toEqual(expect.any(Function))
 
     const config = await service.getConfig()
-    expect(config?.baseUrl).toBe("n")
+    expect(config).toEqual({
+      baseUrl: "https://new-api.example.com",
+      adminToken: "admin-token",
+      userId: "admin",
+    })
   })
 
   it("routes to Veloera service when selected", async () => {
@@ -252,9 +232,15 @@ describe("managedSiteService", () => {
       "~/services/managedSites/managedSiteService"
     )
 
-    mockGetPreferences.mockResolvedValueOnce({
+    const prefs = {
       managedSiteType: SITE_TYPES.VELOERA,
-    })
+      veloera: {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "3",
+      },
+    }
+    mockGetPreferences.mockResolvedValueOnce(prefs).mockResolvedValueOnce(prefs)
 
     const service = await getManagedSiteService()
     expect(service.siteType).toBe(SITE_TYPES.VELOERA)
@@ -263,7 +249,33 @@ describe("managedSiteService", () => {
     expect(service.hydrateComparableChannelKeys).toEqual(expect.any(Function))
 
     const config = await service.getConfig()
-    expect(config?.baseUrl).toBe("v")
+    expect(config).toEqual({
+      baseUrl: "https://veloera.example.com",
+      adminToken: "veloera-token",
+      userId: "3",
+    })
+  })
+
+  it("keeps selected provider identity when selected config is incomplete", async () => {
+    const { getManagedSiteService } = await import(
+      "~/services/managedSites/managedSiteService"
+    )
+
+    const prefs = {
+      managedSiteType: SITE_TYPES.AXON_HUB,
+      axonHub: {
+        baseUrl: "https://axonhub.example.com",
+        email: "admin@example.com",
+        password: "",
+      },
+    }
+    mockGetPreferences.mockResolvedValueOnce(prefs).mockResolvedValueOnce(prefs)
+
+    const service = await getManagedSiteService()
+    expect(service.siteType).toBe(SITE_TYPES.AXON_HUB)
+    expect(service.messagesKey).toBe("axonhub")
+
+    await expect(service.getConfig()).resolves.toBeNull()
   })
 
   it("can resolve an explicit target service without changing active preferences", async () => {
@@ -277,8 +289,50 @@ describe("managedSiteService", () => {
     expect(service).toMatchObject(baseService)
     expect(service.hydrateComparableChannelKeys).toEqual(expect.any(Function))
 
+    mockGetPreferences.mockResolvedValueOnce({
+      managedSiteType: SITE_TYPES.NEW_API,
+      doneHub: {
+        baseUrl: "https://donehub.example.com",
+        adminToken: "done-token",
+        userId: "2",
+      },
+    })
+
     const config = await service.getConfig()
-    expect(config?.baseUrl).toBe("d")
+    expect(config).toEqual({
+      baseUrl: "https://donehub.example.com",
+      adminToken: "done-token",
+      userId: "2",
+    })
+  })
+
+  it("passes runtime config objects directly to converted providers", async () => {
+    const { getManagedSiteServiceForType } = await import(
+      "~/services/managedSites/managedSiteService"
+    )
+    const newApiProvider = await import(
+      "~/services/managedSites/providers/newApi"
+    )
+
+    const service = getManagedSiteServiceForType(SITE_TYPES.NEW_API)
+
+    await service.searchChannel(
+      {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "admin-token",
+        userId: "admin",
+      },
+      "alpha",
+    )
+
+    expect(newApiProvider.searchChannel).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "admin-token",
+        userId: "admin",
+      },
+      "alpha",
+    )
   })
 
   it("routes to Octopus service when selected explicitly", async () => {
@@ -292,8 +346,21 @@ describe("managedSiteService", () => {
     expect(service).toMatchObject(baseService)
     expect(service.hydrateComparableChannelKeys).toBeUndefined()
 
+    mockGetPreferences.mockResolvedValueOnce({
+      managedSiteType: SITE_TYPES.NEW_API,
+      octopus: {
+        baseUrl: "https://octopus.example.com",
+        username: "octo-admin",
+        password: "secret",
+      },
+    })
+
     const config = await service.getConfig()
-    expect(config?.baseUrl).toBe("o")
+    expect(config).toEqual({
+      baseUrl: "https://octopus.example.com",
+      username: "octo-admin",
+      password: "secret",
+    })
   })
 
   it("routes to AxonHub service when selected explicitly", async () => {
@@ -307,11 +374,20 @@ describe("managedSiteService", () => {
     expect(service).toMatchObject(baseService)
     expect(service.hydrateComparableChannelKeys).toBeUndefined()
 
+    mockGetPreferences.mockResolvedValueOnce({
+      managedSiteType: SITE_TYPES.NEW_API,
+      axonHub: {
+        baseUrl: "https://axonhub.example.com",
+        email: "admin@example.com",
+        password: "secret",
+      },
+    })
+
     const config = await service.getConfig()
     expect(config).toEqual({
-      baseUrl: "a",
-      token: "p",
-      userId: "admin@example.com",
+      baseUrl: "https://axonhub.example.com",
+      email: "admin@example.com",
+      password: "secret",
     })
   })
 
@@ -327,11 +403,18 @@ describe("managedSiteService", () => {
     expect(service.hydrateComparableChannelKeys).toEqual(expect.any(Function))
     expect(service.fetchChannelSecretKey).toEqual(expect.any(Function))
 
+    mockGetPreferences.mockResolvedValueOnce({
+      managedSiteType: SITE_TYPES.NEW_API,
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "cch-token",
+      },
+    })
+
     const config = await service.getConfig()
     expect(config).toEqual({
-      baseUrl: "c",
-      token: "t",
-      userId: "admin",
+      baseUrl: "https://cch.example.com",
+      adminToken: "cch-token",
     })
   })
 

--- a/tests/services/managedSiteService/managedSiteService.test.ts
+++ b/tests/services/managedSiteService/managedSiteService.test.ts
@@ -282,6 +282,19 @@ describe("managedSiteService", () => {
     await expect(service.getConfig()).resolves.toBeNull()
   })
 
+  it("falls back to New API service when preferences cannot be read", async () => {
+    const { getManagedSiteService } = await import(
+      "~/services/managedSites/managedSiteService"
+    )
+
+    mockGetPreferences.mockRejectedValueOnce(new Error("storage unavailable"))
+
+    const service = await getManagedSiteService()
+
+    expect(service.siteType).toBe(SITE_TYPES.NEW_API)
+    expect(service.messagesKey).toBe("newapi")
+  })
+
   it("can resolve an explicit target service without changing active preferences", async () => {
     const { getManagedSiteServiceForType } = await import(
       "~/services/managedSites/managedSiteService"

--- a/tests/services/managedSiteService/managedSiteService.test.ts
+++ b/tests/services/managedSiteService/managedSiteService.test.ts
@@ -138,7 +138,7 @@ describe("managedSiteService", () => {
       newApi: {
         baseUrl: "https://new-api.example.com",
         adminToken: "admin-token",
-        userId: "admin",
+        userId: "1",
       },
       octopus: {
         baseUrl: "https://octopus.example.com",
@@ -208,7 +208,7 @@ describe("managedSiteService", () => {
       newApi: {
         baseUrl: "https://new-api.example.com",
         adminToken: "admin-token",
-        userId: "admin",
+        userId: "1",
       },
     }
     mockGetPreferences.mockResolvedValueOnce(prefs).mockResolvedValueOnce(prefs)
@@ -223,7 +223,7 @@ describe("managedSiteService", () => {
     expect(config).toEqual({
       baseUrl: "https://new-api.example.com",
       adminToken: "admin-token",
-      userId: "admin",
+      userId: "1",
     })
   })
 
@@ -316,21 +316,24 @@ describe("managedSiteService", () => {
 
     const service = getManagedSiteServiceForType(SITE_TYPES.NEW_API)
 
-    await service.searchChannel(
-      {
-        baseUrl: "https://new-api.example.com",
-        adminToken: "admin-token",
-        userId: "admin",
-      },
-      "alpha",
-    )
+    const newApiConfig = {
+      baseUrl: "https://new-api.example.com",
+      adminToken: "admin-token",
+      userId: "1",
+    }
+    const octopusConfig = {
+      baseUrl: "https://octopus.example.com",
+      username: "octo-admin",
+      password: "secret",
+    }
+
+    await service.searchChannel(newApiConfig, "alpha")
+
+    // @ts-expect-error New API services must reject other site config shapes.
+    service.searchChannel(octopusConfig, "alpha")
 
     expect(newApiProvider.searchChannel).toHaveBeenCalledWith(
-      {
-        baseUrl: "https://new-api.example.com",
-        adminToken: "admin-token",
-        userId: "admin",
-      },
+      newApiConfig,
       "alpha",
     )
   })

--- a/tests/services/managedSiteService/managedSiteService.test.ts
+++ b/tests/services/managedSiteService/managedSiteService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 
@@ -120,6 +120,10 @@ vi.mock("~/services/managedSites/providers/claudeCodeHub", () => ({
 }))
 
 describe("managedSiteService", () => {
+  beforeEach(() => {
+    mockGetPreferences.mockReset()
+  })
+
   it("reports invalid managed-site config when preferences are missing", async () => {
     const { hasValidManagedSiteConfig } = await import(
       "~/services/managedSites/managedSiteService"
@@ -329,8 +333,10 @@ describe("managedSiteService", () => {
 
     await service.searchChannel(newApiConfig, "alpha")
 
+    type SearchChannelConfig = Parameters<typeof service.searchChannel>[0]
     // @ts-expect-error New API services must reject other site config shapes.
-    service.searchChannel(octopusConfig, "alpha")
+    const invalidConfig: SearchChannelConfig = octopusConfig
+    void invalidConfig
 
     expect(newApiProvider.searchChannel).toHaveBeenCalledWith(
       newApiConfig,

--- a/tests/services/managedSites/channelMatchResolver.test.ts
+++ b/tests/services/managedSites/channelMatchResolver.test.ts
@@ -14,7 +14,7 @@ import { buildManagedSiteChannel } from "~~/tests/test-utils/factories"
 
 const managedConfig = {
   baseUrl: "https://managed.example",
-  token: "managed-token",
+  adminToken: "managed-token",
   userId: "1",
 }
 
@@ -39,7 +39,7 @@ const createManagedSiteServiceStub = (
     prepareChannelFormData: vi.fn(),
     buildChannelPayload: vi.fn(),
     hydrateComparableChannelKeys: vi.fn(
-      async (_baseUrl, _token, _userId, candidates) => candidates,
+      async (_config, candidates) => candidates,
     ),
     autoConfigToManagedSite: vi.fn(),
     ...overrides,
@@ -186,12 +186,11 @@ describe("resolveManagedSiteChannelMatch", () => {
         }),
       ],
     })
-    const hydrateComparableChannelKeys = vi.fn(
-      async (_baseUrl, _token, _userId, candidates) =>
-        candidates.map((channel: ManagedSiteChannel) => ({
-          ...channel,
-          key: "sk-match",
-        })),
+    const hydrateComparableChannelKeys = vi.fn(async (_config, candidates) =>
+      candidates.map((channel: ManagedSiteChannel) => ({
+        ...channel,
+        key: "sk-match",
+      })),
     )
     const service = createManagedSiteServiceStub({
       searchChannel,
@@ -207,12 +206,9 @@ describe("resolveManagedSiteChannelMatch", () => {
     })
 
     expect(searchChannel).toHaveBeenCalledTimes(1)
-    expect(hydrateComparableChannelKeys).toHaveBeenCalledWith(
-      managedConfig.baseUrl,
-      managedConfig.token,
-      managedConfig.userId,
-      [expect.objectContaining({ id: 7 })],
-    )
+    expect(hydrateComparableChannelKeys).toHaveBeenCalledWith(managedConfig, [
+      expect.objectContaining({ id: 7 }),
+    ])
     expect(result.key.matched).toBe(true)
     expect(result.models.matched).toBe(true)
   })
@@ -332,12 +328,11 @@ describe("resolveManagedSiteChannelMatch", () => {
       base_url: "https://api.example.com/v1",
       models: "gpt-4o,gpt-4o-mini",
     })
-    const hydrateComparableChannelKeys = vi.fn(
-      async (_baseUrl, _token, _userId, candidates) =>
-        candidates.map((channel: ManagedSiteChannel) => ({
-          ...channel,
-          key: "sk-match",
-        })),
+    const hydrateComparableChannelKeys = vi.fn(async (_config, candidates) =>
+      candidates.map((channel: ManagedSiteChannel) => ({
+        ...channel,
+        key: "sk-match",
+      })),
     )
     const service = createManagedSiteServiceStub({
       searchChannel: vi.fn().mockResolvedValue({
@@ -354,12 +349,9 @@ describe("resolveManagedSiteChannelMatch", () => {
       key: "sk-match",
     })
 
-    expect(hydrateComparableChannelKeys).toHaveBeenCalledWith(
-      managedConfig.baseUrl,
-      managedConfig.token,
-      managedConfig.userId,
-      [expect.objectContaining({ id: 41 })],
-    )
+    expect(hydrateComparableChannelKeys).toHaveBeenCalledWith(managedConfig, [
+      expect.objectContaining({ id: 41 }),
+    ])
     expect(result.key).toEqual({
       comparable: true,
       matched: true,
@@ -518,9 +510,7 @@ describe("resolveManagedSiteChannelMatch", () => {
     })
 
     expect(fetchChannelSecretKey).toHaveBeenCalledWith(
-      managedConfig.baseUrl,
-      managedConfig.token,
-      managedConfig.userId,
+      expect.objectContaining(managedConfig),
       21,
     )
     expect(result.url).toEqual({
@@ -567,9 +557,7 @@ describe("resolveManagedSiteChannelMatch", () => {
     })
 
     expect(fetchChannelSecretKey).toHaveBeenCalledWith(
-      managedConfig.baseUrl,
-      managedConfig.token,
-      managedConfig.userId,
+      expect.objectContaining(managedConfig),
       24,
     )
     expect(result.key).toEqual({
@@ -623,16 +611,12 @@ describe("resolveManagedSiteChannelMatch", () => {
     expect(fetchChannelSecretKey).toHaveBeenCalledTimes(2)
     expect(fetchChannelSecretKey).toHaveBeenNthCalledWith(
       1,
-      managedConfig.baseUrl,
-      managedConfig.token,
-      managedConfig.userId,
+      expect.objectContaining(managedConfig),
       25,
     )
     expect(fetchChannelSecretKey).toHaveBeenNthCalledWith(
       2,
-      managedConfig.baseUrl,
-      managedConfig.token,
-      managedConfig.userId,
+      expect.objectContaining(managedConfig),
       26,
     )
     expect(result.key).toEqual({
@@ -692,9 +676,7 @@ describe("resolveManagedSiteChannelMatch", () => {
     })
 
     expect(fetchChannelSecretKey).toHaveBeenCalledWith(
-      managedConfig.baseUrl,
-      managedConfig.token,
-      managedConfig.userId,
+      expect.objectContaining(managedConfig),
       33,
     )
     expect(result.key.channel?.id).toBe(32)
@@ -739,9 +721,7 @@ describe("resolveManagedSiteChannelMatch", () => {
 
     expect(fetchChannelSecretKey).toHaveBeenCalledTimes(1)
     expect(fetchChannelSecretKey).toHaveBeenCalledWith(
-      managedConfig.baseUrl,
-      managedConfig.token,
-      managedConfig.userId,
+      expect.objectContaining(managedConfig),
       29,
     )
     expect(result.key.channel?.id).toBe(29)
@@ -827,9 +807,7 @@ describe("resolveManagedSiteChannelMatch", () => {
     })
 
     expect(fetchChannelSecretKey).toHaveBeenCalledWith(
-      managedConfig.baseUrl,
-      managedConfig.token,
-      managedConfig.userId,
+      expect.objectContaining(managedConfig),
       31,
     )
     expect(result.url).toEqual({

--- a/tests/services/managedSites/channelMigration.test.ts
+++ b/tests/services/managedSites/channelMigration.test.ts
@@ -94,7 +94,7 @@ describe("channelMigration", () => {
     vi.clearAllMocks()
     mockDoneHubGetConfig.mockResolvedValue({
       baseUrl: "https://donehub.example.com",
-      token: "donehub-token",
+      adminToken: "donehub-token",
       userId: "9",
     })
     mockDoneHubBuildChannelPayload.mockImplementation((draft: any) => ({
@@ -111,14 +111,14 @@ describe("channelMigration", () => {
     mockDoneHubFetchChannelSecretKey.mockResolvedValue("real-donehub-key")
     mockVeloeraGetConfig.mockResolvedValue({
       baseUrl: "https://veloera.example.com",
-      token: "veloera-token",
+      adminToken: "veloera-token",
       userId: "8",
     })
     mockVeloeraFetchChannelSecretKey.mockResolvedValue("real-veloera-key")
     mockAxonHubGetConfig.mockResolvedValue({
       baseUrl: "https://axonhub.example.com",
-      token: "axonhub-password",
-      userId: "admin@example.com",
+      email: "admin@example.com",
+      password: "axonhub-password",
     })
     mockAxonHubBuildChannelPayload.mockImplementation((draft: any) => ({
       mode: "single",
@@ -140,8 +140,7 @@ describe("channelMigration", () => {
     })
     mockClaudeCodeHubGetConfig.mockResolvedValue({
       baseUrl: "https://cch.example.com",
-      token: "cch-token",
-      userId: "admin",
+      adminToken: "cch-token",
     })
     mockClaudeCodeHubBuildChannelPayload.mockImplementation((draft: any) => ({
       mode: "single",
@@ -209,7 +208,7 @@ describe("channelMigration", () => {
       return {
         getConfig: vi.fn().mockResolvedValue({
           baseUrl: "https://target.example.com",
-          token: "target-token",
+          adminToken: "target-token",
           userId: "1",
         }),
         buildChannelPayload: vi.fn((draft: any) => ({
@@ -309,9 +308,11 @@ describe("channelMigration", () => {
     })
 
     expect(mockDoneHubFetchChannelSecretKey).toHaveBeenCalledWith(
-      "https://donehub.example.com",
-      "donehub-token",
-      "9",
+      {
+        baseUrl: "https://donehub.example.com",
+        adminToken: "donehub-token",
+        userId: "9",
+      },
       21,
     )
     expect(preview.readyCount).toBe(1)
@@ -361,9 +362,11 @@ describe("channelMigration", () => {
     })
 
     expect(mockVeloeraFetchChannelSecretKey).toHaveBeenCalledWith(
-      "https://veloera.example.com",
-      "veloera-token",
-      "8",
+      {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "8",
+      },
       22,
     )
     expect(preview.readyCount).toBe(1)
@@ -420,7 +423,7 @@ describe("channelMigration", () => {
       return {
         getConfig: vi.fn().mockResolvedValue({
           baseUrl: "https://target.example.com",
-          token: "target-token",
+          adminToken: "target-token",
           userId: "1",
         }),
         buildChannelPayload: vi.fn((draft: any) => ({
@@ -1196,9 +1199,11 @@ describe("channelMigration", () => {
     expect(mockAxonHubCreateChannel).toHaveBeenCalledTimes(2)
     expect(mockAxonHubCreateChannel).toHaveBeenNthCalledWith(
       1,
-      "https://axonhub.example.com",
-      "axonhub-password",
-      "admin@example.com",
+      {
+        baseUrl: "https://axonhub.example.com",
+        email: "admin@example.com",
+        password: "axonhub-password",
+      },
       expect.objectContaining({
         channel: expect.objectContaining({
           type: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
@@ -1299,9 +1304,10 @@ describe("channelMigration", () => {
     expect(mockClaudeCodeHubCreateChannel).toHaveBeenCalledTimes(2)
     expect(mockClaudeCodeHubCreateChannel).toHaveBeenNthCalledWith(
       1,
-      "https://cch.example.com",
-      "cch-token",
-      "admin",
+      {
+        baseUrl: "https://cch.example.com",
+        adminToken: "cch-token",
+      },
       expect.objectContaining({
         channel: expect.objectContaining({
           type: CLAUDE_CODE_HUB_PROVIDER_TYPE.CLAUDE,

--- a/tests/services/managedSites/importDuplicateResolution.test.ts
+++ b/tests/services/managedSites/importDuplicateResolution.test.ts
@@ -11,7 +11,7 @@ import { CHANNEL_STATUS } from "~/types/managedSite"
 
 const managedConfig = {
   baseUrl: "https://managed.example",
-  token: "managed-token",
+  adminToken: "managed-token",
   userId: "1",
 }
 

--- a/tests/services/managedSites/managedSiteUtils.test.ts
+++ b/tests/services/managedSites/managedSiteUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  collectManagedConfigSecrets,
   getManagedSiteAdminConfigForType,
   getManagedSiteConfigMissingMessage,
   getManagedSiteContext,
@@ -17,6 +18,30 @@ import {
 const translate = (key: string) => key
 
 describe("managedSite utils", () => {
+  it("collects provider secrets from each runtime config shape", () => {
+    expect(
+      collectManagedConfigSecrets({
+        baseUrl: "https://new-api.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      }),
+    ).toEqual(["admin-token"])
+    expect(
+      collectManagedConfigSecrets({
+        baseUrl: "https://octopus.example.com",
+        username: "admin",
+        password: "octopus-password",
+      }),
+    ).toEqual(["octopus-password"])
+    expect(
+      collectManagedConfigSecrets({
+        baseUrl: "https://token-config.example.com",
+        token: "runtime-token",
+        userId: "1",
+      } as any),
+    ).toEqual(["runtime-token"])
+  })
+
   it("defaults managed-site context to new-api when managedSiteType is missing", () => {
     const prefs = {
       newApi: {

--- a/tests/services/managedSites/managedSiteUtils.test.ts
+++ b/tests/services/managedSites/managedSiteUtils.test.ts
@@ -40,6 +40,14 @@ describe("managedSite utils", () => {
         userId: "1",
       } as any),
     ).toEqual(["runtime-token"])
+    expect(
+      collectManagedConfigSecrets({
+        baseUrl: "https://mixed-config.example.com",
+        token: "runtime-token",
+        adminToken: "admin-token",
+        userId: "1",
+      } as any),
+    ).toEqual(["runtime-token", "admin-token"])
   })
 
   it("defaults managed-site context to new-api when managedSiteType is missing", () => {

--- a/tests/services/managedSites/managedSiteUtils.test.ts
+++ b/tests/services/managedSites/managedSiteUtils.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   getManagedSiteAdminConfigForType,
-  getManagedSiteConfigFromPreferences,
   getManagedSiteConfigMissingMessage,
   getManagedSiteContext,
   getManagedSiteLabelKey,
@@ -18,7 +17,7 @@ import {
 const translate = (key: string) => key
 
 describe("managedSite utils", () => {
-  it("defaults to new-api when managedSiteType is missing", () => {
+  it("defaults managed-site context to new-api when managedSiteType is missing", () => {
     const prefs = {
       newApi: {
         baseUrl: "https://new-api.example.com",
@@ -27,10 +26,6 @@ describe("managedSite utils", () => {
       },
     }
 
-    expect(getManagedSiteConfigFromPreferences(prefs as any)).toEqual({
-      siteType: SITE_TYPES.NEW_API,
-      config: prefs.newApi,
-    })
     expect(getManagedSiteContext(prefs as any)).toEqual({
       siteType: SITE_TYPES.NEW_API,
       messagesKey: "newapi",

--- a/tests/services/managedSites/providers/axonHub.test.ts
+++ b/tests/services/managedSites/providers/axonHub.test.ts
@@ -109,6 +109,12 @@ const axonHubConfig = {
   password: "admin-password",
 }
 
+const passedAxonHubConfig = {
+  baseUrl: "https://passed-axonhub.example",
+  email: "passed-admin@example.com",
+  password: "passed-admin-password",
+}
+
 describe("AxonHub managed-site provider", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -144,23 +150,22 @@ describe("AxonHub managed-site provider", () => {
     })
   })
 
-  it("validates config, reads config, and searches through saved credentials", async () => {
+  it("validates saved config, reads config, and searches through passed config", async () => {
     const provider = await import("~/services/managedSites/providers/axonHub")
 
     await expect(provider.checkValidAxonHubConfig()).resolves.toBe(true)
-    await expect(provider.getAxonHubConfig()).resolves.toEqual({
-      baseUrl: axonHubConfig.baseUrl,
-      token: axonHubConfig.password,
-      userId: axonHubConfig.email,
-    })
+    await expect(provider.getAxonHubConfig()).resolves.toEqual(axonHubConfig)
 
-    await provider.searchChannel("", "", "", "alpha")
+    await provider.searchChannel(passedAxonHubConfig, "alpha")
 
     expect(mockSignIn).toHaveBeenCalledWith(axonHubConfig)
-    expect(mockSearchChannels).toHaveBeenCalledWith(axonHubConfig, "alpha")
+    expect(mockSearchChannels).toHaveBeenCalledWith(
+      passedAxonHubConfig,
+      "alpha",
+    )
   })
 
-  it("returns missing-config fallbacks when saved AxonHub credentials are incomplete", async () => {
+  it("returns missing-config fallbacks for saved AxonHub config helpers", async () => {
     mockGetPreferences.mockResolvedValue(
       buildUserPreferences({
         axonHub: {
@@ -175,26 +180,6 @@ describe("AxonHub managed-site provider", () => {
 
     await expect(provider.checkValidAxonHubConfig()).resolves.toBe(false)
     await expect(provider.getAxonHubConfig()).resolves.toBeNull()
-    await expect(
-      provider.createChannel("", "", "", {
-        mode: "single",
-        channel: {
-          name: "Missing Config",
-          type: AXON_HUB_CHANNEL_TYPE.OPENAI,
-          key: "sk-test",
-          base_url: "https://source.example/v1",
-          models: "gpt-4o",
-          groups: [],
-          priority: 0,
-          weight: 0,
-          status: CHANNEL_STATUS.Enable,
-        },
-      }),
-    ).resolves.toEqual({
-      success: false,
-      data: null,
-      message: "messages:axonhub.configMissing",
-    })
 
     expect(mockSignIn).not.toHaveBeenCalled()
     expect(mockCreateAxonHubChannel).not.toHaveBeenCalled()
@@ -203,7 +188,7 @@ describe("AxonHub managed-site provider", () => {
   it("creates an OpenAI-compatible channel and applies the requested enabled status", async () => {
     const provider = await import("~/services/managedSites/providers/axonHub")
 
-    const result = await provider.createChannel("", "", "", {
+    const result = await provider.createChannel(passedAxonHubConfig, {
       mode: "single",
       channel: {
         name: "  Imported Account  ",
@@ -219,7 +204,7 @@ describe("AxonHub managed-site provider", () => {
     })
 
     expect(result.success).toBe(true)
-    expect(mockCreateAxonHubChannel).toHaveBeenCalledWith(axonHubConfig, {
+    expect(mockCreateAxonHubChannel).toHaveBeenCalledWith(passedAxonHubConfig, {
       type: AXON_HUB_CHANNEL_TYPE.OPENAI,
       name: "Imported Account",
       baseURL: "https://source.example/v1",
@@ -233,7 +218,7 @@ describe("AxonHub managed-site provider", () => {
       orderingWeight: 7,
     })
     expect(mockUpdateAxonHubChannelStatus).toHaveBeenCalledWith(
-      axonHubConfig,
+      passedAxonHubConfig,
       "created-channel-id",
       AXON_HUB_CHANNEL_STATUS.ENABLED,
     )
@@ -269,7 +254,9 @@ describe("AxonHub managed-site provider", () => {
       },
     })
 
-    await expect(provider.createChannel("", "", "", payload)).resolves.toEqual({
+    await expect(
+      provider.createChannel(passedAxonHubConfig, payload),
+    ).resolves.toEqual({
       success: true,
       data: {
         id: "created-channel-id",
@@ -278,7 +265,7 @@ describe("AxonHub managed-site provider", () => {
       message: "success",
     })
 
-    expect(mockCreateAxonHubChannel).toHaveBeenCalledWith(axonHubConfig, {
+    expect(mockCreateAxonHubChannel).toHaveBeenCalledWith(passedAxonHubConfig, {
       type: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
       name: "Migrated Anthropic",
       baseURL: "https://anthropic.example/v1",
@@ -298,7 +285,7 @@ describe("AxonHub managed-site provider", () => {
     const provider = await import("~/services/managedSites/providers/axonHub")
 
     await expect(
-      provider.updateChannel("", "", "", {
+      provider.updateChannel(passedAxonHubConfig, {
         id: 42,
         name: "  Renamed  ",
         type: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
@@ -316,7 +303,7 @@ describe("AxonHub managed-site provider", () => {
 
     expect(mockResolveAxonHubGraphqlId).toHaveBeenCalledWith(42)
     expect(mockUpdateAxonHubChannel).toHaveBeenCalledWith(
-      axonHubConfig,
+      passedAxonHubConfig,
       "gid-42",
       {
         type: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
@@ -332,18 +319,20 @@ describe("AxonHub managed-site provider", () => {
       },
     )
     expect(mockUpdateAxonHubChannelStatus).toHaveBeenCalledWith(
-      axonHubConfig,
+      passedAxonHubConfig,
       "gid-42",
       AXON_HUB_CHANNEL_STATUS.DISABLED,
     )
 
-    await expect(provider.deleteChannel("", "", "", 42)).resolves.toEqual({
+    await expect(
+      provider.deleteChannel(passedAxonHubConfig, 42),
+    ).resolves.toEqual({
       success: true,
       data: true,
       message: "success",
     })
     expect(mockDeleteAxonHubChannel).toHaveBeenCalledWith(
-      axonHubConfig,
+      passedAxonHubConfig,
       "gid-42",
     )
   })
@@ -354,7 +343,7 @@ describe("AxonHub managed-site provider", () => {
     mockDeleteAxonHubChannel.mockResolvedValueOnce(false)
 
     await expect(
-      provider.updateChannel("", "", "", {
+      provider.updateChannel(passedAxonHubConfig, {
         id: 7,
         status: CHANNEL_STATUS.Unknown,
       }),
@@ -365,38 +354,27 @@ describe("AxonHub managed-site provider", () => {
     })
 
     expect(mockUpdateAxonHubChannelStatus).toHaveBeenCalledWith(
-      axonHubConfig,
+      passedAxonHubConfig,
       "gid-7",
       AXON_HUB_CHANNEL_STATUS.DISABLED,
     )
 
-    await expect(provider.deleteChannel("", "", "", 7)).resolves.toEqual({
+    await expect(
+      provider.deleteChannel(passedAxonHubConfig, 7),
+    ).resolves.toEqual({
       success: false,
       data: false,
       message: "messages:axonhub.deleteFailed",
     })
   })
 
-  it("returns delete fallbacks when config is missing or deletion throws", async () => {
+  it("returns delete fallbacks when deletion throws", async () => {
     const provider = await import("~/services/managedSites/providers/axonHub")
 
-    mockGetPreferences.mockResolvedValueOnce(
-      buildUserPreferences({
-        axonHub: {
-          baseUrl: "",
-          email: "",
-          password: "",
-        },
-      }),
-    )
-    await expect(provider.deleteChannel("", "", "", 7)).resolves.toEqual({
-      success: false,
-      data: null,
-      message: "messages:axonhub.configMissing",
-    })
-
     mockDeleteAxonHubChannel.mockRejectedValueOnce(new Error("delete exploded"))
-    await expect(provider.deleteChannel("", "", "", 8)).resolves.toEqual({
+    await expect(
+      provider.deleteChannel(passedAxonHubConfig, 8),
+    ).resolves.toEqual({
       success: false,
       data: null,
       message: "delete exploded",

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -19,6 +19,7 @@ import {
   deleteChannel,
   fetchAvailableModels,
   fetchChannelSecretKey,
+  getClaudeCodeHubConfig,
   hydrateComparableChannelKeys,
   prepareChannelFormData,
   providerToManagedSiteChannel,
@@ -98,6 +99,16 @@ vi.mock("react-hot-toast", () => ({
 }))
 
 describe("Claude Code Hub managed-site provider", () => {
+  const storedClaudeCodeHubConfig = {
+    baseUrl: "https://stored-cch.example.com",
+    adminToken: "stored-admin-token",
+  }
+
+  const passedClaudeCodeHubConfig = {
+    baseUrl: "https://passed-cch.example.com",
+    adminToken: "passed-admin-token",
+  }
+
   beforeEach(() => {
     mockFetchTokenScopedModels.mockReset()
     mockFetchManagedSiteAvailableModels.mockReset()
@@ -345,12 +356,19 @@ describe("Claude Code Hub managed-site provider", () => {
     )
   })
 
-  it("searches, creates, updates, and deletes providers with stored admin config", async () => {
+  it("returns the saved Claude Code Hub runtime config helper shape", async () => {
     mockGetPreferences.mockResolvedValue({
-      claudeCodeHub: {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      claudeCodeHub: storedClaudeCodeHubConfig,
+    })
+
+    await expect(getClaudeCodeHubConfig()).resolves.toEqual(
+      storedClaudeCodeHubConfig,
+    )
+  })
+
+  it("searches, creates, updates, and deletes providers with passed admin config", async () => {
+    mockGetPreferences.mockResolvedValue({
+      claudeCodeHub: storedClaudeCodeHubConfig,
     })
     mockSearchProviders.mockResolvedValue([
       {
@@ -367,7 +385,9 @@ describe("Claude Code Hub managed-site provider", () => {
     mockUpdateProvider.mockResolvedValue({ ok: true })
     mockDeleteProvider.mockResolvedValue({ ok: true })
 
-    await expect(searchChannel("", "", "", "alpha")).resolves.toMatchObject({
+    await expect(
+      searchChannel(passedClaudeCodeHubConfig, "alpha"),
+    ).resolves.toMatchObject({
       total: 1,
       items: [
         expect.objectContaining({
@@ -380,16 +400,13 @@ describe("Claude Code Hub managed-site provider", () => {
       },
     })
     expect(mockSearchProviders).toHaveBeenCalledWith(
-      {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      passedClaudeCodeHubConfig,
       "alpha",
     )
     expect(mockListProviders).not.toHaveBeenCalled()
 
     await expect(
-      createChannel("", "", "", {
+      createChannel(passedClaudeCodeHubConfig, {
         channel: {
           name: "Created Provider",
           type: "codex",
@@ -408,10 +425,7 @@ describe("Claude Code Hub managed-site provider", () => {
       message: "success",
     })
     expect(mockCreateProvider).toHaveBeenCalledWith(
-      {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      passedClaudeCodeHubConfig,
       expect.objectContaining({
         name: "Created Provider",
         provider_type: "codex",
@@ -420,7 +434,7 @@ describe("Claude Code Hub managed-site provider", () => {
     )
 
     await expect(
-      updateChannel("", "", "", {
+      updateChannel(passedClaudeCodeHubConfig, {
         id: 21,
         key: "sk-updated-key",
         base_url: "https://updated.example.com",
@@ -434,67 +448,60 @@ describe("Claude Code Hub managed-site provider", () => {
       message: "success",
     })
 
-    await expect(deleteChannel("", "", "", 21)).resolves.toEqual({
-      success: true,
-      data: { ok: true },
-      message: "success",
-    })
+    await expect(deleteChannel(passedClaudeCodeHubConfig, 21)).resolves.toEqual(
+      {
+        success: true,
+        data: { ok: true },
+        message: "success",
+      },
+    )
   })
 
   it("fetches real provider keys through the Claude Code Hub provider API", async () => {
     mockGetPreferences.mockResolvedValue({
-      claudeCodeHub: {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      claudeCodeHub: storedClaudeCodeHubConfig,
     })
     mockGetUnmaskedProviderKey.mockResolvedValueOnce("sk-real-provider-key")
 
-    await expect(fetchChannelSecretKey("", "", "", 42)).resolves.toBe(
-      "sk-real-provider-key",
-    )
+    await expect(
+      fetchChannelSecretKey(passedClaudeCodeHubConfig, 42),
+    ).resolves.toBe("sk-real-provider-key")
     expect(mockGetUnmaskedProviderKey).toHaveBeenCalledWith(
-      {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      passedClaudeCodeHubConfig,
       42,
     )
   })
 
   it("surfaces provider key reveal failures from edit flows", async () => {
     mockGetPreferences.mockResolvedValue({
-      claudeCodeHub: {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      claudeCodeHub: storedClaudeCodeHubConfig,
     })
     mockGetUnmaskedProviderKey.mockRejectedValueOnce(new Error("reveal failed"))
 
-    await expect(fetchChannelSecretKey("", "", "", 42)).rejects.toThrow(
-      "reveal failed",
-    )
+    await expect(
+      fetchChannelSecretKey(passedClaudeCodeHubConfig, 42),
+    ).rejects.toThrow("reveal failed")
   })
 
   it("hydrates provided Claude Code Hub candidates through provider key reveal", async () => {
     mockGetPreferences.mockResolvedValue({
-      claudeCodeHub: {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      claudeCodeHub: storedClaudeCodeHubConfig,
     })
     mockGetUnmaskedProviderKey.mockResolvedValueOnce("sk-provider-secret")
 
-    const result = await hydrateComparableChannelKeys("", "", "", [
-      {
-        id: 30,
-        type: "openai-compatible",
-        key: "",
-        name: "Masked Provider",
-        base_url: "https://api.example.com",
-        models: "gpt-4o",
-      } as any,
-    ])
+    const result = await hydrateComparableChannelKeys(
+      passedClaudeCodeHubConfig,
+      [
+        {
+          id: 30,
+          type: "openai-compatible",
+          key: "",
+          name: "Masked Provider",
+          base_url: "https://api.example.com",
+          models: "gpt-4o",
+        } as any,
+      ],
+    )
 
     expect(result).toEqual([
       expect.objectContaining({
@@ -506,20 +513,20 @@ describe("Claude Code Hub managed-site provider", () => {
 
   it("hydrates only provided Claude Code Hub duplicate candidates", async () => {
     mockGetPreferences.mockResolvedValue({
-      claudeCodeHub: {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      claudeCodeHub: storedClaudeCodeHubConfig,
     })
     mockGetUnmaskedProviderKey.mockResolvedValueOnce("sk-real-key")
 
-    const result = await hydrateComparableChannelKeys("", "", "", [
-      {
-        id: 31,
-        name: "Matching Masked Provider",
-        key: "",
-      } as any,
-    ])
+    const result = await hydrateComparableChannelKeys(
+      passedClaudeCodeHubConfig,
+      [
+        {
+          id: 31,
+          name: "Matching Masked Provider",
+          key: "",
+        } as any,
+      ],
+    )
 
     expect(result).toEqual([
       expect.objectContaining({
@@ -530,43 +537,19 @@ describe("Claude Code Hub managed-site provider", () => {
     ])
     expect(mockGetUnmaskedProviderKey).toHaveBeenCalledTimes(1)
     expect(mockGetUnmaskedProviderKey).toHaveBeenCalledWith(
-      {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      passedClaudeCodeHubConfig,
       31,
     )
   })
 
-  it("maps missing Claude Code Hub config to unresolved hydration errors", async () => {
-    mockGetPreferences.mockResolvedValueOnce({})
-
-    await expect(
-      hydrateComparableChannelKeys("", "", "", [
-        {
-          id: 32,
-          name: "Masked Provider",
-          key: "",
-        } as any,
-      ]),
-    ).rejects.toMatchObject({
-      name: MatchResolutionUnresolvedError.name,
-      reason:
-        MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS.KEY_RESOLUTION_FAILED,
-    })
-  })
-
   it("maps Claude Code Hub provider key reveal failures to unresolved hydration errors", async () => {
     mockGetPreferences.mockResolvedValue({
-      claudeCodeHub: {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      claudeCodeHub: storedClaudeCodeHubConfig,
     })
     mockGetUnmaskedProviderKey.mockRejectedValueOnce(new Error("reveal failed"))
 
     await expect(
-      hydrateComparableChannelKeys("", "", "", [
+      hydrateComparableChannelKeys(passedClaudeCodeHubConfig, [
         {
           id: 33,
           name: "Masked Provider",
@@ -580,12 +563,22 @@ describe("Claude Code Hub managed-site provider", () => {
     })
   })
 
-  it("surfaces config and API failures for CRUD-style operations", async () => {
+  it("surfaces API failures for CRUD-style operations", async () => {
     mockGetPreferences.mockResolvedValueOnce({})
 
-    await expect(searchChannel("", "", "", "alpha")).resolves.toBeNull()
+    mockGetPreferences.mockResolvedValue({
+      claudeCodeHub: storedClaudeCodeHubConfig,
+    })
+    mockCreateProvider.mockRejectedValueOnce(new Error("create failed"))
+    mockUpdateProvider.mockRejectedValueOnce(new Error("update failed"))
+    mockDeleteProvider.mockRejectedValueOnce(new Error("delete failed"))
+    mockSearchProviders.mockRejectedValueOnce(new Error("search failed"))
+
     await expect(
-      createChannel("", "", "", {
+      searchChannel(passedClaudeCodeHubConfig, "alpha"),
+    ).resolves.toBeNull()
+    await expect(
+      createChannel(passedClaudeCodeHubConfig, {
         channel: {
           name: "Created Provider",
           key: "sk-created-key",
@@ -595,22 +588,10 @@ describe("Claude Code Hub managed-site provider", () => {
     ).resolves.toEqual({
       success: false,
       data: null,
-      message: "messages:claudecodehub.configMissing",
+      message: "create failed",
     })
-
-    mockGetPreferences.mockResolvedValue({
-      claudeCodeHub: {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
-    })
-    mockUpdateProvider.mockRejectedValueOnce(new Error("update failed"))
-    mockDeleteProvider.mockRejectedValueOnce(new Error("delete failed"))
-    mockSearchProviders.mockRejectedValueOnce(new Error("search failed"))
-
-    await expect(searchChannel("", "", "", "alpha")).resolves.toBeNull()
     await expect(
-      updateChannel("", "", "", {
+      updateChannel(passedClaudeCodeHubConfig, {
         id: 21,
         key: "sk-updated-key",
       } as any),
@@ -619,11 +600,13 @@ describe("Claude Code Hub managed-site provider", () => {
       data: null,
       message: "update failed",
     })
-    await expect(deleteChannel("", "", "", 21)).resolves.toEqual({
-      success: false,
-      data: null,
-      message: "delete failed",
-    })
+    await expect(deleteChannel(passedClaudeCodeHubConfig, 21)).resolves.toEqual(
+      {
+        success: false,
+        data: null,
+        message: "delete failed",
+      },
+    )
   })
 
   it("builds channel payloads, fetches models, and matches only comparable providers", async () => {
@@ -667,13 +650,10 @@ describe("Claude Code Hub managed-site provider", () => {
     ).resolves.toEqual(["gpt-4o"])
 
     mockGetPreferences.mockResolvedValue({
-      claudeCodeHub: {
-        baseUrl: "https://cch.example.com",
-        adminToken: "admin-token",
-      },
+      claudeCodeHub: storedClaudeCodeHubConfig,
     })
     await expect(
-      hydrateComparableChannelKeys("", "", "", [
+      hydrateComparableChannelKeys(passedClaudeCodeHubConfig, [
         {
           id: 31,
           name: "Comparable Provider",
@@ -718,6 +698,14 @@ describe("Claude Code Hub managed-site provider", () => {
       success: true,
       message: "messages:claudecodehub.importSuccess",
     })
+    expect(mockSearchProviders).toHaveBeenNthCalledWith(
+      1,
+      {
+        baseUrl: "https://cch.example.com",
+        adminToken: "admin-token",
+      },
+      "https://api.example.com",
+    )
     expect(toastLoading).toHaveBeenCalledWith(
       "messages:accountOperations.importingToClaudeCodeHub",
       { id: "toast-id" },

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -15,6 +15,7 @@ import {
   buildChannelPayload,
   buildClaudeCodeHubCreatePayloadFromFormData,
   buildClaudeCodeHubUpdatePayloadFromChannelData,
+  checkValidClaudeCodeHubConfig,
   createChannel,
   deleteChannel,
   fetchAvailableModels,
@@ -364,6 +365,32 @@ describe("Claude Code Hub managed-site provider", () => {
     await expect(getClaudeCodeHubConfig()).resolves.toEqual(
       storedClaudeCodeHubConfig,
     )
+  })
+
+  it("validates saved Claude Code Hub config only when required fields exist", async () => {
+    const claudeCodeHubApi = await import("~/services/apiService/claudeCodeHub")
+    vi.mocked(
+      claudeCodeHubApi.validateClaudeCodeHubConfig,
+    ).mockResolvedValueOnce(true)
+    mockGetPreferences.mockResolvedValueOnce({
+      claudeCodeHub: storedClaudeCodeHubConfig,
+    })
+
+    await expect(checkValidClaudeCodeHubConfig()).resolves.toBe(true)
+    expect(claudeCodeHubApi.validateClaudeCodeHubConfig).toHaveBeenCalledWith(
+      storedClaudeCodeHubConfig,
+    )
+
+    vi.mocked(claudeCodeHubApi.validateClaudeCodeHubConfig).mockClear()
+    mockGetPreferences.mockResolvedValueOnce({
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "",
+      },
+    })
+
+    await expect(checkValidClaudeCodeHubConfig()).resolves.toBe(false)
+    expect(claudeCodeHubApi.validateClaudeCodeHubConfig).not.toHaveBeenCalled()
   })
 
   it("searches, creates, updates, and deletes providers with passed admin config", async () => {

--- a/tests/services/managedSites/runtimeConfig.test.ts
+++ b/tests/services/managedSites/runtimeConfig.test.ts
@@ -156,6 +156,36 @@ describe("managed-site runtime config resolver", () => {
     ).toBeNull()
   })
 
+  it("returns null for non-numeric access-token managed-site user IDs", () => {
+    const prefs = buildUserPreferences({
+      newApi: {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "new-token",
+        userId: "admin",
+      },
+      doneHub: {
+        baseUrl: "https://donehub.example.com",
+        adminToken: "done-token",
+        userId: "2a",
+      },
+      veloera: {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: " root ",
+      },
+    })
+
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.NEW_API),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.DONE_HUB),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.VELOERA),
+    ).toBeNull()
+  })
+
   it("resolves the current runtime config and falls back to New API when unset", () => {
     const prefs = buildUserPreferences({
       managedSiteType: undefined,

--- a/tests/services/managedSites/runtimeConfig.test.ts
+++ b/tests/services/managedSites/runtimeConfig.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  getCurrentManagedSiteRuntimeConfig,
+  getManagedSiteLegacyAdminConfig,
+  getManagedSiteRuntimeConfigForType,
+  resolveCurrentManagedSiteRuntimeConfig,
+  resolveManagedSiteRuntimeConfigForType,
+} from "~/services/managedSites/runtimeConfig"
+import { buildUserPreferences } from "~~/tests/test-utils/factories"
+
+const mockGetPreferences = vi.hoisted(() => vi.fn())
+
+vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/services/preferences/userPreferences")
+    >()
+
+  return {
+    ...actual,
+    userPreferences: {
+      ...actual.userPreferences,
+      getPreferences: mockGetPreferences,
+    },
+  }
+})
+
+describe("managed-site runtime config resolver", () => {
+  beforeEach(() => {
+    mockGetPreferences.mockReset()
+  })
+
+  it("resolves full runtime configs for every managed-site type", () => {
+    const prefs = buildUserPreferences({
+      newApi: {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "new-token",
+        userId: "1",
+      },
+      doneHub: {
+        baseUrl: "https://donehub.example.com",
+        adminToken: "done-token",
+        userId: "2",
+      },
+      veloera: {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "3",
+      },
+      octopus: {
+        baseUrl: "https://octopus.example.com",
+        username: "octo-admin",
+        password: "octo-password",
+      },
+      axonHub: {
+        baseUrl: "https://axonhub.example.com",
+        email: "admin@example.com",
+        password: "axon-password",
+      },
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "cch-token",
+      },
+    })
+
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.NEW_API),
+    ).toEqual({
+      siteType: SITE_TYPES.NEW_API,
+      config: prefs.newApi,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.DONE_HUB),
+    ).toEqual({
+      siteType: SITE_TYPES.DONE_HUB,
+      config: prefs.doneHub,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.VELOERA),
+    ).toEqual({
+      siteType: SITE_TYPES.VELOERA,
+      config: prefs.veloera,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.OCTOPUS),
+    ).toEqual({
+      siteType: SITE_TYPES.OCTOPUS,
+      config: prefs.octopus,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.AXON_HUB),
+    ).toEqual({
+      siteType: SITE_TYPES.AXON_HUB,
+      config: prefs.axonHub,
+    })
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.CLAUDE_CODE_HUB),
+    ).toEqual({
+      siteType: SITE_TYPES.CLAUDE_CODE_HUB,
+      config: prefs.claudeCodeHub,
+    })
+  })
+
+  it("returns null for incomplete configs", () => {
+    const prefs = buildUserPreferences({
+      newApi: {
+        baseUrl: "   ",
+        adminToken: "new-token",
+        userId: "1",
+      },
+      doneHub: {
+        baseUrl: "https://donehub.example.com",
+        adminToken: "",
+        userId: "2",
+      },
+      veloera: {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "",
+      },
+      octopus: {
+        baseUrl: "https://octopus.example.com",
+        username: "",
+        password: "octo-password",
+      },
+      axonHub: {
+        baseUrl: "https://axonhub.example.com",
+        email: "admin@example.com",
+        password: "",
+      },
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "",
+      },
+    })
+
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.NEW_API),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.DONE_HUB),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.VELOERA),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.OCTOPUS),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.AXON_HUB),
+    ).toBeNull()
+    expect(
+      resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.CLAUDE_CODE_HUB),
+    ).toBeNull()
+  })
+
+  it("resolves the current runtime config and falls back to New API when unset", () => {
+    const prefs = buildUserPreferences({
+      managedSiteType: undefined,
+      newApi: {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "new-token",
+        userId: "1",
+      },
+    })
+
+    expect(resolveCurrentManagedSiteRuntimeConfig(prefs)).toEqual({
+      siteType: SITE_TYPES.NEW_API,
+      config: prefs.newApi,
+    })
+  })
+
+  it("loads preferences and resolves the current runtime config", async () => {
+    const prefs = buildUserPreferences({
+      managedSiteType: SITE_TYPES.VELOERA,
+      veloera: {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "3",
+      },
+    })
+    mockGetPreferences.mockResolvedValueOnce(prefs)
+
+    await expect(getCurrentManagedSiteRuntimeConfig()).resolves.toEqual({
+      siteType: SITE_TYPES.VELOERA,
+      config: prefs.veloera,
+    })
+    expect(mockGetPreferences).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns null when loading current preferences rejects", async () => {
+    mockGetPreferences.mockRejectedValueOnce(new Error("storage unavailable"))
+
+    await expect(getCurrentManagedSiteRuntimeConfig()).resolves.toBeNull()
+    expect(mockGetPreferences).toHaveBeenCalledTimes(1)
+  })
+
+  it("loads preferences and resolves an explicit runtime config", async () => {
+    const prefs = buildUserPreferences({
+      managedSiteType: SITE_TYPES.NEW_API,
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "cch-token",
+      },
+    })
+    mockGetPreferences.mockResolvedValueOnce(prefs)
+
+    await expect(
+      getManagedSiteRuntimeConfigForType(SITE_TYPES.CLAUDE_CODE_HUB),
+    ).resolves.toEqual({
+      siteType: SITE_TYPES.CLAUDE_CODE_HUB,
+      config: prefs.claudeCodeHub,
+    })
+    expect(mockGetPreferences).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns null when loading preferences for an explicit config rejects", async () => {
+    mockGetPreferences.mockRejectedValueOnce(new Error("storage unavailable"))
+
+    await expect(
+      getManagedSiteRuntimeConfigForType(SITE_TYPES.DONE_HUB),
+    ).resolves.toBeNull()
+    expect(mockGetPreferences).toHaveBeenCalledTimes(1)
+  })
+
+  it("converts full runtime configs to the legacy admin shape for compatibility consumers", () => {
+    const prefs = buildUserPreferences({
+      newApi: {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "new-token",
+        userId: "1",
+      },
+      octopus: {
+        baseUrl: "https://octopus.example.com",
+        username: "octo-admin",
+        password: "octo-password",
+      },
+      axonHub: {
+        baseUrl: "https://axonhub.example.com",
+        email: "admin@example.com",
+        password: "axon-password",
+      },
+      claudeCodeHub: {
+        baseUrl: "https://cch.example.com",
+        adminToken: "cch-token",
+      },
+    })
+
+    expect(
+      getManagedSiteLegacyAdminConfig(
+        resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.NEW_API)!,
+      ),
+    ).toEqual({
+      baseUrl: "https://new-api.example.com",
+      adminToken: "new-token",
+      userId: "1",
+    })
+    expect(
+      getManagedSiteLegacyAdminConfig(
+        resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.OCTOPUS)!,
+      ),
+    ).toEqual({
+      baseUrl: "https://octopus.example.com",
+      adminToken: "",
+      userId: "octo-admin",
+    })
+    expect(
+      getManagedSiteLegacyAdminConfig(
+        resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.AXON_HUB)!,
+      ),
+    ).toEqual({
+      baseUrl: "https://axonhub.example.com",
+      adminToken: "axon-password",
+      userId: "admin@example.com",
+    })
+    expect(
+      getManagedSiteLegacyAdminConfig(
+        resolveManagedSiteRuntimeConfigForType(
+          prefs,
+          SITE_TYPES.CLAUDE_CODE_HUB,
+        )!,
+      ),
+    ).toEqual({
+      baseUrl: "https://cch.example.com",
+      adminToken: "cch-token",
+      userId: "admin",
+    })
+  })
+})

--- a/tests/services/managedSites/runtimeConfig.test.ts
+++ b/tests/services/managedSites/runtimeConfig.test.ts
@@ -156,6 +156,17 @@ describe("managed-site runtime config resolver", () => {
     ).toBeNull()
   })
 
+  it("returns unknown managed-site values from the exhaustive fallback", () => {
+    const prefs = buildUserPreferences()
+
+    expect(
+      resolveManagedSiteRuntimeConfigForType(
+        prefs,
+        "future-managed-site" as any,
+      ),
+    ).toBe("future-managed-site")
+  })
+
   it("returns null for non-numeric access-token managed-site user IDs", () => {
     const prefs = buildUserPreferences({
       newApi: {

--- a/tests/services/managedSites/tokenBatchExport.test.ts
+++ b/tests/services/managedSites/tokenBatchExport.test.ts
@@ -76,7 +76,7 @@ const buildService = (
     messagesKey: "newapi",
     getConfig: vi.fn().mockResolvedValue({
       baseUrl: "https://target.example.com",
-      token: "admin-token",
+      adminToken: "admin-token",
       userId: "1",
     }),
     prepareChannelFormData: vi.fn(async (account, token) => ({
@@ -184,6 +184,18 @@ describe("managed-site token batch export", () => {
       failedCount: 0,
     })
     expect(service.createChannel).toHaveBeenCalledTimes(1)
+    expect(service.createChannel).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://target.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      },
+      expect.objectContaining({
+        channel: expect.objectContaining({
+          key: "token-secret",
+        }),
+      }),
+    )
   })
 
   it("reports channel creation failures without marking the item created", async () => {

--- a/tests/services/managedSites/tokenChannelStatus.test.ts
+++ b/tests/services/managedSites/tokenChannelStatus.test.ts
@@ -115,7 +115,7 @@ const createManagedSiteServiceStub = (
     checkValidConfig: vi.fn().mockResolvedValue(true),
     getConfig: vi.fn().mockResolvedValue({
       baseUrl: "https://managed.example",
-      token: "managed-admin-token",
+      adminToken: "managed-admin-token",
       userId: "1",
     }),
     fetchAvailableModels: vi.fn(),
@@ -133,7 +133,7 @@ const createManagedSiteServiceStub = (
     }),
     buildChannelPayload: vi.fn(),
     hydrateComparableChannelKeys: vi.fn(
-      async (_baseUrl, _token, _userId, candidates) => candidates,
+      async (_config, candidates) => candidates,
     ),
     autoConfigToManagedSite: vi.fn(),
     ...overrides,
@@ -769,9 +769,11 @@ describe("getManagedSiteTokenChannelStatus", () => {
     })
 
     expect(fetchChannelSecretKey).toHaveBeenCalledWith(
-      "https://managed.example",
-      "managed-admin-token",
-      "1",
+      {
+        baseUrl: "https://managed.example",
+        adminToken: "managed-admin-token",
+        userId: "1",
+      },
       43,
     )
     expect(result).toMatchObject({
@@ -810,7 +812,7 @@ describe("getManagedSiteTokenChannelStatus", () => {
     const service = createManagedSiteServiceStub({
       getConfig: vi.fn().mockResolvedValue({
         baseUrl: "https://managed.example",
-        token: "secret-admin-value",
+        adminToken: "secret-admin-value",
         userId: "1",
       }),
       prepareChannelFormData: vi
@@ -849,7 +851,7 @@ describe("getManagedSiteTokenChannelStatus", () => {
     const service = createManagedSiteServiceStub({
       getConfig: vi.fn().mockResolvedValue({
         baseUrl: "https://managed.example",
-        token: "secret-admin-value",
+        adminToken: "secret-admin-value",
         userId: "1",
       }),
     })

--- a/tests/services/modelRedirect/ModelRedirectService.bulkClear.test.ts
+++ b/tests/services/modelRedirect/ModelRedirectService.bulkClear.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
-import {
-  getManagedSiteAdminConfig,
-  getManagedSiteConfig,
-} from "~/services/managedSites/utils/managedSite"
 import { ModelRedirectService } from "~/services/models/modelRedirect/ModelRedirectService"
 import { userPreferences } from "~/services/preferences/userPreferences"
 
@@ -36,30 +32,16 @@ vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
   }
 })
 
-vi.mock("~/services/managedSites/utils/managedSite", () => ({
-  getManagedSiteAdminConfig: vi.fn(),
-  getManagedSiteConfig: vi.fn(),
-}))
 const mockedUserPreferences = userPreferences as unknown as {
   getPreferences: ReturnType<typeof vi.fn>
 }
-const mockedGetManagedSiteAdminConfig =
-  getManagedSiteAdminConfig as unknown as ReturnType<typeof vi.fn>
-const mockedGetManagedSiteConfig =
-  getManagedSiteConfig as unknown as ReturnType<typeof vi.fn>
 
 describe("ModelRedirectService.clearChannelModelMappings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockedUserPreferences.getPreferences.mockResolvedValue({})
-    mockedGetManagedSiteAdminConfig.mockReturnValue({
-      baseUrl: "https://example.com",
-      adminToken: "token",
-      userId: "1",
-    })
-    mockedGetManagedSiteConfig.mockReturnValue({
-      siteType: SITE_TYPES.NEW_API,
-      config: {
+    mockedUserPreferences.getPreferences.mockResolvedValue({
+      managedSiteType: SITE_TYPES.NEW_API,
+      newApi: {
         baseUrl: "https://example.com",
         adminToken: "token",
         userId: "1",
@@ -68,7 +50,14 @@ describe("ModelRedirectService.clearChannelModelMappings", () => {
   })
 
   it("returns a clear error when managed site config is missing", async () => {
-    mockedGetManagedSiteAdminConfig.mockReturnValue(null)
+    mockedUserPreferences.getPreferences.mockResolvedValueOnce({
+      managedSiteType: SITE_TYPES.NEW_API,
+      newApi: {
+        baseUrl: "",
+        adminToken: "",
+        userId: "",
+      },
+    })
 
     const result = await ModelRedirectService.clearChannelModelMappings([1, 2])
 

--- a/tests/services/modelSync/modelSyncService.test.ts
+++ b/tests/services/modelSync/modelSyncService.test.ts
@@ -3,13 +3,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ChannelType } from "~/constants/newApi"
 import { SITE_TYPES } from "~/constants/siteType"
 import { getApiService } from "~/services/apiService"
+import type { ManagedSiteRuntimeConfig } from "~/services/managedSites/runtimeConfig"
 import { matchesProbeFilterRule } from "~/services/models/modelSync/channelModelFilterEvaluator"
 import { ModelSyncService } from "~/services/models/modelSync/modelSyncService"
+import type { ChannelConfigMap } from "~/types/channelConfig"
 import type {
   ChannelModelFilterRule,
   ChannelModelPatternFilterRule,
   ChannelModelProbeFilterRule,
 } from "~/types/channelModelFilters"
+import type { ManagedSiteChannel } from "~/types/managedSite"
+import type { ExecutionItemResult } from "~/types/managedSiteModelSync"
 
 const {
   listAllChannelsMock,
@@ -83,6 +87,207 @@ const makeProbeRule = (
   description: partial.description,
 })
 
+function makeRuntimeConfig(
+  partial: Partial<
+    Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.NEW_API }>
+  >,
+): Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.NEW_API }>
+function makeRuntimeConfig(
+  partial: Partial<
+    Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.OCTOPUS }>
+  >,
+): Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.OCTOPUS }>
+function makeRuntimeConfig(
+  partial: Partial<
+    Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.AXON_HUB }>
+  >,
+): Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.AXON_HUB }>
+function makeRuntimeConfig(
+  partial: Partial<
+    Extract<
+      ManagedSiteRuntimeConfig,
+      { siteType: typeof SITE_TYPES.CLAUDE_CODE_HUB }
+    >
+  >,
+): Extract<
+  ManagedSiteRuntimeConfig,
+  { siteType: typeof SITE_TYPES.CLAUDE_CODE_HUB }
+>
+function makeRuntimeConfig(
+  partial: Partial<
+    Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.DONE_HUB }>
+  >,
+): Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.DONE_HUB }>
+function makeRuntimeConfig(
+  partial: Partial<
+    Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.VELOERA }>
+  >,
+): Extract<ManagedSiteRuntimeConfig, { siteType: typeof SITE_TYPES.VELOERA }>
+function makeRuntimeConfig(
+  partial: Partial<ManagedSiteRuntimeConfig> = {},
+): ManagedSiteRuntimeConfig {
+  if (partial.siteType === SITE_TYPES.OCTOPUS) {
+    return {
+      siteType: SITE_TYPES.OCTOPUS,
+      config: {
+        baseUrl: "https://managed.example.com",
+        username: "admin",
+        password: "secret",
+        ...partial.config,
+      },
+    }
+  }
+
+  if (partial.siteType === SITE_TYPES.AXON_HUB) {
+    return {
+      siteType: SITE_TYPES.AXON_HUB,
+      config: {
+        baseUrl: "https://managed.example.com",
+        email: "admin@example.com",
+        password: "secret",
+        ...partial.config,
+      },
+    }
+  }
+
+  if (partial.siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
+    return {
+      siteType: SITE_TYPES.CLAUDE_CODE_HUB,
+      config: {
+        baseUrl: "https://managed.example.com",
+        adminToken: "admin-token",
+        ...partial.config,
+      },
+    }
+  }
+
+  if (partial.siteType === SITE_TYPES.DONE_HUB) {
+    return {
+      siteType: SITE_TYPES.DONE_HUB,
+      config: {
+        baseUrl: "https://managed.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+        ...partial.config,
+      },
+    }
+  }
+
+  if (partial.siteType === SITE_TYPES.VELOERA) {
+    return {
+      siteType: SITE_TYPES.VELOERA,
+      config: {
+        baseUrl: "https://managed.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+        ...partial.config,
+      },
+    }
+  }
+
+  return {
+    siteType: SITE_TYPES.NEW_API,
+    config: {
+      baseUrl: "https://managed.example.com",
+      adminToken: "admin-token",
+      userId: "1",
+      ...(partial.config as
+        | Partial<
+            Extract<
+              ManagedSiteRuntimeConfig,
+              { siteType: typeof SITE_TYPES.NEW_API }
+            >["config"]
+          >
+        | undefined),
+    },
+  }
+}
+
+const makeNewApiRuntimeConfig = (
+  config: Partial<{
+    baseUrl: string
+    adminToken: string
+    userId: string
+  }> = {},
+): ManagedSiteRuntimeConfig =>
+  makeRuntimeConfig({
+    siteType: SITE_TYPES.NEW_API,
+    config: {
+      baseUrl: config.baseUrl ?? "https://managed.example.com",
+      adminToken: config.adminToken ?? "admin-token",
+      userId: config.userId ?? "1",
+    },
+  })
+
+const makeExampleRuntimeConfig = (): ManagedSiteRuntimeConfig =>
+  makeNewApiRuntimeConfig({
+    baseUrl: "https://example.com",
+    adminToken: "token",
+    userId: "1",
+  })
+
+const makeChannel = (
+  partial: Partial<ManagedSiteChannel> & Pick<ManagedSiteChannel, "id">,
+): ManagedSiteChannel => ({
+  id: partial.id,
+  type: partial.type ?? ChannelType.OpenAI,
+  key: partial.key ?? "",
+  name: partial.name ?? `Channel ${partial.id}`,
+  base_url: partial.base_url ?? "https://channel.example.com",
+  models: partial.models ?? "",
+  status: partial.status ?? 1,
+  weight: partial.weight ?? 1,
+  priority: partial.priority ?? 0,
+  openai_organization: partial.openai_organization ?? null,
+  test_model: partial.test_model ?? null,
+  created_time: partial.created_time ?? 0,
+  test_time: partial.test_time ?? 0,
+  response_time: partial.response_time ?? 0,
+  other: partial.other ?? "",
+  balance: partial.balance ?? 0,
+  balance_updated_time: partial.balance_updated_time ?? 0,
+  group: partial.group ?? "",
+  used_quota: partial.used_quota ?? 0,
+  model_mapping: partial.model_mapping ?? "",
+  status_code_mapping: partial.status_code_mapping ?? "",
+  auto_ban: partial.auto_ban ?? 0,
+  other_info: partial.other_info ?? "",
+  tag: partial.tag ?? null,
+  param_override: partial.param_override ?? null,
+  header_override: partial.header_override ?? null,
+  remark: partial.remark ?? null,
+  channel_info: partial.channel_info ?? {
+    is_multi_key: false,
+    multi_key_size: 0,
+    multi_key_status_list: null,
+    multi_key_polling_index: 0,
+    multi_key_mode: "",
+  },
+  setting: partial.setting ?? "",
+  settings: partial.settings ?? "",
+})
+
+const makeChannelConfigs = (
+  rulesByChannelId: Record<number, ChannelModelFilterRule[]>,
+): ChannelConfigMap =>
+  Object.fromEntries(
+    Object.entries(rulesByChannelId).map(([channelId, rules]) => {
+      const numericChannelId = Number(channelId)
+      return [
+        numericChannelId,
+        {
+          channelId: numericChannelId,
+          modelFilterSettings: {
+            rules,
+            updatedAt: 0,
+          },
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      ]
+    }),
+  )
+
 beforeEach(() => {
   vi.clearAllMocks()
   getManagedSiteServiceForTypeMock.mockReturnValue({
@@ -100,9 +305,11 @@ beforeEach(() => {
 describe("ModelSyncService - allowed model filtering", () => {
   const createService = (allowed?: string[]) =>
     new ModelSyncService(
-      "https://example.com",
-      "dummy-token",
-      "1",
+      makeNewApiRuntimeConfig({
+        baseUrl: "https://example.com",
+        adminToken: "dummy-token",
+        userId: "1",
+      }),
       undefined,
       allowed,
     )
@@ -146,7 +353,7 @@ describe("ModelSyncService - allowed model filtering", () => {
 })
 
 describe("ModelSyncService - siteType routing", () => {
-  it("forwards ManagedSiteType hint to apiService listAllChannels", async () => {
+  it("forwards runtime config site type to apiService listAllChannels", async () => {
     listAllChannelsMock.mockResolvedValue({
       items: [],
       total: 0,
@@ -154,20 +361,53 @@ describe("ModelSyncService - siteType routing", () => {
     })
 
     const service = new ModelSyncService(
-      "https://example.com",
-      "token",
-      "1",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      SITE_TYPES.VELOERA,
+      makeRuntimeConfig({
+        siteType: SITE_TYPES.VELOERA,
+        config: {
+          baseUrl: "https://example.com",
+          adminToken: "token",
+          userId: "1",
+        },
+      }),
     )
 
     await service.listChannels()
 
     expect(getApiService).toHaveBeenCalledWith(SITE_TYPES.VELOERA)
     expect(listAllChannelsMock).toHaveBeenCalled()
+  })
+
+  it("derives api-service requests from the stored runtime config at the boundary", async () => {
+    const runtimeConfig = makeRuntimeConfig({
+      siteType: SITE_TYPES.AXON_HUB,
+      config: {
+        baseUrl: "https://axon.example.com",
+        email: "root@example.com",
+        password: "axon-password",
+      },
+    })
+    listAllChannelsMock.mockResolvedValue({
+      items: [],
+      total: 0,
+      type_counts: {},
+    })
+
+    const service = new ModelSyncService(runtimeConfig)
+
+    await service.listChannels()
+
+    expect(getApiService).toHaveBeenCalledWith(SITE_TYPES.AXON_HUB)
+    expect(listAllChannelsMock).toHaveBeenCalledWith(
+      {
+        baseUrl: runtimeConfig.config.baseUrl,
+        auth: {
+          authType: "access_token",
+          accessToken: runtimeConfig.config.password,
+          userId: runtimeConfig.config.email,
+        },
+      },
+      expect.anything(),
+    )
   })
 })
 
@@ -178,7 +418,12 @@ describe("ModelSyncService - global and channel filters", () => {
     rules: ChannelModelFilterRule[] | null | undefined,
     models: string[],
   ): Promise<string[]> => {
-    const service = new ModelSyncService("https://example.com", "token")
+    const service = new ModelSyncService(
+      makeNewApiRuntimeConfig({
+        baseUrl: "https://example.com",
+        adminToken: "token",
+      }),
+    )
     return (service as any).applyFilters(rules, models)
   }
 
@@ -251,7 +496,7 @@ describe("ModelSyncService - channel execution", () => {
       }
     })
 
-    const service = new ModelSyncService("https://example.com", "token", "1")
+    const service = new ModelSyncService(makeExampleRuntimeConfig())
     ;(service as any).rateLimiter = { acquire }
 
     await service.listChannels()
@@ -262,12 +507,12 @@ describe("ModelSyncService - channel execution", () => {
   it("skips channel updates when the normalized model set is unchanged", async () => {
     fetchChannelModelsMock.mockResolvedValueOnce([" model-b ", "model-a"])
 
-    const service = new ModelSyncService("https://example.com", "token", "1")
-    const channel = {
+    const service = new ModelSyncService(makeExampleRuntimeConfig())
+    const channel = makeChannel({
       id: 1,
       name: "Alpha",
       models: "model-a,model-b",
-    } as any
+    })
 
     const result = await service.runForChannel(channel, 0)
 
@@ -290,9 +535,7 @@ describe("ModelSyncService - channel execution", () => {
     ])
 
     const service = new ModelSyncService(
-      "https://example.com",
-      "token",
-      "1",
+      makeExampleRuntimeConfig(),
       undefined,
       undefined,
       undefined,
@@ -304,25 +547,23 @@ describe("ModelSyncService - channel execution", () => {
         }),
       ],
     )
-    service.setChannelConfigs({
-      7: {
-        modelFilterSettings: {
-          rules: [
-            makeFilterRule({
-              id: "include-claude",
-              action: "include",
-              pattern: "claude",
-            }),
-          ],
-        },
-      },
-    } as any)
+    service.setChannelConfigs(
+      makeChannelConfigs({
+        7: [
+          makeFilterRule({
+            id: "include-claude",
+            action: "include",
+            pattern: "claude",
+          }),
+        ],
+      }),
+    )
 
-    const channel = {
+    const channel = makeChannel({
       id: 7,
       name: "Scoped",
       models: "gpt-4o",
-    } as any
+    })
 
     const result = await service.runForChannel(channel, 0)
 
@@ -343,12 +584,12 @@ describe("ModelSyncService - channel execution", () => {
   it("clears stored models when the upstream response only contains blank entries", async () => {
     fetchChannelModelsMock.mockResolvedValueOnce([" ", "", "   "])
 
-    const service = new ModelSyncService("https://example.com", "token", "1")
-    const channel = {
+    const service = new ModelSyncService(makeExampleRuntimeConfig())
+    const channel = makeChannel({
       id: 8,
       name: "Blank Upstream",
       models: "gpt-4o",
-    } as any
+    })
 
     const result = await service.runForChannel(channel, 0)
 
@@ -370,12 +611,12 @@ describe("ModelSyncService - channel execution", () => {
     vi.useFakeTimers()
     fetchChannelModelsMock.mockRejectedValue(new Error("upstream failed"))
 
-    const service = new ModelSyncService("https://example.com", "token", "1")
-    const channel = {
+    const service = new ModelSyncService(makeExampleRuntimeConfig())
+    const channel = makeChannel({
       id: 2,
       name: "Beta",
       models: "gpt-4o",
-    } as any
+    })
 
     try {
       const resultPromise = service.runForChannel(channel, 1)
@@ -400,12 +641,12 @@ describe("ModelSyncService - channel execution", () => {
       httpStatus: 503,
     })
 
-    const service = new ModelSyncService("https://example.com", "token", "1")
-    const channel = {
+    const service = new ModelSyncService(makeExampleRuntimeConfig())
+    const channel = makeChannel({
       id: 9,
       name: "Status Only",
       models: "gpt-4o",
-    } as any
+    })
 
     const result = await service.runForChannel(channel, 0)
 
@@ -431,22 +672,20 @@ describe("ModelSyncService - probe-backed filters", () => {
     }))
 
     const service = new ModelSyncService(
-      "https://managed.example.com",
-      "admin-token",
-      "1",
+      makeRuntimeConfig({ siteType: SITE_TYPES.NEW_API }),
       undefined,
       undefined,
       undefined,
       [makeProbeRule()],
     )
-    const channel = {
+    const channel = makeChannel({
       id: 77,
       name: "Probe Channel",
       type: ChannelType.OpenAI,
       base_url: "https://channel.example.com",
       key: "sk-channel-key",
       models: "model-a,model-b",
-    } as any
+    })
 
     const result = await service.runForChannel(channel, 0)
 
@@ -479,31 +718,28 @@ describe("ModelSyncService - probe-backed filters", () => {
 
   it("resolves hidden channel keys through the managed-site provider", async () => {
     fetchChannelModelsMock.mockResolvedValueOnce(["model-a"])
+    const runtimeConfig = makeRuntimeConfig({ siteType: SITE_TYPES.NEW_API })
 
     const service = new ModelSyncService(
-      "https://managed.example.com",
-      "admin-token",
-      "1",
+      runtimeConfig,
       undefined,
       undefined,
       undefined,
       [makeProbeRule()],
     )
-    const channel = {
+    const channel = makeChannel({
       id: 78,
       name: "Hidden Key",
       type: ChannelType.OpenAI,
       base_url: "https://channel.example.com",
       key: "",
       models: "",
-    } as any
+    })
 
     await service.runForChannel(channel, 0)
 
     expect(fetchChannelSecretKeyMock).toHaveBeenCalledWith(
-      "https://managed.example.com",
-      "admin-token",
-      "1",
+      runtimeConfig.config,
       78,
     )
     expect(runApiVerificationProbeMock).toHaveBeenCalledWith(
@@ -520,30 +756,26 @@ describe("ModelSyncService - probe-backed filters", () => {
 
     const duplicateRule = makeProbeRule({ id: "duplicate" })
     const service = new ModelSyncService(
-      "https://managed.example.com",
-      "admin-token",
-      "1",
+      makeRuntimeConfig({ siteType: SITE_TYPES.NEW_API }),
       undefined,
       undefined,
       undefined,
       [duplicateRule],
     )
-    service.setChannelConfigs({
-      79: {
-        modelFilterSettings: {
-          rules: [makeProbeRule({ id: "channel-duplicate" })],
-        },
-      },
-    } as any)
+    service.setChannelConfigs(
+      makeChannelConfigs({
+        79: [makeProbeRule({ id: "channel-duplicate" })],
+      }),
+    )
 
-    const channel = {
+    const channel = makeChannel({
       id: 79,
       name: "Cached",
       type: ChannelType.OpenAI,
       base_url: "https://channel.example.com",
       key: "sk-channel-key",
       models: "",
-    } as any
+    })
 
     await service.runForChannel(channel, 0)
 
@@ -562,9 +794,7 @@ describe("ModelSyncService - probe-backed filters", () => {
     )
 
     const service = new ModelSyncService(
-      "https://managed.example.com",
-      "admin-token",
-      "1",
+      makeRuntimeConfig({ siteType: SITE_TYPES.NEW_API }),
       undefined,
       undefined,
       undefined,
@@ -575,14 +805,14 @@ describe("ModelSyncService - probe-backed filters", () => {
         }),
       ],
     )
-    const channel = {
+    const channel = makeChannel({
       id: 99,
       name: "Any Mode",
       type: ChannelType.OpenAI,
       base_url: "https://channel.example.com",
       key: "sk-key",
       models: "",
-    } as any
+    })
 
     const result = await service.runForChannel(channel, 0)
 
@@ -599,17 +829,15 @@ describe("ModelSyncService - probe-backed filters", () => {
 
   it("marks a model as unmatched when probe execution throws", async () => {
     const context = {
-      channel: {
+      channel: makeChannel({
         id: 92,
         type: ChannelType.OpenAI,
         base_url: "https://channel.example.com",
         key: "sk-channel-key",
-      },
-      siteType: SITE_TYPES.VELOERA,
-      managedSiteBaseUrl: "https://managed.example.com",
-      adminToken: "admin-token",
+      }),
+      managedConfig: makeRuntimeConfig({ siteType: SITE_TYPES.VELOERA }),
       cache: new Map<string, boolean>(),
-    } as any
+    }
     runApiVerificationProbeMock.mockRejectedValueOnce(
       new Error("probe failed with sk-channel-key"),
     )
@@ -623,17 +851,15 @@ describe("ModelSyncService - probe-backed filters", () => {
 
   it("rejects probe filtering when the channel base URL is missing", async () => {
     const context = {
-      channel: {
+      channel: makeChannel({
         id: 93,
         type: ChannelType.OpenAI,
         base_url: "   ",
         key: "sk-channel-key",
-      },
-      siteType: SITE_TYPES.VELOERA,
-      managedSiteBaseUrl: "https://managed.example.com",
-      adminToken: "admin-token",
+      }),
+      managedConfig: makeRuntimeConfig({ siteType: SITE_TYPES.VELOERA }),
       cache: new Map<string, boolean>(),
-    } as any
+    }
 
     await expect(
       matchesProbeFilterRule(makeProbeRule(), "model-a", context),
@@ -666,22 +892,20 @@ describe("ModelSyncService - probe-backed filters", () => {
     getManagedSiteServiceForTypeMock.mockReturnValue({})
 
     const service = new ModelSyncService(
-      "https://managed.example.com",
-      "admin-token",
-      "1",
+      makeRuntimeConfig({ siteType: SITE_TYPES.NEW_API }),
       undefined,
       undefined,
       undefined,
       [makeProbeRule()],
     )
-    const channel = {
+    const channel = makeChannel({
       id: 80,
       name: "Unsupported Provider",
       type: ChannelType.OpenAI,
       base_url: "https://channel.example.com",
       key: "",
       models: "model-a",
-    } as any
+    })
 
     const result = await service.runForChannel(channel, 0)
 
@@ -697,22 +921,20 @@ describe("ModelSyncService - probe-backed filters", () => {
     fetchChannelModelsMock.mockResolvedValueOnce(["model-a"])
 
     const service = new ModelSyncService(
-      "https://managed.example.com",
-      "admin-token",
-      "1",
+      makeRuntimeConfig({ siteType: SITE_TYPES.NEW_API }),
       undefined,
       undefined,
       undefined,
       [makeProbeRule()],
     )
-    const channel = {
+    const channel = makeChannel({
       id: 81,
       name: "Unsupported Type",
       type: ChannelType.Midjourney,
       base_url: "https://channel.example.com",
       key: "sk-channel-key",
       models: "model-a",
-    } as any
+    })
 
     const result = await service.runForChannel(channel, 0)
 
@@ -731,22 +953,20 @@ describe("ModelSyncService - probe-backed filters", () => {
     )
 
     const service = new ModelSyncService(
-      "https://managed.example.com",
-      "admin-token",
-      "1",
+      makeRuntimeConfig({ siteType: SITE_TYPES.NEW_API }),
       undefined,
       undefined,
       undefined,
       [makeProbeRule()],
     )
-    const channel = {
+    const channel = makeChannel({
       id: 82,
       name: "Secret Safe",
       type: ChannelType.OpenAI,
       base_url: "https://channel.example.com",
       key: "",
       models: "model-a",
-    } as any
+    })
 
     const result = await service.runForChannel(channel, 0)
 
@@ -758,18 +978,15 @@ describe("ModelSyncService - probe-backed filters", () => {
 
   it("resolves a hidden key only once across repeated probe evaluations", async () => {
     const context = {
-      channel: {
+      channel: makeChannel({
         id: 90,
         type: ChannelType.OpenAI,
         base_url: "https://channel.example.com",
         key: "",
-      },
-      siteType: SITE_TYPES.VELOERA,
-      managedSiteBaseUrl: "https://managed.example.com",
-      adminToken: "admin-token",
-      userId: "1",
+      }),
+      managedConfig: makeRuntimeConfig({ siteType: SITE_TYPES.VELOERA }),
       cache: new Map<string, boolean>(),
-    } as any
+    }
 
     await matchesProbeFilterRule(makeProbeRule(), "model-a", context)
     await matchesProbeFilterRule(
@@ -783,17 +1000,15 @@ describe("ModelSyncService - probe-backed filters", () => {
 
   it("treats empty probe rules as non-matches", async () => {
     const context = {
-      channel: {
+      channel: makeChannel({
         id: 91,
         type: ChannelType.OpenAI,
         base_url: "https://channel.example.com",
         key: "sk-channel-key",
-      },
-      siteType: SITE_TYPES.VELOERA,
-      managedSiteBaseUrl: "https://managed.example.com",
-      adminToken: "admin-token",
+      }),
+      managedConfig: makeRuntimeConfig({ siteType: SITE_TYPES.VELOERA }),
       cache: new Map<string, boolean>(),
-    } as any
+    }
 
     await expect(
       matchesProbeFilterRule(
@@ -809,7 +1024,7 @@ describe("ModelSyncService - probe-backed filters", () => {
 
 describe("ModelSyncService - batching and mapping", () => {
   it("returns empty statistics without progress callbacks when no channels are provided", async () => {
-    const service = new ModelSyncService("https://example.com", "token", "1")
+    const service = new ModelSyncService(makeExampleRuntimeConfig())
     const onProgress = vi.fn()
 
     const result = await service.runBatch([], {
@@ -830,10 +1045,10 @@ describe("ModelSyncService - batching and mapping", () => {
   })
 
   it("records failures when a worker throws unexpectedly during batch execution", async () => {
-    const service = new ModelSyncService("https://example.com", "token", "1")
+    const service = new ModelSyncService(makeExampleRuntimeConfig())
     const runForChannelSpy = vi
       .spyOn(service, "runForChannel")
-      .mockImplementation(async (channel) => {
+      .mockImplementation(async (channel): Promise<ExecutionItemResult> => {
         if (channel.id === 2) {
           throw new Error("worker exploded")
         }
@@ -845,14 +1060,14 @@ describe("ModelSyncService - batching and mapping", () => {
           attempts: 0,
           finishedAt: 1,
           message: "Success",
-        } as any
+        }
       })
 
     const onProgress = vi.fn()
     const result = await service.runBatch(
       [
-        { id: 1, name: "Alpha", models: "" } as any,
-        { id: 2, name: "Beta", models: "" } as any,
+        makeChannel({ id: 1, name: "Alpha", models: "" }),
+        makeChannel({ id: 2, name: "Beta", models: "" }),
       ],
       {
         concurrency: 5,
@@ -883,14 +1098,14 @@ describe("ModelSyncService - batching and mapping", () => {
   })
 
   it("merges existing channel models with mapping keys before updating model_mapping", async () => {
-    const service = new ModelSyncService("https://example.com", "token", "1")
+    const service = new ModelSyncService(makeExampleRuntimeConfig())
 
     await service.updateChannelModelMapping(
-      {
+      makeChannel({
         id: 3,
         name: "Gamma",
         models: "gpt-4o,claude-3",
-      } as any,
+      }),
       {
         "gpt-4o": "gpt-4o",
         "deepseek-chat": "deepseek-chat",

--- a/tests/services/modelSync/modelSyncService.test.ts
+++ b/tests/services/modelSync/modelSyncService.test.ts
@@ -409,6 +409,46 @@ describe("ModelSyncService - siteType routing", () => {
       expect.anything(),
     )
   })
+
+  it("derives defensive Octopus and Claude Code Hub auth shapes", async () => {
+    listAllChannelsMock.mockResolvedValue({
+      items: [],
+      total: 0,
+      type_counts: {},
+    })
+    const octopusConfig = makeRuntimeConfig({ siteType: SITE_TYPES.OCTOPUS })
+    const cchConfig = makeRuntimeConfig({
+      siteType: SITE_TYPES.CLAUDE_CODE_HUB,
+    })
+
+    await new ModelSyncService(octopusConfig).listChannels()
+    await new ModelSyncService(cchConfig).listChannels()
+
+    expect(listAllChannelsMock).toHaveBeenNthCalledWith(
+      1,
+      {
+        baseUrl: octopusConfig.config.baseUrl,
+        auth: {
+          authType: "access_token",
+          accessToken: "",
+          userId: octopusConfig.config.username,
+        },
+      },
+      expect.anything(),
+    )
+    expect(listAllChannelsMock).toHaveBeenNthCalledWith(
+      2,
+      {
+        baseUrl: cchConfig.config.baseUrl,
+        auth: {
+          authType: "access_token",
+          accessToken: cchConfig.config.adminToken,
+          userId: "admin",
+        },
+      },
+      expect.anything(),
+    )
+  })
 })
 
 describe("ModelSyncService - global and channel filters", () => {
@@ -974,6 +1014,90 @@ describe("ModelSyncService - probe-backed filters", () => {
     expect(result.message).not.toContain("sk-hidden-channel-key")
     expect(result.message).not.toContain("123456")
     expect(updateChannelModelsMock).not.toHaveBeenCalled()
+  })
+
+  it("redacts token-shaped runtime configs from key-resolution failures", async () => {
+    fetchChannelSecretKeyMock.mockRejectedValueOnce(
+      new Error("failed with runtime-token sk-hidden-channel-key 123456"),
+    )
+    const context = {
+      channel: makeChannel({
+        id: 83,
+        type: ChannelType.OpenAI,
+        base_url: "https://channel.example.com",
+        key: "",
+      }),
+      managedConfig: {
+        siteType: SITE_TYPES.NEW_API,
+        config: {
+          baseUrl: "https://managed.example.com",
+          token: "runtime-token",
+          userId: "1",
+        },
+      } as any,
+      cache: new Map<string, boolean>(),
+    }
+
+    await expect(
+      matchesProbeFilterRule(makeProbeRule(), "model-a", context),
+    ).rejects.toMatchObject({
+      reason: "key-unavailable",
+    })
+  })
+
+  it("redacts Octopus and AxonHub secrets from key-resolution failures", async () => {
+    const cases = [
+      {
+        runtimeConfig: makeRuntimeConfig({ siteType: SITE_TYPES.OCTOPUS }),
+        secret: "secret",
+      },
+      {
+        runtimeConfig: makeRuntimeConfig({ siteType: SITE_TYPES.AXON_HUB }),
+        secret: "secret",
+      },
+    ]
+
+    for (const item of cases) {
+      fetchChannelSecretKeyMock.mockRejectedValueOnce(
+        new Error(`failed with ${item.secret} sk-hidden-channel-key 123456`),
+      )
+      const context = {
+        channel: makeChannel({
+          id: 84,
+          type: ChannelType.OpenAI,
+          base_url: "https://channel.example.com",
+          key: "",
+        }),
+        managedConfig: item.runtimeConfig,
+        cache: new Map<string, boolean>(),
+      }
+
+      await expect(
+        matchesProbeFilterRule(makeProbeRule(), "model-a", context),
+      ).rejects.toMatchObject({
+        reason: "key-unavailable",
+      })
+    }
+  })
+
+  it("rejects unusable keys returned by the managed-site provider", async () => {
+    fetchChannelSecretKeyMock.mockResolvedValueOnce("sk-mask***")
+    const context = {
+      channel: makeChannel({
+        id: 85,
+        type: ChannelType.OpenAI,
+        base_url: "https://channel.example.com",
+        key: "",
+      }),
+      managedConfig: makeRuntimeConfig({ siteType: SITE_TYPES.NEW_API }),
+      cache: new Map<string, boolean>(),
+    }
+
+    await expect(
+      matchesProbeFilterRule(makeProbeRule(), "model-a", context),
+    ).rejects.toMatchObject({
+      reason: "key-unavailable",
+    })
   })
 
   it("resolves a hidden key only once across repeated probe evaluations", async () => {

--- a/tests/services/modelSync/scheduler.more.test.ts
+++ b/tests/services/modelSync/scheduler.more.test.ts
@@ -201,9 +201,14 @@ describe("modelSyncScheduler additional scheduler flows", () => {
     await modelSyncScheduler.listChannels()
 
     expect(mocks.modelSyncServiceCtor).toHaveBeenCalledWith(
-      "https://example.com",
-      "token",
-      "1",
+      {
+        siteType: "new-api",
+        config: {
+          baseUrl: "https://example.com",
+          adminToken: "token",
+          userId: "1",
+        },
+      },
       {
         requestsPerMinute: 10,
         burst: 2,
@@ -217,7 +222,6 @@ describe("modelSyncScheduler additional scheduler flows", () => {
           probeIds: ["text-generation"],
         }),
       ],
-      "new-api",
     )
   })
 })

--- a/tests/services/modelSync/scheduler.more.test.ts
+++ b/tests/services/modelSync/scheduler.more.test.ts
@@ -223,6 +223,8 @@ describe("modelSyncScheduler additional scheduler flows", () => {
         }),
       ],
     )
+    const [, , , , sanitizedFilters] = mocks.modelSyncServiceCtor.mock.calls[0]
+    expect(sanitizedFilters[0]).not.toHaveProperty("apiKey")
   })
 })
 

--- a/tests/services/modelSync/scheduler.test.ts
+++ b/tests/services/modelSync/scheduler.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import { getManagedSiteServiceForType } from "~/services/managedSites/managedSiteService"
-import * as managedSiteUtils from "~/services/managedSites/utils/managedSite"
+import { ModelSyncService } from "~/services/models/modelSync/modelSyncService"
 import {
   handleManagedSiteModelSyncMessage,
   modelSyncScheduler,
@@ -19,8 +19,20 @@ import {
   hasAlarmsAPI,
 } from "~/utils/browser/browserApi"
 
+const { modelSyncListChannelsMock, modelSyncServiceConstructorMock } =
+  vi.hoisted(() => ({
+    modelSyncListChannelsMock: vi.fn(),
+    modelSyncServiceConstructorMock: vi.fn(),
+  }))
+
 vi.mock("~/services/preferences/userPreferences", () => ({
   DEFAULT_PREFERENCES: {
+    managedSiteType: "new-api",
+    newApi: {
+      baseUrl: "",
+      adminToken: "",
+      userId: "",
+    },
     managedSiteModelSync: {
       enabled: true,
       interval: 60_000,
@@ -54,6 +66,21 @@ vi.mock("~/services/managedSites/managedSiteService", () => ({
   getManagedSiteServiceForType: vi.fn(),
 }))
 
+vi.mock("~/services/models/modelSync/modelSyncService", () => ({
+  ModelSyncService: vi.fn(function (this: unknown, ...args: unknown[]) {
+    modelSyncServiceConstructorMock(...args)
+    return {
+      listChannels: modelSyncListChannelsMock,
+    }
+  }),
+}))
+
+vi.mock("~/services/managedSites/channelConfigStorage", () => ({
+  channelConfigStorage: {
+    getAllConfigs: vi.fn().mockResolvedValue({}),
+  },
+}))
+
 const mockedUserPreferences = userPreferences as unknown as {
   getPreferences: ReturnType<typeof vi.fn>
 }
@@ -67,6 +94,10 @@ const mockedBrowserApi = {
 
 const mockedGetManagedSiteServiceForType =
   getManagedSiteServiceForType as unknown as ReturnType<typeof vi.fn>
+
+const mockedModelSyncService = ModelSyncService as unknown as ReturnType<
+  typeof vi.fn
+>
 
 describe("modelSyncScheduler.setupAlarm", () => {
   beforeEach(() => {
@@ -137,6 +168,11 @@ describe("handleManagedSiteModelSyncMessage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockedBrowserApi.hasAlarmsAPI.mockReturnValue(true)
+    modelSyncListChannelsMock.mockResolvedValue({
+      items: [],
+      total: 0,
+      type_counts: {},
+    })
   })
 
   it("returns next scheduled time from the alarm", async () => {
@@ -187,15 +223,10 @@ describe("handleManagedSiteModelSyncMessage", () => {
       },
     })
 
-    const getManagedSiteAdminConfigSpy = vi
-      .spyOn(managedSiteUtils, "getManagedSiteAdminConfig")
-      .mockReturnValue(null)
-
     await expect(modelSyncScheduler.listChannels()).rejects.toThrow(
       "messages:claudecodehub.configMissing",
     )
 
-    expect(getManagedSiteAdminConfigSpy).toHaveBeenCalled()
     expect(mockedGetManagedSiteServiceForType).not.toHaveBeenCalled()
   })
 
@@ -203,7 +234,6 @@ describe("handleManagedSiteModelSyncMessage", () => {
     const managedConfig = {
       baseUrl: "https://cch.example.com",
       adminToken: "admin-token",
-      userId: "admin",
     }
     const searchChannel = vi.fn().mockResolvedValue({
       items: [{ id: 42, name: "Claude Provider" }],
@@ -222,10 +252,6 @@ describe("handleManagedSiteModelSyncMessage", () => {
       },
     })
 
-    const getManagedSiteAdminConfigSpy = vi
-      .spyOn(managedSiteUtils, "getManagedSiteAdminConfig")
-      .mockReturnValue(managedConfig)
-
     mockedGetManagedSiteServiceForType.mockReturnValue({
       searchChannel,
     })
@@ -236,23 +262,16 @@ describe("handleManagedSiteModelSyncMessage", () => {
       type_counts: { codex: 1 },
     })
 
-    expect(getManagedSiteAdminConfigSpy).toHaveBeenCalled()
     expect(mockedGetManagedSiteServiceForType).toHaveBeenCalledWith(
       SITE_TYPES.CLAUDE_CODE_HUB,
     )
-    expect(searchChannel).toHaveBeenCalledWith(
-      managedConfig.baseUrl,
-      managedConfig.adminToken,
-      managedConfig.userId,
-      "",
-    )
+    expect(searchChannel).toHaveBeenCalledWith(managedConfig, "")
   })
 
   it("returns the Claude Code Hub empty fallback when the managed-site service has no channel list", async () => {
     const managedConfig = {
       baseUrl: "https://cch.example.com",
       adminToken: "admin-token",
-      userId: "admin",
     }
     const searchChannel = vi.fn().mockResolvedValue(null)
 
@@ -267,10 +286,6 @@ describe("handleManagedSiteModelSyncMessage", () => {
       },
     })
 
-    vi.spyOn(managedSiteUtils, "getManagedSiteAdminConfig").mockReturnValue(
-      managedConfig,
-    )
-
     mockedGetManagedSiteServiceForType.mockReturnValue({
       searchChannel,
     })
@@ -281,11 +296,36 @@ describe("handleManagedSiteModelSyncMessage", () => {
       type_counts: {},
     })
 
-    expect(searchChannel).toHaveBeenCalledWith(
-      managedConfig.baseUrl,
-      managedConfig.adminToken,
-      managedConfig.userId,
-      "",
+    expect(searchChannel).toHaveBeenCalledWith(managedConfig, "")
+  })
+
+  it("constructs model sync with the current runtime config object", async () => {
+    const managedConfig = {
+      baseUrl: "https://new-api.example.com",
+      adminToken: "admin-token",
+      userId: "42",
+    }
+    mockedUserPreferences.getPreferences.mockResolvedValue({
+      managedSiteType: SITE_TYPES.NEW_API,
+      newApi: managedConfig,
+      managedSiteModelSync: {
+        ...(DEFAULT_PREFERENCES as any).managedSiteModelSync,
+      },
+    })
+
+    await modelSyncScheduler.listChannels()
+
+    expect(mockedModelSyncService).toHaveBeenCalledTimes(1)
+    expect(modelSyncServiceConstructorMock).toHaveBeenCalledWith(
+      {
+        siteType: SITE_TYPES.NEW_API,
+        config: managedConfig,
+      },
+      expect.anything(),
+      expect.any(Array),
+      {},
+      [],
     )
+    expect(modelSyncListChannelsMock).toHaveBeenCalled()
   })
 })

--- a/tests/services/newApiService/newApiService.test.ts
+++ b/tests/services/newApiService/newApiService.test.ts
@@ -825,6 +825,11 @@ describe("newApiService", () => {
       const { fetchChannelSecretKey } = await import(
         "~/services/managedSites/providers/newApi"
       )
+      const config = {
+        baseUrl: "https://new-api.example.com/api/v1",
+        adminToken: "ignored-admin-token",
+        userId: "managed-user",
+      }
 
       mockGetPreferences.mockResolvedValueOnce(
         createMockUserPreferencesWithNewApi({
@@ -840,14 +845,9 @@ describe("newApiService", () => {
       )
       fetchNewApiChannelKeyMock.mockResolvedValueOnce("resolved-secret")
 
-      await expect(
-        fetchChannelSecretKey(
-          "https://new-api.example.com/api/v1",
-          "ignored-admin-token",
-          "managed-user",
-          99,
-        ),
-      ).resolves.toBe("resolved-secret")
+      await expect(fetchChannelSecretKey(config, 99)).resolves.toBe(
+        "resolved-secret",
+      )
 
       expect(fetchNewApiChannelKeyMock).toHaveBeenCalledWith({
         baseUrl: "https://new-api.example.com/api/v1",
@@ -863,6 +863,11 @@ describe("newApiService", () => {
       const { fetchChannelSecretKey } = await import(
         "~/services/managedSites/providers/newApi"
       )
+      const config = {
+        baseUrl: "https://other.example.com/api/v1",
+        adminToken: "ignored-admin-token",
+        userId: "managed-user",
+      }
 
       mockGetPreferences.mockResolvedValueOnce(
         createMockUserPreferencesWithNewApi({
@@ -878,12 +883,7 @@ describe("newApiService", () => {
       )
       fetchNewApiChannelKeyMock.mockResolvedValueOnce("resolved-secret")
 
-      await fetchChannelSecretKey(
-        "https://other.example.com/api/v1",
-        "ignored-admin-token",
-        "managed-user",
-        100,
-      )
+      await fetchChannelSecretKey(config, 100)
 
       expect(fetchNewApiChannelKeyMock).toHaveBeenCalledWith({
         baseUrl: "https://other.example.com/api/v1",
@@ -901,22 +901,22 @@ describe("newApiService", () => {
       const { hydrateComparableChannelKeys } = await import(
         "~/services/managedSites/providers/newApi"
       )
+      const config = {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      }
 
       mockGetPreferences.mockResolvedValueOnce(
         createMockUserPreferencesWithNewApi(),
       )
 
-      const result = await hydrateComparableChannelKeys(
-        "https://new-api.example.com",
-        "admin-token",
-        1,
-        [
-          createMockNewApiChannel({
-            id: 11,
-            key: "sk-visible",
-          }),
-        ],
-      )
+      const result = await hydrateComparableChannelKeys(config, [
+        createMockNewApiChannel({
+          id: 11,
+          key: "sk-visible",
+        }),
+      ])
 
       expect(fetchNewApiChannelKeyMock).not.toHaveBeenCalled()
       expect(result).toEqual([
@@ -931,25 +931,25 @@ describe("newApiService", () => {
       const { hydrateComparableChannelKeys } = await import(
         "~/services/managedSites/providers/newApi"
       )
+      const config = {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      }
 
       mockGetPreferences.mockResolvedValueOnce(
         createMockUserPreferencesWithNewApi(),
       )
       fetchNewApiChannelKeyMock.mockResolvedValueOnce("sk-revealed")
 
-      const result = await hydrateComparableChannelKeys(
-        "https://new-api.example.com",
-        "admin-token",
-        1,
-        [
-          createMockNewApiChannel({
-            id: 12,
-            key: "",
-            base_url: "https://api.example.com/v1",
-            models: "gpt-4o",
-          }),
-        ],
-      )
+      const result = await hydrateComparableChannelKeys(config, [
+        createMockNewApiChannel({
+          id: 12,
+          key: "",
+          base_url: "https://api.example.com/v1",
+          models: "gpt-4o",
+        }),
+      ])
 
       expect(result).toEqual([
         expect.objectContaining({
@@ -970,6 +970,11 @@ describe("newApiService", () => {
         NEW_API_CHANNEL_KEY_ERROR_KINDS,
         NewApiChannelKeyRequirementError,
       } = await import("~/services/managedSites/providers/newApiSession")
+      const config = {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      }
 
       mockGetPreferences.mockResolvedValueOnce(
         createMockUserPreferencesWithNewApi(),
@@ -981,12 +986,9 @@ describe("newApiService", () => {
       )
 
       await expect(
-        hydrateComparableChannelKeys(
-          "https://new-api.example.com",
-          "admin-token",
-          1,
-          [createMockNewApiChannel({ id: 13, key: "" })],
-        ),
+        hydrateComparableChannelKeys(config, [
+          createMockNewApiChannel({ id: 13, key: "" }),
+        ]),
       ).rejects.toMatchObject({
         name: MatchResolutionUnresolvedError.name,
         reason:
@@ -1001,6 +1003,11 @@ describe("newApiService", () => {
       const { MatchResolutionUnresolvedError } = await import(
         "~/services/managedSites/channelMatch"
       )
+      const config = {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      }
 
       mockGetPreferences.mockResolvedValueOnce(
         createMockUserPreferencesWithNewApi(),
@@ -1010,12 +1017,9 @@ describe("newApiService", () => {
       )
 
       await expect(
-        hydrateComparableChannelKeys(
-          "https://new-api.example.com",
-          "admin-token",
-          1,
-          [createMockNewApiChannel({ id: 14, key: "" })],
-        ),
+        hydrateComparableChannelKeys(config, [
+          createMockNewApiChannel({ id: 14, key: "" }),
+        ]),
       ).rejects.toMatchObject({
         name: MatchResolutionUnresolvedError.name,
         reason:
@@ -1351,9 +1355,11 @@ describe("newApiService", () => {
     it("uses the New API site override for channel mutations", async () => {
       const { createChannel, deleteChannel, searchChannel, updateChannel } =
         await import("~/services/managedSites/providers/newApi")
-      const baseUrl = "https://new-api.example.com"
-      const adminToken = "admin-token"
-      const userId = 1
+      const config = {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      }
       const createChannelData: CreateChannelPayload = {
         mode: "single",
         channel: {
@@ -1376,25 +1382,53 @@ describe("newApiService", () => {
       mockUpdateChannel.mockResolvedValueOnce({ success: true })
       mockDeleteChannel.mockResolvedValueOnce({ success: true })
 
-      await searchChannel(baseUrl, adminToken, userId, "test")
-      await createChannel(baseUrl, adminToken, userId, createChannelData)
-      await updateChannel(baseUrl, adminToken, userId, updateChannelData)
-      await deleteChannel(baseUrl, adminToken, userId, 7)
+      await searchChannel(config, "test")
+      await createChannel(config, createChannelData)
+      await updateChannel(config, updateChannelData)
+      await deleteChannel(config, 7)
 
       expect(mockSearchChannel).toHaveBeenCalledWith(
-        expect.objectContaining({ baseUrl }),
+        expect.objectContaining({
+          baseUrl: config.baseUrl,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            accessToken: config.adminToken,
+            userId: config.userId,
+          },
+        }),
         "test",
       )
       expect(mockCreateChannel).toHaveBeenCalledWith(
-        expect.objectContaining({ baseUrl }),
+        expect.objectContaining({
+          baseUrl: config.baseUrl,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            accessToken: config.adminToken,
+            userId: config.userId,
+          },
+        }),
         createChannelData,
       )
       expect(mockUpdateChannel).toHaveBeenCalledWith(
-        expect.objectContaining({ baseUrl }),
+        expect.objectContaining({
+          baseUrl: config.baseUrl,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            accessToken: config.adminToken,
+            userId: config.userId,
+          },
+        }),
         updateChannelData,
       )
       expect(mockDeleteChannel).toHaveBeenCalledWith(
-        expect.objectContaining({ baseUrl }),
+        expect.objectContaining({
+          baseUrl: config.baseUrl,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            accessToken: config.adminToken,
+            userId: config.userId,
+          },
+        }),
         7,
       )
     })

--- a/tests/services/octopusService/octopusService.more.test.ts
+++ b/tests/services/octopusService/octopusService.more.test.ts
@@ -556,6 +556,13 @@ describe("octopus additional flows", () => {
       message: "messages:octopus.configMissing",
     })
 
+    mockGetPreferences.mockResolvedValueOnce({
+      octopus: {
+        baseUrl: "",
+        username: "",
+        password: "",
+      },
+    })
     mockConvertToDisplayData.mockReturnValue(displaySiteData)
     mockEnsureAccountApiToken.mockResolvedValueOnce(apiToken)
     mockSearchChannels.mockResolvedValueOnce([])

--- a/tests/services/octopusService/octopusService.more.test.ts
+++ b/tests/services/octopusService/octopusService.more.test.ts
@@ -44,6 +44,12 @@ const {
   mockFetchManagedSiteAvailableModels: vi.fn(),
 }))
 
+const passedOctopusConfig = {
+  baseUrl: "https://passed-octopus.example.com",
+  username: "passed-octo-user",
+  password: "passed-octo-pass",
+}
+
 vi.mock("react-hot-toast", () => ({
   default: mockToast,
 }))
@@ -156,7 +162,7 @@ describe("octopus additional flows", () => {
       "~/services/managedSites/providers/octopus"
     )
 
-    const created = await createChannel("ignored", "", "", {
+    const created = await createChannel(passedOctopusConfig, {
       mode: "single",
       channel: {
         name: " Octopus Channel ",
@@ -174,9 +180,9 @@ describe("octopus additional flows", () => {
     expect(created.success).toBe(true)
     expect(mockCreateChannelApi).toHaveBeenCalledWith(
       {
-        baseUrl: "https://octopus.example.com",
-        username: "octo-user",
-        password: "octo-pass",
+        baseUrl: "https://passed-octopus.example.com",
+        username: "passed-octo-user",
+        password: "passed-octo-pass",
       },
       {
         name: " Octopus Channel ",
@@ -190,7 +196,7 @@ describe("octopus additional flows", () => {
       },
     )
 
-    const updated = await updateChannel("ignored", "", "", {
+    const updated = await updateChannel(passedOctopusConfig, {
       id: 12,
       name: "Updated Octopus Channel",
       type: OctopusOutboundType.Anthropic,
@@ -202,9 +208,9 @@ describe("octopus additional flows", () => {
     expect(updated.success).toBe(true)
     expect(mockUpdateChannelApi).toHaveBeenCalledWith(
       {
-        baseUrl: "https://octopus.example.com",
-        username: "octo-user",
-        password: "octo-pass",
+        baseUrl: "https://passed-octopus.example.com",
+        username: "passed-octo-user",
+        password: "passed-octo-pass",
       },
       {
         id: 12,
@@ -215,38 +221,6 @@ describe("octopus additional flows", () => {
         model: "claude-3.7-sonnet",
       },
     )
-  })
-
-  it("returns a config-missing response when Octopus credentials are unavailable", async () => {
-    const { createChannel, deleteChannel } = await import(
-      "~/services/managedSites/providers/octopus"
-    )
-    mockGetPreferences.mockResolvedValue({
-      octopus: {
-        baseUrl: "",
-        username: "",
-        password: "",
-      },
-    })
-
-    const createResult = await createChannel("ignored", "", "", {
-      mode: "single",
-      channel: {},
-    } as any)
-    const deleteResult = await deleteChannel("ignored", "", "", 99)
-
-    expect(createResult).toEqual({
-      success: false,
-      data: null,
-      message: "Octopus config not found",
-    })
-    expect(deleteResult).toEqual({
-      success: false,
-      data: null,
-      message: "Octopus config not found",
-    })
-    expect(mockCreateChannelApi).not.toHaveBeenCalled()
-    expect(mockDeleteChannelApi).not.toHaveBeenCalled()
   })
 
   it("prepares Octopus channel form data with a normalized /v1 base URL", async () => {
@@ -414,6 +388,12 @@ describe("octopus additional flows", () => {
     const { checkValidOctopusConfig, getOctopusConfig, searchChannel } =
       await import("~/services/managedSites/providers/octopus")
 
+    await expect(getOctopusConfig()).resolves.toEqual({
+      baseUrl: "https://octopus.example.com",
+      username: "octo-user",
+      password: "octo-pass",
+    })
+
     mockGetPreferences.mockResolvedValueOnce(null)
     await expect(checkValidOctopusConfig()).resolves.toBe(false)
 
@@ -443,7 +423,10 @@ describe("octopus additional flows", () => {
         password: "",
       },
     })
-    await expect(searchChannel("ignored", "", "", "proxy")).resolves.toBeNull()
+    mockSearchChannels.mockRejectedValueOnce(new Error("search failed"))
+    await expect(
+      searchChannel(passedOctopusConfig, "proxy"),
+    ).resolves.toBeNull()
   })
 
   it("converts Octopus channels to managed-site data and searches channels through the provider config", async () => {
@@ -472,7 +455,7 @@ describe("octopus additional flows", () => {
     mockSearchChannels.mockResolvedValueOnce([apiChannel])
 
     const converted = octopusChannelToManagedSite(apiChannel)
-    const result = await searchChannel("ignored", "", "", "octopus")
+    const result = await searchChannel(passedOctopusConfig, "octopus")
     const models = await fetchAvailableModels(account, token)
 
     expect(converted).toMatchObject({
@@ -491,9 +474,9 @@ describe("octopus additional flows", () => {
     })
     expect(mockSearchChannels).toHaveBeenCalledWith(
       {
-        baseUrl: "https://octopus.example.com",
-        username: "octo-user",
-        password: "octo-pass",
+        baseUrl: "https://passed-octopus.example.com",
+        username: "passed-octo-user",
+        password: "passed-octo-pass",
       },
       "octopus",
     )
@@ -513,19 +496,19 @@ describe("octopus additional flows", () => {
     )
 
     mockCreateChannelApi.mockRejectedValueOnce(new Error("create exploded"))
-    const createResult = await createChannel("ignored", "", "", {
+    const createResult = await createChannel(passedOctopusConfig, {
       mode: "single",
       channel: {},
     } as any)
 
     mockUpdateChannelApi.mockRejectedValueOnce(new Error("update exploded"))
-    const updateResult = await updateChannel("ignored", "", "", {
+    const updateResult = await updateChannel(passedOctopusConfig, {
       id: 9,
       status: 1,
     } as any)
 
     mockDeleteChannelApi.mockRejectedValueOnce(new Error("delete exploded"))
-    const deleteResult = await deleteChannel("ignored", "", "", 9)
+    const deleteResult = await deleteChannel(passedOctopusConfig, 9)
 
     expect(createResult).toEqual({
       success: false,
@@ -584,21 +567,12 @@ describe("octopus additional flows", () => {
 
     const rejected = await autoConfigToOctopus(buildSiteAccount(), "toast-7")
 
-    expect(mockSearchChannels).toHaveBeenCalledWith(
-      {
-        baseUrl: "https://octopus.example.com",
-        username: "octo-user",
-        password: "octo-pass",
-      },
-      "https://proxy.example.com",
-    )
-    expect(mockCreateChannelApi).toHaveBeenCalled()
+    expect(mockSearchChannels).not.toHaveBeenCalled()
+    expect(mockCreateChannelApi).not.toHaveBeenCalled()
     expect(rejected).toEqual({
       success: false,
-      message: "octopus rejected channel",
+      message: "messages:octopus.configMissing",
     })
-    expect(mockToast.error).toHaveBeenCalledWith("octopus rejected channel", {
-      id: "toast-7",
-    })
+    expect(mockToast.error).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/octopusService/octopusService.more.test.ts
+++ b/tests/services/octopusService/octopusService.more.test.ts
@@ -557,11 +557,7 @@ describe("octopus additional flows", () => {
     })
 
     mockGetPreferences.mockResolvedValueOnce({
-      octopus: {
-        baseUrl: "",
-        username: "",
-        password: "",
-      },
+      octopus: passedOctopusConfig,
     })
     mockConvertToDisplayData.mockReturnValue(displaySiteData)
     mockEnsureAccountApiToken.mockResolvedValueOnce(apiToken)

--- a/tests/services/octopusService/octopusService.more.test.ts
+++ b/tests/services/octopusService/octopusService.more.test.ts
@@ -557,7 +557,11 @@ describe("octopus additional flows", () => {
     })
 
     mockGetPreferences.mockResolvedValueOnce({
-      octopus: passedOctopusConfig,
+      octopus: {
+        baseUrl: "",
+        username: "",
+        password: "",
+      },
     })
     mockConvertToDisplayData.mockReturnValue(displaySiteData)
     mockEnsureAccountApiToken.mockResolvedValueOnce(apiToken)

--- a/tests/services/veloeraService/veloeraService.more.test.ts
+++ b/tests/services/veloeraService/veloeraService.more.test.ts
@@ -362,15 +362,43 @@ describe("veloeraService additional flows", () => {
     })
 
     await searchChannel(
-      "https://veloera.example.com",
-      "veloera-token",
-      "200",
+      {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "200",
+      },
       "proxy",
     )
-    await createChannel("https://veloera.example.com", "veloera-token", "200", {
-      mode: "single",
-      channel: {
-        name: "Veloera Channel",
+    await createChannel(
+      {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "200",
+      },
+      {
+        mode: "single",
+        channel: {
+          name: "Veloera Channel",
+          type: 1,
+          key: "veloera-key",
+          base_url: "https://proxy.example.com",
+          models: "gpt-4o",
+          groups: ["default"],
+          priority: 0,
+          weight: 0,
+          status: 1,
+        },
+      } as any,
+    )
+    await updateChannel(
+      {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "200",
+      },
+      {
+        id: 7,
+        name: "Updated Veloera Channel",
         type: 1,
         key: "veloera-key",
         base_url: "https://proxy.example.com",
@@ -379,24 +407,14 @@ describe("veloeraService additional flows", () => {
         priority: 0,
         weight: 0,
         status: 1,
-      },
-    } as any)
-    await updateChannel("https://veloera.example.com", "veloera-token", "200", {
-      id: 7,
-      name: "Updated Veloera Channel",
-      type: 1,
-      key: "veloera-key",
-      base_url: "https://proxy.example.com",
-      models: "gpt-4o",
-      groups: ["default"],
-      priority: 0,
-      weight: 0,
-      status: 1,
-    } as any)
+      } as any,
+    )
     await deleteChannel(
-      "https://veloera.example.com",
-      "veloera-token",
-      "200",
+      {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "veloera-token",
+        userId: "200",
+      },
       7,
     )
     const models = await fetchAvailableModels(account, token)
@@ -465,9 +483,11 @@ describe("veloeraService additional flows", () => {
     })
     await expect(
       fetchChannelSecretKey(
-        "https://veloera.example.com",
-        "veloera-token",
-        "200",
+        {
+          baseUrl: "https://veloera.example.com",
+          adminToken: "veloera-token",
+          userId: "200",
+        },
         42,
       ),
     ).resolves.toBe("veloera-secret")
@@ -478,9 +498,11 @@ describe("veloeraService additional flows", () => {
     })
     await expect(
       fetchChannelSecretKey(
-        "https://veloera.example.com",
-        "veloera-token",
-        "200",
+        {
+          baseUrl: "https://veloera.example.com",
+          adminToken: "veloera-token",
+          userId: "200",
+        },
         42,
       ),
     ).rejects.toThrow("veloera_channel_key_missing")

--- a/tests/services/veloeraService/veloeraService.test.ts
+++ b/tests/services/veloeraService/veloeraService.test.ts
@@ -257,16 +257,21 @@ describe("veloeraService", () => {
     it("passes SITE_TYPES.VELOERA site hint to apiService wrappers", async () => {
       const { searchChannel, createChannel, updateChannel, deleteChannel } =
         await import("~/services/managedSites/providers/veloera")
+      const config = {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "token",
+        userId: "1",
+      }
 
       mockSearchChannel.mockResolvedValueOnce(null)
-      await searchChannel("https://veloera.example.com", "token", "1", "k")
+      await searchChannel(config, "k")
       expect(mockSearchChannel).toHaveBeenLastCalledWith(
         {
-          baseUrl: "https://veloera.example.com",
+          baseUrl: config.baseUrl,
           auth: {
             authType: "access_token",
-            accessToken: "token",
-            userId: "1",
+            accessToken: config.adminToken,
+            userId: config.userId,
           },
         },
         "k",
@@ -287,19 +292,14 @@ describe("veloeraService", () => {
           status: 1,
         },
       }
-      await createChannel(
-        "https://veloera.example.com",
-        "token",
-        "1",
-        createPayload,
-      )
+      await createChannel(config, createPayload)
       expect(mockCreateChannel).toHaveBeenLastCalledWith(
         {
-          baseUrl: "https://veloera.example.com",
+          baseUrl: config.baseUrl,
           auth: {
             authType: "access_token",
-            accessToken: "token",
-            userId: "1",
+            accessToken: config.adminToken,
+            userId: config.userId,
           },
         },
         createPayload,
@@ -316,33 +316,28 @@ describe("veloeraService", () => {
         groups: ["default"],
         priority: 0,
       }
-      await updateChannel(
-        "https://veloera.example.com",
-        "token",
-        "1",
-        updatePayload,
-      )
+      await updateChannel(config, updatePayload)
       expect(mockUpdateChannel).toHaveBeenLastCalledWith(
         {
-          baseUrl: "https://veloera.example.com",
+          baseUrl: config.baseUrl,
           auth: {
             authType: "access_token",
-            accessToken: "token",
-            userId: "1",
+            accessToken: config.adminToken,
+            userId: config.userId,
           },
         },
         updatePayload,
       )
 
       mockDeleteChannel.mockResolvedValueOnce({ success: true, message: "ok" })
-      await deleteChannel("https://veloera.example.com", "token", "1", 1)
+      await deleteChannel(config, 1)
       expect(mockDeleteChannel).toHaveBeenLastCalledWith(
         {
-          baseUrl: "https://veloera.example.com",
+          baseUrl: config.baseUrl,
           auth: {
             authType: "access_token",
-            accessToken: "token",
-            userId: "1",
+            accessToken: config.adminToken,
+            userId: config.userId,
           },
         },
         1,
@@ -355,18 +350,18 @@ describe("veloeraService", () => {
       const { fetchChannelSecretKey } = await import(
         "~/services/managedSites/providers/veloera"
       )
+      const config = {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "token",
+        userId: "1",
+      }
 
       mockFetchVeloeraChannel.mockResolvedValueOnce({
         id: 88,
         key: "sk-veloera-channel-key",
       })
 
-      const result = await fetchChannelSecretKey(
-        "https://veloera.example.com",
-        "token",
-        "1",
-        88,
-      )
+      const result = await fetchChannelSecretKey(config, 88)
 
       expect(mockFetchVeloeraChannel).toHaveBeenCalledWith(
         {
@@ -388,21 +383,21 @@ describe("veloeraService", () => {
       const { hydrateComparableChannelKeys } = await import(
         "~/services/managedSites/providers/veloera"
       )
+      const config = {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      }
 
       mockFetchVeloeraChannel.mockResolvedValueOnce({
         id: 40,
         key: "sk-veloera-detail",
       })
 
-      const result = await hydrateComparableChannelKeys(
-        "https://veloera.example.com",
-        "admin-token",
-        "1",
-        [
-          createMockManagedSiteChannel({ id: 40, key: "" }) as any,
-          createMockManagedSiteChannel({ id: 41, key: "sk-visible" }) as any,
-        ],
-      )
+      const result = await hydrateComparableChannelKeys(config, [
+        createMockManagedSiteChannel({ id: 40, key: "" }) as any,
+        createMockManagedSiteChannel({ id: 41, key: "sk-visible" }) as any,
+      ])
 
       expect(mockFetchVeloeraChannel).toHaveBeenCalledTimes(1)
       expect(mockFetchVeloeraChannel).toHaveBeenCalledWith(
@@ -422,18 +417,20 @@ describe("veloeraService", () => {
       const { MatchResolutionUnresolvedError } = await import(
         "~/services/managedSites/channelMatch"
       )
+      const config = {
+        baseUrl: "https://veloera.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      }
 
       mockFetchVeloeraChannel.mockRejectedValueOnce(
         new Error("detail unavailable"),
       )
 
       await expect(
-        hydrateComparableChannelKeys(
-          "https://veloera.example.com",
-          "admin-token",
-          "1",
-          [createMockManagedSiteChannel({ id: 42, key: "" }) as any],
-        ),
+        hydrateComparableChannelKeys(config, [
+          createMockManagedSiteChannel({ id: 42, key: "" }) as any,
+        ]),
       ).rejects.toBeInstanceOf(MatchResolutionUnresolvedError)
     })
   })

--- a/tests/utils/managedSite.test.ts
+++ b/tests/utils/managedSite.test.ts
@@ -4,7 +4,6 @@ import { SITE_TYPES } from "~/constants/siteType"
 import {
   getManagedSiteAdminConfig,
   getManagedSiteAdminConfigForType,
-  getManagedSiteConfigFromPreferences,
   getManagedSiteContext,
   getManagedSiteContextForType,
   getManagedSiteLabelKey,
@@ -19,7 +18,7 @@ import {
 } from "~/services/preferences/userPreferences"
 
 describe("managedSite", () => {
-  it("resolves Done Hub config when selected", () => {
+  it("resolves Done Hub admin config when selected", () => {
     const prefs = {
       ...DEFAULT_PREFERENCES,
       managedSiteType: SITE_TYPES.DONE_HUB,
@@ -30,9 +29,11 @@ describe("managedSite", () => {
       },
     } satisfies UserPreferences
 
-    const { siteType, config } = getManagedSiteConfigFromPreferences(prefs)
-    expect(siteType).toBe(SITE_TYPES.DONE_HUB)
-    expect(config).toEqual(prefs.doneHub)
+    expect(getManagedSiteAdminConfig(prefs)).toEqual({
+      baseUrl: prefs.doneHub.baseUrl,
+      adminToken: prefs.doneHub.adminToken,
+      userId: prefs.doneHub.userId,
+    })
   })
 
   it("returns Done Hub messages key + label key", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Managed-site flow migrated to explicit, site-typed runtime config objects passed across services and providers.

* **Security**
  * Expanded secret collection and redaction to sanitize a wider set of managed-site credentials in diagnostics.

* **Documentation**
  * Added design and implementation plan for the runtime-config migration.

* **Tests**
  * Updated and expanded tests for runtime config resolution, provider adapters, import/migration, token export, key-resolution, and scheduler/sync paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->