### PR TITLE
feat(balance-history): show estimated today income

### DIFF
--- a/docs/superpowers/plans/2026-05-23-estimated-today-income.md
+++ b/docs/superpowers/plans/2026-05-23-estimated-today-income.md
@@ -1,0 +1,1568 @@
+# Estimated Today Income Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in runtime-derived estimated today-income view, shown beside the trusted log/API income in Popup and Balance History without overwriting stored `today_income`.
+
+**Architecture:** Keep account storage and daily balance snapshots as raw observed data. Add a pure daily-balance-history estimate helper that derives trusted and estimated values from current-day and previous-day snapshots, then reuse it from Balance History selectors and Popup account data context. Persist only a default-off `balanceHistory.estimatedTodayIncome.enabled` preference.
+
+**Tech Stack:** TypeScript, React, Vitest, Testing Library, WXT extension storage services, existing i18next locale JSON files.
+
+---
+
+## File Structure
+
+- Modify `src/types/dailyBalanceHistory.ts`
+  - Add `BalanceHistoryEstimatedTodayIncomePreferences`.
+  - Add `estimatedTodayIncome` to `BalanceHistoryPreferences`.
+  - Add estimate status/result types shared by selectors and UI.
+- Modify `src/services/preferences/migrations/preferencesMigration.ts`
+  - Bump `CURRENT_PREFERENCES_VERSION`.
+  - Add a migration that preserves existing balance-history settings and defaults estimated income to disabled.
+  - Update the v11 -> v12 balance-history migration to include the new nested default for fresh migrations from older data.
+- Modify `src/contexts/UserPreferencesContext.tsx`
+  - No API shape change is required beyond the normalized preference snapshot already using `deepOverride`; tests should prove the new nested default is exposed.
+- Create `src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts`
+  - Owns pure per-account estimate calculation in raw quota units.
+  - Owns money conversion helpers for per-account and aggregate estimated income.
+- Modify `src/services/history/dailyBalanceHistory/selectors.ts`
+  - Add `estimatedIncome` to `DailyBalanceHistoryMetric`.
+  - Return estimated-income series and range summary fields when data is available.
+  - Keep trusted `income` behavior unchanged.
+- Modify `src/features/BalanceHistory/BalanceHistory.tsx`
+  - Add localized metric labels for trusted income and estimated income.
+  - Include estimated-income metric options only when the new preference is enabled.
+  - Wire charts, breakdowns, overview KPIs, and table rows to the new selector fields.
+- Modify `src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx`
+  - Add an optional estimated-income column controlled by a prop.
+- Modify `src/features/AccountManagement/hooks/AccountDataContext.tsx`
+  - Load daily balance history store with account data.
+  - Expose Popup-ready estimated today-income totals derived by the shared helper.
+- Modify `src/entrypoints/popup/components/BalanceSection/AccountBalanceSummary.tsx`
+  - When enabled, show trusted today income and estimated today income as separate fields.
+  - When disabled, preserve current layout and labels.
+- Modify `src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx`
+  - Add the default-off estimated-income switch to the existing balance-history card.
+- Modify locale files:
+  - `src/locales/en/balanceHistory.json`
+  - `src/locales/zh-CN/balanceHistory.json`
+  - `src/locales/zh-TW/balanceHistory.json`
+  - `src/locales/ja/balanceHistory.json`
+  - `src/locales/vi/balanceHistory.json`
+  - `src/locales/en/account.json`
+  - `src/locales/zh-CN/account.json`
+  - `src/locales/zh-TW/account.json`
+  - `src/locales/ja/account.json`
+  - `src/locales/vi/account.json`
+- Modify tests:
+  - `tests/services/configMigration/preferences/preferencesMigration.test.ts`
+  - `tests/contexts/UserPreferencesContext.test.tsx`
+  - `tests/services/dailyBalanceHistory/selectors.test.ts`
+  - Create `tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts`
+  - `tests/entrypoints/options/BalanceHistorySettings.test.tsx`
+  - `tests/entrypoints/popup/BalanceSection.test.tsx`
+  - `tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx`
+
+---
+
+### Task 1: Add Preference Model And Migration
+
+**Files:**
+
+- Modify: `src/types/dailyBalanceHistory.ts`
+- Modify: `src/services/preferences/migrations/preferencesMigration.ts`
+- Test: `tests/services/configMigration/preferences/preferencesMigration.test.ts`
+- Test: `tests/contexts/UserPreferencesContext.test.tsx`
+
+- [ ] **Step 1: Add failing migration coverage**
+
+Add tests proving the nested preference defaults to disabled and existing settings are preserved:
+
+```ts
+it("defaults estimated today income to disabled when migrating balance history preferences", () => {
+  const migrated = migratePreferences(
+    createV0Preferences({
+      balanceHistory: {
+        enabled: true,
+        endOfDayCapture: { enabled: true },
+        retentionDays: 45,
+      },
+      preferencesVersion: 24,
+    } as any),
+  )
+
+  expect(migrated.balanceHistory).toMatchObject({
+    enabled: true,
+    endOfDayCapture: { enabled: true },
+    retentionDays: 45,
+    estimatedTodayIncome: { enabled: false },
+  })
+  expect(migrated.preferencesVersion).toBe(CURRENT_PREFERENCES_VERSION)
+})
+```
+
+In `tests/contexts/UserPreferencesContext.test.tsx`, add a normalization test:
+
+```ts
+it("normalizes missing estimated today income preferences to disabled", async () => {
+  const preferences = buildUserPreferences()
+  preferences.balanceHistory = {
+    enabled: true,
+    endOfDayCapture: { enabled: false },
+    retentionDays: 30,
+  } as any
+
+  mockGetPreferences.mockResolvedValue(preferences)
+
+  render(<UserPreferencesProvider><Probe /></UserPreferencesProvider>)
+
+  await waitFor(() => {
+    expect((latestContext as any)?.preferences.balanceHistory).toMatchObject({
+      enabled: true,
+      estimatedTodayIncome: { enabled: false },
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx
+```
+
+Expected: FAIL because `estimatedTodayIncome` and the new migration do not exist.
+
+- [ ] **Step 3: Add the preference types and default**
+
+Update `src/types/dailyBalanceHistory.ts`:
+
+```ts
+export interface BalanceHistoryEstimatedTodayIncomePreferences {
+  enabled: boolean
+}
+
+export interface BalanceHistoryPreferences {
+  enabled: boolean
+  endOfDayCapture: BalanceHistoryEndOfDayCapturePreferences
+  estimatedTodayIncome: BalanceHistoryEstimatedTodayIncomePreferences
+  retentionDays: number
+}
+
+export const DEFAULT_BALANCE_HISTORY_PREFERENCES: BalanceHistoryPreferences = {
+  enabled: false,
+  endOfDayCapture: { enabled: false },
+  estimatedTodayIncome: { enabled: false },
+  retentionDays: 365,
+}
+```
+
+- [ ] **Step 4: Add the migration**
+
+In `src/services/preferences/migrations/preferencesMigration.ts`:
+
+```ts
+export const CURRENT_PREFERENCES_VERSION = 25
+```
+
+Update migration `12` so older migrations create the nested default:
+
+```ts
+balanceHistory: {
+  enabled,
+  endOfDayCapture: { enabled: endOfDayCaptureEnabled },
+  estimatedTodayIncome: {
+    enabled:
+      typeof stored?.estimatedTodayIncome?.enabled === "boolean"
+        ? stored.estimatedTodayIncome.enabled
+        : DEFAULT_BALANCE_HISTORY_PREFERENCES.estimatedTodayIncome.enabled,
+  },
+  retentionDays,
+},
+```
+
+Add migration `25` after migration `24`:
+
+```ts
+25: (prefs: UserPreferences): UserPreferences => {
+  logger.debug(
+    "Migrating preferences from v24 to v25 (estimated today income preference)",
+  )
+
+  const stored = (prefs as any).balanceHistory as
+    | Partial<BalanceHistoryPreferences>
+    | undefined
+
+  return {
+    ...prefs,
+    balanceHistory: {
+      enabled:
+        typeof stored?.enabled === "boolean"
+          ? stored.enabled
+          : DEFAULT_BALANCE_HISTORY_PREFERENCES.enabled,
+      endOfDayCapture: {
+        enabled:
+          typeof stored?.endOfDayCapture?.enabled === "boolean"
+            ? stored.endOfDayCapture.enabled
+            : DEFAULT_BALANCE_HISTORY_PREFERENCES.endOfDayCapture.enabled,
+      },
+      estimatedTodayIncome: {
+        enabled:
+          typeof stored?.estimatedTodayIncome?.enabled === "boolean"
+            ? stored.estimatedTodayIncome.enabled
+            : DEFAULT_BALANCE_HISTORY_PREFERENCES.estimatedTodayIncome.enabled,
+      },
+      retentionDays: clampBalanceHistoryRetentionDays(stored?.retentionDays),
+    },
+    preferencesVersion: 25,
+  }
+},
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/dailyBalanceHistory.ts src/services/preferences/migrations/preferencesMigration.ts tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx
+git commit -m "feat(balance-history): add estimated income preference"
+```
+
+---
+
+### Task 2: Add Pure Today-Income Estimate Helper
+
+**Files:**
+
+- Create: `src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts`
+- Test: `tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Create `tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import {
+  estimateTodayIncomeForAccount,
+  buildEstimatedTodayIncomeMoneyTotals,
+} from "~/services/history/dailyBalanceHistory/todayIncomeEstimate"
+import { DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION } from "~/types/dailyBalanceHistory"
+
+const store = {
+  schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+  snapshotsByAccountId: {
+    account: {
+      "2026-05-22": {
+        quota: 1_000_000,
+        today_income: 0,
+        today_quota_consumption: 0,
+        capturedAt: 1,
+        source: "alarm",
+      },
+      "2026-05-23": {
+        quota: 1_600_000,
+        today_income: 100_000,
+        today_quota_consumption: 200_000,
+        capturedAt: 2,
+        source: "refresh",
+      },
+    },
+  },
+} as const
+
+describe("today income estimate", () => {
+  it("derives estimated income from balance movement and today consumption", () => {
+    expect(
+      estimateTodayIncomeForAccount({
+        enabled: true,
+        store,
+        accountId: "account",
+        currentDayKey: "2026-05-23",
+        hasManualBalance: false,
+      }),
+    ).toEqual({
+      reportedTodayIncome: 100_000,
+      estimatedTodayIncome: 800_000,
+      compensation: 700_000,
+      status: "available",
+    })
+  })
+
+  it.each([
+    ["disabled", { enabled: false }, "disabled"],
+    ["missing current snapshot", { accountId: "missing" }, "missing_current_snapshot"],
+    ["missing baseline", { currentDayKey: "2026-05-22" }, "missing_baseline"],
+    ["manual balance", { hasManualBalance: true }, "manual_balance"],
+  ])("returns %s status", (_label, overrides, status) => {
+    expect(
+      estimateTodayIncomeForAccount({
+        enabled: true,
+        store,
+        accountId: "account",
+        currentDayKey: "2026-05-23",
+        hasManualBalance: false,
+        ...overrides,
+      } as any).status,
+    ).toBe(status)
+  })
+
+  it("returns missing_cashflow when current consumption is null", () => {
+    expect(
+      estimateTodayIncomeForAccount({
+        enabled: true,
+        store: {
+          ...store,
+          snapshotsByAccountId: {
+            account: {
+              ...store.snapshotsByAccountId.account,
+              "2026-05-23": {
+                ...store.snapshotsByAccountId.account["2026-05-23"],
+                today_quota_consumption: null,
+              },
+            },
+          },
+        },
+        accountId: "account",
+        currentDayKey: "2026-05-23",
+        hasManualBalance: false,
+      }).status,
+    ).toBe("missing_cashflow")
+  })
+
+  it("returns invalid_estimate for negative estimates", () => {
+    expect(
+      estimateTodayIncomeForAccount({
+        enabled: true,
+        store: {
+          ...store,
+          snapshotsByAccountId: {
+            account: {
+              ...store.snapshotsByAccountId.account,
+              "2026-05-23": {
+                ...store.snapshotsByAccountId.account["2026-05-23"],
+                quota: 500_000,
+                today_quota_consumption: 0,
+              },
+            },
+          },
+        },
+        accountId: "account",
+        currentDayKey: "2026-05-23",
+        hasManualBalance: false,
+      }).status,
+    ).toBe("invalid_estimate")
+  })
+})
+```
+
+- [ ] **Step 2: Run the failing helper tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts
+```
+
+Expected: FAIL because the helper file does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts`:
+
+```ts
+import { UI_CONSTANTS } from "~/constants/ui"
+import type { CurrencyAmount, CurrencyType, SiteAccount } from "~/types"
+import type {
+  DailyBalanceHistoryStore,
+  TodayIncomeEstimateResult,
+} from "~/types/dailyBalanceHistory"
+
+import { subtractDaysFromDayKey } from "./dayKeys"
+
+type EstimateAccountInput = Pick<SiteAccount, "id" | "manualBalanceUsd" | "exchange_rate">
+
+export function estimateTodayIncomeForAccount(params: {
+  enabled: boolean
+  store: DailyBalanceHistoryStore | null
+  accountId: string
+  currentDayKey: string
+  hasManualBalance: boolean
+}): TodayIncomeEstimateResult {
+  if (!params.enabled) {
+    return {
+      reportedTodayIncome: null,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "disabled",
+    }
+  }
+
+  if (params.hasManualBalance) {
+    return {
+      reportedTodayIncome: null,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "manual_balance",
+    }
+  }
+
+  const current =
+    params.store?.snapshotsByAccountId[params.accountId]?.[params.currentDayKey]
+  if (!current) {
+    return {
+      reportedTodayIncome: null,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "missing_current_snapshot",
+    }
+  }
+
+  const baselineDayKey = subtractDaysFromDayKey(params.currentDayKey, 1)
+  const baseline =
+    params.store?.snapshotsByAccountId[params.accountId]?.[baselineDayKey]
+  if (!baseline) {
+    return {
+      reportedTodayIncome: current.today_income,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "missing_baseline",
+    }
+  }
+
+  if (typeof current.today_quota_consumption !== "number") {
+    return {
+      reportedTodayIncome: current.today_income,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "missing_cashflow",
+    }
+  }
+
+  const estimatedTodayIncome =
+    current.quota - baseline.quota + current.today_quota_consumption
+  const reportedTodayIncome =
+    typeof current.today_income === "number" ? current.today_income : null
+
+  if (!Number.isFinite(estimatedTodayIncome) || estimatedTodayIncome < 0) {
+    return {
+      reportedTodayIncome,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "invalid_estimate",
+    }
+  }
+
+  return {
+    reportedTodayIncome,
+    estimatedTodayIncome,
+    compensation:
+      reportedTodayIncome === null
+        ? null
+        : estimatedTodayIncome - reportedTodayIncome,
+    status: "available",
+  }
+}
+
+export function hasManualBalance(account: Pick<SiteAccount, "manualBalanceUsd">) {
+  return typeof account.manualBalanceUsd === "string" && account.manualBalanceUsd.trim().length > 0
+}
+
+export function convertQuotaToMoney(params: {
+  quota: number
+  currencyType: CurrencyType
+  exchangeRate: number
+}) {
+  const usd = params.quota / UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+  return params.currencyType === "CNY" ? usd * params.exchangeRate : usd
+}
+
+export function buildEstimatedTodayIncomeMoneyTotals(params: {
+  enabled: boolean
+  store: DailyBalanceHistoryStore | null
+  accounts: EstimateAccountInput[]
+  currentDayKey: string
+}): {
+  trusted: CurrencyAmount
+  estimated: CurrencyAmount | null
+  availableAccounts: number
+  totalAccounts: number
+} {
+  let trustedUsd = 0
+  let trustedCny = 0
+  let estimatedUsd = 0
+  let estimatedCny = 0
+  let availableAccounts = 0
+
+  for (const account of params.accounts) {
+    const result = estimateTodayIncomeForAccount({
+      enabled: params.enabled,
+      store: params.store,
+      accountId: account.id,
+      currentDayKey: params.currentDayKey,
+      hasManualBalance: hasManualBalance(account),
+    })
+
+    const trustedQuota = result.reportedTodayIncome ?? 0
+    trustedUsd += convertQuotaToMoney({
+      quota: trustedQuota,
+      currencyType: "USD",
+      exchangeRate: account.exchange_rate,
+    })
+    trustedCny += convertQuotaToMoney({
+      quota: trustedQuota,
+      currencyType: "CNY",
+      exchangeRate: account.exchange_rate,
+    })
+
+    if (result.status !== "available" || result.estimatedTodayIncome === null) {
+      continue
+    }
+
+    availableAccounts += 1
+    estimatedUsd += convertQuotaToMoney({
+      quota: result.estimatedTodayIncome,
+      currencyType: "USD",
+      exchangeRate: account.exchange_rate,
+    })
+    estimatedCny += convertQuotaToMoney({
+      quota: result.estimatedTodayIncome,
+      currencyType: "CNY",
+      exchangeRate: account.exchange_rate,
+    })
+  }
+
+  return {
+    trusted: { USD: trustedUsd, CNY: trustedCny },
+    estimated:
+      availableAccounts > 0 ? { USD: estimatedUsd, CNY: estimatedCny } : null,
+    availableAccounts,
+    totalAccounts: params.accounts.length,
+  }
+}
+```
+
+Also add `TodayIncomeEstimateResult` and status types to `src/types/dailyBalanceHistory.ts`:
+
+```ts
+export type TodayIncomeEstimateStatus =
+  | "available"
+  | "disabled"
+  | "missing_current_snapshot"
+  | "missing_baseline"
+  | "missing_cashflow"
+  | "manual_balance"
+  | "invalid_estimate"
+
+export interface TodayIncomeEstimateResult {
+  reportedTodayIncome: number | null
+  estimatedTodayIncome: number | null
+  compensation: number | null
+  status: TodayIncomeEstimateStatus
+}
+```
+
+- [ ] **Step 4: Run helper tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/dailyBalanceHistory.ts src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts
+git commit -m "feat(balance-history): derive estimated today income"
+```
+
+---
+
+### Task 3: Extend Balance History Selectors
+
+**Files:**
+
+- Modify: `src/services/history/dailyBalanceHistory/selectors.ts`
+- Test: `tests/services/dailyBalanceHistory/selectors.test.ts`
+
+- [ ] **Step 1: Add failing selector tests**
+
+In `tests/services/dailyBalanceHistory/selectors.test.ts`, add cases for `estimatedIncome`:
+
+```ts
+it("builds estimated income per-account series without changing trusted income", () => {
+  const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+  const store = createStore({
+    a1: {
+      "2026-02-06": {
+        quota: 10 * factor,
+        today_income: 0,
+        today_quota_consumption: 0,
+        capturedAt: 0,
+        source: "alarm",
+      },
+      "2026-02-07": {
+        quota: 12 * factor,
+        today_income: 0.5 * factor,
+        today_quota_consumption: 1 * factor,
+        capturedAt: 1,
+        source: "refresh",
+      },
+    },
+  })
+
+  const result = buildPerAccountDailyBalanceMoneySeries({
+    store,
+    accountIds: ["a1"],
+    startDayKey: "2026-02-07",
+    endDayKey: "2026-02-07",
+    currencyType: "USD",
+    estimatedTodayIncomeEnabled: true,
+  })
+
+  expect(result.seriesByAccountId.a1.income).toEqual([0.5])
+  expect(result.seriesByAccountId.a1.estimatedIncome).toEqual([3])
+  expect(result.coverageByDay[0]).toMatchObject({
+    cashflowAccounts: 1,
+    estimatedIncomeAccounts: 1,
+  })
+})
+```
+
+Add a range summary test:
+
+```ts
+it("summarizes estimated income separately from trusted income", () => {
+  const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+  const store = createStore({
+    a1: {
+      "2026-02-06": {
+        quota: 10 * factor,
+        today_income: 0,
+        today_quota_consumption: 0,
+        capturedAt: 0,
+        source: "alarm",
+      },
+      "2026-02-07": {
+        quota: 12 * factor,
+        today_income: 0.5 * factor,
+        today_quota_consumption: 1 * factor,
+        capturedAt: 1,
+        source: "refresh",
+      },
+    },
+  })
+
+  const result = buildAccountRangeSummaries({
+    store,
+    accountIds: ["a1"],
+    startDayKey: "2026-02-07",
+    endDayKey: "2026-02-07",
+    currencyType: "USD",
+    estimatedTodayIncomeEnabled: true,
+  })
+
+  expect(result.summaries[0].incomeTotal).toBe(0.5)
+  expect(result.summaries[0].estimatedIncomeTotal).toBe(3)
+  expect(result.summaries[0].estimatedIncomeDays).toBe(1)
+})
+```
+
+- [ ] **Step 2: Run failing selector tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/dailyBalanceHistory/selectors.test.ts
+```
+
+Expected: FAIL because selector params and output fields do not exist.
+
+- [ ] **Step 3: Extend selector types and implementation**
+
+Update `src/services/history/dailyBalanceHistory/selectors.ts`:
+
+```ts
+export type DailyBalanceHistoryMetric =
+  | "balance"
+  | "income"
+  | "estimatedIncome"
+  | "outcome"
+  | "net"
+
+interface DailyBalanceHistoryCoverage {
+  totalAccounts: number
+  snapshotAccounts: number
+  cashflowAccounts: number
+  estimatedIncomeAccounts: number
+}
+
+interface PerAccountDailyBalanceMoneySeries {
+  balance: Array<number | null>
+  income: Array<number | null>
+  estimatedIncome: Array<number | null>
+  outcome: Array<number | null>
+  net: Array<number | null>
+}
+
+interface AccountRangeSummary {
+  accountId: string
+  startBalance: number | null
+  endBalance: number | null
+  incomeTotal: number | null
+  estimatedIncomeTotal: number | null
+  outcomeTotal: number | null
+  netTotal: number | null
+  snapshotDays: number
+  cashflowDays: number
+  estimatedIncomeDays: number
+  totalDays: number
+}
+```
+
+Add optional selector params:
+
+```ts
+estimatedTodayIncomeEnabled?: boolean
+manualBalanceAccountIds?: Set<string>
+```
+
+When building per-account series, initialize and fill `estimatedIncome`:
+
+```ts
+const estimatedIncome = dayKeys.map(() => null) as Array<number | null>
+
+const estimate = estimateTodayIncomeForAccount({
+  enabled: estimatedTodayIncomeEnabled === true,
+  store,
+  accountId,
+  currentDayKey: dayKey,
+  hasManualBalance: manualBalanceAccountIds?.has(accountId) === true,
+})
+
+if (estimate.status === "available" && estimate.estimatedTodayIncome !== null) {
+  coverageByDay[index].estimatedIncomeAccounts += 1
+  estimatedIncome[index] =
+    (estimate.estimatedTodayIncome / conversionFactor) * exchangeRate
+}
+```
+
+Return each series as `{ balance, income, estimatedIncome, outcome, net }`.
+
+For aggregate series and summaries, keep existing `income` behavior unchanged. Add estimated totals only from available estimate values.
+
+- [ ] **Step 4: Run selector tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/dailyBalanceHistory/selectors.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/history/dailyBalanceHistory/selectors.ts tests/services/dailyBalanceHistory/selectors.test.ts
+git commit -m "feat(balance-history): add estimated income selectors"
+```
+
+---
+
+### Task 4: Add Balance History Settings And Locale Copy
+
+**Files:**
+
+- Modify: `src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx`
+- Modify locale files listed in File Structure.
+- Test: `tests/entrypoints/options/BalanceHistorySettings.test.tsx`
+
+- [ ] **Step 1: Add failing settings test**
+
+In `tests/entrypoints/options/BalanceHistorySettings.test.tsx`, update the first test expected payload:
+
+```ts
+expect(updateBalanceHistory).toHaveBeenCalledWith({
+  enabled: true,
+  endOfDayCapture: { enabled: true },
+  estimatedTodayIncome: { enabled: false },
+  retentionDays: 14,
+})
+```
+
+Add a toggle test:
+
+```ts
+it("saves estimated today income display preference", async () => {
+  const updateBalanceHistory = vi.fn().mockResolvedValue(true)
+  vi.mocked(useUserPreferencesContext).mockReturnValue({
+    preferences: {
+      balanceHistory: {
+        enabled: true,
+        endOfDayCapture: { enabled: false },
+        estimatedTodayIncome: { enabled: false },
+        retentionDays: 30,
+      },
+    },
+    updateBalanceHistory,
+  } as any)
+
+  renderSubject()
+
+  const switches = screen.getAllByRole("switch")
+  fireEvent.click(switches[2])
+  fireEvent.click(await screen.findByText("balanceHistory:actions.applySettings"))
+
+  await waitFor(() => {
+    expect(updateBalanceHistory).toHaveBeenCalledWith({
+      enabled: true,
+      endOfDayCapture: { enabled: false },
+      estimatedTodayIncome: { enabled: true },
+      retentionDays: 30,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run failing settings test**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/options/BalanceHistorySettings.test.tsx
+```
+
+Expected: FAIL because the third switch and payload field do not exist.
+
+- [ ] **Step 3: Implement the setting**
+
+In `BalanceHistorySettings.tsx`, add local state:
+
+```ts
+const [estimatedTodayIncomeEnabled, setEstimatedTodayIncomeEnabled] =
+  useState<boolean>(
+    preferences.balanceHistory?.estimatedTodayIncome?.enabled ?? false,
+  )
+```
+
+Update the existing `useEffect`:
+
+```ts
+setEstimatedTodayIncomeEnabled(
+  preferences.balanceHistory?.estimatedTodayIncome?.enabled ?? false,
+)
+```
+
+Add the setting to `handleApplySettings()` payload:
+
+```ts
+estimatedTodayIncome: { enabled: estimatedTodayIncomeEnabled },
+```
+
+Add a `CardItem`-style row matching the current file's structure:
+
+```tsx
+<div
+  id="balance-history-estimated-today-income"
+  className="flex items-center justify-between gap-3"
+>
+  <div>
+    <Label className="text-sm font-medium">
+      {t("settings.estimatedTodayIncome")}
+    </Label>
+    <div className="dark:text-dark-text-tertiary text-xs text-gray-500">
+      {t("settings.estimatedTodayIncomeHint")}
+    </div>
+  </div>
+  <Switch
+    checked={estimatedTodayIncomeEnabled}
+    onChange={setEstimatedTodayIncomeEnabled}
+  />
+</div>
+```
+
+- [ ] **Step 4: Add locale keys**
+
+Add to `src/locales/en/balanceHistory.json` under `settings`:
+
+```json
+"estimatedTodayIncome": "Show estimated today income",
+"estimatedTodayIncomeHint": "Uses balance history to estimate rewards that do not appear in site income logs. Unavailable when the previous-day baseline is missing."
+```
+
+Add matching keys to the other locale files:
+
+```json
+// src/locales/zh-CN/balanceHistory.json
+"estimatedTodayIncome": "显示估算今日收入",
+"estimatedTodayIncomeHint": "基于余额历史估算未进入站点收入日志的奖励；缺少前一日基准快照时不可用。"
+```
+
+```json
+// src/locales/zh-TW/balanceHistory.json
+"estimatedTodayIncome": "顯示估算今日收入",
+"estimatedTodayIncomeHint": "基於餘額歷史估算未進入站點收入記錄的獎勵；缺少前一日基準快照時不可用。"
+```
+
+```json
+// src/locales/ja/balanceHistory.json
+"estimatedTodayIncome": "推定の本日収入を表示",
+"estimatedTodayIncomeHint": "残高履歴を使って、サイトの収入ログに出ない報酬を推定します。前日の基準スナップショットがない場合は利用できません。"
+```
+
+```json
+// src/locales/vi/balanceHistory.json
+"estimatedTodayIncome": "Hiển thị thu nhập hôm nay ước tính",
+"estimatedTodayIncomeHint": "Dùng lịch sử số dư để ước tính phần thưởng không xuất hiện trong nhật ký thu nhập của trang. Không khả dụng khi thiếu ảnh chụp số dư chuẩn của ngày trước."
+```
+
+Keep key shapes identical across all locales.
+
+- [ ] **Step 5: Run settings test and i18n check**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/options/BalanceHistorySettings.test.tsx
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS and no unexpected locale extraction diff.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx src/locales/en/balanceHistory.json src/locales/zh-CN/balanceHistory.json src/locales/zh-TW/balanceHistory.json src/locales/ja/balanceHistory.json src/locales/vi/balanceHistory.json tests/entrypoints/options/BalanceHistorySettings.test.tsx
+git commit -m "feat(balance-history): add estimated income setting"
+```
+
+---
+
+### Task 5: Wire Estimated Income Into Balance History UI
+
+**Files:**
+
+- Modify: `src/features/BalanceHistory/BalanceHistory.tsx`
+- Modify: `src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx`
+- Modify locale files listed in File Structure for `balanceHistory.json`
+- Test: `tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx`
+
+- [ ] **Step 1: Add failing table test**
+
+In `tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx`, add:
+
+```tsx
+it("renders estimated income column only when enabled", () => {
+  const rows = [
+    buildRow({
+      estimatedIncomeTotal: 3,
+      estimatedIncomeDays: 1,
+    } as any),
+  ]
+
+  const { rerender } = render(
+    <BalanceHistoryAccountSummaryTable
+      rows={rows as any}
+      isLoading={false}
+      currencySymbol="$"
+      showEstimatedIncome={false}
+    />,
+  )
+
+  expect(
+    screen.queryByText("balanceHistory:table.columns.estimatedIncomeTotal"),
+  ).not.toBeInTheDocument()
+
+  rerender(
+    <BalanceHistoryAccountSummaryTable
+      rows={rows as any}
+      isLoading={false}
+      currencySymbol="$"
+      showEstimatedIncome
+    />,
+  )
+
+  expect(
+    screen.getByText("balanceHistory:table.columns.estimatedIncomeTotal"),
+  ).toBeInTheDocument()
+  expect(screen.getByText("$3.00")).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run failing table test**
+
+Run:
+
+```bash
+pnpm vitest --run tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
+```
+
+Expected: FAIL because the prop and columns do not exist.
+
+- [ ] **Step 3: Update table row and prop types**
+
+In `BalanceHistoryAccountSummaryTable.tsx`:
+
+```ts
+export type BalanceHistoryAccountSummaryRow = {
+  id: string
+  label: string
+  startBalance: number | null
+  endBalance: number | null
+  netTotal: number | null
+  incomeTotal: number | null
+  estimatedIncomeTotal: number | null
+  outcomeTotal: number | null
+  snapshotDays: number
+  cashflowDays: number
+  estimatedIncomeDays: number
+  totalDays: number
+}
+
+interface BalanceHistoryAccountSummaryTableProps {
+  rows: BalanceHistoryAccountSummaryRow[]
+  isLoading: boolean
+  currencySymbol: string
+  showEstimatedIncome?: boolean
+}
+```
+
+Add the column after trusted income when `showEstimatedIncome` is true:
+
+```ts
+...(showEstimatedIncome
+  ? [
+      {
+        accessorKey: "estimatedIncomeTotal",
+        header: t("table.columns.estimatedIncomeTotal"),
+        cell: ({ row }: { row: Row<BalanceHistoryAccountSummaryRow> }) => (
+          <div className="text-sm">
+            {formatMoney(row.original.estimatedIncomeTotal)}
+          </div>
+        ),
+        sortingFn: sortNullableNumber,
+      } satisfies ColumnDef<BalanceHistoryAccountSummaryRow, unknown>,
+    ]
+  : []),
+```
+
+- [ ] **Step 4: Wire Balance History page**
+
+In `BalanceHistory.tsx`, compute:
+
+```ts
+const estimatedTodayIncomeEnabled =
+  preferences.balanceHistory?.estimatedTodayIncome?.enabled === true
+const manualBalanceAccountIds = useMemo(
+  () =>
+    new Set(
+      accounts
+        .filter(
+          (account) =>
+            typeof account.manualBalanceUsd === "string" &&
+            account.manualBalanceUsd.trim().length > 0,
+        )
+        .map((account) => account.id),
+    ),
+  [accounts],
+)
+```
+
+Pass to selectors:
+
+```ts
+estimatedTodayIncomeEnabled,
+manualBalanceAccountIds,
+```
+
+Add `estimatedIncome` to `getBalanceHistoryMetricLabel()`:
+
+```ts
+case "estimatedIncome":
+  return t("balanceHistory:metrics.estimatedIncome")
+```
+
+Include metric menu items only when enabled:
+
+```tsx
+{estimatedTodayIncomeEnabled && (
+  <DropdownMenuRadioItem value="estimatedIncome">
+    {t("metrics.estimatedIncome")}
+  </DropdownMenuRadioItem>
+)}
+```
+
+Pass table props:
+
+```tsx
+<BalanceHistoryAccountSummaryTable
+  rows={tableRows}
+  isLoading={isLoading}
+  currencySymbol={currencySymbol}
+  showEstimatedIncome={estimatedTodayIncomeEnabled}
+/>
+```
+
+When building `tableRows`, include:
+
+```ts
+estimatedIncomeTotal: summary.estimatedIncomeTotal,
+estimatedIncomeDays: summary.estimatedIncomeDays,
+```
+
+- [ ] **Step 5: Add Balance History locale keys**
+
+Add to `src/locales/en/balanceHistory.json`:
+
+```json
+"metrics": {
+  "estimatedIncome": "Estimated income"
+},
+"table": {
+  "columns": {
+    "estimatedIncomeTotal": "Estimated income total"
+  }
+}
+```
+
+Add matching keys to the other locale files:
+
+```json
+// src/locales/zh-CN/balanceHistory.json
+"metrics": {
+  "estimatedIncome": "估算收入"
+},
+"table": {
+  "columns": {
+    "estimatedIncomeTotal": "估算收入合计"
+  }
+}
+```
+
+```json
+// src/locales/zh-TW/balanceHistory.json
+"metrics": {
+  "estimatedIncome": "估算收入"
+},
+"table": {
+  "columns": {
+    "estimatedIncomeTotal": "估算收入合計"
+  }
+}
+```
+
+```json
+// src/locales/ja/balanceHistory.json
+"metrics": {
+  "estimatedIncome": "推定収入"
+},
+"table": {
+  "columns": {
+    "estimatedIncomeTotal": "推定収入合計"
+  }
+}
+```
+
+```json
+// src/locales/vi/balanceHistory.json
+"metrics": {
+  "estimatedIncome": "Thu nhập ước tính"
+},
+"table": {
+  "columns": {
+    "estimatedIncomeTotal": "Tổng thu nhập ước tính"
+  }
+}
+```
+
+Preserve all existing keys and localized meaning.
+
+- [ ] **Step 6: Run Balance History tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/dailyBalanceHistory/selectors.test.ts tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS and no unexpected locale extraction diff.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/services/history/dailyBalanceHistory/selectors.ts src/features/BalanceHistory/BalanceHistory.tsx src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx src/locales/en/balanceHistory.json src/locales/zh-CN/balanceHistory.json src/locales/zh-TW/balanceHistory.json src/locales/ja/balanceHistory.json src/locales/vi/balanceHistory.json tests/services/dailyBalanceHistory/selectors.test.ts tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
+git commit -m "feat(balance-history): show estimated income metric"
+```
+
+---
+
+### Task 6: Wire Estimated Income Into Popup
+
+**Files:**
+
+- Modify: `src/features/AccountManagement/hooks/AccountDataContext.tsx`
+- Modify: `src/entrypoints/popup/components/BalanceSection/AccountBalanceSummary.tsx`
+- Modify account locale files listed in File Structure
+- Test: `tests/entrypoints/popup/BalanceSection.test.tsx`
+
+- [ ] **Step 1: Add failing Popup tests**
+
+In `tests/entrypoints/popup/BalanceSection.test.tsx`, extend `createAccountDataContextValue()` with:
+
+```ts
+todayIncomeEstimateTotals: {
+  trusted: { USD: 1.25, CNY: 8.75 },
+  estimated: null,
+  availableAccounts: 0,
+  totalAccounts: 1,
+},
+```
+
+Add tests:
+
+```tsx
+it("keeps one income card when estimated income display is disabled", () => {
+  mockUseUserPreferencesContext.mockReturnValue({
+    currencyType: "USD",
+    showTodayCashflow: true,
+    updateCurrencyType: vi.fn(),
+    preferences: {
+      balanceHistory: {
+        estimatedTodayIncome: { enabled: false },
+      },
+    },
+  })
+
+  render(<AccountBalanceSummary />)
+
+  expect(screen.getByText("account:stats.todayIncome")).toBeInTheDocument()
+  expect(
+    screen.queryByText("account:stats.estimatedTodayIncome"),
+  ).not.toBeInTheDocument()
+})
+
+it("shows trusted and estimated today income when enabled", () => {
+  mockUseUserPreferencesContext.mockReturnValue({
+    currencyType: "USD",
+    showTodayCashflow: true,
+    updateCurrencyType: vi.fn(),
+    preferences: {
+      balanceHistory: {
+        estimatedTodayIncome: { enabled: true },
+      },
+    },
+  })
+  mockUseAccountDataContext.mockReturnValue(
+    createAccountDataContextValue({
+      todayIncomeEstimateTotals: {
+        trusted: { USD: 1.25, CNY: 8.75 },
+        estimated: { USD: 2.75, CNY: 19.25 },
+        availableAccounts: 1,
+        totalAccounts: 1,
+      },
+    }),
+  )
+
+  render(<AccountBalanceSummary />)
+
+  expect(screen.getByText("account:stats.trustedTodayIncome")).toBeInTheDocument()
+  expect(screen.getByText("account:stats.estimatedTodayIncome")).toBeInTheDocument()
+  expect(screen.getAllByTestId("countup").at(-1)).toHaveAttribute("data-end", "2.75")
+})
+```
+
+- [ ] **Step 2: Run failing Popup test**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/popup/BalanceSection.test.tsx
+```
+
+Expected: FAIL because context field and labels do not exist.
+
+- [ ] **Step 3: Extend AccountDataContext**
+
+In `AccountDataContext.tsx`, import:
+
+```ts
+import { dailyBalanceHistoryStorage } from "~/services/history/dailyBalanceHistory/storage"
+import { getDayKeyFromUnixSeconds } from "~/services/history/dailyBalanceHistory/dayKeys"
+import { buildEstimatedTodayIncomeMoneyTotals } from "~/services/history/dailyBalanceHistory/todayIncomeEstimate"
+```
+
+Add to `AccountDataContextType`:
+
+```ts
+todayIncomeEstimateTotals: {
+  trusted: CurrencyAmount
+  estimated: CurrencyAmount | null
+  availableAccounts: number
+  totalAccounts: number
+}
+```
+
+Add state default:
+
+```ts
+const [todayIncomeEstimateTotals, setTodayIncomeEstimateTotals] = useState({
+  trusted: { USD: 0, CNY: 0 },
+  estimated: null,
+  availableAccounts: 0,
+  totalAccounts: 0,
+})
+```
+
+In `loadAccountData()`, include the daily balance store:
+
+```ts
+const [
+  allAccounts,
+  allBookmarks,
+  storedOrderedIds,
+  accountStats,
+  currentTagStore,
+  pinnedIds,
+  balanceHistoryStore,
+] = await Promise.all([
+  accountStorage.getAllAccounts(),
+  accountStorage.getAllBookmarks(),
+  accountStorage.getOrderedList(),
+  accountStorage.getAccountStats(),
+  tagStorage.getTagStore(),
+  accountStorage.getPinnedList(),
+  dailyBalanceHistoryStorage.getStore(),
+])
+```
+
+Compute and set totals:
+
+```ts
+const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
+const enabledAccounts = allAccounts.filter((account) => account.disabled !== true)
+setTodayIncomeEstimateTotals(
+  buildEstimatedTodayIncomeMoneyTotals({
+    enabled:
+      preferences.balanceHistory?.estimatedTodayIncome?.enabled === true,
+    store: balanceHistoryStore,
+    accounts: enabledAccounts,
+    currentDayKey: todayKey,
+  }),
+)
+```
+
+Include `preferences` from `useUserPreferencesContext()` and add it to `loadAccountData` dependencies. Add `todayIncomeEstimateTotals` to the provider value and memo dependencies.
+
+- [ ] **Step 4: Update Popup component**
+
+In `AccountBalanceSummary.tsx`, read:
+
+```ts
+const {
+  accounts,
+  displayData,
+  stats,
+  isInitialLoad,
+  prevTotalConsumption,
+  todayIncomeEstimateTotals,
+} = useAccountDataContext()
+const { currencyType, showTodayCashflow, updateCurrencyType, preferences } =
+  useUserPreferencesContext()
+const estimatedTodayIncomeEnabled =
+  preferences.balanceHistory?.estimatedTodayIncome?.enabled === true
+```
+
+When disabled, keep the current two-column layout. When enabled, use a three-column grid:
+
+```tsx
+<div
+  className={
+    estimatedTodayIncomeEnabled
+      ? "grid grid-cols-1 gap-3 sm:grid-cols-3"
+      : "grid grid-cols-2 gap-3"
+  }
+>
+```
+
+For trusted income label:
+
+```tsx
+{estimatedTodayIncomeEnabled
+  ? t("account:stats.trustedTodayIncome")
+  : t("account:stats.todayIncome")}
+```
+
+Add estimated card only when enabled:
+
+```tsx
+{estimatedTodayIncomeEnabled && (
+  <div className="space-y-1">
+    <Caption className="font-medium">
+      {t("account:stats.estimatedTodayIncome")}
+    </Caption>
+    {todayIncomeEstimateTotals.estimated ? (
+      <BalanceDisplay
+        value={todayIncomeEstimateTotals.estimated[currencyType]}
+        startValue={0}
+        isInitialLoad={isInitialLoad}
+        currencyType={currencyType}
+        onCurrencyToggle={handleCurrencyToggle}
+        prefix={
+          todayIncomeEstimateTotals.estimated[currencyType] > 0 ? "+" : ""
+        }
+        size="md"
+      />
+    ) : (
+      <div className="dark:text-dark-text-tertiary text-2xl font-bold text-gray-500">
+        -
+      </div>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 5: Add account locale keys**
+
+Add to `src/locales/en/account.json` under `stats`:
+
+```json
+"trustedTodayIncome": "Trusted income",
+"estimatedTodayIncome": "Estimated income"
+```
+
+Add matching keys to the other locale files:
+
+```json
+// src/locales/zh-CN/account.json
+"trustedTodayIncome": "可信收入",
+"estimatedTodayIncome": "估算收入"
+```
+
+```json
+// src/locales/zh-TW/account.json
+"trustedTodayIncome": "可信收入",
+"estimatedTodayIncome": "估算收入"
+```
+
+```json
+// src/locales/ja/account.json
+"trustedTodayIncome": "信頼済み収入",
+"estimatedTodayIncome": "推定収入"
+```
+
+```json
+// src/locales/vi/account.json
+"trustedTodayIncome": "Thu nhập tin cậy",
+"estimatedTodayIncome": "Thu nhập ước tính"
+```
+
+Keep key shape identical across locales.
+
+- [ ] **Step 6: Run Popup tests and i18n check**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/popup/BalanceSection.test.tsx
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS and no unexpected locale extraction diff.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/AccountManagement/hooks/AccountDataContext.tsx src/entrypoints/popup/components/BalanceSection/AccountBalanceSummary.tsx src/locales/en/account.json src/locales/zh-CN/account.json src/locales/zh-TW/account.json src/locales/ja/account.json src/locales/vi/account.json tests/entrypoints/popup/BalanceSection.test.tsx
+git commit -m "feat(popup): show estimated today income"
+```
+
+---
+
+### Task 7: Final Validation
+
+**Files:**
+
+- No new implementation files. This task verifies the integrated change.
+
+- [ ] **Step 1: Run focused related tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts tests/services/dailyBalanceHistory/selectors.test.ts tests/entrypoints/options/BalanceHistorySettings.test.tsx tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx tests/entrypoints/popup/BalanceSection.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run TypeScript compile**
+
+Run:
+
+```bash
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run i18n extraction check**
+
+Run:
+
+```bash
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS with no unexpected locale file rewrites.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff --check
+git status --porcelain=v1
+```
+
+Expected:
+
+- `git diff --check` reports no whitespace errors.
+- Only task-scoped files are modified or staged.
+- Pre-existing unrelated untracked files such as `notify.py` and `store-description/` remain untracked and untouched.
+
+- [ ] **Step 5: Stage task files and run staged validation**
+
+Stage only task-scoped files:
+
+```bash
+git add src/types/dailyBalanceHistory.ts src/services/preferences/migrations/preferencesMigration.ts src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts src/services/history/dailyBalanceHistory/selectors.ts src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx src/features/BalanceHistory/BalanceHistory.tsx src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx src/features/AccountManagement/hooks/AccountDataContext.tsx src/entrypoints/popup/components/BalanceSection/AccountBalanceSummary.tsx src/locales/en/balanceHistory.json src/locales/zh-CN/balanceHistory.json src/locales/zh-TW/balanceHistory.json src/locales/ja/balanceHistory.json src/locales/vi/balanceHistory.json src/locales/en/account.json src/locales/zh-CN/account.json src/locales/zh-TW/account.json src/locales/ja/account.json src/locales/vi/account.json tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts tests/services/dailyBalanceHistory/selectors.test.ts tests/entrypoints/options/BalanceHistorySettings.test.tsx tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx tests/entrypoints/popup/BalanceSection.test.tsx
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit remaining integration changes**
+
+If any task-scoped changes remain uncommitted after task commits and validation passes:
+
+```bash
+git commit -m "feat(balance-history): estimate today income from balance snapshots"
+```
+
+Expected: commit succeeds and hooks pass.

--- a/docs/superpowers/plans/2026-05-23-estimated-today-income.md
+++ b/docs/superpowers/plans/2026-05-23-estimated-today-income.md
@@ -130,7 +130,7 @@ it("normalizes missing estimated today income preferences to disabled", async ()
 Run:
 
 ```bash
-pnpm vitest --run tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx
+pnpm vitest related --run tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx
 ```
 
 Expected: FAIL because `estimatedTodayIncome` and the new migration do not exist.
@@ -226,7 +226,7 @@ Add migration `25` after migration `24`:
 Run:
 
 ```bash
-pnpm vitest --run tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx
+pnpm vitest related --run tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx
 ```
 
 Expected: PASS.
@@ -372,7 +372,7 @@ describe("today income estimate", () => {
 Run:
 
 ```bash
-pnpm vitest --run tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts
+pnpm vitest related --run tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts
 ```
 
 Expected: FAIL because the helper file does not exist.
@@ -578,7 +578,7 @@ export interface TodayIncomeEstimateResult {
 Run:
 
 ```bash
-pnpm vitest --run tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts
+pnpm vitest related --run tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts
 ```
 
 Expected: PASS.
@@ -687,7 +687,7 @@ it("summarizes estimated income separately from trusted income", () => {
 Run:
 
 ```bash
-pnpm vitest --run tests/services/dailyBalanceHistory/selectors.test.ts
+pnpm vitest related --run tests/services/dailyBalanceHistory/selectors.test.ts
 ```
 
 Expected: FAIL because selector params and output fields do not exist.
@@ -770,7 +770,7 @@ For aggregate series and summaries, keep existing `income` behavior unchanged. A
 Run:
 
 ```bash
-pnpm vitest --run tests/services/dailyBalanceHistory/selectors.test.ts
+pnpm vitest related --run tests/services/dailyBalanceHistory/selectors.test.ts
 ```
 
 Expected: PASS.
@@ -844,7 +844,7 @@ it("saves estimated today income display preference", async () => {
 Run:
 
 ```bash
-pnpm vitest --run tests/entrypoints/options/BalanceHistorySettings.test.tsx
+pnpm vitest related --run tests/entrypoints/options/BalanceHistorySettings.test.tsx
 ```
 
 Expected: FAIL because the third switch and payload field do not exist.
@@ -938,7 +938,7 @@ Keep key shapes identical across all locales.
 Run:
 
 ```bash
-pnpm vitest --run tests/entrypoints/options/BalanceHistorySettings.test.tsx
+pnpm vitest related --run tests/entrypoints/options/BalanceHistorySettings.test.tsx
 pnpm run i18n:extract:ci
 ```
 
@@ -1009,7 +1009,7 @@ it("renders estimated income column only when enabled", () => {
 Run:
 
 ```bash
-pnpm vitest --run tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
+pnpm vitest related --run tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
 ```
 
 Expected: FAIL because the prop and columns do not exist.
@@ -1197,7 +1197,7 @@ Preserve all existing keys and localized meaning.
 Run:
 
 ```bash
-pnpm vitest --run tests/services/dailyBalanceHistory/selectors.test.ts tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
+pnpm vitest related --run tests/services/dailyBalanceHistory/selectors.test.ts tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
 pnpm run i18n:extract:ci
 ```
 
@@ -1292,7 +1292,7 @@ it("shows trusted and estimated today income when enabled", () => {
 Run:
 
 ```bash
-pnpm vitest --run tests/entrypoints/popup/BalanceSection.test.tsx
+pnpm vitest related --run tests/entrypoints/popup/BalanceSection.test.tsx
 ```
 
 Expected: FAIL because context field and labels do not exist.
@@ -1479,7 +1479,7 @@ Keep key shape identical across locales.
 Run:
 
 ```bash
-pnpm vitest --run tests/entrypoints/popup/BalanceSection.test.tsx
+pnpm vitest related --run tests/entrypoints/popup/BalanceSection.test.tsx
 pnpm run i18n:extract:ci
 ```
 
@@ -1505,7 +1505,7 @@ git commit -m "feat(popup): show estimated today income"
 Run:
 
 ```bash
-pnpm vitest --run tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts tests/services/dailyBalanceHistory/selectors.test.ts tests/entrypoints/options/BalanceHistorySettings.test.tsx tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx tests/entrypoints/popup/BalanceSection.test.tsx
+pnpm vitest related --run tests/services/configMigration/preferences/preferencesMigration.test.ts tests/contexts/UserPreferencesContext.test.tsx tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts tests/services/dailyBalanceHistory/selectors.test.ts tests/entrypoints/options/BalanceHistorySettings.test.tsx tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx tests/entrypoints/popup/BalanceSection.test.tsx
 ```
 
 Expected: PASS.

--- a/docs/superpowers/specs/2026-05-23-estimated-today-income-design.md
+++ b/docs/superpowers/specs/2026-05-23-estimated-today-income-design.md
@@ -1,0 +1,296 @@
+# Estimated Today Income Design
+
+Date: 2026-05-23
+
+## Goal
+
+Add an optional estimated today-income view that can account for balance
+increases not represented in a site's income logs, such as welfare-site rewards,
+farm rewards, wheel rewards, or other backend-side balance writes.
+
+The feature should let users compare two income values:
+
+- Trusted today income: the current log/API-reported `today_income`.
+- Estimated today income: a runtime-derived value based on balance movement and
+  today's consumption.
+
+The estimate is additive display context. It must not overwrite the trusted
+stored account field.
+
+## Background
+
+Issue #366 reports that today's income can miss rewards from external check-in
+and welfare mechanisms even when the total balance updates correctly. The
+reported successful case is redemption-assist balance growth, while manual
+check-in, automatic check-in, and welfare rewards do not consistently appear in
+today income.
+
+Issue #369 proposes calculating income from balance movement:
+
+```text
+today income = current balance - yesterday final balance + today consumption
+```
+
+That formula is useful directionally, but it depends on a reliable previous-day
+baseline. Browser-extension alarms can be missed when the browser is closed,
+the device is off, or the extension service worker is not woken. Because of
+that, this feature must be explicit, opt-in, and visibly separate from the
+trusted log/API income value.
+
+## Current Context
+
+Account refresh currently fetches and stores:
+
+- `account_info.quota`
+- `account_info.today_income`
+- `account_info.today_quota_consumption`
+- token and request counters
+
+When balance history is enabled, `accountStorage.refreshAccount()` also calls
+`maybeCaptureDailyBalanceSnapshot()` to store a daily snapshot:
+
+```ts
+{
+  quota,
+  today_income,
+  today_quota_consumption,
+  capturedAt,
+  source,
+}
+```
+
+`today_income` comes from site logs or API endpoints. It is a trusted reported
+value, but it cannot represent rewards that only mutate backend balance fields
+without producing a compatible income log.
+
+Balance history selectors already derive chart and table series from stored
+snapshots. Popup balance UI reads account display data converted from account
+storage. The new estimate should use one shared helper so Popup and Balance
+History do not compute different income values.
+
+## Selected Approach
+
+Keep storage authoritative for raw observed data, and derive estimated today
+income at runtime.
+
+Persist only:
+
+- Existing account data.
+- Existing balance-history snapshots.
+- A new user preference that controls estimated-income display.
+
+Do not persist:
+
+- `estimated_today_income` inside account storage.
+- `estimated_today_income` inside balance-history snapshots.
+- Rewritten or compensated `account_info.today_income`.
+
+Runtime selectors/helpers should expose both values:
+
+```ts
+interface TodayIncomeEstimateResult {
+  reportedTodayIncome: number | null
+  estimatedTodayIncome: number | null
+  status:
+    | "available"
+    | "disabled"
+    | "missing_current_snapshot"
+    | "missing_baseline"
+    | "missing_cashflow"
+    | "manual_balance"
+    | "invalid_estimate"
+}
+```
+
+## Income Semantics
+
+Trusted today income:
+
+```text
+reportedTodayIncome = current.today_income
+```
+
+Estimated today income:
+
+```text
+estimatedTodayIncome =
+  current.quota - baseline.quota + current.today_quota_consumption
+```
+
+Where:
+
+- `current` is the current-day balance-history snapshot for the account.
+- `baseline` is the previous day's last stored snapshot for the account.
+- `today_quota_consumption` is the current-day trusted consumption value.
+
+The estimate should be available only when all of these are true:
+
+- The preference is enabled.
+- A current-day snapshot exists.
+- A previous-day baseline snapshot exists.
+- Current-day `today_quota_consumption` is a finite number.
+- The account does not use `manualBalanceUsd`.
+- The calculated estimate is finite and non-negative.
+
+If the estimate is unavailable, UI should still show the trusted income value.
+It should not silently substitute zero or a negative estimate.
+
+## Preference
+
+Add a preference under balance-history settings, default disabled:
+
+```ts
+balanceHistory: {
+  estimatedTodayIncome: {
+    enabled: false
+  }
+}
+```
+
+The setting belongs with Balance History because the estimate depends on
+balance-history snapshots and baseline coverage.
+
+The switch label should be conservative, for example "Show estimated today
+income". The description should explain that the estimate is based on balance
+history and may include rewards that do not appear in site logs. It should also
+state that the value is unavailable when the required baseline is missing.
+
+## UI Behavior
+
+When the preference is disabled:
+
+- Popup keeps today's income behavior unchanged.
+- Balance History keeps existing income metrics unchanged.
+- No estimated-income fields are shown.
+
+When the preference is enabled:
+
+- Popup can show two visible fields:
+  - trusted today income
+  - estimated today income
+- Balance History can expose two income metrics:
+  - trusted income
+  - estimated income
+- If an estimate is unavailable for an account/day, the estimated field should
+  display an unavailable state instead of a numeric value.
+
+The UI should not present the estimate as more authoritative than the trusted
+value. Labels should make the distinction clear without adding a third
+always-visible "compensation" field. Compensation remains an internal derived
+delta:
+
+```text
+compensation = estimatedTodayIncome - reportedTodayIncome
+```
+
+That delta can be used for tooltips, tests, or diagnostics, but it is not a
+primary visible metric.
+
+## Data Flow
+
+```text
+account refresh
+  -> store trusted account fields
+  -> capture raw daily balance snapshot
+  -> shared estimated-income helper derives runtime values
+  -> Popup and Balance History consume the same derived output
+```
+
+The helper should live in the daily-balance-history service area because it
+depends on snapshot semantics, day keys, and baseline selection.
+
+Popup should not reimplement snapshot math. If Popup needs the estimate, it
+should call the shared helper or receive a display-ready result from a shared
+selector.
+
+## Baseline Selection
+
+For a current day `D`, use the account's stored snapshot from `D - 1` as the
+baseline. The store currently keeps one snapshot per account/day, and newer
+captures overwrite earlier captures, so that entry represents the last captured
+snapshot for that day.
+
+Do not scan arbitrarily far back for a baseline. Using older days would turn a
+daily estimate into a multi-day balance delta and make the label misleading.
+
+## Error And Edge Cases
+
+Missing baseline:
+
+- Return `missing_baseline`.
+- Do not calculate an estimate.
+
+Missing cashflow:
+
+- When `today_quota_consumption` is `null`, return `missing_cashflow`.
+- This usually means today cashflow fetching was disabled or unavailable.
+
+Manual balance:
+
+- If `manualBalanceUsd` is set, return `manual_balance`.
+- Manual balances are user-supplied overrides and cannot be used as site
+  balance movement evidence.
+
+Negative or non-finite estimate:
+
+- Return `invalid_estimate`.
+- Do not show a negative income estimate.
+
+Disabled preference:
+
+- Return `disabled` and only display trusted income.
+
+Partial account coverage:
+
+- Balance History aggregate estimated-income series should use `null` for days
+  where any selected account lacks a valid estimate, matching the existing
+  snapshot/cashflow coverage behavior.
+- Per-account series may show gaps independently.
+
+## Testing
+
+Add focused Vitest coverage for the shared helper/selector:
+
+- available estimate from current and previous-day snapshots
+- disabled preference
+- missing current snapshot
+- missing baseline
+- missing cashflow
+- manual balance
+- negative estimate
+- non-finite estimate
+
+Update Balance History selector tests to prove trusted and estimated income are
+separate metrics and do not contaminate each other.
+
+Update Popup component tests to prove:
+
+- disabled preference preserves current today-income behavior
+- enabled preference shows trusted and estimated fields
+- unavailable estimates do not render misleading numeric values
+
+Update Balance History settings tests for the new switch and default-disabled
+preference.
+
+No new Playwright E2E is required for the first implementation because the main
+risk is deterministic selector and component behavior. Reconsider E2E only if
+implementation crosses a browser-runtime boundary beyond existing preference
+storage and rendering paths.
+
+## Non-Goals
+
+- Do not change backend API adapters to fetch new income fields.
+- Do not overwrite `account_info.today_income`.
+- Do not persist estimated values in snapshots.
+- Do not infer income from days older than the previous local day.
+- Do not add a default-visible compensation field.
+- Do not enable estimated-income display by default.
+
+## Open Implementation Notes
+
+- Preference migration should preserve existing `balanceHistory` settings and
+  default `estimatedTodayIncome.enabled` to `false`.
+- Labels should use locale keys and keep the estimate wording explicit.
+- The helper should return status codes, not localized messages, so UI layers
+  can decide how much explanation to show.
+- Balance History and Popup should share the same runtime derivation path.

--- a/src/constants/runtimeActions.ts
+++ b/src/constants/runtimeActions.ts
@@ -354,6 +354,10 @@ export const RuntimeActionIds = {
     RuntimeActionPrefixes.BalanceHistory,
     "prune",
   ),
+  BalanceHistoryDebugSeedEstimateSnapshots: composeRuntimeAction(
+    RuntimeActionPrefixes.BalanceHistory,
+    "debugSeedEstimateSnapshots",
+  ),
 
   WebdavAutoSyncSetup: composeRuntimeAction(
     RuntimeActionPrefixes.WebdavAutoSync,

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -495,7 +495,8 @@ export const UserPreferencesProvider = ({
     try {
       setIsLoading(true)
       const prefs = await userPreferences.getPreferences()
-      setPreferences(prefs)
+      const nextPreferences = normalizeContextPreferenceSnapshot(prefs)
+      setPreferences(nextPreferences)
     } catch (error) {
       logger.error("加载用户偏好设置失败", error)
     } finally {

--- a/src/entrypoints/popup/components/BalanceSection/AccountBalanceSummary.tsx
+++ b/src/entrypoints/popup/components/BalanceSection/AccountBalanceSummary.tsx
@@ -33,13 +33,13 @@ const BalanceDisplay: React.FC<{
 }) => {
   const { t } = useTranslation("common")
 
-  const sizeClass = size === "md" ? "text-2xl" : "text-4xl"
+  const sizeClass = size === "md" ? "text-base" : "text-3xl"
 
   return (
-    <div className="flex items-center space-x-1 break-all">
+    <div className="flex min-w-0 items-center space-x-1">
       <button
         onClick={onCurrencyToggle}
-        className={`${sizeClass} dark:text-dark-text-primary p-0 text-left font-bold tracking-tight text-gray-900 transition-colors hover:text-blue-600`}
+        className={`${sizeClass} dark:text-dark-text-primary min-w-0 p-0 text-left leading-tight font-bold tracking-tight break-words text-gray-900 tabular-nums transition-colors hover:text-blue-600`}
         aria-label={t("currency.clickToSwitch", {
           currency:
             currencyType === "USD" ? t("currency.cny") : t("currency.usd"),
@@ -103,7 +103,7 @@ export default function AccountBalanceSummary() {
 
   return (
     <div className="space-y-3">
-      <div className="space-y-1">
+      <div className="dark:bg-dark-bg-secondary/40 space-y-1 rounded-lg bg-gray-50/80 p-3">
         <BodySmall className="font-medium">
           {t("account:stats.totalBalance")}
         </BodySmall>
@@ -121,11 +121,11 @@ export default function AccountBalanceSummary() {
         <div
           className={
             estimatedTodayIncomeEnabled
-              ? "grid grid-cols-1 gap-3 sm:grid-cols-3"
-              : "grid grid-cols-2 gap-3"
+              ? "grid grid-cols-3 gap-2"
+              : "grid grid-cols-2 gap-2"
           }
         >
-          <div className="space-y-1">
+          <div className="dark:bg-dark-bg-secondary/30 min-w-0 space-y-1 rounded-md bg-gray-50/70 p-2">
             <Caption className="font-medium">
               {t("account:stats.todayConsumption")}
             </Caption>
@@ -142,7 +142,7 @@ export default function AccountBalanceSummary() {
             />
           </div>
 
-          <div className="space-y-1">
+          <div className="dark:bg-dark-bg-secondary/30 min-w-0 space-y-1 rounded-md bg-gray-50/70 p-2">
             <Caption className="font-medium">
               {estimatedTodayIncomeEnabled
                 ? t("account:stats.trustedTodayIncome")
@@ -160,7 +160,7 @@ export default function AccountBalanceSummary() {
           </div>
 
           {estimatedTodayIncomeEnabled && (
-            <div className="space-y-1">
+            <div className="dark:bg-dark-bg-secondary/30 min-w-0 space-y-1 rounded-md bg-gray-50/70 p-2">
               <Caption className="font-medium">
                 {t("account:stats.estimatedTodayIncome")}
               </Caption>
@@ -179,7 +179,7 @@ export default function AccountBalanceSummary() {
                   size="md"
                 />
               ) : (
-                <div className="dark:text-dark-text-tertiary text-2xl font-bold text-gray-500">
+                <div className="dark:text-dark-text-tertiary text-base font-bold text-gray-500">
                   -
                 </div>
               )}

--- a/src/entrypoints/popup/components/BalanceSection/AccountBalanceSummary.tsx
+++ b/src/entrypoints/popup/components/BalanceSection/AccountBalanceSummary.tsx
@@ -69,10 +69,18 @@ const BalanceDisplay: React.FC<{
  */
 export default function AccountBalanceSummary() {
   const { t } = useTranslation(["account", "common"])
-  const { accounts, displayData, stats, isInitialLoad, prevTotalConsumption } =
-    useAccountDataContext()
-  const { currencyType, showTodayCashflow, updateCurrencyType } =
+  const {
+    accounts,
+    displayData,
+    stats,
+    isInitialLoad,
+    prevTotalConsumption,
+    todayIncomeEstimateTotals,
+  } = useAccountDataContext()
+  const { currencyType, showTodayCashflow, updateCurrencyType, preferences } =
     useUserPreferencesContext()
+  const estimatedTodayIncomeEnabled =
+    preferences.balanceHistory?.estimatedTodayIncome?.enabled === true
 
   const totalConsumption = useMemo(
     () => calculateTotalConsumption(stats, accounts),
@@ -110,7 +118,13 @@ export default function AccountBalanceSummary() {
       </div>
 
       {showTodayCashflow && (
-        <div className="grid grid-cols-2 gap-3">
+        <div
+          className={
+            estimatedTodayIncomeEnabled
+              ? "grid grid-cols-1 gap-3 sm:grid-cols-3"
+              : "grid grid-cols-2 gap-3"
+          }
+        >
           <div className="space-y-1">
             <Caption className="font-medium">
               {t("account:stats.todayConsumption")}
@@ -130,7 +144,9 @@ export default function AccountBalanceSummary() {
 
           <div className="space-y-1">
             <Caption className="font-medium">
-              {t("account:stats.todayIncome")}
+              {estimatedTodayIncomeEnabled
+                ? t("account:stats.trustedTodayIncome")
+                : t("account:stats.todayIncome")}
             </Caption>
             <BalanceDisplay
               value={totalIncome[currencyType]}
@@ -142,6 +158,33 @@ export default function AccountBalanceSummary() {
               size="md"
             />
           </div>
+
+          {estimatedTodayIncomeEnabled && (
+            <div className="space-y-1">
+              <Caption className="font-medium">
+                {t("account:stats.estimatedTodayIncome")}
+              </Caption>
+              {todayIncomeEstimateTotals.estimated ? (
+                <BalanceDisplay
+                  value={todayIncomeEstimateTotals.estimated[currencyType]}
+                  startValue={0}
+                  isInitialLoad={isInitialLoad}
+                  currencyType={currencyType}
+                  onCurrencyToggle={handleCurrencyToggle}
+                  prefix={
+                    todayIncomeEstimateTotals.estimated[currencyType] > 0
+                      ? "+"
+                      : ""
+                  }
+                  size="md"
+                />
+              ) : (
+                <div className="dark:text-dark-text-tertiary text-2xl font-bold text-gray-500">
+                  -
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/features/AccountManagement/components/AccountList/BalanceDisplay.tsx
+++ b/src/features/AccountManagement/components/AccountList/BalanceDisplay.tsx
@@ -48,19 +48,8 @@ const AnimatedValue: React.FC<{
       ? 0
       : getDisplayMoneyValue(startValue)
     const shouldAnimate = hasCommittedRef.current
-
-    return (
-      <div
-        className={`truncate transition-all duration-200 ${
-          isRefreshing
-            ? "animate-pulse opacity-60"
-            : onClick
-              ? "cursor-pointer hover:scale-105 hover:opacity-80"
-              : ""
-        } ${className}`}
-        onClick={onClick}
-        title={title}
-      >
+    const content = (
+      <>
         {prefix}
         {getCurrencySymbol(currencyType)}
         {shouldAnimate ? (
@@ -79,6 +68,40 @@ const AnimatedValue: React.FC<{
           displayEndValue.toFixed(UI_CONSTANTS.MONEY.DECIMALS)
         )}
         {suffix}
+      </>
+    )
+
+    if (onClick) {
+      return (
+        <button
+          type="button"
+          className={`ml-auto block max-w-full truncate bg-transparent p-0 text-right transition-all duration-200 ${
+            isRefreshing
+              ? "animate-pulse opacity-60"
+              : "cursor-pointer hover:scale-105 hover:opacity-80"
+          } ${className}`}
+          onClick={onClick}
+          title={title}
+          aria-label={title}
+        >
+          {content}
+        </button>
+      )
+    }
+
+    return (
+      <div
+        className={`ml-auto max-w-full truncate text-right transition-all duration-200 ${
+          isRefreshing
+            ? "animate-pulse opacity-60"
+            : onClick
+              ? "cursor-pointer hover:scale-105 hover:opacity-80"
+              : ""
+        } ${className}`}
+        onClick={onClick}
+        title={title}
+      >
+        {content}
       </div>
     )
   },
@@ -87,12 +110,16 @@ const AnimatedValue: React.FC<{
 const BalanceDisplay: React.FC<BalanceDisplayProps> = React.memo(({ site }) => {
   const { t } = useTranslation("account")
   const { isInitialLoad, prevBalances } = useAccountDataContext()
-  const { currencyType, showTodayCashflow } = useUserPreferencesContext()
+  const { currencyType, showTodayCashflow, preferences } =
+    useUserPreferencesContext()
   const { handleRefreshAccount, refreshingAccountId } =
     useAccountActionsContext()
 
   const isRefreshing = refreshingAccountId === site.id
   const isAccountDisabled = site.disabled === true
+  const estimatedTodayIncomeEnabled =
+    preferences?.balanceHistory?.estimatedTodayIncome?.enabled === true
+  const estimatedTodayIncome = site.estimatedTodayIncome?.[currencyType]
 
   const handleRefreshClick = async () => {
     if (isAccountDisabled) return
@@ -106,7 +133,7 @@ const BalanceDisplay: React.FC<BalanceDisplayProps> = React.memo(({ site }) => {
     : t("list.balance.refreshBalance")
 
   return (
-    <div className="w-full overflow-hidden text-right">
+    <div className="flex w-full flex-col items-end overflow-hidden text-right">
       {/* Balance */}
       <AnimatedValue
         value={site.balance[currencyType]}
@@ -121,7 +148,7 @@ const BalanceDisplay: React.FC<BalanceDisplayProps> = React.memo(({ site }) => {
 
       {/* Today's Statistics */}
       {showTodayCashflow && (
-        <div className="space-y-0.5">
+        <div className="flex max-w-full flex-wrap justify-end gap-x-1.5 gap-y-0.5">
           {/* Consumption */}
           <AnimatedValue
             value={site.todayConsumption[currencyType]}
@@ -159,6 +186,27 @@ const BalanceDisplay: React.FC<BalanceDisplayProps> = React.memo(({ site }) => {
             onClick={isAccountDisabled ? undefined : handleRefreshClick}
             isRefreshing={isRefreshing}
           />
+
+          {estimatedTodayIncomeEnabled &&
+            typeof estimatedTodayIncome === "number" && (
+              <AnimatedValue
+                value={estimatedTodayIncome}
+                startValue={0}
+                prefix="~"
+                className={`text-[10px] sm:text-xs ${
+                  estimatedTodayIncome > 0
+                    ? "text-indigo-500"
+                    : "dark:text-dark-text-tertiary text-gray-400"
+                }`}
+                title={
+                  isAccountDisabled
+                    ? t("list.site.disabled")
+                    : t("stats.estimatedTodayIncome")
+                }
+                onClick={isAccountDisabled ? undefined : handleRefreshClick}
+                isRefreshing={isRefreshing}
+              />
+            )}
         </div>
       )}
     </div>

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -45,6 +45,7 @@ import type {
   Tag,
   TagStore,
 } from "~/types"
+import { TODAY_INCOME_ESTIMATE_STATUS } from "~/types/dailyBalanceHistory"
 import { SortingCriteriaType } from "~/types/sorting"
 import {
   getActiveTabs,
@@ -323,7 +324,7 @@ export const AccountDataProvider = ({
 
         estimatedByAccountId.set(
           account.id,
-          estimate.status === "available" &&
+          estimate.status === TODAY_INCOME_ESTIMATE_STATUS.available &&
             estimate.estimatedTodayIncome !== null
             ? convertQuotaToMoney({
                 quota: estimate.estimatedTodayIncome,
@@ -346,6 +347,10 @@ export const AccountDataProvider = ({
 
   const accountsRef = useRef<SiteAccount[]>([])
   accountsRef.current = accounts
+  const targetedReloadGenerationRef = useRef(0)
+  const targetedReloadGenerationByAccountIdRef = useRef<Record<string, number>>(
+    {},
+  )
   const hasLoadedAccountDataRef = useRef(false)
   hasLoadedAccountDataRef.current = hasLoadedAccountData
   const hasResolvedInitialCurrentTabRef = useRef(false)
@@ -815,6 +820,13 @@ export const AccountDataProvider = ({
       }
 
       try {
+        const reloadGeneration = targetedReloadGenerationRef.current + 1
+        targetedReloadGenerationRef.current = reloadGeneration
+        for (const accountId of uniqueIds) {
+          targetedReloadGenerationByAccountIdRef.current[accountId] =
+            reloadGeneration
+        }
+
         const reloadedAccounts = await Promise.all(
           uniqueIds.map(async (accountId) => {
             const account = await accountStorage.getAccountById(accountId)
@@ -824,16 +836,24 @@ export const AccountDataProvider = ({
             return account
           }),
         )
+        const activeReloadedAccounts = reloadedAccounts.filter(
+          (account) =>
+            targetedReloadGenerationByAccountIdRef.current[account.id] ===
+            reloadGeneration,
+        )
+        if (activeReloadedAccounts.length === 0) {
+          return
+        }
 
         const reloadedById = Object.fromEntries(
-          reloadedAccounts.map((account) => [account.id, account]),
+          activeReloadedAccounts.map((account) => [account.id, account]),
         )
 
         const mergedAccounts = accountsRef.current.map(
           (account) => reloadedById[account.id] ?? account,
         )
         const knownIds = new Set(mergedAccounts.map((account) => account.id))
-        for (const account of reloadedAccounts) {
+        for (const account of activeReloadedAccounts) {
           if (!knownIds.has(account.id)) {
             mergedAccounts.push(account)
           }
@@ -843,14 +863,50 @@ export const AccountDataProvider = ({
         setAccounts(mergedAccounts)
         const balanceHistoryStore = await dailyBalanceHistoryStorage.getStore()
         const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
+        const latestAccounts = accountsRef.current
+        const latestKnownIds = new Set(
+          latestAccounts.map((account) => account.id),
+        )
+        const latestMergedAccounts = latestAccounts.map(
+          (account) => reloadedById[account.id] ?? account,
+        )
+        for (const account of activeReloadedAccounts) {
+          if (!latestKnownIds.has(account.id)) {
+            latestMergedAccounts.push(account)
+          }
+        }
+
+        accountsRef.current = latestMergedAccounts
+        setAccounts(latestMergedAccounts)
         setDisplayData(
           buildDisplayDataWithBalanceHistory({
-            nextAccounts: mergedAccounts,
+            nextAccounts: latestMergedAccounts,
             currentTagStore: tagStore,
             balanceHistoryStore,
             todayKey,
           }),
         )
+        const enabledAccounts = latestMergedAccounts.filter(
+          (account) =>
+            account.disabled !== true &&
+            account.excludeFromTodayIncome !== true,
+        )
+        setTodayIncomeEstimateTotals(
+          buildEstimatedTodayIncomeMoneyTotals({
+            enabled: estimatedTodayIncomeEnabled,
+            store: balanceHistoryStore,
+            accounts: enabledAccounts,
+            currentDayKey: todayKey,
+          }),
+        )
+        for (const account of activeReloadedAccounts) {
+          if (
+            targetedReloadGenerationByAccountIdRef.current[account.id] ===
+            reloadGeneration
+          ) {
+            delete targetedReloadGenerationByAccountIdRef.current[account.id]
+          }
+        }
       } catch (error) {
         logger.warn(
           "Account-scoped reload failed; falling back to full reload",
@@ -883,7 +939,12 @@ export const AccountDataProvider = ({
         void reloadAccountsById(updatedAccountIds)
       }
     })
-  }, [buildDisplayDataWithBalanceHistory, loadAccountData, tagStore])
+  }, [
+    buildDisplayDataWithBalanceHistory,
+    estimatedTodayIncomeEnabled,
+    loadAccountData,
+    tagStore,
+  ])
 
   const handleSort = useCallback(
     (field: SortField) => {

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -22,7 +22,11 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { getDayKeyFromUnixSeconds } from "~/services/history/dailyBalanceHistory/dayKeys"
 import { dailyBalanceHistoryStorage } from "~/services/history/dailyBalanceHistory/storage"
-import { buildEstimatedTodayIncomeMoneyTotals } from "~/services/history/dailyBalanceHistory/todayIncomeEstimate"
+import {
+  buildEstimatedTodayIncomeMoneyTotals,
+  convertQuotaToMoney,
+  estimateTodayIncomeForAccount,
+} from "~/services/history/dailyBalanceHistory/todayIncomeEstimate"
 import { createDynamicSortComparator } from "~/services/preferences/utils/sortingPriority"
 import {
   buildAccountSearchIndex,
@@ -295,6 +299,51 @@ export const AccountDataProvider = ({
     [],
   )
 
+  const buildDisplayDataWithBalanceHistory = useCallback(
+    (params: {
+      nextAccounts: SiteAccount[]
+      currentTagStore: TagStore
+      balanceHistoryStore: Awaited<
+        ReturnType<typeof dailyBalanceHistoryStorage.getStore>
+      >
+      todayKey: string
+    }) => {
+      const estimatedByAccountId = new Map<string, CurrencyAmount | null>()
+
+      for (const account of params.nextAccounts) {
+        const estimate = estimateTodayIncomeForAccount({
+          enabled:
+            estimatedTodayIncomeEnabled &&
+            account.disabled !== true &&
+            account.excludeFromTodayIncome !== true,
+          store: params.balanceHistoryStore,
+          account,
+          currentDayKey: params.todayKey,
+        })
+
+        estimatedByAccountId.set(
+          account.id,
+          estimate.status === "available" &&
+            estimate.estimatedTodayIncome !== null
+            ? convertQuotaToMoney({
+                quota: estimate.estimatedTodayIncome,
+                exchangeRate: account.exchange_rate,
+              })
+            : null,
+        )
+      }
+
+      return buildDisplayDataWithResolvedTags(
+        params.nextAccounts,
+        params.currentTagStore,
+      ).map((site) => ({
+        ...site,
+        estimatedTodayIncome: estimatedByAccountId.get(site.id) ?? null,
+      }))
+    },
+    [buildDisplayDataWithResolvedTags, estimatedTodayIncomeEnabled],
+  )
+
   const accountsRef = useRef<SiteAccount[]>([])
   accountsRef.current = accounts
   const hasLoadedAccountDataRef = useRef(false)
@@ -512,10 +561,13 @@ export const AccountDataProvider = ({
         accountStorage.getPinnedList(),
         dailyBalanceHistoryStorage.getStore(),
       ])
-      const displaySiteData = buildDisplayDataWithResolvedTags(
-        allAccounts,
+      const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
+      const displaySiteData = buildDisplayDataWithBalanceHistory({
+        nextAccounts: allAccounts,
         currentTagStore,
-      )
+        balanceHistoryStore,
+        todayKey,
+      })
 
       setTagStore(currentTagStore)
       setTags(
@@ -533,7 +585,6 @@ export const AccountDataProvider = ({
       setBookmarks(allBookmarks)
       setStats(accountStats)
       setDisplayData(displaySiteData)
-      const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
       const enabledAccounts = allAccounts.filter(
         (account) =>
           account.disabled !== true && account.excludeFromTodayIncome !== true,
@@ -572,7 +623,7 @@ export const AccountDataProvider = ({
       }
     }
   }, [
-    buildDisplayDataWithResolvedTags,
+    buildDisplayDataWithBalanceHistory,
     estimatedTodayIncomeEnabled,
     prevTotalConsumption,
     prevBalances,

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -841,8 +841,15 @@ export const AccountDataProvider = ({
 
         accountsRef.current = mergedAccounts
         setAccounts(mergedAccounts)
+        const balanceHistoryStore = await dailyBalanceHistoryStorage.getStore()
+        const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
         setDisplayData(
-          buildDisplayDataWithResolvedTags(mergedAccounts, tagStore),
+          buildDisplayDataWithBalanceHistory({
+            nextAccounts: mergedAccounts,
+            currentTagStore: tagStore,
+            balanceHistoryStore,
+            todayKey,
+          }),
         )
       } catch (error) {
         logger.warn(
@@ -876,7 +883,7 @@ export const AccountDataProvider = ({
         void reloadAccountsById(updatedAccountIds)
       }
     })
-  }, [buildDisplayDataWithResolvedTags, loadAccountData, tagStore])
+  }, [buildDisplayDataWithBalanceHistory, loadAccountData, tagStore])
 
   const handleSort = useCallback(
     (field: SortField) => {

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -20,6 +20,9 @@ import {
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { getDayKeyFromUnixSeconds } from "~/services/history/dailyBalanceHistory/dayKeys"
+import { dailyBalanceHistoryStorage } from "~/services/history/dailyBalanceHistory/storage"
+import { buildEstimatedTodayIncomeMoneyTotals } from "~/services/history/dailyBalanceHistory/todayIncomeEstimate"
 import { createDynamicSortComparator } from "~/services/preferences/utils/sortingPriority"
 import {
   buildAccountSearchIndex,
@@ -131,6 +134,12 @@ interface AccountDataContextType {
   isRefreshing: boolean
   isRefreshingDisabledAccounts: boolean
   prevTotalConsumption: CurrencyAmount
+  todayIncomeEstimateTotals: {
+    trusted: CurrencyAmount
+    estimated: CurrencyAmount | null
+    availableAccounts: number
+    totalAccounts: number
+  }
   prevBalances: CurrencyAmountMap
   /**
    * Accounts that share the same origin with the current active tab (site-level match).
@@ -200,7 +209,10 @@ export const AccountDataProvider = ({
     updateSortConfig,
     sortingPriorityConfig,
     refreshOnOpen,
+    preferences,
   } = useUserPreferencesContext()
+  const estimatedTodayIncomeEnabled =
+    preferences.balanceHistory?.estimatedTodayIncome?.enabled === true
   const [accounts, setAccounts] = useState<SiteAccount[]>([])
   const [bookmarks, setBookmarks] = useState<SiteBookmark[]>([])
   const [displayData, setDisplayData] = useState<DisplaySiteData[]>([])
@@ -224,6 +236,14 @@ export const AccountDataProvider = ({
     useState(false)
   const [prevTotalConsumption, setPrevTotalConsumption] =
     useState<CurrencyAmount>({ USD: 0, CNY: 0 })
+  const [todayIncomeEstimateTotals, setTodayIncomeEstimateTotals] = useState<
+    AccountDataContextType["todayIncomeEstimateTotals"]
+  >({
+    trusted: { USD: 0, CNY: 0 },
+    estimated: null,
+    availableAccounts: 0,
+    totalAccounts: 0,
+  })
   const [prevBalances, setPrevBalances] = useState<CurrencyAmountMap>({})
   const [sortField, setSortField] = useState<SortField>(initialSortField)
   const [sortOrder, setSortOrder] = useState<SortOrder>(initialSortOrder)
@@ -482,6 +502,7 @@ export const AccountDataProvider = ({
         accountStats,
         currentTagStore,
         pinnedIds,
+        balanceHistoryStore,
       ] = await Promise.all([
         accountStorage.getAllAccounts(),
         accountStorage.getAllBookmarks(),
@@ -489,6 +510,7 @@ export const AccountDataProvider = ({
         accountStorage.getAccountStats(),
         tagStorage.getTagStore(),
         accountStorage.getPinnedList(),
+        dailyBalanceHistoryStorage.getStore(),
       ])
       const displaySiteData = buildDisplayDataWithResolvedTags(
         allAccounts,
@@ -511,6 +533,19 @@ export const AccountDataProvider = ({
       setBookmarks(allBookmarks)
       setStats(accountStats)
       setDisplayData(displaySiteData)
+      const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
+      const enabledAccounts = allAccounts.filter(
+        (account) =>
+          account.disabled !== true && account.excludeFromTodayIncome !== true,
+      )
+      setTodayIncomeEstimateTotals(
+        buildEstimatedTodayIncomeMoneyTotals({
+          enabled: estimatedTodayIncomeEnabled,
+          store: balanceHistoryStore,
+          accounts: enabledAccounts,
+          currentDayKey: todayKey,
+        }),
+      )
 
       const entryIdSet = new Set<string>([
         ...displaySiteData.map((site) => site.id),
@@ -536,7 +571,12 @@ export const AccountDataProvider = ({
         setHasLoadedAccountData(true)
       }
     }
-  }, [buildDisplayDataWithResolvedTags, prevTotalConsumption, prevBalances])
+  }, [
+    buildDisplayDataWithResolvedTags,
+    estimatedTodayIncomeEnabled,
+    prevTotalConsumption,
+    prevBalances,
+  ])
 
   /**
    * Tag CRUD actions exposed to UIs (AccountDialog, filters).
@@ -1148,6 +1188,7 @@ export const AccountDataProvider = ({
       isRefreshing,
       isRefreshingDisabledAccounts,
       prevTotalConsumption,
+      todayIncomeEstimateTotals,
       prevBalances,
       detectedSiteAccounts,
       detectedAccount,
@@ -1186,6 +1227,7 @@ export const AccountDataProvider = ({
       isRefreshing,
       isRefreshingDisabledAccounts,
       prevTotalConsumption,
+      todayIncomeEstimateTotals,
       prevBalances,
       detectedSiteAccounts,
       detectedAccount,

--- a/src/features/BalanceHistory/BalanceHistory.tsx
+++ b/src/features/BalanceHistory/BalanceHistory.tsx
@@ -101,10 +101,7 @@ const QUICK_RANGES = [
 type BalanceHistoryBreakdownChartType = "pie" | "bar"
 type BalanceHistoryTrendSeriesScope = "accounts" | "total"
 type BalanceHistoryQuickRangeId = (typeof QUICK_RANGES)[number]["id"]
-type BalanceHistoryVisibleMetric = Exclude<
-  DailyBalanceHistoryMetric,
-  "estimatedIncome"
->
+type BalanceHistoryVisibleMetric = DailyBalanceHistoryMetric
 
 /**
  * Returns the localized label for a supported balance-history metric.
@@ -118,6 +115,8 @@ function getBalanceHistoryMetricLabel(
       return t("balanceHistory:metrics.balance")
     case "income":
       return t("balanceHistory:metrics.income")
+    case "estimatedIncome":
+      return t("balanceHistory:metrics.estimatedIncome")
     case "outcome":
       return t("balanceHistory:metrics.outcome")
     case "net":
@@ -125,6 +124,18 @@ function getBalanceHistoryMetricLabel(
     default:
       return assertNever(metric, `Unexpected balance history metric: ${metric}`)
   }
+}
+
+/**
+ * Keeps a selected metric within the currently enabled Balance History surface.
+ */
+function resolveVisibleMetric(
+  metric: BalanceHistoryVisibleMetric,
+  estimatedTodayIncomeEnabled: boolean,
+): BalanceHistoryVisibleMetric {
+  return metric === "estimatedIncome" && !estimatedTodayIncomeEnabled
+    ? "income"
+    : metric
 }
 
 /**
@@ -184,6 +195,8 @@ export default function BalanceHistory() {
 
   const { preferences, currencyType, updateCurrencyType } =
     useUserPreferencesContext()
+  const estimatedTodayIncomeEnabled =
+    preferences.balanceHistory?.estimatedTodayIncome?.enabled === true
 
   const [accounts, setAccounts] = useState<SiteAccount[]>([])
   const [tagStore, setTagStore] = useState<TagStore | null>(null)
@@ -335,6 +348,41 @@ export default function BalanceHistory() {
   const accountDisplayLabelById = useMemo(
     () => buildAccountDisplayNameMap(accounts),
     [accounts],
+  )
+
+  const manualBalanceAccountIds = useMemo(
+    () =>
+      new Set(
+        accounts
+          .filter(
+            (account) =>
+              typeof account.manualBalanceUsd === "string" &&
+              account.manualBalanceUsd.trim().length > 0,
+          )
+          .map((account) => account.id),
+      ),
+    [accounts],
+  )
+
+  useEffect(() => {
+    if (!estimatedTodayIncomeEnabled && trendMetric === "estimatedIncome") {
+      setTrendMetric("income")
+    }
+  }, [estimatedTodayIncomeEnabled, trendMetric])
+
+  useEffect(() => {
+    if (!estimatedTodayIncomeEnabled && breakdownMetric === "estimatedIncome") {
+      setBreakdownMetric("income")
+    }
+  }, [breakdownMetric, estimatedTodayIncomeEnabled])
+
+  const effectiveTrendMetric = resolveVisibleMetric(
+    trendMetric,
+    estimatedTodayIncomeEnabled,
+  )
+  const effectiveBreakdownMetric = resolveVisibleMetric(
+    breakdownMetric,
+    estimatedTodayIncomeEnabled,
   )
 
   const effectiveAccountIds = useMemo(() => {
@@ -552,13 +600,17 @@ export default function BalanceHistory() {
       endDayKey: effectiveRange.endDayKey,
       currencyType,
       exchangeRateByAccountId,
+      estimatedTodayIncomeEnabled,
+      manualBalanceAccountIds,
     })
   }, [
     currencyType,
     effectiveAccountIds,
     effectiveRange.endDayKey,
     effectiveRange.startDayKey,
+    estimatedTodayIncomeEnabled,
     exchangeRateByAccountId,
+    manualBalanceAccountIds,
     store,
   ])
 
@@ -575,7 +627,9 @@ export default function BalanceHistory() {
 
       for (const accountId of effectiveAccountIds) {
         const value =
-          perAccountSeries.seriesByAccountId[accountId]?.[trendMetric]?.[index]
+          perAccountSeries.seriesByAccountId[accountId]?.[
+            effectiveTrendMetric
+          ]?.[index]
 
         if (typeof value !== "number" || !Number.isFinite(value)) continue
         covered += 1
@@ -588,18 +642,20 @@ export default function BalanceHistory() {
     return totals
   }, [
     effectiveAccountIds,
+    effectiveTrendMetric,
     perAccountSeries.dayKeys,
     perAccountSeries.seriesByAccountId,
-    trendMetric,
   ])
 
   const totalTrendCoverageSummary = useMemo(() => {
     const totalAccounts = effectiveAccountIds.length
 
     const coverageCounts = perAccountSeries.coverageByDay.map((coverage) => {
-      return trendMetric === "balance"
+      return effectiveTrendMetric === "balance"
         ? coverage.snapshotAccounts
-        : coverage.cashflowAccounts
+        : effectiveTrendMetric === "estimatedIncome"
+          ? coverage.estimatedIncomeAccounts
+          : coverage.cashflowAccounts
     })
 
     const availableCoverage = coverageCounts.filter((count) => count > 0)
@@ -618,7 +674,11 @@ export default function BalanceHistory() {
       maxCovered,
       partialDays,
     }
-  }, [effectiveAccountIds.length, perAccountSeries.coverageByDay, trendMetric])
+  }, [
+    effectiveAccountIds.length,
+    effectiveTrendMetric,
+    perAccountSeries.coverageByDay,
+  ])
 
   const rangeSummaries = useMemo(() => {
     return buildAccountRangeSummaries({
@@ -628,13 +688,17 @@ export default function BalanceHistory() {
       endDayKey: effectiveRange.endDayKey,
       currencyType,
       exchangeRateByAccountId,
+      estimatedTodayIncomeEnabled,
+      manualBalanceAccountIds,
     })
   }, [
     currencyType,
     effectiveAccountIds,
     effectiveRange.endDayKey,
     effectiveRange.startDayKey,
+    estimatedTodayIncomeEnabled,
     exchangeRateByAccountId,
+    manualBalanceAccountIds,
     store,
   ])
 
@@ -658,7 +722,7 @@ export default function BalanceHistory() {
 
     for (const accountId of effectiveAccountIds) {
       const values =
-        perAccountSeries.seriesByAccountId[accountId]?.[trendMetric] ??
+        perAccountSeries.seriesByAccountId[accountId]?.[effectiveTrendMetric] ??
         perAccountSeries.dayKeys.map(() => null)
 
       const hasAnyData = values.some(
@@ -676,16 +740,16 @@ export default function BalanceHistory() {
   }, [
     accountDisplayLabelById,
     effectiveAccountIds,
+    effectiveTrendMetric,
     perAccountSeries.dayKeys,
     perAccountSeries.seriesByAccountId,
     t,
     totalTrendValues,
-    trendMetric,
     trendScope,
   ])
 
   const trendOption = useMemo(() => {
-    const metricLabel = getBalanceHistoryMetricLabel(t, trendMetric)
+    const metricLabel = getBalanceHistoryMetricLabel(t, effectiveTrendMetric)
     return buildMultiSeriesTrendOption({
       dayKeys: perAccountSeries.dayKeys,
       series: trendSeries,
@@ -702,15 +766,15 @@ export default function BalanceHistory() {
     isDark,
     perAccountSeries.dayKeys,
     t,
+    effectiveTrendMetric,
     trendChartType,
-    trendMetric,
     trendSeries,
   ])
 
   const breakdownData = useMemo(() => {
     const entries: Array<{ name: string; value: number }> = []
 
-    if (breakdownMetric === "balance") {
+    if (effectiveBreakdownMetric === "balance") {
       const referenceDayKey = breakdownBalanceDayKey || effectiveRange.endDayKey
       const referenceIndex = perAccountSeries.dayKeys.indexOf(referenceDayKey)
 
@@ -732,11 +796,13 @@ export default function BalanceHistory() {
     } else {
       for (const summary of rangeSummaries.summaries) {
         const value =
-          breakdownMetric === "income"
+          effectiveBreakdownMetric === "income"
             ? summary.incomeTotal
-            : breakdownMetric === "outcome"
+            : effectiveBreakdownMetric === "outcome"
               ? summary.outcomeTotal
-              : summary.netTotal
+              : effectiveBreakdownMetric === "estimatedIncome"
+                ? summary.estimatedIncomeTotal
+                : summary.netTotal
 
         if (typeof value !== "number" || !Number.isFinite(value)) continue
 
@@ -761,7 +827,7 @@ export default function BalanceHistory() {
   }, [
     accountDisplayLabelById,
     breakdownBalanceDayKey,
-    breakdownMetric,
+    effectiveBreakdownMetric,
     effectiveAccountIds,
     effectiveRange.endDayKey,
     perAccountSeries.dayKeys,
@@ -778,7 +844,7 @@ export default function BalanceHistory() {
   const breakdownOption = useMemo(() => {
     if (!breakdownData.values.length) return null
 
-    const valueLabel = `${getBalanceHistoryMetricLabel(t, breakdownMetric)} (${currencySymbol})`
+    const valueLabel = `${getBalanceHistoryMetricLabel(t, effectiveBreakdownMetric)} (${currencySymbol})`
 
     return breakdownChartType === "pie"
       ? buildAccountBreakdownPieOption({
@@ -805,7 +871,7 @@ export default function BalanceHistory() {
     formatTooltipMoneyValue,
     isDark,
     t,
-    breakdownMetric,
+    effectiveBreakdownMetric,
   ])
 
   const overviewTotals = useMemo(() => {
@@ -862,9 +928,11 @@ export default function BalanceHistory() {
       endBalance: summary.endBalance,
       netTotal: summary.netTotal,
       incomeTotal: summary.incomeTotal,
+      estimatedIncomeTotal: summary.estimatedIncomeTotal,
       outcomeTotal: summary.outcomeTotal,
       snapshotDays: summary.snapshotDays,
       cashflowDays: summary.cashflowDays,
+      estimatedIncomeDays: summary.estimatedIncomeDays,
       totalDays: summary.totalDays,
     }))
   }, [accountDisplayLabelById, rangeSummaries.summaries])
@@ -912,10 +980,19 @@ export default function BalanceHistory() {
     )
   }, [perAccountSeries.coverageByDay])
 
+  const estimatedIncomeAvailableDays = useMemo(() => {
+    return perAccountSeries.coverageByDay.reduce(
+      (acc, item) => acc + (item.estimatedIncomeAccounts > 0 ? 1 : 0),
+      0,
+    )
+  }, [perAccountSeries.coverageByDay])
+
   const hasAnyPerAccountTrendMetricData =
-    trendMetric === "balance"
+    effectiveTrendMetric === "balance"
       ? snapshotAvailableDays > 0
-      : cashflowAvailableDays > 0
+      : effectiveTrendMetric === "estimatedIncome"
+        ? estimatedIncomeAvailableDays > 0
+        : cashflowAvailableDays > 0
 
   const hasAnyTotalTrendMetricData = useMemo(() => {
     return totalTrendValues.some(
@@ -1275,7 +1352,7 @@ export default function BalanceHistory() {
                                 {t("breakdown.title")}:{" "}
                                 {getBalanceHistoryMetricLabel(
                                   t,
-                                  breakdownMetric,
+                                  effectiveBreakdownMetric,
                                 )}
                               </span>
                               <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
@@ -1283,7 +1360,7 @@ export default function BalanceHistory() {
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="start" className="w-44">
                             <DropdownMenuRadioGroup
-                              value={breakdownMetric}
+                              value={effectiveBreakdownMetric}
                               onValueChange={(value) =>
                                 setBreakdownMetric(
                                   value as BalanceHistoryVisibleMetric,
@@ -1296,6 +1373,11 @@ export default function BalanceHistory() {
                               <DropdownMenuRadioItem value="income">
                                 {t("metrics.income")}
                               </DropdownMenuRadioItem>
+                              {estimatedTodayIncomeEnabled && (
+                                <DropdownMenuRadioItem value="estimatedIncome">
+                                  {t("metrics.estimatedIncome")}
+                                </DropdownMenuRadioItem>
+                              )}
                               <DropdownMenuRadioItem value="outcome">
                                 {t("metrics.outcome")}
                               </DropdownMenuRadioItem>
@@ -1340,7 +1422,7 @@ export default function BalanceHistory() {
                       </div>
                     </div>
 
-                    {breakdownMetric === "balance" && (
+                    {effectiveBreakdownMetric === "balance" && (
                       <div className="flex flex-wrap items-center gap-2">
                         <Label className="dark:text-dark-text-tertiary text-xs text-gray-500">
                           {t("breakdown.controls.reference")}
@@ -1393,14 +1475,17 @@ export default function BalanceHistory() {
                               >
                                 <span className="min-w-0 truncate">
                                   {t("trend.title")}:{" "}
-                                  {getBalanceHistoryMetricLabel(t, trendMetric)}
+                                  {getBalanceHistoryMetricLabel(
+                                    t,
+                                    effectiveTrendMetric,
+                                  )}
                                 </span>
                                 <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
                               </button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="start" className="w-44">
                               <DropdownMenuRadioGroup
-                                value={trendMetric}
+                                value={effectiveTrendMetric}
                                 onValueChange={(value) =>
                                   setTrendMetric(
                                     value as BalanceHistoryVisibleMetric,
@@ -1413,6 +1498,11 @@ export default function BalanceHistory() {
                                 <DropdownMenuRadioItem value="income">
                                   {t("metrics.income")}
                                 </DropdownMenuRadioItem>
+                                {estimatedTodayIncomeEnabled && (
+                                  <DropdownMenuRadioItem value="estimatedIncome">
+                                    {t("metrics.estimatedIncome")}
+                                  </DropdownMenuRadioItem>
+                                )}
                                 <DropdownMenuRadioItem value="outcome">
                                   {t("metrics.outcome")}
                                 </DropdownMenuRadioItem>
@@ -1516,7 +1606,10 @@ export default function BalanceHistory() {
                     ) : (
                       <div className="dark:text-dark-text-secondary text-sm text-gray-600">
                         {t("trend.emptyMetric", {
-                          metric: getBalanceHistoryMetricLabel(t, trendMetric),
+                          metric: getBalanceHistoryMetricLabel(
+                            t,
+                            effectiveTrendMetric,
+                          ),
                         })}
                       </div>
                     )}
@@ -1531,6 +1624,7 @@ export default function BalanceHistory() {
                     rows={tableRows}
                     isLoading={isLoading}
                     currencySymbol={currencySymbol}
+                    showEstimatedIncome={estimatedTodayIncomeEnabled}
                   />
                 </div>
               </Card>

--- a/src/features/BalanceHistory/BalanceHistory.tsx
+++ b/src/features/BalanceHistory/BalanceHistory.tsx
@@ -101,13 +101,17 @@ const QUICK_RANGES = [
 type BalanceHistoryBreakdownChartType = "pie" | "bar"
 type BalanceHistoryTrendSeriesScope = "accounts" | "total"
 type BalanceHistoryQuickRangeId = (typeof QUICK_RANGES)[number]["id"]
+type BalanceHistoryVisibleMetric = Exclude<
+  DailyBalanceHistoryMetric,
+  "estimatedIncome"
+>
 
 /**
  * Returns the localized label for a supported balance-history metric.
  */
 function getBalanceHistoryMetricLabel(
   t: TFunction,
-  metric: DailyBalanceHistoryMetric,
+  metric: BalanceHistoryVisibleMetric,
 ) {
   switch (metric) {
     case "balance":
@@ -190,14 +194,14 @@ export default function BalanceHistory() {
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([])
 
   const [trendMetric, setTrendMetric] =
-    useState<DailyBalanceHistoryMetric>("balance")
+    useState<BalanceHistoryVisibleMetric>("balance")
   const [trendChartType, setTrendChartType] =
     useState<BalanceHistoryTrendChartType>("line")
   const [trendScope, setTrendScope] =
     useState<BalanceHistoryTrendSeriesScope>("accounts")
 
   const [breakdownMetric, setBreakdownMetric] =
-    useState<DailyBalanceHistoryMetric>("balance")
+    useState<BalanceHistoryVisibleMetric>("balance")
   const [breakdownChartType, setBreakdownChartType] =
     useState<BalanceHistoryBreakdownChartType>("pie")
   const [breakdownBalanceDayKey, setBreakdownBalanceDayKey] =
@@ -1282,7 +1286,7 @@ export default function BalanceHistory() {
                               value={breakdownMetric}
                               onValueChange={(value) =>
                                 setBreakdownMetric(
-                                  value as DailyBalanceHistoryMetric,
+                                  value as BalanceHistoryVisibleMetric,
                                 )
                               }
                             >
@@ -1399,7 +1403,7 @@ export default function BalanceHistory() {
                                 value={trendMetric}
                                 onValueChange={(value) =>
                                   setTrendMetric(
-                                    value as DailyBalanceHistoryMetric,
+                                    value as BalanceHistoryVisibleMetric,
                                   )
                                 }
                               >

--- a/src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx
+++ b/src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx
@@ -30,9 +30,11 @@ export type BalanceHistoryAccountSummaryRow = {
   endBalance: number | null
   netTotal: number | null
   incomeTotal: number | null
+  estimatedIncomeTotal: number | null
   outcomeTotal: number | null
   snapshotDays: number
   cashflowDays: number
+  estimatedIncomeDays: number
   totalDays: number
 }
 
@@ -40,6 +42,7 @@ interface BalanceHistoryAccountSummaryTableProps {
   rows: BalanceHistoryAccountSummaryRow[]
   isLoading: boolean
   currencySymbol: string
+  showEstimatedIncome?: boolean
 }
 
 /**
@@ -66,6 +69,7 @@ export default function BalanceHistoryAccountSummaryTable({
   rows,
   isLoading,
   currencySymbol,
+  showEstimatedIncome = false,
 }: BalanceHistoryAccountSummaryTableProps) {
   const { t } = useTranslation("balanceHistory")
   const isInitialLoading = isLoading && rows.length === 0
@@ -126,6 +130,24 @@ export default function BalanceHistoryAccountSummaryTable({
         ),
         sortingFn: sortNullableNumber,
       },
+      ...(showEstimatedIncome
+        ? [
+            {
+              accessorKey: "estimatedIncomeTotal",
+              header: t("table.columns.estimatedIncomeTotal"),
+              cell: ({
+                row,
+              }: {
+                row: Row<BalanceHistoryAccountSummaryRow>
+              }) => (
+                <div className="text-sm">
+                  {formatMoney(row.original.estimatedIncomeTotal)}
+                </div>
+              ),
+              sortingFn: sortNullableNumber,
+            } satisfies ColumnDef<BalanceHistoryAccountSummaryRow, unknown>,
+          ]
+        : []),
       {
         accessorKey: "outcomeTotal",
         header: t("table.columns.outcomeTotal"),
@@ -165,7 +187,7 @@ export default function BalanceHistoryAccountSummaryTable({
         ),
       },
     ]
-  }, [currencySymbol, t])
+  }, [currencySymbol, showEstimatedIncome, t])
 
   const table = useReactTable({
     data: rows,

--- a/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistory.search.ts
+++ b/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistory.search.ts
@@ -49,11 +49,33 @@ export const balanceHistorySearchControls: OptionsSearchItemDefinition[] = [
     },
   ),
   buildControlDefinition(
+    "control:balance-history-estimated-today-income",
+    "balanceHistory",
+    "balance-history-estimated-today-income",
+    "balanceHistory:settings.estimatedTodayIncome",
+    582,
+    {
+      descriptionKey: "balanceHistory:settings.estimatedTodayIncomeHint",
+      breadcrumbsKeys: [
+        ...DEFAULT_BREADCRUMBS,
+        "settings:tabs.balanceHistory",
+        "balanceHistory:title",
+      ],
+      keywords: [
+        "balance history",
+        "estimated today income",
+        "estimated income",
+        "today income",
+        "income",
+      ],
+    },
+  ),
+  buildControlDefinition(
     "control:balance-history-retention-days",
     "balanceHistory",
     "balance-history-retention-days",
     "balanceHistory:settings.retentionDays",
-    582,
+    583,
     {
       breadcrumbsKeys: [
         ...DEFAULT_BREADCRUMBS,

--- a/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistory.search.ts
+++ b/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistory.search.ts
@@ -90,7 +90,7 @@ export const balanceHistorySearchControls: OptionsSearchItemDefinition[] = [
     "balanceHistory",
     "balance-history-apply-settings",
     "balanceHistory:actions.applySettings",
-    583,
+    584,
     {
       breadcrumbsKeys: [
         ...DEFAULT_BREADCRUMBS,

--- a/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
+++ b/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
@@ -11,10 +11,11 @@ import {
   Label,
   Switch,
 } from "~/components/ui"
+import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { clampBalanceHistoryRetentionDays } from "~/services/history/dailyBalanceHistory/utils"
 import { DEFAULT_BALANCE_HISTORY_PREFERENCES } from "~/types/dailyBalanceHistory"
-import { hasAlarmsAPI } from "~/utils/browser/browserApi"
+import { hasAlarmsAPI, sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
@@ -58,6 +59,7 @@ export default function BalanceHistorySettings() {
   }, [preferences.balanceHistory])
 
   const alarmsSupported = hasAlarmsAPI()
+  const showDebugSeedAction = import.meta.env.MODE === "development"
 
   const safeRetentionDays = useMemo(
     () => clampBalanceHistoryRetentionDays(retentionDays),
@@ -98,6 +100,35 @@ export default function BalanceHistorySettings() {
     t,
     updateBalanceHistory,
   ])
+
+  const handleSeedEstimateSnapshots = useCallback(async () => {
+    let toastId: string | undefined
+    try {
+      toastId = toast.loading("Seeding estimated income snapshots…")
+      const response = await sendRuntimeMessage<{
+        success: boolean
+        data?: { seeded: number; skipped: number }
+        error?: string
+      }>({
+        action: RuntimeActionIds.BalanceHistoryDebugSeedEstimateSnapshots,
+      })
+
+      if (!response?.success) {
+        toast.error(response?.error ?? "Failed to seed test snapshots", {
+          id: toastId,
+        })
+        return
+      }
+
+      toast.success(
+        `Seeded ${response.data?.seeded ?? 0} account(s), skipped ${response.data?.skipped ?? 0}. Check Popup stats or Balance History metrics.`,
+        { id: toastId },
+      )
+    } catch (error) {
+      logger.error("Failed to seed estimated income test snapshots", error)
+      toast.error(getErrorMessage(error), { id: toastId })
+    }
+  }, [])
 
   return (
     <SettingSection
@@ -197,6 +228,16 @@ export default function BalanceHistorySettings() {
             >
               {t("actions.applySettings")}
             </Button>
+            {showDebugSeedAction && (
+              <Button
+                id="balance-history-debug-seed-estimate-snapshots"
+                variant="secondary"
+                size="sm"
+                onClick={() => void handleSeedEstimateSnapshots()}
+              >
+                Dev: Seed estimate snapshots
+              </Button>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
+++ b/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
@@ -34,6 +34,10 @@ export default function BalanceHistorySettings() {
   const [endOfDayCaptureEnabled, setEndOfDayCaptureEnabled] = useState<boolean>(
     preferences.balanceHistory?.endOfDayCapture?.enabled ?? false,
   )
+  const [estimatedTodayIncomeEnabled, setEstimatedTodayIncomeEnabled] =
+    useState<boolean>(
+      preferences.balanceHistory?.estimatedTodayIncome?.enabled ?? false,
+    )
   const [retentionDays, setRetentionDays] = useState<number>(
     preferences.balanceHistory?.retentionDays ??
       DEFAULT_BALANCE_HISTORY_PREFERENCES.retentionDays,
@@ -43,6 +47,9 @@ export default function BalanceHistorySettings() {
     setEnabled(preferences.balanceHistory?.enabled ?? false)
     setEndOfDayCaptureEnabled(
       preferences.balanceHistory?.endOfDayCapture?.enabled ?? false,
+    )
+    setEstimatedTodayIncomeEnabled(
+      preferences.balanceHistory?.estimatedTodayIncome?.enabled ?? false,
     )
     setRetentionDays(
       preferences.balanceHistory?.retentionDays ??
@@ -64,6 +71,7 @@ export default function BalanceHistorySettings() {
       const success = await updateBalanceHistory({
         enabled,
         endOfDayCapture: { enabled: endOfDayCaptureEnabled },
+        estimatedTodayIncome: { enabled: estimatedTodayIncomeEnabled },
         retentionDays: safeRetentionDays,
       })
 
@@ -85,6 +93,7 @@ export default function BalanceHistorySettings() {
   }, [
     enabled,
     endOfDayCaptureEnabled,
+    estimatedTodayIncomeEnabled,
     safeRetentionDays,
     t,
     updateBalanceHistory,
@@ -110,7 +119,11 @@ export default function BalanceHistorySettings() {
                 {t("settings.enabledHint")}
               </div>
             </div>
-            <Switch checked={enabled} onChange={setEnabled} />
+            <Switch
+              aria-label={t("settings.enabled")}
+              checked={enabled}
+              onChange={setEnabled}
+            />
           </div>
 
           <div
@@ -126,9 +139,29 @@ export default function BalanceHistorySettings() {
               </div>
             </div>
             <Switch
+              aria-label={t("settings.endOfDayCapture")}
               checked={endOfDayCaptureEnabled}
               onChange={setEndOfDayCaptureEnabled}
               disabled={!alarmsSupported}
+            />
+          </div>
+
+          <div
+            id="balance-history-estimated-today-income"
+            className="flex items-center justify-between gap-3"
+          >
+            <div>
+              <Label className="text-sm font-medium">
+                {t("settings.estimatedTodayIncome")}
+              </Label>
+              <div className="dark:text-dark-text-tertiary text-xs text-gray-500">
+                {t("settings.estimatedTodayIncomeHint")}
+              </div>
+            </div>
+            <Switch
+              aria-label={t("settings.estimatedTodayIncome")}
+              checked={estimatedTodayIncomeEnabled}
+              onChange={setEstimatedTodayIncomeEnabled}
             />
           </div>
 

--- a/src/locales/en/account.json
+++ b/src/locales/en/account.json
@@ -181,10 +181,12 @@
   },
   "stats": {
     "completion": "Completion",
+    "estimatedTodayIncome": "Estimated income",
     "prompt": "Prompt",
     "todayConsumption": "Today's Consumption",
     "todayIncome": "Today's Income",
-    "totalBalance": "Total Balance"
+    "totalBalance": "Total Balance",
+    "trustedTodayIncome": "Trusted income"
   },
   "title": "Account Management"
 }

--- a/src/locales/en/balanceHistory.json
+++ b/src/locales/en/balanceHistory.json
@@ -82,6 +82,7 @@
   },
   "metrics": {
     "balance": "Balance",
+    "estimatedIncome": "Estimated income",
     "income": "Income",
     "net": "Net change",
     "outcome": "Outcome"
@@ -122,6 +123,7 @@
       "account": "Account",
       "cashflowCoverage": "Cashflow coverage",
       "endBalance": "End balance",
+      "estimatedIncomeTotal": "Estimated income total",
       "incomeTotal": "Income total",
       "outcomeTotal": "Outcome total",
       "rangeNet": "Range net",

--- a/src/locales/en/balanceHistory.json
+++ b/src/locales/en/balanceHistory.json
@@ -110,6 +110,8 @@
     "enabledHint": "When disabled, no snapshots are recorded and scheduled capture is turned off.",
     "endOfDayCapture": "End-of-day capture",
     "endOfDayCaptureHint": "Best-effort daily capture near {{time}} (requires Alarms API).",
+    "estimatedTodayIncome": "Show estimated today income",
+    "estimatedTodayIncomeHint": "Uses balance history to estimate rewards that do not appear in site income logs. Unavailable when the previous-day baseline is missing.",
     "retentionDays": "Retention (days)"
   },
   "summary": {

--- a/src/locales/ja/account.json
+++ b/src/locales/ja/account.json
@@ -172,10 +172,12 @@
   },
   "stats": {
     "completion": "補完",
+    "estimatedTodayIncome": "推定収入",
     "prompt": "プロンプト",
     "todayConsumption": "本日の消費",
     "todayIncome": "本日の収入",
-    "totalBalance": "総残高"
+    "totalBalance": "総残高",
+    "trustedTodayIncome": "信頼済み収入"
   },
   "title": "アカウント管理"
 }

--- a/src/locales/ja/balanceHistory.json
+++ b/src/locales/ja/balanceHistory.json
@@ -110,6 +110,8 @@
     "enabledHint": "無効にすると、スナップショットは記録されず、定期取得も停止します。",
     "endOfDayCapture": "日次終了時の記録",
     "endOfDayCaptureHint": "{{time}} 付近でベストエフォートの日次記録を行います（Alarms API が必要です）。",
+    "estimatedTodayIncome": "推定の本日収入を表示",
+    "estimatedTodayIncomeHint": "残高履歴を使って、サイトの収入ログに出ない報酬を推定します。前日の基準スナップショットがない場合は利用できません。",
     "retentionDays": "保持日数"
   },
   "summary": {

--- a/src/locales/ja/balanceHistory.json
+++ b/src/locales/ja/balanceHistory.json
@@ -82,6 +82,7 @@
   },
   "metrics": {
     "balance": "残高",
+    "estimatedIncome": "推定収入",
     "income": "収入",
     "net": "純増減",
     "outcome": "支出"
@@ -122,6 +123,7 @@
       "account": "アカウント",
       "cashflowCoverage": "キャッシュフローのカバー率",
       "endBalance": "期末残高",
+      "estimatedIncomeTotal": "推定収入合計",
       "incomeTotal": "総収入",
       "outcomeTotal": "総支出",
       "rangeNet": "期間純増減",

--- a/src/locales/vi/account.json
+++ b/src/locales/vi/account.json
@@ -172,10 +172,12 @@
   },
   "stats": {
     "completion": "Hoàn thành",
+    "estimatedTodayIncome": "Thu nhập ước tính",
     "prompt": "Nhắc nhở",
     "todayConsumption": "Tiêu hao hôm nay",
     "todayIncome": "Thu nhập hôm nay",
-    "totalBalance": "Tổng số dư"
+    "totalBalance": "Tổng số dư",
+    "trustedTodayIncome": "Thu nhập tin cậy"
   },
   "title": "Quản lý tài khoản"
 }

--- a/src/locales/vi/balanceHistory.json
+++ b/src/locales/vi/balanceHistory.json
@@ -110,6 +110,8 @@
     "enabledHint": "Sau khi đóng, sẽ không ghi lại ảnh chụp nhanh và cũng không lên lịch thu thập cuối ngày.",
     "endOfDayCapture": "Thu thập cuối ngày",
     "endOfDayCaptureHint": "Cố gắng thu thập một lần mỗi ngày vào khoảng {{time}} (yêu cầu trình duyệt hỗ trợ Alarms API).",
+    "estimatedTodayIncome": "Hiển thị thu nhập hôm nay ước tính",
+    "estimatedTodayIncomeHint": "Dùng lịch sử số dư để ước tính phần thưởng không xuất hiện trong nhật ký thu nhập của trang. Không khả dụng khi thiếu ảnh chụp số dư chuẩn của ngày trước.",
     "retentionDays": "Số ngày lưu giữ"
   },
   "summary": {

--- a/src/locales/vi/balanceHistory.json
+++ b/src/locales/vi/balanceHistory.json
@@ -82,6 +82,7 @@
   },
   "metrics": {
     "balance": "Số dư",
+    "estimatedIncome": "Thu nhập ước tính",
     "income": "Thu nhập",
     "net": "Thay đổi ròng",
     "outcome": "Chi phí"
@@ -122,6 +123,7 @@
       "account": "Tài khoản",
       "cashflowCoverage": "Độ bao phủ thu chi",
       "endBalance": "Số dư cuối kỳ",
+      "estimatedIncomeTotal": "Tổng thu nhập ước tính",
       "incomeTotal": "Thu nhập trong kỳ",
       "outcomeTotal": "Chi phí trong kỳ",
       "rangeNet": "Thay đổi ròng trong kỳ",

--- a/src/locales/zh-CN/account.json
+++ b/src/locales/zh-CN/account.json
@@ -172,10 +172,12 @@
   },
   "stats": {
     "completion": "补全",
+    "estimatedTodayIncome": "估算收入",
     "prompt": "提示",
     "todayConsumption": "今日消耗",
     "todayIncome": "今日收入",
-    "totalBalance": "总余额"
+    "totalBalance": "总余额",
+    "trustedTodayIncome": "可信收入"
   },
   "title": "账户管理"
 }

--- a/src/locales/zh-CN/balanceHistory.json
+++ b/src/locales/zh-CN/balanceHistory.json
@@ -110,6 +110,8 @@
     "enabledHint": "关闭后不会记录快照，也不会安排日终抓取。",
     "endOfDayCapture": "日终抓取",
     "endOfDayCaptureHint": "在每天 {{time}} 左右尽力抓取一次（需要浏览器支持 Alarms API）。",
+    "estimatedTodayIncome": "显示估算今日收入",
+    "estimatedTodayIncomeHint": "基于余额历史估算未进入站点收入日志的奖励；缺少前一日基准快照时不可用。",
     "retentionDays": "保留天数"
   },
   "summary": {

--- a/src/locales/zh-CN/balanceHistory.json
+++ b/src/locales/zh-CN/balanceHistory.json
@@ -82,6 +82,7 @@
   },
   "metrics": {
     "balance": "余额",
+    "estimatedIncome": "估算收入",
     "income": "收入",
     "net": "净变化",
     "outcome": "支出"
@@ -122,6 +123,7 @@
       "account": "账户",
       "cashflowCoverage": "收支覆盖",
       "endBalance": "结束余额",
+      "estimatedIncomeTotal": "估算收入合计",
       "incomeTotal": "区间收入",
       "outcomeTotal": "区间支出",
       "rangeNet": "区间净变化",

--- a/src/locales/zh-TW/account.json
+++ b/src/locales/zh-TW/account.json
@@ -172,10 +172,12 @@
   },
   "stats": {
     "completion": "補全",
+    "estimatedTodayIncome": "估算收入",
     "prompt": "提示",
     "todayConsumption": "今日消耗",
     "todayIncome": "今日收入",
-    "totalBalance": "總餘額"
+    "totalBalance": "總餘額",
+    "trustedTodayIncome": "可信收入"
   },
   "title": "帳戶管理"
 }

--- a/src/locales/zh-TW/balanceHistory.json
+++ b/src/locales/zh-TW/balanceHistory.json
@@ -82,6 +82,7 @@
   },
   "metrics": {
     "balance": "餘額",
+    "estimatedIncome": "估算收入",
     "income": "收入",
     "net": "淨變化",
     "outcome": "支出"
@@ -122,6 +123,7 @@
       "account": "帳戶",
       "cashflowCoverage": "收支覆蓋",
       "endBalance": "結束餘額",
+      "estimatedIncomeTotal": "估算收入合計",
       "incomeTotal": "區間收入",
       "outcomeTotal": "區間支出",
       "rangeNet": "區間淨變化",

--- a/src/locales/zh-TW/balanceHistory.json
+++ b/src/locales/zh-TW/balanceHistory.json
@@ -110,6 +110,8 @@
     "enabledHint": "關閉後不會記錄快照，也不會安排日終抓取。",
     "endOfDayCapture": "日終抓取",
     "endOfDayCaptureHint": "在每天 {{time}} 左右盡力抓取一次（需要瀏覽器支援 Alarms API）。",
+    "estimatedTodayIncome": "顯示估算今日收入",
+    "estimatedTodayIncomeHint": "基於餘額歷史估算未進入站點收入記錄的獎勵；缺少前一日基準快照時不可用。",
     "retentionDays": "保留天數"
   },
   "summary": {

--- a/src/services/history/dailyBalanceHistory/scheduler.ts
+++ b/src/services/history/dailyBalanceHistory/scheduler.ts
@@ -23,6 +23,7 @@ import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
 import { DAILY_BALANCE_HISTORY_ALARM_NAME } from "./constants"
+import { getDayKeyFromUnixSeconds, subtractDaysFromDayKey } from "./dayKeys"
 import { dailyBalanceHistoryStorage } from "./storage"
 import { clampBalanceHistoryRetentionDays } from "./utils"
 
@@ -231,6 +232,90 @@ class DailyBalanceHistoryScheduler {
     return { success, failed, refreshedCount }
   }
 
+  async debugSeedEstimateSnapshots(): Promise<{
+    seeded: number
+    skipped: number
+    todayKey: string
+    yesterdayKey: string
+  }> {
+    const prefs = await userPreferences.getPreferences()
+    const config = prefs.balanceHistory ?? DEFAULT_BALANCE_HISTORY_PREFERENCES
+    const retentionDays = Math.max(
+      2,
+      clampBalanceHistoryRetentionDays(config.retentionDays),
+    )
+    const nowMs = Date.now()
+    const todayKey = getDayKeyFromUnixSeconds(Math.floor(nowMs / 1000))
+    const yesterdayKey = subtractDaysFromDayKey(todayKey, 1)
+    const accounts = await accountStorage.getEnabledAccounts()
+    let seeded = 0
+    let skipped = 0
+
+    for (const account of accounts) {
+      if (
+        account.excludeFromTodayIncome === true ||
+        (typeof account.manualBalanceUsd === "string" &&
+          account.manualBalanceUsd.trim() !== "")
+      ) {
+        skipped += 1
+        continue
+      }
+
+      const info = account.account_info
+      const quota = Number(info?.quota)
+      if (!Number.isFinite(quota) || quota <= 0) {
+        skipped += 1
+        continue
+      }
+
+      const todayConsumption = Number.isFinite(info?.today_quota_consumption)
+        ? Math.max(0, Number(info.today_quota_consumption))
+        : 1_000_000
+      const trustedIncome = Number.isFinite(info?.today_income)
+        ? Math.max(0, Number(info.today_income))
+        : 0
+      const estimatedIncome = Math.max(trustedIncome + 1_000_000, 1_000_000)
+      const baselineQuota = Math.max(
+        0,
+        quota + todayConsumption - estimatedIncome,
+      )
+      const yesterdayCapturedAt = nowMs - 24 * 60 * 60 * 1000
+
+      const yesterdayOk = await dailyBalanceHistoryStorage.upsertSnapshot({
+        accountId: account.id,
+        dayKey: yesterdayKey,
+        retentionDays,
+        snapshot: {
+          quota: baselineQuota,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: yesterdayCapturedAt,
+          source: "refresh",
+        },
+      })
+      const todayOk = await dailyBalanceHistoryStorage.upsertSnapshot({
+        accountId: account.id,
+        dayKey: todayKey,
+        retentionDays,
+        snapshot: {
+          quota,
+          today_income: trustedIncome,
+          today_quota_consumption: todayConsumption,
+          capturedAt: nowMs,
+          source: "refresh",
+        },
+      })
+
+      if (yesterdayOk && todayOk) {
+        seeded += 1
+      } else {
+        skipped += 1
+      }
+    }
+
+    return { seeded, skipped, todayKey, yesterdayKey }
+  }
+
   async runEndOfDayCapture(params: {
     trigger: DailyBalanceHistoryCaptureSource
   }) {
@@ -326,6 +411,18 @@ export const handleDailyBalanceHistoryMessage = async (
       case RuntimeActionIds.BalanceHistoryPrune: {
         const ok = await dailyBalanceHistoryScheduler.pruneNow()
         sendResponse({ success: ok })
+        break
+      }
+
+      case RuntimeActionIds.BalanceHistoryDebugSeedEstimateSnapshots: {
+        if (import.meta.env.MODE !== "development") {
+          sendResponse({ success: false, error: "Debug action unavailable" })
+          break
+        }
+
+        const result =
+          await dailyBalanceHistoryScheduler.debugSeedEstimateSnapshots()
+        sendResponse({ success: true, data: result })
         break
       }
 

--- a/src/services/history/dailyBalanceHistory/selectors.ts
+++ b/src/services/history/dailyBalanceHistory/selectors.ts
@@ -2,7 +2,10 @@ import { UI_CONSTANTS } from "~/constants/ui"
 import { listDayKeysInRange } from "~/services/history/dailyBalanceHistory/dayKeys"
 import { estimateTodayIncomeForAccount } from "~/services/history/dailyBalanceHistory/todayIncomeEstimate"
 import type { CurrencyType } from "~/types"
-import type { DailyBalanceHistoryStore } from "~/types/dailyBalanceHistory"
+import {
+  TODAY_INCOME_ESTIMATE_STATUS,
+  type DailyBalanceHistoryStore,
+} from "~/types/dailyBalanceHistory"
 
 interface DailyBalanceHistoryCoverage {
   totalAccounts: number
@@ -391,7 +394,7 @@ export function buildPerAccountDailyBalanceMoneySeries(params: {
         })
 
         if (
-          estimate.status !== "available" ||
+          estimate.status !== TODAY_INCOME_ESTIMATE_STATUS.available ||
           estimate.estimatedTodayIncome === null
         ) {
           continue
@@ -515,7 +518,7 @@ export function buildAccountRangeSummaries(params: {
         })
 
         if (
-          estimate.status !== "available" ||
+          estimate.status !== TODAY_INCOME_ESTIMATE_STATUS.available ||
           estimate.estimatedTodayIncome === null
         ) {
           continue

--- a/src/services/history/dailyBalanceHistory/selectors.ts
+++ b/src/services/history/dailyBalanceHistory/selectors.ts
@@ -3,20 +3,28 @@ import type { CurrencyType } from "~/types"
 import type { DailyBalanceHistoryStore } from "~/types/dailyBalanceHistory"
 
 import { listDayKeysInRange } from "./dayKeys"
+import { estimateTodayIncomeForAccount } from "./todayIncomeEstimate"
 
 interface DailyBalanceHistoryCoverage {
   totalAccounts: number
   snapshotAccounts: number
   cashflowAccounts: number
+  estimatedIncomeAccounts: number
 }
 
 type ExchangeRateLookup = Record<string, number> | Map<string, number>
 
-export type DailyBalanceHistoryMetric = "balance" | "income" | "outcome" | "net"
+export type DailyBalanceHistoryMetric =
+  | "balance"
+  | "income"
+  | "estimatedIncome"
+  | "outcome"
+  | "net"
 
 interface PerAccountDailyBalanceMoneySeries {
   balance: Array<number | null>
   income: Array<number | null>
+  estimatedIncome: Array<number | null>
   outcome: Array<number | null>
   net: Array<number | null>
 }
@@ -26,10 +34,12 @@ interface AccountRangeSummary {
   startBalance: number | null
   endBalance: number | null
   incomeTotal: number | null
+  estimatedIncomeTotal: number | null
   outcomeTotal: number | null
   netTotal: number | null
   snapshotDays: number
   cashflowDays: number
+  estimatedIncomeDays: number
   totalDays: number
 }
 
@@ -55,6 +65,38 @@ function resolveExchangeRate(params: {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? value
     : UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
+}
+
+/**
+ * Builds the minimal account shape required by the today-income estimate helper.
+ */
+function buildEstimateAccount(params: {
+  accountId: string
+  manualBalanceAccountIds?: Set<string>
+}): {
+  id: string
+  manualBalanceUsd?: string
+} {
+  const { accountId, manualBalanceAccountIds } = params
+
+  return {
+    id: accountId,
+    manualBalanceUsd:
+      manualBalanceAccountIds?.has(accountId) === true ? "manual" : undefined,
+  }
+}
+
+/**
+ * Converts a quota-unit value into the requested chart currency.
+ */
+function convertQuotaToSelectedMoney(params: {
+  quota: number
+  conversionFactor: number
+  exchangeRate: number
+}): number {
+  const { quota, conversionFactor, exchangeRate } = params
+
+  return (quota / conversionFactor) * exchangeRate
 }
 
 /**
@@ -90,6 +132,7 @@ export function buildAggregatedDailyBalanceSeries(params: {
         totalAccounts,
         snapshotAccounts: 0,
         cashflowAccounts: 0,
+        estimatedIncomeAccounts: 0,
       })),
     }
   }
@@ -129,6 +172,7 @@ export function buildAggregatedDailyBalanceSeries(params: {
       totalAccounts,
       snapshotAccounts,
       cashflowAccounts,
+      estimatedIncomeAccounts: 0,
     })
 
     quotaTotals.push(snapshotAccounts === totalAccounts ? quotaSum : null)
@@ -187,6 +231,7 @@ export function buildAggregatedDailyBalanceMoneySeries(params: {
         totalAccounts,
         snapshotAccounts: 0,
         cashflowAccounts: 0,
+        estimatedIncomeAccounts: 0,
       })),
     }
   }
@@ -235,6 +280,7 @@ export function buildAggregatedDailyBalanceMoneySeries(params: {
       totalAccounts,
       snapshotAccounts,
       cashflowAccounts,
+      estimatedIncomeAccounts: 0,
     })
 
     balanceTotals.push(snapshotAccounts === totalAccounts ? balanceSum : null)
@@ -258,6 +304,8 @@ export function buildPerAccountDailyBalanceMoneySeries(params: {
   endDayKey: string
   currencyType: CurrencyType
   exchangeRateByAccountId?: ExchangeRateLookup
+  estimatedTodayIncomeEnabled?: boolean
+  manualBalanceAccountIds?: Set<string>
 }): {
   dayKeys: string[]
   seriesByAccountId: Record<string, PerAccountDailyBalanceMoneySeries>
@@ -270,6 +318,8 @@ export function buildPerAccountDailyBalanceMoneySeries(params: {
     endDayKey,
     currencyType,
     exchangeRateByAccountId,
+    estimatedTodayIncomeEnabled = false,
+    manualBalanceAccountIds,
   } = params
 
   const dayKeys = listDayKeysInRange({ startDayKey, endDayKey })
@@ -279,6 +329,7 @@ export function buildPerAccountDailyBalanceMoneySeries(params: {
     totalAccounts,
     snapshotAccounts: 0,
     cashflowAccounts: 0,
+    estimatedIncomeAccounts: 0,
   }))
 
   const seriesByAccountId: Record<string, PerAccountDailyBalanceMoneySeries> =
@@ -299,6 +350,7 @@ export function buildPerAccountDailyBalanceMoneySeries(params: {
 
     const balance = dayKeys.map(() => null) as Array<number | null>
     const income = dayKeys.map(() => null) as Array<number | null>
+    const estimatedIncome = dayKeys.map(() => null) as Array<number | null>
     const outcome = dayKeys.map(() => null) as Array<number | null>
     const net = dayKeys.map(() => null) as Array<number | null>
 
@@ -330,7 +382,36 @@ export function buildPerAccountDailyBalanceMoneySeries(params: {
       }
     }
 
-    seriesByAccountId[accountId] = { balance, income, outcome, net }
+    for (let index = 0; index < dayKeys.length; index += 1) {
+      const estimate = estimateTodayIncomeForAccount({
+        enabled: estimatedTodayIncomeEnabled,
+        store,
+        account: buildEstimateAccount({ accountId, manualBalanceAccountIds }),
+        currentDayKey: dayKeys[index],
+      })
+
+      if (
+        estimate.status !== "available" ||
+        estimate.estimatedTodayIncome === null
+      ) {
+        continue
+      }
+
+      estimatedIncome[index] = convertQuotaToSelectedMoney({
+        quota: estimate.estimatedTodayIncome,
+        conversionFactor,
+        exchangeRate,
+      })
+      coverageByDay[index].estimatedIncomeAccounts += 1
+    }
+
+    seriesByAccountId[accountId] = {
+      balance,
+      income,
+      estimatedIncome,
+      outcome,
+      net,
+    }
   }
 
   return { dayKeys, seriesByAccountId, coverageByDay }
@@ -348,6 +429,8 @@ export function buildAccountRangeSummaries(params: {
   endDayKey: string
   currencyType: CurrencyType
   exchangeRateByAccountId?: ExchangeRateLookup
+  estimatedTodayIncomeEnabled?: boolean
+  manualBalanceAccountIds?: Set<string>
 }): {
   dayKeys: string[]
   summaries: AccountRangeSummary[]
@@ -359,6 +442,8 @@ export function buildAccountRangeSummaries(params: {
     endDayKey,
     currencyType,
     exchangeRateByAccountId,
+    estimatedTodayIncomeEnabled = false,
+    manualBalanceAccountIds,
   } = params
 
   const dayKeys = listDayKeysInRange({ startDayKey, endDayKey })
@@ -395,28 +480,56 @@ export function buildAccountRangeSummaries(params: {
 
     let snapshotDays = 0
     let cashflowDays = 0
+    let estimatedIncomeDays = 0
     let incomeSum = 0
+    let estimatedIncomeSum = 0
     let outcomeSum = 0
 
-    if (perDay) {
-      for (const dayKey of dayKeys) {
+    for (const dayKey of dayKeys) {
+      if (perDay) {
         const snapshot = perDay[dayKey]
-        if (!snapshot) continue
-        snapshotDays += 1
+        if (snapshot) {
+          snapshotDays += 1
 
-        if (
-          typeof snapshot.today_income === "number" &&
-          typeof snapshot.today_quota_consumption === "number"
-        ) {
-          cashflowDays += 1
-          incomeSum += (snapshot.today_income / conversionFactor) * exchangeRate
-          outcomeSum +=
-            (snapshot.today_quota_consumption / conversionFactor) * exchangeRate
+          if (
+            typeof snapshot.today_income === "number" &&
+            typeof snapshot.today_quota_consumption === "number"
+          ) {
+            cashflowDays += 1
+            incomeSum +=
+              (snapshot.today_income / conversionFactor) * exchangeRate
+            outcomeSum +=
+              (snapshot.today_quota_consumption / conversionFactor) *
+              exchangeRate
+          }
         }
       }
+
+      const estimate = estimateTodayIncomeForAccount({
+        enabled: estimatedTodayIncomeEnabled,
+        store,
+        account: buildEstimateAccount({ accountId, manualBalanceAccountIds }),
+        currentDayKey: dayKey,
+      })
+
+      if (
+        estimate.status !== "available" ||
+        estimate.estimatedTodayIncome === null
+      ) {
+        continue
+      }
+
+      estimatedIncomeDays += 1
+      estimatedIncomeSum += convertQuotaToSelectedMoney({
+        quota: estimate.estimatedTodayIncome,
+        conversionFactor,
+        exchangeRate,
+      })
     }
 
     const incomeTotal = cashflowDays > 0 ? incomeSum : null
+    const estimatedIncomeTotal =
+      estimatedIncomeDays > 0 ? estimatedIncomeSum : null
     const outcomeTotal = cashflowDays > 0 ? outcomeSum : null
     const netTotal =
       cashflowDays > 0 && incomeTotal !== null && outcomeTotal !== null
@@ -428,10 +541,12 @@ export function buildAccountRangeSummaries(params: {
       startBalance,
       endBalance,
       incomeTotal,
+      estimatedIncomeTotal,
       outcomeTotal,
       netTotal,
       snapshotDays,
       cashflowDays,
+      estimatedIncomeDays,
       totalDays,
     })
   }

--- a/src/services/history/dailyBalanceHistory/selectors.ts
+++ b/src/services/history/dailyBalanceHistory/selectors.ts
@@ -1,9 +1,8 @@
 import { UI_CONSTANTS } from "~/constants/ui"
+import { listDayKeysInRange } from "~/services/history/dailyBalanceHistory/dayKeys"
+import { estimateTodayIncomeForAccount } from "~/services/history/dailyBalanceHistory/todayIncomeEstimate"
 import type { CurrencyType } from "~/types"
 import type { DailyBalanceHistoryStore } from "~/types/dailyBalanceHistory"
-
-import { listDayKeysInRange } from "./dayKeys"
-import { estimateTodayIncomeForAccount } from "./todayIncomeEstimate"
 
 interface DailyBalanceHistoryCoverage {
   totalAccounts: number
@@ -382,27 +381,29 @@ export function buildPerAccountDailyBalanceMoneySeries(params: {
       }
     }
 
-    for (let index = 0; index < dayKeys.length; index += 1) {
-      const estimate = estimateTodayIncomeForAccount({
-        enabled: estimatedTodayIncomeEnabled,
-        store,
-        account: buildEstimateAccount({ accountId, manualBalanceAccountIds }),
-        currentDayKey: dayKeys[index],
-      })
+    if (estimatedTodayIncomeEnabled) {
+      for (let index = 0; index < dayKeys.length; index += 1) {
+        const estimate = estimateTodayIncomeForAccount({
+          enabled: true,
+          store,
+          account: buildEstimateAccount({ accountId, manualBalanceAccountIds }),
+          currentDayKey: dayKeys[index],
+        })
 
-      if (
-        estimate.status !== "available" ||
-        estimate.estimatedTodayIncome === null
-      ) {
-        continue
+        if (
+          estimate.status !== "available" ||
+          estimate.estimatedTodayIncome === null
+        ) {
+          continue
+        }
+
+        estimatedIncome[index] = convertQuotaToSelectedMoney({
+          quota: estimate.estimatedTodayIncome,
+          conversionFactor,
+          exchangeRate,
+        })
+        coverageByDay[index].estimatedIncomeAccounts += 1
       }
-
-      estimatedIncome[index] = convertQuotaToSelectedMoney({
-        quota: estimate.estimatedTodayIncome,
-        conversionFactor,
-        exchangeRate,
-      })
-      coverageByDay[index].estimatedIncomeAccounts += 1
     }
 
     seriesByAccountId[accountId] = {
@@ -505,26 +506,28 @@ export function buildAccountRangeSummaries(params: {
         }
       }
 
-      const estimate = estimateTodayIncomeForAccount({
-        enabled: estimatedTodayIncomeEnabled,
-        store,
-        account: buildEstimateAccount({ accountId, manualBalanceAccountIds }),
-        currentDayKey: dayKey,
-      })
+      if (estimatedTodayIncomeEnabled) {
+        const estimate = estimateTodayIncomeForAccount({
+          enabled: true,
+          store,
+          account: buildEstimateAccount({ accountId, manualBalanceAccountIds }),
+          currentDayKey: dayKey,
+        })
 
-      if (
-        estimate.status !== "available" ||
-        estimate.estimatedTodayIncome === null
-      ) {
-        continue
+        if (
+          estimate.status !== "available" ||
+          estimate.estimatedTodayIncome === null
+        ) {
+          continue
+        }
+
+        estimatedIncomeDays += 1
+        estimatedIncomeSum += convertQuotaToSelectedMoney({
+          quota: estimate.estimatedTodayIncome,
+          conversionFactor,
+          exchangeRate,
+        })
       }
-
-      estimatedIncomeDays += 1
-      estimatedIncomeSum += convertQuotaToSelectedMoney({
-        quota: estimate.estimatedTodayIncome,
-        conversionFactor,
-        exchangeRate,
-      })
     }
 
     const incomeTotal = cashflowDays > 0 ? incomeSum : null

--- a/src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts
+++ b/src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts
@@ -1,0 +1,187 @@
+import { UI_CONSTANTS } from "~/constants/ui"
+import type { CurrencyAmount, SiteAccount } from "~/types"
+import type {
+  DailyBalanceHistoryStore,
+  TodayIncomeEstimateResult,
+} from "~/types/dailyBalanceHistory"
+
+import { subtractDaysFromDayKey } from "./dayKeys"
+
+type TodayIncomeEstimateAccount = Pick<SiteAccount, "id" | "manualBalanceUsd">
+
+type TodayIncomeMoneyTotalsAccount = Pick<
+  SiteAccount,
+  "id" | "manualBalanceUsd" | "exchange_rate"
+>
+
+const NULL_RESULT_BY_STATUS = {
+  disabled: {
+    reportedTodayIncome: null,
+    estimatedTodayIncome: null,
+    compensation: null,
+    status: "disabled",
+  },
+  missing_current_snapshot: {
+    reportedTodayIncome: null,
+    estimatedTodayIncome: null,
+    compensation: null,
+    status: "missing_current_snapshot",
+  },
+  manual_balance: {
+    reportedTodayIncome: null,
+    estimatedTodayIncome: null,
+    compensation: null,
+    status: "manual_balance",
+  },
+} as const satisfies Record<string, TodayIncomeEstimateResult>
+
+/**
+ * Detects accounts whose balance is user-entered rather than snapshot-derived.
+ */
+export function hasManualBalance(
+  account: Pick<SiteAccount, "manualBalanceUsd">,
+): boolean {
+  return (
+    typeof account.manualBalanceUsd === "string" &&
+    account.manualBalanceUsd.trim() !== ""
+  )
+}
+
+/**
+ * Estimates today's income from today's snapshot and exactly yesterday's baseline.
+ */
+export function estimateTodayIncomeForAccount(params: {
+  enabled: boolean
+  store: DailyBalanceHistoryStore | null
+  account: TodayIncomeEstimateAccount
+  currentDayKey: string
+}): TodayIncomeEstimateResult {
+  const { enabled, store, account, currentDayKey } = params
+
+  if (!enabled) return NULL_RESULT_BY_STATUS.disabled
+  if (hasManualBalance(account)) return NULL_RESULT_BY_STATUS.manual_balance
+
+  const currentSnapshot =
+    store?.snapshotsByAccountId[account.id]?.[currentDayKey]
+  if (!currentSnapshot) return NULL_RESULT_BY_STATUS.missing_current_snapshot
+
+  const reportedTodayIncome = Number.isFinite(currentSnapshot.today_income)
+    ? currentSnapshot.today_income
+    : null
+
+  const previousDayKey = subtractDaysFromDayKey(currentDayKey, 1)
+  const previousDayBaseline =
+    store?.snapshotsByAccountId[account.id]?.[previousDayKey]
+  if (!previousDayBaseline) {
+    return {
+      reportedTodayIncome,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "missing_baseline",
+    }
+  }
+
+  if (typeof currentSnapshot.today_quota_consumption !== "number") {
+    return {
+      reportedTodayIncome,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "missing_cashflow",
+    }
+  }
+
+  const estimatedTodayIncome =
+    currentSnapshot.quota -
+    previousDayBaseline.quota +
+    currentSnapshot.today_quota_consumption
+
+  if (!Number.isFinite(estimatedTodayIncome) || estimatedTodayIncome < 0) {
+    return {
+      reportedTodayIncome,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "invalid_estimate",
+    }
+  }
+
+  return {
+    reportedTodayIncome,
+    estimatedTodayIncome,
+    compensation:
+      reportedTodayIncome === null
+        ? null
+        : estimatedTodayIncome - reportedTodayIncome,
+    status: "available",
+  }
+}
+
+/**
+ * Converts raw quota units into both supported money totals.
+ */
+export function convertQuotaToMoney(params: {
+  quota: number
+  exchangeRate: number
+}): CurrencyAmount {
+  const usd = params.quota / UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+  return {
+    USD: usd,
+    CNY: usd * params.exchangeRate,
+  }
+}
+
+/**
+ * Builds aggregate reported and estimated today-income money totals.
+ */
+export function buildEstimatedTodayIncomeMoneyTotals(params: {
+  enabled: boolean
+  store: DailyBalanceHistoryStore | null
+  accounts: TodayIncomeMoneyTotalsAccount[]
+  currentDayKey: string
+}): {
+  trusted: CurrencyAmount
+  estimated: CurrencyAmount | null
+  availableAccounts: number
+  totalAccounts: number
+} {
+  const { enabled, store, accounts, currentDayKey } = params
+  const trusted = { USD: 0, CNY: 0 }
+  const estimated = { USD: 0, CNY: 0 }
+  let availableAccounts = 0
+
+  for (const account of accounts) {
+    const result = estimateTodayIncomeForAccount({
+      enabled,
+      store,
+      account,
+      currentDayKey,
+    })
+
+    if (result.reportedTodayIncome !== null) {
+      const trustedMoney = convertQuotaToMoney({
+        quota: result.reportedTodayIncome,
+        exchangeRate: account.exchange_rate,
+      })
+      trusted.USD += trustedMoney.USD
+      trusted.CNY += trustedMoney.CNY
+    }
+
+    if (result.status !== "available" || result.estimatedTodayIncome === null) {
+      continue
+    }
+
+    const estimatedMoney = convertQuotaToMoney({
+      quota: result.estimatedTodayIncome,
+      exchangeRate: account.exchange_rate,
+    })
+    estimated.USD += estimatedMoney.USD
+    estimated.CNY += estimatedMoney.CNY
+    availableAccounts += 1
+  }
+
+  return {
+    trusted,
+    estimated: availableAccounts > 0 ? estimated : null,
+    availableAccounts,
+    totalAccounts: accounts.length,
+  }
+}

--- a/src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts
+++ b/src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts
@@ -1,11 +1,11 @@
 import { UI_CONSTANTS } from "~/constants/ui"
+import { subtractDaysFromDayKey } from "~/services/history/dailyBalanceHistory/dayKeys"
 import type { CurrencyAmount, SiteAccount } from "~/types"
 import type {
   DailyBalanceHistoryStore,
   TodayIncomeEstimateResult,
 } from "~/types/dailyBalanceHistory"
-
-import { subtractDaysFromDayKey } from "./dayKeys"
+import { TODAY_INCOME_ESTIMATE_STATUS } from "~/types/dailyBalanceHistory"
 
 type TodayIncomeEstimateAccount = Pick<SiteAccount, "id" | "manualBalanceUsd">
 
@@ -19,19 +19,19 @@ const NULL_RESULT_BY_STATUS = {
     reportedTodayIncome: null,
     estimatedTodayIncome: null,
     compensation: null,
-    status: "disabled",
+    status: TODAY_INCOME_ESTIMATE_STATUS.disabled,
   },
   missing_current_snapshot: {
     reportedTodayIncome: null,
     estimatedTodayIncome: null,
     compensation: null,
-    status: "missing_current_snapshot",
+    status: TODAY_INCOME_ESTIMATE_STATUS.missingCurrentSnapshot,
   },
   manual_balance: {
     reportedTodayIncome: null,
     estimatedTodayIncome: null,
     compensation: null,
-    status: "manual_balance",
+    status: TODAY_INCOME_ESTIMATE_STATUS.manualBalance,
   },
 } as const satisfies Record<string, TodayIncomeEstimateResult>
 
@@ -77,7 +77,7 @@ export function estimateTodayIncomeForAccount(params: {
       reportedTodayIncome,
       estimatedTodayIncome: null,
       compensation: null,
-      status: "missing_baseline",
+      status: TODAY_INCOME_ESTIMATE_STATUS.missingBaseline,
     }
   }
 
@@ -86,7 +86,7 @@ export function estimateTodayIncomeForAccount(params: {
       reportedTodayIncome,
       estimatedTodayIncome: null,
       compensation: null,
-      status: "missing_cashflow",
+      status: TODAY_INCOME_ESTIMATE_STATUS.missingCashflow,
     }
   }
 
@@ -100,7 +100,7 @@ export function estimateTodayIncomeForAccount(params: {
       reportedTodayIncome,
       estimatedTodayIncome: null,
       compensation: null,
-      status: "invalid_estimate",
+      status: TODAY_INCOME_ESTIMATE_STATUS.invalidEstimate,
     }
   }
 
@@ -111,7 +111,7 @@ export function estimateTodayIncomeForAccount(params: {
       reportedTodayIncome === null
         ? null
         : estimatedTodayIncome - reportedTodayIncome,
-    status: "available",
+    status: TODAY_INCOME_ESTIMATE_STATUS.available,
   }
 }
 

--- a/src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts
+++ b/src/services/history/dailyBalanceHistory/todayIncomeEstimate.ts
@@ -165,7 +165,10 @@ export function buildEstimatedTodayIncomeMoneyTotals(params: {
       trusted.CNY += trustedMoney.CNY
     }
 
-    if (result.status !== "available" || result.estimatedTodayIncome === null) {
+    if (
+      result.status !== TODAY_INCOME_ESTIMATE_STATUS.available ||
+      result.estimatedTodayIncome === null
+    ) {
       continue
     }
 

--- a/src/services/preferences/migrations/preferencesMigration.ts
+++ b/src/services/preferences/migrations/preferencesMigration.ts
@@ -37,7 +37,7 @@ import { migrateSortingConfig } from "./sortingConfigMigration"
 const logger = createLogger("PreferencesMigration")
 
 // Current version of the preferences schema
-export const CURRENT_PREFERENCES_VERSION = 24
+export const CURRENT_PREFERENCES_VERSION = 25
 
 /**
  * Migration function type
@@ -312,6 +312,13 @@ const migrations: Record<number, PreferencesMigrationFunction> = {
       balanceHistory: {
         enabled,
         endOfDayCapture: { enabled: endOfDayCaptureEnabled },
+        estimatedTodayIncome: {
+          enabled:
+            typeof stored?.estimatedTodayIncome?.enabled === "boolean"
+              ? stored.estimatedTodayIncome.enabled
+              : DEFAULT_BALANCE_HISTORY_PREFERENCES.estimatedTodayIncome
+                  .enabled,
+        },
         retentionDays,
       },
       preferencesVersion: 12,
@@ -524,6 +531,42 @@ const migrations: Record<number, PreferencesMigrationFunction> = {
         enabled: false,
       },
       preferencesVersion: 24,
+    }
+  },
+
+  // Version 24 -> 25: Introduce estimated today income balance-history preference
+  25: (prefs: UserPreferences): UserPreferences => {
+    logger.debug(
+      "Migrating preferences from v24 to v25 (estimated today income preference)",
+    )
+
+    const stored = (prefs as any).balanceHistory as
+      | Partial<BalanceHistoryPreferences>
+      | undefined
+
+    return {
+      ...prefs,
+      balanceHistory: {
+        enabled:
+          typeof stored?.enabled === "boolean"
+            ? stored.enabled
+            : DEFAULT_BALANCE_HISTORY_PREFERENCES.enabled,
+        endOfDayCapture: {
+          enabled:
+            typeof stored?.endOfDayCapture?.enabled === "boolean"
+              ? stored.endOfDayCapture.enabled
+              : DEFAULT_BALANCE_HISTORY_PREFERENCES.endOfDayCapture.enabled,
+        },
+        estimatedTodayIncome: {
+          enabled:
+            typeof stored?.estimatedTodayIncome?.enabled === "boolean"
+              ? stored.estimatedTodayIncome.enabled
+              : DEFAULT_BALANCE_HISTORY_PREFERENCES.estimatedTodayIncome
+                  .enabled,
+        },
+        retentionDays: clampBalanceHistoryRetentionDays(stored?.retentionDays),
+      },
+      preferencesVersion: 25,
     }
   },
 }

--- a/src/types/dailyBalanceHistory.ts
+++ b/src/types/dailyBalanceHistory.ts
@@ -40,14 +40,18 @@ export interface DailyBalanceHistoryStore {
   snapshotsByAccountId: Record<string, Record<string, DailyBalanceSnapshot>>
 }
 
+export const TODAY_INCOME_ESTIMATE_STATUS = {
+  available: "available",
+  disabled: "disabled",
+  missingCurrentSnapshot: "missing_current_snapshot",
+  missingBaseline: "missing_baseline",
+  missingCashflow: "missing_cashflow",
+  manualBalance: "manual_balance",
+  invalidEstimate: "invalid_estimate",
+} as const
+
 export type TodayIncomeEstimateStatus =
-  | "available"
-  | "disabled"
-  | "missing_current_snapshot"
-  | "missing_baseline"
-  | "missing_cashflow"
-  | "manual_balance"
-  | "invalid_estimate"
+  (typeof TODAY_INCOME_ESTIMATE_STATUS)[keyof typeof TODAY_INCOME_ESTIMATE_STATUS]
 
 export interface TodayIncomeEstimateResult {
   reportedTodayIncome: number | null

--- a/src/types/dailyBalanceHistory.ts
+++ b/src/types/dailyBalanceHistory.ts
@@ -44,6 +44,10 @@ export interface BalanceHistoryEndOfDayCapturePreferences {
   enabled: boolean
 }
 
+export interface BalanceHistoryEstimatedTodayIncomePreferences {
+  enabled: boolean
+}
+
 /**
  * User preferences controlling daily balance history capture and retention.
  *
@@ -54,11 +58,13 @@ export interface BalanceHistoryEndOfDayCapturePreferences {
 export interface BalanceHistoryPreferences {
   enabled: boolean
   endOfDayCapture: BalanceHistoryEndOfDayCapturePreferences
+  estimatedTodayIncome: BalanceHistoryEstimatedTodayIncomePreferences
   retentionDays: number
 }
 
 export const DEFAULT_BALANCE_HISTORY_PREFERENCES: BalanceHistoryPreferences = {
   enabled: false,
   endOfDayCapture: { enabled: false },
+  estimatedTodayIncome: { enabled: false },
   retentionDays: 365,
 }

--- a/src/types/dailyBalanceHistory.ts
+++ b/src/types/dailyBalanceHistory.ts
@@ -40,6 +40,22 @@ export interface DailyBalanceHistoryStore {
   snapshotsByAccountId: Record<string, Record<string, DailyBalanceSnapshot>>
 }
 
+export type TodayIncomeEstimateStatus =
+  | "available"
+  | "disabled"
+  | "missing_current_snapshot"
+  | "missing_baseline"
+  | "missing_cashflow"
+  | "manual_balance"
+  | "invalid_estimate"
+
+export interface TodayIncomeEstimateResult {
+  reportedTodayIncome: number | null
+  estimatedTodayIncome: number | null
+  compensation: number | null
+  status: TodayIncomeEstimateStatus
+}
+
 export interface BalanceHistoryEndOfDayCapturePreferences {
   enabled: boolean
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -421,6 +421,7 @@ export interface DisplaySiteData {
   balance: CurrencyAmount
   todayConsumption: CurrencyAmount
   todayIncome: CurrencyAmount
+  estimatedTodayIncome?: CurrencyAmount | null
   todayTokens: TokenUsage
   health: HealthStatus
   last_sync_time?: number

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -413,9 +413,9 @@ describe("UserPreferencesContext", () => {
     expect(context.taskNotifications).toEqual(
       DEFAULT_TASK_NOTIFICATION_PREFERENCES,
     )
-    expect(
-      (latestContext as any)?.preferences.taskNotifications,
-    ).toBeUndefined()
+    expect((latestContext as any)?.preferences.taskNotifications).toEqual(
+      DEFAULT_TASK_NOTIFICATION_PREFERENCES,
+    )
   })
 
   it("hydrates missing task notification preferences before applying local updates", async () => {
@@ -897,6 +897,24 @@ describe("UserPreferencesContext", () => {
     })
     expect(mockedSendRuntimeMessage).toHaveBeenCalledWith({
       action: RuntimeActionIds.PreferencesRefreshContextMenus,
+    })
+  })
+
+  it("normalizes missing estimated today income preferences to disabled", async () => {
+    const preferences = clonePreferences()
+    preferences.balanceHistory = {
+      enabled: true,
+      endOfDayCapture: { enabled: false },
+      retentionDays: 30,
+    } as any
+
+    await renderProvider(preferences)
+
+    await waitFor(() => {
+      expect((latestContext as any)?.preferences.balanceHistory).toMatchObject({
+        enabled: true,
+        estimatedTodayIncome: { enabled: false },
+      })
     })
   })
 

--- a/tests/entrypoints/options/BalanceHistory.test.tsx
+++ b/tests/entrypoints/options/BalanceHistory.test.tsx
@@ -26,7 +26,7 @@ import { tagStorage } from "~/services/tags/tagStorage"
 import { DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION } from "~/types/dailyBalanceHistory"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { openSettingsTab, pushWithinOptionsPage } from "~/utils/navigation"
-import { render, screen, waitFor } from "~~/tests/test-utils/render"
+import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const getMetricDropdownButtonName = (
   section: "breakdown" | "trend",
@@ -1186,6 +1186,11 @@ describe("BalanceHistory options page", () => {
           name: "balanceHistory:breakdown.chartTypes.pie",
         }),
       ).toBeDisabled()
+      await user.click(
+        screen.getByRole("button", {
+          name: "balanceHistory:breakdown.chartTypes.histogram",
+        }),
+      )
 
       await user.click(
         screen.getByRole("button", {
@@ -1232,6 +1237,88 @@ describe("BalanceHistory options page", () => {
           ),
         }),
       ).toBeInTheDocument()
+      await user.click(
+        screen.getByRole("button", {
+          name: "balanceHistory:trend.chartTypes.bar",
+        }),
+      )
+      await user.click(
+        screen.getByRole("button", {
+          name: "balanceHistory:trend.chartTypes.line",
+        }),
+      )
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
+
+  it("updates currency and manual date controls", async () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const FIXED_NOW = new Date(2026, 1, 7, 12, 0, 0)
+    const fixedNowMs = FIXED_NOW.getTime()
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(fixedNowMs)
+    const updateCurrencyType = vi.fn(async () => {})
+
+    try {
+      const todayKey = getDayKeyFromUnixSeconds(Math.floor(fixedNowMs / 1000))
+      vi.mocked(useUserPreferencesContext).mockReturnValue({
+        ...createMockUserPreferencesContext({
+          enabled: true,
+          currencyType: "USD",
+        }),
+        updateCurrencyType,
+      } as any)
+      vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([
+        {
+          id: "a1",
+          site_name: "Site A",
+          site_url: "https://a.example.com",
+          site_type: SITE_TYPES.ONE_API,
+          account_info: { username: "User A" },
+        },
+      ] as any)
+      vi.mocked(dailyBalanceHistoryStorage.getStore).mockResolvedValue({
+        schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+        snapshotsByAccountId: {
+          a1: {
+            [todayKey]: {
+              quota: 10 * factor,
+              today_income: 1 * factor,
+              today_quota_consumption: 2 * factor,
+              capturedAt: 0,
+              source: "refresh",
+            },
+          },
+        },
+      } as any)
+
+      render(<BalanceHistory />)
+
+      expect(await screen.findByText(PAGE_TITLE)).toBeInTheDocument()
+
+      const user = userEvent.setup()
+      await user.click(
+        screen.getByRole("button", { name: "settings:display.usd" }),
+      )
+      await user.click(
+        screen.getByRole("button", { name: "settings:display.cny" }),
+      )
+
+      fireEvent.change(screen.getByLabelText(START_DAY_LABEL), {
+        target: { value: "2026-02-01" },
+      })
+      fireEvent.change(screen.getByLabelText(END_DAY_LABEL), {
+        target: { value: "2026-02-07" },
+      })
+      fireEvent.change(
+        screen.getByLabelText("balanceHistory:breakdown.controls.reference"),
+        { target: { value: "2026-02-07" } },
+      )
+
+      expect(updateCurrencyType).toHaveBeenCalledTimes(1)
+      expect(updateCurrencyType).toHaveBeenCalledWith("CNY")
+      expect(screen.getByLabelText(START_DAY_LABEL)).toHaveValue("2026-02-01")
+      expect(screen.getByLabelText(END_DAY_LABEL)).toHaveValue("2026-02-07")
     } finally {
       dateNowSpy.mockRestore()
     }

--- a/tests/entrypoints/options/BalanceHistory.test.tsx
+++ b/tests/entrypoints/options/BalanceHistory.test.tsx
@@ -138,12 +138,14 @@ describe("BalanceHistory options page", () => {
     showTodayCashflow = true,
     enabled = false,
     endOfDayCaptureEnabled = false,
+    estimatedTodayIncomeEnabled = false,
     retentionDays = DEFAULT_RETENTION_DAYS,
     currencyType = "USD",
   }: {
     showTodayCashflow?: boolean
     enabled?: boolean
     endOfDayCaptureEnabled?: boolean
+    estimatedTodayIncomeEnabled?: boolean
     retentionDays?: number
     currencyType?: "USD" | "CNY"
   } = {}) =>
@@ -153,6 +155,7 @@ describe("BalanceHistory options page", () => {
         balanceHistory: {
           enabled,
           endOfDayCapture: { enabled: endOfDayCaptureEnabled },
+          estimatedTodayIncome: { enabled: estimatedTodayIncomeEnabled },
           retentionDays,
         },
       },
@@ -1229,6 +1232,154 @@ describe("BalanceHistory options page", () => {
           ),
         }),
       ).toBeInTheDocument()
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
+
+  it("does not expose selected estimated income metrics after the preference is disabled", async () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const FIXED_NOW = new Date(2026, 1, 7, 12, 0, 0)
+    const fixedNowMs = FIXED_NOW.getTime()
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(fixedNowMs)
+
+    try {
+      const todayKey = getDayKeyFromUnixSeconds(Math.floor(fixedNowMs / 1000))
+
+      vi.mocked(useUserPreferencesContext).mockReturnValue(
+        createMockUserPreferencesContext({
+          enabled: true,
+          estimatedTodayIncomeEnabled: true,
+        }),
+      )
+      vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([
+        {
+          id: "a1",
+          site_name: "Site A",
+          site_url: "https://a.example.com",
+          site_type: SITE_TYPES.ONE_API,
+          account_info: { username: "User A" },
+        },
+      ] as any)
+      vi.mocked(dailyBalanceHistoryStorage.getStore).mockResolvedValue({
+        schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+        snapshotsByAccountId: {
+          a1: {
+            [todayKey]: {
+              quota: 10 * factor,
+              today_income: 1 * factor,
+              today_quota_consumption: 4 * factor,
+              capturedAt: 0,
+              source: "refresh",
+            },
+          },
+        },
+      } as any)
+
+      const { rerender } = render(<BalanceHistory />)
+
+      expect(await screen.findByText(PAGE_TITLE)).toBeInTheDocument()
+
+      const user = userEvent.setup()
+      await user.click(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "breakdown",
+            "balanceHistory:metrics.balance",
+          ),
+        }),
+      )
+      await user.click(
+        await screen.findByRole("menuitemradio", {
+          name: "balanceHistory:metrics.estimatedIncome",
+        }),
+      )
+      await user.click(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "trend",
+            "balanceHistory:metrics.balance",
+          ),
+        }),
+      )
+      await user.click(
+        await screen.findByRole("menuitemradio", {
+          name: "balanceHistory:metrics.estimatedIncome",
+        }),
+      )
+
+      expect(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "breakdown",
+            "balanceHistory:metrics.estimatedIncome",
+          ),
+        }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "trend",
+            "balanceHistory:metrics.estimatedIncome",
+          ),
+        }),
+      ).toBeInTheDocument()
+
+      vi.mocked(useUserPreferencesContext).mockReturnValue(
+        createMockUserPreferencesContext({
+          enabled: true,
+          estimatedTodayIncomeEnabled: false,
+        }),
+      )
+
+      rerender(<BalanceHistory />)
+
+      expect(
+        screen.queryByRole("button", {
+          name: getMetricDropdownButtonName(
+            "breakdown",
+            "balanceHistory:metrics.estimatedIncome",
+          ),
+        }),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", {
+          name: getMetricDropdownButtonName(
+            "trend",
+            "balanceHistory:metrics.estimatedIncome",
+          ),
+        }),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "breakdown",
+            "balanceHistory:metrics.income",
+          ),
+        }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "trend",
+            "balanceHistory:metrics.income",
+          ),
+        }),
+      ).toBeInTheDocument()
+
+      await user.click(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "breakdown",
+            "balanceHistory:metrics.income",
+          ),
+        }),
+      )
+      expect(
+        screen.queryByRole("menuitemradio", {
+          name: "balanceHistory:metrics.estimatedIncome",
+        }),
+      ).not.toBeInTheDocument()
     } finally {
       dateNowSpy.mockRestore()
     }

--- a/tests/entrypoints/options/BalanceHistory.test.tsx
+++ b/tests/entrypoints/options/BalanceHistory.test.tsx
@@ -1471,4 +1471,109 @@ describe("BalanceHistory options page", () => {
       dateNowSpy.mockRestore()
     }
   })
+
+  it("uses estimated income metrics while the preference is enabled", async () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const fixedNowMs = new Date(2026, 1, 7, 12, 0, 0).getTime()
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(fixedNowMs)
+
+    try {
+      const todayKey = getDayKeyFromUnixSeconds(Math.floor(fixedNowMs / 1000))
+      const previousDayKey = subtractDaysFromDayKey(todayKey, 1)
+
+      vi.mocked(useUserPreferencesContext).mockReturnValue(
+        createMockUserPreferencesContext({
+          enabled: true,
+          estimatedTodayIncomeEnabled: true,
+        }),
+      )
+      vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([
+        {
+          id: "a1",
+          site_name: "Site A",
+          site_url: "https://a.example.com",
+          site_type: SITE_TYPES.ONE_API,
+          account_info: { username: "User A" },
+        },
+      ] as any)
+      vi.mocked(dailyBalanceHistoryStorage.getStore).mockResolvedValue({
+        schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+        snapshotsByAccountId: {
+          a1: {
+            [previousDayKey]: {
+              quota: 10 * factor,
+              today_income: 0,
+              today_quota_consumption: 0,
+              capturedAt: 0,
+              source: "alarm",
+            },
+            [todayKey]: {
+              quota: 12 * factor,
+              today_income: 0.5 * factor,
+              today_quota_consumption: 1 * factor,
+              capturedAt: 1,
+              source: "refresh",
+            },
+          },
+        },
+      } as any)
+
+      render(<BalanceHistory />)
+
+      expect(await screen.findByText(PAGE_TITLE)).toBeInTheDocument()
+
+      const user = userEvent.setup()
+      await user.click(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "breakdown",
+            "balanceHistory:metrics.balance",
+          ),
+        }),
+      )
+      await user.click(
+        await screen.findByRole("menuitemradio", {
+          name: "balanceHistory:metrics.estimatedIncome",
+        }),
+      )
+
+      expect(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "breakdown",
+            "balanceHistory:metrics.estimatedIncome",
+          ),
+        }),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByLabelText("balanceHistory:breakdown.controls.reference"),
+      ).not.toBeInTheDocument()
+
+      await user.click(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "trend",
+            "balanceHistory:metrics.balance",
+          ),
+        }),
+      )
+      await user.click(
+        await screen.findByRole("menuitemradio", {
+          name: "balanceHistory:metrics.estimatedIncome",
+        }),
+      )
+
+      expect(
+        screen.getByRole("button", {
+          name: getMetricDropdownButtonName(
+            "trend",
+            "balanceHistory:metrics.estimatedIncome",
+          ),
+        }),
+      ).toBeInTheDocument()
+      expect(echarts.init).toHaveBeenCalled()
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
 })

--- a/tests/entrypoints/options/BalanceHistorySettings.test.tsx
+++ b/tests/entrypoints/options/BalanceHistorySettings.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import BalanceHistorySettings from "~/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings"
 import { hasAlarmsAPI } from "~/utils/browser/browserApi"
@@ -38,7 +39,15 @@ vi.mock("react-hot-toast", () => {
 describe("BalanceHistorySettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
     vi.mocked(hasAlarmsAPI).mockReturnValue(true)
+    ;(globalThis as any).browser = {
+      ...(globalThis as any).browser,
+      runtime: {
+        ...((globalThis as any).browser?.runtime ?? {}),
+        sendMessage: vi.fn(),
+      },
+    }
   })
 
   const renderSubject = () => render(<BalanceHistorySettings />)
@@ -136,5 +145,55 @@ describe("BalanceHistorySettings", () => {
         name: "balanceHistory:settings.estimatedTodayIncome",
       }),
     ).not.toBeDisabled()
+  })
+
+  it("shows a development-only action to seed estimated-income snapshots", async () => {
+    vi.stubEnv("MODE", "development")
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValue({ success: true, data: { seeded: 2, skipped: 1 } })
+    ;(globalThis as any).browser.runtime.sendMessage = sendMessage
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: {
+        balanceHistory: {
+          enabled: true,
+          endOfDayCapture: { enabled: false },
+          estimatedTodayIncome: { enabled: true },
+          retentionDays: 30,
+        },
+      },
+      updateBalanceHistory: vi.fn().mockResolvedValue(true),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(await screen.findByText("Dev: Seed estimate snapshots"))
+
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith({
+        action: RuntimeActionIds.BalanceHistoryDebugSeedEstimateSnapshots,
+      })
+    })
+  })
+
+  it("hides the estimated-income snapshot seed action outside development mode", () => {
+    vi.stubEnv("MODE", "production")
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: {
+        balanceHistory: {
+          enabled: true,
+          endOfDayCapture: { enabled: false },
+          estimatedTodayIncome: { enabled: true },
+          retentionDays: 30,
+        },
+      },
+      updateBalanceHistory: vi.fn().mockResolvedValue(true),
+    } as any)
+
+    renderSubject()
+
+    expect(
+      screen.queryByText("Dev: Seed estimate snapshots"),
+    ).not.toBeInTheDocument()
   })
 })

--- a/tests/entrypoints/options/BalanceHistorySettings.test.tsx
+++ b/tests/entrypoints/options/BalanceHistorySettings.test.tsx
@@ -1,3 +1,4 @@
+import toast from "react-hot-toast"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
@@ -78,6 +79,83 @@ describe("BalanceHistorySettings", () => {
         estimatedTodayIncome: { enabled: false },
         retentionDays: 14,
       })
+    })
+  })
+
+  it("falls back to default retention days when preferences omit balance history", async () => {
+    const updateBalanceHistory = vi.fn().mockResolvedValue(true)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: {},
+      updateBalanceHistory,
+    } as any)
+
+    renderSubject()
+
+    expect(
+      await screen.findByLabelText("balanceHistory:settings.retentionDays"),
+    ).toHaveValue(365)
+
+    fireEvent.click(screen.getByText("balanceHistory:actions.applySettings"))
+
+    await waitFor(() => {
+      expect(updateBalanceHistory).toHaveBeenCalledWith({
+        enabled: false,
+        endOfDayCapture: { enabled: false },
+        estimatedTodayIncome: { enabled: false },
+        retentionDays: 365,
+      })
+    })
+  })
+
+  it("shows a local error when saving settings returns false", async () => {
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: {
+        balanceHistory: {
+          enabled: true,
+          endOfDayCapture: { enabled: false },
+          retentionDays: 30,
+        },
+      },
+      updateBalanceHistory: vi.fn().mockResolvedValue(false),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(
+      await screen.findByText("balanceHistory:actions.applySettings"),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings:messages.saveSettingsFailed",
+        { id: "toast-id" },
+      )
+    })
+  })
+
+  it("shows exception details when saving settings throws", async () => {
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: {
+        balanceHistory: {
+          enabled: true,
+          endOfDayCapture: { enabled: false },
+          retentionDays: 30,
+        },
+      },
+      updateBalanceHistory: vi.fn().mockRejectedValue(new Error("disk full")),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(
+      await screen.findByText("balanceHistory:actions.applySettings"),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "balanceHistory:messages.error.settingsSaveFailed",
+        { id: "toast-id" },
+      )
     })
   })
 
@@ -173,6 +251,92 @@ describe("BalanceHistorySettings", () => {
       expect(sendMessage).toHaveBeenCalledWith({
         action: RuntimeActionIds.BalanceHistoryDebugSeedEstimateSnapshots,
       })
+    })
+  })
+
+  it("shows a local error when the development seed action fails", async () => {
+    vi.stubEnv("MODE", "development")
+    const sendMessage = vi.fn().mockResolvedValue({
+      success: false,
+      error: "seed unavailable",
+    })
+    ;(globalThis as any).browser.runtime.sendMessage = sendMessage
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: {
+        balanceHistory: {
+          enabled: true,
+          endOfDayCapture: { enabled: false },
+          estimatedTodayIncome: { enabled: true },
+          retentionDays: 30,
+        },
+      },
+      updateBalanceHistory: vi.fn().mockResolvedValue(true),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(await screen.findByText("Dev: Seed estimate snapshots"))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("seed unavailable", {
+        id: "toast-id",
+      })
+    })
+  })
+
+  it("shows exception details when the development seed action throws", async () => {
+    vi.stubEnv("MODE", "development")
+    const sendMessage = vi.fn().mockRejectedValue(new Error("runtime closed"))
+    ;(globalThis as any).browser.runtime.sendMessage = sendMessage
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: {
+        balanceHistory: {
+          enabled: true,
+          endOfDayCapture: { enabled: false },
+          estimatedTodayIncome: { enabled: true },
+          retentionDays: 30,
+        },
+      },
+      updateBalanceHistory: vi.fn().mockResolvedValue(true),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(await screen.findByText("Dev: Seed estimate snapshots"))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("runtime closed", {
+        id: "toast-id",
+      })
+    })
+  })
+
+  it("uses the clamped retention value from numeric input", async () => {
+    const updateBalanceHistory = vi.fn().mockResolvedValue(true)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: {
+        balanceHistory: {
+          enabled: true,
+          endOfDayCapture: { enabled: false },
+          estimatedTodayIncome: { enabled: true },
+          retentionDays: 30,
+        },
+      },
+      updateBalanceHistory,
+    } as any)
+
+    renderSubject()
+
+    fireEvent.change(
+      await screen.findByLabelText("balanceHistory:settings.retentionDays"),
+      { target: { value: "9999" } },
+    )
+    fireEvent.click(screen.getByText("balanceHistory:actions.applySettings"))
+
+    await waitFor(() => {
+      expect(updateBalanceHistory).toHaveBeenCalledWith(
+        expect.objectContaining({ retentionDays: 3650 }),
+      )
     })
   })
 

--- a/tests/entrypoints/options/BalanceHistorySettings.test.tsx
+++ b/tests/entrypoints/options/BalanceHistorySettings.test.tsx
@@ -66,7 +66,43 @@ describe("BalanceHistorySettings", () => {
       expect(updateBalanceHistory).toHaveBeenCalledWith({
         enabled: true,
         endOfDayCapture: { enabled: true },
+        estimatedTodayIncome: { enabled: false },
         retentionDays: 14,
+      })
+    })
+  })
+
+  it("saves estimated today income display preference", async () => {
+    const updateBalanceHistory = vi.fn().mockResolvedValue(true)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: {
+        balanceHistory: {
+          enabled: true,
+          endOfDayCapture: { enabled: false },
+          estimatedTodayIncome: { enabled: false },
+          retentionDays: 30,
+        },
+      },
+      updateBalanceHistory,
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(
+      await screen.findByRole("switch", {
+        name: "balanceHistory:settings.estimatedTodayIncome",
+      }),
+    )
+    fireEvent.click(
+      await screen.findByText("balanceHistory:actions.applySettings"),
+    )
+
+    await waitFor(() => {
+      expect(updateBalanceHistory).toHaveBeenCalledWith({
+        enabled: true,
+        endOfDayCapture: { enabled: false },
+        estimatedTodayIncome: { enabled: true },
+        retentionDays: 30,
       })
     })
   })
@@ -90,8 +126,15 @@ describe("BalanceHistorySettings", () => {
       await screen.findByText("balanceHistory:settings.alarmUnsupported"),
     ).toBeInTheDocument()
 
-    const switches = screen.getAllByRole("switch")
-    expect(switches).toHaveLength(2)
-    expect(switches[1]).toBeDisabled()
+    expect(
+      screen.getByRole("switch", {
+        name: "balanceHistory:settings.endOfDayCapture",
+      }),
+    ).toBeDisabled()
+    expect(
+      screen.getByRole("switch", {
+        name: "balanceHistory:settings.estimatedTodayIncome",
+      }),
+    ).not.toBeDisabled()
   })
 })

--- a/tests/entrypoints/popup/BalanceSection.test.tsx
+++ b/tests/entrypoints/popup/BalanceSection.test.tsx
@@ -121,6 +121,12 @@ const createAccountDataContextValue = (
     today_total_consumption: 400_000,
     today_total_income: 250_000,
   },
+  todayIncomeEstimateTotals: {
+    trusted: { USD: 1.25, CNY: 8.75 },
+    estimated: null,
+    availableAccounts: 0,
+    totalAccounts: 1,
+  },
   isInitialLoad: false,
   prevTotalConsumption: { USD: 1.5, CNY: 10.5 },
   lastUpdateTime: new Date("2026-03-30T08:00:00.000Z"),
@@ -141,6 +147,11 @@ describe("popup BalanceSection components", () => {
       currencyType: "USD",
       showTodayCashflow: true,
       updateCurrencyType: vi.fn(),
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: false },
+        },
+      },
     })
     mockUseAccountDataContext.mockReturnValue(createAccountDataContextValue())
   })
@@ -156,6 +167,11 @@ describe("popup BalanceSection components", () => {
       currencyType: "USD",
       showTodayCashflow: true,
       updateCurrencyType,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: false },
+        },
+      },
     })
 
     render(<AccountBalanceSummary />)
@@ -239,11 +255,141 @@ describe("popup BalanceSection components", () => {
     expect(incomeValue).toHaveAttribute("data-end", "1.25")
   })
 
+  it("keeps one income card when estimated income display is disabled", () => {
+    mockUseUserPreferencesContext.mockReturnValue({
+      currencyType: "USD",
+      showTodayCashflow: true,
+      updateCurrencyType: vi.fn(),
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: false },
+        },
+      },
+    })
+
+    render(<AccountBalanceSummary />)
+
+    expect(screen.getByText("account:stats.todayIncome")).toBeInTheDocument()
+    expect(
+      screen.queryByText("account:stats.estimatedTodayIncome"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows trusted and estimated today income when enabled", () => {
+    mockUseUserPreferencesContext.mockReturnValue({
+      currencyType: "USD",
+      showTodayCashflow: true,
+      updateCurrencyType: vi.fn(),
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    })
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        todayIncomeEstimateTotals: {
+          trusted: { USD: 9, CNY: 63 },
+          estimated: { USD: 2.75, CNY: 19.25 },
+          availableAccounts: 1,
+          totalAccounts: 1,
+        },
+      }),
+    )
+
+    render(<AccountBalanceSummary />)
+
+    expect(
+      screen.getByText("account:stats.trustedTodayIncome"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("account:stats.estimatedTodayIncome"),
+    ).toBeInTheDocument()
+    expect(screen.getAllByTestId("countup").at(-2)).toHaveAttribute(
+      "data-end",
+      "1.25",
+    )
+    expect(screen.getAllByTestId("countup").at(-1)).toHaveAttribute(
+      "data-end",
+      "2.75",
+    )
+  })
+
+  it("shows unavailable marker when estimated today income is enabled but unavailable", () => {
+    mockUseUserPreferencesContext.mockReturnValue({
+      currencyType: "USD",
+      showTodayCashflow: true,
+      updateCurrencyType: vi.fn(),
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    })
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        todayIncomeEstimateTotals: {
+          trusted: { USD: 1.25, CNY: 8.75 },
+          estimated: null,
+          availableAccounts: 0,
+          totalAccounts: 1,
+        },
+      }),
+    )
+
+    render(<AccountBalanceSummary />)
+
+    expect(
+      screen.getByText("account:stats.estimatedTodayIncome"),
+    ).toBeInTheDocument()
+    expect(screen.getByText("-")).toBeInTheDocument()
+  })
+
+  it("omits plus prefix for non-positive estimated today income values", () => {
+    mockUseUserPreferencesContext.mockReturnValue({
+      currencyType: "USD",
+      showTodayCashflow: true,
+      updateCurrencyType: vi.fn(),
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    })
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        todayIncomeEstimateTotals: {
+          trusted: { USD: 1.25, CNY: 8.75 },
+          estimated: { USD: 0, CNY: -1 },
+          availableAccounts: 1,
+          totalAccounts: 1,
+        },
+      }),
+    )
+
+    render(<AccountBalanceSummary />)
+
+    const estimatedValue = screen.getAllByRole("button", {
+      name: "common:currency.clickToSwitch",
+    })[3]
+    expect(estimatedValue).toHaveTextContent("$0.00")
+    expect(estimatedValue).not.toHaveTextContent("+$0.00")
+    expect(screen.getAllByTestId("countup").at(-1)).toHaveAttribute(
+      "data-end",
+      "0",
+    )
+  })
+
   it("uses initial-load animation, hides cashflow cards when disabled, and shows CNY totals", () => {
     mockUseUserPreferencesContext.mockReturnValue({
       currencyType: "CNY",
       showTodayCashflow: false,
       updateCurrencyType: vi.fn(),
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: false },
+        },
+      },
     })
     mockUseAccountDataContext.mockReturnValue(
       createAccountDataContextValue({

--- a/tests/entrypoints/popup/BalanceSection.test.tsx
+++ b/tests/entrypoints/popup/BalanceSection.test.tsx
@@ -190,6 +190,11 @@ describe("popup BalanceSection components", () => {
         name: "common:currency.clickToSwitch",
       })[0],
     ).toHaveTextContent("$10.00")
+    expect(
+      screen.getAllByRole("button", {
+        name: "common:currency.clickToSwitch",
+      })[0],
+    ).toHaveClass("text-3xl")
 
     expect(consumptionValue).toHaveAttribute("data-start", "1.5")
     expect(consumptionValue).toHaveAttribute("data-end", "0.8")

--- a/tests/features/AccountManagement/components/BalanceDisplay.test.tsx
+++ b/tests/features/AccountManagement/components/BalanceDisplay.test.tsx
@@ -285,6 +285,41 @@ describe("BalanceDisplay", () => {
     expect(handleRefreshAccount).not.toHaveBeenCalled()
   })
 
+  it("renders a neutral enabled estimated income as a refresh action", async () => {
+    const user = userEvent.setup()
+    const handleRefreshAccount = vi.fn().mockResolvedValue(undefined)
+
+    mockUseUserPreferencesContext.mockReturnValue({
+      currencyType: "USD",
+      showTodayCashflow: true,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    })
+    mockUseAccountActionsContext.mockReturnValue({
+      handleRefreshAccount,
+      refreshingAccountId: null,
+    })
+
+    const site = buildDisplaySiteData({
+      disabled: false,
+      estimatedTodayIncome: { USD: 0, CNY: 0 },
+    })
+    render(<BalanceDisplay site={site} />)
+
+    const estimatedButton = screen.getByRole("button", {
+      name: "account:stats.estimatedTodayIncome",
+    })
+    expect(estimatedButton).toHaveTextContent("~$0.00")
+    expect(estimatedButton).toHaveClass("text-gray-400")
+
+    await user.click(estimatedButton)
+
+    expect(handleRefreshAccount).toHaveBeenCalledWith(site, true)
+  })
+
   it("shows disabled titles and neutral cashflow styling without refreshing disabled accounts", async () => {
     const user = userEvent.setup()
     const site = buildDisplaySiteData({

--- a/tests/features/AccountManagement/components/BalanceDisplay.test.tsx
+++ b/tests/features/AccountManagement/components/BalanceDisplay.test.tsx
@@ -243,6 +243,48 @@ describe("BalanceDisplay", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("renders neutral disabled estimated income without a refresh action", async () => {
+    const user = userEvent.setup()
+    const handleRefreshAccount = vi.fn().mockResolvedValue(undefined)
+
+    mockUseUserPreferencesContext.mockReturnValue({
+      currencyType: "USD",
+      showTodayCashflow: true,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    })
+    mockUseAccountActionsContext.mockReturnValue({
+      handleRefreshAccount,
+      refreshingAccountId: null,
+    })
+
+    render(
+      <BalanceDisplay
+        site={buildDisplaySiteData({
+          disabled: true,
+          estimatedTodayIncome: { USD: 0, CNY: 0 },
+        })}
+      />,
+    )
+
+    const disabledValues = screen.getAllByTitle("account:list.site.disabled")
+    const estimatedNode = disabledValues.at(-1)!
+    expect(estimatedNode).toHaveTextContent("~$0.00")
+    expect(estimatedNode).toHaveClass("text-gray-400")
+    expect(
+      screen.queryByRole("button", {
+        name: "account:stats.estimatedTodayIncome",
+      }),
+    ).not.toBeInTheDocument()
+
+    await user.click(estimatedNode)
+
+    expect(handleRefreshAccount).not.toHaveBeenCalled()
+  })
+
   it("shows disabled titles and neutral cashflow styling without refreshing disabled accounts", async () => {
     const user = userEvent.setup()
     const site = buildDisplaySiteData({

--- a/tests/features/AccountManagement/components/BalanceDisplay.test.tsx
+++ b/tests/features/AccountManagement/components/BalanceDisplay.test.tsx
@@ -63,6 +63,11 @@ describe("BalanceDisplay", () => {
     mockUseUserPreferencesContext.mockReturnValue({
       currencyType: "USD",
       showTodayCashflow: true,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: false },
+        },
+      },
     })
     mockUseAccountDataContext.mockReturnValue({
       isInitialLoad: false,
@@ -127,14 +132,115 @@ describe("BalanceDisplay", () => {
     const incomeNode = screen.getByTitle("account:list.balance.refreshIncome")
 
     expect(balanceNode).toHaveClass("cursor-pointer")
+    expect(balanceNode).toHaveClass("ml-auto", "text-right")
     expect(consumptionNode).toHaveClass("text-green-500")
+    expect(consumptionNode).toHaveClass("ml-auto", "text-right")
     expect(incomeNode).toHaveClass("text-blue-500")
+    expect(incomeNode).toHaveClass("ml-auto", "text-right")
     expect(consumptionValue).toHaveAttribute("data-end", "4")
     expect(incomeValue).toHaveAttribute("data-end", "3")
 
     await user.click(balanceNode)
 
     expect(handleRefreshAccount).toHaveBeenCalledWith(updatedSite, true)
+  })
+
+  it("renders the account estimated income when enabled and available", async () => {
+    const user = userEvent.setup()
+    const site = buildDisplaySiteData({
+      balance: { USD: 25.25, CNY: 176.75 },
+      todayConsumption: { USD: 3, CNY: 21 },
+      todayIncome: { USD: 2, CNY: 14 },
+      estimatedTodayIncome: { USD: 5.5, CNY: 38.5 },
+    })
+    const updatedSite = buildDisplaySiteData({
+      ...site,
+      estimatedTodayIncome: { USD: 6.5, CNY: 45.5 },
+    })
+    const handleRefreshAccount = vi.fn().mockResolvedValue(undefined)
+
+    mockUseUserPreferencesContext.mockReturnValue({
+      currencyType: "USD",
+      showTodayCashflow: true,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    })
+    mockUseAccountActionsContext.mockReturnValue({
+      handleRefreshAccount,
+      refreshingAccountId: null,
+    })
+
+    const { rerender } = render(<BalanceDisplay site={site} />)
+
+    expect(screen.queryByTestId("countup")).toBeNull()
+
+    rerender(<BalanceDisplay site={updatedSite} />)
+
+    const estimatedNode = screen.getByTitle(
+      "account:stats.estimatedTodayIncome",
+    )
+    expect(
+      screen.getByRole("button", {
+        name: "account:stats.estimatedTodayIncome",
+      }),
+    ).toHaveTextContent("~$6.50")
+    expect(estimatedNode).toHaveClass("text-indigo-500")
+    expect(estimatedNode).toHaveTextContent("~$6.50")
+    expect(screen.getAllByTestId("countup").at(-1)).toHaveAttribute(
+      "data-end",
+      "6.5",
+    )
+
+    await user.click(estimatedNode)
+
+    expect(handleRefreshAccount).toHaveBeenCalledWith(updatedSite, true)
+  })
+
+  it("hides account estimated income when the preference is disabled or unavailable", () => {
+    mockUseUserPreferencesContext.mockReturnValue({
+      currencyType: "USD",
+      showTodayCashflow: true,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: false },
+        },
+      },
+    })
+
+    const { rerender } = render(
+      <BalanceDisplay
+        site={buildDisplaySiteData({
+          estimatedTodayIncome: { USD: 5.5, CNY: 38.5 },
+        })}
+      />,
+    )
+
+    expect(
+      screen.queryByTitle("account:stats.estimatedTodayIncome"),
+    ).not.toBeInTheDocument()
+
+    mockUseUserPreferencesContext.mockReturnValue({
+      currencyType: "USD",
+      showTodayCashflow: true,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    })
+
+    rerender(
+      <BalanceDisplay
+        site={buildDisplaySiteData({ estimatedTodayIncome: null })}
+      />,
+    )
+
+    expect(
+      screen.queryByTitle("account:stats.estimatedTodayIncome"),
+    ).not.toBeInTheDocument()
   })
 
   it("shows disabled titles and neutral cashflow styling without refreshing disabled accounts", async () => {

--- a/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
@@ -71,6 +71,11 @@ vi.mock("~/contexts/UserPreferencesContext", () => ({
       lastModified: Date.now(),
       criteria: [{ id: "current_site", enabled: true, priority: 0 }],
     },
+    preferences: {
+      balanceHistory: {
+        estimatedTodayIncome: { enabled: false },
+      },
+    },
   }),
 }))
 

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -339,6 +339,15 @@ function createEmptyStats() {
   }
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
 function createBrowserTab(
   overrides: Partial<browser.tabs.Tab> = {},
 ): browser.tabs.Tab {
@@ -2346,6 +2355,12 @@ describe("AccountDataContext auto-checkin runCompleted handling", () => {
       expect(byId.a?.checkIn?.siteStatus?.isCheckedInToday).toBe(true)
       expect(byId.a?.estimatedTodayIncome).toEqual({ USD: 3, CNY: 21 })
       expect(byId.b?.estimatedTodayIncome).toEqual({ USD: 2, CNY: 14 })
+      expect(getLatestCtx().todayIncomeEstimateTotals).toMatchObject({
+        trusted: { USD: 1, CNY: 7 },
+        estimated: { USD: 5, CNY: 35 },
+        availableAccounts: 2,
+        totalAccounts: 2,
+      })
     })
 
     expect(mockGetDailyBalanceHistoryStore).toHaveBeenCalledTimes(2)
@@ -2485,6 +2500,10 @@ describe("AccountDataContext auto-checkin runCompleted handling", () => {
   it("merges concurrent targeted reloads against the latest account snapshot", async () => {
     mockResetExpiredCheckIns.mockResolvedValue(undefined)
     mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    const emptyStore = {
+      schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+      snapshotsByAccountId: {},
+    }
 
     const accountA: any = {
       id: "a",
@@ -2536,6 +2555,7 @@ describe("AccountDataContext auto-checkin runCompleted handling", () => {
       }
       return Promise.resolve(null)
     })
+    mockGetDailyBalanceHistoryStore.mockResolvedValue(emptyStore)
 
     let latestCtx: ReturnType<typeof useAccountDataContext> | null = null
 
@@ -2555,6 +2575,13 @@ describe("AccountDataContext auto-checkin runCompleted handling", () => {
       | ((message: any) => void)
       | undefined
     expect(listener).toBeTypeOf("function")
+
+    mockGetDailyBalanceHistoryStore.mockReset()
+    const reloadAStore = createDeferred<typeof emptyStore>()
+    const reloadBStore = createDeferred<typeof emptyStore>()
+    mockGetDailyBalanceHistoryStore
+      .mockReturnValueOnce(reloadAStore.promise)
+      .mockReturnValueOnce(reloadBStore.promise)
 
     await act(async () => {
       listener!({
@@ -2576,11 +2603,7 @@ describe("AccountDataContext auto-checkin runCompleted handling", () => {
     })
 
     await waitFor(() => {
-      const byId = Object.fromEntries(
-        (latestCtx?.displayData ?? []).map((item: any) => [item.id, item]),
-      )
-      expect(byId.a?.checkIn?.siteStatus?.isCheckedInToday).toBe(true)
-      expect(byId.b?.checkIn?.siteStatus?.isCheckedInToday).toBe(false)
+      expect(mockGetDailyBalanceHistoryStore).toHaveBeenCalledTimes(1)
     })
 
     await act(async () => {
@@ -2592,11 +2615,127 @@ describe("AccountDataContext auto-checkin runCompleted handling", () => {
     })
 
     await waitFor(() => {
+      expect(mockGetDailyBalanceHistoryStore).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      reloadBStore.resolve(emptyStore)
+      await reloadBStore.promise
+    })
+
+    await waitFor(() => {
       const byId = Object.fromEntries(
         (latestCtx?.displayData ?? []).map((item: any) => [item.id, item]),
       )
       expect(byId.a?.checkIn?.siteStatus?.isCheckedInToday).toBe(true)
       expect(byId.b?.checkIn?.siteStatus?.isCheckedInToday).toBe(true)
     })
+
+    await act(async () => {
+      reloadAStore.resolve(emptyStore)
+      await reloadAStore.promise
+    })
+
+    await waitFor(() => {
+      const byId = Object.fromEntries(
+        (latestCtx?.displayData ?? []).map((item: any) => [item.id, item]),
+      )
+      expect(byId.a?.checkIn?.siteStatus?.isCheckedInToday).toBe(true)
+      expect(byId.b?.checkIn?.siteStatus?.isCheckedInToday).toBe(true)
+    })
+  })
+
+  it("ignores older targeted reloads for the same account after a newer reload completes", async () => {
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    const emptyStore = {
+      schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+      snapshotsByAccountId: {},
+    }
+
+    mockGetAllAccounts.mockResolvedValue([
+      {
+        id: "a",
+        checkIn: { siteStatus: { isCheckedInToday: false } },
+      },
+    ])
+    mockGetAllBookmarks.mockResolvedValue([])
+    mockGetOrderedList.mockResolvedValue(["a"])
+    mockGetPinnedList.mockResolvedValue([])
+    mockGetAccountStats.mockResolvedValue(createEmptyStats())
+    mockConvertToDisplayData.mockImplementation((input: any) => {
+      const accounts = Array.isArray(input) ? input : [input]
+      const display = accounts.map((account: any) => ({
+        id: account.id,
+        name: account.id,
+        checkIn: account.checkIn,
+      }))
+      return Array.isArray(input) ? display : display[0]
+    })
+    mockGetDailyBalanceHistoryStore.mockResolvedValue(emptyStore)
+
+    const olderReload = createDeferred<any>()
+    const newerReload = createDeferred<any>()
+    mockGetAccountById
+      .mockReturnValueOnce(olderReload.promise)
+      .mockReturnValueOnce(newerReload.promise)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData).toEqual([
+        expect.objectContaining({
+          id: "a",
+          checkIn: { siteStatus: { isCheckedInToday: false } },
+        }),
+      ])
+    })
+
+    const listener = (globalThis as any).__accountDataContextRuntimeListener as
+      | ((message: any) => void)
+      | undefined
+    expect(listener).toBeTypeOf("function")
+
+    mockGetDailyBalanceHistoryStore.mockClear()
+
+    await act(async () => {
+      listener!({
+        action: RuntimeActionIds.AutoCheckinRunCompleted,
+        updatedAccountIds: ["a"],
+      })
+      listener!({
+        action: RuntimeActionIds.AutoCheckinRunCompleted,
+        updatedAccountIds: ["a"],
+      })
+    })
+
+    await act(async () => {
+      newerReload.resolve({
+        id: "a",
+        checkIn: { siteStatus: { isCheckedInToday: true } },
+      })
+      await newerReload.promise
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData[0]?.checkIn).toEqual({
+        siteStatus: { isCheckedInToday: true },
+      })
+    })
+
+    await act(async () => {
+      olderReload.resolve({
+        id: "a",
+        checkIn: { siteStatus: { isCheckedInToday: false } },
+      })
+      await olderReload.promise
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData[0]?.checkIn).toEqual({
+        siteStatus: { isCheckedInToday: true },
+      })
+    })
+    expect(mockGetDailyBalanceHistoryStore).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -2226,6 +2226,131 @@ describe("AccountDataContext auto-checkin runCompleted handling", () => {
     expect(mockGetAccountById).toHaveBeenCalledWith("a")
   })
 
+  it("preserves estimated today income on targeted reload display rows", async () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+
+    mockUserPreferencesContext.current = {
+      ...mockUserPreferencesContext.current,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    }
+    vi.setSystemTime(new Date("2026-05-23T08:00:00.000Z"))
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+
+    const accountA: any = {
+      id: "a",
+      disabled: false,
+      excludeFromTodayIncome: false,
+      exchange_rate: 7,
+      checkIn: { siteStatus: { isCheckedInToday: false } },
+      account_info: { id: 1 },
+    }
+    const accountB: any = {
+      id: "b",
+      disabled: false,
+      excludeFromTodayIncome: false,
+      exchange_rate: 7,
+      checkIn: { siteStatus: { isCheckedInToday: false } },
+      account_info: { id: 2 },
+    }
+
+    mockGetAllAccounts.mockResolvedValue([accountA, accountB])
+    mockGetAllBookmarks.mockResolvedValue([])
+    mockGetOrderedList.mockResolvedValue(["a", "b"])
+    mockGetPinnedList.mockResolvedValue([])
+    mockGetAccountStats.mockResolvedValue(createEmptyStats())
+    mockConvertToDisplayData.mockImplementation((input: any) => {
+      const accounts = Array.isArray(input) ? input : [input]
+      const display = accounts.map((account: any) => ({
+        id: account.id,
+        name: account.id,
+        checkIn: account.checkIn,
+      }))
+      return Array.isArray(input) ? display : display[0]
+    })
+    mockGetDailyBalanceHistoryStore.mockResolvedValue({
+      schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+      snapshotsByAccountId: {
+        a: {
+          "2026-05-22": {
+            quota: 10 * factor,
+            today_income: 0,
+            today_quota_consumption: 0,
+            capturedAt: 1,
+            source: "alarm",
+          },
+          "2026-05-23": {
+            quota: 12 * factor,
+            today_income: 0.5 * factor,
+            today_quota_consumption: 1 * factor,
+            capturedAt: 2,
+            source: "refresh",
+          },
+        },
+        b: {
+          "2026-05-22": {
+            quota: 20 * factor,
+            today_income: 0,
+            today_quota_consumption: 0,
+            capturedAt: 1,
+            source: "alarm",
+          },
+          "2026-05-23": {
+            quota: 21 * factor,
+            today_income: 0.5 * factor,
+            today_quota_consumption: 1 * factor,
+            capturedAt: 2,
+            source: "refresh",
+          },
+        },
+      },
+    })
+    mockGetAccountById.mockResolvedValue({
+      ...accountA,
+      checkIn: { siteStatus: { isCheckedInToday: true } },
+    })
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "a",
+            estimatedTodayIncome: { USD: 3, CNY: 21 },
+          }),
+        ]),
+      )
+    })
+
+    const listener = (globalThis as any).__accountDataContextRuntimeListener as
+      | ((message: any) => void)
+      | undefined
+    expect(listener).toBeTypeOf("function")
+
+    await act(async () => {
+      listener!({
+        action: RuntimeActionIds.AutoCheckinRunCompleted,
+        updatedAccountIds: ["a"],
+      })
+    })
+
+    await waitFor(() => {
+      const byId = Object.fromEntries(
+        getLatestCtx().displayData.map((item: any) => [item.id, item]),
+      )
+      expect(byId.a?.checkIn?.siteStatus?.isCheckedInToday).toBe(true)
+      expect(byId.a?.estimatedTodayIncome).toEqual({ USD: 3, CNY: 21 })
+      expect(byId.b?.estimatedTodayIncome).toEqual({ USD: 2, CNY: 14 })
+    })
+
+    expect(mockGetDailyBalanceHistoryStore).toHaveBeenCalledTimes(2)
+  })
+
   it("skips reload work when auto-checkin completion does not include any valid account ids", async () => {
     mockGetAllAccounts.mockResolvedValue([{ id: "a" }])
 

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -9,12 +9,14 @@ import {
   DATA_TYPE_CREATED_AT,
 } from "~/constants"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { UI_CONSTANTS } from "~/constants/ui"
 import {
   AccountDataProvider,
   useAccountDataContext,
 } from "~/features/AccountManagement/hooks/AccountDataContext"
 import type { SearchResult } from "~/services/search/accountSearch"
 import type { DisplaySiteData } from "~/types"
+import { DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION } from "~/types/dailyBalanceHistory"
 import { SortingCriteriaType } from "~/types/sorting"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
@@ -47,6 +49,7 @@ const {
   mockSetPinnedListSubset,
   mockSetOrderedListSubset,
   mockGetTagStore,
+  mockGetDailyBalanceHistoryStore,
   mockCreateTag,
   mockRenameTag,
   mockDeleteTag,
@@ -84,6 +87,7 @@ const {
   mockSetPinnedListSubset: vi.fn(),
   mockSetOrderedListSubset: vi.fn(),
   mockGetTagStore: vi.fn(),
+  mockGetDailyBalanceHistoryStore: vi.fn(),
   mockCreateTag: vi.fn(),
   mockRenameTag: vi.fn(),
   mockDeleteTag: vi.fn(),
@@ -154,6 +158,11 @@ const mockUserPreferencesContext = vi.hoisted(() => ({
         { id: "manual_order", enabled: true, priority: 1 },
       ],
     },
+    preferences: {
+      balanceHistory: {
+        estimatedTodayIncome: { enabled: false },
+      },
+    },
     showTodayCashflow: true,
   },
 }))
@@ -192,6 +201,12 @@ vi.mock("~/services/tags/tagStorage", () => ({
     createTag: mockCreateTag,
     renameTag: mockRenameTag,
     deleteTag: mockDeleteTag,
+  },
+}))
+
+vi.mock("~/services/history/dailyBalanceHistory/storage", () => ({
+  dailyBalanceHistoryStorage: {
+    getStore: mockGetDailyBalanceHistoryStore,
   },
 }))
 
@@ -244,11 +259,20 @@ beforeEach(() => {
         { id: "manual_order", enabled: true, priority: 1 },
       ],
     },
+    preferences: {
+      balanceHistory: {
+        estimatedTodayIncome: { enabled: false },
+      },
+    },
     showTodayCashflow: true,
   }
 
   mockResetExpiredCheckIns.mockResolvedValue(undefined)
   mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+  mockGetDailyBalanceHistoryStore.mockResolvedValue({
+    schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+    snapshotsByAccountId: {},
+  })
   mockGetAllAccounts.mockResolvedValue([])
   mockGetAllBookmarks.mockResolvedValue([])
   mockGetOrderedList.mockResolvedValue([])
@@ -710,6 +734,86 @@ describe("AccountDataContext handleReorder", () => {
 })
 
 describe("AccountDataContext initial load orchestration", () => {
+  it("excludes today-income opt-outs from estimated income totals", async () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+
+    mockUserPreferencesContext.current = {
+      ...mockUserPreferencesContext.current,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    }
+    mockGetAllAccounts.mockResolvedValue([
+      {
+        id: "included",
+        disabled: false,
+        excludeFromTodayIncome: false,
+        exchange_rate: 7,
+        account_info: { id: 1 },
+        last_sync_time: 0,
+      },
+      {
+        id: "excluded",
+        disabled: false,
+        excludeFromTodayIncome: true,
+        exchange_rate: 7,
+        account_info: { id: 2 },
+        last_sync_time: 0,
+      },
+    ])
+    mockGetDailyBalanceHistoryStore.mockResolvedValue({
+      schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+      snapshotsByAccountId: {
+        included: {
+          "2026-05-22": {
+            quota: 10 * factor,
+            today_income: 0,
+            today_quota_consumption: 0,
+            capturedAt: 1,
+            source: "alarm",
+          },
+          "2026-05-23": {
+            quota: 12 * factor,
+            today_income: 0.5 * factor,
+            today_quota_consumption: 1 * factor,
+            capturedAt: 2,
+            source: "refresh",
+          },
+        },
+        excluded: {
+          "2026-05-22": {
+            quota: 20 * factor,
+            today_income: 0,
+            today_quota_consumption: 0,
+            capturedAt: 1,
+            source: "alarm",
+          },
+          "2026-05-23": {
+            quota: 30 * factor,
+            today_income: 9 * factor,
+            today_quota_consumption: 1 * factor,
+            capturedAt: 2,
+            source: "refresh",
+          },
+        },
+      },
+    })
+    vi.setSystemTime(new Date("2026-05-23T08:00:00.000Z"))
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().todayIncomeEstimateTotals).toMatchObject({
+        trusted: { USD: 0.5, CNY: 3.5 },
+        estimated: { USD: 3, CNY: 21 },
+        availableAccounts: 1,
+        totalAccounts: 1,
+      })
+    })
+  })
+
   it("keeps initial load active until current-tab and open-tab checks complete", async () => {
     let resolveActiveTabs: ((tabs: browser.tabs.Tab[]) => void) | undefined
     let resolveAllTabs: ((tabs: browser.tabs.Tab[]) => void) | undefined

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -814,6 +814,93 @@ describe("AccountDataContext initial load orchestration", () => {
     })
   })
 
+  it("projects available estimated income onto display account rows", async () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+
+    mockUserPreferencesContext.current = {
+      ...mockUserPreferencesContext.current,
+      preferences: {
+        balanceHistory: {
+          estimatedTodayIncome: { enabled: true },
+        },
+      },
+    }
+    mockGetAllAccounts.mockResolvedValue([
+      {
+        id: "included",
+        disabled: false,
+        excludeFromTodayIncome: false,
+        exchange_rate: 7,
+        account_info: { id: 1 },
+        last_sync_time: 0,
+      },
+      {
+        id: "manual",
+        disabled: false,
+        excludeFromTodayIncome: false,
+        manualBalanceUsd: "12.34",
+        exchange_rate: 7,
+        account_info: { id: 2 },
+        last_sync_time: 0,
+      },
+    ])
+    mockGetDailyBalanceHistoryStore.mockResolvedValue({
+      schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+      snapshotsByAccountId: {
+        included: {
+          "2026-05-22": {
+            quota: 10 * factor,
+            today_income: 0,
+            today_quota_consumption: 0,
+            capturedAt: 1,
+            source: "alarm",
+          },
+          "2026-05-23": {
+            quota: 12 * factor,
+            today_income: 0.5 * factor,
+            today_quota_consumption: 1 * factor,
+            capturedAt: 2,
+            source: "refresh",
+          },
+        },
+        manual: {
+          "2026-05-22": {
+            quota: 10 * factor,
+            today_income: 0,
+            today_quota_consumption: 0,
+            capturedAt: 1,
+            source: "alarm",
+          },
+          "2026-05-23": {
+            quota: 12 * factor,
+            today_income: 0.5 * factor,
+            today_quota_consumption: 1 * factor,
+            capturedAt: 2,
+            source: "refresh",
+          },
+        },
+      },
+    })
+    vi.setSystemTime(new Date("2026-05-23T08:00:00.000Z"))
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "included",
+            estimatedTodayIncome: { USD: 3, CNY: 21 },
+          }),
+          expect.objectContaining({
+            id: "manual",
+            estimatedTodayIncome: null,
+          }),
+        ]),
+      )
+    })
+  })
+
   it("keeps initial load active until current-tab and open-tab checks complete", async () => {
     let resolveActiveTabs: ((tabs: browser.tabs.Tab[]) => void) | undefined
     let resolveAllTabs: ((tabs: browser.tabs.Tab[]) => void) | undefined

--- a/tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
+++ b/tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
@@ -49,9 +49,11 @@ const buildRow = (
   endBalance: 12,
   netTotal: 2,
   incomeTotal: 4,
+  estimatedIncomeTotal: null,
   outcomeTotal: 2,
   snapshotDays: 3,
   cashflowDays: 2,
+  estimatedIncomeDays: 0,
   totalDays: 4,
   ...overrides,
 })
@@ -149,6 +151,42 @@ describe("BalanceHistoryAccountSummaryTable", () => {
     expect(alphaRowScope.getByText("$3.00")).toBeInTheDocument()
     expect(alphaRowScope.getByText("4/5")).toBeInTheDocument()
     expect(alphaRowScope.getByText("3/5")).toBeInTheDocument()
+  })
+
+  it("renders estimated income column only when enabled", () => {
+    const rows = [
+      buildRow({
+        estimatedIncomeTotal: 3,
+        estimatedIncomeDays: 1,
+      }),
+    ]
+
+    const { rerender } = render(
+      <BalanceHistoryAccountSummaryTable
+        rows={rows}
+        isLoading={false}
+        currencySymbol="$"
+        showEstimatedIncome={false}
+      />,
+    )
+
+    expect(
+      screen.queryByText("balanceHistory:table.columns.estimatedIncomeTotal"),
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <BalanceHistoryAccountSummaryTable
+        rows={rows}
+        isLoading={false}
+        currencySymbol="$"
+        showEstimatedIncome
+      />,
+    )
+
+    expect(
+      screen.getByText("balanceHistory:table.columns.estimatedIncomeTotal"),
+    ).toBeInTheDocument()
+    expect(screen.getByText("$3.00")).toBeInTheDocument()
   })
 
   it("toggles nullable numeric sorting from descending to ascending while keeping null balances observable", async () => {

--- a/tests/services/configMigration/preferences/preferencesMigration.test.ts
+++ b/tests/services/configMigration/preferences/preferencesMigration.test.ts
@@ -247,6 +247,49 @@ describe("preferencesMigration", () => {
       expect(result.balanceHistory).toEqual(DEFAULT_BALANCE_HISTORY_PREFERENCES)
     })
 
+    it("defaults estimated today income to disabled when migrating balance history preferences", () => {
+      const migrated = migratePreferences(
+        createV0Preferences({
+          balanceHistory: {
+            enabled: true,
+            endOfDayCapture: { enabled: true },
+            retentionDays: 45,
+          },
+          preferencesVersion: 24,
+        } as any),
+      )
+
+      expect(migrated.balanceHistory).toMatchObject({
+        enabled: true,
+        endOfDayCapture: { enabled: true },
+        retentionDays: 45,
+        estimatedTodayIncome: { enabled: false },
+      })
+      expect(migrated.preferencesVersion).toBe(CURRENT_PREFERENCES_VERSION)
+    })
+
+    it("preserves estimated today income when migrating balance history preferences", () => {
+      const migrated = migratePreferences(
+        createV0Preferences({
+          balanceHistory: {
+            enabled: true,
+            endOfDayCapture: { enabled: true },
+            estimatedTodayIncome: { enabled: true },
+            retentionDays: 45,
+          },
+          preferencesVersion: 24,
+        } as any),
+      )
+
+      expect(migrated.balanceHistory).toMatchObject({
+        enabled: true,
+        endOfDayCapture: { enabled: true },
+        retentionDays: 45,
+        estimatedTodayIncome: { enabled: true },
+      })
+      expect(migrated.preferencesVersion).toBe(CURRENT_PREFERENCES_VERSION)
+    })
+
     it("defaults site announcement polling to disabled for new preference snapshots", () => {
       expect(DEFAULT_PREFERENCES.siteAnnouncementNotifications).toEqual(
         DEFAULT_SITE_ANNOUNCEMENT_PREFERENCES,

--- a/tests/services/configMigration/preferences/preferencesMigration.test.ts
+++ b/tests/services/configMigration/preferences/preferencesMigration.test.ts
@@ -306,6 +306,7 @@ describe("preferencesMigration", () => {
           enabled: "yes" as any,
           endOfDayCapture: { enabled: "no" as any },
           retentionDays: "not-a-number" as any,
+          estimatedTodayIncome: { enabled: false },
         },
       })
 
@@ -322,6 +323,7 @@ describe("preferencesMigration", () => {
           enabled: true,
           endOfDayCapture: { enabled: true },
           retentionDays: 0,
+          estimatedTodayIncome: { enabled: false },
         },
       })
       const highPrefs = createV0Preferences({
@@ -330,6 +332,7 @@ describe("preferencesMigration", () => {
           enabled: true,
           endOfDayCapture: { enabled: false },
           retentionDays: 99999,
+          estimatedTodayIncome: { enabled: false },
         },
       })
 

--- a/tests/services/dailyBalanceHistory/scheduler.test.ts
+++ b/tests/services/dailyBalanceHistory/scheduler.test.ts
@@ -139,6 +139,33 @@ describe("dailyBalanceHistoryScheduler", () => {
     )
   })
 
+  it("schedules tomorrow when today's capture time has already passed", async () => {
+    vi.setSystemTime(new Date(2026, 2, 28, 23, 56, 0, 0))
+    const expected = new Date(Date.now())
+    expected.setDate(expected.getDate() + 1)
+    expected.setHours(23, 55, 0, 0)
+
+    await dailyBalanceHistoryScheduler.initialize()
+
+    expect(mockCreateAlarm).toHaveBeenCalledWith(
+      DAILY_BALANCE_HISTORY_ALARM_NAME,
+      { when: expected.getTime() },
+    )
+  })
+
+  it("ignores unrelated alarms", async () => {
+    let alarmHandler: ((alarm: { name: string }) => Promise<void>) | undefined
+    mockOnAlarm.mockImplementation((handler) => {
+      alarmHandler = handler
+    })
+
+    await dailyBalanceHistoryScheduler.initialize()
+    await alarmHandler?.({ name: "other-alarm" })
+
+    expect(mockGetEnabledAccounts).not.toHaveBeenCalled()
+    expect(mockNotifyTaskResult).not.toHaveBeenCalled()
+  })
+
   it("reuses a preserved future alarm instead of creating a new one", async () => {
     mockGetAlarm.mockResolvedValue({
       name: DAILY_BALANCE_HISTORY_ALARM_NAME,
@@ -147,6 +174,24 @@ describe("dailyBalanceHistoryScheduler", () => {
 
     await dailyBalanceHistoryScheduler.initialize()
 
+    expect(mockCreateAlarm).not.toHaveBeenCalled()
+  })
+
+  it("clears the alarm when capture scheduling is disabled", async () => {
+    mockGetPreferences.mockResolvedValue({
+      balanceHistory: {
+        ...DEFAULT_BALANCE_HISTORY_PREFERENCES,
+        enabled: true,
+        endOfDayCapture: { enabled: false },
+        retentionDays: 30,
+      },
+    })
+
+    await dailyBalanceHistoryScheduler.initialize()
+
+    expect(mockClearAlarm).toHaveBeenCalledWith(
+      DAILY_BALANCE_HISTORY_ALARM_NAME,
+    )
     expect(mockCreateAlarm).not.toHaveBeenCalled()
   })
 
@@ -432,6 +477,87 @@ describe("dailyBalanceHistoryScheduler", () => {
     })
   })
 
+  it("uses default seed cashflow values and skips invalid quotas", async () => {
+    mockGetEnabledAccounts.mockResolvedValue([
+      {
+        id: "defaulted",
+        account_info: {
+          quota: 12_000_000,
+          today_income: Number.NaN,
+          today_quota_consumption: Number.NaN,
+        },
+        exchange_rate: 7,
+      },
+      {
+        id: "invalid",
+        account_info: {
+          quota: 0,
+          today_income: 500_000,
+          today_quota_consumption: 1_000_000,
+        },
+        exchange_rate: 7,
+      },
+    ])
+
+    const result =
+      await dailyBalanceHistoryScheduler.debugSeedEstimateSnapshots()
+
+    expect(mockUpsertSnapshot).toHaveBeenCalledTimes(2)
+    expect(mockUpsertSnapshot).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        accountId: "defaulted",
+        snapshot: expect.objectContaining({
+          quota: 12_000_000,
+          today_income: 0,
+          today_quota_consumption: 0,
+        }),
+      }),
+    )
+    expect(mockUpsertSnapshot).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        accountId: "defaulted",
+        snapshot: expect.objectContaining({
+          quota: 12_000_000,
+          today_income: 0,
+          today_quota_consumption: 1_000_000,
+        }),
+      }),
+    )
+    expect(result).toEqual({
+      seeded: 1,
+      skipped: 1,
+      todayKey: "2026-03-28",
+      yesterdayKey: "2026-03-27",
+    })
+  })
+
+  it("counts failed snapshot writes as skipped during development seeding", async () => {
+    mockGetEnabledAccounts.mockResolvedValue([
+      {
+        id: "failed",
+        account_info: {
+          quota: 12_000_000,
+          today_income: 500_000,
+          today_quota_consumption: 1_000_000,
+        },
+        exchange_rate: 7,
+      },
+    ])
+    mockUpsertSnapshot.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+
+    const result =
+      await dailyBalanceHistoryScheduler.debugSeedEstimateSnapshots()
+
+    expect(result).toEqual({
+      seeded: 0,
+      skipped: 1,
+      todayKey: "2026-03-28",
+      yesterdayKey: "2026-03-27",
+    })
+  })
+
   it("keeps both seeded days even when the configured retention is one day", async () => {
     mockGetPreferences.mockResolvedValue({
       balanceHistory: {
@@ -516,6 +642,56 @@ describe("dailyBalanceHistoryScheduler", () => {
     expect(response).toHaveBeenCalledWith({
       success: false,
       error: "Debug action unavailable",
+    })
+  })
+
+  it("returns null immediately when a capture run is already active", async () => {
+    ;(dailyBalanceHistoryScheduler as any).isRunning = true
+
+    const result = await dailyBalanceHistoryScheduler.runEndOfDayCapture({
+      trigger: "refresh",
+    })
+
+    expect(result).toBeNull()
+    expect(mockGetPreferences).not.toHaveBeenCalled()
+  })
+
+  it("routes malformed refresh message account ids to a full refresh", async () => {
+    const response = vi.fn()
+
+    await handleDailyBalanceHistoryMessage(
+      {
+        action: RuntimeActionIds.BalanceHistoryRefreshNow,
+        accountIds: "not-an-array",
+      },
+      response,
+    )
+
+    expect(mockRefreshAllAccounts).toHaveBeenCalledWith(true)
+    expect(response).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        success: 2,
+        failed: 1,
+        refreshedCount: 1,
+      },
+    })
+  })
+
+  it("returns a runtime error response when message handling throws", async () => {
+    mockPruneAll.mockRejectedValueOnce(new Error("storage closed"))
+    const response = vi.fn()
+
+    await handleDailyBalanceHistoryMessage(
+      {
+        action: RuntimeActionIds.BalanceHistoryPrune,
+      },
+      response,
+    )
+
+    expect(response).toHaveBeenCalledWith({
+      success: false,
+      error: "storage closed",
     })
   })
 

--- a/tests/services/dailyBalanceHistory/scheduler.test.ts
+++ b/tests/services/dailyBalanceHistory/scheduler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { DAILY_BALANCE_HISTORY_ALARM_NAME } from "~/services/history/dailyBalanceHistory/constants"
@@ -18,6 +18,7 @@ const {
   mockGetEnabledAccounts,
   mockRefreshAccount,
   mockRefreshAllAccounts,
+  mockUpsertSnapshot,
   mockPruneAll,
   mockCreateAlarm,
   mockClearAlarm,
@@ -31,6 +32,7 @@ const {
   mockGetEnabledAccounts: vi.fn(),
   mockRefreshAccount: vi.fn(),
   mockRefreshAllAccounts: vi.fn(),
+  mockUpsertSnapshot: vi.fn(),
   mockPruneAll: vi.fn(),
   mockCreateAlarm: vi.fn(),
   mockClearAlarm: vi.fn(),
@@ -57,6 +59,7 @@ vi.mock("~/services/accounts/accountStorage", () => ({
 
 vi.mock("~/services/history/dailyBalanceHistory/storage", () => ({
   dailyBalanceHistoryStorage: {
+    upsertSnapshot: mockUpsertSnapshot,
     pruneAll: mockPruneAll,
   },
 }))
@@ -87,6 +90,7 @@ describe("dailyBalanceHistoryScheduler", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-03-28T08:00:00.000Z"))
     ;(dailyBalanceHistoryScheduler as any).isInitialized = false
@@ -108,12 +112,18 @@ describe("dailyBalanceHistoryScheduler", () => {
       refreshedCount: 1,
     })
     mockRefreshAccount.mockResolvedValue({ refreshed: true })
+    mockUpsertSnapshot.mockResolvedValue(true)
     mockPruneAll.mockResolvedValue(true)
     mockHasAlarmsAPI.mockReturnValue(true)
     mockGetAlarm.mockResolvedValue(undefined)
     mockCreateAlarm.mockResolvedValue(undefined)
     mockClearAlarm.mockResolvedValue(true)
     mockNotifyTaskResult.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.useRealTimers()
   })
 
   it("initializes once, registers the alarm listener, and schedules the next capture", async () => {
@@ -157,6 +167,7 @@ describe("dailyBalanceHistoryScheduler", () => {
       balanceHistory: {
         enabled: true,
         endOfDayCapture: { enabled: false },
+        estimatedTodayIncome: { enabled: false },
         retentionDays: 3650,
       },
     })
@@ -349,6 +360,162 @@ describe("dailyBalanceHistoryScheduler", () => {
     expect(unknownResponse).toHaveBeenCalledWith({
       success: false,
       error: "Unknown action",
+    })
+  })
+
+  it("seeds development snapshots for enabled accounts that can be estimated", async () => {
+    mockGetEnabledAccounts.mockResolvedValue([
+      {
+        id: "included",
+        account_info: {
+          quota: 12_000_000,
+          today_income: 500_000,
+          today_quota_consumption: 1_000_000,
+        },
+        exchange_rate: 7,
+      },
+      {
+        id: "excluded",
+        excludeFromTodayIncome: true,
+        account_info: {
+          quota: 20_000_000,
+          today_income: 1_000_000,
+          today_quota_consumption: 2_000_000,
+        },
+        exchange_rate: 7,
+      },
+      {
+        id: "manual",
+        manualBalanceUsd: "12.34",
+        account_info: {
+          quota: 30_000_000,
+          today_income: 1_000_000,
+          today_quota_consumption: 2_000_000,
+        },
+        exchange_rate: 7,
+      },
+    ])
+
+    const result =
+      await dailyBalanceHistoryScheduler.debugSeedEstimateSnapshots()
+
+    expect(mockUpsertSnapshot).toHaveBeenCalledTimes(2)
+    expect(mockUpsertSnapshot).toHaveBeenNthCalledWith(1, {
+      accountId: "included",
+      dayKey: "2026-03-27",
+      retentionDays: 30,
+      snapshot: {
+        quota: 11_500_000,
+        today_income: 0,
+        today_quota_consumption: 0,
+        capturedAt: Date.now() - 24 * 60 * 60 * 1000,
+        source: "refresh",
+      },
+    })
+    expect(mockUpsertSnapshot).toHaveBeenNthCalledWith(2, {
+      accountId: "included",
+      dayKey: "2026-03-28",
+      retentionDays: 30,
+      snapshot: {
+        quota: 12_000_000,
+        today_income: 500_000,
+        today_quota_consumption: 1_000_000,
+        capturedAt: Date.now(),
+        source: "refresh",
+      },
+    })
+    expect(result).toEqual({
+      seeded: 1,
+      skipped: 2,
+      todayKey: "2026-03-28",
+      yesterdayKey: "2026-03-27",
+    })
+  })
+
+  it("keeps both seeded days even when the configured retention is one day", async () => {
+    mockGetPreferences.mockResolvedValue({
+      balanceHistory: {
+        ...DEFAULT_BALANCE_HISTORY_PREFERENCES,
+        enabled: true,
+        endOfDayCapture: { enabled: true },
+        retentionDays: 1,
+      },
+    })
+    mockGetEnabledAccounts.mockResolvedValue([
+      {
+        id: "included",
+        account_info: {
+          quota: 12_000_000,
+          today_income: 500_000,
+          today_quota_consumption: 1_000_000,
+        },
+        exchange_rate: 7,
+      },
+    ])
+
+    const result =
+      await dailyBalanceHistoryScheduler.debugSeedEstimateSnapshots()
+
+    expect(mockUpsertSnapshot).toHaveBeenCalledTimes(2)
+    expect(mockUpsertSnapshot).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ retentionDays: 2 }),
+    )
+    expect(mockUpsertSnapshot).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ retentionDays: 2 }),
+    )
+    expect(result).toEqual({
+      seeded: 1,
+      skipped: 0,
+      todayKey: "2026-03-28",
+      yesterdayKey: "2026-03-27",
+    })
+  })
+
+  it("routes the development snapshot seed runtime message", async () => {
+    vi.stubEnv("MODE", "development")
+    mockGetEnabledAccounts.mockResolvedValue([
+      {
+        id: "included",
+        account_info: {
+          quota: 12_000_000,
+          today_income: 500_000,
+          today_quota_consumption: 1_000_000,
+        },
+        exchange_rate: 7,
+      },
+    ])
+
+    const response = vi.fn()
+    await handleDailyBalanceHistoryMessage(
+      {
+        action: RuntimeActionIds.BalanceHistoryDebugSeedEstimateSnapshots,
+      },
+      response,
+    )
+
+    expect(response).toHaveBeenCalledWith({
+      success: true,
+      data: expect.objectContaining({ seeded: 1, skipped: 0 }),
+    })
+  })
+
+  it("rejects the snapshot seed runtime message outside development mode", async () => {
+    vi.stubEnv("MODE", "production")
+
+    const response = vi.fn()
+    await handleDailyBalanceHistoryMessage(
+      {
+        action: RuntimeActionIds.BalanceHistoryDebugSeedEstimateSnapshots,
+      },
+      response,
+    )
+
+    expect(mockUpsertSnapshot).not.toHaveBeenCalled()
+    expect(response).toHaveBeenCalledWith({
+      success: false,
+      error: "Debug action unavailable",
     })
   })
 

--- a/tests/services/dailyBalanceHistory/selectors.test.ts
+++ b/tests/services/dailyBalanceHistory/selectors.test.ts
@@ -52,7 +52,12 @@ describe("dailyBalanceHistory selectors", () => {
     expect(result.incomeTotals).toEqual([4])
     expect(result.outcomeTotals).toEqual([6])
     expect(result.coverage).toEqual([
-      { totalAccounts: 2, snapshotAccounts: 2, cashflowAccounts: 2 },
+      {
+        totalAccounts: 2,
+        snapshotAccounts: 2,
+        cashflowAccounts: 2,
+        estimatedIncomeAccounts: 0,
+      },
     ])
   })
 
@@ -161,6 +166,7 @@ describe("dailyBalanceHistory selectors", () => {
       totalAccounts: 2,
       snapshotAccounts: 1,
       cashflowAccounts: 1,
+      estimatedIncomeAccounts: 0,
     })
   })
 
@@ -200,6 +206,7 @@ describe("dailyBalanceHistory selectors", () => {
       totalAccounts: 2,
       snapshotAccounts: 2,
       cashflowAccounts: 1,
+      estimatedIncomeAccounts: 0,
     })
   })
 
@@ -216,8 +223,18 @@ describe("dailyBalanceHistory selectors", () => {
     expect(result.incomeTotals).toEqual([null, null])
     expect(result.outcomeTotals).toEqual([null, null])
     expect(result.coverage).toEqual([
-      { totalAccounts: 2, snapshotAccounts: 0, cashflowAccounts: 0 },
-      { totalAccounts: 2, snapshotAccounts: 0, cashflowAccounts: 0 },
+      {
+        totalAccounts: 2,
+        snapshotAccounts: 0,
+        cashflowAccounts: 0,
+        estimatedIncomeAccounts: 0,
+      },
+      {
+        totalAccounts: 2,
+        snapshotAccounts: 0,
+        cashflowAccounts: 0,
+        estimatedIncomeAccounts: 0,
+      },
     ])
   })
 
@@ -235,8 +252,18 @@ describe("dailyBalanceHistory selectors", () => {
     expect(result.incomeTotals).toEqual([null, null])
     expect(result.outcomeTotals).toEqual([null, null])
     expect(result.coverage).toEqual([
-      { totalAccounts: 2, snapshotAccounts: 0, cashflowAccounts: 0 },
-      { totalAccounts: 2, snapshotAccounts: 0, cashflowAccounts: 0 },
+      {
+        totalAccounts: 2,
+        snapshotAccounts: 0,
+        cashflowAccounts: 0,
+        estimatedIncomeAccounts: 0,
+      },
+      {
+        totalAccounts: 2,
+        snapshotAccounts: 0,
+        cashflowAccounts: 0,
+        estimatedIncomeAccounts: 0,
+      },
     ])
   })
 
@@ -306,13 +333,135 @@ describe("dailyBalanceHistory selectors", () => {
 
     expect(result.dayKeys).toEqual(["2026-02-07"])
     expect(result.coverageByDay).toEqual([
-      { totalAccounts: 2, snapshotAccounts: 1, cashflowAccounts: 1 },
+      {
+        totalAccounts: 2,
+        snapshotAccounts: 1,
+        cashflowAccounts: 1,
+        estimatedIncomeAccounts: 0,
+      },
     ])
     expect(result.seriesByAccountId.a1.balance).toEqual([10])
     expect(result.seriesByAccountId.a2.balance).toEqual([null])
     expect(result.seriesByAccountId.a1.income).toEqual([1])
     expect(result.seriesByAccountId.a1.outcome).toEqual([2])
     expect(result.seriesByAccountId.a1.net).toEqual([-1])
+  })
+
+  it("builds estimated income per-account series without changing trusted income", () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const store = createStore({
+      a1: {
+        "2026-02-06": {
+          quota: 10 * factor,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 0,
+          source: "alarm",
+        },
+        "2026-02-07": {
+          quota: 12 * factor,
+          today_income: 0.5 * factor,
+          today_quota_consumption: 1 * factor,
+          capturedAt: 1,
+          source: "refresh",
+        },
+      },
+    })
+
+    const result = buildPerAccountDailyBalanceMoneySeries({
+      store,
+      accountIds: ["a1"],
+      startDayKey: "2026-02-07",
+      endDayKey: "2026-02-07",
+      currencyType: "USD",
+      estimatedTodayIncomeEnabled: true,
+    })
+
+    expect(result.seriesByAccountId.a1.income).toEqual([0.5])
+    expect(result.seriesByAccountId.a1.estimatedIncome).toEqual([3])
+    expect(result.seriesByAccountId.a1.outcome).toEqual([1])
+    expect(result.seriesByAccountId.a1.net).toEqual([-0.5])
+    expect(result.coverageByDay[0]).toMatchObject({
+      cashflowAccounts: 1,
+      estimatedIncomeAccounts: 1,
+    })
+  })
+
+  it("returns null estimated income per-account series when estimates are disabled", () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const store = createStore({
+      a1: {
+        "2026-02-06": {
+          quota: 10 * factor,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 0,
+          source: "alarm",
+        },
+        "2026-02-07": {
+          quota: 12 * factor,
+          today_income: 0.5 * factor,
+          today_quota_consumption: 1 * factor,
+          capturedAt: 1,
+          source: "refresh",
+        },
+      },
+    })
+
+    const result = buildPerAccountDailyBalanceMoneySeries({
+      store,
+      accountIds: ["a1"],
+      startDayKey: "2026-02-07",
+      endDayKey: "2026-02-07",
+      currencyType: "USD",
+      estimatedTodayIncomeEnabled: false,
+    })
+
+    expect(result.seriesByAccountId.a1.income).toEqual([0.5])
+    expect(result.seriesByAccountId.a1.estimatedIncome).toEqual([null])
+    expect(result.coverageByDay[0]).toMatchObject({
+      cashflowAccounts: 1,
+      estimatedIncomeAccounts: 0,
+    })
+  })
+
+  it("returns null estimated income for manual balance accounts", () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const store = createStore({
+      a1: {
+        "2026-02-06": {
+          quota: 10 * factor,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 0,
+          source: "alarm",
+        },
+        "2026-02-07": {
+          quota: 12 * factor,
+          today_income: 0.5 * factor,
+          today_quota_consumption: 1 * factor,
+          capturedAt: 1,
+          source: "refresh",
+        },
+      },
+    })
+
+    const result = buildPerAccountDailyBalanceMoneySeries({
+      store,
+      accountIds: ["a1"],
+      startDayKey: "2026-02-07",
+      endDayKey: "2026-02-07",
+      currencyType: "USD",
+      estimatedTodayIncomeEnabled: true,
+      manualBalanceAccountIds: new Set(["a1"]),
+    })
+
+    expect(result.seriesByAccountId.a1.income).toEqual([0.5])
+    expect(result.seriesByAccountId.a1.estimatedIncome).toEqual([null])
+    expect(result.coverageByDay[0]).toMatchObject({
+      cashflowAccounts: 1,
+      estimatedIncomeAccounts: 0,
+    })
   })
 
   it("converts per-account daily series into CNY using per-account exchange rates", () => {
@@ -365,8 +514,18 @@ describe("dailyBalanceHistory selectors", () => {
     expect(result.dayKeys).toEqual(["2026-02-07", "2026-02-08"])
     expect(result.seriesByAccountId).toEqual({})
     expect(result.coverageByDay).toEqual([
-      { totalAccounts: 0, snapshotAccounts: 0, cashflowAccounts: 0 },
-      { totalAccounts: 0, snapshotAccounts: 0, cashflowAccounts: 0 },
+      {
+        totalAccounts: 0,
+        snapshotAccounts: 0,
+        cashflowAccounts: 0,
+        estimatedIncomeAccounts: 0,
+      },
+      {
+        totalAccounts: 0,
+        snapshotAccounts: 0,
+        cashflowAccounts: 0,
+        estimatedIncomeAccounts: 0,
+      },
     ])
   })
 
@@ -415,10 +574,12 @@ describe("dailyBalanceHistory selectors", () => {
         startBalance: 10,
         endBalance: 15,
         incomeTotal: 1,
+        estimatedIncomeTotal: null,
         outcomeTotal: 0.5,
         netTotal: 0.5,
         snapshotDays: 2,
         cashflowDays: 1,
+        estimatedIncomeDays: 0,
         totalDays: 2,
       },
       {
@@ -426,13 +587,87 @@ describe("dailyBalanceHistory selectors", () => {
         startBalance: null,
         endBalance: 20,
         incomeTotal: 2,
+        estimatedIncomeTotal: null,
         outcomeTotal: 1,
         netTotal: 1,
         snapshotDays: 1,
         cashflowDays: 1,
+        estimatedIncomeDays: 0,
         totalDays: 2,
       },
     ])
+  })
+
+  it("summarizes estimated income separately from trusted income", () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const store = createStore({
+      a1: {
+        "2026-02-06": {
+          quota: 10 * factor,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 0,
+          source: "alarm",
+        },
+        "2026-02-07": {
+          quota: 12 * factor,
+          today_income: 0.5 * factor,
+          today_quota_consumption: 1 * factor,
+          capturedAt: 1,
+          source: "refresh",
+        },
+      },
+    })
+
+    const result = buildAccountRangeSummaries({
+      store,
+      accountIds: ["a1"],
+      startDayKey: "2026-02-07",
+      endDayKey: "2026-02-07",
+      currencyType: "USD",
+      estimatedTodayIncomeEnabled: true,
+    })
+
+    expect(result.summaries[0].incomeTotal).toBe(0.5)
+    expect(result.summaries[0].estimatedIncomeTotal).toBe(3)
+    expect(result.summaries[0].estimatedIncomeDays).toBe(1)
+    expect(result.summaries[0].outcomeTotal).toBe(1)
+    expect(result.summaries[0].netTotal).toBe(-0.5)
+  })
+
+  it("excludes disabled estimated income from range summaries", () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const store = createStore({
+      a1: {
+        "2026-02-06": {
+          quota: 10 * factor,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 0,
+          source: "alarm",
+        },
+        "2026-02-07": {
+          quota: 12 * factor,
+          today_income: 0.5 * factor,
+          today_quota_consumption: 1 * factor,
+          capturedAt: 1,
+          source: "refresh",
+        },
+      },
+    })
+
+    const result = buildAccountRangeSummaries({
+      store,
+      accountIds: ["a1"],
+      startDayKey: "2026-02-07",
+      endDayKey: "2026-02-07",
+      currencyType: "USD",
+      estimatedTodayIncomeEnabled: false,
+    })
+
+    expect(result.summaries[0].incomeTotal).toBe(0.5)
+    expect(result.summaries[0].estimatedIncomeTotal).toBeNull()
+    expect(result.summaries[0].estimatedIncomeDays).toBe(0)
   })
 
   it("returns null summary totals when an account has no snapshots in the selected range", () => {
@@ -452,10 +687,12 @@ describe("dailyBalanceHistory selectors", () => {
         startBalance: null,
         endBalance: null,
         incomeTotal: null,
+        estimatedIncomeTotal: null,
         outcomeTotal: null,
         netTotal: null,
         snapshotDays: 0,
         cashflowDays: 0,
+        estimatedIncomeDays: 0,
         totalDays: 2,
       },
     ])

--- a/tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts
+++ b/tests/services/dailyBalanceHistory/todayIncomeEstimate.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, it } from "vitest"
+
+import { UI_CONSTANTS } from "~/constants/ui"
+import {
+  buildEstimatedTodayIncomeMoneyTotals,
+  convertQuotaToMoney,
+  estimateTodayIncomeForAccount,
+  hasManualBalance,
+} from "~/services/history/dailyBalanceHistory/todayIncomeEstimate"
+import type { DailyBalanceHistoryStore } from "~/types/dailyBalanceHistory"
+import { DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION } from "~/types/dailyBalanceHistory"
+
+const createStore = (
+  snapshotsByAccountId: DailyBalanceHistoryStore["snapshotsByAccountId"],
+): DailyBalanceHistoryStore => ({
+  schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+  snapshotsByAccountId,
+})
+
+const store = createStore({
+  account: {
+    "2026-05-22": {
+      quota: 1_000_000,
+      today_income: 0,
+      today_quota_consumption: 0,
+      capturedAt: 1,
+      source: "alarm",
+    },
+    "2026-05-23": {
+      quota: 1_600_000,
+      today_income: 100_000,
+      today_quota_consumption: 200_000,
+      capturedAt: 2,
+      source: "refresh",
+    },
+  },
+})
+
+const estimate = (
+  overrides: Partial<Parameters<typeof estimateTodayIncomeForAccount>[0]> = {},
+) =>
+  estimateTodayIncomeForAccount({
+    enabled: true,
+    store,
+    account: { id: "account", manualBalanceUsd: undefined },
+    currentDayKey: "2026-05-23",
+    ...overrides,
+  })
+
+describe("today income estimate", () => {
+  it("estimates today's income from the current and previous-day snapshots", () => {
+    expect(estimate()).toEqual({
+      reportedTodayIncome: 100_000,
+      estimatedTodayIncome: 800_000,
+      compensation: 700_000,
+      status: "available",
+    })
+  })
+
+  it("returns disabled when the preference is off", () => {
+    expect(estimate({ enabled: false })).toEqual({
+      reportedTodayIncome: null,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "disabled",
+    })
+  })
+
+  it("returns missing_current_snapshot when today has no snapshot", () => {
+    expect(estimate({ currentDayKey: "2026-05-24" })).toEqual({
+      reportedTodayIncome: null,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "missing_current_snapshot",
+    })
+  })
+
+  it("returns missing_baseline and preserves reported income when previous-day baseline is absent", () => {
+    expect(estimate({ currentDayKey: "2026-05-22" })).toEqual({
+      reportedTodayIncome: 0,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "missing_baseline",
+    })
+  })
+
+  it("does not fall back to older snapshots when the previous-day baseline is absent", () => {
+    const olderOnlyStore = createStore({
+      account: {
+        "2026-05-21": {
+          quota: 500_000,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 1,
+          source: "alarm",
+        },
+        "2026-05-23": {
+          quota: 1_600_000,
+          today_income: 100_000,
+          today_quota_consumption: 200_000,
+          capturedAt: 2,
+          source: "refresh",
+        },
+      },
+    })
+
+    expect(estimate({ store: olderOnlyStore })).toEqual({
+      reportedTodayIncome: 100_000,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "missing_baseline",
+    })
+  })
+
+  it("returns missing_cashflow and preserves reported income when current consumption is null", () => {
+    const missingCashflowStore = createStore({
+      account: {
+        ...store.snapshotsByAccountId.account,
+        "2026-05-23": {
+          ...store.snapshotsByAccountId.account["2026-05-23"],
+          today_quota_consumption: null,
+        },
+      },
+    })
+
+    expect(estimate({ store: missingCashflowStore })).toEqual({
+      reportedTodayIncome: 100_000,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "missing_cashflow",
+    })
+  })
+
+  it("returns manual_balance when the account has a non-empty manual balance", () => {
+    expect(hasManualBalance({ manualBalanceUsd: " 1.23 " })).toBe(true)
+    expect(hasManualBalance({ manualBalanceUsd: "   " })).toBe(false)
+    expect(
+      estimate({ account: { id: "account", manualBalanceUsd: " 1.23 " } }),
+    ).toEqual({
+      reportedTodayIncome: null,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "manual_balance",
+    })
+  })
+
+  it("returns invalid_estimate and preserves reported income when the estimate is negative", () => {
+    const negativeStore = createStore({
+      account: {
+        "2026-05-22": {
+          quota: 1_000_000,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 1,
+          source: "alarm",
+        },
+        "2026-05-23": {
+          quota: 500_000,
+          today_income: 100_000,
+          today_quota_consumption: 0,
+          capturedAt: 2,
+          source: "refresh",
+        },
+      },
+    })
+
+    expect(estimate({ store: negativeStore })).toEqual({
+      reportedTodayIncome: 100_000,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "invalid_estimate",
+    })
+  })
+
+  it("returns invalid_estimate and preserves reported income when the estimate is non-finite", () => {
+    const nonFiniteStore = createStore({
+      account: {
+        "2026-05-22": {
+          quota: 1_000_000,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 1,
+          source: "alarm",
+        },
+        "2026-05-23": {
+          quota: Number.POSITIVE_INFINITY,
+          today_income: 100_000,
+          today_quota_consumption: 0,
+          capturedAt: 2,
+          source: "refresh",
+        },
+      },
+    })
+
+    expect(estimate({ store: nonFiniteStore })).toEqual({
+      reportedTodayIncome: 100_000,
+      estimatedTodayIncome: null,
+      compensation: null,
+      status: "invalid_estimate",
+    })
+  })
+
+  it("uses null reported income for non-finite snapshot income", () => {
+    const nonFiniteReportedIncomeStore = createStore({
+      account: {
+        "2026-05-22": {
+          quota: 1_000_000,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 1,
+          source: "alarm",
+        },
+        "2026-05-23": {
+          quota: 1_600_000,
+          today_income: Number.NaN,
+          today_quota_consumption: 200_000,
+          capturedAt: 2,
+          source: "refresh",
+        },
+      },
+    })
+
+    expect(estimate({ store: nonFiniteReportedIncomeStore })).toEqual({
+      reportedTodayIncome: null,
+      estimatedTodayIncome: 800_000,
+      compensation: null,
+      status: "available",
+    })
+
+    expect(
+      buildEstimatedTodayIncomeMoneyTotals({
+        enabled: true,
+        store: nonFiniteReportedIncomeStore,
+        accounts: [
+          { id: "account", exchange_rate: 5, manualBalanceUsd: undefined },
+        ],
+        currentDayKey: "2026-05-23",
+      }),
+    ).toEqual({
+      trusted: { USD: 0, CNY: 0 },
+      estimated: { USD: 1.6, CNY: 8 },
+      availableAccounts: 1,
+      totalAccounts: 1,
+    })
+  })
+
+  it("converts quota values to USD and CNY money amounts", () => {
+    const quota = 2 * UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+
+    expect(convertQuotaToMoney({ quota, exchangeRate: 7 })).toEqual({
+      USD: 2,
+      CNY: 14,
+    })
+  })
+
+  it("builds trusted totals from reported income and estimated totals from available estimates", () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const totalsStore = createStore({
+      a1: {
+        "2026-05-22": {
+          quota: 1 * factor,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 1,
+          source: "alarm",
+        },
+        "2026-05-23": {
+          quota: 1.6 * factor,
+          today_income: 0.2 * factor,
+          today_quota_consumption: 0.4 * factor,
+          capturedAt: 2,
+          source: "refresh",
+        },
+      },
+      a2: {
+        "2026-05-23": {
+          quota: 3 * factor,
+          today_income: 0.5 * factor,
+          today_quota_consumption: 0.1 * factor,
+          capturedAt: 2,
+          source: "refresh",
+        },
+      },
+    })
+
+    expect(
+      buildEstimatedTodayIncomeMoneyTotals({
+        enabled: true,
+        store: totalsStore,
+        accounts: [
+          { id: "a1", exchange_rate: 7, manualBalanceUsd: undefined },
+          { id: "a2", exchange_rate: 8, manualBalanceUsd: undefined },
+        ],
+        currentDayKey: "2026-05-23",
+      }),
+    ).toEqual({
+      trusted: { USD: 0.7, CNY: 5.4 },
+      estimated: { USD: 1, CNY: 7 },
+      availableAccounts: 1,
+      totalAccounts: 2,
+    })
+  })
+
+  it("does not trust raw snapshot income when estimate status nulls reported income", () => {
+    const factor = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+    const totalsStore = createStore({
+      disabled: {
+        "2026-05-22": {
+          quota: 1 * factor,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 1,
+          source: "alarm",
+        },
+        "2026-05-23": {
+          quota: 2 * factor,
+          today_income: 0.5 * factor,
+          today_quota_consumption: 0,
+          capturedAt: 2,
+          source: "refresh",
+        },
+      },
+      manual: {
+        "2026-05-22": {
+          quota: 1 * factor,
+          today_income: 0,
+          today_quota_consumption: 0,
+          capturedAt: 1,
+          source: "alarm",
+        },
+        "2026-05-23": {
+          quota: 2 * factor,
+          today_income: 0.75 * factor,
+          today_quota_consumption: 0,
+          capturedAt: 2,
+          source: "refresh",
+        },
+      },
+    })
+
+    expect(
+      buildEstimatedTodayIncomeMoneyTotals({
+        enabled: false,
+        store: totalsStore,
+        accounts: [
+          { id: "disabled", exchange_rate: 7, manualBalanceUsd: undefined },
+        ],
+        currentDayKey: "2026-05-23",
+      }),
+    ).toEqual({
+      trusted: { USD: 0, CNY: 0 },
+      estimated: null,
+      availableAccounts: 0,
+      totalAccounts: 1,
+    })
+
+    expect(
+      buildEstimatedTodayIncomeMoneyTotals({
+        enabled: true,
+        store: totalsStore,
+        accounts: [{ id: "manual", exchange_rate: 8, manualBalanceUsd: "1" }],
+        currentDayKey: "2026-05-23",
+      }),
+    ).toEqual({
+      trusted: { USD: 0, CNY: 0 },
+      estimated: null,
+      availableAccounts: 0,
+      totalAccounts: 1,
+    })
+  })
+})

--- a/tests/services/productAnalytics/settings.test.ts
+++ b/tests/services/productAnalytics/settings.test.ts
@@ -73,6 +73,7 @@ describe("settings product analytics snapshots", () => {
         enabled: true,
         endOfDayCapture: { enabled: true },
         retentionDays: 730,
+        estimatedTodayIncome: { enabled: false },
       },
       newApi: {
         baseUrl: "https://private-new-api.example",
@@ -537,6 +538,7 @@ describe("settings product analytics snapshots", () => {
         enabled: true,
         endOfDayCapture: { enabled: false },
         retentionDays: 365,
+        estimatedTodayIncome: { enabled: false },
       },
       managedSiteModelSync: {
         enabled: true,


### PR DESCRIPTION
Resolves #366 
Resolves #369 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "Estimated Today Income" (default off): runtime-estimated today income shown alongside trusted income in the popup and Balance History, new metric option, and conditional table column; dev-only "Seed estimate snapshots" action.

* **Settings & Migration**
  * New balance-history preference with migration/backfill to default disabled; settings toggle added to UI.

* **Documentation**
  * Added design spec and implementation plan.

* **Localization**
  * New translation keys added for multiple locales.

* **Tests**
  * Expanded coverage across settings, UI, selectors, scheduler, and estimation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->