### PR TITLE
fix(new-api): support themed web routes

### DIFF
--- a/e2e/accountActionShortcuts.spec.ts
+++ b/e2e/accountActionShortcuts.spec.ts
@@ -282,6 +282,9 @@ test("opens provider usage and redeem destinations from the account row menu", a
       },
     }),
   ])
+  await stubNewApiSiteRoutes(context, {
+    baseUrl: "https://shortcut-routes.example.com",
+  })
 
   await page.goto(
     `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ACCOUNT}`,

--- a/src/features/AccountManagement/components/AccountDialog/AutoDetectErrorAlert.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AutoDetectErrorAlert.tsx
@@ -15,12 +15,14 @@ import { openSiteSupportRequestPage } from "~/utils/navigation"
  * @param props Component props describing the error context and handlers.
  * @param props.error Error metadata powering the alert content.
  * @param props.siteUrl Optional site URL used for fallback login redirection.
+ * @param props.siteType Optional current site type hint used for login route resolution.
  * @param props.onHelpClick Optional handler invoked when help action is triggered.
  * @param props.onActionClick Optional handler invoked when custom action button is pressed.
  */
 export default function AutoDetectErrorAlert({
   error,
   siteUrl,
+  siteType,
   onHelpClick,
   onActionClick,
 }: AutoDetectErrorProps) {
@@ -31,7 +33,7 @@ export default function AutoDetectErrorAlert({
       onActionClick()
     } else if (error.type === AutoDetectErrorType.UNAUTHORIZED && siteUrl) {
       // 默认行为：打开登录页面
-      await openLoginTab(siteUrl)
+      await openLoginTab(siteUrl, siteType)
     } else if (error.type === AutoDetectErrorType.CURRENT_TAB_RELOAD_REQUIRED) {
       await reloadCurrentTab()
     }

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -246,6 +246,7 @@ export default function AccountDialog({
               <AutoDetectErrorAlert
                 error={state.detectionError}
                 siteUrl={state.url}
+                siteType={state.siteType}
               />
             )}
 

--- a/src/features/BasicSettings/components/tabs/ManagedSite/NewApiSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/NewApiSettings.tsx
@@ -10,15 +10,18 @@ import {
   Input,
   WorkflowTransitionButton,
 } from "~/components/ui"
-import { getSiteRouteConfigForKey, SITE_TYPES } from "~/constants/siteType"
+import { SITE_TYPES } from "~/constants/siteType"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { NewApiManagedVerificationDialog } from "~/features/ManagedSiteVerification/NewApiManagedVerificationDialog"
 import { useNewApiManagedVerification } from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
+import {
+  resolveAccountSiteRouteUrl,
+  SITE_ROUTE_KINDS,
+} from "~/services/accounts/utils/siteRouteResolver"
 import { isManagedSiteAdminUserIdInputValid } from "~/services/managedSites/utils/adminUserId"
 import { createTab } from "~/utils/browser/browserApi"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
-import { joinUrl } from "~/utils/core/url"
 
 /**
  * Settings panel for configuring New API connection credentials (base URL, admin token, user ID).
@@ -140,15 +143,12 @@ export default function NewApiSettings() {
       ? t("messages:errors.validation.userIdNumeric")
       : undefined
   const shouldShowAdminCredentialsLink = Boolean(trimmedBaseUrl)
-  const adminCredentialsUrl = shouldShowAdminCredentialsLink
-    ? joinUrl(
-        trimmedBaseUrl,
-        getSiteRouteConfigForKey(SITE_TYPES.NEW_API).adminCredentialsPath,
-      )
-    : ""
-
   const handleOpenAdminCredentials = async () => {
-    if (!adminCredentialsUrl) return
+    if (!shouldShowAdminCredentialsLink) return
+    const adminCredentialsUrl = await resolveAccountSiteRouteUrl(
+      { baseUrl: trimmedBaseUrl, siteType: SITE_TYPES.NEW_API },
+      SITE_ROUTE_KINDS.AdminCredentials,
+    )
     try {
       await createTab(adminCredentialsUrl, true)
     } catch {

--- a/src/services/accounts/utils/autoDetectUtils.ts
+++ b/src/services/accounts/utils/autoDetectUtils.ts
@@ -22,20 +22,12 @@ import {
   type AutoDetectErrorCode,
   type AutoDetectFailureReason,
 } from "~/constants/autoDetect"
+import { type AccountSiteType } from "~/constants/siteType"
 import {
-  AIHUBMIX_HOSTNAMES,
-  AIHUBMIX_WEB_ORIGIN,
-  getAccountSiteApiRouter,
-  isAccountSiteType,
-  SITE_TYPES,
-  type AccountSiteType,
-} from "~/constants/siteType"
-import {
-  resolveAccountSiteRouteUrl,
-  SITE_ROUTE_KINDS,
+  getBestEffortLoginUrl,
+  resolveAccountSiteLoginUrl,
 } from "~/services/accounts/utils/siteRouteResolver"
 import { getErrorMessage } from "~/utils/core/error"
-import { joinUrl } from "~/utils/core/url"
 import { t } from "~/utils/i18n/core"
 import { getDocsAutoDetectUrl } from "~/utils/navigation/docsLinks"
 
@@ -100,8 +92,6 @@ const ERROR_KEYWORDS: Record<string, string[]> = {
   NOT_FOUND: ["404", "未找到", "Not Found"],
   SERVER_ERROR: ["500", "服务器错误", "Internal Server Error", "server crash"],
 }
-
-const AIHUBMIX_HOSTNAME_SET: ReadonlySet<string> = new Set(AIHUBMIX_HOSTNAMES)
 
 /**
  * Builds the structured UI error shown when the active tab likely needs a
@@ -237,24 +227,7 @@ export interface AutoDetectErrorProps {
  * @returns Login page URL to open in a new tab.
  */
 export function getLoginUrl(siteUrl: string): string {
-  try {
-    const url = new URL(siteUrl)
-    if (AIHUBMIX_HOSTNAME_SET.has(url.hostname.toLowerCase())) {
-      return joinUrl(
-        AIHUBMIX_WEB_ORIGIN,
-        getAccountSiteApiRouter(SITE_TYPES.AIHUBMIX).loginPath,
-      )
-    }
-
-    // 对于 One API 和 New API，通常登录页面在 /login
-    return joinUrl(
-      `${url.protocol}//${url.host}`,
-      getAccountSiteApiRouter(SITE_TYPES.UNKNOWN).loginPath,
-    )
-  } catch {
-    // If parsing fails, fall back to the original URL (best-effort)
-    return siteUrl
-  }
+  return getBestEffortLoginUrl(siteUrl)
 }
 
 /**
@@ -266,27 +239,7 @@ export async function openLoginTab(
   siteUrl: string,
   siteTypeHint?: AccountSiteType,
 ): Promise<void> {
-  let loginUrl = getLoginUrl(siteUrl)
-  try {
-    const parsedUrl = new URL(siteUrl)
-    const siteType = isAccountSiteType(siteTypeHint)
-      ? siteTypeHint
-      : SITE_TYPES.UNKNOWN
-    if (siteType !== SITE_TYPES.UNKNOWN) {
-      loginUrl = await resolveAccountSiteRouteUrl(
-        {
-          baseUrl:
-            siteType === SITE_TYPES.AIHUBMIX
-              ? AIHUBMIX_WEB_ORIGIN
-              : `${parsedUrl.protocol}//${parsedUrl.host}`,
-          siteType,
-        },
-        SITE_ROUTE_KINDS.Login,
-      )
-    }
-  } catch {
-    loginUrl = getLoginUrl(siteUrl)
-  }
+  const loginUrl = await resolveAccountSiteLoginUrl(siteUrl, siteTypeHint)
   await browser.tabs.create({ url: loginUrl, active: true })
 }
 

--- a/src/services/accounts/utils/autoDetectUtils.ts
+++ b/src/services/accounts/utils/autoDetectUtils.ts
@@ -26,7 +26,9 @@ import {
   AIHUBMIX_HOSTNAMES,
   AIHUBMIX_WEB_ORIGIN,
   getAccountSiteApiRouter,
+  isAccountSiteType,
   SITE_TYPES,
+  type AccountSiteType,
 } from "~/constants/siteType"
 import {
   resolveAccountSiteRouteUrl,
@@ -221,6 +223,7 @@ export function analyzeAutoDetectError(error: any): AutoDetectError {
 export interface AutoDetectErrorProps {
   error: AutoDetectError
   siteUrl?: string
+  siteType?: AccountSiteType
   onHelpClick?: () => void
   onActionClick?: () => void
 }
@@ -257,18 +260,30 @@ export function getLoginUrl(siteUrl: string): string {
 /**
  * Open a new browser tab pointing to the site's login page.
  * @param siteUrl Base site URL used to derive the login page.
+ * @param siteTypeHint Optional already-known site type from the caller.
  */
-export async function openLoginTab(siteUrl: string): Promise<void> {
+export async function openLoginTab(
+  siteUrl: string,
+  siteTypeHint?: AccountSiteType,
+): Promise<void> {
   let loginUrl = getLoginUrl(siteUrl)
   try {
     const parsedUrl = new URL(siteUrl)
-    loginUrl = await resolveAccountSiteRouteUrl(
-      {
-        baseUrl: `${parsedUrl.protocol}//${parsedUrl.host}`,
-        siteType: SITE_TYPES.NEW_API,
-      },
-      SITE_ROUTE_KINDS.Login,
-    )
+    const siteType = isAccountSiteType(siteTypeHint)
+      ? siteTypeHint
+      : SITE_TYPES.UNKNOWN
+    if (siteType !== SITE_TYPES.UNKNOWN) {
+      loginUrl = await resolveAccountSiteRouteUrl(
+        {
+          baseUrl:
+            siteType === SITE_TYPES.AIHUBMIX
+              ? AIHUBMIX_WEB_ORIGIN
+              : `${parsedUrl.protocol}//${parsedUrl.host}`,
+          siteType,
+        },
+        SITE_ROUTE_KINDS.Login,
+      )
+    }
   } catch {
     loginUrl = getLoginUrl(siteUrl)
   }

--- a/src/services/accounts/utils/autoDetectUtils.ts
+++ b/src/services/accounts/utils/autoDetectUtils.ts
@@ -28,6 +28,10 @@ import {
   getAccountSiteApiRouter,
   SITE_TYPES,
 } from "~/constants/siteType"
+import {
+  resolveAccountSiteRouteUrl,
+  SITE_ROUTE_KINDS,
+} from "~/services/accounts/utils/siteRouteResolver"
 import { getErrorMessage } from "~/utils/core/error"
 import { joinUrl } from "~/utils/core/url"
 import { t } from "~/utils/i18n/core"
@@ -255,7 +259,19 @@ export function getLoginUrl(siteUrl: string): string {
  * @param siteUrl Base site URL used to derive the login page.
  */
 export async function openLoginTab(siteUrl: string): Promise<void> {
-  const loginUrl = getLoginUrl(siteUrl)
+  let loginUrl = getLoginUrl(siteUrl)
+  try {
+    const parsedUrl = new URL(siteUrl)
+    loginUrl = await resolveAccountSiteRouteUrl(
+      {
+        baseUrl: `${parsedUrl.protocol}//${parsedUrl.host}`,
+        siteType: SITE_TYPES.NEW_API,
+      },
+      SITE_ROUTE_KINDS.Login,
+    )
+  } catch {
+    loginUrl = getLoginUrl(siteUrl)
+  }
   await browser.tabs.create({ url: loginUrl, active: true })
 }
 

--- a/src/services/accounts/utils/siteRouteResolver.ts
+++ b/src/services/accounts/utils/siteRouteResolver.ts
@@ -44,8 +44,27 @@ const NEW_API_DEFAULT_THEME_ROUTE_PATHS: Record<
 }
 
 const SITE_ROUTE_THEME_CACHE_TTL_MS = 5 * 60 * 1000
+const SITE_ROUTE_THEME_CACHE_MAX_ENTRIES = 100
 
 const themeCache = new Map<string, { fetchedAt: number; theme?: string }>()
+
+/**
+ * Store a New API theme probe result while bounding the short-lived cache.
+ * @param baseUrl Normalized account site base URL.
+ * @param value Cached theme probe result.
+ */
+function setCachedTheme(
+  baseUrl: string,
+  value: { fetchedAt: number; theme?: string },
+) {
+  themeCache.set(baseUrl, value)
+
+  while (themeCache.size > SITE_ROUTE_THEME_CACHE_MAX_ENTRIES) {
+    const oldestKey = themeCache.keys().next().value
+    if (typeof oldestKey !== "string") return
+    themeCache.delete(oldestKey)
+  }
+}
 
 /**
  * Normalize a configured account site URL so resolved route URLs are stable.
@@ -126,10 +145,10 @@ async function fetchNewApiFrontendTheme(
     })
     const theme =
       typeof statusInfo?.theme === "string" ? statusInfo.theme : undefined
-    themeCache.set(normalizedBaseUrl, { fetchedAt: now, theme })
+    setCachedTheme(normalizedBaseUrl, { fetchedAt: now, theme })
     return theme
   } catch {
-    themeCache.set(normalizedBaseUrl, { fetchedAt: now })
+    setCachedTheme(normalizedBaseUrl, { fetchedAt: now })
     return undefined
   }
 }

--- a/src/services/accounts/utils/siteRouteResolver.ts
+++ b/src/services/accounts/utils/siteRouteResolver.ts
@@ -5,6 +5,8 @@ import {
   SITE_TYPES,
   type AccountSiteType,
 } from "~/constants/siteType"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
 import { joinUrl } from "~/utils/core/url"
 
 export const SITE_ROUTE_KINDS = {
@@ -24,18 +26,10 @@ type RouteTarget = {
   siteType: AccountSiteType
 }
 
-type SiteStatusPayload = {
-  success?: boolean
-  data?: {
-    theme?: string
-  } | null
-}
-
 const NEW_API_FRONTEND_THEMES = {
   Default: "default",
 } as const
 
-const NEW_API_STATUS_ENDPOINT = "/api/status"
 const SITE_ANNOUNCEMENTS_ROUTE_KIND = SITE_ROUTE_KINDS.SiteAnnouncements
 const AIHUBMIX_HOSTNAME_SET: ReadonlySet<string> = new Set(AIHUBMIX_HOSTNAMES)
 
@@ -127,19 +121,12 @@ async function fetchNewApiFrontendTheme(
   }
 
   try {
-    const response = await fetch(
-      joinUrl(normalizedBaseUrl, NEW_API_STATUS_ENDPOINT),
-    )
-    if (!response.ok) {
-      themeCache.set(normalizedBaseUrl, { fetchedAt: now })
-      return undefined
-    }
-
-    const payload = (await response.json()) as SiteStatusPayload
+    const statusInfo = await getApiService(SITE_TYPES.NEW_API).fetchSiteStatus({
+      baseUrl: normalizedBaseUrl,
+      auth: { authType: AuthTypeEnum.None },
+    })
     const theme =
-      payload && typeof payload.data?.theme === "string"
-        ? payload.data.theme
-        : undefined
+      typeof statusInfo?.theme === "string" ? statusInfo.theme : undefined
     themeCache.set(normalizedBaseUrl, { fetchedAt: now, theme })
     return theme
   } catch {

--- a/src/services/accounts/utils/siteRouteResolver.ts
+++ b/src/services/accounts/utils/siteRouteResolver.ts
@@ -1,4 +1,6 @@
 import {
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_WEB_ORIGIN,
   getAccountSiteApiRouter,
   SITE_TYPES,
   type AccountSiteType,
@@ -35,6 +37,7 @@ const NEW_API_FRONTEND_THEMES = {
 
 const NEW_API_STATUS_ENDPOINT = "/api/status"
 const SITE_ANNOUNCEMENTS_ROUTE_KIND = SITE_ROUTE_KINDS.SiteAnnouncements
+const AIHUBMIX_HOSTNAME_SET: ReadonlySet<string> = new Set(AIHUBMIX_HOSTNAMES)
 
 const NEW_API_DEFAULT_THEME_ROUTE_PATHS: Record<
   Exclude<SiteRouteKind, typeof SITE_ANNOUNCEMENTS_ROUTE_KIND>,
@@ -58,6 +61,30 @@ const themeCache = new Map<string, { fetchedAt: number; theme?: string }>()
  */
 function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.trim().replace(/\/+$/, "")
+}
+
+/**
+ * Resolve the best-effort login URL when no site type hint is available.
+ * @param siteUrl Site URL provided by the caller.
+ * @returns A normalized login page URL or the original URL when parsing fails.
+ */
+export function getBestEffortLoginUrl(siteUrl: string): string {
+  try {
+    const url = new URL(siteUrl)
+    if (AIHUBMIX_HOSTNAME_SET.has(url.hostname.toLowerCase())) {
+      return joinUrl(
+        AIHUBMIX_WEB_ORIGIN,
+        getAccountSiteApiRouter(SITE_TYPES.AIHUBMIX).loginPath,
+      )
+    }
+
+    return joinUrl(
+      `${url.protocol}//${url.host}`,
+      getAccountSiteApiRouter(SITE_TYPES.UNKNOWN).loginPath,
+    )
+  } catch {
+    return siteUrl
+  }
 }
 
 /**
@@ -161,6 +188,38 @@ export async function resolveAccountSiteRouteUrl(
   const baseUrl = normalizeBaseUrl(target.baseUrl)
   const path = await resolveAccountSiteRoutePath(target, route)
   return joinUrl(baseUrl, path)
+}
+
+/**
+ * Resolve the login page URL for a site with optional site type awareness.
+ * @param siteUrl Site URL provided by the caller.
+ * @param siteTypeHint Already-known site type from the caller.
+ * @returns Full URL for the site's login page, or a best-effort fallback.
+ */
+export async function resolveAccountSiteLoginUrl(
+  siteUrl: string,
+  siteTypeHint?: AccountSiteType,
+): Promise<string> {
+  try {
+    const parsedUrl = new URL(siteUrl)
+    if (siteTypeHint && siteTypeHint !== SITE_TYPES.UNKNOWN) {
+      const baseUrl =
+        siteTypeHint === SITE_TYPES.AIHUBMIX
+          ? AIHUBMIX_WEB_ORIGIN
+          : `${parsedUrl.protocol}//${parsedUrl.host}`
+      return resolveAccountSiteRouteUrl(
+        {
+          baseUrl,
+          siteType: siteTypeHint,
+        },
+        SITE_ROUTE_KINDS.Login,
+      )
+    }
+
+    return getBestEffortLoginUrl(siteUrl)
+  } catch {
+    return getBestEffortLoginUrl(siteUrl)
+  }
 }
 
 /**

--- a/src/services/accounts/utils/siteRouteResolver.ts
+++ b/src/services/accounts/utils/siteRouteResolver.ts
@@ -18,8 +18,7 @@ export const SITE_ROUTE_KINDS = {
   SiteAnnouncements: "siteAnnouncements",
 } as const
 
-export type SiteRouteKind =
-  (typeof SITE_ROUTE_KINDS)[keyof typeof SITE_ROUTE_KINDS]
+type SiteRouteKind = (typeof SITE_ROUTE_KINDS)[keyof typeof SITE_ROUTE_KINDS]
 
 type RouteTarget = {
   baseUrl: string
@@ -44,7 +43,7 @@ const NEW_API_DEFAULT_THEME_ROUTE_PATHS: Record<
   [SITE_ROUTE_KINDS.Redeem]: "/wallet",
 }
 
-export const SITE_ROUTE_THEME_CACHE_TTL_MS = 5 * 60 * 1000
+const SITE_ROUTE_THEME_CACHE_TTL_MS = 5 * 60 * 1000
 
 const themeCache = new Map<string, { fetchedAt: number; theme?: string }>()
 
@@ -141,7 +140,7 @@ async function fetchNewApiFrontendTheme(
  * @param route Named route kind.
  * @returns Route path for the target site and frontend theme.
  */
-export async function resolveAccountSiteRoutePath(
+async function resolveAccountSiteRoutePath(
   target: Pick<RouteTarget, "baseUrl" | "siteType">,
   route: SiteRouteKind,
 ): Promise<string> {

--- a/src/services/accounts/utils/siteRouteResolver.ts
+++ b/src/services/accounts/utils/siteRouteResolver.ts
@@ -1,0 +1,171 @@
+import {
+  getAccountSiteApiRouter,
+  SITE_TYPES,
+  type AccountSiteType,
+} from "~/constants/siteType"
+import { joinUrl } from "~/utils/core/url"
+
+export const SITE_ROUTE_KINDS = {
+  Login: "login",
+  Usage: "usage",
+  CheckIn: "checkIn",
+  AdminCredentials: "adminCredentials",
+  Redeem: "redeem",
+  SiteAnnouncements: "siteAnnouncements",
+} as const
+
+export type SiteRouteKind =
+  (typeof SITE_ROUTE_KINDS)[keyof typeof SITE_ROUTE_KINDS]
+
+type RouteTarget = {
+  baseUrl: string
+  siteType: AccountSiteType
+}
+
+type SiteStatusPayload = {
+  success?: boolean
+  data?: {
+    theme?: string
+  } | null
+}
+
+const NEW_API_FRONTEND_THEMES = {
+  Default: "default",
+} as const
+
+const NEW_API_STATUS_ENDPOINT = "/api/status"
+const SITE_ANNOUNCEMENTS_ROUTE_KIND = SITE_ROUTE_KINDS.SiteAnnouncements
+
+const NEW_API_DEFAULT_THEME_ROUTE_PATHS: Record<
+  Exclude<SiteRouteKind, typeof SITE_ANNOUNCEMENTS_ROUTE_KIND>,
+  string
+> = {
+  [SITE_ROUTE_KINDS.Login]: "/sign-in",
+  [SITE_ROUTE_KINDS.Usage]: "/usage-logs",
+  [SITE_ROUTE_KINDS.CheckIn]: "/profile",
+  [SITE_ROUTE_KINDS.AdminCredentials]: "/profile",
+  [SITE_ROUTE_KINDS.Redeem]: "/wallet",
+}
+
+export const SITE_ROUTE_THEME_CACHE_TTL_MS = 5 * 60 * 1000
+
+const themeCache = new Map<string, { fetchedAt: number; theme?: string }>()
+
+/**
+ * Normalize a configured account site URL so resolved route URLs are stable.
+ * @param baseUrl Account site base URL.
+ * @returns Base URL without trailing slashes.
+ */
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "")
+}
+
+/**
+ * Resolve the legacy/static route path for a supported account site type.
+ * @param siteType Account site type.
+ * @param route Named route kind.
+ * @returns Static path from the site route configuration.
+ */
+function getStaticRoutePath(siteType: AccountSiteType, route: SiteRouteKind) {
+  const config = getAccountSiteApiRouter(siteType)
+  switch (route) {
+    case SITE_ROUTE_KINDS.Login:
+      return config.loginPath
+    case SITE_ROUTE_KINDS.Usage:
+      return config.usagePath
+    case SITE_ROUTE_KINDS.CheckIn:
+      return config.checkInPath
+    case SITE_ROUTE_KINDS.AdminCredentials:
+      return config.adminCredentialsPath
+    case SITE_ROUTE_KINDS.Redeem:
+      return config.redeemPath
+    case SITE_ROUTE_KINDS.SiteAnnouncements:
+      return config.siteAnnouncementsPath
+  }
+}
+
+/**
+ * Fetch the current New API frontend theme, cached briefly per base URL.
+ * @param baseUrl New API deployment base URL.
+ * @returns Frontend theme identifier when available.
+ */
+async function fetchNewApiFrontendTheme(
+  baseUrl: string,
+): Promise<string | undefined> {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+  const cached = themeCache.get(normalizedBaseUrl)
+  const now = Date.now()
+  if (cached && now - cached.fetchedAt < SITE_ROUTE_THEME_CACHE_TTL_MS) {
+    return cached.theme
+  }
+
+  try {
+    const response = await fetch(
+      joinUrl(normalizedBaseUrl, NEW_API_STATUS_ENDPOINT),
+    )
+    if (!response.ok) {
+      themeCache.set(normalizedBaseUrl, { fetchedAt: now })
+      return undefined
+    }
+
+    const payload = (await response.json()) as SiteStatusPayload
+    const theme =
+      payload && typeof payload.data?.theme === "string"
+        ? payload.data.theme
+        : undefined
+    themeCache.set(normalizedBaseUrl, { fetchedAt: now, theme })
+    return theme
+  } catch {
+    themeCache.set(normalizedBaseUrl, { fetchedAt: now })
+    return undefined
+  }
+}
+
+/**
+ * Resolve the web page path for an account site route.
+ * @param target Account site route target.
+ * @param route Named route kind.
+ * @returns Route path for the target site and frontend theme.
+ */
+export async function resolveAccountSiteRoutePath(
+  target: Pick<RouteTarget, "baseUrl" | "siteType">,
+  route: SiteRouteKind,
+): Promise<string> {
+  const staticPath = getStaticRoutePath(target.siteType, route)
+
+  if (
+    target.siteType !== SITE_TYPES.NEW_API ||
+    route === SITE_ANNOUNCEMENTS_ROUTE_KIND
+  ) {
+    return staticPath
+  }
+
+  const theme = await fetchNewApiFrontendTheme(target.baseUrl)
+  if (theme === NEW_API_FRONTEND_THEMES.Default) {
+    return NEW_API_DEFAULT_THEME_ROUTE_PATHS[route]
+  }
+
+  return staticPath
+}
+
+/**
+ * Resolve the full web page URL for an account site route.
+ * @param target Account site route target.
+ * @param route Named route kind.
+ * @returns Full URL for the target site and route.
+ */
+export async function resolveAccountSiteRouteUrl(
+  target: Pick<RouteTarget, "baseUrl" | "siteType">,
+  route: SiteRouteKind,
+): Promise<string> {
+  const baseUrl = normalizeBaseUrl(target.baseUrl)
+  const path = await resolveAccountSiteRoutePath(target, route)
+  return joinUrl(baseUrl, path)
+}
+
+/**
+ * Clear the in-memory theme cache between unit tests.
+ */
+export function clearSiteRouteThemeCacheForTests() {
+  themeCache.clear()
+}

--- a/src/services/apiService/common/type.ts
+++ b/src/services/apiService/common/type.ts
@@ -84,6 +84,7 @@ export interface SiteStatusInfo {
   stripe_unit_price?: number
   PaymentUSDRate?: number
   system_name?: string
+  theme?: string
   /**
    * 是否启用签到功能
    */

--- a/src/services/checkin/autoCheckin/providers/newApi.ts
+++ b/src/services/checkin/autoCheckin/providers/newApi.ts
@@ -1,5 +1,8 @@
-import { getAccountSiteApiRouter } from "~/constants/siteType"
 import { TURNSTILE_DEFAULT_WAIT_TIMEOUT_MS } from "~/constants/turnstile"
+import {
+  resolveAccountSiteRouteUrl,
+  SITE_ROUTE_KINDS,
+} from "~/services/accounts/utils/siteRouteResolver"
 import { buildCompatUserIdHeaders } from "~/services/apiService/common/compatHeaders"
 import { REQUEST_CONFIG } from "~/services/apiService/common/constant"
 import { ApiError } from "~/services/apiService/common/errors"
@@ -74,10 +77,10 @@ function isTurnstileRequiredMessage(message: string): boolean {
 /**
  * Resolve a user-openable URL for manual Turnstile verification.
  */
-function resolveCheckInUrl(account: SiteAccount): string {
-  return joinUrl(
-    account.site_url,
-    getAccountSiteApiRouter(account.site_type).checkInPath,
+function resolveCheckInUrl(account: SiteAccount): Promise<string> {
+  return resolveAccountSiteRouteUrl(
+    { baseUrl: account.site_url, siteType: account.site_type },
+    SITE_ROUTE_KINDS.CheckIn,
   )
 }
 
@@ -331,7 +334,7 @@ async function resolveTurnstileAssistedCheckinResult(params: {
   account: SiteAccount
   responseMessage: string
 }): Promise<CheckinResult> {
-  const checkInUrl = resolveCheckInUrl(params.account)
+  const checkInUrl = await resolveCheckInUrl(params.account)
   const assistedParams = buildTurnstileAssistedParams(
     params.account,
     checkInUrl,

--- a/src/services/checkin/externalCheckInService.ts
+++ b/src/services/checkin/externalCheckInService.ts
@@ -1,13 +1,15 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
-import { getAccountSiteApiRouter } from "~/constants/siteType"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import {
+  resolveAccountSiteRouteUrl,
+  SITE_ROUTE_KINDS,
+} from "~/services/accounts/utils/siteRouteResolver"
 import {
   createTab,
   createWindow,
   hasWindowsAPI,
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
-import { joinUrl } from "~/utils/core/url"
 
 /**
  * External custom check-in flow (background-only).
@@ -142,10 +144,10 @@ export async function handleExternalCheckInMessage(
               openedRedeem = false
               const redeemUrl =
                 account.checkIn?.customCheckIn?.redeemUrl ||
-                joinUrl(
-                  account.site_url,
-                  getAccountSiteApiRouter(account.site_type).redeemPath,
-                )
+                (await resolveAccountSiteRouteUrl(
+                  { baseUrl: account.site_url, siteType: account.site_type },
+                  SITE_ROUTE_KINDS.Redeem,
+                ))
 
               try {
                 openedRedeem = await openExternalPage(redeemUrl)

--- a/src/services/checkin/externalCheckInService.ts
+++ b/src/services/checkin/externalCheckInService.ts
@@ -142,14 +142,13 @@ export async function handleExternalCheckInMessage(
 
             if (shouldOpenRedeem) {
               openedRedeem = false
-              const redeemUrl =
-                account.checkIn?.customCheckIn?.redeemUrl ||
-                (await resolveAccountSiteRouteUrl(
-                  { baseUrl: account.site_url, siteType: account.site_type },
-                  SITE_ROUTE_KINDS.Redeem,
-                ))
-
               try {
+                const redeemUrl =
+                  account.checkIn?.customCheckIn?.redeemUrl ||
+                  (await resolveAccountSiteRouteUrl(
+                    { baseUrl: account.site_url, siteType: account.site_type },
+                    SITE_ROUTE_KINDS.Redeem,
+                  ))
                 openedRedeem = await openExternalPage(redeemUrl)
                 if (!openedRedeem) {
                   redeemError = "Failed to open redeem tab"

--- a/src/services/redemption/redemptionAssist.ts
+++ b/src/services/redemption/redemptionAssist.ts
@@ -1,6 +1,9 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
-import { getAccountSiteApiRouter } from "~/constants/siteType"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import {
+  resolveAccountSiteRouteUrl,
+  SITE_ROUTE_KINDS,
+} from "~/services/accounts/utils/siteRouteResolver"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { redeemService } from "~/services/redemption/redeemService"
 import { isPossibleRedemptionCode } from "~/services/redemption/utils/redemptionCode"
@@ -8,7 +11,6 @@ import { searchAccounts } from "~/services/search/accountSearch"
 import type { DisplaySiteData } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
-import { joinUrl } from "~/utils/core/url"
 import { tryParseOrigin } from "~/utils/core/urlParsing"
 import {
   buildOriginWhitelistPattern,
@@ -252,13 +254,18 @@ class RedemptionAssistService {
         const origin = this.getOrigin(account.baseUrl)
         if (!origin) continue
 
-        const router = getAccountSiteApiRouter(account.siteType)
         const resolvedCheckInUrl =
           account.checkIn?.customCheckIn?.url ||
-          joinUrl(origin, router.checkInPath)
+          (await resolveAccountSiteRouteUrl(
+            { baseUrl: origin, siteType: account.siteType },
+            SITE_ROUTE_KINDS.CheckIn,
+          ))
         const resolvedRedeemUrl =
           account.checkIn?.customCheckIn?.redeemUrl ||
-          joinUrl(origin, router.redeemPath)
+          (await resolveAccountSiteRouteUrl(
+            { baseUrl: origin, siteType: account.siteType },
+            SITE_ROUTE_KINDS.Redeem,
+          ))
 
         const checkInPattern = buildOriginWhitelistPattern(resolvedCheckInUrl)
         if (checkInPattern) patterns.push(checkInPattern)

--- a/src/utils/navigation/index.ts
+++ b/src/utils/navigation/index.ts
@@ -2,7 +2,10 @@ import {
   MENU_ITEM_IDS,
   type OptionsMenuItemId,
 } from "~/constants/optionsMenuIds"
-import { getAccountSiteApiRouter } from "~/constants/siteType"
+import {
+  resolveAccountSiteRouteUrl,
+  SITE_ROUTE_KINDS,
+} from "~/services/accounts/utils/siteRouteResolver"
 import type { DisplaySiteData } from "~/types"
 import { isExtensionPopup, OPTIONS_PAGE_URL } from "~/utils/browser"
 import {
@@ -15,7 +18,6 @@ import {
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
-import { joinUrl } from "~/utils/core/url"
 import {
   getFeedbackDestinationUrls,
   getSiteSupportRequestUrl,
@@ -624,9 +626,9 @@ const _openAccountBaseUrl = async (
  * @param account Account definition containing base URL and site type.
  */
 const _openUsagePage = async (account: DisplaySiteData) => {
-  const logUrl = joinUrl(
-    account.baseUrl,
-    getAccountSiteApiRouter(account.siteType).usagePath,
+  const logUrl = await resolveAccountSiteRouteUrl(
+    account,
+    SITE_ROUTE_KINDS.Usage,
   )
   await createActiveTab(logUrl)
 }
@@ -636,10 +638,7 @@ const _openUsagePage = async (account: DisplaySiteData) => {
  * @param account Account metadata used to resolve the check-in URL.
  */
 const getCheckInPageUrl = (account: DisplaySiteData) =>
-  joinUrl(
-    account.baseUrl,
-    getAccountSiteApiRouter(account.siteType).checkInPath,
-  )
+  resolveAccountSiteRouteUrl(account, SITE_ROUTE_KINDS.CheckIn)
 
 /**
  * Best-effort URL opener for grouped navigation flows.
@@ -718,7 +717,7 @@ const openUrlsBestEffort = async (
  * @param account Account metadata used to resolve the check-in URL.
  */
 const _openCheckInPage = async (account: DisplaySiteData) => {
-  const checkInUrl = getCheckInPageUrl(account)
+  const checkInUrl = await getCheckInPageUrl(account)
   await createActiveTab(checkInUrl)
 }
 
@@ -730,10 +729,7 @@ const _openCheckInPage = async (account: DisplaySiteData) => {
 const _openCustomCheckInPage = async (account: DisplaySiteData) => {
   const customCheckInUrl =
     account.checkIn?.customCheckIn?.url ||
-    joinUrl(
-      account.baseUrl,
-      getAccountSiteApiRouter(account.siteType).checkInPath,
-    )
+    (await resolveAccountSiteRouteUrl(account, SITE_ROUTE_KINDS.CheckIn))
   await createActiveTab(customCheckInUrl)
 }
 
@@ -744,10 +740,7 @@ const _openCustomCheckInPage = async (account: DisplaySiteData) => {
 const _openRedeemPage = async (account: DisplaySiteData) => {
   const redeemUrl =
     account.checkIn?.customCheckIn?.redeemUrl ||
-    joinUrl(
-      account.baseUrl,
-      getAccountSiteApiRouter(account.siteType).redeemPath,
-    )
+    (await resolveAccountSiteRouteUrl(account, SITE_ROUTE_KINDS.Redeem))
   await createActiveTab(redeemUrl)
 }
 
@@ -947,10 +940,8 @@ export const openCheckInPages = async (
   accounts: DisplaySiteData[],
   options?: { openInNewWindow?: boolean },
 ) => {
-  const result = await openUrlsBestEffort(
-    accounts.map(getCheckInPageUrl),
-    options,
-  )
+  const urls = await Promise.all(accounts.map(getCheckInPageUrl))
+  const result = await openUrlsBestEffort(urls, options)
   closeIfPopup()
   return result
 }

--- a/tests/entrypoints/options/BasicSettingsTabs.test.tsx
+++ b/tests/entrypoints/options/BasicSettingsTabs.test.tsx
@@ -2,9 +2,11 @@ import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import CheckinRedeemTab from "~/features/BasicSettings/components/tabs/CheckinRedeem/CheckinRedeemTab"
 import NewApiSettings from "~/features/BasicSettings/components/tabs/ManagedSite/NewApiSettings"
 import WebAiApiCheckTab from "~/features/BasicSettings/components/tabs/WebAiApiCheck/WebAiApiCheckTab"
+import { SITE_ROUTE_KINDS } from "~/services/accounts/utils/siteRouteResolver"
 import {
   fireEvent,
   render,
@@ -13,12 +15,33 @@ import {
   within,
 } from "~~/tests/test-utils/render"
 
-const { mockedUseUserPreferencesContext, showUpdateToastMock } = vi.hoisted(
-  () => ({
-    mockedUseUserPreferencesContext: vi.fn(),
-    showUpdateToastMock: vi.fn(),
-  }),
-)
+const {
+  createTabMock,
+  mockedUseUserPreferencesContext,
+  resolveAccountSiteRouteUrlMock,
+  showUpdateToastMock,
+} = vi.hoisted(() => ({
+  createTabMock: vi.fn(),
+  mockedUseUserPreferencesContext: vi.fn(),
+  resolveAccountSiteRouteUrlMock: vi.fn(),
+  showUpdateToastMock: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/utils/browser/browserApi")>()
+  return {
+    ...actual,
+    createTab: createTabMock,
+  }
+})
+
+vi.mock("~/services/accounts/utils/siteRouteResolver", () => ({
+  SITE_ROUTE_KINDS: {
+    AdminCredentials: "adminCredentials",
+  },
+  resolveAccountSiteRouteUrl: resolveAccountSiteRouteUrlMock,
+}))
 
 vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
   const actual =
@@ -77,7 +100,12 @@ const createContextValue = (overrides: Record<string, unknown> = {}) => ({
 
 describe("BasicSettings tab layout", () => {
   beforeEach(() => {
+    createTabMock.mockReset()
     mockedUseUserPreferencesContext.mockReset()
+    resolveAccountSiteRouteUrlMock.mockReset()
+    resolveAccountSiteRouteUrlMock.mockResolvedValue(
+      "https://managed.example/profile",
+    )
     showUpdateToastMock.mockReset()
     mockedUseUserPreferencesContext.mockReturnValue(createContextValue())
   })
@@ -239,6 +267,36 @@ describe("BasicSettings tab layout", () => {
     expect(showUpdateToastMock).toHaveBeenCalledWith(
       true,
       "settings:newApi.fields.userIdLabel",
+    )
+  })
+
+  it("opens the New API admin credentials page through the theme-aware route resolver", async () => {
+    const user = userEvent.setup()
+    const contextValue = createContextValue({
+      newApiBaseUrl: "https://managed-new-api.example",
+    })
+    mockedUseUserPreferencesContext.mockReturnValue(contextValue)
+
+    render(<NewApiSettings />)
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "settings:newApi.adminCredentialsLink.open",
+      }),
+    )
+
+    await waitFor(() =>
+      expect(resolveAccountSiteRouteUrlMock).toHaveBeenCalledWith(
+        {
+          baseUrl: "https://managed-new-api.example",
+          siteType: SITE_TYPES.NEW_API,
+        },
+        SITE_ROUTE_KINDS.AdminCredentials,
+      ),
+    )
+    expect(createTabMock).toHaveBeenCalledWith(
+      "https://managed.example/profile",
+      true,
     )
   })
 

--- a/tests/features/AccountManagement/components/AccountDialogWarnings.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogWarnings.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import AutoDetectErrorAlert from "~/features/AccountManagement/components/AccountDialog/AutoDetectErrorAlert"
 import { DuplicateAccountWarningDialog } from "~/features/AccountManagement/components/AccountDialog/DuplicateAccountWarningDialog"
 import { ManagedSiteConfigPromptDialog } from "~/features/AccountManagement/components/AccountDialog/ManagedSiteConfigPromptDialog"
@@ -116,8 +117,32 @@ describe("AccountDialog warnings", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Retry login" }))
 
-    expect(openLoginTabMock).toHaveBeenCalledWith("https://site.example.com")
+    expect(openLoginTabMock).toHaveBeenCalledWith(
+      "https://site.example.com",
+      undefined,
+    )
     expect(reloadCurrentTabMock).not.toHaveBeenCalled()
+  })
+
+  it("passes the current site type hint to the default login redirect", () => {
+    render(
+      <AutoDetectErrorAlert
+        error={{
+          type: AutoDetectErrorType.UNAUTHORIZED,
+          message: "Please log in",
+          actionText: "Retry login",
+        }}
+        siteUrl="https://site.example.com"
+        siteType={SITE_TYPES.NEW_API}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry login" }))
+
+    expect(openLoginTabMock).toHaveBeenCalledWith(
+      "https://site.example.com",
+      SITE_TYPES.NEW_API,
+    )
   })
 
   it("does nothing for unauthorized recovery when the site URL is missing", () => {

--- a/tests/services/accounts/siteRouteResolver.test.ts
+++ b/tests/services/accounts/siteRouteResolver.test.ts
@@ -15,14 +15,22 @@ describe("siteRouteResolver", () => {
     vi.restoreAllMocks()
   })
 
+  const mockDefaultNewApiThemeStatus = () =>
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          message: "",
+          data: { theme: "default" },
+        }),
+        {
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    )
+
   it("uses New API default frontend routes when /api/status reports the default theme", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        data: { theme: "default" },
-      }),
-    } as Response)
+    mockDefaultNewApiThemeStatus()
 
     await expect(
       resolveAccountSiteRouteUrl(
@@ -93,13 +101,7 @@ describe("siteRouteResolver", () => {
   })
 
   it("resolves login URLs through the route resolver when a site type hint is available", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        data: { theme: "default" },
-      }),
-    } as Response)
+    mockDefaultNewApiThemeStatus()
 
     await expect(
       resolveAccountSiteLoginUrl(

--- a/tests/services/accounts/siteRouteResolver.test.ts
+++ b/tests/services/accounts/siteRouteResolver.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   clearSiteRouteThemeCacheForTests,
+  getBestEffortLoginUrl,
+  resolveAccountSiteLoginUrl,
   resolveAccountSiteRouteUrl,
   SITE_ROUTE_KINDS,
 } from "~/services/accounts/utils/siteRouteResolver"
@@ -87,6 +89,48 @@ describe("siteRouteResolver", () => {
       ),
     ).resolves.toBe("https://veloera.example/app/me")
 
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("resolves login URLs through the route resolver when a site type hint is available", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { theme: "default" },
+      }),
+    } as Response)
+
+    await expect(
+      resolveAccountSiteLoginUrl(
+        "https://new-api.example/dashboard",
+        SITE_TYPES.NEW_API,
+      ),
+    ).resolves.toBe("https://new-api.example/sign-in")
+  })
+
+  it("uses best-effort login routing when no site type hint is available", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+
+    await expect(
+      resolveAccountSiteLoginUrl("https://unknown.example/dashboard"),
+    ).resolves.toBe("https://unknown.example/login")
+    expect(getBestEffortLoginUrl("not-a-url")).toBe("not-a-url")
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("keeps AIHubMix login routing centralized in the route resolver", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+
+    await expect(
+      resolveAccountSiteLoginUrl(
+        "https://aihubmix.com/statistics",
+        SITE_TYPES.AIHUBMIX,
+      ),
+    ).resolves.toBe("https://console.aihubmix.com/sign-in")
+    expect(
+      getBestEffortLoginUrl("https://console.aihubmix.com/statistics"),
+    ).toBe("https://console.aihubmix.com/sign-in")
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/accounts/siteRouteResolver.test.ts
+++ b/tests/services/accounts/siteRouteResolver.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  clearSiteRouteThemeCacheForTests,
+  resolveAccountSiteRouteUrl,
+  SITE_ROUTE_KINDS,
+} from "~/services/accounts/utils/siteRouteResolver"
+
+describe("siteRouteResolver", () => {
+  beforeEach(() => {
+    clearSiteRouteThemeCacheForTests()
+    vi.restoreAllMocks()
+  })
+
+  it("uses New API default frontend routes when /api/status reports the default theme", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { theme: "default" },
+      }),
+    } as Response)
+
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+        SITE_ROUTE_KINDS.CheckIn,
+      ),
+    ).resolves.toBe("https://new-api.example/profile")
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+        SITE_ROUTE_KINDS.AdminCredentials,
+      ),
+    ).resolves.toBe("https://new-api.example/profile")
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+        SITE_ROUTE_KINDS.Redeem,
+      ),
+    ).resolves.toBe("https://new-api.example/wallet")
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+        SITE_ROUTE_KINDS.Usage,
+      ),
+    ).resolves.toBe("https://new-api.example/usage-logs")
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+        SITE_ROUTE_KINDS.Login,
+      ),
+    ).resolves.toBe("https://new-api.example/sign-in")
+  })
+
+  it("keeps classic New API routes when /api/status is unavailable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"))
+
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+        SITE_ROUTE_KINDS.CheckIn,
+      ),
+    ).resolves.toBe("https://new-api.example/console/personal")
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+        SITE_ROUTE_KINDS.Redeem,
+      ),
+    ).resolves.toBe("https://new-api.example/console/topup")
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+        SITE_ROUTE_KINDS.Usage,
+      ),
+    ).resolves.toBe("https://new-api.example/console/log")
+  })
+
+  it("uses static route config for non-New API sites without probing /api/status", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://veloera.example", siteType: SITE_TYPES.VELOERA },
+        SITE_ROUTE_KINDS.CheckIn,
+      ),
+    ).resolves.toBe("https://veloera.example/app/me")
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/accounts/siteRouteResolver.test.ts
+++ b/tests/services/accounts/siteRouteResolver.test.ts
@@ -121,6 +121,33 @@ describe("siteRouteResolver", () => {
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
+  it("bounds cached New API theme probes for many account sites", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("offline"))
+
+    for (let index = 0; index < 101; index += 1) {
+      await resolveAccountSiteRouteUrl(
+        {
+          baseUrl: `https://new-api-${index}.example`,
+          siteType: SITE_TYPES.NEW_API,
+        },
+        SITE_ROUTE_KINDS.Usage,
+      )
+    }
+
+    await resolveAccountSiteRouteUrl(
+      { baseUrl: "https://new-api-0.example", siteType: SITE_TYPES.NEW_API },
+      SITE_ROUTE_KINDS.Usage,
+    )
+    await resolveAccountSiteRouteUrl(
+      { baseUrl: "https://new-api-100.example", siteType: SITE_TYPES.NEW_API },
+      SITE_ROUTE_KINDS.Usage,
+    )
+
+    expect(fetchSpy).toHaveBeenCalledTimes(102)
+  })
+
   it("keeps AIHubMix login routing centralized in the route resolver", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
 

--- a/tests/services/autoCheckin/providers/newApi.test.ts
+++ b/tests/services/autoCheckin/providers/newApi.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
+import { SITE_ROUTE_KINDS } from "~/services/accounts/utils/siteRouteResolver"
 import { newApiProvider } from "~/services/checkin/autoCheckin/providers/newApi"
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
@@ -19,6 +20,15 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
     await importOriginal<typeof import("~/utils/browser/browserApi")>()
   return { ...actual, isAllowedIncognitoAccess: vi.fn() }
 })
