### PR TITLE
feat(options): add settings shortcuts to standalone page headers

### DIFF
--- a/src/components/OptionsPageSettingsTitleAction.tsx
+++ b/src/components/OptionsPageSettingsTitleAction.tsx
@@ -1,0 +1,47 @@
+import { Settings } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import Tooltip from "~/components/Tooltip"
+import { IconButton } from "~/components/ui"
+import type { ProductAnalyticsScopedActionConfig } from "~/services/productAnalytics/actionConfig"
+import { openSettingsTab } from "~/utils/navigation"
+
+interface OptionsPageSettingsTitleActionProps {
+  tabId: string
+  anchor?: string
+  label?: string
+  analyticsAction?: ProductAnalyticsScopedActionConfig
+}
+
+/**
+ * Compact title-adjacent shortcut for options pages with related Basic Settings.
+ */
+export function OptionsPageSettingsTitleAction({
+  tabId,
+  anchor,
+  label,
+  analyticsAction,
+}: OptionsPageSettingsTitleActionProps) {
+  const { t } = useTranslation("common")
+  const resolvedLabel = label ?? t("labels.settings")
+
+  return (
+    <Tooltip content={resolvedLabel}>
+      <IconButton
+        type="button"
+        size="sm"
+        variant="outline"
+        aria-label={resolvedLabel}
+        analyticsAction={analyticsAction}
+        onClick={() => {
+          void openSettingsTab(tabId, {
+            anchor,
+            preserveHistory: true,
+          })
+        }}
+      >
+        <Settings className="h-4 w-4" />
+      </IconButton>
+    </Tooltip>
+  )
+}

--- a/src/features/AccountManagement/AccountManagement.tsx
+++ b/src/features/AccountManagement/AccountManagement.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState, type MouseEvent } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { OptionsPageSettingsTitleAction } from "~/components/OptionsPageSettingsTitleAction"
 import { PageHeader } from "~/components/PageHeader"
 import { Button } from "~/components/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
@@ -190,6 +191,12 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
       <PageHeader
         icon={UserRound}
         title={t("account:title")}
