### PR TITLE
refactor(browser): centralize popup environment safety

### DIFF
--- a/src/services/siteDetection/autoDetectService.ts
+++ b/src/services/siteDetection/autoDetectService.ts
@@ -357,8 +357,7 @@ async function getUserDataViaBackground(
       fetchContext: summarizeApiServiceFetchContext(fetchContext),
     })
 
-    const shouldSuppressMinimize =
-      typeof window !== "undefined" && isExtensionPopup()
+    const shouldSuppressMinimize = isExtensionPopup()
 
     const response = await sendRuntimeMessage({
       action: RuntimeActionIds.AutoDetectSite,

--- a/src/utils/browser/index.ts
+++ b/src/utils/browser/index.ts
@@ -98,6 +98,10 @@ export function isExtensionPage(url: URL) {
  * @returns True when running inside popup.html.
  */
 export function isExtensionPopup() {
+  if (typeof window === "undefined") {
+    return false
+  }
+
   try {
     const url = new URL(window.location.href)
     return isExtensionPage(url) && url.pathname.endsWith(`/${POPUP_PAGE_PATH}`)

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -547,11 +547,7 @@ async function shouldUseTempWindowFallback(
   }
 
   try {
-    if (
-      typeof window !== "undefined" &&
-      isProtectionBypassFirefoxEnv() &&
-      isExtensionPopup()
-    ) {
+    if (isProtectionBypassFirefoxEnv() && isExtensionPopup()) {
       logSkipTempWindowFallback(
         "Running in Firefox popup; temp window fallback is forcibly disabled to avoid closing the popup.",
         context,

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -236,9 +236,7 @@ export async function getTempWindowFallbackBlockStatus(
 export async function tempWindowFetch(
   params: TempWindowFetchParams,
 ): Promise<TempWindowFetch> {
-  const suppressMinimize =
-    params.suppressMinimize ??
-    (typeof window !== "undefined" && isExtensionPopup())
+  const suppressMinimize = params.suppressMinimize ?? isExtensionPopup()
 
   const payload: TempWindowFetchParams = {
     ...params,
@@ -284,9 +282,7 @@ export async function tempWindowFetch(
 export async function tempWindowTurnstileFetch(
   params: TempWindowTurnstileFetchParams,
 ): Promise<TempWindowTurnstileFetch> {
-  const suppressMinimize =
-    params.suppressMinimize ??
-    (typeof window !== "undefined" && isExtensionPopup())
+  const suppressMinimize = params.suppressMinimize ?? isExtensionPopup()
 
   const payload: TempWindowTurnstileFetchParams = {
     ...params,
@@ -339,9 +335,7 @@ export async function tempWindowGetRenderedTitle(params: {
   const payload = {
     action: RuntimeActionIds.TempWindowGetRenderedTitle,
     ...params,
-    suppressMinimize:
-      params.suppressMinimize ??
-      (typeof window !== "undefined" && isExtensionPopup()),
+    suppressMinimize: params.suppressMinimize ?? isExtensionPopup(),
   }
 
   // Make sure works normally in all contexts, including background

--- a/tests/utils/browser.test.ts
+++ b/tests/utils/browser.test.ts
@@ -247,6 +247,13 @@ describe("browser", () => {
       expect(isExtensionPopup()).toBe(false)
       expect(isExtensionSidePanel()).toBe(false)
     })
+
+    it("returns false when window is unavailable", () => {
+      vi.stubGlobal("window", undefined)
+
+      expect(isExtensionPopup()).toBe(false)
+      expect(isExtensionSidePanel()).toBe(false)
+    })
   })
 
   describe("isExtensionBackground", () => {


### PR DESCRIPTION
## Summary
- rely on isExtensionPopup() directly at popup-aware call sites
- add an internal window guard to isExtensionPopup()
- simplify Firefox popup temp-window fallback detection now that both helpers are safe

## Validation
- pnpm exec vitest run tests/utils/browser.test.ts tests/services/autoDetectService.test.ts --reporter=dot
- pnpm exec vitest run tests/utils/browser.test.ts tests/features/AccountManagement/utils/tempWindowFallbackReminder.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts --reporter=dot
- pnpm compile
- pnpm run validate:staged
- pre-push: pnpm compile && pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes when the extension runs in service worker contexts.
  * Improved popup detection and window minimize behavior in extension popups for better stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->