### PR TITLE
fix: Fix account dialog current-tab title prefill

### DIFF
--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -337,6 +337,7 @@ export function useAccountDialog({
   const sub2apiUseRefreshToken = draft.sub2apiUseRefreshToken
   const sub2apiRefreshToken = draft.sub2apiRefreshToken
   const sub2apiTokenExpiresAt = draft.sub2apiTokenExpiresAt
+  // Keep URL state readable inside async tab-detection guards without rerendering.
   selectedSiteUrlRef.current = url
   const isDetected =
     phase === ACCOUNT_DIALOG_PHASES.ACCOUNT_FORM &&
@@ -705,6 +706,7 @@ export function useAccountDialog({
   const detectSlowHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
+  const currentTabDetectionRunRef = useRef(0)
   const detectedCookieStoreIdRef = useRef<string | null>(null)
   const currentTabCookieImportContextRef =
     useRef<CurrentTabCookieImportContext | null>(null)
@@ -934,10 +936,17 @@ export function useAccountDialog({
     if (mode === DIALOG_MODES.EDIT && account) {
       return
     }
+    const runId = currentTabDetectionRunRef.current + 1
+    currentTabDetectionRunRef.current = runId
+    const isCurrentDetectionRun = () =>
+      currentTabDetectionRunRef.current === runId
     const clearCurrentTabDetection = () => {
+      if (!isCurrentDetectionRun()) return
+
       currentTabCookieImportContextRef.current = null
       currentTabSiteNameRef.current = ""
       setCurrentTabUrl(null)
+      // Preserve a user-selected or typed site name when the URL field is already owned by the user.
       if (!selectedSiteUrlRef.current.trim()) {
         setSiteName("")
       }
@@ -962,6 +971,8 @@ export function useAccountDialog({
             createCurrentTabCookieImportContext(tab, baseUrl)
           setCurrentTabUrl(baseUrl)
           const resolvedSiteName = await getSiteName(tab)
+          if (!isCurrentDetectionRun()) return
+
           currentTabSiteNameRef.current = resolvedSiteName
           if (canApplyCurrentTabTitle()) {
             setSiteName(resolvedSiteName)
@@ -990,6 +1001,8 @@ export function useAccountDialog({
               createCurrentTabCookieImportContext(tab, baseUrl)
             setCurrentTabUrl(baseUrl)
             const resolvedSiteName = await getSiteName(tab)
+            if (!isCurrentDetectionRun()) return
+
             currentTabSiteNameRef.current = resolvedSiteName
             if (canApplyCurrentTabTitle()) {
               setSiteName(resolvedSiteName)

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -316,6 +316,8 @@ export function useAccountDialog({
   const duplicateAccountWarningAcknowledgedSiteUrlRef = useRef<string | null>(
     null,
   )
+  const selectedSiteUrlRef = useRef("")
+  const currentTabSiteNameRef = useRef("")
   const hasConsumedAutoFillCurrentSiteUrlRef = useRef(false)
   const hasExplicitAuthTypeRef = useRef(false)
   const siteName = draft.siteName
@@ -335,6 +337,7 @@ export function useAccountDialog({
   const sub2apiUseRefreshToken = draft.sub2apiUseRefreshToken
   const sub2apiRefreshToken = draft.sub2apiRefreshToken
   const sub2apiTokenExpiresAt = draft.sub2apiTokenExpiresAt
+  selectedSiteUrlRef.current = url
   const isDetected =
     phase === ACCOUNT_DIALOG_PHASES.ACCOUNT_FORM &&
     formSource === ACCOUNT_DIALOG_FORM_SOURCES.DETECTED
@@ -821,6 +824,7 @@ export function useAccountDialog({
       newAccountRef.current = null
       detectedCookieStoreIdRef.current = null
       currentTabCookieImportContextRef.current = null
+      currentTabSiteNameRef.current = ""
       duplicateAccountWarningAcknowledgedSiteUrlRef.current = null
       hasConsumedAutoFillCurrentSiteUrlRef.current = Boolean(nextPrefill)
       const normalizedPrefillAuthType = normalizeOptionalAccountAuthType(
@@ -932,9 +936,13 @@ export function useAccountDialog({
     }
     const clearCurrentTabDetection = () => {
       currentTabCookieImportContextRef.current = null
+      currentTabSiteNameRef.current = ""
       setCurrentTabUrl(null)
-      setSiteName("")
+      if (!selectedSiteUrlRef.current.trim()) {
+        setSiteName("")
+      }
     }
+    const canApplyCurrentTabTitle = () => !selectedSiteUrlRef.current.trim()
 
     try {
       const tabs = await browser.tabs.query({
@@ -953,7 +961,11 @@ export function useAccountDialog({
           currentTabCookieImportContextRef.current =
             createCurrentTabCookieImportContext(tab, baseUrl)
           setCurrentTabUrl(baseUrl)
-          setSiteName(await getSiteName(tab))
+          const resolvedSiteName = await getSiteName(tab)
+          currentTabSiteNameRef.current = resolvedSiteName
+          if (canApplyCurrentTabTitle()) {
+            setSiteName(resolvedSiteName)
+          }
         } catch (error) {
           logger.warn("Failed to parse current tab URL", {
             error,
@@ -977,7 +989,11 @@ export function useAccountDialog({
             currentTabCookieImportContextRef.current =
               createCurrentTabCookieImportContext(tab, baseUrl)
             setCurrentTabUrl(baseUrl)
-            setSiteName(await getSiteName(tab))
+            const resolvedSiteName = await getSiteName(tab)
+            currentTabSiteNameRef.current = resolvedSiteName
+            if (canApplyCurrentTabTitle()) {
+              setSiteName(resolvedSiteName)
+            }
           } else {
             clearCurrentTabDetection()
           }
@@ -1116,6 +1132,9 @@ export function useAccountDialog({
   const handleUseCurrentTabUrl = () => {
     if (currentTabUrl) {
       handleUrlChange(currentTabUrl)
+      if (currentTabSiteNameRef.current.trim()) {
+        setSiteName(currentTabSiteNameRef.current)
+      }
     }
   }
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
@@ -8,6 +8,15 @@ import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
 const originalBrowser = globalThis.browser
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return { promise, resolve }
+}
+
 const {
   mockGetSiteName,
   mockGetActiveTabs,
@@ -792,5 +801,195 @@ describe("useAccountDialog current tab detection", () => {
       )
       expect(result.current.state.siteName).toBe("Detected Site")
     })
+  })
+
+  it("ignores stale current-tab title resolutions after a newer active-tab detection wins", async () => {
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    let activeTab = {
+      id: 20,
+      url: "https://initial.example.com/path",
+    }
+    tabsQueryMock.mockImplementation(async () => [activeTab])
+
+    let activatedListener: (() => void | Promise<void>) | undefined
+    onTabActivatedMock.mockImplementation((listener) => {
+      activatedListener = listener
+      return () => {}
+    })
+
+    const slowTitle = createDeferred<string>()
+    const fastTitle = createDeferred<string>()
+    mockGetSiteName.mockImplementation((tab: browser.tabs.Tab) => {
+      if (tab.id === 21) return slowTitle.promise
+      if (tab.id === 22) return fastTitle.promise
+
+      return Promise.resolve("Initial Site")
+    })
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://initial.example.com",
+      )
+      expect(result.current.state.siteName).toBe("Initial Site")
+    })
+
+    activeTab = {
+      id: 21,
+      url: "https://slow.example.com/path",
+    }
+    act(() => {
+      void activatedListener?.()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://slow.example.com",
+      )
+    })
+
+    activeTab = {
+      id: 22,
+      url: "https://fast.example.com/path",
+    }
+    act(() => {
+      void activatedListener?.()
+    })
+
+    await act(async () => {
+      fastTitle.resolve("Fast Site")
+      await fastTitle.promise
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://fast.example.com",
+      )
+      expect(result.current.state.siteName).toBe("Fast Site")
+    })
+
+    await act(async () => {
+      slowTitle.resolve("Slow Site")
+      await slowTitle.promise
+    })
+
+    expect(result.current.state.currentTabUrl).toBe("https://fast.example.com")
+    expect(result.current.state.siteName).toBe("Fast Site")
+
+    await act(async () => {
+      result.current.handlers.handleUseCurrentTabUrl()
+    })
+
+    expect(result.current.state.url).toBe("https://fast.example.com")
+    expect(result.current.state.siteName).toBe("Fast Site")
+  })
+
+  it("ignores stale fallback active-tab title resolutions after a newer detection wins", async () => {
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    let activeTab = {
+      id: 23,
+      url: "https://fallback-initial.example.com/path",
+    }
+    tabsQueryMock.mockImplementation(async (queryInfo) => {
+      if (queryInfo?.currentWindow) {
+        throw new Error("currentWindow unsupported")
+      }
+
+      return [activeTab]
+    })
+
+    let activatedListener: (() => void | Promise<void>) | undefined
+    onTabActivatedMock.mockImplementation((listener) => {
+      activatedListener = listener
+      return () => {}
+    })
+
+    const slowTitle = createDeferred<string>()
+    const fastTitle = createDeferred<string>()
+    mockGetSiteName.mockImplementation((tab: browser.tabs.Tab) => {
+      if (tab.id === 24) return slowTitle.promise
+      if (tab.id === 25) return fastTitle.promise
+
+      return Promise.resolve("Fallback Initial Site")
+    })
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://fallback-initial.example.com",
+      )
+      expect(result.current.state.siteName).toBe("Fallback Initial Site")
+    })
+
+    activeTab = {
+      id: 24,
+      url: "https://fallback-slow.example.com/path",
+    }
+    act(() => {
+      void activatedListener?.()
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://fallback-slow.example.com",
+      )
+    })
+
+    activeTab = {
+      id: 25,
+      url: "https://fallback-fast.example.com/path",
+    }
+    act(() => {
+      void activatedListener?.()
+    })
+
+    await act(async () => {
+      fastTitle.resolve("Fallback Fast Site")
+      await fastTitle.promise
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://fallback-fast.example.com",
+      )
+      expect(result.current.state.siteName).toBe("Fallback Fast Site")
+    })
+
+    await act(async () => {
+      slowTitle.resolve("Fallback Slow Site")
+      await slowTitle.promise
+    })
+
+    expect(result.current.state.currentTabUrl).toBe(
+      "https://fallback-fast.example.com",
+    )
+    expect(result.current.state.siteName).toBe("Fallback Fast Site")
+
+    await act(async () => {
+      result.current.handlers.handleUseCurrentTabUrl()
+    })
+
+    expect(result.current.state.url).toBe("https://fallback-fast.example.com")
+    expect(result.current.state.siteName).toBe("Fallback Fast Site")
   })
 })

--- a/tests/features/AccountManagement/hooks/useAccountDialog.sponsorPrefill.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.sponsorPrefill.test.tsx
@@ -10,13 +10,19 @@ import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
 const originalBrowser = globalThis.browser
 
-const { mockGetActiveTabs, onTabActivatedMock, onTabUpdatedMock } = vi.hoisted(
-  () => ({
-    mockGetActiveTabs: vi.fn(),
-    onTabActivatedMock: vi.fn(),
-    onTabUpdatedMock: vi.fn(),
-  }),
-)
+const {
+  mockGetActiveTabs,
+  onTabActivatedMock,
+  onTabUpdatedMock,
+  tabActivatedCallbacks,
+} = vi.hoisted(() => ({
+  mockGetActiveTabs: vi.fn(),
+  onTabActivatedMock: vi.fn(),
+  onTabUpdatedMock: vi.fn(),
+  tabActivatedCallbacks: [] as Array<
+    (activeInfo: browser.tabs._OnActivatedActiveInfo) => void
+  >,
+}))
 
 vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
@@ -78,8 +84,73 @@ describe("useAccountDialog sponsor prefill", () => {
       },
     }
     mockGetActiveTabs.mockResolvedValue([])
-    onTabActivatedMock.mockImplementation(() => () => {})
+    tabActivatedCallbacks.splice(0, tabActivatedCallbacks.length)
+    onTabActivatedMock.mockImplementation((callback) => {
+      tabActivatedCallbacks.push(callback)
+      return () => {}
+    })
     onTabUpdatedMock.mockImplementation(() => () => {})
+  })
+
+  it("keeps the current-site prompt live while binding title updates to the selected URL", async () => {
+    const activeTabs = [
+      {
+        id: 1,
+        title: "Current Provider Loading",
+        url: "https://current.example.com/path",
+      },
+      {
+        id: 2,
+        title: "Current Provider Ready",
+        url: "https://current.example.com/dashboard",
+      },
+      {
+        id: 3,
+        title: "Other Provider",
+        url: "https://other.example.com/path",
+      },
+    ] as browser.tabs.Tab[]
+
+    ;(globalThis as any).browser.tabs.query = vi.fn(async () => [activeTabs[0]])
+
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://current.example.com",
+      )
+      expect(result.current.state.siteName).toBe("Current Provider Loading")
+    })
+    ;(globalThis as any).browser.tabs.query = vi.fn(async () => [activeTabs[1]])
+
+    await act(async () => {
+      tabActivatedCallbacks[0]?.({ tabId: 2, windowId: 1 })
+    })
+
+    expect(result.current.state.currentTabUrl).toBe(
+      "https://current.example.com",
+    )
+    expect(result.current.state.siteName).toBe("Current Provider Loading")
+    ;(globalThis as any).browser.tabs.query = vi.fn(async () => [activeTabs[2]])
+
+    await act(async () => {
+      tabActivatedCallbacks[0]?.({ tabId: 3, windowId: 1 })
+    })
+
+    expect(result.current.state.currentTabUrl).toBe("https://other.example.com")
+    expect(result.current.state.siteName).toBe("Current Provider Loading")
+
+    await act(async () => {
+      result.current.handlers.handleUseCurrentTabUrl()
+    })
+
+    expect(result.current.state.url).toBe("https://other.example.com")
+    expect(result.current.state.siteName).toBe("Other Provider")
   })
 
   it("initializes add mode from sponsor prefill without waiting for current-tab detection", async () => {


### PR DESCRIPTION
## Summary
- Keep the add-account current-site prompt synced with the active tab.
- Prevent passive tab changes from overwriting the account name after the account URL is set.
- Apply the active tab URL and title together only when the user clicks use current URL.

## Test Plan
- pnpm exec vitest run tests/features/AccountManagement/hooks/useAccountDialog.sponsorPrefill.test.tsx
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account dialog current-tab handling: ignores stale async detections, preserves user-entered site names when a URL is present, caches detected tab title for use when opting to "use current tab", and keeps the current-site prompt stable while titles/URLs change.

* **Tests**
  * Added deterministic async helpers and new tests covering rapid multi-tab detection and user selection to ensure consistent site name/url behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->