### PR TITLE
fix(site-announcements): preserve inline html title text

### DIFF
--- a/src/services/siteAnnouncements/text.ts
+++ b/src/services/siteAnnouncements/text.ts
@@ -9,9 +9,12 @@ const MARKDOWN_HEADING_LINE_PATTERN = /^\s*#{1,6}\s+/
 const HTML_BLOCK_BOUNDARY_PATTERN =
   /<\/?(?:address|article|aside|blockquote|br|center|dd|details|dialog|div|dl|dt|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|li|main|nav|ol|p|pre|section|table|tbody|td|tfoot|th|thead|tr|ul)\b[^>]*>/gi
 const HTML_TAG_PATTERN = /<[^>]+>/g
+const HTML_TAG_DETECTION_PATTERN = /<\/?[a-z][\s\S]*?>/i
+const DANGLING_HTML_TAG_FRAGMENT_PATTERN = /^<\/?[a-z][\w:-]*(?:\s+[^<>]*)?$/i
 const HTML_ENTITY_PATTERN = /&(?:nbsp|amp|lt|gt|quot|#39);/gi
 const WHITESPACE_PATTERN = /\s+/g
 const LINE_BREAK_PATTERN = /\r\n?/g
+const HTML_BLOCK_BOUNDARY_MARKER = "__SITE_ANNOUNCEMENT_BLOCK_BOUNDARY__"
 const TRAILING_TITLE_DELIMITER_PATTERN = /[。！？!?；;：:.]+$/
 const ANNOUNCEMENT_SHORT_TITLE_LENGTH = 80
 const ANNOUNCEMENT_PREVIEW_LENGTH = 120
@@ -74,13 +77,28 @@ function stripAnnouncementFormatting(value: string): string {
 }
 
 /**
+ * Drops standalone broken HTML tag fragments that can leak from upstream titles.
+ */
+function stripAnnouncementTitleFormatting(value: string): string {
+  const plain = stripAnnouncementFormatting(value)
+  return DANGLING_HTML_TAG_FRAGMENT_PATTERN.test(plain) ? "" : plain
+}
+
+/**
  * Splits announcement content into candidate display lines.
  */
 function splitAnnouncementCandidateLines(value: string): string[] {
-  return value
-    .replace(LINE_BREAK_PATTERN, "\n")
-    .replace(HTML_BLOCK_BOUNDARY_PATTERN, "\n")
-    .split("\n")
+  const normalized = value.replace(LINE_BREAK_PATTERN, "\n")
+
+  if (!HTML_TAG_DETECTION_PATTERN.test(normalized)) {
+    return normalized.split("\n")
+  }
+
+  return normalized
+    .replace(HTML_BLOCK_BOUNDARY_PATTERN, HTML_BLOCK_BOUNDARY_MARKER)
+    .replace(HTML_TAG_PATTERN, " ")
+    .replace(/\n+/g, " ")
+    .split(HTML_BLOCK_BOUNDARY_MARKER)
 }
 
 /**
@@ -216,7 +234,7 @@ export function buildAnnouncementDisplayText(
     previewLength?: number
   } = {},
 ): AnnouncementDisplayText {
-  const explicitTitle = stripAnnouncementFormatting(input.title ?? "")
+  const explicitTitle = stripAnnouncementTitleFormatting(input.title ?? "")
   const content = normalizeAnnouncementText(input.content)
   const previewLength = options.previewLength ?? ANNOUNCEMENT_PREVIEW_LENGTH
 

--- a/tests/services/siteAnnouncements/text.test.ts
+++ b/tests/services/siteAnnouncements/text.test.ts
@@ -64,6 +64,65 @@ describe("site announcement text helpers", () => {
     })
   })
 
+  it("ignores dangling html tag fragments when an upstream title is malformed", () => {
+    expect(
+      buildAnnouncementDisplayText({
+        title: "<span",
+        content:
+          '<span style="font-size: 18px; color: red;">维护通知</span><p>今晚 1 点开始维护。</p>',
+      }),
+    ).toEqual({
+      title: "维护通知",
+      body: '<span style="font-size: 18px; color: red;">维护通知</span><p>今晚 1 点开始维护。</p>',
+      preview: "维护通知 今晚 1 点开始维护。",
+    })
+  })
+
+  it("ignores dangling html tag fragments when inline tags span multiple lines", () => {
+    expect(
+      buildAnnouncementDisplayText({
+        content:
+          '<span\n style="font-size: 18px; color: red;">维护通知</span><p>今晚 1 点开始维护。</p>',
+      }),
+    ).toEqual({
+      title: "维护通知",
+      body: '<span\n style="font-size: 18px; color: red;">维护通知</span><p>今晚 1 点开始维护。</p>',
+      preview: "维护通知 今晚 1 点开始维护。",
+    })
+  })
+
+  it("derives the visible badge text from a styled announcement template", () => {
+    expect(
+      buildAnnouncementDisplayText({
+        content: `<p style="text-align:center;margin:0 0 6px">
+    <span
+        style="display:inline-block;padding:5px 16px;border-radius:50px;font-size:12px;font-weight:600;letter-spacing:1px;background:rgba(99,102,241,.25);border:1px solid rgba(139,92,246,.4);color:#6366f1">📢
+        测试站点  公告中心</span>
+</p>
+
+<h1
+    style="text-align:center;font-size:36px;font-weight:800;background:linear-gradient(135deg,#c7d2fe,#a78bfa,#e879f9,#f472b6);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;margin:6px 0 6px;line-height:1.2">
+    测试站点</h1>
+
+<p style="text-align:center;color:#6b7280;font-size:14px;margin:0 0 2px">用于功能测试  仅供接口调试与演示</p>`,
+      }),
+    ).toEqual({
+      title: "📢 测试站点 公告中心",
+      body: `<p style="text-align:center;margin:0 0 6px">
+    <span
+        style="display:inline-block;padding:5px 16px;border-radius:50px;font-size:12px;font-weight:600;letter-spacing:1px;background:rgba(99,102,241,.25);border:1px solid rgba(139,92,246,.4);color:#6366f1">📢
+        测试站点  公告中心</span>
+</p>
+
+<h1
+    style="text-align:center;font-size:36px;font-weight:800;background:linear-gradient(135deg,#c7d2fe,#a78bfa,#e879f9,#f472b6);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;margin:6px 0 6px;line-height:1.2">
+    测试站点</h1>
+
+<p style="text-align:center;color:#6b7280;font-size:14px;margin:0 0 2px">用于功能测试  仅供接口调试与演示</p>`,
+      preview: "📢 测试站点 公告中心 测试站点 用于功能测试 仅供接口调试与演示",
+    })
+  })
+
   it("derives a plain text leading topic without removing it from the body", () => {
     expect(
       buildAnnouncementDisplayText({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved site announcement display by enhancing text normalization to handle malformed HTML fragments, ensuring titles and content render cleanly and reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->