### PR TITLE
fix(sponsors): keep dev recommendations visible

### DIFF
--- a/src/features/AccountManagement/sponsors/bundledCatalog.ts
+++ b/src/features/AccountManagement/sponsors/bundledCatalog.ts
@@ -5,19 +5,32 @@ import type { RawSponsorCatalog } from "./types"
 
 export const bundledSponsorCatalog = sponsorCatalog as RawSponsorCatalog
 
-/** Returns bundled sponsor data with example-only records injected in development. */
-export function getBundledSponsorCatalog(): RawSponsorCatalog {
+/** Returns example-only sponsor data for local development surfaces. */
+export function getDevelopmentSponsorCatalog(): RawSponsorCatalog | null {
   if (!isDevelopmentMode()) {
-    return bundledSponsorCatalog
+    return null
   }
 
   const devSponsors = bundledSponsorCatalog._examples?.devSponsors
   if (!devSponsors?.length) {
+    return null
+  }
+
+  return {
+    schemaVersion: bundledSponsorCatalog.schemaVersion,
+    items: devSponsors,
+  }
+}
+
+/** Returns bundled sponsor data with example-only records injected in development. */
+export function getBundledSponsorCatalog(): RawSponsorCatalog {
+  const developmentCatalog = getDevelopmentSponsorCatalog()
+  if (!developmentCatalog) {
     return bundledSponsorCatalog
   }
 
   return {
     ...bundledSponsorCatalog,
-    items: [...bundledSponsorCatalog.items, ...devSponsors],
+    items: [...bundledSponsorCatalog.items, ...developmentCatalog.items],
   }
 }

--- a/src/features/AccountManagement/sponsors/catalog.ts
+++ b/src/features/AccountManagement/sponsors/catalog.ts
@@ -9,7 +9,6 @@ import type { AuthTypeEnum } from "~/types"
 import {
   SPONSOR_CATALOG_SCHEMA_VERSION,
   SPONSOR_LOCALE_FALLBACKS,
-  SPONSOR_RECOMMENDATION_LIMITS,
   type SponsorRecommendationSurface,
 } from "./constants"
 import {
@@ -84,7 +83,8 @@ export function selectSponsorRecommendations(
   items: SponsorRecommendation[],
   surface: SponsorRecommendationSurface,
 ): SponsorRecommendation[] {
-  return items.slice(0, SPONSOR_RECOMMENDATION_LIMITS[surface])
+  void surface
+  return items
 }
 
 /** Validates and normalizes one raw sponsor catalog item. */

--- a/src/features/AccountManagement/sponsors/constants.ts
+++ b/src/features/AccountManagement/sponsors/constants.ts
@@ -14,11 +14,3 @@ export const SPONSOR_RECOMMENDATION_SURFACES = {
 
 export type SponsorRecommendationSurface =
   (typeof SPONSOR_RECOMMENDATION_SURFACES)[keyof typeof SPONSOR_RECOMMENDATION_SURFACES]
-
-export const SPONSOR_RECOMMENDATION_LIMITS: Record<
-  SponsorRecommendationSurface,
-  number
-> = {
-  [SPONSOR_RECOMMENDATION_SURFACES.Newcomer]: 2,
-  [SPONSOR_RECOMMENDATION_SURFACES.AddAccountDialog]: 3,
-}

--- a/src/features/AccountManagement/sponsors/loader.ts
+++ b/src/features/AccountManagement/sponsors/loader.ts
@@ -1,6 +1,9 @@
 import { createLogger } from "~/utils/core/logger"
 
-import { getBundledSponsorCatalog } from "./bundledCatalog"
+import {
+  getBundledSponsorCatalog,
+  getDevelopmentSponsorCatalog,
+} from "./bundledCatalog"
 import { normalizeSponsorCatalog } from "./catalog"
 import { SPONSOR_REMOTE_CATALOG_URL } from "./constants"
 import { sponsorCatalogStorage } from "./storage"
@@ -21,6 +24,31 @@ interface LoadSponsorRecommendationsOptions {
 export interface LoadSponsorRecommendationsResult {
   items: SponsorRecommendation[]
   source: SponsorCatalogSource
+}
+
+/** Appends local development examples to display results without persisting them as remote cache. */
+function mergeDevelopmentSponsorRecommendations(
+  items: SponsorRecommendation[],
+  options: LoadSponsorRecommendationsOptions,
+): SponsorRecommendation[] {
+  const developmentCatalog = getDevelopmentSponsorCatalog()
+  if (!developmentCatalog) {
+    return items
+  }
+
+  const normalized = normalizeSponsorCatalog(developmentCatalog, {
+    ...options,
+    source: SPONSOR_CATALOG_SOURCES.Bundled,
+  })
+
+  if (!normalized.ok) {
+    logger.warn("Development sponsor catalog examples are invalid", {
+      errors: normalized.errors,
+    })
+    return items
+  }
+
+  return [...items, ...normalized.items]
 }
 
 /**
@@ -76,7 +104,7 @@ export async function refreshSponsorRecommendations(
   }
 
   return {
-    items: normalized.items,
+    items: mergeDevelopmentSponsorRecommendations(normalized.items, options),
     source: SPONSOR_CATALOG_SOURCES.Remote,
   }
 }
@@ -113,7 +141,7 @@ export async function loadSponsorRecommendations(
 
     if (cached.ok) {
       return {
-        items: cached.items,
+        items: mergeDevelopmentSponsorRecommendations(cached.items, options),
         source: SPONSOR_CATALOG_SOURCES.Cached,
       }
     }

--- a/src/features/AccountManagement/sponsors/loader.ts
+++ b/src/features/AccountManagement/sponsors/loader.ts
@@ -48,7 +48,9 @@ function mergeDevelopmentSponsorRecommendations(
     return items
   }
 
-  return [...items, ...normalized.items]
+  return [...items, ...normalized.items].sort(
+    (a, b) => a.rank - b.rank || a.id.localeCompare(b.id),
+  )
 }
 
 /**

--- a/tests/features/AccountManagement/sponsors/catalog.test.ts
+++ b/tests/features/AccountManagement/sponsors/catalog.test.ts
@@ -753,7 +753,7 @@ describe("sponsor catalog normalization", () => {
     expect(result.items.map((item) => item.id)).toEqual(["padded-id", "z"])
   })
 
-  it("applies surface-specific recommendation limits while preserving ordering", () => {
+  it("returns all recommendations for each surface while preserving ordering", () => {
     const catalog: RawSponsorCatalog = {
       schemaVersion: SPONSOR_CATALOG_SCHEMA_VERSION,
       items: [
@@ -807,7 +807,7 @@ describe("sponsor catalog normalization", () => {
         result.items,
         SPONSOR_RECOMMENDATION_SURFACES.Newcomer,
       ).map((item) => item.id),
-    ).toEqual(["a", "b"])
+    ).toEqual(["a", "b", "c"])
     expect(
       selectSponsorRecommendations(
         result.items,

--- a/tests/features/AccountManagement/sponsors/loader.test.ts
+++ b/tests/features/AccountManagement/sponsors/loader.test.ts
@@ -228,6 +228,39 @@ describe("sponsor recommendation loader", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it("merges development examples with cached recommendations in development", async () => {
+    vi.stubEnv("MODE", "development")
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    vi.mocked(sponsorCatalogStorage.getCachedRemoteCatalog).mockResolvedValue(
+      validRemoteCatalog,
+    )
+
+    const result = await loadSponsorRecommendations({ locale: "zh-CN", now })
+
+    expect(result.source).toBe(SPONSOR_CATALOG_SOURCES.Cached)
+    expect(result.items.map((item) => item.id)).toEqual([
+      "remote-provider",
+      "dev-supported-direct",
+      "dev-supported-access-token",
+      "dev-unsupported-all-fallbacks",
+    ])
+    expect(
+      result.items.find((item) => item.id === "remote-provider"),
+    ).toMatchObject({
+      source: SPONSOR_CATALOG_SOURCES.Cached,
+    })
+    expect(
+      result.items.find((item) => item.id === "dev-supported-direct"),
+    ).toMatchObject({
+      source: SPONSOR_CATALOG_SOURCES.Bundled,
+      accountPrefill: {
+        authType: AuthTypeEnum.Cookie,
+      },
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it("refreshes and caches valid remote recommendations separately", async () => {
     const fetchMock = mockFetchJson(validRemoteCatalog)
 
@@ -241,6 +274,40 @@ describe("sponsor recommendation loader", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(SPONSOR_REMOTE_CATALOG_URL, {
       cache: "no-store",
+    })
+    expect(sponsorCatalogStorage.setCachedRemoteCatalog).toHaveBeenCalledWith(
+      validRemoteCatalog,
+    )
+  })
+
+  it("merges development examples with refreshed remote recommendations in development", async () => {
+    vi.stubEnv("MODE", "development")
+    mockFetchJson(validRemoteCatalog)
+
+    const result = await refreshSponsorRecommendations({
+      locale: "zh-CN",
+      now,
+    })
+
+    expect(result?.source).toBe(SPONSOR_CATALOG_SOURCES.Remote)
+    expect(result?.items.map((item) => item.id)).toEqual([
+      "remote-provider",
+      "dev-supported-direct",
+      "dev-supported-access-token",
+      "dev-unsupported-all-fallbacks",
+    ])
+    expect(
+      result?.items.find((item) => item.id === "remote-provider"),
+    ).toMatchObject({
+      source: SPONSOR_CATALOG_SOURCES.Remote,
+    })
+    expect(
+      result?.items.find((item) => item.id === "dev-supported-direct"),
+    ).toMatchObject({
+      source: SPONSOR_CATALOG_SOURCES.Bundled,
+      accountPrefill: {
+        authType: AuthTypeEnum.Cookie,
+      },
     })
     expect(sponsorCatalogStorage.setCachedRemoteCatalog).toHaveBeenCalledWith(
       validRemoteCatalog,

--- a/tests/features/AccountManagement/sponsors/loader.test.ts
+++ b/tests/features/AccountManagement/sponsors/loader.test.ts
@@ -18,6 +18,80 @@ import {
 import { AuthTypeEnum } from "~/types"
 
 const sponsorLoaderFixtures = vi.hoisted(() => ({
+  developmentSponsors: [
+    {
+      id: "dev-supported-direct",
+      enabled: true,
+      rank: 9000,
+      supportStatus: "supported",
+      urls: {
+        primaryAffiliate: "https://dev-supported.example.test/register",
+        website: "https://dev-supported.example.test",
+      },
+      locales: {
+        "zh-CN": {
+          name: "[DEV] 可直接添加",
+          tagline: "测试 Cookie 认证的 accountPrefill 主按钮和添加账号预填。",
+          postClickNote:
+            "测试 Cookie 认证预填后的提示，会显示在新建账号 URL 下方。",
+        },
+      },
+      accountPrefill: {
+        siteType: "new-api",
+        siteUrl: "https://dev-supported.example.test",
+        authType: "cookie",
+      },
+    },
+    {
+      id: "dev-supported-access-token",
+      enabled: true,
+      rank: 9010,
+      supportStatus: "supported",
+      urls: {
+        primaryAffiliate: "https://dev-token.example.test/register",
+        website: "https://dev-token.example.test",
+        apiKeyCreate:
+          "https://dev-token.example.test/dashboard/api-keys?utm_source=all-api-hub",
+      },
+      locales: {
+        "zh-CN": {
+          name: "[DEV] 访问令牌",
+          tagline: "测试 access token 认证预填。",
+          postClickNote:
+            "测试访问令牌认证预填后的提示，会显示在新建账号 URL 下方。",
+        },
+      },
+      accountPrefill: {
+        siteType: "new-api",
+        siteUrl: "https://dev-token.example.test",
+        authType: "access_token",
+      },
+    },
+    {
+      id: "dev-unsupported-all-fallbacks",
+      enabled: true,
+      rank: 9020,
+      supportStatus: "unsupported",
+      urls: {
+        primaryAffiliate: "https://dev-all-fallbacks.example.test/register",
+        website: "https://dev-all-fallbacks.example.test",
+        apiKeyCreate:
+          "https://dev-all-fallbacks.example.test/dashboard/api-keys?utm_source=all-api-hub",
+      },
+      locales: {
+        "zh-CN": {
+          name: "[DEV] 全部兜底",
+          tagline: "测试全部兜底入口。",
+          postClickNote:
+            "测试赞助商提供的活动提示，可同时显示在添加账号和获取 API Key 的引导中。",
+        },
+      },
+      fallbackHints: {
+        bookmarkManager: true,
+        apiCredentialProfiles: true,
+      },
+    },
+  ],
   bundledCatalog: {
     schemaVersion: 3,
     items: [
@@ -48,84 +122,13 @@ const sponsorLoaderFixtures = vi.hoisted(() => ({
       },
     ],
     _examples: {
-      devSponsors: [
-        {
-          id: "dev-supported-direct",
-          enabled: true,
-          rank: 9000,
-          supportStatus: "supported",
-          urls: {
-            primaryAffiliate: "https://dev-supported.example.test/register",
-            website: "https://dev-supported.example.test",
-          },
-          locales: {
-            "zh-CN": {
-              name: "[DEV] 可直接添加",
-              tagline:
-                "测试 Cookie 认证的 accountPrefill 主按钮和添加账号预填。",
-              postClickNote:
-                "测试 Cookie 认证预填后的提示，会显示在新建账号 URL 下方。",
-            },
-          },
-          accountPrefill: {
-            siteType: "new-api",
-            siteUrl: "https://dev-supported.example.test",
-            authType: "cookie",
-          },
-        },
-        {
-          id: "dev-supported-access-token",
-          enabled: true,
-          rank: 9010,
-          supportStatus: "supported",
-          urls: {
-            primaryAffiliate: "https://dev-token.example.test/register",
-            website: "https://dev-token.example.test",
-            apiKeyCreate:
-              "https://dev-token.example.test/dashboard/api-keys?utm_source=all-api-hub",
-          },
-          locales: {
-            "zh-CN": {
-              name: "[DEV] 访问令牌",
-              tagline: "测试 access token 认证预填。",
-              postClickNote:
-                "测试访问令牌认证预填后的提示，会显示在新建账号 URL 下方。",
-            },
-          },
-          accountPrefill: {
-            siteType: "new-api",
-            siteUrl: "https://dev-token.example.test",
-            authType: "access_token",
-          },
-        },
-        {
-          id: "dev-unsupported-all-fallbacks",
-          enabled: true,
-          rank: 9020,
-          supportStatus: "unsupported",
-          urls: {
-            primaryAffiliate: "https://dev-all-fallbacks.example.test/register",
-            website: "https://dev-all-fallbacks.example.test",
-            apiKeyCreate:
-              "https://dev-all-fallbacks.example.test/dashboard/api-keys?utm_source=all-api-hub",
-          },
-          locales: {
-            "zh-CN": {
-              name: "[DEV] 全部兜底",
-              tagline: "测试全部兜底入口。",
-              postClickNote:
-                "测试赞助商提供的活动提示，可同时显示在添加账号和获取 API Key 的引导中。",
-            },
-          },
-          fallbackHints: {
-            bookmarkManager: true,
-            apiCredentialProfiles: true,
-          },
-        },
-      ],
+      devSponsors: [] as RawSponsorCatalog["items"],
     },
   },
 }))
+
+sponsorLoaderFixtures.bundledCatalog._examples.devSponsors =
+  sponsorLoaderFixtures.developmentSponsors
 
 vi.mock("~~/public/sponsor-catalog.json", () => ({
   default: sponsorLoaderFixtures.bundledCatalog,
@@ -210,6 +213,8 @@ describe("sponsor recommendation loader", () => {
   beforeEach(() => {
     vi.unstubAllGlobals()
     vi.unstubAllEnvs()
+    sponsorLoaderFixtures.bundledCatalog._examples.devSponsors =
+      sponsorLoaderFixtures.developmentSponsors
     vi.mocked(sponsorCatalogStorage.getCachedRemoteCatalog).mockReset()
     vi.mocked(sponsorCatalogStorage.setCachedRemoteCatalog).mockReset()
   })
@@ -259,6 +264,51 @@ describe("sponsor recommendation loader", () => {
       },
     })
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("preserves rank ordering when development examples merge with cached recommendations", async () => {
+    vi.stubEnv("MODE", "development")
+    sponsorLoaderFixtures.bundledCatalog._examples.devSponsors = [
+      {
+        ...sponsorLoaderFixtures.developmentSponsors[0],
+        id: "dev-first",
+        rank: 0,
+      },
+      {
+        ...sponsorLoaderFixtures.developmentSponsors[1],
+        id: "dev-later",
+        rank: 20,
+      },
+    ]
+    vi.mocked(sponsorCatalogStorage.getCachedRemoteCatalog).mockResolvedValue(
+      validRemoteCatalog,
+    )
+
+    const result = await loadSponsorRecommendations({ locale: "zh-CN", now })
+
+    expect(result.items.map((item) => item.id)).toEqual([
+      "dev-first",
+      "remote-provider",
+      "dev-later",
+    ])
+  })
+
+  it("keeps cached recommendations when development examples are invalid", async () => {
+    vi.stubEnv("MODE", "development")
+    sponsorLoaderFixtures.bundledCatalog._examples.devSponsors = [
+      {
+        ...sponsorLoaderFixtures.developmentSponsors[0],
+        enabled: "yes",
+      } as unknown as RawSponsorCatalog["items"][number],
+    ]
+    vi.mocked(sponsorCatalogStorage.getCachedRemoteCatalog).mockResolvedValue(
+      validRemoteCatalog,
+    )
+
+    const result = await loadSponsorRecommendations({ locale: "zh-CN", now })
+
+    expect(result.source).toBe(SPONSOR_CATALOG_SOURCES.Cached)
+    expect(result.items.map((item) => item.id)).toEqual(["remote-provider"])
   })
 
   it("refreshes and caches valid remote recommendations separately", async () => {
@@ -431,6 +481,18 @@ describe("sponsor recommendation loader", () => {
     expect(result.items.map((item) => item.id)).not.toContain(
       "dev-supported-direct",
     )
+  })
+
+  it("does not inject development examples when none are configured", async () => {
+    vi.stubEnv("MODE", "development")
+    sponsorLoaderFixtures.bundledCatalog._examples.devSponsors = []
+    vi.mocked(sponsorCatalogStorage.getCachedRemoteCatalog).mockResolvedValue(
+      null,
+    )
+
+    const result = await loadSponsorRecommendations({ locale: "zh-CN", now })
+
+    expectBundledSponsorFallback(result)
   })
 
   it("returns null when remote refresh fails", async () => {

--- a/tests/features/AccountManagement/sponsors/useSponsorRecommendations.test.tsx
+++ b/tests/features/AccountManagement/sponsors/useSponsorRecommendations.test.tsx
@@ -105,7 +105,7 @@ describe("useSponsorRecommendations", () => {
     expect(mockRefreshSponsorRecommendations).not.toHaveBeenCalled()
   })
 
-  it("loads, limits, and refreshes sponsor recommendations for the selected locale", async () => {
+  it("loads all recommendations and refreshes them for the selected locale", async () => {
     let resolveRefresh:
       | ((result: {
           items: SponsorRecommendation[]
@@ -142,6 +142,7 @@ describe("useSponsorRecommendations", () => {
         "first-provider",
         "second-provider",
         "third-provider",
+        "fourth-provider",
       ])
     })
 
@@ -197,6 +198,8 @@ describe("useSponsorRecommendations", () => {
       expect(result.current.items.map((item) => item.id)).toEqual([
         "first-provider",
         "second-provider",
+        "third-provider",
+        "fourth-provider",
       ])
     })
   })


### PR DESCRIPTION
## Summary
- merge development sponsor examples into cached and refreshed remote sponsor results without persisting them to remote cache
- remove sponsor recommendation surface limits so all normalized recommendations remain visible

## Validation
- pnpm exec vitest run tests/features/AccountManagement/sponsors
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development sponsor examples are now merged into recommendation lists when running in development mode.

* **Refactor**
  * Sponsor recommendation logic reorganized; per-surface recommendation limits removed so surfaces now return the complete ordered set of applicable sponsors.

* **Tests**
  * Updated and expanded tests to cover removal of limits and development-mode sponsor merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->