### PR TITLE
test(e2e): cover account auth isolation

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -42,10 +42,21 @@ concurrency:
 
 jobs:
   e2e-smoke:
+    name: E2E smoke (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-e2e') }}
     continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-optional') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            build_variant: ""
+            command: pnpm e2e
+          - name: dnr-required
+            build_variant: dnr-required
+            command: timeout 180s pnpm exec playwright test e2e/accountCookieDnrRealBrowser.spec.ts --project=chromium --workers=1 --timeout=120000 --grep "isolates same-site"
 
     steps:
       - name: Checkout code
@@ -68,6 +79,8 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build extension
+        env:
+          AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
         run: pnpm build:e2e
 
       - name: Get Playwright version
@@ -87,13 +100,16 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E smoke
-        run: pnpm e2e
+        env:
+          AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
+          AAH_SKIP_E2E_BUILD: "1"
+        run: ${{ matrix.command }}
 
       - name: Upload Playwright artifacts (failure)
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report-${{ github.run_attempt }}
+          name: playwright-report-${{ matrix.name }}-${{ github.run_attempt }}
           path: |
             playwright-report/
             test-results/

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -52,11 +52,13 @@ jobs:
       matrix:
         include:
           - name: default
+            e2e_type: default
             build_variant: ""
-            command: pnpm e2e
+            timeout_minutes: 20
           - name: dnr-required
+            e2e_type: dnr-required
             build_variant: dnr-required
-            command: timeout 180s pnpm exec playwright test e2e/accountCookieDnrRealBrowser.spec.ts --project=chromium --workers=1 --timeout=120000 --grep "isolates same-site"
+            timeout_minutes: 5
 
     steps:
       - name: Checkout code
@@ -100,10 +102,11 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E smoke
+        timeout-minutes: ${{ matrix.timeout_minutes }}
         env:
           AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
           AAH_SKIP_E2E_BUILD: "1"
-        run: ${{ matrix.command }}
+        run: pnpm run e2e:${{ matrix.e2e_type }}
 
       - name: Upload Playwright artifacts (failure)
         if: failure()

--- a/e2e/accountCookieDnrRealBrowser.spec.ts
+++ b/e2e/accountCookieDnrRealBrowser.spec.ts
@@ -1,0 +1,591 @@
+import http from "node:http"
+import type { AddressInfo } from "node:net"
+import type { BrowserContext, Page } from "@playwright/test"
+
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { OPTIONAL_PERMISSION_IDS } from "~/services/permissions/permissionManager"
+import { AuthTypeEnum } from "~/types"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  E2E_BUILD_VARIANT_ENV,
+  E2E_BUILD_VARIANTS,
+} from "~~/e2e/utils/e2eBuildVariants"
+import {
+  closeOtherPages,
+  expectPermissionOnboardingHidden,
+  getManifestOptionalPermissions,
+  getManifestRequiredPermissions,
+  requestAndExpectOptionalPermissions,
+} from "~~/e2e/utils/extensionState"
+import { openAccountManagementPage } from "~~/e2e/utils/realSite/accountAdd"
+
+const BROWSER_CURRENT_SESSION_COOKIE = "session=browser-current"
+const ACCOUNT_A_SESSION_COOKIE = "session=user-a"
+const ACCOUNT_B_SESSION_COOKIE = "session=user-b"
+const ACCESS_TOKEN_A = "access-token-user-a"
+const ACCESS_TOKEN_B = "access-token-user-b"
+const COOKIE_DNR_PERMISSIONS = [
+  OPTIONAL_PERMISSION_IDS.Cookies,
+  OPTIONAL_PERMISSION_IDS.declarativeNetRequestWithHostAccess,
+]
+
+test.describe.configure({ mode: "serial" })
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page, {
+    ignoreConsoleErrorPatterns: [
+      /Failed to load resource: the server responded with a status of 401 \(Unauthorized\)/u,
+    ],
+  })
+  await forceExtensionLanguage(page, "en")
+  await stubLlmMetadataIndex(context)
+})
+
+test("grants the Chromium cookie/DNR optional permissions needed for cookie auth", async ({
+  extensionId,
+  page,
+}) => {
+  const localSite = await startDnrCaptureNewApiServer()
+  try {
+    await openAccountManagementPage({ page, extensionId })
+    await expectPermissionOnboardingHidden(page)
+    await grantCookieDnrPermissions(page, localSite.origin)
+  } finally {
+    await localSite.close()
+  }
+})
+
+test("isolates same-site cookie and access-token accounts through production temp-window fetch", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  test.slow()
+  test.skip(
+    process.env[E2E_BUILD_VARIANT_ENV] !== E2E_BUILD_VARIANTS.DnrRequired,
+    [
+      "Real Chromium DNR cookie isolation requires the E2E-only dnr-required manifest variant.",
+      `Run with ${E2E_BUILD_VARIANT_ENV}=${E2E_BUILD_VARIANTS.DnrRequired}.`,
+    ].join(" "),
+  )
+
+  const localSite = await startDnrCaptureNewApiServer()
+  try {
+    await test.step("open extension and verify cookie/DNR permissions", async () => {
+      await openAccountManagementPage({ page, extensionId })
+      await expectPermissionOnboardingHidden(page)
+      await grantCookieDnrPermissions(page, localSite.origin)
+    })
+
+    await test.step("seed browser login cookie that must not leak into account requests", async () => {
+      await seedBrowserCurrentLoginCookie(context, localSite.origin)
+    })
+
+    await test.step("fetch account A with real Chromium DNR cookie injection", async () => {
+      const response = await runTempWindowAccountFetch(page, {
+        originUrl: localSite.origin,
+        accountId: "e2e-cookie-account-a",
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: ACCOUNT_A_SESSION_COOKIE,
+        fetchOptions: { credentials: "include" },
+      })
+      expect(response).toMatchObject({
+        success: true,
+        status: 200,
+        data: expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            id: "201",
+            username: "cookie-user-a",
+            quota: 33_000,
+          }),
+        }),
+      })
+      await localSite.waitForAuthenticatedSelfRequest(ACCOUNT_A_SESSION_COOKIE)
+    })
+
+    await test.step("fetch account B with real Chromium DNR cookie injection", async () => {
+      const response = await runTempWindowAccountFetch(page, {
+        originUrl: localSite.origin,
+        accountId: "e2e-cookie-account-b",
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: ACCOUNT_B_SESSION_COOKIE,
+        fetchOptions: { credentials: "include" },
+      })
+      expect(response).toMatchObject({
+        success: true,
+        status: 200,
+        data: expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            id: "202",
+            username: "cookie-user-b",
+            quota: 44_000,
+          }),
+        }),
+      })
+      await localSite.waitForAuthenticatedSelfRequest(ACCOUNT_B_SESSION_COOKIE)
+    })
+
+    await test.step("fetch access-token accounts without cookie auth contamination", async () => {
+      const responseA = await runTempWindowAccountFetch(page, {
+        originUrl: localSite.origin,
+        accountId: "e2e-access-token-account-a",
+        authType: AuthTypeEnum.AccessToken,
+        fetchOptions: {
+          credentials: "omit",
+          headers: {
+            Authorization: `Bearer ${ACCESS_TOKEN_A}`,
+          },
+        },
+      })
+      const responseB = await runTempWindowAccountFetch(page, {
+        originUrl: localSite.origin,
+        accountId: "e2e-access-token-account-b",
+        authType: AuthTypeEnum.AccessToken,
+        fetchOptions: {
+          credentials: "omit",
+          headers: {
+            Authorization: `Bearer ${ACCESS_TOKEN_B}`,
+          },
+        },
+      })
+
+      expect(responseA).toMatchObject({
+        success: true,
+        status: 200,
+        data: expect.objectContaining({
+          data: expect.objectContaining({
+            id: "301",
+            username: "token-user-a",
+            quota: 55_000,
+          }),
+        }),
+      })
+      expect(responseB).toMatchObject({
+        success: true,
+        status: 200,
+        data: expect.objectContaining({
+          data: expect.objectContaining({
+            id: "302",
+            username: "token-user-b",
+            quota: 66_000,
+          }),
+        }),
+      })
+    })
+
+    const authenticatedSelfRequests = localSite.selfRequests.filter(
+      (request) => request.matchedSessionCookie || request.matchedAccessToken,
+    )
+    expect(authenticatedSelfRequests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          matchedSessionCookie: ACCOUNT_A_SESSION_COOKIE,
+        }),
+        expect.objectContaining({
+          matchedSessionCookie: ACCOUNT_B_SESSION_COOKIE,
+        }),
+        expect.objectContaining({
+          matchedAccessToken: ACCESS_TOKEN_A,
+        }),
+        expect.objectContaining({
+          matchedAccessToken: ACCESS_TOKEN_B,
+        }),
+      ]),
+    )
+    for (const request of authenticatedSelfRequests) {
+      expect(request.cookieHeader).not.toContain(BROWSER_CURRENT_SESSION_COOKIE)
+    }
+  } finally {
+    await closeOtherPages(context, page)
+    await localSite.close()
+  }
+})
+
+async function grantCookieDnrPermissions(page: Page, origin: string) {
+  const optionalPermissions = await getManifestOptionalPermissions(page)
+  const requiredPermissions = await getManifestRequiredPermissions(page)
+  for (const permission of COOKIE_DNR_PERMISSIONS) {
+    expect([...optionalPermissions, ...requiredPermissions]).toContain(
+      permission,
+    )
+  }
+
+  const missingOptionalPermissions = COOKIE_DNR_PERMISSIONS.filter(
+    (permission) => !requiredPermissions.includes(permission),
+  )
+  await requestAndExpectOptionalPermissions(page, missingOptionalPermissions)
+  const originPattern = `${origin}/*`
+  const hasOriginPermission = await page.evaluate(async (originPattern) => {
+    const chromeApi = (
+      globalThis as typeof globalThis & { chrome?: typeof chrome }
+    ).chrome
+
+    if (!chromeApi?.permissions) {
+      throw new Error("chrome.permissions is unavailable in extension context")
+    }
+
+    return await chromeApi.permissions.contains({
+      origins: [originPattern],
+    })
+  }, originPattern)
+
+  expect(hasOriginPermission, `${originPattern} host access`).toBe(true)
+}
+
+async function runTempWindowAccountFetch(
+  page: Page,
+  params: {
+    originUrl: string
+    accountId: string
+    authType: AuthTypeEnum
+    cookieAuthSessionCookie?: string
+    fetchOptions: RequestInit
+  },
+) {
+  return await page.evaluate(
+    async ({
+      action,
+      accountId,
+      authType,
+      cookieAuthSessionCookie,
+      fetchOptions,
+      originUrl,
+    }) => {
+      const chromeApi = (
+        globalThis as typeof globalThis & { chrome?: typeof chrome }
+      ).chrome
+
+      if (!chromeApi?.runtime?.sendMessage) {
+        throw new Error("chrome.runtime.sendMessage is unavailable")
+      }
+
+      const requestId = `e2e-temp-window-${accountId}-${Date.now()}`
+      const message = {
+        action,
+        originUrl,
+        fetchUrl: `${originUrl}/api/user/self`,
+        fetchOptions,
+        requestId,
+        responseType: "json",
+        suppressMinimize: true,
+        accountId,
+        authType,
+        cookieAuthSessionCookie,
+      }
+
+      const timeout = new Promise<never>((_, reject) => {
+        setTimeout(() => {
+          reject(
+            new Error(`Timed out waiting for tempWindowFetch ${requestId}`),
+          )
+        }, 30_000)
+      })
+
+      const response = new Promise((resolve, reject) => {
+        chromeApi.runtime.sendMessage(message, (result) => {
+          const error = chromeApi.runtime.lastError
+          if (error) {
+            reject(new Error(error.message))
+            return
+          }
+          resolve(result)
+        })
+      })
+
+      return await Promise.race([response, timeout])
+    },
+    {
+      action: RuntimeActionIds.TempWindowFetch,
+      accountId: params.accountId,
+      authType: params.authType,
+      cookieAuthSessionCookie: params.cookieAuthSessionCookie,
+      fetchOptions: params.fetchOptions,
+      originUrl: params.originUrl,
+    },
+  )
+}
+
+type CapturedSelfRequest = {
+  cookieHeader: string
+  matchedSessionCookie: string | null
+  matchedAccessToken: string | null
+}
+
+type DnrCaptureNewApiServer = {
+  origin: string
+  selfRequests: CapturedSelfRequest[]
+  waitForAuthenticatedSelfRequest: (
+    sessionCookie: string,
+  ) => Promise<CapturedSelfRequest>
+  close: () => Promise<void>
+}
+
+async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
+  const selfRequests: CapturedSelfRequest[] = []
+  const waiters: Array<{
+    sessionCookie: string
+    resolve: (request: CapturedSelfRequest) => void
+    reject: (error: Error) => void
+    timeout: ReturnType<typeof setTimeout>
+  }> = []
+
+  const resolveMatchingWaiters = (captured: CapturedSelfRequest) => {
+    for (const waiter of [...waiters]) {
+      if (captured.matchedSessionCookie !== waiter.sessionCookie) {
+        continue
+      }
+      clearTimeout(waiter.timeout)
+      waiters.splice(waiters.indexOf(waiter), 1)
+      waiter.resolve(captured)
+    }
+  }
+
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1")
+    const method = request.method ?? "GET"
+
+    const sendJson = (status: number, body: unknown) => {
+      response.writeHead(status, {
+        "Content-Type": "application/json",
+      })
+      response.end(JSON.stringify(body))
+    }
+
+    if (method === "GET" && url.pathname === "/") {
+      response.writeHead(200, {
+        "Content-Type": "text/html",
+      })
+      response.end(
+        "<!doctype html><html><head><title>Local DNR New API</title></head><body>Local DNR New API</body></html>",
+      )
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/favicon.ico") {
+      response.writeHead(204)
+      response.end()
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/status") {
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          system_name: "Local DNR New API",
+          price: 7,
+          checkin_enabled: false,
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/user/self") {
+      const cookieHeader = request.headers.cookie ?? ""
+      const authorizationHeader = request.headers.authorization ?? ""
+      const matchedSessionCookie = matchAccountSessionCookie(cookieHeader)
+      const matchedAccessToken = matchAccessToken(authorizationHeader)
+      const captured: CapturedSelfRequest = {
+        cookieHeader,
+        matchedSessionCookie,
+        matchedAccessToken,
+      }
+      selfRequests.push(captured)
+      resolveMatchingWaiters(captured)
+
+      const account =
+        (matchedSessionCookie
+          ? ACCOUNT_BY_SESSION_COOKIE[matchedSessionCookie]
+          : null) ??
+        (matchedAccessToken
+          ? ACCOUNT_BY_ACCESS_TOKEN[matchedAccessToken]
+          : null)
+      if (!account) {
+        sendJson(401, {
+          success: false,
+          message: "missing account session cookie",
+        })
+        return
+      }
+
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          id: account.id,
+          username: account.username,
+          access_token: "",
+          quota: account.quota,
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/log/self/stat") {
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          quota: 0,
+          rpm: 0,
+          tpm: 0,
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/log/self") {
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          page: Number(url.searchParams.get("p") ?? "1"),
+          page_size: Number(url.searchParams.get("page_size") ?? "100"),
+          total: 0,
+          items: [],
+        },
+      })
+      return
+    }
+
+    sendJson(404, {
+      success: false,
+      message: `Unhandled local DNR route: ${method} ${url.pathname}`,
+    })
+  })
+
+  const origin = await new Promise<string>((resolve, reject) => {
+    server.on("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo
+      resolve(`http://127.0.0.1:${address.port}`)
+    })
+  })
+
+  const waitForAuthenticatedSelfRequest = async (sessionCookie: string) => {
+    const existing = selfRequests.find(
+      (request) => request.matchedSessionCookie === sessionCookie,
+    )
+    if (existing) return existing
+
+    return await new Promise<CapturedSelfRequest>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const seen = selfRequests
+          .map((request) => request.cookieHeader || "<empty>")
+          .join(", ")
+        reject(
+          new Error(
+            `Timed out waiting for ${sessionCookie}; seen Cookie headers: ${seen}`,
+          ),
+        )
+      }, 15_000)
+
+      waiters.push({
+        sessionCookie,
+        resolve,
+        reject,
+        timeout,
+      })
+    })
+  }
+
+  const close = async () => {
+    for (const waiter of waiters.splice(0)) {
+      clearTimeout(waiter.timeout)
+      waiter.reject(new Error("Local DNR server closed"))
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error)
+        else resolve()
+      })
+    })
+  }
+
+  return {
+    origin,
+    selfRequests,
+    waitForAuthenticatedSelfRequest,
+    close,
+  }
+}
+
+const ACCOUNT_BY_SESSION_COOKIE: Record<
+  string,
+  { id: string; username: string; quota: number }
+> = {
+  [ACCOUNT_A_SESSION_COOKIE]: {
+    id: "201",
+    username: "cookie-user-a",
+    quota: 33_000,
+  },
+  [ACCOUNT_B_SESSION_COOKIE]: {
+    id: "202",
+    username: "cookie-user-b",
+    quota: 44_000,
+  },
+}
+
+const ACCOUNT_BY_ACCESS_TOKEN: Record<
+  string,
+  { id: string; username: string; quota: number }
+> = {
+  [ACCESS_TOKEN_A]: {
+    id: "301",
+    username: "token-user-a",
+    quota: 55_000,
+  },
+  [ACCESS_TOKEN_B]: {
+    id: "302",
+    username: "token-user-b",
+    quota: 66_000,
+  },
+}
+
+function matchAccountSessionCookie(cookieHeader: string) {
+  if (cookieHeader.includes(ACCOUNT_A_SESSION_COOKIE)) {
+    return ACCOUNT_A_SESSION_COOKIE
+  }
+  if (cookieHeader.includes(ACCOUNT_B_SESSION_COOKIE)) {
+    return ACCOUNT_B_SESSION_COOKIE
+  }
+  return null
+}
+
+function matchAccessToken(authorizationHeader: string) {
+  const match = /^Bearer\s+(.+)$/iu.exec(authorizationHeader.trim())
+  const token = match?.[1] ?? authorizationHeader.trim()
+  if (token === ACCESS_TOKEN_A) {
+    return ACCESS_TOKEN_A
+  }
+  if (token === ACCESS_TOKEN_B) {
+    return ACCESS_TOKEN_B
+  }
+  return null
+}
+
+async function seedBrowserCurrentLoginCookie(
+  context: BrowserContext,
+  origin: string,
+) {
+  const url = new URL(origin)
+  await context.addCookies([
+    {
+      name: "session",
+      value: "browser-current",
+      domain: url.hostname,
+      path: "/",
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+      expires: Math.floor(Date.now() / 1000) + 3600,
+    },
+  ])
+}

