### PR TITLE
feat(content): detect selected text on pointer release

### DIFF
--- a/src/entrypoints/content/redemptionAssist/index.ts
+++ b/src/entrypoints/content/redemptionAssist/index.ts
@@ -1,4 +1,9 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import {
+  getClipboardEventText,
+  getSelectedText,
+  registerSelectionEndTextDetection,
+} from "~/entrypoints/content/shared/contentTextDetection"
 import { isEventFromAllApiHubContentUi } from "~/entrypoints/content/shared/contentUi"
 import { isLikelyCopyActionTarget } from "~/entrypoints/content/shared/copyActionTarget"
 import { trackProductAnalyticsActionCompleted } from "~/services/productAnalytics/actions"
@@ -21,6 +26,7 @@ import {
   sendRuntimeMessage,
 } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
+import { isHttpUrl } from "~/utils/core/urlParsing"
 import { t } from "~/utils/i18n/core"
 
 import {
@@ -81,8 +87,7 @@ function setupRedemptionAssistDetection() {
       lastClickScan = now
 
       // Try to get selected text first
-      const selection = window.getSelection()
-      let text = selection?.toString().trim() || ""
+      let text = getSelectedText()
 
       // Fallback: try to read clipboard content if the click target looks like a copy action
       if (
@@ -126,20 +131,18 @@ function setupRedemptionAssistDetection() {
     if (isEventFromAllApiHubContentUi(event.target)) {
       return
     }
-    const selection = window.getSelection()
-    let text = selection?.toString().trim() || ""
-
-    if (!text && event.clipboardData) {
-      const clipText = event.clipboardData.getData("text")
-      if (clipText) {
-        text = clipText
-      }
-    }
+    const text = getClipboardEventText(event)
 
     if (text) {
       void scheduleRedemptionScan(text)
     }
   }
+
+  const cleanupSelectionEndDetection = registerSelectionEndTextDetection(
+    (sourceText) => {
+      void scheduleRedemptionScan(sourceText)
+    },
+  )
 
   document.addEventListener("click", handleClick, true)
   document.addEventListener("copy", handleClipboardEvent, true)
@@ -149,6 +152,7 @@ function setupRedemptionAssistDetection() {
     document.removeEventListener("click", handleClick, true)
     document.removeEventListener("copy", handleClipboardEvent, true)
     document.removeEventListener("cut", handleClipboardEvent, true)
+    cleanupSelectionEndDetection()
   }
 }
 
@@ -322,7 +326,7 @@ async function scanForRedemptionCodes(sourceText?: string) {
 
     // Skip non-http(s) pages to avoid unnecessary background traffic.
     // (e.g. chrome://, about:, file://, extension pages)
-    if (!/^https?:/i.test(url)) {
+    if (!isHttpUrl(url)) {
       return
     }
 

--- a/src/entrypoints/content/shared/contentTextDetection.ts
+++ b/src/entrypoints/content/shared/contentTextDetection.ts
@@ -1,0 +1,39 @@
+import { isEventFromAllApiHubContentUi } from "./contentUi"
+
+/**
+ * Reads the current document selection as trimmed plain text.
+ */
+export function getSelectedText(): string {
+  return window.getSelection()?.toString().trim() || ""
+}
+
+/**
+ * Extracts text from a copy/cut event, preferring the active selection.
+ */
+export function getClipboardEventText(event: ClipboardEvent): string {
+  return getSelectedText() || event.clipboardData?.getData("text").trim() || ""
+}
+
+/**
+ * Registers synchronous pointerup selection-end detection and returns cleanup.
+ */
+export function registerSelectionEndTextDetection(
+  onText: (sourceText: string) => void,
+): () => void {
+  const handlePointerUp = (event: PointerEvent) => {
+    if (isEventFromAllApiHubContentUi(event.target)) {
+      return
+    }
+
+    const selectedText = getSelectedText()
+    if (selectedText) {
+      onText(selectedText)
+    }
+  }
+
+  document.addEventListener("pointerup", handlePointerUp, true)
+
+  return () => {
+    document.removeEventListener("pointerup", handlePointerUp, true)
+  }
+}

--- a/src/entrypoints/content/webAiApiCheck/index.ts
+++ b/src/entrypoints/content/webAiApiCheck/index.ts
@@ -5,7 +5,13 @@ import {
   sendRuntimeMessage,
 } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
+import { isHttpUrl } from "~/utils/core/urlParsing"
 
+import {
+  getClipboardEventText,
+  getSelectedText,
+  registerSelectionEndTextDetection,
+} from "../shared/contentTextDetection"
 import { isEventFromAllApiHubContentUi } from "../shared/contentUi"
 import { isLikelyCopyActionTarget } from "../shared/copyActionTarget"
 import { ensureRedemptionToastUi } from "../shared/uiRoot"
@@ -143,7 +149,7 @@ function setupWebAiApiCheckDetection() {
     if (!text) return
 
     const pageUrl = options?.pageUrl || window.location.href
-    if (!/^https?:/i.test(pageUrl)) return
+    if (!isHttpUrl(pageUrl)) return
 
     const now = Date.now()
     if (toastInFlight) return
@@ -240,9 +246,9 @@ function setupWebAiApiCheckDetection() {
       lastClickScan = now
 
       const pageUrl = window.location.href
-      if (!/^https?:/i.test(pageUrl)) return
+      if (!isHttpUrl(pageUrl)) return
 
-      const selectionText = window.getSelection()?.toString().trim() || ""
+      const selectionText = getSelectedText()
       if (selectionText) {
         void scheduleApiCheckScan(selectionText, { pageUrl })
         return
@@ -291,16 +297,20 @@ function setupWebAiApiCheckDetection() {
     }
 
     const pageUrl = window.location.href
-    if (!/^https?:/i.test(pageUrl)) return
+    if (!isHttpUrl(pageUrl)) return
 
-    const selectionText = window.getSelection()?.toString().trim() || ""
-    const clipboardText = event.clipboardData?.getData("text") || ""
-    const sourceText = selectionText || clipboardText
+    const sourceText = getClipboardEventText(event)
 
     if (sourceText) {
       void scheduleApiCheckScan(sourceText, { pageUrl })
     }
   }
+
+  const cleanupSelectionEndDetection = registerSelectionEndTextDetection(
+    (sourceText) => {
+      void scheduleApiCheckScan(sourceText, { pageUrl: window.location.href })
+    },
+  )
 
   document.addEventListener("click", handleClick, true)
   document.addEventListener("copy", handleClipboardEvent, true)
@@ -314,6 +324,7 @@ function setupWebAiApiCheckDetection() {
     document.removeEventListener("click", handleClick, true)
     document.removeEventListener("copy", handleClipboardEvent, true)
     document.removeEventListener("cut", handleClipboardEvent, true)
+    cleanupSelectionEndDetection()
   }
 }
 

--- a/src/utils/core/urlParsing.ts
+++ b/src/utils/core/urlParsing.ts
@@ -46,6 +46,14 @@ export function tryParseOrigin(
 }
 
 /**
+ * Returns whether the value is an absolute HTTP(S) URL.
+ */
+export function isHttpUrl(value: string | undefined | null): boolean {
+  const parsed = tryParseUrl(value)
+  return parsed?.protocol === "http:" || parsed?.protocol === "https:"
+}
+
+/**
  * Best-effort URL prefix extraction for matching/logging.
  * Returns `origin + pathname` (no query/hash), or `null` when invalid.
  */

--- a/tests/entrypoints/content/redemptionAssist/index.test.ts
+++ b/tests/entrypoints/content/redemptionAssist/index.test.ts
@@ -252,6 +252,74 @@ describe("setupRedemptionAssistContent", () => {
     cleanup()
   })
 
+  it("auto-redeems selected text on pointerup and stops after cleanup", async () => {
+    const getSelectionSpy = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => codeA,
+    } as any)
+
+    mockSendRuntimeMessage.mockImplementation(async (message: any) => {
+      if (message.action === RuntimeActionIds.RedemptionAssistShouldPrompt) {
+        return {
+          success: true,
+          promptableCodes: [codeA],
+        }
+      }
+
+      if (message.action === RuntimeActionIds.RedemptionAssistAutoRedeemByUrl) {
+        return {
+          data: {
+            success: true,
+            message: "redeemed-from-pointerup",
+          },
+        }
+      }
+
+      return { success: false }
+    })
+
+    const { setupRedemptionAssistContent } = await import(
+      "~/entrypoints/content/redemptionAssist"
+    )
+
+    const cleanup = setupRedemptionAssistContent({
+      enableDetection: true,
+      enableContextMenu: false,
+    })
+
+    document.dispatchEvent(new Event("pointerup", { bubbles: true }))
+
+    await waitFor(() => {
+      expect(mockShowRedeemResultToast).toHaveBeenCalledWith(
+        true,
+        "redeemed-from-pointerup",
+      )
+    })
+
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith({
+      action: RuntimeActionIds.RedemptionAssistShouldPrompt,
+      url: window.location.href,
+      codes: [codeA],
+    })
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith({
+      action: RuntimeActionIds.RedemptionAssistAutoRedeemByUrl,
+      url: window.location.href,
+      code: codeA,
+    })
+
+    cleanup()
+    mockSendRuntimeMessage.mockClear()
+    mockShowRedeemResultToast.mockClear()
+    getSelectionSpy.mockReturnValue({
+      toString: () => codeB,
+    } as any)
+
+    document.dispatchEvent(new Event("pointerup", { bubbles: true }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
+    expect(mockShowRedeemResultToast).not.toHaveBeenCalled()
+  })
+
   it("prefers selected text over clipboard reads on click", async () => {
     const readText = vi.fn().mockResolvedValue(codeB)
     Object.defineProperty(navigator, "clipboard", {

--- a/tests/entrypoints/content/shared/contentTextDetection.test.ts
+++ b/tests/entrypoints/content/shared/contentTextDetection.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  getClipboardEventText,
+  getSelectedText,
+  registerSelectionEndTextDetection,
+} from "~/entrypoints/content/shared/contentTextDetection"
+import { CONTENT_UI_HOST_TAG } from "~/entrypoints/content/shared/contentUi"
+
+function mockSelectionText(text: string) {
+  vi.spyOn(window, "getSelection").mockReturnValue({
+    toString: () => text,
+  } as any)
+}
+
+function makeClipboardEvent(type: "copy" | "cut", clipboardText: string) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as any
+  event.clipboardData = {
+    getData: (format: string) => (format === "text" ? clipboardText : ""),
+  }
+  return event as ClipboardEvent
+}
+
+describe("contentTextDetection", () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    document.body.innerHTML = ""
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("extracts trimmed selected text", () => {
+    mockSelectionText("  selected text  ")
+
+    expect(getSelectedText()).toBe("selected text")
+  })
+
+  it("prefers selected text over clipboard event text", () => {
+    mockSelectionText(" selected value ")
+
+    expect(getClipboardEventText(makeClipboardEvent("copy", "clipboard"))).toBe(
+      "selected value",
+    )
+  })
+
+  it("falls back to clipboard event text when selected text is empty", () => {
+    mockSelectionText("   ")
+
+    expect(getClipboardEventText(makeClipboardEvent("cut", "clipboard"))).toBe(
+      "clipboard",
+    )
+  })
+
+  it("runs pointerup selection-end detection synchronously for non-empty selected text", () => {
+    const onText = vi.fn()
+    mockSelectionText(" selected on pointerup ")
+
+    const cleanup = registerSelectionEndTextDetection(onText)
+
+    document.dispatchEvent(new Event("pointerup", { bubbles: true }))
+
+    expect(onText).toHaveBeenCalledWith("selected on pointerup")
+
+    cleanup()
+  })
+
+  it("does not require timers for pointerup selection-end detection", () => {
+    vi.useFakeTimers()
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout")
+    const onText = vi.fn()
+    mockSelectionText("selected without delay")
+
+    const cleanup = registerSelectionEndTextDetection(onText)
+
+    document.dispatchEvent(new Event("pointerup", { bubbles: true }))
+
+    expect(onText).toHaveBeenCalledWith("selected without delay")
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it("does not trigger pointerup selection-end detection for empty selected text", () => {
+    const onText = vi.fn()
+    mockSelectionText("   ")
+
+    const cleanup = registerSelectionEndTextDetection(onText)
+
+    document.dispatchEvent(new Event("pointerup", { bubbles: true }))
+
+    expect(onText).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it("ignores pointerup events from the extension content UI", () => {
+    const onText = vi.fn()
+    mockSelectionText("selected from ui")
+    const host = document.createElement(CONTENT_UI_HOST_TAG)
+    const button = document.createElement("button")
+    host.appendChild(button)
+    document.body.appendChild(host)
+
+    const cleanup = registerSelectionEndTextDetection(onText)
+
+    button.dispatchEvent(new Event("pointerup", { bubbles: true }))
+
+    expect(onText).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it("removes the mouseup listener on cleanup", () => {
+    const onText = vi.fn()
+    mockSelectionText("selected before cleanup")
+
+    const cleanup = registerSelectionEndTextDetection(onText)
+    cleanup()
+
+    document.dispatchEvent(new Event("pointerup", { bubbles: true }))
+
+    expect(onText).not.toHaveBeenCalled()
+  })
+
+  it("does not rely on mouseup for selection-end detection", () => {
+    const onText = vi.fn()
+    mockSelectionText("selected on mouseup")
+
+    const cleanup = registerSelectionEndTextDetection(onText)
+
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }))
+
+    expect(onText).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+})

--- a/tests/entrypoints/content/shared/contentTextDetection.test.ts
+++ b/tests/entrypoints/content/shared/contentTextDetection.test.ts
@@ -116,7 +116,7 @@ describe("contentTextDetection", () => {
     cleanup()
   })
 
-  it("removes the mouseup listener on cleanup", () => {
+  it("removes the pointerup listener on cleanup", () => {
     const onText = vi.fn()
     mockSelectionText("selected before cleanup")
 

--- a/tests/entrypoints/content/webAiApiCheck/index.test.ts
+++ b/tests/entrypoints/content/webAiApiCheck/index.test.ts
@@ -230,6 +230,71 @@ describe("setupWebAiApiCheckContent", () => {
     cleanup()
   })
 
+  it("opens auto-detect for selected text on pointerup and stops after cleanup", async () => {
+    const selectedText = buildApiCheckClipboardText({
+      baseUrl: "https://proxy.example.com/api",
+      apiKey: buildApiKey(),
+    })
+    const getSelectionSpy = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => selectedText,
+    } as any)
+
+    vi.mocked(sendRuntimeMessage).mockImplementation(async (message: any) => {
+      if (message.action === RuntimeActionIds.ApiCheckShouldPrompt) {
+        return {
+          success: true,
+          shouldPrompt: true,
+          enhancedShouldPrompt: false,
+        }
+      }
+      return { success: false }
+    })
+    vi.mocked(showApiCheckConfirmToast).mockResolvedValue(true)
+
+    const cleanup = setupWebAiApiCheckContent({
+      enableDetection: true,
+      enableContextMenu: false,
+    })
+
+    document.dispatchEvent(new Event("pointerup", { bubbles: true }))
+
+    await waitFor(() =>
+      expect(dispatchOpenApiCheckModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceText: selectedText,
+          trigger: "autoDetect",
+        }),
+      ),
+    )
+
+    expect(sendRuntimeMessage).toHaveBeenCalledWith({
+      action: RuntimeActionIds.ApiCheckShouldPrompt,
+      pageUrl: window.location.href,
+    })
+    expect(showApiCheckConfirmToast).toHaveBeenCalledWith({
+      usesEnhancedResult: false,
+    })
+
+    cleanup()
+    vi.mocked(sendRuntimeMessage).mockClear()
+    vi.mocked(showApiCheckConfirmToast).mockClear()
+    vi.mocked(dispatchOpenApiCheckModal).mockClear()
+    getSelectionSpy.mockReturnValue({
+      toString: () =>
+        buildApiCheckClipboardText({
+          baseUrl: "https://proxy.example.com/api",
+          apiKey: buildApiKey(),
+        }),
+    } as any)
+
+    document.dispatchEvent(new Event("pointerup", { bubbles: true }))
+    await flushMicrotasks()
+
+    expect(sendRuntimeMessage).not.toHaveBeenCalled()
+    expect(showApiCheckConfirmToast).not.toHaveBeenCalled()
+    expect(dispatchOpenApiCheckModal).not.toHaveBeenCalled()
+  })
+
   it("does not prompt for enhanced-only matches when enhanced auto-detect is disabled", async () => {
     vi.mocked(sendRuntimeMessage).mockImplementation(async (message: any) => {
       if (message.action === RuntimeActionIds.ApiCheckShouldPrompt) {

--- a/tests/utils/urlParsing.test.ts
+++ b/tests/utils/urlParsing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  isHttpUrl,
   normalizeUrlForBasePath,
   normalizeUrlForOriginKey,
   normalizeUrlPathname,
@@ -104,5 +105,19 @@ describe("urlParsing", () => {
         normalizeUrlForOriginKey(" HTTPS://Example.com/ ", { lowerCase: true }),
       ).toBe("https://example.com")
     })
+  })
+})
+
+describe("isHttpUrl", () => {
+  it("returns true for absolute http and https urls", () => {
+    expect(isHttpUrl("https://example.com/path")).toBe(true)
+    expect(isHttpUrl("http://example.com/path")).toBe(true)
+  })
+
+  it("returns false for non-http, relative, empty, and invalid urls", () => {
+    expect(isHttpUrl("chrome://extensions")).toBe(false)
+    expect(isHttpUrl("/relative/path")).toBe(false)
+    expect(isHttpUrl("")).toBe(false)
+    expect(isHttpUrl("not-a-url")).toBe(false)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Shared, more reliable text-detection for selections and clipboard, including end-of-selection detection with proper cleanup
  * Enhanced URL validation to skip non-http(s) pages for auto-detection

* **Tests**
  * Added comprehensive tests covering selection/clipboard detection, selection-end handling, cleanup behavior, and URL validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->