### PR TITLE
fix(content): initialize i18n for content UI

### DIFF
--- a/src/entrypoints/content/index.ts
+++ b/src/entrypoints/content/index.ts
@@ -12,6 +12,7 @@ import {
   type ContentFeaturePreferenceSource,
 } from "~/services/preferences/contentScriptFeatureDefaults"
 import { createLogger } from "~/utils/core/logger"
+import { ensureContentI18nReady } from "~/utils/i18n/content"
 
 import { setupContentMessageHandlers } from "./messageHandlers"
 import { setContentScriptContext } from "./shared/uiRoot"
@@ -76,6 +77,10 @@ export default defineContentScript({
  */
 function mainLogic() {
   logger.debug("Hello content script", { id: browser.runtime.id })
+
+  void ensureContentI18nReady().catch((error) => {
+    logger.warn("Content i18n initialization failed", error)
+  })
 
   setupContentMessageHandlers()
   return setupContentFeatureControllers()

--- a/src/entrypoints/content/shared/ContentReactRoot.tsx
+++ b/src/entrypoints/content/shared/ContentReactRoot.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react"
 
-import "~/utils/i18n"
 import "~/styles/style.css"
 
 import { ApiCheckModalHost } from "~/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost"

--- a/src/entrypoints/content/shared/uiRoot.ts
+++ b/src/entrypoints/content/shared/uiRoot.ts
@@ -4,6 +4,7 @@ import { createShadowRootUi } from "wxt/utils/content-script-ui/shadow-root"
 
 import { CONTENT_UI_HOST_TAG } from "~/entrypoints/content/shared/contentUi"
 import { createLogger } from "~/utils/core/logger"
+import { ensureContentI18nReady } from "~/utils/i18n/content"
 
 /**
  * Unified logger scoped to mounting the content-script redemption assist UI root.
@@ -59,6 +60,7 @@ export async function ensureRedemptionToastUi(): Promise<void> {
   }
 
   mountingPromise = (async () => {
+    await ensureContentI18nReady()
     const { createElement, ContentReactRoot } = await loadContentUiModules()
 
     const ui = await createShadowRootUi(ctxRef as ContentScriptContext, {

--- a/src/utils/i18n/content.ts
+++ b/src/utils/i18n/content.ts
@@ -1,0 +1,64 @@
+import dayjs from "dayjs"
+
+import "dayjs/locale/ja"
+import "dayjs/locale/vi"
+import "dayjs/locale/zh-cn"
+import "dayjs/locale/zh-tw"
+
+import { initReactI18next } from "react-i18next"
+
+import { DEFAULT_LANG } from "~/constants"
+import { userPreferences } from "~/services/preferences/userPreferences"
+
+import { applyPreferenceLanguage } from "./applyPreferenceLanguage"
+import i18n from "./core"
+import { resolveInitialAppLanguage } from "./language"
+import { mapToDayjsLocale, resources } from "./resources"
+
+let contentI18nReadyPromise: Promise<void> | null = null
+let contentI18nInitialized = false
+
+/**
+ * Initializes i18n for content scripts without reading host-page storage.
+ */
+async function initContentI18n() {
+  await i18n.use(initReactI18next).init({
+    resources,
+    fallbackLng: DEFAULT_LANG,
+    defaultNS: "common",
+    interpolation: { escapeValue: false },
+    returnEmptyString: false,
+    react: { useSuspense: false },
+  })
+
+  const storedLanguage = await userPreferences.getLanguage()
+  const initialLanguage = resolveInitialAppLanguage({
+    userPreferenceLanguage: storedLanguage,
+    detectedLanguage:
+      typeof navigator !== "undefined" ? navigator.language : undefined,
+  })
+
+  await i18n.changeLanguage(initialLanguage)
+  dayjs.locale(mapToDayjsLocale(initialLanguage))
+  contentI18nInitialized = true
+}
+
+/**
+ * Waits for content i18n initialization and refreshes the current preference.
+ */
+export async function ensureContentI18nReady() {
+  const shouldRefreshLanguage = contentI18nInitialized
+
+  if (!contentI18nReadyPromise) {
+    contentI18nReadyPromise = initContentI18n()
+  }
+
+  await contentI18nReadyPromise
+  if (shouldRefreshLanguage) {
+    await applyPreferenceLanguage(await userPreferences.getLanguage())
+  }
+}
+
+i18n.on("languageChanged", (lng) => {
+  dayjs.locale(mapToDayjsLocale(lng))
+})

--- a/src/utils/i18n/content.ts
+++ b/src/utils/i18n/content.ts
@@ -50,7 +50,10 @@ export async function ensureContentI18nReady() {
   const shouldRefreshLanguage = contentI18nInitialized
 
   if (!contentI18nReadyPromise) {
-    contentI18nReadyPromise = initContentI18n()
+    contentI18nReadyPromise = initContentI18n().catch((error) => {
+      contentI18nReadyPromise = null
+      throw error
+    })
   }
 
   await contentI18nReadyPromise

--- a/tests/entrypoints/content/index.test.ts
+++ b/tests/entrypoints/content/index.test.ts
@@ -8,6 +8,7 @@ const setupRedemptionAssistContentMock = vi.fn()
 const setupWebAiApiCheckContentMock = vi.fn()
 const setupContentMessageHandlersMock = vi.fn()
 const setContentScriptContextMock = vi.fn()
+const ensureContentI18nReadyMock = vi.fn()
 const logger = {
   debug: vi.fn(),
   warn: vi.fn(),
@@ -43,6 +44,10 @@ vi.mock("~/entrypoints/content/shared/uiRoot", () => ({
   setContentScriptContext: setContentScriptContextMock,
 }))
 
+vi.mock("~/utils/i18n/content", () => ({
+  ensureContentI18nReady: ensureContentI18nReadyMock,
+}))
+
 vi.mock("~/utils/core/logger", () => ({
   createLogger: vi.fn(() => logger),
 }))
@@ -59,6 +64,8 @@ describe("content entrypoint", () => {
     setupWebAiApiCheckContentMock.mockReset()
     setupContentMessageHandlersMock.mockReset()
     setContentScriptContextMock.mockReset()
+    ensureContentI18nReadyMock.mockReset()
+    ensureContentI18nReadyMock.mockResolvedValue(undefined)
     logger.debug.mockReset()
     logger.warn.mockReset()
 
@@ -130,6 +137,7 @@ describe("content entrypoint", () => {
     await module.default.main(ctx)
 
     expect(setContentScriptContextMock).toHaveBeenCalledWith(ctx)
+    expect(ensureContentI18nReadyMock).toHaveBeenCalledTimes(1)
     expect(setupContentMessageHandlersMock).toHaveBeenCalledTimes(1)
     expect(onInvalidated).toHaveBeenCalledTimes(1)
 

--- a/tests/entrypoints/content/index.test.ts
+++ b/tests/entrypoints/content/index.test.ts
@@ -246,6 +246,42 @@ describe("content entrypoint", () => {
     expect(apiCheckCleanup).toHaveBeenCalledTimes(1)
   })
 
+  it("logs and continues when content i18n initialization fails", async () => {
+    const initError = new Error("i18n unavailable")
+
+    ensureContentI18nReadyMock.mockRejectedValueOnce(initError)
+    setupRedemptionAssistContentMock.mockReturnValue(vi.fn())
+    setupWebAiApiCheckContentMock.mockReturnValue(vi.fn())
+    storageGetMock.mockResolvedValueOnce({
+      redemptionAssist: {
+        enabled: true,
+        contextMenu: { enabled: true },
+      },
+      webAiApiCheck: {
+        enabled: true,
+        contextMenu: { enabled: true },
+        autoDetect: { enabled: true },
+      },
+    })
+
+    const module = await import("~/entrypoints/content/index")
+    const onInvalidated = vi.fn()
+
+    await module.default.main({ onInvalidated } as any)
+
+    await waitFor(() => {
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Content i18n initialization failed",
+        initError,
+      )
+    })
+    expect(setupContentMessageHandlersMock).toHaveBeenCalledTimes(1)
+    expect(setupRedemptionAssistContentMock).toHaveBeenCalledTimes(1)
+    expect(setupWebAiApiCheckContentMock).toHaveBeenCalledTimes(1)
+
+    onInvalidated.mock.calls[0]?.[0]()
+  })
+
   it("ignores unrelated local storage changes that do not include user preferences", async () => {
     const preferences = {
       redemptionAssist: {

--- a/tests/entrypoints/content/shared/uiRoot.test.tsx
+++ b/tests/entrypoints/content/shared/uiRoot.test.tsx
@@ -8,11 +8,13 @@ const {
   createRootMock,
   createShadowRootUiMock,
   loggerWarnMock,
+  ensureContentI18nReadyMock,
   mockContentReactRoot,
 } = vi.hoisted(() => ({
   createRootMock: vi.fn(),
   createShadowRootUiMock: vi.fn(),
   loggerWarnMock: vi.fn(),
+  ensureContentI18nReadyMock: vi.fn(),
   mockContentReactRoot: vi.fn(() => null),
 }))
 
@@ -34,6 +36,10 @@ vi.mock("~/utils/core/logger", () => ({
   }),
 }))
 
+vi.mock("~/utils/i18n/content", () => ({
+  ensureContentI18nReady: ensureContentI18nReadyMock,
+}))
+
 vi.mock("~/entrypoints/content/shared/ContentReactRoot", () => ({
   ContentReactRoot: mockContentReactRoot,
 }))
@@ -42,6 +48,7 @@ describe("uiRoot", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.resetAllMocks()
+    ensureContentI18nReadyMock.mockResolvedValue(undefined)
   })
 
   it("warns and does not try to mount when the content-script context has not been set", async () => {
@@ -56,6 +63,39 @@ describe("uiRoot", () => {
     )
     expect(createShadowRootUiMock).not.toHaveBeenCalled()
     expect(createRootMock).not.toHaveBeenCalled()
+  })
+
+  it("waits for persisted UI language readiness before rendering the shared content UI", async () => {
+    const container = document.createElement("div")
+    const root = {
+      render: vi.fn(),
+      unmount: vi.fn(),
+    }
+    const mountMock = vi.fn()
+
+    createRootMock.mockReturnValue(root)
+    createShadowRootUiMock.mockImplementation(async (_ctx, options) => {
+      mountMock.mockImplementation(() => {
+        options.onMount(container)
+      })
+      return {
+        mount: mountMock,
+      }
+    })
+
+    const { ensureRedemptionToastUi, setContentScriptContext } = await import(
+      "~/entrypoints/content/shared/uiRoot"
+    )
+
+    setContentScriptContext({ contentScript: "ctx" } as any)
+
+    await ensureRedemptionToastUi()
+
+    expect(ensureContentI18nReadyMock).toHaveBeenCalledTimes(1)
+    expect(ensureContentI18nReadyMock.mock.invocationCallOrder[0]).toBeLessThan(
+      createShadowRootUiMock.mock.invocationCallOrder[0],
+    )
+    expect(root.render).toHaveBeenCalledTimes(1)
   })
 
   it("mounts the shared content UI once, skips repeat mounts while active, and remounts after removal", async () => {

--- a/tests/utils/i18nContent.test.ts
+++ b/tests/utils/i18nContent.test.ts
@@ -1,0 +1,120 @@
+import dayjs from "dayjs"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  i18nCoreMock,
+  getLanguageMock,
+  reactI18nextPlugin,
+  resolveInitialAppLanguageMock,
+  mapToDayjsLocaleMock,
+} = vi.hoisted(() => ({
+  i18nCoreMock: {
+    use: vi.fn(),
+    init: vi.fn(),
+    changeLanguage: vi.fn(),
+    on: vi.fn(),
+    resolvedLanguage: "en" as string | undefined,
+    language: "en",
+  },
+  getLanguageMock: vi.fn(),
+  reactI18nextPlugin: { type: "3rdParty" },
+  resolveInitialAppLanguageMock: vi.fn(),
+  mapToDayjsLocaleMock: vi.fn(),
+}))
+
+vi.mock("~/utils/i18n/core", () => ({
+  default: i18nCoreMock,
+}))
+
+vi.mock("~/services/preferences/userPreferences", () => ({
+  userPreferences: {
+    getLanguage: getLanguageMock,
+  },
+}))
+
+vi.mock("~/utils/i18n/language", () => ({
+  normalizeAppLanguage: (language?: string | null) => {
+    const normalized = language?.trim().toLowerCase()
+    if (normalized?.startsWith("en")) return "en"
+    if (normalized?.startsWith("ja")) return "ja"
+    if (normalized?.startsWith("zh-tw")) return "zh-TW"
+    if (normalized?.startsWith("zh")) return "zh-CN"
+    return undefined
+  },
+  resolveInitialAppLanguage: resolveInitialAppLanguageMock,
+}))
+
+vi.mock("~/utils/i18n/resources", () => ({
+  mapToDayjsLocale: mapToDayjsLocaleMock,
+  resources: { en: { common: { hello: "Hello" } } },
+}))
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: reactI18nextPlugin,
+}))
+
+describe("content i18n initialization", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    i18nCoreMock.use.mockReset()
+    i18nCoreMock.use.mockImplementation(() => i18nCoreMock)
+    i18nCoreMock.init.mockReset()
+    i18nCoreMock.changeLanguage.mockReset()
+    i18nCoreMock.on.mockReset()
+    i18nCoreMock.resolvedLanguage = "en"
+    i18nCoreMock.language = "en"
+    getLanguageMock.mockReset()
+    resolveInitialAppLanguageMock.mockReset()
+    mapToDayjsLocaleMock.mockReset()
+    mapToDayjsLocaleMock.mockImplementation((language: string) =>
+      language.toLowerCase(),
+    )
+  })
+
+  it("initializes without app-page language detection and resolves from extension preferences", async () => {
+    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
+    getLanguageMock.mockResolvedValueOnce("ja")
+    resolveInitialAppLanguageMock.mockReturnValueOnce("ja")
+
+    const { ensureContentI18nReady } = await import("~/utils/i18n/content")
+
+    await ensureContentI18nReady()
+
+    expect(i18nCoreMock.use).toHaveBeenCalledTimes(1)
+    expect(i18nCoreMock.use).toHaveBeenCalledWith(reactI18nextPlugin)
+    expect(i18nCoreMock.init).toHaveBeenCalledWith({
+      resources: { en: { common: { hello: "Hello" } } },
+      fallbackLng: "zh-CN",
+      defaultNS: "common",
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+      react: { useSuspense: false },
+    })
+    expect(resolveInitialAppLanguageMock).toHaveBeenCalledWith({
+      userPreferenceLanguage: "ja",
+      detectedLanguage:
+        typeof navigator !== "undefined" ? navigator.language : undefined,
+    })
+    expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
+    expect(localeSpy).toHaveBeenCalledWith("ja")
+
+    localeSpy.mockRestore()
+  })
+
+  it("refreshes persisted language on later readiness calls for already-injected content scripts", async () => {
+    getLanguageMock.mockResolvedValueOnce("zh-CN").mockResolvedValueOnce("en")
+    resolveInitialAppLanguageMock.mockReturnValueOnce("zh-CN")
+    i18nCoreMock.changeLanguage.mockImplementation(async (language: string) => {
+      i18nCoreMock.resolvedLanguage = language
+      i18nCoreMock.language = language
+    })
+
+    const { ensureContentI18nReady } = await import("~/utils/i18n/content")
+
+    await ensureContentI18nReady()
+    await ensureContentI18nReady()
+
+    expect(getLanguageMock).toHaveBeenCalledTimes(2)
+    expect(i18nCoreMock.changeLanguage).toHaveBeenLastCalledWith("en")
+  })
+})

--- a/tests/utils/i18nContent.test.ts
+++ b/tests/utils/i18nContent.test.ts
@@ -117,4 +117,38 @@ describe("content i18n initialization", () => {
     expect(getLanguageMock).toHaveBeenCalledTimes(2)
     expect(i18nCoreMock.changeLanguage).toHaveBeenLastCalledWith("en")
   })
+
+  it("retries initialization after a failed attempt", async () => {
+    const initError = new Error("init failed")
+    i18nCoreMock.init
+      .mockRejectedValueOnce(initError)
+      .mockResolvedValueOnce(undefined)
+    getLanguageMock.mockResolvedValueOnce("ja")
+    resolveInitialAppLanguageMock.mockReturnValueOnce("ja")
+
+    const { ensureContentI18nReady } = await import("~/utils/i18n/content")
+
+    await expect(ensureContentI18nReady()).rejects.toThrow(initError)
+    await ensureContentI18nReady()
+
+    expect(i18nCoreMock.init).toHaveBeenCalledTimes(2)
+    expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
+  })
+
+  it("keeps dayjs locale aligned with later i18n language changes", async () => {
+    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
+
+    await import("~/utils/i18n/content")
+
+    const languageChangedHandler = i18nCoreMock.on.mock.calls.find(
+      ([eventName]) => eventName === "languageChanged",
+    )?.[1]
+    expect(languageChangedHandler).toBeTypeOf("function")
+
+    languageChangedHandler("zh-TW")
+
+    expect(localeSpy).toHaveBeenCalledWith("zh-tw")
+
+    localeSpy.mockRestore()
+  })
 })


### PR DESCRIPTION
## Summary
- add a content-script-specific i18n initializer that avoids host-page browser language detection
- register react-i18next for content React UI so translated content does not fall back to raw keys
- initialize content i18n at content entry startup and wait for it before mounting the shared content UI root

## Validation
- pnpm exec vitest --run tests/utils/i18nContent.test.ts tests/utils/i18nIndex.test.ts tests/entrypoints/content/index.test.ts tests/entrypoints/content/shared/uiRoot.test.tsx tests/entrypoints/content/shared/ContentReactRoot.test.tsx tests/entrypoints/content/shieldBypassAssist/shieldBypassToasts.test.tsx
- pnpm run validate:staged
- pre-push hook: pnpm compile && pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content UI now initializes localized resources on startup so interfaces respect stored language preferences.
  * The in-page UI waits for language readiness before rendering, ensuring correct locale and date formatting.

* **Bug Fixes**
  * Initialization failures are handled gracefully with warnings while UI setup continues.

* **Tests**
  * Added tests validating i18n readiness, retry behavior, language synchronization, and startup ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->