### PR TITLE
feat(account-dialog): Default AnyRouter account auth to Cookie by URL

### DIFF
--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -14,8 +14,8 @@ import {
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import {
   isAccountAuthType,
-  normalizeAccountAuthTypeOrDefault,
   normalizeOptionalAccountAuthType,
+  resolveDefaultAccountAuthType,
 } from "~/features/AccountManagement/utils/accountAuthType"
 import {
   autoDetectAccount,
@@ -220,6 +220,7 @@ export function useAccountDialog({
     null,
   )
   const hasConsumedAutoFillCurrentSiteUrlRef = useRef(false)
+  const hasExplicitAuthTypeRef = useRef(false)
   const siteName = draft.siteName
   const username = draft.username
   const accessToken = draft.accessToken
@@ -327,9 +328,10 @@ export function useAccountDialog({
   )
   const setAuthType = useCallback(
     (value: AuthTypeEnum) => {
-      updateDraft((prev) =>
-        isAccountAuthType(value) ? { ...prev, authType: value } : prev,
-      )
+      if (!isAccountAuthType(value)) return
+
+      hasExplicitAuthTypeRef.current = true
+      updateDraft((prev) => ({ ...prev, authType: value }))
     },
     [updateDraft],
   )
@@ -607,11 +609,16 @@ export function useAccountDialog({
       detectedCookieStoreIdRef.current = null
       duplicateAccountWarningAcknowledgedSiteUrlRef.current = null
       hasConsumedAutoFillCurrentSiteUrlRef.current = Boolean(nextPrefill)
+      const normalizedPrefillAuthType = normalizeOptionalAccountAuthType(
+        nextPrefill?.authType,
+      )
+      const nextSiteType = nextPrefill?.siteType ?? SITE_TYPES.UNKNOWN
+      hasExplicitAuthTypeRef.current = Boolean(normalizedPrefillAuthType)
       setUrl(nextPrefill?.siteUrl ?? "")
       setDraft({
         ...createEmptyAccountDialogDraft(),
-        siteType: nextPrefill?.siteType ?? SITE_TYPES.UNKNOWN,
-        authType: normalizeAccountAuthTypeOrDefault(nextPrefill?.authType),
+        siteType: nextSiteType,
+        authType: normalizedPrefillAuthType || AuthTypeEnum.AccessToken,
       })
       const nextFlowState = getInitialFlowState(mode)
       setPhase(nextFlowState.phase)
@@ -644,6 +651,7 @@ export function useAccountDialog({
             siteAccount.site_type,
             Boolean(siteAccount.sub2apiAuth),
           )
+          hasExplicitAuthTypeRef.current = true
           setDraft({
             siteName: siteAccount.site_name,
             username: siteAccount.account_info.username,
@@ -841,9 +849,42 @@ export function useAccountDialog({
     }
   }, [isDetecting])
 
+  const handleUrlChange = (
+    newUrl: string,
+    options: { applyAuthDefault?: boolean } = {},
+  ) => {
+    const shouldApplyAuthDefault = options.applyAuthDefault !== false
+    duplicateAccountWarningAcknowledgedSiteUrlRef.current = null
+    detectedCookieStoreIdRef.current = null
+    hasConsumedAutoFillCurrentSiteUrlRef.current = true
+    if (newUrl.trim()) {
+      try {
+        const urlObj = new URL(newUrl)
+        const baseUrl = `${urlObj.protocol}//${urlObj.host}`
+        setUrl(baseUrl)
+        if (shouldApplyAuthDefault && !hasExplicitAuthTypeRef.current) {
+          updateDraft((prev) => ({
+            ...prev,
+            authType: resolveDefaultAccountAuthType({
+              siteUrl: baseUrl,
+            }),
+          }))
+        }
+      } catch (error) {
+        logger.warn("Failed to normalize URL input", { error, url: newUrl })
+        setUrl(newUrl)
+      }
+    } else {
+      setUrl("")
+      if (mode === DIALOG_MODES.ADD) {
+        setSiteName("")
+      }
+    }
+  }
+
   const handleUseCurrentTabUrl = () => {
     if (currentTabUrl) {
-      setUrl(currentTabUrl)
+      handleUrlChange(currentTabUrl)
     }
   }
 
@@ -2047,27 +2088,6 @@ export function useAccountDialog({
     } finally {
       if (isCurrentRun()) {
         setIsAutoConfiguring(false)
-      }
-    }
-  }
-
-  const handleUrlChange = (newUrl: string) => {
-    duplicateAccountWarningAcknowledgedSiteUrlRef.current = null
-    detectedCookieStoreIdRef.current = null
-    hasConsumedAutoFillCurrentSiteUrlRef.current = true
-    if (newUrl.trim()) {
-      try {
-        const urlObj = new URL(newUrl)
-        const baseUrl = `${urlObj.protocol}//${urlObj.host}`
-        setUrl(baseUrl)
-      } catch (error) {
-        logger.warn("Failed to normalize URL input", { error, url: newUrl })
-        setUrl(newUrl)
-      }
-    } else {
-      setUrl("")
-      if (mode === DIALOG_MODES.ADD) {
-        setSiteName("")
       }
     }
   }

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -265,7 +265,9 @@ export default function AccountDialog({
                   surface={SPONSOR_RECOMMENDATION_SURFACES.AddAccountDialog}
                   items={sponsorRecommendations.items}
                   onContinueAddAccount={(nextPrefill) => {
-                    handlers.handleUrlChange(nextPrefill.siteUrl)
+                    handlers.handleUrlChange(nextPrefill.siteUrl, {
+                      applyAuthDefault: false,
+                    })
                     setters.setSiteType(nextPrefill.siteType)
                     if (nextPrefill.authType) {
                       setters.setAuthType(nextPrefill.authType)

--- a/src/features/AccountManagement/utils/accountAuthType.ts
+++ b/src/features/AccountManagement/utils/accountAuthType.ts
@@ -2,6 +2,24 @@ import { AuthTypeEnum } from "~/types"
 
 const AUTH_TYPE_VALUES = new Set<string>(Object.values(AuthTypeEnum))
 
+interface AccountAuthDefaultInput {
+  siteUrl?: string | null
+}
+
+const ANYROUTER_HOSTNAMES = new Set(["anyrouter.top"])
+
+/**
+ * Resolves the locally known default auth mode for account add flows.
+ * `siteUrl` is accepted so future domain-backed rules can share this boundary.
+ */
+export function resolveDefaultAccountAuthType({
+  siteUrl,
+}: AccountAuthDefaultInput = {}): AuthTypeEnum {
+  return isKnownAnyRouterUrl(siteUrl)
+    ? AuthTypeEnum.Cookie
+    : AuthTypeEnum.AccessToken
+}
+
 /**
  * Normalizes externally supplied optional auth values: blank means omitted,
  * unknown non-blank values are invalid.
@@ -26,4 +44,17 @@ export function normalizeAccountAuthTypeOrDefault(
 /** Checks whether a value maps to a supported account auth mode. */
 export function isAccountAuthType(value: unknown): value is AuthTypeEnum {
   return typeof value === "string" && AUTH_TYPE_VALUES.has(value)
+}
+
+/**
+ * Checks whether a URL belongs to the known AnyRouter public domain.
+ */
+function isKnownAnyRouterUrl(value: string | null | undefined): boolean {
+  if (!value) return false
+
+  try {
+    return ANYROUTER_HOSTNAMES.has(new URL(value).hostname.toLowerCase())
+  } catch {
+    return false
+  }
 }

--- a/tests/features/AccountManagement/components/AccountDialog.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialog.test.tsx
@@ -630,6 +630,7 @@ describe("AccountDialog", () => {
 
     expect(mockHandlers.handleUrlChange).toHaveBeenCalledWith(
       "https://anyrouter.example.com",
+      { applyAuthDefault: false },
     )
     expect(mockSetters.setSiteType).toHaveBeenCalledWith(SITE_TYPES.ANYROUTER)
     expect(mockSetters.setAuthType).toHaveBeenCalledWith(AuthTypeEnum.Cookie)
@@ -638,6 +639,43 @@ describe("AccountDialog", () => {
       "_blank",
       "noopener,noreferrer",
     )
+  })
+
+  it("does not infer auth when continuing a sponsor without explicit auth", async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal("open", vi.fn())
+    mockSponsorRecommendationItems[0] = {
+      ...mockSponsorRecommendationItems[0],
+      accountPrefill: {
+        siteType: SITE_TYPES.ANYROUTER,
+        siteUrl: "https://anyrouter.example.com",
+      },
+    }
+    mockState.phase = ACCOUNT_DIALOG_PHASES.SITE_INPUT
+    mockState.formSource = ACCOUNT_DIALOG_FORM_SOURCES.MANUAL
+
+    render(
+      <AccountDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.ADD}
+        onSuccess={vi.fn()}
+        onError={vi.fn()}
+      />,
+    )
+
+    await user.click(
+      await screen.findByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.sponsorContinueAddAccountAction,
+      ),
+    )
+
+    expect(mockHandlers.handleUrlChange).toHaveBeenCalledWith(
+      "https://anyrouter.example.com",
+      { applyAuthDefault: false },
+    )
+    expect(mockSetters.setSiteType).toHaveBeenCalledWith(SITE_TYPES.ANYROUTER)
+    expect(mockSetters.setAuthType).not.toHaveBeenCalled()
   })
 
   it("shows the selected sponsor post-click note below the site URL helpers", async () => {

--- a/tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx
@@ -1,0 +1,171 @@
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { DIALOG_MODES } from "~/constants/dialogModes"
+import { SITE_TYPES } from "~/constants/siteType"
+import { useAccountDialog } from "~/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog"
+import { AuthTypeEnum } from "~/types"
+import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
+
+vi.mock("~/components/dialogs/ChannelDialog", () => ({
+  ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
+  useChannelDialog: () => ({
+    openWithAccount: vi.fn(),
+    openSub2ApiTokenCreationDialog: vi.fn(),
+  }),
+}))
+
+vi.mock("~/services/productAnalytics/actions", () => ({
+  startProductAnalyticsAction: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}))
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+
+  return {
+    ...actual,
+    useUserPreferencesContext: () => ({
+      warnOnDuplicateAccountAdd: true,
+      managedSiteType: "new-api",
+      autoFillCurrentSiteUrlOnAccountAdd: true,
+      autoProvisionKeyOnAccountAdd: false,
+    }),
+  }
+})
+
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/utils/browser/browserApi")>()
+  return {
+    ...actual,
+    getActiveTabs: vi.fn(async () => []),
+    getAllTabs: vi.fn(async () => []),
+    onTabActivated: vi.fn(() => () => {}),
+    onTabUpdated: vi.fn(() => () => {}),
+    sendRuntimeMessage: vi.fn(),
+  }
+})
+
+describe("useAccountDialog auth defaults", () => {
+  const renderAccountDialogHook = (
+    props: Parameters<typeof useAccountDialog>[0],
+  ) =>
+    renderHook(() => useAccountDialog(props), {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("uses access-token auth when a sponsor prefill omits auth type and URL has no known default", async () => {
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+      prefill: {
+        siteUrl: "https://anyrouter.example.com",
+        siteType: SITE_TYPES.ANYROUTER,
+        source: "sponsor",
+        sponsorId: "anyrouter",
+      },
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.siteType).toBe(SITE_TYPES.ANYROUTER)
+      expect(result.current.state.authType).toBe(AuthTypeEnum.AccessToken)
+    })
+  })
+
+  it("lets sponsor auth prefill override the local AnyRouter default", async () => {
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+      prefill: {
+        siteUrl: "https://anyrouter.example.com",
+        siteType: SITE_TYPES.ANYROUTER,
+        authType: AuthTypeEnum.AccessToken,
+        source: "sponsor",
+        sponsorId: "anyrouter",
+      },
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.siteType).toBe(SITE_TYPES.ANYROUTER)
+      expect(result.current.state.authType).toBe(AuthTypeEnum.AccessToken)
+    })
+  })
+
+  it("does not change auth when only site type changes before detection", async () => {
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await act(async () => {
+      result.current.setters.setSiteType(SITE_TYPES.ANYROUTER)
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.authType).toBe(AuthTypeEnum.AccessToken)
+    })
+  })
+
+  it("does not overwrite an explicit user auth selection when site type changes", async () => {
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await act(async () => {
+      result.current.setters.setAuthType(AuthTypeEnum.AccessToken)
+      result.current.setters.setSiteType(SITE_TYPES.ANYROUTER)
+    })
+
+    expect(result.current.state.authType).toBe(AuthTypeEnum.AccessToken)
+  })
+
+  it("uses Cookie auth when an AnyRouter URL is entered before site type is known", async () => {
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await act(async () => {
+      result.current.handlers.handleUrlChange("https://anyrouter.top/console")
+    })
+
+    expect(result.current.state.url).toBe("https://anyrouter.top")
+    expect(result.current.state.siteType).toBe(SITE_TYPES.UNKNOWN)
+    expect(result.current.state.authType).toBe(AuthTypeEnum.Cookie)
+  })
+
+  it("does not overwrite explicit auth when an AnyRouter URL is entered", async () => {
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await act(async () => {
+      result.current.setters.setAuthType(AuthTypeEnum.AccessToken)
+      result.current.handlers.handleUrlChange("https://anyrouter.top/console")
+    })
+
+    expect(result.current.state.authType).toBe(AuthTypeEnum.AccessToken)
+  })
+})

--- a/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { DIALOG_MODES } from "~/constants/dialogModes"
 import { useAccountDialog } from "~/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog"
+import { AuthTypeEnum } from "~/types"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
 const originalBrowser = globalThis.browser
@@ -297,6 +298,38 @@ describe("useAccountDialog current tab detection", () => {
     })
 
     expect(result.current.state.url).toBe("https://picked.example.com")
+  })
+
+  it("applies URL auth defaults when the user chooses the current tab", async () => {
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    tabsQueryMock.mockResolvedValue([
+      {
+        id: 7,
+        url: "https://anyrouter.top/console",
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe("https://anyrouter.top")
+    })
+
+    await act(async () => {
+      result.current.handlers.handleUseCurrentTabUrl()
+    })
+
+    expect(result.current.state.url).toBe("https://anyrouter.top")
+    expect(result.current.state.authType).toBe(AuthTypeEnum.Cookie)
   })
 
   it("prefills the add-account url from the current tab when the setting is enabled", async () => {

--- a/tests/features/AccountManagement/utils/accountAuthType.test.ts
+++ b/tests/features/AccountManagement/utils/accountAuthType.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  normalizeAccountAuthTypeOrDefault,
+  normalizeOptionalAccountAuthType,
+  resolveDefaultAccountAuthType,
+} from "~/features/AccountManagement/utils/accountAuthType"
+import { AuthTypeEnum } from "~/types"
+
+describe("account auth type utilities", () => {
+  it("resolves AnyRouter account defaults from its known domain before site type is known", () => {
+    expect(
+      resolveDefaultAccountAuthType({ siteUrl: "https://anyrouter.top" }),
+    ).toBe(AuthTypeEnum.Cookie)
+  })
+
+  it("keeps the existing optional auth normalization behavior", () => {
+    expect(normalizeOptionalAccountAuthType("")).toBeUndefined()
+    expect(normalizeOptionalAccountAuthType(AuthTypeEnum.Cookie)).toBe(
+      AuthTypeEnum.Cookie,
+    )
+    expect(normalizeOptionalAccountAuthType("bad-auth")).toBe(false)
+  })
+
+  it("keeps the existing explicit-or-default normalization behavior", () => {
+    expect(normalizeAccountAuthTypeOrDefault(AuthTypeEnum.Cookie)).toBe(
+      AuthTypeEnum.Cookie,
+    )
+    expect(normalizeAccountAuthTypeOrDefault("bad-auth")).toBe(
+      AuthTypeEnum.AccessToken,
+    )
+  })
+
+  it("resolves unknown and unsupported URL defaults to access-token auth", () => {
+    expect(resolveDefaultAccountAuthType()).toBe(AuthTypeEnum.AccessToken)
+    expect(
+      resolveDefaultAccountAuthType({ siteUrl: "https://example.com" }),
+    ).toBe(AuthTypeEnum.AccessToken)
+    expect(
+      resolveDefaultAccountAuthType({
+        siteUrl: "https://www.anyrouter.top/console",
+      }),
+    ).toBe(AuthTypeEnum.AccessToken)
+    expect(resolveDefaultAccountAuthType({ siteUrl: "not a url" })).toBe(
+      AuthTypeEnum.AccessToken,
+    )
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Intelligent authentication type defaults based on recognized domains when adding accounts.

* **Bug Fixes**
  * Fixed unintended authentication type overrides during sponsor account continuation flows.
  * Authentication type selection is now preserved when editing existing accounts and updating URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->