### PR TITLE
fix(e2e): stabilize low Chrome compatibility checks

### DIFF
--- a/e2e/basicSettingsCommonFlows.spec.ts
+++ b/e2e/basicSettingsCommonFlows.spec.ts
@@ -89,6 +89,15 @@ async function expectConfiguredActionPopup(
     .toBe(expectedPopup)
 }
 
+async function hasSidePanelOpenSupport(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+): Promise<boolean> {
+  return await serviceWorker.evaluate(() => {
+    const chromeApi = (globalThis as any).chrome
+    return typeof chromeApi?.sidePanel?.open === "function"
+  })
+}
+
 async function hasActionClickListeners(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
 ): Promise<boolean> {
@@ -173,8 +182,12 @@ test("updates toolbar action behavior from settings into the live extension acti
     "actionClickBehavior",
     "sidepanel",
   )
-  await expectConfiguredActionPopup(serviceWorker, "")
-  await expectActionClickListenerState(serviceWorker, true)
+  const sidePanelOpenSupported = await hasSidePanelOpenSupport(serviceWorker)
+  await expectConfiguredActionPopup(
+    serviceWorker,
+    sidePanelOpenSupported ? "" : POPUP_PAGE_PATH,
+  )
+  await expectActionClickListenerState(serviceWorker, sidePanelOpenSupported)
 
   await page.getByRole("button", { name: "Popup" }).click()
 

--- a/e2e/utils/extension.ts
+++ b/e2e/utils/extension.ts
@@ -1,10 +1,146 @@
 import fs from "node:fs/promises"
 import path from "node:path"
-import type { BrowserContext } from "@playwright/test"
+import type { BrowserContext, Worker } from "@playwright/test"
 
 import { assertE2eBuildMetadataCurrent } from "~~/e2e/utils/e2eBuildMetadata"
 
 const verifiedExtensionDirs = new Set<string>()
+const extensionServiceWorkerProtocols = new Set([
+  "chrome-extension:",
+  "moz-extension:",
+])
+
+type ExtensionServiceWorkerOptions = {
+  extensionId?: string
+  timeoutMs?: number
+}
+
+type ExtensionServiceWorkerProbe = {
+  hasAlarms: boolean
+  hasRuntimeGetManifest: boolean
+  hasStorageLocal: boolean
+  runtimeId: string | null
+}
+
+/**
+ * Checks whether a Playwright worker URL belongs to a browser extension.
+ */
+export function isExtensionServiceWorkerUrl(workerUrl: string): boolean {
+  try {
+    return extensionServiceWorkerProtocols.has(new URL(workerUrl).protocol)
+  } catch {
+    return false
+  }
+}
+
+async function probeExtensionServiceWorker(
+  worker: Worker,
+): Promise<ExtensionServiceWorkerProbe> {
+  return await worker.evaluate(() => {
+    const chromeApi = (
+      globalThis as typeof globalThis & { chrome?: typeof chrome }
+    ).chrome
+
+    return {
+      hasAlarms: typeof chromeApi?.alarms?.clear === "function",
+      hasRuntimeGetManifest:
+        typeof chromeApi?.runtime?.getManifest === "function",
+      hasStorageLocal: typeof chromeApi?.storage?.local?.get === "function",
+      runtimeId: chromeApi?.runtime?.id ?? null,
+    }
+  })
+}
+
+async function describeServiceWorkerReadiness(
+  worker: Worker,
+  expectedExtensionId?: string,
+): Promise<{ reason: string; ready: boolean }> {
+  const workerUrl = worker.url()
+
+  if (!isExtensionServiceWorkerUrl(workerUrl)) {
+    return { ready: false, reason: "not an extension service worker" }
+  }
+
+  const workerExtensionId = new URL(workerUrl).host
+  if (expectedExtensionId && workerExtensionId !== expectedExtensionId) {
+    return {
+      ready: false,
+      reason: `extension id ${workerExtensionId} did not match ${expectedExtensionId}`,
+    }
+  }
+
+  try {
+    const probe = await probeExtensionServiceWorker(worker)
+    const missingApis = [
+      probe.runtimeId ? null : "chrome.runtime.id",
+      probe.hasRuntimeGetManifest ? null : "chrome.runtime.getManifest",
+      probe.hasStorageLocal ? null : "chrome.storage.local",
+      probe.hasAlarms ? null : "chrome.alarms",
+    ].filter((api): api is string => Boolean(api))
+
+    if (missingApis.length > 0) {
+      return {
+        ready: false,
+        reason: `missing ${missingApis.join(", ")}`,
+      }
+    }
+
+    return { ready: true, reason: "ready" }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { ready: false, reason: `probe failed: ${message}` }
+  }
+}
+
+/**
+ * Resolve the production MV3 service worker and wait until Chrome has attached
+ * the extension APIs used by the E2E storage/alarm helpers.
+ */
+export async function getExtensionServiceWorker(
+  context: BrowserContext,
+  options: ExtensionServiceWorkerOptions = {},
+): Promise<Worker> {
+  const timeoutMs = options.timeoutMs ?? 15_000
+  const deadline = Date.now() + timeoutMs
+  const observedWorkers = new Map<string, string>()
+
+  while (Date.now() <= deadline) {
+    for (const worker of context.serviceWorkers()) {
+      const readiness = await describeServiceWorkerReadiness(
+        worker,
+        options.extensionId,
+      )
+      observedWorkers.set(worker.url(), readiness.reason)
+
+      if (readiness.ready) {
+        return worker
+      }
+    }
+
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) {
+      break
+    }
+
+    await context
+      .waitForEvent("serviceworker", {
+        timeout: Math.min(250, remainingMs),
+      })
+      .catch(() => undefined)
+  }
+
+  const observedSummary =
+    [...observedWorkers.entries()]
+      .map(([workerUrl, reason]) => `${workerUrl} (${reason})`)
+      .join("; ") || "none"
+
+  throw new Error(
+    [
+      "Timed out waiting for an extension service worker with ready browser APIs.",
+      `Observed service workers: ${observedSummary}.`,
+    ].join(" "),
+  )
+}
 
 /**
  * Ensures the built MV3 extension output exists before running E2E.
@@ -40,13 +176,7 @@ export async function getExtensionIdFromServiceWorker(
   context: BrowserContext,
   options?: { timeoutMs?: number },
 ): Promise<string> {
-  const timeoutMs = options?.timeoutMs ?? 15_000
-
-  const existing = context.serviceWorkers()[0]
-  const serviceWorker =
-    existing ??
-    (await context.waitForEvent("serviceworker", { timeout: timeoutMs }))
-
+  const serviceWorker = await getExtensionServiceWorker(context, options)
   return new URL(serviceWorker.url()).host
 }
 

--- a/e2e/utils/extensionState.ts
+++ b/e2e/utils/extensionState.ts
@@ -2,6 +2,7 @@ import type { BrowserContext, Page, Worker } from "@playwright/test"
 import { expect } from "@playwright/test"
 
 import { OPTIONS_OVERVIEW_TEST_IDS } from "~/features/OptionsOverview/testIds"
+import { getExtensionServiceWorker } from "~~/e2e/utils/extension"
 
 /**
  * Detect whether a page URL is an options page carrying the permissions
@@ -22,10 +23,7 @@ function isPermissionOnboardingPage(page: Page): boolean {
 export async function getServiceWorker(
   context: BrowserContext,
 ): Promise<Worker> {
-  return (
-    context.serviceWorkers()[0] ??
-    (await context.waitForEvent("serviceworker", { timeout: 15_000 }))
-  )
+  return await getExtensionServiceWorker(context)
 }
 
 /**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -171,6 +171,45 @@ export default defineConfig([
       "no-console": "off",
     },
   },
+  // Guardrails: keep version-sensitive extension API access inside browser adapter modules.
+  {
+    files: [srcJsFamilyFilePattern],
+    ignores: [
+      "src/utils/browser/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/utils/core/logger.{js,cjs,mjs,jsx,ts,tsx}",
+    ],
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        {
+          name: "chrome",
+          message:
+            "Do not access the global Chrome extension API directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+        },
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "MemberExpression[object.name=/^(globalThis|window)$/][property.name='chrome']",
+          message:
+            "Do not access the global Chrome extension API directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+        },
+        {
+          selector:
+            "MemberExpression[object.type='TSAsExpression'][object.expression.name='globalThis'][property.name='chrome']",
+          message:
+            "Do not access the global Chrome extension API directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+        },
+        {
+          selector:
+            "MemberExpression[object.name='browser'][property.name=/^(action|browserAction|sidebarAction|permissions)$/]",
+          message:
+            "Do not access version-sensitive `browser.*` extension APIs directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+        },
+      ],
+    },
+  },
   // Guardrails: prevent non-entrypoint code from depending on options page internals.
   //
   // Transition plan:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -207,6 +207,18 @@ export default defineConfig([
           message:
             "Do not access version-sensitive `browser.*` extension APIs directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
         },
+        {
+          selector:
+            "MemberExpression[object.type='MemberExpression'][object.object.name=/^(globalThis|window)$/][object.property.name='browser'][property.name=/^(action|browserAction|sidebarAction|permissions)$/]",
+          message:
+            "Do not access version-sensitive `browser.*` extension APIs directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+        },
+        {
+          selector:
+            "MemberExpression[object.type='MemberExpression'][object.object.type='TSAsExpression'][object.object.expression.name=/^(globalThis|window)$/][object.property.name='browser'][property.name=/^(action|browserAction|sidebarAction|permissions)$/]",
+          message:
+            "Do not access version-sensitive `browser.*` extension APIs directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+        },
       ],
     },
   },

--- a/src/entrypoints/background/actionClickBehavior.ts
+++ b/src/entrypoints/background/actionClickBehavior.ts
@@ -10,6 +10,7 @@ import {
 } from "~/services/productAnalytics/events"
 import {
   addActionClickListener,
+  disableNativeSidePanelActionClick,
   getSidePanelSupport,
   removeActionClickListener,
   setActionPopup,
@@ -69,18 +70,7 @@ export async function applyActionClickBehavior(
   // 清理旧的点击监听
   removeActionClickListener(handleActionClick)
 
-  // Keep Chromium on the extension-managed click path so runtime fallback always runs.
-  if (typeof (chrome as any)?.sidePanel?.setPanelBehavior === "function") {
-    try {
-      await chrome.sidePanel.setPanelBehavior({
-        openPanelOnActionClick: false,
-      })
-    } catch (error) {
-      logger.warn(
-        `sidePanel.setPanelBehavior not available:\n${getErrorMessage(error)}`,
-      )
-    }
-  }
+  await disableNativeSidePanelActionClick()
 
   try {
     await setActionPopup(isSidePanel ? "" : POPUP_PAGE_PATH)

--- a/src/entrypoints/background/cookieInterceptor.ts
+++ b/src/entrypoints/background/cookieInterceptor.ts
@@ -5,6 +5,10 @@ import {
 import { AccountStorageConfig, type SiteAccount } from "~/types"
 import { isSameStringSet } from "~/utils"
 import {
+  onPermissionsAdded,
+  onPermissionsRemoved,
+} from "~/utils/browser/browserApi"
+import {
   checkCookieInterceptorRequirement,
   registerWebRequestInterceptor,
   setupWebRequestInterceptor,
@@ -248,6 +252,6 @@ export function setupCookieInterceptorListeners() {
   browser.storage.onChanged.addListener(handleStorageChanged)
 
   // Listen for permission additions and removals
-  chrome.permissions.onAdded.addListener(updateCookieInterceptor)
-  chrome.permissions.onRemoved.addListener(updateCookieInterceptor)
+  onPermissionsAdded(updateCookieInterceptor)
+  onPermissionsRemoved(updateCookieInterceptor)
 }

--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -22,7 +22,10 @@ import { setupSiteAnnouncementsMessagingListeners } from "~/services/siteAnnounc
 import { setupReleaseUpdateMessagingListeners } from "~/services/updates/releaseUpdateService"
 import { setupWebAiApiCheckMessagingListeners } from "~/services/verification/webAiApiCheck/background"
 import { setupWebdavAutoSyncMessagingListeners } from "~/services/webdav/webdavAutoSyncService"
-import { onRuntimeMessage } from "~/utils/browser/browserApi"
+import {
+  containsPermissions,
+  onRuntimeMessage,
+} from "~/utils/browser/browserApi"
 import {
   getCookieHeaderForUrlResult,
   hasCookieReadPermissionForUrl,
@@ -112,8 +115,7 @@ export function setupRuntimeMessageListeners() {
   onRuntimeMessage((request, sender, sendResponse) => {
     try {
       if (request.action === RuntimeActionIds.PermissionsCheck) {
-        void browser.permissions
-          .contains(request.permissions)
+        void containsPermissions(request.permissions)
           .then((hasPermission) => {
             sendResponse({ hasPermission })
           })

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -730,6 +730,29 @@ export const openSidePanel = async (targetTab?: browser.tabs.Tab | null) => {
 }
 
 /**
+ * Keeps Chromium toolbar action clicks on the extension-managed listener path
+ * so fallback behavior can run when side panel opening is unavailable.
+ */
+export async function disableNativeSidePanelActionClick(): Promise<void> {
+  const setPanelBehavior = (globalThis as any).chrome?.sidePanel
+    ?.setPanelBehavior
+
+  if (typeof setPanelBehavior !== "function") {
+    return
+  }
+
+  try {
+    await setPanelBehavior({
+      openPanelOnActionClick: false,
+    })
+  } catch (error) {
+    logger.warn(
+      `sidePanel.setPanelBehavior not available:\n${getErrorMessage(error)}`,
+    )
+  }
+}
+
+/**
  * 检查是否支持 alarms API
  */
 export function hasAlarmsAPI(): boolean {

--- a/tests/entrypoints/background/actionClickBehavior.test.ts
+++ b/tests/entrypoints/background/actionClickBehavior.test.ts
@@ -14,9 +14,9 @@ describe("background applyActionClickBehavior", () => {
   let addActionClickListener: ReturnType<typeof vi.fn>
   let removeActionClickListener: ReturnType<typeof vi.fn>
   let setActionPopup: ReturnType<typeof vi.fn>
+  let disableNativeSidePanelActionClick: ReturnType<typeof vi.fn>
   let getSidePanelSupport: ReturnType<typeof vi.fn>
   let openSidePanelWithFallback: ReturnType<typeof vi.fn>
-  let setPanelBehavior: ReturnType<typeof vi.fn>
   let startProductAnalyticsAction: ReturnType<typeof vi.fn>
   let trackerComplete: ReturnType<typeof vi.fn>
 
@@ -24,23 +24,19 @@ describe("background applyActionClickBehavior", () => {
     addActionClickListener = vi.fn()
     removeActionClickListener = vi.fn()
     setActionPopup = vi.fn().mockResolvedValue(undefined)
+    disableNativeSidePanelActionClick = vi.fn().mockResolvedValue(undefined)
     getSidePanelSupport = vi.fn()
     openSidePanelWithFallback = vi.fn().mockResolvedValue(undefined)
-    setPanelBehavior = vi.fn().mockResolvedValue(undefined)
     trackerComplete = vi.fn().mockResolvedValue(undefined)
     startProductAnalyticsAction = vi.fn().mockReturnValue({
       complete: trackerComplete,
     })
-    ;(globalThis as any).chrome = {
-      sidePanel: {
-        setPanelBehavior,
-      },
-    }
 
     vi.resetModules()
 
     vi.doMock("~/utils/browser/browserApi", () => ({
       addActionClickListener,
+      disableNativeSidePanelActionClick,
       getSidePanelSupport,
       removeActionClickListener,
       setActionPopup,
@@ -56,7 +52,6 @@ describe("background applyActionClickBehavior", () => {
   })
 
   afterEach(() => {
-    ;(globalThis as any).chrome = undefined
     vi.doUnmock("~/utils/browser/browserApi")
     vi.doUnmock("~/utils/navigation")
     vi.doUnmock("~/services/productAnalytics/actions")
@@ -78,9 +73,7 @@ describe("background applyActionClickBehavior", () => {
     await applyActionClickBehavior("sidepanel")
 
     expect(removeActionClickListener).toHaveBeenCalledTimes(1)
-    expect(setPanelBehavior).toHaveBeenCalledWith({
-      openPanelOnActionClick: false,
-    })
+    expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
     expect(setActionPopup).toHaveBeenCalledWith(POPUP_PAGE_PATH)
     expect(addActionClickListener).not.toHaveBeenCalled()
   })
@@ -98,9 +91,7 @@ describe("background applyActionClickBehavior", () => {
     await applyActionClickBehavior("sidepanel")
 
     expect(removeActionClickListener).toHaveBeenCalledTimes(1)
-    expect(setPanelBehavior).toHaveBeenCalledWith({
-      openPanelOnActionClick: false,
-    })
+    expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
     expect(setActionPopup).toHaveBeenCalledWith("")
     expect(addActionClickListener).toHaveBeenCalledTimes(1)
   })
@@ -118,9 +109,7 @@ describe("background applyActionClickBehavior", () => {
     await applyActionClickBehavior("sidepanel")
 
     expect(removeActionClickListener).toHaveBeenCalledTimes(1)
-    expect(setPanelBehavior).toHaveBeenCalledWith({
-      openPanelOnActionClick: false,
-    })
+    expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
     expect(setActionPopup).toHaveBeenCalledWith("")
     expect(addActionClickListener).toHaveBeenCalledTimes(1)
   })

--- a/tests/entrypoints/background/cookieInterceptor.test.ts
+++ b/tests/entrypoints/background/cookieInterceptor.test.ts
@@ -7,12 +7,16 @@ const {
   mockCheckCookieInterceptorRequirement,
   mockRegisterWebRequestInterceptor,
   mockSetupWebRequestInterceptor,
+  mockOnPermissionsAdded,
+  mockOnPermissionsRemoved,
   mockLogger,
 } = vi.hoisted(() => ({
   mockGetAllAccounts: vi.fn(),
   mockCheckCookieInterceptorRequirement: vi.fn(),
   mockRegisterWebRequestInterceptor: vi.fn(),
   mockSetupWebRequestInterceptor: vi.fn(),
+  mockOnPermissionsAdded: vi.fn(),
+  mockOnPermissionsRemoved: vi.fn(),
   mockLogger: {
     warn: vi.fn(),
     debug: vi.fn(),
@@ -39,6 +43,17 @@ vi.mock("~/utils/browser/cookieHelper", () => ({
   registerWebRequestInterceptor: mockRegisterWebRequestInterceptor,
   setupWebRequestInterceptor: mockSetupWebRequestInterceptor,
 }))
+
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    (await importOriginal()) as typeof import("~/utils/browser/browserApi")
+
+  return {
+    ...actual,
+    onPermissionsAdded: mockOnPermissionsAdded,
+    onPermissionsRemoved: mockOnPermissionsRemoved,
+  }
+})
 
 vi.mock("~/utils/core/logger", () => ({
   createLogger: vi.fn(() => mockLogger),
@@ -70,27 +85,20 @@ describe("cookieInterceptor", () => {
 
     mockCheckCookieInterceptorRequirement.mockResolvedValue(true)
     mockGetAllAccounts.mockResolvedValue([])
+    mockOnPermissionsAdded.mockImplementation((listener) => {
+      permissionAddedListeners.push(listener)
+      return vi.fn()
+    })
+    mockOnPermissionsRemoved.mockImplementation((listener) => {
+      permissionRemovedListeners.push(listener)
+      return vi.fn()
+    })
 
     vi.stubGlobal("browser", {
       storage: {
         onChanged: {
           addListener: vi.fn((listener) => {
             storageChangeListeners.push(listener)
-          }),
-        },
-      },
-    })
-
-    vi.stubGlobal("chrome", {
-      permissions: {
-        onAdded: {
-          addListener: vi.fn((listener) => {
-            permissionAddedListeners.push(listener)
-          }),
-        },
-        onRemoved: {
-          addListener: vi.fn((listener) => {
-            permissionRemovedListeners.push(listener)
           }),
         },
       },

--- a/tests/entrypoints/background/runtimeMessages.more.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.more.test.ts
@@ -15,6 +15,7 @@ type RuntimeMessageListener = (
 
 const mocks = vi.hoisted(() => ({
   onRuntimeMessage: vi.fn(),
+  containsPermissions: vi.fn(),
   applyActionClickBehavior: vi.fn(),
   getCookieHeaderForUrlResult: vi.fn(),
   hasCookieReadPermissionForUrl: vi.fn(),
@@ -49,6 +50,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock("~/utils/browser/browserApi", () => ({
+  containsPermissions: mocks.containsPermissions,
   onRuntimeMessage: mocks.onRuntimeMessage,
 }))
 
@@ -182,11 +184,8 @@ describe("setupRuntimeMessageListeners additional routing", () => {
     mocks.hasCookieReadPermissionForUrl.mockResolvedValue(true)
     mocks.setupContextMenus.mockResolvedValue(undefined)
     mocks.trackCookieInterceptorUrl.mockResolvedValue(undefined)
-    ;(globalThis as any).browser = {
-      permissions: {
-        contains: vi.fn().mockResolvedValue(true),
-      },
-    }
+    mocks.containsPermissions.mockResolvedValue(true)
+    ;(globalThis as any).browser = {}
   })
 
   afterEach(() => {
@@ -243,8 +242,6 @@ describe("setupRuntimeMessageListeners additional routing", () => {
   }
 
   it("handles permission checks for both success and failure responses", async () => {
-    const permissionsContains = (globalThis as any).browser.permissions
-      .contains as ReturnType<typeof vi.fn>
     const listener = await loadListener()
 
     const sendResponse = vi.fn()
@@ -262,7 +259,9 @@ describe("setupRuntimeMessageListeners additional routing", () => {
     await waitForAsyncResponse()
     expect(sendResponse).toHaveBeenCalledWith({ hasPermission: true })
 
-    permissionsContains.mockRejectedValueOnce(new Error("permission boom"))
+    mocks.containsPermissions.mockRejectedValueOnce(
+      new Error("permission boom"),
+    )
     const failedResponse = vi.fn()
 
     expect(

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -11,6 +11,7 @@ import {
   createAlarm,
   createNotification,
   createWindow,
+  disableNativeSidePanelActionClick,
   focusTab,
   getActionApi,
   getActiveOrAllTabs,
@@ -1298,6 +1299,39 @@ describe("browserApi action and permissions helpers", () => {
     cleanup()
     removeActionClickListener(listener)
     expect(actionApi.onClicked.removeListener).not.toHaveBeenCalled()
+  })
+
+  it("disables native Chromium side-panel action clicks when supported", async () => {
+    const setPanelBehavior = vi.fn().mockResolvedValue(undefined)
+    ;(globalThis as any).chrome = {
+      sidePanel: {
+        setPanelBehavior,
+      },
+    }
+
+    await disableNativeSidePanelActionClick()
+
+    expect(setPanelBehavior).toHaveBeenCalledWith({
+      openPanelOnActionClick: false,
+    })
+  })
+
+  it("ignores missing native Chromium side-panel action behavior support", async () => {
+    ;(globalThis as any).chrome = {
+      sidePanel: {},
+    }
+
+    await expect(disableNativeSidePanelActionClick()).resolves.toBeUndefined()
+  })
+
+  it("swallows native Chromium side-panel action behavior failures", async () => {
+    ;(globalThis as any).chrome = {
+      sidePanel: {
+        setPanelBehavior: vi.fn().mockRejectedValue(new Error("unsupported")),
+      },
+    }
+
+    await expect(disableNativeSidePanelActionClick()).resolves.toBeUndefined()
   })
 
   it("returns permission helper fallbacks when runtime or permissions APIs fail", async () => {

--- a/tests/utils/extensionServiceWorker.test.ts
+++ b/tests/utils/extensionServiceWorker.test.ts
@@ -1,0 +1,101 @@
+import type { BrowserContext, Worker } from "@playwright/test"
+import { describe, expect, it } from "vitest"
+
+import {
+  getExtensionServiceWorker,
+  isExtensionServiceWorkerUrl,
+} from "~~/e2e/utils/extension"
+
+type MockWorkerOptions = {
+  probe?: {
+    hasAlarms?: boolean
+    hasRuntimeGetManifest?: boolean
+    hasStorageLocal?: boolean
+    runtimeId?: string | null
+  }
+  url: string
+}
+
+function createMockWorker({ probe, url }: MockWorkerOptions): Worker {
+  return {
+    evaluate: async () => ({
+      hasAlarms: probe?.hasAlarms ?? true,
+      hasRuntimeGetManifest: probe?.hasRuntimeGetManifest ?? true,
+      hasStorageLocal: probe?.hasStorageLocal ?? true,
+      runtimeId: probe?.runtimeId ?? new URL(url).host,
+    }),
+    url: () => url,
+  } as unknown as Worker
+}
+
+function createMockContext(workers: Worker[]): BrowserContext {
+  return {
+    serviceWorkers: () => workers,
+    waitForEvent: async () => undefined,
+  } as unknown as BrowserContext
+}
+
+describe("isExtensionServiceWorkerUrl", () => {
+  it("detects browser extension service worker URLs", () => {
+    expect(
+      isExtensionServiceWorkerUrl("chrome-extension://abc123/background.js"),
+    ).toBe(true)
+    expect(
+      isExtensionServiceWorkerUrl("moz-extension://abc123/background.js"),
+    ).toBe(true)
+    expect(isExtensionServiceWorkerUrl("https://example.test/sw.js")).toBe(
+      false,
+    )
+  })
+})
+
+describe("getExtensionServiceWorker", () => {
+  it("skips non-extension workers and workers whose extension APIs are not ready", async () => {
+    const readyWorker = createMockWorker({
+      url: "chrome-extension://ready-extension/background.js",
+    })
+    const context = createMockContext([
+      createMockWorker({ url: "https://example.test/sw.js" }),
+      createMockWorker({
+        probe: { hasStorageLocal: false },
+        url: "chrome-extension://not-ready/background.js",
+      }),
+      readyWorker,
+    ])
+
+    await expect(getExtensionServiceWorker(context)).resolves.toBe(readyWorker)
+  })
+
+  it("honors the expected extension id when multiple extension workers are visible", async () => {
+    const expectedWorker = createMockWorker({
+      url: "chrome-extension://expected-extension/background.js",
+    })
+    const context = createMockContext([
+      createMockWorker({
+        url: "chrome-extension://other-extension/background.js",
+      }),
+      expectedWorker,
+    ])
+
+    await expect(
+      getExtensionServiceWorker(context, {
+        extensionId: "expected-extension",
+      }),
+    ).resolves.toBe(expectedWorker)
+  })
+
+  it("reports observed worker readiness when no usable extension worker appears", async () => {
+    const context = createMockContext([
+      createMockWorker({
+        probe: { hasRuntimeGetManifest: false },
+        url: "chrome-extension://not-ready/background.js",
+      }),
+    ])
+
+    await expect(
+      getExtensionServiceWorker(context, { timeoutMs: 1 }),
+    ).rejects.toThrow(
+      /chrome-extension:\/\/not-ready\/background\.js \(missing chrome\.runtime\.getManifest\)/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- wait for the real extension service worker and required extension APIs before E2E helpers read storage, alarms, or manifest state
- make the toolbar action behavior E2E assertion respect Chrome 114 side panel fallback behavior
- add lint guardrails so version-sensitive Chrome/browser APIs stay behind browser adapter helpers

## Test Plan
- pnpm vitest --run tests/utils/extensionServiceWorker.test.ts tests/utils/extensionLaunch.test.ts tests/utils/browserApi.test.ts tests/entrypoints/background/actionClickBehavior.test.ts tests/entrypoints/background/cookieInterceptor.test.ts tests/entrypoints/background/runtimeMessages.more.test.ts
- pnpm compile
- pnpm exec eslint eslint.config.js e2e/basicSettingsCommonFlows.spec.ts e2e/utils/extension.ts e2e/utils/extensionState.ts src/entrypoints/background/actionClickBehavior.ts src/entrypoints/background/cookieInterceptor.ts src/entrypoints/background/runtimeMessages.ts src/utils/browser/browserApi.ts tests/utils/extensionServiceWorker.test.ts tests/utils/browserApi.test.ts tests/entrypoints/background/actionClickBehavior.test.ts tests/entrypoints/background/cookieInterceptor.test.ts tests/entrypoints/background/runtimeMessages.more.test.ts
- pnpm run validate:push
- E2E Browser Compatibility workflow passed on the pre-rebase branch for Chrome 114/116/120/122/144/147/148/stable with headless runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized browser API handling to make toolbar action and permission behavior more consistent.

* **New Features / Behavior**
  * Toolbar action clicks now respect the browser's side-panel support—popups or side panel behavior adjust accordingly to avoid unwanted native side-panel opens.

* **Tests**
  * Expanded E2E and unit tests for extension service worker readiness, toolbar action behavior, and permission-change handling.

* **Chores**
  * Added ESLint guardrails to discourage direct global browser API usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->