--- a/e2e/accountMultiAuthMockedFlows.spec.ts
+++ b/e2e/accountMultiAuthMockedFlows.spec.ts
@@ -1,16 +1,13 @@
-import type { BrowserContext, Page, Route, Worker } from "@playwright/test"
+import type { BrowserContext, Route, Worker } from "@playwright/test"
 
 import { SITE_TYPES } from "~/constants/siteType"
-import {
-  ACCOUNT_MANAGEMENT_TEST_IDS,
-  getAccountManagementListItemTestId,
-} from "~/features/AccountManagement/testIds"
 import { OPTIONAL_PERMISSION_IDS } from "~/services/permissions/permissionManager"
 import { AuthTypeEnum } from "~/types"
 import { extractSessionCookieHeader } from "~/utils/browser/cookieString"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
   readStoredAccounts,
+  refreshAccountRowsAndReadStorage,
   saveManualAccountFromApp,
 } from "~~/e2e/scenarios/accountManualAdd"
 import {
@@ -550,43 +547,4 @@ function resolveMockedAuthenticatedAccount(headers: Record<string, string>) {
   }
 
   return null
-}
-
-async function refreshAccountRowsAndReadStorage(params: {
-  page: Page
-  serviceWorker: Worker
-  accountIds: string[]
-  expectedQuotas: number[]
-}) {
-  for (const accountId of params.accountIds) {
-    const row = params.page.getByTestId(
-      getAccountManagementListItemTestId(accountId),
-    )
-    await row.hover()
-    await row
-      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowMoreActionsButton)
-      .click()
-    await params.page
-      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowRefreshMenuItem)
-      .click()
-  }
-
-  await expect
-    .poll(async () => {
-      const accounts = await readStoredAccounts(params.serviceWorker)
-      return params.accountIds.map((id) => {
-        const account = accounts.find((candidate) => candidate.id === id)
-        return account?.account_info.quota ?? null
-      })
-    })
-    .toEqual(params.expectedQuotas)
-
-  const accounts = await readStoredAccounts(params.serviceWorker)
-  return params.accountIds.map((id) => {
-    const account = accounts.find((candidate) => candidate.id === id)
-    if (!account) {
-      throw new Error(`Refreshed account ${id} was not found`)
-    }
-    return account
-  })
 }

