### PR TITLE
fix(autodetect): avoid minimizing popup-launched temp windows

### DIFF
--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -925,7 +925,7 @@ export async function handleAutoDetectSite(
   request: any,
   sendResponse: (response?: any) => void,
 ) {
-  const { url, requestId, useIncognito } = request
+  const { url, requestId, useIncognito, suppressMinimize } = request
 
   try {
     if (useIncognito) {
@@ -940,10 +940,15 @@ export async function handleAutoDetectSite(
     }
 
     const siteType = await getAccountSiteType(url)
-    const userData = await getSiteDataFromTab(url, requestId, undefined, {
-      incognito: Boolean(useIncognito),
-      siteType,
-    })
+    const userData = await getSiteDataFromTab(
+      url,
+      requestId,
+      suppressMinimize,
+      {
+        incognito: Boolean(useIncognito),
+        siteType,
+      },
+    )
 
     let result = null
     if (siteType && userData) {

--- a/src/services/siteDetection/autoDetectService.ts
+++ b/src/services/siteDetection/autoDetectService.ts
@@ -33,6 +33,7 @@ import {
   isMessageReceiverUnavailableError,
   sendRuntimeMessage,
 } from "~/utils/browser/browserApi"
+import { isExtensionPopup } from "~/utils/browser/index"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
@@ -356,10 +357,14 @@ async function getUserDataViaBackground(
       fetchContext: summarizeApiServiceFetchContext(fetchContext),
     })
 
+    const shouldSuppressMinimize =
+      typeof window !== "undefined" && isExtensionPopup()
+
     const response = await sendRuntimeMessage({
       action: RuntimeActionIds.AutoDetectSite,
       url: url,
       requestId: requestId,
+      ...(shouldSuppressMinimize ? { suppressMinimize: true } : {}),
       ...(fetchContext?.incognito === true ? { useIncognito: true } : {}),
       ...(fetchContext?.cookieStoreId
         ? { cookieStoreId: fetchContext.cookieStoreId }

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -988,6 +988,53 @@ describe("tempWindowPool window fallback", () => {
     })
   })
 
+  it("does not minimize composite auto-detect temp windows when minimization is suppressed", async () => {
+    tempContextMode = "composite"
+    createWindowMock.mockResolvedValueOnce({ id: 612, tabs: [{ id: 613 }] })
+    tabsQueryMock.mockResolvedValueOnce([{ id: 613 }])
+
+    const { handleAutoDetectSite } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleAutoDetectSite(
+      {
+        url: "https://aihubmix.com",
+        requestId: "req-auto-detect-composite-suppress-minimize",
+        suppressMinimize: true,
+      },
+      sendResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect(createWindowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://aihubmix.com",
+        focused: false,
+        type: "normal",
+      }),
+    )
+    expect((globalThis as any).browser.windows.update).not.toHaveBeenCalledWith(
+      612,
+      {
+        state: "minimized",
+      },
+    )
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        siteType: "new-api",
+        userId: "user-1",
+        user: "alice",
+        accessToken: "access-token",
+        siteTypeHint: "new-api",
+      },
+    })
+  })
+
   it("rejects incognito auto-detect requests when incognito access is unavailable", async () => {
     isAllowedIncognitoAccessMock.mockResolvedValueOnce(false)
 

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -942,6 +942,52 @@ describe("tempWindowPool window fallback", () => {
     })
   })
 
+  it("does not minimize auto-detect temp windows when minimization is suppressed", async () => {
+    tempContextMode = "window"
+    createWindowMock.mockResolvedValueOnce({ id: 610, tabs: [{ id: 611 }] })
+    tabsQueryMock.mockResolvedValueOnce([{ id: 611 }])
+
+    const { handleAutoDetectSite } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleAutoDetectSite(
+      {
+        url: "https://aihubmix.com",
+        requestId: "req-auto-detect-suppress-minimize",
+        suppressMinimize: true,
+      },
+      sendResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect(createWindowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://aihubmix.com",
+        focused: false,
+      }),
+    )
+    expect((globalThis as any).browser.windows.update).not.toHaveBeenCalledWith(
+      610,
+      {
+        state: "minimized",
+      },
+    )
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        siteType: "new-api",
+        userId: "user-1",
+        user: "alice",
+        accessToken: "access-token",
+        siteTypeHint: "new-api",
+      },
+    })
+  })
+
   it("rejects incognito auto-detect requests when incognito access is unavailable", async () => {
     isAllowedIncognitoAccessMock.mockResolvedValueOnce(false)
 

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -52,9 +52,16 @@ describe("autoDetectSmart", () => {
   const browserAny = globalThis.browser as any
   const originalRuntime = browserAny.runtime
   const originalTabs = browserAny.tabs
+  const originalWindow = (globalThis as any).window
 
   beforeEach(() => {
     vi.clearAllMocks()
+
+    if (originalWindow === undefined) {
+      delete (globalThis as any).window
+    } else {
+      ;(globalThis as any).window = originalWindow
+    }
 
     browserAny.runtime = originalRuntime ?? {}
     browserAny.tabs = {
@@ -74,6 +81,11 @@ describe("autoDetectSmart", () => {
   })
 
   afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as any).window
+    } else {
+      ;(globalThis as any).window = originalWindow
+    }
     browserAny.runtime = originalRuntime
     browserAny.tabs = originalTabs
   })
@@ -450,6 +462,41 @@ describe("autoDetectSmart", () => {
       url: "https://aihubmix.com",
     })
     expect(mockFetchUserInfo).not.toHaveBeenCalled()
+  })
+
+  it("suppresses temp-window minimization when background detection starts from the extension popup", async () => {
+    ;(globalThis as any).window = {
+      location: {
+        href: "chrome-extension://extension-id/popup.html",
+      },
+    }
+    mockGetAccountSiteType.mockResolvedValue(SITE_TYPES.AIHUBMIX)
+    mockGetActiveOrAllTabs.mockResolvedValue([
+      {
+        id: 2,
+        active: true,
+        url: "https://console.aihubmix.com/statistics",
+      },
+    ])
+    mockSendRuntimeMessage.mockResolvedValue({
+      success: true,
+      data: {
+        userId: "7",
+        user: { id: 7, username: "aihubmix-user" },
+        accessToken: "console-session-token",
+        siteTypeHint: SITE_TYPES.AIHUBMIX,
+      },
+    })
+
+    const result = await autoDetectSmart("https://aihubmix.com")
+
+    expect(result.success).toBe(true)
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith({
+      action: expect.any(String),
+      requestId: expect.any(String),
+      url: "https://aihubmix.com",
+      suppressMinimize: true,
+    })
   })
 
   it("uses current-tab detection for AIHubMix when the active tab is the API origin", async () => {


### PR DESCRIPTION
## Summary
- suppress temp-window minimization for popup-launched background auto-detect requests
- pass the suppressMinimize flag through the AutoDetectSite background handler
- cover the popup request payload and background no-minimize behavior with focused tests

## Validation
- pnpm exec vitest run tests/services/autoDetectService.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts --reporter=dot
- pnpm compile
- pnpm run validate:staged
- pre-push: pnpm compile && pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-detection initiated from the extension popup now suppresses minimization of temporary windows/contexts, preserving visual context during site-data retrieval.

* **Tests**
  * Added tests confirming suppress-minimize behavior for window and composite temp-context modes and verifying popup-initiated flows include the suppress-minimize flag and preserve window state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->