### PR TITLE
feat(key-management): save one-time API keys to credential profiles

### DIFF
--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -1,6 +1,5 @@
 import { InformationCircleIcon } from "@heroicons/react/24/outline"
 import { useEffect, useState, type ComponentProps } from "react"
-import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { ThemeAwareToaster } from "~/components/ThemeAwareToaster"
@@ -16,11 +15,8 @@ import { useSponsorRecommendations } from "~/features/AccountManagement/sponsors
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
 import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
-import { buildApiCredentialProfileName } from "~/features/KeyManagement/utils/apiCredentialProfileName"
+import { buildOneTimeApiKeyProfileSaveAction } from "~/features/KeyManagement/utils/apiCredentialProfileSaveAction"
 import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
-import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
-import { API_TYPES } from "~/services/verification/aiApiVerification"
-import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { DisplaySiteData } from "~/types"
 import { createLogger } from "~/utils/core/logger"
 import {
@@ -185,35 +181,17 @@ export default function AccountDialog({
         )
       : null
 
-  const handleSavePostSaveOneTimeTokenToApiProfiles = async () => {
-    if (!state.postSaveOneTimeToken?.key) return
-
-    try {
-      const profile = await apiCredentialProfilesStorage.createProfile({
-        name: buildApiCredentialProfileName({
-          accountName: state.draft.siteName || "AIHubMix",
-          tokenName: state.postSaveOneTimeToken.name ?? "",
-        }),
-        apiType: API_TYPES.OPENAI_COMPATIBLE,
+  const postSaveOneTimeKeySaveAction = state.postSaveOneTimeToken
+    ? buildOneTimeApiKeyProfileSaveAction({
+        accountName: state.draft.siteName || "AIHubMix",
         baseUrl: AIHUBMIX_API_ORIGIN,
-        apiKey: state.postSaveOneTimeToken.key,
         tagIds: state.draft.tagIds,
+        token: state.postSaveOneTimeToken,
+        t,
+        logger,
+        source: "AccountDialog",
       })
-      toast.success(
-        t("keyManagement:messages.savedToApiProfiles", {
-          name: profile.name,
-        }),
-      )
-    } catch (error) {
-      logger.error("Failed to save AIHubMix one-time key to API profiles", {
-        message: toSanitizedErrorSummary(error, [
-          state.postSaveOneTimeToken.key,
-        ]),
-      })
-      toast.error(t("keyManagement:messages.saveToApiProfilesFailed"))
-      throw error
-    }
-  }
+    : undefined
 
   return (
     <>
@@ -417,13 +395,7 @@ export default function AccountDialog({
         isOpen={!!state.postSaveOneTimeToken}
         token={state.postSaveOneTimeToken}
         onClose={handlers.handlePostSaveOneTimeTokenClose}
-        saveAction={
-          state.postSaveOneTimeToken
-            ? {
-                onSave: handleSavePostSaveOneTimeTokenToApiProfiles,
-              }
-            : undefined
-        }
+        saveAction={postSaveOneTimeKeySaveAction}
       />
     </>
   )

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -1,10 +1,12 @@
 import { InformationCircleIcon } from "@heroicons/react/24/outline"
 import { useEffect, useState, type ComponentProps } from "react"
+import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { ThemeAwareToaster } from "~/components/ThemeAwareToaster"
 import { Modal } from "~/components/ui/Dialog/Modal"
 import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
+import { AIHUBMIX_API_ORIGIN } from "~/constants/siteType"
 import { useAccountDataContext } from "~/features/AccountManagement/hooks/AccountDataContext"
 import { useDialogStateContext } from "~/features/AccountManagement/hooks/DialogStateContext"
 import { SPONSOR_RECOMMENDATION_SURFACES } from "~/features/AccountManagement/sponsors/constants"
@@ -14,8 +16,13 @@ import { useSponsorRecommendations } from "~/features/AccountManagement/sponsors
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
 import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
+import { buildApiCredentialProfileName } from "~/features/KeyManagement/utils/apiCredentialProfileName"
 import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
+import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { DisplaySiteData } from "~/types"
+import { createLogger } from "~/utils/core/logger"
 import {
   openApiCredentialProfilesPage,
   openFullBookmarkManagerPage,
@@ -33,6 +40,8 @@ import InfoPanel from "./InfoPanel"
 import { ManagedSiteConfigPromptDialog } from "./ManagedSiteConfigPromptDialog"
 import { ACCOUNT_DIALOG_PHASES } from "./models"
 import SiteInfoInput from "./SiteInfoInput"
+
+const logger = createLogger("AccountDialog")
 
 interface AccountDialogProps {
   isOpen: boolean
@@ -175,6 +184,36 @@ export default function AccountDialog({
           postSaveSub2ApiDialogSessionId,
         )
       : null
+
+  const handleSavePostSaveOneTimeTokenToApiProfiles = async () => {
+    if (!state.postSaveOneTimeToken?.key) return
+
+    try {
+      const profile = await apiCredentialProfilesStorage.createProfile({
+        name: buildApiCredentialProfileName({
+          accountName: state.draft.siteName || "AIHubMix",
+          tokenName: state.postSaveOneTimeToken.name ?? "",
+        }),
+        apiType: API_TYPES.OPENAI_COMPATIBLE,
+        baseUrl: AIHUBMIX_API_ORIGIN,
+        apiKey: state.postSaveOneTimeToken.key,
+        tagIds: state.draft.tagIds,
+      })
+      toast.success(
+        t("keyManagement:messages.savedToApiProfiles", {
+          name: profile.name,
+        }),
+      )
+    } catch (error) {
+      logger.error("Failed to save AIHubMix one-time key to API profiles", {
+        message: toSanitizedErrorSummary(error, [
+          state.postSaveOneTimeToken.key,
+        ]),
+      })
+      toast.error(t("keyManagement:messages.saveToApiProfilesFailed"))
+      throw error
+    }
+  }
 
   return (
     <>
@@ -378,6 +417,13 @@ export default function AccountDialog({
         isOpen={!!state.postSaveOneTimeToken}
         token={state.postSaveOneTimeToken}
         onClose={handlers.handlePostSaveOneTimeTokenClose}
+        saveAction={
+          state.postSaveOneTimeToken
+            ? {
+                onSave: handleSavePostSaveOneTimeTokenToApiProfiles,
+              }
+            : undefined
+        }
       />
     </>
   )

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -185,6 +185,7 @@ export default function AccountDialog({
     ? buildOneTimeApiKeyProfileSaveAction({
         accountName: state.draft.siteName || "AIHubMix",
         baseUrl: AIHUBMIX_API_ORIGIN,
+        siteType: state.siteType,
         tagIds: state.draft.tagIds,
         token: state.postSaveOneTimeToken,
         t,

--- a/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
@@ -63,6 +63,7 @@ export default function CopyKeyDialog({
       ? buildOneTimeApiKeyProfileSaveAction({
           accountName: account.name,
           baseUrl: account.baseUrl,
+          siteType: account.siteType,
           tagIds: account.tagIds ?? [],
           token: oneTimeToken,
           t: keyManagementT,

--- a/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
@@ -6,8 +6,10 @@ import { Modal } from "~/components/ui"
 import { useCopyKeyDialog } from "~/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
 import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
+import { buildOneTimeApiKeyProfileSaveAction } from "~/features/KeyManagement/utils/apiCredentialProfileSaveAction"
 import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import type { ApiToken, DisplaySiteData } from "~/types"
+import { createLogger } from "~/utils/core/logger"
 
 import { DialogFooter } from "./DialogFooter"
 import { DialogHeader } from "./DialogHeader"
@@ -30,6 +32,7 @@ export default function CopyKeyDialog({
   account,
 }: CopyKeyDialogProps) {
   const { t } = useTranslation("messages")
+  const keyManagementT = useTranslation("keyManagement").t
   const [isAddTokenDialogOpen, setIsAddTokenDialogOpen] = useState(false)
   const isMountedRef = useRef(true)
   const [ccSwitchContext, setCCSwitchContext] = useState<{
@@ -55,6 +58,18 @@ export default function CopyKeyDialog({
     clearSub2ApiCreateAllowedGroups,
     clearOneTimeToken,
   } = useCopyKeyDialog(isOpen, account)
+  const oneTimeKeySaveAction =
+    account && oneTimeToken
+      ? buildOneTimeApiKeyProfileSaveAction({
+          accountName: account.name,
+          baseUrl: account.baseUrl,
+          tagIds: account.tagIds ?? [],
+          token: oneTimeToken,
+          t: keyManagementT,
+          logger,
+          source: "CopyKeyDialog",
+        })
+      : undefined
 
   const handleOpenAddTokenDialog = () => {
     clearSub2ApiCreateAllowedGroups()
@@ -183,7 +198,10 @@ export default function CopyKeyDialog({
         isOpen={!!oneTimeToken}
         token={oneTimeToken}
         onClose={clearOneTimeToken}
+        saveAction={oneTimeKeySaveAction}
       />
     </>
   )
 }
+
+const logger = createLogger("CopyKeyDialog")

--- a/src/features/KeyManagement/components/AddTokenDialog/index.tsx
+++ b/src/features/KeyManagement/components/AddTokenDialog/index.tsx
@@ -137,6 +137,7 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
       ? buildOneTimeApiKeyProfileSaveAction({
           accountName: currentAccount.name,
           baseUrl: currentAccount.baseUrl,
+          siteType: currentAccount.siteType,
           tagIds: currentAccount.tagIds ?? [],
           token: oneTimeToken,
           t,

--- a/src/features/KeyManagement/components/AddTokenDialog/index.tsx
+++ b/src/features/KeyManagement/components/AddTokenDialog/index.tsx
@@ -22,6 +22,7 @@ import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
 import { KEY_MANAGEMENT_TEST_IDS } from "../../testIds"
+import { buildOneTimeApiKeyProfileSaveAction } from "../../utils/apiCredentialProfileSaveAction"
 import { OneTimeApiKeyDialog } from "../OneTimeApiKeyDialog"
 import { DialogHeader } from "./DialogHeader"
 import { FormActions } from "./FormActions"
@@ -131,6 +132,18 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
     setOneTimeToken(null)
     handleClose()
   }
+  const oneTimeKeySaveAction =
+    oneTimeToken && currentAccount
+      ? buildOneTimeApiKeyProfileSaveAction({
+          accountName: currentAccount.name,
+          baseUrl: currentAccount.baseUrl,
+          tagIds: currentAccount.tagIds ?? [],
+          token: oneTimeToken,
+          t,
+          logger,
+          source: "AddTokenDialog",
+        })
+      : undefined
 
   const handleSubmit = async () => {
     if (
@@ -276,6 +289,7 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
         isOpen={!!oneTimeToken}
         token={oneTimeToken}
         onClose={handleCloseOneTimeKeyDialog}
+        saveAction={oneTimeKeySaveAction}
       />
     </>
   )

--- a/src/features/KeyManagement/components/OneTimeApiKeyDialog.tsx
+++ b/src/features/KeyManagement/components/OneTimeApiKeyDialog.tsx
@@ -16,6 +16,10 @@ interface OneTimeApiKeyDialogProps {
   token: ApiToken | null
   onClose: () => void
   autoCopy?: boolean
+  saveAction?: {
+    onSave: () => Promise<void>
+    label?: string
+  }
 }
 
 /**
@@ -27,10 +31,12 @@ export function OneTimeApiKeyDialog({
   token,
   onClose,
   autoCopy = true,
+  saveAction,
 }: OneTimeApiKeyDialogProps) {
   const { t } = useTranslation("keyManagement")
   const keyInputId = useId()
   const [copied, setCopied] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
 
   const copyKey = useCallback(async () => {
     if (!token?.key) return
@@ -61,6 +67,19 @@ export function OneTimeApiKeyDialog({
     onClose()
   }
 
+  const handleSave = async () => {
+    if (!saveAction || isSaving) return
+
+    setIsSaving(true)
+    try {
+      await saveAction.onSave()
+    } catch {
+      // The caller owns user-facing failure feedback; keep the one-time key visible.
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
   return (
     <Modal
       isOpen={isOpen && !!token}
@@ -89,6 +108,17 @@ export function OneTimeApiKeyDialog({
           >
             {t("oneTimeKey.close")}
           </Button>
+          {saveAction ? (
+            <Button
+              type="button"
+              onClick={() => void handleSave()}
+              loading={isSaving}
+              disabled={isSaving}
+              data-testid={KEY_MANAGEMENT_TEST_IDS.oneTimeKeySaveButton}
+            >
+              {saveAction.label ?? t("actions.saveToApiProfiles")}
+            </Button>
+          ) : null}
           <Button
             type="button"
             onClick={copyKey}

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -39,6 +39,8 @@ import {
   WorkflowTransitionButton,
 } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
+import { buildApiCredentialProfileName } from "~/features/KeyManagement/utils/apiCredentialProfileName"
 import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { OpenInCherryStudio } from "~/services/integrations/cherryStudio"
@@ -73,9 +75,6 @@ import {
   openApiCredentialProfilesPage,
   openSettingsTab,
 } from "~/utils/navigation"
-
-import { KEY_MANAGEMENT_TEST_IDS } from "../../testIds"
-import { buildApiCredentialProfileName } from "../../utils/apiCredentialProfileName"
 
 /**
  * Unified logger scoped to the Key Management token header actions.

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -75,31 +75,12 @@ import {
 } from "~/utils/navigation"
 
 import { KEY_MANAGEMENT_TEST_IDS } from "../../testIds"
+import { buildApiCredentialProfileName } from "../../utils/apiCredentialProfileName"
 
 /**
  * Unified logger scoped to the Key Management token header actions.
  */
 const logger = createLogger("TokenHeader")
-
-/**
- * Build a stable API credential profile name from token and account labels.
- */
-function buildApiCredentialProfileName(params: {
-  accountName: string
-  fallbackAccountName?: string
-  tokenName: string
-}) {
-  const parts = [
-    params.accountName,
-    params.fallbackAccountName ?? "",
-    params.tokenName,
-  ]
-    .map((value) => value.trim())
-    .filter(Boolean)
-    .filter((value, index, list) => list.indexOf(value) === index)
-
-  return parts.join(" - ")
-}
 
 interface TokenHeaderProps {
   /**

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -7,6 +7,7 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   openApiProfilesToastButton: "key-management-open-api-profiles-toast-button",
   addTokenSubmitButton: "key-management-add-token-submit-button",
   oneTimeKeyCloseButton: "key-management-one-time-key-close-button",
+  oneTimeKeySaveButton: "key-management-one-time-key-save-button",
 } as const
 
 export const KEY_MANAGEMENT_TOKEN_ROW_TEST_ID_PREFIX =

--- a/src/features/KeyManagement/utils/apiCredentialProfileName.ts
+++ b/src/features/KeyManagement/utils/apiCredentialProfileName.ts
@@ -1,0 +1,19 @@
+/**
+ * Build a stable API credential profile name from token and account labels.
+ */
+export function buildApiCredentialProfileName(params: {
+  accountName: string
+  fallbackAccountName?: string
+  tokenName: string
+}) {
+  const parts = [
+    params.accountName,
+    params.fallbackAccountName ?? "",
+    params.tokenName,
+  ]
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .filter((value, index, list) => list.indexOf(value) === index)
+
+  return parts.join(" - ")
+}

--- a/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.ts
+++ b/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from "i18next"
 import toast from "react-hot-toast"
 
+import { AIHUBMIX_API_ORIGIN, SITE_TYPES } from "~/constants/siteType"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
@@ -21,6 +22,7 @@ interface BuildOneTimeApiKeyProfileSaveActionParams {
   accountName: string
   fallbackAccountName?: string
   baseUrl: string
+  siteType?: string
   tagIds?: string[]
   token: Pick<ApiToken, "key" | "name">
   t: TFunction
@@ -35,6 +37,7 @@ export function buildOneTimeApiKeyProfileSaveAction({
   accountName,
   fallbackAccountName,
   baseUrl,
+  siteType,
   tagIds,
   token,
   t,
@@ -47,6 +50,7 @@ export function buildOneTimeApiKeyProfileSaveAction({
         accountName,
         fallbackAccountName,
         baseUrl,
+        siteType,
         tagIds,
         token,
         t,
@@ -70,6 +74,7 @@ async function saveOneTimeApiKeyToProfile({
   accountName,
   fallbackAccountName,
   baseUrl,
+  siteType,
   tagIds,
   token,
   t,
@@ -84,7 +89,7 @@ async function saveOneTimeApiKeyToProfile({
         tokenName: token.name ?? "",
       }),
       apiType: API_TYPES.OPENAI_COMPATIBLE,
-      baseUrl,
+      baseUrl: siteType === SITE_TYPES.AIHUBMIX ? AIHUBMIX_API_ORIGIN : baseUrl,
       apiKey: token.key,
       tagIds: tagIds ?? [],
     })

--- a/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.ts
+++ b/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.ts
@@ -1,0 +1,98 @@
+import type { TFunction } from "i18next"
+import toast from "react-hot-toast"
+
+import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
+import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
+import type { ApiToken } from "~/types"
+
+import { buildApiCredentialProfileName } from "./apiCredentialProfileName"
+
+type OneTimeApiKeySaveAction = {
+  onSave: () => Promise<void>
+  label?: string
+}
+
+type OneTimeKeySaveLogger = {
+  error: (message: string, details?: unknown) => void
+}
+
+interface BuildOneTimeApiKeyProfileSaveActionParams {
+  accountName: string
+  fallbackAccountName?: string
+  baseUrl: string
+  tagIds?: string[]
+  token: Pick<ApiToken, "key" | "name">
+  t: TFunction
+  logger: OneTimeKeySaveLogger
+  source: string
+}
+
+/**
+ * Builds a dialog save action that persists a one-time key as an API profile.
+ */
+export function buildOneTimeApiKeyProfileSaveAction({
+  accountName,
+  fallbackAccountName,
+  baseUrl,
+  tagIds,
+  token,
+  t,
+  logger,
+  source,
+}: BuildOneTimeApiKeyProfileSaveActionParams): OneTimeApiKeySaveAction {
+  return {
+    onSave: async () => {
+      const profile = await saveOneTimeApiKeyToProfile({
+        accountName,
+        fallbackAccountName,
+        baseUrl,
+        tagIds,
+        token,
+        t,
+        logger,
+        source,
+      })
+
+      toast.success(
+        t("keyManagement:messages.savedToApiProfiles", {
+          name: profile.name,
+        }),
+      )
+    },
+  }
+}
+
+/**
+ * Persists a one-time key secret with shared profile naming and error handling.
+ */
+async function saveOneTimeApiKeyToProfile({
+  accountName,
+  fallbackAccountName,
+  baseUrl,
+  tagIds,
+  token,
+  t,
+  logger,
+  source,
+}: BuildOneTimeApiKeyProfileSaveActionParams) {
+  try {
+    return await apiCredentialProfilesStorage.createProfile({
+      name: buildApiCredentialProfileName({
+        accountName,
+        fallbackAccountName,
+        tokenName: token.name ?? "",
+      }),
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl,
+      apiKey: token.key,
+      tagIds: tagIds ?? [],
+    })
+  } catch (error) {
+    logger.error(`Failed to save one-time key to API profiles from ${source}`, {
+      message: toSanitizedErrorSummary(error, [token.key]),
+    })
+    toast.error(t("keyManagement:messages.saveToApiProfilesFailed"))
+    throw error
+  }
+}

--- a/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.ts
+++ b/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.ts
@@ -2,12 +2,11 @@ import type { TFunction } from "i18next"
 import toast from "react-hot-toast"
 
 import { AIHUBMIX_API_ORIGIN, SITE_TYPES } from "~/constants/siteType"
+import { buildApiCredentialProfileName } from "~/features/KeyManagement/utils/apiCredentialProfileName"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { ApiToken } from "~/types"
-
-import { buildApiCredentialProfileName } from "./apiCredentialProfileName"
 
 type OneTimeApiKeySaveAction = {
   onSave: () => Promise<void>

--- a/src/features/ModelList/components/ModelKeyDialog/index.tsx
+++ b/src/features/ModelList/components/ModelKeyDialog/index.tsx
@@ -18,6 +18,7 @@ import {
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
 import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
+import { buildOneTimeApiKeyProfileSaveAction } from "~/features/KeyManagement/utils/apiCredentialProfileSaveAction"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
@@ -29,6 +30,7 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
 import type { ApiToken, DisplaySiteData } from "~/types"
+import { createLogger } from "~/utils/core/logger"
 import { openKeysPage } from "~/utils/navigation"
 
 import { MODEL_LIST_TEST_IDS } from "../../testIds"
@@ -39,6 +41,7 @@ import {
 
 const optionsEntrypoint = PRODUCT_ANALYTICS_ENTRYPOINTS.Options
 const keyDialogSurface = PRODUCT_ANALYTICS_SURFACE_IDS.OptionsModelListKeyDialog
+const logger = createLogger("ModelKeyDialog")
 
 /**
  * Modal used by the Model List to help users select or create a key compatible with a specific model.
@@ -122,6 +125,17 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
     modelId,
     modelEnableGroups,
   })
+  const oneTimeKeySaveAction = oneTimeToken
+    ? buildOneTimeApiKeyProfileSaveAction({
+        accountName: account.name,
+        baseUrl: account.baseUrl,
+        tagIds: account.tagIds ?? [],
+        token: oneTimeToken,
+        t,
+        logger,
+        source: "ModelKeyDialog",
+      })
+    : undefined
 
   const requiresExplicitSelection = compatibleTokens.length > 1
 
@@ -461,6 +475,7 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
         isOpen={!!oneTimeToken}
         token={oneTimeToken}
         onClose={clearOneTimeToken}
+        saveAction={oneTimeKeySaveAction}
       />
     </>
   )

--- a/src/features/ModelList/components/ModelKeyDialog/index.tsx
+++ b/src/features/ModelList/components/ModelKeyDialog/index.tsx
@@ -129,6 +129,7 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
     ? buildOneTimeApiKeyProfileSaveAction({
         accountName: account.name,
         baseUrl: account.baseUrl,
+        siteType: account.siteType,
         tagIds: account.tagIds ?? [],
         token: oneTimeToken,
         t,

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { Z_INDEX } from "~/components/ui"
 import { SITE_TYPES } from "~/constants/siteType"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -13,6 +14,7 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { AuthTypeEnum } from "~/types"
 import {
   fireEvent,
@@ -31,6 +33,7 @@ const {
   toastSuccessMock,
   toastErrorMock,
   trackerCompleteMock,
+  createApiCredentialProfileMock,
 } = vi.hoisted(() => ({
   createApiTokenMock: vi.fn(),
   updateApiTokenMock: vi.fn(),
@@ -40,6 +43,7 @@ const {
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
   trackerCompleteMock: vi.fn(),
+  createApiCredentialProfileMock: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -64,6 +68,16 @@ vi.mock("~/services/productAnalytics/actions", () => ({
     startProductAnalyticsActionMock(...args),
 }))
 
+vi.mock(
+  "~/services/apiCredentialProfiles/apiCredentialProfilesStorage",
+  () => ({
+    apiCredentialProfilesStorage: {
+      createProfile: (...args: unknown[]) =>
+        createApiCredentialProfileMock(...args),
+    },
+  }),
+)
+
 const ACCOUNT = {
   id: "acc-1",
   name: "Example",
@@ -74,6 +88,7 @@ const ACCOUNT = {
   userId: 1,
   authType: AuthTypeEnum.AccessToken,
   checkIn: { enableDetection: false },
+  tagIds: ["tag-a"],
 } as any
 
 describe("AddTokenDialog prefill", () => {
@@ -84,6 +99,7 @@ describe("AddTokenDialog prefill", () => {
     fetchUserGroupsMock.mockReset()
     startProductAnalyticsActionMock.mockReset()
     trackerCompleteMock.mockReset()
+    createApiCredentialProfileMock.mockReset()
     startProductAnalyticsActionMock.mockReturnValue({
       complete: trackerCompleteMock,
     })
@@ -496,6 +512,78 @@ describe("AddTokenDialog prefill", () => {
       expect(toastErrorMock).toHaveBeenCalledWith("clipboard denied")
     })
 
+    expect(
+      screen.getByLabelText("keyManagement:oneTimeKey.keyLabel"),
+    ).toHaveValue("sk-created-full-secret")
+  })
+
+  it("saves a created one-time key to an API credential profile without closing the dialog", async () => {
+    fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { desc: "default", ratio: 1 },
+    })
+    createApiTokenMock.mockResolvedValueOnce({
+      id: 7,
+      user_id: 1,
+      key: "sk-created-full-secret",
+      status: 1,
+      name: "My Key",
+      created_time: 1,
+      accessed_time: 1,
+      expired_time: -1,
+      remain_quota: -1,
+      unlimited_quota: true,
+      used_quota: 0,
+    })
+    createApiCredentialProfileMock.mockResolvedValueOnce({
+      id: "profile-1",
+      name: "Example - My Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: ACCOUNT.baseUrl,
+      apiKey: "sk-created-full-secret",
+      tagIds: ACCOUNT.tagIds,
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    const onClose = vi.fn()
+
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+
+    render(
+      <AddTokenDialog
+        isOpen={true}
+        onClose={onClose}
+        availableAccounts={[ACCOUNT]}
+        preSelectedAccountId={ACCOUNT.id}
+      />,
+    )
+
+    await user.type(
+      await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
+      "My Key",
+    )
+    await user.click(
+      screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
+    )
+    await user.click(
+      await screen.findByTestId(KEY_MANAGEMENT_TEST_IDS.oneTimeKeySaveButton),
+    )
+
+    await waitFor(() => {
+      expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
+        name: "Example - My Key",
+        apiType: API_TYPES.OPENAI_COMPATIBLE,
+        baseUrl: ACCOUNT.baseUrl,
+        apiKey: "sk-created-full-secret",
+        tagIds: ACCOUNT.tagIds,
+      })
+    })
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "keyManagement:messages.savedToApiProfiles",
+    )
+    expect(onClose).not.toHaveBeenCalled()
     expect(
       screen.getByLabelText("keyManagement:oneTimeKey.keyLabel"),
     ).toHaveValue("sk-created-full-secret")

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import ModelKeyDialog from "~/features/ModelList/components/ModelKeyDialog"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -10,6 +11,7 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { AuthTypeEnum } from "~/types"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
@@ -23,6 +25,7 @@ const {
   startProductAnalyticsActionMock,
   completeProductAnalyticsActionMock,
   trackProductAnalyticsActionStartedMock,
+  createApiCredentialProfileMock,
 } = vi.hoisted(() => ({
   fetchAccountTokensMock: vi.fn(),
   createApiTokenMock: vi.fn(),
@@ -33,6 +36,7 @@ const {
   startProductAnalyticsActionMock: vi.fn(),
   completeProductAnalyticsActionMock: vi.fn(),
   trackProductAnalyticsActionStartedMock: vi.fn(),
+  createApiCredentialProfileMock: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -78,6 +82,16 @@ vi.mock("~/services/productAnalytics/actions", () => ({
     trackProductAnalyticsActionStartedMock(...args),
 }))
 
+vi.mock(
+  "~/services/apiCredentialProfiles/apiCredentialProfilesStorage",
+  () => ({
+    apiCredentialProfilesStorage: {
+      createProfile: (...args: unknown[]) =>
+        createApiCredentialProfileMock(...args),
+    },
+  }),
+)
+
 const ACCOUNT = {
   id: "acc-1",
   name: "Example",
@@ -88,6 +102,7 @@ const ACCOUNT = {
   userId: 1,
   authType: AuthTypeEnum.AccessToken,
   checkIn: { enableDetection: false },
+  tagIds: ["tag-a"],
 } as any
 
 const TOKEN = {
@@ -120,6 +135,7 @@ describe("ModelKeyDialog", () => {
     startProductAnalyticsActionMock.mockReset()
     completeProductAnalyticsActionMock.mockReset()
     trackProductAnalyticsActionStartedMock.mockReset()
+    createApiCredentialProfileMock.mockReset()
     startProductAnalyticsActionMock.mockReturnValue({
       complete: completeProductAnalyticsActionMock,
     })
@@ -305,6 +321,67 @@ describe("ModelKeyDialog", () => {
     expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Success,
     )
+  })
+
+  it("saves a default-created one-time key to an API credential profile without closing the dialog", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce({
+      ...TOKEN,
+      id: 8,
+      key: "sk-created-full-secret",
+      name: "model-key",
+    })
+    createApiCredentialProfileMock.mockResolvedValueOnce({
+      id: "profile-1",
+      name: "Example - model-key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: ACCOUNT.baseUrl,
+      apiKey: "sk-created-full-secret",
+      tagIds: ACCOUNT.tagIds,
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    const onClose = vi.fn()
+
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+
+    render(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={onClose}
+        account={ACCOUNT}
+        modelId="gpt-4"
+        modelEnableGroups={["default"]}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "modelList:keyDialog.createKey",
+      }),
+    )
+    await user.click(
+      await screen.findByTestId(KEY_MANAGEMENT_TEST_IDS.oneTimeKeySaveButton),
+    )
+
+    await waitFor(() => {
+      expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
+        name: "Example - model-key",
+        apiType: API_TYPES.OPENAI_COMPATIBLE,
+        baseUrl: ACCOUNT.baseUrl,
+        apiKey: "sk-created-full-secret",
+        tagIds: ACCOUNT.tagIds,
+      })
+    })
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "keyManagement:messages.savedToApiProfiles",
+    )
+    expect(onClose).not.toHaveBeenCalled()
+    expect(
+      screen.getByLabelText("keyManagement:oneTimeKey.keyLabel"),
+    ).toHaveValue("sk-created-full-secret")
   })
 
   it("formats optional-prefix compatible created keys before showing the one-time dialog", async () => {

--- a/tests/features/AccountManagement/components/AccountDialog.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialog.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
+import toast from "react-hot-toast"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { DIALOG_MODES } from "~/constants/dialogModes"
@@ -30,6 +31,8 @@ const {
   mockOpenFullBookmarkManagerPage,
   mockOpenApiCredentialProfilesPage,
   mockOpenSiteSupportRequestPage,
+  mockCreateApiCredentialProfile,
+  mockLoggerError,
 } = vi.hoisted(() => ({
   mockSponsorRecommendationItems: [
     {
@@ -186,6 +189,8 @@ const {
   mockOpenFullBookmarkManagerPage: vi.fn(),
   mockOpenApiCredentialProfilesPage: vi.fn(),
   mockOpenSiteSupportRequestPage: vi.fn(),
+  mockCreateApiCredentialProfile: vi.fn(),
+  mockLoggerError: vi.fn(),
 }))
 
 function resetMockState() {
@@ -273,6 +278,9 @@ vi.mock("~/features/KeyManagement/components/OneTimeApiKeyDialog", () => ({
   OneTimeApiKeyDialog: (props: {
     isOpen: boolean
     token: { key?: string } | null
+    saveAction?: {
+      onSave: () => Promise<void>
+    }
   }) => (
     <div data-testid="post-save-one-time-key-dialog">
       <div data-testid="post-save-one-time-key-open">
@@ -281,8 +289,49 @@ vi.mock("~/features/KeyManagement/components/OneTimeApiKeyDialog", () => ({
       <div data-testid="post-save-one-time-key-value">
         {props.token?.key ?? ""}
       </div>
+      {props.saveAction ? (
+        <button
+          type="button"
+          data-testid="post-save-one-time-key-save"
+          onClick={() => props.saveAction?.onSave().catch(() => undefined)}
+        >
+          save
+        </button>
+      ) : null}
     </div>
   ),
+}))
+
+vi.mock(
+  "~/services/apiCredentialProfiles/apiCredentialProfilesStorage",
+  () => ({
+    apiCredentialProfilesStorage: {
+      createProfile: (...args: unknown[]) =>
+        mockCreateApiCredentialProfile(...args),
+    },
+  }),
+)
+
+vi.mock("react-hot-toast", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-hot-toast")>()
+
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+  }
+})
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: mockLoggerError,
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
 }))
 
 vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
@@ -383,6 +432,17 @@ describe("AccountDialog", () => {
       },
     )
     mockHandlers.shouldDeferAccountSaveSuccess.mockReturnValue(false)
+    mockCreateApiCredentialProfile.mockResolvedValue({
+      id: "profile-1",
+      name: "AIHubMix - Default API Key",
+      apiType: "openai-compatible",
+      baseUrl: "https://aihubmix.com",
+      apiKey: "sk-one-time",
+      tagIds: [],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
     mockUseSponsorRecommendations.mockImplementation(() => ({
       isLoading: false,
       items: mockSponsorRecommendationItems,
@@ -797,6 +857,103 @@ describe("AccountDialog", () => {
     expect(
       screen.getByTestId("post-save-one-time-key-value"),
     ).toHaveTextContent("sk-one-time")
+    expect(
+      screen.getByTestId("post-save-one-time-key-save"),
+    ).toBeInTheDocument()
+  })
+
+  it("saves an AIHubMix one-time key to API credential profiles without navigating", async () => {
+    const user = userEvent.setup()
+    mockState.draft.siteName = "AIHubMix"
+    mockState.draft.tagIds = ["tag-a"]
+    mockState.postSaveOneTimeToken = {
+      id: 10,
+      user_id: 13,
+      key: "sk-one-time-full",
+      name: "Default API Key",
+      status: 1,
+      created_time: 1,
+      accessed_time: 1,
+      expired_time: -1,
+      remain_quota: -1,
+      unlimited_quota: true,
+      used_quota: 0,
+    }
+    mockCreateApiCredentialProfile.mockResolvedValueOnce({
+      id: "profile-1",
+      name: "AIHubMix - Default API Key",
+      apiType: "openai-compatible",
+      baseUrl: "https://aihubmix.com",
+      apiKey: "sk-one-time-full",
+      tagIds: ["tag-a"],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+
+    render(
+      <AccountDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.ADD}
+        onSuccess={vi.fn()}
+        onError={vi.fn()}
+      />,
+    )
+
+    await user.click(await screen.findByTestId("post-save-one-time-key-save"))
+
+    await waitFor(() => {
+      expect(mockCreateApiCredentialProfile).toHaveBeenCalledWith({
+        name: "AIHubMix - Default API Key",
+        apiType: "openai-compatible",
+        baseUrl: "https://aihubmix.com",
+        apiKey: "sk-one-time-full",
+        tagIds: ["tag-a"],
+      })
+    })
+    expect(toast.success).toHaveBeenCalledWith(
+      "keyManagement:messages.savedToApiProfiles",
+    )
+    expect(mockHandlers.handlePostSaveOneTimeTokenClose).not.toHaveBeenCalled()
+    expect(mockOpenApiCredentialProfilesPage).not.toHaveBeenCalled()
+  })
+
+  it("keeps the AIHubMix one-time key dialog open when API profile save fails", async () => {
+    const user = userEvent.setup()
+    mockState.draft.siteName = "AIHubMix"
+    mockState.postSaveOneTimeToken = {
+      key: "sk-one-time-full",
+      name: "Default API Key",
+    }
+    mockCreateApiCredentialProfile.mockRejectedValueOnce(
+      new Error("storage failed for sk-one-time-full"),
+    )
+
+    render(
+      <AccountDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.ADD}
+        onSuccess={vi.fn()}
+        onError={vi.fn()}
+      />,
+    )
+
+    await user.click(await screen.findByTestId("post-save-one-time-key-save"))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "keyManagement:messages.saveToApiProfilesFailed",
+      )
+    })
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      "Failed to save AIHubMix one-time key to API profiles",
+      {
+        message: "storage failed for [REDACTED]",
+      },
+    )
+    expect(mockHandlers.handlePostSaveOneTimeTokenClose).not.toHaveBeenCalled()
   })
 
   it("renders the AIHubMix post-save key confirmation dialog", async () => {

--- a/tests/features/AccountManagement/components/AccountDialog.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialog.test.tsx
@@ -948,7 +948,7 @@ describe("AccountDialog", () => {
       )
     })
     expect(mockLoggerError).toHaveBeenCalledWith(
-      "Failed to save AIHubMix one-time key to API profiles",
+      "Failed to save one-time key to API profiles from AccountDialog",
       {
         message: "storage failed for [REDACTED]",
       },

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -12,6 +13,7 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { AuthTypeEnum } from "~/types"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
@@ -27,6 +29,7 @@ const {
   completeProductAnalyticsActionMock,
   toastSuccessMock,
   toastErrorMock,
+  createApiCredentialProfileMock,
 } = vi.hoisted(() => ({
   fetchAccountTokensMock: vi.fn(),
   createApiTokenMock: vi.fn(),
@@ -39,6 +42,7 @@ const {
   completeProductAnalyticsActionMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
+  createApiCredentialProfileMock: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -79,6 +83,16 @@ vi.mock("~/services/productAnalytics/actions", async (importOriginal) => {
   }
 })
 
+vi.mock(
+  "~/services/apiCredentialProfiles/apiCredentialProfilesStorage",
+  () => ({
+    apiCredentialProfilesStorage: {
+      createProfile: (...args: unknown[]) =>
+        createApiCredentialProfileMock(...args),
+    },
+  }),
+)
+
 const ACCOUNT = {
   id: "acc-1",
   name: "Example",
@@ -89,6 +103,7 @@ const ACCOUNT = {
   userId: 1,
   authType: AuthTypeEnum.AccessToken,
   checkIn: { enableDetection: false },
+  tagIds: ["tag-a"],
 } as any
 
 const TOKEN = {
@@ -120,6 +135,7 @@ describe("CopyKeyDialog", () => {
     openWithAccountMock.mockReset()
     startProductAnalyticsActionMock.mockReset()
     completeProductAnalyticsActionMock.mockReset()
+    createApiCredentialProfileMock.mockReset()
     startProductAnalyticsActionMock.mockReturnValue({
       complete: completeProductAnalyticsActionMock,
     })
@@ -730,5 +746,69 @@ describe("CopyKeyDialog", () => {
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
       expect(writeText).toHaveBeenCalledWith("sk-custom-full-secret")
     })
+  })
+
+  it("saves a custom one-time key to an API credential profile without closing the dialog", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { desc: "default", ratio: 1 },
+    })
+    createApiTokenMock.mockResolvedValueOnce({
+      ...TOKEN,
+      id: 10,
+      key: "sk-custom-full-secret",
+      name: "My Key",
+    })
+    createApiCredentialProfileMock.mockResolvedValueOnce({
+      id: "profile-1",
+      name: "Example - My Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: ACCOUNT.baseUrl,
+      apiKey: "sk-custom-full-secret",
+      tagIds: ACCOUNT.tagIds,
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    const onClose = vi.fn()
+
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+
+    render(<CopyKeyDialog isOpen={true} onClose={onClose} account={ACCOUNT} />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.copyKey.createCustomKey",
+      }),
+    )
+    await user.type(
+      await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
+      "My Key",
+    )
+    await user.click(
+      screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
+    )
+    await user.click(
+      await screen.findByTestId(KEY_MANAGEMENT_TEST_IDS.oneTimeKeySaveButton),
+    )
+
+    await waitFor(() => {
+      expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
+        name: "Example - My Key",
+        apiType: API_TYPES.OPENAI_COMPATIBLE,
+        baseUrl: ACCOUNT.baseUrl,
+        apiKey: "sk-custom-full-secret",
+        tagIds: ACCOUNT.tagIds,
+      })
+    })
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "keyManagement:messages.savedToApiProfiles",
+    )
+    expect(onClose).not.toHaveBeenCalled()
+    expect(
+      screen.getByLabelText("keyManagement:oneTimeKey.keyLabel"),
+    ).toHaveValue("sk-custom-full-secret")
   })
 })

--- a/tests/features/KeyManagement/components/OneTimeApiKeyDialog.test.tsx
+++ b/tests/features/KeyManagement/components/OneTimeApiKeyDialog.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { act } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
@@ -112,5 +113,38 @@ describe("OneTimeApiKeyDialog", () => {
 
     expect(onSave).toHaveBeenCalledTimes(1)
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("prevents duplicate save submissions while a save is in flight", async () => {
+    const user = userEvent.setup()
+    let resolveSave: (() => void) | undefined
+    const onSave = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve
+        }),
+    )
+
+    render(
+      <OneTimeApiKeyDialog
+        isOpen={true}
+        token={{ key: "sk-one-time", name: "Default API Key" } as any}
+        onClose={vi.fn()}
+        autoCopy={false}
+        saveAction={{ onSave }}
+      />,
+    )
+
+    const saveButton = screen.getByTestId(
+      KEY_MANAGEMENT_TEST_IDS.oneTimeKeySaveButton,
+    )
+
+    await user.dblClick(saveButton)
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveSave?.()
+    })
   })
 })

--- a/tests/features/KeyManagement/components/OneTimeApiKeyDialog.test.tsx
+++ b/tests/features/KeyManagement/components/OneTimeApiKeyDialog.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
+
+let OneTimeApiKeyDialog: typeof import("~/features/KeyManagement/components/OneTimeApiKeyDialog").OneTimeApiKeyDialog
+
+vi.mock("@headlessui/react", () => {
+  const Dialog = ({ children }: any) => <div>{children}</div>
+  Dialog.Panel = ({ children, ...props }: any) => (
+    <div {...props}>{children}</div>
+  )
+
+  const Transition = ({ show, children }: any) =>
+    show ? <>{children}</> : null
+  Transition.Child = ({ children }: any) => <>{children}</>
+
+  return { Dialog, Transition }
+})
+
+describe("OneTimeApiKeyDialog", () => {
+  beforeEach(async () => {
+    ;({ OneTimeApiKeyDialog } = await import(
+      "~/features/KeyManagement/components/OneTimeApiKeyDialog"
+    ))
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
+  it("renders the save button only when a save action is provided", () => {
+    const token = {
+      key: "sk-one-time",
+      name: "Default API Key",
+    } as any
+
+    const { rerender } = render(
+      <OneTimeApiKeyDialog
+        isOpen={true}
+        token={token}
+        onClose={vi.fn()}
+        autoCopy={false}
+      />,
+    )
+
+    expect(
+      screen.queryByTestId(KEY_MANAGEMENT_TEST_IDS.oneTimeKeySaveButton),
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <OneTimeApiKeyDialog
+        isOpen={true}
+        token={token}
+        onClose={vi.fn()}
+        autoCopy={false}
+        saveAction={{
+          onSave: vi.fn(),
+        }}
+      />,
+    )
+
+    expect(
+      screen.getByTestId(KEY_MANAGEMENT_TEST_IDS.oneTimeKeySaveButton),
+    ).toBeInTheDocument()
+  })
+
+  it("keeps the dialog open when the save action fails", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onSave = vi.fn().mockRejectedValue(new Error("storage failed"))
+
+    render(
+      <OneTimeApiKeyDialog
+        isOpen={true}
+        token={{ key: "sk-one-time", name: "Default API Key" } as any}
+        onClose={onClose}
+        autoCopy={false}
+        saveAction={{ onSave }}
+      />,
+    )
+
+    await user.click(
+      screen.getByTestId(KEY_MANAGEMENT_TEST_IDS.oneTimeKeySaveButton),
+    )
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("keeps the dialog open after a successful save action", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onSave = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <OneTimeApiKeyDialog
+        isOpen={true}
+        token={{ key: "sk-one-time", name: "Default API Key" } as any}
+        onClose={onClose}
+        autoCopy={false}
+        saveAction={{ onSave }}
+      />,
+    )
+
+    await user.click(
+      screen.getByTestId(KEY_MANAGEMENT_TEST_IDS.oneTimeKeySaveButton),
+    )
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/tests/features/KeyManagement/utils/apiCredentialProfileSaveAction.test.ts
+++ b/tests/features/KeyManagement/utils/apiCredentialProfileSaveAction.test.ts
@@ -9,13 +9,16 @@ import {
 import { buildOneTimeApiKeyProfileSaveAction } from "~/features/KeyManagement/utils/apiCredentialProfileSaveAction"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 
-const { createApiCredentialProfileMock, toastSuccessMock } = vi.hoisted(() => ({
-  createApiCredentialProfileMock: vi.fn(),
-  toastSuccessMock: vi.fn(),
-}))
+const { createApiCredentialProfileMock, toastErrorMock, toastSuccessMock } =
+  vi.hoisted(() => ({
+    createApiCredentialProfileMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+    toastSuccessMock: vi.fn(),
+  }))
 
 vi.mock("react-hot-toast", () => ({
   default: {
+    error: toastErrorMock,
     success: toastSuccessMock,
   },
 }))
@@ -33,6 +36,7 @@ vi.mock(
 describe("buildOneTimeApiKeyProfileSaveAction", () => {
   beforeEach(() => {
     createApiCredentialProfileMock.mockReset()
+    toastErrorMock.mockReset()
     toastSuccessMock.mockReset()
   })
 
@@ -112,5 +116,78 @@ describe("buildOneTimeApiKeyProfileSaveAction", () => {
       apiKey: "sk-one-time-full",
       tagIds: [],
     })
+  })
+
+  it("normalizes profile names by trimming, skipping empty parts, and deduplicating labels", async () => {
+    createApiCredentialProfileMock.mockResolvedValueOnce({
+      id: "profile-1",
+      name: "Example - Default API Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://api.example.com",
+      apiKey: "sk-one-time-full",
+      tagIds: [],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    const t = vi.fn((key: string) => key) as unknown as TFunction
+    const logger = { error: vi.fn() }
+
+    const saveAction = buildOneTimeApiKeyProfileSaveAction({
+      accountName: "  Example  ",
+      fallbackAccountName: "Example",
+      baseUrl: "https://api.example.com",
+      siteType: SITE_TYPES.NEW_API,
+      token: {
+        key: "sk-one-time-full",
+        name: "  Default API Key  ",
+      },
+      t,
+      logger,
+      source: "AddTokenDialog",
+    })
+
+    await saveAction.onSave()
+
+    expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
+      name: "Example - Default API Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://api.example.com",
+      apiKey: "sk-one-time-full",
+      tagIds: [],
+    })
+  })
+
+  it("logs, reports, and rethrows profile creation failures", async () => {
+    const error = new Error("storage failed")
+    createApiCredentialProfileMock.mockRejectedValueOnce(error)
+    const t = vi.fn((key: string) => key) as unknown as TFunction
+    const logger = { error: vi.fn() }
+
+    const saveAction = buildOneTimeApiKeyProfileSaveAction({
+      accountName: "Example",
+      baseUrl: "https://api.example.com",
+      siteType: SITE_TYPES.NEW_API,
+      token: {
+        key: "sk-one-time-full",
+        name: "Default API Key",
+      },
+      t,
+      logger,
+      source: "AddTokenDialog",
+    })
+
+    await expect(saveAction.onSave()).rejects.toThrow(error)
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed to save one-time key to API profiles from AddTokenDialog",
+      {
+        message: "storage failed",
+      },
+    )
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "keyManagement:messages.saveToApiProfilesFailed",
+    )
+    expect(toastSuccessMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/features/KeyManagement/utils/apiCredentialProfileSaveAction.test.ts
+++ b/tests/features/KeyManagement/utils/apiCredentialProfileSaveAction.test.ts
@@ -1,0 +1,116 @@
+import type { TFunction } from "i18next"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_WEB_ORIGIN,
+  SITE_TYPES,
+} from "~/constants/siteType"
+import { buildOneTimeApiKeyProfileSaveAction } from "~/features/KeyManagement/utils/apiCredentialProfileSaveAction"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
+
+const { createApiCredentialProfileMock, toastSuccessMock } = vi.hoisted(() => ({
+  createApiCredentialProfileMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}))
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    success: toastSuccessMock,
+  },
+}))
+
+vi.mock(
+  "~/services/apiCredentialProfiles/apiCredentialProfilesStorage",
+  () => ({
+    apiCredentialProfilesStorage: {
+      createProfile: (...args: unknown[]) =>
+        createApiCredentialProfileMock(...args),
+    },
+  }),
+)
+
+describe("buildOneTimeApiKeyProfileSaveAction", () => {
+  beforeEach(() => {
+    createApiCredentialProfileMock.mockReset()
+    toastSuccessMock.mockReset()
+  })
+
+  it("uses the AIHubMix API origin when the source account was saved from the web console", async () => {
+    createApiCredentialProfileMock.mockResolvedValueOnce({
+      id: "profile-1",
+      name: "AIHubMix - Default API Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: AIHUBMIX_API_ORIGIN,
+      apiKey: "sk-one-time-full",
+      tagIds: [],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    const t = vi.fn((key: string) => key) as unknown as TFunction
+    const logger = { error: vi.fn() }
+
+    const saveAction = buildOneTimeApiKeyProfileSaveAction({
+      accountName: "AIHubMix",
+      baseUrl: AIHUBMIX_WEB_ORIGIN,
+      siteType: SITE_TYPES.AIHUBMIX,
+      token: {
+        key: "sk-one-time-full",
+        name: "Default API Key",
+      },
+      t,
+      logger,
+      source: "AddTokenDialog",
+    })
+
+    await saveAction.onSave()
+
+    expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
+      name: "AIHubMix - Default API Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: AIHUBMIX_API_ORIGIN,
+      apiKey: "sk-one-time-full",
+      tagIds: [],
+    })
+  })
+
+  it("keeps non-AIHubMix account base URLs unchanged", async () => {
+    createApiCredentialProfileMock.mockResolvedValueOnce({
+      id: "profile-1",
+      name: "Example - Default API Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://api.example.com",
+      apiKey: "sk-one-time-full",
+      tagIds: [],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+    const t = vi.fn((key: string) => key) as unknown as TFunction
+    const logger = { error: vi.fn() }
+
+    const saveAction = buildOneTimeApiKeyProfileSaveAction({
+      accountName: "Example",
+      baseUrl: "https://api.example.com",
+      siteType: SITE_TYPES.NEW_API,
+      token: {
+        key: "sk-one-time-full",
+        name: "Default API Key",
+      },
+      t,
+      logger,
+      source: "AddTokenDialog",
+    })
+
+    await saveAction.onSave()
+
+    expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
+      name: "Example - Default API Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://api.example.com",
+      apiKey: "sk-one-time-full",
+      tagIds: [],
+    })
+  })
+})


### PR DESCRIPTION
Related issues: #631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save one-time API keys directly into credential profiles from key dialogs; a conditional "Save" button appears for one-time keys.
  * Profile names are auto-generated from account and token names.
  * Success and failure toasts inform the user; dialogs remain open after saving to allow continued interaction.

* **Tests**
  * Coverage added/expanded to verify save flows, profile creation, toasts, and UI behavior (including save-button interactions).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->