--- a/e2e/accountMultiAuthMockedFlows.spec.ts
+++ b/e2e/accountMultiAuthMockedFlows.spec.ts
@@ -1,0 +1,592 @@
+import type { BrowserContext, Page, Route, Worker } from "@playwright/test"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  ACCOUNT_MANAGEMENT_TEST_IDS,
+  getAccountManagementListItemTestId,
+} from "~/features/AccountManagement/testIds"
+import { OPTIONAL_PERMISSION_IDS } from "~/services/permissions/permissionManager"
+import { AuthTypeEnum } from "~/types"
+import { extractSessionCookieHeader } from "~/utils/browser/cookieString"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  readStoredAccounts,
+  saveManualAccountFromApp,
+} from "~~/e2e/scenarios/accountManualAdd"
+import {
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  seedStoredAccounts,
+  seedUserPreferences,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  expectPermissionOnboardingHidden,
+  getManifestOptionalPermissions,
+  getServiceWorker,
+  requestAndExpectOptionalPermissions,
+} from "~~/e2e/utils/extensionState"
+
+const MOCKED_MULTI_ACCOUNT_SITE_URL = "https://multi-account.example.com"
+const MOCKED_ACCOUNT_BY_ACCESS_TOKEN = {
+  "e2e-access-token-a": {
+    id: "101",
+    username: "token-user-a",
+    quota: 11_000,
+  },
+  "e2e-access-token-b": {
+    id: "102",
+    username: "token-user-b",
+    quota: 22_000,
+  },
+  "permission-probe-token": {
+    id: "200",
+    username: "permission-probe-user",
+    quota: 1_000,
+  },
+} as const
+const MOCKED_ACCOUNT_BY_SESSION_COOKIE = {
+  "session=user-a": {
+    id: "201",
+    username: "cookie-user-a",
+    quota: 33_000,
+  },
+  "session=user-b": {
+    id: "202",
+    username: "cookie-user-b",
+    quota: 44_000,
+  },
+} as const
+const COOKIE_AUTH_OPTIONAL_PERMISSION_IDS = new Set<string>([
+  OPTIONAL_PERMISSION_IDS.Cookies,
+  OPTIONAL_PERMISSION_IDS.declarativeNetRequestWithHostAccess,
+  OPTIONAL_PERMISSION_IDS.WebRequest,
+  OPTIONAL_PERMISSION_IDS.WebRequestBlocking,
+])
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page, {
+    ignoreConsoleErrorPatterns: [
+      /Failed to load resource: the server responded with a status of 401 \(Unauthorized\)/u,
+    ],
+  })
+  await forceExtensionLanguage(page, "en")
+  await stubLlmMetadataIndex(context)
+  await stubCredentialIsolatedNewApiSiteRoutes(context)
+})
+
+test("saves two access-token accounts on the same mocked site", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedStoredAccounts(serviceWorker, [])
+  await seedUserPreferences(serviceWorker, {
+    tempWindowFallback: {
+      enabled: false,
+    },
+    warnOnDuplicateAccountAdd: false,
+  })
+
+  await saveManualAccountFromApp({
+    page,
+    extensionId,
+    serviceWorker,
+    baseUrl: MOCKED_MULTI_ACCOUNT_SITE_URL,
+    siteType: SITE_TYPES.NEW_API,
+    account: {
+      authType: AuthTypeEnum.AccessToken,
+      siteName: "Mocked Multi Account",
+      username: "token-user-a",
+      userId: "101",
+      accessToken: "e2e-access-token-a",
+    },
+  })
+  await saveManualAccountFromApp({
+    page,
+    extensionId,
+    serviceWorker,
+    baseUrl: MOCKED_MULTI_ACCOUNT_SITE_URL,
+    siteType: SITE_TYPES.NEW_API,
+    account: {
+      authType: AuthTypeEnum.AccessToken,
+      siteName: "Mocked Multi Account",
+      username: "token-user-b",
+      userId: "102",
+      accessToken: "e2e-access-token-b",
+    },
+  })
+
+  await expectPermissionOnboardingHidden(page)
+
+  const accounts = (await readStoredAccounts(serviceWorker)).filter(
+    (account) => account.site_url === MOCKED_MULTI_ACCOUNT_SITE_URL,
+  )
+  expect(accounts).toHaveLength(2)
+  expect(accounts).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        authType: AuthTypeEnum.AccessToken,
+        account_info: expect.objectContaining({
+          id: "101",
+          access_token: "e2e-access-token-a",
+        }),
+      }),
+      expect.objectContaining({
+        authType: AuthTypeEnum.AccessToken,
+        account_info: expect.objectContaining({
+          id: "102",
+          access_token: "e2e-access-token-b",
+        }),
+      }),
+    ]),
+  )
+
+  const refreshedAccounts = await refreshAccountRowsAndReadStorage({
+    page,
+    serviceWorker,
+    accountIds: accounts.map((account) => account.id),
+    expectedQuotas: [11_000, 22_000],
+  })
+  expect(refreshedAccounts).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        account_info: expect.objectContaining({
+          id: "101",
+          username: "token-user-a",
+          quota: 11_000,
+        }),
+      }),
+      expect.objectContaining({
+        account_info: expect.objectContaining({
+          id: "102",
+          username: "token-user-b",
+          quota: 22_000,
+        }),
+      }),
+    ]),
+  )
+})
+
+test("grants cookie-auth optional permissions and saves two cookie accounts on the same mocked site", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedStoredAccounts(serviceWorker, [])
+  await seedUserPreferences(serviceWorker, {
+    tempWindowFallback: {
+      enabled: true,
+    },
+    warnOnDuplicateAccountAdd: false,
+  })
+
+  await saveManualAccountFromApp({
+    page,
+    extensionId,
+    serviceWorker,
+    baseUrl: MOCKED_MULTI_ACCOUNT_SITE_URL,
+    siteType: SITE_TYPES.NEW_API,
+    account: {
+      authType: AuthTypeEnum.AccessToken,
+      siteName: "Mocked Multi Account",
+      username: "permission-probe-user",
+      userId: "200",
+      accessToken: "permission-probe-token",
+    },
+  })
+
+  const optionalPermissions = await getManifestOptionalPermissions(page)
+  const cookieAuthPermissions =
+    getCookieAuthOptionalPermissions(optionalPermissions)
+  expect(cookieAuthPermissions).toContain("cookies")
+  await requestAndExpectOptionalPermissions(page, cookieAuthPermissions)
+  await seedStoredAccounts(serviceWorker, [])
+  await installMockedTempWindowCookieAuthBridge(serviceWorker)
+
+  await saveManualAccountFromApp({
+    page,
+    extensionId,
+    serviceWorker,
+    baseUrl: MOCKED_MULTI_ACCOUNT_SITE_URL,
+    siteType: SITE_TYPES.NEW_API,
+    account: {
+      authType: AuthTypeEnum.Cookie,
+      siteName: "Mocked Multi Account",
+      username: "cookie-user-a",
+      userId: "201",
+      cookieAuthSessionCookie: "session=user-a; uid=201",
+    },
+  })
+  await saveManualAccountFromApp({
+    page,
+    extensionId,
+    serviceWorker,
+    baseUrl: MOCKED_MULTI_ACCOUNT_SITE_URL,
+    siteType: SITE_TYPES.NEW_API,
+    account: {
+      authType: AuthTypeEnum.Cookie,
+      siteName: "Mocked Multi Account",
+      username: "cookie-user-b",
+      userId: "202",
+      cookieAuthSessionCookie: "session=user-b; uid=202",
+    },
+  })
+
+  await expectPermissionOnboardingHidden(page)
+
+  const accounts = (await readStoredAccounts(serviceWorker)).filter(
+    (account) => account.site_url === MOCKED_MULTI_ACCOUNT_SITE_URL,
+  )
+  expect(accounts).toHaveLength(2)
+  expect(accounts).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        authType: AuthTypeEnum.Cookie,
+        cookieAuth: { sessionCookie: "session=user-a" },
+      }),
+      expect.objectContaining({
+        authType: AuthTypeEnum.Cookie,
+        cookieAuth: { sessionCookie: "session=user-b" },
+      }),
+    ]),
+  )
+
+  const refreshedAccounts = await refreshAccountRowsAndReadStorage({
+    page,
+    serviceWorker,
+    accountIds: accounts.map((account) => account.id),
+    expectedQuotas: [33_000, 44_000],
+  })
+  expect(refreshedAccounts).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        authType: AuthTypeEnum.Cookie,
+        cookieAuth: { sessionCookie: "session=user-a" },
+        account_info: expect.objectContaining({
+          id: "201",
+          username: "cookie-user-a",
+          quota: 33_000,
+        }),
+      }),
+      expect.objectContaining({
+        authType: AuthTypeEnum.Cookie,
+        cookieAuth: { sessionCookie: "session=user-b" },
+        account_info: expect.objectContaining({
+          id: "202",
+          username: "cookie-user-b",
+          quota: 44_000,
+        }),
+      }),
+    ]),
+  )
+})
+
+function getCookieAuthOptionalPermissions(optionalPermissions: string[]) {
+  return optionalPermissions.filter((permission) =>
+    COOKIE_AUTH_OPTIONAL_PERMISSION_IDS.has(permission),
+  )
+}
+
+async function installMockedTempWindowCookieAuthBridge(serviceWorker: Worker) {
+  await serviceWorker.evaluate((cookieAccounts) => {
+    const chromeApi = (globalThis as any).chrome
+    if (!chromeApi?.declarativeNetRequest || !chromeApi?.tabs) {
+      throw new Error("Chrome DNR/tabs APIs are unavailable")
+    }
+
+    const cookieHeaderByTabId = new Map<number, string>()
+    const originalUpdateSessionRules =
+      chromeApi.declarativeNetRequest.updateSessionRules?.bind(
+        chromeApi.declarativeNetRequest,
+      )
+    const originalSendMessage = chromeApi.tabs.sendMessage?.bind(chromeApi.tabs)
+
+    chromeApi.declarativeNetRequest.updateSessionRules = (
+      update: {
+        addRules?: Array<{
+          condition?: { tabIds?: number[] }
+          action?: {
+            requestHeaders?: Array<{
+              header?: string
+              operation?: string
+              value?: string
+            }>
+          }
+        }>
+      },
+      callback?: () => void,
+    ) => {
+      for (const rule of update.addRules ?? []) {
+        const tabId = rule.condition?.tabIds?.[0]
+        const cookieHeader = rule.action?.requestHeaders?.find(
+          (header) =>
+            header.header?.toLowerCase() === "cookie" &&
+            header.operation === "set" &&
+            typeof header.value === "string",
+        )?.value
+
+        if (typeof tabId === "number" && cookieHeader) {
+          cookieHeaderByTabId.set(tabId, cookieHeader)
+        }
+      }
+
+      callback?.()
+      return Promise.resolve()
+    }
+
+    chromeApi.tabs.sendMessage = (
+      tabId: number,
+      message: { action?: string },
+      optionsOrCallback?: unknown,
+      maybeCallback?: (response: unknown) => void,
+    ) => {
+      const callback =
+        typeof optionsOrCallback === "function"
+          ? optionsOrCallback
+          : maybeCallback
+
+      const respond = (response: unknown) => {
+        callback?.(response)
+        return Promise.resolve(response)
+      }
+
+      if (
+        message?.action === "checkCapGuard" ||
+        message?.action === "checkCloudflareGuard"
+      ) {
+        return respond({
+          success: true,
+          passed: true,
+          detection: { isChallenge: false },
+        })
+      }
+
+      if (message?.action === "showShieldBypassUi") {
+        return respond({ success: true })
+      }
+
+      if (message?.action === "performTempWindowFetch") {
+        const cookieHeader = cookieHeaderByTabId.get(tabId) ?? ""
+        const sessionCookie =
+          cookieHeader.match(/(?:^|;\s*)(session=[^;]+)/iu)?.[1] ?? ""
+        const account =
+          cookieAccounts[sessionCookie as keyof typeof cookieAccounts]
+
+        if (!account) {
+          return respond({
+            success: false,
+            status: 401,
+            data: { success: false, message: "mock auth failed" },
+            error: "mock auth failed",
+          })
+        }
+
+        return respond({
+          success: true,
+          status: 200,
+          headers: { "content-type": "application/json" },
+          data: {
+            success: true,
+            message: "ok",
+            data: {
+              id: account.id,
+              username: account.username,
+              access_token: "",
+              quota: account.quota,
+            },
+          },
+        })
+      }
+
+      if (originalSendMessage) {
+        return originalSendMessage(
+          tabId,
+          message,
+          optionsOrCallback as never,
+          maybeCallback,
+        )
+      }
+
+      return respond(undefined)
+    }
+    ;(globalThis as any).__aahRestoreMockedTempWindowCookieAuthBridge = () => {
+      if (originalUpdateSessionRules) {
+        chromeApi.declarativeNetRequest.updateSessionRules =
+          originalUpdateSessionRules
+      }
+      if (originalSendMessage) {
+        chromeApi.tabs.sendMessage = originalSendMessage
+      }
+      cookieHeaderByTabId.clear()
+    }
+  }, MOCKED_ACCOUNT_BY_SESSION_COOKIE)
+}
+
+async function stubCredentialIsolatedNewApiSiteRoutes(context: BrowserContext) {
+  const origin = new URL(MOCKED_MULTI_ACCOUNT_SITE_URL).origin
+  const routePattern = new RegExp(`^${escapeRegExp(origin)}(?:/.*)?$`, "u")
+
+  await context.route(routePattern, async (route: Route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const method = request.method()
+    const fulfillJson = async (status: number, body: unknown) => {
+      await route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      })
+    }
+
+    if (method === "GET" && url.pathname === "/") {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><html><head><title>E2E Multi Account New API</title></head><body>E2E Multi Account New API</body></html>",
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/favicon.ico") {
+      await route.fulfill({
+        status: 204,
+        body: "",
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/status") {
+      await fulfillJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          system_name: "E2E Multi Account New API",
+          price: 7,
+          checkin_enabled: false,
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/user/self") {
+      const account = resolveMockedAuthenticatedAccount(request.headers())
+
+      if (!account) {
+        await fulfillJson(401, {
+          success: false,
+          message: "mock auth failed",
+        })
+        return
+      }
+
+      await fulfillJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          id: account.id,
+          username: account.username,
+          access_token: "",
+          quota: account.quota,
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/log/self/stat") {
+      await fulfillJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          quota: 0,
+          rpm: 0,
+          tpm: 0,
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/log/self") {
+      await fulfillJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          page: Number(url.searchParams.get("p") ?? "1"),
+          page_size: Number(url.searchParams.get("page_size") ?? "100"),
+          total: 0,
+          items: [],
+        },
+      })
+      return
+    }
+
+    await fulfillJson(404, {
+      success: false,
+      message: `Unhandled credential-isolated route: ${method} ${url.pathname}`,
+    })
+  })
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")
+}
+
+function resolveMockedAuthenticatedAccount(headers: Record<string, string>) {
+  const bearerToken = headers.authorization?.match(/^Bearer\s+(.+)$/iu)?.[1]
+  if (bearerToken && bearerToken in MOCKED_ACCOUNT_BY_ACCESS_TOKEN) {
+    return MOCKED_ACCOUNT_BY_ACCESS_TOKEN[
+      bearerToken as keyof typeof MOCKED_ACCOUNT_BY_ACCESS_TOKEN
+    ]
+  }
+
+  const cookieHeader = headers.cookie ?? ""
+  const sessionCookie = extractSessionCookieHeader(cookieHeader)
+  if (sessionCookie && sessionCookie in MOCKED_ACCOUNT_BY_SESSION_COOKIE) {
+    return MOCKED_ACCOUNT_BY_SESSION_COOKIE[
+      sessionCookie as keyof typeof MOCKED_ACCOUNT_BY_SESSION_COOKIE
+    ]
+  }
+
+  return null
+}
+
+async function refreshAccountRowsAndReadStorage(params: {
+  page: Page
+  serviceWorker: Worker
+  accountIds: string[]
+  expectedQuotas: number[]
+}) {
+  for (const accountId of params.accountIds) {
+    const row = params.page.getByTestId(
+      getAccountManagementListItemTestId(accountId),
+    )
+    await row.hover()
+    await row
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowMoreActionsButton)
+      .click()
+    await params.page
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowRefreshMenuItem)
+      .click()
+  }
+
+  await expect
+    .poll(async () => {
+      const accounts = await readStoredAccounts(params.serviceWorker)
+      return params.accountIds.map((id) => {
+        const account = accounts.find((candidate) => candidate.id === id)
+        return account?.account_info.quota ?? null
+      })
+    })
+    .toEqual(params.expectedQuotas)
+
+  const accounts = await readStoredAccounts(params.serviceWorker)
+  return params.accountIds.map((id) => {
+    const account = accounts.find((candidate) => candidate.id === id)
+    if (!account) {
+      throw new Error(`Refreshed account ${id} was not found`)
+    }
+    return account
+  })
+}

--- a/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
+++ b/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
@@ -2,13 +2,19 @@ import http from "node:http"
 import type { AddressInfo, Socket } from "node:net"
 import type { BrowserContext, Page } from "@playwright/test"
 
-import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { SITE_TYPES } from "~/constants/siteType"
 import { OPTIONAL_PERMISSION_IDS } from "~/services/permissions/permissionManager"
 import { AuthTypeEnum } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
+  refreshAccountRowsAndReadStorage,
+  saveManualAccountFromApp,
+} from "~~/e2e/scenarios/accountManualAdd"
+import {
   forceExtensionLanguage,
   installExtensionPageGuards,
+  seedStoredAccounts,
+  seedUserPreferences,
   stubLlmMetadataIndex,
 } from "~~/e2e/utils/commonUserFlows"
 import {
@@ -20,6 +26,7 @@ import {
   expectPermissionOnboardingHidden,
   getManifestOptionalPermissions,
   getManifestRequiredPermissions,
+  getServiceWorker,
   requestAndExpectOptionalPermissions,
 } from "~~/e2e/utils/extensionState"
 import { openAccountManagementPage } from "~~/e2e/utils/realSite/accountAdd"
@@ -62,7 +69,7 @@ test("grants the Chromium cookie/DNR optional permissions needed for cookie auth
   }
 })
 