+
+vi.mock("~/services/accounts/utils/siteRouteResolver", () => ({
+  SITE_ROUTE_KINDS: {
+    CheckIn: "checkIn",
+  },
+  resolveAccountSiteRouteUrl: vi.fn(() =>
+    Promise.resolve("https://test.com/console/personal"),
+  ),
+}))
 
 const mockAccount = buildSiteAccount({
   id: "test-id",
@@ -191,6 +201,49 @@ describe("newApiProvider", () => {
           useIncognito: true,
           turnstileTimeoutMs: 12000,
           turnstilePreTrigger: { kind: "checkinButton" },
+        }),
+      )
+    })
+
+    it("uses the theme-aware New API route for Turnstile-assisted verification pages", async () => {
+      const { fetchApi } = await import("~/services/apiService/common/utils")
+      const { tempWindowTurnstileFetch } = await import(
+        "~/utils/browser/tempWindowFetch"
+      )
+      const { isAllowedIncognitoAccess } = await import(
+        "~/utils/browser/browserApi"
+      )
+      const { resolveAccountSiteRouteUrl } = await import(
+        "~/services/accounts/utils/siteRouteResolver"
+      )
+
+      vi.mocked(fetchApi).mockResolvedValueOnce({
+        success: false,
+        message: "Turnstile token 为空",
+        data: null,
+      })
+      vi.mocked(isAllowedIncognitoAccess).mockResolvedValueOnce(false)
+      vi.mocked(resolveAccountSiteRouteUrl).mockResolvedValueOnce(
+        "https://test.com/profile",
+      )
+      vi.mocked(tempWindowTurnstileFetch).mockResolvedValueOnce({
+        success: false,
+        error: "need manual verification",
+        turnstile: { status: "timeout", hasTurnstile: true },
+      })
+
+      await newApiProvider.checkIn(mockAccount)
+
+      expect(resolveAccountSiteRouteUrl).toHaveBeenCalledWith(
+        {
+          baseUrl: "https://test.com",
+          siteType: SITE_TYPES.NEW_API,
+        },
+        SITE_ROUTE_KINDS.CheckIn,
+      )
+      expect(tempWindowTurnstileFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageUrl: "https://test.com/profile",
         }),
       )
     })

