### PR TITLE
fix(sub2api): enforce adapter identity overrides

### DIFF
--- a/docs/superpowers/plans/2026-06-08-sub2api-adapter-seam-separation.md
+++ b/docs/superpowers/plans/2026-06-08-sub2api-adapter-seam-separation.md
@@ -1,0 +1,725 @@
+# Sub2API Adapter Seam Separation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Sub2API phase-1 identity and token helpers stop falling back to incompatible common One-API endpoints by adding strict override enforcement plus truthful Sub2API `fetchUserInfo()` and `getOrCreateAccessToken()` implementations.
+
+**Architecture:** Keep the phase-1 surface narrow. Change the `apiService` wrapper so `SITE_TYPES.SUB2API` fails fast on missing overrides, then add adapter-owned compatibility overrides in `src/services/apiService/sub2api/index.ts` that reuse the existing JWT hydration, refresh, and re-sync logic instead of business-layer patching. Preserve current browser-session recovery modules such as content-script `localStorage` reads and `tokenResync.ts`; they remain separate support paths and are not replaced in this phase.
+
+**Tech Stack:** TypeScript, WXT extension runtime, Vitest, existing `apiService` adapter pattern, existing Sub2API JWT refresh/resync modules, `pnpm exec vitest`, and `pnpm run validate:staged`.
+
+---
+
+## File Structure
+
+- Modify `src/services/apiService/index.ts`
+  - Add `SITE_TYPES.SUB2API` to `strictOverrideSites` so missing Sub2API helpers throw instead of silently hitting `commonAPI`.
+- Modify `src/services/apiService/sub2api/index.ts`
+  - Export `fetchUserInfo(request)` as a compatibility override backed by `/api/v1/auth/me`.
+  - Export `getOrCreateAccessToken(request)` as a compatibility override backed by existing Sub2API auth hydration, refresh-token restore, and browser-session re-sync behavior.
+- Modify `tests/services/apiService/index.test.ts`
+  - Add strict-override routing tests proving Sub2API does not silently fall back to common helpers.
+- Modify `tests/services/apiService/sub2api/index.test.ts`
+  - Add focused tests for `fetchUserInfo()` and `getOrCreateAccessToken()` behavior.
+- Modify `tests/services/autoDetectService.test.ts`
+  - Add a regression test proving Sub2API API fallback uses the Sub2API override path instead of the common `/api/user/self` contract.
+- Modify `tests/services/accountOperations.autoDetectAccount.test.ts`
+  - Add a regression test proving AccessToken completion for detected Sub2API accounts uses the Sub2API override and preserves the expected result shape.
+
+---
+
+### Task 1: Make Sub2API A Strict Override Site
+
+**Files:**
+- Modify: `src/services/apiService/index.ts`
+- Modify: `tests/services/apiService/index.test.ts`
+
+- [ ] **Step 1: Add a failing wrapper test for missing Sub2API overrides**
+
+In `tests/services/apiService/index.test.ts`, extend the hoisted mocks so the wrapper can observe a real Sub2API override and still verify strict failure for a missing one:
+
+```ts
+const {
+  commonFetchUserInfo,
+  commonFetchModelPricing,
+  commonFetchAccountTokens,
+  commonResolveApiTokenKey,
+  aihubmixFetchAccountTokens,
+  oneHubFetchModelPricing,
+  oneHubFetchAccountTokens,
+  wongResolveApiTokenKey,
+  sub2apiFetchUserInfo,
+} = vi.hoisted(() => ({
+  commonFetchUserInfo: vi.fn(),
+  commonFetchModelPricing: vi.fn(),
+  commonFetchAccountTokens: vi.fn(),
+  commonResolveApiTokenKey: vi.fn(),
+  aihubmixFetchAccountTokens: vi.fn(),
+  oneHubFetchModelPricing: vi.fn(),
+  oneHubFetchAccountTokens: vi.fn(),
+  wongResolveApiTokenKey: vi.fn(),
+  sub2apiFetchUserInfo: vi.fn(),
+}))
+```
+
+Add the Sub2API module mock:
+
+```ts
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchUserInfo: sub2apiFetchUserInfo,
+  // Intentionally omit fetchModelPricing so strict override behavior can be asserted.
+}))
+```
+
+Add these two tests near the AIHubMix strict-override assertions:
+
+```ts
+it("should route Sub2API fetchUserInfo through the site override", async () => {
+  sub2apiFetchUserInfo.mockResolvedValue({ id: "7" } as any)
+
+  const request = {
+    baseUrl: "https://sub2.example.com",
+    auth: { authType: "access_token", accessToken: "jwt-token" },
+  }
+
+  await (getApiService(SITE_TYPES.SUB2API).fetchUserInfo as any)(request)
+
+  expect(sub2apiFetchUserInfo).toHaveBeenCalledTimes(1)
+  expect(sub2apiFetchUserInfo).toHaveBeenCalledWith(request)
+  expect(commonFetchUserInfo).not.toHaveBeenCalled()
+})
+
+it("should not silently fall back to common for missing Sub2API overrides", async () => {
+  commonFetchModelPricing.mockResolvedValue({} as any)
+
+  const request = {
+    baseUrl: "https://sub2.example.com",
+    auth: { authType: "access_token", accessToken: "jwt-token" },
+  }
+
+  expect(() =>
+    (getApiService(SITE_TYPES.SUB2API).fetchModelPricing as any)(request),
+  ).toThrow(
+    `apiService.fetchModelPricing is not implemented for ${SITE_TYPES.SUB2API}`,
+  )
+
+  expect(commonFetchModelPricing).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run the wrapper test to verify the new strict Sub2API case fails**
+
+Run:
+
+```powershell
+pnpm exec vitest --run tests/services/apiService/index.test.ts
+```
+
+Expected before implementation: the new missing-override assertion fails because `SITE_TYPES.SUB2API` is not yet included in `strictOverrideSites`.
+
+- [ ] **Step 3: Add Sub2API to `strictOverrideSites`**
+
+In `src/services/apiService/index.ts`, change:
+
+```ts
+const strictOverrideSites = new Set<ApiOverrideSite>([SITE_TYPES.AIHUBMIX])
+```
+
+to:
+
+```ts
+const strictOverrideSites = new Set<ApiOverrideSite>([
+  SITE_TYPES.AIHUBMIX,
+  SITE_TYPES.SUB2API,
+])
+```
+
+Do not change `siteOverrideMap`, `getApiFunc`, or the generic fallback rules for common-compatible sites.
+
+- [ ] **Step 4: Re-run the wrapper test to verify strict Sub2API behavior passes**
+
+Run:
+
+```powershell
+pnpm exec vitest --run tests/services/apiService/index.test.ts
+```
+
+Expected: `tests/services/apiService/index.test.ts` passes, including the new Sub2API strict-override assertions.
+
+- [ ] **Step 5: Commit the strict override change**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiService/index.ts tests/services/apiService/index.test.ts
+git commit -m "fix(api-service): make sub2api a strict override site"
+```
+
+Expected: one focused commit containing only the wrapper change and its tests.
+
+---
+
+### Task 2: Add Truthful Sub2API `fetchUserInfo()` And `getOrCreateAccessToken()` Overrides
+
+**Files:**
+- Modify: `src/services/apiService/sub2api/index.ts`
+- Modify: `tests/services/apiService/sub2api/index.test.ts`
+
+- [ ] **Step 1: Add failing tests for the two missing Sub2API compatibility overrides**
+
+In `tests/services/apiService/sub2api/index.test.ts`, update the import list to include the new exports:
+
+```ts
+import {
+  createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
+  fetchAccountData,
+  fetchAccountTokens,
+  fetchCheckInStatus,
+  fetchCurrentUser,
+  fetchSiteStatus,
+  fetchSub2ApiAnnouncements,
+  fetchSupportCheckIn,
+  fetchTodayIncome,
+  fetchTodayUsage,
+  fetchTokenById,
+  fetchUserGroups,
+  fetchUserInfo,
+  getOrCreateAccessToken,
+  markSub2ApiAnnouncementRead,
+  refreshAccountData,
+  updateApiToken,
+} from "~/services/apiService/sub2api"
+```
+
+Add this focused `fetchUserInfo` test near the existing `fetchCurrentUser` coverage:
+
+```ts
+it("fetchUserInfo returns the shared compatibility shape from /api/v1/auth/me", async () => {
+  vi.mocked(fetchApi).mockResolvedValueOnce({
+    code: 0,
+    message: "ok",
+    data: {
+      id: 12,
+      username: "alice",
+      email: "alice@example.com",
+      balance: "1.5",
+    },
+  } as any)
+
+  await expect(
+    fetchUserInfo({
+      baseUrl: "https://sub2.example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "jwt-token",
+      },
+    }),
+  ).resolves.toEqual({
+    id: "12",
+    username: "alice",
+    access_token: "jwt-token",
+    user: {
+      id: 12,
+      username: "alice",
+      email: "alice@example.com",
+      balance: "1.5",
+    },
+  })
+
+  expect(fetchApi).toHaveBeenCalledWith(
+    expect.objectContaining({
+      auth: expect.objectContaining({
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "jwt-token",
+      }),
+    }),
+    expect.objectContaining({
+      endpoint: "/api/v1/auth/me",
+      options: expect.objectContaining({
+        method: "GET",
+        cache: "no-store",
+      }),
+    }),
+    true,
+  )
+})
+```
+
+Add this focused `getOrCreateAccessToken` reuse-path test:
+
+```ts
+it("getOrCreateAccessToken reuses the existing Sub2API JWT when present", async () => {
+  vi.mocked(fetchApi).mockResolvedValueOnce({
+    code: 0,
+    message: "ok",
+    data: {
+      id: 12,
+      username: "alice",
+      email: "alice@example.com",
+      balance: "1.5",
+    },
+  } as any)
+
+  await expect(
+    getOrCreateAccessToken({
+      baseUrl: "https://sub2.example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "jwt-token",
+      },
+    }),
+  ).resolves.toEqual({
+    username: "alice",
+    access_token: "jwt-token",
+  })
+
+  expect(fetchApi).toHaveBeenCalledTimes(1)
+  expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+})
+```
+
+Add this refresh-path test:
+
+```ts
+it("getOrCreateAccessToken refreshes the Sub2API JWT when only refresh token state is usable", async () => {
+  const now = 1_700_000_000_000
+  const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        code: 0,
+        message: "ok",
+        data: {
+          access_token: "refreshed-jwt",
+          refresh_token: "rotated-refresh",
+          expires_in: 3600,
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  )
+  vi.stubGlobal("fetch", fetchMock as any)
+
+  vi.mocked(fetchApi).mockResolvedValueOnce({
+    code: 0,
+    message: "ok",
+    data: {
+      id: 12,
+      username: "alice",
+      email: "alice@example.com",
+      balance: "1.5",
+    },
+  } as any)
+
+  await expect(
+    getOrCreateAccessToken({
+      baseUrl: "https://sub2.example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "expired-jwt",
+        refreshToken: "stored-refresh",
+        tokenExpiresAt: now - 1,
+      },
+    }),
+  ).resolves.toEqual({
+    username: "alice",
+    access_token: "refreshed-jwt",
+  })
+
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+  expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+  nowSpy.mockRestore()
+})
+```
+
+Add this resync-path test:
+
+```ts
+it("getOrCreateAccessToken falls back to browser-session re-sync when refresh token restore is unavailable", async () => {
+  vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+    accessToken: "resynced-jwt",
+    source: "existing_tab",
+  })
+
+  vi.mocked(fetchApi).mockResolvedValueOnce({
+    code: 0,
+    message: "ok",
+    data: {
+      id: 12,
+      username: "alice",
+      email: "alice@example.com",
+      balance: "1.5",
+    },
+  } as any)
+
+  await expect(
+    getOrCreateAccessToken({
+      baseUrl: "https://sub2.example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "",
+      },
+    }),
+  ).resolves.toEqual({
+    username: "alice",
+    access_token: "resynced-jwt",
+  })
+
+  expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith("https://sub2.example.com")
+})
+```
+
+- [ ] **Step 2: Run the Sub2API adapter test file to verify the new tests fail**
+
+Run:
+
+```powershell
+pnpm exec vitest --run tests/services/apiService/sub2api/index.test.ts
+```
+
+Expected before implementation: the new test block fails because `fetchUserInfo` and `getOrCreateAccessToken` are not exported yet.
+
+- [ ] **Step 3: Implement `fetchUserInfo(request)` as a compatibility override**
+
+In `src/services/apiService/sub2api/index.ts`, add `AccessTokenInfo` and `UserInfo` to the existing type import list:
+
+```ts
+import type {
+  AccessTokenInfo,
+  AccountData,
+  ApiServiceAccountRequest,
+  ApiServiceRequest,
+  CreateTokenRequest,
+  CreateTokenResult,
+  RefreshAccountResult,
+  SiteStatusInfo,
+  TodayIncomeData,
+  TodayUsageData,
+  UserGroupInfo,
+  UserInfo,
+} from "~/services/apiService/common/type"
+```
+
+Add this helper after `fetchCurrentUser()`:
+
+```ts
+export async function fetchUserInfo(request: ApiServiceRequest): Promise<{
+  id: string
+  username: string
+  access_token: string
+  user: UserInfo
+}> {
+  const jwtRequest = normalizeJwtRequest(request)
+  const body = (await fetchApi<Sub2ApiAuthMeResponse>(
+    jwtRequest,
+    {
+      endpoint: SUB2API_AUTH_ME_ENDPOINT,
+      options: {
+        method: "GET",
+        cache: "no-store",
+      },
+    },
+    true,
+  )) as Sub2ApiAuthMeResponse
+
+  const data = parseSub2ApiEnvelope<Sub2ApiAuthMeData>(
+    body,
+    SUB2API_AUTH_ME_ENDPOINT,
+  )
+  const identity = parseSub2ApiUserIdentity(data)
+
+  return {
+    id: identity.userId,
+    username: identity.username,
+    access_token: jwtRequest.auth.accessToken,
+    user: data as UserInfo,
+  }
+}
+```
+
+Do not add cookie-auth fallback here. This override must require adapter-native JWT auth.
+
+- [ ] **Step 4: Implement `getOrCreateAccessToken(request)` as a truthful Sub2API override**
+
+In `src/services/apiService/sub2api/index.ts`, add this helper after `fetchUserInfo()`:
+
+```ts
+export async function getOrCreateAccessToken(
+  request: ApiServiceRequest,
+): Promise<AccessTokenInfo> {
+  const hydrated = await hydrateSub2ApiAuthRequest(request)
+  let effectiveRequest = hydrated.request
+  let accessToken = normalizeAccessToken(effectiveRequest.auth?.accessToken)
+  let refreshToken = normalizeRefreshToken(effectiveRequest.auth?.refreshToken)
+  const tokenExpiresAt = normalizeTokenExpiresAt(
+    effectiveRequest.auth?.tokenExpiresAt,
+  )
+
+  if (accessToken && (!tokenExpiresAt || !isCloseToExpiry(tokenExpiresAt))) {
+    const userInfo = await fetchUserInfo(effectiveRequest)
+    return {
+      username: userInfo.username,
+      access_token: userInfo.access_token,
+    }
+  }
+
+  if (refreshToken) {
+    const refreshed = await refreshSub2ApiRequestAuth({
+      request: effectiveRequest,
+      refreshToken,
+      accountStorageRef: hydrated.accountStorageRef,
+    })
+    effectiveRequest = refreshed.request
+    accessToken = normalizeAccessToken(effectiveRequest.auth?.accessToken)
+    refreshToken = refreshed.refreshToken
+
+    const userInfo = await fetchUserInfo(effectiveRequest)
+    return {
+      username: userInfo.username,
+      access_token: accessToken,
+    }
+  }
+
+  effectiveRequest = await resyncSub2ApiRequestAuth({
+    request: effectiveRequest,
+    endpoint: SUB2API_AUTH_ME_ENDPOINT,
+    accountStorageRef: hydrated.accountStorageRef,
+  })
+
+  const userInfo = await fetchUserInfo(effectiveRequest)
+  return {
+    username: userInfo.username,
+    access_token: userInfo.access_token,
+  }
+}
+```
+
+Use the existing `hydrateSub2ApiAuthRequest`, `refreshSub2ApiRequestAuth`, and `resyncSub2ApiRequestAuth` helpers. Do not call common `/api/user/self` or common `/api/user/token`.
+
+- [ ] **Step 5: Add a concise protocol comment above the new override pair**
+
+In `src/services/apiService/sub2api/index.ts`, add this short comment above `fetchUserInfo`:
+
+```ts
+/**
+ * Sub2API compatibility overrides for shared account-detection callers.
+ *
+ * Upstream identity lives at `/api/v1/auth/me` behind bearer JWT auth.
+ * This adapter intentionally does not fall back to common `/api/user/self`
+ * or `/api/user/token` semantics.
+ */
+```
+
+Keep the comment narrow and protocol-focused.
+
+- [ ] **Step 6: Re-run the Sub2API adapter tests**
+
+Run:
+
+```powershell
+pnpm exec vitest --run tests/services/apiService/sub2api/index.test.ts
+```
+
+Expected: the new `fetchUserInfo` / `getOrCreateAccessToken` tests pass along with the existing Sub2API adapter suite.
+
+- [ ] **Step 7: Commit the Sub2API compatibility overrides**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiService/sub2api/index.ts tests/services/apiService/sub2api/index.test.ts
+git commit -m "fix(sub2api): override identity and token helpers"
+```
+
+Expected: one focused commit containing only the Sub2API override implementation and its tests.
+
+---
+
+### Task 3: Add Caller-Facing Regression Coverage And Final Validation
+
+**Files:**
+- Modify: `tests/services/autoDetectService.test.ts`
+- Modify: `tests/services/accountOperations.autoDetectAccount.test.ts`
+- Validate: `src/services/apiService/index.ts`
+- Validate: `src/services/apiService/sub2api/index.ts`
+
+- [ ] **Step 1: Add an auto-detect regression proving Sub2API API fallback uses the Sub2API helper seam**
+
+In `tests/services/autoDetectService.test.ts`, add a Sub2API-specific fallback test near the current-tab/API fallback coverage:
+
+```ts
+it("uses the Sub2API apiService override when current-tab detection falls back to API", async () => {
+  mockGetAccountSiteType.mockResolvedValueOnce(SITE_TYPES.SUB2API)
+  mockGetActiveOrAllTabs.mockResolvedValue([
+    {
+      id: 201,
+      active: true,
+      url: "https://sub2.example.com/dashboard",
+    },
+  ])
+  browserAny.tabs.sendMessage.mockResolvedValue({
+    success: false,
+    error: "no local storage user",
+  })
+  mockFetchUserInfo.mockResolvedValueOnce({
+    id: "12",
+    username: "alice",
+    access_token: "jwt-token",
+    user: { id: 12, username: "alice" },
+  })
+
+  const result = await autoDetectSmart("https://sub2.example.com/console")
+
+  expect(result.success).toBe(true)
+  expect(result.data).toMatchObject({
+    userId: "12",
+    siteType: SITE_TYPES.SUB2API,
+    accessToken: "jwt-token",
+  })
+  expect(mockFetchUserInfo).toHaveBeenCalledWith({
+    baseUrl: "https://sub2.example.com/console",
+    auth: {
+      authType: expect.any(String),
+    },
+    fetchContext: {
+      kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+      tabId: 201,
+      origin: "https://sub2.example.com",
+    },
+  })
+})
+```
+
+This test does not verify the low-level endpoint again; it verifies the caller still works through `getApiService(siteType).fetchUserInfo(...)` after the seam change.
+
+- [ ] **Step 2: Add an account-operations regression for detected Sub2API AccessToken completion**
+
+In `tests/services/accountOperations.autoDetectAccount.test.ts`, add:
+
+```ts
+it("uses Sub2API getOrCreateAccessToken override semantics during access-token auto-detect completion", async () => {
+  mockSendRuntimeMessage.mockResolvedValueOnce(null)
+  mockAutoDetectSmart.mockResolvedValueOnce({
+    success: true,
+    data: {
+      userId: "12",
+      user: { id: 12, username: "alice" },
+      siteType: SITE_TYPES.SUB2API,
+      fetchContext: currentTabFetchContext("https://sub2.example.com"),
+    },
+  })
+  mockGetOrCreateAccessToken.mockResolvedValueOnce({
+    username: "alice",
+    access_token: "jwt-token",
+  })
+  mockFetchSiteStatus.mockResolvedValueOnce(null)
+  mockFetchSupportCheckIn.mockResolvedValueOnce(false)
+  mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+  const result = await autoDetectAccount(
+    "https://sub2.example.com",
+    AuthTypeEnum.AccessToken,
+  )
+
+  expect(result.success).toBe(true)
+  expect(mockGetOrCreateAccessToken).toHaveBeenCalledTimes(1)
+  expect(result.data).toMatchObject({
+    siteType: SITE_TYPES.SUB2API,
+    username: "alice",
+    accessToken: "jwt-token",
+    exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+  })
+})
+```
+
+This guards the shared business caller contract without reintroducing any business-layer Sub2API patch.
+
+- [ ] **Step 3: Run the targeted caller regression tests**
+
+Run:
+
+```powershell
+pnpm exec vitest --run tests/services/autoDetectService.test.ts tests/services/accountOperations.autoDetectAccount.test.ts
+```
+
+Expected: both caller-facing regression suites pass.
+
+- [ ] **Step 4: Run the full focused phase-1 validation set**
+
+Run:
+
+```powershell
+pnpm exec vitest --run tests/services/apiService/index.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/autoDetectService.test.ts tests/services/accountOperations.autoDetectAccount.test.ts
+```
+
+Expected: all four focused suites pass.
+
+- [ ] **Step 5: Stage only task-scoped files and run staged validation**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiService/index.ts src/services/apiService/sub2api/index.ts
+git add tests/services/apiService/index.test.ts tests/services/apiService/sub2api/index.test.ts
+git add tests/services/autoDetectService.test.ts tests/services/accountOperations.autoDetectAccount.test.ts
+pnpm run validate:staged
+```
+
+Expected: staged validation exits 0. If formatting changes are applied by lint-staged, inspect the resulting diff before continuing.
+
+- [ ] **Step 6: Inspect the final diff**
+
+Run:
+
+```powershell
+git diff --cached --stat
+git diff --cached --name-status
+```
+
+Expected:
+
+```text
+M src/services/apiService/index.ts
+M src/services/apiService/sub2api/index.ts
+M tests/services/apiService/index.test.ts
+M tests/services/apiService/sub2api/index.test.ts
+M tests/services/autoDetectService.test.ts
+M tests/services/accountOperations.autoDetectAccount.test.ts
+```
+
+No business-layer source files such as `AccountDataContext.tsx`, `useAccountDialog.ts`, or `tokenResync.ts` should be modified in this phase.
+
+- [ ] **Step 7: Commit the caller regression coverage and final integration**
+
+Run:
+
+```powershell
+git commit -m "test(sub2api): cover adapter seam regressions"
+```
+
+Expected: the final task-scoped staged diff is committed cleanly.
+
+- [ ] **Step 8: Record final status**
+
+Run:
+
+```powershell
+git status --porcelain
+git log --oneline -5
+```
+
+Expected: only unrelated pre-existing files remain untracked or modified, and recent commits include the three phase-1 commits from this plan.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: Task 1 implements `strictOverrideSites` for Sub2API. Task 2 adds the required phase-1 overrides `fetchUserInfo` and `getOrCreateAccessToken` using existing Sub2API adapter auth machinery. Task 3 covers the shared callers called out in the spec validation plan and confirms no phase-2 abstraction work leaks in.
+- Placeholder scan: each task includes exact file paths, code snippets, commands, and expected outcomes. No `TODO`, `TBD`, or “similar to previous step” placeholders remain.
+- Type consistency: `fetchUserInfo` returns the same compatibility shape as common/AIHubMix callers expect (`id`, `username`, `access_token`, `user`), and `getOrCreateAccessToken` returns the shared `AccessTokenInfo` shape (`username`, `access_token`).

