### PR TITLE
refactor: Refactor Vite environment mode checks

### DIFF
--- a/src/components/CCSwitchExportDialog.tsx
+++ b/src/components/CCSwitchExportDialog.tsx
@@ -36,6 +36,7 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
 import type { ApiToken, DisplaySiteData } from "~/types"
+import { isTestMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import {
@@ -61,8 +62,7 @@ const DEFAULT_APP: CCSwitchApp = "claude"
 const APP_LIMITATION_NOTICE_ID = "ccswitch-app-limitation"
 // Preserve the real debounce in dev/prod so endpoint edits do not spam model-list
 // requests, but skip the wall-clock delay in Vitest.
-const UPSTREAM_MODEL_FETCH_DEBOUNCE_MS =
-  import.meta.env.MODE === "test" ? 0 : 300
+const UPSTREAM_MODEL_FETCH_DEBOUNCE_MS = isTestMode() ? 0 : 300
 
 const getCCSwitchAppLabel = (t: TFunction, app: CCSwitchApp) => {
   switch (app) {

--- a/src/components/DevDialogDebugMenu.tsx
+++ b/src/components/DevDialogDebugMenu.tsx
@@ -17,6 +17,7 @@ import {
 } from "~/components/ui/dropdown-menu"
 import { changelogOnUpdateState } from "~/services/updates/changelogOnUpdateState"
 import { getManifest } from "~/utils/browser/browserApi"
+import { isDevelopmentMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { openPermissionsOnboardingPage } from "~/utils/navigation"
@@ -89,7 +90,7 @@ function DevDialogDebugMenuContent() {
  * Development-only menu for manually reopening first-run/update dialogs.
  */
 export function DevDialogDebugMenu() {
-  if (import.meta.env.MODE !== "development") {
+  if (!isDevelopmentMode()) {
     return null
   }
 

--- a/src/components/ui/MultiSelect.tsx
+++ b/src/components/ui/MultiSelect.tsx
@@ -18,6 +18,7 @@ import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { cn } from "~/lib/utils"
+import { isTestMode } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
 
 /**
@@ -157,7 +158,7 @@ export function MultiSelect({
   // Headless UI's Combobox `virtual` mode is great for large lists in real browsers,
   // but it doesn't reliably render options in jsdom (tests). Disable virtualization
   // in `test` mode to keep component tests stable and user-event compatible.
-  const shouldUseVirtualOptions = import.meta.env.MODE !== "test"
+  const shouldUseVirtualOptions = !isTestMode()
 
   const handleSelect = (newSelected: MultiSelectOption[]) => {
     onChange(newSelected.map((opt) => opt.value))

--- a/src/entrypoints/background/devActionBranding.ts
+++ b/src/entrypoints/background/devActionBranding.ts
@@ -1,5 +1,6 @@
 import { getManifest } from "~/utils/browser/browserApi"
 import { formatDevActionTitle, getDevBadgeText } from "~/utils/core/devBranding"
+import { isDevelopmentMode } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
 
 /**
@@ -15,7 +16,7 @@ const logger = createLogger("DevActionBranding")
  * background script.
  */
 export async function applyDevActionBranding() {
-  if (import.meta.env.MODE !== "development") return
+  if (!isDevelopmentMode()) return
 
   const actionApi = (browser as any).action ?? (browser as any).browserAction
   if (!actionApi) return

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -30,6 +30,7 @@ import {
   onStartup,
   onSuspend,
 } from "~/utils/browser/browserApi"
+import { isTestMode } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
 import { openOrFocusOptionsMenuItem } from "~/utils/navigation"
 
@@ -53,7 +54,7 @@ const logger = createLogger("BackgroundEntrypoint")
  * lifecycle before they can drive a target page.
  */
 function shouldAutoOpenPermissionsOnboarding(): boolean {
-  return import.meta.env.MODE !== "test"
+  return !isTestMode()
 }
 
 export default defineBackground(() => {

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
@@ -58,6 +58,7 @@ import {
   WebAiApiCheckMessageTypes,
 } from "~/services/verification/webAiApiCheck/messaging"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
+import { isTestMode } from "~/utils/core/environment"
 
 import {
   API_CHECK_OPEN_MODAL_EVENT,
@@ -88,7 +89,7 @@ type ApiCheckExtractionMetadata = NonNullable<
 
 // Preserve the real debounce in dev/prod to avoid bursty background requests
 // while typing, but skip the wall-clock delay in Vitest.
-const MODEL_AUTO_FETCH_DEBOUNCE_MS = import.meta.env.MODE === "test" ? 0 : 300
+const MODEL_AUTO_FETCH_DEBOUNCE_MS = isTestMode() ? 0 : 300
 
 const contentApiCheckAnalyticsScope = {
   featureId: PRODUCT_ANALYTICS_FEATURE_IDS.WebAiApiCheck,

--- a/src/entrypoints/options/constants.ts
+++ b/src/entrypoints/options/constants.ts
@@ -24,6 +24,7 @@ import {
   type OptionsMenuCategoryId,
   type OptionsPageMenuItemId,
 } from "~/constants/optionsMenuIds"
+import { isDevelopmentMode } from "~/utils/core/environment"
 
 import BasicSettings from "./pages/BasicSettings"
 
@@ -168,7 +169,7 @@ const BASE_MENU_ITEMS: MenuItem[] = [
 
 const DEV_MENU_ITEMS: MenuItem[] = []
 
-if (import.meta.env.MODE === "development") {
+if (isDevelopmentMode()) {
   const MeshGradientLab = lazy(() => import("./pages/MeshGradientLab"))
 
   const MeshGradientLabComponent: ComponentType<any> = (props) =>

--- a/src/features/AccountManagement/sponsors/bundledCatalog.ts
+++ b/src/features/AccountManagement/sponsors/bundledCatalog.ts
@@ -1,3 +1,4 @@
+import { isDevelopmentMode } from "~/utils/core/environment"
 import sponsorCatalog from "~~/public/sponsor-catalog.json"
 
 import type { RawSponsorCatalog } from "./types"
@@ -6,7 +7,7 @@ export const bundledSponsorCatalog = sponsorCatalog as RawSponsorCatalog
 
 /** Returns bundled sponsor data with example-only records injected in development. */
 export function getBundledSponsorCatalog(): RawSponsorCatalog {
-  if (import.meta.env.MODE !== "development") {
+  if (!isDevelopmentMode()) {
     return bundledSponsorCatalog
   }
 

--- a/src/features/AutoCheckin/AutoCheckin.tsx
+++ b/src/features/AutoCheckin/AutoCheckin.tsx
@@ -48,6 +48,7 @@ import {
   CHECKIN_RESULT_STATUS,
 } from "~/types/autoCheckin"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
+import { isDevelopmentMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
@@ -194,7 +195,7 @@ export default function AutoCheckin(props: {
     useState<DisplaySiteData | null>(null)
 
   // Dev-only: diagnostics and simulation state for the UI-open pre-trigger flow.
-  // These controls are shown only when `import.meta.env.MODE === "development"`.
+  // These controls are shown only in development mode.
   const [uiOpenPretriggerDiagnostics, setUiOpenPretriggerDiagnostics] =
     useState<{
       isOpen: boolean
@@ -296,7 +297,7 @@ export default function AutoCheckin(props: {
     }
   }, [loadStatus, t])
 
-  const showDebugButtons = import.meta.env.MODE === "development"
+  const showDebugButtons = isDevelopmentMode()
 
   const handleDebugTriggerDailyAlarmNow = useCallback(async () => {
     try {

--- a/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
+++ b/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
@@ -16,6 +16,7 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { clampBalanceHistoryRetentionDays } from "~/services/history/dailyBalanceHistory/utils"
 import { DEFAULT_BALANCE_HISTORY_PREFERENCES } from "~/types/dailyBalanceHistory"
 import { hasAlarmsAPI, sendRuntimeMessage } from "~/utils/browser/browserApi"
+import { isDevelopmentMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
@@ -59,7 +60,7 @@ export default function BalanceHistorySettings() {
   }, [preferences.balanceHistory])
 
   const alarmsSupported = hasAlarmsAPI()
-  const showDebugSeedAction = import.meta.env.MODE === "development"
+  const showDebugSeedAction = isDevelopmentMode()
 
   const safeRetentionDays = useMemo(
     () => clampBalanceHistoryRetentionDays(retentionDays),

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -22,6 +22,7 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
 import type { ApiVerificationHistorySummary } from "~/services/verification/verificationResultHistory"
+import { isProductionMode } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
 import { tryParseUrl } from "~/utils/core/urlParsing"
 
@@ -113,7 +114,7 @@ export default function ModelItem(props: ModelItemProps) {
     : uncontrolledIsExpanded
 
   useEffect(() => {
-    if (!hasExpansionPropMismatch || process.env.NODE_ENV === "production") {
+    if (!hasExpansionPropMismatch || isProductionMode()) {
       return
     }
 

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -22,7 +22,7 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
 import type { ApiVerificationHistorySummary } from "~/services/verification/verificationResultHistory"
-import { isProductionMode } from "~/utils/core/environment"
+import { isProdBuild } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
 import { tryParseUrl } from "~/utils/core/urlParsing"
 
@@ -114,7 +114,7 @@ export default function ModelItem(props: ModelItemProps) {
     : uncontrolledIsExpanded
 
   useEffect(() => {
-    if (!hasExpansionPropMismatch || isProductionMode()) {
+    if (!hasExpansionPropMismatch || isProdBuild()) {
       return
     }
 

--- a/src/hooks/useProductAnalyticsPageView.ts
+++ b/src/hooks/useProductAnalyticsPageView.ts
@@ -6,7 +6,7 @@ import {
   type ProductAnalyticsEntrypoint,
   type ProductAnalyticsPageId,
 } from "~/services/productAnalytics/events"
-import { isDevelopmentMode } from "~/utils/core/environment"
+import { isDevBuild } from "~/utils/core/environment"
 
 interface UseProductAnalyticsPageViewParams {
   entrypoint: ProductAnalyticsEntrypoint
@@ -20,7 +20,7 @@ const recentTrackedEvents = new Map<string, number>()
  * Returns whether an analytics event key has not been tracked in the short dedupe window.
  */
 function shouldTrackRecentEvent(eventKey: string): boolean {
-  if (!isDevelopmentMode()) return true
+  if (!isDevBuild()) return true
 
   const now = Date.now()
   const lastTrackedAt = recentTrackedEvents.get(eventKey)

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -31,6 +31,7 @@ import {
   COOKIE_SESSION_OVERRIDE_HEADER_NAME,
 } from "~/utils/browser/cookieHelper"
 import { executeWithTempWindowFallback } from "~/utils/browser/tempWindowFetch"
+import { isTestMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
@@ -60,8 +61,7 @@ const logger = createLogger("ApiTransportRequest")
 const LOG_REQUEST_MIN_INTERVAL_MS = 200
 
 const logRequestRateLimiter = createMinIntervalLimiter({
-  minIntervalMs:
-    import.meta.env.MODE === "test" ? 0 : LOG_REQUEST_MIN_INTERVAL_MS,
+  minIntervalMs: isTestMode() ? 0 : LOG_REQUEST_MIN_INTERVAL_MS,
 })
 
 /**

--- a/src/services/apiTransport/siteRequestLimiter.ts
+++ b/src/services/apiTransport/siteRequestLimiter.ts
@@ -1,3 +1,5 @@
+import { isTestMode } from "~/utils/core/environment"
+
 type SiteRequestLimiterConfig = {
   enabled?: boolean
   maxConcurrentPerSite: number
@@ -206,7 +208,7 @@ export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
 
 const productionSiteRequestLimiter = createSiteRequestLimiter({
   ...SITE_API_REQUEST_LIMITS,
-  enabled: import.meta.env.MODE !== "test",
+  enabled: !isTestMode(),
 })
 
 /**

--- a/src/services/checkin/autoCheckin/scheduler.ts
+++ b/src/services/checkin/autoCheckin/scheduler.ts
@@ -67,6 +67,7 @@ import {
   onAlarm,
   sendRuntimeMessage,
 } from "~/utils/browser/browserApi"
+import { isDevelopmentMode, isTestMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
@@ -2717,10 +2718,7 @@ export async function runAutoCheckinNow(data: AutoCheckinRunNowRequest = {}) {
  * Reject debug-only auto check-in actions outside development and test modes.
  */
 function ensureAutoCheckinDebugAvailable(action: string) {
-  if (
-    import.meta.env.MODE !== "development" &&
-    import.meta.env.MODE !== "test"
-  ) {
+  if (!isDevelopmentMode() && !isTestMode()) {
     return {
       success: false as const,
       error: `Debug action is only available in development/test mode (${action})`,

--- a/src/services/history/dailyBalanceHistory/scheduler.ts
+++ b/src/services/history/dailyBalanceHistory/scheduler.ts
@@ -22,6 +22,7 @@ import {
   hasAlarmsAPI,
   onAlarm,
 } from "~/utils/browser/browserApi"
+import { isDevelopmentMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
@@ -494,7 +495,7 @@ export const handleDailyBalanceHistoryMessage = async (
       return
     }
 
-    if (import.meta.env.MODE !== "development") {
+    if (!isDevelopmentMode()) {
       sendResponse({ success: false, error: "Debug action unavailable" })
       return
     }

--- a/src/services/productAnalytics/actionConfig.ts
+++ b/src/services/productAnalytics/actionConfig.ts
@@ -4,6 +4,7 @@ import {
   type ProductAnalyticsFeatureId,
   type ProductAnalyticsSurfaceId,
 } from "~/services/productAnalytics/events"
+import { isDevelopmentMode } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("ProductAnalyticsActionConfig")
@@ -84,7 +85,7 @@ function normalizeScopedActionConfig(
  * Emits a development-only diagnostic when a provided action is incomplete.
  */
 function logUnresolvedScopedAction() {
-  if (import.meta.env.DEV) {
+  if (isDevelopmentMode()) {
     logger.debug("Product analytics action config could not be resolved")
   }
 }

--- a/src/services/productAnalytics/actionConfig.ts
+++ b/src/services/productAnalytics/actionConfig.ts
@@ -4,7 +4,7 @@ import {
   type ProductAnalyticsFeatureId,
   type ProductAnalyticsSurfaceId,
 } from "~/services/productAnalytics/events"
-import { isDevelopmentMode } from "~/utils/core/environment"
+import { isDevBuild } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("ProductAnalyticsActionConfig")
@@ -85,7 +85,7 @@ function normalizeScopedActionConfig(
  * Emits a development-only diagnostic when a provided action is incomplete.
  */
 function logUnresolvedScopedAction() {
-  if (isDevelopmentMode()) {
+  if (isDevBuild()) {
     logger.debug("Product analytics action config could not be resolved")
   }
 }

--- a/src/services/productAnalytics/client.ts
+++ b/src/services/productAnalytics/client.ts
@@ -3,7 +3,7 @@ import posthog, { type Properties } from "posthog-js/dist/module.no-external"
 
 import { getManifest } from "~/utils/browser/browserApi"
 import { detectBrowserFamily } from "~/utils/browser/userAgent"
-import { isDevelopmentMode } from "~/utils/core/environment"
+import { isDevBuild } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
 import i18n from "~/utils/i18n/core"
 
@@ -156,7 +156,7 @@ function isDisabledByPolicy(
  * Collapses local development traffic into one stable PostHog profile.
  */
 function resolveDistinctId(anonymousId: string): string {
-  if (isDevelopmentMode()) {
+  if (isDevBuild()) {
     return DEVELOPMENT_DISTINCT_ID
   }
 
@@ -227,7 +227,7 @@ class ProductAnalyticsClient {
 
       return await captureWithAnonymousId(eventName, capture)
     } catch (error) {
-      if (isDevelopmentMode()) {
+      if (isDevBuild()) {
         logger.debug("Failed to capture product analytics event", error)
       }
       return false

--- a/src/services/productAnalytics/runtime.ts
+++ b/src/services/productAnalytics/runtime.ts
@@ -4,7 +4,7 @@ import {
   USER_PREFERENCES_STORAGE_KEYS,
 } from "~/services/core/storageKeys"
 import { userPreferences } from "~/services/preferences/userPreferences"
-import { isDevelopmentMode } from "~/utils/core/environment"
+import { isDevBuild } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
@@ -172,7 +172,7 @@ export async function handleProductAnalyticsMessage(
   try {
     return await resolveProductAnalyticsResponse(type, request)
   } catch (error) {
-    if (isDevelopmentMode()) {
+    if (isDevBuild()) {
       logger.debug("Product analytics runtime request failed", error)
     }
     return { success: false, error: getErrorMessage(error) }
@@ -220,7 +220,7 @@ export function setupProductAnalyticsMessagingListeners() {
  */
 function captureSiteEcosystemSnapshotBestEffort() {
   void captureSiteEcosystemSnapshot().catch((error) => {
-    if (isDevelopmentMode()) {
+    if (isDevBuild()) {
       logger.debug("Product analytics snapshot failed", error)
     }
   })
@@ -231,7 +231,7 @@ function captureSiteEcosystemSnapshotBestEffort() {
  */
 function captureSettingsSnapshotBestEffort() {
   void captureSettingsSnapshot().catch((error) => {
-    if (isDevelopmentMode()) {
+    if (isDevBuild()) {
       logger.debug("Product analytics settings snapshot failed", error)
     }
   })
@@ -242,7 +242,7 @@ function captureSettingsSnapshotBestEffort() {
  */
 function flushShieldBypassDailySummaryBestEffort() {
   void flushShieldBypassDailySummary().catch((error) => {
-    if (isDevelopmentMode()) {
+    if (isDevBuild()) {
       logger.debug("Product analytics shield bypass summary failed", error)
     }
   })

--- a/src/utils/core/environment.ts
+++ b/src/utils/core/environment.ts
@@ -1,6 +1,49 @@
+const RUNTIME_MODES = {
+  Development: "development",
+  Production: "production",
+  Test: "test",
+} as const
+
+type RuntimeMode = string
+
 /**
- * Checks whether the current Vite/WXT runtime mode is development.
+ * Returns the current Vite/WXT mode name, which comes from `--mode`.
+ */
+export function getRuntimeMode(): RuntimeMode {
+  return import.meta.env.MODE
+}
+
+/**
+ * Checks whether the current Vite/WXT mode name is development.
  */
 export function isDevelopmentMode(): boolean {
-  return import.meta.env.MODE === "development"
+  return getRuntimeMode() === RUNTIME_MODES.Development
+}
+
+/**
+ * Checks whether the current Vite/WXT mode name is production.
+ */
+export function isProductionMode(): boolean {
+  return getRuntimeMode() === RUNTIME_MODES.Production
+}
+
+/**
+ * Checks whether the current Vite/WXT mode name is test.
+ */
+export function isTestMode(): boolean {
+  return getRuntimeMode() === RUNTIME_MODES.Test
+}
+
+/**
+ * Checks whether Vite considers this a development build/runtime.
+ */
+export function isDevBuild(): boolean {
+  return import.meta.env.DEV
+}
+
+/**
+ * Checks whether Vite considers this a production build/runtime.
+ */
+export function isProdBuild(): boolean {
+  return import.meta.env.PROD
 }

--- a/src/utils/i18n/index.ts
+++ b/src/utils/i18n/index.ts
@@ -11,7 +11,7 @@ import { initReactI18next } from "react-i18next"
 import { DEFAULT_LANG } from "~/constants"
 import { I18NEXT_LANGUAGE_STORAGE_KEY } from "~/services/core/storageKeys"
 import { userPreferences } from "~/services/preferences/userPreferences"
-import { isDevelopmentMode } from "~/utils/core/environment"
+import { isDevBuild } from "~/utils/core/environment"
 
 import i18n from "./core"
 import { resolveInitialAppLanguage } from "./language"
@@ -21,7 +21,7 @@ i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    debug: isDevelopmentMode(),
+    debug: isDevBuild(),
     fallbackLng: DEFAULT_LANG,
     defaultNS: "common",
     // default config: https://github.com/i18next/i18next-browser-languageDetector#detector-options

--- a/src/utils/i18n/index.ts
+++ b/src/utils/i18n/index.ts
@@ -11,6 +11,7 @@ import { initReactI18next } from "react-i18next"
 import { DEFAULT_LANG } from "~/constants"
 import { I18NEXT_LANGUAGE_STORAGE_KEY } from "~/services/core/storageKeys"
 import { userPreferences } from "~/services/preferences/userPreferences"
+import { isDevelopmentMode } from "~/utils/core/environment"
 
 import i18n from "./core"
 import { resolveInitialAppLanguage } from "./language"
@@ -20,7 +21,7 @@ i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    debug: process.env.NODE_ENV === "development",
+    debug: isDevelopmentMode(),
     fallbackLng: DEFAULT_LANG,
     defaultNS: "common",
     // default config: https://github.com/i18next/i18next-browser-languageDetector#detector-options

--- a/tests/features/ModelList/components/ModelItem.test.tsx
+++ b/tests/features/ModelList/components/ModelItem.test.tsx
@@ -185,6 +185,7 @@ function createDefaultProps() {
 describe("ModelItem", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
   })
 
   it("falls back to the default group label when an unavailable model has no selected or effective group", () => {
@@ -376,4 +377,13 @@ describe("ModelItem", () => {
       }
     },
   )
+
+  it("suppresses expansion prop mismatch warnings in custom production build modes", () => {
+    vi.stubEnv("MODE", "staging")
+    vi.stubEnv("PROD", true)
+
+    render(<ModelItem {...createDefaultProps()} isExpanded={true} />)
+
+    expect(loggerWarnSpy).not.toHaveBeenCalled()
+  })
 })

--- a/tests/hooks/useProductAnalyticsPageView.test.tsx
+++ b/tests/hooks/useProductAnalyticsPageView.test.tsx
@@ -106,6 +106,7 @@ describe("useProductAnalyticsPageView", () => {
 
   it("dedupes initial StrictMode remount app_opened and page_viewed effects", async () => {
     vi.stubEnv("MODE", "development")
+    vi.stubEnv("DEV", true)
 
     function StrictModeHarness() {
       useProductAnalyticsPageView({
@@ -152,8 +153,48 @@ describe("useProductAnalyticsPageView", () => {
     ).toHaveLength(1)
   })
 
+  it("dedupes StrictMode remounts in custom development build modes", async () => {
+    vi.stubEnv("MODE", "local")
+    vi.stubEnv("DEV", true)
+
+    function StrictModeHarness() {
+      useProductAnalyticsPageView({
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+        pageId: PRODUCT_ANALYTICS_PAGE_IDS.OptionsBasicSettings,
+      })
+
+      return null
+    }
+
+    const firstRender = render(
+      <StrictMode>
+        <StrictModeHarness />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      expect(trackProductAnalyticsEventMock).toHaveBeenCalledTimes(2)
+    })
+
+    firstRender.unmount()
+
+    render(
+      <StrictMode>
+        <StrictModeHarness />
+      </StrictMode>,
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledTimes(2)
+  })
+
   it("does not dedupe non-development remounts", async () => {
     vi.stubEnv("MODE", "production")
+    vi.stubEnv("DEV", false)
 
     function Harness() {
       useProductAnalyticsPageView({

--- a/tests/services/productAnalytics/actions.test.ts
+++ b/tests/services/productAnalytics/actions.test.ts
@@ -29,6 +29,11 @@ const { trackMock } = vi.hoisted(() => ({
   trackMock: vi.fn(),
 }))
 
+const { loggerDebugSpy, loggerWarnSpy } = vi.hoisted(() => ({
+  loggerDebugSpy: vi.fn(),
+  loggerWarnSpy: vi.fn(),
+}))
+
 vi.mock("~/services/productAnalytics/events", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("~/services/productAnalytics/events")>()
@@ -38,9 +43,19 @@ vi.mock("~/services/productAnalytics/events", async (importOriginal) => {
   }
 })
 
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    debug: loggerDebugSpy,
+    info: vi.fn(),
+    warn: loggerWarnSpy,
+    error: vi.fn(),
+  }),
+}))
+
 describe("product analytics action helpers", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
     trackMock.mockResolvedValue({ success: true })
   })
 
@@ -154,6 +169,26 @@ describe("product analytics action helpers", () => {
         {},
       ),
     ).toBeUndefined()
+  })
+
+  it("logs incomplete scoped actions in custom development build modes", async () => {
+    vi.stubEnv("MODE", "staging")
+    vi.stubEnv("DEV", true)
+    const { resolveProductAnalyticsActionContext } = await import(
+      "~/services/productAnalytics/actions"
+    )
+
+    expect(
+      resolveProductAnalyticsActionContext(
+        PRODUCT_ANALYTICS_ACTION_IDS.RefreshAccount,
+        {
+          featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AccountManagement,
+        },
+      ),
+    ).toBeUndefined()
+    expect(loggerDebugSpy).toHaveBeenCalledWith(
+      "Product analytics action config could not be resolved",
+    )
   })
 
   it("resolves a scoped action without a surface id", async () => {

--- a/tests/services/productAnalytics/client.test.ts
+++ b/tests/services/productAnalytics/client.test.ts
@@ -114,6 +114,7 @@ describe("productAnalyticsClient", () => {
   })
 
   it("initializes PostHog with privacy-sensitive defaults disabled", async () => {
+    vi.stubEnv("DEV", false)
     vi.stubEnv("VITE_PUBLIC_POSTHOG_PROJECT_TOKEN", "phc_test")
     vi.stubEnv("VITE_PUBLIC_POSTHOG_HOST", "https://posthog.example")
 
@@ -210,8 +211,9 @@ describe("productAnalyticsClient", () => {
     })
   })
 
-  it("uses a fixed distinct id in development mode", async () => {
+  it("uses a fixed distinct id in development builds", async () => {
     vi.stubEnv("MODE", "development")
+    vi.stubEnv("DEV", true)
     vi.stubEnv("VITE_PUBLIC_POSTHOG_PROJECT_TOKEN", "phc_test")
     vi.stubEnv("VITE_PUBLIC_POSTHOG_HOST", "https://posthog.example")
 
@@ -229,6 +231,30 @@ describe("productAnalyticsClient", () => {
       ui_language: "en",
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Popup,
     })
+    expect(posthogMocks.init).toHaveBeenCalledWith(
+      "phc_test",
+      expect.objectContaining({
+        bootstrap: {
+          distinctID: "analytics-development",
+        },
+      }),
+    )
+  })
+
+  it("uses the development distinct id in custom development build modes", async () => {
+    vi.stubEnv("MODE", "local")
+    vi.stubEnv("DEV", true)
+    vi.stubEnv("VITE_PUBLIC_POSTHOG_PROJECT_TOKEN", "phc_test")
+    vi.stubEnv("VITE_PUBLIC_POSTHOG_HOST", "https://posthog.example")
+
+    const client = await importClient()
+
+    await expect(
+      client.capture(PRODUCT_ANALYTICS_EVENTS.AppOpened, {
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Popup,
+      }),
+    ).resolves.toBe(true)
+
     expect(posthogMocks.init).toHaveBeenCalledWith(
       "phc_test",
       expect.objectContaining({

--- a/tests/services/productAnalytics/client.test.ts
+++ b/tests/services/productAnalytics/client.test.ts
@@ -9,25 +9,33 @@ import {
   PRODUCT_ANALYTICS_PAGE_IDS,
 } from "~/services/productAnalytics/events"
 
-const { posthogMocks, preferenceMocks, getManifestMock, i18nCoreMock } =
-  vi.hoisted(() => ({
-    posthogMocks: {
-      init: vi.fn(),
-      capture: vi.fn(),
-      getFeatureFlagPayload: vi.fn(),
-    },
-    preferenceMocks: {
-      isEnabled: vi.fn(),
-      getOrCreateAnonymousId: vi.fn(),
-      getAnonymousIdIfEnabled: vi.fn(),
-      withAnonymousIdIfEnabled: vi.fn(),
-    },
-    getManifestMock: vi.fn(() => ({ version: "3.37.0" })),
-    i18nCoreMock: {
-      resolvedLanguage: "en" as string | undefined,
-      language: "en",
-    },
-  }))
+const {
+  posthogMocks,
+  preferenceMocks,
+  getManifestMock,
+  i18nCoreMock,
+  mockIsDevBuild,
+  mockLoggerDebug,
+} = vi.hoisted(() => ({
+  posthogMocks: {
+    init: vi.fn(),
+    capture: vi.fn(),
+    getFeatureFlagPayload: vi.fn(),
+  },
+  preferenceMocks: {
+    isEnabled: vi.fn(),
+    getOrCreateAnonymousId: vi.fn(),
+    getAnonymousIdIfEnabled: vi.fn(),
+    withAnonymousIdIfEnabled: vi.fn(),
+  },
+  getManifestMock: vi.fn(() => ({ version: "3.37.0" })),
+  i18nCoreMock: {
+    resolvedLanguage: "en" as string | undefined,
+    language: "en",
+  },
+  mockIsDevBuild: vi.fn(() => false),
+  mockLoggerDebug: vi.fn(),
+}))
 
 vi.mock("posthog-js/dist/module.no-external", () => ({
   default: posthogMocks,
@@ -39,6 +47,19 @@ vi.mock("~/services/productAnalytics/preferences", () => ({
 
 vi.mock("~/utils/browser/browserApi", () => ({
   getManifest: getManifestMock,
+}))
+
+vi.mock("~/utils/core/environment", () => ({
+  isDevBuild: mockIsDevBuild,
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    debug: mockLoggerDebug,
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
 }))
 
 vi.mock("~/utils/i18n/core", () => ({
@@ -71,6 +92,7 @@ describe("productAnalyticsClient", () => {
     getManifestMock.mockReturnValue({ version: "3.37.0" })
     i18nCoreMock.resolvedLanguage = "en"
     i18nCoreMock.language = "en"
+    mockIsDevBuild.mockReturnValue(false)
     vi.stubGlobal("navigator", {
       language: "en-US",
       userAgent:
@@ -214,6 +236,7 @@ describe("productAnalyticsClient", () => {
   it("uses a fixed distinct id in development builds", async () => {
     vi.stubEnv("MODE", "development")
     vi.stubEnv("DEV", true)
+    mockIsDevBuild.mockReturnValue(true)
     vi.stubEnv("VITE_PUBLIC_POSTHOG_PROJECT_TOKEN", "phc_test")
     vi.stubEnv("VITE_PUBLIC_POSTHOG_HOST", "https://posthog.example")
 
@@ -244,6 +267,7 @@ describe("productAnalyticsClient", () => {
   it("uses the development distinct id in custom development build modes", async () => {
     vi.stubEnv("MODE", "local")
     vi.stubEnv("DEV", true)
+    mockIsDevBuild.mockReturnValue(true)
     vi.stubEnv("VITE_PUBLIC_POSTHOG_PROJECT_TOKEN", "phc_test")
     vi.stubEnv("VITE_PUBLIC_POSTHOG_HOST", "https://posthog.example")
 
@@ -411,6 +435,48 @@ describe("productAnalyticsClient", () => {
     expect(preferenceMocks.withAnonymousIdIfEnabled).toHaveBeenCalledTimes(1)
     expect(posthogMocks.init).not.toHaveBeenCalled()
     expect(posthogMocks.capture).not.toHaveBeenCalled()
+  })
+
+  it("returns false without debug logging when capture work throws outside dev builds", async () => {
+    vi.stubEnv("VITE_PUBLIC_POSTHOG_PROJECT_TOKEN", "phc_test")
+    vi.stubEnv("VITE_PUBLIC_POSTHOG_HOST", "https://posthog.example")
+    preferenceMocks.withAnonymousIdIfEnabled.mockRejectedValueOnce(
+      new Error("anonymous id unavailable"),
+    )
+
+    const client = await importClient()
+
+    await expect(
+      client.capture(PRODUCT_ANALYTICS_EVENTS.AppOpened, {
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Popup,
+      }),
+    ).resolves.toBe(false)
+
+    expect(mockLoggerDebug).not.toHaveBeenCalled()
+  })
+
+  it("logs capture work failures in custom development build modes", async () => {
+    vi.stubEnv("MODE", "local")
+    vi.stubEnv("DEV", true)
+    mockIsDevBuild.mockReturnValue(true)
+    vi.stubEnv("VITE_PUBLIC_POSTHOG_PROJECT_TOKEN", "phc_test")
+    vi.stubEnv("VITE_PUBLIC_POSTHOG_HOST", "https://posthog.example")
+    preferenceMocks.withAnonymousIdIfEnabled.mockRejectedValueOnce(
+      new Error("anonymous id unavailable"),
+    )
+
+    const client = await importClient()
+
+    await expect(
+      client.capture(PRODUCT_ANALYTICS_EVENTS.AppOpened, {
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Popup,
+      }),
+    ).resolves.toBe(false)
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      "Failed to capture product analytics event",
+      expect.any(Error),
+    )
   })
 
   it("runs PostHog initialization and capture inside the enabled anonymous-id work", async () => {

--- a/tests/services/productAnalytics/runtime.test.ts
+++ b/tests/services/productAnalytics/runtime.test.ts
@@ -34,6 +34,7 @@ const {
   },
   stateMocks: {
     getState: vi.fn(),
+    getShieldBypassSummaryState: vi.fn(),
     setLastSettingsSnapshotAt: vi.fn(),
     setLastSiteEcosystemSnapshotAt: vi.fn(),
   },
@@ -128,6 +129,7 @@ describe("product analytics runtime", () => {
     captureMock.mockResolvedValue(true)
     preferenceMocks.isEnabled.mockResolvedValue(true)
     stateMocks.getState.mockResolvedValue({})
+    stateMocks.getShieldBypassSummaryState.mockResolvedValue({})
     stateMocks.setLastSettingsSnapshotAt.mockResolvedValue(true)
     stateMocks.setLastSiteEcosystemSnapshotAt.mockResolvedValue(true)
     getAllAccountsMock.mockResolvedValue([])
@@ -232,9 +234,19 @@ describe("product analytics runtime", () => {
     expect(captureMock).not.toHaveBeenCalled()
   })
 
+  it("ignores unsupported runtime message types", async () => {
+    await expect(
+      handleProductAnalyticsMessage(
+        "unknown" as Parameters<typeof handleProductAnalyticsMessage>[0],
+        {},
+      ),
+    ).resolves.toEqual({ success: false })
+
+    expect(captureMock).not.toHaveBeenCalled()
+  })
+
   it("returns a runtime failure when event capture throws", async () => {
     captureMock.mockRejectedValueOnce(new Error("capture unavailable"))
-    mockIsDevBuild.mockReturnValue(true)
 
     await expect(
       handleProductAnalyticsMessage(ProductAnalyticsMessageTypes.TrackEvent, {
@@ -249,10 +261,7 @@ describe("product analytics runtime", () => {
       error: "capture unavailable",
     })
 
-    expect(mockLoggerDebug).toHaveBeenCalledWith(
-      "Product analytics runtime request failed",
-      expect.any(Error),
-    )
+    expect(mockLoggerDebug).not.toHaveBeenCalled()
   })
 
   it("logs runtime capture failures in custom development build modes", async () => {
@@ -420,6 +429,59 @@ describe("product analytics runtime", () => {
 
     expect(captureMock).toHaveBeenCalledTimes(2)
     expect(stateMocks.setLastSiteEcosystemSnapshotAt).not.toHaveBeenCalled()
+  })
+
+  it("logs startup site ecosystem snapshot failures in dev builds", async () => {
+    getAllAccountsMock.mockRejectedValueOnce(new Error("accounts unavailable"))
+    mockIsDevBuild.mockReturnValue(true)
+
+    const { triggerStartupSiteEcosystemSnapshot } = await import(
+      "~/services/productAnalytics/runtime"
+    )
+
+    triggerStartupSiteEcosystemSnapshot()
+    await vi.runAllTimersAsync()
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      "Product analytics snapshot failed",
+      expect.any(Error),
+    )
+  })
+
+  it("logs startup settings snapshot failures in dev builds", async () => {
+    stateMocks.getState.mockRejectedValueOnce(new Error("state unavailable"))
+    mockIsDevBuild.mockReturnValue(true)
+
+    const { triggerStartupSettingsSnapshot } = await import(
+      "~/services/productAnalytics/runtime"
+    )
+
+    triggerStartupSettingsSnapshot()
+    await vi.runAllTimersAsync()
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      "Product analytics settings snapshot failed",
+      expect.any(Error),
+    )
+  })
+
+  it("logs startup shield bypass summary failures in dev builds", async () => {
+    mockIsDevBuild.mockReturnValue(true)
+    stateMocks.getShieldBypassSummaryState.mockRejectedValueOnce(
+      new Error("shield summary unavailable"),
+    )
+
+    const { triggerStartupShieldBypassDailySummary } = await import(
+      "~/services/productAnalytics/runtime"
+    )
+
+    triggerStartupShieldBypassDailySummary()
+    await vi.runAllTimersAsync()
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      "Product analytics shield bypass summary failed",
+      expect.any(Error),
+    )
   })
 
   it("debounces local account storage changes and cleanup removes the listener", async () => {

--- a/tests/services/productAnalytics/runtime.test.ts
+++ b/tests/services/productAnalytics/runtime.test.ts
@@ -17,7 +17,7 @@ const {
   captureMock,
   getAllAccountsMock,
   getPreferencesMock,
-  mockIsDevelopmentMode,
+  mockIsDevBuild,
   mockLoggerDebug,
   mockOnProductAnalyticsMessage,
   preferenceMocks,
@@ -26,7 +26,7 @@ const {
   captureMock: vi.fn(),
   getAllAccountsMock: vi.fn(),
   getPreferencesMock: vi.fn(),
-  mockIsDevelopmentMode: vi.fn(() => false),
+  mockIsDevBuild: vi.fn(() => false),
   mockLoggerDebug: vi.fn(),
   mockOnProductAnalyticsMessage: vi.fn(() => vi.fn()),
   preferenceMocks: {
@@ -46,7 +46,7 @@ vi.mock("~/services/productAnalytics/client", () => ({
 }))
 
 vi.mock("~/utils/core/environment", () => ({
-  isDevelopmentMode: mockIsDevelopmentMode,
+  isDevBuild: mockIsDevBuild,
 }))
 
 vi.mock("~/utils/core/logger", () => ({
@@ -132,7 +132,7 @@ describe("product analytics runtime", () => {
     stateMocks.setLastSiteEcosystemSnapshotAt.mockResolvedValue(true)
     getAllAccountsMock.mockResolvedValue([])
     getPreferencesMock.mockResolvedValue(createDefaultPreferences())
-    mockIsDevelopmentMode.mockReturnValue(false)
+    mockIsDevBuild.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -234,7 +234,30 @@ describe("product analytics runtime", () => {
 
   it("returns a runtime failure when event capture throws", async () => {
     captureMock.mockRejectedValueOnce(new Error("capture unavailable"))
-    mockIsDevelopmentMode.mockReturnValue(true)
+    mockIsDevBuild.mockReturnValue(true)
+
+    await expect(
+      handleProductAnalyticsMessage(ProductAnalyticsMessageTypes.TrackEvent, {
+        eventName: PRODUCT_ANALYTICS_EVENTS.PageViewed,
+        properties: {
+          page_id: "options_basic_settings",
+          entrypoint: "options",
+        },
+      }),
+    ).resolves.toEqual({
+      success: false,
+      error: "capture unavailable",
+    })
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      "Product analytics runtime request failed",
+      expect.any(Error),
+    )
+  })
+
+  it("logs runtime capture failures in custom development build modes", async () => {
+    captureMock.mockRejectedValueOnce(new Error("capture unavailable"))
+    mockIsDevBuild.mockReturnValue(true)
 
     await expect(
       handleProductAnalyticsMessage(ProductAnalyticsMessageTypes.TrackEvent, {

--- a/tests/utils/environment.test.ts
+++ b/tests/utils/environment.test.ts
@@ -50,6 +50,15 @@ describe("environment helpers", () => {
     expect(getRuntimeMode()).toBe("staging")
   })
 
+  it("treats custom production modes as prod builds, not production mode names", () => {
+    vi.stubEnv("MODE", "staging")
+    vi.stubEnv("DEV", false)
+    vi.stubEnv("PROD", true)
+
+    expect(isProductionMode()).toBe(false)
+    expect(isProdBuild()).toBe(true)
+  })
+
   it("detects Vite dev and production build flags separately from mode names", () => {
     vi.stubEnv("MODE", "development")
     vi.stubEnv("DEV", false)

--- a/tests/utils/environment.test.ts
+++ b/tests/utils/environment.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { isDevelopmentMode } from "~/utils/core/environment"
+import {
+  getRuntimeMode,
+  isDevBuild,
+  isDevelopmentMode,
+  isProdBuild,
+  isProductionMode,
+  isTestMode,
+} from "~/utils/core/environment"
 
 describe("environment helpers", () => {
   afterEach(() => {
@@ -11,11 +18,45 @@ describe("environment helpers", () => {
     vi.stubEnv("MODE", "development")
 
     expect(isDevelopmentMode()).toBe(true)
+    expect(isProductionMode()).toBe(false)
+    expect(isTestMode()).toBe(false)
+    expect(getRuntimeMode()).toBe("development")
   })
 
   it("returns false outside development mode", () => {
     vi.stubEnv("MODE", "test")
 
     expect(isDevelopmentMode()).toBe(false)
+    expect(isProductionMode()).toBe(false)
+    expect(isTestMode()).toBe(true)
+    expect(getRuntimeMode()).toBe("test")
+  })
+
+  it("detects production mode", () => {
+    vi.stubEnv("MODE", "production")
+
+    expect(isDevelopmentMode()).toBe(false)
+    expect(isProductionMode()).toBe(true)
+    expect(isTestMode()).toBe(false)
+    expect(getRuntimeMode()).toBe("production")
+  })
+
+  it("preserves custom runtime mode values", () => {
+    vi.stubEnv("MODE", "staging")
+
+    expect(isDevelopmentMode()).toBe(false)
+    expect(isProductionMode()).toBe(false)
+    expect(isTestMode()).toBe(false)
+    expect(getRuntimeMode()).toBe("staging")
+  })
+
+  it("detects Vite dev and production build flags separately from mode names", () => {
+    vi.stubEnv("MODE", "development")
+    vi.stubEnv("DEV", false)
+    vi.stubEnv("PROD", true)
+
+    expect(isDevelopmentMode()).toBe(true)
+    expect(isDevBuild()).toBe(false)
+    expect(isProdBuild()).toBe(true)
   })
 })

--- a/tests/utils/i18nIndex.test.ts
+++ b/tests/utils/i18nIndex.test.ts
@@ -83,6 +83,7 @@ describe("app i18n initialization", () => {
 
   it("registers plugins, initializes i18n, changes language when preferences win, and syncs dayjs", async () => {
     vi.stubEnv("MODE", "development")
+    vi.stubEnv("DEV", true)
 
     const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
     getLanguageMock.mockResolvedValueOnce("ja")
@@ -143,7 +144,25 @@ describe("app i18n initialization", () => {
     }
   })
 
+  it("enables i18n debug output in custom development build modes", async () => {
+    vi.stubEnv("MODE", "local")
+    vi.stubEnv("DEV", true)
+    getLanguageMock.mockResolvedValueOnce(undefined)
+    resolveInitialAppLanguageMock.mockReturnValueOnce("en")
+
+    await import("~/utils/i18n/index")
+
+    await vi.waitFor(() => {
+      expect(i18nCoreMock.init).toHaveBeenCalledWith(
+        expect.objectContaining({
+          debug: true,
+        }),
+      )
+    })
+  })
+
   it("keeps the current resolved language without calling changeLanguage again", async () => {
+    vi.stubEnv("DEV", false)
     const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("ja")
     i18nCoreMock.resolvedLanguage = "ja"
     i18nCoreMock.language = "en"

--- a/tests/utils/i18nIndex.test.ts
+++ b/tests/utils/i18nIndex.test.ts
@@ -82,7 +82,7 @@ describe("app i18n initialization", () => {
   })
 
   it("registers plugins, initializes i18n, changes language when preferences win, and syncs dayjs", async () => {
-    vi.stubEnv("NODE_ENV", "development")
+    vi.stubEnv("MODE", "development")
 
     const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
     getLanguageMock.mockResolvedValueOnce("ja")


### PR DESCRIPTION
## Summary
- Centralize Vite/WXT mode-name checks in a shared environment helper.
- Replace scattered direct development/test/production mode comparisons across runtime code.
- Add helper coverage for mode names and Vite dev/prod build flags.

## Test Plan
- pnpm exec vitest run tests/utils/environment.test.ts
- pnpm compile
- pnpm knip
- pnpm run validate:staged
- pre-push validate:push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and expanded runtime environment helpers; switched app-wide dev/test/prod checks to use the new predicates, standardizing debug UI, onboarding, analytics gating, and test-mode shortcuts.

* **Tests**
  * Expanded tests to cover runtime modes and build flags, adding cases for custom modes and dev/build flag permutations to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->