-test("isolates same-site cookie and access-token accounts through production temp-window fetch", async ({
+test("isolates same-site cookie and access-token accounts through account refresh UI", async ({
   context,
   extensionId,
   page,
@@ -72,6 +79,24 @@ test("isolates same-site cookie and access-token accounts through production tem
 
   const localSite = await startDnrCaptureNewApiServer()
   try {
+    const serviceWorker = await getServiceWorker(context)
+    await seedStoredAccounts(serviceWorker, [])
+    await seedUserPreferences(serviceWorker, {
+      tempWindowFallback: {
+        enabled: true,
+        useInPopup: true,
+        useInSidePanel: true,
+        useInOptions: true,
+        useForAutoRefresh: true,
+        useForManualRefresh: true,
+        tempContextMode: "composite",
+      },
+      tempWindowFallbackReminder: {
+        dismissed: true,
+      },
+      warnOnDuplicateAccountAdd: false,
+    })
+
     await test.step("open extension and verify cookie/DNR permissions", async () => {
       await openAccountManagementPage({ page, extensionId })
       await expectPermissionOnboardingHidden(page)
@@ -82,98 +107,126 @@ test("isolates same-site cookie and access-token accounts through production tem
       await seedBrowserCurrentLoginCookie(context, localSite.origin)
     })
 
-    await test.step("fetch account A with real Chromium DNR cookie injection", async () => {
-      const response = await runTempWindowAccountFetch(page, {
-        originUrl: localSite.origin,
-        accountId: "e2e-cookie-account-a",
-        authType: AuthTypeEnum.Cookie,
-        cookieAuthSessionCookie: ACCOUNT_A_SESSION_COOKIE,
-        fetchOptions: { credentials: "include" },
-      })
-      expect(response).toMatchObject({
-        success: true,
-        status: 200,
-        data: expect.objectContaining({
-          success: true,
-          data: expect.objectContaining({
-            id: "201",
+    const savedAccounts =
+      await test.step("save cookie and access-token accounts through the account UI", async () => {
+        const cookieAccountA = await saveManualAccountFromApp({
+          page,
+          extensionId,
+          serviceWorker,
+          baseUrl: localSite.origin,
+          siteType: SITE_TYPES.NEW_API,
+          account: {
+            authType: AuthTypeEnum.Cookie,
+            siteName: "Local DNR New API",
             username: "cookie-user-a",
-            quota: 33_000,
-          }),
-        }),
-      })
-      await localSite.waitForAuthenticatedSelfRequest(ACCOUNT_A_SESSION_COOKIE)
-    })
-
-    await test.step("fetch account B with real Chromium DNR cookie injection", async () => {
-      const response = await runTempWindowAccountFetch(page, {
-        originUrl: localSite.origin,
-        accountId: "e2e-cookie-account-b",
-        authType: AuthTypeEnum.Cookie,
-        cookieAuthSessionCookie: ACCOUNT_B_SESSION_COOKIE,
-        fetchOptions: { credentials: "include" },
-      })
-      expect(response).toMatchObject({
-        success: true,
-        status: 200,
-        data: expect.objectContaining({
-          success: true,
-          data: expect.objectContaining({
-            id: "202",
+            userId: "201",
+            cookieAuthSessionCookie: ACCOUNT_A_SESSION_COOKIE,
+          },
+        })
+        const cookieAccountB = await saveManualAccountFromApp({
+          page,
+          extensionId,
+          serviceWorker,
+          baseUrl: localSite.origin,
+          siteType: SITE_TYPES.NEW_API,
+          account: {
+            authType: AuthTypeEnum.Cookie,
+            siteName: "Local DNR New API",
             username: "cookie-user-b",
-            quota: 44_000,
-          }),
-        }),
+            userId: "202",
+            cookieAuthSessionCookie: ACCOUNT_B_SESSION_COOKIE,
+          },
+        })
+        const tokenAccountA = await saveManualAccountFromApp({
+          page,
+          extensionId,
+          serviceWorker,
+          baseUrl: localSite.origin,
+          siteType: SITE_TYPES.NEW_API,
+          account: {
+            authType: AuthTypeEnum.AccessToken,
+            siteName: "Local DNR New API",
+            username: "token-user-a",
+            userId: "301",
+            accessToken: ACCESS_TOKEN_A,
+          },
+        })
+        const tokenAccountB = await saveManualAccountFromApp({
+          page,
+          extensionId,
+          serviceWorker,
+          baseUrl: localSite.origin,
+          siteType: SITE_TYPES.NEW_API,
+          account: {
+            authType: AuthTypeEnum.AccessToken,
+            siteName: "Local DNR New API",
+            username: "token-user-b",
+            userId: "302",
+            accessToken: ACCESS_TOKEN_B,
+          },
+        })
+
+        return [cookieAccountA, cookieAccountB, tokenAccountA, tokenAccountB]
       })
-      await localSite.waitForAuthenticatedSelfRequest(ACCOUNT_B_SESSION_COOKIE)
+
+    await test.step("reset captured requests and stored balances before final UI refresh", async () => {
+      localSite.clearSelfRequests()
+      await seedStoredAccounts(
+        serviceWorker,
+        savedAccounts.map((account, index) => ({
+          ...account,
+          account_info: {
+            ...account.account_info,
+            quota: 1_000 + index,
+          },
+        })),
+      )
     })
 
-    await test.step("fetch access-token accounts without cookie auth contamination", async () => {
-      const responseA = await runTempWindowAccountFetch(page, {
-        originUrl: localSite.origin,
-        accountId: "e2e-access-token-account-a",
-        authType: AuthTypeEnum.AccessToken,
-        fetchOptions: {
-          credentials: "omit",
-          headers: {
-            Authorization: `Bearer ${ACCESS_TOKEN_A}`,
-          },
-        },
-      })
-      const responseB = await runTempWindowAccountFetch(page, {
-        originUrl: localSite.origin,
-        accountId: "e2e-access-token-account-b",
-        authType: AuthTypeEnum.AccessToken,
-        fetchOptions: {
-          credentials: "omit",
-          headers: {
-            Authorization: `Bearer ${ACCESS_TOKEN_B}`,
-          },
-        },
+    await test.step("refresh the saved accounts from the account management UI", async () => {
+      const refreshedAccounts = await refreshAccountRowsAndReadStorage({
+        page,
+        serviceWorker,
+        accountIds: savedAccounts.map((account) => account.id),
+        expectedQuotas: [33_000, 44_000, 55_000, 66_000],
       })
 
-      expect(responseA).toMatchObject({
-        success: true,
-        status: 200,
-        data: expect.objectContaining({
-          data: expect.objectContaining({
-            id: "301",
-            username: "token-user-a",
-            quota: 55_000,
+      expect(refreshedAccounts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            authType: AuthTypeEnum.Cookie,
+            account_info: expect.objectContaining({
+              id: "201",
+              username: "cookie-user-a",
+              quota: 33_000,
+            }),
           }),
-        }),
-      })
-      expect(responseB).toMatchObject({
-        success: true,
-        status: 200,
-        data: expect.objectContaining({
-          data: expect.objectContaining({
-            id: "302",
-            username: "token-user-b",
-            quota: 66_000,
+          expect.objectContaining({
+            authType: AuthTypeEnum.Cookie,
+            account_info: expect.objectContaining({
+              id: "202",
+              username: "cookie-user-b",
+              quota: 44_000,
+            }),
           }),
-        }),
-      })
+          expect.objectContaining({
+            authType: AuthTypeEnum.AccessToken,
+            account_info: expect.objectContaining({
+              id: "301",
+              username: "token-user-a",
+              quota: 55_000,
+            }),
+          }),
+          expect.objectContaining({
+            authType: AuthTypeEnum.AccessToken,
+            account_info: expect.objectContaining({
+              id: "302",
+              username: "token-user-b",
+              quota: 66_000,
+            }),
+          }),
+        ]),
+      )
     })
 
     const authenticatedSelfRequests = localSite.selfRequests.filter(
@@ -245,79 +298,6 @@ async function grantCookieDnrPermissions(page: Page, origin: string) {
   expect(hasOriginPermission, `${originPattern} host access`).toBe(true)
 }
 
-async function runTempWindowAccountFetch(
-  page: Page,
-  params: {
-    originUrl: string
-    accountId: string
-    authType: AuthTypeEnum
-    cookieAuthSessionCookie?: string
-    fetchOptions: RequestInit
-  },
-) {
-  return await page.evaluate(
-    async ({
-      action,
-      accountId,
-      authType,
-      cookieAuthSessionCookie,
-      fetchOptions,
-      originUrl,
-    }) => {
-      const chromeApi = (
-        globalThis as typeof globalThis & { chrome?: typeof chrome }
-      ).chrome
-
-      if (!chromeApi?.runtime?.sendMessage) {
-        throw new Error("chrome.runtime.sendMessage is unavailable")
-      }
-
-      const requestId = `e2e-temp-window-${accountId}-${Date.now()}`
-      const message = {
-        action,
-        originUrl,
-        fetchUrl: `${originUrl}/api/user/self`,
-        fetchOptions,
-        requestId,
-        responseType: "json",
-        suppressMinimize: true,
-        accountId,
-        authType,
-        cookieAuthSessionCookie,
-      }
-
-      const timeout = new Promise<never>((_, reject) => {
-        setTimeout(() => {
-          reject(
-            new Error(`Timed out waiting for tempWindowFetch ${requestId}`),
-          )
-        }, 30_000)
-      })
-
-      const response = new Promise((resolve, reject) => {
-        chromeApi.runtime.sendMessage(message, (result) => {
-          const error = chromeApi.runtime.lastError
-          if (error) {
-            reject(new Error(error.message))
-            return
-          }
-          resolve(result)
-        })
-      })
-
-      return await Promise.race([response, timeout])
-    },
-    {
-      action: RuntimeActionIds.TempWindowFetch,
-      accountId: params.accountId,
-      authType: params.authType,
-      cookieAuthSessionCookie: params.cookieAuthSessionCookie,
-      fetchOptions: params.fetchOptions,
-      originUrl: params.originUrl,
-    },
-  )
-}
-
 type CapturedSelfRequest = {
   cookieHeader: string
   matchedSessionCookie: string | null
@@ -327,6 +307,7 @@ type CapturedSelfRequest = {
 type DnrCaptureNewApiServer = {
   origin: string
   selfRequests: CapturedSelfRequest[]
+  clearSelfRequests: () => void
   waitForAuthenticatedSelfRequest: (
     sessionCookie: string,
   ) => Promise<CapturedSelfRequest>
@@ -527,6 +508,9 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
   return {
     origin,
     selfRequests,
+    clearSelfRequests: () => {
+      selfRequests.splice(0)
+    },
     waitForAuthenticatedSelfRequest,
     close,
   }

--- a/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
+++ b/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
@@ -1,5 +1,5 @@
 import http from "node:http"
-import type { AddressInfo } from "node:net"
+import type { AddressInfo, Socket } from "node:net"
 import type { BrowserContext, Page } from "@playwright/test"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
@@ -50,6 +50,8 @@ test("grants the Chromium cookie/DNR optional permissions needed for cookie auth
   extensionId,
   page,
 }) => {
+  skipUnlessDnrRequiredVariant()
+
   const localSite = await startDnrCaptureNewApiServer()
   try {
     await openAccountManagementPage({ page, extensionId })
@@ -66,13 +68,7 @@ test("isolates same-site cookie and access-token accounts through production tem
   page,
 }) => {
   test.slow()
-  test.skip(
-    process.env[E2E_BUILD_VARIANT_ENV] !== E2E_BUILD_VARIANTS.DnrRequired,
-    [
-      "Real Chromium DNR cookie isolation requires the E2E-only dnr-required manifest variant.",
-      `Run with ${E2E_BUILD_VARIANT_ENV}=${E2E_BUILD_VARIANTS.DnrRequired}.`,
-    ].join(" "),
-  )
+  skipUnlessDnrRequiredVariant()
 
   const localSite = await startDnrCaptureNewApiServer()
   try {
@@ -208,6 +204,16 @@ test("isolates same-site cookie and access-token accounts through production tem
   }
 })
 
+function skipUnlessDnrRequiredVariant() {
+  test.skip(
+    process.env[E2E_BUILD_VARIANT_ENV] !== E2E_BUILD_VARIANTS.DnrRequired,
+    [
+      "Real Chromium DNR cookie isolation requires the E2E-only dnr-required manifest variant.",
+      `Run with ${E2E_BUILD_VARIANT_ENV}=${E2E_BUILD_VARIANTS.DnrRequired}.`,
+    ].join(" "),
+  )
+}
+
 async function grantCookieDnrPermissions(page: Page, origin: string) {
   const optionalPermissions = await getManifestOptionalPermissions(page)
   const requiredPermissions = await getManifestRequiredPermissions(page)
@@ -329,6 +335,7 @@ type DnrCaptureNewApiServer = {
 
 async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
   const selfRequests: CapturedSelfRequest[] = []
+  const sockets = new Set<Socket>()
   const waiters: Array<{
     sessionCookie: string
     resolve: (request: CapturedSelfRequest) => void
@@ -461,6 +468,11 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
     })
   })
 
+  server.on("connection", (socket) => {
+    sockets.add(socket)
+    socket.on("close", () => sockets.delete(socket))
+  })
+
   const origin = await new Promise<string>((resolve, reject) => {
     server.on("error", reject)
     server.listen(0, "127.0.0.1", () => {
@@ -506,6 +518,9 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
         if (error) reject(error)
         else resolve()
       })
+      for (const socket of sockets) {
+        socket.destroy()
+      }
     })
   }
 

--- a/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
+++ b/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
@@ -232,6 +232,15 @@ test("isolates same-site cookie and access-token accounts through account refres
     const authenticatedSelfRequests = localSite.selfRequests.filter(
       (request) => request.matchedSessionCookie || request.matchedAccessToken,
     )
+    const cookieAccountASequence = expectCookieDnrFallbackSequence(
+      localSite.selfRequests,
+      ACCOUNT_A_SESSION_COOKIE,
+    )
+    expectCookieDnrFallbackSequence(
+      localSite.selfRequests,
+      ACCOUNT_B_SESSION_COOKIE,
+      cookieAccountASequence.successIndex + 1,
+    )
     expect(authenticatedSelfRequests).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -302,6 +311,7 @@ type CapturedSelfRequest = {
   cookieHeader: string
   matchedSessionCookie: string | null
   matchedAccessToken: string | null
+  responseStatus: number
 }
 
 type DnrCaptureNewApiServer = {
@@ -380,14 +390,6 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
       const authorizationHeader = request.headers.authorization ?? ""
       const matchedSessionCookie = matchAccountSessionCookie(cookieHeader)
       const matchedAccessToken = matchAccessToken(authorizationHeader)
-      const captured: CapturedSelfRequest = {
-        cookieHeader,
-        matchedSessionCookie,
-        matchedAccessToken,
-      }
-      selfRequests.push(captured)
-      resolveMatchingWaiters(captured)
-
       const account =
         (matchedSessionCookie
           ? ACCOUNT_BY_SESSION_COOKIE[matchedSessionCookie]
@@ -395,6 +397,15 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
         (matchedAccessToken
           ? ACCOUNT_BY_ACCESS_TOKEN[matchedAccessToken]
           : null)
+      const captured: CapturedSelfRequest = {
+        cookieHeader,
+        matchedSessionCookie,
+        matchedAccessToken,
+        responseStatus: account ? 200 : 401,
+      }
+      selfRequests.push(captured)
+      resolveMatchingWaiters(captured)
+
       if (!account) {
         sendJson(401, {
           success: false,
@@ -556,6 +567,47 @@ function matchAccountSessionCookie(cookieHeader: string) {
     return ACCOUNT_B_SESSION_COOKIE
   }
   return null
+}
+
+function expectCookieDnrFallbackSequence(
+  requests: CapturedSelfRequest[],
+  targetSessionCookie: string,
+  startIndex = 0,
+) {
+  const successIndex = requests.findIndex(
+    (request, index) =>
+      index >= startIndex &&
+      request.responseStatus === 200 &&
+      request.matchedSessionCookie === targetSessionCookie,
+  )
+  expect(
+    successIndex,
+    `${targetSessionCookie} DNR success request`,
+  ).toBeGreaterThanOrEqual(startIndex)
+
+  const primaryFailureIndex = requests.findIndex(
+    (request, index) =>
+      index >= startIndex &&
+      index < successIndex &&
+      request.responseStatus === 401 &&
+      request.cookieHeader.includes(BROWSER_CURRENT_SESSION_COOKIE) &&
+      !request.matchedSessionCookie &&
+      !request.matchedAccessToken,
+  )
+  expect(
+    primaryFailureIndex,
+    `${targetSessionCookie} primary browser-cookie 401 request`,
+  ).toBeGreaterThanOrEqual(startIndex)
+
+  expect(requests[successIndex].cookieHeader).toContain(targetSessionCookie)
+  expect(requests[successIndex].cookieHeader).not.toContain(
+    BROWSER_CURRENT_SESSION_COOKIE,
+  )
+
+  return {
+    primaryFailureIndex,
+    successIndex,
+  }
 }
 
 function matchAccessToken(authorizationHeader: string) {

--- a/e2e/e2e-build-inputs.json
+++ b/e2e/e2e-build-inputs.json
@@ -2,6 +2,8 @@
   "src",
   "public",
   "e2e/e2e-build-variants.json",
+  "e2e/utils/e2eBuildVariants.shared.d.ts",
+  "e2e/utils/e2eBuildVariants.shared.js",
   "e2e/utils/e2eBuildVariants.ts",
   "e2e/utils/e2eBuildMetadata.ts",
   "e2e/utils/extension.ts",

--- a/e2e/e2e-build-inputs.json
+++ b/e2e/e2e-build-inputs.json
@@ -1,6 +1,8 @@
 [
   "src",
   "public",
+  "e2e/e2e-build-variants.json",
+  "e2e/utils/e2eBuildVariants.ts",
   "e2e/utils/e2eBuildMetadata.ts",
   "e2e/utils/extension.ts",
   "scripts/e2e-build.mjs",

--- a/e2e/e2e-build-variants.json
+++ b/e2e/e2e-build-variants.json
@@ -1,0 +1,19 @@
+{
+  "envName": "AAH_E2E_BUILD_VARIANT",
+  "defaultVariant": "default",
+  "variants": {
+    "default": {
+      "extensionDirName": "chrome-mv3-test",
+      "testOutDirTemplate": "{{browser}}-mv{{manifestVersion}}-test",
+      "requiredChromiumPermissions": []
+    },
+    "dnr-required": {
+      "extensionDirName": "chrome-mv3-test-dnr-required",
+      "testOutDirTemplate": "{{browser}}-mv{{manifestVersion}}-test-dnr-required",
+      "requiredChromiumPermissions": [
+        "cookies",
+        "declarativeNetRequestWithHostAccess"
+      ]
+    }
+  }
+}

--- a/e2e/fixtures/extensionTest.ts
+++ b/e2e/fixtures/extensionTest.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import { test as base, expect as baseExpect, chromium } from "@playwright/test"
 
 import { stubSponsorRemoteCatalog } from "~~/e2e/utils/commonUserFlows"
+import { getE2eExtensionDirName } from "~~/e2e/utils/e2eBuildVariants"
 import {
   assertBuiltExtensionExists,
   getExtensionIdFromServiceWorker,
@@ -19,16 +20,21 @@ export const test = base.extend<ExtensionFixtures>({
     void browserName
     const extensionDir = process.env.AAH_EXTENSION_DIR
       ? path.resolve(process.cwd(), process.env.AAH_EXTENSION_DIR)
-      : path.resolve(process.cwd(), ".output", "chrome-mv3-test")
+      : path.resolve(process.cwd(), ".output", getE2eExtensionDirName())
     await assertBuiltExtensionExists(extensionDir)
     await run(extensionDir)
   },
 
   context: async ({ extensionDir }, run, testInfo) => {
     const headless = testInfo.project.use.headless ?? true
-    const userDataDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), `all-api-hub-e2e-${testInfo.workerIndex}-`),
-    )
+    const reusableUserDataDir = process.env.AAH_E2E_USER_DATA_DIR
+      ? path.resolve(process.cwd(), process.env.AAH_E2E_USER_DATA_DIR)
+      : null
+    const userDataDir =
+      reusableUserDataDir ??
+      (await fs.mkdtemp(
+        path.join(os.tmpdir(), `all-api-hub-e2e-${testInfo.workerIndex}-`),
+      ))
 
     const args = [
       `--disable-extensions-except=${extensionDir}`,
@@ -63,7 +69,9 @@ export const test = base.extend<ExtensionFixtures>({
       }
 
       try {
-        await fs.rm(userDataDir, { recursive: true, force: true })
+        if (!reusableUserDataDir) {
+          await fs.rm(userDataDir, { recursive: true, force: true })
+        }
       } catch (error) {
         console.warn(`Failed to remove userDataDir '${userDataDir}'`, error)
       }

--- a/e2e/permissionsOnboardingUserFlows.spec.ts
+++ b/e2e/permissionsOnboardingUserFlows.spec.ts
@@ -1,4 +1,4 @@
-import type { Page, Worker } from "@playwright/test"
+import type { Worker } from "@playwright/test"
 
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
@@ -11,42 +11,15 @@ import {
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
+  getManifestOptionalPermissions,
   getPlasmoStorageRawValue,
   getServiceWorker,
+  hasOptionalPermission,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
 const OPTIONAL_PERMISSIONS_STORAGE_KEY = "optional_permissions_state"
 const COOKIE_PERMISSION = "cookies"
-async function hasOptionalPermission(page: Page, permission: string) {
-  return await page.evaluate(async (permission) => {
-    const chromeApi = (
-      globalThis as typeof globalThis & { chrome?: typeof chrome }
-    ).chrome
-
-    if (!chromeApi?.permissions) {
-      throw new Error("chrome.permissions is unavailable in extension context")
-    }
-
-    return await chromeApi.permissions.contains({
-      permissions: [permission],
-    })
-  }, permission)
-}
-
-async function getManifestOptionalPermissions(page: Page) {
-  return await page.evaluate(() => {
-    const chromeApi = (
-      globalThis as typeof globalThis & { chrome?: typeof chrome }
-    ).chrome
-
-    if (!chromeApi?.runtime?.getManifest) {
-      throw new Error("chrome.runtime.getManifest is unavailable")
-    }
-
-    return [...(chromeApi.runtime.getManifest().optional_permissions ?? [])]
-  })
-}
 
 async function getLastSeenOptionalPermissions(serviceWorker: Worker) {
   const raw = await getPlasmoStorageRawValue<unknown>(

--- a/e2e/scenarios/accountManualAdd.ts
+++ b/e2e/scenarios/accountManualAdd.ts
@@ -1,7 +1,10 @@
 import type { Locator, Page, Worker } from "@playwright/test"
 
 import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
-import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import {
+  ACCOUNT_MANAGEMENT_TEST_IDS,
+  getAccountManagementListItemTestId,
+} from "~/features/AccountManagement/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import {
   AuthTypeEnum,
@@ -99,6 +102,59 @@ export async function saveManualAccountFromApp(params: {
   })
   await expectAccountListItemVisible(params.page, savedAccount.id)
   return savedAccount
+}
+
+export async function refreshAccountRowsAndReadStorage(params: {
+  page: Page
+  serviceWorker: Worker
+  accountIds: string[]
+  expectedQuotas: number[]
+}) {
+  expect(params.accountIds.length).toBe(params.expectedQuotas.length)
+
+  for (const [index, accountId] of params.accountIds.entries()) {
+    const row = params.page.getByTestId(
+      getAccountManagementListItemTestId(accountId),
+    )
+    await row.hover()
+    await row
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowMoreActionsButton)
+      .click()
+    await params.page
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowRefreshMenuItem)
+      .click()
+
+    await waitForStoredAccountQuota({
+      serviceWorker: params.serviceWorker,
+      accountId,
+      expectedQuota: params.expectedQuotas[index],
+    })
+  }
+
+  const accounts = await readStoredAccounts(params.serviceWorker)
+  return params.accountIds.map((id) => {
+    const account = accounts.find((candidate) => candidate.id === id)
+    if (!account) {
+      throw new Error(`Refreshed account ${id} was not found`)
+    }
+    return account
+  })
+}
+
+async function waitForStoredAccountQuota(params: {
+  serviceWorker: Worker
+  accountId: string
+  expectedQuota: number
+}) {
+  await expect
+    .poll(async () => {
+      const accounts = await readStoredAccounts(params.serviceWorker)
+      const account = accounts.find(
+        (candidate) => candidate.id === params.accountId,
+      )
+      return account?.account_info.quota ?? null
+    })
+    .toEqual(params.expectedQuota)
 }
 
 async function waitForManualSavedAccount(params: {

--- a/e2e/scenarios/accountManualAdd.ts
+++ b/e2e/scenarios/accountManualAdd.ts
@@ -1,0 +1,239 @@
+import type { Locator, Page, Worker } from "@playwright/test"
+
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import {
+  AuthTypeEnum,
+  type AccountStorageConfig,
+  type SiteAccount,
+} from "~/types"
+import { extractSessionCookieHeader } from "~/utils/browser/cookieString"
+import { expect } from "~~/e2e/fixtures/extensionTest"
+import { getPlasmoStorageRawValue } from "~~/e2e/utils/extensionState"
+import {
+  expectAccountListItemVisible,
+  openAccountManagementPage,
+} from "~~/e2e/utils/realSite/accountAdd"
+
+type ManualAccountInput = {
+  siteName: string
+  username: string
+  userId: string
+  exchangeRate?: string
+}
+
+type AccessTokenManualAccountInput = ManualAccountInput & {
+  authType: AuthTypeEnum.AccessToken
+  accessToken: string
+}
+
+type CookieManualAccountInput = ManualAccountInput & {
+  authType: AuthTypeEnum.Cookie
+  cookieAuthSessionCookie: string
+}
+
+type ManualAccountAddInput =
+  | AccessTokenManualAccountInput
+  | CookieManualAccountInput
+
+export async function readStoredAccounts(
+  serviceWorker: Worker,
+): Promise<SiteAccount[]> {
+  const raw = await getPlasmoStorageRawValue<unknown>(
+    serviceWorker,
+    STORAGE_KEYS.ACCOUNTS,
+  )
+
+  if (typeof raw !== "string") return []
+
+  try {
+    const parsed = JSON.parse(raw) as AccountStorageConfig
+    return Array.isArray(parsed.accounts) ? parsed.accounts : []
+  } catch {
+    return []
+  }
+}
+
+export async function saveManualAccountFromApp(params: {
+  page: Page
+  extensionId: string
+  serviceWorker: Worker
+  baseUrl: string
+  siteType?: AccountSiteType
+  account: ManualAccountAddInput
+}): Promise<SiteAccount> {
+  const siteType = params.siteType ?? SITE_TYPES.NEW_API
+
+  await openAccountManagementPage({
+    page: params.page,
+    extensionId: params.extensionId,
+  })
+
+  await params.page
+    .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton)
+    .click()
+  const dialog = getManualAccountDialog(params.page)
+  await expect(dialog.dialog).toBeVisible()
+
+  await dialog.siteUrlInput.fill(params.baseUrl)
+  await selectDialogAuthType(params.page, params.account.authType)
+  await params.page
+    .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.manualAddButton)
+    .click()
+
+  await fillManualAccountForm(dialog, {
+    siteType,
+    account: params.account,
+  })
+
+  await expect(dialog.confirmAddButton).toBeEnabled({ timeout: 60_000 })
+  await dialog.confirmAddButton.click()
+  await expect(dialog.dialog).toBeHidden({ timeout: 60_000 })
+
+  const savedAccount = await waitForManualSavedAccount({
+    serviceWorker: params.serviceWorker,
+    siteType,
+    baseUrl: params.baseUrl,
+    account: params.account,
+  })
+  await expectAccountListItemVisible(params.page, savedAccount.id)
+  return savedAccount
+}
+
+async function waitForManualSavedAccount(params: {
+  serviceWorker: Worker
+  siteType: AccountSiteType
+  baseUrl: string
+  account: ManualAccountAddInput
+}): Promise<SiteAccount> {
+  let savedAccount: SiteAccount | null = null
+
+  await expect
+    .poll(
+      async () => {
+        savedAccount =
+          (await readStoredAccounts(params.serviceWorker)).find((account) => {
+            if (
+              account.site_type !== params.siteType ||
+              account.site_url !== params.baseUrl ||
+              account.authType !== params.account.authType
+            ) {
+              return false
+            }
+
+            if (params.account.authType === AuthTypeEnum.AccessToken) {
+              return (
+                account.account_info.id === params.account.userId &&
+                account.account_info.access_token === params.account.accessToken
+              )
+            }
+
+            return (
+              account.cookieAuth?.sessionCookie ===
+              extractSessionCookieHeader(params.account.cookieAuthSessionCookie)
+            )
+          }) ?? null
+
+        return savedAccount
+      },
+      { timeout: 60_000 },
+    )
+    .not.toBeNull()
+
+  return savedAccount!
+}
+
+function getManualAccountDialog(page: Page) {
+  const dialog = page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.accountDialog)
+
+  return {
+    dialog,
+    siteUrlInput: dialog.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput),
+    siteNameInput: dialog.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.siteNameInput,
+    ),
+    siteTypeTrigger: dialog.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.siteTypeTrigger,
+    ),
+    authTypeTrigger: dialog.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger,
+    ),
+    usernameInput: dialog.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.usernameInput,
+    ),
+    userIdInput: dialog.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.userIdInput),
+    accessTokenInput: dialog.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.accessTokenInput,
+    ),
+    confirmAddButton: dialog.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.confirmAddButton,
+    ),
+  }
+}
+
+async function fillManualAccountForm(
+  dialog: ReturnType<typeof getManualAccountDialog>,
+  params: {
+    siteType: AccountSiteType
+    account: ManualAccountAddInput
+  },
+) {
+  await selectByTriggerDataAttribute({
+    trigger: dialog.siteTypeTrigger,
+    expectedAttribute: "data-site-type",
+    value: params.siteType,
+  })
+  await dialog.siteNameInput.fill(params.account.siteName)
+  await dialog.usernameInput.fill(params.account.username)
+  await dialog.userIdInput.fill(params.account.userId)
+  await dialog.dialog
+    .getByPlaceholder("Please enter exchange rate")
+    .fill(params.account.exchangeRate ?? "7")
+
+  if (params.account.authType === AuthTypeEnum.AccessToken) {
+    await dialog.accessTokenInput.fill(params.account.accessToken)
+    return
+  }
+
+  await dialog.dialog
+    .getByPlaceholder("Paste Cookie header value")
+    .fill(params.account.cookieAuthSessionCookie)
+}
+
+async function selectDialogAuthType(page: Page, authType: AuthTypeEnum) {
+  const trigger = page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger)
+  await selectByTriggerDataAttribute({
+    trigger,
+    expectedAttribute: "data-auth-type",
+    value: authType,
+    optionName:
+      authType === AuthTypeEnum.Cookie
+        ? "Cookie Authentication"
+        : "Access Token Authentication",
+  })
+}
+
+async function selectByTriggerDataAttribute(params: {
+  trigger: Locator
+  expectedAttribute: string
+  value: string
+  optionName?: string
+}) {
+  if (
+    (await params.trigger.getAttribute(params.expectedAttribute)) ===
+    params.value
+  ) {
+    return
+  }
+
+  await params.trigger.click()
+  await params.trigger
+    .page()
+    .getByRole("option", { name: params.optionName ?? params.value })
+    .click()
+  await expect(params.trigger).toHaveAttribute(
+    params.expectedAttribute,
+    params.value,
+  )
+}

--- a/e2e/setup/build.setup.ts
+++ b/e2e/setup/build.setup.ts
@@ -4,13 +4,14 @@ import { fileURLToPath } from "node:url"
 import { test as setup } from "@playwright/test"
 
 import { isE2eBuildCurrent } from "~~/e2e/utils/e2eBuildMetadata"
+import { getE2eExtensionDirName } from "~~/e2e/utils/e2eBuildVariants"
 
 const rootDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
   "..",
 )
-const extensionDir = path.join(rootDir, ".output", "chrome-mv3-test")
+const extensionDir = path.join(rootDir, ".output", getE2eExtensionDirName())
 
 setup("build extension for e2e", async () => {
   if (process.env.AAH_SKIP_E2E_BUILD === "1") {

--- a/e2e/utils/e2eBuildMetadata.ts
+++ b/e2e/utils/e2eBuildMetadata.ts
@@ -4,6 +4,8 @@ import fs from "node:fs/promises"
 import path from "node:path"
 import { promisify } from "node:util"
 
+import { readE2eBuildVariant } from "~~/e2e/utils/e2eBuildVariants"
+
 const execFileAsync = promisify(execFile)
 
 const E2E_BUILD_METADATA_FILE = ".aah-e2e-build.json"
@@ -12,6 +14,7 @@ const IGNORED_DIRECTORY_NAMES = new Set(["node_modules", ".git", ".output"])
 
 type E2eBuildMetadata = {
   version: 1
+  buildVariant?: string
   gitHead: string
   inputHash: string
   inputPaths: string[]
@@ -20,7 +23,7 @@ type E2eBuildMetadata = {
 
 type E2eBuildMetadataSnapshot = Pick<
   E2eBuildMetadata,
-  "gitHead" | "inputHash" | "inputPaths"
+  "buildVariant" | "gitHead" | "inputHash" | "inputPaths"
 >
 
 type E2eBuildMetadataOptions = {
@@ -53,6 +56,7 @@ async function createE2eBuildMetadataSnapshot(
   ])
 
   return {
+    buildVariant: readE2eBuildVariant(),
     gitHead,
     inputHash,
     inputPaths,
@@ -133,6 +137,12 @@ export function getE2eBuildMetadataMismatches(
   if (metadata.gitHead !== current.gitHead) {
     mismatches.push(
       `Built from git HEAD ${metadata.gitHead}, current HEAD is ${current.gitHead}.`,
+    )
+  }
+
+  if ((metadata.buildVariant ?? "default") !== current.buildVariant) {
+    mismatches.push(
+      `Built for E2E variant ${metadata.buildVariant ?? "default"}, current variant is ${current.buildVariant}.`,
     )
   }
 

--- a/e2e/utils/e2eBuildVariants.shared.d.ts
+++ b/e2e/utils/e2eBuildVariants.shared.d.ts
@@ -1,0 +1,22 @@
+export declare const E2E_BUILD_VARIANTS: {
+  readonly Default: "default"
+  readonly DnrRequired: "dnr-required"
+}
+
+export declare const E2E_BUILD_VARIANT_ENV: string
+
+export declare function readE2eBuildVariant(
+  env?: Record<string, string | undefined>,
+): "default" | "dnr-required"
+
+export declare function getE2eExtensionDirName(
+  variant?: "default" | "dnr-required",
+): string
+
+export declare function getE2eTestOutDirTemplate(
+  variant?: "default" | "dnr-required",
+): string
+
+export declare function getE2eRequiredChromiumPermissions(
+  variant?: "default" | "dnr-required",
+): string[]

--- a/e2e/utils/e2eBuildVariants.shared.js
+++ b/e2e/utils/e2eBuildVariants.shared.js
@@ -1,0 +1,47 @@
+import fs from "node:fs"
+import { fileURLToPath } from "node:url"
+
+export const E2E_BUILD_VARIANTS = {
+  Default: "default",
+  DnrRequired: "dnr-required",
+}
+
+const E2E_BUILD_VARIANT_VALUES = Object.values(E2E_BUILD_VARIANTS)
+const e2eBuildVariantsConfig = readE2eBuildVariantsConfig()
+
+export const E2E_BUILD_VARIANT_ENV = e2eBuildVariantsConfig.envName
+
+export function readE2eBuildVariant(env = process.env) {
+  const value = env[E2E_BUILD_VARIANT_ENV]?.trim()
+  if (!value) return e2eBuildVariantsConfig.defaultVariant
+  if (isE2eBuildVariant(value)) return value
+
+  throw new Error(`Unsupported ${E2E_BUILD_VARIANT_ENV} '${value}'`)
+}
+
+export function getE2eExtensionDirName(variant = readE2eBuildVariant()) {
+  return e2eBuildVariantsConfig.variants[variant].extensionDirName
+}
+
+export function getE2eTestOutDirTemplate(variant = readE2eBuildVariant()) {
+  return e2eBuildVariantsConfig.variants[variant].testOutDirTemplate
+}
+
+export function getE2eRequiredChromiumPermissions(
+  variant = readE2eBuildVariant(),
+) {
+  return [
+    ...e2eBuildVariantsConfig.variants[variant].requiredChromiumPermissions,
+  ]
+}
+
+function isE2eBuildVariant(value) {
+  return E2E_BUILD_VARIANT_VALUES.includes(value)
+}
+
+function readE2eBuildVariantsConfig() {
+  const configPath = fileURLToPath(
+    new URL("../e2e-build-variants.json", import.meta.url),
+  )
+  return JSON.parse(fs.readFileSync(configPath, "utf8"))
+}

--- a/e2e/utils/e2eBuildVariants.ts
+++ b/e2e/utils/e2eBuildVariants.ts
@@ -1,67 +1,39 @@
-import fs from "node:fs"
-import { fileURLToPath } from "node:url"
+import {
+  getE2eExtensionDirName as getSharedE2eExtensionDirName,
+  getE2eRequiredChromiumPermissions as getSharedE2eRequiredChromiumPermissions,
+  getE2eTestOutDirTemplate as getSharedE2eTestOutDirTemplate,
+  readE2eBuildVariant as readSharedE2eBuildVariant,
+  E2E_BUILD_VARIANT_ENV as SHARED_E2E_BUILD_VARIANT_ENV,
+  E2E_BUILD_VARIANTS as SHARED_E2E_BUILD_VARIANTS,
+} from "./e2eBuildVariants.shared"
 
-export const E2E_BUILD_VARIANTS = {
-  Default: "default",
-  DnrRequired: "dnr-required",
-} as const
+export const E2E_BUILD_VARIANTS = SHARED_E2E_BUILD_VARIANTS
 
-const E2E_BUILD_VARIANT_VALUES = [
+const _E2E_BUILD_VARIANT_VALUES = [
   E2E_BUILD_VARIANTS.Default,
   E2E_BUILD_VARIANTS.DnrRequired,
 ] as const
 
-type E2eBuildVariant = (typeof E2E_BUILD_VARIANT_VALUES)[number]
-type E2eBuildVariantConfig = {
-  extensionDirName: string
-  testOutDirTemplate: string
-  requiredChromiumPermissions: string[]
-}
-type E2eBuildVariantsConfig = {
-  envName: string
-  defaultVariant: E2eBuildVariant
-  variants: Record<E2eBuildVariant, E2eBuildVariantConfig>
-}
+type E2eBuildVariant = (typeof _E2E_BUILD_VARIANT_VALUES)[number]
 
-const e2eBuildVariantsConfig = readE2eBuildVariantsConfig()
-
-export const E2E_BUILD_VARIANT_ENV = e2eBuildVariantsConfig.envName
+export const E2E_BUILD_VARIANT_ENV = SHARED_E2E_BUILD_VARIANT_ENV
 
 export function readE2eBuildVariant(
   env: Record<string, string | undefined> = process.env,
 ): E2eBuildVariant {
-  const value = env[E2E_BUILD_VARIANT_ENV]?.trim()
-  if (!value) return E2E_BUILD_VARIANTS.Default
-  if (isE2eBuildVariant(value)) return value
-
-  throw new Error(`Unsupported ${E2E_BUILD_VARIANT_ENV} '${value}'`)
+  return readSharedE2eBuildVariant(env) as E2eBuildVariant
 }
 
 export function getE2eExtensionDirName(variant = readE2eBuildVariant()) {
-  return e2eBuildVariantsConfig.variants[variant].extensionDirName
+  return getSharedE2eExtensionDirName(variant)
 }
 
 export function getE2eTestOutDirTemplate(variant = readE2eBuildVariant()) {
-  return e2eBuildVariantsConfig.variants[variant].testOutDirTemplate
+  return getSharedE2eTestOutDirTemplate(variant)
 }
 
 export function getE2eRequiredChromiumPermissions(
   variant = readE2eBuildVariant(),
 ) {
-  return [
-    ...e2eBuildVariantsConfig.variants[variant].requiredChromiumPermissions,
-  ]
-}
-
-function isE2eBuildVariant(value: string): value is E2eBuildVariant {
-  return E2E_BUILD_VARIANT_VALUES.includes(value as E2eBuildVariant)
-}
-
-function readE2eBuildVariantsConfig(): E2eBuildVariantsConfig {
-  const configPath = fileURLToPath(
-    new URL("../e2e-build-variants.json", import.meta.url),
-  )
-  return JSON.parse(
-    fs.readFileSync(configPath, "utf8"),
-  ) as E2eBuildVariantsConfig
+  return getSharedE2eRequiredChromiumPermissions(variant)
 }

--- a/e2e/utils/e2eBuildVariants.ts
+++ b/e2e/utils/e2eBuildVariants.ts
@@ -1,6 +1,6 @@
-import e2eBuildVariantsConfig from "../e2e-build-variants.json"
+import fs from "node:fs"
+import { fileURLToPath } from "node:url"
 
-export const E2E_BUILD_VARIANT_ENV = e2eBuildVariantsConfig.envName
 export const E2E_BUILD_VARIANTS = {
   Default: "default",
   DnrRequired: "dnr-required",
@@ -12,6 +12,20 @@ const E2E_BUILD_VARIANT_VALUES = [
 ] as const
 
 type E2eBuildVariant = (typeof E2E_BUILD_VARIANT_VALUES)[number]
+type E2eBuildVariantConfig = {
+  extensionDirName: string
+  testOutDirTemplate: string
+  requiredChromiumPermissions: string[]
+}
+type E2eBuildVariantsConfig = {
+  envName: string
+  defaultVariant: E2eBuildVariant
+  variants: Record<E2eBuildVariant, E2eBuildVariantConfig>
+}
+
+const e2eBuildVariantsConfig = readE2eBuildVariantsConfig()
+
+export const E2E_BUILD_VARIANT_ENV = e2eBuildVariantsConfig.envName
 
 export function readE2eBuildVariant(
   env: Record<string, string | undefined> = process.env,
@@ -41,4 +55,13 @@ export function getE2eRequiredChromiumPermissions(
 
 function isE2eBuildVariant(value: string): value is E2eBuildVariant {
   return E2E_BUILD_VARIANT_VALUES.includes(value as E2eBuildVariant)
+}
+
+function readE2eBuildVariantsConfig(): E2eBuildVariantsConfig {
+  const configPath = fileURLToPath(
+    new URL("../e2e-build-variants.json", import.meta.url),
+  )
+  return JSON.parse(
+    fs.readFileSync(configPath, "utf8"),
+  ) as E2eBuildVariantsConfig
 }

--- a/e2e/utils/e2eBuildVariants.ts
+++ b/e2e/utils/e2eBuildVariants.ts
@@ -1,0 +1,44 @@
+import e2eBuildVariantsConfig from "../e2e-build-variants.json"
+
+export const E2E_BUILD_VARIANT_ENV = e2eBuildVariantsConfig.envName
+export const E2E_BUILD_VARIANTS = {
+  Default: "default",
+  DnrRequired: "dnr-required",
+} as const
+
+const E2E_BUILD_VARIANT_VALUES = [
+  E2E_BUILD_VARIANTS.Default,
+  E2E_BUILD_VARIANTS.DnrRequired,
+] as const
+
+type E2eBuildVariant = (typeof E2E_BUILD_VARIANT_VALUES)[number]
+
+export function readE2eBuildVariant(
+  env: Record<string, string | undefined> = process.env,
+): E2eBuildVariant {
+  const value = env[E2E_BUILD_VARIANT_ENV]?.trim()
+  if (!value) return E2E_BUILD_VARIANTS.Default
+  if (isE2eBuildVariant(value)) return value
+
+  throw new Error(`Unsupported ${E2E_BUILD_VARIANT_ENV} '${value}'`)
+}
+
+export function getE2eExtensionDirName(variant = readE2eBuildVariant()) {
+  return e2eBuildVariantsConfig.variants[variant].extensionDirName
+}
+
+export function getE2eTestOutDirTemplate(variant = readE2eBuildVariant()) {
+  return e2eBuildVariantsConfig.variants[variant].testOutDirTemplate
+}
+
+export function getE2eRequiredChromiumPermissions(
+  variant = readE2eBuildVariant(),
+) {
+  return [
+    ...e2eBuildVariantsConfig.variants[variant].requiredChromiumPermissions,
+  ]
+}
+
+function isE2eBuildVariant(value: string): value is E2eBuildVariant {
+  return E2E_BUILD_VARIANT_VALUES.includes(value as E2eBuildVariant)
+}

--- a/e2e/utils/extensionState.ts
+++ b/e2e/utils/extensionState.ts
@@ -104,6 +104,98 @@ export async function getPlasmoStorageRawValue<T>(
   }, key)
 }
 
+async function getManifestPermissionsField(
+  page: Page,
+  field: "permissions" | "optional_permissions",
+): Promise<string[]> {
+  return await page.evaluate((field) => {
+    const chromeApi = (
+      globalThis as typeof globalThis & { chrome?: typeof chrome }
+    ).chrome
+
+    if (!chromeApi?.runtime?.getManifest) {
+      throw new Error("chrome.runtime.getManifest is unavailable")
+    }
+
+    return [...(chromeApi.runtime.getManifest()[field] ?? [])]
+  }, field)
+}
+
+/**
+ * Read required permissions declared by the built extension manifest.
+ */
+export async function getManifestRequiredPermissions(
+  page: Page,
+): Promise<string[]> {
+  return await getManifestPermissionsField(page, "permissions")
+}
+
+/**
+ * Read optional permissions declared by the built extension manifest.
+ */
+export async function getManifestOptionalPermissions(
+  page: Page,
+): Promise<string[]> {
+  return await getManifestPermissionsField(page, "optional_permissions")
+}
+
+/**
+ * Check whether a specific extension optional permission is currently granted.
+ */
+export async function hasOptionalPermission(
+  page: Page,
+  permission: string,
+): Promise<boolean> {
+  return await page.evaluate(async (permission) => {
+    const chromeApi = (
+      globalThis as typeof globalThis & { chrome?: typeof chrome }
+    ).chrome
+
+    if (!chromeApi?.permissions) {
+      throw new Error("chrome.permissions is unavailable in extension context")
+    }
+
+    return await chromeApi.permissions.contains({
+      permissions: [permission],
+    })
+  }, permission)
+}
+
+/**
+ * Request optional permissions from the extension page and verify the browser
+ * actually grants each requested permission.
+ */
+export async function requestAndExpectOptionalPermissions(
+  page: Page,
+  permissions: string[],
+) {
+  if (permissions.length === 0) {
+    return
+  }
+
+  const granted = await page.evaluate(async (permissions) => {
+    const chromeApi = (
+      globalThis as typeof globalThis & { chrome?: typeof chrome }
+    ).chrome
+
+    if (!chromeApi?.permissions) {
+      throw new Error("chrome.permissions is unavailable in extension context")
+    }
+
+    return await chromeApi.permissions.request({ permissions })
+  }, permissions)
+
+  expect(granted).toBe(true)
+
+  for (const permission of permissions) {
+    await expect
+      .poll(() => hasOptionalPermission(page, permission), {
+        message: `${permission} permission should be granted`,
+      })
+      .toBe(true)
+  }
+}
+
 /**
  * Close every page in the context except the one the test actively drives.
  */

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "test:ci": "vitest --run --coverage",
     "e2e:install": "playwright install --with-deps chromium",
     "e2e": "playwright test",
+    "e2e:default": "playwright test",
+    "e2e:dnr-required": "playwright test e2e/dnrRequired --project=chromium --workers=1 --timeout=120000",
     "e2e:real-site": "playwright test e2e/realSite",
     "e2e:diagnostics": "node scripts/diagnostics/e2e-diagnostics.mjs",
     "e2e:ui": "playwright test --ui",

--- a/scripts/e2e-build.mjs
+++ b/scripts/e2e-build.mjs
@@ -5,7 +5,13 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
-const extensionDir = path.join(rootDir, ".output", "chrome-mv3-test")
+const buildVariantConfig = readE2eBuildVariantConfig()
+const buildVariant = getE2eBuildVariant(buildVariantConfig)
+const extensionDir = path.join(
+  rootDir,
+  ".output",
+  getExtensionDirName(buildVariantConfig, buildVariant),
+)
 const metadataPath = path.join(extensionDir, ".aah-e2e-build.json")
 const inputPaths = JSON.parse(
   fs.readFileSync(path.join(rootDir, "e2e", "e2e-build-inputs.json"), "utf8"),
@@ -31,6 +37,7 @@ fs.writeFileSync(
   `${JSON.stringify(
     {
       version: 1,
+      buildVariant,
       gitHead: getGitHead(),
       inputHash: createInputHash(),
       inputPaths,
@@ -59,6 +66,42 @@ function run(command, args) {
     }
     process.exit(result.status ?? 1)
   }
+}
+
+/**
+ * Returns the requested E2E build variant.
+ * @param config E2E build variant config.
+ * @returns The stable build variant identifier.
+ */
+function getE2eBuildVariant(config) {
+  const value = process.env[config.envName]?.trim()
+  if (!value) return config.defaultVariant
+  if (Object.prototype.hasOwnProperty.call(config.variants, value)) return value
+
+  throw new Error(`Unsupported ${config.envName} '${value}'`)
+}
+
+/**
+ * Maps the selected E2E variant to its output extension directory.
+ * @param config E2E build variant config.
+ * @param variant Selected E2E build variant.
+ * @returns The output directory name under .output.
+ */
+function getExtensionDirName(config, variant) {
+  return config.variants[variant].extensionDirName
+}
+
+/**
+ * Reads the E2E build variant config shared with TS build/test helpers.
+ * @returns Parsed E2E build variant config.
+ */
+function readE2eBuildVariantConfig() {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(rootDir, "e2e", "e2e-build-variants.json"),
+      "utf8",
+    ),
+  )
 }
 
 /**

--- a/scripts/e2e-build.mjs
+++ b/scripts/e2e-build.mjs
@@ -4,13 +4,17 @@ import fs from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
+import {
+  getE2eExtensionDirName,
+  readE2eBuildVariant,
+} from "../e2e/utils/e2eBuildVariants.shared.js"
+
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
-const buildVariantConfig = readE2eBuildVariantConfig()
-const buildVariant = getE2eBuildVariant(buildVariantConfig)
+const buildVariant = readE2eBuildVariant()
 const extensionDir = path.join(
   rootDir,
   ".output",
-  getExtensionDirName(buildVariantConfig, buildVariant),
+  getE2eExtensionDirName(buildVariant),
 )
 const metadataPath = path.join(extensionDir, ".aah-e2e-build.json")
 const inputPaths = JSON.parse(
@@ -66,42 +70,6 @@ function run(command, args) {
     }
     process.exit(result.status ?? 1)
   }
-}
-
-/**
- * Returns the requested E2E build variant.
- * @param config E2E build variant config.
- * @returns The stable build variant identifier.
- */
-function getE2eBuildVariant(config) {
-  const value = process.env[config.envName]?.trim()
-  if (!value) return config.defaultVariant
-  if (Object.prototype.hasOwnProperty.call(config.variants, value)) return value
-
-  throw new Error(`Unsupported ${config.envName} '${value}'`)
-}
-
-/**
- * Maps the selected E2E variant to its output extension directory.
- * @param config E2E build variant config.
- * @param variant Selected E2E build variant.
- * @returns The output directory name under .output.
- */
-function getExtensionDirName(config, variant) {
-  return config.variants[variant].extensionDirName
-}
-
-/**
- * Reads the E2E build variant config shared with TS build/test helpers.
- * @returns Parsed E2E build variant config.
- */
-function readE2eBuildVariantConfig() {
-  return JSON.parse(
-    fs.readFileSync(
-      path.join(rootDir, "e2e", "e2e-build-variants.json"),
-      "utf8",
-    ),
-  )
 }
 
 /**

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -1018,6 +1018,7 @@ export default function AccountActionButtons({
                   icon={ArrowPathIcon}
                   label={t("actions.refresh")}
                   disabled={refreshingAccountId === site.id}
+                  testId={ACCOUNT_MANAGEMENT_TEST_IDS.rowRefreshMenuItem}
                 />
 
                 {isQuickCheckinEligible && (

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -41,6 +41,7 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   rowRedeemMenuItem: "account-management-row-redeem-menu-item",
   rowPinToggleMenuItem: "account-management-row-pin-toggle-menu-item",
   rowQuickCheckinMenuItem: "account-management-row-quick-checkin-menu-item",
+  rowRefreshMenuItem: "account-management-row-refresh-menu-item",
   rowDisableToggleMenuItem: "account-management-row-disable-toggle-menu-item",
   rowDeleteMenuItem: "account-management-row-delete-menu-item",
   deleteConfirmButton: "account-management-delete-confirm-button",

--- a/src/utils/browser/dnrCookieInjector.ts
+++ b/src/utils/browser/dnrCookieInjector.ts
@@ -48,6 +48,13 @@ function buildRuleId(tabId: number): number {
 }
 
 /**
+ * Escape a URL origin so it can be embedded safely in a DNR regex filter.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+/**
  * Build a session-scoped DNR rule that forces the Cookie header for a specific
  * tab and URL.
  */
@@ -67,9 +74,8 @@ export function buildTempWindowCookieRule(params: TempWindowCookieRuleParams) {
     },
     condition: {
       tabIds: [params.tabId],
-      urlFilter: `||${new URL(params.url).hostname}/`,
-      isUrlFilterCaseSensitive: true,
-      resourceTypes: ["xmlhttprequest"],
+      regexFilter: `^${escapeRegExp(new URL(params.url).origin)}/`,
+      resourceTypes: ["xmlhttprequest", "other"],
     },
   } as const
 }

--- a/tests/utils/dnrCookieInjector.test.ts
+++ b/tests/utils/dnrCookieInjector.test.ts
@@ -50,7 +50,7 @@ describe("dnrCookieInjector", () => {
     }
 
     expect(rule.condition.tabIds).toEqual([123])
-    expect(rule.condition.urlFilter).toBe("||example.com/")
+    expect(rule.condition.regexFilter).toBe("^https://example\\.com/")
   })
 
   it("buildTempWindowCookieRule falls back to the base rule id when tab id is unavailable", () => {
@@ -61,7 +61,17 @@ describe("dnrCookieInjector", () => {
     })
 
     expect(rule.id).toBe(TEMP_WINDOW_DNR_RULE_ID_BASE)
-    expect(rule.condition.urlFilter).toBe("||example.com/")
+    expect(rule.condition.regexFilter).toBe("^https://example\\.com/")
+  })
+
+  it("buildTempWindowCookieRule preserves URL ports in the DNR filter", () => {
+    const rule = buildTempWindowCookieRule({
+      tabId: 9,
+      url: "http://127.0.0.1:3100/api/user/self",
+      cookieHeader: "session=user-a",
+    })
+
+    expect(rule.condition.regexFilter).toBe("^http://127\\.0\\.0\\.1:3100/")
   })
 
   it("applyTempWindowCookieRule should call updateSessionRules with remove+add", async () => {

--- a/tests/utils/e2eBuildMetadata.test.ts
+++ b/tests/utils/e2eBuildMetadata.test.ts
@@ -122,6 +122,7 @@ describe("E2E build metadata", () => {
           builtAt: "2026-05-18T00:00:00.000Z",
         },
         {
+          buildVariant: "default",
           gitHead: "new-head",
           inputHash: "same-hash",
           inputPaths: ["src"],
@@ -141,6 +142,7 @@ describe("E2E build metadata", () => {
           builtAt: "2026-05-18T00:00:00.000Z",
         },
         {
+          buildVariant: "default",
           gitHead: "same-head",
           inputHash: "new-hash",
           inputPaths: ["src"],
@@ -160,6 +162,7 @@ describe("E2E build metadata", () => {
           builtAt: "2026-05-18T00:00:00.000Z",
         },
         {
+          buildVariant: "default",
           gitHead: "new-head",
           inputHash: "new-hash",
           inputPaths: ["src"],
@@ -182,6 +185,7 @@ describe("E2E build metadata", () => {
           builtAt: "2026-05-18T00:00:00.000Z",
         },
         {
+          buildVariant: "default",
           gitHead: "same-head",
           inputHash: "same-hash",
           inputPaths: ["src"],

--- a/tests/utils/e2eBuildVariants.test.ts
+++ b/tests/utils/e2eBuildVariants.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  E2E_BUILD_VARIANT_ENV,
+  E2E_BUILD_VARIANTS,
+  getE2eExtensionDirName,
+  getE2eRequiredChromiumPermissions,
+  readE2eBuildVariant,
+} from "~~/e2e/utils/e2eBuildVariants"
+
+describe("E2E build variants", () => {
+  it("uses the default variant when the env value is missing", () => {
+    expect(readE2eBuildVariant({})).toBe(E2E_BUILD_VARIANTS.Default)
+  })
+
+  it("uses a configured env variant", () => {
+    expect(
+      readE2eBuildVariant({
+        [E2E_BUILD_VARIANT_ENV]: E2E_BUILD_VARIANTS.DnrRequired,
+      }),
+    ).toBe(E2E_BUILD_VARIANTS.DnrRequired)
+  })
+
+  it("rejects unsupported env variants", () => {
+    expect(() =>
+      readE2eBuildVariant({
+        [E2E_BUILD_VARIANT_ENV]: "unknown",
+      }),
+    ).toThrow("Unsupported AAH_E2E_BUILD_VARIANT 'unknown'")
+  })
+
+  it("resolves variant-specific extension directories and permissions", () => {
+    expect(getE2eExtensionDirName(E2E_BUILD_VARIANTS.DnrRequired)).toBe(
+      "chrome-mv3-test-dnr-required",
+    )
+    expect(
+      getE2eRequiredChromiumPermissions(E2E_BUILD_VARIANTS.DnrRequired),
+    ).toEqual(["cookies", "declarativeNetRequestWithHostAccess"])
+  })
+})

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -2,18 +2,25 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { defineConfig } from "wxt"
 
+import {
+  getE2eRequiredChromiumPermissions,
+  getE2eTestOutDirTemplate,
+  readE2eBuildVariant,
+} from "./e2e/utils/e2eBuildVariants"
 import { reactDevToolsAuto } from "./plugins/react-devtools-auto"
+
+type BrowserTarget = "chrome" | "firefox" | "safari" | string
+type ManifestPermission = string
 
 const requestedMode = readWxtCliMode()
 const isTestBuild = requestedMode === "test"
+const e2eBuildVariant = readE2eBuildVariant()
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   srcDir: "src",
   publicDir: "src/public",
-  outDirTemplate: isTestBuild
-    ? "{{browser}}-mv{{manifestVersion}}-test"
-    : "{{browser}}-mv{{manifestVersion}}{{modeSuffix}}",
+  outDirTemplate: getOutDirTemplate(),
   modules: ["@wxt-dev/auto-icons", "@wxt-dev/module-react"],
   manifest: (env) => {
     const projectPath = getProjectRootPath()
@@ -21,38 +28,15 @@ export default defineConfig({
       env.command === "serve"
         ? buildDevManifestDescription(projectPath)
         : "__MSG_manifest_description__"
+    const requiredPermissions = getManifestRequiredPermissions(env.browser)
+    const optionalPermissions = getManifestOptionalPermissions(env.browser)
 
     return {
       name: "__MSG_manifest_name__",
       description,
       default_locale: "en",
-      permissions: [
-        "tabs",
-        "storage",
-        "alarms",
-        "contextMenus",
-        ...(env.browser === "firefox" || env.browser === "safari"
-          ? []
-          : ["sidePanel"]),
-      ],
-      ...(env.browser === "firefox"
-        ? {
-            optional_permissions: [
-              "cookies",
-              "webRequest",
-              "webRequestBlocking",
-              "clipboardRead",
-              "notifications",
-            ],
-          }
-        : {
-            optional_permissions: [
-              "cookies",
-              "declarativeNetRequestWithHostAccess",
-              "clipboardRead",
-              "notifications",
-            ],
-          }),
+      permissions: requiredPermissions,
+      optional_permissions: optionalPermissions,
       // ensure can get site cookies, please refer to https://stackoverflow.com/a/70070106/22460724
       host_permissions: ["<all_urls>"],
       browser_specific_settings: {
@@ -92,6 +76,73 @@ export default defineConfig({
 })
 
 const MANIFEST_DESCRIPTION_MAX_LEN = 132
+const MANIFEST_BROWSER_TARGETS = {
+  Firefox: "firefox",
+  Safari: "safari",
+} as const
+const PRODUCTION_OUT_DIR_TEMPLATE =
+  "{{browser}}-mv{{manifestVersion}}{{modeSuffix}}"
+const CORE_EXTENSION_PERMISSIONS = [
+  "tabs",
+  "storage",
+  "alarms",
+  "contextMenus",
+] as const
+const CHROMIUM_ONLY_REQUIRED_PERMISSIONS = ["sidePanel"] as const
+const FIREFOX_COOKIE_OPTIONAL_PERMISSIONS = [
+  "cookies",
+  "webRequest",
+  "webRequestBlocking",
+] as const
+const CHROMIUM_COOKIE_DNR_OPTIONAL_PERMISSIONS = [
+  "cookies",
+  "declarativeNetRequestWithHostAccess",
+] as const
+const COMMON_OPTIONAL_PERMISSIONS = ["clipboardRead", "notifications"] as const
+
+function getOutDirTemplate() {
+  if (!isTestBuild) return PRODUCTION_OUT_DIR_TEMPLATE
+
+  return getE2eTestOutDirTemplate(e2eBuildVariant)
+}
+
+function getManifestRequiredPermissions(browser: BrowserTarget) {
+  const permissions: ManifestPermission[] = [...CORE_EXTENSION_PERMISSIONS]
+
+  if (isChromiumManifestTarget(browser)) {
+    permissions.push(...CHROMIUM_ONLY_REQUIRED_PERMISSIONS)
+    permissions.push(...getE2eRequiredChromiumPermissions(e2eBuildVariant))
+  }
+
+  return permissions
+}
+
+function getManifestOptionalPermissions(browser: BrowserTarget) {
+  const browserOptionalPermissions = isFirefoxManifestTarget(browser)
+    ? FIREFOX_COOKIE_OPTIONAL_PERMISSIONS
+    : getChromiumOptionalPermissions()
+
+  return [...browserOptionalPermissions, ...COMMON_OPTIONAL_PERMISSIONS]
+}
+
+function getChromiumOptionalPermissions() {
+  const requiredPermissions = getE2eRequiredChromiumPermissions(e2eBuildVariant)
+
+  return CHROMIUM_COOKIE_DNR_OPTIONAL_PERMISSIONS.filter(
+    (permission) => !requiredPermissions.includes(permission),
+  )
+}
+
+function isFirefoxManifestTarget(browser: BrowserTarget) {
+  return browser === MANIFEST_BROWSER_TARGETS.Firefox
+}
+
+function isChromiumManifestTarget(browser: BrowserTarget) {
+  return (
+    browser !== MANIFEST_BROWSER_TARGETS.Firefox &&
+    browser !== MANIFEST_BROWSER_TARGETS.Safari
+  )
+}
 
 /**
  * Get the absolute path to the project root directory.

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -12,6 +12,31 @@ import { reactDevToolsAuto } from "./plugins/react-devtools-auto"
 type BrowserTarget = "chrome" | "firefox" | "safari" | string
 type ManifestPermission = string
 
+const MANIFEST_DESCRIPTION_MAX_LEN = 132
+const MANIFEST_BROWSER_TARGETS = {
+  Firefox: "firefox",
+  Safari: "safari",
+} as const
+const PRODUCTION_OUT_DIR_TEMPLATE =
+  "{{browser}}-mv{{manifestVersion}}{{modeSuffix}}"
+const CORE_EXTENSION_PERMISSIONS = [
+  "tabs",
+  "storage",
+  "alarms",
+  "contextMenus",
+] as const
+const CHROMIUM_ONLY_REQUIRED_PERMISSIONS = ["sidePanel"] as const
+const FIREFOX_COOKIE_OPTIONAL_PERMISSIONS = [
+  "cookies",
+  "webRequest",
+  "webRequestBlocking",
+] as const
+const CHROMIUM_COOKIE_DNR_OPTIONAL_PERMISSIONS = [
+  "cookies",
+  "declarativeNetRequestWithHostAccess",
+] as const
+const COMMON_OPTIONAL_PERMISSIONS = ["clipboardRead", "notifications"] as const
+
 const requestedMode = readWxtCliMode()
 const isTestBuild = requestedMode === "test"
 const e2eBuildVariant = readE2eBuildVariant()
@@ -74,31 +99,6 @@ export default defineConfig({
     }
   },
 })
-
-const MANIFEST_DESCRIPTION_MAX_LEN = 132
-const MANIFEST_BROWSER_TARGETS = {
-  Firefox: "firefox",
-  Safari: "safari",
-} as const
-const PRODUCTION_OUT_DIR_TEMPLATE =
-  "{{browser}}-mv{{manifestVersion}}{{modeSuffix}}"
-const CORE_EXTENSION_PERMISSIONS = [
-  "tabs",
-  "storage",
-  "alarms",
-  "contextMenus",
-] as const
-const CHROMIUM_ONLY_REQUIRED_PERMISSIONS = ["sidePanel"] as const
-const FIREFOX_COOKIE_OPTIONAL_PERMISSIONS = [
-  "cookies",
-  "webRequest",
-  "webRequestBlocking",
-] as const
-const CHROMIUM_COOKIE_DNR_OPTIONAL_PERMISSIONS = [
-  "cookies",
-  "declarativeNetRequestWithHostAccess",
-] as const
-const COMMON_OPTIONAL_PERMISSIONS = ["clipboardRead", "notifications"] as const
 
 function getOutDirTemplate() {
   if (!isTestBuild) return PRODUCTION_OUT_DIR_TEMPLATE


### PR DESCRIPTION
## Summary
- Add mocked multi-account auth isolation E2E coverage.
- Add DNR-required real-browser account isolation coverage and build variant wiring.
- Update the E2E smoke workflow to run the DNR-required account isolation path.

## Test Plan
- pnpm run validate:push
- git push pre-push hook: pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive end-to-end coverage for multi-account auth, cookie vs token flows, cookie isolation, DNR-required scenarios, and build-variant gated tests.
  * New E2E helpers and scenarios to seed, refresh and validate saved accounts and captured authenticated requests.

* **Chores**
  * Enabled multiple E2E build variants and incorporated variant-aware build metadata.
  * Centralized permission and manifest computation and improved test environment setup and reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->