### PR TITLE
fix(webdav): retry cstcloud overwrite moves

### DIFF
--- a/src/services/webdav/webdavService.ts
+++ b/src/services/webdav/webdavService.ts
@@ -370,9 +370,10 @@ async function moveWebdavContent(params: {
 
   let res = await move()
 
-  if (res.status === 409) {
+  if (shouldRetryMoveAfterDeletingDestination(res.status)) {
     // RFC 4918 section 9.9.3 requires Overwrite:T to delete the destination
-    // before MOVE; Nutstore returns 409 instead when the destination exists.
+    // before MOVE. Some providers reject that overwrite step instead:
+    // Nutstore returns 409 and cstcloud returns 500 when the destination exists.
     await deleteWebdavDestinationBeforeMoveRetry(params)
     res = await move()
   }
@@ -381,6 +382,13 @@ async function moveWebdavContent(params: {
   if (res.status === 401 || res.status === 403)
     throw new WebdavHttpError(t("messages:webdav.authFailed"), res.status)
   throw new WebdavHttpError(t("messages:webdav.safeCommitFailed"), res.status)
+}
+
+/**
+ * Detects provider overwrite failures that can safely retry after deleting the destination.
+ */
+function shouldRetryMoveAfterDeletingDestination(status: number) {
+  return status === 409 || status === 500
 }
 
 /**

--- a/tests/services/webdavService.test.ts
+++ b/tests/services/webdavService.test.ts
@@ -889,6 +889,49 @@ describe("webdavService", () => {
       })
     })
 
+    it("falls back by deleting the existing destination when cstcloud rejects overwrite MOVE with 500", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
+      globalAny.fetch
+        .mockResolvedValueOnce({ status: 201 })
+        .mockResolvedValueOnce({ status: 405 })
+        .mockResolvedValueOnce({ status: 204 })
+        .mockResolvedValueOnce({
+          status: 200,
+          text: vi.fn().mockResolvedValue('{"cstcloud":true}'),
+        })
+        .mockResolvedValueOnce({ status: 500 })
+        .mockResolvedValueOnce({ status: 204 })
+        .mockResolvedValueOnce({ status: 201 })
+
+      await expect(uploadBackup('{"cstcloud":true}')).resolves.toBe(true)
+
+      const officialUrl =
+        "https://example.com/webdav/all-api-hub-backup/all-api-hub-1-0.json"
+      expect(globalAny.fetch).toHaveBeenCalledTimes(7)
+      expect((globalAny.fetch.mock.calls[3][1] as RequestInit).method).toBe(
+        "GET",
+      )
+      expect((globalAny.fetch.mock.calls[4][1] as RequestInit).method).toBe(
+        "MOVE",
+      )
+      expect(globalAny.fetch.mock.calls[5][0]).toBe(officialUrl)
+      expect((globalAny.fetch.mock.calls[5][1] as RequestInit).method).toBe(
+        "DELETE",
+      )
+      expect(globalAny.fetch.mock.calls[6][0]).toBe(
+        globalAny.fetch.mock.calls[4][0],
+      )
+      expect((globalAny.fetch.mock.calls[6][1] as RequestInit).method).toBe(
+        "MOVE",
+      )
+      expect(
+        (globalAny.fetch.mock.calls[6][1] as RequestInit).headers,
+      ).toMatchObject({
+        Destination: officialUrl,
+        Overwrite: "T",
+      })
+    })
+
     it("reports safe commit failure when the Nutstore overwrite fallback delete fails", async () => {
       mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
       globalAny.fetch


### PR DESCRIPTION
## Summary
- Retry WebDAV overwrite MOVE failures for providers that return 500 when the destination already exists.
- Keep the fallback narrow to existing overwrite-recovery statuses: 409 and 500.
- Add a cstcloud regression case that verifies temp upload readback still happens before DELETE + retry MOVE.

Closes #920

## Test Plan
- pnpm vitest run tests/services/webdavService.test.ts
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WebDAV file operations to handle additional error scenarios when overwriting existing files, ensuring backup uploads complete successfully in cases where they previously failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->