### PR TITLE
fix(account-dialog): import cookies from source tab

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,13 +109,13 @@ jobs:
         run: pnpm exec vitest --run --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results

--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -53,6 +53,41 @@ import {
 const logger = createLogger("RuntimeMessages")
 
 /**
+ * Resolves the browser cookie store that should be used for a cookie import request.
+ */
+async function resolveCookieStoreIdFromImportRequest(
+  request: Record<string, unknown>,
+): Promise<string | undefined> {
+  if (
+    typeof request.cookieStoreId === "string" &&
+    request.cookieStoreId.trim()
+  ) {
+    return request.cookieStoreId.trim()
+  }
+
+  if (
+    typeof request.sourceTabId !== "number" ||
+    request.sourceTabIncognito !== true ||
+    typeof browser.cookies?.getAllCookieStores !== "function"
+  ) {
+    return undefined
+  }
+
+  try {
+    const cookieStores = await browser.cookies.getAllCookieStores()
+    return cookieStores.find((store) =>
+      store.tabIds?.includes(request.sourceTabId as number),
+    )?.id
+  } catch (error) {
+    logger.warn("Failed to resolve source tab cookie store", {
+      error: getErrorMessage(error),
+      sourceTabId: request.sourceTabId,
+    })
+    return undefined
+  }
+}
+
+/**
  * Registers runtime message handlers for background scripts.
  * Routes browser.runtime messages to feature-specific handlers based on action prefixes.
  */
@@ -181,10 +216,7 @@ export function setupRuntimeMessageListeners() {
             }
 
             const cookieStoreId =
-              typeof request.cookieStoreId === "string" &&
-              request.cookieStoreId.trim()
-                ? request.cookieStoreId
-                : undefined
+              await resolveCookieStoreIdFromImportRequest(request)
             const result = await getCookieHeaderForUrlResult(request.url, {
               includeSession: true,
               ...(cookieStoreId ? { storeId: cookieStoreId } : {}),

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -980,6 +980,7 @@ export function useAccountDialog({
         logger.warn("Failed to query current tab in fallback mode", {
           error: fallbackError,
         })
+        clearCurrentTabDetection()
       }
     }
   }, [account, mode, setSiteName])

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -110,6 +110,30 @@ import {
 
 const AUTO_DETECT_SLOW_HINT_DELAY_MS = 10_000
 
+interface CurrentTabCookieImportContext {
+  origin: string
+  tabId?: number
+  incognito?: boolean
+  cookieStoreId?: string
+}
+
+/**
+ * Captures the current tab context needed to import cookies from the same browser profile.
+ */
+function createCurrentTabCookieImportContext(
+  tab: browser.tabs.Tab,
+  origin: string,
+): CurrentTabCookieImportContext {
+  return {
+    origin,
+    ...(typeof tab.id === "number" ? { tabId: tab.id } : {}),
+    ...(tab.incognito === true ? { incognito: true } : {}),
+    ...(typeof tab.cookieStoreId === "string" && tab.cookieStoreId.trim()
+      ? { cookieStoreId: tab.cookieStoreId.trim() }
+      : {}),
+  }
+}
+
 /**
  * Logger scoped to the account dialog lifecycle. Ensure we never include raw tokens/cookies in log details.
  */
@@ -671,6 +695,8 @@ export function useAccountDialog({
     null,
   )
   const detectedCookieStoreIdRef = useRef<string | null>(null)
+  const currentTabCookieImportContextRef =
+    useRef<CurrentTabCookieImportContext | null>(null)
 
   const { openWithAccount: openChannelDialog, openSub2ApiTokenCreationDialog } =
     useChannelDialog()
@@ -786,6 +812,7 @@ export function useAccountDialog({
     (nextPrefill?: AddAccountPrefill | null) => {
       newAccountRef.current = null
       detectedCookieStoreIdRef.current = null
+      currentTabCookieImportContextRef.current = null
       duplicateAccountWarningAcknowledgedSiteUrlRef.current = null
       hasConsumedAutoFillCurrentSiteUrlRef.current = Boolean(nextPrefill)
       const normalizedPrefillAuthType = normalizeOptionalAccountAuthType(
@@ -895,6 +922,12 @@ export function useAccountDialog({
     if (mode === DIALOG_MODES.EDIT && account) {
       return
     }
+    const clearCurrentTabDetection = () => {
+      currentTabCookieImportContextRef.current = null
+      setCurrentTabUrl(null)
+      setSiteName("")
+    }
+
     try {
       const tabs = await browser.tabs.query({
         active: true,
@@ -906,8 +939,11 @@ export function useAccountDialog({
           const urlObj = new URL(tab.url)
           const baseUrl = `${urlObj.protocol}//${urlObj.host}`
           if (!baseUrl.startsWith("http")) {
+            clearCurrentTabDetection()
             return
           }
+          currentTabCookieImportContextRef.current =
+            createCurrentTabCookieImportContext(tab, baseUrl)
           setCurrentTabUrl(baseUrl)
           setSiteName(await getSiteName(tab))
         } catch (error) {
@@ -915,9 +951,10 @@ export function useAccountDialog({
             error,
             tabUrl: tab.url,
           })
-          setCurrentTabUrl(null)
-          setSiteName("")
+          clearCurrentTabDetection()
         }
+      } else {
+        clearCurrentTabDetection()
       }
     } catch (error) {
       logger.warn("Failed to query current tab, falling back", { error })
@@ -929,9 +966,15 @@ export function useAccountDialog({
           const urlObj = new URL(tab.url)
           const baseUrl = `${urlObj.protocol}//${urlObj.host}`
           if (baseUrl.startsWith("http")) {
+            currentTabCookieImportContextRef.current =
+              createCurrentTabCookieImportContext(tab, baseUrl)
             setCurrentTabUrl(baseUrl)
             setSiteName(await getSiteName(tab))
+          } else {
+            clearCurrentTabDetection()
           }
+        } else {
+          clearCurrentTabDetection()
         }
       } catch (fallbackError) {
         logger.warn("Failed to query current tab in fallback mode", {
@@ -1097,6 +1140,34 @@ export function useAccountDialog({
     void openSettingsTab("permissions")
   }, [])
 
+  const getCookieImportContextForUrl = useCallback((targetUrl: string) => {
+    if (detectedCookieStoreIdRef.current) {
+      return { cookieStoreId: detectedCookieStoreIdRef.current }
+    }
+
+    const currentTabContext = currentTabCookieImportContextRef.current
+    if (!currentTabContext) {
+      return {}
+    }
+
+    const targetOrigin = tryParseOrigin(targetUrl)
+    if (!targetOrigin || targetOrigin !== currentTabContext.origin) {
+      return {}
+    }
+
+    return {
+      ...(currentTabContext.cookieStoreId
+        ? { cookieStoreId: currentTabContext.cookieStoreId }
+        : {}),
+      ...(typeof currentTabContext.tabId === "number"
+        ? { sourceTabId: currentTabContext.tabId }
+        : {}),
+      ...(currentTabContext.incognito === true
+        ? { sourceTabIncognito: true }
+        : {}),
+    }
+  }, [])
+
   const handleRequestCookieAuthPermissions = useCallback(async () => {
     const cookieAuthPermissions = getCookieAuthPermissions()
 
@@ -1193,9 +1264,7 @@ export function useAccountDialog({
       const response = await sendRuntimeMessage<CookieImportResponse>({
         action: RuntimeActionIds.AccountDialogImportCookieAuthSessionCookie,
         url: url.trim(),
-        ...(detectedCookieStoreIdRef.current
-          ? { cookieStoreId: detectedCookieStoreIdRef.current }
-          : {}),
+        ...getCookieImportContextForUrl(url.trim()),
       })
       if (response?.success && response.data) {
         setCookieAuthSessionCookie(response.data)
@@ -1585,9 +1654,7 @@ export function useAccountDialog({
               action:
                 RuntimeActionIds.AccountDialogImportCookieAuthSessionCookie,
               url: url.trim(),
-              ...(detectedCookieStoreIdRef.current
-                ? { cookieStoreId: detectedCookieStoreIdRef.current }
-                : {}),
+              ...getCookieImportContextForUrl(url.trim()),
             })
             const header =
               typeof cookieResponse?.data === "string"

--- a/tests/entrypoints/background/runtimeMessages.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.test.ts
@@ -16,6 +16,7 @@ describe("setupRuntimeMessageListeners routing", () => {
   let hasCookieReadPermissionForUrl: ReturnType<typeof vi.fn>
   let handleManagedSiteModelSyncMessage: ReturnType<typeof vi.fn>
   let setupContextMenus: ReturnType<typeof vi.fn>
+  let originalBrowserCookies: unknown
 
   beforeEach(() => {
     runtimeMessageListener = undefined
@@ -24,6 +25,7 @@ describe("setupRuntimeMessageListeners routing", () => {
     hasCookieReadPermissionForUrl = vi.fn().mockResolvedValue(true)
     handleManagedSiteModelSyncMessage = vi.fn()
     setupContextMenus = vi.fn().mockResolvedValue(undefined)
+    originalBrowserCookies = (globalThis as any).browser?.cookies
 
     vi.resetModules()
 
@@ -97,6 +99,7 @@ describe("setupRuntimeMessageListeners routing", () => {
     vi.doUnmock("~/services/redemption/redemptionAssist")
     vi.doUnmock("~/services/history/usageHistory/scheduler")
     vi.doUnmock("~/services/webdav/webdavAutoSyncService")
+    ;(globalThis as any).browser.cookies = originalBrowserCookies
     vi.resetModules()
     vi.restoreAllMocks()
   })

--- a/tests/entrypoints/background/runtimeMessages.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.test.ts
@@ -276,6 +276,55 @@ describe("setupRuntimeMessageListeners routing", () => {
     })
   })
 
+  it("resolves the cookie store from the source tab for incognito cookie import requests", async () => {
+    getCookieHeaderForUrlResult.mockResolvedValueOnce({
+      header: "session=incognito",
+    })
+    const getAllCookieStores = vi.fn().mockResolvedValueOnce([
+      { id: "0", tabIds: [1] },
+      { id: "1-incognito", tabIds: [42] },
+    ])
+    ;(globalThis as any).browser.cookies = {
+      ...((globalThis as any).browser.cookies ?? {}),
+      getAllCookieStores,
+    }
+
+    const { setupRuntimeMessageListeners } = await import(
+      "~/entrypoints/background/runtimeMessages"
+    )
+
+    setupRuntimeMessageListeners()
+    expect(runtimeMessageListener).toBeTypeOf("function")
+
+    const sendResponse = vi.fn()
+    const result = runtimeMessageListener?.(
+      {
+        action: RuntimeActionIds.AccountDialogImportCookieAuthSessionCookie,
+        url: "https://example.com",
+        sourceTabId: 42,
+        sourceTabIncognito: true,
+      },
+      {},
+      sendResponse,
+    )
+
+    expect(result).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(getAllCookieStores).toHaveBeenCalledTimes(1)
+    expect(getCookieHeaderForUrlResult).toHaveBeenCalledWith(
+      "https://example.com",
+      {
+        includeSession: true,
+        storeId: "1-incognito",
+      },
+    )
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: "session=incognito",
+    })
+  })
+
   it("returns a permission failure before reading cookies when access is missing", async () => {
     hasCookieReadPermissionForUrl.mockResolvedValueOnce(false)
 

--- a/tests/entrypoints/background/runtimeMessages.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.test.ts
@@ -325,6 +325,53 @@ describe("setupRuntimeMessageListeners routing", () => {
     })
   })
 
+  it("falls back to the default cookie store when source-tab store lookup fails", async () => {
+    getCookieHeaderForUrlResult.mockResolvedValueOnce({
+      header: "session=regular",
+    })
+    const getAllCookieStores = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("cookie store lookup failed"))
+    ;(globalThis as any).browser.cookies = {
+      ...((globalThis as any).browser.cookies ?? {}),
+      getAllCookieStores,
+    }
+
+    const { setupRuntimeMessageListeners } = await import(
+      "~/entrypoints/background/runtimeMessages"
+    )
+
+    setupRuntimeMessageListeners()
+    expect(runtimeMessageListener).toBeTypeOf("function")
+
+    const sendResponse = vi.fn()
+    const result = runtimeMessageListener?.(
+      {
+        action: RuntimeActionIds.AccountDialogImportCookieAuthSessionCookie,
+        url: "https://example.com",
+        sourceTabId: 42,
+        sourceTabIncognito: true,
+      },
+      {},
+      sendResponse,
+    )
+
+    expect(result).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(getAllCookieStores).toHaveBeenCalledTimes(1)
+    expect(getCookieHeaderForUrlResult).toHaveBeenCalledWith(
+      "https://example.com",
+      {
+        includeSession: true,
+      },
+    )
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: "session=regular",
+    })
+  })
+
   it("returns a permission failure before reading cookies when access is missing", async () => {
     hasCookieReadPermissionForUrl.mockResolvedValueOnce(false)
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
@@ -168,6 +168,62 @@ describe("useAccountDialog current tab detection", () => {
     })
   })
 
+  it("clears stale current-tab detection when fallback active-tab lookup returns no tab", async () => {
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    let activatedListener: (() => void | Promise<void>) | undefined
+    onTabActivatedMock.mockImplementation((listener) => {
+      activatedListener = listener
+      return () => {}
+    })
+    tabsQueryMock.mockResolvedValueOnce([
+      {
+        id: 13,
+        url: "https://initial.example.com/path",
+      },
+    ])
+    tabsQueryMock.mockResolvedValueOnce([
+      {
+        id: 13,
+        url: "https://initial.example.com/path",
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://initial.example.com",
+      )
+      expect(result.current.state.siteName).toBe("Detected Site")
+    })
+
+    tabsQueryMock.mockImplementation(async (queryInfo) => {
+      if (queryInfo?.currentWindow) {
+        throw new Error("currentWindow unsupported")
+      }
+
+      return []
+    })
+
+    await act(async () => {
+      await activatedListener?.()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBeNull()
+      expect(result.current.state.siteName).toBe("")
+    })
+  })
+
   it("clears current-tab detection when the active tab URL cannot be parsed", async () => {
     const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
       typeof vi.fn
@@ -193,6 +249,167 @@ describe("useAccountDialog current tab detection", () => {
       expect(result.current.state.siteName).toBe("")
     })
     expect(mockGetSiteName).not.toHaveBeenCalled()
+  })
+
+  it("clears current-tab detection when the primary active-tab lookup returns no tab", async () => {
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    tabsQueryMock.mockResolvedValue([])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBeNull()
+      expect(result.current.state.siteName).toBe("")
+    })
+    expect(mockGetSiteName).not.toHaveBeenCalled()
+  })
+
+  it("clears current-tab detection when the primary active-tab lookup returns a tab without a URL", async () => {
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    tabsQueryMock.mockResolvedValue([{ id: 16 }])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBeNull()
+      expect(result.current.state.siteName).toBe("")
+    })
+    expect(mockGetSiteName).not.toHaveBeenCalled()
+  })
+
+  it("clears current-tab detection when fallback finds a non-http tab", async () => {
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    let activatedListener: (() => void | Promise<void>) | undefined
+    onTabActivatedMock.mockImplementation((listener) => {
+      activatedListener = listener
+      return () => {}
+    })
+    tabsQueryMock.mockResolvedValueOnce([
+      {
+        id: 14,
+        url: "https://initial.example.com/path",
+      },
+    ])
+    tabsQueryMock.mockResolvedValueOnce([
+      {
+        id: 14,
+        url: "https://initial.example.com/path",
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://initial.example.com",
+      )
+      expect(result.current.state.siteName).toBe("Detected Site")
+    })
+
+    tabsQueryMock.mockImplementation(async (queryInfo) => {
+      if (queryInfo?.currentWindow) {
+        throw new Error("currentWindow unsupported")
+      }
+
+      return [
+        {
+          id: 14,
+          url: "chrome://extensions",
+        },
+      ]
+    })
+
+    await act(async () => {
+      await activatedListener?.()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBeNull()
+      expect(result.current.state.siteName).toBe("")
+    })
+  })
+
+  it("clears current-tab detection when fallback active-tab lookup returns a tab without a URL", async () => {
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    let activatedListener: (() => void | Promise<void>) | undefined
+    onTabActivatedMock.mockImplementation((listener) => {
+      activatedListener = listener
+      return () => {}
+    })
+    tabsQueryMock.mockResolvedValueOnce([
+      {
+        id: 15,
+        url: "https://initial.example.com/path",
+      },
+    ])
+    tabsQueryMock.mockResolvedValueOnce([
+      {
+        id: 15,
+        url: "https://initial.example.com/path",
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://initial.example.com",
+      )
+      expect(result.current.state.siteName).toBe("Detected Site")
+    })
+
+    tabsQueryMock.mockImplementation(async (queryInfo) => {
+      if (queryInfo?.currentWindow) {
+        throw new Error("currentWindow unsupported")
+      }
+
+      return [{ id: 15 }]
+    })
+
+    await act(async () => {
+      await activatedListener?.()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBeNull()
+      expect(result.current.state.siteName).toBe("")
+    })
   })
 
   it("ignores non-http tabs and only refreshes on tab updates for the active tab", async () => {

--- a/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
@@ -138,21 +138,18 @@ describe("useAccountDialog current tab detection", () => {
     const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
       typeof vi.fn
     >
-    tabsQueryMock
-      .mockRejectedValueOnce(new Error("currentWindow unsupported"))
-      .mockResolvedValueOnce([
+    tabsQueryMock.mockImplementation(async (queryInfo) => {
+      if (queryInfo?.currentWindow) {
+        throw new Error("currentWindow unsupported")
+      }
+
+      return [
         {
           id: 2,
           url: "https://fallback.example.com/dashboard",
         },
-      ])
-      .mockRejectedValueOnce(new Error("currentWindow unsupported"))
-      .mockResolvedValueOnce([
-        {
-          id: 2,
-          url: "https://fallback.example.com/dashboard",
-        },
-      ])
+      ]
+    })
 
     const { result } = renderHook(() =>
       useAccountDialog({

--- a/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { COOKIE_IMPORT_FAILURE_REASONS } from "~/constants/cookieImport"
 import { DIALOG_MODES } from "~/constants/dialogModes"
+import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { useAccountDialog } from "~/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import {
@@ -160,6 +161,58 @@ describe("useAccountDialog cookie import feedback", () => {
     expect(result.current.state.showCookiePermissionWarning).toBe(false)
     expect(toast.error).toHaveBeenCalledWith(
       "accountDialog:messages.importCookiesEmpty",
+    )
+  })
+
+  it("sends the current incognito tab context when importing cookies manually", async () => {
+    vi.mocked(toast.success).mockClear()
+    const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
+    vi.mocked(sendRuntimeMessage).mockResolvedValueOnce({
+      success: true,
+      data: "session=incognito",
+    })
+    ;(globalThis as any).browser.tabs.query = vi.fn(async () => [
+      {
+        id: 42,
+        incognito: true,
+        url: "https://example.com/dashboard",
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe("https://example.com")
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://example.com")
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleImportCookieAuthSessionCookie()
+    })
+
+    expect(sendRuntimeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.AccountDialogImportCookieAuthSessionCookie,
+        url: "https://example.com",
+        sourceTabId: 42,
+        sourceTabIncognito: true,
+      }),
+    )
+    expect(result.current.state.cookieAuthSessionCookie).toBe(
+      "session=incognito",
+    )
+    expect(toast.success).toHaveBeenCalledWith(
+      "accountDialog:messages.importCookiesSuccess",
     )
   })
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
@@ -226,6 +226,149 @@ describe("useAccountDialog cookie import feedback", () => {
     )
   })
 
+  it("trims and sends the current tab cookie store when importing from a matching origin", async () => {
+    const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
+    vi.mocked(sendRuntimeMessage).mockResolvedValueOnce({
+      success: true,
+      data: "session=container",
+    })
+    ;(globalThis as any).browser.tabs.query = vi.fn(async () => [
+      {
+        id: 43,
+        cookieStoreId: " firefox-container-1 ",
+        incognito: false,
+        url: "https://example.com/dashboard",
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe("https://example.com")
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://example.com")
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleImportCookieAuthSessionCookie()
+    })
+
+    expect(sendRuntimeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.AccountDialogImportCookieAuthSessionCookie,
+        url: "https://example.com",
+        cookieStoreId: "firefox-container-1",
+        sourceTabId: 43,
+      }),
+    )
+    expect(sendRuntimeMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceTabIncognito: true,
+      }),
+    )
+  })
+
+  it("skips current-tab context when importing cookies for a different origin", async () => {
+    const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
+    vi.mocked(sendRuntimeMessage).mockResolvedValueOnce({
+      success: true,
+      data: "session=other",
+    })
+    ;(globalThis as any).browser.tabs.query = vi.fn(async () => [
+      {
+        id: 44,
+        cookieStoreId: "firefox-container-2",
+        incognito: true,
+        url: "https://current.example.com/dashboard",
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://current.example.com",
+      )
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://other.example.com")
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleImportCookieAuthSessionCookie()
+    })
+
+    expect(sendRuntimeMessage).toHaveBeenCalledWith({
+      action: RuntimeActionIds.AccountDialogImportCookieAuthSessionCookie,
+      url: "https://other.example.com",
+    })
+  })
+
+  it("sends matching current-tab context without a source tab id when the tab id is unavailable", async () => {
+    const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
+    vi.mocked(sendRuntimeMessage).mockResolvedValueOnce({
+      success: true,
+      data: "session=no-tab-id",
+    })
+    ;(globalThis as any).browser.tabs.query = vi.fn(async () => [
+      {
+        cookieStoreId: "firefox-container-3",
+        url: "https://example.com/dashboard",
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe("https://example.com")
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://example.com")
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleImportCookieAuthSessionCookie()
+    })
+
+    expect(sendRuntimeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.AccountDialogImportCookieAuthSessionCookie,
+        url: "https://example.com",
+        cookieStoreId: "firefox-container-3",
+      }),
+    )
+    expect(sendRuntimeMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceTabId: expect.any(Number),
+      }),
+    )
+  })
+
   it("drops stale current-tab import context when current-tab queries fail", async () => {
     vi.mocked(toast.success).mockClear()
     const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")

--- a/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
@@ -19,6 +19,9 @@ import {
 import { AuthTypeEnum } from "~/types"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
+type OnTabActivated = typeof import("~/utils/browser/browserApi").onTabActivated
+type OnTabUpdated = typeof import("~/utils/browser/browserApi").onTabUpdated
+
 const { mockOpenWithAccount, mockOpenSub2ApiTokenCreationDialog } = vi.hoisted(
   () => ({
     mockOpenWithAccount: vi.fn(),
@@ -40,6 +43,11 @@ const {
   mockHasPermission: vi.fn(),
   mockHasPermissions: vi.fn(),
   mockOnOptionalPermissionsChanged: vi.fn(() => vi.fn()),
+}))
+
+const { mockOnTabActivated, mockOnTabUpdated } = vi.hoisted(() => ({
+  mockOnTabActivated: vi.fn<OnTabActivated>(() => () => {}),
+  mockOnTabUpdated: vi.fn<OnTabUpdated>(() => () => {}),
 }))
 
 const { mockTrackProductAnalyticsEvent } = vi.hoisted(() => ({
@@ -90,8 +98,8 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
     ...actual,
     getActiveTabs: vi.fn(async () => []),
     getAllTabs: vi.fn(async () => []),
-    onTabActivated: vi.fn(() => () => {}),
-    onTabUpdated: vi.fn(() => () => {}),
+    onTabActivated: mockOnTabActivated,
+    onTabUpdated: mockOnTabUpdated,
     sendRuntimeMessage: vi.fn(),
   }
 })
@@ -126,6 +134,8 @@ describe("useAccountDialog cookie import feedback", () => {
       requestedResults: [],
     })
     mockOnOptionalPermissionsChanged.mockReturnValue(vi.fn())
+    mockOnTabActivated.mockReturnValue(vi.fn())
+    mockOnTabUpdated.mockReturnValue(vi.fn())
     await accountStorage.clearAllData()
   })
 
@@ -211,6 +221,68 @@ describe("useAccountDialog cookie import feedback", () => {
     expect(result.current.state.cookieAuthSessionCookie).toBe(
       "session=incognito",
     )
+    expect(toast.success).toHaveBeenCalledWith(
+      "accountDialog:messages.importCookiesSuccess",
+    )
+  })
+
+  it("drops stale current-tab import context when current-tab queries fail", async () => {
+    vi.mocked(toast.success).mockClear()
+    const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
+    vi.mocked(sendRuntimeMessage).mockResolvedValueOnce({
+      success: true,
+      data: "session=regular",
+    })
+    let onActivated: Parameters<OnTabActivated>[0] | undefined
+    mockOnTabActivated.mockImplementation((listener) => {
+      onActivated = listener
+      return vi.fn()
+    })
+    ;(globalThis as any).browser.tabs.query = vi.fn().mockResolvedValue([
+      {
+        id: 42,
+        incognito: true,
+        url: "https://example.com/dashboard",
+      },
+    ])
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe("https://example.com")
+    })
+
+    vi.mocked(globalThis.browser.tabs.query).mockRejectedValue(
+      new Error("tab query failed"),
+    )
+
+    await act(async () => {
+      await onActivated?.({ tabId: 42, windowId: 1 })
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBeNull()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://example.com")
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleImportCookieAuthSessionCookie()
+    })
+
+    expect(sendRuntimeMessage).toHaveBeenCalledWith({
+      action: RuntimeActionIds.AccountDialogImportCookieAuthSessionCookie,
+      url: "https://example.com",
+    })
     expect(toast.success).toHaveBeenCalledWith(
       "accountDialog:messages.importCookiesSuccess",
     )


### PR DESCRIPTION
## Summary
- Import cookies from the source tab when the account dialog opens from an incognito tab.
- Add focused background/runtime-message and account-dialog hook coverage.

## Test Plan
- pnpm exec vitest --run tests/entrypoints/background/runtimeMessages.test.ts tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
- git diff --check origin/main..HEAD
- git push pre-push validation: pnpm compile && pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable cookie import that preserves per-tab and incognito context and consolidates store-resolution logic.

* **Bug Fixes**
  * Improved fallback when cookie-store resolution fails so imports still proceed gracefully and stale tab detection is cleared.

* **Tests**
  * Expanded coverage for incognito, fallback, tab-context selection, and current-tab detection/cleanup scenarios.

* **Chores**
  * Updated CI coverage upload tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->