### PR TITLE
fix(toast): prevent duplicate notifications in dialogs

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -14,6 +14,7 @@ import {
   UpdateLogDialogProvider,
 } from "~/components/dialogs/UpdateLogDialog"
 import { ThemeAwareToaster } from "~/components/ThemeAwareToaster"
+import { ToasterPortalProvider } from "~/components/toast/ToasterPortal"
 import { DeviceProvider } from "~/contexts/DeviceContext"
 import { ReleaseUpdateStatusProvider } from "~/contexts/ReleaseUpdateStatusContext"
 import { ThemeProvider } from "~/contexts/ThemeContext"
@@ -31,19 +32,21 @@ export function AppLayout({ children }: AppLayoutProps) {
     <DeviceProvider>
       <UserPreferencesProvider>
         <ThemeProvider>
-          <ReleaseUpdateStatusProvider>
-            <ChannelDialogProvider>
-              <UpdateLogDialogProvider>
-                <ChangelogOnUpdateUiOpenHandler />
-                <AutoCheckinUiOpenPretrigger />
-                <UpdateLogDialogContainer />
-                {children}
-                <ChannelDialogContainer />
-                <DuplicateChannelWarningDialogContainer />
-              </UpdateLogDialogProvider>
-            </ChannelDialogProvider>
-          </ReleaseUpdateStatusProvider>
-          <ThemeAwareToaster reverseOrder={false} />
+          <ToasterPortalProvider>
+            <ReleaseUpdateStatusProvider>
+              <ChannelDialogProvider>
+                <UpdateLogDialogProvider>
+                  <ChangelogOnUpdateUiOpenHandler />
+                  <AutoCheckinUiOpenPretrigger />
+                  <UpdateLogDialogContainer />
+                  {children}
+                  <ChannelDialogContainer />
+                  <DuplicateChannelWarningDialogContainer />
+                </UpdateLogDialogProvider>
+              </ChannelDialogProvider>
+            </ReleaseUpdateStatusProvider>
+            <ThemeAwareToaster reverseOrder={false} />
+          </ToasterPortalProvider>
         </ThemeProvider>
       </UserPreferencesProvider>
     </DeviceProvider>

--- a/src/components/ThemeAwareToaster.tsx
+++ b/src/components/ThemeAwareToaster.tsx
@@ -1,8 +1,10 @@
 import { XMarkIcon } from "@heroicons/react/24/outline"
 import type { CSSProperties } from "react"
+import { createPortal } from "react-dom"
 import toast, { ToastBar, Toaster } from "react-hot-toast"
 
 import { getThemeAwareToastStyles } from "~/components/toast/themeAwareToastStyles"
+import { useToasterPortalHost } from "~/components/toast/ToasterPortal"
 import { useTheme } from "~/contexts/ThemeContext"
 
 interface ThemeAwareToasterProps {
@@ -25,8 +27,9 @@ export const ThemeAwareToaster = ({
   containerStyle,
 }: ThemeAwareToasterProps) => {
   const { resolvedTheme } = useTheme()
+  const portalHost = useToasterPortalHost()
 
-  return (
+  const toaster = (
     <Toaster
       position={position}
       reverseOrder={reverseOrder}
@@ -78,4 +81,6 @@ export const ThemeAwareToaster = ({
       )}
     </Toaster>
   )
+
+  return portalHost ? createPortal(toaster, portalHost) : toaster
 }

--- a/src/components/toast/ToasterPortal.tsx
+++ b/src/components/toast/ToasterPortal.tsx
@@ -1,0 +1,72 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react"
+
+const ToasterPortalActiveHostContext = createContext<HTMLElement | null>(null)
+const ToasterPortalRegisterContext = createContext<
+  ((host: HTMLElement) => () => void) | null
+>(null)
+
+interface ToasterPortalProviderProps {
+  children: ReactNode
+}
+
+/**
+ * Tracks modal-local toaster hosts so the single global toaster can stay
+ * inside Headless UI's active dialog portal instead of the inert app tree.
+ */
+export function ToasterPortalProvider({
+  children,
+}: ToasterPortalProviderProps) {
+  const [hosts, setHosts] = useState<HTMLElement[]>([])
+
+  const registerHost = useCallback((host: HTMLElement) => {
+    setHosts((currentHosts) =>
+      currentHosts.includes(host) ? currentHosts : [...currentHosts, host],
+    )
+
+    return () => {
+      setHosts((currentHosts) =>
+        currentHosts.filter((currentHost) => currentHost !== host),
+      )
+    }
+  }, [])
+
+  return (
+    <ToasterPortalRegisterContext.Provider value={registerHost}>
+      <ToasterPortalActiveHostContext.Provider value={hosts.at(-1) ?? null}>
+        {children}
+      </ToasterPortalActiveHostContext.Provider>
+    </ToasterPortalRegisterContext.Provider>
+  )
+}
+
+/**
+ * Modal-local mount point for the global toaster.
+ */
+export function ToasterPortalHost() {
+  const registerHost = useContext(ToasterPortalRegisterContext)
+  const [host, setHost] = useState<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!registerHost || !host) {
+      return undefined
+    }
+
+    return registerHost(host)
+  }, [host, registerHost])
+
+  return <div ref={setHost} data-slot="toaster-portal-host" />
+}
+
+/**
+ * Returns the currently active modal toaster host, if a modal is open.
+ */
+export function useToasterPortalHost() {
+  return useContext(ToasterPortalActiveHostContext)
+}

