### PR TITLE
feat(account-management): allow clearing account list sort

### DIFF
--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -56,9 +56,9 @@ import {
 import { sendSiteAnnouncementsMessage } from "~/services/siteAnnouncements/messaging"
 import { sendWebdavAutoSyncMessage } from "~/services/webdav/webdavAutoSyncMessaging"
 import type {
+  ActiveSortField,
   CurrencyType,
   DashboardTabType,
-  SortField,
   SortOrder,
 } from "~/types"
 import { DEFAULT_ACCOUNT_AUTO_REFRESH } from "~/types/accountAutoRefresh"
@@ -243,7 +243,7 @@ interface UserPreferencesContextType {
   currencyType: CurrencyType
   showTodayCashflow: boolean
   sortingPriorityConfig: SortingPriorityConfig
-  sortField: SortField
+  sortField: ActiveSortField
   sortOrder: SortOrder
   autoRefresh: boolean
   refreshInterval: number
@@ -292,7 +292,7 @@ interface UserPreferencesContextType {
   updateCurrencyType: (currencyType: CurrencyType) => Promise<boolean>
   updateShowTodayCashflow: (enabled: boolean) => Promise<boolean>
   updateSortConfig: (
-    sortField: SortField,
+    sortField: ActiveSortField,
     sortOrder: SortOrder,
   ) => Promise<boolean>
   updateSortingPriorityConfig: (
@@ -848,7 +848,7 @@ export const UserPreferencesProvider = ({
   )
 
   const updateSortConfig = useCallback(
-    async (sortField: SortField, sortOrder: SortOrder) => {
+    async (sortField: ActiveSortField, sortOrder: SortOrder) => {
       const success = await userPreferences.updateSortConfig(
         sortField,
         sortOrder,
@@ -2025,7 +2025,10 @@ export const UserPreferencesProvider = ({
     activeTab: preferences?.activeTab || DATA_TYPE_CASHFLOW,
     currencyType: preferences?.currencyType || "USD",
     showTodayCashflow: preferences?.showTodayCashflow ?? true,
-    sortField: preferences?.sortField || UI_CONSTANTS.SORT.DEFAULT_FIELD,
+    sortField:
+      preferences?.sortField === undefined
+        ? UI_CONSTANTS.SORT.DEFAULT_FIELD
+        : preferences.sortField,
     sortOrder: preferences?.sortOrder || UI_CONSTANTS.SORT.DEFAULT_ORDER,
     sortingPriorityConfig:
       preferences?.sortingPriorityConfig || DEFAULT_SORTING_PRIORITY_CONFIG,

--- a/src/features/AccountManagement/components/AccountList/index.tsx
+++ b/src/features/AccountManagement/components/AccountList/index.tsx
@@ -360,6 +360,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     displayData,
     isInitialLoad,
     handleSort,
+    clearSortConfig,
     sortField,
     sortOrder,
     handleReorder,
@@ -1288,6 +1289,18 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
               <span className="text-[10px] font-medium sm:text-xs">
                 {t("common:total") + ": " + displayedResults.length}
               </span>
+              {sortField !== null && !inSearchMode ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 shrink-0 px-2 text-xs"
+                  onClick={clearSortConfig}
+                  aria-label={t("account:list.clearSort")}
+                >
+                  {t("account:list.clearSort")}
+                </Button>
+              ) : null}
               <Button
                 type="button"
                 variant={isBulkMode ? "secondary" : "outline"}

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -38,6 +38,7 @@ import {
 import { tagStorage } from "~/services/tags/tagStorage"
 import type {
   AccountStats,
+  ActiveSortField,
   CurrencyAmount,
   CurrencyAmountMap,
   DisplaySiteData,
@@ -189,7 +190,8 @@ interface AccountDataContextType {
     latestSyncTime?: number
   }>
   handleSort: (field: SortField) => void
-  sortField: SortField
+  clearSortConfig: () => void
+  sortField: ActiveSortField
   sortOrder: SortOrder
   isPinFeatureEnabled: boolean
   isManualSortFeatureEnabled: boolean
@@ -253,7 +255,7 @@ export const AccountDataProvider = ({
     totalAccounts: 0,
   })
   const [prevBalances, setPrevBalances] = useState<CurrencyAmountMap>({})
-  const [sortField, setSortField] = useState<SortField>(initialSortField)
+  const [sortField, setSortField] = useState<ActiveSortField>(initialSortField)
   const [sortOrder, setSortOrder] = useState<SortOrder>(initialSortOrder)
   const [detectedSiteAccounts, setDetectedSiteAccounts] = useState<
     SiteAccount[]
@@ -980,6 +982,11 @@ export const AccountDataProvider = ({
     [showTodayCashflow, sortField, sortOrder, updateSortConfig],
   )
 
+  const clearSortConfig = useCallback(() => {
+    setSortField(null)
+    void updateSortConfig(null, sortOrder)
+  }, [sortOrder, updateSortConfig])
+
   useEffect(() => {
     if (showTodayCashflow !== false) return
 
@@ -1340,6 +1347,7 @@ export const AccountDataProvider = ({
       handleRefresh,
       handleRefreshDisabledAccounts,
       handleSort,
+      clearSortConfig,
       sortField,
       sortOrder,
       isPinFeatureEnabled,
@@ -1379,6 +1387,7 @@ export const AccountDataProvider = ({
       handleRefresh,
       handleRefreshDisabledAccounts,
       handleSort,
+      clearSortConfig,
       sortField,
       sortOrder,
       isPinFeatureEnabled,

--- a/src/locales/en/account.json
+++ b/src/locales/en/account.json
@@ -129,6 +129,7 @@
       "refreshCashflow": "Click to refresh today's consumption",
       "refreshIncome": "Click to refresh today's income"
     },
+    "clearSort": "Clear sort",
     "dragHandle": "Drag to reorder",
     "header": {
       "account": "Account",

--- a/src/locales/ja/account.json
+++ b/src/locales/ja/account.json
@@ -120,6 +120,7 @@
       "refreshCashflow": "クリックして本日の消費を更新",
       "refreshIncome": "クリックして本日の収入を更新"
     },
+    "clearSort": "並び替えを解除",
     "dragHandle": "ドラッグして並び替え",
     "header": {
       "account": "アカウント",

--- a/src/locales/vi/account.json
+++ b/src/locales/vi/account.json
@@ -120,6 +120,7 @@
       "refreshCashflow": "Nhấp để làm mới tiêu dùng hôm nay",
       "refreshIncome": "Nhấp để làm mới thu nhập hôm nay"
     },
+    "clearSort": "Xóa sắp xếp",
     "dragHandle": "Kéo để sắp xếp",
     "header": {
       "account": "Tài khoản",

--- a/src/locales/zh-CN/account.json
+++ b/src/locales/zh-CN/account.json
@@ -120,6 +120,7 @@
       "refreshCashflow": "点击刷新今日消费",
       "refreshIncome": "点击刷新今日收入"
     },
+    "clearSort": "清除排序",
     "dragHandle": "拖动排序",
     "header": {
       "account": "账号",

--- a/src/locales/zh-TW/account.json
+++ b/src/locales/zh-TW/account.json
@@ -120,6 +120,7 @@
       "refreshCashflow": "點擊重新整理今日消費",
       "refreshIncome": "點擊重新整理今日收入"
     },
+    "clearSort": "清除排序",
     "dragHandle": "拖動排序",
     "header": {
       "account": "帳號",

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -25,7 +25,12 @@ import {
   patchTouchesSharedPreferences,
   restoreWebdavLocalOnlyPreferences,
 } from "~/services/preferences/webdavSharedPreferences"
-import { CurrencyType, DashboardTabType, SortField, SortOrder } from "~/types"
+import {
+  ActiveSortField,
+  CurrencyType,
+  DashboardTabType,
+  SortOrder,
+} from "~/types"
 import {
   AccountAutoRefresh,
   DEFAULT_ACCOUNT_AUTO_REFRESH,
@@ -275,7 +280,7 @@ export interface UserPreferences {
   /**
    * 用户自定义排序字段
    */
-  sortField: SortField
+  sortField: ActiveSortField
   /**
    * 用户自定义排序顺序
    */
@@ -795,7 +800,7 @@ class UserPreferencesService {
    * Update sort field/order.
    */
   async updateSortConfig(
-    sortField: SortField,
+    sortField: ActiveSortField,
     sortOrder: SortOrder,
   ): Promise<boolean> {
     return this.savePreferences({ sortField, sortOrder })

--- a/src/services/preferences/utils/sortingPriority.ts
+++ b/src/services/preferences/utils/sortingPriority.ts
@@ -6,6 +6,7 @@ import {
 } from "~/constants"
 import { compareAccountDisplayNames } from "~/services/accounts/utils/accountDisplayName"
 import type {
+  ActiveSortField,
   CurrencyType,
   DisplaySiteData,
   SiteAccount,
@@ -144,7 +145,7 @@ function compareByUserSortField(
  * @param b Second display entry for comparison.
  * @param criteriaId Sorting criteria identifier.
  * @param detectedAccount Account currently detected in browser context.
- * @param userSortField Field selected by user for tie-breaking.
+ * @param userSortField Field selected by user for tie-breaking, or null when field sorting is cleared.
  * @param currencyType Currency type referenced by balance/consumption fields.
  * @param sortOrder Sort direction (`asc` or `desc`).
  * @param matchedAccountScores Map of account IDs to open-tab match scores.
@@ -156,7 +157,7 @@ function applySortingCriteria(
   b: DisplaySiteData,
   criteriaId: SortingCriteriaType,
   detectedAccount: SiteAccount | null,
-  userSortField: SortField,
+  userSortField: ActiveSortField,
   currencyType: CurrencyType,
   sortOrder: "asc" | "desc",
   matchedAccountScores: Record<string, number>,
@@ -248,6 +249,7 @@ function applySortingCriteria(
     } // Higher score = higher priority
 
     case SortingCriteriaType.USER_SORT_FIELD:
+      if (userSortField === null) return 0
       return compareByUserSortField(
         a,
         b,
@@ -277,7 +279,7 @@ function applySortingCriteria(
  * Creates a dynamic comparator function for sorting site data based on a data-only configuration.
  * @param config Sorting priority configuration containing data-only fields.
  * @param detectedAccount Currently detected site account, used for 'current_site' priority.
- * @param userSortField Field selected by the user for sorting ('name', 'balance', 'consumption', 'income').
+ * @param userSortField Field selected by the user for sorting, or null when field sorting is cleared.
  * @param currencyType Currency used for balance/consumption/income comparisons.
  * @param sortOrder Sort order ('asc' or 'desc').
  * @param matchedAccountScores Map of account IDs to matching scores from open tabs.
@@ -288,7 +290,7 @@ function applySortingCriteria(
 export function createDynamicSortComparator(
   config: SortingPriorityConfig,
   detectedAccount: SiteAccount | null,
-  userSortField: SortField,
+  userSortField: ActiveSortField,
   currencyType: CurrencyType,
   sortOrder: "asc" | "desc",
   matchedAccountScores: Record<string, number> = {},

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -241,6 +241,14 @@ export const PRODUCT_ANALYTICS_STATUS_KINDS = {
 export type ProductAnalyticsStatusKind =
   (typeof PRODUCT_ANALYTICS_STATUS_KINDS)[keyof typeof PRODUCT_ANALYTICS_STATUS_KINDS]
 
+export const PRODUCT_ANALYTICS_SORT_FIELDS = {
+  None: "none",
+} as const
+
+export type ProductAnalyticsSortField =
+  | SortField
+  | (typeof PRODUCT_ANALYTICS_SORT_FIELDS)[keyof typeof PRODUCT_ANALYTICS_SORT_FIELDS]
+
 export const PRODUCT_ANALYTICS_TELEMETRY_SOURCES = {
   Models: "models",
   OpenAiBilling: "openaiBilling",
@@ -1003,7 +1011,7 @@ export type ProductAnalyticsEventPayloadMap = {
     open_changelog_on_update_enabled?: boolean
     active_tab?: DashboardTabType
     currency_type?: CurrencyType
-    sort_field?: SortField
+    sort_field?: ProductAnalyticsSortField
     sort_order?: SortOrder
     sorting_priority_configured?: boolean
     sorting_priority_customized?: boolean
@@ -1100,7 +1108,7 @@ export type ProductAnalyticsEventPayloadMap = {
     open_changelog_on_update_enabled?: boolean
     active_tab?: DashboardTabType
     currency_type?: CurrencyType
-    sort_field?: SortField
+    sort_field?: ProductAnalyticsSortField
     sort_order?: SortOrder
     sorting_priority_configured?: boolean
     sorting_priority_customized?: boolean

--- a/src/services/productAnalytics/privacy.ts
+++ b/src/services/productAnalytics/privacy.ts
@@ -38,6 +38,7 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SETTING_IDS,
   PRODUCT_ANALYTICS_SITE_TYPES,
+  PRODUCT_ANALYTICS_SORT_FIELDS,
   PRODUCT_ANALYTICS_SOURCE_KINDS,
   PRODUCT_ANALYTICS_SPONSOR_ACTION_KINDS,
   PRODUCT_ANALYTICS_SPONSOR_CATALOG_SOURCES,
@@ -509,7 +510,7 @@ const FIELD_ALLOWED_VALUES: Record<string, readonly string[]> = {
   skip_reason: Object.values(PRODUCT_ANALYTICS_AUTO_CHECKIN_SKIP_REASONS),
   source_managed_site_type: Object.values(PRODUCT_ANALYTICS_MANAGED_SITE_TYPES),
   source_kind: Object.values(PRODUCT_ANALYTICS_SOURCE_KINDS),
-  sort_field: SORT_FIELDS,
+  sort_field: [...SORT_FIELDS, ...Object.values(PRODUCT_ANALYTICS_SORT_FIELDS)],
   sort_order: SORT_ORDERS,
   sponsor_action_kind: Object.values(PRODUCT_ANALYTICS_SPONSOR_ACTION_KINDS),
   sponsor_catalog_source: Object.values(

--- a/src/services/productAnalytics/settings.ts
+++ b/src/services/productAnalytics/settings.ts
@@ -29,6 +29,7 @@ import {
   PRODUCT_ANALYTICS_EVENTS,
   PRODUCT_ANALYTICS_MODE_IDS,
   PRODUCT_ANALYTICS_SETTING_IDS,
+  PRODUCT_ANALYTICS_SORT_FIELDS,
   trackProductAnalyticsEvent,
   type ProductAnalyticsEntrypoint,
   type ProductAnalyticsEventPayload,
@@ -256,7 +257,7 @@ function buildDisplayPreferencesSnapshot(
     active_tab: preferences.activeTab,
     currency_type: preferences.currencyType,
     show_today_cashflow_enabled: preferences.showTodayCashflow !== false,
-    sort_field: preferences.sortField,
+    sort_field: preferences.sortField ?? PRODUCT_ANALYTICS_SORT_FIELDS.None,
     sort_order: preferences.sortOrder,
     sorting_priority_configured: Boolean(sortingPriorityConfig),
     sorting_priority_customized: isSortingPriorityCustomized(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -400,6 +400,7 @@ export const SORT_FIELDS = [
   DATA_TYPE_CREATED_AT,
 ] as const
 export type SortField = (typeof SORT_FIELDS)[number]
+export type ActiveSortField = SortField | null
 
 export const SORT_ORDERS = ["asc", "desc"] as const
 export type SortOrder = (typeof SORT_ORDERS)[number]

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -477,6 +477,17 @@ describe("UserPreferencesContext", () => {
     expect((latestContext as any)?.showTodayCashflow).toBe(false)
   })
 
+  it("preserves a cleared active sort field from persisted preferences", async () => {
+    const preferences = clonePreferences()
+    preferences.sortField = null
+
+    await renderProvider(preferences)
+
+    expect((latestContext as any)?.sortField).toBeNull()
+    expect((latestContext as any)?.preferences.sortField).toBeNull()
+    expect(mockedUserPreferences.savePreferences).not.toHaveBeenCalled()
+  })
+
   it("falls back to default task notification preferences when they are missing", async () => {
     const preferences = clonePreferences()
     delete (preferences as Partial<UserPreferences>).taskNotifications

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -592,6 +592,44 @@ describe("AccountList", () => {
     expect(clearSortConfig).toHaveBeenCalledTimes(1)
   })
 
+  it("hides the clear sort action when field sorting has been cleared", () => {
+    const clearSortConfig = vi.fn()
+
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        clearSortConfig,
+        sortField: null,
+        sortOrder: "asc",
+      }),
+    )
+
+    render(<AccountList />)
+
+    expect(
+      screen.queryByRole("button", { name: "account:list.clearSort" }),
+    ).not.toBeInTheDocument()
+    expect(clearSortConfig).not.toHaveBeenCalled()
+  })
+
+  it("hides the clear sort action while search mode is active", () => {
+    const clearSortConfig = vi.fn()
+
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        clearSortConfig,
+        sortField: "name",
+        sortOrder: "asc",
+      }),
+    )
+
+    render(<AccountList initialSearchQuery="Alpha" />)
+
+    expect(
+      screen.queryByRole("button", { name: "account:list.clearSort" }),
+    ).not.toBeInTheDocument()
+    expect(clearSortConfig).not.toHaveBeenCalled()
+  })
+
   it("auto-loads dnd during idle time after the first render settles", async () => {
     mockUseAccountDataContext.mockReturnValue(
       createAccountDataContextValue({

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -448,6 +448,7 @@ function createAccountDataContextValue(
     displayData: [enabledAlpha, disabledBeta, enabledGamma, unsyncedDelta],
     isInitialLoad: false,
     handleSort: vi.fn(),
+    clearSortConfig: vi.fn(),
     sortField: "name",
     sortOrder: "asc",
     handleReorder: vi.fn(),
@@ -568,6 +569,27 @@ describe("AccountList", () => {
         name: "account:list.sort account:list.header.createdAt",
       }),
     ).toBeInTheDocument()
+  })
+
+  it("shows a clear sort action when field sorting is active", async () => {
+    const user = userEvent.setup()
+    const clearSortConfig = vi.fn()
+
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        clearSortConfig,
+        sortField: "name",
+        sortOrder: "asc",
+      }),
+    )
+
+    render(<AccountList />)
+
+    await user.click(
+      screen.getByRole("button", { name: "account:list.clearSort" }),
+    )
+
+    expect(clearSortConfig).toHaveBeenCalledTimes(1)
   })
 
   it("auto-loads dnd during idle time after the first render settles", async () => {

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -2025,6 +2025,32 @@ describe("AccountDataContext sorting behavior", () => {
     )
   })
 
+  it("clears the active field sort without resetting the current sort direction", async () => {
+    mockUserPreferencesContext.current = {
+      ...mockUserPreferencesContext.current,
+      sortField: DATA_TYPE_BALANCE,
+      sortOrder: "desc",
+    }
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().sortField).toBe(DATA_TYPE_BALANCE)
+      expect(getLatestCtx().sortOrder).toBe("desc")
+    })
+
+    act(() => {
+      getLatestCtx().clearSortConfig()
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().sortField).toBeNull()
+      expect(getLatestCtx().sortOrder).toBe("desc")
+    })
+
+    expect(mockUpdateSortConfig).toHaveBeenCalledWith(null, "desc")
+  })
+
   it("initializes created-time sorting to newest first and then toggles", async () => {
     const getLatestCtx = await renderAccountDataProvider()
 

--- a/tests/services/configMigration/preferences/preferencesMigration.test.ts
+++ b/tests/services/configMigration/preferences/preferencesMigration.test.ts
@@ -679,6 +679,16 @@ describe("preferencesMigration", () => {
       expect(result.language).toBe("zh-CN")
     })
 
+    it("preserves a cleared active sort field during migration", () => {
+      const prefs = createV0Preferences({
+        sortField: null,
+      })
+
+      const result = migratePreferences(prefs)
+
+      expect(result.sortField).toBeNull()
+    })
+
     it("canonicalizes legacy zh_CN language values during migration", () => {
       const prefs = createV0Preferences({
         language: "zh_CN",

--- a/tests/services/productAnalytics/privacy.test.ts
+++ b/tests/services/productAnalytics/privacy.test.ts
@@ -26,6 +26,7 @@ import {
   PRODUCT_ANALYTICS_PERMISSION_OUTCOMES,
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SETTING_IDS,
+  PRODUCT_ANALYTICS_SORT_FIELDS,
   PRODUCT_ANALYTICS_SOURCE_KINDS,
   PRODUCT_ANALYTICS_SPONSOR_ACTION_KINDS,
   PRODUCT_ANALYTICS_SPONSOR_CATALOG_SOURCES,
@@ -649,6 +650,23 @@ describe("product analytics privacy filtering", () => {
       auto_detect_enhanced_enabled: true,
       reminder_dismissed: true,
       task_notifications_balance_history_capture_task_enabled: false,
+    })
+  })
+
+  it("keeps the cleared sort sentinel in settings snapshots", () => {
+    const sanitized = sanitizeProductAnalyticsEvent(
+      PRODUCT_ANALYTICS_EVENTS.SettingsSnapshotCaptured,
+      {
+        setting_id: "display_preferences_snapshot",
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+        sort_field: PRODUCT_ANALYTICS_SORT_FIELDS.None,
+      },
+    )
+
+    expect(sanitized).toEqual({
+      setting_id: "display_preferences_snapshot",
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      sort_field: PRODUCT_ANALYTICS_SORT_FIELDS.None,
     })
   })
 

--- a/tests/services/productAnalytics/settings.test.ts
+++ b/tests/services/productAnalytics/settings.test.ts
@@ -12,6 +12,7 @@ import {
   PRODUCT_ANALYTICS_EVENTS,
   PRODUCT_ANALYTICS_MODE_IDS,
   PRODUCT_ANALYTICS_SETTING_IDS,
+  PRODUCT_ANALYTICS_SORT_FIELDS,
   trackProductAnalyticsEvent,
 } from "~/services/productAnalytics/events"
 import {
@@ -491,6 +492,32 @@ describe("settings product analytics snapshots", () => {
     expect(snapshot).not.toHaveProperty("setting_id")
     expect(JSON.stringify(snapshot)).not.toContain("private")
     expect(JSON.stringify(snapshot)).not.toContain("https://")
+  })
+
+  it("reports cleared display sort as none in settings snapshots", () => {
+    const preferences = createPreferences({ sortField: null })
+
+    const [displaySnapshot] = buildSettingsSnapshotEvents(
+      preferences,
+      PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      { sortField: null },
+    )
+    const aggregateSnapshot = buildAggregateSettingsSnapshotEvent(
+      preferences,
+      PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+    )
+
+    expect(displaySnapshot).toEqual(
+      expect.objectContaining({
+        setting_id: "display_preferences_snapshot",
+        sort_field: PRODUCT_ANALYTICS_SORT_FIELDS.None,
+      }),
+    )
+    expect(aggregateSnapshot).toEqual(
+      expect.objectContaining({
+        sort_field: PRODUCT_ANALYTICS_SORT_FIELDS.None,
+      }),
+    )
   })
 
   it("tracks only affected snapshots for a preference patch", () => {

--- a/tests/utils/sortingPriority.test.ts
+++ b/tests/utils/sortingPriority.test.ts
@@ -815,6 +815,47 @@ describe("createDynamicSortComparator", () => {
   })
 
   describe("USER_SORT_FIELD criterion - name", () => {
+    it("should skip user field sorting when no sort field is active", () => {
+      const matchedAccount = createDisplaySiteData({
+        id: "matched",
+        name: "Zulu",
+        balance: { USD: 1, CNY: 7 },
+      })
+      const unmatchedAccount = createDisplaySiteData({
+        id: "unmatched",
+        name: "Alpha",
+        balance: { USD: 100, CNY: 700 },
+      })
+
+      const config: SortingPriorityConfig = {
+        criteria: [
+          {
+            id: SortingCriteriaType.USER_SORT_FIELD,
+            enabled: true,
+            priority: 0,
+          },
+          {
+            id: SortingCriteriaType.MATCHED_OPEN_TABS,
+            enabled: true,
+            priority: 1,
+          },
+        ],
+        lastModified: Date.now(),
+      }
+
+      const comparator = createDynamicSortComparator(
+        config,
+        null,
+        null,
+        "USD",
+        "asc",
+        { matched: 5 },
+      )
+
+      expect(comparator(matchedAccount, unmatchedAccount)).toBeLessThan(0)
+      expect(comparator(unmatchedAccount, matchedAccount)).toBeGreaterThan(0)
+    })
+
     it("should sort by name in ascending order", () => {
       const accountA = createDisplaySiteData({ id: "a", name: "Alpha" })
       const accountB = createDisplaySiteData({ id: "b", name: "Beta" })


### PR DESCRIPTION
## Summary
- Add a clear-sort action to the account list when field sorting is active.
- Persist cleared sorting as a null active sort field so priority criteria like matched open tabs can apply.
- Keep analytics, migration, i18n, and focused tests aligned with the new cleared-sort state.

## Test Plan
- pnpm run validate:staged
- pnpm run validate:push
- pnpm exec vitest run tests/features/AccountManagement/hooks/AccountDataContext.test.tsx tests/features/AccountManagement/components/AccountList.test.tsx tests/utils/sortingPriority.test.ts tests/contexts/UserPreferencesContext.test.tsx tests/services/productAnalytics/settings.test.ts tests/services/productAnalytics/privacy.test.ts
- pnpm run i18n:extract:ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Clear sort" button to the account list header (shown when a sort is active and hidden in search mode)
  * Clearing sort preserves the current sort direction so it can be re-applied quickly
  * Added localized labels for the new control in English, Japanese, Vietnamese, Simplified Chinese, and Traditional Chinese
<!-- end of auto-generated comment: release notes by coderabbit.ai -->