### PR TITLE
fix(site-announcements): Scope site announcement checks to visible results

### DIFF
--- a/src/features/SiteAnnouncements/SiteAnnouncements.tsx
+++ b/src/features/SiteAnnouncements/SiteAnnouncements.tsx
@@ -113,6 +113,13 @@ export default function SiteAnnouncementsPage({
   )
 
   const selectedStatus = status.find((item) => item.siteKey === siteKey)
+  const manualCheckAccountIds = useMemo(
+    () => [...new Set(filteredRecords.map((record) => record.accountId))],
+    [filteredRecords],
+  )
+  const shouldScopeManualCheck = records.length > 0
+  const canRunManualCheck =
+    !shouldScopeManualCheck || manualCheckAccountIds.length > 0
   const unreadCount = records.filter((record) => !record.read).length
   const notifiedCount = records.filter((record) => record.notifiedAt).length
   const affectedSiteCount = siteOptions.filter(
@@ -155,9 +162,22 @@ export default function SiteAnnouncementsPage({
     })
     setIsChecking(true)
     try {
-      const response = await sendRuntimeMessage({
-        action: RuntimeActionIds.SiteAnnouncementsCheckNow,
-      })
+      if (!canRunManualCheck) {
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
+          insights: { itemCount: 0 },
+        })
+        return
+      }
+
+      const checkRequest = shouldScopeManualCheck
+        ? {
+            action: RuntimeActionIds.SiteAnnouncementsCheckNow,
+            accountIds: manualCheckAccountIds,
+          }
+        : {
+            action: RuntimeActionIds.SiteAnnouncementsCheckNow,
+          }
+      const response = await sendRuntimeMessage(checkRequest)
       const success = response?.success === true
       const checkResult = response?.data as
         | SiteAnnouncementCheckResult
@@ -325,6 +345,7 @@ export default function SiteAnnouncementsPage({
             <Button
               type="button"
               loading={isChecking}
+              disabled={!canRunManualCheck}
               onClick={() =>
                 void handleCheckNow(
                   PRODUCT_ANALYTICS_SURFACE_IDS.OptionsSiteAnnouncementsPage,
@@ -383,6 +404,7 @@ export default function SiteAnnouncementsPage({
                 void handleCheckNow(
                   PRODUCT_ANALYTICS_SURFACE_IDS.OptionsSiteAnnouncementsEmptyState,
                 ),
+              disabled: !canRunManualCheck,
               loading: isChecking,
               leftIcon: <RefreshCcw className="h-4 w-4" />,
             }}

--- a/src/features/SiteAnnouncements/SiteAnnouncements.tsx
+++ b/src/features/SiteAnnouncements/SiteAnnouncements.tsx
@@ -119,7 +119,7 @@ export default function SiteAnnouncementsPage({
   )
   const shouldScopeManualCheck = records.length > 0
   const canRunManualCheck =
-    !shouldScopeManualCheck || manualCheckAccountIds.length > 0
+    !isLoading && (!shouldScopeManualCheck || manualCheckAccountIds.length > 0)
   const unreadCount = records.filter((record) => !record.read).length
   const notifiedCount = records.filter((record) => record.notifiedAt).length
   const affectedSiteCount = siteOptions.filter(
@@ -162,13 +162,6 @@ export default function SiteAnnouncementsPage({
     })
     setIsChecking(true)
     try {
-      if (!canRunManualCheck) {
-        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
-          insights: { itemCount: 0 },
-        })
-        return
-      }
-
       const checkRequest = shouldScopeManualCheck
         ? {
             action: RuntimeActionIds.SiteAnnouncementsCheckNow,

--- a/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
+++ b/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
@@ -464,6 +464,34 @@ describe("SiteAnnouncementsPage", () => {
     })
   })
 
+  it("disables manual checks while announcements are loading", async () => {
+    vi.mocked(sendRuntimeMessage).mockImplementation(
+      (message: any) =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            switch (message.action) {
+              case RuntimeActionIds.SiteAnnouncementsListRecords:
+                resolve({ success: true, data: records })
+                break
+              case RuntimeActionIds.SiteAnnouncementsGetStatus:
+                resolve({ success: true, data: status })
+                break
+              default:
+                resolve({ success: true })
+            }
+          }, 100)
+        }),
+    )
+
+    render(<SiteAnnouncementsPage />)
+
+    expect(
+      await screen.findByRole("button", {
+        name: "siteAnnouncements:actions.checkNow",
+      }),
+    ).toBeDisabled()
+  })
+
   it("shows success feedback and reloads after a manual check", async () => {
     const user = userEvent.setup()
 

--- a/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
+++ b/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
@@ -507,6 +507,148 @@ describe("SiteAnnouncementsPage", () => {
     ).toHaveLength(2)
   })
 
+  it("checks all visible site accounts when no filters are selected", async () => {
+    const user = userEvent.setup()
+
+    render(<SiteAnnouncementsPage />)
+
+    await screen.findByText("siteAnnouncements:title")
+    await user.click(
+      screen.getByRole("button", {
+        name: "siteAnnouncements:actions.checkNow",
+      }),
+    )
+
+    await waitFor(() => {
+      const checkNowMessages = vi
+        .mocked(sendRuntimeMessage)
+        .mock.calls.map((call) => call[0] as { action?: string })
+        .filter(
+          (message) =>
+            message.action === RuntimeActionIds.SiteAnnouncementsCheckNow,
+        )
+
+      expect(checkNowMessages.at(-1)).toEqual({
+        action: RuntimeActionIds.SiteAnnouncementsCheckNow,
+        accountIds: ["account-1", "account-2"],
+      })
+    })
+  })
+
+  it("checks the selected site scope when manually checking filtered announcements", async () => {
+    const user = userEvent.setup()
+
+    render(<SiteAnnouncementsPage />)
+
+    await screen.findByText("siteAnnouncements:title")
+    await user.click(
+      screen.getByRole("combobox", {
+        name: "siteAnnouncements:filters.site",
+      }),
+    )
+    await user.click(screen.getByRole("option", { name: "Alpha API" }))
+    await user.click(
+      screen.getByRole("button", {
+        name: "siteAnnouncements:actions.checkNow",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(sendRuntimeMessage).toHaveBeenCalledWith({
+        action: RuntimeActionIds.SiteAnnouncementsCheckNow,
+        accountIds: ["account-1"],
+      })
+    })
+  })
+
+  it("checks the visible site scope when display filters are selected", async () => {
+    const user = userEvent.setup()
+
+    render(<SiteAnnouncementsPage />)
+
+    await screen.findByText("siteAnnouncements:title")
+    await user.click(screen.getAllByRole("combobox")[1]!)
+    await user.click(screen.getByRole("option", { name: "sub2api" }))
+    await user.click(
+      screen.getByRole("button", {
+        name: "siteAnnouncements:actions.checkNow",
+      }),
+    )
+
+    await waitFor(() => {
+      const checkNowMessages = vi
+        .mocked(sendRuntimeMessage)
+        .mock.calls.map((call) => call[0] as { action?: string })
+        .filter(
+          (message) =>
+            message.action === RuntimeActionIds.SiteAnnouncementsCheckNow,
+        )
+
+      expect(checkNowMessages.at(-1)).toEqual({
+        action: RuntimeActionIds.SiteAnnouncementsCheckNow,
+        accountIds: ["account-2"],
+      })
+    })
+  })
+
+  it("disables manual checks when filters leave no visible announcements", async () => {
+    const user = userEvent.setup()
+
+    vi.mocked(sendRuntimeMessage).mockImplementation(async (message: any) => {
+      switch (message.action) {
+        case RuntimeActionIds.SiteAnnouncementsListRecords:
+          return { success: true, data: records }
+        case RuntimeActionIds.SiteAnnouncementsGetStatus:
+          return {
+            success: true,
+            data: [
+              ...status,
+              {
+                siteKey: "site-3",
+                siteName: "Gamma API",
+                siteType: "new-api",
+                baseUrl: "https://gamma.example.com",
+                accountId: "account-3",
+                providerId: "common",
+                status: "success",
+                records: [],
+              },
+            ],
+          }
+        default:
+          return { success: true }
+      }
+    })
+
+    render(<SiteAnnouncementsPage />)
+
+    await screen.findByText("siteAnnouncements:title")
+    await user.click(
+      screen.getByRole("combobox", {
+        name: "siteAnnouncements:filters.site",
+      }),
+    )
+    await user.click(screen.getByRole("option", { name: "Gamma API" }))
+
+    await waitFor(() => {
+      for (const button of screen.getAllByRole("button", {
+        name: "siteAnnouncements:actions.checkNow",
+      })) {
+        expect(button).toBeDisabled()
+      }
+    })
+
+    expect(
+      vi
+        .mocked(sendRuntimeMessage)
+        .mock.calls.some(
+          (call) =>
+            (call[0] as { action?: string }).action ===
+            RuntimeActionIds.SiteAnnouncementsCheckNow,
+        ),
+    ).toBe(false)
+  })
+
   it("shows failure feedback when the manual check throws", async () => {
     const user = userEvent.setup()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Check now" button now respects current filters and scopes runtime requests to the relevant accounts.
  * "Check now" actions are disabled when filters yield no visible announcements or when announcement/status data are still loading.

* **Tests**
  * Added tests covering scoped "Check now" behavior, disabled state during loading, and regression for empty-filter disabling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->