### PR TITLE
fix(sub2api): stabilize key secret and lifecycle flows

### DIFF
--- a/e2e/scenarios/accountKeyLifecycle.ts
+++ b/e2e/scenarios/accountKeyLifecycle.ts
@@ -8,6 +8,7 @@ import {
   submitTokenCreationFromKeyManagementPage,
 } from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
+import { formatScenarioError } from "~~/e2e/utils/scenarioErrors"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
@@ -50,14 +51,6 @@ function throwScenarioError(params: {
   if (params.cleanupError) {
     throw params.cleanupError
   }
-}
-
-function formatScenarioError(error: unknown) {
-  if (error instanceof Error) {
-    return error.message
-  }
-
-  return String(error)
 }
 
 type AccountKeyLifecycleEnvironment = {

--- a/e2e/scenarios/accountKeyLifecycle.ts
+++ b/e2e/scenarios/accountKeyLifecycle.ts
@@ -39,7 +39,7 @@ function throwScenarioError(params: {
   if (params.primaryError && params.cleanupError) {
     throw new AggregateError(
       [params.primaryError, params.cleanupError],
-      params.message,
+      `${params.message}: primary=${formatScenarioError(params.primaryError)}; cleanup=${formatScenarioError(params.cleanupError)}`,
     )
   }
 
@@ -50,6 +50,14 @@ function throwScenarioError(params: {
   if (params.cleanupError) {
     throw params.cleanupError
   }
+}
+
+function formatScenarioError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
 }
 
 type AccountKeyLifecycleEnvironment = {

--- a/e2e/scenarios/accountKeyToApiProfile.ts
+++ b/e2e/scenarios/accountKeyToApiProfile.ts
@@ -83,7 +83,7 @@ function throwScenarioError(params: {
   if (params.primaryError && params.cleanupError) {
     throw new AggregateError(
       [params.primaryError, params.cleanupError],
-      params.message,
+      `${params.message}: primary=${formatScenarioError(params.primaryError)}; cleanup=${formatScenarioError(params.cleanupError)}`,
     )
   }
 
@@ -94,6 +94,14 @@ function throwScenarioError(params: {
   if (params.cleanupError) {
     throw params.cleanupError
   }
+}
+
+function formatScenarioError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
 }
 
 export async function runAccountKeyToApiProfileScenario(

--- a/e2e/scenarios/accountKeyToApiProfile.ts
+++ b/e2e/scenarios/accountKeyToApiProfile.ts
@@ -12,6 +12,7 @@ import {
   type SavedApiCredentialProfileExpectation,
 } from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
+import { formatScenarioError } from "~~/e2e/utils/scenarioErrors"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
@@ -94,14 +95,6 @@ function throwScenarioError(params: {
   if (params.cleanupError) {
     throw params.cleanupError
   }
-}
-
-function formatScenarioError(error: unknown) {
-  if (error instanceof Error) {
-    return error.message
-  }
-
-  return String(error)
 }
 
 export async function runAccountKeyToApiProfileScenario(

--- a/e2e/utils/accountLifecycle.ts
+++ b/e2e/utils/accountLifecycle.ts
@@ -250,10 +250,21 @@ async function submitCreateTokenForm(params: {
 }
 
 async function closeOneTimeKeyDialogIfPresent(page: Page) {
-  await page
-    .getByTestId(KEY_MANAGEMENT_TEST_IDS.oneTimeKeyCloseButton)
-    .click({ timeout: 5_000 })
-    .catch(() => undefined)
+  const closeButton = page.getByTestId(
+    KEY_MANAGEMENT_TEST_IDS.oneTimeKeyCloseButton,
+  )
+  const isVisible = await closeButton
+    .waitFor({ state: "visible", timeout: 5_000 })
+    .then(() => true)
+    .catch(() => false)
+
+  if (!isVisible) {
+    return false
+  }
+
+  await closeButton.click()
+  await expect(closeButton).toBeHidden({ timeout: 30_000 })
+  return true
 }
 
 async function closeAddTokenDialogIfPresent(page: Page) {
@@ -268,7 +279,12 @@ async function closeAddTokenDialogIfPresent(page: Page) {
 }
 
 async function closeTokenCreationDialogsIfPresent(page: Page) {
-  await closeOneTimeKeyDialogIfPresent(page)
+  const closedOneTimeKeyDialog = await closeOneTimeKeyDialogIfPresent(page)
+  if (closedOneTimeKeyDialog) {
+    await expect(
+      page.getByTestId(KEY_MANAGEMENT_TEST_IDS.addTokenDialog),
+    ).toBeHidden({ timeout: 30_000 })
+  }
   await closeAddTokenDialogIfPresent(page)
 }
 

--- a/e2e/utils/scenarioErrors.ts
+++ b/e2e/utils/scenarioErrors.ts
@@ -1,0 +1,7 @@
+export function formatScenarioError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { shouldShowOneTimeKeyDialogForCreatedToken } from "~/features/KeyManagement/utils"
 import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import { resolveSub2ApiQuickCreateResolution } from "~/services/accounts/accountOperations"
 import {
@@ -203,7 +204,11 @@ export function useCopyKeyDialog(
       setCreateError(null)
 
       try {
-        if (createdToken) {
+        const shouldShowOneTimeKeyDialog =
+          !!createdToken &&
+          shouldShowOneTimeKeyDialogForCreatedToken(account, createdToken)
+
+        if (createdToken && shouldShowOneTimeKeyDialog) {
           setTokens((currentTokens) => {
             const withoutCreated = currentTokens.filter(
               (token) => token.id !== createdToken.id,

--- a/src/features/KeyManagement/components/AddTokenDialog/index.tsx
+++ b/src/features/KeyManagement/components/AddTokenDialog/index.tsx
@@ -22,6 +22,7 @@ import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
 import { KEY_MANAGEMENT_TEST_IDS } from "../../testIds"
+import { shouldShowOneTimeKeyDialogForCreatedToken } from "../../utils"
 import { buildOneTimeApiKeyProfileSaveAction } from "../../utils/apiCredentialProfileSaveAction"
 import { OneTimeApiKeyDialog } from "../OneTimeApiKeyDialog"
 import { DialogHeader } from "./DialogHeader"
@@ -193,8 +194,15 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
               currentAccount.siteType,
             )
           : undefined
+        const shouldShowOneTimeKeyDialog =
+          !!createdToken &&
+          showOneTimeKeyDialog &&
+          shouldShowOneTimeKeyDialogForCreatedToken(
+            currentAccount,
+            createdToken,
+          )
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
-        if (createdToken && showOneTimeKeyDialog) {
+        if (shouldShowOneTimeKeyDialog) {
           setOneTimeToken(displayCreatedToken ?? createdToken)
         } else {
           toast.success(t("dialog.createSuccess"))
@@ -207,7 +215,7 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
           }
         }
 
-        if (createdToken && showOneTimeKeyDialog) {
+        if (shouldShowOneTimeKeyDialog) {
           return
         }
       }

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -1413,6 +1413,30 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
     })
   }
 
+  const removeTokenFromInventory = (
+    token: Pick<AccountToken, "accountId" | "id">,
+  ) => {
+    setTokenInventories((prev) => {
+      const inventory = prev[token.accountId]
+      if (!inventory) {
+        return prev
+      }
+
+      const nextTokens = inventory.tokens.filter((item) => item.id !== token.id)
+      if (nextTokens.length === inventory.tokens.length) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        [token.accountId]: {
+          ...inventory,
+          tokens: nextTokens,
+        },
+      }
+    })
+  }
+
   const handleAddToken = () => {
     setIsAddTokenOpen(true)
   }
@@ -1452,6 +1476,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
       const { service, request } = createDisplayAccountApiContext(account)
       await service.deleteApiToken(request, token.id)
       clearTokenVisibilityState(token)
+      removeTokenFromInventory(token)
       invalidateManagedSiteStatusForToken(token)
       toast.success(
         t("keyManagement:messages.deleteSuccess", { name: token.name }),

--- a/src/features/KeyManagement/utils.ts
+++ b/src/features/KeyManagement/utils.ts
@@ -1,5 +1,11 @@
 // 格式化密钥显示
+import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
+import {
+  hasUsableApiTokenKey,
+  isMaskedApiTokenKey,
+} from "~/services/apiService/common/apiKey"
+import type { DisplaySiteData } from "~/types"
 import { t } from "~/utils/i18n/core"
 
 // 构建 token 在 UI 中的唯一标识 (accountId + tokenId)，避免跨账号 tokenId 冲突
@@ -27,3 +33,27 @@ export const formatQuota = (quota: number, unlimited: boolean) => {
   if (unlimited || quota < 0) return t("keyManagement:dialog.unlimitedQuota")
   return `$${(quota / UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR).toFixed(2)}`
 }
+
+/**
+ * AIHubMix may only expose the full API key secret in create responses; later
+ * list/detail reads can be masked.
+ *
+ * Sources:
+ * - https://docs.aihubmix.com/en/api/CliEndpoints/create-key
+ * - https://github.com/Wei-Shaw/sub2api
+ *
+ * Sub2API also returns key DTOs from `/api/v1/keys`, but upstream exposes
+ * list/get/create routes with the key value directly, so a create DTO is not a
+ * one-time-only secret by itself.
+ */
+export const shouldShowOneTimeKeyDialogForAccount = (
+  account: Pick<DisplaySiteData, "siteType">,
+) => account.siteType === SITE_TYPES.AIHUBMIX
+
+export const shouldShowOneTimeKeyDialogForCreatedToken = (
+  account: Pick<DisplaySiteData, "siteType">,
+  token: { key: string },
+) =>
+  shouldShowOneTimeKeyDialogForAccount(account) &&
+  hasUsableApiTokenKey(token.key) &&
+  !isMaskedApiTokenKey(token.key)

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { shouldShowOneTimeKeyDialogForCreatedToken } from "~/features/KeyManagement/utils"
 import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
   canManageDisplayAccountTokens,
@@ -227,7 +228,11 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
       setIsLoading(true)
 
       try {
-        if (createdToken) {
+        const shouldShowOneTimeKeyDialog =
+          !!createdToken &&
+          shouldShowOneTimeKeyDialogForCreatedToken(account, createdToken)
+
+        if (createdToken && shouldShowOneTimeKeyDialog) {
           setTokens((currentTokens) => {
             const withoutCreated = currentTokens.filter(
               (token) => token.id !== createdToken.id,

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -1315,7 +1315,10 @@ export async function fetchTokenById(
  *
  * Source: https://github.com/Wei-Shaw/sub2api
  * User key routes live under `/api/v1/keys`; upstream exposes list/get/create
- * DTOs with `key` directly and does not define a separate reveal endpoint.
+ * DTOs with a full `key` directly and does not define a separate reveal
+ * endpoint. The detail fallback below is defensive for forks or unexpected
+ * cached/masked inventory data; it must stay inside Sub2API routes instead of
+ * falling through to One/New API's `/api/token/{id}/key` contract.
  */
 export async function resolveApiTokenKey(
   request: ApiServiceRequest,

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -12,7 +12,9 @@ import {
   determineHealthStatus,
   extractDefaultExchangeRate as extractCommonDefaultExchangeRate,
 } from "~/services/apiService/common"
+import { hasUsableApiTokenKey } from "~/services/apiService/common/apiKey"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
+import { resolveApiTokenKeyWithFetcher } from "~/services/apiService/common/tokenKeyResolver"
 import type {
   AccessTokenInfo,
   AccountData,
@@ -1308,6 +1310,32 @@ export async function fetchTokenById(
 }
 
 /**
+ * Resolve a Sub2API key secret without falling back to One/New API-compatible
+ * `/api/token/{id}/key` semantics.
+ *
+ * Source: https://github.com/Wei-Shaw/sub2api
+ * User key routes live under `/api/v1/keys`; upstream exposes list/get/create
+ * DTOs with `key` directly and does not define a separate reveal endpoint.
+ */
+export async function resolveApiTokenKey(
+  request: ApiServiceRequest,
+  token: Pick<ApiToken, "id" | "key">,
+): Promise<string> {
+  return await resolveApiTokenKeyWithFetcher(
+    request,
+    token,
+    async (detailRequest, tokenId) => {
+      const detail = await fetchTokenById(detailRequest, tokenId)
+      if (!hasUsableApiTokenKey(detail.key)) {
+        throw new Error("token_secret_key_unresolvable")
+      }
+
+      return detail.key
+    },
+  )
+}
+
+/**
  * Fetch the list of user groups available in Sub2API and their associated rates, then build a mapping of group name to `UserGroupInfo` for use in the extension.
  */
 export async function fetchUserGroups(
@@ -1352,12 +1380,24 @@ export async function createApiToken(
     const groupId = await resolveSelectedGroupId(request, tokenData.group)
     const payload = translateSub2ApiCreateTokenRequest(tokenData, groupId)
 
-    await fetchSub2ApiData<unknown>(request, SUB2API_KEYS_ENDPOINT, {
-      method: "POST",
-      body: JSON.stringify(payload),
-    })
+    const created = await fetchSub2ApiData<Sub2ApiKeyData | undefined>(
+      request,
+      SUB2API_KEYS_ENDPOINT,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
+      { allowMissingData: true },
+    )
 
-    return true
+    if (!created || typeof created !== "object" || !("id" in created)) {
+      return true
+    }
+
+    return parseSub2ApiKey(created, {
+      defaultUserId: request.auth?.userId,
+      endpoint: SUB2API_KEYS_ENDPOINT,
+    })
   } catch (error) {
     logger.error("Failed to create Sub2API key", {
       accountId: request.accountId,

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -1383,22 +1383,23 @@ export async function createApiToken(
     const groupId = await resolveSelectedGroupId(request, tokenData.group)
     const payload = translateSub2ApiCreateTokenRequest(tokenData, groupId)
 
-    const created = await fetchSub2ApiData<Sub2ApiKeyData | undefined>(
-      request,
-      SUB2API_KEYS_ENDPOINT,
-      {
-        method: "POST",
-        body: JSON.stringify(payload),
-      },
-      { allowMissingData: true },
-    )
+    const { data: created, request: hydratedRequest } =
+      await fetchSub2ApiDataWithRequest<Sub2ApiKeyData | undefined>(
+        request,
+        SUB2API_KEYS_ENDPOINT,
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+        },
+        { allowMissingData: true },
+      )
 
     if (!created || typeof created !== "object" || !("id" in created)) {
       return true
     }
 
     return parseSub2ApiKey(created, {
-      defaultUserId: request.auth?.userId,
+      defaultUserId: hydratedRequest.auth?.userId,
       endpoint: SUB2API_KEYS_ENDPOINT,
     })
   } catch (error) {

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -91,6 +91,14 @@ const ACCOUNT = {
   tagIds: ["tag-a"],
 } as any
 
+const AIHUBMIX_ACCOUNT = {
+  ...ACCOUNT,
+  id: "aihubmix-1",
+  name: "AIHubMix",
+  siteType: SITE_TYPES.AIHUBMIX,
+  baseUrl: "https://aihubmix.com",
+}
+
 describe("AddTokenDialog prefill", () => {
   beforeEach(() => {
     createApiTokenMock.mockReset()
@@ -407,7 +415,7 @@ describe("AddTokenDialog prefill", () => {
     )
   })
 
-  it("shows a one-time key dialog when create returns a full token", async () => {
+  it("shows a one-time key dialog when AIHubMix create returns a full token", async () => {
     fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "default", ratio: 1 },
@@ -435,8 +443,8 @@ describe("AddTokenDialog prefill", () => {
       <AddTokenDialog
         isOpen={true}
         onClose={() => {}}
-        availableAccounts={[ACCOUNT]}
-        preSelectedAccountId={ACCOUNT.id}
+        availableAccounts={[AIHUBMIX_ACCOUNT]}
+        preSelectedAccountId={AIHUBMIX_ACCOUNT.id}
       />,
     )
 
@@ -462,7 +470,7 @@ describe("AddTokenDialog prefill", () => {
     })
   })
 
-  it("keeps the one-time key dialog open and shows a fallback when clipboard copy fails", async () => {
+  it("keeps the AIHubMix one-time key dialog open and shows a fallback when clipboard copy fails", async () => {
     fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "default", ratio: 1 },
@@ -490,8 +498,8 @@ describe("AddTokenDialog prefill", () => {
       <AddTokenDialog
         isOpen={true}
         onClose={() => {}}
-        availableAccounts={[ACCOUNT]}
-        preSelectedAccountId={ACCOUNT.id}
+        availableAccounts={[AIHUBMIX_ACCOUNT]}
+        preSelectedAccountId={AIHUBMIX_ACCOUNT.id}
       />,
     )
 
@@ -517,7 +525,7 @@ describe("AddTokenDialog prefill", () => {
     ).toHaveValue("sk-created-full-secret")
   })
 
-  it("saves a created one-time key to an API credential profile without closing the dialog", async () => {
+  it("saves a created AIHubMix one-time key to an API credential profile without closing the dialog", async () => {
     fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "default", ratio: 1 },
@@ -537,11 +545,11 @@ describe("AddTokenDialog prefill", () => {
     })
     createApiCredentialProfileMock.mockResolvedValueOnce({
       id: "profile-1",
-      name: "Example - My Key",
+      name: "AIHubMix - My Key",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
-      baseUrl: ACCOUNT.baseUrl,
+      baseUrl: AIHUBMIX_ACCOUNT.baseUrl,
       apiKey: "sk-created-full-secret",
-      tagIds: ACCOUNT.tagIds,
+      tagIds: AIHUBMIX_ACCOUNT.tagIds,
       notes: "",
       createdAt: 1,
       updatedAt: 1,
@@ -555,8 +563,8 @@ describe("AddTokenDialog prefill", () => {
       <AddTokenDialog
         isOpen={true}
         onClose={onClose}
-        availableAccounts={[ACCOUNT]}
-        preSelectedAccountId={ACCOUNT.id}
+        availableAccounts={[AIHUBMIX_ACCOUNT]}
+        preSelectedAccountId={AIHUBMIX_ACCOUNT.id}
       />,
     )
 
@@ -573,11 +581,11 @@ describe("AddTokenDialog prefill", () => {
 
     await waitFor(() => {
       expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
-        name: "Example - My Key",
+        name: "AIHubMix - My Key",
         apiType: API_TYPES.OPENAI_COMPATIBLE,
-        baseUrl: ACCOUNT.baseUrl,
+        baseUrl: AIHUBMIX_ACCOUNT.baseUrl,
         apiKey: "sk-created-full-secret",
-        tagIds: ACCOUNT.tagIds,
+        tagIds: AIHUBMIX_ACCOUNT.tagIds,
       })
     })
     expect(toastSuccessMock).toHaveBeenCalledWith(
@@ -609,8 +617,8 @@ describe("AddTokenDialog prefill", () => {
         isOpen={true}
         onClose={onClose}
         onSuccess={onSuccess}
-        availableAccounts={[ACCOUNT]}
-        preSelectedAccountId={ACCOUNT.id}
+        availableAccounts={[AIHUBMIX_ACCOUNT]}
+        preSelectedAccountId={AIHUBMIX_ACCOUNT.id}
       />,
     )
 
@@ -631,6 +639,61 @@ describe("AddTokenDialog prefill", () => {
       expect(onClose).toHaveBeenCalled()
     })
 
+    expect(
+      screen.queryByText("keyManagement:oneTimeKey.title"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("does not show a one-time key dialog for masked AIHubMix create responses", async () => {
+    fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { desc: "default", ratio: 1 },
+    })
+    const createdToken = {
+      id: 7,
+      user_id: 1,
+      key: "sk-aihub********masked",
+      status: 1,
+      name: "Masked AIHubMix Key",
+      created_time: 1,
+      accessed_time: 1,
+      expired_time: -1,
+      remain_quota: -1,
+      unlimited_quota: true,
+      used_quota: 0,
+    }
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+    const onClose = vi.fn()
+    const onSuccess = vi.fn()
+
+    const user = userEvent.setup()
+
+    render(
+      <AddTokenDialog
+        isOpen={true}
+        onClose={onClose}
+        onSuccess={onSuccess}
+        availableAccounts={[AIHUBMIX_ACCOUNT]}
+        preSelectedAccountId={AIHUBMIX_ACCOUNT.id}
+      />,
+    )
+
+    await user.type(
+      await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
+      "Masked AIHubMix Key",
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
+    )
+
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        "keyManagement:dialog.createSuccess",
+      )
+      expect(onSuccess).toHaveBeenCalledWith(createdToken)
+      expect(onClose).toHaveBeenCalled()
+    })
     expect(
       screen.queryByText("keyManagement:oneTimeKey.title"),
     ).not.toBeInTheDocument()
@@ -688,6 +751,65 @@ describe("AddTokenDialog prefill", () => {
       expect(onClose).toHaveBeenCalled()
     })
 
+    expect(
+      screen.queryByText("keyManagement:oneTimeKey.title"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("does not show a one-time key dialog for Sub2API create responses", async () => {
+    fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { desc: "default", ratio: 1 },
+    })
+    const createdToken = {
+      id: 8,
+      user_id: 1,
+      key: "sk-sub2api-created-full-secret",
+      status: 1,
+      name: "Sub2API Key",
+      created_time: 1,
+      accessed_time: 1,
+      expired_time: -1,
+      remain_quota: -1,
+      unlimited_quota: true,
+      used_quota: 0,
+    }
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+    const onClose = vi.fn()
+    const onSuccess = vi.fn()
+    const sub2ApiAccount = {
+      ...ACCOUNT,
+      siteType: SITE_TYPES.SUB2API,
+    }
+
+    const user = userEvent.setup()
+
+    render(
+      <AddTokenDialog
+        isOpen={true}
+        onClose={onClose}
+        onSuccess={onSuccess}
+        availableAccounts={[sub2ApiAccount]}
+        preSelectedAccountId={sub2ApiAccount.id}
+      />,
+    )
+
+    await user.type(
+      await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
+      "Sub2API Key",
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
+    )
+
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        "keyManagement:dialog.createSuccess",
+      )
+      expect(onSuccess).toHaveBeenCalledWith(createdToken)
+      expect(onClose).toHaveBeenCalledOnce()
+    })
     expect(
       screen.queryByText("keyManagement:oneTimeKey.title"),
     ).not.toBeInTheDocument()
@@ -888,7 +1010,7 @@ describe("AddTokenDialog prefill", () => {
     })
   })
 
-  it("closes through the one-time key dialog acknowledgement", async () => {
+  it("closes through the AIHubMix one-time key dialog acknowledgement", async () => {
     fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "default", ratio: 1 },
@@ -915,8 +1037,8 @@ describe("AddTokenDialog prefill", () => {
       <AddTokenDialog
         isOpen={true}
         onClose={onClose}
-        availableAccounts={[ACCOUNT]}
-        preSelectedAccountId={ACCOUNT.id}
+        availableAccounts={[AIHUBMIX_ACCOUNT]}
+        preSelectedAccountId={AIHUBMIX_ACCOUNT.id}
       />,
     )
 
@@ -995,20 +1117,12 @@ describe("AddTokenDialog prefill", () => {
     createApiTokenMock.mockResolvedValueOnce(true)
 
     const user = userEvent.setup()
-    const aihubmixAccount = {
-      ...ACCOUNT,
-      id: "aihubmix-1",
-      name: "AIHubMix",
-      siteType: SITE_TYPES.AIHUBMIX,
-      baseUrl: "https://aihubmix.com",
-    }
-
     render(
       <AddTokenDialog
         isOpen={true}
         onClose={() => {}}
-        availableAccounts={[aihubmixAccount]}
-        preSelectedAccountId={aihubmixAccount.id}
+        availableAccounts={[AIHUBMIX_ACCOUNT]}
+        preSelectedAccountId={AIHUBMIX_ACCOUNT.id}
       />,
     )
 

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -3082,6 +3082,109 @@ describe("useKeyManagement enabled account filtering", () => {
     confirmSpy.mockRestore()
   })
 
+  it("deletes a token when the account inventory has not been loaded", async () => {
+    const account = createDisplayAccount({
+      id: "delete-empty-inventory-acc",
+      name: "Delete Empty Inventory Account",
+    })
+    const token = createToken({
+      id: 910,
+      key: "token-910",
+      name: "Delete Empty Inventory Token",
+      accountId: account.id,
+      accountName: account.name,
+      expired_time: 0,
+    })
+
+    vi.mocked(useAccountData).mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+
+    const fetchAccountTokens = vi.fn().mockResolvedValue([])
+    const deleteApiToken = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getApiService).mockReturnValue({
+      fetchAccountTokens,
+      deleteApiToken,
+    } as any)
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.handleDeleteToken(token)
+    })
+
+    expect(deleteApiToken).toHaveBeenCalledWith(expect.anything(), token.id)
+    expect(result.current.tokenInventories[account.id]).toBeUndefined()
+    expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
+      "keyManagement:messages.deleteSuccess",
+    )
+  })
+
+  it("keeps stale inventory unchanged when deleting a token missing from it", async () => {
+    const account = createDisplayAccount({
+      id: "delete-stale-inventory-acc",
+      name: "Delete Stale Inventory Account",
+    })
+    const loadedToken = createToken({
+      id: 911,
+      key: "token-911",
+      name: "Loaded Token",
+      accountId: account.id,
+      accountName: account.name,
+      expired_time: 0,
+    })
+    const staleToken = createToken({
+      id: 912,
+      key: "token-912",
+      name: "Stale Token",
+      accountId: account.id,
+      accountName: account.name,
+      expired_time: 0,
+    })
+
+    vi.mocked(useAccountData).mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+
+    const fetchAccountTokens = vi.fn().mockResolvedValue([loadedToken])
+    const deleteApiToken = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getApiService).mockReturnValue({
+      fetchAccountTokens,
+      deleteApiToken,
+    } as any)
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount(account.id)
+    })
+
+    await waitFor(() =>
+      expect(result.current.tokenInventories[account.id]?.tokens).toEqual([
+        loadedToken,
+      ]),
+    )
+
+    await act(async () => {
+      await result.current.handleDeleteToken(staleToken)
+    })
+
+    expect(deleteApiToken).toHaveBeenCalledWith(
+      expect.anything(),
+      staleToken.id,
+    )
+    expect(result.current.tokenInventories[account.id]?.tokens).toEqual([
+      loadedToken,
+    ])
+    expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
+      "keyManagement:messages.deleteSuccess",
+    )
+  })
+
   it("shows the delete error when token deletion fails", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
     const account = createDisplayAccount({

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -3204,6 +3204,61 @@ describe("useKeyManagement enabled account filtering", () => {
     confirmSpy.mockRestore()
   })
 
+  it("removes a deleted token from local inventory before the refresh finishes", async () => {
+    const account = createDisplayAccount({
+      id: "delete-optimistic-acc",
+      name: "Delete Optimistic Account",
+    })
+    const token = createToken({
+      id: 911,
+      key: "sk-delete-optimistic",
+      name: "Delete Optimistic Token",
+      accountId: account.id,
+      accountName: account.name,
+      expired_time: 0,
+    })
+
+    vi.mocked(useAccountData).mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+
+    let resolveRefresh: (tokens: (typeof token)[]) => void = () => {}
+    const fetchAccountTokens = vi
+      .fn()
+      .mockResolvedValueOnce([token])
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve
+          }),
+      )
+    const deleteApiToken = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getApiService).mockReturnValue({
+      fetchAccountTokens,
+      deleteApiToken,
+    } as any)
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount(account.id)
+    })
+
+    await waitFor(() => expect(result.current.tokens).toHaveLength(1))
+
+    await act(async () => {
+      await result.current.handleDeleteToken(token)
+    })
+
+    expect(result.current.tokens).toEqual([])
+
+    await act(async () => {
+      resolveRefresh([])
+    })
+  })
+
   it("does not show delete failure feedback when analytics completion rejects after a successful delete", async () => {
     const account = createDisplayAccount({
       id: "delete-analytics-fail-acc",

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
@@ -78,4 +78,42 @@ describe("ModelKeyDialog sub2api support", () => {
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
     })
   })
+
+  it("refreshes inventory instead of showing one-time UI when Sub2API create returns a token DTO", async () => {
+    fetchAccountTokensMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([TOKEN])
+    createApiTokenMock.mockResolvedValueOnce({
+      ...TOKEN,
+      id: 9,
+      key: "sk-sub2api-created-full-secret",
+      name: "sub2api-created",
+    })
+
+    const user = userEvent.setup()
+
+    render(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={ACCOUNT}
+        modelId="gpt-4"
+        modelEnableGroups={["default"]}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "modelList:keyDialog.createKey",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(createApiTokenMock).toHaveBeenCalledTimes(1)
+      expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
+    })
+    expect(
+      screen.queryByText("keyManagement:oneTimeKey.title"),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import ModelKeyDialog from "~/features/ModelList/components/ModelKeyDialog"
 import {
@@ -109,7 +110,7 @@ const AIHUBMIX_ACCOUNT = {
   ...ACCOUNT,
   id: "aihubmix-1",
   name: "AIHubMix",
-  siteType: "AIHubMix",
+  siteType: SITE_TYPES.AIHUBMIX,
   baseUrl: "https://aihubmix.com",
 }
 

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -105,6 +105,14 @@ const ACCOUNT = {
   tagIds: ["tag-a"],
 } as any
 
+const AIHUBMIX_ACCOUNT = {
+  ...ACCOUNT,
+  id: "aihubmix-1",
+  name: "AIHubMix",
+  siteType: "AIHubMix",
+  baseUrl: "https://aihubmix.com",
+}
+
 const TOKEN = {
   id: 1,
   user_id: 1,
@@ -280,7 +288,7 @@ describe("ModelKeyDialog", () => {
     ).toBeInTheDocument()
   })
 
-  it("shows a one-time key dialog when default create returns a full token", async () => {
+  it("shows a one-time key dialog when AIHubMix default create returns a full token", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     createApiTokenMock.mockResolvedValueOnce({
       ...TOKEN,
@@ -298,7 +306,7 @@ describe("ModelKeyDialog", () => {
       <ModelKeyDialog
         isOpen={true}
         onClose={() => {}}
-        account={ACCOUNT}
+        account={AIHUBMIX_ACCOUNT}
         modelId="gpt-4"
         modelEnableGroups={["default"]}
       />,
@@ -338,7 +346,7 @@ describe("ModelKeyDialog", () => {
     )
   })
 
-  it("saves a default-created one-time key to an API credential profile without closing the dialog", async () => {
+  it("saves an AIHubMix default-created one-time key to an API credential profile without closing the dialog", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     createApiTokenMock.mockResolvedValueOnce({
       ...TOKEN,
@@ -348,11 +356,11 @@ describe("ModelKeyDialog", () => {
     })
     createApiCredentialProfileMock.mockResolvedValueOnce({
       id: "profile-1",
-      name: "Example - model-key",
+      name: "AIHubMix - model-key",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
-      baseUrl: ACCOUNT.baseUrl,
+      baseUrl: AIHUBMIX_ACCOUNT.baseUrl,
       apiKey: "sk-created-full-secret",
-      tagIds: ACCOUNT.tagIds,
+      tagIds: AIHUBMIX_ACCOUNT.tagIds,
       notes: "",
       createdAt: 1,
       updatedAt: 1,
@@ -366,7 +374,7 @@ describe("ModelKeyDialog", () => {
       <ModelKeyDialog
         isOpen={true}
         onClose={onClose}
-        account={ACCOUNT}
+        account={AIHUBMIX_ACCOUNT}
         modelId="gpt-4"
         modelEnableGroups={["default"]}
       />,
@@ -383,11 +391,11 @@ describe("ModelKeyDialog", () => {
 
     await waitFor(() => {
       expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
-        name: "Example - model-key",
+        name: "AIHubMix - model-key",
         apiType: API_TYPES.OPENAI_COMPATIBLE,
-        baseUrl: ACCOUNT.baseUrl,
+        baseUrl: AIHUBMIX_ACCOUNT.baseUrl,
         apiKey: "sk-created-full-secret",
-        tagIds: ACCOUNT.tagIds,
+        tagIds: AIHUBMIX_ACCOUNT.tagIds,
       })
     })
     expect(toastSuccessMock).toHaveBeenCalledWith(
@@ -399,7 +407,7 @@ describe("ModelKeyDialog", () => {
     ).toHaveValue("sk-created-full-secret")
   })
 
-  it("formats optional-prefix compatible created keys before showing the one-time dialog", async () => {
+  it("keeps AIHubMix created keys unchanged before showing the one-time dialog", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     createApiTokenMock.mockResolvedValueOnce({
       ...TOKEN,
@@ -417,7 +425,7 @@ describe("ModelKeyDialog", () => {
       <ModelKeyDialog
         isOpen={true}
         onClose={() => {}}
-        account={{ ...ACCOUNT, siteType: "Veloera" }}
+        account={AIHUBMIX_ACCOUNT}
         modelId="gpt-4"
         modelEnableGroups={["default"]}
       />,
@@ -434,11 +442,60 @@ describe("ModelKeyDialog", () => {
     ).toBeInTheDocument()
     expect(
       screen.getByLabelText("keyManagement:oneTimeKey.keyLabel"),
-    ).toHaveValue("sk-created-full-secret")
+    ).toHaveValue("created-full-secret")
 
     await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith("sk-created-full-secret")
+      expect(writeText).toHaveBeenCalledWith("created-full-secret")
     })
+  })
+
+  it("refreshes instead of showing a one-time key when AIHubMix create returns a masked key", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        ...TOKEN,
+        id: 11,
+        key: "sk-refreshed-compatible",
+        name: "refreshed",
+      },
+    ])
+    createApiTokenMock.mockResolvedValueOnce({
+      ...TOKEN,
+      id: 8,
+      key: "sk-created********masked",
+      name: "masked-created-token",
+    })
+
+    const user = userEvent.setup()
+
+    render(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={AIHUBMIX_ACCOUNT}
+        modelId="gpt-4"
+        modelEnableGroups={["default"]}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "modelList:keyDialog.createKey",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
+    })
+
+    expect(
+      screen.queryByText("keyManagement:oneTimeKey.title"),
+    ).not.toBeInTheDocument()
+    expect(
+      await screen.findByRole("button", { name: "common:actions.copyKey" }),
+    ).toBeInTheDocument()
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Success,
+    )
   })
 
   it("shows a compatibility error when default create returns an incompatible full token", async () => {
@@ -460,7 +517,7 @@ describe("ModelKeyDialog", () => {
       <ModelKeyDialog
         isOpen={true}
         onClose={() => {}}
-        account={ACCOUNT}
+        account={AIHUBMIX_ACCOUNT}
         modelId="gpt-4"
         modelEnableGroups={["default"]}
       />,
@@ -509,7 +566,7 @@ describe("ModelKeyDialog", () => {
       <ModelKeyDialog
         isOpen={true}
         onClose={() => {}}
-        account={ACCOUNT}
+        account={AIHUBMIX_ACCOUNT}
         modelId="gpt-4"
         modelEnableGroups={["default"]}
       />,

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -86,6 +86,39 @@ describe("CopyKeyDialog sub2api support", () => {
     })
   })
 
+  it("refreshes inventory instead of showing one-time UI when Sub2API create returns a token DTO", async () => {
+    fetchAccountTokensMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([TOKEN])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      vip: { desc: "VIP", ratio: 2 },
+    })
+    createApiTokenMock.mockResolvedValueOnce({
+      ...TOKEN,
+      id: 9,
+      key: "sk-sub2api-created-full-secret",
+      name: "sub2api-created",
+    })
+
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.copyKey.createKey",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
+      expect(createApiTokenMock).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      screen.queryByText("keyManagement:oneTimeKey.title"),
+    ).not.toBeInTheDocument()
+  })
+
   it("requires explicit group selection when multiple Sub2API groups exist", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     fetchUserGroupsMock

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
@@ -110,7 +111,7 @@ const AIHUBMIX_ACCOUNT = {
   ...ACCOUNT,
   id: "aihubmix-1",
   name: "AIHubMix",
-  siteType: "AIHubMix",
+  siteType: SITE_TYPES.AIHUBMIX,
   baseUrl: "https://aihubmix.com",
 }
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -106,6 +106,14 @@ const ACCOUNT = {
   tagIds: ["tag-a"],
 } as any
 
+const AIHUBMIX_ACCOUNT = {
+  ...ACCOUNT,
+  id: "aihubmix-1",
+  name: "AIHubMix",
+  siteType: "AIHubMix",
+  baseUrl: "https://aihubmix.com",
+}
+
 const TOKEN = {
   id: 1,
   user_id: 1,
@@ -172,7 +180,7 @@ describe("CopyKeyDialog", () => {
     })
   })
 
-  it("shows a one-time key dialog when create returns a full token", async () => {
+  it("shows a one-time key dialog when AIHubMix create returns a full token", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     createApiTokenMock.mockResolvedValueOnce({
       ...TOKEN,
@@ -186,7 +194,13 @@ describe("CopyKeyDialog", () => {
       .spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined)
 
-    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={AIHUBMIX_ACCOUNT}
+      />,
+    )
 
     await user.click(
       await screen.findByRole("button", {
@@ -207,7 +221,7 @@ describe("CopyKeyDialog", () => {
     })
   })
 
-  it("shows the created one-time token without refetching inventory", async () => {
+  it("shows the AIHubMix created one-time token without refetching inventory", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     createApiTokenMock.mockResolvedValueOnce({
       ...TOKEN,
@@ -220,7 +234,13 @@ describe("CopyKeyDialog", () => {
       .spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined)
 
-    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={AIHUBMIX_ACCOUNT}
+      />,
+    )
 
     await user.click(
       await screen.findByRole("button", {
@@ -239,6 +259,45 @@ describe("CopyKeyDialog", () => {
     })
   })
 
+  it("refreshes instead of showing a one-time key when AIHubMix create returns a masked key", async () => {
+    fetchAccountTokensMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([TOKEN])
+    createApiTokenMock.mockResolvedValueOnce({
+      ...TOKEN,
+      id: 9,
+      key: "sk-created********masked",
+      name: "aihubmix-masked",
+    })
+
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={AIHUBMIX_ACCOUNT}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.copyKey.createKey",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
+      expect(writeText).toHaveBeenCalledWith("sk-test")
+    })
+    expect(
+      screen.queryByText("keyManagement:oneTimeKey.title"),
+    ).not.toBeInTheDocument()
+  })
+
   it("refreshes instead of showing a one-time key when create returns a token-shaped object with an invalid secret", async () => {
     fetchAccountTokensMock
       .mockResolvedValueOnce([])
@@ -255,7 +314,13 @@ describe("CopyKeyDialog", () => {
       .spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined)
 
-    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={AIHUBMIX_ACCOUNT}
+      />,
+    )
 
     await user.click(
       await screen.findByRole("button", {
@@ -702,7 +767,7 @@ describe("CopyKeyDialog", () => {
     })
   })
 
-  it("shows one-time key dialog for custom AddTokenDialog create returns", async () => {
+  it("shows one-time key dialog for custom AIHubMix AddTokenDialog create returns", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({
@@ -720,7 +785,13 @@ describe("CopyKeyDialog", () => {
       .spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined)
 
-    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={AIHUBMIX_ACCOUNT}
+      />,
+    )
 
     await user.click(
       await screen.findByRole("button", {
@@ -748,7 +819,7 @@ describe("CopyKeyDialog", () => {
     })
   })
 
-  it("saves a custom one-time key to an API credential profile without closing the dialog", async () => {
+  it("saves a custom AIHubMix one-time key to an API credential profile without closing the dialog", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({
@@ -762,11 +833,11 @@ describe("CopyKeyDialog", () => {
     })
     createApiCredentialProfileMock.mockResolvedValueOnce({
       id: "profile-1",
-      name: "Example - My Key",
+      name: "AIHubMix - My Key",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
-      baseUrl: ACCOUNT.baseUrl,
+      baseUrl: AIHUBMIX_ACCOUNT.baseUrl,
       apiKey: "sk-custom-full-secret",
-      tagIds: ACCOUNT.tagIds,
+      tagIds: AIHUBMIX_ACCOUNT.tagIds,
       notes: "",
       createdAt: 1,
       updatedAt: 1,
@@ -776,7 +847,13 @@ describe("CopyKeyDialog", () => {
     const user = userEvent.setup()
     vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
 
-    render(<CopyKeyDialog isOpen={true} onClose={onClose} account={ACCOUNT} />)
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={onClose}
+        account={AIHUBMIX_ACCOUNT}
+      />,
+    )
 
     await user.click(
       await screen.findByRole("button", {
@@ -796,11 +873,11 @@ describe("CopyKeyDialog", () => {
 
     await waitFor(() => {
       expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
-        name: "Example - My Key",
+        name: "AIHubMix - My Key",
         apiType: API_TYPES.OPENAI_COMPATIBLE,
-        baseUrl: ACCOUNT.baseUrl,
+        baseUrl: AIHUBMIX_ACCOUNT.baseUrl,
         apiKey: "sk-custom-full-secret",
-        tagIds: ACCOUNT.tagIds,
+        tagIds: AIHUBMIX_ACCOUNT.tagIds,
       })
     })
     expect(toastSuccessMock).toHaveBeenCalledWith(

--- a/tests/features/KeyManagement/utils.test.ts
+++ b/tests/features/KeyManagement/utils.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
 import {
   buildTokenIdentityKey,
   formatKey,
   formatQuota,
+  shouldShowOneTimeKeyDialogForAccount,
+  shouldShowOneTimeKeyDialogForCreatedToken,
 } from "~/features/KeyManagement/utils"
 
 const { tMock } = vi.hoisted(() => ({
@@ -71,6 +74,53 @@ describe("KeyManagement utils", () => {
       const quota = UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR * 1.25
 
       expect(formatQuota(quota, false)).toBe("$1.25")
+    })
+  })
+
+  describe("shouldShowOneTimeKeyDialogForAccount", () => {
+    it("shows the one-time key dialog for AIHubMix create responses", () => {
+      expect(
+        shouldShowOneTimeKeyDialogForAccount({
+          siteType: SITE_TYPES.AIHUBMIX,
+        }),
+      ).toBe(true)
+    })
+
+    it("does not force a one-time key dialog for Sub2API create responses", () => {
+      expect(
+        shouldShowOneTimeKeyDialogForAccount({
+          siteType: SITE_TYPES.SUB2API,
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe("shouldShowOneTimeKeyDialogForCreatedToken", () => {
+    it("requires an AIHubMix account and a usable unmasked secret", () => {
+      expect(
+        shouldShowOneTimeKeyDialogForCreatedToken(
+          { siteType: SITE_TYPES.AIHUBMIX },
+          { key: "sk-aihubmix-full-secret" },
+        ),
+      ).toBe(true)
+    })
+
+    it("does not show the dialog for masked AIHubMix created keys", () => {
+      expect(
+        shouldShowOneTimeKeyDialogForCreatedToken(
+          { siteType: SITE_TYPES.AIHUBMIX },
+          { key: "sk-aihub********masked" },
+        ),
+      ).toBe(false)
+    })
+
+    it("does not show the dialog for full Sub2API created keys", () => {
+      expect(
+        shouldShowOneTimeKeyDialogForCreatedToken(
+          { siteType: SITE_TYPES.SUB2API },
+          { key: "sk-sub2api-full-secret" },
+        ),
+      ).toBe(false)
     })
   })
 })

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -12,6 +12,7 @@ import {
   fetchAccountTokens,
   fetchTokenById,
   fetchUserGroups,
+  resolveApiTokenKey,
   updateApiToken,
 } from "~/services/apiService/sub2api"
 import {
@@ -190,6 +191,46 @@ describe("apiService sub2api key management service", () => {
     )
   })
 
+  it("resolves usable inventory keys without calling unsupported compatible reveal endpoints", async () => {
+    await expect(
+      resolveApiTokenKey(createRequest(), {
+        id: 1,
+        key: "sub2api-full-secret",
+      }),
+    ).resolves.toBe("sub2api-full-secret")
+
+    expect(fetchApiMock).not.toHaveBeenCalled()
+  })
+
+  it("tries the Sub2API key detail endpoint before rejecting masked inventory keys", async () => {
+    fetchApiMock.mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: {
+        id: 1,
+        user_id: 1,
+        key: "sk-still********masked",
+        name: "demo key",
+        status: "active",
+        quota: 1.5,
+        quota_used: 0,
+        created_at: "2026-03-06T00:00:00.000Z",
+        updated_at: "2026-03-06T00:00:00.000Z",
+        expires_at: null,
+      },
+    })
+
+    await expect(
+      resolveApiTokenKey(createRequest(), {
+        id: 1,
+        key: "sk-still********masked",
+      }),
+    ).rejects.toThrow("token_secret_key_unresolvable")
+
+    expect(fetchApiMock).toHaveBeenCalledTimes(1)
+    expect(fetchApiMock.mock.calls[0]?.[1]?.endpoint).toBe("/api/v1/keys/1")
+  })
+
   it("resolves the current group and strips unsupported fields on create", async () => {
     const now = Date.UTC(2026, 2, 6, 0, 0, 0)
     vi.spyOn(Date, "now").mockReturnValue(now)
@@ -223,8 +264,14 @@ describe("apiService sub2api key management service", () => {
       expired_time: Math.floor((now + 36 * 60 * 60 * 1000) / 1000),
     })
 
-    await expect(createApiToken(createRequest(), tokenRequest)).resolves.toBe(
-      true,
+    await expect(
+      createApiToken(createRequest(), tokenRequest),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: 1,
+        key: "new-key",
+        name: "demo key",
+      }),
     )
 
     const postCall = fetchApiMock.mock.calls[1]

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -285,6 +285,58 @@ describe("apiService sub2api key management service", () => {
     })
   })
 
+  it("uses hydrated auth user id when create returns a key DTO without user_id", async () => {
+    getAccountByIdMock.mockResolvedValue({
+      account_info: {
+        id: "42",
+        access_token: "stored-jwt",
+      },
+    })
+    fetchApiMock
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: [{ id: 9, name: "vip", description: "VIP plan" }],
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: {
+          id: 1,
+          key: "new-key",
+          name: "demo key",
+          status: "active",
+          quota: 1.5,
+          quota_used: 0,
+          created_at: "2026-03-06T00:00:00.000Z",
+          updated_at: "2026-03-06T00:00:00.000Z",
+          expires_at: null,
+          group: { id: 9, name: "vip" },
+        },
+      })
+
+    await expect(
+      createApiToken(
+        createRequest({
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            accessToken: "stale-jwt",
+          },
+        }),
+        createTokenRequest(),
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: 1,
+        user_id: 42,
+        key: "new-key",
+      }),
+    )
+    expect((fetchApiMock.mock.calls[1]?.[0] as any)?.auth?.accessToken).toBe(
+      "stored-jwt",
+    )
+  })
+
   it("preserves consumed quota when translating shared edit payloads", async () => {
     const editedRemainQuota = 1500000
     const preservedConsumedQuotaUsd = 0.5

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -231,6 +231,35 @@ describe("apiService sub2api key management service", () => {
     expect(fetchApiMock.mock.calls[0]?.[1]?.endpoint).toBe("/api/v1/keys/1")
   })
 
+  it("resolves masked inventory keys from the Sub2API key detail endpoint", async () => {
+    fetchApiMock.mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: {
+        id: 1,
+        user_id: 1,
+        key: "sub2api-detail-full-secret",
+        name: "demo key",
+        status: "active",
+        quota: 1.5,
+        quota_used: 0,
+        created_at: "2026-03-06T00:00:00.000Z",
+        updated_at: "2026-03-06T00:00:00.000Z",
+        expires_at: null,
+      },
+    })
+
+    await expect(
+      resolveApiTokenKey(createRequest(), {
+        id: 1,
+        key: "sk-still********masked",
+      }),
+    ).resolves.toBe("sub2api-detail-full-secret")
+
+    expect(fetchApiMock).toHaveBeenCalledTimes(1)
+    expect(fetchApiMock.mock.calls[0]?.[1]?.endpoint).toBe("/api/v1/keys/1")
+  })
+
   it("resolves the current group and strips unsupported fields on create", async () => {
     const now = Date.UTC(2026, 2, 6, 0, 0, 0)
     vi.spyOn(Date, "now").mockReturnValue(now)


### PR DESCRIPTION
## Summary
- resolve Sub2API API key secrets through the Sub2API adapter routes instead of One/New API reveal semantics
- keep create-returned key DTOs as normal adapter results, while showing one-time secret UI only for AIHubMix responses that contain a usable unmasked full key
- stabilize Key Management create/delete lifecycle state so created keys reload and deleted keys leave local inventory immediately after successful deletion
- harden real-site E2E cleanup/error reporting around key creation, one-time dialogs, and cleanup failures

## Root Cause
Sub2API create started returning a token DTO. Upper-layer UI treated any token-shaped create response as a one-time secret, which pushed Sub2API into the one-time key dialog branch even though Sub2API keys remain retrievable through /api/v1/keys list/detail routes. That created an E2E/UI cleanup race around dialog overlays and stale key inventory.

## Validation
- pnpm exec vitest run tests/features/KeyManagement/utils.test.ts tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx tests/services/apiService/sub2api/keyManagement.test.ts tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
- pnpm run validate:staged
- pnpm run validate:push
- pnpm build:e2e
- AAH_SKIP_E2E_BUILD=1 pnpm exec playwright test e2e/realSite/sub2apiAccountAdd.spec.ts --project=chromium --reporter=list
- Real-Site E2E workflow 27196519204: success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context-aware one-time key dialog: shown only for supported account types and usable, unmasked secrets.
  * Sub2API token creation now refreshes inventory (does not surface one-time key UI).

* **Bug Fixes**
  * Optimistic token deletion removes tokens from the UI immediately after deletion.
  * Improved aggregation of scenario error messages for clearer diagnostics.

* **Tests**
  * Expanded coverage for AIHubMix/Sub2API flows and token/key resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->