### PR TITLE
fix(cookie-auth): restore scoped 401 temp-window fallback

### DIFF
--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -386,8 +386,9 @@ export async function tempWindowGetRenderedTitle(params: {
   return await sendRuntimeMessage(payload)
 }
 
-const TEMP_WINDOW_FALLBACK_STATUS = new Set([403])
+const TEMP_WINDOW_FALLBACK_STATUS = new Set([401, 403])
 const TEMP_WINDOW_FALLBACK_CODES = new Set<ApiErrorCode>([
+  API_ERROR_CODES.HTTP_401,
   API_ERROR_CODES.HTTP_403,
   API_ERROR_CODES.CONTENT_TYPE_MISMATCH,
 ])
@@ -397,7 +398,7 @@ const TEMP_WINDOW_FALLBACK_CODES = new Set<ApiErrorCode>([
  * @param error The error thrown by the primary request, which may contain a `statusCode` and/or `code` property.
  * @param error.statusCode Optional HTTP status code from the failed request, if available.
  * @param error.code Optional API error code from the failed request, if available.
- * @param allowlist Optional allowlist of status codes and error codes that should trigger temp window fallback. When omitted, defaults to HTTP 403 and `CONTENT_TYPE_MISMATCH` (plus `HTTP_403`) allowlisting. When provided, it fully overrides defaults: omitted fields (e.g. `statusCodes` or `codes`) are treated as empty lists.
+ * @param allowlist Optional allowlist of status codes and error codes that should trigger temp window fallback. When omitted, defaults to HTTP 401/403 and `CONTENT_TYPE_MISMATCH` (plus `HTTP_401`/`HTTP_403`) allowlisting. When provided, it fully overrides defaults: omitted fields (e.g. `statusCodes` or `codes`) are treated as empty lists.
  */
 export function matchesTempWindowFallbackAllowlist(
   error: { statusCode?: number; code?: ApiErrorCode },

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -425,7 +425,6 @@ function isCookieAuthUnauthorizedFallback(
   error: ApiError,
   context: TempWindowFallbackContext,
 ): boolean {
-  if (context.tempWindowFallback) return false
   if (context.authType !== AuthTypeEnum.Cookie) return false
   if (!context.cookieAuthSessionCookie?.trim()) return false
 

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -23,6 +23,7 @@ import {
   TempWindowFallbackPreferences,
   userPreferences,
 } from "~/services/preferences/userPreferences"
+import { AuthTypeEnum } from "~/types"
 import {
   TEMP_WINDOW_HEALTH_STATUS_CODES,
   type TempWindowHealthStatusCode,
@@ -386,9 +387,8 @@ export async function tempWindowGetRenderedTitle(params: {
   return await sendRuntimeMessage(payload)
 }
 
-const TEMP_WINDOW_FALLBACK_STATUS = new Set([401, 403])
+const TEMP_WINDOW_FALLBACK_STATUS = new Set([403])
 const TEMP_WINDOW_FALLBACK_CODES = new Set<ApiErrorCode>([
-  API_ERROR_CODES.HTTP_401,
   API_ERROR_CODES.HTTP_403,
   API_ERROR_CODES.CONTENT_TYPE_MISMATCH,
 ])
@@ -398,7 +398,7 @@ const TEMP_WINDOW_FALLBACK_CODES = new Set<ApiErrorCode>([
  * @param error The error thrown by the primary request, which may contain a `statusCode` and/or `code` property.
  * @param error.statusCode Optional HTTP status code from the failed request, if available.
  * @param error.code Optional API error code from the failed request, if available.
- * @param allowlist Optional allowlist of status codes and error codes that should trigger temp window fallback. When omitted, defaults to HTTP 401/403 and `CONTENT_TYPE_MISMATCH` (plus `HTTP_401`/`HTTP_403`) allowlisting. When provided, it fully overrides defaults: omitted fields (e.g. `statusCodes` or `codes`) are treated as empty lists.
+ * @param allowlist Optional allowlist of status codes and error codes that should trigger temp window fallback. When omitted, defaults to HTTP 403 and `CONTENT_TYPE_MISMATCH` (plus `HTTP_403`) allowlisting. When provided, it fully overrides defaults: omitted fields (e.g. `statusCodes` or `codes`) are treated as empty lists.
  */
 export function matchesTempWindowFallbackAllowlist(
   error: { statusCode?: number; code?: ApiErrorCode },
@@ -416,6 +416,20 @@ export function matchesTempWindowFallbackAllowlist(
     !!error.statusCode && statusAllowlist.has(error.statusCode)
 
   return hasCodeFallback || hasStatusFallback
+}
+
+/**
+ * Allows 401 fallback only for cookie-auth requests that can replay a stored account cookie.
+ */
+function isCookieAuthUnauthorizedFallback(
+  error: ApiError,
+  context: TempWindowFallbackContext,
+): boolean {
+  if (context.tempWindowFallback) return false
+  if (context.authType !== AuthTypeEnum.Cookie) return false
+  if (!context.cookieAuthSessionCookie?.trim()) return false
+
+  return error.statusCode === 401 || error.code === API_ERROR_CODES.HTTP_401
 }
 
 /**
@@ -504,7 +518,10 @@ async function shouldUseTempWindowFallback(
     return false
   }
 
-  if (!matchesTempWindowFallbackAllowlist(error, context.tempWindowFallback)) {
+  if (
+    !matchesTempWindowFallbackAllowlist(error, context.tempWindowFallback) &&
+    !isCookieAuthUnauthorizedFallback(error, context)
+  ) {
     logSkipTempWindowFallback(
       "Error does not match any temp window fallback codes or statuses.",
       context,

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -423,6 +423,45 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
     expect(result).toBe("<html>challenge cleared</html>")
   })
 
+  it("falls back on 401 cookie-auth failures so stored account cookies can be replayed", async () => {
+    mocks.sendRuntimeMessageMock.mockResolvedValue({
+      success: true,
+      status: 200,
+      data: {
+        success: true,
+        data: { account: "stored-cookie" },
+        message: "ok",
+      },
+    })
+
+    const result = await executeWithTempWindowFallback(
+      buildContext({
+        onlyData: true,
+        accountId: "acct-1",
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "session=stored-account",
+      }),
+      async () => {
+        throw new ApiError(
+          "current browser session is unauthorized",
+          401,
+          "/api/models",
+          API_ERROR_CODES.HTTP_401,
+        )
+      },
+    )
+
+    expect(result).toEqual({ account: "stored-cookie" })
+    expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.TempWindowFetch,
+        accountId: "acct-1",
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "session=stored-account",
+      }),
+    )
+  })
+
   it("surfaces temp-window transport failures as ApiError with a fallback message", async () => {
     mocks.sendRuntimeMessageMock.mockResolvedValue({
       success: false,

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -462,6 +462,23 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
     )
   })
 
+  it("does not fall back on 401 token-auth failures", async () => {
+    const error = new ApiError(
+      "access token is unauthorized",
+      401,
+      "/api/models",
+      API_ERROR_CODES.HTTP_401,
+    )
+
+    await expect(
+      executeWithTempWindowFallback(buildContext(), async () => {
+        throw error
+      }),
+    ).rejects.toBe(error)
+
+    expect(mocks.sendRuntimeMessageMock).not.toHaveBeenCalled()
+  })
+
   it("surfaces temp-window transport failures as ApiError with a fallback message", async () => {
     mocks.sendRuntimeMessageMock.mockResolvedValue({
       success: false,

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -462,6 +462,49 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
     )
   })
 
+  it("falls back on 401 cookie-auth failures even when a request has a custom fallback allowlist", async () => {
+    mocks.sendRuntimeMessageMock.mockResolvedValue({
+      success: true,
+      status: 200,
+      data: {
+        success: true,
+        data: { account: "stored-cookie" },
+        message: "ok",
+      },
+    })
+
+    const result = await executeWithTempWindowFallback(
+      buildContext({
+        onlyData: true,
+        accountId: "acct-1",
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "session=stored-account",
+        tempWindowFallback: {
+          statusCodes: [429],
+          codes: [API_ERROR_CODES.HTTP_429],
+        },
+      }),
+      async () => {
+        throw new ApiError(
+          "current browser session is unauthorized",
+          401,
+          "/api/models",
+          API_ERROR_CODES.HTTP_401,
+        )
+      },
+    )
+
+    expect(result).toEqual({ account: "stored-cookie" })
+    expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.TempWindowFetch,
+        accountId: "acct-1",
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "session=stored-account",
+      }),
+    )
+  })
+
   it("does not fall back on 401 token-auth failures", async () => {
     const error = new ApiError(
       "access token is unauthorized",


### PR DESCRIPTION
## Summary
- Restore the 401 temp-window fallback for cookie-auth requests.
- Scope the fallback so non-auth 401 responses and incompatible request shapes do not retry through a temporary window.
- Add focused tempWindowFetch fallback coverage.

## Test Plan
- pnpm exec vitest --run tests/utils/tempWindowFetch.fallback.test.ts
- git diff --check origin/main..HEAD
- git push pre-push validation: pnpm compile && pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie-based authentication recovery: the app now more reliably falls back to a stored session cookie on 401 errors, reducing user-facing auth interruptions.
  * Smarter fallback decisions: fallback is only attempted for cookie-based sessions, while token-based failures continue to propagate for correct handling.
  * Added tests to validate both behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->