### PR TITLE
feat(product-announcements): add product risk notice channel

### DIFF
--- a/docs/superpowers/plans/2026-06-06-product-risk-announcements.md
+++ b/docs/superpowers/plans/2026-06-06-product-risk-announcements.md
@@ -1,0 +1,2138 @@
+# Product Risk Announcements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a project-controlled remote product risk announcement channel with a fixed announcement icon, local seen/dismissed state, and a focused Overview risk banner.
+
+**Architecture:** Add an independent `productAnnouncements` service domain with bundled JSON, best-effort remote refresh, local extension storage, typed runtime messaging, and selector-driven presentation models. UI entrypoints consume sanitized state through typed messages: Options gets the persistent header popover plus Overview banner, while Popup gets only a compact high-risk entry point.
+
+**Tech Stack:** TypeScript, React, WXT, `@plasmohq/storage`, `@webext-core/messaging`, Radix Popover, existing `IconButton`/`Badge` primitives, Vitest, Testing Library, i18next extraction.
+
+---
+
+## File Structure
+
+- Create `public/product-announcements.json`
+  - Bundled fallback feed. Start with schema version 1 and an empty `announcements` array.
+- Create `src/services/productAnnouncements/types.ts`
+  - Own raw feed types, normalized notice types, severity constants, state shape, and presentation list types.
+- Create `src/services/productAnnouncements/constants.ts`
+  - Own schema version, bundled/remote URL constants, refresh interval, locale fallbacks, and alarm name.
+- Create `src/services/productAnnouncements/versionRange.ts`
+  - Parse and evaluate simple semver-like ranges such as `>=3.44.0 <3.44.1`.
+- Create `src/services/productAnnouncements/urlPolicy.ts`
+  - Validate CTA URLs against the project allow-list.
+- Create `src/services/productAnnouncements/catalog.ts`
+  - Validate remote/bundled feed payloads, apply locale fallback, filter by version/time/dismissal, sort active notices, and produce UI-ready notices.
+- Modify `src/services/core/storageKeys.ts`
+  - Add product announcement storage key and lock.
+- Create `src/services/productAnnouncements/storage.ts`
+  - Persist state, cached feed, seen timestamps, and dismissed revisions.
+- Create `src/services/productAnnouncements/service.ts`
+  - Load cached notices immediately, refresh stale remote feed in the background, reconcile the refresh alarm, and expose mark-seen/dismiss APIs.
+- Create `src/services/productAnnouncements/messaging.ts`
+  - Define typed runtime messages for `getState`, `refresh`, `markSeen`, and `dismiss`.
+- Modify `src/services/runtimeMessaging/messageTypes.ts`
+  - Add `ProductAnnouncementsMessageTypes`.
+- Modify `src/entrypoints/background/runtimeMessages.ts`
+  - Register product announcement typed message listeners.
+- Modify `src/entrypoints/background/servicesInit.ts`
+  - Initialize product announcement refresh alarm with the other alarm-backed services.
+- Create `src/features/ProductAnnouncements/hooks/useProductAnnouncements.ts`
+  - React hook for Options/Popup surfaces.
+- Create `src/features/ProductAnnouncements/ProductAnnouncementButton.tsx`
+  - Fixed icon button with unread badge and popover.
+- Create `src/features/ProductAnnouncements/ProductAnnouncementPopover.tsx`
+  - Current notice list with Active/Dismissed filters, empty states, CTA, and dismiss action.
+- Create `src/features/ProductAnnouncements/ProductAnnouncementBanner.tsx`
+  - Compact Overview risk banner for the highest-priority active `critical`/`warning` notice.
+- Create `src/features/ProductAnnouncements/ProductAnnouncementList.tsx`
+  - Shared list rendering used by the popover.
+- Create `src/features/ProductAnnouncements/testIds.ts`
+  - Stable selectors for critical controls and lists.
+- Modify `src/entrypoints/options/components/Header.tsx`
+  - Add the fixed product announcement entry to the right-side header utility group.
+- Modify `src/features/OptionsOverview/OptionsOverview.tsx`
+  - Render the risk banner above the Overview grid.
+- Modify `src/entrypoints/popup/components/HeaderSection.tsx`
+  - Add compact product announcement entry only when active `critical`/`warning` notices exist.
+- Modify `src/services/productAnalytics/events.ts`
+  - Add product announcement feature/action/surface enums and controlled severity/action-kind values.
+- Modify `src/services/productAnalytics/privacy.ts`
+  - Allow only safe product announcement analytics fields.
+- Add locale namespace files:
+  - `src/locales/zh-CN/productAnnouncements.json`
+  - `src/locales/en/productAnnouncements.json`
+  - `src/locales/ja/productAnnouncements.json`
+  - `src/locales/zh-TW/productAnnouncements.json`
+  - `src/locales/vi/productAnnouncements.json`
+- Create or modify tests:
+  - `tests/services/productAnnouncements/versionRange.test.ts`
+  - `tests/services/productAnnouncements/urlPolicy.test.ts`
+  - `tests/services/productAnnouncements/catalog.test.ts`
+  - `tests/services/productAnnouncements/storage.test.ts`
+  - `tests/services/productAnnouncements/service.test.ts`
+  - `tests/services/productAnnouncements/messaging.test.ts`
+  - `tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx`
+  - `tests/features/ProductAnnouncements/ProductAnnouncementBanner.test.tsx`
+  - `tests/entrypoints/options/Header.productAnnouncements.test.tsx`
+  - `tests/entrypoints/popup/HeaderSection.productAnnouncements.test.tsx`
+  - `tests/services/productAnalytics/privacy.test.ts`
+
+## Task 1: Feed Contracts, Version Ranges, And URL Policy
+
+**Files:**
+- Create: `public/product-announcements.json`
+- Create: `src/services/productAnnouncements/types.ts`
+- Create: `src/services/productAnnouncements/constants.ts`
+- Create: `src/services/productAnnouncements/versionRange.ts`
+- Create: `src/services/productAnnouncements/urlPolicy.ts`
+- Test: `tests/services/productAnnouncements/versionRange.test.ts`
+- Test: `tests/services/productAnnouncements/urlPolicy.test.ts`
+
+- [ ] **Step 1: Add the bundled empty feed**
+
+Create `public/product-announcements.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "defaultLocale": "zh-CN",
+  "announcements": []
+}
+```
+
+- [ ] **Step 2: Write failing version range tests**
+
+Create `tests/services/productAnnouncements/versionRange.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { isVersionInRange } from "~/services/productAnnouncements/versionRange"
+
+describe("product announcement version ranges", () => {
+  it("matches bounded semver-like ranges", () => {
+    expect(isVersionInRange("3.44.0", ">=3.44.0 <3.44.1")).toBe(true)
+    expect(isVersionInRange("3.44.0.1", ">=3.44.0 <3.44.1")).toBe(true)
+    expect(isVersionInRange("3.44.1", ">=3.44.0 <3.44.1")).toBe(false)
+    expect(isVersionInRange("3.43.9", ">=3.44.0 <3.44.1")).toBe(false)
+  })
+
+  it("supports exact and wildcard ranges", () => {
+    expect(isVersionInRange("3.44.0", "3.44.0")).toBe(true)
+    expect(isVersionInRange("3.44.1", "3.44.0")).toBe(false)
+    expect(isVersionInRange("3.44.1", "*")).toBe(true)
+  })
+
+  it("fails closed for invalid ranges or versions", () => {
+    expect(isVersionInRange("dev", ">=3.44.0")).toBe(false)
+    expect(isVersionInRange("3.44.0", "=>3.44.0")).toBe(false)
+    expect(isVersionInRange("3.44.0", "")).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 3: Write failing URL policy tests**
+
+Create `tests/services/productAnnouncements/urlPolicy.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { sanitizeProductAnnouncementCta } from "~/services/productAnnouncements/urlPolicy"
+
+describe("product announcement CTA URL policy", () => {
+  it("keeps project-owned and GitHub release links", () => {
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "View release",
+        url: "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+      }),
+    ).toEqual({
+      label: "View release",
+      url: "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+    })
+
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "Read docs",
+        url: "https://all-api-hub.qixing1217.top/changelog.html",
+      }),
+    ).toEqual({
+      label: "Read docs",
+      url: "https://all-api-hub.qixing1217.top/changelog.html",
+    })
+  })
+
+  it("drops unsafe or incomplete links", () => {
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "Run",
+        url: "javascript:alert(1)",
+      }),
+    ).toBeNull()
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "External",
+        url: "https://evil.example.test/path",
+      }),
+    ).toBeNull()
+    expect(sanitizeProductAnnouncementCta({ label: "", url: "https://github.com/qixing-jk/all-api-hub" })).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 4: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnnouncements/versionRange.test.ts tests/services/productAnnouncements/urlPolicy.test.ts
+```
+
+Expected: FAIL because the modules do not exist yet.
+
+- [ ] **Step 5: Add constants and types**
+
+Create `src/services/productAnnouncements/constants.ts`:
+
+```ts
+import bundledProductAnnouncementFeed from "~~/public/product-announcements.json"
+
+export const PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION =
+  bundledProductAnnouncementFeed.schemaVersion
+
+export const PRODUCT_ANNOUNCEMENT_REMOTE_URL =
+  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/product-announcements.json"
+
+export const PRODUCT_ANNOUNCEMENT_REFRESH_ALARM =
+  "productAnnouncementsRefresh"
+
+export const PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES = 12 * 60
+
+export const PRODUCT_ANNOUNCEMENT_LOCALE_FALLBACKS = [
+  "zh-CN",
+  "en",
+] as const
+
+export const PRODUCT_ANNOUNCEMENT_SEVERITIES = {
+  Critical: "critical",
+  Warning: "warning",
+  Info: "info",
+} as const
+```
+
+Create `src/services/productAnnouncements/types.ts`:
+
+```ts
+import type { ValueOf } from "~/types"
+
+import { PRODUCT_ANNOUNCEMENT_SEVERITIES } from "./constants"
+
+export type ProductAnnouncementSeverity = ValueOf<
+  typeof PRODUCT_ANNOUNCEMENT_SEVERITIES
+>
+
+export interface RawProductAnnouncementCta {
+  label?: unknown
+  url?: unknown
+}
+
+export interface RawProductAnnouncementContent {
+  title?: unknown
+  message?: unknown
+  cta?: RawProductAnnouncementCta
+}
+
+export interface RawProductAnnouncement {
+  id?: unknown
+  revision?: unknown
+  severity?: unknown
+  priority?: unknown
+  affectedVersions?: unknown
+  startsAt?: unknown
+  expiresAt?: unknown
+  content?: unknown
+}
+
+export interface RawProductAnnouncementFeed {
+  schemaVersion?: unknown
+  defaultLocale?: unknown
+  announcements?: unknown
+}
+
+export interface ProductAnnouncementCta {
+  label: string
+  url: string
+}
+
+export interface ProductAnnouncement {
+  id: string
+  revision: number
+  severity: ProductAnnouncementSeverity
+  priority: number
+  startsAt: number
+  expiresAt: number
+  title: string
+  message: string
+  cta?: ProductAnnouncementCta
+  dismissed: boolean
+  seen: boolean
+}
+
+export interface ProductAnnouncementState {
+  schemaVersion: 1
+  lastFetchedAt?: number
+  cachedFeed?: RawProductAnnouncementFeed
+  dismissed: Record<string, number>
+  seenAt: Record<string, number>
+  lastShownAt: Record<string, number>
+}
+```
+
+- [ ] **Step 6: Implement version matching**
+
+Create `src/services/productAnnouncements/versionRange.ts`:
+
+```ts
+function normalizeVersion(value: string): number[] | null {
+  const normalized = value.trim().replace(/^v/i, "")
+  if (!/^\d+(?:\.\d+)*$/.test(normalized)) return null
+  return normalized.split(".").map((part) => Number.parseInt(part, 10))
+}
+
+function compareVersions(left: number[], right: number[]): number {
+  const length = Math.max(left.length, right.length)
+  for (let index = 0; index < length; index++) {
+    const leftPart = left[index] ?? 0
+    const rightPart = right[index] ?? 0
+    if (leftPart !== rightPart) return leftPart - rightPart
+  }
+  return 0
+}
+
+function evaluateComparator(current: number[], token: string): boolean {
+  const match = /^(>=|<=|>|<|=)?(.+)$/.exec(token.trim())
+  if (!match) return false
+
+  const operator = match[1] ?? "="
+  const target = normalizeVersion(match[2])
+  if (!target) return false
+
+  const comparison = compareVersions(current, target)
+  switch (operator) {
+    case ">=":
+      return comparison >= 0
+    case "<=":
+      return comparison <= 0
+    case ">":
+      return comparison > 0
+    case "<":
+      return comparison < 0
+    case "=":
+      return comparison === 0
+    default:
+      return false
+  }
+}
+
+export function isVersionInRange(
+  currentVersion: string,
+  range: string,
+): boolean {
+  const trimmedRange = range.trim()
+  if (!trimmedRange) return false
+  if (trimmedRange === "*") return normalizeVersion(currentVersion) !== null
+
+  const current = normalizeVersion(currentVersion)
+  if (!current) return false
+
+  return trimmedRange
+    .split(/\s+/)
+    .every((token) => evaluateComparator(current, token))
+}
+```
+
+- [ ] **Step 7: Implement CTA policy**
+
+Create `src/services/productAnnouncements/urlPolicy.ts`:
+
+```ts
+import type {
+  ProductAnnouncementCta,
+  RawProductAnnouncementCta,
+} from "./types"
+
+const ALLOWED_CTA_HOSTS = new Set([
+  "github.com",
+  "all-api-hub.qixing1217.top",
+])
+
+function isAllowedGithubPath(url: URL): boolean {
+  return (
+    url.hostname === "github.com" &&
+    url.pathname.startsWith("/qixing-jk/all-api-hub/")
+  )
+}
+
+function isAllowedDocsPath(url: URL): boolean {
+  return url.hostname === "all-api-hub.qixing1217.top"
+}
+
+export function sanitizeProductAnnouncementCta(
+  value: RawProductAnnouncementCta | undefined,
+): ProductAnnouncementCta | null {
+  const label = typeof value?.label === "string" ? value.label.trim() : ""
+  const urlValue = typeof value?.url === "string" ? value.url.trim() : ""
+  if (!label || !urlValue) return null
+
+  let url: URL
+  try {
+    url = new URL(urlValue)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== "https:" || !ALLOWED_CTA_HOSTS.has(url.hostname)) {
+    return null
+  }
+
+  if (!isAllowedGithubPath(url) && !isAllowedDocsPath(url)) {
+    return null
+  }
+
+  return { label, url: url.toString() }
+}
+```
+
+- [ ] **Step 8: Run the focused tests and commit**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnnouncements/versionRange.test.ts tests/services/productAnnouncements/urlPolicy.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add public/product-announcements.json src/services/productAnnouncements/types.ts src/services/productAnnouncements/constants.ts src/services/productAnnouncements/versionRange.ts src/services/productAnnouncements/urlPolicy.ts tests/services/productAnnouncements/versionRange.test.ts tests/services/productAnnouncements/urlPolicy.test.ts
+git commit -m "feat(product-announcements): add feed contracts"
+```
+
+## Task 2: Feed Normalization And Presentation Selectors
+
+**Files:**
+- Create: `src/services/productAnnouncements/catalog.ts`
+- Test: `tests/services/productAnnouncements/catalog.test.ts`
+
+- [ ] **Step 1: Write failing catalog tests**
+
+Create `tests/services/productAnnouncements/catalog.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import {
+  PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+  PRODUCT_ANNOUNCEMENT_SEVERITIES,
+} from "~/services/productAnnouncements/constants"
+import {
+  normalizeProductAnnouncementFeed,
+  selectProductAnnouncementView,
+} from "~/services/productAnnouncements/catalog"
+
+const now = Date.parse("2026-06-06T12:00:00.000Z")
+const baseFeed = {
+  schemaVersion: PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+  defaultLocale: "zh-CN",
+  announcements: [
+    {
+      id: "critical-risk",
+      revision: 1,
+      severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical,
+      priority: 100,
+      affectedVersions: ">=3.44.0 <3.44.1",
+      startsAt: "2026-06-06T00:00:00.000Z",
+      expiresAt: "2026-06-20T00:00:00.000Z",
+      content: {
+        "zh-CN": {
+          title: "关键风险",
+          message: "请升级到 3.44.1。",
+          cta: {
+            label: "查看修复说明",
+            url: "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+          },
+        },
+        en: {
+          title: "Critical risk",
+          message: "Update to 3.44.1.",
+        },
+      },
+    },
+    {
+      id: "info-note",
+      revision: 1,
+      severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Info,
+      priority: 1,
+      affectedVersions: "*",
+      startsAt: "2026-06-01T00:00:00.000Z",
+      expiresAt: "2026-07-01T00:00:00.000Z",
+      content: {
+        en: {
+          title: "FYI",
+          message: "Informational note.",
+        },
+      },
+    },
+  ],
+}
+
+describe("product announcement feed normalization", () => {
+  it("filters by version and resolves localized content with fallback", () => {
+    const normalized = normalizeProductAnnouncementFeed(baseFeed, {
+      currentVersion: "3.44.0",
+      locale: "zh-TW",
+      now,
+      dismissed: {},
+      seenAt: {},
+    })
+
+    expect(normalized.errors).toEqual([])
+    expect(normalized.notices.map((notice) => notice.id)).toEqual([
+      "critical-risk",
+      "info-note",
+    ])
+    expect(normalized.notices[0]).toMatchObject({
+      title: "关键风险",
+      message: "请升级到 3.44.1。",
+      cta: {
+        label: "查看修复说明",
+        url: "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+      },
+      seen: false,
+      dismissed: false,
+    })
+    expect(normalized.notices[1]).toMatchObject({
+      title: "FYI",
+      message: "Informational note.",
+    })
+  })
+
+  it("keeps dismissed notices in the list while excluding them from active selectors", () => {
+    const normalized = normalizeProductAnnouncementFeed(baseFeed, {
+      currentVersion: "3.44.0",
+      locale: "zh-CN",
+      now,
+      dismissed: { "critical-risk": 1 },
+      seenAt: { "critical-risk": now - 1000 },
+    })
+    const view = selectProductAnnouncementView(normalized.notices)
+
+    expect(normalized.notices.find((item) => item.id === "critical-risk")).toMatchObject({
+      dismissed: true,
+      seen: true,
+    })
+    expect(view.activeNotices.map((notice) => notice.id)).toEqual(["info-note"])
+    expect(view.dismissedNotices.map((notice) => notice.id)).toEqual([
+      "critical-risk",
+    ])
+    expect(view.unseenActiveCount).toBe(1)
+    expect(view.primaryRiskNotice).toBeNull()
+  })
+
+  it("resurfaces higher revisions and sorts active notices by severity and priority", () => {
+    const feed = {
+      ...baseFeed,
+      announcements: [
+        ...(baseFeed.announcements as any[]),
+        {
+          id: "warning",
+          revision: 2,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning,
+          priority: 200,
+          affectedVersions: "*",
+          startsAt: "2026-06-05T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": { title: "警告", message: "请注意。" },
+          },
+        },
+      ],
+    }
+
+    const normalized = normalizeProductAnnouncementFeed(feed, {
+      currentVersion: "3.44.0",
+      locale: "zh-CN",
+      now,
+      dismissed: { warning: 1 },
+      seenAt: {},
+    })
+    const view = selectProductAnnouncementView(normalized.notices)
+
+    expect(view.activeNotices.map((notice) => notice.id)).toEqual([
+      "critical-risk",
+      "warning",
+      "info-note",
+    ])
+    expect(view.primaryRiskNotice?.id).toBe("critical-risk")
+  })
+})
+```
+
+- [ ] **Step 2: Run the catalog test and verify it fails**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnnouncements/catalog.test.ts
+```
+
+Expected: FAIL because `catalog.ts` does not exist.
+
+- [ ] **Step 3: Implement feed normalization**
+
+Create `src/services/productAnnouncements/catalog.ts` with these exported functions:
+
+```ts
+import {
+  PRODUCT_ANNOUNCEMENT_LOCALE_FALLBACKS,
+  PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+  PRODUCT_ANNOUNCEMENT_SEVERITIES,
+} from "./constants"
+import { isVersionInRange } from "./versionRange"
+import { sanitizeProductAnnouncementCta } from "./urlPolicy"
+import type {
+  ProductAnnouncement,
+  ProductAnnouncementSeverity,
+  RawProductAnnouncement,
+  RawProductAnnouncementContent,
+  RawProductAnnouncementFeed,
+} from "./types"
+
+interface NormalizeOptions {
+  currentVersion: string
+  locale: string
+  now: number
+  dismissed: Record<string, number>
+  seenAt: Record<string, number>
+}
+
+export interface NormalizeProductAnnouncementResult {
+  notices: ProductAnnouncement[]
+  errors: string[]
+}
+
+export interface ProductAnnouncementView {
+  notices: ProductAnnouncement[]
+  activeNotices: ProductAnnouncement[]
+  dismissedNotices: ProductAnnouncement[]
+  primaryRiskNotice: ProductAnnouncement | null
+  unseenActiveCount: number
+}
+
+const SEVERITY_RANK: Record<ProductAnnouncementSeverity, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+}
+
+function isSeverity(value: unknown): value is ProductAnnouncementSeverity {
+  return Object.values(PRODUCT_ANNOUNCEMENT_SEVERITIES).includes(
+    value as ProductAnnouncementSeverity,
+  )
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function resolveLocaleKeys(locale: string, defaultLocale: string): string[] {
+  const language = locale.split("-")[0]
+  return [
+    locale,
+    language,
+    ...PRODUCT_ANNOUNCEMENT_LOCALE_FALLBACKS,
+    defaultLocale,
+  ].filter((value, index, array) => value && array.indexOf(value) === index)
+}
+
+function parseTimestamp(value: unknown): number | null {
+  if (typeof value !== "string") return null
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+function normalizeAnnouncement(
+  value: RawProductAnnouncement,
+  defaultLocale: string,
+  options: NormalizeOptions,
+): ProductAnnouncement | null {
+  const id = typeof value.id === "string" ? value.id.trim() : ""
+  const revision = typeof value.revision === "number" ? value.revision : NaN
+  const severity = isSeverity(value.severity) ? value.severity : null
+  const priority = typeof value.priority === "number" ? value.priority : 0
+  const affectedVersions =
+    typeof value.affectedVersions === "string" ? value.affectedVersions : ""
+  const startsAt = parseTimestamp(value.startsAt)
+  const expiresAt = parseTimestamp(value.expiresAt)
+  const content = asRecord(value.content)
+
+  if (
+    !id ||
+    !Number.isInteger(revision) ||
+    revision < 1 ||
+    !severity ||
+    !startsAt ||
+    !expiresAt ||
+    startsAt > options.now ||
+    expiresAt <= options.now ||
+    !isVersionInRange(options.currentVersion, affectedVersions) ||
+    !content
+  ) {
+    return null
+  }
+
+  const localized = resolveLocaleKeys(options.locale, defaultLocale)
+    .map((key) => asRecord(content[key]) as RawProductAnnouncementContent | null)
+    .find(Boolean)
+  const title = typeof localized?.title === "string" ? localized.title.trim() : ""
+  const message =
+    typeof localized?.message === "string" ? localized.message.trim() : ""
+  if (!title || !message) return null
+
+  const dismissedRevision = options.dismissed[id]
+  const dismissed =
+    typeof dismissedRevision === "number" && dismissedRevision >= revision
+
+  return {
+    id,
+    revision,
+    severity,
+    priority,
+    startsAt,
+    expiresAt,
+    title,
+    message,
+    cta: sanitizeProductAnnouncementCta(localized?.cta),
+    dismissed,
+    seen: typeof options.seenAt[id] === "number",
+  }
+}
+
+export function normalizeProductAnnouncementFeed(
+  feed: RawProductAnnouncementFeed,
+  options: NormalizeOptions,
+): NormalizeProductAnnouncementResult {
+  if (feed.schemaVersion !== PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION) {
+    return { notices: [], errors: ["unsupported_schema"] }
+  }
+
+  const defaultLocale =
+    typeof feed.defaultLocale === "string" && feed.defaultLocale.trim()
+      ? feed.defaultLocale.trim()
+      : "zh-CN"
+  const announcements = Array.isArray(feed.announcements)
+    ? feed.announcements
+    : []
+
+  const notices = announcements
+    .map((announcement) =>
+      normalizeAnnouncement(
+        announcement as RawProductAnnouncement,
+        defaultLocale,
+        options,
+      ),
+    )
+    .filter((notice): notice is ProductAnnouncement => Boolean(notice))
+    .sort(compareProductAnnouncements)
+
+  return { notices, errors: [] }
+}
+
+export function compareProductAnnouncements(
+  left: ProductAnnouncement,
+  right: ProductAnnouncement,
+): number {
+  return (
+    SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity] ||
+    right.priority - left.priority ||
+    right.startsAt - left.startsAt ||
+    left.id.localeCompare(right.id)
+  )
+}
+
+export function selectProductAnnouncementView(
+  notices: ProductAnnouncement[],
+): ProductAnnouncementView {
+  const activeNotices = notices.filter((notice) => !notice.dismissed)
+  const dismissedNotices = notices.filter((notice) => notice.dismissed)
+  const primaryRiskNotice =
+    activeNotices.find(
+      (notice) =>
+        notice.severity === PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical ||
+        notice.severity === PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning,
+    ) ?? null
+
+  return {
+    notices,
+    activeNotices,
+    dismissedNotices,
+    primaryRiskNotice,
+    unseenActiveCount: activeNotices.filter((notice) => !notice.seen).length,
+  }
+}
+```
+
+- [ ] **Step 4: Run focused tests and commit**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnnouncements/catalog.test.ts tests/services/productAnnouncements/versionRange.test.ts tests/services/productAnnouncements/urlPolicy.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/services/productAnnouncements/catalog.ts tests/services/productAnnouncements/catalog.test.ts
+git commit -m "feat(product-announcements): normalize feed notices"
+```
+
+## Task 3: Storage And Best-Effort Refresh Service
+
+**Files:**
+- Modify: `src/services/core/storageKeys.ts`
+- Create: `src/services/productAnnouncements/storage.ts`
+- Create: `src/services/productAnnouncements/service.ts`
+- Test: `tests/services/productAnnouncements/storage.test.ts`
+- Test: `tests/services/productAnnouncements/service.test.ts`
+
+- [ ] **Step 1: Write failing storage tests**
+
+Create `tests/services/productAnnouncements/storage.test.ts`:
+
+```ts
+import { Storage } from "@plasmohq/storage"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION } from "~/services/productAnnouncements/constants"
+import { productAnnouncementStorage } from "~/services/productAnnouncements/storage"
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+
+const storage = new Storage({ area: "local" })
+
+describe("product announcement storage", () => {
+  beforeEach(async () => {
+    await storage.remove(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE)
+  })
+
+  it("returns an empty sanitized state by default", async () => {
+    await expect(productAnnouncementStorage.getState()).resolves.toEqual({
+      schemaVersion: 1,
+      dismissed: {},
+      seenAt: {},
+      lastShownAt: {},
+    })
+  })
+
+  it("persists cached feed, seen state, and dismissed revisions", async () => {
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = 100
+      state.cachedFeed = {
+        schemaVersion: PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }
+      state.seenAt.notice = 200
+      state.dismissed.notice = 1
+    })
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      lastFetchedAt: 100,
+      seenAt: { notice: 200 },
+      dismissed: { notice: 1 },
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Write failing service tests**
+
+Create `tests/services/productAnnouncements/service.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { productAnnouncementService } from "~/services/productAnnouncements/service"
+import { productAnnouncementStorage } from "~/services/productAnnouncements/storage"
+
+const fetchMock = vi.fn()
+
+describe("product announcement service", () => {
+  beforeEach(async () => {
+    vi.stubGlobal("fetch", fetchMock)
+    fetchMock.mockReset()
+    await productAnnouncementStorage.setState({
+      schemaVersion: 1,
+      dismissed: {},
+      seenAt: {},
+      lastShownAt: {},
+    })
+  })
+
+  it("returns cached state immediately when refresh fails", async () => {
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = Date.now() - 1000
+      state.cachedFeed = {
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }
+    })
+    fetchMock.mockRejectedValue(new Error("network failed"))
+
+    const state = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(state.view.notices).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("marks visible notice ids as seen without dismissing them", async () => {
+    await productAnnouncementService.markSeen(["notice-a"], 123)
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      seenAt: { "notice-a": 123 },
+      dismissed: {},
+    })
+  })
+
+  it("dismisses a notice revision", async () => {
+    await productAnnouncementService.dismiss("notice-a", 2)
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      dismissed: { "notice-a": 2 },
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Run tests and verify they fail**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnnouncements/storage.test.ts tests/services/productAnnouncements/service.test.ts
+```
+
+Expected: FAIL because storage/service do not exist.
+
+- [ ] **Step 4: Add storage key and lock**
+
+Modify `src/services/core/storageKeys.ts`:
+
+```ts
+// In STORAGE_LOCKS:
+PRODUCT_ANNOUNCEMENTS: "all-api-hub:product-announcements",
+
+// Near other private key groups:
+const PRODUCT_ANNOUNCEMENTS_STORAGE_KEYS = {
+  STATE: "productAnnouncements_state_v1",
+} as const
+
+// In STORAGE_KEYS:
+PRODUCT_ANNOUNCEMENTS_STATE: PRODUCT_ANNOUNCEMENTS_STORAGE_KEYS.STATE,
+```
+
+- [ ] **Step 5: Implement storage**
+
+Create `src/services/productAnnouncements/storage.ts`:
+
+```ts
+import { Storage } from "@plasmohq/storage"
+
+import {
+  STORAGE_KEYS,
+  STORAGE_LOCKS,
+} from "~/services/core/storageKeys"
+import { withExtensionStorageWriteLock } from "~/services/core/storageLock"
+import { createLogger } from "~/utils/core/logger"
+
+import type { ProductAnnouncementState } from "./types"
+
+const logger = createLogger("ProductAnnouncementStorage")
+
+function createEmptyState(): ProductAnnouncementState {
+  return {
+    schemaVersion: 1,
+    dismissed: {},
+    seenAt: {},
+    lastShownAt: {},
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function sanitizeNumberRecord(value: unknown): Record<string, number> {
+  const record = asRecord(value)
+  if (!record) return {}
+
+  return Object.fromEntries(
+    Object.entries(record).filter(
+      ([key, entry]) => key && typeof entry === "number",
+    ),
+  ) as Record<string, number>
+}
+
+function sanitizeState(value: unknown): ProductAnnouncementState {
+  const record = asRecord(value)
+  if (!record || record.schemaVersion !== 1) return createEmptyState()
+
+  return {
+    schemaVersion: 1,
+    lastFetchedAt:
+      typeof record.lastFetchedAt === "number"
+        ? record.lastFetchedAt
+        : undefined,
+    cachedFeed: asRecord(record.cachedFeed) ?? undefined,
+    dismissed: sanitizeNumberRecord(record.dismissed),
+    seenAt: sanitizeNumberRecord(record.seenAt),
+    lastShownAt: sanitizeNumberRecord(record.lastShownAt),
+  }
+}
+
+class ProductAnnouncementStorage {
+  private storage = new Storage({ area: "local" })
+
+  async getState(): Promise<ProductAnnouncementState> {
+    try {
+      return sanitizeState(
+        await this.storage.get(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE),
+      )
+    } catch (error) {
+      logger.warn("Failed to read product announcement state", error)
+      return createEmptyState()
+    }
+  }
+
+  async setState(state: ProductAnnouncementState): Promise<void> {
+    await this.storage.set(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE, state)
+  }
+
+  async updateState(
+    updater: (state: ProductAnnouncementState) => void,
+  ): Promise<ProductAnnouncementState> {
+    return withExtensionStorageWriteLock(
+      STORAGE_LOCKS.PRODUCT_ANNOUNCEMENTS,
+      async () => {
+        const state = await this.getState()
+        updater(state)
+        await this.setState(state)
+        return state
+      },
+    )
+  }
+}
+
+export const productAnnouncementStorage = new ProductAnnouncementStorage()
+```
+
+- [ ] **Step 6: Implement best-effort service**
+
+Create `src/services/productAnnouncements/service.ts`:
+
+```ts
+import bundledFeed from "~~/public/product-announcements.json"
+
+import {
+  createAlarm,
+  getAlarm,
+  getManifest,
+  onAlarm,
+} from "~/utils/browser/browserApi"
+import { createLogger } from "~/utils/core/logger"
+
+import {
+  normalizeProductAnnouncementFeed,
+  selectProductAnnouncementView,
+  type ProductAnnouncementView,
+} from "./catalog"
+import {
+  PRODUCT_ANNOUNCEMENT_REFRESH_ALARM,
+  PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES,
+  PRODUCT_ANNOUNCEMENT_REMOTE_URL,
+} from "./constants"
+import { productAnnouncementStorage } from "./storage"
+import type { RawProductAnnouncementFeed } from "./types"
+
+const logger = createLogger("ProductAnnouncementService")
+
+interface GetCurrentStateOptions {
+  locale: string
+  currentVersion?: string
+  now?: number
+}
+
+export interface ProductAnnouncementRuntimeState {
+  view: ProductAnnouncementView
+  lastFetchedAt?: number
+}
+
+function getCurrentVersion() {
+  return getManifest().version?.trim() || "0.0.0"
+}
+
+class ProductAnnouncementService {
+  private initialized = false
+
+  initialize() {
+    if (this.initialized) return
+    this.initialized = true
+
+    onAlarm((alarm) => {
+      if (alarm.name === PRODUCT_ANNOUNCEMENT_REFRESH_ALARM) {
+        void this.refreshRemoteFeed()
+      }
+    })
+
+    void this.reconcileRefreshAlarm()
+  }
+
+  async reconcileRefreshAlarm(): Promise<void> {
+    const existing = await getAlarm(PRODUCT_ANNOUNCEMENT_REFRESH_ALARM)
+    if (existing) return
+
+    await createAlarm(PRODUCT_ANNOUNCEMENT_REFRESH_ALARM, {
+      delayInMinutes: PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES,
+      periodInMinutes: PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES,
+    })
+  }
+
+  async getCurrentState(
+    options: GetCurrentStateOptions,
+  ): Promise<ProductAnnouncementRuntimeState> {
+    const state = await productAnnouncementStorage.getState()
+    const feed = state.cachedFeed ?? bundledFeed
+    const normalized = normalizeProductAnnouncementFeed(
+      feed as RawProductAnnouncementFeed,
+      {
+        currentVersion: options.currentVersion ?? getCurrentVersion(),
+        locale: options.locale,
+        now: options.now ?? Date.now(),
+        dismissed: state.dismissed,
+        seenAt: state.seenAt,
+      },
+    )
+
+    return {
+      view: selectProductAnnouncementView(normalized.notices),
+      lastFetchedAt: state.lastFetchedAt,
+    }
+  }
+
+  async refreshRemoteFeed(now = Date.now()): Promise<boolean> {
+    try {
+      const response = await fetch(PRODUCT_ANNOUNCEMENT_REMOTE_URL, {
+        cache: "no-store",
+      })
+      if (!response.ok) return false
+
+      const feed = (await response.json()) as RawProductAnnouncementFeed
+      await productAnnouncementStorage.updateState((state) => {
+        state.cachedFeed = feed
+        state.lastFetchedAt = now
+      })
+      return true
+    } catch (error) {
+      logger.warn("Product announcement refresh failed", error)
+      return false
+    }
+  }
+
+  async markSeen(ids: string[], now = Date.now()): Promise<void> {
+    await productAnnouncementStorage.updateState((state) => {
+      ids.forEach((id) => {
+        if (id) state.seenAt[id] = now
+      })
+    })
+  }
+
+  async dismiss(id: string, revision: number): Promise<void> {
+    await productAnnouncementStorage.updateState((state) => {
+      if (id && Number.isInteger(revision)) {
+        state.dismissed[id] = revision
+      }
+    })
+  }
+}
+
+export const productAnnouncementService = new ProductAnnouncementService()
+```
+
+- [ ] **Step 7: Run focused tests and commit**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnnouncements/storage.test.ts tests/services/productAnnouncements/service.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/services/core/storageKeys.ts src/services/productAnnouncements/storage.ts src/services/productAnnouncements/service.ts tests/services/productAnnouncements/storage.test.ts tests/services/productAnnouncements/service.test.ts
+git commit -m "feat(product-announcements): persist notice state"
+```
+
+## Task 4: Typed Runtime Messaging And Background Initialization
+
+**Files:**
+- Modify: `src/services/runtimeMessaging/messageTypes.ts`
+- Create: `src/services/productAnnouncements/messaging.ts`
+- Modify: `src/services/productAnnouncements/service.ts`
+- Modify: `src/entrypoints/background/runtimeMessages.ts`
+- Modify: `src/entrypoints/background/servicesInit.ts`
+- Test: `tests/services/productAnnouncements/messaging.test.ts`
+
+- [ ] **Step 1: Write failing messaging tests**
+
+Create `tests/services/productAnnouncements/messaging.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  resolveProductAnnouncementDismissMessage,
+  resolveProductAnnouncementGetStateMessage,
+  resolveProductAnnouncementMarkSeenMessage,
+  resolveProductAnnouncementRefreshMessage,
+} from "~/services/productAnnouncements/service"
+
+describe("product announcement runtime message resolvers", () => {
+  it("returns current state response", async () => {
+    const response = await resolveProductAnnouncementGetStateMessage({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(response.success).toBe(true)
+    expect(response.success ? response.data.view.notices : []).toEqual([])
+  })
+
+  it("handles refresh, seen, and dismiss messages", async () => {
+    await expect(resolveProductAnnouncementRefreshMessage()).resolves.toMatchObject({
+      success: true,
+    })
+    await expect(
+      resolveProductAnnouncementMarkSeenMessage({ ids: ["notice-a"], now: 1 }),
+    ).resolves.toEqual({ success: true, data: undefined })
+    await expect(
+      resolveProductAnnouncementDismissMessage({
+        id: "notice-a",
+        revision: 1,
+      }),
+    ).resolves.toEqual({ success: true, data: undefined })
+  })
+})
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnnouncements/messaging.test.ts
+```
+
+Expected: FAIL because resolver functions do not exist.
+
+- [ ] **Step 3: Add message types and messaging module**
+
+Modify `src/services/runtimeMessaging/messageTypes.ts`:
+
+```ts
+export const ProductAnnouncementsMessageTypes = {
+  GetState: "productAnnouncements:getState",
+  Refresh: "productAnnouncements:refresh",
+  MarkSeen: "productAnnouncements:markSeen",
+  Dismiss: "productAnnouncements:dismiss",
+} as const
+```
+
+Create `src/services/productAnnouncements/messaging.ts`:
+
+```ts
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
+import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
+import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
+
+import type { ProductAnnouncementRuntimeState } from "./service"
+
+export interface ProductAnnouncementsGetStateRequest {
+  locale: string
+  currentVersion?: string
+  now?: number
+}
+
+export interface ProductAnnouncementsMarkSeenRequest {
+  ids: string[]
+  now?: number
+}
+
+export interface ProductAnnouncementsDismissRequest {
+  id: string
+  revision: number
+}
+
+interface ProductAnnouncementsProtocolMap {
+  [ProductAnnouncementsMessageTypes.GetState](
+    data: ProductAnnouncementsGetStateRequest,
+  ): RuntimeMessageResponse<ProductAnnouncementRuntimeState>
+  [ProductAnnouncementsMessageTypes.Refresh](): RuntimeMessageResponse<boolean>
+  [ProductAnnouncementsMessageTypes.MarkSeen](
+    data: ProductAnnouncementsMarkSeenRequest,
+  ): RuntimeMessageResponse<undefined>
+  [ProductAnnouncementsMessageTypes.Dismiss](
+    data: ProductAnnouncementsDismissRequest,
+  ): RuntimeMessageResponse<undefined>
+}
+
+export const {
+  sendMessage: sendProductAnnouncementsMessage,
+  onMessage: onProductAnnouncementsMessage,
+} = defineExtensionMessaging<ProductAnnouncementsProtocolMap>({
+  logger: createRuntimeMessagingLogger("ProductAnnouncementsMessaging"),
+})
+```
+
+- [ ] **Step 4: Add resolver functions and listener setup**
+
+Append to `src/services/productAnnouncements/service.ts`:
+
+```ts
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
+import {
+  createRuntimeMessageFailure,
+  type RuntimeMessageResponse,
+} from "~/services/runtimeMessaging/result"
+import { getErrorMessage } from "~/utils/core/errorUtils"
+
+import {
+  onProductAnnouncementsMessage,
+  type ProductAnnouncementsDismissRequest,
+  type ProductAnnouncementsGetStateRequest,
+  type ProductAnnouncementsMarkSeenRequest,
+} from "./messaging"
+
+export async function resolveProductAnnouncementGetStateMessage(
+  request: ProductAnnouncementsGetStateRequest,
+): Promise<RuntimeMessageResponse<ProductAnnouncementRuntimeState>> {
+  try {
+    return {
+      success: true,
+      data: await productAnnouncementService.getCurrentState(request),
+    }
+  } catch (error) {
+    return createRuntimeMessageFailure(getErrorMessage(error))
+  }
+}
+
+export async function resolveProductAnnouncementRefreshMessage(): Promise<
+  RuntimeMessageResponse<boolean>
+> {
+  try {
+    return {
+      success: true,
+      data: await productAnnouncementService.refreshRemoteFeed(),
+    }
+  } catch (error) {
+    return createRuntimeMessageFailure(getErrorMessage(error))
+  }
+}
+
+export async function resolveProductAnnouncementMarkSeenMessage(
+  request: ProductAnnouncementsMarkSeenRequest,
+): Promise<RuntimeMessageResponse<undefined>> {
+  try {
+    await productAnnouncementService.markSeen(request.ids, request.now)
+    return { success: true, data: undefined }
+  } catch (error) {
+    return createRuntimeMessageFailure(getErrorMessage(error))
+  }
+}
+
+export async function resolveProductAnnouncementDismissMessage(
+  request: ProductAnnouncementsDismissRequest,
+): Promise<RuntimeMessageResponse<undefined>> {
+  try {
+    await productAnnouncementService.dismiss(request.id, request.revision)
+    return { success: true, data: undefined }
+  } catch (error) {
+    return createRuntimeMessageFailure(getErrorMessage(error))
+  }
+}
+
+export function setupProductAnnouncementMessagingListeners() {
+  return [
+    onProductAnnouncementsMessage(
+      ProductAnnouncementsMessageTypes.GetState,
+      ({ data }) => resolveProductAnnouncementGetStateMessage(data),
+    ),
+    onProductAnnouncementsMessage(
+      ProductAnnouncementsMessageTypes.Refresh,
+      () => resolveProductAnnouncementRefreshMessage(),
+    ),
+    onProductAnnouncementsMessage(
+      ProductAnnouncementsMessageTypes.MarkSeen,
+      ({ data }) => resolveProductAnnouncementMarkSeenMessage(data),
+    ),
+    onProductAnnouncementsMessage(
+      ProductAnnouncementsMessageTypes.Dismiss,
+      ({ data }) => resolveProductAnnouncementDismissMessage(data),
+    ),
+  ]
+}
+```
+
+If adding these imports creates duplicated import blocks in `service.ts`, consolidate them at the top of the file.
+
+- [ ] **Step 5: Wire background runtime and service init**
+
+Modify `src/entrypoints/background/runtimeMessages.ts`:
+
+```ts
+import { setupProductAnnouncementMessagingListeners } from "~/services/productAnnouncements/service"
+
+// inside setupRuntimeMessageListeners()
+setupProductAnnouncementMessagingListeners()
+```
+
+Modify `src/entrypoints/background/servicesInit.ts`:
+
+```ts
+import { productAnnouncementService } from "~/services/productAnnouncements/service"
+
+// in alarmSchedulersInit Promise.allSettled([...])
+productAnnouncementService.initialize(),
+```
+
+- [ ] **Step 6: Run focused tests and commit**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnnouncements/messaging.test.ts tests/entrypoints/background/runtimeMessages.test.ts tests/entrypoints/background/runtimeMessages.more.test.ts
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/services/runtimeMessaging/messageTypes.ts src/services/productAnnouncements/messaging.ts src/services/productAnnouncements/service.ts src/entrypoints/background/runtimeMessages.ts src/entrypoints/background/servicesInit.ts tests/services/productAnnouncements/messaging.test.ts
+git commit -m "feat(product-announcements): add runtime messaging"
+```
+
+## Task 5: Product Announcement Hook And Header Popover
+
+**Files:**
+- Create: `src/features/ProductAnnouncements/testIds.ts`
+- Create: `src/features/ProductAnnouncements/hooks/useProductAnnouncements.ts`
+- Create: `src/features/ProductAnnouncements/ProductAnnouncementList.tsx`
+- Create: `src/features/ProductAnnouncements/ProductAnnouncementPopover.tsx`
+- Create: `src/features/ProductAnnouncements/ProductAnnouncementButton.tsx`
+- Add locales: `src/locales/*/productAnnouncements.json`
+- Test: `tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx`
+
+- [ ] **Step 1: Write failing button/popover tests**
+
+Create `tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx`:
+
+```tsx
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ProductAnnouncementButton } from "~/features/ProductAnnouncements/ProductAnnouncementButton"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
+import { render, screen, waitFor } from "~~/tests/test-utils/render"
+
+const sendMessageMock = vi.fn()
+
+vi.mock("~/services/productAnnouncements/messaging", () => ({
+  sendProductAnnouncementsMessage: (...args: unknown[]) =>
+    sendMessageMock(...args),
+}))
+
+describe("ProductAnnouncementButton", () => {
+  beforeEach(() => {
+    sendMessageMock.mockReset()
+    sendMessageMock.mockResolvedValue({
+      success: true,
+      data: {
+        view: {
+          notices: [
+            {
+              id: "risk",
+              revision: 1,
+              severity: "critical",
+              priority: 100,
+              startsAt: Date.parse("2026-06-06T00:00:00Z"),
+              expiresAt: Date.parse("2026-06-20T00:00:00Z"),
+              title: "Critical risk",
+              message: "Update now.",
+              seen: false,
+              dismissed: false,
+            },
+          ],
+          activeNotices: [],
+          dismissedNotices: [],
+          primaryRiskNotice: null,
+          unseenActiveCount: 1,
+        },
+      },
+    })
+  })
+
+  it("shows an unseen badge and marks notices seen when opened", async () => {
+    const user = userEvent.setup()
+    render(<ProductAnnouncementButton surface="options-header" />, {
+      withReleaseUpdateStatusProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    expect(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByText("1")).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+
+    expect(await screen.findByText("Critical risk")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.MarkSeen,
+        { ids: ["risk"] },
+      )
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+pnpm vitest --run tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx
+```
+
+Expected: FAIL because components do not exist.
+
+- [ ] **Step 3: Add locale namespace files**
+
+Create `src/locales/zh-CN/productAnnouncements.json`:
+
+```json
+{
+  "actions": {
+    "dismiss": "不再显示",
+    "open": "产品公告",
+    "viewAll": "查看全部"
+  },
+  "empty": {
+    "active": "暂无产品公告",
+    "dismissed": "暂无已关闭公告"
+  },
+  "filters": {
+    "active": "当前公告",
+    "dismissed": "已关闭"
+  },
+  "labels": {
+    "critical": "严重",
+    "info": "信息",
+    "warning": "提醒"
+  },
+  "title": "产品公告"
+}
+```
+
+Create equivalent key shapes in `en`, `ja`, `zh-TW`, and `vi`. Use concise direct translations; do not add extra keys.
+
+- [ ] **Step 4: Implement hook and UI components**
+
+Create `src/features/ProductAnnouncements/testIds.ts`:
+
+```ts
+export const PRODUCT_ANNOUNCEMENT_TEST_IDS = {
+  button: "product-announcement-button",
+  badge: "product-announcement-badge",
+  popover: "product-announcement-popover",
+  activeList: "product-announcement-active-list",
+  dismissedList: "product-announcement-dismissed-list",
+} as const
+```
+
+Create `src/features/ProductAnnouncements/hooks/useProductAnnouncements.ts`:
+
+```ts
+import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { sendProductAnnouncementsMessage } from "~/services/productAnnouncements/messaging"
+import type { ProductAnnouncementRuntimeState } from "~/services/productAnnouncements/service"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
+
+const EMPTY_STATE: ProductAnnouncementRuntimeState = {
+  view: {
+    notices: [],
+    activeNotices: [],
+    dismissedNotices: [],
+    primaryRiskNotice: null,
+    unseenActiveCount: 0,
+  },
+}
+
+export function useProductAnnouncements() {
+  const { i18n } = useTranslation()
+  const [state, setState] =
+    useState<ProductAnnouncementRuntimeState>(EMPTY_STATE)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const response = await sendProductAnnouncementsMessage(
+        ProductAnnouncementsMessageTypes.GetState,
+        { locale: i18n.language },
+      )
+      if (response.success) setState(response.data)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [i18n.language])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const markSeen = useCallback(
+    async (ids: string[]) => {
+      if (ids.length === 0) return
+      await sendProductAnnouncementsMessage(
+        ProductAnnouncementsMessageTypes.MarkSeen,
+        { ids },
+      )
+      await load()
+    },
+    [load],
+  )
+
+  const dismiss = useCallback(
+    async (id: string, revision: number) => {
+      await sendProductAnnouncementsMessage(
+        ProductAnnouncementsMessageTypes.Dismiss,
+        { id, revision },
+      )
+      await load()
+    },
+    [load],
+  )
+
+  return {
+    state,
+    isLoading,
+    reload: load,
+    markSeen,
+    dismiss,
+  }
+}
+```
+
+Implement `ProductAnnouncementList.tsx`, `ProductAnnouncementPopover.tsx`, and `ProductAnnouncementButton.tsx` using:
+
+- `Bell` or `Megaphone` from `lucide-react`.
+- `IconButton`, `Badge`, `Button`, `Popover`, `PopoverTrigger`, `PopoverContent`.
+- `PRODUCT_ANNOUNCEMENT_TEST_IDS`.
+- `useTranslation("productAnnouncements")`.
+
+Required behavior:
+
+- Button always renders for Options.
+- Badge renders only when `state.view.unseenActiveCount > 0`.
+- Popover has Active and Dismissed filter buttons.
+- Opening the popover calls `markSeen` for currently active unseen notice ids.
+- Dismiss action calls `dismiss(id, revision)`.
+- CTA opens sanitized URL in a new tab with `rel="noopener noreferrer"`.
+
+- [ ] **Step 5: Run focused tests and i18n extraction check**
+
+Run:
+
+```bash
+pnpm vitest --run tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS and no unexpected i18n changes.
+
+Commit:
+
+```bash
+git add src/features/ProductAnnouncements src/locales/zh-CN/productAnnouncements.json src/locales/en/productAnnouncements.json src/locales/ja/productAnnouncements.json src/locales/zh-TW/productAnnouncements.json src/locales/vi/productAnnouncements.json tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx
+git commit -m "feat(product-announcements): add header popover"
+```
+
+## Task 6: Options Header, Overview Banner, And Popup Entry
+
+**Files:**
+- Modify: `src/entrypoints/options/components/Header.tsx`
+- Modify: `src/features/OptionsOverview/OptionsOverview.tsx`
+- Create: `src/features/ProductAnnouncements/ProductAnnouncementBanner.tsx`
+- Modify: `src/entrypoints/popup/components/HeaderSection.tsx`
+- Test: `tests/features/ProductAnnouncements/ProductAnnouncementBanner.test.tsx`
+- Test: `tests/entrypoints/options/Header.productAnnouncements.test.tsx`
+- Test: `tests/entrypoints/popup/HeaderSection.productAnnouncements.test.tsx`
+
+- [ ] **Step 1: Write focused UI integration tests**
+
+Create `tests/features/ProductAnnouncements/ProductAnnouncementBanner.test.tsx`:
+
+```tsx
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { ProductAnnouncementBanner } from "~/features/ProductAnnouncements/ProductAnnouncementBanner"
+import { render, screen } from "~~/tests/test-utils/render"
+
+describe("ProductAnnouncementBanner", () => {
+  it("renders the primary risk notice and exposes view-all and dismiss actions", async () => {
+    const user = userEvent.setup()
+    const onViewAll = vi.fn()
+    const onDismiss = vi.fn()
+
+    render(
+      <ProductAnnouncementBanner
+        notice={{
+          id: "risk",
+          revision: 1,
+          severity: "warning",
+          priority: 10,
+          startsAt: 1,
+          expiresAt: 2,
+          title: "Risk notice",
+          message: "Please review.",
+          seen: false,
+          dismissed: false,
+        }}
+        additionalCount={2}
+        onViewAll={onViewAll}
+        onDismiss={onDismiss}
+      />,
+      { withReleaseUpdateStatusProvider: false },
+    )
+
+    expect(screen.getByText("Risk notice")).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.viewAll",
+      }),
+    )
+    expect(onViewAll).toHaveBeenCalledTimes(1)
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.dismiss",
+      }),
+    )
+    expect(onDismiss).toHaveBeenCalledWith("risk", 1)
+  })
+})
+```
+
+Create header integration tests that mock `ProductAnnouncementButton` and assert it renders in Options header and conditionally in Popup header. Keep these tests narrow; do not exercise the popover again.
+
+- [ ] **Step 2: Implement banner component**
+
+Create `src/features/ProductAnnouncements/ProductAnnouncementBanner.tsx`:
+
+```tsx
+import { AlertTriangle } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Badge, Button } from "~/components/ui"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+
+interface ProductAnnouncementBannerProps {
+  notice: ProductAnnouncement
+  additionalCount: number
+  onViewAll: () => void
+  onDismiss: (id: string, revision: number) => void
+}
+
+export function ProductAnnouncementBanner({
+  notice,
+  additionalCount,
+  onViewAll,
+  onDismiss,
+}: ProductAnnouncementBannerProps) {
+  const { t } = useTranslation("productAnnouncements")
+
+  return (
+    <section className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-sm font-semibold">{notice.title}</h2>
+            <Badge variant={notice.severity === "critical" ? "danger" : "warning"} size="sm">
+              {t(`labels.${notice.severity}`)}
+            </Badge>
+          </div>
+          <p className="mt-1 line-clamp-2 text-sm">{notice.message}</p>
+          {additionalCount > 0 ? (
+            <p className="mt-1 text-xs">
+              {t("summary.additional", { count: additionalCount })}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button size="sm" variant="secondary" onClick={onViewAll}>
+            {t("actions.viewAll")}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => onDismiss(notice.id, notice.revision)}
+          >
+            {t("actions.dismiss")}
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}
+```
+
+Add `summary.additional` to all `productAnnouncements.json` locales.
+
+- [ ] **Step 3: Wire Options header and Overview**
+
+Modify `src/entrypoints/options/components/Header.tsx`:
+
+```tsx
+import { ProductAnnouncementButton } from "~/features/ProductAnnouncements/ProductAnnouncementButton"
+
+// in the right-side utility group, before HeaderThemeSwitcher:
+<ProductAnnouncementButton surface="options-header" />
+```
+
+Modify `src/features/OptionsOverview/OptionsOverview.tsx` to load product announcements and render the banner above `<OptionsOverviewGrid />`. Use the fixed button's internal event/open state if possible; if not possible in first pass, `onViewAll` can dispatch a DOM custom event consumed by `ProductAnnouncementButton`. Prefer a shared context only if this direct wiring becomes awkward.
+
+- [ ] **Step 4: Wire Popup compact entry**
+
+Modify `src/entrypoints/popup/components/HeaderSection.tsx`:
+
+```tsx
+import { ProductAnnouncementButton } from "~/features/ProductAnnouncements/ProductAnnouncementButton"
+
+// in the header action group, before CompactThemeToggle:
+<ProductAnnouncementButton surface="popup-header" onlyWhenRisk />
+```
+
+`onlyWhenRisk` should hide the button unless `primaryRiskNotice` exists. Add this prop to `ProductAnnouncementButton`.
+
+- [ ] **Step 5: Run focused UI tests and commit**
+
+Run:
+
+```bash
+pnpm vitest --run tests/features/ProductAnnouncements/ProductAnnouncementBanner.test.tsx tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx tests/entrypoints/options/Header.productAnnouncements.test.tsx tests/entrypoints/popup/HeaderSection.productAnnouncements.test.tsx
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/features/ProductAnnouncements src/entrypoints/options/components/Header.tsx src/features/OptionsOverview/OptionsOverview.tsx src/entrypoints/popup/components/HeaderSection.tsx src/locales tests/features/ProductAnnouncements tests/entrypoints/options/Header.productAnnouncements.test.tsx tests/entrypoints/popup/HeaderSection.productAnnouncements.test.tsx
+git commit -m "feat(product-announcements): surface risk notices"
+```
+
+## Task 7: Privacy-Safe Analytics
+
+**Files:**
+- Modify: `src/services/productAnalytics/events.ts`
+- Modify: `src/services/productAnalytics/privacy.ts`
+- Create: `src/features/ProductAnnouncements/analytics.ts`
+- Modify: product announcement UI components from Tasks 5-6
+- Test: `tests/services/productAnalytics/privacy.test.ts`
+
+- [ ] **Step 1: Add failing privacy test**
+
+Append to `tests/services/productAnalytics/privacy.test.ts`:
+
+```ts
+it("keeps safe product announcement fields and drops remote copy", () => {
+  const sanitized = sanitizeProductAnalyticsEvent(
+    PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+    {
+      feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ProductAnnouncements,
+      action_id: PRODUCT_ANALYTICS_ACTION_IDS.OpenProductAnnouncements,
+      surface_id: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsProductAnnouncementsHeader,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      result: PRODUCT_ANALYTICS_RESULTS.Success,
+      product_announcement_id: "2026-06-risk",
+      product_announcement_severity: "critical",
+      product_announcement_action_kind: "open_list",
+      product_announcement_active_count: 2,
+      product_announcement_title: "Private remote title",
+      product_announcement_message: "Remote body",
+      product_announcement_url: "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+    },
+  )
+
+  expect(sanitized).toEqual({
+    feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ProductAnnouncements,
+    action_id: PRODUCT_ANALYTICS_ACTION_IDS.OpenProductAnnouncements,
+    surface_id: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsProductAnnouncementsHeader,
+    entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    result: PRODUCT_ANALYTICS_RESULTS.Success,
+    product_announcement_id: "2026-06-risk",
+    product_announcement_severity: "critical",
+    product_announcement_action_kind: "open_list",
+    product_announcement_active_count: 2,
+  })
+})
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnalytics/privacy.test.ts
+```
+
+Expected: FAIL because enums/allow-list fields do not exist.
+
+- [ ] **Step 3: Add analytics enums and sanitizer allow-list**
+
+Modify `src/services/productAnalytics/events.ts`:
+
+```ts
+// PRODUCT_ANALYTICS_FEATURE_IDS
+ProductAnnouncements: "product_announcements",
+
+// PRODUCT_ANALYTICS_ACTION_IDS
+OpenProductAnnouncements: "open_product_announcements",
+DismissProductAnnouncement: "dismiss_product_announcement",
+OpenProductAnnouncementCta: "open_product_announcement_cta",
+
+// PRODUCT_ANALYTICS_SURFACE_IDS
+OptionsProductAnnouncementsHeader: "options_product_announcements_header",
+OptionsProductAnnouncementsBanner: "options_product_announcements_banner",
+PopupProductAnnouncementsHeader: "popup_product_announcements_header",
+```
+
+Add controlled value constants for:
+
+```ts
+export const PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS = {
+  OpenList: "open_list",
+  Dismiss: "dismiss",
+  OpenCta: "open_cta",
+  MarkSeen: "mark_seen",
+} as const
+
+export const PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_SEVERITIES = {
+  Critical: "critical",
+  Warning: "warning",
+  Info: "info",
+} as const
+```
+
+Modify `src/services/productAnalytics/privacy.ts` to allow:
+
+- `product_announcement_id`
+- `product_announcement_severity`
+- `product_announcement_action_kind`
+- `product_announcement_active_count`
+
+Allow enum validation for severity/action kind and number validation for active count. Do not allow title/message/url.
+
+- [ ] **Step 4: Add UI tracking helper**
+
+Create `src/features/ProductAnnouncements/analytics.ts`:
+
+```ts
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS,
+  PRODUCT_ANALYTICS_RESULTS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+  type ProductAnalyticsSurfaceId,
+} from "~/services/productAnalytics/events"
+import { trackProductAnalyticsActionCompleted } from "~/services/productAnalytics/actions"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+
+export function trackProductAnnouncementAction(params: {
+  actionId: typeof PRODUCT_ANALYTICS_ACTION_IDS.OpenProductAnnouncements
+  surfaceId: ProductAnalyticsSurfaceId
+  entrypoint: typeof PRODUCT_ANALYTICS_ENTRYPOINTS.Options | typeof PRODUCT_ANALYTICS_ENTRYPOINTS.Popup
+  actionKind: string
+  notice?: ProductAnnouncement
+  activeCount?: number
+}) {
+  trackProductAnalyticsActionCompleted({
+    featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ProductAnnouncements,
+    actionId: params.actionId,
+    surfaceId: params.surfaceId,
+    entrypoint: params.entrypoint,
+    result: PRODUCT_ANALYTICS_RESULTS.Success,
+    properties: {
+      product_announcement_id: params.notice?.id,
+      product_announcement_severity: params.notice?.severity,
+      product_announcement_action_kind: params.actionKind,
+      product_announcement_active_count: params.activeCount,
+    },
+  })
+}
+```
+
+Adjust the exact helper call shape to match the existing analytics action API if `trackProductAnalyticsActionCompleted` expects a different signature. Keep fields identical to the privacy test.
+
+- [ ] **Step 5: Wire tracking to UI interactions**
+
+Track:
+
+- opening the fixed list.
+- dismissing a notice.
+- clicking a CTA.
+
+Do not track title, message, or URL.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnalytics/privacy.test.ts tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx tests/features/ProductAnnouncements/ProductAnnouncementBanner.test.tsx
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/services/productAnalytics/events.ts src/services/productAnalytics/privacy.ts src/features/ProductAnnouncements/analytics.ts src/features/ProductAnnouncements tests/services/productAnalytics/privacy.test.ts
+git commit -m "feat(product-announcements): track safe notice actions"
+```
+
+## Task 8: Final Validation And Handoff
+
+**Files:**
+- Review all task-scoped files.
+
+- [ ] **Step 1: Inspect task-scoped diff**
+
+Run:
+
+```bash
+git status --porcelain
+git diff --stat HEAD~7..HEAD
+git diff HEAD~7..HEAD -- public/product-announcements.json src/services/productAnnouncements src/features/ProductAnnouncements src/entrypoints/options/components/Header.tsx src/features/OptionsOverview/OptionsOverview.tsx src/entrypoints/popup/components/HeaderSection.tsx src/services/runtimeMessaging/messageTypes.ts src/entrypoints/background/runtimeMessages.ts src/entrypoints/background/servicesInit.ts src/services/core/storageKeys.ts src/services/productAnalytics src/locales tests
+```
+
+Expected: only product-announcement related changes plus intended locale files.
+
+- [ ] **Step 2: Run focused product announcement tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/productAnnouncements tests/features/ProductAnnouncements tests/entrypoints/options/Header.productAnnouncements.test.tsx tests/entrypoints/popup/HeaderSection.productAnnouncements.test.tsx tests/services/productAnalytics/privacy.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run type and i18n checks**
+
+Run:
+
+```bash
+pnpm compile
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS and no unexpected locale extraction changes.
+
+- [ ] **Step 4: Run pre-commit gate**
+
+Stage task-scoped files only, then run:
+
+```bash
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Push gate decision**
+
+Because this feature adds new service modules, runtime messaging, background initialization, and product analytics enums, run:
+
+```bash
+pnpm run validate:push
+```
+
+Expected: PASS. If `knip` reports unused exports, either wire the export into the intended call site or remove it; do not suppress.
+
+- [ ] **Step 6: Final commit if needed**
+
+If validation caused formatting or generated locale changes:
+
+```bash
+git add <task-scoped files>
+git commit -m "chore(product-announcements): validate notice channel"
+```
+
+Expected: no unrelated files staged. Leave pre-existing untracked files such as `notify.py` and `store-description/` untouched unless the user explicitly scopes them in.
+
+## Self-Review Notes
+
+- Spec coverage:
+  - Remote static feed and bundled fallback: Tasks 1-3.
+  - Locale fallback and multiple active notices: Task 2.
+  - Seen vs dismissed state: Tasks 2-5.
+  - Fixed Options icon and complete current list: Tasks 5-6.
+  - Overview risk banner and compact Popup entry: Task 6.
+  - Privacy-safe telemetry: Task 7.
+  - Validation and E2E decision: Task 8 keeps coverage at Vitest/component level because the first implementation risk is parsing, storage, messaging, and header UI state.
+- No placeholders remain; if implementation discovers a missing existing helper signature, adjust the local step to match the actual helper rather than adding a parallel abstraction.

--- a/docs/superpowers/specs/2026-06-06-product-risk-announcements-design.md
+++ b/docs/superpowers/specs/2026-06-06-product-risk-announcements-design.md
@@ -1,0 +1,421 @@
+# Product Risk Announcements Design
+
+Date: 2026-06-06
+
+## Purpose
+
+Add a low-noise remote announcement channel for All API Hub's own product
+risk notices. The channel exists to warn installed users about severe version
+bugs, data-risk issues, compatibility regressions, migration actions, or
+temporary mitigations when store updates or release notes are not enough.
+
+This is not a general product-news feed or a site-announcement replacement. It
+should stay quiet by default and surface only notices that require user
+awareness or action.
+
+## Current Context
+
+The repository already has a `SiteAnnouncements` feature. That feature fetches
+announcements from user-added upstream sites, stores local records, tracks
+read state, supports manual checks, and can send task notifications for newly
+discovered site announcements.
+
+Product risk announcements have a different owner and threat model:
+
+- the publisher is All API Hub, not a user-added site.
+- notices target installed extension versions, not saved accounts.
+- the primary action is risk mitigation or update guidance.
+- remote content must be constrained enough for extension security and store
+  review.
+
+For that reason, product risk announcements should use a separate
+`productAnnouncements` domain instead of reusing `siteAnnouncements` storage or
+message contracts.
+
+## Goals
+
+- Let the extension fetch a remote JSON announcement feed controlled by the
+  project.
+- Show notices only when they apply to the current extension version, language,
+  time window, and local dismissal state.
+- Provide a persistent announcement icon entry so users can reopen current
+  product notices after reading or dismissing the top-level prompt.
+- Support one announcement with multiple localized content blocks so dismissal
+  is shared across languages.
+- Handle multiple active notices with deterministic priority and low visual
+  noise.
+- Persist local dismissal state by `id` and `revision` so important updates to
+  an existing notice can resurface.
+- Keep fetch failures silent and non-blocking.
+- Keep remote content safe: no remote JavaScript, no arbitrary HTML, and no
+  arbitrary external links.
+- Make the feature independently testable at the parser, selector, storage,
+  service, and UI layers.
+
+## Non-Goals
+
+- Do not build a full announcement center in the first version.
+- Do not add an admin backend or remote write API.
+- Do not sync read or dismissed state across devices.
+- Do not use this channel for marketing, routine changelog entries, or normal
+  feature promotion.
+- Do not send browser system notifications in the first version.
+- Do not let remote JSON control feature flags, settings, extension behavior,
+  or arbitrary navigation.
+- Do not merge product announcements with user-site announcements.
+
+## Remote Feed
+
+Use the same repository-controlled static-data pattern as sponsor
+recommendations: keep a bundled JSON file under `public/` and fetch the latest
+copy from the `main` branch raw URL.
+
+The bundled fallback file should be:
+
+```text
+public/product-announcements.json
+```
+
+The default production URL should be:
+
+```text
+https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/product-announcements.json
+```
+
+The extension only reads this document. Keep the URL behind a single service
+constant so it can move with the sponsor catalog if the project later changes
+remote static-data hosting.
+
+The feed should be versioned:
+
+```json
+{
+  "schemaVersion": 1,
+  "defaultLocale": "en",
+  "announcements": [
+    {
+      "id": "2026-06-balance-history-risk",
+      "revision": 1,
+      "severity": "critical",
+      "priority": 100,
+      "affectedVersions": ">=3.44.0 <3.44.1",
+      "startsAt": "2026-06-06T00:00:00Z",
+      "expiresAt": "2026-06-20T00:00:00Z",
+      "content": {
+        "en": {
+          "title": "Balance history sync may fail",
+          "message": "Some users on 3.44.0 may see balance history sync failures. Disable auto sync temporarily or update to 3.44.1.",
+          "cta": {
+            "label": "View fix notes",
+            "url": "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1"
+          }
+        },
+        "zh-CN": {
+          "title": "Balance history sync may fail",
+          "message": "Users on 3.44.0 may need to disable auto sync temporarily or update to 3.44.1.",
+          "cta": {
+            "label": "View fix notes",
+            "url": "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+### Field Rules
+
+- `schemaVersion`: supported feed schema. Unsupported schemas are ignored.
+- `defaultLocale`: fallback locale for incomplete language coverage.
+- `id`: stable announcement identity. It must not change for copy-only edits to
+  the same incident.
+- `revision`: increment when a dismissed notice needs to resurface.
+- `severity`: one of `critical`, `warning`, or `info`.
+- `priority`: numeric ranking within a severity tier. Larger values sort first.
+- `affectedVersions`: semver-like range string for installed extension
+  versions.
+- `startsAt` and `expiresAt`: ISO timestamps defining the active window.
+- `content`: localized content blocks keyed by locale.
+- `cta`: optional, validated action link. Invalid links are dropped without
+  dropping the whole notice.
+
+## Locale Handling
+
+Each announcement owns one identity and multiple localized content blocks. A
+user who dismisses the notice in one language should not see the same
+`id`/`revision` again after switching languages.
+
+Locale resolution order:
+
+1. exact app language, such as `zh-CN`.
+2. language family fallback, such as `zh`.
+3. configured project fallback for known variants, such as `zh-CN` for
+   Traditional Chinese if no better content exists.
+4. feed-level `defaultLocale`.
+5. discard the announcement if no valid content block can be resolved.
+
+The resolved content block must contain a non-empty `title` and `message`.
+CTA labels are shown only when the CTA URL is valid and allowed.
+
+## Multiple Active Notices
+
+The product should not stack several expanded banners at the top of the UI.
+Selectors should produce a sorted active list, then the UI should choose a
+primary notice and summarize the rest.
+
+Sort order:
+
+1. severity: `critical` before `warning` before `info`.
+2. `priority`: larger first.
+3. `startsAt`: newer first.
+4. `id`: stable lexical fallback.
+
+Display behavior:
+
+- A persistent announcement icon is available from the Options header. It
+  should remain visible even when there are no active notices, with an empty
+  state in the popover or sheet.
+- The icon shows a badge only for unseen active notices. No badge means there
+  is nothing new, not that the list is unavailable.
+- Opening the icon shows the complete current product-announcement list from
+  the cached feed, including active notices and dismissed notices behind a
+  filter or tab.
+- Opening the list marks visible active notices as seen. It must not dismiss
+  them.
+- Options Overview can additionally show the top active `critical` or
+  `warning` notice as a risk banner. The banner should include a "view all"
+  affordance that opens the same list.
+- Popup can show the same compact icon or a compact entry point for active
+  `critical` or `warning` notices, but it should not stack multiple banners.
+- `info` notices remain available through the fixed announcement entry. They
+  should not interrupt popup usage or appear as Overview risk banners.
+- Dismissing the primary notice promotes the next active notice, if any.
+- Bulk dismiss can apply to current active `warning` and `info` notices.
+  `critical` notices should be dismissed one at a time.
+
+## Local State
+
+Persist product announcement state in extension local storage, separate from
+site-announcement state.
+
+```ts
+interface ProductAnnouncementState {
+  schemaVersion: 1
+  lastFetchedAt?: number
+  dismissed: Record<string, number>
+  seenAt: Record<string, number>
+  lastShownAt: Record<string, number>
+  cachedFeed?: ProductAnnouncementFeed
+}
+```
+
+State semantics:
+
+- `dismissed[id] = revision` means the user closed that notice revision.
+- if the remote `revision` is higher than the dismissed revision, the notice is
+  eligible again.
+- `seenAt` records when a notice was viewed or expanded.
+- seen notices should lose unread badge emphasis, but they should stay visible
+  in the fixed announcement list until they expire, are removed from the remote
+  feed, or are explicitly dismissed.
+- dismissed notices should disappear from banners and unread counts, but remain
+  available from the fixed list's dismissed filter while they are still present
+  in the cached feed.
+- `lastShownAt` can throttle repeated exposure for severe notices if needed.
+- `cachedFeed` allows the UI to keep showing the last valid feed when refresh
+  fails.
+
+Use a storage write lock if the feature can update state from both background
+and UI entrypoints.
+
+## Fetching And Refresh
+
+The fetch path should be best-effort:
+
+- background alarm refreshes every 12 hours.
+- Options and Popup ask the background service for current notices; the service
+  returns cached notices immediately and may refresh stale cache in the
+  background.
+- failed refreshes keep the previous valid cached feed.
+- fetch failures should not show user-facing errors, block page rendering, or
+  affect normal extension workflows.
+- any request cancellation or timeout should exist only to prevent indefinitely
+  hanging background work; it should not be used as a user-visible readiness
+  gate.
+- requests must not include saved account data, site URLs, tokens, prompts, or
+  user-entered text.
+
+The service should normalize the remote feed at the boundary. Downstream UI and
+selectors should receive typed, sanitized notices rather than raw remote JSON.
+
+## Security Boundaries
+
+Remote content is data, not behavior.
+
+- Accept only JSON from configured announcement URLs.
+- Do not evaluate remote JavaScript.
+- Do not render arbitrary HTML.
+- Prefer plain text body content. If Markdown is added later, use a small,
+  sanitized subset and no raw HTML.
+- CTA URLs must pass an allow-list, such as project GitHub releases, project
+  docs, or an owned product domain.
+- CTA actions should be limited to safe navigation. Do not let remote data
+  modify settings, trigger destructive actions, or invoke privileged runtime
+  operations.
+- Unsupported schemas, invalid dates, invalid version ranges, invalid locale
+  content, and malformed CTA links should fail closed.
+
+## UI Surfaces
+
+### Persistent Header Entry
+
+The primary user entry is a fixed icon button in the Options header, near the
+existing version and utility controls. This follows the same product shape as
+New API's notification bell: a stable place to reopen notices, with a badge
+only when unseen active notices exist.
+
+In this repo, the Options header already has a right-side utility group with
+theme, feedback, language, development, and search icon controls. The product
+announcement button should live in that group. Popup can use a matching compact
+entry in its header action group when active `critical` or `warning` notices
+exist.
+
+The button should use the existing `IconButton` style, tooltip behavior, and
+header spacing. It should not look like a promotional widget.
+
+### Announcement Popover Or Sheet
+
+The fixed entry opens a compact popover or sheet containing the current product
+announcement list. MVP tabs or filters:
+
+- active notices.
+- dismissed notices.
+
+The list should show severity, localized title, short message preview,
+publish/start date, CTA when allowed, and a per-notice dismiss action. Selecting
+a notice opens details in the same popover/sheet or a small dialog. Opening the
+list marks visible active notices as seen, not dismissed.
+
+### Options Overview Risk Banner
+
+The Overview page is the main risk-surfacing surface, not the permanent archive.
+Place a compact risk banner near the top of the page only when a non-dismissed
+`critical` or `warning` notice applies. The banner should use existing
+alert/card primitives and local icon patterns.
+
+The banner should include:
+
+- severity tone.
+- localized title and message.
+- optional CTA.
+- dismiss action.
+- "view all" action.
+- compact count for additional active notices.
+
+### Popup
+
+Popup should remain dense and task-oriented. Show a compact announcement icon
+or notice entry for active `critical` or `warning` announcements. It can open a
+small list directly if space allows, or navigate to the Options announcement
+entry. It should not render a multi-notice feed inline.
+
+### Future Notice Page
+
+A dedicated route/page is not part of the MVP because the fixed header popover
+or sheet is enough for current notices. Add a page later only if active or
+historical notices become common enough that a popover becomes cramped.
+
+## Runtime Structure
+
+Preferred structure:
+
+```text
+src/services/productAnnouncements/
+  constants.ts
+  fetcher.ts
+  messaging.ts
+  selectors.ts
+  service.ts
+  storage.ts
+  types.ts
+  urlPolicy.ts
+  versionRange.ts
+
+src/features/ProductAnnouncements/
+  ProductAnnouncementButton.tsx
+  ProductAnnouncementBanner.tsx
+  ProductAnnouncementPopover.tsx
+  ProductAnnouncementList.tsx
+  utils.ts
+```
+
+The background owns remote fetch, cache refresh, and typed runtime messaging.
+UI entrypoints request the current sanitized presentation model through typed
+messaging instead of fetching the remote feed directly.
+
+## Telemetry Decision
+
+Add privacy-safe product analytics for the feature because it is a user-visible
+risk and recovery channel.
+
+Allowed fields:
+
+- controlled announcement `id`.
+- `severity`.
+- fetch status category.
+- active notice count.
+- action type: shown, expanded, dismissed, CTA clicked.
+- surface: Options Overview or Popup.
+
+Do not record remote message text, CTA URL, user account data, site URLs,
+backend error bodies, or stack traces.
+
+## Testing Strategy
+
+Focused unit tests should cover:
+
+- feed parser rejects unsupported schemas and malformed notices.
+- locale resolution falls back in the expected order.
+- version range matching includes and excludes correct app versions.
+- expired and future notices are filtered out.
+- dismissed `id`/`revision` notices stay hidden from banners and unread badge
+  counts while remaining available in the fixed list's dismissed filter.
+- higher remote revisions resurface after dismissal.
+- multiple notices sort by severity, priority, date, and id.
+- CTA URL allow-list drops unsafe URLs.
+- fetch failure keeps the last valid cached feed.
+- storage sanitization handles unreadable or incompatible state.
+
+Component tests should cover:
+
+- fixed header icon renders with and without active notices.
+- unseen active notices produce a badge, while seen notices do not.
+- opening the fixed list marks visible active notices as seen but not dismissed.
+- the fixed list can show active and dismissed notices through its filters.
+- Overview shows the primary critical or warning notice and additional count.
+- dismissing the primary notice promotes the next active notice.
+- critical notices are not bulk-dismissed.
+- Popup shows only compact critical or warning notice entry points.
+
+E2E decision:
+
+- Do not add Playwright E2E for the first implementation unless routing from
+  Popup to Options or extension-runtime integration cannot be covered with
+  component and service tests. The primary risks are parsing, filtering,
+  storage, and presentation state, which are better covered with Vitest.
+
+## Rollout
+
+1. Add typed domain models, parser, version matcher, URL policy, and selectors.
+2. Add storage and background service with stale-cache refresh.
+3. Add typed messaging for UI entrypoints.
+4. Add the fixed Options header announcement entry and complete current-notice
+   popover/sheet.
+5. Add the Overview risk banner and compact Popup entry point.
+6. Add a development-only preview override so maintainers can render sample
+   notices without publishing remote JSON.
+7. Add settings/search/deep-link updates only if a new user-visible settings
+   control or page is introduced.
+8. Add docs or release-note mention only after the feature has shipped and the
+   remote feed path is live.

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "otpauth": "^9.5.0",
     "postcss": "^8.5.6",
     "posthog-js": "^1.373.2",
+    "radix-ui": "^1.5.0",
     "react": "^19.1.1",
     "react-countup": "^6.5.3",
     "react-dom": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       posthog-js:
         specifier: ^1.373.2
         version: 1.373.2
+      radix-ui:
+        specifier: ^1.5.0
+        version: 1.5.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.1.1
         version: 19.2.0
@@ -2007,11 +2010,56 @@ packages:
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
+  '@radix-ui/number@1.1.2':
+    resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
+
   '@radix-ui/primitive@1.0.0':
     resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
+  '@radix-ui/react-accessible-icon@1.1.9':
+    resolution: {integrity: sha512-5W9KzJz/3DeYbGJHbZv8Q6AkxMOKUmALfc+PRg9dWwJZMk6zD37Sz8sZrF7UD6CBkiJvn7dNeRzn5G7XiCMyig==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.13':
+    resolution: {integrity: sha512-xITxBB2p5m5tAe7M0F95kb4uAh7jSIKGlExMEm93HlW+XxZHV2eXFbPWLktd4JhRiwcnXNbO7iekcrbZy6ZCvA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-alert-dialog@1.1.16':
+    resolution: {integrity: sha512-vPaIgo0mxYlvcFaM9jB2Uot9TjGXMuAPEvrc6BOLeV+I5U8s1dkIoouYaa6lmSfc5SPMo5x5djOTOTvaigdGMQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.0.2':
     resolution: {integrity: sha512-fqYwhhI9IarZ0ll2cUSfKuXHlJK0qE4AfnRrPBbRwEH/4mGQn04/QFGomLi8TXWIdv9WJk//KgGm+aDxVIr1wA==}
@@ -2021,6 +2069,45 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.9':
+    resolution: {integrity: sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.9':
+    resolution: {integrity: sha512-Xy+Dpxt/5n9rVTdPrNFmf8GwG1NlT1pzCF/z1MgOGZMLZWdWl+km+ZRWGQAPEhbkzSwYEsfYmTca8NhUtVxqnw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.12':
+    resolution: {integrity: sha512-NQCQyWC7QrDPhjMn8hUqFeU0lUrprIgm1AyMgLbzuQJibNnatdc3SSMo3/UGFu/eUkJUU1cEcKCnyhXTQzq6tA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2045,6 +2132,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-checkbox@1.3.4':
+    resolution: {integrity: sha512-m3JmIOAX5ZzZ6VPjxEU2dbTOhoHi0nT5riwcDwe8idocsWf4a5DXJLDtZ6LfJwMBx7W+A2b7kp2TgPEKtaiF6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collapsible@1.1.12':
     resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
@@ -2058,8 +2158,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collapsible@1.1.13':
+    resolution: {integrity: sha512-F0s8+p2XNpfc3k02zBfB0jPWbkHVG162+p7BdUMyJ2308QMqZ+oaclX+FAzKFovgL5OqRU+Rvy6f/vbdlJVaqA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.9':
+    resolution: {integrity: sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2085,6 +2211,28 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.3.0':
+    resolution: {integrity: sha512-d7CouXhAW+CGmFOqmB+IEvd3E9GcaqfgvfjCc3hfulp2pkaUCEVEGa0SN5nNWYA+IvQ6g1Pt+S5dpNn1AoY9hg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-context@1.0.0':
     resolution: {integrity: sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==}
     peerDependencies:
@@ -2092,6 +2240,15 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2118,8 +2275,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.16':
+    resolution: {integrity: sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2152,8 +2331,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.12':
+    resolution: {integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dropdown-menu@2.1.16':
     resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.17':
+    resolution: {integrity: sha512-S6b3Jm57sY5EdDyOMLkacbB0qMnKhy1RCKZCt795ZkmtUOAvojYIZ5p7dXHIh5Cyr3jCLLI5/g64V3FKLudZmw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2172,6 +2377,15 @@ packages:
 
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2198,6 +2412,45 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-focus-scope@1.1.9':
+    resolution: {integrity: sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-form@0.1.9':
+    resolution: {integrity: sha512-eTPyThIKDacJ3mJDvYwf/PSmsEYlOyA2Qcb+aGyWwYv+P5w57VPUkMVA2XJ9z0Du2KBY1HoHQzhPV9iYL/r4hg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.16':
+    resolution: {integrity: sha512-hAileDBtd6CX7nlZOarOnISQ6PP4q0e16BX51ulzdZ+7IzjL0sDTVpFdmSYrIjw6zVNsfQBao5gG6AWr3qwfvA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.0.0':
     resolution: {integrity: sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==}
     peerDependencies:
@@ -2212,8 +2465,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-label@2.1.9':
+    resolution: {integrity: sha512-rDoTeMbCwRVcnmo7NGT9IlPo1yXmEI+xc1URP3oeewwZEV4mdTp1dYUhYbQdo4D1q2SjKVvv4N1gNY77QAQtjA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2238,8 +2513,86 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-menu@2.1.17':
+    resolution: {integrity: sha512-fmbNnFyf+JYCN0DhhWnEdUTDnZD1mXaPQWivdsPIb8oOSbARfD3LIQJbLCG8a8QLCwoMxiJ7GVPIFcC8Dw8v2Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.17':
+    resolution: {integrity: sha512-AKtZ4O782yO7qwIyq73WpulYt1IHhQ0htDb6wNcxzxnSDCcSWMVBiU9ycpcA90XzQO4IVIxIErtak6Kg/Vt0rQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.15':
+    resolution: {integrity: sha512-/fS8hKCcRt4DwCGa5QIB3juRXmfYSOk4a2AEe/BDIyy7Hm+eje2Y13oUx5zejl+wFt1owrM7E8NWlbaEl5EGpg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.9':
+    resolution: {integrity: sha512-fvCzA9hm7yN5xxTPJIi4VhSmH5gv+76ILsxguBK3cm3icD5BR4vW7POQmu8Zio0yh91uuouG/Kang40IbMkaSQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.4':
+    resolution: {integrity: sha512-qoDSkObZ9faJlsjlwyBH6ia7kq9vaJ2QwWTowT3nQpzPvUTAKesmWuGJYpd91HIoJqS+5ZPXy5uFPp+HlwdaAg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popover@1.1.15':
     resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.16':
+    resolution: {integrity: sha512-8brVpAU5Uq7Bh0c8EFc4ZTf2JJTYn0o+1L+CUJB3UYIOkTjKGMgoHvduylrahdmNlr3DfH0rFq2DrbNZXgaspw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2270,6 +2623,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.3.0':
+    resolution: {integrity: sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.0.0':
     resolution: {integrity: sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==}
     peerDependencies:
@@ -2281,6 +2647,19 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-portal@1.1.11':
+    resolution: {integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
@@ -2303,6 +2682,19 @@ packages:
 
   '@radix-ui/react-presence@1.1.5':
     resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2352,6 +2744,45 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.5':
+    resolution: {integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.9':
+    resolution: {integrity: sha512-+EOkvg1Zn1vI1+fRDfRSAiJ7BWfcDAo5ASMmbqrcLZ4s4USk2FGkoHgeb2X+CkUgo2zJMiyObwf1k44CrRWsyw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.4.0':
+    resolution: {integrity: sha512-eHdV5bLx9sH+tBnbDjkIBdvQEH/c6MEtQYhTbxkaDK9qsIFFLtmJYEQFVdwhnruWotLfQmIuWEL/J+L3utE8rQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -2365,8 +2796,73 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.12':
+    resolution: {integrity: sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.11':
+    resolution: {integrity: sha512-DS39ziOgea75U/TrXKU2/oKp0be2jrDHnzFLvahg/0iNAT1Zq16e4Uw0WXwyXvsK+mG3BRyMb7A3NRZMDuEXtQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.2.6':
     resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.3.0':
+    resolution: {integrity: sha512-mENc7WpJvJcW8hlMpzfFcHcEhTvYS5JMBmi9HVC1Q00uhBwML086MHYUV8QQdQv6lcu0Wg8dzd1RB8AFADcG/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.9':
+    resolution: {integrity: sha512-gvgW+JV/Mbjj6darztTetnmElpQEzZrXpJvfj+dOxNAxiyHEAyUvEjjl4zxblvmjmKmi3jfPoy7ZdxzCuUBJSA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.4.0':
+    resolution: {integrity: sha512-RHcPlLOThRJM51DSIC33ZnpDEBYhyEFroVWkd2P54PGGjkmAt14RboYUU9E1MFst666zFHM0tGtWvMjSOtU1pw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2406,11 +2902,111 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.2.5':
+    resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.3.0':
+    resolution: {integrity: sha512-GP1EZwhoZO/GGnhM1P5/2Vpm8iN8EnngyU0oezn2l78kN8tj25pyrvjIaT7azBhK615KSt+P2w39y57YV5jVkA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.14':
+    resolution: {integrity: sha512-D5jwp9JNuwDeCw3CYD2Fz+sSHo0droQjC8u75dJHe4aWr5q6yBiXZU+hurXnKudRgEpUkD5TsI6bjHPo5ThUxA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.16':
+    resolution: {integrity: sha512-WUymDDiN2DpoGudRN1aW4wF5O3BNQjZZO/5nngPoNiEVqjyOzirvZZNO0R6dC1ifucSINVaSv8JX1aq47VGgiA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.12':
+    resolution: {integrity: sha512-TEgECgJaWGAHJJZGzNNEYTNBdIXqX7LchANycpyP7DkfjmuiSN7ISt1k/ZRGVJgVJonsgP4vwaiKMn5utrcwWQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.11':
+    resolution: {integrity: sha512-FikrKJemoBGZQ6uRID0HJqSPBP6D7OppdD2OhLl0ZYLlAyPXI7MezoYGmumwNkrAoRm35xXkb4C8JPfJZZzcaw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.12':
+    resolution: {integrity: sha512-4wHtJVdIgqMmEwUvxA0BYg/2JMRbt0L3+8UD8Ml/nhKkfXtiZcM8u/S15gQ5xj9YEd/0qlrm5bE805LsjQ+J8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tooltip@1.0.5':
     resolution: {integrity: sha512-cDKVcfzyO6PpckZekODJZDe5ZxZ2fCZlzKzTmPhe4mX9qTHRfLcKgqb0OKf22xLwDequ2tVleim+ZYx3rabD5w==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-tooltip@1.2.9':
+    resolution: {integrity: sha512-u6F9MmTtBSLkiXNVDrtB/yPCZarM9smNswC24YYLV/M+bth6J3Gs3vlJezEoFwKZvPvxhCpUYdUnOsNG/0XOlA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-use-callback-ref@1.0.0':
     resolution: {integrity: sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==}
@@ -2419,6 +3015,15 @@ packages:
 
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2440,8 +3045,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2468,6 +3091,24 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-escape-keydown@1.1.2':
+    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.0.0':
     resolution: {integrity: sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==}
     peerDependencies:
@@ -2482,8 +3123,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-previous@1.1.1':
     resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2505,6 +3164,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.2':
+    resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.0.0':
     resolution: {integrity: sha512-imZ3aYcoYCKhhgNpkNDh/aTiU05qw9hX+HHI1QDBTyIlcFjgeFlKKySNGMwTp7nYFLQg/j0VA2FmCY4WPDDHMg==}
     peerDependencies:
@@ -2512,6 +3180,15 @@ packages:
 
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2538,11 +3215,27 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-visually-hidden@1.2.5':
+    resolution: {integrity: sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/rect@1.0.0':
     resolution: {integrity: sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==}
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@radix-ui/rect@1.1.2':
+    resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
   '@rc-component/async-validator@5.1.0':
     resolution: {integrity: sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==}
@@ -7502,6 +8195,19 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  radix-ui@1.5.0:
+    resolution: {integrity: sha512-Nzh2HNpClgB31FBHRqt2xG8XNUfVfQRpf34hACC5PNrXTd5JdXdqOXwLs3BL+D8CNYiNQiJiT8QGr5Q4vq+00w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -7922,6 +8628,16 @@ packages:
 
   react-remove-scroll@2.7.1:
     resolution: {integrity: sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
@@ -11186,11 +11902,55 @@ snapshots:
 
   '@radix-ui/number@1.1.1': {}
 
+  '@radix-ui/number@1.1.2': {}
+
   '@radix-ui/primitive@1.0.0':
     dependencies:
       '@babel/runtime': 7.28.4
 
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/primitive@1.1.4': {}
+
+  '@radix-ui/react-accessible-icon@1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-accordion@1.2.13(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collapsible': 1.1.13(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-alert-dialog@1.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dialog': 1.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
   '@radix-ui/react-arrow@1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -11202,6 +11962,37 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-arrow@1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-aspect-ratio@1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-avatar@1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
@@ -11224,6 +12015,22 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-checkbox@1.3.4(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -11234,6 +12041,22 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-collapsible@1.1.13(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
@@ -11252,6 +12075,18 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-collection@1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-compose-refs@1.0.0(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -11263,12 +12098,37 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.12
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-context-menu@2.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-menu': 2.1.17(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-context@1.0.0(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       react: 19.2.0
 
   '@radix-ui/react-context@1.1.2(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.1.12)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
@@ -11318,7 +12178,35 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-dialog@1.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      aria-hidden: 1.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.12)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-direction@1.1.2(@types/react@19.1.12)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
@@ -11359,6 +12247,19 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -11374,12 +12275,33 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-dropdown-menu@2.1.17(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-menu': 2.1.17(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-focus-guards@1.0.0(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       react: 19.2.0
 
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.1.12)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
@@ -11405,6 +12327,48 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-focus-scope@1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-form@0.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-label': 2.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-hover-card@1.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-id@1.0.0(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -11418,9 +12382,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.12
 
+  '@radix-ui/react-id@1.1.2(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-label@2.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
@@ -11453,6 +12433,108 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-menu@2.1.17(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      aria-hidden: 1.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.12)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-menubar@1.1.17(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-menu': 2.1.17(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-navigation-menu@1.2.15(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-one-time-password-field@0.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-password-toggle-field@0.1.4(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -11472,6 +12554,29 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-remove-scroll: 2.7.1(@types/react@19.1.12)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-popover@1.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      aria-hidden: 1.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.12)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
@@ -11512,6 +12617,24 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-popper@1.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-arrow': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-portal@1.0.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -11525,6 +12648,16 @@ snapshots:
       '@radix-ui/react-primitive': 1.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+
+  '@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -11548,6 +12681,15 @@ snapshots:
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.12)(react@19.2.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
@@ -11586,6 +12728,43 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-progress@1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-radio-group@1.4.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -11597,6 +12776,40 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.12)(react@19.2.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-roving-focus@1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-scroll-area@1.2.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
@@ -11632,6 +12845,64 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-select@2.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      aria-hidden: 1.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.12)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-separator@1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-slider@1.4.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-slot@1.0.0(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -11658,6 +12929,105 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.12
 
+  '@radix-ui/react-slot@1.2.5(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-switch@1.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-tabs@1.1.14(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-toast@1.2.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-toggle-group@1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toggle': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-toggle@1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
+  '@radix-ui/react-toolbar@1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-separator': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toggle-group': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-tooltip@1.0.5(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -11678,12 +13048,38 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@radix-ui/react-tooltip@1.2.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/react-use-callback-ref@1.0.0(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       react: 19.2.0
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.1.12)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
@@ -11703,9 +13099,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.12
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.12)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
       '@types/react': 19.1.12
@@ -11729,6 +13140,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.12
 
+  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   '@radix-ui/react-use-layout-effect@1.0.0(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -11740,7 +13164,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.12
 
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   '@radix-ui/react-use-previous@1.1.1(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@19.1.12)(react@19.2.0)':
     dependencies:
       react: 19.2.0
     optionalDependencies:
@@ -11759,6 +13195,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.12
 
+  '@radix-ui/react-use-rect@1.1.2(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
   '@radix-ui/react-use-size@1.0.0(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -11768,6 +13211,13 @@ snapshots:
   '@radix-ui/react-use-size@1.1.1(@types/react@19.1.12)(react@19.2.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.12)(react@19.2.0)
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.1.12)(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
       react: 19.2.0
     optionalDependencies:
       '@types/react': 19.1.12
@@ -11788,11 +13238,22 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
 
+  '@radix-ui/react-visually-hidden@1.2.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   '@radix-ui/rect@1.0.0':
     dependencies:
       '@babel/runtime': 7.29.2
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@radix-ui/rect@1.1.2': {}
 
   '@rc-component/async-validator@5.1.0':
     dependencies:
@@ -17465,6 +18926,69 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  radix-ui@1.5.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-accessible-icon': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-accordion': 1.2.13(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-alert-dialog': 1.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-arrow': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-aspect-ratio': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-avatar': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-checkbox': 1.3.4(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collapsible': 1.1.13(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collection': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-context-menu': 2.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dialog': 1.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dropdown-menu': 2.1.17(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-form': 0.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-hover-card': 1.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-label': 2.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-menu': 2.1.17(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-menubar': 1.1.17(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-navigation-menu': 1.2.15(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-one-time-password-field': 0.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-password-toggle-field': 0.1.4(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popover': 1.1.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-progress': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-radio-group': 1.4.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-scroll-area': 1.2.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-select': 2.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-separator': 1.1.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slider': 1.4.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-switch': 1.3.0(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-tabs': 1.1.14(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toast': 1.2.16(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toggle': 1.1.11(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toggle-group': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-toolbar': 1.1.12(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-tooltip': 1.2.9(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.1.12)(react@19.2.0)
+      '@radix-ui/react-visually-hidden': 1.2.5(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+      '@types/react-dom': 19.2.2(@types/react@19.1.12)
+
   range-parser@1.2.1: {}
 
   raw-body@3.0.2:
@@ -18002,6 +19526,17 @@ snapshots:
       '@types/react': 19.1.12
 
   react-remove-scroll@2.7.1(@types/react@19.1.12)(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.12)(react@19.2.0)
+      react-style-singleton: 2.2.3(@types/react@19.1.12)(react@19.2.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.1.12)(react@19.2.0)
+      use-sidecar: 1.1.3(@types/react@19.1.12)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.12
+
+  react-remove-scroll@2.7.2(@types/react@19.1.12)(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-remove-scroll-bar: 2.3.8(@types/react@19.1.12)(react@19.2.0)

--- a/public/product-announcements.json
+++ b/public/product-announcements.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "defaultLocale": "zh-CN",
+  "announcements": [],
+  "_examples": {
+    "devAnnouncements": [
+      {
+        "id": "dev-critical-product-risk",
+        "revision": 1,
+        "severity": "critical",
+        "priority": 100,
+        "affectedVersions": "*",
+        "startsAt": "2026-01-01T00:00:00.000Z",
+        "expiresAt": "2099-01-01T00:00:00.000Z",
+        "content": {
+          "zh-CN": {
+            "title": "[DEV] 严重风险公告",
+            "message": "用于测试 Overview 风险横幅、弹窗未读计数和 Popup 风险入口。",
+            "cta": {
+              "label": "查看发布说明",
+              "url": "https://github.com/qixing-jk/all-api-hub/releases"
+            }
+          },
+          "en": {
+            "title": "[DEV] Critical risk announcement",
+            "message": "Exercises the Overview risk banner, unread popover count, and Popup risk entry.",
+            "cta": {
+              "label": "View release notes",
+              "url": "https://github.com/qixing-jk/all-api-hub/releases"
+            }
+          }
+        }
+      },
+      {
+        "id": "dev-warning-product-risk",
+        "revision": 1,
+        "severity": "warning",
+        "priority": 80,
+        "affectedVersions": "*",
+        "startsAt": "2026-01-01T00:00:00.000Z",
+        "expiresAt": "2099-01-01T00:00:00.000Z",
+        "content": {
+          "zh-CN": {
+            "title": "[DEV] 提醒公告",
+            "message": "用于测试多个风险公告排序和 dismiss 后的风险横幅降级。"
+          },
+          "en": {
+            "title": "[DEV] Warning announcement",
+            "message": "Exercises multi-risk sorting and banner fallback after dismissing the critical notice."
+          }
+        }
+      },
+      {
+        "id": "dev-info-product-announcement",
+        "revision": 1,
+        "severity": "info",
+        "priority": 10,
+        "affectedVersions": "*",
+        "startsAt": "2026-01-01T00:00:00.000Z",
+        "expiresAt": "2099-01-01T00:00:00.000Z",
+        "content": {
+          "en": {
+            "title": "[DEV] Info announcement",
+            "message": "Exercises locale fallback and the non-risk announcement list item."
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -72,6 +72,18 @@ export { EmptyState } from "./EmptyState"
 export { Modal } from "./Dialog/Modal"
 export { DestructiveConfirmDialog } from "./Dialog/DestructiveConfirmDialog"
 export { Separator } from "./Separator"
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+} from "./sheet"
 export { Checkbox } from "./checkbox"
 export {
   Command,

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,181 @@
+import { XIcon } from "lucide-react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+import * as React from "react"
+
+import { Z_INDEX } from "~/constants/designTokens"
+import { cn } from "~/lib/utils"
+import { t } from "~/utils/i18n/core"
+
+import { FloatingLayerProvider } from "./floating-layer"
+
+/**
+ * Sheet provides a Radix dialog root for edge-anchored modal panels.
+ */
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+/**
+ * SheetTrigger toggles the sheet when activated.
+ */
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+/**
+ * SheetClose closes the active sheet from inside its content.
+ */
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+/**
+ * SheetPortal renders sheet layers outside the normal DOM tree.
+ */
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+/**
+ * SheetOverlay blocks background interaction while the sheet is open.
+ */
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 fixed inset-0 bg-black/50",
+        Z_INDEX.modal,
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+/**
+ * SheetContent renders the edge-anchored modal surface with an optional close button.
+ */
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <FloatingLayerProvider layer="modal-contained">
+        <SheetPrimitive.Content
+          data-slot="sheet-content"
+          className={cn(
+            "bg-background data-[state=closed]:animate-out data-[state=open]:animate-in fixed flex flex-col gap-4 overflow-hidden shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+            Z_INDEX.modal,
+            side === "right" &&
+              "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+            side === "left" &&
+              "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+            side === "top" &&
+              "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+            side === "bottom" &&
+              "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 max-h-[85vh] rounded-t-xl border-t",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          {showCloseButton && (
+            <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+              <XIcon className="size-4" />
+              <span className="sr-only">{t("common:actions.close")}</span>
+            </SheetPrimitive.Close>
+          )}
+        </SheetPrimitive.Content>
+      </FloatingLayerProvider>
+    </SheetPortal>
+  )
+}
+
+/**
+ * SheetHeader groups the title and supporting text.
+ */
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+/**
+ * SheetFooter arranges actions at the bottom of sheet content.
+ */
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+/**
+ * SheetTitle provides the accessible sheet title.
+ */
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+/**
+ * SheetDescription provides the accessible sheet description.
+ */
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -17,6 +17,7 @@ import { setupManagedSiteModelSyncMessagingListeners } from "~/services/models/m
 import { setupTaskNotificationMessagingListeners } from "~/services/notifications/taskNotificationService"
 import { setupPreferencesMessagingListeners } from "~/services/preferences/runtimePreferencesService"
 import { setupProductAnalyticsMessagingListeners } from "~/services/productAnalytics/runtime"
+import { setupProductAnnouncementMessagingListeners } from "~/services/productAnnouncements/service"
 import { setupRedemptionAssistMessagingListeners } from "~/services/redemption/redemptionAssist"
 import { setupSiteAnnouncementsMessagingListeners } from "~/services/siteAnnouncements/scheduler"
 import { setupReleaseUpdateMessagingListeners } from "~/services/updates/releaseUpdateService"
@@ -105,6 +106,7 @@ export function setupRuntimeMessageListeners() {
   setupUsageHistoryMessagingListeners()
   setupDailyBalanceHistoryMessagingListeners()
   setupSiteAnnouncementsMessagingListeners()
+  setupProductAnnouncementMessagingListeners()
   setupPreferencesMessagingListeners()
   setupManagedSiteModelSyncMessagingListeners()
   setupAccountKeyRepairMessagingListeners()

--- a/src/entrypoints/background/servicesInit.ts
+++ b/src/entrypoints/background/servicesInit.ts
@@ -5,6 +5,7 @@ import { usageHistoryScheduler } from "~/services/history/usageHistory/scheduler
 import { modelMetadataService } from "~/services/models/modelMetadata"
 import { modelSyncScheduler } from "~/services/models/modelSync"
 import { initializeTaskNotificationService } from "~/services/notifications/taskNotificationService"
+import { productAnnouncementService } from "~/services/productAnnouncements/service"
 import { redemptionAssistService } from "~/services/redemption/redemptionAssist"
 import { siteAnnouncementScheduler } from "~/services/siteAnnouncements/scheduler"
 import { releaseUpdateService } from "~/services/updates/releaseUpdateService"
@@ -58,6 +59,7 @@ export async function initializeServices() {
         autoCheckinScheduler.initialize(),
         dailyBalanceHistoryScheduler.initialize(),
         siteAnnouncementScheduler.initialize(),
+        productAnnouncementService.initialize(),
         releaseUpdateService.initialize(),
       ])
       initializeTaskNotificationService()

--- a/src/entrypoints/options/components/Header.tsx
+++ b/src/entrypoints/options/components/Header.tsx
@@ -13,6 +13,7 @@ import { LanguageSwitcher } from "~/components/LanguageSwitcher"
 import { Heading5, IconButton } from "~/components/ui"
 import { VersionBadge } from "~/components/VersionBadge"
 import { Z_INDEX } from "~/constants/designTokens"
+import { ProductAnnouncementButton } from "~/features/ProductAnnouncements/ProductAnnouncementButton"
 import { useIsMobile } from "~/hooks/useMediaQuery"
 import { cn } from "~/lib/utils"
 import { getRepository } from "~/utils/navigation/packageMeta"
@@ -206,6 +207,7 @@ function Header({
               showMobileExpandedSearch && "hidden md:flex",
             )}
           >
+            <ProductAnnouncementButton surface="options-header" />
             <HeaderThemeSwitcher />
             <FeedbackDropdownMenu language={i18n.language} />
             <LanguageSwitcher variant="icon-dropdown" />

--- a/src/entrypoints/popup/components/HeaderSection.tsx
+++ b/src/entrypoints/popup/components/HeaderSection.tsx
@@ -17,6 +17,7 @@ import { VersionBadge } from "~/components/VersionBadge"
 import { COLORS } from "~/constants/designTokens"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import { useAccountDataContext } from "~/features/AccountManagement/hooks/AccountDataContext"
+import { ProductAnnouncementButton } from "~/features/ProductAnnouncements/ProductAnnouncementButton"
 import { buildAccountRefreshDiagnostics } from "~/services/productAnalytics/accountRefresh"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
@@ -207,6 +208,7 @@ export default function HeaderSection({
       {/* Action Buttons Section */}
       <ProductAnalyticsScope entrypoint={entrypoint} surfaceId={headerSurface}>
         <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+          <ProductAnnouncementButton surface="popup-header" onlyWhenRisk />
           <CompactThemeToggle />
           <FeedbackDropdownMenu language={i18n.language} />
 

--- a/src/features/OptionsOverview/OptionsOverview.tsx
+++ b/src/features/OptionsOverview/OptionsOverview.tsx
@@ -6,6 +6,9 @@ import { PageHeader } from "~/components/PageHeader"
 import { Alert, Button, Spinner } from "~/components/ui"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { PermissionOnboardingDialog } from "~/features/OptionsOverview/components/dialogs/PermissionOnboardingDialog"
+import { requestProductAnnouncementPopoverOpen } from "~/features/ProductAnnouncements/events"
+import { useProductAnnouncements } from "~/features/ProductAnnouncements/hooks/useProductAnnouncements"
+import { ProductAnnouncementBanner } from "~/features/ProductAnnouncements/ProductAnnouncementBanner"
 import { setLastSeenOptionalPermissions } from "~/services/permissions/optionalPermissionState"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -17,6 +20,7 @@ import {
   PRODUCT_ANALYTICS_TARGET_KINDS,
   trackProductAnalyticsEvent,
 } from "~/services/productAnalytics/events"
+import { PRODUCT_ANNOUNCEMENT_SEVERITIES } from "~/services/productAnnouncements/constants"
 import { pushWithinOptionsPage } from "~/utils/navigation"
 
 import { OptionsOverviewGrid } from "./components/OptionsOverviewGrid"
@@ -57,9 +61,24 @@ export function getPermissionsOnboardingReasonFromUrl(): string | null {
 export default function OptionsOverview() {
   const { t } = useTranslation(["optionsOverview", "common"])
   const { isLoading, error, viewModel, reload } = useOptionsOverviewData()
+  const {
+    state: productAnnouncementState,
+    dismiss: dismissProductAnnouncement,
+  } = useProductAnnouncements()
   const [permissionsOnboardingReason, setPermissionsOnboardingReason] =
     useState<string | null>(() => getPermissionsOnboardingReasonFromUrl())
   const showPermissionsOnboarding = permissionsOnboardingReason !== null
+  const primaryRiskNotice =
+    productAnnouncementState.view.primaryRiskNotice ?? null
+  const additionalRiskNoticeCount = primaryRiskNotice
+    ? productAnnouncementState.view.activeNotices.filter(
+        (notice) =>
+          notice.id !== primaryRiskNotice.id &&
+          !notice.dismissed &&
+          (notice.severity === PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical ||
+            notice.severity === PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning),
+      ).length
+    : 0
 
   useEffect(() => {
     const applyUrlState = () => {
@@ -121,6 +140,10 @@ export default function OptionsOverview() {
     pushWithinOptionsPage(`#${target.menuItemId}`, target.params ?? {})
   }
 
+  const handleViewAllProductAnnouncements = () => {
+    requestProductAnnouncementPopoverOpen("options-header")
+  }
+
   return (
     <div className="space-y-6 p-6" data-testid={OPTIONS_OVERVIEW_TEST_IDS.page}>
       <PageHeader
@@ -159,11 +182,21 @@ export default function OptionsOverview() {
       ) : null}
 
       {viewModel ? (
-        <OptionsOverviewGrid
-          viewModel={viewModel}
-          t={t}
-          onNavigate={handleNavigate}
-        />
+        <>
+          {primaryRiskNotice ? (
+            <ProductAnnouncementBanner
+              notice={primaryRiskNotice}
+              additionalCount={additionalRiskNoticeCount}
+              onViewAll={handleViewAllProductAnnouncements}
+              onDismiss={dismissProductAnnouncement}
+            />
+          ) : null}
+          <OptionsOverviewGrid
+            viewModel={viewModel}
+            t={t}
+            onNavigate={handleNavigate}
+          />
+        </>
       ) : null}
 
       <PermissionOnboardingDialog

--- a/src/features/ProductAnnouncements/ProductAnnouncementBanner.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementBanner.tsx
@@ -1,0 +1,159 @@
+import type { TFunction } from "i18next"
+import { AlertTriangle } from "lucide-react"
+import type { ComponentProps } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Badge, Button } from "~/components/ui"
+import { cn } from "~/lib/utils"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+
+import {
+  PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS,
+  trackProductAnnouncementAction,
+} from "./analytics"
+import { PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES } from "./presentation"
+
+interface ProductAnnouncementBannerProps {
+  notice: ProductAnnouncement
+  additionalCount: number
+  onViewAll: () => void
+  onDismiss: (id: string, revision: number) => void
+}
+
+type BadgeVariant = ComponentProps<typeof Badge>["variant"]
+
+const SEVERITY_BADGE_VARIANTS: Record<
+  ProductAnnouncement["severity"],
+  BadgeVariant
+> = {
+  critical: "danger",
+  warning: "warning",
+  info: "info",
+}
+
+/**
+ * Returns localized copy for the fixed product announcement severity set.
+ */
+function getSeverityLabel(
+  severity: ProductAnnouncement["severity"],
+  t: TFunction<"productAnnouncements">,
+) {
+  if (severity === "critical") {
+    return t("labels.critical")
+  }
+
+  if (severity === "warning") {
+    return t("labels.warning")
+  }
+
+  return t("labels.info")
+}
+
+/**
+ * Resolves the plural summary with static keys so every locale keeps the same key family.
+ */
+function getAdditionalSummary(
+  additionalCount: number,
+  t: TFunction<"productAnnouncements">,
+) {
+  if (additionalCount === 1) {
+    return t("summary.additional_one", { riskCount: additionalCount })
+  }
+
+  return t("summary.additional_other", { riskCount: additionalCount })
+}
+
+/**
+ * Renders the highest-priority active risk notice as a compact Overview banner.
+ */
+export function ProductAnnouncementBanner({
+  notice,
+  additionalCount,
+  onViewAll,
+  onDismiss,
+}: ProductAnnouncementBannerProps) {
+  const { t } = useTranslation("productAnnouncements")
+  const activeCount = additionalCount + 1
+  const handleViewAll = () => {
+    trackProductAnnouncementAction({
+      actionKind: PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS.OpenList,
+      activeCount,
+      notice,
+      surface: "options-banner",
+    })
+    onViewAll()
+  }
+  const handleDismiss = () => {
+    trackProductAnnouncementAction({
+      actionKind: PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS.Dismiss,
+      activeCount,
+      notice,
+      surface: "options-banner",
+    })
+    onDismiss(notice.id, notice.revision)
+  }
+  const severityStyles = PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES[notice.severity]
+
+  return (
+    <section
+      className={cn(
+        "dark:bg-dark-bg-secondary/95 dark:text-dark-text-primary overflow-hidden rounded-lg border border-slate-200/80 bg-white/95 p-3 text-slate-900 shadow-sm shadow-slate-200/60 dark:border-white/10 dark:shadow-black/20",
+      )}
+    >
+      <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <span
+            className={cn(
+              "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md",
+              severityStyles.icon,
+            )}
+          >
+            <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+          </span>
+          <div className="min-w-0 space-y-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <h2 className="min-w-0 text-sm leading-5 font-semibold break-words">
+                {notice.title}
+              </h2>
+              <Badge
+                variant={SEVERITY_BADGE_VARIANTS[notice.severity]}
+                size="sm"
+                className={cn("shrink-0", severityStyles.badge)}
+              >
+                {getSeverityLabel(notice.severity, t)}
+              </Badge>
+            </div>
+            <p className="dark:text-dark-text-secondary text-sm leading-5 break-words whitespace-pre-wrap text-slate-600">
+              {notice.message}
+            </p>
+            {additionalCount > 0 ? (
+              <p className="dark:text-dark-text-tertiary text-xs leading-5 font-medium text-slate-500">
+                {getAdditionalSummary(additionalCount, t)}
+              </p>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="dark:text-dark-text-secondary h-8 border-slate-200 bg-white/70 px-3 text-xs text-slate-700 hover:bg-slate-50 dark:border-white/10 dark:bg-white/[0.04] dark:hover:bg-white/[0.08]"
+            onClick={handleViewAll}
+          >
+            {t("actions.viewAll")}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="dark:text-dark-text-secondary h-8 px-3 text-xs text-slate-600 hover:bg-slate-100 dark:hover:bg-white/[0.08]"
+            onClick={handleDismiss}
+          >
+            {t("actions.dismiss")}
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/features/ProductAnnouncements/ProductAnnouncementBanner.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementBanner.tsx
@@ -11,7 +11,10 @@ import {
   PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS,
   trackProductAnnouncementAction,
 } from "./analytics"
-import { PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES } from "./presentation"
+import {
+  getProductAnnouncementSeverityLabel,
+  PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES,
+} from "./presentation"
 
 interface ProductAnnouncementBannerProps {
   notice: ProductAnnouncement
@@ -29,24 +32,6 @@ const SEVERITY_BADGE_VARIANTS: Record<
   critical: "danger",
   warning: "warning",
   info: "info",
-}
-
-/**
- * Returns localized copy for the fixed product announcement severity set.
- */
-function getSeverityLabel(
-  severity: ProductAnnouncement["severity"],
-  t: TFunction<"productAnnouncements">,
-) {
-  if (severity === "critical") {
-    return t("labels.critical")
-  }
-
-  if (severity === "warning") {
-    return t("labels.warning")
-  }
-
-  return t("labels.info")
 }
 
 /**
@@ -120,7 +105,7 @@ export function ProductAnnouncementBanner({
                 size="sm"
                 className={cn("shrink-0", severityStyles.badge)}
               >
-                {getSeverityLabel(notice.severity, t)}
+                {getProductAnnouncementSeverityLabel(notice.severity, t)}
               </Badge>
             </div>
             <p className="dark:text-dark-text-secondary text-sm leading-5 break-words whitespace-pre-wrap text-slate-600">

--- a/src/features/ProductAnnouncements/ProductAnnouncementButton.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementButton.tsx
@@ -1,0 +1,267 @@
+import { MegaphoneIcon } from "@heroicons/react/24/outline"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Badge, IconButton } from "~/components/ui"
+import { Popover, PopoverTrigger } from "~/components/ui/popover"
+import { Sheet, SheetContent, SheetTrigger } from "~/components/ui/sheet"
+import { useIsSmallScreen } from "~/hooks/useMediaQuery"
+import { cn } from "~/lib/utils"
+
+import {
+  PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS,
+  trackProductAnnouncementAction,
+} from "./analytics"
+import {
+  isProductAnnouncementOpenEvent,
+  PRODUCT_ANNOUNCEMENT_OPEN_EVENT,
+} from "./events"
+import { useProductAnnouncements } from "./hooks/useProductAnnouncements"
+import {
+  getVisibleActiveProductAnnouncements,
+  ProductAnnouncementPanel,
+  ProductAnnouncementPopover,
+} from "./ProductAnnouncementPopover"
+import { PRODUCT_ANNOUNCEMENT_TEST_IDS } from "./testIds"
+
+export type ProductAnnouncementButtonSurface = "options-header" | "popup-header"
+
+interface ProductAnnouncementButtonProps {
+  surface: ProductAnnouncementButtonSurface
+  onlyWhenRisk?: boolean
+  className?: string
+}
+
+/**
+ * Renders the persistent product announcement header trigger with active risk badge state.
+ */
+export function ProductAnnouncementButton({
+  surface,
+  onlyWhenRisk = false,
+  className,
+}: ProductAnnouncementButtonProps) {
+  const { t } = useTranslation("productAnnouncements")
+  const isSmallScreen = useIsSmallScreen()
+  const [open, setOpen] = useState(false)
+  const { state, isLoading, markSeen, dismiss, restore } =
+    useProductAnnouncements()
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const preserveTriggerFocusOnOpenRef = useRef(false)
+  const activeRiskCount = state.view.activeRiskCount
+  const activeNotices = getVisibleActiveProductAnnouncements(state)
+  const markSeenIdsRef = useRef<Set<string>>(new Set())
+  const buttonLabel =
+    activeRiskCount > 0
+      ? t("actions.openWithRiskCount", { riskCount: activeRiskCount })
+      : t("actions.open")
+
+  const trackOpenList = useCallback(() => {
+    trackProductAnnouncementAction({
+      actionKind: PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS.OpenList,
+      activeCount: activeNotices.length,
+      surface,
+    })
+  }, [activeNotices.length, surface])
+
+  useEffect(() => {
+    const handleOpenRequest = (event: Event) => {
+      if (
+        !isProductAnnouncementOpenEvent(event) ||
+        event.detail.surface !== surface
+      ) {
+        return
+      }
+
+      triggerRef.current?.focus()
+      preserveTriggerFocusOnOpenRef.current = true
+      setOpen(true)
+    }
+
+    window.addEventListener(PRODUCT_ANNOUNCEMENT_OPEN_EVENT, handleOpenRequest)
+
+    return () => {
+      window.removeEventListener(
+        PRODUCT_ANNOUNCEMENT_OPEN_EVENT,
+        handleOpenRequest,
+      )
+    }
+  }, [surface])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const unseenActiveIds = activeNotices
+      .filter((notice) => !notice.seen)
+      .map((notice) => notice.id)
+      .filter((id) => !markSeenIdsRef.current.has(id))
+
+    if (unseenActiveIds.length === 0) {
+      return
+    }
+
+    unseenActiveIds.forEach((id) => markSeenIdsRef.current.add(id))
+
+    void markSeen(unseenActiveIds).then((success) => {
+      if (success) {
+        return
+      }
+
+      unseenActiveIds.forEach((id) => markSeenIdsRef.current.delete(id))
+    })
+  }, [activeNotices, markSeen, open])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        preserveTriggerFocusOnOpenRef.current = false
+      }
+
+      if (nextOpen && !open) {
+        trackOpenList()
+      }
+
+      setOpen(nextOpen)
+    },
+    [open, trackOpenList],
+  )
+
+  const handleOpenAutoFocus = useCallback((event: Event) => {
+    if (!preserveTriggerFocusOnOpenRef.current) {
+      return
+    }
+
+    event.preventDefault()
+    preserveTriggerFocusOnOpenRef.current = false
+  }, [])
+
+  const handleClose = useCallback(() => {
+    setOpen(false)
+  }, [])
+
+  const handleDismiss = useCallback(
+    (id: string, revision: number) => {
+      const notice = activeNotices.find((item) => item.id === id)
+      trackProductAnnouncementAction({
+        actionKind: PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS.Dismiss,
+        activeCount: activeNotices.length,
+        ...(notice ? { notice } : {}),
+        surface,
+      })
+      dismiss(id, revision)
+    },
+    [activeNotices, dismiss, surface],
+  )
+
+  const handleRestore = useCallback(
+    (id: string) => {
+      const notice = state.view.dismissedNotices.find((item) => item.id === id)
+      trackProductAnnouncementAction({
+        actionKind: PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS.Restore,
+        activeCount: activeNotices.length,
+        ...(notice ? { notice } : {}),
+        surface,
+      })
+      return restore(id)
+    },
+    [activeNotices.length, restore, state.view.dismissedNotices, surface],
+  )
+
+  const handleOpenCta = useCallback(
+    (notice: (typeof activeNotices)[number]) => {
+      trackProductAnnouncementAction({
+        actionKind: PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS.OpenCta,
+        activeCount: activeNotices.length,
+        notice,
+        surface,
+      })
+    },
+    [activeNotices.length, surface],
+  )
+
+  const shouldReserveSlot = onlyWhenRisk && surface === "popup-header"
+  const shouldShowButton =
+    !onlyWhenRisk || Boolean(state.view.primaryRiskNotice)
+  const shouldUseSheet = surface === "popup-header" || isSmallScreen
+
+  const triggerButton = (
+    <IconButton
+      ref={triggerRef}
+      type="button"
+      variant="outline"
+      size="sm"
+      aria-label={buttonLabel}
+      data-testid={PRODUCT_ANNOUNCEMENT_TEST_IDS.button}
+      className={cn("relative", className)}
+    >
+      <MegaphoneIcon className="h-4 w-4" />
+      {activeRiskCount > 0 ? (
+        <Badge
+          variant="danger"
+          size="sm"
+          aria-hidden="true"
+          data-testid={PRODUCT_ANNOUNCEMENT_TEST_IDS.badge}
+          className="pointer-events-none absolute -top-1 -right-1 min-w-4 px-1 text-[0.6rem] leading-3"
+        >
+          {activeRiskCount > 99 ? "99+" : activeRiskCount}
+        </Badge>
+      ) : null}
+    </IconButton>
+  )
+
+  const button = shouldShowButton ? (
+    shouldUseSheet ? (
+      <Sheet open={open} onOpenChange={handleOpenChange}>
+        <SheetTrigger asChild>{triggerButton}</SheetTrigger>
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          className="p-4"
+          data-testid={PRODUCT_ANNOUNCEMENT_TEST_IDS.sheet}
+          onOpenAutoFocus={handleOpenAutoFocus}
+        >
+          <ProductAnnouncementPanel
+            surface="sheet"
+            state={state}
+            isLoading={isLoading}
+            onDismiss={handleDismiss}
+            onRestore={handleRestore}
+            onOpenCta={handleOpenCta}
+            onClose={handleClose}
+          />
+        </SheetContent>
+      </Sheet>
+    ) : (
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+        <ProductAnnouncementPopover
+          state={state}
+          isLoading={isLoading}
+          onDismiss={handleDismiss}
+          onRestore={handleRestore}
+          onOpenCta={handleOpenCta}
+          onClose={handleClose}
+          onOpenAutoFocus={handleOpenAutoFocus}
+        />
+      </Popover>
+    )
+  ) : null
+
+  if (shouldReserveSlot) {
+    return (
+      <span
+        aria-hidden={!shouldShowButton ? "true" : undefined}
+        data-testid={PRODUCT_ANNOUNCEMENT_TEST_IDS.reservedSlot}
+        className={cn(
+          "inline-flex h-6 w-6 shrink-0 items-center justify-center sm:h-8 sm:w-8",
+          className,
+        )}
+      >
+        {button}
+      </span>
+    )
+  }
+
+  return button
+}

--- a/src/features/ProductAnnouncements/ProductAnnouncementList.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementList.tsx
@@ -1,0 +1,193 @@
+import type { TFunction } from "i18next"
+import { ExternalLink } from "lucide-react"
+import type { ComponentProps } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Badge, Button } from "~/components/ui"
+import { cn } from "~/lib/utils"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+
+import { PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES } from "./presentation"
+
+interface ProductAnnouncementListProps {
+  notices: ProductAnnouncement[]
+  emptyMessage: string
+  isLoading?: boolean
+  testId: string
+  onDismiss: (id: string, revision: number) => void
+  onRestore: (id: string) => void | Promise<void>
+  onOpenCta?: (notice: ProductAnnouncement) => void
+}
+
+type BadgeVariant = ComponentProps<typeof Badge>["variant"]
+
+const SEVERITY_BADGE_VARIANTS: Record<
+  ProductAnnouncement["severity"],
+  BadgeVariant
+> = {
+  critical: "danger",
+  warning: "warning",
+  info: "info",
+}
+
+/**
+ * Returns localized copy for the fixed product announcement severity set.
+ */
+function getSeverityLabel(
+  severity: ProductAnnouncement["severity"],
+  t: TFunction<"productAnnouncements">,
+) {
+  if (severity === "critical") {
+    return t("labels.critical")
+  }
+
+  if (severity === "warning") {
+    return t("labels.warning")
+  }
+
+  return t("labels.info")
+}
+
+/**
+ * Keeps CTA rendering limited to safe HTTPS navigation even if upstream validation changes.
+ */
+function isHttpsUrl(url: string) {
+  try {
+    return new URL(url).protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Renders a compact scrollable announcement list for the header popover.
+ */
+export function ProductAnnouncementList({
+  notices,
+  emptyMessage,
+  isLoading = false,
+  testId,
+  onDismiss,
+  onRestore,
+  onOpenCta,
+}: ProductAnnouncementListProps) {
+  const { t } = useTranslation("productAnnouncements")
+
+  if (isLoading) {
+    return (
+      <div
+        data-testid={testId}
+        className="py-6 text-center text-sm text-gray-500 dark:text-gray-400"
+      >
+        {t("loading")}
+      </div>
+    )
+  }
+
+  if (notices.length === 0) {
+    return (
+      <div
+        data-testid={testId}
+        className="py-6 text-center text-sm text-gray-500 dark:text-gray-400"
+      >
+        {emptyMessage}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-testid={testId}
+      className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
+    >
+      {notices.map((notice) => {
+        const cta = notice.cta && isHttpsUrl(notice.cta.url) ? notice.cta : null
+        const dismissLabel = t("actions.dismissFor", { title: notice.title })
+        const dismissAriaLabel =
+          dismissLabel === "productAnnouncements:actions.dismissFor"
+            ? `${t("actions.dismiss")} ${notice.title}`
+            : dismissLabel
+        const restoreLabel = t("actions.restoreFor", { title: notice.title })
+        const restoreAriaLabel =
+          restoreLabel === "productAnnouncements:actions.restoreFor"
+            ? `${t("actions.restore")} ${notice.title}`
+            : restoreLabel
+
+        return (
+          <article
+            key={`${notice.id}:${notice.revision}`}
+            className={cn(
+              "dark:bg-dark-bg-secondary/95 relative overflow-hidden rounded-md border bg-white/95 p-3 shadow-sm shadow-slate-200/40 transition-colors dark:shadow-black/20",
+              notice.seen
+                ? "border-slate-200/80 dark:border-white/10"
+                : "border-slate-300/80 dark:border-white/20",
+            )}
+          >
+            <div className="flex min-w-0 items-start justify-between gap-2">
+              <h3 className="dark:text-dark-text-primary min-w-0 flex-1 text-sm leading-5 font-medium break-words text-gray-900">
+                {!notice.seen ? (
+                  <>
+                    <span
+                      className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full bg-blue-500 align-middle dark:bg-blue-300"
+                      aria-hidden="true"
+                    />
+                    <span className="sr-only">{t("labels.unread")} </span>
+                  </>
+                ) : null}
+                <Badge
+                  variant={SEVERITY_BADGE_VARIANTS[notice.severity]}
+                  size="sm"
+                  className={cn(
+                    "mr-1.5 px-1.5 py-0 align-[0.0625rem] text-[0.625rem] leading-4 font-medium",
+                    PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES[notice.severity].badge,
+                  )}
+                >
+                  {getSeverityLabel(notice.severity, t)}
+                </Badge>
+                {notice.title}
+              </h3>
+              {notice.dismissed ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 shrink-0 px-2 text-xs leading-none"
+                  aria-label={restoreAriaLabel}
+                  onClick={() => onRestore(notice.id)}
+                >
+                  {t("actions.restore")}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 shrink-0 px-2 text-xs leading-none"
+                  aria-label={dismissAriaLabel}
+                  onClick={() => onDismiss(notice.id, notice.revision)}
+                >
+                  {t("actions.dismiss")}
+                </Button>
+              )}
+            </div>
+            <p className="dark:text-dark-text-secondary mt-2 text-xs leading-5 break-words whitespace-pre-wrap text-gray-600">
+              {notice.message}
+            </p>
+            {cta ? (
+              <a
+                href={cta.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex max-w-full items-center gap-1 text-xs font-medium text-blue-600 underline-offset-4 hover:underline dark:text-blue-300"
+                onClick={() => onOpenCta?.(notice)}
+              >
+                <span className="min-w-0 break-words">{cta.label}</span>
+                <ExternalLink className="h-3 w-3 shrink-0" />
+              </a>
+            ) : null}
+          </article>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/features/ProductAnnouncements/ProductAnnouncementList.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementList.tsx
@@ -1,4 +1,3 @@
-import type { TFunction } from "i18next"
 import { ExternalLink } from "lucide-react"
 import type { ComponentProps } from "react"
 import { useTranslation } from "react-i18next"
@@ -7,7 +6,10 @@ import { Badge, Button } from "~/components/ui"
 import { cn } from "~/lib/utils"
 import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
 
-import { PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES } from "./presentation"
+import {
+  getProductAnnouncementSeverityLabel,
+  PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES,
+} from "./presentation"
 
 interface ProductAnnouncementListProps {
   notices: ProductAnnouncement[]
@@ -28,24 +30,6 @@ const SEVERITY_BADGE_VARIANTS: Record<
   critical: "danger",
   warning: "warning",
   info: "info",
-}
-
-/**
- * Returns localized copy for the fixed product announcement severity set.
- */
-function getSeverityLabel(
-  severity: ProductAnnouncement["severity"],
-  t: TFunction<"productAnnouncements">,
-) {
-  if (severity === "critical") {
-    return t("labels.critical")
-  }
-
-  if (severity === "warning") {
-    return t("labels.warning")
-  }
-
-  return t("labels.info")
 }
 
 /**
@@ -142,7 +126,7 @@ export function ProductAnnouncementList({
                     PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES[notice.severity].badge,
                   )}
                 >
-                  {getSeverityLabel(notice.severity, t)}
+                  {getProductAnnouncementSeverityLabel(notice.severity, t)}
                 </Badge>
                 {notice.title}
               </h3>

--- a/src/features/ProductAnnouncements/ProductAnnouncementPopover.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementPopover.tsx
@@ -1,0 +1,178 @@
+import { Archive, Bell, X } from "lucide-react"
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Button, IconButton } from "~/components/ui"
+import { PopoverContent } from "~/components/ui/popover"
+import { SheetDescription, SheetTitle } from "~/components/ui/sheet"
+import { cn } from "~/lib/utils"
+import type { ProductAnnouncementRuntimeState } from "~/services/productAnnouncements/service"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+
+import { ProductAnnouncementList } from "./ProductAnnouncementList"
+import { PRODUCT_ANNOUNCEMENT_TEST_IDS } from "./testIds"
+
+interface ProductAnnouncementPopoverProps {
+  state: ProductAnnouncementRuntimeState
+  isLoading: boolean
+  onDismiss: (id: string, revision: number) => void
+  onRestore: (id: string) => Promise<boolean>
+  onOpenCta?: (notice: ProductAnnouncement) => void
+  onClose: () => void
+  onOpenAutoFocus?: (event: Event) => void
+}
+
+type ProductAnnouncementFilter = "active" | "dismissed"
+type ProductAnnouncementPanelSurface = "popover" | "sheet"
+
+/**
+ * Resolves active notices, tolerating older or test fixtures that only populate the full notice list.
+ */
+export function getVisibleActiveProductAnnouncements(
+  state: ProductAnnouncementRuntimeState,
+) {
+  if (state.view.activeNotices.length > 0) {
+    return state.view.activeNotices
+  }
+
+  return state.view.notices.filter((notice) => !notice.dismissed)
+}
+
+interface ProductAnnouncementPanelProps
+  extends Omit<ProductAnnouncementPopoverProps, "onOpenAutoFocus"> {
+  surface: ProductAnnouncementPanelSurface
+}
+
+/**
+ * Renders shared announcement panel content for popover and sheet surfaces.
+ */
+function ProductAnnouncementPanel({
+  surface,
+  state,
+  isLoading,
+  onDismiss,
+  onRestore,
+  onOpenCta,
+  onClose,
+}: ProductAnnouncementPanelProps) {
+  const { t } = useTranslation("productAnnouncements")
+  const [filter, setFilter] = useState<ProductAnnouncementFilter>("active")
+  const activeNotices = getVisibleActiveProductAnnouncements(state)
+  const visibleNotices =
+    filter === "active" ? activeNotices : state.view.dismissedNotices
+  const handleRestore = async (id: string) => {
+    await onRestore(id)
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+      <div className="flex items-center justify-between gap-3">
+        {surface === "sheet" ? (
+          <SheetTitle className="dark:text-dark-text-primary truncate text-base text-gray-900">
+            {t("title")}
+          </SheetTitle>
+        ) : (
+          <h2 className="dark:text-dark-text-primary truncate text-base font-semibold text-gray-900">
+            {t("title")}
+          </h2>
+        )}
+        {surface === "sheet" ? (
+          <SheetDescription className="sr-only">
+            {t("empty.active")}
+          </SheetDescription>
+        ) : null}
+        <IconButton
+          type="button"
+          variant="ghost"
+          size="xs"
+          aria-label={t("actions.close")}
+          data-testid={PRODUCT_ANNOUNCEMENT_TEST_IDS.closeButton}
+          className="dark:hover:text-dark-text-primary shrink-0 text-gray-500 hover:text-gray-900 dark:text-gray-400"
+          onClick={onClose}
+        >
+          <X className="h-3.5 w-3.5" aria-hidden="true" />
+        </IconButton>
+      </div>
+      <div className="dark:bg-dark-bg-tertiary grid grid-cols-2 gap-1 rounded-lg bg-gray-100 p-1">
+        <Button
+          type="button"
+          variant={filter === "active" ? "secondary" : "ghost"}
+          size="sm"
+          className={cn(
+            "h-8 min-w-0 gap-1.5 px-3 text-xs",
+            filter === "active" && "dark:bg-dark-bg-primary bg-white shadow-sm",
+          )}
+          aria-pressed={filter === "active"}
+          onClick={() => setFilter("active")}
+        >
+          <Bell className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span className="truncate">{t("filters.active")}</span>
+        </Button>
+        <Button
+          type="button"
+          variant={filter === "dismissed" ? "secondary" : "ghost"}
+          size="sm"
+          className={cn(
+            "h-8 min-w-0 gap-1.5 px-3 text-xs",
+            filter === "dismissed" &&
+              "dark:bg-dark-bg-primary bg-white shadow-sm",
+          )}
+          aria-pressed={filter === "dismissed"}
+          onClick={() => setFilter("dismissed")}
+        >
+          <Archive className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span className="truncate">{t("filters.dismissed")}</span>
+        </Button>
+      </div>
+      <ProductAnnouncementList
+        notices={visibleNotices}
+        emptyMessage={
+          filter === "active" ? t("empty.active") : t("empty.dismissed")
+        }
+        isLoading={isLoading}
+        testId={
+          filter === "active"
+            ? PRODUCT_ANNOUNCEMENT_TEST_IDS.activeList
+            : PRODUCT_ANNOUNCEMENT_TEST_IDS.dismissedList
+        }
+        onDismiss={onDismiss}
+        onRestore={handleRestore}
+        onOpenCta={onOpenCta}
+      />
+    </div>
+  )
+}
+
+/**
+ * Shows active and dismissed product announcements in a compact popover panel.
+ */
+export function ProductAnnouncementPopover({
+  state,
+  isLoading,
+  onDismiss,
+  onRestore,
+  onOpenCta,
+  onClose,
+  onOpenAutoFocus,
+}: ProductAnnouncementPopoverProps) {
+  return (
+    <PopoverContent
+      align="end"
+      className="flex max-h-[min(var(--radix-popover-content-available-height,32rem),70vh,32rem)] w-[min(calc(100vw-2rem),28rem)] max-w-[calc(100vw-2rem)] flex-col p-4"
+      data-testid={PRODUCT_ANNOUNCEMENT_TEST_IDS.popover}
+      onOpenAutoFocus={onOpenAutoFocus}
+    >
+      <ProductAnnouncementPanel
+        surface="popover"
+        state={state}
+        isLoading={isLoading}
+        onDismiss={onDismiss}
+        onRestore={onRestore}
+        onOpenCta={onOpenCta}
+        onClose={onClose}
+      />
+    </PopoverContent>
+  )
+}
+
+export { ProductAnnouncementPanel }

--- a/src/features/ProductAnnouncements/analytics.ts
+++ b/src/features/ProductAnnouncements/analytics.ts
@@ -1,0 +1,101 @@
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_EVENTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS,
+  PRODUCT_ANALYTICS_RESULTS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+  trackProductAnalyticsEvent,
+  type ProductAnalyticsActionId,
+  type ProductAnalyticsEntrypoint,
+  type ProductAnalyticsSurfaceId,
+} from "~/services/productAnalytics/events"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+
+import type { ProductAnnouncementButtonSurface } from "./ProductAnnouncementButton"
+
+type ProductAnnouncementAnalyticsSurface =
+  | ProductAnnouncementButtonSurface
+  | "options-banner"
+
+export const PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS = {
+  OpenList: PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS.OpenList,
+  Dismiss: PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS.Dismiss,
+  Restore: PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS.Restore,
+  OpenCta: PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS.OpenCta,
+} as const
+
+type ProductAnnouncementAnalyticsActionKind =
+  (typeof PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS)[keyof typeof PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS]
+
+const PRODUCT_ANNOUNCEMENT_SURFACE_TO_ANALYTICS = {
+  "options-header": {
+    surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsProductAnnouncementsHeader,
+    entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+  },
+  "options-banner": {
+    surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsProductAnnouncementsBanner,
+    entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+  },
+  "popup-header": {
+    surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.PopupProductAnnouncementsHeader,
+    entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Popup,
+  },
+} satisfies Record<
+  ProductAnnouncementAnalyticsSurface,
+  {
+    surfaceId: ProductAnalyticsSurfaceId
+    entrypoint: ProductAnalyticsEntrypoint
+  }
+>
+
+const PRODUCT_ANNOUNCEMENT_ACTION_KIND_TO_ACTION = {
+  [PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS.OpenList]:
+    PRODUCT_ANALYTICS_ACTION_IDS.OpenProductAnnouncements,
+  [PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS.Dismiss]:
+    PRODUCT_ANALYTICS_ACTION_IDS.DismissProductAnnouncement,
+  [PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS.Restore]:
+    PRODUCT_ANALYTICS_ACTION_IDS.RestoreProductAnnouncement,
+  [PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS.OpenCta]:
+    PRODUCT_ANALYTICS_ACTION_IDS.OpenProductAnnouncementCta,
+} satisfies Record<
+  ProductAnnouncementAnalyticsActionKind,
+  ProductAnalyticsActionId
+>
+
+/** Tracks product announcement interactions using only controlled metadata. */
+export function trackProductAnnouncementAction({
+  actionKind,
+  activeCount,
+  notice,
+  surface,
+}: {
+  actionKind: ProductAnnouncementAnalyticsActionKind
+  activeCount?: number
+  notice?: ProductAnnouncement
+  surface: ProductAnnouncementAnalyticsSurface
+}) {
+  const surfaceContext = PRODUCT_ANNOUNCEMENT_SURFACE_TO_ANALYTICS[surface]
+
+  void trackProductAnalyticsEvent(
+    PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+    {
+      feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ProductAnnouncements,
+      action_id: PRODUCT_ANNOUNCEMENT_ACTION_KIND_TO_ACTION[actionKind],
+      surface_id: surfaceContext.surfaceId,
+      entrypoint: surfaceContext.entrypoint,
+      result: PRODUCT_ANALYTICS_RESULTS.Success,
+      product_announcement_action_kind: actionKind,
+      ...(notice
+        ? {
+            product_announcement_id: notice.id,
+            product_announcement_severity: notice.severity,
+          }
+        : {}),
+      ...(typeof activeCount === "number"
+        ? { product_announcement_active_count: activeCount }
+        : {}),
+    },
+  )
+}

--- a/src/features/ProductAnnouncements/events.ts
+++ b/src/features/ProductAnnouncements/events.ts
@@ -1,0 +1,47 @@
+import type { ProductAnnouncementButtonSurface } from "./ProductAnnouncementButton"
+
+export const PRODUCT_ANNOUNCEMENT_OPEN_EVENT =
+  "all-api-hub:product-announcements:open"
+
+export const PRODUCT_ANNOUNCEMENT_RELOAD_EVENT =
+  "all-api-hub:product-announcements:reload"
+
+interface ProductAnnouncementOpenEventDetail {
+  surface: ProductAnnouncementButtonSurface
+}
+
+/**
+ * Requests a specific announcement button surface to open its popover.
+ */
+export function requestProductAnnouncementPopoverOpen(
+  surface: ProductAnnouncementButtonSurface,
+) {
+  window.dispatchEvent(
+    new CustomEvent<ProductAnnouncementOpenEventDetail>(
+      PRODUCT_ANNOUNCEMENT_OPEN_EVENT,
+      {
+        detail: { surface },
+      },
+    ),
+  )
+}
+
+/**
+ * Requests mounted announcement consumers to reload their local view state.
+ */
+export function requestProductAnnouncementsReload() {
+  window.dispatchEvent(new Event(PRODUCT_ANNOUNCEMENT_RELOAD_EVENT))
+}
+
+/**
+ * Narrows a browser Event to the feature-owned announcement open request.
+ */
+export function isProductAnnouncementOpenEvent(
+  event: Event,
+): event is CustomEvent<ProductAnnouncementOpenEventDetail> {
+  return (
+    event.type === PRODUCT_ANNOUNCEMENT_OPEN_EVENT &&
+    typeof (event as CustomEvent<ProductAnnouncementOpenEventDetail>).detail
+      ?.surface === "string"
+  )
+}

--- a/src/features/ProductAnnouncements/hooks/useProductAnnouncements.ts
+++ b/src/features/ProductAnnouncements/hooks/useProductAnnouncements.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import {
+  PRODUCT_ANNOUNCEMENT_RELOAD_EVENT,
+  requestProductAnnouncementsReload,
+} from "~/features/ProductAnnouncements/events"
+import type { ProductAnnouncementView } from "~/services/productAnnouncements/catalog"
+import { sendProductAnnouncementsMessage } from "~/services/productAnnouncements/messaging"
+import type { ProductAnnouncementRuntimeState } from "~/services/productAnnouncements/service"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
+
+const EMPTY_VIEW: ProductAnnouncementView = {
+  notices: [],
+  activeNotices: [],
+  dismissedNotices: [],
+  primaryRiskNotice: null,
+  activeRiskCount: 0,
+  unseenActiveCount: 0,
+}
+
+const EMPTY_STATE: ProductAnnouncementRuntimeState = {
+  view: EMPTY_VIEW,
+}
+
+/**
+ * Loads product announcements through background messaging and exposes best-effort mutations.
+ */
+export function useProductAnnouncements() {
+  const { i18n } = useTranslation()
+  const [state, setState] =
+    useState<ProductAnnouncementRuntimeState>(EMPTY_STATE)
+  const [isLoading, setIsLoading] = useState(true)
+  const isMountedRef = useRef(false)
+  const reloadSequenceRef = useRef(0)
+
+  const reload = useCallback(async () => {
+    if (!isMountedRef.current) {
+      return
+    }
+
+    const sequence = reloadSequenceRef.current + 1
+    reloadSequenceRef.current = sequence
+    setIsLoading(true)
+
+    try {
+      const response = await sendProductAnnouncementsMessage(
+        ProductAnnouncementsMessageTypes.GetState,
+        { locale: i18n.language },
+      )
+
+      if (
+        response.success &&
+        isMountedRef.current &&
+        sequence === reloadSequenceRef.current
+      ) {
+        setState(response.data)
+      }
+    } catch {
+      // Announcement state is best-effort; UI should not fail when messaging is unavailable.
+    } finally {
+      if (isMountedRef.current && sequence === reloadSequenceRef.current) {
+        setIsLoading(false)
+      }
+    }
+  }, [i18n.language])
+
+  const markSeen = useCallback(async (ids: string[]) => {
+    if (ids.length === 0) {
+      return true
+    }
+
+    try {
+      const response = await sendProductAnnouncementsMessage(
+        ProductAnnouncementsMessageTypes.MarkSeen,
+        { ids },
+      )
+
+      if (response.success && isMountedRef.current) {
+        requestProductAnnouncementsReload()
+      }
+
+      return response.success
+    } catch {
+      // Ignore best-effort read-state updates when the background service is unavailable.
+      return false
+    }
+  }, [])
+
+  const dismiss = useCallback(async (id: string, revision: number) => {
+    try {
+      const response = await sendProductAnnouncementsMessage(
+        ProductAnnouncementsMessageTypes.Dismiss,
+        { id, revision },
+      )
+
+      if (response.success && isMountedRef.current) {
+        requestProductAnnouncementsReload()
+      }
+    } catch {
+      // Keep the current list visible if dismissal cannot be persisted.
+    }
+  }, [])
+
+  const restore = useCallback(async (id: string) => {
+    try {
+      const response = await sendProductAnnouncementsMessage(
+        ProductAnnouncementsMessageTypes.Restore,
+        { id },
+      )
+
+      if (response.success && isMountedRef.current) {
+        requestProductAnnouncementsReload()
+      }
+
+      return response.success
+    } catch {
+      // Keep the current dismissed list visible if restore cannot be persisted.
+      return false
+    }
+  }, [])
+
+  useEffect(() => {
+    isMountedRef.current = true
+    void reload()
+
+    return () => {
+      isMountedRef.current = false
+      reloadSequenceRef.current += 1
+    }
+  }, [reload])
+
+  useEffect(() => {
+    const handleReloadRequest = () => {
+      void reload()
+    }
+
+    window.addEventListener(
+      PRODUCT_ANNOUNCEMENT_RELOAD_EVENT,
+      handleReloadRequest,
+    )
+
+    return () => {
+      window.removeEventListener(
+        PRODUCT_ANNOUNCEMENT_RELOAD_EVENT,
+        handleReloadRequest,
+      )
+    }
+  }, [reload])
+
+  return {
+    state,
+    isLoading,
+    reload,
+    markSeen,
+    dismiss,
+    restore,
+  }
+}

--- a/src/features/ProductAnnouncements/presentation.ts
+++ b/src/features/ProductAnnouncements/presentation.ts
@@ -1,3 +1,5 @@
+import type { TFunction } from "i18next"
+
 import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
 
 export const PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES: Record<
@@ -22,4 +24,22 @@ export const PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES: Record<
       "border-blue-200/80 bg-blue-500/10 text-blue-700 dark:border-blue-900/60 dark:bg-blue-500/15 dark:text-blue-300",
     icon: "bg-blue-500/10 text-blue-600 dark:bg-blue-500/15 dark:text-blue-300",
   },
+}
+
+/**
+ * Returns localized copy for the fixed product announcement severity set.
+ */
+export function getProductAnnouncementSeverityLabel(
+  severity: ProductAnnouncement["severity"],
+  t: TFunction<"productAnnouncements">,
+) {
+  if (severity === "critical") {
+    return t("labels.critical")
+  }
+
+  if (severity === "warning") {
+    return t("labels.warning")
+  }
+
+  return t("labels.info")
 }

--- a/src/features/ProductAnnouncements/presentation.ts
+++ b/src/features/ProductAnnouncements/presentation.ts
@@ -1,0 +1,25 @@
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+
+export const PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES: Record<
+  ProductAnnouncement["severity"],
+  {
+    badge: string
+    icon: string
+  }
+> = {
+  critical: {
+    badge:
+      "border-red-200/80 bg-red-500/10 text-red-700 dark:border-red-900/60 dark:bg-red-500/15 dark:text-red-300",
+    icon: "bg-red-500/10 text-red-600 dark:bg-red-500/15 dark:text-red-300",
+  },
+  warning: {
+    badge:
+      "border-amber-200/80 bg-amber-500/10 text-amber-700 dark:border-amber-900/60 dark:bg-amber-500/15 dark:text-amber-300",
+    icon: "bg-amber-500/10 text-amber-600 dark:bg-amber-500/15 dark:text-amber-300",
+  },
+  info: {
+    badge:
+      "border-blue-200/80 bg-blue-500/10 text-blue-700 dark:border-blue-900/60 dark:bg-blue-500/15 dark:text-blue-300",
+    icon: "bg-blue-500/10 text-blue-600 dark:bg-blue-500/15 dark:text-blue-300",
+  },
+}

--- a/src/features/ProductAnnouncements/testIds.ts
+++ b/src/features/ProductAnnouncements/testIds.ts
@@ -1,0 +1,10 @@
+export const PRODUCT_ANNOUNCEMENT_TEST_IDS = {
+  button: "product-announcement-button",
+  reservedSlot: "product-announcement-reserved-slot",
+  badge: "product-announcement-badge",
+  popover: "product-announcement-popover",
+  sheet: "product-announcement-sheet",
+  closeButton: "product-announcement-close-button",
+  activeList: "product-announcement-active-list",
+  dismissedList: "product-announcement-dismissed-list",
+} as const

--- a/src/locales/en/productAnnouncements.json
+++ b/src/locales/en/productAnnouncements.json
@@ -1,0 +1,32 @@
+{
+  "actions": {
+    "close": "Close product announcements",
+    "dismiss": "Dismiss",
+    "dismissFor": "Dismiss {{title}}",
+    "open": "Product announcements",
+    "openWithRiskCount": "Product announcements, {{riskCount}} active risk notices",
+    "restore": "Restore",
+    "restoreFor": "Restore {{title}}",
+    "viewAll": "View all"
+  },
+  "empty": {
+    "active": "No product announcements",
+    "dismissed": "No dismissed announcements"
+  },
+  "filters": {
+    "active": "Active",
+    "dismissed": "Dismissed"
+  },
+  "labels": {
+    "critical": "Critical",
+    "info": "Info",
+    "unread": "Unread",
+    "warning": "Warning"
+  },
+  "loading": "Loading product announcements...",
+  "summary": {
+    "additional_one": "{{riskCount}} more risk notice",
+    "additional_other": "{{riskCount}} more risk notices"
+  },
+  "title": "Product announcements"
+}

--- a/src/locales/ja/productAnnouncements.json
+++ b/src/locales/ja/productAnnouncements.json
@@ -1,0 +1,32 @@
+{
+  "actions": {
+    "close": "製品のお知らせを閉じる",
+    "dismiss": "表示しない",
+    "dismissFor": "{{title}}を表示しない",
+    "open": "製品のお知らせ",
+    "openWithRiskCount": "製品のお知らせ、対応が必要なリスク通知{{riskCount}}件",
+    "restore": "再表示",
+    "restoreFor": "{{title}}を再表示",
+    "viewAll": "すべて表示"
+  },
+  "empty": {
+    "active": "製品のお知らせはありません",
+    "dismissed": "閉じたお知らせはありません"
+  },
+  "filters": {
+    "active": "現在のお知らせ",
+    "dismissed": "閉じたもの"
+  },
+  "labels": {
+    "critical": "重大",
+    "info": "情報",
+    "unread": "未読",
+    "warning": "注意"
+  },
+  "loading": "製品のお知らせを読み込んでいます...",
+  "summary": {
+    "additional_one": "他に {{riskCount}} 件のリスク通知",
+    "additional_other": "他に {{riskCount}} 件のリスク通知"
+  },
+  "title": "製品のお知らせ"
+}

--- a/src/locales/vi/productAnnouncements.json
+++ b/src/locales/vi/productAnnouncements.json
@@ -1,0 +1,32 @@
+{
+  "actions": {
+    "close": "Đóng thông báo sản phẩm",
+    "dismiss": "Không hiển thị nữa",
+    "dismissFor": "Không hiển thị {{title}} nữa",
+    "open": "Thông báo sản phẩm",
+    "openWithRiskCount": "Thông báo sản phẩm, {{riskCount}} thông báo rủi ro cần xử lý",
+    "restore": "Hiển thị lại",
+    "restoreFor": "Hiển thị lại {{title}}",
+    "viewAll": "Xem tất cả"
+  },
+  "empty": {
+    "active": "Chưa có thông báo sản phẩm",
+    "dismissed": "Chưa có thông báo đã đóng"
+  },
+  "filters": {
+    "active": "Thông báo hiện tại",
+    "dismissed": "Đã đóng"
+  },
+  "labels": {
+    "critical": "Nghiêm trọng",
+    "info": "Thông tin",
+    "unread": "Chưa đọc",
+    "warning": "Nhắc nhở"
+  },
+  "loading": "Đang tải thông báo sản phẩm...",
+  "summary": {
+    "additional_one": "Còn {{riskCount}} thông báo rủi ro khác",
+    "additional_other": "Còn {{riskCount}} thông báo rủi ro khác"
+  },
+  "title": "Thông báo sản phẩm"
+}

--- a/src/locales/zh-CN/productAnnouncements.json
+++ b/src/locales/zh-CN/productAnnouncements.json
@@ -1,0 +1,32 @@
+{
+  "actions": {
+    "close": "关闭产品公告",
+    "dismiss": "不再显示",
+    "dismissFor": "不再显示：{{title}}",
+    "open": "产品公告",
+    "openWithRiskCount": "产品公告，{{riskCount}} 条风险公告待处理",
+    "restore": "恢复显示",
+    "restoreFor": "恢复显示：{{title}}",
+    "viewAll": "查看全部"
+  },
+  "empty": {
+    "active": "暂无产品公告",
+    "dismissed": "暂无已关闭公告"
+  },
+  "filters": {
+    "active": "当前公告",
+    "dismissed": "已关闭"
+  },
+  "labels": {
+    "critical": "严重",
+    "info": "信息",
+    "unread": "未读",
+    "warning": "提醒"
+  },
+  "loading": "正在加载产品公告...",
+  "summary": {
+    "additional_one": "还有 {{riskCount}} 条风险公告",
+    "additional_other": "还有 {{riskCount}} 条风险公告"
+  },
+  "title": "产品公告"
+}

--- a/src/locales/zh-TW/productAnnouncements.json
+++ b/src/locales/zh-TW/productAnnouncements.json
@@ -1,0 +1,32 @@
+{
+  "actions": {
+    "close": "關閉產品公告",
+    "dismiss": "不再顯示",
+    "dismissFor": "不再顯示：{{title}}",
+    "open": "產品公告",
+    "openWithRiskCount": "產品公告，{{riskCount}} 則風險公告待處理",
+    "restore": "恢復顯示",
+    "restoreFor": "恢復顯示：{{title}}",
+    "viewAll": "查看全部"
+  },
+  "empty": {
+    "active": "暫無產品公告",
+    "dismissed": "暫無已關閉公告"
+  },
+  "filters": {
+    "active": "目前公告",
+    "dismissed": "已關閉"
+  },
+  "labels": {
+    "critical": "嚴重",
+    "info": "資訊",
+    "unread": "未讀",
+    "warning": "提醒"
+  },
+  "loading": "正在載入產品公告...",
+  "summary": {
+    "additional_one": "還有 {{riskCount}} 則風險公告",
+    "additional_other": "還有 {{riskCount}} 則風險公告"
+  },
+  "title": "產品公告"
+}

--- a/src/services/core/storageKeys.ts
+++ b/src/services/core/storageKeys.ts
@@ -68,6 +68,11 @@ export const STORAGE_LOCKS = {
    */
   SITE_ANNOUNCEMENTS: "all-api-hub:site-announcements",
   /**
+   * Exclusive lock used for read-modify-write sequences touching product
+   * announcement state and cached feed data.
+   */
+  PRODUCT_ANNOUNCEMENTS: "all-api-hub:product-announcements",
+  /**
    * Exclusive lock used for read-modify-write sequences touching the sponsor
    * recommendation catalog cache.
    */
@@ -127,6 +132,10 @@ const SITE_ANNOUNCEMENTS_STORAGE_KEYS = {
   STORE: "siteAnnouncements_store",
 } as const
 
+const PRODUCT_ANNOUNCEMENTS_STORAGE_KEYS = {
+  STATE: "productAnnouncements_state_v1",
+} as const
+
 const SPONSOR_CATALOG_STORAGE_KEYS = {
   CACHE: "sponsorCatalog_cache_v1",
 } as const
@@ -156,6 +165,7 @@ export const STORAGE_KEYS = {
   RELEASE_UPDATE_STATUS: RELEASE_UPDATE_STORAGE_KEYS.STATUS,
   DAILY_BALANCE_HISTORY_STORE: DAILY_BALANCE_HISTORY_STORAGE_KEYS.STORE,
   SITE_ANNOUNCEMENTS_STORE: SITE_ANNOUNCEMENTS_STORAGE_KEYS.STORE,
+  PRODUCT_ANNOUNCEMENTS_STATE: PRODUCT_ANNOUNCEMENTS_STORAGE_KEYS.STATE,
   SPONSOR_CATALOG_CACHE: SPONSOR_CATALOG_STORAGE_KEYS.CACHE,
   SPONSOR_ADD_ACCOUNT_PENDING_PREFILL:
     SPONSOR_ADD_ACCOUNT_INTENT_STORAGE_KEYS.PENDING_PREFILL,

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -302,6 +302,7 @@ export const PRODUCT_ANALYTICS_FEATURE_IDS = {
   OptionsOverview: "options_overview",
   PermissionRequest: "permission_request",
   ProductAnalyticsSettings: "product_analytics_settings",
+  ProductAnnouncements: "product_announcements",
   RedemptionAssist: "redemption_assist",
   ShareSnapshots: "share_snapshots",
   ShieldBypassAssist: "shield_bypass_assist",
@@ -376,6 +377,8 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
     "detected_api_credential_check_dismissed",
   DetectedApiCredentialReviewStarted: "detected_api_credential_review_started",
   DismissDetectedApiCredentialCheck: "dismiss_detected_api_credential_check",
+  DismissProductAnnouncement: "dismiss_product_announcement",
+  RestoreProductAnnouncement: "restore_product_announcement",
   AutoFetchApiCredentialModelList: "auto_fetch_api_credential_model_list",
   FetchApiCredentialModelList: "fetch_api_credential_model_list",
   FilterAutoCheckinResults: "filter_auto_checkin_results",
@@ -436,6 +439,8 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
   OpenPopupKeyManagement: "open_popup_key_management",
   OpenPopupModelManagement: "open_popup_model_management",
   OpenPopupSettingsPage: "open_popup_settings_page",
+  OpenProductAnnouncementCta: "open_product_announcement_cta",
+  OpenProductAnnouncements: "open_product_announcements",
   OpenSidepanelFromPopup: "open_sidepanel_from_popup",
   OpenSidepanelFromToolbarAction: "open_sidepanel_from_toolbar_action",
   ClearApiCredentialProfileFilters: "clear_api_credential_profile_filters",
@@ -618,6 +623,8 @@ export const PRODUCT_ANALYTICS_SURFACE_IDS = {
   OptionsOverviewAutomationOverview: "options_overview_automation_overview",
   OptionsOverviewRecentUsage: "options_overview_recent_usage",
   OptionsOverviewStatusSummary: "options_overview_status_summary",
+  OptionsProductAnnouncementsBanner: "options_product_announcements_banner",
+  OptionsProductAnnouncementsHeader: "options_product_announcements_header",
   OptionsSiteAnnouncementCard: "options_site_announcement_card",
   OptionsSiteAnnouncementsEmptyState: "options_site_announcements_empty_state",
   OptionsSiteAnnouncementsPage: "options_site_announcements_page",
@@ -640,6 +647,7 @@ export const PRODUCT_ANALYTICS_SURFACE_IDS = {
     "popup_api_credential_profiles_empty_state",
   PopupApiCredentialProfilesStats: "popup_api_credential_profiles_stats",
   PopupHeader: "popup_header",
+  PopupProductAnnouncementsHeader: "popup_product_announcements_header",
   PopupViewTabs: "popup_view_tabs",
   SidepanelActionBar: "sidepanel_action_bar",
   SidepanelHeader: "sidepanel_header",
@@ -794,6 +802,28 @@ export type ProductAnalyticsSponsorSupportStatus =
 
 export type ProductAnalyticsSponsorId = string
 
+export const PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS = {
+  OpenList: "open_list",
+  Dismiss: "dismiss",
+  Restore: "restore",
+  OpenCta: "open_cta",
+  MarkSeen: "mark_seen",
+} as const
+
+export type ProductAnalyticsProductAnnouncementActionKind =
+  (typeof PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS)[keyof typeof PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS]
+
+export const PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_SEVERITIES = {
+  Critical: "critical",
+  Warning: "warning",
+  Info: "info",
+} as const
+
+export type ProductAnalyticsProductAnnouncementSeverity =
+  (typeof PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_SEVERITIES)[keyof typeof PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_SEVERITIES]
+
+export type ProductAnalyticsProductAnnouncementId = string
+
 export const PRODUCT_ANALYTICS_SITE_TYPES = [
   ...new Set([...ACCOUNT_SITE_TYPES, ...MANAGED_SITE_TYPES]),
 ] as ReadonlyArray<(typeof ACCOUNT_SITE_TYPES)[number] | ManagedSiteType>
@@ -915,6 +945,10 @@ export type ProductAnalyticsEventPayloadMap = {
     sponsor_support_status?: ProductAnalyticsSponsorSupportStatus
     sponsor_supported_count?: number
     sponsor_unsupported_count?: number
+    product_announcement_id?: ProductAnalyticsProductAnnouncementId
+    product_announcement_severity?: ProductAnalyticsProductAnnouncementSeverity
+    product_announcement_action_kind?: ProductAnalyticsProductAnnouncementActionKind
+    product_announcement_active_count?: number
     entrypoint: ProductAnalyticsEntrypoint
   }
   [PRODUCT_ANALYTICS_EVENTS.ShieldBypassSummaryCaptured]: {

--- a/src/services/productAnalytics/privacy.ts
+++ b/src/services/productAnalytics/privacy.ts
@@ -32,6 +32,8 @@ import {
   PRODUCT_ANALYTICS_PERMISSION_IDS,
   PRODUCT_ANALYTICS_PERMISSION_OPERATIONS,
   PRODUCT_ANALYTICS_PERMISSION_OUTCOMES,
+  PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS,
+  PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_SEVERITIES,
   PRODUCT_ANALYTICS_REQUESTED_AUTH_MODES,
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SETTING_IDS,
@@ -127,6 +129,10 @@ const EVENT_ALLOWED_KEYS = {
     "sponsor_support_status",
     "sponsor_supported_count",
     "sponsor_unsupported_count",
+    "product_announcement_id",
+    "product_announcement_severity",
+    "product_announcement_action_kind",
+    "product_announcement_active_count",
     "entrypoint",
   ],
   [PRODUCT_ANALYTICS_EVENTS.ShieldBypassSummaryCaptured]: [
@@ -512,6 +518,12 @@ const FIELD_ALLOWED_VALUES: Record<string, readonly string[]> = {
   sponsor_support_status: Object.values(
     PRODUCT_ANALYTICS_SPONSOR_SUPPORT_STATUSES,
   ),
+  product_announcement_action_kind: Object.values(
+    PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_ACTION_KINDS,
+  ),
+  product_announcement_severity: Object.values(
+    PRODUCT_ANALYTICS_PRODUCT_ANNOUNCEMENT_SEVERITIES,
+  ),
   status_kind: Object.values(PRODUCT_ANALYTICS_STATUS_KINDS),
   surface_id: Object.values(PRODUCT_ANALYTICS_SURFACE_IDS),
   target_page_id: Object.values(PRODUCT_ANALYTICS_OPTIONS_PAGE_TARGET_IDS),
@@ -542,6 +554,8 @@ const PRIVACY_REVIEWED_ALLOWED_KEYS = new Set([
   "auto_checkin_enabled_accounts",
   "detection_enabled_accounts",
   "provider_available_accounts",
+  "product_announcement_id",
+  "product_announcement_active_count",
   "runnable_accounts",
   "total_accounts",
   "cache_hit",
@@ -611,6 +625,7 @@ const RAW_NUMBER_ALLOWED_KEYS = new Set([
   "min_refresh_interval_seconds",
   "model_count",
   "polling_interval_minutes",
+  "product_announcement_active_count",
   "provider_available_accounts",
   "rate_limit_burst",
   "rate_limit_rpm",
@@ -737,6 +752,10 @@ function isAllowedFieldValue(
   }
 
   if (key === "sponsor_id") {
+    return /^[a-z0-9][a-z0-9-]*$/.test(value)
+  }
+
+  if (key === "product_announcement_id") {
     return /^[a-z0-9][a-z0-9-]*$/.test(value)
   }
 

--- a/src/services/productAnnouncements/catalog.ts
+++ b/src/services/productAnnouncements/catalog.ts
@@ -1,0 +1,313 @@
+import {
+  PRODUCT_ANNOUNCEMENT_LOCALE_FALLBACKS,
+  PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+  PRODUCT_ANNOUNCEMENT_SEVERITIES,
+} from "./constants"
+import type {
+  ProductAnnouncement,
+  ProductAnnouncementCta,
+  ProductAnnouncementSeverity,
+  RawProductAnnouncementCta,
+  RawProductAnnouncementFeed,
+} from "./types"
+import { sanitizeProductAnnouncementCta } from "./urlPolicy"
+import { isVersionInRange } from "./versionRange"
+
+interface NormalizeOptions {
+  currentVersion: string
+  locale: string
+  now: number
+  dismissed: Record<string, number>
+  seenAt: Record<string, number>
+}
+
+interface NormalizeProductAnnouncementResult {
+  notices: ProductAnnouncement[]
+  errors: string[]
+}
+
+export interface ProductAnnouncementView {
+  notices: ProductAnnouncement[]
+  activeNotices: ProductAnnouncement[]
+  dismissedNotices: ProductAnnouncement[]
+  primaryRiskNotice: ProductAnnouncement | null
+  activeRiskCount: number
+  unseenActiveCount: number
+}
+
+interface LocalizedAnnouncementContent {
+  title: string
+  message: string
+  cta: ProductAnnouncementCta | null
+}
+
+const DEFAULT_PRODUCT_ANNOUNCEMENT_LOCALE = "zh-CN"
+
+const SEVERITY_RANK: Record<ProductAnnouncementSeverity, number> = {
+  [PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical]: 0,
+  [PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning]: 1,
+  [PRODUCT_ANNOUNCEMENT_SEVERITIES.Info]: 2,
+}
+
+/**
+ * Checks whether a feed value can be inspected as a plain object.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Reads a required display or identifier string after trimming whitespace.
+ */
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+/**
+ * Parses ISO timestamp fields from raw announcement data.
+ */
+function readTimestamp(value: unknown): number | null {
+  if (typeof value !== "string") return null
+
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+/**
+ * Reads the positive integer revision used for dismissal comparisons.
+ */
+function readRevision(value: unknown): number | null {
+  if (typeof value !== "number") return null
+
+  return Number.isInteger(value) && value >= 1 ? value : null
+}
+
+/**
+ * Reads the optional priority value, defaulting invalid values to neutral rank.
+ */
+function readPriority(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
+}
+
+/**
+ * Narrows a raw severity value to the supported announcement severities.
+ */
+function isProductAnnouncementSeverity(
+  value: string,
+): value is ProductAnnouncementSeverity {
+  return (
+    value === PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical ||
+    value === PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning ||
+    value === PRODUCT_ANNOUNCEMENT_SEVERITIES.Info
+  )
+}
+
+/**
+ * Reads a raw severity value when it matches the supported severity union.
+ */
+function readSeverity(value: unknown): ProductAnnouncementSeverity | null {
+  return typeof value === "string" && isProductAnnouncementSeverity(value)
+    ? value
+    : null
+}
+
+/**
+ * Resolves the feed default locale while preserving the product fallback.
+ */
+function getDefaultLocale(feed: RawProductAnnouncementFeed): string {
+  return (
+    readNonEmptyString(feed.defaultLocale) ??
+    DEFAULT_PRODUCT_ANNOUNCEMENT_LOCALE
+  )
+}
+
+/**
+ * Builds the locale lookup chain for localized announcement content.
+ */
+function getLocaleCandidates(locale: string, defaultLocale: string): string[] {
+  const candidates = [
+    readNonEmptyString(locale),
+    readNonEmptyString(locale.split("-")[0]),
+    ...PRODUCT_ANNOUNCEMENT_LOCALE_FALLBACKS,
+    defaultLocale,
+  ]
+
+  return candidates.filter(
+    (candidate, index): candidate is string =>
+      candidate !== null && candidates.indexOf(candidate) === index,
+  )
+}
+
+/**
+ * Converts unknown CTA data into the shape accepted by the URL policy helper.
+ */
+function readCta(value: unknown): RawProductAnnouncementCta | undefined {
+  if (!isRecord(value)) return undefined
+
+  return {
+    label: value.label,
+    url: value.url,
+  }
+}
+
+/**
+ * Selects the first valid localized content block for the requested locale.
+ */
+function resolveLocalizedContent(
+  content: Record<string, unknown>,
+  locale: string,
+  defaultLocale: string,
+): LocalizedAnnouncementContent | null {
+  for (const candidate of getLocaleCandidates(locale, defaultLocale)) {
+    const localized = content[candidate]
+    if (!isRecord(localized)) continue
+
+    const title = readNonEmptyString(localized.title)
+    const message = readNonEmptyString(localized.message)
+    if (!title || !message) continue
+
+    return {
+      title,
+      message,
+      cta: sanitizeProductAnnouncementCta(readCta(localized.cta)),
+    }
+  }
+
+  return null
+}
+
+/**
+ * Orders notices by risk, product priority, freshness, and stable identity.
+ */
+function sortProductAnnouncements(
+  left: ProductAnnouncement,
+  right: ProductAnnouncement,
+): number {
+  return (
+    SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity] ||
+    right.priority - left.priority ||
+    right.startsAt - left.startsAt ||
+    left.id.localeCompare(right.id)
+  )
+}
+
+/**
+ * Converts one raw feed item into a display-ready notice when it is applicable.
+ */
+function normalizeProductAnnouncement(
+  rawAnnouncement: unknown,
+  options: NormalizeOptions,
+  defaultLocale: string,
+): ProductAnnouncement | null {
+  if (!isRecord(rawAnnouncement)) return null
+
+  const id = readNonEmptyString(rawAnnouncement.id)
+  const revision = readRevision(rawAnnouncement.revision)
+  const severity = readSeverity(rawAnnouncement.severity)
+  const affectedVersions =
+    typeof rawAnnouncement.affectedVersions === "string"
+      ? rawAnnouncement.affectedVersions
+      : null
+  const startsAt = readTimestamp(rawAnnouncement.startsAt)
+  const expiresAt = readTimestamp(rawAnnouncement.expiresAt)
+  const content = isRecord(rawAnnouncement.content)
+    ? rawAnnouncement.content
+    : null
+
+  if (
+    !id ||
+    revision === null ||
+    !severity ||
+    affectedVersions === null ||
+    startsAt === null ||
+    expiresAt === null ||
+    !content ||
+    startsAt > options.now ||
+    options.now >= expiresAt ||
+    !isVersionInRange(options.currentVersion, affectedVersions)
+  ) {
+    return null
+  }
+
+  const localized = resolveLocalizedContent(
+    content,
+    options.locale,
+    defaultLocale,
+  )
+  if (!localized) return null
+
+  const dismissedRevision = options.dismissed[id]
+  const notice: ProductAnnouncement = {
+    id,
+    revision,
+    severity,
+    priority: readPriority(rawAnnouncement.priority),
+    startsAt,
+    expiresAt,
+    title: localized.title,
+    message: localized.message,
+    dismissed:
+      typeof dismissedRevision === "number" && dismissedRevision >= revision,
+    seen: typeof options.seenAt[id] === "number",
+  }
+
+  if (localized.cta) {
+    notice.cta = localized.cta
+  }
+
+  return notice
+}
+
+/**
+ * Normalizes a raw product announcement feed into display-ready notices.
+ */
+export function normalizeProductAnnouncementFeed(
+  feed: RawProductAnnouncementFeed,
+  options: NormalizeOptions,
+): NormalizeProductAnnouncementResult {
+  if (feed.schemaVersion !== PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION) {
+    return { notices: [], errors: ["unsupported_schema"] }
+  }
+
+  const defaultLocale = getDefaultLocale(feed)
+  const rawAnnouncements = Array.isArray(feed.announcements)
+    ? feed.announcements
+    : []
+  const notices = rawAnnouncements
+    .map((announcement) =>
+      normalizeProductAnnouncement(announcement, options, defaultLocale),
+    )
+    .filter((notice): notice is ProductAnnouncement => notice !== null)
+    .sort(sortProductAnnouncements)
+
+  return { notices, errors: [] }
+}
+
+/**
+ * Derives active, dismissed, and risk-focused presentation groups.
+ */
+export function selectProductAnnouncementView(
+  notices: ProductAnnouncement[],
+): ProductAnnouncementView {
+  const activeNotices = notices.filter((notice) => !notice.dismissed)
+  const dismissedNotices = notices.filter((notice) => notice.dismissed)
+  const activeRiskNotices = activeNotices.filter(
+    (notice) =>
+      notice.severity === PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical ||
+      notice.severity === PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning,
+  )
+  const primaryRiskNotice =
+    activeRiskNotices.length > 0 ? activeRiskNotices[0] : null
+
+  return {
+    notices,
+    activeNotices,
+    dismissedNotices,
+    primaryRiskNotice,
+    activeRiskCount: activeRiskNotices.length,
+    unseenActiveCount: activeNotices.filter((notice) => !notice.seen).length,
+  }
+}

--- a/src/services/productAnnouncements/constants.ts
+++ b/src/services/productAnnouncements/constants.ts
@@ -1,0 +1,19 @@
+import bundledProductAnnouncementFeed from "~~/public/product-announcements.json"
+
+export const PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION =
+  bundledProductAnnouncementFeed.schemaVersion
+
+export const PRODUCT_ANNOUNCEMENT_REMOTE_URL =
+  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/product-announcements.json"
+
+export const PRODUCT_ANNOUNCEMENT_REFRESH_ALARM = "productAnnouncementsRefresh"
+
+export const PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES = 12 * 60
+
+export const PRODUCT_ANNOUNCEMENT_LOCALE_FALLBACKS = ["zh-CN", "en"] as const
+
+export const PRODUCT_ANNOUNCEMENT_SEVERITIES = {
+  Critical: "critical",
+  Warning: "warning",
+  Info: "info",
+} as const

--- a/src/services/productAnnouncements/constants.ts
+++ b/src/services/productAnnouncements/constants.ts
@@ -3,6 +3,8 @@ import bundledProductAnnouncementFeed from "~~/public/product-announcements.json
 export const PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION =
   bundledProductAnnouncementFeed.schemaVersion
 
+// Product-owned data-only feed from public/product-announcements.json on main;
+// consumers schema-validate it and fall back to the bundled feed.
 export const PRODUCT_ANNOUNCEMENT_REMOTE_URL =
   "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/product-announcements.json"
 

--- a/src/services/productAnnouncements/messaging.ts
+++ b/src/services/productAnnouncements/messaging.ts
@@ -1,0 +1,49 @@
+import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
+import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
+import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
+
+import type { ProductAnnouncementRuntimeState } from "./service"
+
+export interface ProductAnnouncementsGetStateRequest {
+  locale: string
+  currentVersion?: string
+  now?: number
+}
+
+export interface ProductAnnouncementsMarkSeenRequest {
+  ids: string[]
+  now?: number
+}
+
+export interface ProductAnnouncementsDismissRequest {
+  id: string
+  revision: number
+}
+
+export interface ProductAnnouncementsRestoreRequest {
+  id: string
+}
+
+interface ProductAnnouncementsProtocolMap {
+  [ProductAnnouncementsMessageTypes.GetState](
+    data: ProductAnnouncementsGetStateRequest,
+  ): RuntimeMessageResponse<ProductAnnouncementRuntimeState>
+  [ProductAnnouncementsMessageTypes.Refresh](): RuntimeMessageResponse<boolean>
+  [ProductAnnouncementsMessageTypes.MarkSeen](
+    data: ProductAnnouncementsMarkSeenRequest,
+  ): RuntimeMessageResponse<undefined>
+  [ProductAnnouncementsMessageTypes.Dismiss](
+    data: ProductAnnouncementsDismissRequest,
+  ): RuntimeMessageResponse<undefined>
+  [ProductAnnouncementsMessageTypes.Restore](
+    data: ProductAnnouncementsRestoreRequest,
+  ): RuntimeMessageResponse<undefined>
+}
+
+export const {
+  sendMessage: sendProductAnnouncementsMessage,
+  onMessage: onProductAnnouncementsMessage,
+} = defineExtensionMessaging<ProductAnnouncementsProtocolMap>({
+  logger: createRuntimeMessagingLogger("ProductAnnouncementsMessaging"),
+})

--- a/src/services/productAnnouncements/service.ts
+++ b/src/services/productAnnouncements/service.ts
@@ -36,6 +36,7 @@ import {
 const logger = createLogger("ProductAnnouncementService")
 const REFRESH_INTERVAL_MS =
   PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES * 60 * 1000
+const REMOTE_FEED_FETCH_TIMEOUT_MS = 15_000
 const INVALID_PRODUCT_ANNOUNCEMENT_STATE_REQUEST_ERROR =
   "Invalid product announcement state request"
 const INVALID_PRODUCT_ANNOUNCEMENT_MARK_SEEN_REQUEST_ERROR =
@@ -194,9 +195,15 @@ class ProductAnnouncementService {
   }
 
   private async performRemoteFeedRefresh(now: number): Promise<boolean> {
+    const abortController = new AbortController()
+    const timeoutId = globalThis.setTimeout(() => {
+      abortController.abort()
+    }, REMOTE_FEED_FETCH_TIMEOUT_MS)
+
     try {
       const response = await fetch(PRODUCT_ANNOUNCEMENT_REMOTE_URL, {
         cache: "no-store",
+        signal: abortController.signal,
       })
       if (!response.ok) {
         logger.warn("Failed to refresh product announcement feed", {
@@ -233,6 +240,8 @@ class ProductAnnouncementService {
     } catch (error) {
       logger.warn("Failed to refresh product announcement feed", error)
       return false
+    } finally {
+      globalThis.clearTimeout(timeoutId)
     }
   }
 

--- a/src/services/productAnnouncements/service.ts
+++ b/src/services/productAnnouncements/service.ts
@@ -1,0 +1,548 @@
+import type { ProductAnnouncementView } from "~/services/productAnnouncements/catalog"
+import {
+  normalizeProductAnnouncementFeed,
+  selectProductAnnouncementView,
+} from "~/services/productAnnouncements/catalog"
+import {
+  PRODUCT_ANNOUNCEMENT_REFRESH_ALARM,
+  PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES,
+  PRODUCT_ANNOUNCEMENT_REMOTE_URL,
+} from "~/services/productAnnouncements/constants"
+import { productAnnouncementStorage } from "~/services/productAnnouncements/storage"
+import type { RawProductAnnouncementFeed } from "~/services/productAnnouncements/types"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
+import { createRuntimeMessageFailure } from "~/services/runtimeMessaging/result"
+import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
+import {
+  createAlarm,
+  getAlarm,
+  getManifest,
+  onAlarm,
+} from "~/utils/browser/browserApi"
+import { isDevelopmentMode } from "~/utils/core/environment"
+import { getErrorMessage } from "~/utils/core/error"
+import { createLogger } from "~/utils/core/logger"
+import { isPlainObject } from "~/utils/core/object"
+import bundledFeed from "~~/public/product-announcements.json"
+
+import {
+  onProductAnnouncementsMessage,
+  type ProductAnnouncementsDismissRequest,
+  type ProductAnnouncementsGetStateRequest,
+  type ProductAnnouncementsMarkSeenRequest,
+  type ProductAnnouncementsRestoreRequest,
+} from "./messaging"
+
+const logger = createLogger("ProductAnnouncementService")
+const REFRESH_INTERVAL_MS =
+  PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES * 60 * 1000
+const INVALID_PRODUCT_ANNOUNCEMENT_STATE_REQUEST_ERROR =
+  "Invalid product announcement state request"
+const INVALID_PRODUCT_ANNOUNCEMENT_MARK_SEEN_REQUEST_ERROR =
+  "Invalid product announcement mark-seen request"
+const INVALID_PRODUCT_ANNOUNCEMENT_DISMISS_REQUEST_ERROR =
+  "Invalid product announcement dismiss request"
+const INVALID_PRODUCT_ANNOUNCEMENT_RESTORE_REQUEST_ERROR =
+  "Invalid product announcement restore request"
+
+export interface ProductAnnouncementRuntimeState {
+  view: ProductAnnouncementView
+  lastFetchedAt?: number
+}
+
+interface GetCurrentProductAnnouncementStateOptions {
+  locale: string
+  currentVersion?: string
+  now?: number
+}
+
+/**
+ * Checks the feed-level shape before trusting remote or persisted catalog data.
+ */
+function isValidProductAnnouncementFeed(
+  feed: RawProductAnnouncementFeed,
+): boolean {
+  return (
+    isPlainObject(feed) &&
+    (feed.defaultLocale == null || typeof feed.defaultLocale === "string") &&
+    Array.isArray(feed.announcements)
+  )
+}
+
+/**
+ * Adds bundled development examples to the runtime view without persisting them.
+ */
+function getRuntimeProductAnnouncementFeed(
+  feed: RawProductAnnouncementFeed,
+): RawProductAnnouncementFeed {
+  if (!isDevelopmentMode()) {
+    return feed
+  }
+
+  const devAnnouncements = Array.isArray(
+    bundledFeed._examples?.devAnnouncements,
+  )
+    ? bundledFeed._examples.devAnnouncements
+    : []
+  if (devAnnouncements.length === 0) {
+    return feed
+  }
+
+  return {
+    ...feed,
+    announcements: [
+      ...(Array.isArray(feed.announcements) ? feed.announcements : []),
+      ...devAnnouncements,
+    ],
+  }
+}
+
+class ProductAnnouncementService {
+  private isInitialized = false
+  private refreshPromise: Promise<boolean> | null = null
+
+  async initialize(): Promise<void> {
+    if (this.isInitialized) {
+      return
+    }
+
+    onAlarm(async (alarm) => {
+      if (alarm.name !== PRODUCT_ANNOUNCEMENT_REFRESH_ALARM) {
+        return
+      }
+
+      await this.refreshRemoteFeed()
+    })
+
+    this.isInitialized = true
+    await this.reconcileRefreshAlarm()
+    void this.refreshRemoteFeed()
+  }
+
+  async reconcileRefreshAlarm(): Promise<void> {
+    const existingAlarm = await getAlarm(PRODUCT_ANNOUNCEMENT_REFRESH_ALARM)
+    if (existingAlarm) {
+      return
+    }
+
+    await createAlarm(PRODUCT_ANNOUNCEMENT_REFRESH_ALARM, {
+      delayInMinutes: PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES,
+      periodInMinutes: PRODUCT_ANNOUNCEMENT_REFRESH_INTERVAL_MINUTES,
+    })
+  }
+
+  async getCurrentState(
+    options: GetCurrentProductAnnouncementStateOptions,
+  ): Promise<ProductAnnouncementRuntimeState> {
+    const state = await productAnnouncementStorage.getState()
+    const currentVersion =
+      options.currentVersion?.trim() || getManifest().version || "0.0.0"
+    const now = options.now ?? Date.now()
+    const normalizeOptions = {
+      currentVersion,
+      locale: options.locale,
+      now,
+      dismissed: state.dismissed,
+      seenAt: state.seenAt,
+    }
+    const bundledRuntimeFeed = getRuntimeProductAnnouncementFeed(bundledFeed)
+    const cachedNormalized = state.cachedFeed
+      ? isValidProductAnnouncementFeed(state.cachedFeed)
+        ? normalizeProductAnnouncementFeed(
+            getRuntimeProductAnnouncementFeed(state.cachedFeed),
+            normalizeOptions,
+          )
+        : { notices: [], errors: ["malformed_feed"] }
+      : null
+    const normalized =
+      cachedNormalized && cachedNormalized.errors.length === 0
+        ? cachedNormalized
+        : normalizeProductAnnouncementFeed(bundledRuntimeFeed, normalizeOptions)
+
+    if (this.shouldRefresh(state.cachedFeed, state.lastFetchedAt, now)) {
+      void this.refreshRemoteFeed()
+    }
+
+    return {
+      view: selectProductAnnouncementView(normalized.notices),
+      lastFetchedAt: state.lastFetchedAt,
+    }
+  }
+
+  async refreshRemoteFeed(now = Date.now()): Promise<boolean> {
+    if (this.refreshPromise) {
+      return this.refreshPromise
+    }
+
+    this.refreshPromise = this.performRemoteFeedRefresh(now).finally(() => {
+      this.refreshPromise = null
+    })
+
+    return this.refreshPromise
+  }
+
+  private shouldRefresh(
+    cachedFeed: RawProductAnnouncementFeed | undefined,
+    lastFetchedAt: number | undefined,
+    now: number,
+  ): boolean {
+    return (
+      !cachedFeed ||
+      typeof lastFetchedAt !== "number" ||
+      now - lastFetchedAt >= REFRESH_INTERVAL_MS
+    )
+  }
+
+  private async performRemoteFeedRefresh(now: number): Promise<boolean> {
+    try {
+      const response = await fetch(PRODUCT_ANNOUNCEMENT_REMOTE_URL, {
+        cache: "no-store",
+      })
+      if (!response.ok) {
+        logger.warn("Failed to refresh product announcement feed", {
+          status: response.status,
+        })
+        return false
+      }
+
+      const feed = (await response.json()) as RawProductAnnouncementFeed
+      if (!isValidProductAnnouncementFeed(feed)) {
+        logger.warn("Rejected malformed product announcement feed")
+        return false
+      }
+
+      const normalized = normalizeProductAnnouncementFeed(feed, {
+        currentVersion: getManifest().version || "0.0.0",
+        locale: "zh-CN",
+        now,
+        dismissed: {},
+        seenAt: {},
+      })
+      if (normalized.errors.length > 0) {
+        logger.warn("Rejected invalid product announcement feed", {
+          errors: normalized.errors,
+        })
+        return false
+      }
+
+      await productAnnouncementStorage.updateState((state) => {
+        state.cachedFeed = feed
+        state.lastFetchedAt = now
+      })
+      return true
+    } catch (error) {
+      logger.warn("Failed to refresh product announcement feed", error)
+      return false
+    }
+  }
+
+  async markSeen(ids: string[], now = Date.now()): Promise<void> {
+    const uniqueIds = [...new Set(ids.map((id) => id.trim()).filter(Boolean))]
+    if (uniqueIds.length === 0) {
+      return
+    }
+
+    await productAnnouncementStorage.updateState((state) => {
+      for (const id of uniqueIds) {
+        state.seenAt[id] = now
+      }
+    })
+  }
+
+  async dismiss(id: string, revision: number): Promise<void> {
+    const trimmedId = id.trim()
+    if (!trimmedId || !Number.isInteger(revision)) {
+      return
+    }
+
+    await productAnnouncementStorage.updateState((state) => {
+      state.dismissed[trimmedId] = revision
+    })
+  }
+
+  async restore(id: string): Promise<void> {
+    const trimmedId = id.trim()
+    if (!trimmedId) {
+      return
+    }
+
+    await productAnnouncementStorage.updateState((state) => {
+      const dismissed = { ...state.dismissed }
+      delete dismissed[trimmedId]
+      state.dismissed = dismissed
+    })
+  }
+}
+
+export const productAnnouncementService = new ProductAnnouncementService()
+
+let productAnnouncementsMessagingCleanup: (() => void)[] | null = null
+
+/**
+ * Register typed background listeners for product-announcement messages.
+ */
+export function setupProductAnnouncementMessagingListeners() {
+  if (productAnnouncementsMessagingCleanup) {
+    return
+  }
+
+  productAnnouncementsMessagingCleanup = [
+    onProductAnnouncementsMessage(
+      ProductAnnouncementsMessageTypes.GetState,
+      ({ data }) => resolveProductAnnouncementGetStateMessage(data),
+    ),
+    onProductAnnouncementsMessage(
+      ProductAnnouncementsMessageTypes.Refresh,
+      () => resolveProductAnnouncementRefreshMessage(),
+    ),
+    onProductAnnouncementsMessage(
+      ProductAnnouncementsMessageTypes.MarkSeen,
+      ({ data }) => resolveProductAnnouncementMarkSeenMessage(data),
+    ),
+    onProductAnnouncementsMessage(
+      ProductAnnouncementsMessageTypes.Dismiss,
+      ({ data }) => resolveProductAnnouncementDismissMessage(data),
+    ),
+    onProductAnnouncementsMessage(
+      ProductAnnouncementsMessageTypes.Restore,
+      ({ data }) => resolveProductAnnouncementRestoreMessage(data),
+    ),
+  ]
+}
+
+/**
+ * Accepts omitted timestamps and rejects non-finite runtime payload numbers.
+ */
+function isFiniteOptionalNumber(value: unknown): value is number | undefined {
+  return (
+    value === undefined || (typeof value === "number" && Number.isFinite(value))
+  )
+}
+
+/**
+ * Validates and normalizes get-state requests from untrusted runtime messages.
+ */
+function normalizeProductAnnouncementGetStateRequest(
+  request: ProductAnnouncementsGetStateRequest,
+): ProductAnnouncementsGetStateRequest | null {
+  if (!isPlainObject(request)) {
+    return null
+  }
+
+  const locale = typeof request.locale === "string" ? request.locale.trim() : ""
+  if (!locale) {
+    return null
+  }
+
+  if (
+    request.currentVersion !== undefined &&
+    typeof request.currentVersion !== "string"
+  ) {
+    return null
+  }
+
+  if (!isFiniteOptionalNumber(request.now)) {
+    return null
+  }
+
+  return {
+    locale,
+    ...(request.currentVersion !== undefined
+      ? { currentVersion: request.currentVersion }
+      : {}),
+    ...(request.now !== undefined ? { now: request.now } : {}),
+  }
+}
+
+/**
+ * Validates mark-seen runtime payloads and trims every notice id.
+ */
+function normalizeProductAnnouncementMarkSeenRequest(
+  request: ProductAnnouncementsMarkSeenRequest,
+): ProductAnnouncementsMarkSeenRequest | null {
+  if (!isPlainObject(request) || !Array.isArray(request.ids)) {
+    return null
+  }
+
+  const ids: string[] = []
+  for (const id of request.ids) {
+    if (typeof id !== "string") {
+      return null
+    }
+
+    const trimmedId = id.trim()
+    if (!trimmedId) {
+      return null
+    }
+
+    ids.push(trimmedId)
+  }
+
+  if (ids.length === 0) {
+    return null
+  }
+
+  if (!isFiniteOptionalNumber(request.now)) {
+    return null
+  }
+
+  return {
+    ids,
+    ...(request.now !== undefined ? { now: request.now } : {}),
+  }
+}
+
+/**
+ * Validates dismiss runtime payloads and trims the target notice id.
+ */
+function normalizeProductAnnouncementDismissRequest(
+  request: ProductAnnouncementsDismissRequest,
+): ProductAnnouncementsDismissRequest | null {
+  if (!isPlainObject(request)) {
+    return null
+  }
+
+  const id = typeof request.id === "string" ? request.id.trim() : ""
+  if (!id) {
+    return null
+  }
+
+  if (!Number.isInteger(request.revision) || request.revision <= 0) {
+    return null
+  }
+
+  return {
+    id,
+    revision: request.revision,
+  }
+}
+
+/**
+ * Validates restore runtime payloads and trims the target notice id.
+ */
+function normalizeProductAnnouncementRestoreRequest(
+  request: ProductAnnouncementsRestoreRequest,
+): ProductAnnouncementsRestoreRequest | null {
+  if (!isPlainObject(request)) {
+    return null
+  }
+
+  const id = typeof request.id === "string" ? request.id.trim() : ""
+  if (!id) {
+    return null
+  }
+
+  return { id }
+}
+
+/**
+ * Resolve a typed request for the current product-announcement state.
+ */
+export async function resolveProductAnnouncementGetStateMessage(
+  request: ProductAnnouncementsGetStateRequest,
+): Promise<RuntimeMessageResponse<ProductAnnouncementRuntimeState>> {
+  try {
+    const normalizedRequest =
+      normalizeProductAnnouncementGetStateRequest(request)
+    if (!normalizedRequest) {
+      return createRuntimeMessageFailure(
+        INVALID_PRODUCT_ANNOUNCEMENT_STATE_REQUEST_ERROR,
+      )
+    }
+
+    return {
+      success: true,
+      data: await productAnnouncementService.getCurrentState(normalizedRequest),
+    }
+  } catch (error) {
+    return createRuntimeMessageFailure(getErrorMessage(error))
+  }
+}
+
+/**
+ * Resolve a typed request to refresh the product-announcement feed.
+ */
+export async function resolveProductAnnouncementRefreshMessage(): Promise<
+  RuntimeMessageResponse<boolean>
+> {
+  try {
+    return {
+      success: true,
+      data: await productAnnouncementService.refreshRemoteFeed(),
+    }
+  } catch (error) {
+    return createRuntimeMessageFailure(getErrorMessage(error))
+  }
+}
+
+/**
+ * Resolve a typed request to mark product announcements as seen.
+ */
+export async function resolveProductAnnouncementMarkSeenMessage(
+  request: ProductAnnouncementsMarkSeenRequest,
+): Promise<RuntimeMessageResponse<undefined>> {
+  try {
+    const normalizedRequest =
+      normalizeProductAnnouncementMarkSeenRequest(request)
+    if (!normalizedRequest) {
+      return createRuntimeMessageFailure(
+        INVALID_PRODUCT_ANNOUNCEMENT_MARK_SEEN_REQUEST_ERROR,
+      )
+    }
+
+    await productAnnouncementService.markSeen(
+      normalizedRequest.ids,
+      normalizedRequest.now,
+    )
+    return { success: true, data: undefined }
+  } catch (error) {
+    return createRuntimeMessageFailure(getErrorMessage(error))
+  }
+}
+
+/**
+ * Resolve a typed request to dismiss one product announcement revision.
+ */
+export async function resolveProductAnnouncementDismissMessage(
+  request: ProductAnnouncementsDismissRequest,
+): Promise<RuntimeMessageResponse<undefined>> {
+  try {
+    const normalizedRequest =
+      normalizeProductAnnouncementDismissRequest(request)
+    if (!normalizedRequest) {
+      return createRuntimeMessageFailure(
+        INVALID_PRODUCT_ANNOUNCEMENT_DISMISS_REQUEST_ERROR,
+      )
+    }
+
+    await productAnnouncementService.dismiss(
+      normalizedRequest.id,
+      normalizedRequest.revision,
+    )
+    return { success: true, data: undefined }
+  } catch (error) {
+    return createRuntimeMessageFailure(getErrorMessage(error))
+  }
+}
+
+/**
+ * Resolve a typed request to restore one dismissed product announcement.
+ */
+export async function resolveProductAnnouncementRestoreMessage(
+  request: ProductAnnouncementsRestoreRequest,
+): Promise<RuntimeMessageResponse<undefined>> {
+  try {
+    const normalizedRequest =
+      normalizeProductAnnouncementRestoreRequest(request)
+    if (!normalizedRequest) {
+      return createRuntimeMessageFailure(
+        INVALID_PRODUCT_ANNOUNCEMENT_RESTORE_REQUEST_ERROR,
+      )
+    }
+
+    await productAnnouncementService.restore(normalizedRequest.id)
+    return { success: true, data: undefined }
+  } catch (error) {
+    return createRuntimeMessageFailure(getErrorMessage(error))
+  }
+}

--- a/src/services/productAnnouncements/storage.ts
+++ b/src/services/productAnnouncements/storage.ts
@@ -66,7 +66,10 @@ function sanitizeState(value: unknown): ProductAnnouncementState {
     lastShownAt: sanitizeNumberRecord(value.lastShownAt),
   }
 
-  if (typeof value.lastFetchedAt === "number") {
+  if (
+    typeof value.lastFetchedAt === "number" &&
+    Number.isFinite(value.lastFetchedAt)
+  ) {
     state.lastFetchedAt = value.lastFetchedAt
   }
 

--- a/src/services/productAnnouncements/storage.ts
+++ b/src/services/productAnnouncements/storage.ts
@@ -1,0 +1,120 @@
+import { Storage } from "@plasmohq/storage"
+
+import { STORAGE_KEYS, STORAGE_LOCKS } from "~/services/core/storageKeys"
+import { withExtensionStorageWriteLock } from "~/services/core/storageWriteLock"
+import { createLogger } from "~/utils/core/logger"
+import { isPlainObject } from "~/utils/core/object"
+
+import type {
+  ProductAnnouncementState,
+  RawProductAnnouncementFeed,
+} from "./types"
+
+const logger = createLogger("ProductAnnouncementStorage")
+const PRODUCT_ANNOUNCEMENT_STATE_SCHEMA_VERSION = 1 as const
+
+/**
+ * Creates an empty product announcement state with the current schema version.
+ */
+function createEmptyState(): ProductAnnouncementState {
+  return {
+    schemaVersion: PRODUCT_ANNOUNCEMENT_STATE_SCHEMA_VERSION,
+    dismissed: {},
+    seenAt: {},
+    lastShownAt: {},
+  }
+}
+
+/**
+ * Keeps only string-to-number record entries from persisted state maps.
+ */
+function sanitizeNumberRecord(value: unknown): Record<string, number> {
+  if (!isPlainObject(value)) {
+    return {}
+  }
+
+  const sanitized: Record<string, number> = {}
+  for (const [key, recordValue] of Object.entries(value)) {
+    const trimmedKey = key.trim()
+    if (
+      trimmedKey &&
+      typeof recordValue === "number" &&
+      Number.isFinite(recordValue)
+    ) {
+      sanitized[trimmedKey] = recordValue
+    }
+  }
+
+  return sanitized
+}
+
+/**
+ * Validates persisted state and drops data from incompatible schemas.
+ */
+function sanitizeState(value: unknown): ProductAnnouncementState {
+  if (
+    !isPlainObject(value) ||
+    value.schemaVersion !== PRODUCT_ANNOUNCEMENT_STATE_SCHEMA_VERSION
+  ) {
+    return createEmptyState()
+  }
+
+  const state: ProductAnnouncementState = {
+    schemaVersion: PRODUCT_ANNOUNCEMENT_STATE_SCHEMA_VERSION,
+    dismissed: sanitizeNumberRecord(value.dismissed),
+    seenAt: sanitizeNumberRecord(value.seenAt),
+    lastShownAt: sanitizeNumberRecord(value.lastShownAt),
+  }
+
+  if (typeof value.lastFetchedAt === "number") {
+    state.lastFetchedAt = value.lastFetchedAt
+  }
+
+  if (isPlainObject(value.cachedFeed)) {
+    state.cachedFeed = value.cachedFeed as RawProductAnnouncementFeed
+  }
+
+  return state
+}
+
+class ProductAnnouncementStorage {
+  private storage = new Storage({ area: "local" })
+
+  private async withStorageWriteLock<T>(work: () => Promise<T>): Promise<T> {
+    return withExtensionStorageWriteLock(
+      STORAGE_LOCKS.PRODUCT_ANNOUNCEMENTS,
+      work,
+    )
+  }
+
+  async getState(): Promise<ProductAnnouncementState> {
+    try {
+      const stored = await this.storage.get(
+        STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE,
+      )
+      return sanitizeState(stored)
+    } catch (error) {
+      logger.warn("Failed to load product announcement state", error)
+      return createEmptyState()
+    }
+  }
+
+  async setState(state: ProductAnnouncementState): Promise<void> {
+    await this.storage.set(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE, state)
+  }
+
+  async updateState(
+    updater: (
+      state: ProductAnnouncementState,
+    ) => ProductAnnouncementState | void,
+  ): Promise<ProductAnnouncementState> {
+    return this.withStorageWriteLock(async () => {
+      const current = await this.getState()
+      const updated = updater(current) ?? current
+      await this.setState(updated)
+      return updated
+    })
+  }
+}
+
+export const productAnnouncementStorage = new ProductAnnouncementStorage()

--- a/src/services/productAnnouncements/types.ts
+++ b/src/services/productAnnouncements/types.ts
@@ -1,0 +1,49 @@
+import { PRODUCT_ANNOUNCEMENT_SEVERITIES } from "./constants"
+
+type ValueOf<T> = T[keyof T]
+
+export type ProductAnnouncementSeverity = ValueOf<
+  typeof PRODUCT_ANNOUNCEMENT_SEVERITIES
+>
+
+export interface RawProductAnnouncementCta {
+  label?: unknown
+  url?: unknown
+}
+
+export interface RawProductAnnouncementFeed {
+  schemaVersion?: unknown
+  defaultLocale?: unknown
+  announcements?: unknown
+  _examples?: {
+    devAnnouncements?: unknown
+  }
+}
+
+export interface ProductAnnouncementCta {
+  label: string
+  url: string
+}
+
+export interface ProductAnnouncement {
+  id: string
+  revision: number
+  severity: ProductAnnouncementSeverity
+  priority: number
+  startsAt: number
+  expiresAt: number
+  title: string
+  message: string
+  cta?: ProductAnnouncementCta
+  dismissed: boolean
+  seen: boolean
+}
+
+export interface ProductAnnouncementState {
+  schemaVersion: 1
+  lastFetchedAt?: number
+  cachedFeed?: RawProductAnnouncementFeed
+  dismissed: Record<string, number>
+  seenAt: Record<string, number>
+  lastShownAt: Record<string, number>
+}

--- a/src/services/productAnnouncements/urlPolicy.ts
+++ b/src/services/productAnnouncements/urlPolicy.ts
@@ -1,0 +1,51 @@
+import type { ProductAnnouncementCta, RawProductAnnouncementCta } from "./types"
+
+/**
+ * Hosts that product announcement CTA links may target.
+ */
+const ALLOWED_CTA_HOSTS = new Set(["github.com", "all-api-hub.qixing1217.top"])
+
+/**
+ * Allows links that stay inside the project repository namespace.
+ */
+function isAllowedGithubPath(url: URL): boolean {
+  return (
+    url.hostname === "github.com" &&
+    url.pathname.startsWith("/qixing-jk/all-api-hub/")
+  )
+}
+
+/**
+ * Allows links to the project documentation site.
+ */
+function isAllowedDocsPath(url: URL): boolean {
+  return url.hostname === "all-api-hub.qixing1217.top"
+}
+
+/**
+ * Normalizes announcement CTA data and drops links outside the product allowlist.
+ */
+export function sanitizeProductAnnouncementCta(
+  value: RawProductAnnouncementCta | undefined,
+): ProductAnnouncementCta | null {
+  const label = typeof value?.label === "string" ? value.label.trim() : ""
+  const urlValue = typeof value?.url === "string" ? value.url.trim() : ""
+  if (!label || !urlValue) return null
+
+  let url: URL
+  try {
+    url = new URL(urlValue)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== "https:" || !ALLOWED_CTA_HOSTS.has(url.hostname)) {
+    return null
+  }
+
+  if (!isAllowedGithubPath(url) && !isAllowedDocsPath(url)) {
+    return null
+  }
+
+  return { label, url: url.toString() }
+}

--- a/src/services/productAnnouncements/urlPolicy.ts
+++ b/src/services/productAnnouncements/urlPolicy.ts
@@ -3,15 +3,18 @@ import type { ProductAnnouncementCta, RawProductAnnouncementCta } from "./types"
 /**
  * Hosts that product announcement CTA links may target.
  */
-const ALLOWED_CTA_HOSTS = new Set(["github.com", "all-api-hub.qixing1217.top"])
+const GITHUB_HOST = "github.com"
+const DOCS_HOST = "all-api-hub.qixing1217.top"
+const GITHUB_REPO_PATH_PREFIX = "/qixing-jk/all-api-hub/"
+const ALLOWED_CTA_HOSTS = new Set([GITHUB_HOST, DOCS_HOST])
 
 /**
  * Allows links that stay inside the project repository namespace.
  */
 function isAllowedGithubPath(url: URL): boolean {
   return (
-    url.hostname === "github.com" &&
-    url.pathname.startsWith("/qixing-jk/all-api-hub/")
+    url.hostname === GITHUB_HOST &&
+    url.pathname.startsWith(GITHUB_REPO_PATH_PREFIX)
   )
 }
 
@@ -19,7 +22,7 @@ function isAllowedGithubPath(url: URL): boolean {
  * Allows links to the project documentation site.
  */
 function isAllowedDocsPath(url: URL): boolean {
-  return url.hostname === "all-api-hub.qixing1217.top"
+  return url.hostname === DOCS_HOST
 }
 
 /**

--- a/src/services/productAnnouncements/versionRange.ts
+++ b/src/services/productAnnouncements/versionRange.ts
@@ -1,0 +1,68 @@
+/**
+ * Converts app release strings into numeric segments for range comparisons.
+ */
+function normalizeVersion(value: string): number[] | null {
+  const normalized = value.trim().replace(/^v/i, "")
+  if (!/^\d+(?:\.\d+)*$/.test(normalized)) return null
+  return normalized.split(".").map((part) => Number.parseInt(part, 10))
+}
+
+/**
+ * Compares version segments while treating missing trailing segments as zero.
+ */
+function compareVersions(left: number[], right: number[]): number {
+  const length = Math.max(left.length, right.length)
+  for (let index = 0; index < length; index++) {
+    const leftPart = left[index] ?? 0
+    const rightPart = right[index] ?? 0
+    if (leftPart !== rightPart) return leftPart - rightPart
+  }
+  return 0
+}
+
+/**
+ * Evaluates a single comparator token from a whitespace-delimited range.
+ */
+function evaluateComparator(current: number[], token: string): boolean {
+  const match = /^(>=|<=|>|<|=)?(.+)$/.exec(token.trim())
+  if (!match) return false
+
+  const operator = match[1] ?? "="
+  const target = normalizeVersion(match[2])
+  if (!target) return false
+
+  const comparison = compareVersions(current, target)
+  switch (operator) {
+    case ">=":
+      return comparison >= 0
+    case "<=":
+      return comparison <= 0
+    case ">":
+      return comparison > 0
+    case "<":
+      return comparison < 0
+    case "=":
+      return comparison === 0
+    default:
+      return false
+  }
+}
+
+/**
+ * Checks whether the current app version is included in a simple semver range.
+ */
+export function isVersionInRange(
+  currentVersion: string,
+  range: string,
+): boolean {
+  const trimmedRange = range.trim()
+  if (!trimmedRange) return false
+  if (trimmedRange === "*") return normalizeVersion(currentVersion) !== null
+
+  const current = normalizeVersion(currentVersion)
+  if (!current) return false
+
+  return trimmedRange
+    .split(/\s+/)
+    .every((token) => evaluateComparator(current, token))
+}

--- a/src/services/runtimeMessaging/messageTypes.ts
+++ b/src/services/runtimeMessaging/messageTypes.ts
@@ -46,6 +46,14 @@ export const SiteAnnouncementsMessageTypes = {
   UpdatePreferences: "siteAnnouncements:updatePreferences",
 } as const
 
+export const ProductAnnouncementsMessageTypes = {
+  GetState: "productAnnouncements:getState",
+  Refresh: "productAnnouncements:refresh",
+  MarkSeen: "productAnnouncements:markSeen",
+  Dismiss: "productAnnouncements:dismiss",
+  Restore: "productAnnouncements:restore",
+} as const
+
 export const WebdavAutoSyncMessageTypes = {
   Setup: "webdavAutoSync:setup",
   SyncNow: "webdavAutoSync:syncNow",

--- a/tests/entrypoints/background/runtimeMessages.more.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.more.test.ts
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => ({
   setupDailyBalanceHistoryMessagingListeners: vi.fn(),
   setupTaskNotificationMessagingListeners: vi.fn(),
   setupSiteAnnouncementsMessagingListeners: vi.fn(),
+  setupProductAnnouncementMessagingListeners: vi.fn(),
   setupPreferencesMessagingListeners: vi.fn(),
   setupLdohSiteLookupMessagingListeners: vi.fn(),
   setupWebAiApiCheckMessagingListeners: vi.fn(),
@@ -144,6 +145,11 @@ vi.mock("~/services/siteAnnouncements/scheduler", () => ({
     mocks.setupSiteAnnouncementsMessagingListeners,
 }))
 
+vi.mock("~/services/productAnnouncements/service", () => ({
+  setupProductAnnouncementMessagingListeners:
+    mocks.setupProductAnnouncementMessagingListeners,
+}))
+
 vi.mock("~/services/preferences/runtimePreferencesService", () => ({
   setupPreferencesMessagingListeners: mocks.setupPreferencesMessagingListeners,
 }))
@@ -218,6 +224,9 @@ describe("setupRuntimeMessageListeners additional routing", () => {
     ).toHaveBeenCalledTimes(1)
     expect(
       mocks.setupSiteAnnouncementsMessagingListeners,
+    ).toHaveBeenCalledTimes(1)
+    expect(
+      mocks.setupProductAnnouncementMessagingListeners,
     ).toHaveBeenCalledTimes(1)
     expect(mocks.setupPreferencesMessagingListeners).toHaveBeenCalledTimes(1)
     expect(

--- a/tests/entrypoints/background/runtimeMessages.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.test.ts
@@ -18,6 +18,7 @@ describe("setupRuntimeMessageListeners routing", () => {
   let originalBrowserCookies: unknown
   let setupManagedSiteModelSyncMessagingListeners: ReturnType<typeof vi.fn>
   let setupPreferencesMessagingListeners: ReturnType<typeof vi.fn>
+  let setupProductAnnouncementMessagingListeners: ReturnType<typeof vi.fn>
   let setupRedemptionAssistMessagingListeners: ReturnType<typeof vi.fn>
   let setupProductAnalyticsMessagingListeners: ReturnType<typeof vi.fn>
 
@@ -28,6 +29,7 @@ describe("setupRuntimeMessageListeners routing", () => {
     originalBrowserCookies = (globalThis as any).browser?.cookies
     setupManagedSiteModelSyncMessagingListeners = vi.fn()
     setupPreferencesMessagingListeners = vi.fn()
+    setupProductAnnouncementMessagingListeners = vi.fn()
     setupRedemptionAssistMessagingListeners = vi.fn()
     setupProductAnalyticsMessagingListeners = vi.fn()
 
@@ -60,6 +62,10 @@ describe("setupRuntimeMessageListeners routing", () => {
 
     vi.doMock("~/services/preferences/runtimePreferencesService", () => ({
       setupPreferencesMessagingListeners,
+    }))
+
+    vi.doMock("~/services/productAnnouncements/service", () => ({
+      setupProductAnnouncementMessagingListeners,
     }))
 
     // runtimeMessages imports these modules; provide minimal stubs to avoid heavy side effects.
@@ -107,6 +113,7 @@ describe("setupRuntimeMessageListeners routing", () => {
     vi.doUnmock("~/utils/browser/cookieHelper")
     vi.doUnmock("~/services/models/modelSync")
     vi.doUnmock("~/services/preferences/runtimePreferencesService")
+    vi.doUnmock("~/services/productAnnouncements/service")
     vi.doUnmock("~/services/checkin/autoCheckin/scheduler")
     vi.doUnmock("~/services/accounts/autoRefreshService")
     vi.doUnmock("~/services/managedSites/channelConfigStorage")
@@ -187,6 +194,16 @@ describe("setupRuntimeMessageListeners routing", () => {
     setupRuntimeMessageListeners()
     expect(runtimeMessageListener).toBeTypeOf("function")
     expect(setupProductAnalyticsMessagingListeners).toHaveBeenCalledTimes(1)
+  })
+
+  it("sets up typed product announcement messaging listeners", async () => {
+    const { setupRuntimeMessageListeners } = await import(
+      "~/entrypoints/background/runtimeMessages"
+    )
+
+    setupRuntimeMessageListeners()
+    expect(runtimeMessageListener).toBeTypeOf("function")
+    expect(setupProductAnnouncementMessagingListeners).toHaveBeenCalledTimes(1)
   })
 
   it("does not route typed-only product analytics actions through the raw listener", async () => {

--- a/tests/entrypoints/background/servicesInit.test.ts
+++ b/tests/entrypoints/background/servicesInit.test.ts
@@ -12,6 +12,7 @@ const {
   autoRefreshInitMock,
   redemptionAssistInitMock,
   releaseUpdateInitMock,
+  productAnnouncementInitMock,
   initBackgroundI18nMock,
 } = vi.hoisted(() => ({
   usageInitMock: vi.fn(),
@@ -23,6 +24,7 @@ const {
   autoRefreshInitMock: vi.fn(),
   redemptionAssistInitMock: vi.fn(),
   releaseUpdateInitMock: vi.fn(),
+  productAnnouncementInitMock: vi.fn(),
   initBackgroundI18nMock: vi.fn(),
 }))
 
@@ -62,6 +64,10 @@ vi.mock("~/services/updates/releaseUpdateService", () => ({
   releaseUpdateService: { initialize: releaseUpdateInitMock },
 }))
 
+vi.mock("~/services/productAnnouncements/service", () => ({
+  productAnnouncementService: { initialize: productAnnouncementInitMock },
+}))
+
 vi.mock("~/utils/i18n/background", () => ({
   initBackgroundI18n: initBackgroundI18nMock,
 }))
@@ -84,6 +90,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
       autoCheckin: false,
       dailyBalance: false,
       releaseUpdate: false,
+      productAnnouncement: false,
     }
 
     let i18nObservedAllAlarmInits = false
@@ -110,6 +117,9 @@ describe("initializeServices alarm bootstrap ordering", () => {
     const releaseUpdateInit: InitMock = vi.fn(async () => {
       alarmInitCalled.releaseUpdate = true
     })
+    const productAnnouncementInit: InitMock = vi.fn(async () => {
+      alarmInitCalled.productAnnouncement = true
+    })
 
     const modelMetadataInit: InitMock = vi.fn(async () => {})
     const autoRefreshInit: InitMock = vi.fn(async () => {})
@@ -121,6 +131,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     autoCheckinInitMock.mockImplementation(autoCheckinInit)
     dailyBalanceInitMock.mockImplementation(dailyBalanceInit)
     releaseUpdateInitMock.mockImplementation(releaseUpdateInit)
+    productAnnouncementInitMock.mockImplementation(productAnnouncementInit)
     modelMetadataInitMock.mockImplementation(modelMetadataInit)
     autoRefreshInitMock.mockImplementation(autoRefreshInit)
     redemptionAssistInitMock.mockImplementation(redemptionAssistInit)
@@ -132,7 +143,8 @@ describe("initializeServices alarm bootstrap ordering", () => {
         alarmInitCalled.modelSync &&
         alarmInitCalled.autoCheckin &&
         alarmInitCalled.dailyBalance &&
-        alarmInitCalled.releaseUpdate
+        alarmInitCalled.releaseUpdate &&
+        alarmInitCalled.productAnnouncement
       return i18nPromise
     })
 
@@ -144,6 +156,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(autoCheckinInit).toHaveBeenCalledTimes(1)
     expect(dailyBalanceInit).toHaveBeenCalledTimes(1)
     expect(releaseUpdateInit).toHaveBeenCalledTimes(1)
+    expect(productAnnouncementInit).toHaveBeenCalledTimes(1)
     expect(i18nObservedAllAlarmInits).toBe(true)
 
     resolveI18n?.()
@@ -173,6 +186,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     autoCheckinInitMock.mockResolvedValue(undefined)
     dailyBalanceInitMock.mockResolvedValue(undefined)
     releaseUpdateInitMock.mockResolvedValue(undefined)
+    productAnnouncementInitMock.mockResolvedValue(undefined)
     modelMetadataInitMock.mockResolvedValue(undefined)
     autoRefreshInitMock.mockResolvedValue(undefined)
     redemptionAssistInitMock.mockResolvedValue(undefined)
@@ -186,6 +200,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(autoCheckinInitMock).toHaveBeenCalledTimes(1)
     expect(dailyBalanceInitMock).toHaveBeenCalledTimes(1)
     expect(releaseUpdateInitMock).toHaveBeenCalledTimes(1)
+    expect(productAnnouncementInitMock).toHaveBeenCalledTimes(1)
     expect(initBackgroundI18nMock).toHaveBeenCalledTimes(1)
 
     resolveI18n?.()
@@ -203,6 +218,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(autoCheckinInitMock).toHaveBeenCalledTimes(1)
     expect(dailyBalanceInitMock).toHaveBeenCalledTimes(1)
     expect(releaseUpdateInitMock).toHaveBeenCalledTimes(1)
+    expect(productAnnouncementInitMock).toHaveBeenCalledTimes(1)
     expect(initBackgroundI18nMock).toHaveBeenCalledTimes(1)
     expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
     expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)
@@ -221,6 +237,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     autoCheckinInitMock.mockResolvedValue(undefined)
     dailyBalanceInitMock.mockResolvedValue(undefined)
     releaseUpdateInitMock.mockResolvedValue(undefined)
+    productAnnouncementInitMock.mockResolvedValue(undefined)
     modelMetadataInitMock.mockResolvedValue(undefined)
     autoRefreshInitMock.mockResolvedValue(undefined)
     redemptionAssistInitMock.mockResolvedValue(undefined)
@@ -233,6 +250,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(autoCheckinInitMock).toHaveBeenCalledTimes(1)
     expect(dailyBalanceInitMock).toHaveBeenCalledTimes(1)
     expect(releaseUpdateInitMock).toHaveBeenCalledTimes(1)
+    expect(productAnnouncementInitMock).toHaveBeenCalledTimes(1)
     expect(initBackgroundI18nMock).toHaveBeenCalledTimes(1)
     expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
     expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)

--- a/tests/entrypoints/options/Header.productAnnouncements.test.tsx
+++ b/tests/entrypoints/options/Header.productAnnouncements.test.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import Header from "~/entrypoints/options/components/Header"
+import { ProductAnnouncementButton } from "~/features/ProductAnnouncements/ProductAnnouncementButton"
+import { render, screen } from "~~/tests/test-utils/render"
+
+vi.mock("~/assets/icon.png", () => ({
+  default: "icon.png",
+}))
+
+vi.mock("~/components/LanguageSwitcher", () => ({
+  LanguageSwitcher: () => <div data-testid="language-switcher" />,
+}))
+
+vi.mock("~/entrypoints/options/components/HeaderThemeSwitcher", () => ({
+  default: () => <div data-testid="theme-switcher" />,
+}))
+
+vi.mock("~/features/ProductAnnouncements/ProductAnnouncementButton", () => ({
+  ProductAnnouncementButton: vi.fn(
+    ({
+      surface,
+      onlyWhenRisk,
+    }: {
+      surface: string
+      onlyWhenRisk?: boolean
+    }) => (
+      <div
+        data-testid="product-announcement-button"
+        data-surface={surface}
+        data-only-when-risk={onlyWhenRisk ? "true" : "false"}
+      />
+    ),
+  ),
+}))
+
+vi.mock("~/components/dialogs/UpdateLogDialog", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/components/dialogs/UpdateLogDialog")
+    >()
+
+  return {
+    ...actual,
+    useUpdateLogDialogContext: () => ({
+      state: { isOpen: false, version: null },
+      openDialog: vi.fn(),
+      closeDialog: vi.fn(),
+    }),
+  }
+})
+
+vi.mock("~/contexts/ReleaseUpdateStatusContext", () => ({
+  useReleaseUpdateStatus: () => ({
+    status: null,
+    isLoading: false,
+    isChecking: false,
+    error: null,
+    refresh: vi.fn(),
+    checkNow: vi.fn(),
+  }),
+}))
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+  return {
+    ...actual,
+    UserPreferencesProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useUserPreferencesContext: () => ({
+      themeMode: "system",
+      updateThemeMode: vi.fn().mockResolvedValue(true),
+    }),
+  }
+})
+
+describe("options Header product announcements", () => {
+  it("renders the product announcement button in the header utility group", () => {
+    render(
+      <Header
+        onSearchOpen={vi.fn()}
+        onTitleClick={vi.fn()}
+        onMenuToggle={vi.fn()}
+        isMobileSidebarOpen={false}
+      />,
+      { withReleaseUpdateStatusProvider: false },
+    )
+
+    expect(screen.getByTestId("product-announcement-button")).toHaveAttribute(
+      "data-surface",
+      "options-header",
+    )
+    expect(ProductAnnouncementButton).toHaveBeenCalledWith(
+      expect.objectContaining({ surface: "options-header" }),
+      undefined,
+    )
+  })
+})

--- a/tests/entrypoints/options/pages/OptionsOverview/OptionsOverview.test.tsx
+++ b/tests/entrypoints/options/pages/OptionsOverview/OptionsOverview.test.tsx
@@ -19,6 +19,7 @@ import {
   PRODUCT_ANALYTICS_TARGET_KINDS,
   trackProductAnalyticsEvent,
 } from "~/services/productAnalytics/events"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
 import { act, render, screen } from "~~/tests/test-utils/render"
 
 const {
@@ -335,6 +336,19 @@ const setupViewModel: OptionsOverviewViewModel = {
   ],
 }
 
+const riskNotice = {
+  id: "risk",
+  revision: 1,
+  severity: "warning",
+  priority: 10,
+  startsAt: 1,
+  expiresAt: 2,
+  title: "Risk notice",
+  message: "Please review.",
+  seen: false,
+  dismissed: false,
+} satisfies ProductAnnouncement
+
 describe("OptionsOverview", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -391,6 +405,58 @@ describe("OptionsOverview", () => {
         name: "optionsOverview:configurationOverview.open",
       }),
     ).not.toBeInTheDocument()
+  })
+
+  it("surfaces product risk announcements and opens the header popover request", async () => {
+    const dismiss = vi.fn()
+    useOptionsOverviewDataMock.mockReturnValue({
+      isLoading: false,
+      error: null,
+      viewModel: setupViewModel,
+      reload: vi.fn(),
+    })
+    useProductAnnouncementsMock.mockReturnValue({
+      state: {
+        view: {
+          notices: [riskNotice],
+          activeNotices: [
+            riskNotice,
+            { ...riskNotice, id: "info", severity: "info" },
+            { ...riskNotice, id: "dismissed", dismissed: true },
+            { ...riskNotice, id: "critical", severity: "critical" },
+          ],
+          dismissedNotices: [
+            { ...riskNotice, id: "dismissed", dismissed: true },
+          ],
+          primaryRiskNotice: riskNotice,
+          unseenActiveCount: 1,
+        },
+      },
+      isLoading: false,
+      reload: vi.fn(),
+      markSeen: vi.fn().mockResolvedValue(true),
+      dismiss,
+    })
+
+    renderOverview()
+
+    expect(screen.getByText("Risk notice")).toBeVisible()
+    expect(
+      screen.getByText("productAnnouncements:summary.additional_one"),
+    ).toBeVisible()
+
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.viewAll",
+      }),
+    )
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.dismiss",
+      }),
+    )
+
+    expect(dismiss).toHaveBeenCalledWith("risk", 1)
   })
 
   it("opens permissions onboarding from Overview URL state", async () => {

--- a/tests/entrypoints/options/pages/OptionsOverview/OptionsOverview.test.tsx
+++ b/tests/entrypoints/options/pages/OptionsOverview/OptionsOverview.test.tsx
@@ -26,16 +26,25 @@ const {
   setLastSeenOptionalPermissionsMock,
   trackProductAnalyticsEventMock,
   useOptionsOverviewDataMock,
+  useProductAnnouncementsMock,
 } = vi.hoisted(() => ({
   pushWithinOptionsPageMock: vi.fn(),
   setLastSeenOptionalPermissionsMock: vi.fn(),
   trackProductAnalyticsEventMock: vi.fn(),
   useOptionsOverviewDataMock: vi.fn(),
+  useProductAnnouncementsMock: vi.fn(),
 }))
 
 vi.mock("~/features/OptionsOverview/useOptionsOverviewData", () => ({
   useOptionsOverviewData: useOptionsOverviewDataMock,
 }))
+
+vi.mock(
+  "~/features/ProductAnnouncements/hooks/useProductAnnouncements",
+  () => ({
+    useProductAnnouncements: useProductAnnouncementsMock,
+  }),
+)
 
 vi.mock("~/services/permissions/optionalPermissionState", () => ({
   setLastSeenOptionalPermissions: setLastSeenOptionalPermissionsMock,
@@ -331,6 +340,21 @@ describe("OptionsOverview", () => {
     vi.clearAllMocks()
     setLastSeenOptionalPermissionsMock.mockResolvedValue(undefined)
     trackProductAnalyticsEventMock.mockResolvedValue(true)
+    useProductAnnouncementsMock.mockReturnValue({
+      state: {
+        view: {
+          notices: [],
+          activeNotices: [],
+          dismissedNotices: [],
+          primaryRiskNotice: null,
+          unseenActiveCount: 0,
+        },
+      },
+      isLoading: false,
+      reload: vi.fn(),
+      markSeen: vi.fn().mockResolvedValue(true),
+      dismiss: vi.fn(),
+    })
     window.history.replaceState(null, "", "/")
   })
 

--- a/tests/entrypoints/popup/HeaderSection.productAnnouncements.test.tsx
+++ b/tests/entrypoints/popup/HeaderSection.productAnnouncements.test.tsx
@@ -1,0 +1,125 @@
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import HeaderSection from "~/entrypoints/popup/components/HeaderSection"
+import { ProductAnnouncementButton } from "~/features/ProductAnnouncements/ProductAnnouncementButton"
+import { render, screen } from "~~/tests/test-utils/render"
+
+vi.mock("~/assets/icon.png", () => ({
+  default: "icon.png",
+}))
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+  return {
+    ...actual,
+    UserPreferencesProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useUserPreferencesContext: () => ({
+      themeMode: "system",
+      updateThemeMode: vi.fn().mockResolvedValue(true),
+    }),
+  }
+})
+
+vi.mock("~/contexts/ReleaseUpdateStatusContext", () => ({
+  useReleaseUpdateStatus: () => ({
+    status: null,
+    isLoading: false,
+    isChecking: false,
+    error: null,
+    refresh: vi.fn(),
+    checkNow: vi.fn(),
+  }),
+}))
+
+vi.mock("~/components/dialogs/UpdateLogDialog", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/components/dialogs/UpdateLogDialog")
+    >()
+
+  return {
+    ...actual,
+    useUpdateLogDialogContext: () => ({
+      state: { isOpen: false, version: null },
+      openDialog: vi.fn(),
+      closeDialog: vi.fn(),
+    }),
+  }
+})
+
+vi.mock("~/utils/browser", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/browser")>()
+  return {
+    ...actual,
+    isExtensionSidePanel: vi.fn().mockReturnValue(false),
+  }
+})
+
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/utils/browser/browserApi")>()
+  return {
+    ...actual,
+    getSidePanelSupport: vi.fn().mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    }),
+  }
+})
+
+vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
+  useAccountDataContext: () => ({
+    isRefreshing: false,
+    handleRefresh: vi.fn().mockResolvedValue({ success: 0, failed: 0 }),
+  }),
+}))
+
+vi.mock("~/services/productAnalytics/actions", () => ({
+  startProductAnalyticsAction: vi.fn(() => ({
+    complete: vi.fn().mockResolvedValue(undefined),
+  })),
+  trackProductAnalyticsActionStarted: vi.fn(),
+}))
+
+vi.mock("~/features/ProductAnnouncements/ProductAnnouncementButton", () => ({
+  ProductAnnouncementButton: vi.fn(
+    ({
+      surface,
+      onlyWhenRisk,
+    }: {
+      surface: string
+      onlyWhenRisk?: boolean
+    }) => (
+      <div
+        data-testid="product-announcement-button"
+        data-surface={surface}
+        data-only-when-risk={onlyWhenRisk ? "true" : "false"}
+      />
+    ),
+  ),
+}))
+
+describe("popup HeaderSection product announcements", () => {
+  it("renders the risk-only product announcement button in the popup header", () => {
+    render(<HeaderSection />, { withReleaseUpdateStatusProvider: false })
+
+    expect(screen.getByTestId("product-announcement-button")).toHaveAttribute(
+      "data-surface",
+      "popup-header",
+    )
+    expect(screen.getByTestId("product-announcement-button")).toHaveAttribute(
+      "data-only-when-risk",
+      "true",
+    )
+    expect(ProductAnnouncementButton).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "popup-header",
+        onlyWhenRisk: true,
+      }),
+      undefined,
+    )
+  })
+})

--- a/tests/features/ProductAnnouncements/ProductAnnouncementBanner.test.tsx
+++ b/tests/features/ProductAnnouncements/ProductAnnouncementBanner.test.tsx
@@ -1,0 +1,406 @@
+import { within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { requestProductAnnouncementPopoverOpen } from "~/features/ProductAnnouncements/events"
+import { useProductAnnouncements } from "~/features/ProductAnnouncements/hooks/useProductAnnouncements"
+import { ProductAnnouncementBanner } from "~/features/ProductAnnouncements/ProductAnnouncementBanner"
+import { ProductAnnouncementButton } from "~/features/ProductAnnouncements/ProductAnnouncementButton"
+import { PRODUCT_ANNOUNCEMENT_TEST_IDS } from "~/features/ProductAnnouncements/testIds"
+import { PRODUCT_ANALYTICS_EVENTS } from "~/services/productAnalytics/events"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
+import { render, screen, waitFor } from "~~/tests/test-utils/render"
+
+const { sendMessageMock } = vi.hoisted(() => ({
+  sendMessageMock: vi.fn(),
+}))
+
+const { trackProductAnalyticsEventMock } = vi.hoisted(() => ({
+  trackProductAnalyticsEventMock: vi.fn(),
+}))
+
+const riskNotice = {
+  id: "risk",
+  revision: 1,
+  severity: "warning",
+  priority: 10,
+  startsAt: 1,
+  expiresAt: 2,
+  title: "Risk notice",
+  message: "Please review.",
+  seen: false,
+  dismissed: false,
+} as const
+
+const seenRiskNotice = {
+  ...riskNotice,
+  seen: true,
+} as const
+
+function createState(
+  overrides: Partial<{
+    notices: ProductAnnouncement[]
+    activeNotices: ProductAnnouncement[]
+    dismissedNotices: ProductAnnouncement[]
+    primaryRiskNotice: ProductAnnouncement | null
+  }> = {},
+) {
+  const notices = overrides.notices ?? [riskNotice]
+  const activeNotices = overrides.activeNotices ?? [riskNotice]
+
+  return {
+    success: true,
+    data: {
+      view: {
+        notices,
+        activeNotices,
+        dismissedNotices: overrides.dismissedNotices ?? [],
+        primaryRiskNotice:
+          overrides.primaryRiskNotice === undefined
+            ? activeNotices[0] ?? null
+            : overrides.primaryRiskNotice,
+        unseenActiveCount: 0,
+      },
+    },
+  }
+}
+
+function createEmptyState() {
+  return createState({
+    notices: [],
+    activeNotices: [],
+    primaryRiskNotice: null,
+  })
+}
+
+function ProductAnnouncementBannerFromHook() {
+  const { state, dismiss } = useProductAnnouncements()
+  const primaryRiskNotice = state.view.primaryRiskNotice
+
+  if (!primaryRiskNotice) {
+    return null
+  }
+
+  return (
+    <ProductAnnouncementBanner
+      notice={primaryRiskNotice}
+      additionalCount={0}
+      onViewAll={() => requestProductAnnouncementPopoverOpen("options-header")}
+      onDismiss={dismiss}
+    />
+  )
+}
+
+vi.mock("~/services/productAnnouncements/messaging", () => ({
+  sendProductAnnouncementsMessage: (...args: unknown[]) =>
+    sendMessageMock(...args),
+}))
+
+vi.mock("~/services/productAnalytics/events", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/productAnalytics/events")>()
+
+  return {
+    ...actual,
+    trackProductAnalyticsEvent: (...args: unknown[]) =>
+      trackProductAnalyticsEventMock(...args),
+  }
+})
+
+describe("ProductAnnouncementBanner", () => {
+  beforeEach(() => {
+    sendMessageMock.mockReset()
+    sendMessageMock.mockResolvedValue(createState())
+    trackProductAnalyticsEventMock.mockReset()
+  })
+
+  it("renders the primary risk notice and exposes view-all and dismiss actions", async () => {
+    const user = userEvent.setup()
+    const onViewAll = vi.fn()
+    const onDismiss = vi.fn()
+
+    render(
+      <ProductAnnouncementBanner
+        notice={riskNotice}
+        additionalCount={2}
+        onViewAll={onViewAll}
+        onDismiss={onDismiss}
+      />,
+      {
+        withReleaseUpdateStatusProvider: false,
+        withThemeProvider: false,
+        withUserPreferencesProvider: false,
+      },
+    )
+
+    expect(screen.getByText("Risk notice")).toBeInTheDocument()
+    expect(screen.getByText("Please review.")).not.toHaveClass("line-clamp-2")
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.viewAll",
+      }),
+    )
+    expect(onViewAll).toHaveBeenCalledTimes(1)
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.dismiss",
+      }),
+    )
+    expect(onDismiss).toHaveBeenCalledWith("risk", 1)
+  })
+
+  it("tracks banner view-all and dismiss actions with safe notice metadata", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ProductAnnouncementBanner
+        notice={riskNotice}
+        additionalCount={2}
+        onViewAll={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+      {
+        withReleaseUpdateStatusProvider: false,
+        withThemeProvider: false,
+        withUserPreferencesProvider: false,
+      },
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.viewAll",
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.dismiss",
+      }),
+    )
+
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      expect.objectContaining({
+        feature_id: "product_announcements",
+        action_id: "open_product_announcements",
+        surface_id: "options_product_announcements_banner",
+        entrypoint: "options",
+        result: "success",
+        product_announcement_id: "risk",
+        product_announcement_severity: "warning",
+        product_announcement_action_kind: "open_list",
+        product_announcement_active_count: 3,
+      }),
+    )
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      expect.objectContaining({
+        action_id: "dismiss_product_announcement",
+        product_announcement_id: "risk",
+        product_announcement_severity: "warning",
+        product_announcement_action_kind: "dismiss",
+        product_announcement_active_count: 3,
+      }),
+    )
+
+    const payloadText = JSON.stringify(
+      trackProductAnalyticsEventMock.mock.calls,
+    )
+    expect(payloadText).not.toContain("Risk notice")
+    expect(payloadText).not.toContain("Please review.")
+  })
+
+  it("opens the matching header popover from the banner view-all action and preserves trigger focus", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <>
+        <ProductAnnouncementButton surface="options-header" />
+        <ProductAnnouncementBanner
+          notice={riskNotice}
+          additionalCount={0}
+          onViewAll={() =>
+            requestProductAnnouncementPopoverOpen("options-header")
+          }
+          onDismiss={vi.fn()}
+        />
+      </>,
+      {
+        withReleaseUpdateStatusProvider: false,
+        withThemeProvider: false,
+        withUserPreferencesProvider: false,
+      },
+    )
+
+    const trigger = await screen.findByRole("button", {
+      name: "productAnnouncements:actions.open",
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.viewAll",
+      }),
+    )
+
+    const popover = await screen.findByTestId(
+      PRODUCT_ANNOUNCEMENT_TEST_IDS.popover,
+    )
+    expect(within(popover).getByText("Risk notice")).toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledTimes(1)
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      expect.objectContaining({
+        action_id: "open_product_announcements",
+        surface_id: "options_product_announcements_banner",
+        product_announcement_action_kind: "open_list",
+      }),
+    )
+    expect(
+      trackProductAnalyticsEventMock.mock.calls.some(([, payload]) => {
+        return (
+          typeof payload === "object" &&
+          payload !== null &&
+          "surface_id" in payload &&
+          payload.surface_id === "options_product_announcements_header"
+        )
+      }),
+    ).toBe(false)
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.MarkSeen,
+        { ids: ["risk"] },
+      )
+    })
+  })
+
+  it("does not open the header popover when the banner requests another surface", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <>
+        <ProductAnnouncementButton surface="options-header" />
+        <ProductAnnouncementBanner
+          notice={riskNotice}
+          additionalCount={0}
+          onViewAll={() =>
+            requestProductAnnouncementPopoverOpen("popup-header")
+          }
+          onDismiss={vi.fn()}
+        />
+      </>,
+      {
+        withReleaseUpdateStatusProvider: false,
+        withThemeProvider: false,
+        withUserPreferencesProvider: false,
+      },
+    )
+
+    await screen.findByRole("button", {
+      name: "productAnnouncements:actions.open",
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.viewAll",
+      }),
+    )
+
+    expect(
+      screen.queryByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.popover),
+    ).not.toBeInTheDocument()
+  })
+
+  it("refreshes the header popover state after the banner dismisses the risk notice", async () => {
+    const user = userEvent.setup()
+    let dismissed = false
+
+    sendMessageMock.mockImplementation((type) => {
+      if (type === ProductAnnouncementsMessageTypes.Dismiss) {
+        dismissed = true
+        return Promise.resolve({ success: true, data: undefined })
+      }
+
+      if (type === ProductAnnouncementsMessageTypes.GetState) {
+        return Promise.resolve(
+          dismissed
+            ? createEmptyState()
+            : createState({
+                notices: [seenRiskNotice],
+                activeNotices: [seenRiskNotice],
+                primaryRiskNotice: seenRiskNotice,
+              }),
+        )
+      }
+
+      return Promise.resolve({ success: true, data: undefined })
+    })
+
+    render(
+      <>
+        <ProductAnnouncementButton surface="options-header" />
+        <ProductAnnouncementBannerFromHook />
+      </>,
+      {
+        withReleaseUpdateStatusProvider: false,
+        withThemeProvider: false,
+        withUserPreferencesProvider: false,
+      },
+    )
+
+    const trigger = await screen.findByRole("button", {
+      name: "productAnnouncements:actions.open",
+    })
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.dismiss",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", {
+          name: "productAnnouncements:actions.dismiss",
+        }),
+      ).not.toBeInTheDocument()
+    })
+
+    await user.click(trigger)
+
+    const popover = await screen.findByTestId(
+      PRODUCT_ANNOUNCEMENT_TEST_IDS.popover,
+    )
+    expect(within(popover).queryByText("Risk notice")).not.toBeInTheDocument()
+  })
+
+  it("uses explicit one and other summary keys for additional risk counts", () => {
+    const renderBanner = (additionalCount: number) =>
+      render(
+        <ProductAnnouncementBanner
+          notice={riskNotice}
+          additionalCount={additionalCount}
+          onViewAll={vi.fn()}
+          onDismiss={vi.fn()}
+        />,
+        {
+          withReleaseUpdateStatusProvider: false,
+          withThemeProvider: false,
+          withUserPreferencesProvider: false,
+        },
+      )
+
+    const { unmount } = renderBanner(1)
+    expect(
+      screen.getByText("productAnnouncements:summary.additional_one"),
+    ).toBeInTheDocument()
+
+    unmount()
+
+    renderBanner(2)
+    expect(
+      screen.getByText("productAnnouncements:summary.additional_other"),
+    ).toBeInTheDocument()
+  })
+})

--- a/tests/features/ProductAnnouncements/ProductAnnouncementBanner.test.tsx
+++ b/tests/features/ProductAnnouncements/ProductAnnouncementBanner.test.tsx
@@ -403,4 +403,34 @@ describe("ProductAnnouncementBanner", () => {
       screen.getByText("productAnnouncements:summary.additional_other"),
     ).toBeInTheDocument()
   })
+
+  it("renders localized labels for every severity", () => {
+    const severities: ProductAnnouncement["severity"][] = [
+      "critical",
+      "warning",
+      "info",
+    ]
+
+    for (const severity of severities) {
+      const { unmount } = render(
+        <ProductAnnouncementBanner
+          notice={{ ...riskNotice, severity }}
+          additionalCount={0}
+          onViewAll={vi.fn()}
+          onDismiss={vi.fn()}
+        />,
+        {
+          withReleaseUpdateStatusProvider: false,
+          withThemeProvider: false,
+          withUserPreferencesProvider: false,
+        },
+      )
+
+      expect(
+        screen.getByText(`productAnnouncements:labels.${severity}`),
+      ).toBeInTheDocument()
+
+      unmount()
+    }
+  })
 })

--- a/tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx
+++ b/tests/features/ProductAnnouncements/ProductAnnouncementButton.test.tsx
@@ -1,0 +1,1107 @@
+import { act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { requestProductAnnouncementPopoverOpen } from "~/features/ProductAnnouncements/events"
+import { useProductAnnouncements } from "~/features/ProductAnnouncements/hooks/useProductAnnouncements"
+import { ProductAnnouncementButton } from "~/features/ProductAnnouncements/ProductAnnouncementButton"
+import { PRODUCT_ANALYTICS_EVENTS } from "~/services/productAnalytics/events"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
+import { render, renderHook, screen, waitFor } from "~~/tests/test-utils/render"
+
+const { mediaQueryState, sendMessageMock, trackProductAnalyticsEventMock } =
+  vi.hoisted(() => ({
+    mediaQueryState: {
+      isSmallScreen: false,
+    },
+    sendMessageMock: vi.fn(),
+    trackProductAnalyticsEventMock: vi.fn(),
+  }))
+
+const riskNotice = {
+  id: "risk",
+  revision: 1,
+  severity: "critical",
+  priority: 100,
+  startsAt: Date.parse("2026-06-06T00:00:00Z"),
+  expiresAt: Date.parse("2026-06-20T00:00:00Z"),
+  title: "Critical risk",
+  message: "Update now.",
+  seen: false,
+  dismissed: false,
+} as const
+
+const warningNotice = {
+  id: "warning",
+  revision: 2,
+  severity: "warning",
+  priority: 90,
+  startsAt: Date.parse("2026-06-06T00:00:00Z"),
+  expiresAt: Date.parse("2026-06-20T00:00:00Z"),
+  title: "Warning notice",
+  message: "Check configuration.",
+  cta: {
+    label: "Secure notes",
+    url: "https://github.com/qixing-jk/all-api-hub/releases",
+  },
+  seen: false,
+  dismissed: false,
+} as const
+
+const unsafeCtaNotice = {
+  ...warningNotice,
+  id: "unsafe",
+  title: "Unsafe CTA",
+  cta: {
+    label: "Unsafe notes",
+    url: "http://example.com/insecure",
+  },
+} as const
+
+const dismissedNotice = {
+  ...warningNotice,
+  id: "dismissed",
+  title: "Dismissed notice",
+  seen: true,
+  dismissed: true,
+} as const
+
+function createState(
+  overrides: Partial<{
+    notices: unknown[]
+    activeNotices: unknown[]
+    dismissedNotices: unknown[]
+    primaryRiskNotice: unknown
+    activeRiskCount: number
+    unseenActiveCount: number
+  }> = {},
+) {
+  const notices = overrides.notices ?? [riskNotice]
+  const activeNotices =
+    overrides.activeNotices ??
+    notices.filter(
+      (notice) =>
+        typeof notice === "object" &&
+        notice !== null &&
+        "dismissed" in notice &&
+        !notice.dismissed,
+    )
+  const activeRiskNotices = activeNotices.filter(
+    (notice) =>
+      typeof notice === "object" &&
+      notice !== null &&
+      "dismissed" in notice &&
+      !notice.dismissed &&
+      "severity" in notice &&
+      (notice.severity === "critical" || notice.severity === "warning"),
+  )
+
+  return {
+    success: true,
+    data: {
+      view: {
+        notices,
+        activeNotices,
+        dismissedNotices:
+          overrides.dismissedNotices ??
+          notices.filter(
+            (notice) =>
+              typeof notice === "object" &&
+              notice !== null &&
+              "dismissed" in notice &&
+              notice.dismissed,
+          ),
+        primaryRiskNotice:
+          overrides.primaryRiskNotice ??
+          (activeRiskNotices.length > 0 ? activeRiskNotices[0] : null),
+        activeRiskCount: overrides.activeRiskCount ?? activeRiskNotices.length,
+        unseenActiveCount:
+          overrides.unseenActiveCount ??
+          activeNotices.filter(
+            (notice) =>
+              typeof notice === "object" &&
+              notice !== null &&
+              "seen" in notice &&
+              !notice.seen,
+          ).length,
+      },
+    },
+  }
+}
+
+function renderButton() {
+  return render(<ProductAnnouncementButton surface="options-header" />, {
+    withReleaseUpdateStatusProvider: false,
+    withThemeProvider: false,
+    withUserPreferencesProvider: false,
+  })
+}
+
+vi.mock("~/services/productAnnouncements/messaging", () => ({
+  sendProductAnnouncementsMessage: (...args: unknown[]) =>
+    sendMessageMock(...args),
+}))
+
+vi.mock("~/services/productAnalytics/events", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/productAnalytics/events")>()
+
+  return {
+    ...actual,
+    trackProductAnalyticsEvent: (...args: unknown[]) =>
+      trackProductAnalyticsEventMock(...args),
+  }
+})
+
+vi.mock("~/hooks/useMediaQuery", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/hooks/useMediaQuery")>()
+
+  return {
+    ...actual,
+    useIsSmallScreen: () => mediaQueryState.isSmallScreen,
+  }
+})
+
+describe("ProductAnnouncementButton", () => {
+  beforeEach(() => {
+    mediaQueryState.isSmallScreen = false
+    sendMessageMock.mockReset()
+    sendMessageMock.mockResolvedValue(createState({ unseenActiveCount: 1 }))
+    trackProductAnalyticsEventMock.mockReset()
+  })
+
+  it("marks unseen notices seen when opened", async () => {
+    const user = userEvent.setup()
+    renderButton()
+
+    expect(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.openWithRiskCount",
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("product-announcement-badge")).toHaveTextContent(
+      "1",
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.openWithRiskCount",
+      }),
+    )
+
+    expect(await screen.findByText("Critical risk")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.MarkSeen,
+        { ids: ["risk"] },
+      )
+    })
+  })
+
+  it("exposes active risk count in the announcement button name", async () => {
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice, warningNotice],
+        activeNotices: [
+          { ...riskNotice, seen: true },
+          warningNotice,
+          { ...dismissedNotice, severity: "warning", dismissed: true },
+        ],
+        activeRiskCount: 2,
+        unseenActiveCount: 1,
+      }),
+    )
+
+    renderButton()
+
+    expect(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.openWithRiskCount",
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("product-announcement-badge")).toHaveTextContent(
+      "2",
+    )
+  })
+
+  it("uses the shared header utility button style", async () => {
+    renderButton()
+
+    const trigger = await screen.findByRole("button", {
+      name: "productAnnouncements:actions.openWithRiskCount",
+    })
+    expect(trigger).toHaveClass("h-6", "w-6", "border")
+    expect(trigger.querySelector("svg")).toHaveClass("h-4", "w-4")
+  })
+
+  it("keeps active risk count visible after opening marks notices seen", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockImplementation((type) => {
+      if (type === ProductAnnouncementsMessageTypes.MarkSeen) {
+        return Promise.resolve({ success: true, data: undefined })
+      }
+
+      return Promise.resolve(
+        createState({
+          notices: [riskNotice],
+          activeNotices: [{ ...riskNotice, seen: false }],
+          primaryRiskNotice: riskNotice,
+          activeRiskCount: 1,
+          unseenActiveCount: 1,
+        }),
+      )
+    })
+
+    renderButton()
+
+    const trigger = await screen.findByRole("button", {
+      name: "productAnnouncements:actions.openWithRiskCount",
+    })
+    await user.click(trigger)
+
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.MarkSeen,
+        { ids: ["risk"] },
+      )
+    })
+    expect(screen.getByTestId("product-announcement-badge")).toHaveTextContent(
+      "1",
+    )
+  })
+
+  it("uses activeNotices as the source for seen marking when available", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice, warningNotice],
+        activeNotices: [warningNotice],
+        unseenActiveCount: 1,
+      }),
+    )
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+
+    await screen.findByText("Warning notice")
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.MarkSeen,
+        { ids: ["warning"] },
+      )
+    })
+  })
+
+  it("does not clamp specific announcement entry title or message copy", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice],
+        activeNotices: [riskNotice],
+        unseenActiveCount: 0,
+      }),
+    )
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+
+    expect(screen.getByText("Critical risk").closest("h3")).not.toHaveClass(
+      "line-clamp-2",
+    )
+    expect(screen.getByText("Update now.")).not.toHaveClass("line-clamp-4")
+  })
+
+  it("does not truncate specific announcement entry CTA labels", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [warningNotice],
+        activeNotices: [warningNotice],
+        unseenActiveCount: 0,
+      }),
+    )
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+
+    expect(await screen.findByText("Secure notes")).not.toHaveClass("truncate")
+  })
+
+  it("marks unseen notices seen when they arrive after an already-open popover", async () => {
+    const user = userEvent.setup()
+    let resolveInitialState: (value: unknown) => void = () => {}
+    const initialStatePromise = new Promise((resolve) => {
+      resolveInitialState = resolve
+    })
+
+    sendMessageMock.mockImplementation((type) => {
+      if (type === ProductAnnouncementsMessageTypes.GetState) {
+        return initialStatePromise
+      }
+
+      return Promise.resolve({ success: true, data: undefined })
+    })
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+
+    resolveInitialState(
+      createState({
+        notices: [riskNotice],
+        activeNotices: [riskNotice],
+        unseenActiveCount: 1,
+      }),
+    )
+
+    expect(await screen.findByText("Critical risk")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.MarkSeen,
+        { ids: ["risk"] },
+      )
+    })
+  })
+
+  it("retries marking the same notice seen after a failed seen update", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockImplementation((type) => {
+      if (type === ProductAnnouncementsMessageTypes.MarkSeen) {
+        const markSeenCalls = sendMessageMock.mock.calls.filter(
+          ([messageType]) =>
+            messageType === ProductAnnouncementsMessageTypes.MarkSeen,
+        )
+
+        if (markSeenCalls.length === 1) {
+          return Promise.resolve({ success: false, error: "temporary failure" })
+        }
+
+        return Promise.resolve({ success: true, data: undefined })
+      }
+
+      return Promise.resolve(
+        createState({
+          notices: [riskNotice],
+          activeNotices: [riskNotice],
+          unseenActiveCount: 1,
+        }),
+      )
+    })
+
+    renderButton()
+
+    const trigger = await screen.findByRole("button", {
+      name: "productAnnouncements:actions.openWithRiskCount",
+    })
+    await user.click(trigger)
+    await waitFor(() => {
+      expect(
+        sendMessageMock.mock.calls.filter(
+          ([type]) => type === ProductAnnouncementsMessageTypes.MarkSeen,
+        ),
+      ).toHaveLength(1)
+    })
+
+    await user.click(trigger)
+    await user.click(trigger)
+
+    await waitFor(() => {
+      expect(
+        sendMessageMock.mock.calls.filter(
+          ([type]) => type === ProductAnnouncementsMessageTypes.MarkSeen,
+        ),
+      ).toHaveLength(2)
+    })
+  })
+
+  it("dismisses a notice through a uniquely labelled dismiss button and reloads", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockImplementation((type) => {
+      if (type === ProductAnnouncementsMessageTypes.GetState) {
+        return Promise.resolve(
+          createState({
+            notices: [
+              { ...riskNotice, seen: true },
+              { ...warningNotice, seen: true },
+            ],
+            activeNotices: [
+              { ...riskNotice, seen: true },
+              { ...warningNotice, seen: true },
+            ],
+            unseenActiveCount: 0,
+          }),
+        )
+      }
+
+      return Promise.resolve({ success: true, data: undefined })
+    })
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Critical risk/,
+      }),
+    )
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      ProductAnnouncementsMessageTypes.Dismiss,
+      { id: "risk", revision: 1 },
+    )
+    expect(
+      sendMessageMock.mock.calls.filter(
+        ([type]) => type === ProductAnnouncementsMessageTypes.GetState,
+      ),
+    ).toHaveLength(2)
+  })
+
+  it("switches filters with plain button semantics", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice, dismissedNotice],
+        activeNotices: [riskNotice],
+        dismissedNotices: [dismissedNotice],
+        unseenActiveCount: 0,
+      }),
+    )
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+    expect(
+      screen
+        .getByRole("button", {
+          name: "productAnnouncements:filters.active",
+        })
+        .querySelector("svg"),
+    ).toHaveClass("h-3.5", "w-3.5")
+    expect(
+      screen
+        .getByRole("button", {
+          name: "productAnnouncements:filters.dismissed",
+        })
+        .querySelector("svg"),
+    ).toHaveClass("h-3.5", "w-3.5")
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:filters.dismissed",
+      }),
+    )
+
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument()
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId("product-announcement-popover"),
+    ).toBeInTheDocument()
+    expect(await screen.findByText("Dismissed notice")).toBeInTheDocument()
+  })
+
+  it("closes the announcement popover from an explicit close button", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice],
+        activeNotices: [riskNotice],
+        unseenActiveCount: 0,
+      }),
+    )
+
+    renderButton()
+
+    const trigger = await screen.findByRole("button", {
+      name: "productAnnouncements:actions.open",
+    })
+    await user.click(trigger)
+
+    expect(
+      await screen.findByTestId("product-announcement-popover"),
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.close",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("product-announcement-popover"),
+      ).not.toBeInTheDocument()
+    })
+    expect(trigger).toHaveFocus()
+  })
+
+  it("uses a modal sheet instead of an anchored popover on small screens", async () => {
+    mediaQueryState.isSmallScreen = true
+    const user = userEvent.setup()
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice],
+        activeNotices: [riskNotice],
+        unseenActiveCount: 0,
+      }),
+    )
+
+    renderButton()
+
+    const trigger = await screen.findByRole("button", {
+      name: "productAnnouncements:actions.open",
+    })
+    await user.click(trigger)
+
+    expect(
+      await screen.findByTestId("product-announcement-sheet"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId("product-announcement-popover"),
+    ).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.close",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("product-announcement-sheet"),
+      ).not.toBeInTheDocument()
+    })
+    expect(trigger).toHaveFocus()
+  })
+
+  it("uses a modal sheet for popup risk announcements", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice],
+        activeNotices: [riskNotice],
+        primaryRiskNotice: riskNotice,
+        unseenActiveCount: 0,
+      }),
+    )
+
+    render(<ProductAnnouncementButton surface="popup-header" onlyWhenRisk />, {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.openWithRiskCount",
+      }),
+    )
+
+    expect(
+      await screen.findByTestId("product-announcement-sheet"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId("product-announcement-popover"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("restores a dismissed notice without switching away from the dismissed filter", async () => {
+    const user = userEvent.setup()
+    let restored = false
+    sendMessageMock.mockImplementation((type) => {
+      if (type === ProductAnnouncementsMessageTypes.Restore) {
+        restored = true
+        return Promise.resolve({ success: true, data: undefined })
+      }
+
+      if (type === ProductAnnouncementsMessageTypes.GetState) {
+        return Promise.resolve(
+          restored
+            ? createState({
+                notices: [{ ...dismissedNotice, dismissed: false, seen: true }],
+                activeNotices: [
+                  { ...dismissedNotice, dismissed: false, seen: true },
+                ],
+                dismissedNotices: [],
+                activeRiskCount: 1,
+                unseenActiveCount: 0,
+              })
+            : createState({
+                notices: [{ ...dismissedNotice, seen: true }],
+                activeNotices: [],
+                dismissedNotices: [{ ...dismissedNotice, seen: true }],
+                activeRiskCount: 0,
+                unseenActiveCount: 0,
+              }),
+        )
+      }
+
+      return Promise.resolve({ success: true, data: undefined })
+    })
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:filters.dismissed",
+      }),
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Dismissed notice/,
+      }),
+    )
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      ProductAnnouncementsMessageTypes.Restore,
+      { id: "dismissed" },
+    )
+    expect(
+      sendMessageMock.mock.calls.filter(
+        ([type]) => type === ProductAnnouncementsMessageTypes.GetState,
+      ),
+    ).toHaveLength(2)
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "productAnnouncements:filters.dismissed",
+        }),
+      ).toHaveAttribute("aria-pressed", "true")
+    })
+    expect(
+      await screen.findByText("productAnnouncements:empty.dismissed"),
+    ).toBeInTheDocument()
+  })
+
+  it("keeps the dismissed filter selected when restore fails", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockImplementation((type) => {
+      if (type === ProductAnnouncementsMessageTypes.Restore) {
+        return Promise.resolve({ success: false, error: "missing listener" })
+      }
+
+      if (type === ProductAnnouncementsMessageTypes.GetState) {
+        return Promise.resolve(
+          createState({
+            notices: [{ ...dismissedNotice, seen: true }],
+            activeNotices: [],
+            dismissedNotices: [{ ...dismissedNotice, seen: true }],
+            activeRiskCount: 0,
+            unseenActiveCount: 0,
+          }),
+        )
+      }
+
+      return Promise.resolve({ success: true, data: undefined })
+    })
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:filters.dismissed",
+      }),
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Dismissed notice/,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.Restore,
+        { id: "dismissed" },
+      )
+    })
+    expect(
+      screen.getByRole("button", {
+        name: "productAnnouncements:filters.dismissed",
+      }),
+    ).toHaveAttribute("aria-pressed", "true")
+    expect(
+      sendMessageMock.mock.calls.filter(
+        ([type]) => type === ProductAnnouncementsMessageTypes.GetState,
+      ),
+    ).toHaveLength(1)
+  })
+
+  it("tracks opening, dismissing, and CTA clicks with safe announcement metadata", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [warningNotice],
+        activeNotices: [warningNotice],
+        unseenActiveCount: 1,
+      }),
+    )
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.openWithRiskCount",
+      }),
+    )
+    await user.click(await screen.findByRole("link", { name: /Secure notes/ }))
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Warning notice/,
+      }),
+    )
+
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      expect.objectContaining({
+        feature_id: "product_announcements",
+        action_id: "open_product_announcements",
+        surface_id: "options_product_announcements_header",
+        entrypoint: "options",
+        result: "success",
+        product_announcement_action_kind: "open_list",
+        product_announcement_active_count: 1,
+      }),
+    )
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      expect.objectContaining({
+        action_id: "open_product_announcement_cta",
+        product_announcement_id: "warning",
+        product_announcement_severity: "warning",
+        product_announcement_action_kind: "open_cta",
+        product_announcement_active_count: 1,
+      }),
+    )
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      expect.objectContaining({
+        action_id: "dismiss_product_announcement",
+        product_announcement_id: "warning",
+        product_announcement_severity: "warning",
+        product_announcement_action_kind: "dismiss",
+        product_announcement_active_count: 1,
+      }),
+    )
+
+    const payloadText = JSON.stringify(
+      trackProductAnalyticsEventMock.mock.calls,
+    )
+    expect(payloadText).not.toContain("Warning notice")
+    expect(payloadText).not.toContain("Check configuration.")
+    expect(payloadText).not.toContain("https://")
+    expect(payloadText).not.toContain("Secure notes")
+  })
+
+  it("renders only HTTPS announcement CTA links", async () => {
+    const user = userEvent.setup()
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [warningNotice, unsafeCtaNotice],
+        activeNotices: [warningNotice, unsafeCtaNotice],
+        unseenActiveCount: 0,
+      }),
+    )
+
+    renderButton()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    )
+
+    expect(
+      await screen.findByRole("link", { name: /Secure notes/ }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/qixing-jk/all-api-hub/releases",
+    )
+    expect(screen.queryByRole("link", { name: /Unsafe notes/ })).toBeNull()
+  })
+
+  it("opens and focuses the trigger when the matching surface is requested", async () => {
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice],
+        activeNotices: [riskNotice],
+        unseenActiveCount: 0,
+      }),
+    )
+
+    renderButton()
+
+    const trigger = await screen.findByRole("button", {
+      name: "productAnnouncements:actions.open",
+    })
+
+    act(() => {
+      requestProductAnnouncementPopoverOpen("options-header")
+    })
+
+    expect(await screen.findByText("Critical risk")).toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it("ignores open requests for a different surface", async () => {
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice],
+        activeNotices: [riskNotice],
+        unseenActiveCount: 0,
+      }),
+    )
+
+    renderButton()
+
+    await screen.findByRole("button", {
+      name: "productAnnouncements:actions.open",
+    })
+
+    act(() => {
+      requestProductAnnouncementPopoverOpen("popup-header")
+    })
+
+    expect(screen.queryByText("Critical risk")).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId("product-announcement-popover"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("reserves a non-focusable popup slot until risk state is available", async () => {
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice],
+        activeNotices: [riskNotice],
+        primaryRiskNotice: null,
+        unseenActiveCount: 0,
+      }),
+    )
+
+    render(<ProductAnnouncementButton surface="popup-header" onlyWhenRisk />, {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    expect(
+      screen.getByTestId("product-announcement-reserved-slot"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "productAnnouncements:actions.open",
+      }),
+    ).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.GetState,
+        { locale: "en" },
+      )
+    })
+  })
+
+  it("uses the reserved popup slot when risk notices become visible", async () => {
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [riskNotice],
+        activeNotices: [riskNotice],
+        primaryRiskNotice: riskNotice,
+        unseenActiveCount: 0,
+      }),
+    )
+
+    render(<ProductAnnouncementButton surface="popup-header" onlyWhenRisk />, {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    const slot = screen.getByTestId("product-announcement-reserved-slot")
+    expect(
+      await screen.findByRole("button", {
+        name: "productAnnouncements:actions.openWithRiskCount",
+      }),
+    ).toBeInTheDocument()
+    expect(slot).toContainElement(
+      screen.getByTestId("product-announcement-button"),
+    )
+  })
+
+  it("ignores stale announcement loads after a newer reload wins", async () => {
+    let resolveSlowState: (value: unknown) => void = () => {}
+    const slowStatePromise = new Promise((resolve) => {
+      resolveSlowState = resolve
+    })
+
+    sendMessageMock.mockImplementationOnce(() => slowStatePromise)
+    sendMessageMock.mockResolvedValue(
+      createState({
+        notices: [warningNotice],
+        activeNotices: [warningNotice],
+        unseenActiveCount: 1,
+      }),
+    )
+
+    const { result } = renderHook(() => useProductAnnouncements(), {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    await act(async () => {
+      await result.current.reload()
+    })
+    await waitFor(() => {
+      expect(result.current.state.view.notices[0]?.id).toBe("warning")
+    })
+
+    await act(async () => {
+      resolveSlowState(
+        createState({
+          notices: [riskNotice],
+          activeNotices: [riskNotice],
+          unseenActiveCount: 1,
+        }),
+      )
+      await slowStatePromise
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.view.notices[0]?.id).toBe("warning")
+    })
+  })
+
+  it("does not reload after a pending dismiss resolves post-unmount", async () => {
+    let resolveDismiss: (value: unknown) => void = () => {}
+    const dismissPromise = new Promise((resolve) => {
+      resolveDismiss = resolve
+    })
+
+    sendMessageMock.mockImplementation((type) => {
+      if (type === ProductAnnouncementsMessageTypes.Dismiss) {
+        return dismissPromise
+      }
+
+      return Promise.resolve(
+        createState({
+          notices: [riskNotice],
+          activeNotices: [riskNotice],
+          unseenActiveCount: 1,
+        }),
+      )
+    })
+
+    const { result, unmount } = renderHook(() => useProductAnnouncements(), {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.GetState,
+        { locale: "en" },
+      )
+    })
+
+    const dismissResult = result.current.dismiss("risk", 1)
+
+    unmount()
+
+    await act(async () => {
+      resolveDismiss({ success: true, data: undefined })
+      await dismissResult
+    })
+
+    expect(
+      sendMessageMock.mock.calls.filter(
+        ([type]) => type === ProductAnnouncementsMessageTypes.GetState,
+      ),
+    ).toHaveLength(1)
+  })
+
+  it("does not reload after a pending restore resolves post-unmount", async () => {
+    let resolveRestore: (value: unknown) => void = () => {}
+    const restorePromise = new Promise((resolve) => {
+      resolveRestore = resolve
+    })
+
+    sendMessageMock.mockImplementation((type) => {
+      if (type === ProductAnnouncementsMessageTypes.Restore) {
+        return restorePromise
+      }
+
+      return Promise.resolve(
+        createState({
+          notices: [dismissedNotice],
+          activeNotices: [],
+          dismissedNotices: [dismissedNotice],
+          unseenActiveCount: 0,
+        }),
+      )
+    })
+
+    const { result, unmount } = renderHook(() => useProductAnnouncements(), {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    })
+
+    await waitFor(() => {
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        ProductAnnouncementsMessageTypes.GetState,
+        { locale: "en" },
+      )
+    })
+
+    const restoreResult = result.current.restore("dismissed")
+
+    unmount()
+
+    await act(async () => {
+      resolveRestore({ success: true, data: undefined })
+      await restoreResult
+    })
+
+    expect(
+      sendMessageMock.mock.calls.filter(
+        ([type]) => type === ProductAnnouncementsMessageTypes.GetState,
+      ),
+    ).toHaveLength(1)
+  })
+})

--- a/tests/features/ProductAnnouncements/ProductAnnouncementList.test.tsx
+++ b/tests/features/ProductAnnouncements/ProductAnnouncementList.test.tsx
@@ -1,0 +1,103 @@
+import userEvent from "@testing-library/user-event"
+import type { ComponentProps } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ProductAnnouncementList } from "~/features/ProductAnnouncements/ProductAnnouncementList"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+import { render, screen } from "~~/tests/test-utils/render"
+
+const notice = {
+  id: "risk",
+  revision: 1,
+  severity: "warning",
+  priority: 10,
+  startsAt: 1,
+  expiresAt: 2,
+  title: "Risk notice",
+  message: "Please review.",
+  seen: false,
+  dismissed: false,
+} satisfies ProductAnnouncement
+
+function renderList(
+  props: Partial<ComponentProps<typeof ProductAnnouncementList>> = {},
+) {
+  return render(
+    <ProductAnnouncementList
+      notices={props.notices ?? []}
+      emptyMessage={props.emptyMessage ?? "Nothing to review"}
+      isLoading={props.isLoading}
+      testId={props.testId ?? "product-announcement-list"}
+      onDismiss={props.onDismiss ?? vi.fn()}
+      onRestore={props.onRestore ?? vi.fn()}
+      onOpenCta={props.onOpenCta}
+    />,
+    {
+      withReleaseUpdateStatusProvider: false,
+      withThemeProvider: false,
+      withUserPreferencesProvider: false,
+    },
+  )
+}
+
+describe("ProductAnnouncementList", () => {
+  it("renders loading and empty states", () => {
+    const { rerender } = renderList({ isLoading: true })
+
+    expect(screen.getByText("productAnnouncements:loading")).toBeVisible()
+
+    rerender(
+      <ProductAnnouncementList
+        notices={[]}
+        emptyMessage="Nothing to review"
+        testId="product-announcement-list"
+        onDismiss={vi.fn()}
+        onRestore={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText("Nothing to review")).toBeVisible()
+  })
+
+  it("falls back to generic action labels when scoped translations are missing", async () => {
+    const user = userEvent.setup()
+    const onDismiss = vi.fn()
+    const onRestore = vi.fn()
+
+    renderList({
+      notices: [notice, { ...notice, id: "dismissed", dismissed: true }],
+      onDismiss,
+      onRestore,
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.dismiss Risk notice",
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "productAnnouncements:actions.restore Risk notice",
+      }),
+    )
+
+    expect(onDismiss).toHaveBeenCalledWith("risk", 1)
+    expect(onRestore).toHaveBeenCalledWith("dismissed")
+  })
+
+  it("does not render malformed CTA URLs", () => {
+    renderList({
+      notices: [
+        {
+          ...notice,
+          cta: {
+            label: "Broken link",
+            url: "not a url",
+          },
+        },
+      ],
+    })
+
+    expect(screen.queryByRole("link", { name: "Broken link" })).toBeNull()
+  })
+})

--- a/tests/features/ProductAnnouncements/analytics.test.ts
+++ b/tests/features/ProductAnnouncements/analytics.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS,
+  trackProductAnnouncementAction,
+} from "~/features/ProductAnnouncements/analytics"
+import { PRODUCT_ANALYTICS_EVENTS } from "~/services/productAnalytics/events"
+import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
+
+const trackProductAnalyticsEventMock = vi.hoisted(() => vi.fn())
+
+vi.mock("~/services/productAnalytics/events", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/productAnalytics/events")>()
+
+  return {
+    ...actual,
+    trackProductAnalyticsEvent: trackProductAnalyticsEventMock,
+  }
+})
+
+const notice = {
+  id: "risk",
+  revision: 1,
+  severity: "critical",
+  priority: 100,
+  startsAt: 1,
+  expiresAt: 2,
+  title: "Risk notice",
+  message: "Please review.",
+  seen: false,
+  dismissed: false,
+} satisfies ProductAnnouncement
+
+describe("product announcement analytics", () => {
+  it("tracks controlled notice metadata when present", () => {
+    trackProductAnnouncementAction({
+      actionKind: PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS.OpenCta,
+      activeCount: 2,
+      notice,
+      surface: "popup-header",
+    })
+
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      expect.objectContaining({
+        action_id: "open_product_announcement_cta",
+        surface_id: "popup_product_announcements_header",
+        entrypoint: "popup",
+        product_announcement_id: "risk",
+        product_announcement_severity: "critical",
+        product_announcement_active_count: 2,
+      }),
+    )
+  })
+
+  it("omits optional notice and count metadata when absent", () => {
+    trackProductAnnouncementAction({
+      actionKind: PRODUCT_ANNOUNCEMENT_ANALYTICS_ACTION_KINDS.OpenList,
+      surface: "options-header",
+    })
+
+    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      expect.not.objectContaining({
+        product_announcement_id: expect.anything(),
+        product_announcement_active_count: expect.anything(),
+      }),
+    )
+  })
+})

--- a/tests/services/productAnalytics/privacy.test.ts
+++ b/tests/services/productAnalytics/privacy.test.ts
@@ -176,6 +176,74 @@ describe("product analytics privacy filtering", () => {
     })
   })
 
+  it("keeps safe product announcement fields and drops remote copy", () => {
+    const sanitized = sanitizeProductAnalyticsEvent(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      {
+        feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ProductAnnouncements,
+        action_id: PRODUCT_ANALYTICS_ACTION_IDS.OpenProductAnnouncements,
+        surface_id:
+          PRODUCT_ANALYTICS_SURFACE_IDS.OptionsProductAnnouncementsHeader,
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+        result: PRODUCT_ANALYTICS_RESULTS.Success,
+        product_announcement_id: "2026-06-risk",
+        product_announcement_severity: "critical",
+        product_announcement_action_kind: "open_list",
+        product_announcement_active_count: 2,
+        product_announcement_title: "Private remote title",
+        product_announcement_message: "Remote body",
+        product_announcement_url:
+          "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+      },
+    )
+
+    expect(sanitized).toEqual({
+      feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ProductAnnouncements,
+      action_id: PRODUCT_ANALYTICS_ACTION_IDS.OpenProductAnnouncements,
+      surface_id:
+        PRODUCT_ANALYTICS_SURFACE_IDS.OptionsProductAnnouncementsHeader,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      result: PRODUCT_ANALYTICS_RESULTS.Success,
+      product_announcement_id: "2026-06-risk",
+      product_announcement_severity: "critical",
+      product_announcement_action_kind: "open_list",
+      product_announcement_active_count: 2,
+    })
+  })
+
+  it("keeps safe product announcement restore fields", () => {
+    const sanitized = sanitizeProductAnalyticsEvent(
+      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+      {
+        feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ProductAnnouncements,
+        action_id: PRODUCT_ANALYTICS_ACTION_IDS.RestoreProductAnnouncement,
+        surface_id:
+          PRODUCT_ANALYTICS_SURFACE_IDS.OptionsProductAnnouncementsHeader,
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+        result: PRODUCT_ANALYTICS_RESULTS.Success,
+        product_announcement_id: "2026-06-risk",
+        product_announcement_severity: "warning",
+        product_announcement_action_kind: "restore",
+        product_announcement_active_count: 0,
+        product_announcement_title: "Private remote title",
+        product_announcement_message: "Remote body",
+      },
+    )
+
+    expect(sanitized).toEqual({
+      feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ProductAnnouncements,
+      action_id: PRODUCT_ANALYTICS_ACTION_IDS.RestoreProductAnnouncement,
+      surface_id:
+        PRODUCT_ANALYTICS_SURFACE_IDS.OptionsProductAnnouncementsHeader,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      result: PRODUCT_ANALYTICS_RESULTS.Success,
+      product_announcement_id: "2026-06-risk",
+      product_announcement_severity: "warning",
+      product_announcement_action_kind: "restore",
+      product_announcement_active_count: 0,
+    })
+  })
+
   it("keeps Key Management action enums without leaking account token details", () => {
     const sanitized = sanitizeProductAnalyticsEvent(
       PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,

--- a/tests/services/productAnnouncements/catalog.test.ts
+++ b/tests/services/productAnnouncements/catalog.test.ts
@@ -1,0 +1,426 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  normalizeProductAnnouncementFeed,
+  selectProductAnnouncementView,
+} from "~/services/productAnnouncements/catalog"
+import {
+  PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+  PRODUCT_ANNOUNCEMENT_SEVERITIES,
+} from "~/services/productAnnouncements/constants"
+
+const now = Date.parse("2026-06-06T12:00:00.000Z")
+const baseFeed = {
+  schemaVersion: PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+  defaultLocale: "zh-CN",
+  announcements: [
+    {
+      id: "critical-risk",
+      revision: 1,
+      severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical,
+      priority: 100,
+      affectedVersions: ">=3.44.0 <3.44.1",
+      startsAt: "2026-06-06T00:00:00.000Z",
+      expiresAt: "2026-06-20T00:00:00.000Z",
+      content: {
+        "zh-CN": {
+          title: "关键风险",
+          message: "请升级到 3.44.1。",
+          cta: {
+            label: "查看修复说明",
+            url: "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+          },
+        },
+        en: {
+          title: "Critical risk",
+          message: "Update to 3.44.1.",
+        },
+      },
+    },
+    {
+      id: "info-note",
+      revision: 1,
+      severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Info,
+      priority: 1,
+      affectedVersions: "*",
+      startsAt: "2026-06-01T00:00:00.000Z",
+      expiresAt: "2026-07-01T00:00:00.000Z",
+      content: {
+        en: {
+          title: "FYI",
+          message: "Informational note.",
+        },
+      },
+    },
+    {
+      id: "future-risk",
+      revision: 1,
+      severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical,
+      priority: 500,
+      affectedVersions: ">=9.0.0 <10.0.0",
+      startsAt: "2026-06-01T00:00:00.000Z",
+      expiresAt: "2026-07-01T00:00:00.000Z",
+      content: {
+        "zh-CN": {
+          title: "未来版本风险",
+          message: "仅影响未来版本。",
+        },
+      },
+    },
+  ],
+}
+
+describe("product announcement feed normalization", () => {
+  it("returns an unsupported schema error for incompatible feeds", () => {
+    expect(
+      normalizeProductAnnouncementFeed(
+        {
+          ...baseFeed,
+          schemaVersion: 999,
+        },
+        {
+          currentVersion: "3.44.0",
+          locale: "zh-CN",
+          now,
+          dismissed: {},
+          seenAt: {},
+        },
+      ),
+    ).toEqual({ notices: [], errors: ["unsupported_schema"] })
+  })
+
+  it("treats missing, invalid, or non-array announcements as empty", () => {
+    const feeds = [
+      {
+        schemaVersion: PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+        defaultLocale: "zh-CN",
+      },
+      {
+        schemaVersion: PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+        defaultLocale: "zh-CN",
+        announcements: null,
+      },
+      {
+        schemaVersion: PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+        defaultLocale: "zh-CN",
+        announcements: { id: "not-an-array" },
+      },
+    ]
+
+    for (const feed of feeds) {
+      expect(
+        normalizeProductAnnouncementFeed(feed, {
+          currentVersion: "3.44.0",
+          locale: "zh-CN",
+          now,
+          dismissed: {},
+          seenAt: {},
+        }),
+      ).toEqual({ notices: [], errors: [] })
+    }
+  })
+
+  it("filters by version and resolves localized content with fallback", () => {
+    const normalized = normalizeProductAnnouncementFeed(baseFeed, {
+      currentVersion: "3.44.0",
+      locale: "zh-TW",
+      now,
+      dismissed: {},
+      seenAt: {},
+    })
+
+    expect(normalized.errors).toEqual([])
+    expect(normalized.notices.map((notice) => notice.id)).toEqual([
+      "critical-risk",
+      "info-note",
+    ])
+    expect(normalized.notices.map((notice) => notice.id)).not.toContain(
+      "future-risk",
+    )
+    expect(normalized.notices[0]).toMatchObject({
+      title: "关键风险",
+      message: "请升级到 3.44.1。",
+      cta: {
+        label: "查看修复说明",
+        url: "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+      },
+      seen: false,
+      dismissed: false,
+    })
+    expect(normalized.notices[1]).toMatchObject({
+      title: "FYI",
+      message: "Informational note.",
+    })
+  })
+
+  it("excludes expired and not-yet-started notices", () => {
+    const feed = {
+      ...baseFeed,
+      announcements: [
+        {
+          id: "active-window",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Info,
+          priority: 1,
+          affectedVersions: "*",
+          startsAt: "2026-06-01T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": {
+              title: "有效公告",
+              message: "仍在展示窗口内。",
+            },
+          },
+        },
+        {
+          id: "expired",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical,
+          priority: 100,
+          affectedVersions: "*",
+          startsAt: "2026-06-01T00:00:00.000Z",
+          expiresAt: "2026-06-06T12:00:00.000Z",
+          content: {
+            "zh-CN": {
+              title: "已过期",
+              message: "不应展示。",
+            },
+          },
+        },
+        {
+          id: "not-yet-started",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Critical,
+          priority: 100,
+          affectedVersions: "*",
+          startsAt: "2026-06-06T12:00:00.001Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": {
+              title: "尚未开始",
+              message: "不应展示。",
+            },
+          },
+        },
+      ],
+    }
+
+    const normalized = normalizeProductAnnouncementFeed(feed, {
+      currentVersion: "3.44.0",
+      locale: "zh-CN",
+      now,
+      dismissed: {},
+      seenAt: {},
+    })
+
+    expect(normalized.notices.map((notice) => notice.id)).toEqual([
+      "active-window",
+    ])
+  })
+
+  it("excludes notices without valid localized content", () => {
+    const feed = {
+      ...baseFeed,
+      announcements: [
+        {
+          id: "missing-title",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Info,
+          priority: 1,
+          affectedVersions: "*",
+          startsAt: "2026-06-01T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": {
+              title: "   ",
+              message: "缺少有效标题。",
+            },
+          },
+        },
+        {
+          id: "missing-message",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Info,
+          priority: 1,
+          affectedVersions: "*",
+          startsAt: "2026-06-01T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": {
+              title: "缺少有效内容",
+              message: "",
+            },
+          },
+        },
+      ],
+    }
+
+    const normalized = normalizeProductAnnouncementFeed(feed, {
+      currentVersion: "3.44.0",
+      locale: "zh-CN",
+      now,
+      dismissed: {},
+      seenAt: {},
+    })
+
+    expect(normalized).toMatchObject({ notices: [], errors: [] })
+  })
+
+  it("drops unsafe CTAs while keeping otherwise valid notices", () => {
+    const feed = {
+      ...baseFeed,
+      announcements: [
+        {
+          id: "unsafe-cta",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Info,
+          priority: 1,
+          affectedVersions: "*",
+          startsAt: "2026-06-01T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": {
+              title: "链接公告",
+              message: "正文有效。",
+              cta: {
+                label: "打开外部链接",
+                url: "https://evil.example.test/path",
+              },
+            },
+          },
+        },
+      ],
+    }
+
+    const normalized = normalizeProductAnnouncementFeed(feed, {
+      currentVersion: "3.44.0",
+      locale: "zh-CN",
+      now,
+      dismissed: {},
+      seenAt: {},
+    })
+
+    expect(normalized.notices).toHaveLength(1)
+    expect(normalized.notices[0]).toMatchObject({
+      id: "unsafe-cta",
+      title: "链接公告",
+      message: "正文有效。",
+    })
+    expect(normalized.notices[0]?.cta).toBeUndefined()
+  })
+
+  it("keeps dismissed notices in the list while excluding them from active selectors", () => {
+    const normalized = normalizeProductAnnouncementFeed(baseFeed, {
+      currentVersion: "3.44.0",
+      locale: "zh-CN",
+      now,
+      dismissed: { "critical-risk": 1 },
+      seenAt: { "critical-risk": now - 1000 },
+    })
+    const view = selectProductAnnouncementView(normalized.notices)
+
+    expect(
+      normalized.notices.find((item) => item.id === "critical-risk"),
+    ).toMatchObject({
+      dismissed: true,
+      seen: true,
+    })
+    expect(view.activeNotices.map((notice) => notice.id)).toEqual(["info-note"])
+    expect(view.dismissedNotices.map((notice) => notice.id)).toEqual([
+      "critical-risk",
+    ])
+    expect(view.activeRiskCount).toBe(0)
+    expect(view.unseenActiveCount).toBe(1)
+    expect(view.primaryRiskNotice).toBeNull()
+  })
+
+  it("resurfaces higher revisions and sorts active notices by severity and tie breakers", () => {
+    const feed = {
+      ...baseFeed,
+      announcements: [
+        ...(baseFeed.announcements as any[]),
+        {
+          id: "warning-priority-top",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning,
+          priority: 300,
+          affectedVersions: "*",
+          startsAt: "2026-06-02T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": { title: "高优先级警告", message: "请优先处理。" },
+          },
+        },
+        {
+          id: "warning-newer-start",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning,
+          priority: 200,
+          affectedVersions: "*",
+          startsAt: "2026-06-06T01:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": { title: "较新的警告", message: "请注意。" },
+          },
+        },
+        {
+          id: "warning",
+          revision: 2,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning,
+          priority: 200,
+          affectedVersions: "*",
+          startsAt: "2026-06-05T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": { title: "警告", message: "请注意。" },
+          },
+        },
+        {
+          id: "warning-alpha",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning,
+          priority: 150,
+          affectedVersions: "*",
+          startsAt: "2026-06-04T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": { title: "A 警告", message: "请注意。" },
+          },
+        },
+        {
+          id: "warning-beta",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Warning,
+          priority: 150,
+          affectedVersions: "*",
+          startsAt: "2026-06-04T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": { title: "B 警告", message: "请注意。" },
+          },
+        },
+      ],
+    }
+
+    const normalized = normalizeProductAnnouncementFeed(feed, {
+      currentVersion: "3.44.0",
+      locale: "zh-CN",
+      now,
+      dismissed: { warning: 1 },
+      seenAt: {},
+    })
+    const view = selectProductAnnouncementView(normalized.notices)
+
+    expect(view.activeNotices.map((notice) => notice.id)).toEqual([
+      "critical-risk",
+      "warning-priority-top",
+      "warning-newer-start",
+      "warning",
+      "warning-alpha",
+      "warning-beta",
+      "info-note",
+    ])
+    expect(view.primaryRiskNotice?.id).toBe("critical-risk")
+    expect(view.activeRiskCount).toBe(6)
+  })
+})

--- a/tests/services/productAnnouncements/catalog.test.ts
+++ b/tests/services/productAnnouncements/catalog.test.ts
@@ -120,6 +120,85 @@ describe("product announcement feed normalization", () => {
     }
   })
 
+  it("uses the built-in default locale when the feed default is blank", () => {
+    const normalized = normalizeProductAnnouncementFeed(
+      {
+        ...baseFeed,
+        defaultLocale: "   ",
+      },
+      {
+        currentVersion: "3.44.0",
+        locale: "zh-TW",
+        now,
+        dismissed: {},
+        seenAt: {},
+      },
+    )
+
+    expect(normalized.notices[0]).toMatchObject({
+      id: "critical-risk",
+      title: "关键风险",
+    })
+  })
+
+  it("rejects announcements with invalid severity, version range, or content shape", () => {
+    const feed = {
+      ...baseFeed,
+      announcements: [
+        {
+          id: "invalid-severity",
+          revision: 1,
+          severity: "notice",
+          priority: 1,
+          affectedVersions: "*",
+          startsAt: "2026-06-01T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": {
+              title: "无效级别",
+              message: "不应展示。",
+            },
+          },
+        },
+        {
+          id: "invalid-version-range",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Info,
+          priority: 1,
+          affectedVersions: 3,
+          startsAt: "2026-06-01T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: {
+            "zh-CN": {
+              title: "无效版本范围",
+              message: "不应展示。",
+            },
+          },
+        },
+        {
+          id: "invalid-content",
+          revision: 1,
+          severity: PRODUCT_ANNOUNCEMENT_SEVERITIES.Info,
+          priority: 1,
+          affectedVersions: "*",
+          startsAt: "2026-06-01T00:00:00.000Z",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          content: "zh-CN",
+        },
+      ],
+    }
+
+    const normalized = normalizeProductAnnouncementFeed(feed, {
+      currentVersion: "3.44.0",
+      locale: "zh-CN",
+      now,
+      dismissed: {},
+      seenAt: {},
+    })
+
+    expect(normalized).toEqual({ notices: [], errors: [] })
+  })
+
   it("filters by version and resolves localized content with fallback", () => {
     const normalized = normalizeProductAnnouncementFeed(baseFeed, {
       currentVersion: "3.44.0",

--- a/tests/services/productAnnouncements/messaging.test.ts
+++ b/tests/services/productAnnouncements/messaging.test.ts
@@ -8,10 +8,25 @@ import {
   resolveProductAnnouncementMarkSeenMessage,
   resolveProductAnnouncementRefreshMessage,
   resolveProductAnnouncementRestoreMessage,
+  setupProductAnnouncementMessagingListeners,
 } from "~/services/productAnnouncements/service"
 import { productAnnouncementStorage } from "~/services/productAnnouncements/storage"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 
 const fetchMock = vi.fn()
+const onMessageMock = vi.hoisted(() => vi.fn())
+
+vi.mock("~/services/productAnnouncements/messaging", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/services/productAnnouncements/messaging")
+    >()
+
+  return {
+    ...actual,
+    onProductAnnouncementsMessage: onMessageMock,
+  }
+})
 
 function resetProductAnnouncementServiceState() {
   ;(productAnnouncementService as any).isInitialized = false
@@ -22,6 +37,7 @@ describe("product announcement runtime message resolvers", () => {
   beforeEach(async () => {
     resetProductAnnouncementServiceState()
     vi.clearAllMocks()
+    onMessageMock.mockReturnValue(() => {})
     vi.stubGlobal("fetch", fetchMock)
     fetchMock.mockResolvedValue({
       ok: true,
@@ -126,6 +142,58 @@ describe("product announcement runtime message resolvers", () => {
     await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
       dismissed: {},
     })
+  })
+
+  it("registers product announcement messaging listeners once", async () => {
+    setupProductAnnouncementMessagingListeners()
+    setupProductAnnouncementMessagingListeners()
+
+    expect(onMessageMock).toHaveBeenCalledTimes(5)
+    expect(onMessageMock.mock.calls.map(([type]) => type)).toEqual([
+      ProductAnnouncementsMessageTypes.GetState,
+      ProductAnnouncementsMessageTypes.Refresh,
+      ProductAnnouncementsMessageTypes.MarkSeen,
+      ProductAnnouncementsMessageTypes.Dismiss,
+      ProductAnnouncementsMessageTypes.Restore,
+    ])
+
+    const findHandler = (
+      messageType: (typeof ProductAnnouncementsMessageTypes)[keyof typeof ProductAnnouncementsMessageTypes],
+    ) => {
+      const handler = onMessageMock.mock.calls.find(
+        ([type]) => type === messageType,
+      )?.[1] as ((payload: { data: unknown }) => Promise<unknown>) | undefined
+
+      if (!handler) {
+        throw new Error(`Missing handler for ${messageType}`)
+      }
+
+      return handler
+    }
+
+    await expect(
+      findHandler(ProductAnnouncementsMessageTypes.GetState)({
+        data: { locale: "zh-CN" },
+      }),
+    ).resolves.toMatchObject({ success: true })
+    await expect(
+      findHandler(ProductAnnouncementsMessageTypes.Refresh)({ data: {} }),
+    ).resolves.toEqual({ success: true, data: true })
+    await expect(
+      findHandler(ProductAnnouncementsMessageTypes.MarkSeen)({
+        data: { ids: ["notice-a"] },
+      }),
+    ).resolves.toEqual({ success: true, data: undefined })
+    await expect(
+      findHandler(ProductAnnouncementsMessageTypes.Dismiss)({
+        data: { id: "notice-a", revision: 1 },
+      }),
+    ).resolves.toEqual({ success: true, data: undefined })
+    await expect(
+      findHandler(ProductAnnouncementsMessageTypes.Restore)({
+        data: { id: "notice-a" },
+      }),
+    ).resolves.toEqual({ success: true, data: undefined })
   })
 
   it("returns failure responses for malformed get-state messages", async () => {

--- a/tests/services/productAnnouncements/messaging.test.ts
+++ b/tests/services/productAnnouncements/messaging.test.ts
@@ -53,6 +53,44 @@ describe("product announcement runtime message resolvers", () => {
     })
   })
 
+  it("returns current state with default version and current time", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [
+          {
+            id: "always",
+            revision: 1,
+            severity: "info",
+            priority: 1,
+            affectedVersions: "*",
+            startsAt: "2026-01-01T00:00:00Z",
+            expiresAt: "2099-01-01T00:00:00Z",
+            content: {
+              "zh-CN": {
+                title: "Always visible",
+                message: "Uses default request values.",
+              },
+            },
+          },
+        ],
+      }),
+    })
+
+    await resolveProductAnnouncementRefreshMessage()
+
+    const response = await resolveProductAnnouncementGetStateMessage({
+      locale: "zh-CN",
+    })
+
+    expect(response.success).toBe(true)
+    expect(response.success ? response.data.view.notices[0]?.id : null).toBe(
+      "always",
+    )
+  })
+
   it("handles refresh, seen, dismiss, and restore messages", async () => {
     await expect(resolveProductAnnouncementRefreshMessage()).resolves.toEqual({
       success: true,
@@ -60,6 +98,7 @@ describe("product announcement runtime message resolvers", () => {
     })
     expect(fetchMock).toHaveBeenCalledWith(PRODUCT_ANNOUNCEMENT_REMOTE_URL, {
       cache: "no-store",
+      signal: expect.any(AbortSignal),
     })
     await expect(
       resolveProductAnnouncementMarkSeenMessage({
@@ -206,5 +245,63 @@ describe("product announcement runtime message resolvers", () => {
         error: "Invalid product announcement restore request",
       })
     }
+  })
+
+  it("returns failure responses when service operations throw", async () => {
+    const getStateSpy = vi
+      .spyOn(productAnnouncementService, "getCurrentState")
+      .mockRejectedValueOnce(new Error("state failed"))
+    await expect(
+      resolveProductAnnouncementGetStateMessage({ locale: "zh-CN" }),
+    ).resolves.toEqual({
+      success: false,
+      error: "state failed",
+    })
+    getStateSpy.mockRestore()
+
+    const refreshSpy = vi
+      .spyOn(productAnnouncementService, "refreshRemoteFeed")
+      .mockRejectedValueOnce(new Error("refresh failed"))
+    await expect(resolveProductAnnouncementRefreshMessage()).resolves.toEqual({
+      success: false,
+      error: "refresh failed",
+    })
+    refreshSpy.mockRestore()
+
+    const markSeenSpy = vi
+      .spyOn(productAnnouncementService, "markSeen")
+      .mockRejectedValueOnce(new Error("seen failed"))
+    await expect(
+      resolveProductAnnouncementMarkSeenMessage({ ids: ["notice-a"] }),
+    ).resolves.toEqual({
+      success: false,
+      error: "seen failed",
+    })
+    markSeenSpy.mockRestore()
+
+    const dismissSpy = vi
+      .spyOn(productAnnouncementService, "dismiss")
+      .mockRejectedValueOnce(new Error("dismiss failed"))
+    await expect(
+      resolveProductAnnouncementDismissMessage({
+        id: "notice-a",
+        revision: 1,
+      }),
+    ).resolves.toEqual({
+      success: false,
+      error: "dismiss failed",
+    })
+    dismissSpy.mockRestore()
+
+    const restoreSpy = vi
+      .spyOn(productAnnouncementService, "restore")
+      .mockRejectedValueOnce(new Error("restore failed"))
+    await expect(
+      resolveProductAnnouncementRestoreMessage({ id: "notice-a" }),
+    ).resolves.toEqual({
+      success: false,
+      error: "restore failed",
+    })
+    restoreSpy.mockRestore()
   })
 })

--- a/tests/services/productAnnouncements/messaging.test.ts
+++ b/tests/services/productAnnouncements/messaging.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { PRODUCT_ANNOUNCEMENT_REMOTE_URL } from "~/services/productAnnouncements/constants"
+import {
+  productAnnouncementService,
+  resolveProductAnnouncementDismissMessage,
+  resolveProductAnnouncementGetStateMessage,
+  resolveProductAnnouncementMarkSeenMessage,
+  resolveProductAnnouncementRefreshMessage,
+  resolveProductAnnouncementRestoreMessage,
+} from "~/services/productAnnouncements/service"
+import { productAnnouncementStorage } from "~/services/productAnnouncements/storage"
+
+const fetchMock = vi.fn()
+
+function resetProductAnnouncementServiceState() {
+  ;(productAnnouncementService as any).isInitialized = false
+  ;(productAnnouncementService as any).refreshPromise = null
+}
+
+describe("product announcement runtime message resolvers", () => {
+  beforeEach(async () => {
+    resetProductAnnouncementServiceState()
+    vi.clearAllMocks()
+    vi.stubGlobal("fetch", fetchMock)
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }),
+    })
+    await productAnnouncementStorage.setState({
+      schemaVersion: 1,
+      dismissed: {},
+      seenAt: {},
+      lastShownAt: {},
+    })
+  })
+
+  it("returns current state response", async () => {
+    const response = await resolveProductAnnouncementGetStateMessage({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(response.success).toBe(true)
+    expect(response.success ? response.data.view.notices : []).toEqual([])
+    await vi.waitFor(() => {
+      expect((productAnnouncementService as any).refreshPromise).toBeNull()
+    })
+  })
+
+  it("handles refresh, seen, dismiss, and restore messages", async () => {
+    await expect(resolveProductAnnouncementRefreshMessage()).resolves.toEqual({
+      success: true,
+      data: true,
+    })
+    expect(fetchMock).toHaveBeenCalledWith(PRODUCT_ANNOUNCEMENT_REMOTE_URL, {
+      cache: "no-store",
+    })
+    await expect(
+      resolveProductAnnouncementMarkSeenMessage({
+        ids: [" notice-a "],
+        now: 1,
+      }),
+    ).resolves.toEqual({ success: true, data: undefined })
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      seenAt: { "notice-a": 1 },
+    })
+    await expect(
+      resolveProductAnnouncementDismissMessage({
+        id: " notice-a ",
+        revision: 1,
+      }),
+    ).resolves.toEqual({ success: true, data: undefined })
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      dismissed: { "notice-a": 1 },
+    })
+    await expect(
+      resolveProductAnnouncementRestoreMessage({
+        id: " notice-a ",
+      }),
+    ).resolves.toEqual({ success: true, data: undefined })
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      dismissed: {},
+    })
+  })
+
+  it("returns failure responses for malformed get-state messages", async () => {
+    for (const request of [
+      undefined,
+      null,
+      "zh-CN",
+      {},
+      { locale: "" },
+      { locale: "   " },
+      { locale: 1 },
+      { locale: "zh-CN", currentVersion: 3.44 },
+      { locale: "zh-CN", now: Number.NaN },
+      { locale: "zh-CN", now: Number.POSITIVE_INFINITY },
+      { locale: "zh-CN", now: "2026-06-06" },
+    ]) {
+      await expect(
+        resolveProductAnnouncementGetStateMessage(request as any),
+      ).resolves.toEqual({
+        success: false,
+        error: "Invalid product announcement state request",
+      })
+    }
+  })
+
+  it("returns failure responses for malformed mark-seen messages", async () => {
+    for (const request of [
+      undefined,
+      null,
+      "notice-a",
+      {},
+      { ids: "notice-a" },
+      { ids: [] },
+      { ids: [""] },
+      { ids: ["   "] },
+      { ids: ["notice-a", 1] },
+      { ids: ["notice-a"], now: Number.NaN },
+      { ids: ["notice-a"], now: Number.NEGATIVE_INFINITY },
+      { ids: ["notice-a"], now: "1" },
+    ]) {
+      await expect(
+        resolveProductAnnouncementMarkSeenMessage(request as any),
+      ).resolves.toEqual({
+        success: false,
+        error: "Invalid product announcement mark-seen request",
+      })
+    }
+  })
+
+  it("returns failure responses for malformed dismiss messages", async () => {
+    for (const request of [
+      undefined,
+      null,
+      "notice-a",
+      {},
+      {
+        id: "",
+        revision: 1,
+      },
+      {
+        id: "   ",
+        revision: 1,
+      },
+      {
+        id: 1,
+        revision: 1,
+      },
+      {
+        id: "notice-a",
+        revision: 1.5,
+      },
+      {
+        id: "notice-a",
+        revision: 0,
+      },
+      {
+        id: "notice-a",
+        revision: -1,
+      },
+      {
+        id: "notice-a",
+        revision: "1",
+      },
+      {
+        revision: 1,
+      },
+    ]) {
+      await expect(
+        resolveProductAnnouncementDismissMessage(request as any),
+      ).resolves.toEqual({
+        success: false,
+        error: "Invalid product announcement dismiss request",
+      })
+    }
+  })
+
+  it("returns failure responses for malformed restore messages", async () => {
+    for (const request of [
+      undefined,
+      null,
+      "notice-a",
+      {},
+      {
+        id: "",
+      },
+      {
+        id: "   ",
+      },
+      {
+        id: 1,
+      },
+    ]) {
+      await expect(
+        resolveProductAnnouncementRestoreMessage(request as any),
+      ).resolves.toEqual({
+        success: false,
+        error: "Invalid product announcement restore request",
+      })
+    }
+  })
+})

--- a/tests/services/productAnnouncements/service.test.ts
+++ b/tests/services/productAnnouncements/service.test.ts
@@ -1,0 +1,446 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { Storage } from "@plasmohq/storage"
+
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import { PRODUCT_ANNOUNCEMENT_REFRESH_ALARM } from "~/services/productAnnouncements/constants"
+import { productAnnouncementService } from "~/services/productAnnouncements/service"
+import { productAnnouncementStorage } from "~/services/productAnnouncements/storage"
+
+const fetchMock = vi.fn()
+const storage = new Storage({ area: "local" })
+const browserApiMocks = vi.hoisted(() => ({
+  createAlarm: vi.fn(),
+  getAlarm: vi.fn(),
+  getManifest: vi.fn(),
+  onAlarm: vi.fn(),
+}))
+
+vi.mock("~~/public/product-announcements.json", () => ({
+  default: {
+    schemaVersion: 1,
+    defaultLocale: "zh-CN",
+    announcements: [
+      {
+        id: "bundled-notice",
+        revision: 1,
+        severity: "warning",
+        priority: 1,
+        affectedVersions: ">=3.0.0",
+        startsAt: "2026-01-01T00:00:00Z",
+        expiresAt: "2027-01-01T00:00:00Z",
+        content: {
+          "zh-CN": {
+            title: "Bundled notice",
+            message: "Bundled fallback notice",
+          },
+        },
+      },
+    ],
+    _examples: {
+      devAnnouncements: [
+        {
+          id: "dev-critical-announcement",
+          revision: 1,
+          severity: "critical",
+          priority: 100,
+          affectedVersions: "*",
+          startsAt: "2026-01-01T00:00:00Z",
+          expiresAt: "2027-01-01T00:00:00Z",
+          content: {
+            "zh-CN": {
+              title: "[DEV] Critical risk",
+              message: "Development critical announcement",
+            },
+          },
+        },
+      ],
+    },
+  },
+}))
+
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/utils/browser/browserApi")>()
+
+  return {
+    ...actual,
+    createAlarm: browserApiMocks.createAlarm,
+    getAlarm: browserApiMocks.getAlarm,
+    getManifest: browserApiMocks.getManifest,
+    onAlarm: browserApiMocks.onAlarm,
+  }
+})
+
+function resetServiceState() {
+  ;(productAnnouncementService as any).isInitialized = false
+  ;(productAnnouncementService as any).refreshPromise = null
+}
+
+describe("product announcement service", () => {
+  beforeEach(async () => {
+    resetServiceState()
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    vi.stubGlobal("fetch", fetchMock)
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }),
+    })
+    browserApiMocks.getAlarm.mockResolvedValue({
+      name: PRODUCT_ANNOUNCEMENT_REFRESH_ALARM,
+    })
+    browserApiMocks.getManifest.mockReturnValue({
+      manifest_version: 3,
+      name: "All API Hub",
+      version: "3.44.0",
+    })
+    browserApiMocks.onAlarm.mockReturnValue(() => {})
+    await productAnnouncementStorage.setState({
+      schemaVersion: 1,
+      dismissed: {},
+      seenAt: {},
+      lastShownAt: {},
+    })
+  })
+
+  it("returns cached state immediately when refresh fails", async () => {
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = Date.parse("2026-06-05T00:00:00Z")
+      state.cachedFeed = {
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }
+    })
+    fetchMock.mockRejectedValue(new Error("network failed"))
+
+    const state = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(state.view.notices).toEqual([])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      cachedFeed: {
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      },
+    })
+  })
+
+  it("marks visible notice ids as seen without dismissing them", async () => {
+    await productAnnouncementService.markSeen(["notice-a"], 123)
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      seenAt: { "notice-a": 123 },
+      dismissed: {},
+    })
+  })
+
+  it("trims notice ids before marking them as seen", async () => {
+    await productAnnouncementService.markSeen([" notice-a ", "   "], 123)
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      seenAt: { "notice-a": 123 },
+      dismissed: {},
+    })
+  })
+
+  it("dismisses a notice revision", async () => {
+    await productAnnouncementService.dismiss(" notice-a ", 2)
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      dismissed: { "notice-a": 2 },
+    })
+  })
+
+  it("restores a dismissed notice revision", async () => {
+    await productAnnouncementService.dismiss(" notice-a ", 2)
+
+    await productAnnouncementService.restore(" notice-a ")
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      dismissed: {},
+    })
+    await expect(
+      storage.get(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE),
+    ).resolves.toMatchObject({
+      dismissed: {},
+    })
+  })
+
+  it("restores dismissed bundled development announcements into the active risk view", async () => {
+    vi.stubEnv("MODE", "development")
+
+    await productAnnouncementService.dismiss("dev-critical-announcement", 1)
+    const dismissedState = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+    expect(
+      dismissedState.view.dismissedNotices.map((notice) => notice.id),
+    ).toContain("dev-critical-announcement")
+
+    await productAnnouncementService.restore("dev-critical-announcement")
+
+    const restoredState = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+    expect(
+      restoredState.view.activeNotices.map((notice) => notice.id),
+    ).toContain("dev-critical-announcement")
+    expect(restoredState.view.primaryRiskNotice?.id).toBe(
+      "dev-critical-announcement",
+    )
+  })
+
+  it("ignores whitespace-only dismiss ids", async () => {
+    await productAnnouncementService.dismiss("   ", 2)
+
+    const state = await productAnnouncementStorage.getState()
+    expect(state.dismissed).toEqual({})
+  })
+
+  it("treats unsupported HTTP 200 remote feeds as refresh failures", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 999,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }),
+    })
+
+    await expect(
+      productAnnouncementService.refreshRemoteFeed(123),
+    ).resolves.toBe(false)
+
+    const state = await productAnnouncementStorage.getState()
+    expect(state.lastFetchedAt).toBeUndefined()
+    expect(state.cachedFeed).toBeUndefined()
+  })
+
+  it("treats malformed HTTP 200 remote feeds as refresh failures", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: "not-an-array",
+      }),
+    })
+
+    await expect(
+      productAnnouncementService.refreshRemoteFeed(123),
+    ).resolves.toBe(false)
+
+    const state = await productAnnouncementStorage.getState()
+    expect(state.lastFetchedAt).toBeUndefined()
+    expect(state.cachedFeed).toBeUndefined()
+  })
+
+  it("falls back to bundled notices when persisted cached feed is malformed", async () => {
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = 100
+      state.cachedFeed = {
+        schemaVersion: 999,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }
+    })
+
+    const state = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(state.view.notices).toMatchObject([{ id: "bundled-notice" }])
+    expect(state.lastFetchedAt).toBe(100)
+  })
+
+  it("falls back to bundled notices when persisted cached feed has malformed shape", async () => {
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = 100
+      state.cachedFeed = {
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: "not-an-array",
+      }
+    })
+
+    const state = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(state.view.notices).toMatchObject([{ id: "bundled-notice" }])
+    expect(state.lastFetchedAt).toBe(100)
+  })
+
+  it("injects bundled development examples only in development mode", async () => {
+    vi.stubEnv("MODE", "development")
+
+    const state = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(state.view.notices.map((notice) => notice.id)).toEqual([
+      "dev-critical-announcement",
+      "bundled-notice",
+    ])
+    expect(state.view.primaryRiskNotice?.id).toBe("dev-critical-announcement")
+  })
+
+  it("merges bundled development examples with cached remote notices in development mode", async () => {
+    vi.stubEnv("MODE", "development")
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = 100
+      state.cachedFeed = {
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [
+          {
+            id: "cached-info",
+            revision: 1,
+            severity: "info",
+            priority: 1,
+            affectedVersions: "*",
+            startsAt: "2026-01-01T00:00:00Z",
+            expiresAt: "2027-01-01T00:00:00Z",
+            content: {
+              "zh-CN": {
+                title: "Cached info",
+                message: "Cached remote notice",
+              },
+            },
+          },
+        ],
+      }
+    })
+
+    const state = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(state.view.notices.map((notice) => notice.id)).toEqual([
+      "dev-critical-announcement",
+      "cached-info",
+    ])
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      cachedFeed: {
+        announcements: [expect.objectContaining({ id: "cached-info" })],
+      },
+    })
+  })
+
+  it("does not inject bundled development examples outside development mode", async () => {
+    vi.stubEnv("MODE", "production")
+
+    const state = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(state.view.notices.map((notice) => notice.id)).toEqual([
+      "bundled-notice",
+    ])
+  })
+
+  it("starts a non-blocking refresh when cache is missing", async () => {
+    await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("starts a non-blocking refresh when cache is missing even with a fresh timestamp", async () => {
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = Date.parse("2026-06-06T00:00:00Z") - 1000
+    })
+
+    await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("starts a single non-blocking refresh for concurrent stale reads", async () => {
+    let resolveFetch!: (value: unknown) => void
+    const fetchDeferred = new Promise((resolve) => {
+      resolveFetch = resolve
+    })
+    fetchMock.mockReturnValue(fetchDeferred)
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = 100
+      state.cachedFeed = {
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }
+    })
+
+    await Promise.all([
+      productAnnouncementService.getCurrentState({
+        locale: "zh-CN",
+        currentVersion: "3.44.0",
+        now: Date.parse("2026-06-06T00:00:00Z"),
+      }),
+      productAnnouncementService.getCurrentState({
+        locale: "zh-CN",
+        currentVersion: "3.44.0",
+        now: Date.parse("2026-06-06T00:00:00Z"),
+      }),
+    ])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    resolveFetch({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }),
+    })
+    await vi.waitFor(() => {
+      expect((productAnnouncementService as any).refreshPromise).toBeNull()
+    })
+  })
+
+  it("initializes once and triggers the initial refresh path", async () => {
+    const service = new (
+      productAnnouncementService as any
+    ).constructor() as typeof productAnnouncementService
+
+    await service.initialize()
+    await service.initialize()
+
+    expect(browserApiMocks.onAlarm).toHaveBeenCalledTimes(1)
+    expect(browserApiMocks.getAlarm).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/services/productAnnouncements/service.test.ts
+++ b/tests/services/productAnnouncements/service.test.ts
@@ -155,6 +155,15 @@ describe("product announcement service", () => {
     })
   })
 
+  it("ignores empty seen id batches", async () => {
+    await productAnnouncementService.markSeen([" notice-a "], 123)
+    await productAnnouncementService.markSeen(["   "], 456)
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      seenAt: { "notice-a": 123 },
+    })
+  })
+
   it("dismisses a notice revision", async () => {
     await productAnnouncementService.dismiss(" notice-a ", 2)
 
@@ -175,6 +184,16 @@ describe("product announcement service", () => {
       storage.get(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE),
     ).resolves.toMatchObject({
       dismissed: {},
+    })
+  })
+
+  it("ignores whitespace-only restore ids", async () => {
+    await productAnnouncementService.dismiss(" notice-a ", 2)
+
+    await productAnnouncementService.restore("   ")
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      dismissed: { "notice-a": 2 },
     })
   })
 
@@ -221,6 +240,24 @@ describe("product announcement service", () => {
         defaultLocale: "zh-CN",
         announcements: [],
       }),
+    })
+
+    await expect(
+      productAnnouncementService.refreshRemoteFeed(123),
+    ).resolves.toBe(false)
+
+    const state = await productAnnouncementStorage.getState()
+    expect(state.lastFetchedAt).toBeUndefined()
+    expect(state.cachedFeed).toBeUndefined()
+  })
+
+  it("treats non-success remote responses as refresh failures", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => {
+        throw new Error("body should not be read")
+      },
     })
 
     await expect(
@@ -482,5 +519,17 @@ describe("product announcement service", () => {
       },
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("refreshes the remote feed when the product announcement alarm fires", async () => {
+    await productAnnouncementService.initialize()
+    await vi.waitFor(() => {
+      expect((productAnnouncementService as any).refreshPromise).toBeNull()
+    })
+
+    const alarmHandler = browserApiMocks.onAlarm.mock.calls[0]?.[0]
+    await alarmHandler({ name: PRODUCT_ANNOUNCEMENT_REFRESH_ALARM })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/services/productAnnouncements/service.test.ts
+++ b/tests/services/productAnnouncements/service.test.ts
@@ -251,6 +251,28 @@ describe("product announcement service", () => {
     expect(state.cachedFeed).toBeUndefined()
   })
 
+  it("times out a stuck remote refresh and clears the single-flight promise", async () => {
+    vi.useFakeTimers()
+    fetchMock.mockImplementation((_, init?: RequestInit) => {
+      return new Promise((_, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"))
+        })
+      })
+    })
+
+    try {
+      const refresh = productAnnouncementService.refreshRemoteFeed(123)
+
+      await vi.advanceTimersByTimeAsync(15_000)
+
+      await expect(refresh).resolves.toBe(false)
+      expect((productAnnouncementService as any).refreshPromise).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("falls back to bundled notices when persisted cached feed is malformed", async () => {
     await productAnnouncementStorage.updateState((state) => {
       state.lastFetchedAt = 100
@@ -441,6 +463,24 @@ describe("product announcement service", () => {
 
     expect(browserApiMocks.onAlarm).toHaveBeenCalledTimes(1)
     expect(browserApiMocks.getAlarm).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores unrelated alarms and creates the refresh alarm when missing", async () => {
+    browserApiMocks.getAlarm.mockResolvedValue(null)
+
+    await productAnnouncementService.initialize()
+
+    const alarmHandler = browserApiMocks.onAlarm.mock.calls[0]?.[0]
+    await alarmHandler({ name: "other-alarm" })
+
+    expect(browserApiMocks.createAlarm).toHaveBeenCalledWith(
+      PRODUCT_ANNOUNCEMENT_REFRESH_ALARM,
+      {
+        delayInMinutes: 720,
+        periodInMinutes: 720,
+      },
+    )
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/services/productAnnouncements/storage.test.ts
+++ b/tests/services/productAnnouncements/storage.test.ts
@@ -96,6 +96,21 @@ describe("product announcement storage", () => {
     ).resolves.not.toHaveProperty("lastFetchedAt")
   })
 
+  it("drops malformed persisted state maps", async () => {
+    await storage.set(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE, {
+      schemaVersion: 1,
+      dismissed: null,
+      seenAt: [],
+      lastShownAt: "not-a-map",
+    })
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      dismissed: {},
+      seenAt: {},
+      lastShownAt: {},
+    })
+  })
+
   it("returns an empty state when storage read fails", async () => {
     const getSpy = vi
       .spyOn((productAnnouncementStorage as any).storage, "get")

--- a/tests/services/productAnnouncements/storage.test.ts
+++ b/tests/services/productAnnouncements/storage.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Storage } from "@plasmohq/storage"
 
@@ -80,5 +80,34 @@ describe("product announcement storage", () => {
         announcements: [],
       },
     })
+  })
+
+  it("drops non-finite persisted last fetch timestamps", async () => {
+    await storage.set(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE, {
+      schemaVersion: 1,
+      dismissed: {},
+      seenAt: {},
+      lastShownAt: {},
+      lastFetchedAt: Number.POSITIVE_INFINITY,
+    })
+
+    await expect(
+      productAnnouncementStorage.getState(),
+    ).resolves.not.toHaveProperty("lastFetchedAt")
+  })
+
+  it("returns an empty state when storage read fails", async () => {
+    const getSpy = vi
+      .spyOn((productAnnouncementStorage as any).storage, "get")
+      .mockRejectedValueOnce(new Error("storage unavailable"))
+
+    await expect(productAnnouncementStorage.getState()).resolves.toEqual({
+      schemaVersion: 1,
+      dismissed: {},
+      seenAt: {},
+      lastShownAt: {},
+    })
+
+    getSpy.mockRestore()
   })
 })

--- a/tests/services/productAnnouncements/storage.test.ts
+++ b/tests/services/productAnnouncements/storage.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { Storage } from "@plasmohq/storage"
+
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import { PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION } from "~/services/productAnnouncements/constants"
+import { productAnnouncementStorage } from "~/services/productAnnouncements/storage"
+
+const storage = new Storage({ area: "local" })
+
+describe("product announcement storage", () => {
+  beforeEach(async () => {
+    await storage.remove(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE)
+  })
+
+  it("returns an empty sanitized state by default", async () => {
+    await expect(productAnnouncementStorage.getState()).resolves.toEqual({
+      schemaVersion: 1,
+      dismissed: {},
+      seenAt: {},
+      lastShownAt: {},
+    })
+  })
+
+  it("persists cached feed, seen state, and dismissed revisions", async () => {
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = 100
+      state.cachedFeed = {
+        schemaVersion: PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      }
+      state.seenAt.notice = 200
+      state.dismissed.notice = 1
+    })
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      lastFetchedAt: 100,
+      cachedFeed: {
+        schemaVersion: PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      },
+      seenAt: { notice: 200 },
+      dismissed: { notice: 1 },
+    })
+  })
+
+  it("sanitizes persisted number records and keeps state across feed schema changes", async () => {
+    await storage.set(STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE, {
+      schemaVersion: 1,
+      dismissed: {
+        " notice-a ": 1,
+        "   ": 2,
+        noticeB: "3",
+      },
+      seenAt: {
+        " notice-a ": 100,
+        noticeB: Number.NaN,
+      },
+      lastShownAt: {
+        " notice-c ": 200,
+        noticeD: Number.POSITIVE_INFINITY,
+      },
+      cachedFeed: {
+        schemaVersion: 999,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      },
+    })
+
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      schemaVersion: 1,
+      dismissed: { "notice-a": 1 },
+      seenAt: { "notice-a": 100 },
+      lastShownAt: { "notice-c": 200 },
+      cachedFeed: {
+        schemaVersion: 999,
+        defaultLocale: "zh-CN",
+        announcements: [],
+      },
+    })
+  })
+})

--- a/tests/services/productAnnouncements/urlPolicy.test.ts
+++ b/tests/services/productAnnouncements/urlPolicy.test.ts
@@ -44,6 +44,18 @@ describe("product announcement CTA URL policy", () => {
         url: "https://github.com/qixing-jk/all-api-hub",
       }),
     ).toBeNull()
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "Broken",
+        url: "not a url",
+      }),
+    ).toBeNull()
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "Other repo",
+        url: "https://github.com/qixing-jk/other-project/issues/1",
+      }),
+    ).toBeNull()
   })
 
   it("trims labels and normalizes accepted URLs", () => {

--- a/tests/services/productAnnouncements/urlPolicy.test.ts
+++ b/tests/services/productAnnouncements/urlPolicy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import { sanitizeProductAnnouncementCta } from "~/services/productAnnouncements/urlPolicy"
+
+describe("product announcement CTA URL policy", () => {
+  it("keeps project-owned and GitHub release links", () => {
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "View release",
+        url: "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+      }),
+    ).toEqual({
+      label: "View release",
+      url: "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.44.1",
+    })
+
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "Read docs",
+        url: "https://all-api-hub.qixing1217.top/changelog.html",
+      }),
+    ).toEqual({
+      label: "Read docs",
+      url: "https://all-api-hub.qixing1217.top/changelog.html",
+    })
+  })
+
+  it("drops unsafe or incomplete links", () => {
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "Run",
+        url: "javascript:alert(1)",
+      }),
+    ).toBeNull()
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "External",
+        url: "https://evil.example.test/path",
+      }),
+    ).toBeNull()
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "",
+        url: "https://github.com/qixing-jk/all-api-hub",
+      }),
+    ).toBeNull()
+  })
+
+  it("trims labels and normalizes accepted URLs", () => {
+    expect(
+      sanitizeProductAnnouncementCta({
+        label: "  Read changelog  ",
+        url: "  https://all-api-hub.qixing1217.top/changelog.html?version=3.44.1#latest  ",
+      }),
+    ).toEqual({
+      label: "Read changelog",
+      url: "https://all-api-hub.qixing1217.top/changelog.html?version=3.44.1#latest",
+    })
+  })
+})

--- a/tests/services/productAnnouncements/versionRange.test.ts
+++ b/tests/services/productAnnouncements/versionRange.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { isVersionInRange } from "~/services/productAnnouncements/versionRange"
+
+describe("product announcement version ranges", () => {
+  it("matches bounded semver-like ranges", () => {
+    expect(isVersionInRange("3.44.0", ">=3.44.0 <3.44.1")).toBe(true)
+    expect(isVersionInRange("3.44.0.1", ">=3.44.0 <3.44.1")).toBe(true)
+    expect(isVersionInRange("3.44.1", ">=3.44.0 <3.44.1")).toBe(false)
+    expect(isVersionInRange("3.43.9", ">=3.44.0 <3.44.1")).toBe(false)
+  })
+
+  it("supports exact and wildcard ranges", () => {
+    expect(isVersionInRange("3.44.0", "3.44.0")).toBe(true)
+    expect(isVersionInRange("3.44.1", "3.44.0")).toBe(false)
+    expect(isVersionInRange("3.44.1", "*")).toBe(true)
+  })
+
+  it("supports optional v prefixes and explicit equality comparators", () => {
+    expect(isVersionInRange("v3.44.0", "=3.44.0")).toBe(true)
+    expect(isVersionInRange("3.44.0", "=v3.44.0")).toBe(true)
+    expect(isVersionInRange("v3.44.1", "=3.44.0")).toBe(false)
+  })
+
+  it("fails closed for invalid ranges or versions", () => {
+    expect(isVersionInRange("dev", ">=3.44.0")).toBe(false)
+    expect(isVersionInRange("3.44.0", "=>3.44.0")).toBe(false)
+    expect(isVersionInRange("3.44.0", "")).toBe(false)
+  })
+})

--- a/tests/services/productAnnouncements/versionRange.test.ts
+++ b/tests/services/productAnnouncements/versionRange.test.ts
@@ -22,6 +22,13 @@ describe("product announcement version ranges", () => {
     expect(isVersionInRange("v3.44.1", "=3.44.0")).toBe(false)
   })
 
+  it("supports greater-than and less-than comparators", () => {
+    expect(isVersionInRange("3.44.1", ">3.44.0")).toBe(true)
+    expect(isVersionInRange("3.44.0", ">3.44.0")).toBe(false)
+    expect(isVersionInRange("3.43.9", "<3.44.0")).toBe(true)
+    expect(isVersionInRange("3.44.0", "<3.44.0")).toBe(false)
+  })
+
   it("fails closed for invalid ranges or versions", () => {
     expect(isVersionInRange("dev", ">=3.44.0")).toBe(false)
     expect(isVersionInRange("3.44.0", "=>3.44.0")).toBe(false)

--- a/tests/services/productAnnouncements/versionRange.test.ts
+++ b/tests/services/productAnnouncements/versionRange.test.ts
@@ -29,6 +29,11 @@ describe("product announcement version ranges", () => {
     expect(isVersionInRange("3.44.0", "<3.44.0")).toBe(false)
   })
 
+  it("supports inclusive upper-bound comparators", () => {
+    expect(isVersionInRange("3.44.0", "<=3.44.0")).toBe(true)
+    expect(isVersionInRange("3.44.1", "<=3.44.0")).toBe(false)
+  })
+
   it("fails closed for invalid ranges or versions", () => {
     expect(isVersionInRange("dev", ">=3.44.0")).toBe(false)
     expect(isVersionInRange("3.44.0", "=>3.44.0")).toBe(false)


### PR DESCRIPTION
## Summary
- add product-owned risk announcement feed normalization, persisted state, background refresh, and runtime messaging
- surface product notices in the Options header, Overview banner, and Popup header with responsive popover/sheet UI
- add privacy-safe analytics events plus focused service, runtime, UI, locale, and sanitizer coverage

## Test Plan
- pnpm run validate:push
- git push pre-push hook: pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product announcements: risk badges (Critical/Warning/Info), Options overview banner, header/popup trigger, responsive popover/sheet list, view all, dismiss/restore, unseen badges, and safe CTA handling.
* **Localization**
  * Added English, Japanese, Vietnamese, Simplified and Traditional Chinese translations.
* **Analytics**
  * Privacy-safe telemetry for announcement actions with controlled fields.
* **Tests**
  * Comprehensive tests covering UI, storage, messaging, parsing, URL policy, and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->