--- a/tests/services/externalCheckInService.test.ts
+++ b/tests/services/externalCheckInService.test.ts
@@ -1,15 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
-import { getAccountSiteApiRouter } from "~/constants/siteType"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { SITE_ROUTE_KINDS } from "~/services/accounts/utils/siteRouteResolver"
 import { handleExternalCheckInMessage } from "~/services/checkin/externalCheckInService"
 import {
   createTab,
   createWindow,
   hasWindowsAPI,
 } from "~/utils/browser/browserApi"
-import { joinUrl } from "~/utils/core/url"
 
 vi.mock("~/services/accounts/accountStorage", () => ({
   accountStorage: {
@@ -29,20 +28,26 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
-vi.mock("~/constants/siteType", () => ({
-  getAccountSiteApiRouter: vi.fn(() => ({ redeemPath: "/redeem" })),
-}))
-
-vi.mock("~/utils/core/url", () => ({
-  joinUrl: vi.fn((base: string, path: string) => `${base}${path}`),
+vi.mock("~/services/accounts/utils/siteRouteResolver", () => ({
+  SITE_ROUTE_KINDS: {
+    Redeem: "redeem",
+  },
+  resolveAccountSiteRouteUrl: vi.fn((account: { baseUrl: string }) =>
+    Promise.resolve(`${account.baseUrl}/redeem`),
+  ),
 }))
 
 const mockedAccountStorage = vi.mocked(accountStorage)
 const mockedCreateTab = vi.mocked(createTab)
 const mockedCreateWindow = vi.mocked(createWindow)
 const mockedHasWindowsAPI = vi.mocked(hasWindowsAPI)
-const mockedGetAccountSiteApiRouter = vi.mocked(getAccountSiteApiRouter)
-const mockedJoinUrl = vi.mocked(joinUrl)
+
+const getMockedRouteResolver = async () => {
+  const { resolveAccountSiteRouteUrl } = await import(
+    "~/services/accounts/utils/siteRouteResolver"
+  )
+  return vi.mocked(resolveAccountSiteRouteUrl)
+}
 
 describe("handleExternalCheckInMessage", () => {
   beforeEach(() => {
@@ -198,8 +203,11 @@ describe("handleExternalCheckInMessage", () => {
       sendResponse,
     )
 
-    expect(mockedGetAccountSiteApiRouter).toHaveBeenCalledWith("one-api")
-    expect(mockedJoinUrl).toHaveBeenCalledWith("https://example.com", "/redeem")
+    const mockedResolveAccountSiteRouteUrl = await getMockedRouteResolver()
+    expect(mockedResolveAccountSiteRouteUrl).toHaveBeenCalledWith(
+      { baseUrl: "https://example.com", siteType: "one-api" },
+      SITE_ROUTE_KINDS.Redeem,
+    )
     expect(mockedCreateTab).toHaveBeenNthCalledWith(
       1,
       "https://example.com/redeem",
@@ -300,8 +308,11 @@ describe("handleExternalCheckInMessage", () => {
       sendResponse,
     )
 
-    expect(mockedGetAccountSiteApiRouter).toHaveBeenCalledWith("one-api")
-    expect(mockedJoinUrl).toHaveBeenCalledWith("https://example.com", "/redeem")
+    const mockedResolveAccountSiteRouteUrl = await getMockedRouteResolver()
+    expect(mockedResolveAccountSiteRouteUrl).toHaveBeenCalledWith(
+      { baseUrl: "https://example.com", siteType: "one-api" },
+      SITE_ROUTE_KINDS.Redeem,
+    )
     expect(mockedCreateWindow).toHaveBeenCalledWith({
       url: "https://example.com/redeem",
       focused: true,
@@ -353,7 +364,8 @@ describe("handleExternalCheckInMessage", () => {
       sendResponse,
     )
 
-    expect(mockedJoinUrl).not.toHaveBeenCalled()
+    const mockedResolveAccountSiteRouteUrl = await getMockedRouteResolver()
+    expect(mockedResolveAccountSiteRouteUrl).not.toHaveBeenCalled()
     expect(mockedCreateTab).toHaveBeenCalledTimes(1)
     expect(sendResponse).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/services/externalCheckInService.test.ts
+++ b/tests/services/externalCheckInService.test.ts
@@ -279,6 +279,60 @@ describe("handleExternalCheckInMessage", () => {
     )
   })
 
+  it("marks account when check-in opens even if redeem URL resolution fails", async () => {
+    const sendResponse = vi.fn()
+    mockedAccountStorage.getAccountById.mockResolvedValue({
+      id: "a2-route-error",
+      site_url: "https://example.com",
+      site_type: "one-api",
+      checkIn: {
+        customCheckIn: {
+          url: "https://checkin.example",
+          openRedeemWithCheckIn: true,
+        },
+      },
+    } as any)
+
+    const mockedResolveAccountSiteRouteUrl = await getMockedRouteResolver()
+    mockedResolveAccountSiteRouteUrl.mockRejectedValueOnce(
+      new Error("redeem route missing"),
+    )
+    mockedCreateTab.mockResolvedValueOnce({ id: 23 } as any)
+    mockedAccountStorage.markAccountAsCustomCheckedIn.mockResolvedValue(true)
+
+    await handleExternalCheckInMessage(
+      {
+        action: RuntimeActionIds.ExternalCheckInOpenAndMark,
+        accountIds: ["a2-route-error"],
+      },
+      sendResponse,
+    )
+
+    expect(mockedCreateTab).toHaveBeenCalledWith(
+      "https://checkin.example",
+      true,
+    )
+    expect(
+      mockedAccountStorage.markAccountAsCustomCheckedIn,
+    ).toHaveBeenCalledWith("a2-route-error")
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          results: [
+            expect.objectContaining({
+              accountId: "a2-route-error",
+              openedRedeem: false,
+              openedCheckIn: true,
+              markedCheckedIn: true,
+              redeemError: "redeem route missing",
+            }),
+          ],
+        }),
+      }),
+    )
+  })
+
   it("opens pages in a new window when requested", async () => {
     const sendResponse = vi.fn()
     mockedHasWindowsAPI.mockReturnValue(true)

--- a/tests/services/redemptionAssist.test.ts
+++ b/tests/services/redemptionAssist.test.ts
@@ -1,7 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { SITE_ROUTE_KINDS } from "~/services/accounts/utils/siteRouteResolver"
 import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
+
+vi.mock("~/services/accounts/utils/siteRouteResolver", () => ({
+  SITE_ROUTE_KINDS: {
+    CheckIn: "checkIn",
+    Redeem: "redeem",
+  },
+  resolveAccountSiteRouteUrl: vi.fn(
+    (account: { baseUrl: string }, route: "checkIn" | "redeem") =>
+      Promise.resolve(
+        `${account.baseUrl}${route === "checkIn" ? "/profile" : "/wallet"}`,
+      ),
+  ),
+}))
 
 vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
   const actual =
@@ -260,6 +274,85 @@ describe("redemptionAssist shouldPrompt batch filtering", () => {
     })
     expect(getAllAccounts).toHaveBeenCalledTimes(1)
     expect(convertToDisplayData).toHaveBeenCalledTimes(1)
+  })
+
+  it("derives default check-in and redeem whitelist patterns through the site route resolver", async () => {
+    vi.resetModules()
+    const { userPreferences } = await import(
+      "~/services/preferences/userPreferences"
+    )
+    vi.mocked(userPreferences.getPreferences).mockResolvedValue({
+      ...DEFAULT_PREFERENCES,
+      redemptionAssist: {
+        enabled: true,
+        contextMenu: {
+          enabled: true,
+        },
+        urlWhitelist: {
+          enabled: true,
+          patterns: [],
+          includeAccountSiteUrls: false,
+          includeCheckInAndRedeemUrls: true,
+        },
+        relaxedCodeValidation: false,
+      },
+    })
+
+    const getAllAccounts = vi.fn().mockResolvedValue([])
+    const convertToDisplayData = vi.fn().mockReturnValue([
+      {
+        id: "acc_default_routes",
+        siteType: "new-api",
+        baseUrl: "https://new-api-default.example/path",
+        disabled: false,
+      },
+    ])
+
+    vi.doMock("~/services/accounts/accountStorage", () => ({
+      accountStorage: {
+        getAllAccounts,
+        convertToDisplayData,
+      },
+    }))
+
+    const { resolveAccountSiteRouteUrl } = await import(
+      "~/services/accounts/utils/siteRouteResolver"
+    )
+    const { handleRedemptionAssistMessage } = await import(
+      "~/services/redemption/redemptionAssist"
+    )
+
+    const validHex = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+    const sendResponse = vi.fn()
+
+    await handleRedemptionAssistMessage(
+      {
+        action: RuntimeActionIds.RedemptionAssistShouldPrompt,
+        url: "https://new-api-default.example/wallet/code",
+        codes: [validHex],
+      },
+      { tab: { id: 12 } } as any,
+      sendResponse,
+    )
+
+    expect(resolveAccountSiteRouteUrl).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://new-api-default.example",
+        siteType: "new-api",
+      },
+      SITE_ROUTE_KINDS.CheckIn,
+    )
+    expect(resolveAccountSiteRouteUrl).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://new-api-default.example",
+        siteType: "new-api",
+      },
+      SITE_ROUTE_KINDS.Redeem,
+    )
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      promptableCodes: [validHex],
+    })
   })
 
   it("updates runtime settings through the message handler and disables promptability immediately", async () => {

--- a/tests/utils/autoDetectUtils.test.ts
+++ b/tests/utils/autoDetectUtils.test.ts
@@ -441,17 +441,24 @@ describe("autoDetectUtils", () => {
     })
 
     it("uses the New API default frontend sign-in route when a site type hint is available", async () => {
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          success: true,
-          data: { theme: "default" },
-        }),
-      } as Response)
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: { theme: "default" },
+          }),
+          {
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
 
       await openLoginTab("https://new-api-login.example", SITE_TYPES.NEW_API)
       expect(fetchSpy).toHaveBeenCalledWith(
         "https://new-api-login.example/api/status",
+        expect.objectContaining({
+          method: "GET",
+        }),
       )
       expect(browser.tabs.create).toHaveBeenCalledWith({
         url: "https://new-api-login.example/sign-in",

--- a/tests/utils/autoDetectUtils.test.ts
+++ b/tests/utils/autoDetectUtils.test.ts
@@ -9,6 +9,7 @@ import {
   openLoginTab,
   reloadCurrentTab,
 } from "~/services/accounts/utils/autoDetectUtils"
+import { clearSiteRouteThemeCacheForTests } from "~/services/accounts/utils/siteRouteResolver"
 import { getDocsAutoDetectUrl } from "~/utils/navigation/docsLinks"
 
 const { tMock } = vi.hoisted(() => ({
@@ -39,6 +40,10 @@ afterAll(() => {
 })
 
 describe("autoDetectUtils", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"))
+  })
+
   describe("analyzeAutoDetectError", () => {
     describe("Timeout errors", () => {
       it("should detect timeout error with Chinese text", () => {
@@ -419,6 +424,8 @@ describe("autoDetectUtils", () => {
   describe("openLoginTab", () => {
     beforeEach(() => {
       vi.clearAllMocks()
+      clearSiteRouteThemeCacheForTests()
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"))
     })
 
     it("should create new tab with login URL", async () => {
@@ -430,6 +437,28 @@ describe("autoDetectUtils", () => {
         url: "https://example.com/login",
         active: true,
       })
+    })
+
+    it("uses the New API default frontend sign-in route when available", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { theme: "default" },
+        }),
+      } as Response)
+
+      await openLoginTab("https://new-api-login.example")
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://new-api-login.example/api/status",
+      )
+      expect(browser.tabs.create).toHaveBeenCalledWith({
+        url: "https://new-api-login.example/sign-in",
+        active: true,
+      })
+
+      fetchSpy.mockRestore()
     })
 
     it("should open tab in active state", async () => {

--- a/tests/utils/autoDetectUtils.test.ts
+++ b/tests/utils/autoDetectUtils.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { AUTO_DETECT_ERROR_CODES } from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
 import {
   analyzeAutoDetectError,
   AutoDetectErrorType,
@@ -439,7 +440,7 @@ describe("autoDetectUtils", () => {
       })
     })
 
-    it("uses the New API default frontend sign-in route when available", async () => {
+    it("uses the New API default frontend sign-in route when a site type hint is available", async () => {
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -448,8 +449,7 @@ describe("autoDetectUtils", () => {
         }),
       } as Response)
 
-      await openLoginTab("https://new-api-login.example")
-
+      await openLoginTab("https://new-api-login.example", SITE_TYPES.NEW_API)
       expect(fetchSpy).toHaveBeenCalledWith(
         "https://new-api-login.example/api/status",
       )
@@ -459,6 +459,29 @@ describe("autoDetectUtils", () => {
       })
 
       fetchSpy.mockRestore()
+    })
+
+    it("uses the hinted non-New API site route without probing New API status", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch")
+
+      await openLoginTab(
+        "https://console.aihubmix.com/statistics",
+        SITE_TYPES.AIHUBMIX,
+      )
+      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(browser.tabs.create).toHaveBeenCalledWith({
+        url: "https://console.aihubmix.com/sign-in",
+        active: true,
+      })
+    })
+
+    it("falls back to the generic login URL when the site type hint is unavailable", async () => {
+      await openLoginTab("https://fallback.example/path", SITE_TYPES.UNKNOWN)
+
+      expect(browser.tabs.create).toHaveBeenCalledWith({
+        url: "https://fallback.example/login",
+        active: true,
+      })
     })
 
     it("should open tab in active state", async () => {

--- a/tests/utils/autoDetectUtils.test.ts
+++ b/tests/utils/autoDetectUtils.test.ts
@@ -536,11 +536,10 @@ describe("autoDetectUtils", () => {
       )
     })
 
-    it("should call getLoginUrl internally", async () => {
+    it("should use the best-effort login route when no hint is available", async () => {
       const siteUrl = "https://example.com/dashboard"
       await openLoginTab(siteUrl)
 
-      // Verify that the /login path is appended correctly
       expect(browser.tabs.create).toHaveBeenCalledWith({
         url: "https://example.com/login",
         active: true,

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { getAccountSiteApiRouter } from "~/constants/siteType"
 import { isExtensionPopup } from "~/utils/browser"
 import {
   createTab as createTabApi,
@@ -10,7 +9,6 @@ import {
   hasWindowsAPI,
   openSidePanel as openSidePanelApi,
 } from "~/utils/browser/browserApi"
-import { joinUrl } from "~/utils/core/url"
 import {
   navigateWithinOptionsPage,
   openAboutPage,
@@ -77,16 +75,22 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
-vi.mock("~/constants/siteType", () => ({
-  getAccountSiteApiRouter: vi.fn(() => ({
-    usagePath: "/usage",
-    checkInPath: "/checkin",
-    redeemPath: "/redeem",
-  })),
-}))
-
-vi.mock("~/utils/core/url", () => ({
-  joinUrl: vi.fn((base: string, path: string) => `${base}${path}`),
+vi.mock("~/services/accounts/utils/siteRouteResolver", () => ({
+  SITE_ROUTE_KINDS: {
+    Usage: "usage",
+    CheckIn: "checkIn",
+    Redeem: "redeem",
+  },
+  resolveAccountSiteRouteUrl: vi.fn(
+    (account: { baseUrl: string }, route: "usage" | "checkIn" | "redeem") => {
+      const routePaths = {
+        usage: "/usage",
+        checkIn: "/checkin",
+        redeem: "/redeem",
+      } as const
+      return Promise.resolve(`${account.baseUrl}${routePaths[route]}`)
+    },
+  ),
 }))
 
 vi.mock("~/utils/navigation/feedbackLinks", () => ({
@@ -115,8 +119,13 @@ const mockedFocusTab = vi.mocked(focusTabApi)
 const mockedGetExtensionURL = vi.mocked(getExtensionURL)
 const mockedHasWindowsAPI = vi.mocked(hasWindowsAPI)
 const mockedOpenSidePanel = vi.mocked(openSidePanelApi)
-const mockedGetAccountSiteApiRouter = vi.mocked(getAccountSiteApiRouter)
-const mockedJoinUrl = vi.mocked(joinUrl)
+
+const getMockedRouteResolver = async () => {
+  const { resolveAccountSiteRouteUrl } = await import(
+    "~/services/accounts/utils/siteRouteResolver"
+  )
+  return vi.mocked(resolveAccountSiteRouteUrl)
+}
 
 describe("navigation utilities", () => {
   beforeEach(() => {
@@ -166,6 +175,10 @@ describe("navigation utilities", () => {
   })
 
   it("openUsagePage should open usage URL built from site router", async () => {
+    const mockedResolveAccountSiteRouteUrl = await getMockedRouteResolver()
+    mockedResolveAccountSiteRouteUrl.mockResolvedValueOnce(
+      "https://example.com/usage-resolved",
+    )
     const account = {
       baseUrl: "https://example.com",
       siteType: "one-api",
@@ -173,10 +186,14 @@ describe("navigation utilities", () => {
 
     await openUsagePage(account)
 
-    expect(mockedGetAccountSiteApiRouter).toHaveBeenCalledWith("one-api")
-    expect(mockedJoinUrl).toHaveBeenCalledWith("https://example.com", "/usage")
-    const url = mockedJoinUrl.mock.results[0].value
-    expect(mockedCreateTab).toHaveBeenCalledWith(url, true)
+    expect(mockedResolveAccountSiteRouteUrl).toHaveBeenCalledWith(
+      account,
+      "usage",
+    )
+    expect(mockedCreateTab).toHaveBeenCalledWith(
+      "https://example.com/usage-resolved",
+      true,
+    )
   })
 
   it("openModelsPage should open models page for the default view, accounts, and stored profiles", async () => {
@@ -406,6 +423,10 @@ describe("navigation utilities", () => {
   })
 
   it("openCheckInPages should open grouped check-in tabs by default", async () => {
+    const mockedResolveAccountSiteRouteUrl = await getMockedRouteResolver()
+    mockedResolveAccountSiteRouteUrl
+      .mockResolvedValueOnce("https://example.com/checkin-resolved")
+      .mockResolvedValueOnce("https://example.org/checkin-resolved")
     mockedCreateTab
       .mockResolvedValueOnce({ id: 11 } as any)
       .mockResolvedValueOnce({ id: 12 } as any)
@@ -422,11 +443,11 @@ describe("navigation utilities", () => {
     ])
 
     expect(mockedCreateTab).toHaveBeenCalledWith(
-      "https://example.com/checkin",
+      "https://example.com/checkin-resolved",
       true,
     )
     expect(mockedCreateTab).toHaveBeenCalledWith(
-      "https://example.org/checkin",
+      "https://example.org/checkin-resolved",
       true,
     )
     expect(result).toEqual({ openedCount: 2, failedCount: 0 })


### PR DESCRIPTION
Resolves #880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized account-site route resolution for login, admin-credentials, check-in, redeem and usage URLs.
  * Default login/open-login behavior now preserves an optional site-type hint so redirects use the appropriate site-specific sign-in.
  * Theme-aware New API routing with short-lived caching for stable path selection; navigation/check-in flows now await resolved URLs.

* **Tests**
  * Expanded tests covering route resolution, theme probing, site-type hints, and related flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qixing-jk/all-api-hub/pull/882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->