### PR TITLE
refactor(api-service): expose site capabilities

### DIFF
--- a/docs/superpowers/plans/2026-06-10-api-service-capabilities.md
+++ b/docs/superpowers/plans/2026-06-10-api-service-capabilities.md
@@ -1,0 +1,679 @@
+# Api Service Capabilities Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-api-service-capabilities-design.md`
+
+**Goal:** Add a small capability declaration Module at the `apiService` Seam so callers can avoid unsupported Sub2API and AIHubMix flows before invoking missing Adapter functions.
+
+**Architecture:** Keep the existing strict missing-method throw as the final guard. Add capabilities beside the site Adapter registration in `src/services/apiService/index.ts`, expose them through `getApiService(site).capabilities`, then update the two known risky callers to check the capability Interface before invoking `fetchModelPricing` or `redeemCode`.
+
+**Tech Stack:** TypeScript, React Query, Vitest, Testing Library where existing hook tests require it.
+
+---
+
+## File Structure
+
+- Modify `src/services/apiService/index.ts`
+  - Owns the `apiService` Seam.
+  - Add `ApiServiceCapabilities`.
+  - Add default capabilities and per-site overrides in the existing registration area.
+  - Return `capabilities` on both `getApiService(site)` and the default exported wrapper object.
+  - Preserve `strictOverrideSites` behavior.
+
+- Modify `tests/services/apiService/index.test.ts`
+  - Verify default and site-specific capabilities.
+  - Verify strict missing-method throw still happens for Sub2API / AIHubMix.
+
+- Modify `src/features/ModelList/hooks/useModelData.ts`
+  - Check `getApiService(account.siteType).capabilities.modelPricing` before calling `fetchModelPricing`.
+  - For unsupported accounts, throw a local unsupported error so the existing query error state handles the skipped source.
+
+- Modify `tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx`
+  - Add or update a focused test proving Sub2API does not call `fetchModelPricing` when model pricing is unsupported.
+  - If existing mock setup is easier in `useModelData` tests, use the closest existing test file that already exercises the direct and all-accounts model-data hook paths.
+
+- Modify `src/services/redemption/redeemService.ts`
+  - Check `getApiService(account.site_type).capabilities.redeemCode` before calling `redeemCode`.
+  - Return a localized unsupported failure result instead of relying on `apiService.redeemCode is not implemented...`.
+
+- Modify `tests/services/redemption/redeemService.test.ts`
+  - Add tests for unsupported Sub2API and AIHubMix redemption.
+  - If this file does not exist, create it and mock `accountStorage` plus `getApiService`.
+
+- Modify locale files only if an existing suitable message key does not exist.
+  - Prefer reusing `redemptionAssist:messages.redeemFailed` if there is no current unsupported-copy key and this plan is intended to stay narrow.
+  - If adding a key, update the Chinese source and sibling locale files consistently, then run i18n extraction validation.
+
+## Design Details
+
+Add this Interface in `src/services/apiService/index.ts`:
+
+```ts
+export type ApiServiceCapabilities = {
+  keyManagement: boolean
+  modelPricing: boolean
+  redeemCode: boolean
+  siteAnnouncements: boolean
+}
+```
+
+Start with this default:
+
+```ts
+const defaultApiServiceCapabilities: ApiServiceCapabilities = {
+  keyManagement: true,
+  modelPricing: true,
+  redeemCode: true,
+  siteAnnouncements: true,
+}
+```
+
+Use an override helper:
+
+```ts
+type ApiServiceCapabilityOverrides = Partial<ApiServiceCapabilities>
+
+const withCapabilities = (
+  overrides: ApiServiceCapabilityOverrides = {},
+): ApiServiceCapabilities => ({
+  ...defaultApiServiceCapabilities,
+  ...overrides,
+})
+```
+
+Site-specific first slice:
+
+```ts
+const siteCapabilityOverrides: Partial<
+  Record<ApiOverrideSite, ApiServiceCapabilityOverrides>
+> = {
+  [SITE_TYPES.SUB2API]: {
+    modelPricing: false,
+    redeemCode: false,
+  },
+  [SITE_TYPES.AIHUBMIX]: {
+    redeemCode: false,
+  },
+}
+```
+
+Do not move Sub2API announcement functions in this plan. `siteAnnouncements` is included so the Interface has the needed shape for the next cleanup, but this slice should not refactor announcement providers.
+
+## Task 1: Expose ApiService Capabilities
+
+**Files:**
+- Modify: `src/services/apiService/index.ts`
+- Test: `tests/services/apiService/index.test.ts`
+
+- [ ] **Step 1: Write failing capability tests**
+
+Add these tests near the existing strict override tests in `tests/services/apiService/index.test.ts`:
+
+```ts
+it("should expose default capabilities for common-compatible sites", () => {
+  expect(getApiService(undefined).capabilities).toEqual({
+    keyManagement: true,
+    modelPricing: true,
+    redeemCode: true,
+    siteAnnouncements: true,
+  })
+
+  expect(getApiService(SITE_TYPES.ONE_HUB).capabilities).toEqual({
+    keyManagement: true,
+    modelPricing: true,
+    redeemCode: true,
+    siteAnnouncements: true,
+  })
+})
+
+it("should expose Sub2API capability overrides", () => {
+  expect(getApiService(SITE_TYPES.SUB2API).capabilities).toEqual({
+    keyManagement: true,
+    modelPricing: false,
+    redeemCode: false,
+    siteAnnouncements: true,
+  })
+})
+
+it("should expose AIHubMix capability overrides", () => {
+  expect(getApiService(SITE_TYPES.AIHUBMIX).capabilities).toEqual({
+    keyManagement: true,
+    modelPricing: true,
+    redeemCode: false,
+    siteAnnouncements: true,
+  })
+})
+```
+
+- [ ] **Step 2: Run the failing apiService tests**
+
+Run:
+
+```bash
+pnpm vitest run tests/services/apiService/index.test.ts
+```
+
+Expected: FAIL because `capabilities` is undefined.
+
+- [ ] **Step 3: Add capabilities to the apiService Seam**
+
+In `src/services/apiService/index.ts`, add the capability type and helpers below `strictOverrideSites`:
+
+```ts
+export type ApiServiceCapabilities = {
+  keyManagement: boolean
+  modelPricing: boolean
+  redeemCode: boolean
+  siteAnnouncements: boolean
+}
+
+type ApiServiceCapabilityOverrides = Partial<ApiServiceCapabilities>
+
+const defaultApiServiceCapabilities: ApiServiceCapabilities = {
+  keyManagement: true,
+  modelPricing: true,
+  redeemCode: true,
+  siteAnnouncements: true,
+}
+
+const siteCapabilityOverrides: Partial<
+  Record<ApiOverrideSite, ApiServiceCapabilityOverrides>
+> = {
+  [SITE_TYPES.SUB2API]: {
+    modelPricing: false,
+    redeemCode: false,
+  },
+  [SITE_TYPES.AIHUBMIX]: {
+    redeemCode: false,
+  },
+}
+
+const getApiServiceCapabilities = (
+  site: ApiOverrideSite | null,
+): ApiServiceCapabilities => ({
+  ...defaultApiServiceCapabilities,
+  ...(site ? siteCapabilityOverrides[site] : undefined),
+})
+```
+
+Update `apiForSite` so returned scoped objects include capabilities:
+
+```ts
+const apiForSite = (site: ApiOverrideSite) => {
+  const scopedAPI = {
+    capabilities: getApiServiceCapabilities(site),
+  } as {
+    capabilities: ApiServiceCapabilities
+  } & {
+    [K in keyof typeof commonAPI]: (typeof commonAPI)[K]
+  }
+
+  for (const key in commonAPI) {
+    // eslint-disable-next-line import/namespace
+    const func = commonAPI[key as keyof typeof commonAPI]
+    if (typeof func === "function") {
+      ;(scopedAPI as any)[key] = createSiteScopedFunction(
+        key as keyof typeof commonAPI,
+        site,
+      )
+    } else {
+      ;(scopedAPI as any)[key] = func
+    }
+  }
+
+  return scopedAPI
+}
+```
+
+Update `exportedAPI` so the default wrapper includes capabilities:
+
+```ts
+const exportedAPI = {
+  capabilities: getApiServiceCapabilities(null),
+} as {
+  capabilities: ApiServiceCapabilities
+} & {
+  [K in keyof typeof commonAPI]: WithSiteHint<(typeof commonAPI)[K]>
+}
+```
+
+- [ ] **Step 4: Run apiService tests**
+
+Run:
+
+```bash
+pnpm vitest run tests/services/apiService/index.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git status --porcelain
+git add src/services/apiService/index.ts tests/services/apiService/index.test.ts
+git commit -m "refactor(api-service): expose site capabilities"
+```
+
+Only stage the two task-scoped files. If unrelated staged files already exist, do not commit; report the unsafe index state.
+
+## Task 2: Guard Unsupported Model Pricing
+
+**Files:**
+- Modify: `src/features/ModelList/hooks/useModelData.ts`
+- Test: `tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx`
+
+- [ ] **Step 1: Inspect existing model-list hook tests**
+
+Run:
+
+```bash
+rg -n "fetchModelPricing|Sub2API|modelPricing|all accounts|all-accounts" tests/entrypoints/options/pages/ModelList src/features/ModelList/hooks/useModelData.ts
+```
+
+Use the existing test file that already mocks `getApiService` and renders the model-list data hook. Prefer the smallest existing file over creating a new test harness.
+
+- [ ] **Step 2: Write the failing unsupported-pricing test**
+
+Add a test that configures a Sub2API account and a mocked service with `capabilities.modelPricing=false`. The exact harness may differ, but the assertion must prove `fetchModelPricing` is not called.
+
+Use this behavior shape:
+
+```ts
+const fetchModelPricing = vi.fn()
+
+mockGetApiService.mockReturnValue({
+  capabilities: {
+    keyManagement: true,
+    modelPricing: false,
+    redeemCode: false,
+    siteAnnouncements: true,
+  },
+  fetchModelPricing,
+})
+
+// Render or invoke the model-data hook with one Sub2API account.
+// Wait for the query to settle into the existing error/empty state.
+
+expect(fetchModelPricing).not.toHaveBeenCalled()
+```
+
+If the existing test helper expects per-site responses, configure only the Sub2API service as unsupported and keep common-compatible accounts unchanged.
+
+- [ ] **Step 3: Run the failing model-list test**
+
+Run the focused test file:
+
+```bash
+pnpm vitest run tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+```
+
+Expected: FAIL because current code calls `fetchModelPricing` before any capability check.
+
+- [ ] **Step 4: Add a local unsupported-pricing error helper**
+
+In `src/features/ModelList/hooks/useModelData.ts`, add a small helper near other error helpers:
+
+```ts
+const createUnsupportedModelPricingError = () =>
+  new Error("model_pricing_unsupported")
+```
+
+In the direct account query function, replace:
+
+```ts
+const data = await getApiService(
+  currentAccount.siteType,
+).fetchModelPricing({
+  baseUrl: currentAccount.baseUrl,
+  accountId: currentAccount.id,
+  auth: {
+    authType: currentAccount.authType,
+    userId: currentAccount.userId,
+    accessToken: currentAccount.token,
+    cookie: currentAccount.cookieAuthSessionCookie,
+  },
+})
+```
+
+with:
+
+```ts
+const service = getApiService(currentAccount.siteType)
+if (!service.capabilities.modelPricing) {
+  throw createUnsupportedModelPricingError()
+}
+
+const data = await service.fetchModelPricing({
+  baseUrl: currentAccount.baseUrl,
+  accountId: currentAccount.id,
+  auth: {
+    authType: currentAccount.authType,
+    userId: currentAccount.userId,
+    accessToken: currentAccount.token,
+    cookie: currentAccount.cookieAuthSessionCookie,
+  },
+})
+```
+
+In the all-accounts query function, replace:
+
+```ts
+const data = await getApiService(account.siteType).fetchModelPricing({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+```
+
+with:
+
+```ts
+const service = getApiService(account.siteType)
+if (!service.capabilities.modelPricing) {
+  throw createUnsupportedModelPricingError()
+}
+
+const data = await service.fetchModelPricing({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+```
+
+- [ ] **Step 5: Run the focused model-list test**
+
+Run:
+
+```bash
+pnpm vitest run tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git status --porcelain
+git add src/features/ModelList/hooks/useModelData.ts tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+git commit -m "fix(model-list): skip unsupported model pricing"
+```
+
+Only stage the two task-scoped files. If the final test file differs because the existing harness lives elsewhere, stage that actual test file instead.
+
+## Task 3: Guard Unsupported Redemption
+
+**Files:**
+- Modify: `src/services/redemption/redeemService.ts`
+- Test: `tests/services/redemption/redeemService.test.ts`
+
+- [ ] **Step 1: Check whether redemption tests already exist**
+
+Run:
+
+```bash
+rg -n "redeemCodeForAccount|redeemService|redeemCode" tests/services tests/features src/services/redemption
+```
+
+If `tests/services/redemption/redeemService.test.ts` already exists, add the new tests there. If it does not exist, create it.
+
+- [ ] **Step 2: Write failing unsupported redemption tests**
+
+Use this new test file if no existing file is present:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { AuthTypeEnum } from "~/types"
+
+const { getAccountById, getApiService, redeemCode } = vi.hoisted(() => ({
+  getAccountById: vi.fn(),
+  getApiService: vi.fn(),
+  redeemCode: vi.fn(),
+}))
+
+vi.mock("~/services/accounts/accountStorage", () => ({
+  accountStorage: {
+    getAccountById,
+    getDisplayDataById: vi.fn(),
+    convertToDisplayData: vi.fn(),
+  },
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService,
+}))
+
+vi.mock("~/utils/i18n/core", () => ({
+  t: (key: string, options?: Record<string, unknown>) =>
+    options ? `${key}:${JSON.stringify(options)}` : key,
+}))
+
+describe("redeemService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getApiService.mockReturnValue({
+      capabilities: {
+        keyManagement: true,
+        modelPricing: true,
+        redeemCode: false,
+        siteAnnouncements: true,
+      },
+      redeemCode,
+    })
+  })
+
+  it("does not call redeemCode for Sub2API accounts", async () => {
+    const { redeemService } = await import("~/services/redemption/redeemService")
+    getAccountById.mockResolvedValue({
+      id: "account-1",
+      site_type: SITE_TYPES.SUB2API,
+      site_url: "https://sub2.example.com",
+      disabled: false,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        id: "user-1",
+        access_token: "jwt-token",
+      },
+    })
+
+    const result = await redeemService.redeemCodeForAccount("account-1", "CODE")
+
+    expect(result.success).toBe(false)
+    expect(redeemCode).not.toHaveBeenCalled()
+  })
+
+  it("does not call redeemCode for AIHubMix accounts", async () => {
+    const { redeemService } = await import("~/services/redemption/redeemService")
+    getAccountById.mockResolvedValue({
+      id: "account-2",
+      site_type: SITE_TYPES.AIHUBMIX,
+      site_url: "https://aihubmix.com",
+      disabled: false,
+      authType: AuthTypeEnum.AccessToken,
+      account_info: {
+        id: "aihubmix-user",
+        access_token: "access-token",
+      },
+    })
+
+    const result = await redeemService.redeemCodeForAccount("account-2", "CODE")
+
+    expect(result.success).toBe(false)
+    expect(redeemCode).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 3: Run the failing redemption test**
+
+Run:
+
+```bash
+pnpm vitest run tests/services/redemption/redeemService.test.ts
+```
+
+Expected: FAIL because `redeemService` still calls `redeemCode` even when capabilities say unsupported.
+
+- [ ] **Step 4: Add the redemption capability guard**
+
+In `src/services/redemption/redeemService.ts`, replace:
+
+```ts
+const creditedAmount = await getApiService(account.site_type).redeemCode(
+  {
+    baseUrl: account.site_url,
+    accountId,
+    auth: {
+      authType: account.authType,
+      userId: account.account_info.id,
+      accessToken: account.account_info.access_token,
+      cookie: account.cookieAuth?.sessionCookie,
+    },
+  },
+  code,
+)
+```
+
+with:
+
+```ts
+const service = getApiService(account.site_type)
+if (!service.capabilities.redeemCode) {
+  return {
+    success: false,
+    message: t("redemptionAssist:messages.redeemFailed"),
+  }
+}
+
+const creditedAmount = await service.redeemCode(
+  {
+    baseUrl: account.site_url,
+    accountId,
+    auth: {
+      authType: account.authType,
+      userId: account.account_info.id,
+      accessToken: account.account_info.access_token,
+      cookie: account.cookieAuth?.sessionCookie,
+    },
+  },
+  code,
+)
+```
+
+If product copy review requires a more specific unsupported message, add `redemptionAssist:messages.redeemUnsupported` to the Chinese source and sibling locales, then use that key instead of `redeemFailed`.
+
+- [ ] **Step 5: Run redemption tests**
+
+Run:
+
+```bash
+pnpm vitest run tests/services/redemption/redeemService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git status --porcelain
+git add src/services/redemption/redeemService.ts tests/services/redemption/redeemService.test.ts
+git commit -m "fix(redemption): skip unsupported site adapters"
+```
+
+Only stage the two task-scoped files. If locale files were added, stage those task-scoped locale files too.
+
+## Task 4: Focused Validation And Cleanup
+
+**Files:**
+- Inspect final diff across task-scoped files.
+- No new implementation files expected beyond the files listed above.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+pnpm vitest run tests/services/apiService/index.test.ts tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx tests/services/redemption/redeemService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run related validation for changed source files**
+
+Run:
+
+```bash
+pnpm vitest related --run src/services/apiService/index.ts src/features/ModelList/hooks/useModelData.ts src/services/redemption/redeemService.ts
+```
+
+Expected: PASS. If `vitest related` is unavailable or fails because no related tests are found, classify it as tooling and keep the focused test results as the main evidence.
+
+- [ ] **Step 3: Run pre-commit-equivalent validation**
+
+Stage only task-scoped files, then run:
+
+```bash
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git diff --cached --stat
+git diff --cached
+```
+
+Confirm:
+
+- `strictOverrideSites` still throws for missing Sub2API / AIHubMix functions.
+- `capabilities` exists on both default and site-scoped services.
+- Model List checks `modelPricing` before calling `fetchModelPricing`.
+- Redemption checks `redeemCode` before calling `redeemCode`.
+- No Sub2API announcement placeholder cleanup is included in this slice.
+
+- [ ] **Step 5: Final commit if not already committed per task**
+
+If tasks were not committed individually, commit the final staged task-scoped diff:
+
+```bash
+git commit -m "refactor(api-service): add capability guards"
+```
+
+If tasks were committed individually, skip this step and report the commit hashes.
+
+## Out Of Scope
+
+- Do not remove `fetchSub2ApiAnnouncements` or `markSub2ApiAnnouncementRead` from `common/index.ts` in this slice.
+- Do not redesign the full Adapter type hierarchy.
+- Do not make TypeScript enforce function presence based on capability values yet.
+- Do not change AIHubMix one-time-key behavior.
+- Do not change Sub2API refresh-token or announcement sync behavior.
+
+## Self-Review Notes
+
+- Spec coverage: The plan adds the capability Module, exposes it through the `apiService` Seam, and updates the two known risky call sites: Model List pricing and redemption.
+- Placeholder scan: No steps rely on unspecified implementation. Where an existing test harness may vary, the required behavior and assertions are explicit.
+- Type consistency: The capability property names are consistent across type, defaults, overrides, tests, and callers: `keyManagement`, `modelPricing`, `redeemCode`, `siteAnnouncements`.

--- a/docs/superpowers/plans/2026-06-10-api-service-capabilities.md
+++ b/docs/superpowers/plans/2026-06-10-api-service-capabilities.md
@@ -29,7 +29,7 @@
   - Check `getApiService(account.siteType).capabilities.modelPricing` before calling `fetchModelPricing`.
   - For unsupported accounts, throw a local unsupported error so the existing query error state handles the skipped source.
 
-- Modify `tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx`
+- Modify `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
   - Add or update a focused test proving Sub2API does not call `fetchModelPricing` when model pricing is unsupported.
   - If existing mock setup is easier in `useModelData` tests, use the closest existing test file that already exercises the direct and all-accounts model-data hook paths.
 
@@ -37,7 +37,7 @@
   - Check `getApiService(account.site_type).capabilities.redeemCode` before calling `redeemCode`.
   - Return a localized unsupported failure result instead of relying on `apiService.redeemCode is not implemented...`.
 
-- Modify `tests/services/redemption/redeemService.test.ts`
+- Modify `tests/services/redeemService.test.ts`
   - Add tests for unsupported Sub2API and AIHubMix redemption.
   - If this file does not exist, create it and mock `accountStorage` plus `getApiService`.
 
@@ -264,7 +264,7 @@ Only stage the two task-scoped files. If unrelated staged files already exist, d
 
 **Files:**
 - Modify: `src/features/ModelList/hooks/useModelData.ts`
-- Test: `tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx`
+- Test: `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
 
 - [ ] **Step 1: Inspect existing model-list hook tests**
 
@@ -308,7 +308,7 @@ If the existing test helper expects per-site responses, configure only the Sub2A
 Run the focused test file:
 
 ```bash
-pnpm vitest run tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+pnpm vitest run tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
 ```
 
 Expected: FAIL because current code calls `fetchModelPricing` before any capability check.
@@ -399,7 +399,7 @@ const data = await service.fetchModelPricing({
 Run:
 
 ```bash
-pnpm vitest run tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+pnpm vitest run tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
 ```
 
 Expected: PASS.
@@ -410,7 +410,7 @@ Run:
 
 ```bash
 git status --porcelain
-git add src/features/ModelList/hooks/useModelData.ts tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+git add src/features/ModelList/hooks/useModelData.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
 git commit -m "fix(model-list): skip unsupported model pricing"
 ```
 
@@ -420,7 +420,7 @@ Only stage the two task-scoped files. If the final test file differs because the
 
 **Files:**
 - Modify: `src/services/redemption/redeemService.ts`
-- Test: `tests/services/redemption/redeemService.test.ts`
+- Test: `tests/services/redeemService.test.ts`
 
 - [ ] **Step 1: Check whether redemption tests already exist**
 
@@ -430,7 +430,7 @@ Run:
 rg -n "redeemCodeForAccount|redeemService|redeemCode" tests/services tests/features src/services/redemption
 ```
 
-If `tests/services/redemption/redeemService.test.ts` already exists, add the new tests there. If it does not exist, create it.
+If `tests/services/redeemService.test.ts` already exists, add the new tests there. If it does not exist, create it.
 
 - [ ] **Step 2: Write failing unsupported redemption tests**
 
@@ -526,7 +526,7 @@ describe("redeemService", () => {
 Run:
 
 ```bash
-pnpm vitest run tests/services/redemption/redeemService.test.ts
+pnpm vitest run tests/services/redeemService.test.ts
 ```
 
 Expected: FAIL because `redeemService` still calls `redeemCode` even when capabilities say unsupported.
@@ -584,7 +584,7 @@ If product copy review requires a more specific unsupported message, add `redemp
 Run:
 
 ```bash
-pnpm vitest run tests/services/redemption/redeemService.test.ts
+pnpm vitest run tests/services/redeemService.test.ts
 ```
 
 Expected: PASS.
@@ -595,7 +595,7 @@ Run:
 
 ```bash
 git status --porcelain
-git add src/services/redemption/redeemService.ts tests/services/redemption/redeemService.test.ts
+git add src/services/redemption/redeemService.ts tests/services/redeemService.test.ts
 git commit -m "fix(redemption): skip unsupported site adapters"
 ```
 
@@ -612,7 +612,7 @@ Only stage the two task-scoped files. If locale files were added, stage those ta
 Run:
 
 ```bash
-pnpm vitest run tests/services/apiService/index.test.ts tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx tests/services/redemption/redeemService.test.ts
+pnpm vitest run tests/services/apiService/index.test.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx tests/services/redeemService.test.ts
 ```
 
 Expected: PASS.

--- a/docs/superpowers/specs/2026-06-10-api-service-capabilities-design.md
+++ b/docs/superpowers/specs/2026-06-10-api-service-capabilities-design.md
@@ -1,0 +1,243 @@
+# API Service Capabilities Design
+
+Date: 2026-06-10
+
+## Purpose
+
+Make unsupported account-site operations explicit at the `apiService` seam so
+callers can avoid known-missing adapter behavior before invoking a function.
+
+This design follows the Sub2API adapter seam separation work. That earlier
+phase made incompatible adapters fail fast when they do not implement a helper.
+This phase adds a small capability declaration layer for cases where a caller
+can make a better local decision than surfacing a strict missing-method error.
+
+## Current Context
+
+`src/services/apiService/index.ts` resolves account-site helpers through a site
+override map. Compatible One-API/New-API-family sites may safely inherit common
+helpers. Strict override sites such as Sub2API and AIHubMix should not silently
+fall back to incompatible common helpers.
+
+The strict missing-method throw is useful as a final development guard, but it
+is too late for user-facing flows where the application already knows a feature
+is unsupported for a site type:
+
+- Model List account pricing calls `fetchModelPricing`.
+- Redemption calls `redeemCode`.
+
+For Sub2API, both model pricing and redemption are unsupported in the current
+adapter slice. For AIHubMix, redemption is unsupported while model pricing has
+dedicated account semantics.
+
+Without explicit capabilities, callers either need to call a missing helper and
+handle the thrown implementation error, or duplicate site-type checks in
+feature code. Both options make compatibility rules harder to discover and
+harder to evolve.
+
+## Problem
+
+The repository currently has two related but different concepts:
+
+- function availability: whether an adapter exports a helper implementation
+- product capability: whether a user-facing operation should be attempted for a
+  site type
+
+Strict override sites protect function availability by throwing when a helper is
+missing. They do not give callers a declarative product-capability answer
+before the call starts.
+
+This causes three risks:
+
+1. User-facing flows can surface internal implementation errors instead of a
+   local unsupported state.
+2. Feature code can grow scattered site-type conditionals for the same
+   compatibility rule.
+3. Cached or preloaded data can hide unsupported status unless the capability
+   decision happens before fetch and cache-return paths.
+
+## Goals
+
+- Add a small capability object to `getApiService(site)` results.
+- Keep capability declarations beside the site adapter registration so adapter
+  support rules are discoverable at the seam.
+- Preserve strict missing-method throws as the final guard for accidental calls.
+- Let Model List skip unsupported model-pricing loads before cache lookup and
+  before `fetchModelPricing`.
+- Let Redemption skip unsupported `redeemCode` calls and return the existing
+  localized failure copy.
+- Keep the first capability slice narrow and directly tied to known risky
+  callers.
+
+## Non-Goals
+
+- Do not redesign the full adapter type hierarchy.
+- Do not make TypeScript conditionally remove methods based on capability
+  values.
+- Do not remove Sub2API announcement placeholders or refactor announcement
+  providers in this slice.
+- Do not change AIHubMix one-time-key behavior.
+- Do not change Sub2API refresh-token, browser-session recovery, or
+  announcement sync behavior.
+- Do not add new user-facing copy unless the existing failure copy cannot cover
+  the narrow unsupported path.
+
+## Capability Contract
+
+The first slice should expose this shape:
+
+```ts
+export type ApiServiceCapabilities = {
+  keyManagement: boolean
+  modelPricing: boolean
+  redeemCode: boolean
+  siteAnnouncements: boolean
+}
+```
+
+Default capabilities are all `true`. This preserves behavior for common
+compatible sites and existing partial override sites unless a site explicitly
+declares otherwise.
+
+Initial overrides:
+
+- Sub2API:
+  - `modelPricing: false`
+  - `redeemCode: false`
+- AIHubMix:
+  - `redeemCode: false`
+
+`siteAnnouncements` is included because announcement support is another known
+adapter compatibility axis, but this slice should only declare the field. It
+should not move or remove announcement functions.
+
+## API Service Seam Design
+
+`src/services/apiService/index.ts` remains the owner of the adapter seam.
+
+The capability declaration should live near `strictOverrideSites` and
+`siteOverrideMap` because those structures already define site compatibility
+policy.
+
+`getApiService(site)` should return:
+
+- default wrapper object with `capabilities` for unknown, undefined, or
+  common-compatible routing
+- site-scoped wrapper object with `capabilities` for recognized override sites
+
+The wrapper should still build callable functions through the existing
+`createWrappedFunction` and `createSiteScopedFunction` paths. Capability
+metadata must not bypass, weaken, or remove the strict missing-method throw.
+
+The strict throw remains the final guard:
+
+- callers should use capabilities when they can intentionally skip unsupported
+  product behavior
+- accidental direct calls to missing strict-site helpers should still fail fast
+
+## Model List Behavior
+
+Account-backed model pricing should check
+`getApiService(account.siteType).capabilities.modelPricing` before attempting a
+pricing load.
+
+The check must run before:
+
+- `modelPricingCache.get(...)`
+- `fetchModelPricing(...)`
+
+This ordering is important because unsupported sites should not show stale
+cached pricing as a successful load. The unsupported state should flow through
+the existing query error handling rather than becoming a special UI branch in
+this slice.
+
+The request payload for supported sites must remain unchanged:
+
+- `baseUrl`
+- `accountId`
+- `auth.authType`
+- `auth.userId`
+- `auth.accessToken`
+- `auth.cookie`
+
+The same rule applies to both single-account and all-accounts model-data query
+paths.
+
+## Redemption Behavior
+
+Redemption should check
+`getApiService(account.site_type).capabilities.redeemCode` before invoking the
+adapter's `redeemCode` helper.
+
+For unsupported sites, return:
+
+```ts
+{
+  success: false,
+  message: t("redemptionAssist:messages.redeemFailed"),
+}
+```
+
+This keeps the slice narrow and avoids new locale churn. Supported redemption
+requests must preserve the existing request payload and response handling,
+including display-account lookup and credited amount formatting.
+
+## Testing Strategy
+
+Focused tests should cover:
+
+- default capabilities for common-compatible service results
+- Sub2API capability overrides
+- AIHubMix capability overrides
+- strict missing-method throw behavior still active for Sub2API and AIHubMix
+- Sub2API model pricing does not call `fetchModelPricing` when unsupported
+- unsupported Sub2API model pricing does not return stale cached pricing
+- Sub2API and AIHubMix redemption do not call `redeemCode` when unsupported
+
+E2E is not required for this slice. The main risk is service seam behavior and
+hook/service branching, which is covered by focused Vitest and Testing Library
+tests.
+
+## Validation Plan
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/apiService/index.test.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx tests/services/redeemService.test.ts
+```
+
+Related validation:
+
+```powershell
+pnpm vitest related --run src/services/apiService/index.ts src/features/ModelList/hooks/useModelData.ts src/services/redemption/redeemService.ts
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Diff inspection should confirm:
+
+- `capabilities` exists on default and site-scoped services.
+- Sub2API and AIHubMix strict missing-method behavior remains intact.
+- Model List capability checks run before cache lookup and fetch.
+- Redemption capability checks run before adapter invocation.
+- No announcement-provider cleanup leaked into this slice.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later phases may expand the capability object or replace it with a more typed
+adapter contract if the codebase needs stronger compile-time enforcement.
+
+Likely future capability axes include:
+
+- announcement provider support
+- browser-session identity resolution
+- auth restoration or session recovery
+- managed-site channel operations
+
+Those follow-ups should be driven by concrete callers and compatibility gaps.
+This slice only adds the runtime declaration needed to protect the current
+Model List pricing and Redemption flows.

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -111,6 +111,9 @@ function createInvalidFormatError() {
   return error
 }
 
+const createUnsupportedModelPricingError = () =>
+  new Error("model_pricing_unsupported")
+
 /** Counts only valid model rows so analytics never includes raw model ids. */
 function getPricingModelCount(pricing: PricingResponse | null | undefined) {
   return Array.isArray(pricing?.data) ? pricing.data.length : 0
@@ -509,6 +512,11 @@ function useSingleAccountModelData(params: {
         throw new Error("No account selected")
       }
 
+      const service = getApiService(currentAccount.siteType)
+      if (!service.capabilities.modelPricing) {
+        throw createUnsupportedModelPricingError()
+      }
+
       const cacheKey = createModelPricingCacheKey(currentAccount)
 
       const cached = await modelPricingCache.get(cacheKey)
@@ -518,9 +526,7 @@ function useSingleAccountModelData(params: {
       }
       directLoadCacheHitRef.current = false
 
-      const data = await getApiService(
-        currentAccount.siteType,
-      ).fetchModelPricing({
+      const data = await service.fetchModelPricing({
         baseUrl: currentAccount.baseUrl,
         accountId: currentAccount.id,
         auth: {
@@ -913,13 +919,18 @@ function useAllAccountsModelData(
       refetchOnWindowFocus: false,
       retry: 1,
       queryFn: async () => {
+        const service = getApiService(account.siteType)
+        if (!service.capabilities.modelPricing) {
+          throw createUnsupportedModelPricingError()
+        }
+
         const cacheKey = createModelPricingCacheKey(account)
         const cached = await modelPricingCache.get(cacheKey)
         if (cached && Array.isArray(cached.data)) {
           return cached
         }
 
-        const data = await getApiService(account.siteType).fetchModelPricing({
+        const data = await service.fetchModelPricing({
           baseUrl: account.baseUrl,
           accountId: account.id,
           auth: {

--- a/src/services/apiService/index.ts
+++ b/src/services/apiService/index.ts
@@ -38,6 +38,41 @@ const strictOverrideSites = new Set<ApiOverrideSite>([
   SITE_TYPES.SUB2API,
 ])
 
+type ApiServiceCapabilities = {
+  keyManagement: boolean
+  modelPricing: boolean
+  redeemCode: boolean
+  siteAnnouncements: boolean
+}
+
+type ApiServiceCapabilityOverrides = Partial<ApiServiceCapabilities>
+
+const defaultApiServiceCapabilities: ApiServiceCapabilities = {
+  keyManagement: true,
+  modelPricing: true,
+  redeemCode: true,
+  siteAnnouncements: true,
+}
+
+const siteCapabilityOverrides: Partial<
+  Record<ApiOverrideSite, ApiServiceCapabilityOverrides>
+> = {
+  [SITE_TYPES.SUB2API]: {
+    modelPricing: false,
+    redeemCode: false,
+  },
+  [SITE_TYPES.AIHUBMIX]: {
+    redeemCode: false,
+  },
+}
+
+const getApiServiceCapabilities = (
+  site: ApiOverrideSite | null,
+): ApiServiceCapabilities => ({
+  ...defaultApiServiceCapabilities,
+  ...(site ? siteCapabilityOverrides[site] : undefined),
+})
+
 const hasOwnOverrideSite = (value: unknown): value is ApiOverrideSite =>
   typeof value === "string" &&
   Object.prototype.hasOwnProperty.call(siteOverrideMap, value)
@@ -132,6 +167,8 @@ const createSiteScopedFunction = <T extends (...args: any[]) => any>(
 const apiForSite = (site: ApiOverrideSite) => {
   const scopedAPI = {} as {
     [K in keyof typeof commonAPI]: (typeof commonAPI)[K]
+  } & {
+    capabilities: ApiServiceCapabilities
   }
 
   for (const key in commonAPI) {
@@ -147,6 +184,8 @@ const apiForSite = (site: ApiOverrideSite) => {
     }
   }
 
+  scopedAPI.capabilities = getApiServiceCapabilities(site)
+
   return scopedAPI
 }
 
@@ -161,6 +200,8 @@ export const getApiService = (site: unknown) =>
 // 创建导出对象
 const exportedAPI = {} as {
   [K in keyof typeof commonAPI]: WithSiteHint<(typeof commonAPI)[K]>
+} & {
+  capabilities: ApiServiceCapabilities
 }
 
 // 遍历 commonAPI 并包装每个函数
@@ -175,3 +216,5 @@ for (const key in commonAPI) {
     ;(exportedAPI as any)[key] = func
   }
 }
+
+exportedAPI.capabilities = getApiServiceCapabilities(null)

--- a/src/services/apiService/index.ts
+++ b/src/services/apiService/index.ts
@@ -38,7 +38,7 @@ const strictOverrideSites = new Set<ApiOverrideSite>([
   SITE_TYPES.SUB2API,
 ])
 
-type ApiServiceCapabilities = {
+export type ApiServiceCapabilities = {
   keyManagement: boolean
   modelPricing: boolean
   redeemCode: boolean

--- a/src/services/redemption/redeemService.ts
+++ b/src/services/redemption/redeemService.ts
@@ -44,7 +44,15 @@ class RedeemService {
         }
       }
 
-      const creditedAmount = await getApiService(account.site_type).redeemCode(
+      const service = getApiService(account.site_type)
+      if (!service.capabilities.redeemCode) {
+        return {
+          success: false,
+          message: t("redemptionAssist:messages.redeemFailed"),
+        }
+      }
+
+      const creditedAmount = await service.redeemCode(
         {
           baseUrl: account.site_url,
           accountId,

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -138,6 +138,22 @@ const createDeferred = <T,>() => {
   return { promise, resolve, reject }
 }
 
+const createMockApiService = (
+  fetchModelPricing: ReturnType<typeof vi.fn>,
+  overrides: {
+    capabilities?: {
+      modelPricing?: boolean
+    }
+  } = {},
+) =>
+  ({
+    fetchModelPricing,
+    capabilities: {
+      modelPricing: true,
+      ...overrides.capabilities,
+    },
+  }) as any
+
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -271,7 +287,7 @@ describe("useModelData all-accounts loading", () => {
       usable_group: {},
     })
     const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue({ fetchModelPricing } as any)
+    mockedGetApiService.mockReturnValue(createMockApiService(fetchModelPricing))
 
     const accounts = [
       createDisplayAccount({
@@ -310,7 +326,7 @@ describe("useModelData all-accounts loading", () => {
       usable_group: {},
     })
     const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue({ fetchModelPricing } as any)
+    mockedGetApiService.mockReturnValue(createMockApiService(fetchModelPricing))
 
     const accounts = [
       createDisplayAccount({
@@ -339,6 +355,45 @@ describe("useModelData all-accounts loading", () => {
       (call) => call[0]?.accountId,
     )
     expect(calledAccountIds).toEqual(expect.arrayContaining(["a", "b"]))
+  })
+
+  it("does not invoke model pricing for unsupported Sub2API accounts", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+    const fetchModelPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("fetch should not be called"))
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "unsupported-sub2api",
+      baseUrl: "https://sub2api.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      userId: "sub2api-user",
+    })
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAccountSource(account),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.loadErrorMessage).toBe(
+          "modelList:status.loadFailed",
+        )
+      },
+      { timeout: 3000 },
+    )
+    expect(fetchModelPricing).not.toHaveBeenCalled()
   })
 
   it("tracks single-account pricing load success with model-count insight once", async () => {
@@ -370,7 +425,9 @@ describe("useModelData all-accounts loading", () => {
       success: true,
       usable_group: { default: true },
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const account = createDisplayAccount({
       id: "analytics-single-success",
@@ -421,7 +478,9 @@ describe("useModelData all-accounts loading", () => {
       success: true,
       usable_group: {},
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const account = createDisplayAccount({
       id: "analytics-invalid-format",
@@ -483,7 +542,9 @@ describe("useModelData all-accounts loading", () => {
 
       return Promise.reject(new Error("private backend failure"))
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const accounts = [
       createDisplayAccount({
@@ -553,7 +614,9 @@ describe("useModelData all-accounts loading", () => {
 
       return Promise.reject(new TypeError("Failed to fetch"))
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const accounts = [
       createDisplayAccount({
@@ -628,7 +691,9 @@ describe("useModelData all-accounts loading", () => {
         usable_group: {},
       })
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const accounts = [
       createDisplayAccount({
@@ -695,7 +760,9 @@ describe("useModelData all-accounts loading", () => {
         usable_group: {},
       })
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const accounts = [
       createDisplayAccount({
@@ -810,7 +877,9 @@ describe("useModelData all-accounts loading", () => {
     toastErrorMock.mockReset()
 
     const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const fallbackToken = {
       id: 8,
@@ -935,7 +1004,9 @@ describe("useModelData all-accounts loading", () => {
         success: true,
         usable_group: { default: true },
       })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const firstAccount = createDisplayAccount({
       id: "credential-change-account",
@@ -1007,7 +1078,9 @@ describe("useModelData all-accounts loading", () => {
     toastErrorMock.mockReset()
 
     const fetchModelPricing = vi.fn()
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const account = createDisplayAccount({
       id: "cached-pricing-account",
@@ -1071,6 +1144,74 @@ describe("useModelData all-accounts loading", () => {
     await modelPricingCache.invalidate(cacheKey)
   })
 
+  it("does not return cached pricing for unsupported Sub2API accounts", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    const fetchModelPricing = vi.fn()
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "cached-unsupported-sub2api",
+      baseUrl: "https://cached-sub2api.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      userId: "cached-sub2api-user",
+    })
+    const cacheKey = [
+      account.id,
+      account.baseUrl,
+      account.userId,
+      account.siteType,
+      account.authType,
+    ].join("|")
+
+    await modelPricingCache.invalidate(cacheKey)
+    await modelPricingCache.set(cacheKey, {
+      data: [
+        {
+          model_name: "stale-sub2api-model",
+          quota_type: 0,
+          model_ratio: 1,
+          model_price: 1,
+          completion_ratio: 1,
+          enable_groups: ["default"],
+          supported_endpoint_types: [],
+        },
+      ],
+      group_ratio: { default: 1 },
+      success: true,
+      usable_group: { default: "default" },
+    })
+
+    try {
+      const { result } = renderHook(
+        () =>
+          useModelData({
+            selectedSource: createAccountSource(account),
+            accounts: [account],
+          }),
+        { wrapper: createWrapper() },
+      )
+
+      await waitFor(
+        () => {
+          expect(result.current.loadErrorMessage).toBe(
+            "modelList:status.loadFailed",
+          )
+        },
+        { timeout: 3000 },
+      )
+      expect(fetchModelPricing).not.toHaveBeenCalled()
+      expect(result.current.pricingData).toBeNull()
+    } finally {
+      await modelPricingCache.invalidate(cacheKey)
+    }
+  })
+
   it("marks all-account queries as loading before each account returns data", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
@@ -1090,7 +1231,9 @@ describe("useModelData all-accounts loading", () => {
     const fetchModelPricing = vi.fn().mockImplementation(({ accountId }) => {
       return accountId === "a" ? firstDeferred.promise : secondDeferred.promise
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const accounts = [
       createDisplayAccount({
@@ -1174,7 +1317,7 @@ describe("useModelData all-accounts loading", () => {
     toastErrorMock.mockReset()
     const fetchModelPricing = vi.fn()
     const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue({ fetchModelPricing } as any)
+    mockedGetApiService.mockReturnValue(createMockApiService(fetchModelPricing))
     mockFetchApiCredentialModelIds.mockResolvedValueOnce([
       "gpt-4o-mini",
       "claude-3-5-sonnet",
@@ -1224,7 +1367,9 @@ describe("useModelData all-accounts loading", () => {
     toastErrorMock.mockReset()
 
     const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const account = createDisplayAccount({
       id: "error-account",
@@ -1270,7 +1415,9 @@ describe("useModelData all-accounts loading", () => {
     toastErrorMock.mockReset()
 
     const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const account = createDisplayAccount({
       id: "fallback-account",
@@ -1404,7 +1551,9 @@ describe("useModelData all-accounts loading", () => {
         success: true,
         usable_group: { default: true },
       })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const account = createDisplayAccount({
       id: "fallback-reset-account",
@@ -1510,7 +1659,9 @@ describe("useModelData all-accounts loading", () => {
         success: true,
         usable_group: {},
       })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
     mockFetchDisplayAccountTokens.mockReturnValueOnce(deferredTokens.promise)
 
     const firstAccount = createDisplayAccount({
@@ -1592,7 +1743,9 @@ describe("useModelData all-accounts loading", () => {
     toastErrorMock.mockReset()
 
     const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
     mockFetchDisplayAccountTokens.mockRejectedValueOnce(
       new InvalidTokenPayloadError({
         accountId: "invalid-token-account",
@@ -1639,7 +1792,9 @@ describe("useModelData all-accounts loading", () => {
     toastErrorMock.mockReset()
 
     const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const fallbackToken = {
       id: 5,
@@ -1710,7 +1865,9 @@ describe("useModelData all-accounts loading", () => {
     toastErrorMock.mockReset()
 
     const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const fallbackToken = {
       id: 6,
@@ -1803,7 +1960,9 @@ describe("useModelData all-accounts loading", () => {
 
       return Promise.reject(new Error("boom"))
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const accounts = [
       createDisplayAccount({
@@ -1864,7 +2023,9 @@ describe("useModelData all-accounts loading", () => {
       success: true,
       usable_group: {},
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchModelPricing } as any)
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
 
     const account = createDisplayAccount({
       id: "single-invalid-format",

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -12,7 +12,10 @@ import {
   createProfileSource,
 } from "~/features/ModelList/modelManagementSources"
 import { InvalidTokenPayloadError } from "~/services/accounts/utils/apiServiceRequest"
-import { getApiService } from "~/services/apiService"
+import {
+  getApiService,
+  type ApiServiceCapabilities,
+} from "~/services/apiService"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import { modelPricingCache } from "~/services/models/modelPricingCache"
 import {
@@ -141,9 +144,7 @@ const createDeferred = <T,>() => {
 const createMockApiService = (
   fetchModelPricing: ReturnType<typeof vi.fn>,
   overrides: {
-    capabilities?: {
-      modelPricing?: boolean
-    }
+    capabilities?: Partial<Pick<ApiServiceCapabilities, "modelPricing">>
   } = {},
 ) =>
   ({
@@ -381,6 +382,53 @@ describe("useModelData all-accounts loading", () => {
         useModelData({
           selectedSource: createAccountSource(account),
           accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.loadErrorMessage).toBe(
+          "modelList:status.loadFailed",
+        )
+      },
+      { timeout: 3000 },
+    )
+    expect(fetchModelPricing).not.toHaveBeenCalled()
+  })
+
+  it("does not invoke all-account pricing when capability is disabled", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+    const fetchModelPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("fetch should not be called"))
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const accounts = [
+      createDisplayAccount({
+        id: "unsupported-all-a",
+        baseUrl: "https://unsupported-a.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        userId: "unsupported-a-user",
+      }),
+      createDisplayAccount({
+        id: "unsupported-all-b",
+        baseUrl: "https://unsupported-b.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        userId: "unsupported-b-user",
+      }),
+    ]
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts,
         }),
       { wrapper: createWrapper() },
     )

--- a/tests/services/apiService/index.test.ts
+++ b/tests/services/apiService/index.test.ts
@@ -218,6 +218,40 @@ describe("apiService index wrapper", () => {
     expect(commonFetchAccountTokens).not.toHaveBeenCalled()
   })
 
+  it("should expose default capabilities for common-compatible sites", () => {
+    expect(getApiService(undefined).capabilities).toEqual({
+      keyManagement: true,
+      modelPricing: true,
+      redeemCode: true,
+      siteAnnouncements: true,
+    })
+
+    expect(getApiService(SITE_TYPES.ONE_HUB).capabilities).toEqual({
+      keyManagement: true,
+      modelPricing: true,
+      redeemCode: true,
+      siteAnnouncements: true,
+    })
+  })
+
+  it("should expose Sub2API capability overrides", () => {
+    expect(getApiService(SITE_TYPES.SUB2API).capabilities).toEqual({
+      keyManagement: true,
+      modelPricing: false,
+      redeemCode: false,
+      siteAnnouncements: true,
+    })
+  })
+
+  it("should expose AIHubMix capability overrides", () => {
+    expect(getApiService(SITE_TYPES.AIHUBMIX).capabilities).toEqual({
+      keyManagement: true,
+      modelPricing: true,
+      redeemCode: false,
+      siteAnnouncements: true,
+    })
+  })
+
   it("should not silently fall back to common for missing AIHubMix overrides", async () => {
     commonFetchModelPricing.mockResolvedValue({} as any)
 

--- a/tests/services/redeemService.test.ts
+++ b/tests/services/redeemService.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { getApiService } from "~/services/apiService"
 import { redeemService } from "~/services/redemption/redeemService"
@@ -80,6 +81,9 @@ describe("redeemService.redeemCodeForAccount", () => {
       accountStorage.getDisplayDataById as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce(displayData)
     ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      capabilities: {
+        redeemCode: true,
+      },
       redeemCode,
     })
 
@@ -137,6 +141,9 @@ describe("redeemService.redeemCodeForAccount", () => {
       accountStorage.convertToDisplayData as unknown as ReturnType<typeof vi.fn>
     ).mockReturnValueOnce(convertedDisplayData)
     ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      capabilities: {
+        redeemCode: true,
+      },
       redeemCode,
     })
 
@@ -182,6 +189,9 @@ describe("redeemService.redeemCodeForAccount", () => {
       accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce(account)
     ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      capabilities: {
+        redeemCode: true,
+      },
       redeemCode,
     })
 
@@ -212,6 +222,9 @@ describe("redeemService.redeemCodeForAccount", () => {
       accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce(account)
     ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      capabilities: {
+        redeemCode: true,
+      },
       redeemCode,
     })
 
@@ -221,5 +234,74 @@ describe("redeemService.redeemCodeForAccount", () => {
       success: false,
       message: "redemptionAssist:messages.redeemFailed",
     })
+  })
+
+  it("returns a local failure for unsupported Sub2API redemption", async () => {
+    const account = {
+      id: "sub2api-1",
+      disabled: false,
+      site_type: SITE_TYPES.SUB2API,
+      site_url: "https://sub2api.example.com",
+      authType: "bearer",
+      account_info: {
+        id: "user-sub2api",
+        access_token: "token-sub2api",
+      },
+    }
+    const redeemCode = vi.fn()
+
+    ;(
+      accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(account)
+    ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      capabilities: {
+        redeemCode: false,
+      },
+      redeemCode,
+    })
+
+    const result = await redeemService.redeemCodeForAccount("sub2api-1", "CODE")
+
+    expect(result).toEqual({
+      success: false,
+      message: "redemptionAssist:messages.redeemFailed",
+    })
+    expect(redeemCode).not.toHaveBeenCalled()
+  })
+
+  it("returns a local failure for unsupported AIHubMix redemption", async () => {
+    const account = {
+      id: "aihubmix-1",
+      disabled: false,
+      site_type: SITE_TYPES.AIHUBMIX,
+      site_url: "https://aihubmix.com",
+      authType: "bearer",
+      account_info: {
+        id: "user-aihubmix",
+        access_token: "token-aihubmix",
+      },
+    }
+    const redeemCode = vi.fn()
+
+    ;(
+      accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(account)
+    ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      capabilities: {
+        redeemCode: false,
+      },
+      redeemCode,
+    })
+
+    const result = await redeemService.redeemCodeForAccount(
+      "aihubmix-1",
+      "CODE",
+    )
+
+    expect(result).toEqual({
+      success: false,
+      message: "redemptionAssist:messages.redeemFailed",
+    })
+    expect(redeemCode).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Add an API service capabilities contract for unsupported adapter features.
- Skip model pricing calls for adapters that do not support pricing endpoints.
- Skip redemption calls for adapters that do not support redemption endpoints.
- Document the capability rollout plan and design spec.

## Test Plan
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatic detection of feature availability per account type.
  * Enhanced handling and user-facing messages when model pricing or redemption are unavailable.
  * Avoids unnecessary network/cache operations for unsupported features.

* **Documentation**
  * Added comprehensive design and implementation plans for the API service capabilities system.

* **Tests**
  * Expanded test coverage to assert capability gating for pricing and redemption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->