### PR TITLE
feat: Disable site announcement auto polling by default

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -6,6 +6,7 @@ import { cn } from "~/lib/utils"
 interface PageHeaderProps {
   icon: ComponentType<{ className?: string }>
   title: ReactNode
+  titleActions?: ReactNode
   description?: ReactNode
   actions?: ReactNode
   spacing?: "default" | "compact"
@@ -18,6 +19,7 @@ interface PageHeaderProps {
  * @param props Component props bundle.
  * @param props.icon Icon component rendered next to the title.
  * @param props.title Header title node.
+ * @param props.titleActions Optional compact action elements rendered next to the title.
  * @param props.description Optional helper text shown below the title.
  * @param props.actions Optional action elements rendered on the right.
  * @param props.spacing Adjusts vertical spacing (default or compact).
@@ -27,6 +29,7 @@ interface PageHeaderProps {
 export function PageHeader({
   icon: Icon,
   title,
+  titleActions,
   description,
   actions,
   spacing = "default",
@@ -43,9 +46,12 @@ export function PageHeader({
               iconClassName,
             )}
           />
-          <Heading2 className="dark:text-dark-text-primary text-gray-900">
-            {title}
-          </Heading2>
+          <div className="flex min-w-0 items-center gap-2">
+            <Heading2 className="dark:text-dark-text-primary text-gray-900">
+              {title}
+            </Heading2>
+            {titleActions}
+          </div>
         </div>
         {actions && (
           <div className="flex shrink-0 flex-wrap items-center gap-3">

--- a/src/features/SiteAnnouncements/SiteAnnouncements.tsx
+++ b/src/features/SiteAnnouncements/SiteAnnouncements.tsx
@@ -1,12 +1,22 @@
-import { Bell, CheckCheck, Inbox, Megaphone, RefreshCcw } from "lucide-react"
+import {
+  Bell,
+  CheckCheck,
+  Inbox,
+  Megaphone,
+  RefreshCcw,
+  Settings,
+} from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { PageHeader } from "~/components/PageHeader"
-import { Button } from "~/components/ui"
+import Tooltip from "~/components/Tooltip"
+import { Button, IconButton } from "~/components/ui"
 import { EmptyState } from "~/components/ui/EmptyState"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -25,6 +35,7 @@ import type {
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { showResultToast } from "~/utils/core/toastHelpers"
+import { openSettingsTab } from "~/utils/navigation"
 
 import { SiteAnnouncementsFiltersCard } from "./components/SiteAnnouncementsFiltersCard"
 import { SiteAnnouncementsList } from "./components/SiteAnnouncementsList"
@@ -51,6 +62,7 @@ export default function SiteAnnouncementsPage({
   refreshKey,
 }: SiteAnnouncementsPageProps) {
   const { t } = useTranslation("siteAnnouncements")
+  const { siteAnnouncementNotifications } = useUserPreferencesContext()
   const [records, setRecords] = useState<SiteAnnouncementRecord[]>([])
   const [status, setStatus] = useState<SiteAnnouncementSiteState[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -118,6 +130,7 @@ export default function SiteAnnouncementsPage({
   const affectedSiteCount = siteOptions.filter(
     (option) => option.announcementCount > 0,
   ).length
+  const isPollingDisabled = !siteAnnouncementNotifications.enabled
 
   const metrics = useMemo<AnnouncementMetric[]>(
     () => [
@@ -220,6 +233,13 @@ export default function SiteAnnouncementsPage({
     }
   }
 
+  const handleOpenPollingSettings = useCallback(() => {
+    void openSettingsTab("general", {
+      anchor: SETTINGS_ANCHORS.SITE_ANNOUNCEMENT_NOTIFICATIONS_ENABLED,
+      preserveHistory: true,
+    })
+  }, [])
+
   const handleMarkRead = async (recordId: string) => {
     const tracker = startProductAnalyticsAction({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.SiteAnnouncements,
@@ -303,6 +323,19 @@ export default function SiteAnnouncementsPage({
       <PageHeader
         icon={Megaphone}
         title={t("title")}
+        titleActions={
+          <Tooltip content={t("actions.pollingSettings")}>
+            <IconButton
+              type="button"
+              size="sm"
+              variant="outline"
+              aria-label={t("actions.pollingSettings")}
+              onClick={handleOpenPollingSettings}
+            >
+              <Settings className="h-4 w-4" />
+            </IconButton>
+          </Tooltip>
+        }
         description={t("description")}
         className="mb-5"
         actions={
@@ -376,7 +409,15 @@ export default function SiteAnnouncementsPage({
             title={
               records.length === 0 ? t("empty.title") : t("empty.filtered")
             }
-            description={records.length === 0 ? t("empty.description") : null}
+            description={
+              records.length === 0
+                ? t(
+                    isPollingDisabled
+                      ? "empty.descriptionWhenPollingDisabled"
+                      : "empty.description",
+                  )
+                : null
+            }
             action={{
               label: t("actions.checkNow"),
               onClick: () =>

--- a/src/locales/en/siteAnnouncements.json
+++ b/src/locales/en/siteAnnouncements.json
@@ -5,6 +5,7 @@
     "expand": "Expand",
     "markAllRead": "Mark all read",
     "markRead": "Mark read",
+    "pollingSettings": "Polling settings",
     "viewSource": "View site announcement"
   },
   "badges": {
@@ -14,6 +15,7 @@
   "description": "Review announcements fetched in the background, manage unread state, and trigger a manual check.",
   "empty": {
     "description": "New announcements discovered by background checks will appear here.",
+    "descriptionWhenPollingDisabled": "You can check manually now; automatic polling can be managed in settings.",
     "filtered": "No announcements match the current filters",
     "title": "No announcement records"
   },

--- a/src/locales/ja/siteAnnouncements.json
+++ b/src/locales/ja/siteAnnouncements.json
@@ -5,6 +5,7 @@
     "expand": "展開",
     "markAllRead": "すべて既読",
     "markRead": "既読にする",
+    "pollingSettings": "取得設定",
     "viewSource": "サイト公告を表示"
   },
   "badges": {
@@ -14,6 +15,7 @@
   "description": "バックグラウンドで取得したサイト公告を確認し、未読状態を管理して手動確認を実行できます。",
   "empty": {
     "description": "バックグラウンド確認で新しい公告が見つかるとここに表示されます。",
+    "descriptionWhenPollingDisabled": "今すぐ手動確認できます。自動取得は設定で管理できます。",
     "filtered": "現在のフィルターに一致する公告はありません",
     "title": "公告記録はありません"
   },

--- a/src/locales/vi/siteAnnouncements.json
+++ b/src/locales/vi/siteAnnouncements.json
@@ -5,6 +5,7 @@
     "expand": "Mở rộng",
     "markAllRead": "Đánh dấu tất cả đã đọc",
     "markRead": "Đánh dấu đã đọc",
+    "pollingSettings": "Cài đặt lấy tự động",
     "viewSource": "Xem thông báo trang web"
   },
   "badges": {
@@ -14,6 +15,7 @@
   "description": "Xem các bản ghi thông báo trang web được lấy về dưới nền, xử lý trạng thái chưa đọc và kích hoạt kiểm tra thủ công.",
   "empty": {
     "description": "Thông báo mới sẽ được hiển thị ở đây sau khi được kiểm tra dưới nền.",
+    "descriptionWhenPollingDisabled": "Bạn có thể kiểm tra thủ công ngay bây giờ; tự động lấy có thể được quản lý trong cài đặt.",
     "filtered": "Không có thông báo nào với các bộ lọc hiện tại",
     "title": "Chưa có bản ghi thông báo nào"
   },

--- a/src/locales/zh-CN/siteAnnouncements.json
+++ b/src/locales/zh-CN/siteAnnouncements.json
@@ -5,6 +5,7 @@
     "expand": "展开",
     "markAllRead": "全部已读",
     "markRead": "标记已读",
+    "pollingSettings": "抓取设置",
     "viewSource": "查看站点公告"
   },
   "badges": {
@@ -14,6 +15,7 @@
   "description": "查看后台拉取到的网站公告记录，处理未读状态，并手动触发一次检查。",
   "empty": {
     "description": "后台检查到新公告后会显示在这里。",
+    "descriptionWhenPollingDisabled": "你可以立即手动检查；自动抓取可在设置中管理。",
     "filtered": "当前筛选条件下没有公告",
     "title": "暂无公告记录"
   },

--- a/src/locales/zh-TW/siteAnnouncements.json
+++ b/src/locales/zh-TW/siteAnnouncements.json
@@ -5,6 +5,7 @@
     "expand": "展開",
     "markAllRead": "全部已讀",
     "markRead": "標記已讀",
+    "pollingSettings": "抓取設定",
     "viewSource": "查看網站公告"
   },
   "badges": {
@@ -14,6 +15,7 @@
   "description": "查看背景拉取到的網站公告記錄，處理未讀狀態，並手動觸發一次檢查。",
   "empty": {
     "description": "背景檢查到新公告後會顯示在這裡。",
+    "descriptionWhenPollingDisabled": "你可以立即手動檢查；自動抓取可在設定中管理。",
     "filtered": "目前篩選條件下沒有公告",
     "title": "暫無公告記錄"
   },

--- a/src/services/preferences/migrations/preferencesMigration.ts
+++ b/src/services/preferences/migrations/preferencesMigration.ts
@@ -18,6 +18,7 @@ import {
   type BalanceHistoryPreferences,
 } from "~/types/dailyBalanceHistory"
 import { DEFAULT_OCTOPUS_CONFIG } from "~/types/octopusConfig"
+import { normalizeSiteAnnouncementPreferences } from "~/types/siteAnnouncements"
 import {
   DEFAULT_TASK_NOTIFICATION_PREFERENCES,
   normalizeTaskNotificationPreferences,
@@ -36,7 +37,7 @@ import { migrateSortingConfig } from "./sortingConfigMigration"
 const logger = createLogger("PreferencesMigration")
 
 // Current version of the preferences schema
-export const CURRENT_PREFERENCES_VERSION = 23
+export const CURRENT_PREFERENCES_VERSION = 24
 
 /**
  * Migration function type
@@ -504,6 +505,25 @@ const migrations: Record<number, PreferencesMigrationFunction> = {
           ? normalizeTaskNotificationPreferences(stored)
           : DEFAULT_TASK_NOTIFICATION_PREFERENCES,
       preferencesVersion: 23,
+    }
+  },
+
+  // Version 23 -> 24: Disable automatic site-announcement polling by default
+  // and for existing users. Manual checks remain available from the page.
+  24: (prefs: UserPreferences): UserPreferences => {
+    logger.debug(
+      "Migrating preferences from v23 to v24 (disable site announcement polling)",
+    )
+
+    return {
+      ...prefs,
+      siteAnnouncementNotifications: {
+        ...normalizeSiteAnnouncementPreferences(
+          prefs.siteAnnouncementNotifications,
+        ),
+        enabled: false,
+      },
+      preferencesVersion: 24,
     }
   },
 }

--- a/src/types/siteAnnouncements.ts
+++ b/src/types/siteAnnouncements.ts
@@ -34,7 +34,7 @@ export interface SiteAnnouncementPreferences {
 
 export const DEFAULT_SITE_ANNOUNCEMENT_PREFERENCES: SiteAnnouncementPreferences =
   {
-    enabled: true,
+    enabled: false,
     notificationEnabled: true,
     intervalMinutes: 360,
   }

--- a/src/utils/navigation/index.ts
+++ b/src/utils/navigation/index.ts
@@ -337,10 +337,13 @@ const _openFullBookmarkManagerPage = (params?: { search?: string }) => {
  */
 const navigateToBasicSettings = (
   tabId?: string,
-  options?: { preserveHistory?: boolean },
+  options?: { preserveHistory?: boolean; anchor?: string },
 ) => {
   const targetHash = getBasicSettingsHash()
-  const searchParams = tabId ? { tab: tabId } : undefined
+  const searchParams =
+    tabId || options?.anchor
+      ? { tab: tabId, anchor: options?.anchor }
+      : undefined
 
   if (isOnOptionsPage()) {
     if (options?.preserveHistory) {
@@ -444,7 +447,7 @@ const _openPermissionsOnboardingPage = (params?: { reason?: string }) => {
  */
 const _openSettingsTab = (
   tabId: string,
-  options?: { preserveHistory?: boolean },
+  options?: { preserveHistory?: boolean; anchor?: string },
 ) => {
   return navigateToBasicSettings(tabId, options)
 }

--- a/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
+++ b/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import SiteAnnouncementsPage from "~/entrypoints/options/pages/SiteAnnouncements"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -17,6 +18,7 @@ import type {
 } from "~/types/siteAnnouncements"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { showResultToast } from "~/utils/core/toastHelpers"
+import { openSettingsTab } from "~/utils/navigation"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
@@ -40,6 +42,10 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
 
 vi.mock("~/utils/core/toastHelpers", () => ({
   showResultToast: vi.fn(),
+}))
+
+vi.mock("~/utils/navigation", () => ({
+  openSettingsTab: vi.fn(),
 }))
 
 vi.mock("~/services/productAnalytics/actions", () => ({
@@ -238,6 +244,24 @@ describe("SiteAnnouncementsPage", () => {
     )
     await waitFor(() => {
       expect(screen.queryByText("Second line")).not.toBeInTheDocument()
+    })
+  })
+
+  it("shows an icon-only settings shortcut next to the title", async () => {
+    const user = userEvent.setup()
+
+    render(<SiteAnnouncementsPage />)
+
+    await screen.findByText("siteAnnouncements:title")
+    await user.click(
+      screen.getByRole("button", {
+        name: "siteAnnouncements:actions.pollingSettings",
+      }),
+    )
+
+    expect(openSettingsTab).toHaveBeenCalledWith("general", {
+      anchor: SETTINGS_ANCHORS.SITE_ANNOUNCEMENT_NOTIFICATIONS_ENABLED,
+      preserveHistory: true,
     })
   })
 
@@ -742,7 +766,9 @@ describe("SiteAnnouncementsPage", () => {
       await screen.findByText("siteAnnouncements:empty.title"),
     ).toBeInTheDocument()
     expect(
-      screen.getByText("siteAnnouncements:empty.description"),
+      screen.getByText(
+        "siteAnnouncements:empty.descriptionWhenPollingDisabled",
+      ),
     ).toBeInTheDocument()
 
     await user.click(

--- a/tests/services/configMigration/preferences/preferencesMigration.test.ts
+++ b/tests/services/configMigration/preferences/preferencesMigration.test.ts
@@ -24,6 +24,7 @@ import type {
 } from "~/types/channelModelFilters"
 import { DEFAULT_BALANCE_HISTORY_PREFERENCES } from "~/types/dailyBalanceHistory"
 import { DEFAULT_NEW_API_CONFIG } from "~/types/newApiConfig"
+import { DEFAULT_SITE_ANNOUNCEMENT_PREFERENCES } from "~/types/siteAnnouncements"
 import { SortingCriteriaType } from "~/types/sorting"
 import {
   DEFAULT_TASK_NOTIFICATION_PREFERENCES,
@@ -244,6 +245,15 @@ describe("preferencesMigration", () => {
 
       expect(result.preferencesVersion).toBe(CURRENT_PREFERENCES_VERSION)
       expect(result.balanceHistory).toEqual(DEFAULT_BALANCE_HISTORY_PREFERENCES)
+    })
+
+    it("defaults site announcement polling to disabled for new preference snapshots", () => {
+      expect(DEFAULT_PREFERENCES.siteAnnouncementNotifications).toEqual(
+        DEFAULT_SITE_ANNOUNCEMENT_PREFERENCES,
+      )
+      expect(DEFAULT_PREFERENCES.siteAnnouncementNotifications?.enabled).toBe(
+        false,
+      )
     })
 
     it("normalizes invalid balance-history settings during v11->v12 migration", () => {
@@ -1220,6 +1230,26 @@ describe("preferencesMigration", () => {
       expect(result.taskNotifications).toEqual(
         DEFAULT_TASK_NOTIFICATION_PREFERENCES,
       )
+    })
+
+    it("forces site announcement polling off during v23 to v24 migration", () => {
+      const prefs = createV0Preferences({
+        preferencesVersion: 23,
+        siteAnnouncementNotifications: {
+          enabled: true,
+          notificationEnabled: false,
+          intervalMinutes: 120,
+        },
+      })
+
+      const result = migratePreferences(prefs)
+
+      expect(result.preferencesVersion).toBe(CURRENT_PREFERENCES_VERSION)
+      expect(result.siteAnnouncementNotifications).toEqual({
+        enabled: false,
+        notificationEnabled: false,
+        intervalMinutes: 120,
+      })
     })
 
     it("falls back to defaults when stored taskNotifications is a non-object during v18 to v19 migration", () => {

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -715,6 +715,13 @@ describe("navigation utilities", () => {
       `${OPTIONS_PAGE_URL}?tab=permissions#basic`,
       true,
     )
+    await openSettingsTab("general", {
+      anchor: "site-announcement-notifications-enabled",
+    })
+    expect(mockedCreateTab).toHaveBeenCalledWith(
+      `${OPTIONS_PAGE_URL}?tab=general&anchor=site-announcement-notifications-enabled#basic`,
+      true,
+    )
     expect(mockedCreateTab).toHaveBeenCalledWith(
       `${OPTIONS_PAGE_URL}?onboarding=permissions&reason=debug#basic`,
       true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added polling settings button to Site Announcements page header.

* **Changes**
  * Site announcement notifications now default to disabled.
  * Updated messaging when polling is disabled.
  * Enhanced settings navigation with anchor-based deep linking.

* **Documentation**
  * Added polling settings translations in English, Japanese, Vietnamese, and Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->