+        titleActions={
+          <OptionsPageSettingsTitleAction
+            tabId="accountManagement"
+            anchor="account-management"
+          />
+        }
         description={t("account:description")}
         actions={
           <ProductAnalyticsScope

--- a/src/features/AutoCheckin/AutoCheckin.tsx
+++ b/src/features/AutoCheckin/AutoCheckin.tsx
@@ -10,6 +10,7 @@ import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { AutoCheckinPretriggerCompletionDialog } from "~/components/AutoCheckinPretriggerCompletionDialog"
+import { OptionsPageSettingsTitleAction } from "~/components/OptionsPageSettingsTitleAction"
 import { PageHeader } from "~/components/PageHeader"
 import { Button } from "~/components/ui"
 import { Modal } from "~/components/ui/Dialog/Modal"
@@ -985,6 +986,12 @@ export default function AutoCheckin(props: {
       <PageHeader
         icon={CalendarCheck2}
         title={t("execution.title")}
+        titleActions={
+          <OptionsPageSettingsTitleAction
+            tabId="checkinRedeem"
+            anchor="auto-checkin"
+          />
+        }
         description={t("description")}
         spacing="compact"
       />

--- a/src/features/BalanceHistory/BalanceHistory.tsx
+++ b/src/features/BalanceHistory/BalanceHistory.tsx
@@ -11,6 +11,7 @@ import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { EChart } from "~/components/charts/EChart"
+import { OptionsPageSettingsTitleAction } from "~/components/OptionsPageSettingsTitleAction"
 import { PageHeader } from "~/components/PageHeader"
 import {
   Alert,
@@ -941,6 +942,18 @@ export default function BalanceHistory() {
       <PageHeader
         icon={LineChart}
         title={t("title")}
+        titleActions={
+          <OptionsPageSettingsTitleAction
+            tabId="balanceHistory"
+            anchor="balance-history"
+            analyticsAction={{
+              featureId: PRODUCT_ANALYTICS_FEATURE_IDS.BalanceHistory,
+              actionId: PRODUCT_ANALYTICS_ACTION_IDS.OpenBalanceHistorySettings,
+              surfaceId: balanceHistorySurface,
+              entrypoint: optionsEntrypoint,
+            }}
+          />
+        }
         description={t("description")}
         actions={
           <div className="flex flex-wrap items-center gap-2">
@@ -960,21 +973,6 @@ export default function BalanceHistory() {
             >
               {t("actions.prune")}
             </Button>
-            <WorkflowTransitionButton
-              size="sm"
-              variant="outline"
-              onClick={openBalanceHistorySettings}
-              leftIcon={<Settings className="h-4 w-4" />}
-              analyticsAction={{
-                featureId: PRODUCT_ANALYTICS_FEATURE_IDS.BalanceHistory,
-                actionId:
-                  PRODUCT_ANALYTICS_ACTION_IDS.OpenBalanceHistorySettings,
-                surfaceId: balanceHistorySurface,
-                entrypoint: optionsEntrypoint,
-              }}
-            >
-              {t("common:labels.settings")}
-            </WorkflowTransitionButton>
           </div>
         }
       />

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -46,6 +46,7 @@ import { useTranslation } from "react-i18next"
 import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
 import ManagedSiteConfigRequiredState from "~/components/ManagedSiteConfigRequiredState"
 import ManagedSiteTypeSwitcher from "~/components/ManagedSiteTypeSwitcher"
+import { OptionsPageSettingsTitleAction } from "~/components/OptionsPageSettingsTitleAction"
 import { PageHeader } from "~/components/PageHeader"
 import {
   Badge,
@@ -1187,6 +1188,12 @@ export default function ManagedSiteChannels({
       <PageHeader
         icon={Layers}
         title={t("title")}
+        titleActions={
+          <OptionsPageSettingsTitleAction
+            tabId="managedSite"
+            anchor="managed-site-selector"
+          />
+        }
         description={t("description")}
         actions={
           <>

--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next"
 
 import ManagedSiteConfigRequiredState from "~/components/ManagedSiteConfigRequiredState"
 import ManagedSiteTypeSwitcher from "~/components/ManagedSiteTypeSwitcher"
+import { OptionsPageSettingsTitleAction } from "~/components/OptionsPageSettingsTitleAction"
 import { PageHeader } from "~/components/PageHeader"
 import { Button, EmptyState, Input } from "~/components/ui"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
@@ -1224,6 +1225,12 @@ export default function ManagedSiteModelSync({
       <PageHeader
         icon={RefreshCcw}
         title={t("execution.title")}
+        titleActions={
+          <OptionsPageSettingsTitleAction
+            tabId="managedSite"
+            anchor="managed-site-model-sync"
+          />
+        }
         description={t("description")}
         actions={
           <ManagedSiteTypeSwitcher

--- a/src/features/SiteAnnouncements/SiteAnnouncements.tsx
+++ b/src/features/SiteAnnouncements/SiteAnnouncements.tsx
@@ -1,17 +1,10 @@
-import {
-  Bell,
-  CheckCheck,
-  Inbox,
-  Megaphone,
-  RefreshCcw,
-  Settings,
-} from "lucide-react"
+import { Bell, CheckCheck, Inbox, Megaphone, RefreshCcw } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { OptionsPageSettingsTitleAction } from "~/components/OptionsPageSettingsTitleAction"
 import { PageHeader } from "~/components/PageHeader"
-import Tooltip from "~/components/Tooltip"
-import { Button, IconButton } from "~/components/ui"
+import { Button } from "~/components/ui"
 import { EmptyState } from "~/components/ui/EmptyState"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
@@ -35,7 +28,6 @@ import type {
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { showResultToast } from "~/utils/core/toastHelpers"
-import { openSettingsTab } from "~/utils/navigation"
 
 import { SiteAnnouncementsFiltersCard } from "./components/SiteAnnouncementsFiltersCard"
 import { SiteAnnouncementsList } from "./components/SiteAnnouncementsList"
@@ -246,13 +238,6 @@ export default function SiteAnnouncementsPage({
     }
   }
 
-  const handleOpenPollingSettings = useCallback(() => {
-    void openSettingsTab("general", {
-      anchor: SETTINGS_ANCHORS.SITE_ANNOUNCEMENT_NOTIFICATIONS_ENABLED,
-      preserveHistory: true,
-    })
-  }, [])
-
   const handleMarkRead = async (recordId: string) => {
     const tracker = startProductAnalyticsAction({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.SiteAnnouncements,
@@ -337,17 +322,11 @@ export default function SiteAnnouncementsPage({
         icon={Megaphone}
         title={t("title")}
         titleActions={
-          <Tooltip content={t("actions.pollingSettings")}>
-            <IconButton
-              type="button"
-              size="sm"
-              variant="outline"
-              aria-label={t("actions.pollingSettings")}
-              onClick={handleOpenPollingSettings}
-            >
-              <Settings className="h-4 w-4" />
-            </IconButton>
-          </Tooltip>
+          <OptionsPageSettingsTitleAction
+            tabId="general"
+            anchor={SETTINGS_ANCHORS.SITE_ANNOUNCEMENT_NOTIFICATIONS_ENABLED}
+            label={t("actions.pollingSettings")}
+          />
         }
         description={t("description")}
         className="mb-5"

--- a/src/features/UsageAnalytics/UsageAnalytics.tsx
+++ b/src/features/UsageAnalytics/UsageAnalytics.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { EChart } from "~/components/charts/EChart"
+import { OptionsPageSettingsTitleAction } from "~/components/OptionsPageSettingsTitleAction"
 import { PageHeader } from "~/components/PageHeader"
 import { Button, Card, WorkflowTransitionButton } from "~/components/ui"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
@@ -574,6 +575,19 @@ export default function UsageAnalytics() {
       <PageHeader
         icon={BarChart3}
         title={t("title")}
+        titleActions={
+          <OptionsPageSettingsTitleAction
+            tabId="accountUsage"
+            anchor="usage-history-sync"
+            label={t("actions.openAccountUsageSettings")}
+            analyticsAction={{
+              featureId: PRODUCT_ANALYTICS_FEATURE_IDS.UsageAnalytics,
+              actionId: PRODUCT_ANALYTICS_ACTION_IDS.OpenUsageSyncSettings,
+              surfaceId: headerSurface,
+              entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+            }}
+          />
+        }
         description={t("description")}
         actions={
           <ProductAnalyticsScope
@@ -582,17 +596,6 @@ export default function UsageAnalytics() {
             surfaceId={headerSurface}
           >
             <div className="flex flex-wrap items-center gap-2">
-              <WorkflowTransitionButton
-                size="sm"
-                variant="outline"
-                onClick={handleOpenAccountUsageSettings}
-                leftIcon={<Settings className="h-4 w-4" />}
-                analyticsAction={
-                  PRODUCT_ANALYTICS_ACTION_IDS.OpenUsageSyncSettings
-                }
-              >
-                {t("actions.openAccountUsageSettings")}
-              </WorkflowTransitionButton>
               <Button
                 size="sm"
                 variant="secondary"

--- a/src/utils/navigation/index.ts
+++ b/src/utils/navigation/index.ts
@@ -332,6 +332,7 @@ const _openFullBookmarkManagerPage = (params?: { search?: string }) => {
  * Navigates to the basic settings area, optionally focusing a sub-tab.
  * @param tabId Optional tab ID within settings.
  * @param options Optional in-page navigation behavior tweaks.
+ * @param options.anchor Optional element anchor within the selected settings tab.
  * @param options.preserveHistory When true and already inside options.html,
  * push a new history entry so users can return to the originating context.
  */

--- a/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
+++ b/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
@@ -13,6 +13,7 @@ import {
   type ProductAnalyticsActionId,
   type ProductAnalyticsFeatureId,
 } from "~/services/productAnalytics/events"
+import { openSettingsTab } from "~/utils/navigation"
 import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const openAddAccountMock = vi.fn()
@@ -85,6 +86,15 @@ vi.mock("~/services/productAnalytics/actions", () => ({
   trackProductAnalyticsActionStarted: (...args: any[]) =>
     trackProductAnalyticsActionStartedMock(...args),
 }))
+
+vi.mock("~/utils/navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/navigation")>()
+
+  return {
+    ...actual,
+    openSettingsTab: vi.fn(),
+  }
+})
 
 vi.mock("~/features/AccountManagement/components/AccountList", () => ({
   default: () => <div>AccountList</div>,
@@ -190,6 +200,21 @@ const expectAccountHeaderActionSpanStarted = ({
 }
 
 describe("options AccountManagement page", () => {
+  it("opens account management settings from the title shortcut", async () => {
+    render(<AccountManagement />)
+
+    await screen.findByText("AccountList")
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:labels.settings" }),
+    )
+
+    expect(openSettingsTab).toHaveBeenCalledWith("accountManagement", {
+      anchor: "account-management",
+      preserveHistory: true,
+    })
+  })
+
   it("renders accounts view and opens add account dialog", async () => {
     render(<AccountManagement />)
 

--- a/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
+++ b/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
@@ -12,6 +12,7 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { openSettingsTab } from "~/utils/navigation"
 import { render, screen, waitFor, within } from "~~/tests/test-utils/render"
 
 const { toast } = vi.hoisted(() => ({
@@ -84,6 +85,15 @@ vi.mock("~/services/productAnalytics/actions", () => ({
   trackProductAnalyticsActionStarted: trackProductAnalyticsActionStartedMock,
 }))
 
+vi.mock("~/utils/navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/navigation")>()
+
+  return {
+    ...actual,
+    openSettingsTab: vi.fn(),
+  }
+})
+
 afterEach(() => {
   vi.restoreAllMocks()
   vi.clearAllMocks()
@@ -95,6 +105,36 @@ describe("AutoCheckin account actions", () => {
       complete: completeProductAnalyticsActionMock,
     })
     trackProductAnalyticsActionCompletedMock.mockReset()
+  })
+
+  it("opens auto check-in settings from the title shortcut", async () => {
+    const user = userEvent.setup()
+    const browserApi = await import("~/utils/browser/browserApi")
+
+    vi.spyOn(browserApi, "sendRuntimeMessage").mockImplementation(
+      async (message: any) => {
+        if (message.action === RuntimeActionIds.AutoCheckinGetStatus) {
+          return {
+            success: true,
+            data: { perAccount: {} },
+          }
+        }
+
+        return { success: true }
+      },
+    )
+
+    render(<AutoCheckin routeParams={{}} />)
+
+    await screen.findByText("autoCheckin:execution.title")
+    await user.click(
+      screen.getByRole("button", { name: "common:labels.settings" }),
+    )
+
+    expect(openSettingsTab).toHaveBeenCalledWith("checkinRedeem", {
+      anchor: "auto-checkin",
+      preserveHistory: true,
+    })
   })
 
   it("retries a failed account, reloads status, and hides row actions after success", async () => {

--- a/tests/entrypoints/options/BalanceHistory.test.tsx
+++ b/tests/entrypoints/options/BalanceHistory.test.tsx
@@ -25,7 +25,7 @@ import {
 import { tagStorage } from "~/services/tags/tagStorage"
 import { DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION } from "~/types/dailyBalanceHistory"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
-import { pushWithinOptionsPage } from "~/utils/navigation"
+import { openSettingsTab, pushWithinOptionsPage } from "~/utils/navigation"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const getMetricDropdownButtonName = (
@@ -104,6 +104,7 @@ vi.mock("~/utils/navigation", async () => {
   const actual = await vi.importActual<any>("~/utils/navigation")
   return {
     ...actual,
+    openSettingsTab: vi.fn(),
     pushWithinOptionsPage: vi.fn(),
   }
 })
@@ -1054,6 +1055,34 @@ describe("BalanceHistory options page", () => {
     expect(vi.mocked(pushWithinOptionsPage)).toHaveBeenCalledWith("#basic", {
       tab: "balanceHistory",
       anchor: "balance-history",
+    })
+  })
+
+  it("opens Balance History settings from the title shortcut", async () => {
+    vi.mocked(useUserPreferencesContext).mockReturnValue(
+      createMockUserPreferencesContext({ enabled: false }),
+    )
+
+    render(<BalanceHistory />)
+
+    expect(await screen.findByText(DISABLED_HINT_TITLE)).toBeInTheDocument()
+
+    const user = userEvent.setup()
+    await user.click(
+      screen.getByRole("button", {
+        name: "common:labels.settings",
+      }),
+    )
+
+    expect(vi.mocked(openSettingsTab)).toHaveBeenCalledWith("balanceHistory", {
+      anchor: "balance-history",
+      preserveHistory: true,
+    })
+    expect(trackProductAnalyticsActionStartedMock).toHaveBeenCalledWith({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.BalanceHistory,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.OpenBalanceHistorySettings,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsBalanceHistoryPage,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
     })
   })
 

--- a/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
+++ b/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
@@ -489,31 +489,42 @@ describe("SiteAnnouncementsPage", () => {
   })
 
   it("disables manual checks while announcements are loading", async () => {
-    vi.mocked(sendRuntimeMessage).mockImplementation(
-      (message: any) =>
-        new Promise((resolve) => {
-          setTimeout(() => {
-            switch (message.action) {
-              case RuntimeActionIds.SiteAnnouncementsListRecords:
-                resolve({ success: true, data: records })
-                break
-              case RuntimeActionIds.SiteAnnouncementsGetStatus:
-                resolve({ success: true, data: status })
-                break
-              default:
-                resolve({ success: true })
-            }
-          }, 100)
-        }),
-    )
+    let resolveRecords!: (response: {
+      success: true
+      data: typeof records
+    }) => void
+    let resolveStatus!: (response: {
+      success: true
+      data: typeof status
+    }) => void
+    vi.mocked(sendRuntimeMessage).mockImplementation((message: any) => {
+      switch (message.action) {
+        case RuntimeActionIds.SiteAnnouncementsListRecords:
+          return new Promise((resolve) => {
+            resolveRecords = resolve
+          })
+        case RuntimeActionIds.SiteAnnouncementsGetStatus:
+          return new Promise((resolve) => {
+            resolveStatus = resolve
+          })
+        default:
+          return Promise.resolve({ success: true })
+      }
+    })
 
     render(<SiteAnnouncementsPage />)
 
-    expect(
-      await screen.findByRole("button", {
-        name: "siteAnnouncements:actions.checkNow",
-      }),
-    ).toBeDisabled()
+    await screen.findByText("siteAnnouncements:title")
+    const manualCheckButton = await screen.findByRole("button", {
+      name: "siteAnnouncements:actions.checkNow",
+    })
+    expect(manualCheckButton).toBeDisabled()
+
+    resolveRecords({ success: true, data: records })
+    resolveStatus({ success: true, data: status })
+    await waitFor(() => {
+      expect(manualCheckButton).toBeEnabled()
+    })
   })
 
   it("shows success feedback and reloads after a manual check", async () => {

--- a/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
+++ b/tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
@@ -518,7 +518,9 @@ describe("SiteAnnouncementsPage", () => {
     const manualCheckButton = await screen.findByRole("button", {
       name: "siteAnnouncements:actions.checkNow",
     })
-    expect(manualCheckButton).toBeDisabled()
+    await waitFor(() => {
+      expect(manualCheckButton).toBeDisabled()
+    })
 
     resolveRecords({ success: true, data: records })
     resolveStatus({ success: true, data: status })

--- a/tests/entrypoints/options/UsageAnalytics.test.tsx
+++ b/tests/entrypoints/options/UsageAnalytics.test.tsx
@@ -124,12 +124,16 @@ describe("UsageAnalytics (settings moved)", () => {
     })
 
     const user = userEvent.setup()
-    await screen.findByText("usageAnalytics:title")
+    const pageTitle = await screen.findByRole("heading", {
+      name: "usageAnalytics:title",
+    })
+    const titleActionContainer = pageTitle.parentElement
+    expect(titleActionContainer).not.toBeNull()
 
     await user.click(
-      screen.getAllByRole("button", {
+      within(titleActionContainer as HTMLElement).getByRole("button", {
         name: "usageAnalytics:actions.openAccountUsageSettings",
-      })[0]!,
+      }),
     )
 
     expect(vi.mocked(openSettingsTab)).toHaveBeenCalledWith("accountUsage", {

--- a/tests/entrypoints/options/UsageAnalytics.test.tsx
+++ b/tests/entrypoints/options/UsageAnalytics.test.tsx
@@ -1,10 +1,11 @@
+import { within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import UsageAnalytics from "~/entrypoints/options/pages/UsageAnalytics"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { usageHistoryStorage } from "~/services/history/usageHistory/storage"
-import { pushWithinOptionsPage } from "~/utils/navigation"
+import { openSettingsTab, pushWithinOptionsPage } from "~/utils/navigation"
 import { render, screen } from "~~/tests/test-utils/render"
 
 const { useThemeMock, useUserPreferencesContextMock } = vi.hoisted(() => ({
@@ -30,6 +31,7 @@ vi.mock("~/utils/navigation", async () => {
   const actual = await vi.importActual<any>("~/utils/navigation")
   return {
     ...actual,
+    openSettingsTab: vi.fn(),
     pushWithinOptionsPage: vi.fn(),
   }
 })
@@ -93,16 +95,46 @@ describe("UsageAnalytics (settings moved)", () => {
     })
 
     const user = userEvent.setup()
-    await screen.findByText("usageAnalytics:empty.title")
+    const emptyCardTitle = await screen.findByText("usageAnalytics:empty.title")
+    const emptyCardContent = emptyCardTitle.parentElement
+    expect(emptyCardContent).not.toBeNull()
+
+    await user.click(
+      within(emptyCardContent as HTMLElement).getByRole("button", {
+        name: "usageAnalytics:actions.openAccountUsageSettings",
+      }),
+    )
+
+    expect(vi.mocked(pushWithinOptionsPage)).toHaveBeenCalledWith("#basic", {
+      tab: "accountUsage",
+      anchor: "usage-history-sync",
+    })
+  })
+
+  it("opens account usage settings from the title shortcut", async () => {
+    vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([] as any)
+    vi.mocked(usageHistoryStorage.getStore).mockResolvedValue({
+      schemaVersion: 2,
+      accounts: {},
+    } as any)
+
+    render(<UsageAnalytics />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    const user = userEvent.setup()
+    await screen.findByText("usageAnalytics:title")
+
     await user.click(
       screen.getAllByRole("button", {
         name: "usageAnalytics:actions.openAccountUsageSettings",
       })[0]!,
     )
 
-    expect(vi.mocked(pushWithinOptionsPage)).toHaveBeenCalledWith("#basic", {
-      tab: "accountUsage",
+    expect(vi.mocked(openSettingsTab)).toHaveBeenCalledWith("accountUsage", {
       anchor: "usage-history-sync",
+      preserveHistory: true,
     })
   })
 })

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -473,6 +473,23 @@ describe("ManagedSiteChannels", () => {
     })
   })
 
+  it("opens managed-site settings from the title shortcut", async () => {
+    mockChannels([{ id: 1, name: "Alpha", base_url: "https://site-a.example" }])
+
+    render(<ManagedSiteChannels />)
+
+    await waitForRowText("Alpha")
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:labels.settings" }),
+    )
+
+    expect(openSettingsTab).toHaveBeenCalledWith("managedSite", {
+      anchor: "managed-site-selector",
+      preserveHistory: true,
+    })
+  })
+
   it("uses routeParams.channelId to focus a channel and restores the full list when cleared", async () => {
     mockChannels([
       { id: 1, name: "Alpha", base_url: "https://site-a.example" },

--- a/tests/entrypoints/options/pages/UsageAnalytics/UsageAnalyticsNavigation.test.tsx
+++ b/tests/entrypoints/options/pages/UsageAnalytics/UsageAnalyticsNavigation.test.tsx
@@ -11,7 +11,7 @@ import {
   PRODUCT_ANALYTICS_FEATURE_IDS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
-import { pushWithinOptionsPage } from "~/utils/navigation"
+import { openSettingsTab, pushWithinOptionsPage } from "~/utils/navigation"
 import { render, screen } from "~~/tests/test-utils/render"
 
 const { trackProductAnalyticsActionStartedMock } = vi.hoisted(() => ({
@@ -50,6 +50,7 @@ vi.mock("~/utils/navigation", async () => {
     )
   return {
     ...actual,
+    openSettingsTab: vi.fn(),
     pushWithinOptionsPage: vi.fn(),
   }
 })
@@ -83,6 +84,7 @@ describe("UsageAnalytics navigation", () => {
   })
 
   it("navigates to account usage settings from header", async () => {
+    vi.mocked(openSettingsTab).mockClear()
     vi.mocked(pushWithinOptionsPage).mockClear()
     vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([] as any)
     const accountStore = createEmptyUsageHistoryAccountStore()
@@ -105,10 +107,11 @@ describe("UsageAnalytics navigation", () => {
     })
     fireEvent.click(settingsButton)
 
-    expect(pushWithinOptionsPage).toHaveBeenCalledWith("#basic", {
-      tab: "accountUsage",
+    expect(openSettingsTab).toHaveBeenCalledWith("accountUsage", {
       anchor: "usage-history-sync",
+      preserveHistory: true,
     })
+    expect(pushWithinOptionsPage).not.toHaveBeenCalled()
     expectUsageAnalyticsAction(
       PRODUCT_ANALYTICS_ACTION_IDS.OpenUsageSyncSettings,
       PRODUCT_ANALYTICS_SURFACE_IDS.OptionsUsageAnalyticsHeader,
@@ -116,6 +119,7 @@ describe("UsageAnalytics navigation", () => {
   })
 
   it("shows a settings shortcut in the empty reminder", async () => {
+    vi.mocked(openSettingsTab).mockClear()
     vi.mocked(pushWithinOptionsPage).mockClear()
     vi.mocked(accountStorage.getAllAccounts).mockResolvedValue([] as any)
     vi.mocked(usageHistoryStorage.getStore).mockResolvedValue({

--- a/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
+++ b/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
@@ -321,6 +321,25 @@ describe("ManagedSiteModelSync page", () => {
     expect(toast.success).toHaveBeenCalled()
   })
 
+  it("opens managed-site model sync settings from the title shortcut", async () => {
+    render(<ManagedSiteModelSync />)
+
+    expect(
+      await screen.findByText(
+        "managedSiteModelSync:execution.overview.enabled",
+      ),
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "common:labels.settings" }),
+    )
+
+    expect(mockOpenSettingsTab).toHaveBeenCalledWith("managedSite", {
+      anchor: "managed-site-model-sync",
+      preserveHistory: true,
+    })
+  })
+
   it("shows a configuration empty state and skips model-sync loading when managed-site config is missing", async () => {
     mockUseUserPreferencesContext.mockReturnValue({
       preferences: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a compact settings shortcut (icon + tooltip + accessible label) in page headers for Account Management, Auto Check‑in, Balance History, Managed Site Channels, Managed Site Model Sync, Site Announcements, and Usage Analytics — tapping it opens the related settings and preserves navigation history; analytics attached. Previous header CTAs for these settings were consolidated into this title shortcut.

* **Tests**
  * Added/updated tests to verify the title shortcut opens the correct settings screens and triggers analytics.

* **Documentation**
  * Small JSDoc update documenting an optional anchor parameter for settings navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->