### PR TITLE
fix(site-announcements): realign polling cooldown after alarm restore

### DIFF
--- a/src/services/siteAnnouncements/scheduler.ts
+++ b/src/services/siteAnnouncements/scheduler.ts
@@ -196,9 +196,25 @@ async function rescheduleAnnouncementAlarm(params: {
 function getAnnouncementAlarmDelayMinutes(params: {
   intervalMinutes: number
   siteStates: SiteAnnouncementSiteState[]
+  accounts: SiteAccount[]
 }): number {
   const now = Date.now()
   let nextDelayMinutes = Number.POSITIVE_INFINITY
+  const siteKeysWithStatus = new Set(
+    params.siteStates.map((siteState) => siteState.siteKey),
+  )
+
+  for (const account of dedupeCommonAccounts(params.accounts)) {
+    const provider = getSiteAnnouncementProvider(account.site_type)
+    const siteKey = provider.createSiteKey({
+      accountId: account.id,
+      siteType: account.site_type,
+      baseUrl: account.site_url,
+    })
+    if (!siteKeysWithStatus.has(siteKey)) {
+      return 1
+    }
+  }
 
   for (const siteState of params.siteStates) {
     const expiresAt = getAnnouncementCooldownExpiresAt({
@@ -294,11 +310,13 @@ class SiteAnnouncementScheduler {
     }
 
     const siteStates = await siteAnnouncementStorage.getStatus()
+    const accounts = await accountStorage.getEnabledAccounts()
     await rescheduleAnnouncementAlarm({
       intervalMinutes,
       delayInMinutes: getAnnouncementAlarmDelayMinutes({
         intervalMinutes,
         siteStates,
+        accounts,
       }),
     })
   }

--- a/src/services/siteAnnouncements/scheduler.ts
+++ b/src/services/siteAnnouncements/scheduler.ts
@@ -191,6 +191,34 @@ async function rescheduleAnnouncementAlarm(params: {
 }
 
 /**
+ * Chooses the next alarm delay from persisted site cooldowns.
+ */
+function getAnnouncementAlarmDelayMinutes(params: {
+  intervalMinutes: number
+  siteStates: SiteAnnouncementSiteState[]
+}): number {
+  const now = Date.now()
+  let nextDelayMinutes = Number.POSITIVE_INFINITY
+
+  for (const siteState of params.siteStates) {
+    const expiresAt = getAnnouncementCooldownExpiresAt({
+      siteState,
+      intervalMinutes: params.intervalMinutes,
+    })
+    if (expiresAt == null) {
+      continue
+    }
+
+    nextDelayMinutes = Math.min(
+      nextDelayMinutes,
+      Math.max(1, Math.ceil((expiresAt - now) / 60_000)),
+    )
+  }
+
+  return Number.isFinite(nextDelayMinutes) ? nextDelayMinutes : 1
+}
+
+/**
  * Removes duplicate common-provider accounts that share one announcement source.
  */
 function dedupeCommonAccounts(accounts: SiteAccount[]): SiteAccount[] {
@@ -265,9 +293,13 @@ class SiteAnnouncementScheduler {
       return
     }
 
+    const siteStates = await siteAnnouncementStorage.getStatus()
     await rescheduleAnnouncementAlarm({
       intervalMinutes,
-      delayInMinutes: intervalMinutes,
+      delayInMinutes: getAnnouncementAlarmDelayMinutes({
+        intervalMinutes,
+        siteStates,
+      }),
     })
   }
 
@@ -480,7 +512,7 @@ class SiteAnnouncementScheduler {
         )
         const delayInMinutes = Math.max(
           1,
-          (nextCooldownExpiresAt - Date.now()) / 60_000,
+          Math.ceil((nextCooldownExpiresAt - Date.now()) / 60_000),
         )
         await rescheduleAnnouncementAlarm({
           intervalMinutes,

--- a/src/services/siteAnnouncements/scheduler.ts
+++ b/src/services/siteAnnouncements/scheduler.ts
@@ -200,11 +200,24 @@ function getAnnouncementAlarmDelayMinutes(params: {
 }): number {
   const now = Date.now()
   let nextDelayMinutes = Number.POSITIVE_INFINITY
+  const accounts = dedupeCommonAccounts(params.accounts)
+  const enabledSiteKeys = new Set(
+    accounts.map((account) => {
+      const provider = getSiteAnnouncementProvider(account.site_type)
+      return provider.createSiteKey({
+        accountId: account.id,
+        siteType: account.site_type,
+        baseUrl: account.site_url,
+      })
+    }),
+  )
   const siteKeysWithStatus = new Set(
-    params.siteStates.map((siteState) => siteState.siteKey),
+    params.siteStates
+      .filter((siteState) => enabledSiteKeys.has(siteState.siteKey))
+      .map((siteState) => siteState.siteKey),
   )
 
-  for (const account of dedupeCommonAccounts(params.accounts)) {
+  for (const account of accounts) {
     const provider = getSiteAnnouncementProvider(account.site_type)
     const siteKey = provider.createSiteKey({
       accountId: account.id,
@@ -217,6 +230,10 @@ function getAnnouncementAlarmDelayMinutes(params: {
   }
 
   for (const siteState of params.siteStates) {
+    if (!enabledSiteKeys.has(siteState.siteKey)) {
+      continue
+    }
+
     const expiresAt = getAnnouncementCooldownExpiresAt({
       siteState,
       intervalMinutes: params.intervalMinutes,
@@ -594,7 +611,11 @@ export const handleSiteAnnouncementMessage = async (
   try {
     switch (request.action) {
       case RuntimeActionIds.SiteAnnouncementsGetStatus: {
-        await siteAnnouncementScheduler.reconcileScheduleFromPreferences()
+        try {
+          await siteAnnouncementScheduler.reconcileScheduleFromPreferences()
+        } catch (error) {
+          logger.warn("Failed to reconcile site announcement schedule", error)
+        }
         sendResponse({
           success: true,
           data: await siteAnnouncementStorage.getStatus(),

--- a/src/services/siteAnnouncements/scheduler.ts
+++ b/src/services/siteAnnouncements/scheduler.ts
@@ -300,24 +300,27 @@ class SiteAnnouncementScheduler {
       return
     }
 
+    const siteStates = await siteAnnouncementStorage.getStatus()
+    const accounts = await accountStorage.getEnabledAccounts()
+    const delayInMinutes = getAnnouncementAlarmDelayMinutes({
+      intervalMinutes,
+      siteStates,
+      accounts,
+    })
     const existingAlarm = await getAlarm(SITE_ANNOUNCEMENTS_ALARM_NAME)
     if (
       existingAlarm &&
       existingAlarm.periodInMinutes != null &&
-      Math.abs(existingAlarm.periodInMinutes - intervalMinutes) < 0.001
+      Math.abs(existingAlarm.periodInMinutes - intervalMinutes) < 0.001 &&
+      existingAlarm.scheduledTime != null &&
+      existingAlarm.scheduledTime <= Date.now() + delayInMinutes * 60_000
     ) {
       return
     }
 
-    const siteStates = await siteAnnouncementStorage.getStatus()
-    const accounts = await accountStorage.getEnabledAccounts()
     await rescheduleAnnouncementAlarm({
       intervalMinutes,
-      delayInMinutes: getAnnouncementAlarmDelayMinutes({
-        intervalMinutes,
-        siteStates,
-        accounts,
-      }),
+      delayInMinutes,
     })
   }
 

--- a/src/services/siteAnnouncements/scheduler.ts
+++ b/src/services/siteAnnouncements/scheduler.ts
@@ -22,6 +22,7 @@ import {
 import {
   clearAlarm,
   createAlarm,
+  getAlarm,
   hasAlarmsAPI,
   onAlarm,
 } from "~/utils/browser/browserApi"
@@ -147,6 +148,25 @@ function createSiteState(params: {
 }
 
 /**
+ * Returns whether a site announcement check is still inside its cooldown window.
+ */
+function isWithinAnnouncementCooldown(params: {
+  siteState: Pick<SiteAnnouncementSiteState, "lastCheckedAt">
+  now: number
+  intervalMinutes: number
+}): boolean {
+  const lastCheckedAt = params.siteState.lastCheckedAt
+  if (typeof lastCheckedAt !== "number") {
+    return false
+  }
+
+  return (
+    params.now - lastCheckedAt <
+    clampIntervalMinutes(params.intervalMinutes) * 60 * 1000
+  )
+}
+
+/**
  * Removes duplicate common-provider accounts that share one announcement source.
  */
 function dedupeCommonAccounts(accounts: SiteAccount[]): SiteAccount[] {
@@ -174,17 +194,6 @@ function dedupeCommonAccounts(accounts: SiteAccount[]): SiteAccount[] {
   }
 
   return result
-}
-
-/**
- * Reads the master polling switch. Manual checks bypass this so users can
- * refresh the announcement page on demand even when automatic polling is off.
- */
-async function isAutomaticPollingEnabled(): Promise<boolean> {
-  const prefs = await userPreferences.getPreferences()
-  return normalizeSiteAnnouncementPreferences(
-    prefs.siteAnnouncementNotifications,
-  ).enabled
 }
 
 class SiteAnnouncementScheduler {
@@ -216,14 +225,26 @@ class SiteAnnouncementScheduler {
       return
     }
 
+    const intervalMinutes = clampIntervalMinutes(config.intervalMinutes)
+
     if (!config.enabled) {
       await clearAlarm(SITE_ANNOUNCEMENTS_ALARM_NAME)
       return
     }
 
+    const existingAlarm = await getAlarm(SITE_ANNOUNCEMENTS_ALARM_NAME)
+    if (
+      existingAlarm &&
+      existingAlarm.periodInMinutes != null &&
+      Math.abs(existingAlarm.periodInMinutes - intervalMinutes) < 0.001
+    ) {
+      return
+    }
+
+    await clearAlarm(SITE_ANNOUNCEMENTS_ALARM_NAME)
     await createAlarm(SITE_ANNOUNCEMENTS_ALARM_NAME, {
-      periodInMinutes: clampIntervalMinutes(config.intervalMinutes),
-      delayInMinutes: 1,
+      periodInMinutes: intervalMinutes,
+      delayInMinutes: intervalMinutes,
     })
   }
 
@@ -232,6 +253,10 @@ class SiteAnnouncementScheduler {
     await this.applySchedule(
       normalizeSiteAnnouncementPreferences(prefs.siteAnnouncementNotifications),
     )
+  }
+
+  async reconcileScheduleFromPreferences(): Promise<void> {
+    await this.applyScheduleFromPreferences()
   }
 
   async updateSettings(
@@ -279,9 +304,27 @@ class SiteAnnouncementScheduler {
     }
 
     try {
-      if (params.trigger === "alarm" && !(await isAutomaticPollingEnabled())) {
+      const automaticPollingPreferences =
+        params.trigger === "alarm"
+          ? normalizeSiteAnnouncementPreferences(
+              (await userPreferences.getPreferences())
+                .siteAnnouncementNotifications,
+            )
+          : undefined
+
+      if (params.trigger === "alarm" && !automaticPollingPreferences?.enabled) {
         return result
       }
+
+      const siteStatesByKey =
+        params.trigger === "alarm"
+          ? new Map(
+              (await siteAnnouncementStorage.getStatus()).map((site) => [
+                site.siteKey,
+                site,
+              ]),
+            )
+          : undefined
 
       const accounts = params.accountIds?.length
         ? await Promise.all(
@@ -302,6 +345,26 @@ class SiteAnnouncementScheduler {
           baseUrl: account.site_url,
         })
         const now = Date.now()
+        const existingSiteState = siteStatesByKey?.get(siteKey)
+
+        if (
+          params.trigger === "alarm" &&
+          automaticPollingPreferences &&
+          existingSiteState &&
+          isWithinAnnouncementCooldown({
+            siteState: existingSiteState,
+            now,
+            intervalMinutes: automaticPollingPreferences.intervalMinutes,
+          })
+        ) {
+          logger.debug("Skipping site announcement check within cooldown", {
+            siteKey,
+            intervalMinutes: automaticPollingPreferences.intervalMinutes,
+            lastCheckedAt: existingSiteState.lastCheckedAt ?? null,
+          })
+          continue
+        }
+
         result.checked += 1
 
         try {
@@ -425,6 +488,7 @@ export const handleSiteAnnouncementMessage = async (
   try {
     switch (request.action) {
       case RuntimeActionIds.SiteAnnouncementsGetStatus: {
+        await siteAnnouncementScheduler.reconcileScheduleFromPreferences()
         sendResponse({
           success: true,
           data: await siteAnnouncementStorage.getStatus(),

--- a/src/services/siteAnnouncements/scheduler.ts
+++ b/src/services/siteAnnouncements/scheduler.ts
@@ -148,6 +148,23 @@ function createSiteState(params: {
 }
 
 /**
+ * Returns the timestamp when a site's cooldown expires, if it has been checked.
+ */
+function getAnnouncementCooldownExpiresAt(params: {
+  siteState: Pick<SiteAnnouncementSiteState, "lastCheckedAt">
+  intervalMinutes: number
+}): number | null {
+  const lastCheckedAt = params.siteState.lastCheckedAt
+  if (typeof lastCheckedAt !== "number") {
+    return null
+  }
+
+  return (
+    lastCheckedAt + clampIntervalMinutes(params.intervalMinutes) * 60 * 1000
+  )
+}
+
+/**
  * Returns whether a site announcement check is still inside its cooldown window.
  */
 function isWithinAnnouncementCooldown(params: {
@@ -155,15 +172,22 @@ function isWithinAnnouncementCooldown(params: {
   now: number
   intervalMinutes: number
 }): boolean {
-  const lastCheckedAt = params.siteState.lastCheckedAt
-  if (typeof lastCheckedAt !== "number") {
-    return false
-  }
+  const expiresAt = getAnnouncementCooldownExpiresAt(params)
+  return expiresAt != null && params.now < expiresAt
+}
 
-  return (
-    params.now - lastCheckedAt <
-    clampIntervalMinutes(params.intervalMinutes) * 60 * 1000
-  )
+/**
+ * Recreates the site announcement alarm with a specific first-run delay.
+ */
+async function rescheduleAnnouncementAlarm(params: {
+  intervalMinutes: number
+  delayInMinutes: number
+}): Promise<void> {
+  await clearAlarm(SITE_ANNOUNCEMENTS_ALARM_NAME)
+  await createAlarm(SITE_ANNOUNCEMENTS_ALARM_NAME, {
+    periodInMinutes: params.intervalMinutes,
+    delayInMinutes: params.delayInMinutes,
+  })
 }
 
 /**
@@ -241,9 +265,8 @@ class SiteAnnouncementScheduler {
       return
     }
 
-    await clearAlarm(SITE_ANNOUNCEMENTS_ALARM_NAME)
-    await createAlarm(SITE_ANNOUNCEMENTS_ALARM_NAME, {
-      periodInMinutes: intervalMinutes,
+    await rescheduleAnnouncementAlarm({
+      intervalMinutes,
       delayInMinutes: intervalMinutes,
     })
   }
@@ -335,6 +358,7 @@ class SiteAnnouncementScheduler {
               .filter((account) => account.disabled !== true),
           )
         : await accountStorage.getEnabledAccounts()
+      let nextCooldownExpiresAt: number | undefined
 
       for (const account of dedupeCommonAccounts(accounts)) {
         const provider = getSiteAnnouncementProvider(account.site_type)
@@ -357,6 +381,17 @@ class SiteAnnouncementScheduler {
             intervalMinutes: automaticPollingPreferences.intervalMinutes,
           })
         ) {
+          const cooldownExpiresAt = getAnnouncementCooldownExpiresAt({
+            siteState: existingSiteState,
+            intervalMinutes: automaticPollingPreferences.intervalMinutes,
+          })
+          if (cooldownExpiresAt != null) {
+            nextCooldownExpiresAt = Math.min(
+              nextCooldownExpiresAt ?? cooldownExpiresAt,
+              cooldownExpiresAt,
+            )
+          }
+
           logger.debug("Skipping site announcement check within cooldown", {
             siteKey,
             intervalMinutes: automaticPollingPreferences.intervalMinutes,
@@ -433,6 +468,24 @@ class SiteAnnouncementScheduler {
             now,
           })
         }
+      }
+
+      if (
+        params.trigger === "alarm" &&
+        automaticPollingPreferences?.enabled &&
+        nextCooldownExpiresAt != null
+      ) {
+        const intervalMinutes = clampIntervalMinutes(
+          automaticPollingPreferences.intervalMinutes,
+        )
+        const delayInMinutes = Math.max(
+          1,
+          (nextCooldownExpiresAt - Date.now()) / 60_000,
+        )
+        await rescheduleAnnouncementAlarm({
+          intervalMinutes,
+          delayInMinutes,
+        })
       }
 
       return result

--- a/tests/services/siteAnnouncements/scheduler.test.ts
+++ b/tests/services/siteAnnouncements/scheduler.test.ts
@@ -300,6 +300,61 @@ describe("siteAnnouncementScheduler", () => {
     nowSpy.mockRestore()
   })
 
+  it("realigns an existing same-period alarm when an enabled site has no status", async () => {
+    const intervalMinutes = 360
+    const now = 1_800_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+    getAlarmMock
+      .mockResolvedValueOnce({
+        name: "siteAnnouncementsCheck",
+        periodInMinutes: intervalMinutes,
+        scheduledTime: now + intervalMinutes * 60 * 1000,
+      })
+      .mockResolvedValueOnce({
+        name: "siteAnnouncementsCheck",
+        periodInMinutes: intervalMinutes,
+        scheduledTime: now + intervalMinutes * 60 * 1000,
+      })
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey: "notice:new-api:https://checked.example.com",
+      siteName: "Checked",
+      siteType: "new-api",
+      baseUrl: "https://checked.example.com",
+      accountId: "checked-account",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: "success",
+      lastCheckedAt: now - 10 * 60 * 1000,
+    })
+    getEnabledAccountsMock.mockResolvedValue([
+      createAccount({
+        id: "checked-account",
+        site_url: "https://checked.example.com",
+      }),
+      createAccount({
+        id: "unchecked-account",
+        site_url: "https://unchecked.example.com",
+      }),
+    ])
+
+    await siteAnnouncementScheduler.initialize()
+    createAlarmMock.mockClear()
+    clearAlarmMock.mockClear()
+
+    const response = vi.fn()
+    await handleSiteAnnouncementMessage(
+      { action: RuntimeActionIds.SiteAnnouncementsGetStatus },
+      response,
+    )
+
+    expect(clearAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck")
+    expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
+      periodInMinutes: intervalMinutes,
+      delayInMinutes: 1,
+    })
+    nowSpy.mockRestore()
+  })
+
   it("keeps announcement alarm cleared when status is queried while polling is disabled", async () => {
     getPreferencesMock.mockResolvedValue({
       siteAnnouncementNotifications: {

--- a/tests/services/siteAnnouncements/scheduler.test.ts
+++ b/tests/services/siteAnnouncements/scheduler.test.ts
@@ -15,6 +15,7 @@ import { SITE_ANNOUNCEMENT_PROVIDER_IDS } from "~/types/siteAnnouncements"
 const {
   clearAlarmMock,
   createAlarmMock,
+  getAlarmMock,
   getEnabledAccountsMock,
   getAccountByIdMock,
   hasAlarmsAPIMock,
@@ -27,6 +28,7 @@ const {
 } = vi.hoisted(() => ({
   clearAlarmMock: vi.fn(),
   createAlarmMock: vi.fn(),
+  getAlarmMock: vi.fn(),
   getEnabledAccountsMock: vi.fn(),
   getAccountByIdMock: vi.fn(),
   hasAlarmsAPIMock: vi.fn(() => true),
@@ -42,6 +44,7 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => ({
   ...(await importOriginal<typeof import("~/utils/browser/browserApi")>()),
   clearAlarm: clearAlarmMock,
   createAlarm: createAlarmMock,
+  getAlarm: getAlarmMock,
   hasAlarmsAPI: hasAlarmsAPIMock,
   onAlarm: onAlarmMock,
 }))
@@ -119,6 +122,7 @@ describe("siteAnnouncementScheduler", () => {
     ;(siteAnnouncementScheduler as any).isInitialized = false
     ;(siteAnnouncementScheduler as any).isRunning = false
     hasAlarmsAPIMock.mockReturnValue(true)
+    getAlarmMock.mockResolvedValue(undefined)
     getPreferencesMock.mockResolvedValue({
       siteAnnouncementNotifications: {
         enabled: true,
@@ -137,7 +141,7 @@ describe("siteAnnouncementScheduler", () => {
     expect(onAlarmMock).toHaveBeenCalled()
     expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
       periodInMinutes: 360,
-      delayInMinutes: 1,
+      delayInMinutes: 360,
     })
   })
 
@@ -154,7 +158,71 @@ describe("siteAnnouncementScheduler", () => {
 
     expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
       periodInMinutes: 360,
-      delayInMinutes: 1,
+      delayInMinutes: 360,
+    })
+  })
+
+  it("preserves an existing announcement alarm when the period already matches", async () => {
+    getAlarmMock.mockResolvedValueOnce({
+      name: "siteAnnouncementsCheck",
+      periodInMinutes: 360,
+      scheduledTime: Date.now() + 60_000,
+    })
+
+    await siteAnnouncementScheduler.initialize()
+
+    expect(clearAlarmMock).not.toHaveBeenCalled()
+    expect(createAlarmMock).not.toHaveBeenCalled()
+  })
+
+  it("recreates a missing announcement alarm when status is queried", async () => {
+    getAlarmMock
+      .mockResolvedValueOnce({
+        name: "siteAnnouncementsCheck",
+        periodInMinutes: 360,
+        scheduledTime: Date.now() + 60_000,
+      })
+      .mockResolvedValueOnce(undefined)
+
+    await siteAnnouncementScheduler.initialize()
+    expect(createAlarmMock).not.toHaveBeenCalled()
+
+    const response = vi.fn()
+    await handleSiteAnnouncementMessage(
+      { action: RuntimeActionIds.SiteAnnouncementsGetStatus },
+      response,
+    )
+
+    expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
+      periodInMinutes: 360,
+      delayInMinutes: 360,
+    })
+    expect(response.mock.calls[0][0]).toMatchObject({
+      success: true,
+      data: [],
+    })
+  })
+
+  it("keeps announcement alarm cleared when status is queried while polling is disabled", async () => {
+    getPreferencesMock.mockResolvedValue({
+      siteAnnouncementNotifications: {
+        enabled: false,
+        notificationEnabled: true,
+        intervalMinutes: 360,
+      },
+    })
+
+    const response = vi.fn()
+    await handleSiteAnnouncementMessage(
+      { action: RuntimeActionIds.SiteAnnouncementsGetStatus },
+      response,
+    )
+
+    expect(clearAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck")
+    expect(createAlarmMock).not.toHaveBeenCalled()
+    expect(response.mock.calls[0][0]).toMatchObject({
+      success: true,
+      data: [],
     })
   })
 
@@ -226,6 +294,34 @@ describe("siteAnnouncementScheduler", () => {
 
     expect(getEnabledAccountsMock).not.toHaveBeenCalled()
     expect(providerFetchMock).not.toHaveBeenCalled()
+  })
+
+  it("skips alarm-triggered checks for sites checked within the configured interval", async () => {
+    const now = 1_800_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey: "notice:new-api:https://example.com",
+      siteName: "Example",
+      siteType: "new-api",
+      baseUrl: "https://example.com",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: "success",
+      lastCheckedAt: now - 10 * 60 * 1000,
+    })
+    getEnabledAccountsMock.mockResolvedValue([createAccount()])
+
+    await siteAnnouncementScheduler.initialize()
+
+    const alarmHandler = onAlarmMock.mock.calls[0]?.[0]
+    expect(alarmHandler).toBeTypeOf("function")
+
+    await alarmHandler?.({ name: "siteAnnouncementsCheck" })
+
+    expect(getEnabledAccountsMock).toHaveBeenCalledTimes(1)
+    expect(providerFetchMock).not.toHaveBeenCalled()
+    nowSpy.mockRestore()
   })
 
   it("filters explicit account ids down to existing enabled accounts", async () => {

--- a/tests/services/siteAnnouncements/scheduler.test.ts
+++ b/tests/services/siteAnnouncements/scheduler.test.ts
@@ -324,6 +324,50 @@ describe("siteAnnouncementScheduler", () => {
     nowSpy.mockRestore()
   })
 
+  it("realigns the alarm to the cooldown boundary when an alarm fires just before a manual check expires", async () => {
+    const intervalMinutes = 360
+    const intervalMs = intervalMinutes * 60 * 1000
+    const lastCheckedAt = 1_800_000_000_000
+    const now = lastCheckedAt + intervalMs - 60_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+    getPreferencesMock.mockResolvedValue({
+      siteAnnouncementNotifications: {
+        enabled: true,
+        notificationEnabled: true,
+        intervalMinutes,
+      },
+    })
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey: "notice:new-api:https://example.com",
+      siteName: "Example",
+      siteType: "new-api",
+      baseUrl: "https://example.com",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: "success",
+      lastCheckedAt,
+    })
+    getEnabledAccountsMock.mockResolvedValue([createAccount()])
+
+    await siteAnnouncementScheduler.initialize()
+
+    const alarmHandler = onAlarmMock.mock.calls[0]?.[0]
+    expect(alarmHandler).toBeTypeOf("function")
+    createAlarmMock.mockClear()
+    clearAlarmMock.mockClear()
+
+    await alarmHandler?.({ name: "siteAnnouncementsCheck" })
+
+    expect(providerFetchMock).not.toHaveBeenCalled()
+    expect(clearAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck")
+    expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
+      periodInMinutes: intervalMinutes,
+      delayInMinutes: 1,
+    })
+    nowSpy.mockRestore()
+  })
+
   it("filters explicit account ids down to existing enabled accounts", async () => {
     providerFetchMock.mockResolvedValue({
       providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,

--- a/tests/services/siteAnnouncements/scheduler.test.ts
+++ b/tests/services/siteAnnouncements/scheduler.test.ts
@@ -141,7 +141,7 @@ describe("siteAnnouncementScheduler", () => {
     expect(onAlarmMock).toHaveBeenCalled()
     expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
       periodInMinutes: 360,
-      delayInMinutes: 360,
+      delayInMinutes: 1,
     })
   })
 
@@ -158,7 +158,7 @@ describe("siteAnnouncementScheduler", () => {
 
     expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
       periodInMinutes: 360,
-      delayInMinutes: 360,
+      delayInMinutes: 1,
     })
   })
 
@@ -195,12 +195,62 @@ describe("siteAnnouncementScheduler", () => {
 
     expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
       periodInMinutes: 360,
-      delayInMinutes: 360,
+      delayInMinutes: 1,
     })
     expect(response.mock.calls[0][0]).toMatchObject({
       success: true,
       data: [],
     })
+  })
+
+  it("recreates a missing announcement alarm with a short delay when stored status is overdue", async () => {
+    const intervalMinutes = 360
+    const intervalMs = intervalMinutes * 60 * 1000
+    const lastCheckedAt = 1_800_000_000_000
+    const now = lastCheckedAt + intervalMs + 5 * 60 * 1000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+    getAlarmMock
+      .mockResolvedValueOnce({
+        name: "siteAnnouncementsCheck",
+        periodInMinutes: intervalMinutes,
+        scheduledTime: now + 60_000,
+      })
+      .mockResolvedValueOnce(undefined)
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey: "notice:new-api:https://example.com",
+      siteName: "Example",
+      siteType: "new-api",
+      baseUrl: "https://example.com",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: "success",
+      lastCheckedAt,
+    })
+
+    await siteAnnouncementScheduler.initialize()
+    createAlarmMock.mockClear()
+    clearAlarmMock.mockClear()
+
+    const response = vi.fn()
+    await handleSiteAnnouncementMessage(
+      { action: RuntimeActionIds.SiteAnnouncementsGetStatus },
+      response,
+    )
+
+    expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
+      periodInMinutes: intervalMinutes,
+      delayInMinutes: 1,
+    })
+    expect(response.mock.calls[0][0]).toMatchObject({
+      success: true,
+      data: [
+        expect.objectContaining({
+          siteKey: "notice:new-api:https://example.com",
+        }),
+      ],
+    })
+    nowSpy.mockRestore()
   })
 
   it("keeps announcement alarm cleared when status is queried while polling is disabled", async () => {

--- a/tests/services/siteAnnouncements/scheduler.test.ts
+++ b/tests/services/siteAnnouncements/scheduler.test.ts
@@ -133,6 +133,7 @@ describe("siteAnnouncementScheduler", () => {
     savePreferencesMock.mockResolvedValue(true)
     notifySiteAnnouncementsMock.mockResolvedValue({ success: true })
     getAccountByIdMock.mockResolvedValue(null)
+    getEnabledAccountsMock.mockResolvedValue([])
   })
 
   it("initializes a six-hour alarm from preferences", async () => {
@@ -253,6 +254,52 @@ describe("siteAnnouncementScheduler", () => {
     nowSpy.mockRestore()
   })
 
+  it("recreates a missing announcement alarm with a short delay when an enabled site has no status", async () => {
+    const intervalMinutes = 360
+    const now = 1_800_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+    getAlarmMock
+      .mockResolvedValueOnce({
+        name: "siteAnnouncementsCheck",
+        periodInMinutes: intervalMinutes,
+        scheduledTime: now + 60_000,
+      })
+      .mockResolvedValueOnce(undefined)
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey: "notice:new-api:https://removed.example.com",
+      siteName: "Removed",
+      siteType: "new-api",
+      baseUrl: "https://removed.example.com",
+      accountId: "removed-account",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: "success",
+      lastCheckedAt: now - 10 * 60 * 1000,
+    })
+    getEnabledAccountsMock.mockResolvedValue([
+      createAccount({
+        id: "unchecked-account",
+        site_url: "https://unchecked.example.com",
+      }),
+    ])
+
+    await siteAnnouncementScheduler.initialize()
+    createAlarmMock.mockClear()
+    clearAlarmMock.mockClear()
+
+    const response = vi.fn()
+    await handleSiteAnnouncementMessage(
+      { action: RuntimeActionIds.SiteAnnouncementsGetStatus },
+      response,
+    )
+
+    expect(createAlarmMock).toHaveBeenCalledWith("siteAnnouncementsCheck", {
+      periodInMinutes: intervalMinutes,
+      delayInMinutes: 1,
+    })
+    nowSpy.mockRestore()
+  })
+
   it("keeps announcement alarm cleared when status is queried while polling is disabled", async () => {
     getPreferencesMock.mockResolvedValue({
       siteAnnouncementNotifications: {
@@ -289,6 +336,7 @@ describe("siteAnnouncementScheduler", () => {
 
     const alarmHandler = onAlarmMock.mock.calls[0]?.[0]
     expect(alarmHandler).toBeTypeOf("function")
+    getEnabledAccountsMock.mockClear()
 
     await alarmHandler?.({ name: "other-alarm" })
 
@@ -339,6 +387,7 @@ describe("siteAnnouncementScheduler", () => {
 
     const alarmHandler = onAlarmMock.mock.calls[0]?.[0]
     expect(alarmHandler).toBeTypeOf("function")
+    getEnabledAccountsMock.mockClear()
 
     await alarmHandler?.({ name: "siteAnnouncementsCheck" })
 
@@ -366,6 +415,7 @@ describe("siteAnnouncementScheduler", () => {
 
     const alarmHandler = onAlarmMock.mock.calls[0]?.[0]
     expect(alarmHandler).toBeTypeOf("function")
+    getEnabledAccountsMock.mockClear()
 
     await alarmHandler?.({ name: "siteAnnouncementsCheck" })
 

--- a/tests/services/siteAnnouncements/scheduler.test.ts
+++ b/tests/services/siteAnnouncements/scheduler.test.ts
@@ -355,6 +355,67 @@ describe("siteAnnouncementScheduler", () => {
     nowSpy.mockRestore()
   })
 
+  it("ignores removed site cooldowns when realigning the next announcement alarm", async () => {
+    const intervalMinutes = 360
+    const now = 1_800_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+    getAlarmMock
+      .mockResolvedValueOnce({
+        name: "siteAnnouncementsCheck",
+        periodInMinutes: intervalMinutes,
+        scheduledTime: now + intervalMinutes * 60 * 1000,
+      })
+      .mockResolvedValueOnce({
+        name: "siteAnnouncementsCheck",
+        periodInMinutes: intervalMinutes,
+        scheduledTime: now + intervalMinutes * 60 * 1000,
+      })
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey: "notice:new-api:https://active.example.com",
+      siteName: "Active",
+      siteType: "new-api",
+      baseUrl: "https://active.example.com",
+      accountId: "active-account",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: "success",
+      lastCheckedAt: now,
+    })
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey: "notice:new-api:https://removed.example.com",
+      siteName: "Removed",
+      siteType: "new-api",
+      baseUrl: "https://removed.example.com",
+      accountId: "removed-account",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: "success",
+      lastCheckedAt: now - intervalMinutes * 60 * 1000,
+    })
+    getEnabledAccountsMock.mockResolvedValue([
+      createAccount({
+        id: "active-account",
+        site_url: "https://active.example.com",
+      }),
+    ])
+
+    await siteAnnouncementScheduler.initialize()
+    createAlarmMock.mockClear()
+    clearAlarmMock.mockClear()
+
+    const response = vi.fn()
+    await handleSiteAnnouncementMessage(
+      { action: RuntimeActionIds.SiteAnnouncementsGetStatus },
+      response,
+    )
+
+    expect(clearAlarmMock).not.toHaveBeenCalled()
+    expect(createAlarmMock).not.toHaveBeenCalled()
+    expect(response.mock.calls[0][0]).toMatchObject({
+      success: true,
+    })
+    nowSpy.mockRestore()
+  })
+
   it("keeps announcement alarm cleared when status is queried while polling is disabled", async () => {
     getPreferencesMock.mockResolvedValue({
       siteAnnouncementNotifications: {
@@ -937,6 +998,34 @@ describe("siteAnnouncementScheduler", () => {
     expect(unknownResponse).toHaveBeenCalledWith({
       success: false,
       error: "Unknown action",
+    })
+  })
+
+  it("returns current status when schedule reconciliation fails", async () => {
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey: "notice:new-api:https://example.com",
+      siteName: "Example",
+      siteType: "new-api",
+      baseUrl: "https://example.com",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: "success",
+    })
+    getPreferencesMock.mockRejectedValueOnce(new Error("prefs failed"))
+
+    const response = vi.fn()
+    await handleSiteAnnouncementMessage(
+      { action: RuntimeActionIds.SiteAnnouncementsGetStatus },
+      response,
+    )
+
+    expect(response.mock.calls[0][0]).toMatchObject({
+      success: true,
+      data: [
+        expect.objectContaining({
+          siteKey: "notice:new-api:https://example.com",
+        }),
+      ],
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic polling now respects configured check intervals across all sites
  * Checks are properly deferred during cooldown periods

* **Improvements**
  * Alarm scheduling dynamically adjusts based on earliest cooldown expiries
  * Reduced unnecessary alarm updates by validating existing schedule before recreating
  * Schedule reconciliation now runs during status queries to ensure alarms align with stored state

* **Tests**
  * Expanded test coverage for alarm reconciliation, cooldown deferral, and schedule/status edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->