### PR TITLE
fix(runtime-messaging): use callback-based extension transport

### DIFF
--- a/src/services/accounts/accountKeyAutoProvisioning/messaging.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/messaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
 import type { AccountKeyRepairProgress } from "~/types/accountKeyAutoProvisioning"

--- a/src/services/accounts/autoRefreshMessaging.ts
+++ b/src/services/accounts/autoRefreshMessaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
 import type { AccountAutoRefresh } from "~/types/accountAutoRefresh"

--- a/src/services/checkin/autoCheckin/messaging.ts
+++ b/src/services/checkin/autoCheckin/messaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import { AutoCheckinMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import type { DisplaySiteData } from "~/types"

--- a/src/services/checkin/externalCheckInMessaging.ts
+++ b/src/services/checkin/externalCheckInMessaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
 

--- a/src/services/history/dailyBalanceHistory/messaging.ts
+++ b/src/services/history/dailyBalanceHistory/messaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import { BalanceHistoryMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"

--- a/src/services/history/usageHistory/messaging.ts
+++ b/src/services/history/usageHistory/messaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import { UsageHistoryMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"

--- a/src/services/integrations/ldohSiteLookup/runtime.ts
+++ b/src/services/integrations/ldohSiteLookup/runtime.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import {
   createRuntimeMessageFailure,

--- a/src/services/managedSites/channelConfigMessaging.ts
+++ b/src/services/managedSites/channelConfigMessaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
 import type { ChannelConfig } from "~/types/channelConfig"

--- a/src/services/models/modelSync/messaging.ts
+++ b/src/services/models/modelSync/messaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import { ModelSyncMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"

--- a/src/services/notifications/messaging.ts
+++ b/src/services/notifications/messaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
 import type { TaskNotificationChannel } from "~/types/taskNotifications"

--- a/src/services/preferences/messaging.ts
+++ b/src/services/preferences/messaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
 

--- a/src/services/productAnalytics/messaging.ts
+++ b/src/services/productAnalytics/messaging.ts
@@ -1,5 +1,7 @@
-import { defineExtensionMessaging, type Logger } from "@webext-core/messaging"
-
+import {
+  defineExtensionMessaging,
+  type Logger,
+} from "~/services/runtimeMessaging/extensionMessaging"
 import { createLogger } from "~/utils/core/logger"
 
 import type {

--- a/src/services/redemption/redemptionAssistMessaging.ts
+++ b/src/services/redemption/redemptionAssistMessaging.ts
@@ -1,6 +1,8 @@
-import { defineExtensionMessaging, type Logger } from "@webext-core/messaging"
-
 import type { RedemptionAssistPreferences } from "~/services/preferences/userPreferences"
+import {
+  defineExtensionMessaging,
+  type Logger,
+} from "~/services/runtimeMessaging/extensionMessaging"
 import { createLogger } from "~/utils/core/logger"
 
 import type {

--- a/src/services/runtimeMessaging/extensionMessaging.ts
+++ b/src/services/runtimeMessaging/extensionMessaging.ts
@@ -118,6 +118,11 @@ function createNoResponseError(): SerializedRuntimeMessagingError {
 /**
  * Browser extension messaging transport that keeps Chrome/Edge async response
  * channels open with `sendResponse` + `return true`.
+ *
+ * Chrome runtime messaging contract:
+ * https://developer.chrome.com/docs/extensions/develop/concepts/messaging#responses
+ * This transport intentionally uses the non-fallback `sendResponse`/`return true`
+ * path because async handlers must keep the response channel open in Chrome/Edge.
  */
 export function defineExtensionMessaging<
   TProtocolMap extends Record<string, any> = Record<string, any>,

--- a/src/services/runtimeMessaging/extensionMessaging.ts
+++ b/src/services/runtimeMessaging/extensionMessaging.ts
@@ -1,0 +1,311 @@
+import type {
+  ExtensionMessagingConfig,
+  ExtensionMessenger,
+  GetReturnType,
+  MaybePromise,
+  Message,
+} from "@webext-core/messaging"
+
+export type { Logger } from "@webext-core/messaging"
+
+interface RuntimeMessagingResponse {
+  res?: unknown
+  err?: SerializedRuntimeMessagingError
+}
+
+interface SerializedRuntimeMessagingError {
+  message: string
+  name?: string
+  stack?: string
+}
+
+type ExtensionMessage = {
+  sender: browser.runtime.MessageSender
+}
+
+type RuntimeMessageListener = (
+  message: unknown,
+  sender: browser.runtime.MessageSender,
+  sendResponse: (response?: RuntimeMessagingResponse) => void,
+) => boolean
+
+type RuntimeMessageHandler<
+  TProtocolMap extends Record<string, any>,
+  TType extends keyof TProtocolMap,
+> = (
+  message: Message<TProtocolMap, TType> & ExtensionMessage,
+) => MaybePromise<GetReturnType<TProtocolMap[TType]>>
+
+/**
+ * Converts unknown thrown values into a stable message for runtime transport.
+ */
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === "string") {
+    return error
+  }
+
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+/**
+ * Reduces thrown values to fields that can cross the extension message channel.
+ */
+function serializeError(error: unknown): SerializedRuntimeMessagingError {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    }
+  }
+
+  return {
+    message: getErrorMessage(error),
+    name: "Error",
+  }
+}
+
+/**
+ * Restores a serialized runtime messaging error for the original sender.
+ */
+function deserializeError(error: SerializedRuntimeMessagingError): Error {
+  const deserialized = new Error(error.message)
+  deserialized.name = error.name ?? "Error"
+  if (error.stack) {
+    deserialized.stack = error.stack
+  }
+  return deserialized
+}
+
+/**
+ * Narrows unknown message payloads to objects before inspecting fields.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+/**
+ * Detects the message envelope shape used by webext-core typed messages.
+ */
+function isTypedRuntimeMessage(
+  message: unknown,
+): message is Record<string, unknown> & { type: string; timestamp: number } {
+  return (
+    isRecord(message) &&
+    typeof message.type === "string" &&
+    typeof message.timestamp === "number"
+  )
+}
+
+/**
+ * Creates the fallback error used when a browser message receives no response.
+ */
+function createNoResponseError(): SerializedRuntimeMessagingError {
+  return {
+    message: "No response",
+    name: "Error",
+  }
+}
+
+/**
+ * Browser extension messaging transport that keeps Chrome/Edge async response
+ * channels open with `sendResponse` + `return true`.
+ */
+export function defineExtensionMessaging<
+  TProtocolMap extends Record<string, any> = Record<string, any>,
+>(config: ExtensionMessagingConfig = {}): ExtensionMessenger<TProtocolMap> {
+  type MessageType = keyof TProtocolMap & string
+
+  let removeRootListener: (() => void) | undefined
+  const perTypeListeners: Partial<{
+    [TType in MessageType]: RuntimeMessageHandler<TProtocolMap, TType>
+  }> = {}
+  let idSeq = Math.floor(Math.random() * 10000)
+
+  /**
+   * Removes the root runtime listener after the last typed listener is gone.
+   */
+  function cleanupRootListener() {
+    if (Object.keys(perTypeListeners).length > 0) {
+      return
+    }
+
+    removeRootListener?.()
+    removeRootListener = undefined
+  }
+
+  /**
+   * Generates a lightweight trace id compatible with webext-core messages.
+   */
+  function getNextId() {
+    return idSeq++
+  }
+
+  /**
+   * Runs a registered typed listener and responds through the callback channel.
+   */
+  function processMessage(
+    rawMessage: unknown,
+    sender: browser.runtime.MessageSender,
+    sendResponse: (response?: RuntimeMessagingResponse) => void,
+  ) {
+    if (!isTypedRuntimeMessage(rawMessage)) {
+      if (config.throwOnUnknownMessageFormat) {
+        const error = new Error(
+          `[messaging] Unknown message format, must include the 'type' & 'timestamp' fields, received: ${JSON.stringify(
+            rawMessage,
+          )}`,
+        )
+        config.logger?.error(error)
+        throw error
+      }
+
+      return false
+    }
+
+    const listener = perTypeListeners[rawMessage.type as MessageType]
+    if (!listener) {
+      return false
+    }
+
+    config.logger?.debug("[messaging] Received message", rawMessage)
+
+    Promise.resolve()
+      .then(() =>
+        listener({
+          ...rawMessage,
+          sender,
+        } as Message<TProtocolMap, MessageType> & ExtensionMessage),
+      )
+      .then((res) => {
+        config.logger?.debug(`[messaging] onMessage {id=${rawMessage.id}} ->`, {
+          res,
+        })
+        sendResponse({ res })
+      })
+      .catch((error) => {
+        const err = serializeError(error)
+        config.logger?.debug(`[messaging] onMessage {id=${rawMessage.id}} ->`, {
+          err,
+        })
+        sendResponse({ err })
+      })
+  }
+
+  /**
+   * Installs the single root listener for this messenger instance.
+   */
+  function addRootListener() {
+    const listener: RuntimeMessageListener = (
+      message,
+      sender,
+      sendResponse,
+    ) => {
+      if (!isTypedRuntimeMessage(message)) {
+        if (config.throwOnUnknownMessageFormat) {
+          const error = new Error(
+            `[messaging] Unknown message format, must include the 'type' & 'timestamp' fields, received: ${JSON.stringify(
+              message,
+            )}`,
+          )
+          config.logger?.error(error)
+          throw error
+        }
+
+        return false
+      }
+
+      if (!perTypeListeners[message.type as MessageType]) {
+        return false
+      }
+
+      processMessage(message, sender, sendResponse)
+      return true
+    }
+
+    browser.runtime.onMessage.addListener(listener)
+    return () => {
+      browser.runtime.onMessage.removeListener(listener)
+    }
+  }
+
+  return {
+    async sendMessage(type, data, arg) {
+      const message = {
+        id: getNextId(),
+        type,
+        data,
+        timestamp: Date.now(),
+      }
+      config.logger?.debug(`[messaging] sendMessage {id=${message.id}} ->`)
+
+      const response =
+        arg == null
+          ? await browser.runtime.sendMessage(message)
+          : await browser.tabs.sendMessage(
+              typeof arg === "number" ? arg : arg.tabId,
+              message,
+              typeof arg === "object" && arg.frameId != null
+                ? { frameId: arg.frameId }
+                : undefined,
+            )
+      const { res, err } = (response ?? {
+        err: createNoResponseError(),
+      }) as RuntimeMessagingResponse
+
+      config.logger?.debug(`[messaging] sendMessage {id=${message.id}} <-`, {
+        res,
+        err,
+      })
+
+      if (err) {
+        throw deserializeError(err)
+      }
+
+      return res as GetReturnType<TProtocolMap[typeof type]>
+    },
+    onMessage(type, onReceived) {
+      if (!removeRootListener) {
+        config.logger?.debug(
+          `[messaging] "${String(
+            type,
+          )}" initialized the message listener for this context`,
+        )
+        removeRootListener = addRootListener()
+      }
+
+      if (perTypeListeners[type as MessageType]) {
+        const error = new Error(
+          `[messaging] In this JS context, only one listener can be setup for ${String(
+            type,
+          )}`,
+        )
+        config.logger?.error(error)
+        throw error
+      }
+
+      perTypeListeners[type as MessageType] =
+        onReceived as RuntimeMessageHandler<TProtocolMap, MessageType>
+      config.logger?.log(`[messaging] Added listener for ${String(type)}`)
+
+      return () => {
+        delete perTypeListeners[type as MessageType]
+        cleanupRootListener()
+      }
+    },
+    removeAllListeners() {
+      Object.keys(perTypeListeners).forEach((type) => {
+        delete perTypeListeners[type as MessageType]
+      })
+      cleanupRootListener()
+    },
+  } as ExtensionMessenger<TProtocolMap>
+}

--- a/src/services/runtimeMessaging/extensionMessaging.ts
+++ b/src/services/runtimeMessaging/extensionMessaging.ts
@@ -37,13 +37,9 @@ type RuntimeMessageHandler<
 ) => MaybePromise<GetReturnType<TProtocolMap[TType]>>
 
 /**
- * Converts unknown thrown values into a stable message for runtime transport.
+ * Converts non-Error thrown values into a stable message for runtime transport.
  */
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message
-  }
-
+function getNonErrorMessage(error: unknown): string {
   if (typeof error === "string") {
     return error
   }
@@ -68,7 +64,7 @@ function serializeError(error: unknown): SerializedRuntimeMessagingError {
   }
 
   return {
-    message: getErrorMessage(error),
+    message: getNonErrorMessage(error),
     name: "Error",
   }
 }
@@ -158,47 +154,31 @@ export function defineExtensionMessaging<
    * Runs a registered typed listener and responds through the callback channel.
    */
   function processMessage(
-    rawMessage: unknown,
+    message: Record<string, unknown> & { type: string; timestamp: number },
     sender: browser.runtime.MessageSender,
     sendResponse: (response?: RuntimeMessagingResponse) => void,
   ) {
-    if (!isTypedRuntimeMessage(rawMessage)) {
-      if (config.throwOnUnknownMessageFormat) {
-        const error = new Error(
-          `[messaging] Unknown message format, must include the 'type' & 'timestamp' fields, received: ${JSON.stringify(
-            rawMessage,
-          )}`,
-        )
-        config.logger?.error(error)
-        throw error
-      }
-
-      return false
-    }
-
-    const listener = perTypeListeners[rawMessage.type as MessageType]
-    if (!listener) {
-      return false
-    }
-
-    config.logger?.debug("[messaging] Received message", rawMessage)
+    const listener = perTypeListeners[
+      message.type as MessageType
+    ] as RuntimeMessageHandler<TProtocolMap, MessageType>
+    config.logger?.debug("[messaging] Received message", message)
 
     Promise.resolve()
       .then(() =>
         listener({
-          ...rawMessage,
+          ...message,
           sender,
         } as Message<TProtocolMap, MessageType> & ExtensionMessage),
       )
       .then((res) => {
-        config.logger?.debug(`[messaging] onMessage {id=${rawMessage.id}} ->`, {
+        config.logger?.debug(`[messaging] onMessage {id=${message.id}} ->`, {
           res,
         })
         sendResponse({ res })
       })
       .catch((error) => {
         const err = serializeError(error)
-        config.logger?.debug(`[messaging] onMessage {id=${rawMessage.id}} ->`, {
+        config.logger?.debug(`[messaging] onMessage {id=${message.id}} ->`, {
           err,
         })
         sendResponse({ err })

--- a/src/services/runtimeMessaging/logger.ts
+++ b/src/services/runtimeMessaging/logger.ts
@@ -1,5 +1,4 @@
-import type { Logger } from "@webext-core/messaging"
-
+import type { Logger } from "~/services/runtimeMessaging/extensionMessaging"
 import { createLogger } from "~/utils/core/logger"
 
 /**

--- a/src/services/siteAnnouncements/messaging.ts
+++ b/src/services/siteAnnouncements/messaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import { SiteAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"

--- a/src/services/updates/messaging.ts
+++ b/src/services/updates/messaging.ts
@@ -1,5 +1,4 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
 

--- a/src/services/verification/webAiApiCheck/messaging.ts
+++ b/src/services/verification/webAiApiCheck/messaging.ts
@@ -1,5 +1,7 @@
-import { defineExtensionMessaging, type Logger } from "@webext-core/messaging"
-
+import {
+  defineExtensionMessaging,
+  type Logger,
+} from "~/services/runtimeMessaging/extensionMessaging"
 import { createLogger } from "~/utils/core/logger"
 
 import type {

--- a/src/services/webdav/webdavAutoSyncMessaging.ts
+++ b/src/services/webdav/webdavAutoSyncMessaging.ts
@@ -1,6 +1,5 @@
-import { defineExtensionMessaging } from "@webext-core/messaging"
-
 import type { UserPreferences } from "~/services/preferences/userPreferences"
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import { WebdavAutoSyncMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"

--- a/tests/services/ldohSiteLookup.runtime.test.ts
+++ b/tests/services/ldohSiteLookup.runtime.test.ts
@@ -7,7 +7,7 @@ const { sendLdohSiteLookupMessageMock, isReceiverUnavailableMock } = vi.hoisted(
   }),
 )
 
-vi.mock("@webext-core/messaging", () => ({
+vi.mock("~/services/runtimeMessaging/extensionMessaging", () => ({
   defineExtensionMessaging: () => ({
     sendMessage: sendLdohSiteLookupMessageMock,
     onMessage: vi.fn(),

--- a/tests/services/privacyMessagingLoggers.test.ts
+++ b/tests/services/privacyMessagingLoggers.test.ts
@@ -19,7 +19,7 @@ const messagingMock = vi.hoisted(() => ({
     | undefined,
 }))
 
-vi.mock("@webext-core/messaging", () => ({
+vi.mock("~/services/runtimeMessaging/extensionMessaging", () => ({
   defineExtensionMessaging: messagingMock.defineExtensionMessaging,
 }))
 

--- a/tests/services/runtimeMessaging/extensionMessaging.test.ts
+++ b/tests/services/runtimeMessaging/extensionMessaging.test.ts
@@ -11,6 +11,7 @@ type RuntimeMessageListener = (
 interface TestProtocolMap {
   "test:ping"(data: { value: string }): { echoed: string }
   "test:fail"(): { ok: boolean }
+  "test:other"(): { ok: boolean }
   "test:void"(): undefined
 }
 
@@ -192,6 +193,71 @@ describe("extension messaging transport", () => {
     })
   })
 
+  it.each([
+    ["string failure", "string failure"],
+    [{ code: "bad-input" }, '{"code":"bad-input"}'],
+  ])("serializes non-error listener failures: %s", async (failure, message) => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    messenger.onMessage("test:fail", () => {
+      throw failure
+    })
+    const sendResponse = vi.fn()
+
+    expect(
+      runtime.getListener()(
+        {
+          id: 1,
+          type: "test:fail",
+          timestamp: Date.now(),
+        },
+        {},
+        sendResponse,
+      ),
+    ).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({
+        err: expect.objectContaining({
+          message,
+          name: "Error",
+        }),
+      })
+    })
+  })
+
+  it("serializes circular non-error listener failures", async () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    const failure: Record<string, unknown> = { code: "circular" }
+    failure.self = failure
+    messenger.onMessage("test:fail", () => {
+      throw failure
+    })
+    const sendResponse = vi.fn()
+
+    expect(
+      runtime.getListener()(
+        {
+          id: 1,
+          type: "test:fail",
+          timestamp: Date.now(),
+        },
+        {},
+        sendResponse,
+      ),
+    ).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({
+        err: expect.objectContaining({
+          message: "[object Object]",
+          name: "Error",
+        }),
+      })
+    })
+  })
+
   it("rejects when the browser returns no response", async () => {
     const runtime = createRuntimeMock()
     const messenger = defineExtensionMessaging<TestProtocolMap>()
@@ -218,5 +284,41 @@ describe("extension messaging transport", () => {
       }),
       { frameId: 3 },
     )
+  })
+
+  it("keeps the root listener until the last typed listener is removed", () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+
+    const removePing = messenger.onMessage("test:ping", vi.fn())
+    const removeOther = messenger.onMessage("test:other", vi.fn())
+
+    removePing()
+    expect(runtime.removeListener).not.toHaveBeenCalled()
+
+    removeOther()
+    expect(runtime.removeListener).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws when registering duplicate listeners for the same type", () => {
+    createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+
+    messenger.onMessage("test:ping", vi.fn())
+
+    expect(() => messenger.onMessage("test:ping", vi.fn())).toThrow(
+      "only one listener can be setup",
+    )
+  })
+
+  it("removes the root listener when all typed listeners are cleared", () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+
+    messenger.onMessage("test:ping", vi.fn())
+    messenger.onMessage("test:other", vi.fn())
+    messenger.removeAllListeners()
+
+    expect(runtime.removeListener).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/services/runtimeMessaging/extensionMessaging.test.ts
+++ b/tests/services/runtimeMessaging/extensionMessaging.test.ts
@@ -114,6 +114,22 @@ describe("extension messaging transport", () => {
     ).toBe(false)
   })
 
+  it("throws on malformed envelopes when strict format validation is enabled", () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>({
+      throwOnUnknownMessageFormat: true,
+    })
+    messenger.onMessage("test:ping", vi.fn())
+    const listener = runtime.getListener()
+
+    expect(() => listener("not-object", {}, vi.fn())).toThrow(
+      "Unknown message format",
+    )
+    expect(() => listener({ action: "legacy" }, {}, vi.fn())).toThrow(
+      "Unknown message format",
+    )
+  })
+
   it("serializes listener failures so senders reject with a readable error", async () => {
     const runtime = createRuntimeMock()
     const messenger = defineExtensionMessaging<TestProtocolMap>()

--- a/tests/services/runtimeMessaging/extensionMessaging.test.ts
+++ b/tests/services/runtimeMessaging/extensionMessaging.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
+
+type RuntimeMessageListener = (
+  message: unknown,
+  sender: browser.runtime.MessageSender,
+  sendResponse: (response?: unknown) => void,
+) => boolean
+
+interface TestProtocolMap {
+  "test:ping"(data: { value: string }): { echoed: string }
+  "test:fail"(): { ok: boolean }
+  "test:void"(): undefined
+}
+
+function createRuntimeMock() {
+  const listeners = new Set<RuntimeMessageListener>()
+  const addListener = vi.fn((listener: RuntimeMessageListener) => {
+    listeners.add(listener)
+  })
+  const removeListener = vi.fn((listener: RuntimeMessageListener) => {
+    listeners.delete(listener)
+  })
+  const sendMessage = vi.fn()
+  const tabsSendMessage = vi.fn()
+
+  ;(globalThis as any).browser = {
+    runtime: {
+      onMessage: {
+        addListener,
+        removeListener,
+      },
+      sendMessage,
+    },
+    tabs: {
+      sendMessage: tabsSendMessage,
+    },
+  }
+
+  return {
+    addListener,
+    removeListener,
+    sendMessage,
+    tabsSendMessage,
+    getListener: () => {
+      const listener = Array.from(listeners)[0]
+      expect(listener).toBeTypeOf("function")
+      return listener
+    },
+  }
+}
+
+describe("extension messaging transport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("keeps the runtime channel open and responds through sendResponse", async () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    const handler = vi
+      .fn()
+      .mockResolvedValue({ echoed: "pong" } satisfies { echoed: string })
+
+    const remove = messenger.onMessage("test:ping", handler)
+    const sendResponse = vi.fn()
+
+    const handled = runtime.getListener()(
+      {
+        id: 1,
+        type: "test:ping",
+        data: { value: "pong" },
+        timestamp: Date.now(),
+      },
+      { id: "sender" } as browser.runtime.MessageSender,
+      sendResponse,
+    )
+
+    expect(handled).toBe(true)
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({ res: { echoed: "pong" } })
+    })
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { value: "pong" },
+        sender: { id: "sender" },
+        type: "test:ping",
+      }),
+    )
+
+    remove()
+    expect(runtime.removeListener).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not claim unknown message formats or unregistered types", () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    messenger.onMessage("test:ping", vi.fn())
+    const listener = runtime.getListener()
+
+    expect(listener("not-object", {}, vi.fn())).toBe(false)
+    expect(listener({ action: "legacy" }, {}, vi.fn())).toBe(false)
+    expect(
+      listener(
+        {
+          id: 1,
+          type: "test:unknown",
+          timestamp: Date.now(),
+        },
+        {},
+        vi.fn(),
+      ),
+    ).toBe(false)
+  })
+
+  it("serializes listener failures so senders reject with a readable error", async () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    messenger.onMessage("test:fail", async () => {
+      throw new TypeError("boom")
+    })
+    const sendResponse = vi.fn()
+
+    expect(
+      runtime.getListener()(
+        {
+          id: 1,
+          type: "test:fail",
+          timestamp: Date.now(),
+        },
+        {},
+        sendResponse,
+      ),
+    ).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({
+        err: expect.objectContaining({
+          message: "boom",
+          name: "TypeError",
+        }),
+      })
+    })
+
+    runtime.sendMessage.mockResolvedValueOnce(sendResponse.mock.calls[0]?.[0])
+
+    await expect(messenger.sendMessage("test:fail")).rejects.toThrow("boom")
+  })
+
+  it("serializes synchronous listener failures without closing the channel", async () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    messenger.onMessage("test:fail", () => {
+      throw new Error("sync boom")
+    })
+    const sendResponse = vi.fn()
+
+    const handled = runtime.getListener()(
+      {
+        id: 1,
+        type: "test:fail",
+        timestamp: Date.now(),
+      },
+      {},
+      sendResponse,
+    )
+
+    expect(handled).toBe(true)
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({
+        err: expect.objectContaining({
+          message: "sync boom",
+        }),
+      })
+    })
+  })
+
+  it("rejects when the browser returns no response", async () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    runtime.sendMessage.mockResolvedValueOnce(undefined)
+
+    await expect(
+      messenger.sendMessage("test:ping", { value: "lost" }),
+    ).rejects.toThrow("No response")
+  })
+
+  it("targets tabs and frames through tabs.sendMessage", async () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    runtime.tabsSendMessage.mockResolvedValueOnce({ res: undefined })
+
+    await expect(
+      messenger.sendMessage("test:void", undefined, { tabId: 7, frameId: 3 }),
+    ).resolves.toBeUndefined()
+
+    expect(runtime.tabsSendMessage).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({
+        type: "test:void",
+      }),
+      { frameId: 3 },
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add a local typed extension messaging transport that responds with sendResponse + return true
- route existing typed runtime messaging modules through the callback-based transport
- cover async responses, unknown messages, serialized errors, no-response fallback, and tab/frame sends

## Validation
- pnpm vitest --run tests/services/runtimeMessaging/extensionMessaging.test.ts tests/services/runtimeTypedMessagingSetup.test.ts tests/services/privacyMessagingLoggers.test.ts tests/services/ldohSiteLookup.runtime.test.ts
- pnpm run validate:push
- pnpm run validate:staged
- pre-push hook: pnpm run validate:push

Fixes #918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized the extension runtime messaging implementation across services to unify message handling and improve reliability.
* **Tests**
  * Added extensive end-to-end tests for the messaging transport covering listener lifecycle, routing, envelope validation, tab/frame targeting, and robust error serialization/propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->