--- a/src/components/ui/Dialog/Modal.tsx
+++ b/src/components/ui/Dialog/Modal.tsx
@@ -6,6 +6,7 @@ import { Z_INDEX } from "~/constants/designTokens"
 import { cn } from "~/lib/utils"
 import { t } from "~/utils/i18n/core"
 
+import { ToasterPortalHost } from "../../toast/ToasterPortal"
 import { FloatingLayerProvider } from "../floating-layer"
 
 type Size = "sm" | "md" | "lg"
@@ -94,6 +95,7 @@ export function Modal({
           />
         </Transition.Child>
 
+        <ToasterPortalHost />
         {floatingContent}
 
         <div className="fixed inset-0 flex items-center justify-center p-4">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -6,6 +6,7 @@ import { Z_INDEX } from "~/constants/designTokens"
 import { cn } from "~/lib/utils"
 import { t } from "~/utils/i18n/core"
 
+import { ToasterPortalHost } from "../toast/ToasterPortal"
 import { FloatingLayerProvider } from "./floating-layer"
 
 /**
@@ -78,6 +79,7 @@ function DialogContent({
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
+      <ToasterPortalHost />
       <FloatingLayerProvider layer="modal-contained">
         <DialogPrimitive.Content
           data-slot="dialog-content"

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -2,7 +2,6 @@ import { InformationCircleIcon } from "@heroicons/react/24/outline"
 import { useEffect, useState, type ComponentProps } from "react"
 import { useTranslation } from "react-i18next"
 
-import { ThemeAwareToaster } from "~/components/ThemeAwareToaster"
 import { Modal } from "~/components/ui/Dialog/Modal"
 import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
 import { AIHUBMIX_API_ORIGIN } from "~/constants/siteType"
@@ -208,12 +207,6 @@ export default function AccountDialog({
         onClose={handlers.handleClose}
         size="lg"
         panelTestId={ACCOUNT_MANAGEMENT_TEST_IDS.accountDialog}
-        floatingContent={
-          <ThemeAwareToaster
-            position="top-center"
-            containerStyle={{ zIndex: 75 }}
-          />
-        }
         header={<DialogHeader mode={mode} />}
         footer={
           <ActionButtons

--- a/tests/components/ThemeAwareToaster.test.tsx
+++ b/tests/components/ThemeAwareToaster.test.tsx
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react"
+import { useState } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ThemeAwareToaster } from "~/components/ThemeAwareToaster"
+import {
+  ToasterPortalHost,
+  ToasterPortalProvider,
+} from "~/components/toast/ToasterPortal"
 
 const {
   dismissMock,
@@ -177,5 +182,96 @@ describe("ThemeAwareToaster", () => {
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument()
     expect(dismissMock).not.toHaveBeenCalled()
+  })
+
+  it("moves the global toaster into the active modal portal host", () => {
+    function Harness() {
+      const [isModalOpen, setIsModalOpen] = useState(false)
+
+      return (
+        <ToasterPortalProvider>
+          <button type="button" onClick={() => setIsModalOpen(true)}>
+            Open modal
+          </button>
+          <div data-testid="layout-toaster-slot">
+            <ThemeAwareToaster />
+          </div>
+          {isModalOpen ? (
+            <div data-testid="modal-shell">
+              <ToasterPortalHost />
+            </div>
+          ) : null}
+        </ToasterPortalProvider>
+      )
+    }
+
+    render(<Harness />)
+
+    expect(screen.getByTestId("layout-toaster-slot")).toContainElement(
+      screen.getByTestId("mock-toaster"),
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Open modal" }))
+
+    expect(screen.getByTestId("modal-shell")).toContainElement(
+      screen.getByTestId("mock-toaster"),
+    )
+    expect(screen.getByTestId("layout-toaster-slot")).not.toContainElement(
+      screen.getByTestId("mock-toaster"),
+    )
+  })
+
+  it("returns the toaster to the previous modal host when the top host closes", () => {
+    function Harness() {
+      const [isFirstModalOpen, setIsFirstModalOpen] = useState(false)
+      const [isSecondModalOpen, setIsSecondModalOpen] = useState(false)
+
+      return (
+        <ToasterPortalProvider>
+          <div data-testid="layout-toaster-slot">
+            <ThemeAwareToaster />
+          </div>
+          <button type="button" onClick={() => setIsFirstModalOpen(true)}>
+            Open first modal
+          </button>
+          <button type="button" onClick={() => setIsSecondModalOpen(true)}>
+            Open second modal
+          </button>
+          <button type="button" onClick={() => setIsSecondModalOpen(false)}>
+            Close second modal
+          </button>
+          {isFirstModalOpen ? (
+            <div data-testid="first-modal-shell">
+              <ToasterPortalHost />
+            </div>
+          ) : null}
+          {isSecondModalOpen ? (
+            <div data-testid="second-modal-shell">
+              <ToasterPortalHost />
+            </div>
+          ) : null}
+        </ToasterPortalProvider>
+      )
+    }
+
+    render(<Harness />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Open first modal" }))
+
+    expect(screen.getByTestId("first-modal-shell")).toContainElement(
+      screen.getByTestId("mock-toaster"),
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Open second modal" }))
+
+    expect(screen.getByTestId("second-modal-shell")).toContainElement(
+      screen.getByTestId("mock-toaster"),
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Close second modal" }))
+
+    expect(screen.getByTestId("first-modal-shell")).toContainElement(
+      screen.getByTestId("mock-toaster"),
+    )
   })
 })

--- a/tests/components/ThemeAwareToaster.test.tsx
+++ b/tests/components/ThemeAwareToaster.test.tsx
@@ -193,6 +193,9 @@ describe("ThemeAwareToaster", () => {
           <button type="button" onClick={() => setIsModalOpen(true)}>
             Open modal
           </button>
+          <button type="button" onClick={() => setIsModalOpen(false)}>
+            Close modal
+          </button>
           <div data-testid="layout-toaster-slot">
             <ThemeAwareToaster />
           </div>
@@ -219,6 +222,13 @@ describe("ThemeAwareToaster", () => {
     expect(screen.getByTestId("layout-toaster-slot")).not.toContainElement(
       screen.getByTestId("mock-toaster"),
     )
+
+    fireEvent.click(screen.getByRole("button", { name: "Close modal" }))
+
+    expect(screen.getByTestId("layout-toaster-slot")).toContainElement(
+      screen.getByTestId("mock-toaster"),
+    )
+    expect(screen.queryByTestId("modal-shell")).not.toBeInTheDocument()
   })
 
   it("returns the toaster to the previous modal host when the top host closes", () => {
@@ -239,6 +249,9 @@ describe("ThemeAwareToaster", () => {
           </button>
           <button type="button" onClick={() => setIsSecondModalOpen(false)}>
             Close second modal
+          </button>
+          <button type="button" onClick={() => setIsFirstModalOpen(false)}>
+            Close first modal
           </button>
           {isFirstModalOpen ? (
             <div data-testid="first-modal-shell">
@@ -273,5 +286,12 @@ describe("ThemeAwareToaster", () => {
     expect(screen.getByTestId("first-modal-shell")).toContainElement(
       screen.getByTestId("mock-toaster"),
     )
+
+    fireEvent.click(screen.getByRole("button", { name: "Close first modal" }))
+
+    expect(screen.getByTestId("layout-toaster-slot")).toContainElement(
+      screen.getByTestId("mock-toaster"),
+    )
+    expect(screen.queryByTestId("first-modal-shell")).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Toasts now appear in the correct layer when modals or dialogs are open, preventing them from being obscured or shown behind modal content.

* **Refactor**
  * Reworked the toast delivery mechanism so a single toaster correctly targets the active modal/dialog context for consistent layering.

* **Tests**
  * Added tests verifying toasts move into and out of the active modal host as dialogs open and close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->