### PR TITLE
refactor(browser): centralize extension runtime APIs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -171,7 +171,7 @@ export default defineConfig([
       "no-console": "off",
     },
   },
-  // Guardrails: keep version-sensitive extension API access inside browser adapter modules.
+  // Guardrails: keep runtime extension API access inside browser adapter modules.
   {
     files: [srcJsFamilyFilePattern],
     ignores: [
@@ -182,6 +182,11 @@ export default defineConfig([
       "no-restricted-globals": [
         "error",
         {
+          name: "browser",
+          message:
+            "Do not access the global WebExtension API directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+        },
+        {
           name: "chrome",
           message:
             "Do not access the global Chrome extension API directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
@@ -190,34 +195,27 @@ export default defineConfig([
       "no-restricted-syntax": [
         "error",
         {
-          selector:
-            "MemberExpression[object.name=/^(globalThis|window)$/][property.name='chrome']",
+          selector: "MemberExpression[object.name=/^(browser|chrome)$/]",
           message:
-            "Do not access the global Chrome extension API directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+            "Do not access global WebExtension APIs directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
         },
         {
           selector:
-            "MemberExpression[object.type='TSAsExpression'][object.expression.name='globalThis'][property.name='chrome']",
+            "MemberExpression[object.type='TSAsExpression'][object.expression.name=/^(browser|chrome)$/]",
           message:
-            "Do not access the global Chrome extension API directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+            "Do not access casted global WebExtension APIs directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
         },
         {
           selector:
-            "MemberExpression[object.name='browser'][property.name=/^(action|browserAction|sidebarAction|permissions)$/]",
+            "MemberExpression[object.name=/^(globalThis|window)$/][property.name=/^(browser|chrome)$/]:not(MemberExpression[object.name=/^(globalThis|window)$/][property.name=/^(browser|chrome)$/] MemberExpression)",
           message:
-            "Do not access version-sensitive `browser.*` extension APIs directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+            "Do not access global WebExtension APIs through `globalThis` or `window` in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
         },
         {
           selector:
-            "MemberExpression[object.type='MemberExpression'][object.object.name=/^(globalThis|window)$/][object.property.name='browser'][property.name=/^(action|browserAction|sidebarAction|permissions)$/]",
+            "MemberExpression[object.type='TSAsExpression'][object.expression.name=/^(globalThis|window)$/][property.name=/^(browser|chrome)$/]:not(MemberExpression[object.type='TSAsExpression'][object.expression.name=/^(globalThis|window)$/][property.name=/^(browser|chrome)$/] MemberExpression)",
           message:
-            "Do not access version-sensitive `browser.*` extension APIs directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
-        },
-        {
-          selector:
-            "MemberExpression[object.type='MemberExpression'][object.object.type='TSAsExpression'][object.object.expression.name=/^(globalThis|window)$/][object.property.name='browser'][property.name=/^(action|browserAction|sidebarAction|permissions)$/]",
-          message:
-            "Do not access version-sensitive `browser.*` extension APIs directly in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
+            "Do not access casted global WebExtension APIs through `globalThis` or `window` in app code. Add a guarded wrapper in `~/utils/browser/browserApi` or another `~/utils/browser/**` adapter.",
         },
       ],
     },

--- a/src/entrypoints/background/contextMenus.ts
+++ b/src/entrypoints/background/contextMenus.ts
@@ -12,6 +12,14 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
+import {
+  createContextMenu,
+  getBrowserI18nMessage,
+  hasContextMenusAPI,
+  onContextMenuClicked,
+  removeContextMenu,
+  sendTabMessage,
+} from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 
 /**
@@ -22,9 +30,12 @@ const logger = createLogger("ContextMenus")
 const REDEMPTION_MENU_ID = "redemption-assist-context-menu"
 const API_CHECK_MENU_ID = "ai-api-check-context-menu"
 
-let clickListenerInstalled = false
+let cleanupContextMenuClickListener: (() => void) | null = null
 
-const handleContextMenuClick = async (info: any, tab: any) => {
+const handleContextMenuClick = async (
+  info: browser.contextMenus.OnClickData,
+  tab?: browser.tabs.Tab,
+) => {
   if (!tab?.id) return
 
   const selectionText = (info.selectionText || "").trim()
@@ -57,7 +68,7 @@ const handleContextMenuClick = async (info: any, tab: any) => {
         return
       }
 
-      await browser.tabs.sendMessage(tab.id, {
+      await sendTabMessage(tab.id, {
         action: RuntimeActionIds.RedemptionAssistContextMenuTrigger,
         selectionText,
         pageUrl,
@@ -66,7 +77,7 @@ const handleContextMenuClick = async (info: any, tab: any) => {
     }
 
     if (isApiCheckMenu) {
-      await browser.tabs.sendMessage(tab.id, {
+      await sendTabMessage(tab.id, {
         action: RuntimeActionIds.ApiCheckContextMenuTrigger,
         selectionText,
         pageUrl,
@@ -85,17 +96,18 @@ const handleContextMenuClick = async (info: any, tab: any) => {
  * Ensures the context menu click listener is installed, with best-effort error handling.
  */
 function ensureContextMenuClickListener() {
-  if (!browser?.contextMenus) {
+  if (!hasContextMenusAPI()) {
     return
   }
 
-  if (clickListenerInstalled) {
+  if (cleanupContextMenuClickListener) {
     return
   }
 
   try {
-    browser.contextMenus.onClicked.addListener(handleContextMenuClick)
-    clickListenerInstalled = true
+    cleanupContextMenuClickListener = onContextMenuClicked(
+      handleContextMenuClick,
+    )
   } catch (error) {
     logger.error("Failed to install context menu click listener", error)
   }
@@ -105,7 +117,7 @@ function ensureContextMenuClickListener() {
  * Refreshes the right-click context menu entries based on the latest user preferences.
  */
 export async function refreshContextMenus(preferences: UserPreferences) {
-  if (!browser?.contextMenus) {
+  if (!hasContextMenusAPI()) {
     logger.warn("contextMenus API unavailable")
     return
   }
@@ -114,11 +126,11 @@ export async function refreshContextMenus(preferences: UserPreferences) {
 
   try {
     const redemptionTitle =
-      browser.i18n?.getMessage("context_menu_redeem_selection") ||
+      getBrowserI18nMessage("context_menu_redeem_selection") ||
       "使用兑换助手兑换选中文本"
 
     const apiCheckTitle =
-      browser.i18n?.getMessage("context_menu_ai_api_check") ||
+      getBrowserI18nMessage("context_menu_ai_api_check") ||
       "快速测试 AI API 的功能可用性"
 
     const shouldShowRedemptionAssistMenu =
@@ -130,11 +142,11 @@ export async function refreshContextMenus(preferences: UserPreferences) {
       (preferences.webAiApiCheck?.contextMenu?.enabled ?? true)
 
     // Best-effort cleanup: remove only the menus we own to avoid breaking other features.
-    await browser.contextMenus.remove(REDEMPTION_MENU_ID).catch(() => {})
-    await browser.contextMenus.remove(API_CHECK_MENU_ID).catch(() => {})
+    await removeContextMenu(REDEMPTION_MENU_ID).catch(() => {})
+    await removeContextMenu(API_CHECK_MENU_ID).catch(() => {})
 
     if (shouldShowRedemptionAssistMenu) {
-      browser.contextMenus.create({
+      createContextMenu({
         id: REDEMPTION_MENU_ID,
         title: redemptionTitle,
         contexts: ["selection"],
@@ -142,7 +154,7 @@ export async function refreshContextMenus(preferences: UserPreferences) {
     }
 
     if (shouldShowApiCheckMenu) {
-      browser.contextMenus.create({
+      createContextMenu({
         id: API_CHECK_MENU_ID,
         title: apiCheckTitle,
         contexts: ["page", "selection"],

--- a/src/entrypoints/background/cookieInterceptor.ts
+++ b/src/entrypoints/background/cookieInterceptor.ts
@@ -7,6 +7,7 @@ import { isSameStringSet } from "~/utils"
 import {
   onPermissionsAdded,
   onPermissionsRemoved,
+  onStorageChanged,
 } from "~/utils/browser/browserApi"
 import {
   checkCookieInterceptorRequirement,
@@ -249,7 +250,7 @@ async function handleStorageChanged(
  */
 export function setupCookieInterceptorListeners() {
   // Listen for storage changes
-  browser.storage.onChanged.addListener(handleStorageChanged)
+  onStorageChanged(handleStorageChanged)
 
   // Listen for permission additions and removals
   onPermissionsAdded(updateCookieInterceptor)

--- a/src/entrypoints/background/devActionBranding.ts
+++ b/src/entrypoints/background/devActionBranding.ts
@@ -1,4 +1,4 @@
-import { getManifest } from "~/utils/browser/browserApi"
+import { getActionApi, getManifest } from "~/utils/browser/browserApi"
 import { formatDevActionTitle, getDevBadgeText } from "~/utils/core/devBranding"
 import { isDevelopmentMode } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
@@ -18,10 +18,8 @@ const logger = createLogger("DevActionBranding")
 export async function applyDevActionBranding() {
   if (!isDevelopmentMode()) return
 
-  const actionApi = (browser as any).action ?? (browser as any).browserAction
-  if (!actionApi) return
-
   try {
+    const actionApi = getActionApi()
     const manifest = getManifest()
     const versionName = (manifest as any).version_name as string | undefined
     const title = formatDevActionTitle(manifest.name, versionName)

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -26,6 +26,7 @@ import { tagStorage } from "~/services/tags/tagStorage"
 import { changelogOnUpdateState } from "~/services/updates/changelogOnUpdateState"
 import {
   getManifest,
+  getRuntimeId,
   onInstalled,
   onStartup,
   onSuspend,
@@ -58,7 +59,7 @@ function shouldAutoOpenPermissionsOnboarding(): boolean {
 }
 
 export default defineBackground(() => {
-  logger.debug("Hello background", { id: browser.runtime.id })
+  logger.debug("Hello background", { id: getRuntimeId() })
 
   // Apply dev-only branding early so the toolbar action is visually distinguishable.
   void applyDevActionBranding()

--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -24,6 +24,8 @@ import { setupWebAiApiCheckMessagingListeners } from "~/services/verification/we
 import { setupWebdavAutoSyncMessagingListeners } from "~/services/webdav/webdavAutoSyncService"
 import {
   containsPermissions,
+  getAllCookieStores,
+  hasCookieStoresAPI,
   onRuntimeMessage,
 } from "~/utils/browser/browserApi"
 import {
@@ -69,13 +71,13 @@ async function resolveCookieStoreIdFromImportRequest(
   if (
     typeof request.sourceTabId !== "number" ||
     request.sourceTabIncognito !== true ||
-    typeof browser.cookies?.getAllCookieStores !== "function"
+    !hasCookieStoresAPI()
   ) {
     return undefined
   }
 
   try {
-    const cookieStores = await browser.cookies.getAllCookieStores()
+    const cookieStores = await getAllCookieStores()
     return cookieStores.find((store) =>
       store.tabIds?.includes(request.sourceTabId as number),
     )?.id

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -2077,7 +2077,7 @@ async function openTabInCompositeWindow(params: {
       const existingCompositeWindow = await getWindow(previousCompositeWindowId)
       if (!existingCompositeWindow) {
         throw createRecoverableWindowCreationError(
-          WINDOW_CREATION_FAILURE_REASONS.WINDOWS_API_UNAVAILABLE,
+          WINDOW_CREATION_FAILURE_REASONS.WINDOW_HANDLE_UNAVAILABLE,
         )
       }
       existingCompositeWindowConfirmed = true

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -41,12 +41,18 @@ import {
   classifyRecoverableWindowCreationFailure,
   createTab,
   createWindow,
+  getTab,
+  getWindow,
   hasWindowsAPI,
   isAllowedIncognitoAccess,
   onTabRemoved,
   onWindowRemoved,
+  queryTabs,
   removeTabOrWindow,
+  sendTabMessage,
   sendTabMessageWithRetry,
+  updateTab,
+  updateWindow,
   WINDOW_CREATION_FAILURE_REASONS,
   type WindowCreationFailureReason,
 } from "~/utils/browser/browserApi"
@@ -113,7 +119,7 @@ async function showShieldBypassUiInTab(meta: {
 }) {
   for (let attempt = 1; attempt <= SHIELD_BYPASS_UI_MAX_RETRIES; attempt += 1) {
     try {
-      await browser.tabs.sendMessage(meta.tabId, {
+      await sendTabMessage(meta.tabId, {
         action: RuntimeActionIds.ContentShowShieldBypassUi,
         origin: meta.origin,
         requestId: meta.requestId,
@@ -1225,7 +1231,7 @@ export async function handleTempWindowTurnstileFetch(
     const { tabId } = context
 
     // Ensure the temp tab is on the requested page URL so Turnstile can render.
-    await browser.tabs.update(tabId, { url: pageUrl })
+    await updateTab(tabId, { url: pageUrl })
     await waitForTabComplete(tabId, {
       requestId: tempRequestId,
       origin: normalizeOrigin(originUrl),
@@ -1803,7 +1809,7 @@ async function openPopupWindowTempContext(params: {
 
     windowId = popupWindowId
 
-    const tabs = await browser.tabs.query({
+    const tabs = await queryTabs({
       windowId,
       active: true,
     })
@@ -1822,7 +1828,7 @@ async function openPopupWindowTempContext(params: {
     // Best-effort minimize to reduce disturbance unless suppressed (e.g., popup context).
     if (!params.suppressMinimize) {
       try {
-        await browser.windows.update(windowId, { state: "minimized" })
+        await updateWindow(windowId, { state: "minimized" })
         logTempWindow("quietWindowMinimized", {
           requestId: params.requestId,
           origin: params.origin,
@@ -2068,7 +2074,12 @@ async function openTabInCompositeWindow(params: {
     let existingCompositeWindowConfirmed = false
 
     try {
-      await browser.windows.get(previousCompositeWindowId)
+      const existingCompositeWindow = await getWindow(previousCompositeWindowId)
+      if (!existingCompositeWindow) {
+        throw createRecoverableWindowCreationError(
+          WINDOW_CREATION_FAILURE_REASONS.WINDOWS_API_UNAVAILABLE,
+        )
+      }
       existingCompositeWindowConfirmed = true
       const tab = await createTab(params.url, false, {
         windowId: previousCompositeWindowId,
@@ -2163,7 +2174,7 @@ async function openTabInCompositeWindow(params: {
 
       if (!params.suppressMinimize) {
         try {
-          await browser.windows.update(windowId, { state: "minimized" })
+          await updateWindow(windowId, { state: "minimized" })
           logTempWindow("compositeWindowMinimized", {
             requestId: params.requestId,
             origin: params.origin,
@@ -2179,7 +2190,7 @@ async function openTabInCompositeWindow(params: {
         }
       }
 
-      const tabs = await browser.tabs.query({
+      const tabs = await queryTabs({
         windowId,
         active: true,
       })
@@ -2405,7 +2416,7 @@ function clearStaleTempRequestMappings() {
  */
 async function isContextAlive(context: TempContext) {
   try {
-    await browser.tabs.get(context.tabId)
+    await getTab(context.tabId)
     return true
   } catch {
     return false
@@ -2533,7 +2544,7 @@ function waitForTabComplete(
 
     const checkStatus = async () => {
       try {
-        const tab = await browser.tabs.get(tabId)
+        const tab = await getTab(tabId)
 
         attempts += 1
         if (tab.status !== lastTabStatus) {

--- a/src/entrypoints/content/index.ts
+++ b/src/entrypoints/content/index.ts
@@ -83,8 +83,13 @@ function mainLogic() {
     logger.warn("Content i18n initialization failed", error)
   })
 
-  setupContentMessageHandlers()
-  return setupContentFeatureControllers()
+  const cleanupMessageHandlers = setupContentMessageHandlers()
+  const cleanupFeatureControllers = setupContentFeatureControllers()
+
+  return () => {
+    cleanupMessageHandlers()
+    cleanupFeatureControllers()
+  }
 }
 
 /**

--- a/src/entrypoints/content/index.ts
+++ b/src/entrypoints/content/index.ts
@@ -11,6 +11,7 @@ import {
   type ContentFeaturePreferences,
   type ContentFeaturePreferenceSource,
 } from "~/services/preferences/contentScriptFeatureDefaults"
+import { getRuntimeId, onStorageChanged } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 import { ensureContentI18nReady } from "~/utils/i18n/content"
 
@@ -76,7 +77,7 @@ export default defineContentScript({
  * Bootstraps content-script side features: sanitizeUrlForLog, message handlers, and redemption assist UI.
  */
 function mainLogic() {
-  logger.debug("Hello content script", { id: browser.runtime.id })
+  logger.debug("Hello content script", { id: getRuntimeId() })
 
   void ensureContentI18nReady().catch((error) => {
     logger.warn("Content i18n initialization failed", error)
@@ -139,12 +140,12 @@ function setupContentFeatureControllers() {
     void applyPreferences()
   }
 
-  browser.storage.onChanged.addListener(handleStorageChanged)
+  const cleanupStorageChanged = onStorageChanged(handleStorageChanged)
   void applyPreferences()
 
   return () => {
     disposed = true
-    browser.storage.onChanged.removeListener(handleStorageChanged)
+    cleanupStorageChanged()
     cleanupRedemptionAssist()
     cleanupWebAiApiCheck()
   }

--- a/src/entrypoints/content/messageHandlers/index.ts
+++ b/src/entrypoints/content/messageHandlers/index.ts
@@ -10,6 +10,7 @@ import {
   handleWaitAndGetUserInfo,
   handleWaitForTurnstileToken,
 } from "~/entrypoints/content/messageHandlers/handlers"
+import { onRuntimeMessage } from "~/utils/browser/browserApi"
 
 /**
  * Registers content-script message handlers for fetching storage data,
@@ -17,7 +18,7 @@ import {
  * Each branch replies via sendResponse so browser.runtime ports stay alive.
  */
 export function setupContentMessageHandlers() {
-  browser.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+  return onRuntimeMessage((request, _sender, sendResponse) => {
     if (request.action === RuntimeActionIds.ContentGetLocalStorage) {
       return handleGetLocalStorage(request, sendResponse)
     }

--- a/src/entrypoints/content/redemptionAssist/index.ts
+++ b/src/entrypoints/content/redemptionAssist/index.ts
@@ -22,7 +22,10 @@ import {
   sendRedemptionAssistMessage,
 } from "~/services/redemption/redemptionAssistMessaging"
 import { extractRedemptionCodesFromText } from "~/services/redemption/utils/redemptionCode"
-import { checkPermissionViaMessage } from "~/utils/browser/browserApi"
+import {
+  checkPermissionViaMessage,
+  onRuntimeMessage,
+} from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 import { isHttpUrl } from "~/utils/core/urlParsing"
 import { t } from "~/utils/i18n/core"
@@ -175,14 +178,7 @@ function registerContextMenuTriggerListener() {
     void handleContextMenuRedemption(selectionText, pageUrl)
   }
 
-  browser.runtime.onMessage.addListener(listener)
-  return () => {
-    try {
-      browser.runtime.onMessage.removeListener(listener)
-    } catch (error) {
-      logger.debug("Failed to remove redemption context menu listener", error)
-    }
-  }
+  return onRuntimeMessage(listener)
 }
 
 /**

--- a/src/entrypoints/content/webAiApiCheck/index.ts
+++ b/src/entrypoints/content/webAiApiCheck/index.ts
@@ -4,7 +4,10 @@ import {
   sendWebAiApiCheckMessage,
   WebAiApiCheckMessageTypes,
 } from "~/services/verification/webAiApiCheck/messaging"
-import { checkPermissionViaMessage } from "~/utils/browser/browserApi"
+import {
+  checkPermissionViaMessage,
+  onRuntimeMessage,
+} from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 import { isHttpUrl } from "~/utils/core/urlParsing"
 
@@ -75,14 +78,7 @@ function registerContextMenuTriggerListener() {
     })
   }
 
-  browser.runtime.onMessage.addListener(listener)
-  return () => {
-    try {
-      browser.runtime.onMessage.removeListener(listener)
-    } catch (error) {
-      logger.debug("Failed to remove ApiCheck context menu listener", error)
-    }
-  }
+  return onRuntimeMessage(listener)
 }
 
 /**

--- a/src/entrypoints/content/webAiApiCheck/index.ts
+++ b/src/entrypoints/content/webAiApiCheck/index.ts
@@ -78,7 +78,14 @@ function registerContextMenuTriggerListener() {
     })
   }
 
-  return onRuntimeMessage(listener)
+  const cleanup = onRuntimeMessage(listener)
+  return () => {
+    try {
+      cleanup()
+    } catch (error) {
+      logger.debug("Failed to remove ApiCheck context menu listener", error)
+    }
+  }
 }
 
 /**

--- a/src/features/AccountManagement/components/AccountDialog/AutoDetectErrorAlert.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AutoDetectErrorAlert.tsx
@@ -8,6 +8,7 @@ import {
   reloadCurrentTab,
   type AutoDetectErrorProps,
 } from "~/services/accounts/utils/autoDetectUtils"
+import { createTab } from "~/utils/browser/browserApi"
 import { openSiteSupportRequestPage } from "~/utils/navigation"
 
 /**
@@ -44,7 +45,7 @@ export default function AutoDetectErrorAlert({
       onHelpClick()
     } else if (error.helpDocUrl) {
       // 默认行为：打开帮助文档
-      browser.tabs.create({ url: error.helpDocUrl, active: true })
+      void createTab(error.helpDocUrl, true)
     }
   }
 

--- a/src/features/AccountManagement/components/AccountDialog/AutoDetectSlowHintAlert.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AutoDetectSlowHintAlert.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next"
 
 import { Alert, Button } from "~/components/ui"
 import { DestructiveConfirmDialog } from "~/components/ui/Dialog/DestructiveConfirmDialog"
-import { reloadRuntime } from "~/utils/browser/browserApi"
+import { createTab, reloadRuntime } from "~/utils/browser/browserApi"
 import { getDocsAutoDetectUrl } from "~/utils/navigation/docsLinks"
 
 export interface AutoDetectSlowHintAlertProps {
@@ -31,7 +31,7 @@ export default function AutoDetectSlowHintAlert({
       onHelpClick()
       return
     }
-    browser.tabs.create({ url: helpDocUrl, active: true })
+    void createTab(helpDocUrl, true)
   }
 
   const handleReloadExtension = () => {

--- a/src/features/AccountManagement/components/AccountDialog/InfoPanel.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/InfoPanel.tsx
@@ -5,6 +5,7 @@ import { LdohIcon } from "~/components/icons/LdohIcon"
 import { Button } from "~/components/ui"
 import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
 import { LDOH_ORIGIN } from "~/services/integrations/ldohSiteLookup/constants"
+import { createTab } from "~/utils/browser/browserApi"
 
 import {
   ACCOUNT_DIALOG_FORM_SOURCES,
@@ -37,7 +38,7 @@ export default function InfoPanel({ mode, phase, formSource }: InfoPanelProps) {
     isAddMode && phase === ACCOUNT_DIALOG_PHASES.SITE_INPUT
 
   const handleOpenLdohSiteList = () => {
-    browser.tabs.create({ url: LDOH_ORIGIN, active: true })
+    void createTab(LDOH_ORIGIN, true)
   }
 
   const getTitle = () => {

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -91,9 +91,11 @@ import { deepOverride } from "~/utils"
 import {
   getActiveTabs,
   getAllTabs,
+  getBrowserApiCapabilities,
   onTabActivated,
   onTabUpdated,
   sendRuntimeMessage,
+  sendTabMessage,
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
@@ -954,12 +956,9 @@ export function useAccountDialog({
     const canApplyCurrentTabTitle = () => !selectedSiteUrlRef.current.trim()
 
     try {
-      const tabs = await browser.tabs.query({
-        active: true,
-        currentWindow: true,
-      })
+      const tabs = await getActiveTabs()
       const tab = tabs[0]
-      if (tab.url) {
+      if (tab?.url) {
         try {
           const urlObj = new URL(tab.url)
           const baseUrl = `${urlObj.protocol}//${urlObj.host}`
@@ -988,37 +987,8 @@ export function useAccountDialog({
         clearCurrentTabDetection()
       }
     } catch (error) {
-      logger.warn("Failed to query current tab, falling back", { error })
-      // Fallback for Firefox Android
-      try {
-        const tabs = await browser.tabs.query({ active: true })
-        const tab = tabs[0]
-        if (tab.url) {
-          const urlObj = new URL(tab.url)
-          const baseUrl = `${urlObj.protocol}//${urlObj.host}`
-          if (baseUrl.startsWith("http")) {
-            currentTabCookieImportContextRef.current =
-              createCurrentTabCookieImportContext(tab, baseUrl)
-            setCurrentTabUrl(baseUrl)
-            const resolvedSiteName = await getSiteName(tab)
-            if (!isCurrentDetectionRun()) return
-
-            currentTabSiteNameRef.current = resolvedSiteName
-            if (canApplyCurrentTabTitle()) {
-              setSiteName(resolvedSiteName)
-            }
-          } else {
-            clearCurrentTabDetection()
-          }
-        } else {
-          clearCurrentTabDetection()
-        }
-      } catch (fallbackError) {
-        logger.warn("Failed to query current tab in fallback mode", {
-          error: fallbackError,
-        })
-        clearCurrentTabDetection()
-      }
+      logger.warn("Failed to query current tab", { error })
+      clearCurrentTabDetection()
     }
   }, [account, mode, setSiteName])
 
@@ -1439,7 +1409,7 @@ export function useAccountDialog({
         typeof (value as any)?.sub2apiAuth?.refreshToken === "string" &&
         (value as any).sub2apiAuth.refreshToken.trim().length > 0
 
-      if (targetOrigin && browser?.tabs?.sendMessage) {
+      if (targetOrigin && getBrowserApiCapabilities().hasTabs) {
         const tabs = await getAllTabs().catch(() => [])
         const candidates = tabs
           .filter((tab) => {
@@ -1453,7 +1423,7 @@ export function useAccountDialog({
           if (typeof tabId !== "number") continue
 
           try {
-            const response = await browser.tabs.sendMessage(tabId, {
+            const response = await sendTabMessage(tabId, {
               action: RuntimeActionIds.ContentGetUserFromLocalStorage,
               url: baseUrl,
               siteType: SITE_TYPES.SUB2API,

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -57,6 +57,7 @@ import {
   onTabActivated,
   onTabRemoved,
   onTabUpdated,
+  sendTabMessage,
 } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 
@@ -487,7 +488,7 @@ export const AccountDataProvider = ({
 
         try {
           // Ask the content script to read the site's localStorage and return the current userId.
-          const userResponse = await browser.tabs.sendMessage(tabId, {
+          const userResponse = await sendTabMessage(tabId, {
             action: RuntimeActionIds.ContentGetUserFromLocalStorage,
             url: parsedUrl.origin,
             siteType: siteTypeForUserRead,

--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -47,6 +47,7 @@ import type {
   ExecutionProgress,
   ExecutionResult,
 } from "~/types/managedSiteModelSync"
+import { onRuntimeMessage } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 import { showWarningToast } from "~/utils/core/toastHelpers"
 
@@ -457,10 +458,7 @@ export default function ManagedSiteModelSync({
       }
     }
 
-    browser.runtime.onMessage.addListener(handleMessage)
-    return () => {
-      browser.runtime.onMessage.removeListener(handleMessage)
-    }
+    return onRuntimeMessage(handleMessage)
   }, [
     completeModelSyncActionAnalytics,
     isConfigMissing,

--- a/src/services/accounts/utils/autoDetectUtils.ts
+++ b/src/services/accounts/utils/autoDetectUtils.ts
@@ -27,6 +27,7 @@ import {
   getBestEffortLoginUrl,
   resolveAccountSiteLoginUrl,
 } from "~/services/accounts/utils/siteRouteResolver"
+import { createTab, queryTabs, reloadTab } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { t } from "~/utils/i18n/core"
 import { getDocsAutoDetectUrl } from "~/utils/navigation/docsLinks"
@@ -240,7 +241,7 @@ export async function openLoginTab(
   siteTypeHint?: AccountSiteType,
 ): Promise<void> {
   const loginUrl = await resolveAccountSiteLoginUrl(siteUrl, siteTypeHint)
-  await browser.tabs.create({ url: loginUrl, active: true })
+  await createTab(loginUrl, true)
 }
 
 /**
@@ -248,13 +249,13 @@ export async function openLoginTab(
  * script can attach before the next auto-detect attempt.
  */
 export async function reloadCurrentTab(): Promise<void> {
-  const tabs = await browser.tabs.query({
+  const tabs = await queryTabs({
     active: true,
     currentWindow: true,
   })
 
   const activeTab = tabs[0]
   if (typeof activeTab?.id === "number") {
-    await browser.tabs.reload(activeTab.id)
+    await reloadTab(activeTab.id)
   }
 }

--- a/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
+++ b/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
@@ -27,6 +27,7 @@ import {
   API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES,
   DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG,
 } from "~/types/apiCredentialProfiles"
+import { onStorageChanged } from "~/utils/browser/browserApi"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 
@@ -73,8 +74,7 @@ export function subscribeToApiCredentialProfilesChanges(
     callback()
   }
 
-  browser.storage.onChanged.addListener(listener)
-  return () => browser.storage.onChanged.removeListener(listener)
+  return onStorageChanged(listener)
 }
 
 /**

--- a/src/services/apiService/sub2api/tokenResync.ts
+++ b/src/services/apiService/sub2api/tokenResync.ts
@@ -1,6 +1,11 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
-import { getAllTabs, sendRuntimeMessage } from "~/utils/browser/browserApi"
+import {
+  getAllTabs,
+  getBrowserApiCapabilities,
+  sendRuntimeMessage,
+  sendTabMessage,
+} from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 import { tryParseOrigin } from "~/utils/core/urlParsing"
 
@@ -32,7 +37,7 @@ type Sub2ApiResyncedToken = {
  */
 async function readUserFromTab(tabId: number, baseUrl: string) {
   try {
-    return await browser.tabs.sendMessage(tabId, {
+    return await sendTabMessage(tabId, {
       action: RuntimeActionIds.ContentGetUserFromLocalStorage,
       url: baseUrl,
       siteType: SITE_TYPES.SUB2API,
@@ -55,7 +60,7 @@ async function readSub2ApiAuthTokenFromExistingTab(
   const origin = tryParseOrigin(baseUrl)
   if (!origin) return null
 
-  if (!browser?.tabs?.query) return null
+  if (!getBrowserApiCapabilities().hasTabs) return null
 
   const tabs = await getAllTabs().catch(() => [])
   const candidates = tabs

--- a/src/services/productAnalytics/runtime.ts
+++ b/src/services/productAnalytics/runtime.ts
@@ -4,6 +4,10 @@ import {
   USER_PREFERENCES_STORAGE_KEYS,
 } from "~/services/core/storageKeys"
 import { userPreferences } from "~/services/preferences/userPreferences"
+import {
+  hasStorageChangedListener,
+  onStorageChanged,
+} from "~/utils/browser/browserApi"
 import { isDevBuild } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
@@ -256,7 +260,7 @@ export function setupProductAnalyticsAccountChangeListener() {
     return cleanupAccountChangeListener
   }
 
-  if (!browser.storage?.onChanged) {
+  if (!hasStorageChangedListener()) {
     return () => {}
   }
 
@@ -281,7 +285,7 @@ export function setupProductAnalyticsAccountChangeListener() {
     schedule()
   }
 
-  browser.storage.onChanged.addListener(handleStorageChanged)
+  const cleanupStorageChanged = onStorageChanged(handleStorageChanged)
 
   cleanupAccountChangeListener = () => {
     if (!cleanupAccountChangeListener) {
@@ -293,7 +297,7 @@ export function setupProductAnalyticsAccountChangeListener() {
       clearTimeout(timer)
       timer = null
     }
-    browser.storage.onChanged.removeListener(handleStorageChanged)
+    cleanupStorageChanged()
     cleanupAccountChangeListener = null
   }
 
@@ -308,7 +312,7 @@ export function setupProductAnalyticsPreferencesChangeListener() {
     return cleanupPreferencesChangeListener
   }
 
-  if (!browser.storage?.onChanged) {
+  if (!hasStorageChangedListener()) {
     return () => {}
   }
 
@@ -333,7 +337,7 @@ export function setupProductAnalyticsPreferencesChangeListener() {
     schedule()
   }
 
-  browser.storage.onChanged.addListener(handleStorageChanged)
+  const cleanupStorageChanged = onStorageChanged(handleStorageChanged)
 
   cleanupPreferencesChangeListener = () => {
     if (!cleanupPreferencesChangeListener) {
@@ -345,7 +349,7 @@ export function setupProductAnalyticsPreferencesChangeListener() {
       clearTimeout(timer)
       timer = null
     }
-    browser.storage.onChanged.removeListener(handleStorageChanged)
+    cleanupStorageChanged()
     cleanupPreferencesChangeListener = null
   }
 

--- a/src/services/runtimeMessaging/extensionMessaging.ts
+++ b/src/services/runtimeMessaging/extensionMessaging.ts
@@ -6,6 +6,12 @@ import type {
   Message,
 } from "@webext-core/messaging"
 
+import {
+  onRuntimeMessage,
+  sendRuntimeMessageOnce,
+  sendTabMessage,
+} from "~/utils/browser/browserApi"
+
 export type { Logger } from "@webext-core/messaging"
 
 interface RuntimeMessagingResponse {
@@ -216,10 +222,7 @@ export function defineExtensionMessaging<
       return true
     }
 
-    browser.runtime.onMessage.addListener(listener)
-    return () => {
-      browser.runtime.onMessage.removeListener(listener)
-    }
+    return onRuntimeMessage(listener)
   }
 
   return {
@@ -234,8 +237,8 @@ export function defineExtensionMessaging<
 
       const response =
         arg == null
-          ? await browser.runtime.sendMessage(message)
-          : await browser.tabs.sendMessage(
+          ? await sendRuntimeMessageOnce(message)
+          : await sendTabMessage(
               typeof arg === "number" ? arg : arg.tabId,
               message,
               typeof arg === "object" && arg.frameId != null

--- a/src/services/siteDetection/autoDetectService.ts
+++ b/src/services/siteDetection/autoDetectService.ts
@@ -30,8 +30,10 @@ import {
 import { AuthTypeEnum, type Sub2ApiAuthConfig } from "~/types"
 import {
   getActiveOrAllTabs,
+  getBrowserApiCapabilities,
   isMessageReceiverUnavailableError,
   sendRuntimeMessage,
+  sendTabMessage,
 } from "~/utils/browser/browserApi"
 import { isExtensionPopup } from "~/utils/browser/index"
 import { getErrorMessage } from "~/utils/core/error"
@@ -103,12 +105,7 @@ function isGenericUserDataMissingError(error?: string): boolean {
  * @returns Capability flags indicating windows/tabs/runtime availability.
  */
 function detectPlatformCapabilities() {
-  const b = (globalThis as any).browser
-  return {
-    hasWindows: !!b?.windows,
-    hasTabs: !!b?.tabs,
-    hasBackgroundMessaging: !!b?.runtime,
-  }
+  return getBrowserApiCapabilities()
 }
 
 /**
@@ -487,7 +484,7 @@ async function getUserDataFromCurrentTab(
   try {
     // 通过 content script 获取用户信息
     try {
-      const userResponse = await browser.tabs.sendMessage(tabId, {
+      const userResponse = await sendTabMessage(tabId, {
         action: RuntimeActionIds.ContentGetUserFromLocalStorage,
         url: url,
         siteType,

--- a/src/services/updates/releaseUpdateService.ts
+++ b/src/services/updates/releaseUpdateService.ts
@@ -7,7 +7,10 @@ import { createRuntimeMessageFailure } from "~/services/runtimeMessaging/result"
 import {
   createAlarm,
   getAlarm,
+  getExtensionURL,
+  getManagementSelf,
   getManifest,
+  getRuntimeId,
   hasAlarmsAPI,
   onAlarm,
 } from "~/utils/browser/browserApi"
@@ -256,42 +259,9 @@ async function detectInstallEligibility(): Promise<DetectInstallEligibilityResul
     return { eligible: false, reason: RELEASE_UPDATE_REASONS.SafariUnsupported }
   }
 
-  const getSelf = (browser as any)?.management?.getSelf as
-    | (() => Promise<{ installType?: string }>)
-    | undefined
-
-  if (typeof getSelf !== "function") {
-    return {
-      eligible: false,
-      reason: runtimeUrl.startsWith("moz-extension://")
-        ? RELEASE_UPDATE_REASONS.FirefoxAmbiguous
-        : RELEASE_UPDATE_REASONS.ApiUnavailable,
-    }
-  }
-
+  let info: Awaited<ReturnType<typeof getManagementSelf>> = null
   try {
-    const info = await getSelf()
-    const installType = info?.installType
-
-    if (runtimeUrl.startsWith("moz-extension://")) {
-      return {
-        eligible: false,
-        reason: RELEASE_UPDATE_REASONS.FirefoxAmbiguous,
-      }
-    }
-
-    if (installType === "development") {
-      return {
-        eligible: true,
-        reason: RELEASE_UPDATE_REASONS.ChromiumDevelopment,
-      }
-    }
-
-    if (isKnownChromiumStoreBuild()) {
-      return { eligible: false, reason: RELEASE_UPDATE_REASONS.StoreBuild }
-    }
-
-    return { eligible: false, reason: RELEASE_UPDATE_REASONS.Unknown }
+    info = await getManagementSelf()
   } catch (error) {
     logger.debug("management.getSelf failed", error)
     return {
@@ -301,6 +271,37 @@ async function detectInstallEligibility(): Promise<DetectInstallEligibilityResul
         : RELEASE_UPDATE_REASONS.ApiUnavailable,
     }
   }
+
+  if (!info) {
+    return {
+      eligible: false,
+      reason: runtimeUrl.startsWith("moz-extension://")
+        ? RELEASE_UPDATE_REASONS.FirefoxAmbiguous
+        : RELEASE_UPDATE_REASONS.ApiUnavailable,
+    }
+  }
+
+  const installType = info.installType
+
+  if (runtimeUrl.startsWith("moz-extension://")) {
+    return {
+      eligible: false,
+      reason: RELEASE_UPDATE_REASONS.FirefoxAmbiguous,
+    }
+  }
+
+  if (installType === "development") {
+    return {
+      eligible: true,
+      reason: RELEASE_UPDATE_REASONS.ChromiumDevelopment,
+    }
+  }
+
+  if (isKnownChromiumStoreBuild()) {
+    return { eligible: false, reason: RELEASE_UPDATE_REASONS.StoreBuild }
+  }
+
+  return { eligible: false, reason: RELEASE_UPDATE_REASONS.Unknown }
 }
 
 /**
@@ -315,7 +316,7 @@ function getCurrentManifestVersion(): string {
  */
 function getRuntimeBaseUrl(): string {
   try {
-    return browser.runtime.getURL("")
+    return getExtensionURL("")
   } catch {
     return ""
   }
@@ -325,7 +326,7 @@ function getRuntimeBaseUrl(): string {
  * Check whether the current Chromium runtime ID matches a known store build.
  */
 function isKnownChromiumStoreBuild(): boolean {
-  const runtimeId = browser.runtime?.id
+  const runtimeId = getRuntimeId()
   if (typeof runtimeId !== "string" || !runtimeId) {
     return false
   }

--- a/src/services/verification/verificationResultHistory/storage.ts
+++ b/src/services/verification/verificationResultHistory/storage.ts
@@ -10,6 +10,7 @@ import type {
   ApiVerificationProbeStatus,
 } from "~/services/verification/aiApiVerification"
 import { apiVerificationProbeRegistry } from "~/services/verification/aiApiVerification/probeRegistry"
+import { onStorageChanged } from "~/utils/browser/browserApi"
 
 import {
   API_VERIFICATION_RESULT_HISTORY_CONFIG_VERSION,
@@ -57,8 +58,7 @@ export function subscribeToVerificationResultHistoryChanges(
     callback()
   }
 
-  browser.storage.onChanged.addListener(listener)
-  return () => browser.storage.onChanged.removeListener(listener)
+  return onStorageChanged(listener)
 }
 
 /**

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -49,6 +49,7 @@ import {
   hasAlarmsAPI,
   isMessageReceiverUnavailableError,
   onAlarm,
+  onStorageChanged,
   sendRuntimeMessage,
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
@@ -347,8 +348,7 @@ class WebdavAutoSyncService {
       void this.handleSharedAccountStorageChanged()
     }
 
-    browser.storage.onChanged.addListener(listener)
-    return () => browser.storage.onChanged.removeListener(listener)
+    return onStorageChanged(listener)
   }
 
   private hasDeletedSharedEntries(change: browser.storage.StorageChange) {

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -121,6 +121,22 @@ export async function updateTab(
 }
 
 /**
+ * Retrieves a tab by id.
+ * @param tabId Target tab ID.
+ */
+export async function getTab(tabId: number): Promise<browser.tabs.Tab> {
+  return await browser.tabs.get(tabId)
+}
+
+/**
+ * Reloads a tab by id.
+ * @param tabId Target tab ID.
+ */
+export async function reloadTab(tabId: number): Promise<void> {
+  await browser.tabs.reload(tabId)
+}
+
+/**
  * 查询标签页
  * @param queryInfo 标签查询条件对象。
  */
@@ -128,6 +144,19 @@ export async function queryTabs(
   queryInfo: browser.tabs._QueryQueryInfo,
 ): Promise<browser.tabs.Tab[]> {
   return await browser.tabs.query(queryInfo)
+}
+
+/**
+ * Sends a message to a tab without retrying.
+ *
+ * Use this when a caller intentionally owns missing-receiver fallback behavior.
+ */
+export async function sendTabMessage<TResponse = any>(
+  tabId: number,
+  message: unknown,
+  options?: browser.tabs._SendMessageOptions,
+): Promise<TResponse> {
+  return (await browser.tabs.sendMessage(tabId, message, options)) as TResponse
 }
 
 /**
@@ -166,6 +195,31 @@ export async function createWindow(
 ): Promise<browser.windows.Window | null> {
   if (hasWindowsAPI()) {
     return await browser.windows.create(createData)
+  }
+  return null
+}
+
+/**
+ * Retrieves a browser window by id when the windows API is available.
+ */
+export async function getWindow(
+  windowId: number,
+): Promise<browser.windows.Window | null> {
+  if (hasWindowsAPI()) {
+    return await browser.windows.get(windowId)
+  }
+  return null
+}
+
+/**
+ * Updates a browser window when the windows API is available.
+ */
+export async function updateWindow(
+  windowId: number,
+  updateInfo: browser.windows._UpdateUpdateInfo,
+): Promise<browser.windows.Window | null> {
+  if (hasWindowsAPI()) {
+    return await browser.windows.update(windowId, updateInfo)
   }
   return null
 }
@@ -282,6 +336,19 @@ export async function sendRuntimeMessage<TResponse>(
   options?: SendMessageRetryOptions,
 ): Promise<TResponse> {
   return await sendMessageWithRetry<TResponse>(message, options)
+}
+
+/**
+ * Sends a runtime message without retrying.
+ *
+ * Use this for transports that need to preserve the raw WebExtension messaging
+ * contract and handle missing responses themselves.
+ */
+export async function sendRuntimeMessageOnce<TResponse = any>(
+  message: unknown,
+  options?: browser.runtime._SendMessageOptions,
+): Promise<TResponse> {
+  return (await browser.runtime.sendMessage(message, options)) as TResponse
 }
 
 /**
@@ -441,6 +508,51 @@ export function getExtensionURL(path: string): string {
 }
 
 /**
+ * Returns the current extension runtime id when available.
+ */
+export function getRuntimeId(): string | undefined {
+  const runtimeId = (globalThis as any).browser?.runtime?.id
+  return typeof runtimeId === "string" ? runtimeId : undefined
+}
+
+export interface BrowserApiCapabilities {
+  hasWindows: boolean
+  hasTabs: boolean
+  hasBackgroundMessaging: boolean
+}
+
+/**
+ * Detects the currently exposed high-level WebExtension APIs.
+ */
+export function getBrowserApiCapabilities(): BrowserApiCapabilities {
+  const runtimeBrowser = (globalThis as any).browser
+  return {
+    hasWindows: !!runtimeBrowser?.windows,
+    hasTabs: !!runtimeBrowser?.tabs,
+    hasBackgroundMessaging: !!runtimeBrowser?.runtime,
+  }
+}
+
+export interface BrowserManagementSelfInfo {
+  installType?: string
+}
+
+/**
+ * Reads extension installation metadata when the management API is available.
+ */
+export async function getManagementSelf(): Promise<BrowserManagementSelfInfo | null> {
+  const getSelf = (globalThis as any).browser?.management?.getSelf as
+    | (() => Promise<BrowserManagementSelfInfo>)
+    | undefined
+
+  if (typeof getSelf !== "function") {
+    return null
+  }
+
+  return await getSelf()
+}
+
+/**
  * 监听 runtime 消息
  * 返回清理函数
  *
@@ -458,6 +570,46 @@ export function onRuntimeMessage(
   return () => {
     browser.runtime.onMessage.removeListener(callback)
   }
+}
+
+/**
+ * Subscribes to local/browser storage changes when the API is available.
+ */
+export function onStorageChanged(
+  callback: (
+    changes: Record<string, browser.storage.StorageChange>,
+    areaName: string,
+  ) => void,
+): () => void {
+  const onChanged = (globalThis as any).browser?.storage?.onChanged as
+    | {
+        addListener?: (listener: typeof callback) => void
+        removeListener?: (listener: typeof callback) => void
+      }
+    | undefined
+
+  if (
+    typeof onChanged?.addListener !== "function" ||
+    typeof onChanged?.removeListener !== "function"
+  ) {
+    return () => {}
+  }
+
+  onChanged.addListener(callback)
+  return () => {
+    onChanged.removeListener?.(callback)
+  }
+}
+
+/**
+ * Returns whether storage change subscriptions are available.
+ */
+export function hasStorageChangedListener(): boolean {
+  const onChanged = (globalThis as any).browser?.storage?.onChanged
+  return (
+    typeof onChanged?.addListener === "function" &&
+    typeof onChanged?.removeListener === "function"
+  )
 }
 
 /**
@@ -845,6 +997,106 @@ export function hasNotificationsAPI(): boolean {
 }
 
 /**
+ * Checks whether the context menus API is available.
+ */
+export function hasContextMenusAPI(): boolean {
+  return !!(globalThis as any).browser?.contextMenus
+}
+
+/**
+ * Subscribes to context menu click events when supported.
+ */
+export function onContextMenuClicked(
+  callback: (
+    info: browser.contextMenus.OnClickData,
+    tab?: browser.tabs.Tab,
+  ) => void | Promise<void>,
+): () => void {
+  const onClicked = (globalThis as any).browser?.contextMenus?.onClicked as
+    | {
+        addListener?: (listener: typeof callback) => void
+        removeListener?: (listener: typeof callback) => void
+      }
+    | undefined
+
+  if (
+    typeof onClicked?.addListener !== "function" ||
+    typeof onClicked?.removeListener !== "function"
+  ) {
+    return () => {}
+  }
+
+  onClicked.addListener(callback)
+  return () => {
+    onClicked.removeListener?.(callback)
+  }
+}
+
+/**
+ * Creates a context menu item.
+ */
+export function createContextMenu(
+  createProperties: browser.contextMenus._CreateCreateProperties,
+): number | string | undefined {
+  if (!hasContextMenusAPI()) {
+    return undefined
+  }
+
+  return browser.contextMenus.create(createProperties)
+}
+
+/**
+ * Removes a context menu item.
+ */
+export async function removeContextMenu(
+  menuItemId: number | string,
+): Promise<void> {
+  if (!hasContextMenusAPI()) {
+    return
+  }
+
+  await browser.contextMenus.remove(menuItemId)
+}
+
+/**
+ * Reads a localized browser message from the extension manifest locale bundle.
+ */
+export function getBrowserI18nMessage(
+  messageName: string,
+  substitutions?: string | Array<string | number>,
+): string {
+  const getMessage = (globalThis as any).browser?.i18n?.getMessage
+  if (typeof getMessage !== "function") {
+    return ""
+  }
+
+  return getMessage(messageName, substitutions)
+}
+
+/**
+ * Checks whether browser cookie-store enumeration is available.
+ */
+export function hasCookieStoresAPI(): boolean {
+  return (
+    typeof (globalThis as any).browser?.cookies?.getAllCookieStores ===
+    "function"
+  )
+}
+
+/**
+ * Lists browser cookie stores when supported.
+ */
+export async function getAllCookieStores(): Promise<
+  browser.cookies.CookieStore[]
+> {
+  if (!hasCookieStoresAPI()) {
+    return []
+  }
+
+  return await browser.cookies.getAllCookieStores()
+}
+
+/**
  * Creates or replaces a browser notification. Returns the created id, or null
  * when notifications are unavailable or creation fails.
  */
@@ -974,6 +1226,11 @@ type ActionClickListener = (tab: browser.tabs.Tab, info?: any) => void
 
 type ActionAPI = {
   setPopup: (details: { popup?: string }) => Promise<void> | void
+  setBadgeText?: (details: { text: string }) => Promise<void> | void
+  setBadgeBackgroundColor?: (details: {
+    color: string | [number, number, number, number]
+  }) => Promise<void> | void
+  setTitle?: (details: { title: string }) => Promise<void> | void
   onClicked: {
     addListener: (listener: ActionClickListener) => void
     removeListener: (listener: ActionClickListener) => void

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -156,6 +156,10 @@ export async function sendTabMessage<TResponse = any>(
   message: unknown,
   options?: browser.tabs._SendMessageOptions,
 ): Promise<TResponse> {
+  if (typeof options === "undefined") {
+    return (await browser.tabs.sendMessage(tabId, message)) as TResponse
+  }
+
   return (await browser.tabs.sendMessage(tabId, message, options)) as TResponse
 }
 
@@ -527,9 +531,10 @@ export interface BrowserApiCapabilities {
 export function getBrowserApiCapabilities(): BrowserApiCapabilities {
   const runtimeBrowser = (globalThis as any).browser
   return {
-    hasWindows: !!runtimeBrowser?.windows,
-    hasTabs: !!runtimeBrowser?.tabs,
-    hasBackgroundMessaging: !!runtimeBrowser?.runtime,
+    hasWindows: typeof runtimeBrowser?.windows?.create === "function",
+    hasTabs: typeof runtimeBrowser?.tabs?.query === "function",
+    hasBackgroundMessaging:
+      typeof runtimeBrowser?.runtime?.sendMessage === "function",
   }
 }
 
@@ -1000,7 +1005,13 @@ export function hasNotificationsAPI(): boolean {
  * Checks whether the context menus API is available.
  */
 export function hasContextMenusAPI(): boolean {
-  return !!(globalThis as any).browser?.contextMenus
+  const contextMenus = (globalThis as any).browser?.contextMenus
+  return (
+    typeof contextMenus?.create === "function" &&
+    typeof contextMenus?.remove === "function" &&
+    typeof contextMenus?.onClicked?.addListener === "function" &&
+    typeof contextMenus?.onClicked?.removeListener === "function"
+  )
 }
 
 /**
@@ -1038,11 +1049,17 @@ export function onContextMenuClicked(
 export function createContextMenu(
   createProperties: browser.contextMenus._CreateCreateProperties,
 ): number | string | undefined {
-  if (!hasContextMenusAPI()) {
+  const create = (globalThis as any).browser?.contextMenus?.create as
+    | ((
+        properties: browser.contextMenus._CreateCreateProperties,
+      ) => number | string | undefined)
+    | undefined
+
+  if (typeof create !== "function") {
     return undefined
   }
 
-  return browser.contextMenus.create(createProperties)
+  return create(createProperties)
 }
 
 /**
@@ -1051,11 +1068,15 @@ export function createContextMenu(
 export async function removeContextMenu(
   menuItemId: number | string,
 ): Promise<void> {
-  if (!hasContextMenusAPI()) {
+  const remove = (globalThis as any).browser?.contextMenus?.remove as
+    | ((id: number | string) => Promise<void> | void)
+    | undefined
+
+  if (typeof remove !== "function") {
     return
   }
 
-  await browser.contextMenus.remove(menuItemId)
+  await remove(menuItemId)
 }
 
 /**

--- a/src/utils/navigation/index.ts
+++ b/src/utils/navigation/index.ts
@@ -15,6 +15,8 @@ import {
   focusTab,
   getExtensionURL,
   hasWindowsAPI,
+  queryTabs as queryTabsApi,
+  updateTab as updateTabApi,
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
@@ -207,7 +209,7 @@ const updateTab = async (
   tabId: number,
   updateInfo: browser.tabs._UpdateUpdateProperties,
 ): Promise<void> => {
-  await browser.tabs.update(tabId, updateInfo)
+  await updateTabApi(tabId, updateInfo)
 }
 
 /**
@@ -226,7 +228,7 @@ const queryTabs = async (
   queryInfo: browser.tabs._QueryQueryInfo,
 ): Promise<browser.tabs.Tab[]> => {
   try {
-    return (await browser.tabs.query(queryInfo)) || []
+    return (await queryTabsApi(queryInfo)) || []
   } catch (error) {
     logger.warn("Failed to query tabs", error)
     return []

--- a/tests/entrypoints/background/contextMenus.test.ts
+++ b/tests/entrypoints/background/contextMenus.test.ts
@@ -35,6 +35,7 @@ describe("background context menu refresh", () => {
 
   const contextMenusCreate = vi.fn()
   const contextMenusRemove = vi.fn().mockResolvedValue(undefined)
+  const contextMenusRemoveListener = vi.fn()
   const contextMenusAddListener = vi.fn(
     (listener: (info: any, tab: any) => unknown) => {
       listeners.push(listener)
@@ -48,6 +49,7 @@ describe("background context menu refresh", () => {
       remove: contextMenusRemove,
       onClicked: {
         addListener: contextMenusAddListener,
+        removeListener: contextMenusRemoveListener,
       },
     },
     tabs: {
@@ -64,6 +66,7 @@ describe("background context menu refresh", () => {
     contextMenusCreate.mockClear()
     contextMenusRemove.mockClear()
     contextMenusAddListener.mockClear()
+    contextMenusRemoveListener.mockClear()
     tabsSendMessage.mockClear()
     startProductAnalyticsActionMock.mockReset()
     trackerCompleteMock.mockReset()
@@ -144,6 +147,7 @@ describe("background context menu refresh", () => {
       expect.objectContaining({
         action: RuntimeActionIds.ApiCheckContextMenuTrigger,
       }),
+      undefined,
     )
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.WebAiApiCheck,
@@ -220,6 +224,7 @@ describe("background context menu refresh", () => {
       expect.objectContaining({
         action: RuntimeActionIds.ApiCheckContextMenuTrigger,
       }),
+      undefined,
     )
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.WebAiApiCheck,

--- a/tests/entrypoints/background/contextMenus.test.ts
+++ b/tests/entrypoints/background/contextMenus.test.ts
@@ -146,8 +146,9 @@ describe("background context menu refresh", () => {
       123,
       expect.objectContaining({
         action: RuntimeActionIds.ApiCheckContextMenuTrigger,
+        pageUrl: "https://example.com",
+        selectionText: "sk-test",
       }),
-      undefined,
     )
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.WebAiApiCheck,
@@ -223,8 +224,9 @@ describe("background context menu refresh", () => {
       123,
       expect.objectContaining({
         action: RuntimeActionIds.ApiCheckContextMenuTrigger,
+        pageUrl: "https://example.com",
+        selectionText: "sk-test",
       }),
-      undefined,
     )
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.WebAiApiCheck,

--- a/tests/entrypoints/background/contextMenus.test.ts
+++ b/tests/entrypoints/background/contextMenus.test.ts
@@ -196,6 +196,47 @@ describe("background context menu refresh", () => {
     )
   })
 
+  it("forwards selected text from the redemption context-menu action", async () => {
+    const { refreshContextMenus } = await import(
+      "~/entrypoints/background/contextMenus"
+    )
+
+    await refreshContextMenus({
+      redemptionAssist: { enabled: true, contextMenu: { enabled: true } },
+      webAiApiCheck: { enabled: true, contextMenu: { enabled: true } },
+    } as any)
+
+    await Promise.all(
+      listeners.map((listener) =>
+        listener(
+          {
+            menuItemId: "redemption-assist-context-menu",
+            selectionText: "coupon-code",
+            pageUrl: "https://example.com",
+          },
+          { id: 123, url: "https://example.com" },
+        ),
+      ),
+    )
+
+    expect(tabsSendMessage).toHaveBeenCalledWith(
+      123,
+      expect.objectContaining({
+        action: RuntimeActionIds.RedemptionAssistContextMenuTrigger,
+        pageUrl: "https://example.com",
+        selectionText: "coupon-code",
+      }),
+    )
+    expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.RedemptionAssist,
+      actionId:
+        PRODUCT_ANALYTICS_ACTION_IDS.TriggerRedemptionAssistFromContextMenu,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.BackgroundContextMenu,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+    })
+    expect(trackerCompleteMock).toHaveBeenCalledWith()
+  })
+
   it("reports a failed AI API Check context-menu action when forwarding fails", async () => {
     tabsSendMessage.mockRejectedValueOnce(new Error("content unavailable"))
     const { refreshContextMenus } = await import(

--- a/tests/entrypoints/background/cookieInterceptor.test.ts
+++ b/tests/entrypoints/background/cookieInterceptor.test.ts
@@ -100,6 +100,7 @@ describe("cookieInterceptor", () => {
           addListener: vi.fn((listener) => {
             storageChangeListeners.push(listener)
           }),
+          removeListener: vi.fn(),
         },
       },
     })

--- a/tests/entrypoints/background/devActionBranding.test.ts
+++ b/tests/entrypoints/background/devActionBranding.test.ts
@@ -12,9 +12,15 @@ const {
   loggerDebugMock: vi.fn(),
 }))
 
-vi.mock("~/utils/browser/browserApi", () => ({
-  getManifest: (...args: unknown[]) => getManifestMock(...args),
-}))
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/utils/browser/browserApi")>()
+
+  return {
+    ...actual,
+    getManifest: (...args: unknown[]) => getManifestMock(...args),
+  }
+})
 
 vi.mock("~/utils/core/devBranding", () => ({
   formatDevActionTitle: (...args: unknown[]) =>

--- a/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
@@ -226,6 +226,48 @@ describe("tempWindowPool open/close handlers", () => {
     })
   })
 
+  it("recreates the composite window when the existing window handle is unavailable", async () => {
+    tempContextMode = "composite"
+    createWindowMock
+      .mockResolvedValueOnce({ id: 901 })
+      .mockResolvedValueOnce({ id: 905 })
+    windowsGetMock.mockResolvedValueOnce(null)
+    tabsQueryMock
+      .mockResolvedValueOnce([{ id: 902 }])
+      .mockResolvedValueOnce([{ id: 906 }])
+
+    const { handleOpenTempWindow } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const firstResponse = vi.fn()
+    await handleOpenTempWindow(
+      {
+        requestId: "req-composite-null-window-initial",
+        url: "https://example.com/composite/null-window/initial",
+      },
+      firstResponse,
+    )
+
+    const secondResponse = vi.fn()
+    await handleOpenTempWindow(
+      {
+        requestId: "req-composite-null-window-recreated",
+        url: "https://example.com/composite/null-window/recreated",
+      },
+      secondResponse,
+    )
+
+    expect(windowsGetMock).toHaveBeenCalledWith(901)
+    expect(createWindowMock).toHaveBeenCalledTimes(2)
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+    expect(secondResponse).toHaveBeenCalledWith({
+      success: true,
+      windowId: 905,
+      tabId: 906,
+    })
+  })
+
   it("recreates the composite window even when stale-window cleanup fails", async () => {
     tempContextMode = "composite"
     createWindowMock

--- a/tests/entrypoints/content/index.test.ts
+++ b/tests/entrypoints/content/index.test.ts
@@ -63,6 +63,7 @@ describe("content entrypoint", () => {
     setupRedemptionAssistContentMock.mockReset()
     setupWebAiApiCheckContentMock.mockReset()
     setupContentMessageHandlersMock.mockReset()
+    setupContentMessageHandlersMock.mockReturnValue(vi.fn())
     setContentScriptContextMock.mockReset()
     ensureContentI18nReadyMock.mockReset()
     ensureContentI18nReadyMock.mockResolvedValue(undefined)
@@ -208,6 +209,48 @@ describe("content entrypoint", () => {
     )
     expect(secondRedemptionCleanup).toHaveBeenCalledTimes(1)
     expect(secondApiCheckCleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it("cleans up message handlers when the content context is invalidated", async () => {
+    const cleanupMessageHandlers = vi.fn()
+    const cleanupRedemption = vi.fn()
+    const cleanupApiCheck = vi.fn()
+
+    setupContentMessageHandlersMock.mockReturnValue(cleanupMessageHandlers)
+    setupRedemptionAssistContentMock.mockReturnValue(cleanupRedemption)
+    setupWebAiApiCheckContentMock.mockReturnValue(cleanupApiCheck)
+    storageGetMock.mockResolvedValueOnce({
+      redemptionAssist: {
+        enabled: true,
+        contextMenu: { enabled: true },
+      },
+      webAiApiCheck: {
+        enabled: true,
+        contextMenu: { enabled: true },
+        autoDetect: { enabled: true },
+      },
+    })
+
+    const module = await import("~/entrypoints/content/index")
+    const onInvalidated = vi.fn()
+
+    await module.default.main({ onInvalidated } as any)
+
+    const cleanup = onInvalidated.mock.calls[0]?.[0]
+    expect(cleanup).toBeTypeOf("function")
+
+    await waitFor(() => {
+      expect(setupRedemptionAssistContentMock).toHaveBeenCalledTimes(1)
+      expect(setupWebAiApiCheckContentMock).toHaveBeenCalledTimes(1)
+    })
+
+    cleanup()
+
+    expect(cleanupMessageHandlers).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(cleanupRedemption).toHaveBeenCalledTimes(1)
+      expect(cleanupApiCheck).toHaveBeenCalledTimes(1)
+    })
   })
 
   it("falls back to default feature preferences when storage lookup fails", async () => {

--- a/tests/entrypoints/content/redemptionAssist/index.test.ts
+++ b/tests/entrypoints/content/redemptionAssist/index.test.ts
@@ -56,10 +56,16 @@ vi.mock("~/services/productAnalytics/actions", () => ({
     mockTrackProductAnalyticsActionCompleted(...args),
 }))
 
-vi.mock("~/utils/browser/browserApi", () => ({
-  checkPermissionViaMessage: mockCheckPermissionViaMessage,
-  sendRuntimeMessage: mockSendRuntimeMessage,
-}))
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/utils/browser/browserApi")>()
+
+  return {
+    ...actual,
+    checkPermissionViaMessage: mockCheckPermissionViaMessage,
+    sendRuntimeMessage: mockSendRuntimeMessage,
+  }
+})
 
 vi.mock("~/services/redemption/redemptionAssistMessaging", () => ({
   RedemptionAssistMessageTypes,
@@ -163,7 +169,7 @@ describe("setupRedemptionAssistContent", () => {
     expect(removeListener).toHaveBeenCalledWith(listener)
   })
 
-  it("logs debug when removing the context-menu listener fails", async () => {
+  it("propagates context-menu listener removal failures through the shared adapter", async () => {
     const removeListenerError = new Error("remove failed")
     ;(globalThis as any).browser = {
       runtime: {
@@ -185,11 +191,7 @@ describe("setupRedemptionAssistContent", () => {
       enableContextMenu: true,
     })
 
-    expect(() => cleanup()).not.toThrow()
-    expect(logger.debug).toHaveBeenCalledWith(
-      "Failed to remove redemption context menu listener",
-      removeListenerError,
-    )
+    expect(() => cleanup()).toThrow(removeListenerError)
   })
 
   it("deduplicates repeated clipboard scans and auto-redeems a single selected code", async () => {

--- a/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
+++ b/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
@@ -247,8 +247,9 @@ describe("AutoCheckin account actions", () => {
     let resolveRetry:
       | ((value: { success: boolean; error?: string }) => void)
       | undefined
-    vi.spyOn(browserApi, "sendRuntimeMessage").mockImplementation(
-      async (message: any) => {
+    const sendRuntimeMessageSpy = vi
+      .spyOn(browserApi, "sendRuntimeMessage")
+      .mockImplementation(async (message: unknown, data?: unknown) => {
         if (message === AutoCheckinMessageTypes.GetStatus) {
           return {
             success: true,
@@ -267,6 +268,7 @@ describe("AutoCheckin account actions", () => {
         }
 
         if (message === AutoCheckinMessageTypes.RetryAccount) {
+          expect(data).toEqual({ accountId: "alpha" })
           return await new Promise<{ success: boolean; error?: string }>(
             (resolve) => {
               resolveRetry = resolve
@@ -275,8 +277,7 @@ describe("AutoCheckin account actions", () => {
         }
 
         return { success: true }
-      },
-    )
+      })
 
     render(<AutoCheckin routeParams={{}} />)
 
@@ -288,8 +289,18 @@ describe("AutoCheckin account actions", () => {
     await waitFor(() => {
       expect(retryButton).toBeDisabled()
     })
+    await waitFor(() => {
+      expect(sendRuntimeMessageSpy).toHaveBeenCalledWith(
+        AutoCheckinMessageTypes.RetryAccount,
+        { accountId: "alpha" },
+      )
+    })
 
-    resolveRetry?.({ success: false, error: "backend rejected retry" })
+    if (!resolveRetry) {
+      throw new Error("Retry request resolver was not assigned")
+    }
+
+    resolveRetry({ success: false, error: "backend rejected retry" })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(

--- a/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
@@ -103,6 +103,9 @@ vi.mock("~/utils/browser/browserApi", () => ({
       tabUpdatedListener = null
     }
   }),
+  sendTabMessage: vi.fn((tabId: number, message: unknown) =>
+    globalThis.browser.tabs.sendMessage(tabId, message),
+  ),
 }))
 
 /**

--- a/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
@@ -103,8 +103,15 @@ vi.mock("~/utils/browser/browserApi", () => ({
       tabUpdatedListener = null
     }
   }),
-  sendTabMessage: vi.fn((tabId: number, message: unknown) =>
-    globalThis.browser.tabs.sendMessage(tabId, message),
+  sendTabMessage: vi.fn(
+    (
+      tabId: number,
+      message: unknown,
+      options?: browser.tabs._SendMessageOptions,
+    ) =>
+      typeof options === "undefined"
+        ? globalThis.browser.tabs.sendMessage(tabId, message)
+        : globalThis.browser.tabs.sendMessage(tabId, message, options),
   ),
 }))
 

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -99,8 +99,15 @@ const {
   mockToastPromise: vi.fn(),
   mockGetActiveTabs: vi.fn<() => Promise<browser.tabs.Tab[]>>(async () => []),
   mockGetAllTabs: vi.fn<() => Promise<browser.tabs.Tab[]>>(async () => []),
-  mockSendTabMessage: vi.fn((tabId: number, message: unknown) =>
-    globalThis.browser.tabs.sendMessage(tabId, message),
+  mockSendTabMessage: vi.fn(
+    (
+      tabId: number,
+      message: unknown,
+      options?: browser.tabs._SendMessageOptions,
+    ) =>
+      typeof options === "undefined"
+        ? globalThis.browser.tabs.sendMessage(tabId, message)
+        : globalThis.browser.tabs.sendMessage(tabId, message, options),
   ),
   mockOnRuntimeMessage: vi.fn<
     (

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -60,6 +60,7 @@ const {
   mockToastPromise,
   mockGetActiveTabs,
   mockGetAllTabs,
+  mockSendTabMessage,
   mockOnRuntimeMessage,
   mockOnTabActivated,
   mockOnTabRemoved,
@@ -98,6 +99,9 @@ const {
   mockToastPromise: vi.fn(),
   mockGetActiveTabs: vi.fn<() => Promise<browser.tabs.Tab[]>>(async () => []),
   mockGetAllTabs: vi.fn<() => Promise<browser.tabs.Tab[]>>(async () => []),
+  mockSendTabMessage: vi.fn((tabId: number, message: unknown) =>
+    globalThis.browser.tabs.sendMessage(tabId, message),
+  ),
   mockOnRuntimeMessage: vi.fn<
     (
       listener: (
@@ -221,6 +225,7 @@ vi.mock("~/utils/core/logger", () => ({
 vi.mock("~/utils/browser/browserApi", () => ({
   getActiveTabs: mockGetActiveTabs,
   getAllTabs: mockGetAllTabs,
+  sendTabMessage: mockSendTabMessage,
   onRuntimeMessage: mockOnRuntimeMessage,
   onTabActivated: mockOnTabActivated,
   onTabRemoved: mockOnTabRemoved,

--- a/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
@@ -106,7 +106,27 @@ describe("useAccountDialog current tab detection", () => {
     }
 
     mockGetSiteName.mockResolvedValue("Detected Site")
-    mockGetActiveTabs.mockResolvedValue([])
+    mockGetActiveTabs.mockImplementation(async () => {
+      const query = (globalThis as any).browser?.tabs?.query
+      if (typeof query !== "function") {
+        return []
+      }
+
+      try {
+        const tabs = await query({ active: true, currentWindow: true })
+        if (tabs?.length) {
+          return tabs
+        }
+      } catch {
+        // Mirror getActiveTabs fallback behavior for tests that model Firefox Android.
+      }
+
+      try {
+        return (await query({ active: true })) ?? []
+      } catch {
+        return []
+      }
+    })
     onTabActivatedMock.mockImplementation(() => () => {})
     onTabUpdatedMock.mockImplementation(() => () => {})
   })
@@ -425,29 +445,33 @@ describe("useAccountDialog current tab detection", () => {
     const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
       typeof vi.fn
     >
-    tabsQueryMock
-      .mockResolvedValueOnce([
-        {
-          id: 3,
-          url: "chrome://extensions",
-        },
-      ])
-      .mockResolvedValueOnce([
-        {
-          id: 3,
-          url: "chrome://extensions",
-        },
-      ])
-      .mockResolvedValueOnce([
-        {
-          id: 4,
-          url: "https://active.example.com/dashboard",
-        },
-      ])
+    let activeTab = {
+      id: 3,
+      url: "chrome://extensions",
+    }
+    tabsQueryMock.mockImplementation(async () => [activeTab])
 
-    mockGetActiveTabs
-      .mockResolvedValueOnce([{ id: 999 } as any])
-      .mockResolvedValueOnce([{ id: 4 } as any])
+    mockGetActiveTabs.mockImplementation(async () => {
+      const query = (globalThis as any).browser?.tabs?.query
+      if (typeof query !== "function") {
+        return []
+      }
+
+      try {
+        const tabs = await query({ active: true, currentWindow: true })
+        if (tabs?.length) {
+          return tabs
+        }
+      } catch {
+        // Mirror getActiveTabs fallback behavior for tests that model Firefox Android.
+      }
+
+      try {
+        return (await query({ active: true })) ?? []
+      } catch {
+        return []
+      }
+    })
 
     let updatedListener: ((tabId: number) => void | Promise<void>) | undefined
     onTabUpdatedMock.mockImplementation((listener) => {
@@ -477,6 +501,17 @@ describe("useAccountDialog current tab detection", () => {
     expect(mockGetSiteName).not.toHaveBeenCalledWith(
       expect.objectContaining({ id: 123 }),
     )
+
+    await waitFor(() => {
+      expect(mockGetSiteName).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: 4 }),
+      )
+    })
+
+    activeTab = {
+      id: 4,
+      url: "https://active.example.com/dashboard",
+    }
 
     await act(async () => {
       await updatedListener?.(4)

--- a/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
@@ -324,6 +324,25 @@ describe("useAccountDialog current tab detection", () => {
     expect(mockGetSiteName).not.toHaveBeenCalled()
   })
 
+  it("clears current-tab detection when active-tab lookup fails", async () => {
+    mockGetActiveTabs.mockRejectedValueOnce(new Error("tabs unavailable"))
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBeNull()
+      expect(result.current.state.siteName).toBe("")
+    })
+    expect(mockGetSiteName).not.toHaveBeenCalled()
+  })
+
   it("clears current-tab detection when fallback finds a non-http tab", async () => {
     const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
       typeof vi.fn

--- a/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
@@ -136,6 +136,28 @@ describe("useAccountDialog cookie import feedback", () => {
     mockOnOptionalPermissionsChanged.mockReturnValue(vi.fn())
     mockOnTabActivated.mockReturnValue(vi.fn())
     mockOnTabUpdated.mockReturnValue(vi.fn())
+    const { getActiveTabs } = await import("~/utils/browser/browserApi")
+    vi.mocked(getActiveTabs).mockImplementation(async () => {
+      const query = (globalThis as any).browser?.tabs?.query
+      if (typeof query !== "function") {
+        return []
+      }
+
+      try {
+        const tabs = await query({ active: true, currentWindow: true })
+        if (tabs?.length) {
+          return tabs
+        }
+      } catch {
+        // Mirror getActiveTabs fallback behavior for tests that model Firefox Android.
+      }
+
+      try {
+        return (await query({ active: true })) ?? []
+      } catch {
+        return []
+      }
+    })
     await accountStorage.clearAllData()
   })
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.sponsorPrefill.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.sponsorPrefill.test.tsx
@@ -83,7 +83,27 @@ describe("useAccountDialog sponsor prefill", () => {
         sendMessage: vi.fn(),
       },
     }
-    mockGetActiveTabs.mockResolvedValue([])
+    mockGetActiveTabs.mockImplementation(async () => {
+      const query = (globalThis as any).browser?.tabs?.query
+      if (typeof query !== "function") {
+        return []
+      }
+
+      try {
+        const tabs = await query({ active: true, currentWindow: true })
+        if (tabs?.length) {
+          return tabs
+        }
+      } catch {
+        // Mirror getActiveTabs fallback behavior for tests that model Firefox Android.
+      }
+
+      try {
+        return (await query({ active: true })) ?? []
+      } catch {
+        return []
+      }
+    })
     tabActivatedCallbacks.splice(0, tabActivatedCallbacks.length)
     onTabActivatedMock.mockImplementation((callback) => {
       tabActivatedCallbacks.push(callback)

--- a/tests/services/apiService/sub2api/tokenResync.test.ts
+++ b/tests/services/apiService/sub2api/tokenResync.test.ts
@@ -3,26 +3,37 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { resyncSub2ApiAuthToken } from "~/services/apiService/sub2api/tokenResync"
 
-const { mockGetAllTabs, mockSendRuntimeMessage } = vi.hoisted(() => ({
+const {
+  mockGetAllTabs,
+  mockGetBrowserApiCapabilities,
+  mockSendRuntimeMessage,
+  mockSendTabMessage,
+} = vi.hoisted(() => ({
   mockGetAllTabs: vi.fn(),
+  mockGetBrowserApiCapabilities: vi.fn(),
   mockSendRuntimeMessage: vi.fn(),
+  mockSendTabMessage: vi.fn(),
 }))
 
 vi.mock("~/utils/browser/browserApi", () => ({
   getAllTabs: mockGetAllTabs,
+  getBrowserApiCapabilities: mockGetBrowserApiCapabilities,
   sendRuntimeMessage: mockSendRuntimeMessage,
+  sendTabMessage: mockSendTabMessage,
 }))
 
 describe("Sub2API token re-sync", () => {
-  const mockTabSendMessage = vi.fn()
-
   beforeEach(() => {
     vi.clearAllMocks()
     vi.unstubAllGlobals()
+    mockGetBrowserApiCapabilities.mockReturnValue({
+      hasWindows: true,
+      hasTabs: true,
+      hasBackgroundMessaging: true,
+    })
     vi.stubGlobal("browser", {
       tabs: {
         query: vi.fn(),
-        sendMessage: mockTabSendMessage,
       },
     })
   })
@@ -48,7 +59,7 @@ describe("Sub2API token re-sync", () => {
       { id: 3, url: "https://sub2.example.com/console", active: true },
     ])
 
-    mockTabSendMessage
+    mockSendTabMessage
       .mockResolvedValueOnce({
         success: true,
         data: { accessToken: "   " },
@@ -64,12 +75,12 @@ describe("Sub2API token re-sync", () => {
       accessToken: "token-from-tab",
       source: "existing_tab",
     })
-    expect(mockTabSendMessage).toHaveBeenNthCalledWith(1, 3, {
+    expect(mockSendTabMessage).toHaveBeenNthCalledWith(1, 3, {
       action: RuntimeActionIds.ContentGetUserFromLocalStorage,
       url: "https://sub2.example.com",
       siteType: "sub2api",
     })
-    expect(mockTabSendMessage).toHaveBeenNthCalledWith(2, 2, {
+    expect(mockSendTabMessage).toHaveBeenNthCalledWith(2, 2, {
       action: RuntimeActionIds.ContentGetUserFromLocalStorage,
       url: "https://sub2.example.com",
       siteType: "sub2api",
@@ -81,7 +92,7 @@ describe("Sub2API token re-sync", () => {
     mockGetAllTabs.mockResolvedValueOnce([
       { id: 10, url: "https://sub2.example.com/dashboard", active: true },
     ])
-    mockTabSendMessage.mockResolvedValueOnce({
+    mockSendTabMessage.mockResolvedValueOnce({
       success: false,
     })
     mockSendRuntimeMessage.mockResolvedValueOnce({
@@ -106,7 +117,7 @@ describe("Sub2API token re-sync", () => {
     mockGetAllTabs.mockResolvedValueOnce([
       { id: 11, url: "https://sub2.example.com/dashboard", active: true },
     ])
-    mockTabSendMessage.mockRejectedValueOnce(new Error("receiver missing"))
+    mockSendTabMessage.mockRejectedValueOnce(new Error("receiver missing"))
     mockSendRuntimeMessage.mockRejectedValueOnce(new Error("window blocked"))
 
     await expect(

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -66,6 +66,7 @@ describe("autoDetectSmart", () => {
     browserAny.runtime = originalRuntime ?? {}
     browserAny.tabs = {
       ...(typeof originalTabs === "object" && originalTabs ? originalTabs : {}),
+      query: vi.fn().mockResolvedValue([]),
       sendMessage: vi.fn(),
     }
 

--- a/tests/services/updates/releaseUpdateService.test.ts
+++ b/tests/services/updates/releaseUpdateService.test.ts
@@ -159,6 +159,90 @@ describe("releaseUpdateService", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled()
   })
 
+  it("classifies Chromium installs as API-unavailable when management self lookup fails", async () => {
+    ;(globalThis as any).browser.management.getSelf.mockRejectedValueOnce(
+      new Error("management unavailable"),
+    )
+
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    const status = await releaseUpdateService.getStatus()
+
+    expect(status).toMatchObject({
+      eligible: false,
+      reason: "api-unavailable",
+      currentVersion: "3.32.0",
+      latestVersion: null,
+      updateAvailable: false,
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it("classifies Chromium installs as API-unavailable when management self returns no info", async () => {
+    ;(globalThis as any).browser.management.getSelf.mockResolvedValueOnce(null)
+
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    const status = await releaseUpdateService.getStatus()
+
+    expect(status).toMatchObject({
+      eligible: false,
+      reason: "api-unavailable",
+      currentVersion: "3.32.0",
+      latestVersion: null,
+      updateAvailable: false,
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it("keeps Firefox installs ambiguous even when management self reports development", async () => {
+    browserAny.runtime.id = "{bc73541a-133d-4b50-b261-36ea20df0d24}"
+    browserAny.runtime.getURL = vi.fn(
+      () => "moz-extension://firefox-extension/",
+    )
+    ;(globalThis as any).browser.management.getSelf.mockResolvedValueOnce({
+      installType: "development",
+    })
+
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    const status = await releaseUpdateService.getStatus()
+
+    expect(status).toMatchObject({
+      eligible: false,
+      reason: "firefox-ambiguous",
+      currentVersion: "3.32.0",
+      latestVersion: null,
+      updateAvailable: false,
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it("classifies known Chromium store builds as ineligible", async () => {
+    browserAny.runtime.id = "lapnciffpekdengooeolaienkeoilfeo"
+
+    const { releaseUpdateService } = await import(
+      "~/services/updates/releaseUpdateService"
+    )
+
+    const status = await releaseUpdateService.getStatus()
+
+    expect(status).toMatchObject({
+      eligible: false,
+      reason: "store-build",
+      currentVersion: "3.32.0",
+      latestVersion: null,
+      updateAvailable: false,
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
   it("registers the daily alarm once and preserves an existing matching schedule", async () => {
     getAlarmMock.mockResolvedValueOnce({
       name: "releaseUpdateDailyCheck",

--- a/tests/services/updates/releaseUpdateService.test.ts
+++ b/tests/services/updates/releaseUpdateService.test.ts
@@ -6,18 +6,29 @@ import { STORAGE_KEYS } from "~/services/core/storageKeys"
 const {
   createAlarmMock,
   getAlarmMock,
+  getExtensionUrlMock,
+  getManagementSelfMock,
   getManifestMock,
+  getRuntimeIdMock,
   hasAlarmsApiMock,
   onAlarmMock,
   withExtensionStorageWriteLockMock,
 } = vi.hoisted(() => ({
   createAlarmMock: vi.fn(),
   getAlarmMock: vi.fn(),
+  getExtensionUrlMock: vi.fn((path: string) =>
+    (globalThis as any).browser.runtime.getURL(path),
+  ),
+  getManagementSelfMock: vi.fn(async () => {
+    const getSelf = (globalThis as any).browser?.management?.getSelf
+    return typeof getSelf === "function" ? await getSelf() : null
+  }),
   getManifestMock: vi.fn(() => ({
     manifest_version: 3,
     version: "3.32.0",
     optional_permissions: [],
   })),
+  getRuntimeIdMock: vi.fn(() => (globalThis as any).browser?.runtime?.id),
   hasAlarmsApiMock: vi.fn(() => true),
   onAlarmMock: vi.fn(),
   withExtensionStorageWriteLockMock: vi.fn(
@@ -50,7 +61,10 @@ vi.mock("~/services/core/storageWriteLock", () => ({
 vi.mock("~/utils/browser/browserApi", () => ({
   createAlarm: createAlarmMock,
   getAlarm: getAlarmMock,
+  getExtensionURL: getExtensionUrlMock,
+  getManagementSelf: getManagementSelfMock,
   getManifest: getManifestMock,
+  getRuntimeId: getRuntimeIdMock,
   hasAlarmsAPI: hasAlarmsApiMock,
   onAlarm: onAlarmMock,
 }))
@@ -180,11 +194,9 @@ describe("releaseUpdateService", () => {
     const first = releaseUpdateService.initialize()
     const second = releaseUpdateService.initialize()
 
-    for (let index = 0; index < 10 && !resolveAlarm; index++) {
-      await Promise.resolve()
-    }
-
-    expect(resolveAlarm).toEqual(expect.any(Function))
+    await vi.waitFor(() => {
+      expect(resolveAlarm).toEqual(expect.any(Function))
+    })
 
     if (resolveAlarm) {
       resolveAlarm()

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -543,11 +543,13 @@ describe("browserApi direct adapter helpers", () => {
         sendMessage: vi.fn().mockResolvedValue({ ok: true }),
       },
       tabs: {
+        query: vi.fn().mockResolvedValue([]),
         get: vi.fn().mockResolvedValue({ id: 3 }),
         reload: vi.fn().mockResolvedValue(undefined),
         sendMessage: vi.fn().mockResolvedValue({ received: true }),
       },
       windows: {
+        create: vi.fn().mockResolvedValue({ id: 5 }),
         get: vi.fn().mockResolvedValue({ id: 5 }),
         update: vi.fn().mockResolvedValue({ id: 5, focused: true }),
       },
@@ -596,7 +598,6 @@ describe("browserApi direct adapter helpers", () => {
     expect((globalThis as any).browser.tabs.sendMessage).toHaveBeenCalledWith(
       3,
       message,
-      undefined,
     )
     expect(
       (globalThis as any).browser.runtime.sendMessage,
@@ -609,6 +610,20 @@ describe("browserApi direct adapter helpers", () => {
       hasWindows: true,
       hasTabs: true,
       hasBackgroundMessaging: true,
+    })
+  })
+
+  it("reports browser API capabilities only when required methods are callable", () => {
+    ;(globalThis as any).browser = {
+      windows: {},
+      tabs: {},
+      runtime: {},
+    }
+
+    expect(getBrowserApiCapabilities()).toEqual({
+      hasWindows: false,
+      hasTabs: false,
+      hasBackgroundMessaging: false,
     })
   })
 
@@ -694,6 +709,26 @@ describe("browserApi direct adapter helpers", () => {
     expect(createContextMenu({ id: "menu-2", title: "Menu" })).toBeUndefined()
     await expect(removeContextMenu("menu-2")).resolves.toBeUndefined()
     expect(() => onContextMenuClicked(listener)()).not.toThrow()
+  })
+
+  it("guards context menu helpers by method availability", async () => {
+    ;(globalThis as any).browser.contextMenus = {
+      onClicked: {
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      },
+    }
+
+    expect(hasContextMenusAPI()).toBe(false)
+    expect(createContextMenu({ id: "menu-3", title: "Menu" })).toBeUndefined()
+    await expect(removeContextMenu("menu-3")).resolves.toBeUndefined()
+    ;(globalThis as any).browser.contextMenus = {
+      create: vi.fn(() => "menu-4"),
+    }
+
+    expect(hasContextMenusAPI()).toBe(false)
+    expect(createContextMenu({ id: "menu-4", title: "Menu" })).toBe("menu-4")
+    await expect(removeContextMenu("menu-4")).resolves.toBeUndefined()
   })
 
   it("wraps browser i18n messages and cookie-store enumeration", async () => {

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -9,6 +9,7 @@ import {
   clearNotification,
   containsPermissions,
   createAlarm,
+  createContextMenu,
   createNotification,
   createWindow,
   disableNativeSidePanelActionClick,
@@ -19,21 +20,33 @@ import {
   getActiveTabs,
   getAlarm,
   getAllAlarms,
+  getAllCookieStores,
   getAllTabs,
+  getBrowserApiCapabilities,
+  getBrowserI18nMessage,
   getExtensionURL,
+  getManagementSelf,
   getManifest,
   getManifestVersion,
+  getRuntimeId,
+  getTab,
+  getWindow,
   hasAlarmsAPI,
+  hasContextMenusAPI,
+  hasCookieStoresAPI,
   hasNotificationsAPI,
+  hasStorageChangedListener,
   isAllowedIncognitoAccess,
   isMessageReceiverUnavailableError,
   onAlarm,
+  onContextMenuClicked,
   onInstalled,
   onNotificationClicked,
   onPermissionsAdded,
   onPermissionsRemoved,
   onRuntimeMessage,
   onStartup,
+  onStorageChanged,
   onSuspend,
   onTabActivated,
   onTabRemoved,
@@ -41,15 +54,20 @@ import {
   onWindowRemoved,
   PERMISSION_OPERATION_FAILURE_REASONS,
   reloadRuntime,
+  reloadTab,
   removeActionClickListener,
+  removeContextMenu,
   removePermissions,
   removePermissionsDetailed,
   removeTabOrWindow,
   requestPermissions,
   requestPermissionsDetailed,
   sendRuntimeActionMessage,
+  sendRuntimeMessageOnce,
+  sendTabMessage,
   sendTabMessageWithRetry,
   setActionPopup,
+  updateWindow,
   WINDOW_CREATION_FAILURE_REASONS,
 } from "~/utils/browser/browserApi"
 
@@ -513,6 +531,187 @@ describe("browserApi sendTabMessageWithRetry", () => {
         return result
       })(),
     ).resolves.toEqual({ ok: true })
+  })
+})
+
+describe("browserApi direct adapter helpers", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    ;(globalThis as any).browser = {
+      runtime: {
+        id: "runtime-1",
+        sendMessage: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      tabs: {
+        get: vi.fn().mockResolvedValue({ id: 3 }),
+        reload: vi.fn().mockResolvedValue(undefined),
+        sendMessage: vi.fn().mockResolvedValue({ received: true }),
+      },
+      windows: {
+        get: vi.fn().mockResolvedValue({ id: 5 }),
+        update: vi.fn().mockResolvedValue({ id: 5, focused: true }),
+      },
+      storage: {
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+      contextMenus: {
+        create: vi.fn(() => "menu-1"),
+        remove: vi.fn().mockResolvedValue(undefined),
+        onClicked: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+      i18n: {
+        getMessage: vi.fn(() => "Localized title"),
+      },
+      cookies: {
+        getAllCookieStores: vi.fn().mockResolvedValue([{ id: "default" }]),
+      },
+    }
+  })
+
+  afterAll(() => {
+    ;(globalThis as any).browser = originalBrowser
+    ;(globalThis as any).chrome = originalChrome
+  })
+
+  it("delegates one-shot tab and runtime operations to the exposed browser APIs", async () => {
+    const message = { action: "test" }
+
+    await expect(getTab(3)).resolves.toEqual({ id: 3 })
+    await expect(reloadTab(3)).resolves.toBeUndefined()
+    await expect(sendTabMessage(3, message)).resolves.toEqual({
+      received: true,
+    })
+    await expect(sendRuntimeMessageOnce(message)).resolves.toEqual({
+      ok: true,
+    })
+
+    expect((globalThis as any).browser.tabs.get).toHaveBeenCalledWith(3)
+    expect((globalThis as any).browser.tabs.reload).toHaveBeenCalledWith(3)
+    expect((globalThis as any).browser.tabs.sendMessage).toHaveBeenCalledWith(
+      3,
+      message,
+      undefined,
+    )
+    expect(
+      (globalThis as any).browser.runtime.sendMessage,
+    ).toHaveBeenCalledWith(message, undefined)
+  })
+
+  it("reports runtime id and high-level API capabilities", () => {
+    expect(getRuntimeId()).toBe("runtime-1")
+    expect(getBrowserApiCapabilities()).toEqual({
+      hasWindows: true,
+      hasTabs: true,
+      hasBackgroundMessaging: true,
+    })
+  })
+
+  it("reads management self info when the management API is available", async () => {
+    ;(globalThis as any).browser.management = {
+      getSelf: vi.fn().mockResolvedValue({ installType: "development" }),
+    }
+
+    await expect(getManagementSelf()).resolves.toEqual({
+      installType: "development",
+    })
+    expect((globalThis as any).browser.management.getSelf).toHaveBeenCalled()
+  })
+
+  it("returns null when management self info is unavailable", async () => {
+    ;(globalThis as any).browser.management = {}
+
+    await expect(getManagementSelf()).resolves.toBeNull()
+  })
+
+  it("returns undefined runtime id and false capabilities when browser is missing", () => {
+    ;(globalThis as any).browser = undefined
+
+    expect(getRuntimeId()).toBeUndefined()
+    expect(getBrowserApiCapabilities()).toEqual({
+      hasWindows: false,
+      hasTabs: false,
+      hasBackgroundMessaging: false,
+    })
+  })
+
+  it("delegates guarded window helpers and falls back when windows are unavailable", async () => {
+    await expect(getWindow(5)).resolves.toEqual({ id: 5 })
+    await expect(updateWindow(5, { focused: true })).resolves.toEqual({
+      id: 5,
+      focused: true,
+    })
+
+    expect((globalThis as any).browser.windows.get).toHaveBeenCalledWith(5)
+    expect((globalThis as any).browser.windows.update).toHaveBeenCalledWith(5, {
+      focused: true,
+    })
+    ;(globalThis as any).browser.windows = undefined
+    await expect(getWindow(5)).resolves.toBeNull()
+    await expect(updateWindow(5, { focused: true })).resolves.toBeNull()
+  })
+
+  it("subscribes to storage changes and returns no-op cleanup when unavailable", () => {
+    const listener = vi.fn()
+    const cleanup = onStorageChanged(listener)
+
+    expect(hasStorageChangedListener()).toBe(true)
+    expect(
+      (globalThis as any).browser.storage.onChanged.addListener,
+    ).toHaveBeenCalledWith(listener)
+
+    cleanup()
+    expect(
+      (globalThis as any).browser.storage.onChanged.removeListener,
+    ).toHaveBeenCalledWith(listener)
+    ;(globalThis as any).browser.storage = {}
+    expect(hasStorageChangedListener()).toBe(false)
+    expect(() => onStorageChanged(listener)()).not.toThrow()
+  })
+
+  it("wraps context menu availability, creation, removal, and click listeners", async () => {
+    const listener = vi.fn()
+
+    expect(hasContextMenusAPI()).toBe(true)
+    expect(createContextMenu({ id: "menu-1", title: "Menu" })).toBe("menu-1")
+    await expect(removeContextMenu("menu-1")).resolves.toBeUndefined()
+
+    const cleanup = onContextMenuClicked(listener)
+    expect(
+      (globalThis as any).browser.contextMenus.onClicked.addListener,
+    ).toHaveBeenCalledWith(listener)
+    cleanup()
+    expect(
+      (globalThis as any).browser.contextMenus.onClicked.removeListener,
+    ).toHaveBeenCalledWith(listener)
+    ;(globalThis as any).browser.contextMenus = undefined
+    expect(hasContextMenusAPI()).toBe(false)
+    expect(createContextMenu({ id: "menu-2", title: "Menu" })).toBeUndefined()
+    await expect(removeContextMenu("menu-2")).resolves.toBeUndefined()
+    expect(() => onContextMenuClicked(listener)()).not.toThrow()
+  })
+
+  it("wraps browser i18n messages and cookie-store enumeration", async () => {
+    expect(getBrowserI18nMessage("context_menu", ["name"])).toBe(
+      "Localized title",
+    )
+    expect((globalThis as any).browser.i18n.getMessage).toHaveBeenCalledWith(
+      "context_menu",
+      ["name"],
+    )
+
+    expect(hasCookieStoresAPI()).toBe(true)
+    await expect(getAllCookieStores()).resolves.toEqual([{ id: "default" }])
+    ;(globalThis as any).browser.i18n = {}
+    ;(globalThis as any).browser.cookies = {}
+    expect(getBrowserI18nMessage("missing")).toBe("")
+    expect(hasCookieStoresAPI()).toBe(false)
+    await expect(getAllCookieStores()).resolves.toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary
- route WebExtension runtime browser/chrome access through browser adapter wrappers
- add browserApi wrappers for tabs, windows, runtime, storage, context menus, i18n, cookie stores, management, and action metadata
- tighten eslint guardrails and update focused adapter/call-site tests

## Test Plan
- pnpm exec vitest tests/utils/browserApi.test.ts tests/utils/autoDetectUtils.test.ts tests/services/runtimeMessaging/extensionMessaging.test.ts tests/entrypoints/background/contextMenus.test.ts tests/services/apiService/sub2api/tokenResync.test.ts tests/services/updates/releaseUpdateService.test.ts --run
- pnpm exec eslint eslint.config.js
- temporary lint negative fixture for browser/chrome/globalThis/window/cast access, then removed
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized cross‑browser API wrappers for tabs, windows, messaging, storage, context menus, cookies and i18n; unified one‑shot vs retry messaging and safer capability checks.
  * Routed UI help/documentation links and tab interactions through unified tab handling.

* **Bug Fixes**
  * Improved listener registration/cleanup and guarded feature flows to reduce runtime errors and ensure proper teardown.

* **Chore**
  * ESLint guidance clarified to enforce guarded runtime API usage.

* **Tests**
  * Updated tests/mocks to reflect wrapper usage and lifecycle changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->