--- a/docs/superpowers/specs/2026-06-08-sub2api-adapter-seam-separation-design.md
+++ b/docs/superpowers/specs/2026-06-08-sub2api-adapter-seam-separation-design.md
@@ -1,0 +1,288 @@
+# Sub2API Adapter Seam Separation Design
+
+Date: 2026-06-08
+
+## Purpose
+
+Separate Sub2API's JWT-session and browser-session behavior from shared
+business logic so that Sub2API no longer relies on incompatible common
+`apiService` fallbacks such as `/api/user/self`.
+
+The first implementation phase should fix the current seam for Sub2API only.
+It should make required Sub2API overrides explicit, tighten fallback policy,
+and keep the broader `apiService` capability redesign out of scope for now.
+
+## Current Context
+
+`src/services/apiService/index.ts` resolves helpers by checking the site
+override map first and then falling back to `commonAPI` when the site adapter
+does not export the requested helper.
+
+That fallback model works for One-API/New-API-family compatibility buckets,
+but Sub2API is not one of those buckets:
+
+- Sub2API current-user reads use `GET /api/v1/auth/me`.
+- Sub2API account and key requests depend on bearer JWT auth.
+- Sub2API may recover or refresh bearer auth from `refresh_token` and
+  `token_expires_at`.
+- Sub2API browser pages persist `auth_token`, `auth_user`, `refresh_token`,
+  and `token_expires_at` in `localStorage`.
+- `GET /api/v1/auth/me` is an authenticated identity endpoint, not a browser
+  session discovery endpoint. It cannot discover a page's current
+  `refresh_token` unless the extension already has usable auth material.
+
+The repo already contains working Sub2API-specific logic in the adapter layer:
+
+- `fetchCurrentUser()` reads `/api/v1/auth/me`.
+- `executeAuthenticatedSub2ApiRequest()` refreshes or re-syncs JWT auth for
+  adapter-owned requests.
+- `tokenResync.ts` can recover auth from an existing tab or temp window.
+- the content message handler can read Sub2API session state from
+  `localStorage`.
+
+The architectural problem is that these capabilities are not the primary seam
+for all Sub2API identity flows. Shared business logic still calls generic
+helpers such as `fetchUserInfo()` and `getOrCreateAccessToken()` through
+`getApiService(siteType)`, which silently falls back to common One-API-style
+helpers when Sub2API does not override them.
+
+## Problem
+
+The current seam is shallow for incompatible site types:
+
+- `getApiService(SITE_TYPES.SUB2API).fetchUserInfo(...)` falls back to
+  `common.fetchUserInfo()`, which calls `/api/user/self`.
+- `getApiService(SITE_TYPES.SUB2API).getOrCreateAccessToken(...)` falls back to
+  `common.getOrCreateAccessToken()`, which depends on `/api/user/self` and
+  `/api/user/token`.
+- shared business logic cannot tell whether a helper is truly implemented for
+  Sub2API or only inherited through an incompatible fallback.
+- the adapter already knows how to restore Sub2API auth, but some call paths
+  bypass that adapter knowledge and force business-layer repair logic.
+
+This creates three kinds of friction:
+
+1. Real protocol mismatch: Sub2API can hit incompatible common endpoints.
+2. Poor locality: identity and session concerns are split between adapter code
+   and business code.
+3. Weak test surface: missing adapter overrides do not fail fast; they degrade
+   into incorrect common behavior.
+
+There is also an important semantic mismatch hidden inside the shared helper
+names:
+
+- authenticated identity fetch: "who is this account, given valid auth?"
+- browser-session identity resolution: "who is currently logged into this page?"
+
+For Sub2API, those are related but different operations. The first can often be
+API-only; the second still depends on browser-session state.
+
+## Goals
+
+- Make Sub2API an explicit non-common site adapter for account identity and
+  token flows.
+- Prevent silent fallback from Sub2API to incompatible common helpers.
+- Move Sub2API identity-fetch and token-fetch semantics behind explicit
+  Sub2API adapter overrides.
+- Preserve the existing browser-session import and token re-sync behavior,
+  while making business callers depend on adapter-owned entrypoints instead of
+  protocol assumptions.
+- Keep the change narrow enough to implement in a focused first phase.
+
+## Non-Goals
+
+- Do not redesign the full `apiService` interface for every incompatible site
+  type in this phase.
+- Do not introduce a new generic capability registry across all site adapters
+  yet.
+- Do not remove the current Sub2API browser-session read path from content
+  scripts or temp-window flows.
+- Do not try to replace current browser-session import/recovery flows with
+  `fetchUserInfo()`.
+- Do not change user-facing Sub2API account import, refresh, key management, or
+  auto-detect behavior beyond routing them through the correct adapter seam.
+- Do not broaden this phase into AIHubMix or other adapter families.
+
+## Design
+
+### 1. Treat Sub2API As A Strict Override Site
+
+`SITE_TYPES.SUB2API` should join `strictOverrideSites`.
+
+That means: when shared callers request a helper that Sub2API does not
+explicitly implement, the system should fail fast instead of silently calling
+`commonAPI`.
+
+This is the correct seam because Sub2API is not a partial compatibility bucket.
+It is a different auth/session model with adapter-owned behavior. Fast failure
+will expose missing overrides during development and tests rather than at
+runtime against the wrong upstream contract.
+
+### 2. Make Current-Identity Fetch An Explicit Sub2API Override
+
+Sub2API should export `fetchUserInfo(request)` as an adapter override.
+
+This override should:
+
+- require access-token auth, not cookie auth
+- call `/api/v1/auth/me`
+- parse the response using existing Sub2API parsing helpers
+- return the shared `UserInfo` shape expected by existing callers
+
+This override is specifically for authenticated identity fetch when the adapter
+already has usable auth material. It is not a replacement for browser-session
+discovery or session import from an already-open Sub2API page.
+
+The main purpose is not to invent a new shared abstraction. It is to ensure
+that existing callers which still expect `fetchUserInfo()` now hit a truthful
+Sub2API implementation instead of common fallback behavior.
+
+`fetchCurrentUser()` should remain the deeper internal module for Sub2API's
+normalized account identity. `fetchUserInfo()` becomes a compatibility adapter
+over that deeper module.
+
+### 3. Make Access-Token Resolution An Explicit Sub2API Override
+
+Sub2API should export `getOrCreateAccessToken(request)` as an adapter override.
+
+For Sub2API, "get or create access token" does not mean "read `/api/user/self`
+and create `/api/user/token` if missing." It means:
+
+- if a valid `auth.accessToken` already exists, use it
+- if it is expired and a refresh token exists, refresh it
+- if adapter-owned refresh fails but browser-session recovery is available,
+  re-sync from browser session
+- if none of those paths produce a usable bearer token, return a login-required
+  error
+
+This keeps Sub2API token lifecycle knowledge inside the adapter, where the
+refresh and re-sync logic already lives.
+
+In other words, API-only operation is sufficient when Sub2API auth material is
+already present in the request or persisted account state. API-only operation is
+not sufficient for the separate problem of discovering/importing auth material
+from an already-logged-in browser page.
+
+The first phase does not need to rename this helper globally. It only needs to
+override the existing shared helper name with truthful Sub2API semantics.
+
+### 4. Preserve Browser-Session Identity Reads As Adapter-Owned Support Logic
+
+The current content-script path that reads Sub2API `localStorage` remains
+necessary in phase 1.
+
+It serves two distinct use cases:
+
+- identifying which account is currently logged into an already-open Sub2API
+  page
+- recovering or importing a Sub2API browser session that includes refresh-token
+  state
+
+This remains necessary because `/api/v1/auth/me` only works after the extension
+already has valid bearer auth. It does not discover the page's current
+`refresh_token`, and therefore cannot replace browser-session import/recovery by
+itself.
+
+Those are not equivalent to generic current-user API fetches. The design for
+this phase is therefore:
+
+- keep `ContentGetUserFromLocalStorage`
+- keep `tokenResync.ts`
+- keep the current `auth_user` parsing path
+- stop treating these as business-layer protocol knowledge
+- treat them as Sub2API adapter support modules
+
+Business logic may still call these paths indirectly in phase 1, but the design
+goal is that their ownership is explicitly Sub2API-specific and not part of
+`commonAPI` semantics.
+
+### 5. Restrict Phase-1 Surface To Concrete Missing Overrides
+
+The first phase should only require the overrides that are already known to be
+unsafe when inherited from `commonAPI`.
+
+Required phase-1 overrides:
+
+- `fetchUserInfo`
+- `getOrCreateAccessToken`
+
+Recommended phase-1 review targets, to confirm whether explicit Sub2API
+implementations are also needed now:
+
+- `validateAccountConnection`
+- `fetchAccountQuota`
+
+If these review targets are not used by active Sub2API flows in this phase,
+they can stay for a later pass. The important rule is that phase 1 must close
+the confirmed wrong-path calls, not redesign every helper preemptively.
+
+## Business-Logic Integration
+
+This phase should simplify business callers by making Sub2API truthfully answer
+the helpers they already use.
+
+Impacted caller families include:
+
+- auto-detect API fallback logic
+- account add/edit flows that resolve an access token or user profile
+- current-tab account matching flows that must identify the page's active login
+- Sub2API refresh flows that currently rely on `authUpdate`
+
+The desired direction is:
+
+- shared business logic keeps calling `getApiService(siteType)`
+- Sub2API returns adapter-owned behavior for the helpers it supports
+- missing Sub2API helpers fail loudly because Sub2API is strict
+
+This improves locality without forcing the broader capability redesign in the
+same change.
+
+## Validation Plan
+
+Focused validation:
+
+- add or update Sub2API adapter tests that prove `fetchUserInfo()` calls
+  `/api/v1/auth/me`
+- add or update tests that prove Sub2API no longer falls back to common
+  `/api/user/self`
+- add or update tests that prove `getOrCreateAccessToken()` for Sub2API uses
+  existing bearer auth / refresh / re-sync semantics rather than common token
+  creation semantics
+- add or update tests for the strict override failure path when Sub2API is
+  missing a required helper
+
+Integration-focused checks:
+
+- run affected tests for `autoDetectService`
+- run affected tests for `accountOperations`
+- run affected Sub2API adapter tests
+
+Repository validation:
+
+- run the focused Vitest set for touched Sub2API/account-detection/account
+  operation files
+- run `pnpm run validate:staged` before commit
+
+## Follow-Up, Not In Scope For This Spec
+
+The broader `apiService` redesign for incompatible site capabilities should be
+handled as a separate second phase.
+
+That later phase may introduce explicit optional adapter capabilities for
+concepts such as:
+
+- authenticated identity fetch
+- browser-session identity resolution
+- auth restoration / session recovery
+
+The important boundary discovered during phase-1 investigation is:
+
+- authenticated identity fetch can be API-only
+- browser-session identity resolution cannot be reduced to generic
+  `fetchUserInfo()`
+- browser-session auth import/recovery cannot be reduced to generic
+  `getOrCreateAccessToken()`
+
+This spec intentionally does not define that broader interface. It only creates
+the correct seam for Sub2API now and prevents further spread of incompatible
+fallback behavior.

