### PR TITLE
fix: Fix AIHubMix duplicate site detection

### DIFF
--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -42,7 +42,10 @@ import {
   AutoDetectError,
   AutoDetectErrorType,
 } from "~/services/accounts/utils/autoDetectUtils"
-import { normalizeAccountSiteUrlForOriginKey } from "~/services/accounts/utils/siteUrlNormalization"
+import {
+  isSameAccountSiteOrigin,
+  normalizeAccountSiteUrlForDuplicateCheck,
+} from "~/services/accounts/utils/siteUrlNormalization"
 import { getManagedSiteServiceForType } from "~/services/managedSites/managedSiteService"
 import {
   getManagedSiteConfigMissingMessage,
@@ -554,13 +557,18 @@ export function useAccountDialog({
       )
       return true
     }
-    const existingSiteAccounts = accounts.filter(
-      (acc) =>
-        normalizeSiteUrlForDuplicateCheck({
-          value: acc.site_url,
+    const existingSiteAccounts = accounts.filter((acc) => {
+      return isSameAccountSiteOrigin(
+        {
+          url: acc.site_url,
           siteType: acc.site_type,
-        }) === normalizedBaseUrl,
-    )
+        },
+        {
+          url: baseUrl,
+          siteType,
+        },
+      )
+    })
 
     if (existingSiteAccounts.length === 0) {
       return true
@@ -2538,10 +2546,12 @@ function normalizeSiteUrlForDuplicateCheck(params: {
   value: string
   siteType?: AccountSiteType | string
 }): string {
-  return normalizeAccountSiteUrlForOriginKey({
-    url: params.value,
-    siteType: params.siteType,
-  })
+  return (
+    normalizeAccountSiteUrlForDuplicateCheck({
+      url: params.value,
+      siteType: params.siteType,
+    }) ?? params.value.trim().toLowerCase()
+  )
 }
 
 /**

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -22,6 +22,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { isSameAccountSiteOrigin } from "~/services/accounts/utils/siteUrlNormalization"
 import { getDayKeyFromUnixSeconds } from "~/services/history/dailyBalanceHistory/dayKeys"
 import { dailyBalanceHistoryStorage } from "~/services/history/dailyBalanceHistory/storage"
 import {
@@ -58,7 +59,6 @@ import {
   onTabUpdated,
 } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
-import { tryParseOrigin } from "~/utils/core/urlParsing"
 
 /**
  * Unified logger scoped to account data context and refresh orchestration.
@@ -419,12 +419,16 @@ export const AccountDataProvider = ({
         return
       }
 
-      const origin = parsedUrl.origin
-
       // Site-level detection: find any stored accounts that belong to the same origin.
       // This answers "does this site already exist in the user's accounts?".
       const originAccounts = accountsRef.current.filter((account) => {
-        return tryParseOrigin(account.site_url) === origin
+        return isSameAccountSiteOrigin(
+          {
+            url: account.site_url,
+            siteType: account.site_type,
+          },
+          { url: tabUrl },
+        )
       })
       const siteTypeForUserRead =
         originAccounts.find(
@@ -485,7 +489,7 @@ export const AccountDataProvider = ({
           // Ask the content script to read the site's localStorage and return the current userId.
           const userResponse = await browser.tabs.sendMessage(tabId, {
             action: RuntimeActionIds.ContentGetUserFromLocalStorage,
-            url: origin,
+            url: parsedUrl.origin,
             siteType: siteTypeForUserRead,
           })
 
@@ -504,7 +508,7 @@ export const AccountDataProvider = ({
         } catch (error) {
           logger.debug("Failed to re-verify website user ID from active tab", {
             tabId,
-            origin,
+            origin: parsedUrl.origin,
             error,
           })
           verifiedUserId = null

--- a/src/services/accounts/accountDedupe.ts
+++ b/src/services/accounts/accountDedupe.ts
@@ -1,11 +1,6 @@
-import { SITE_TYPES } from "~/constants/siteType"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
-import {
-  isAIHubMixSiteUrl,
-  normalizeAccountSiteUrlForOriginKey,
-} from "~/services/accounts/utils/siteUrlNormalization"
+import { normalizeAccountSiteUrlForDuplicateCheck } from "~/services/accounts/utils/siteUrlNormalization"
 import type { SiteAccount } from "~/types"
-import { sanitizeOriginUrl } from "~/utils/core/url"
 
 export type AccountDedupeKeepStrategy =
   | "keepPinned"
@@ -150,14 +145,10 @@ export function scanDuplicateAccounts(input: {
   >()
 
   for (const account of input.accounts) {
-    const origin =
-      account.site_type === SITE_TYPES.AIHUBMIX ||
-      isAIHubMixSiteUrl(account.site_url)
-        ? normalizeAccountSiteUrlForOriginKey({
-            url: account.site_url,
-            siteType: account.site_type,
-          })
-        : sanitizeOriginUrl(account.site_url)
+    const origin = normalizeAccountSiteUrlForDuplicateCheck({
+      url: account.site_url,
+      siteType: account.site_type,
+    })
     const userId = normalizeAccountIdentity(account.account_info?.id)
 
     if (!origin || userId === null) {

--- a/src/services/accounts/utils/siteUrlNormalization.ts
+++ b/src/services/accounts/utils/siteUrlNormalization.ts
@@ -5,6 +5,7 @@ import {
   SITE_TYPES,
   type AccountSiteType,
 } from "~/constants/siteType"
+import { sanitizeOriginUrl } from "~/utils/core/url"
 import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
 
 const AIHUBMIX_HOSTNAME_SET: ReadonlySet<string> = new Set(AIHUBMIX_HOSTNAMES)
@@ -107,4 +108,45 @@ export function normalizeAccountSiteUrlForOriginKey(params: {
   }
 
   return normalizeUrlForOriginKey(params.url, { lowerCase: true })
+}
+
+/**
+ * Produces the scannable origin key used by duplicate-site detection.
+ */
+export function normalizeAccountSiteUrlForDuplicateCheck(params: {
+  siteType?: AccountSiteType | string
+  url: string
+}): string | undefined {
+  if (
+    params.siteType === SITE_TYPES.AIHUBMIX &&
+    (!params.url.trim() || isAIHubMixSiteUrl(params.url))
+  ) {
+    return AIHUBMIX_WEB_ORIGIN.toLowerCase()
+  }
+
+  if (isAIHubMixSiteUrl(params.url)) {
+    return AIHUBMIX_WEB_ORIGIN.toLowerCase()
+  }
+
+  return sanitizeOriginUrl(params.url)?.toLowerCase()
+}
+
+/**
+ * Compares account site URLs using the same canonical origin key used by
+ * duplicate-account scans and add-flow warnings.
+ */
+export function isSameAccountSiteOrigin(
+  left: {
+    siteType?: AccountSiteType | string
+    url: string
+  },
+  right: {
+    siteType?: AccountSiteType | string
+    url: string
+  },
+): boolean {
+  const leftKey = normalizeAccountSiteUrlForDuplicateCheck(left)
+  const rightKey = normalizeAccountSiteUrlForDuplicateCheck(right)
+
+  return Boolean(leftKey && rightKey && leftKey === rightKey)
 }

--- a/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
@@ -224,6 +224,64 @@ describe("AccountDataContext current tab detection", () => {
     expect(sendMessageSpy).toHaveBeenCalledTimes(1)
   })
 
+  it("matches AIHubMix current tab across main and console origins", async () => {
+    activeTabs = [{ id: 104, url: "https://aihubmix.com/statistics" }]
+
+    const aihubmixAccount = createAccount({
+      id: "acc-aihubmix",
+      baseUrl: "https://console.aihubmix.com",
+      userId: "aihubmix-user",
+      siteType: SITE_TYPES.AIHUBMIX,
+    })
+
+    mockResetExpiredCheckIns.mockResolvedValue(undefined)
+    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
+    mockGetAllAccounts.mockResolvedValue([aihubmixAccount])
+    mockGetAllBookmarks.mockResolvedValue([])
+    mockGetOrderedList.mockResolvedValue([])
+    mockGetPinnedList.mockResolvedValue([])
+    mockGetAccountStats.mockResolvedValue({
+      total_quota: 0,
+      today_total_consumption: 0,
+      today_total_requests: 0,
+      today_total_prompt_tokens: 0,
+      today_total_completion_tokens: 0,
+      today_total_income: 0,
+    })
+    mockConvertToDisplayData.mockReturnValue([{ id: "acc-aihubmix" }])
+
+    const sendMessageSpy = vi
+      .spyOn(browser.tabs, "sendMessage")
+      .mockResolvedValue({
+        success: true,
+        data: { userId: "aihubmix-user", user: { username: "aihubmix-user" } },
+      } as any)
+
+    let latestCtx: ReturnType<typeof useAccountDataContext> | null = null
+
+    render(
+      <I18nextProvider i18n={testI18n}>
+        <AccountDataProvider>
+          <ContextProbe onChange={(ctx) => (latestCtx = ctx)} />
+        </AccountDataProvider>
+      </I18nextProvider>,
+    )
+
+    await waitFor(() => {
+      expect(
+        latestCtx?.detectedSiteAccounts.map((account) => account.id),
+      ).toEqual(["acc-aihubmix"])
+      expect(latestCtx?.detectedAccount?.id).toBe("acc-aihubmix")
+    })
+
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      104,
+      expect.objectContaining({
+        siteType: SITE_TYPES.AIHUBMIX,
+      }),
+    )
+  })
+
   it("normalizes string identities from current-tab user verification before matching", async () => {
     activeTabs = [{ id: 102, url: "https://foo.example.com/dashboard" }]
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.duplicateAccountWarning.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.duplicateAccountWarning.test.tsx
@@ -279,6 +279,41 @@ describe("useAccountDialog duplicate account warning", () => {
     )
   })
 
+  it("warns for AIHubMix duplicates before the add draft site type is selected", async () => {
+    await accountStorage.addAccount(
+      buildSiteAccount({
+        site_name: "AIHubMix Existing",
+        site_url: "https://console.aihubmix.com",
+        site_type: SITE_TYPES.AIHUBMIX,
+        account_info: {
+          ...defaultAccountInfo,
+          id: "11",
+          username: "aihubmix-user",
+        },
+      }),
+    )
+
+    const { result } = await renderDuplicateWarningHook()
+
+    await act(async () => {
+      result.current.handlers.handleUrlChange("https://aihubmix.com")
+      result.current.setters.setUserId("11")
+    })
+
+    act(() => {
+      void result.current.handlers.handleShowManualForm()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.duplicateAccountWarning).toMatchObject({
+        isOpen: true,
+        siteUrl: "https://console.aihubmix.com",
+        existingUserId: "11",
+        existingUsername: "aihubmix-user",
+      })
+    })
+  })
+
   it("normalizes duplicate warning account identities before exact-match detection", async () => {
     await accountStorage.addAccount(
       buildSiteAccount({

--- a/tests/services/accounts/siteUrlNormalization.test.ts
+++ b/tests/services/accounts/siteUrlNormalization.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   isAIHubMixSiteUrl,
+  isSameAccountSiteOrigin,
+  normalizeAccountSiteUrlForDuplicateCheck,
   normalizeAccountSiteUrlForManagedChannel,
   normalizeAccountSiteUrlForOriginKey,
   normalizeAccountSiteUrlForStorage,
@@ -46,6 +48,33 @@ describe("siteUrlNormalization", () => {
         url: "https://www.aihubmix.com/statistics",
       }),
     ).toBe("https://aihubmix.com")
+  })
+
+  it("matches AIHubMix account-site origins across main and console hostnames", () => {
+    expect(
+      isSameAccountSiteOrigin(
+        {
+          siteType: SITE_TYPES.AIHUBMIX,
+          url: "https://console.aihubmix.com/dashboard",
+        },
+        {
+          url: "https://aihubmix.com/statistics?tab=detail",
+        },
+      ),
+    ).toBe(true)
+  })
+
+  it("keeps duplicate-check keys scannable and rejects invalid URLs", () => {
+    expect(
+      normalizeAccountSiteUrlForDuplicateCheck({
+        url: "example.com/path",
+      }),
+    ).toBe("https://example.com")
+    expect(
+      normalizeAccountSiteUrlForDuplicateCheck({
+        url: "not a valid url",
+      }),
+    ).toBeUndefined()
   })
 
   it("preserves non-AIHubMix storage URLs and origin keys", () => {


### PR DESCRIPTION
## Summary
- Centralize duplicate-site origin normalization for account duplicate checks.
- Treat AIHubMix main, www, and console hostnames as the same account site for add warnings and current-site detection.
- Reuse the helper in account dedupe without changing invalid URL handling.

## Test Plan
- pnpm exec vitest run tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
- pnpm exec vitest run tests/features/AccountManagement/hooks/useAccountDialog.duplicateAccountWarning.test.tsx
- pnpm exec vitest run tests/services/accounts/siteUrlNormalization.test.ts tests/services/accountDedupe.test.ts
- pnpm compile
- pnpm run validate:staged
- git push pre-push hook: pnpm compile && pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account duplicate detection to prevent false positives
  * Fixed AIHubMix account detection across multiple domains

<!-- end of auto-generated comment: release notes by coderabbit.ai -->