--- a/src/services/apiService/index.ts
+++ b/src/services/apiService/index.ts
@@ -33,7 +33,10 @@ type SiteOverrideMap = typeof siteOverrideMap
 
 export type ApiOverrideSite = keyof SiteOverrideMap
 
-const strictOverrideSites = new Set<ApiOverrideSite>([SITE_TYPES.AIHUBMIX])
+const strictOverrideSites = new Set<ApiOverrideSite>([
+  SITE_TYPES.AIHUBMIX,
+  SITE_TYPES.SUB2API,
+])
 
 const hasOwnOverrideSite = (value: unknown): value is ApiOverrideSite =>
   typeof value === "string" &&

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -791,6 +791,7 @@ export async function fetchCurrentUser(
 /**
  * Sub2API compatibility overrides for shared account-detection callers.
  *
+ * Source: https://github.com/Wei-Shaw/sub2api
  * Upstream identity lives at `/api/v1/auth/me` behind bearer JWT auth.
  * This adapter intentionally does not fall back to common `/api/user/self`
  * or `/api/user/token` semantics.
@@ -825,7 +826,12 @@ export async function fetchUserInfo(request: ApiServiceRequest): Promise<{
     id: String(identity.userId),
     username: identity.username,
     access_token: accessToken,
-    user: data as UserInfo,
+    user: {
+      ...(data as Record<string, unknown>),
+      id: String(identity.userId),
+      username: identity.username,
+      access_token: accessToken,
+    } as UserInfo,
   }
 }
 

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -8,9 +8,13 @@ import {
   AccountUpdateUserTimestampMode,
   type AccountUpdateUserTimestampMode as AccountUpdateUserTimestampModeValue,
 } from "~/services/accounts/accountDefaults"
-import { determineHealthStatus } from "~/services/apiService/common"
+import {
+  determineHealthStatus,
+  extractDefaultExchangeRate as extractCommonDefaultExchangeRate,
+} from "~/services/apiService/common"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import type {
+  AccessTokenInfo,
   AccountData,
   ApiServiceAccountRequest,
   ApiServiceRequest,
@@ -21,6 +25,7 @@ import type {
   TodayIncomeData,
   TodayUsageData,
   UserGroupInfo,
+  UserInfo,
 } from "~/services/apiService/common/type"
 import { fetchApi } from "~/services/apiService/common/utils"
 import {
@@ -784,6 +789,168 @@ export async function fetchCurrentUser(
 }
 
 /**
+ * Sub2API compatibility overrides for shared account-detection callers.
+ *
+ * Upstream identity lives at `/api/v1/auth/me` behind bearer JWT auth.
+ * This adapter intentionally does not fall back to common `/api/user/self`
+ * or `/api/user/token` semantics.
+ */
+export async function fetchUserInfo(request: ApiServiceRequest): Promise<{
+  id: string
+  username: string
+  access_token: string
+  user: UserInfo
+}> {
+  const jwtRequest = normalizeJwtRequest(request)
+  const accessToken = normalizeAccessToken(jwtRequest.auth.accessToken)
+  const body = (await fetchApi<Sub2ApiAuthMeResponse>(
+    jwtRequest,
+    {
+      endpoint: SUB2API_AUTH_ME_ENDPOINT,
+      options: {
+        method: "GET",
+        cache: "no-store",
+      },
+    },
+    true,
+  )) as Sub2ApiAuthMeResponse
+
+  const data = parseSub2ApiEnvelope<Sub2ApiAuthMeData>(
+    body,
+    SUB2API_AUTH_ME_ENDPOINT,
+  )
+  const identity = parseSub2ApiUserIdentity(data)
+
+  return {
+    id: String(identity.userId),
+    username: identity.username,
+    access_token: accessToken,
+    user: data as UserInfo,
+  }
+}
+
+const fetchSub2ApiAccessTokenInfo = async (
+  request: ApiServiceRequest,
+): Promise<AccessTokenInfo> => {
+  const userInfo = await fetchUserInfo(request)
+
+  return {
+    username: userInfo.username,
+    access_token: userInfo.access_token,
+  }
+}
+
+const fetchSub2ApiAccessTokenInfoWithResyncedAuth = async (params: {
+  request: ApiServiceRequest
+  accountStorageRef: Sub2ApiAccountStorageRef
+}): Promise<AccessTokenInfo> => {
+  const resyncedRequest = await resyncSub2ApiRequestAuth({
+    request: params.request,
+    endpoint: SUB2API_AUTH_ME_ENDPOINT,
+    accountStorageRef: params.accountStorageRef,
+  })
+
+  try {
+    return await fetchSub2ApiAccessTokenInfo(resyncedRequest)
+  } catch (retryError) {
+    if (isUnauthorizedError(retryError)) {
+      throw createLoginRequiredError(SUB2API_AUTH_ME_ENDPOINT)
+    }
+
+    throw retryError
+  }
+}
+
+const fetchSub2ApiAccessTokenInfoWithAuthRecovery = async (params: {
+  request: ApiServiceRequest
+  refreshToken: string
+  accountStorageRef: Sub2ApiAccountStorageRef
+}): Promise<AccessTokenInfo> => {
+  try {
+    return await fetchSub2ApiAccessTokenInfo(params.request)
+  } catch (error) {
+    if (!isUnauthorizedError(error)) {
+      throw error
+    }
+
+    if (params.refreshToken) {
+      try {
+        const refreshed = await refreshSub2ApiRequestAuth({
+          request: params.request,
+          refreshToken: params.refreshToken,
+          accountStorageRef: params.accountStorageRef,
+        })
+
+        return await fetchSub2ApiAccessTokenInfo(refreshed.request)
+      } catch (refreshError) {
+        logger.warn("Failed to restore Sub2API user info via refresh token", {
+          endpoint: SUB2API_AUTH_ME_ENDPOINT,
+          error: getSafeErrorMessage(refreshError),
+        })
+      }
+    }
+
+    return await fetchSub2ApiAccessTokenInfoWithResyncedAuth({
+      request: params.request,
+      accountStorageRef: params.accountStorageRef,
+    })
+  }
+}
+
+/**
+ * Return a reusable Sub2API JWT for shared token-detection callers.
+ */
+export async function getOrCreateAccessToken(
+  request: ApiServiceRequest,
+): Promise<AccessTokenInfo> {
+  const hydrated = await hydrateSub2ApiAuthRequest(request)
+  let effectiveRequest = hydrated.request
+  let accessToken = normalizeAccessToken(effectiveRequest.auth?.accessToken)
+  const refreshToken = normalizeRefreshToken(
+    effectiveRequest.auth?.refreshToken,
+  )
+  const tokenExpiresAt = normalizeTokenExpiresAt(
+    effectiveRequest.auth?.tokenExpiresAt,
+  )
+
+  if (accessToken && (!tokenExpiresAt || !isCloseToExpiry(tokenExpiresAt))) {
+    return await fetchSub2ApiAccessTokenInfoWithAuthRecovery({
+      request: effectiveRequest,
+      refreshToken,
+      accountStorageRef: hydrated.accountStorageRef,
+    })
+  }
+
+  if (refreshToken) {
+    try {
+      const refreshed = await refreshSub2ApiRequestAuth({
+        request: effectiveRequest,
+        refreshToken,
+        accountStorageRef: hydrated.accountStorageRef,
+      })
+      effectiveRequest = refreshed.request
+      accessToken = normalizeAccessToken(effectiveRequest.auth?.accessToken)
+
+      const userInfo = await fetchUserInfo(effectiveRequest)
+      return {
+        username: userInfo.username,
+        access_token: accessToken,
+      }
+    } catch (refreshError) {
+      logger.warn("Failed to restore Sub2API user info via refresh token", {
+        endpoint: SUB2API_AUTH_ME_ENDPOINT,
+        error: getSafeErrorMessage(refreshError),
+      })
+    }
+  }
+
+  return await fetchSub2ApiAccessTokenInfoWithResyncedAuth({
+    request: effectiveRequest,
+    accountStorageRef: hydrated.accountStorageRef,
+  })
+}
+
+/**
  * Sub2API does not expose the One-API-style public `/api/status` endpoint.
  * Return a synthetic status payload so shared callers can skip that request and
  * still treat built-in check-in as unsupported.
@@ -795,6 +962,12 @@ export async function fetchSiteStatus(
     checkin_enabled: false,
   }
 }
+
+/**
+ * Keep strict Sub2API routing compatible with shared account completion code
+ * while reusing the common status exchange-rate fallback order.
+ */
+export const extractDefaultExchangeRate = extractCommonDefaultExchangeRate
 
 /**
  * Sub2API does not support the extension's built-in check-in flow.

--- a/tests/services/accountOperations.autoDetectAccount.test.ts
+++ b/tests/services/accountOperations.autoDetectAccount.test.ts
@@ -121,6 +121,37 @@ describe("accountOperations autoDetectAccount", () => {
     expect(result.data?.exchangeRate).toBe(UI_CONSTANTS.EXCHANGE_RATE.DEFAULT)
   })
 
+  it("uses detected Sub2API access-token semantics during auto-detect completion", async () => {
+    mockSendRuntimeMessage.mockResolvedValueOnce(null)
+    mockAutoDetectSmart.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "12",
+        user: { id: 12, username: "alice" },
+        siteType: SITE_TYPES.SUB2API,
+        accessToken: "jwt-token",
+        fetchContext: currentTabFetchContext("https://sub2.example.com"),
+      },
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce(null)
+    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await autoDetectAccount(
+      "https://sub2.example.com",
+      AuthTypeEnum.AccessToken,
+    )
+
+    expect(result.success).toBe(true)
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(result.data).toMatchObject({
+      siteType: SITE_TYPES.SUB2API,
+      username: "alice",
+      accessToken: "jwt-token",
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+    })
+  })
+
   it("continues detection when cookie-interceptor tracking fails", async () => {
     mockSendRuntimeMessage.mockRejectedValueOnce(new Error("track failed"))
     mockAutoDetectSmart.mockResolvedValueOnce({

--- a/tests/services/apiService/index.test.ts
+++ b/tests/services/apiService/index.test.ts
@@ -8,19 +8,25 @@ const {
   commonFetchModelPricing,
   commonFetchAccountTokens,
   commonResolveApiTokenKey,
+  commonExtractDefaultExchangeRate,
   aihubmixFetchAccountTokens,
   oneHubFetchModelPricing,
   oneHubFetchAccountTokens,
   wongResolveApiTokenKey,
+  sub2apiFetchUserInfo,
+  sub2apiExtractDefaultExchangeRate,
 } = vi.hoisted(() => ({
   commonFetchUserInfo: vi.fn(),
   commonFetchModelPricing: vi.fn(),
   commonFetchAccountTokens: vi.fn(),
   commonResolveApiTokenKey: vi.fn(),
+  commonExtractDefaultExchangeRate: vi.fn(),
   aihubmixFetchAccountTokens: vi.fn(),
   oneHubFetchModelPricing: vi.fn(),
   oneHubFetchAccountTokens: vi.fn(),
   wongResolveApiTokenKey: vi.fn(),
+  sub2apiFetchUserInfo: vi.fn(),
+  sub2apiExtractDefaultExchangeRate: vi.fn(),
 }))
 
 vi.mock("~/services/apiService/common", () => ({
@@ -28,6 +34,7 @@ vi.mock("~/services/apiService/common", () => ({
   fetchModelPricing: commonFetchModelPricing,
   fetchAccountTokens: commonFetchAccountTokens,
   resolveApiTokenKey: commonResolveApiTokenKey,
+  extractDefaultExchangeRate: commonExtractDefaultExchangeRate,
 }))
 
 vi.mock("~/services/apiService/oneHub", () => ({
@@ -42,6 +49,12 @@ vi.mock("~/services/apiService/aihubmix", () => ({
 
 vi.mock("~/services/apiService/wong", () => ({
   resolveApiTokenKey: wongResolveApiTokenKey,
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchUserInfo: sub2apiFetchUserInfo,
+  extractDefaultExchangeRate: sub2apiExtractDefaultExchangeRate,
+  // Intentionally omit fetchModelPricing so strict override behavior can be asserted.
 }))
 
 describe("apiService index wrapper", () => {
@@ -217,6 +230,56 @@ describe("apiService index wrapper", () => {
       (getApiService(SITE_TYPES.AIHUBMIX).fetchModelPricing as any)(request),
     ).toThrow(
       `apiService.fetchModelPricing is not implemented for ${SITE_TYPES.AIHUBMIX}`,
+    )
+
+    expect(commonFetchModelPricing).not.toHaveBeenCalled()
+  })
+
+  it("should route Sub2API fetchUserInfo through the site override", async () => {
+    sub2apiFetchUserInfo.mockResolvedValue({ id: "7" } as any)
+
+    const request = {
+      baseUrl: "https://sub2.example.com",
+      auth: { authType: "access_token", accessToken: "jwt-token" },
+    }
+
+    await (getApiService(SITE_TYPES.SUB2API).fetchUserInfo as any)(request)
+
+    expect(sub2apiFetchUserInfo).toHaveBeenCalledTimes(1)
+    expect(sub2apiFetchUserInfo).toHaveBeenCalledWith(request)
+    expect(commonFetchUserInfo).not.toHaveBeenCalled()
+  })
+
+  it("should route Sub2API exchange-rate extraction through the site override", () => {
+    sub2apiExtractDefaultExchangeRate.mockReturnValue(7.2)
+
+    const siteStatus = {
+      checkin_enabled: false,
+      price: 7.2,
+    }
+
+    const rate = (
+      getApiService(SITE_TYPES.SUB2API).extractDefaultExchangeRate as any
+    )(siteStatus)
+
+    expect(rate).toBe(7.2)
+    expect(sub2apiExtractDefaultExchangeRate).toHaveBeenCalledTimes(1)
+    expect(sub2apiExtractDefaultExchangeRate).toHaveBeenCalledWith(siteStatus)
+    expect(commonExtractDefaultExchangeRate).not.toHaveBeenCalled()
+  })
+
+  it("should not silently fall back to common for missing Sub2API overrides", async () => {
+    commonFetchModelPricing.mockResolvedValue({} as any)
+
+    const request = {
+      baseUrl: "https://sub2.example.com",
+      auth: { authType: "access_token", accessToken: "jwt-token" },
+    }
+
+    expect(() =>
+      (getApiService(SITE_TYPES.SUB2API).fetchModelPricing as any)(request),
+    ).toThrow(
+      `apiService.fetchModelPricing is not implemented for ${SITE_TYPES.SUB2API}`,
     )
 
     expect(commonFetchModelPricing).not.toHaveBeenCalled()

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -10,6 +10,7 @@ import { fetchApi } from "~/services/apiService/common/utils"
 import {
   createApiToken,
   deleteApiToken,
+  extractDefaultExchangeRate,
   fetchAccountAvailableModels,
   fetchAccountData,
   fetchAccountTokens,
@@ -22,6 +23,8 @@ import {
   fetchTodayUsage,
   fetchTokenById,
   fetchUserGroups,
+  fetchUserInfo,
+  getOrCreateAccessToken,
   markSub2ApiAnnouncementRead,
   refreshAccountData,
   updateApiToken,
@@ -55,6 +58,9 @@ vi.mock("~/services/apiService/common", () => ({
     status: SiteHealthStatus.Unknown,
     message: "determineHealthStatus",
   })),
+  extractDefaultExchangeRate: (
+    statusInfo: { price?: number; stripe_unit_price?: number } | null,
+  ) => statusInfo?.price ?? statusInfo?.stripe_unit_price ?? null,
 }))
 
 vi.mock("~/services/apiService/common/utils", () => ({
@@ -1144,6 +1150,277 @@ describe("apiService sub2api exported operations", () => {
     })
   })
 
+  it("fetchUserInfo returns the shared compatibility shape from /api/v1/auth/me", async () => {
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: {
+        id: 12,
+        username: "alice",
+        email: "alice@example.com",
+        balance: "1.5",
+      },
+    } as any)
+
+    await expect(
+      fetchUserInfo({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "jwt-token",
+        },
+      }),
+    ).resolves.toEqual({
+      id: "12",
+      username: "alice",
+      access_token: "jwt-token",
+      user: {
+        id: 12,
+        username: "alice",
+        email: "alice@example.com",
+        balance: "1.5",
+      },
+    })
+
+    expect(fetchApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "jwt-token",
+        }),
+      }),
+      expect.objectContaining({
+        endpoint: "/api/v1/auth/me",
+        options: expect.objectContaining({
+          method: "GET",
+          cache: "no-store",
+        }),
+      }),
+      true,
+    )
+  })
+
+  it("getOrCreateAccessToken reuses the existing Sub2API JWT when present", async () => {
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: {
+        id: 12,
+        username: "alice",
+        email: "alice@example.com",
+        balance: "1.5",
+      },
+    } as any)
+
+    await expect(
+      getOrCreateAccessToken({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "jwt-token",
+        },
+      }),
+    ).resolves.toEqual({
+      username: "alice",
+      access_token: "jwt-token",
+    })
+
+    expect(fetchApi).toHaveBeenCalledTimes(1)
+    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+  })
+
+  it("getOrCreateAccessToken refreshes the Sub2API JWT when only refresh token state is usable", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          code: 0,
+          message: "ok",
+          data: {
+            access_token: "refreshed-jwt",
+            refresh_token: "rotated-refresh",
+            expires_in: 3600,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    vi.stubGlobal("fetch", fetchMock as any)
+
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: {
+        id: 12,
+        username: "alice",
+        email: "alice@example.com",
+        balance: "1.5",
+      },
+    } as any)
+
+    await expect(
+      getOrCreateAccessToken({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "expired-jwt",
+          refreshToken: "stored-refresh",
+          tokenExpiresAt: now - 1,
+        },
+      }),
+    ).resolves.toEqual({
+      username: "alice",
+      access_token: "refreshed-jwt",
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+    nowSpy.mockRestore()
+  })
+
+  it("getOrCreateAccessToken refreshes and retries when a JWT without expiry metadata is stale", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          code: 0,
+          message: "ok",
+          data: {
+            access_token: "refreshed-jwt",
+            refresh_token: "rotated-refresh",
+            expires_in: 3600,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    vi.stubGlobal("fetch", fetchMock as any)
+
+    vi.mocked(fetchApi)
+      .mockRejectedValueOnce(
+        new ApiError("Unauthorized", 401, "/api/v1/auth/me"),
+      )
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: {
+          id: 12,
+          username: "alice",
+          email: "alice@example.com",
+          balance: "1.5",
+        },
+      } as any)
+
+    await expect(
+      getOrCreateAccessToken({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "stale-jwt",
+          refreshToken: "stored-refresh",
+        },
+      }),
+    ).resolves.toEqual({
+      username: "alice",
+      access_token: "refreshed-jwt",
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchApi).toHaveBeenCalledTimes(2)
+    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+    expect(
+      (vi.mocked(fetchApi).mock.calls[1]?.[0] as any)?.auth?.accessToken,
+    ).toBe("refreshed-jwt")
+    nowSpy.mockRestore()
+  })
+
+  it("getOrCreateAccessToken falls back to browser-session re-sync when refresh token restore fails", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"))
+    vi.stubGlobal("fetch", fetchMock as any)
+
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "resynced-jwt",
+      source: "existing_tab",
+    })
+
+    vi.mocked(fetchApi)
+      .mockRejectedValueOnce(
+        new ApiError("Unauthorized", 401, "/api/v1/auth/me"),
+      )
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: {
+          id: 12,
+          username: "alice",
+          email: "alice@example.com",
+          balance: "1.5",
+        },
+      } as any)
+
+    await expect(
+      getOrCreateAccessToken({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "expired-jwt",
+          refreshToken: "stored-refresh",
+        },
+      }),
+    ).resolves.toEqual({
+      username: "alice",
+      access_token: "resynced-jwt",
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      "https://sub2.example.com",
+    )
+    expect(fetchApi).toHaveBeenCalledTimes(2)
+    expect(
+      (vi.mocked(fetchApi).mock.calls[1]?.[0] as any)?.auth?.accessToken,
+    ).toBe("resynced-jwt")
+  })
+
+  it("getOrCreateAccessToken falls back to browser-session re-sync when no refresh token is available", async () => {
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "resynced-jwt",
+      source: "existing_tab",
+    })
+
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: {
+        id: 12,
+        username: "alice",
+        email: "alice@example.com",
+        balance: "1.5",
+      },
+    } as any)
+
+    await expect(
+      getOrCreateAccessToken({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "",
+        },
+      }),
+    ).resolves.toEqual({
+      username: "alice",
+      access_token: "resynced-jwt",
+    })
+
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      "https://sub2.example.com",
+    )
+  })
+
   it("fetches account data with check-in detection forcibly disabled", async () => {
     vi.mocked(fetchApi).mockResolvedValueOnce({
       code: 0,
@@ -1178,6 +1455,18 @@ describe("apiService sub2api exported operations", () => {
     })
 
     expect(vi.mocked(fetchApi)).not.toHaveBeenCalled()
+  })
+
+  it("reuses the common exchange-rate extraction contract for status payloads", () => {
+    expect(
+      extractDefaultExchangeRate({
+        checkin_enabled: false,
+        price: 7.2,
+      } as any),
+    ).toBe(7.2)
+    expect(extractDefaultExchangeRate({ checkin_enabled: false } as any)).toBe(
+      null,
+    )
   })
 
   it("fetches user groups by combining available groups and rates", async () => {

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -1175,8 +1175,9 @@ describe("apiService sub2api exported operations", () => {
       username: "alice",
       access_token: "jwt-token",
       user: {
-        id: 12,
+        id: "12",
         username: "alice",
+        access_token: "jwt-token",
         email: "alice@example.com",
         balance: "1.5",
       },
@@ -1277,6 +1278,53 @@ describe("apiService sub2api exported operations", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+    nowSpy.mockRestore()
+  })
+
+  it("getOrCreateAccessToken falls back to browser-session re-sync when proactive refresh fails", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+    const fetchMock = vi.fn().mockRejectedValue(new Error("refresh failed"))
+    vi.stubGlobal("fetch", fetchMock as any)
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "resynced-jwt",
+      source: "existing_tab",
+    })
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: {
+        id: 12,
+        username: "alice",
+        email: "alice@example.com",
+        balance: "1.5",
+      },
+    } as any)
+
+    await expect(
+      getOrCreateAccessToken({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "expired-jwt",
+          refreshToken: "stored-refresh",
+          tokenExpiresAt: now - 1,
+        },
+      }),
+    ).resolves.toEqual({
+      username: "alice",
+      access_token: "resynced-jwt",
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      "https://sub2.example.com",
+    )
+    expect((vi.mocked(fetchApi).mock.calls[0]?.[0] as any)?.auth).toMatchObject(
+      {
+        accessToken: "resynced-jwt",
+      },
+    )
     nowSpy.mockRestore()
   })
 
@@ -1419,6 +1467,68 @@ describe("apiService sub2api exported operations", () => {
     expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
       "https://sub2.example.com",
     )
+  })
+
+  it("getOrCreateAccessToken returns login-required when re-sync is unavailable", async () => {
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce(null)
+
+    await expect(
+      getOrCreateAccessToken({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "messages:sub2api.loginRequired",
+      code: API_ERROR_CODES.HTTP_401,
+    })
+
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      "https://sub2.example.com",
+    )
+  })
+
+  it("getOrCreateAccessToken converts 401 after re-sync into login-required", async () => {
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "resynced-jwt",
+      source: "existing_tab",
+    })
+    vi.mocked(fetchApi).mockRejectedValueOnce(
+      new ApiError("still unauthorized", 401, "/api/v1/auth/me"),
+    )
+
+    await expect(
+      getOrCreateAccessToken({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "messages:sub2api.loginRequired",
+      code: API_ERROR_CODES.HTTP_401,
+    })
+  })
+
+  it("getOrCreateAccessToken preserves non-auth errors after re-sync retry", async () => {
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "resynced-jwt",
+      source: "existing_tab",
+    })
+    vi.mocked(fetchApi).mockRejectedValueOnce(new Error("server exploded"))
+
+    await expect(
+      getOrCreateAccessToken({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "",
+        },
+      }),
+    ).rejects.toThrow("server exploded")
   })
 
   it("fetches account data with check-in detection forcibly disabled", async () => {

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -8,6 +8,7 @@ import {
 import { SITE_TYPES } from "~/constants/siteType"
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
 import { autoDetectSmart } from "~/services/siteDetection/autoDetectService"
+import { AuthTypeEnum } from "~/types"
 
 const {
   mockFetchUserInfo,
@@ -254,6 +255,47 @@ describe("autoDetectSmart", () => {
         origin: "https://example.com",
         incognito: true,
         cookieStoreId: "1-incognito",
+      },
+    })
+  })
+
+  it("does not report Sub2API API fallback success from cookie-auth user-info calls", async () => {
+    mockGetAccountSiteType.mockResolvedValueOnce(SITE_TYPES.SUB2API)
+    mockGetActiveOrAllTabs.mockResolvedValue([
+      {
+        id: 201,
+        active: true,
+        url: "https://sub2.example.com/dashboard",
+      },
+    ])
+    browserAny.tabs.sendMessage.mockResolvedValue({
+      success: false,
+      error: "no local storage user",
+    })
+    mockFetchUserInfo.mockRejectedValue(
+      new Error("messages:sub2api.loginRequired"),
+    )
+
+    const result = await autoDetectSmart("https://sub2.example.com/console")
+
+    expect(result.success).toBe(false)
+    expect(result.data).toBeUndefined()
+    expect(mockFetchUserInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+        },
+      }),
+    )
+    expect(mockFetchUserInfo).toHaveBeenCalledWith({
+      baseUrl: "https://sub2.example.com/console",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+      },
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 201,
+        origin: "https://sub2.example.com",
       },
     })
   })


### PR DESCRIPTION
## Summary
- Document the Sub2API adapter seam separation plan and design boundary
- Make Sub2API a strict apiService override site instead of falling back to common One-API helpers
- Add Sub2API identity/token override behavior and regression coverage for auto-detect callers

Supersedes #930. This branch is recreated from the clean reviewed stack and intentionally excludes the temporary empty commit used to retrigger integrations on #930.

## Test Plan
- git diff --check origin/main..HEAD
- pnpm exec vitest run tests/services/apiService/index.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/autoDetectService.test.ts tests/services/accountOperations.autoDetectAccount.test.ts
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Sub2API adapter with dedicated user-info and access-token handling so Sub2API flows are handled distinctly.

* **Documentation**
  * Add design and implementation plan documenting Sub2API seam separation and validation checklist.

* **Bug Fixes**
  * Enforce strict Sub2API override behavior so missing Sub2API capabilities fail instead of silently falling back.

* **Tests**
  * Add regression and integration tests covering Sub2API auth, token lifecycles, and routing through the override seam.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->