### PR TITLE
fix(model-list): restore per-row model actions

### DIFF
--- a/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
+++ b/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
@@ -30,6 +30,7 @@ import {
   type BatchVerifyModelItem,
 } from "~/features/ModelList/batchVerification"
 import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
+import { formatModelListSourceLabel } from "~/features/ModelList/sourceLabels"
 import {
   getBatchVerifyModelCheckboxTestId,
   getBatchVerifyRowTestId,
@@ -867,81 +868,98 @@ export function BatchVerifyModelsDialog({
     return "outline"
   }
 
-  const renderRow = (row: BatchVerifyRow) => (
-    <div
-      data-testid={getBatchVerifyRowTestId(row.item.key)}
-      className="dark:border-dark-bg-tertiary rounded-md border border-gray-100 p-3"
-    >
-      <div className="flex items-start justify-between gap-3">
-        <Checkbox
-          checked={selectedModelKeySet.has(row.item.key)}
-          onCheckedChange={() => toggleModel(row.item.key)}
-          disabled={isRunning}
-          aria-label={t("modelList:batchVerify.modelSelection.toggle", {
-            model: row.item.modelId,
-          })}
-          data-testid={getBatchVerifyModelCheckboxTestId(row.item.key)}
-          className="mt-0.5"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 flex-wrap items-center gap-2">
-            <div className="dark:text-dark-text-primary min-w-0 truncate text-sm font-medium text-gray-900">
-              {row.item.modelId}
+  const renderRow = (row: BatchVerifyRow) => {
+    const sourceLabel = formatModelListSourceLabel(row.item.source, {
+      formatProfileLabel: ({ name, host }) =>
+        t("modelList:sourceLabels.profileBadge", { name, host }),
+    })
+
+    return (
+      <div
+        data-testid={getBatchVerifyRowTestId(row.item.key)}
+        className="dark:border-dark-bg-tertiary rounded-md border border-gray-100 p-3"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <Checkbox
+            checked={selectedModelKeySet.has(row.item.key)}
+            onCheckedChange={() => toggleModel(row.item.key)}
+            disabled={isRunning}
+            aria-label={t("modelList:batchVerify.modelSelection.toggle", {
+              model: row.item.modelId,
+            })}
+            data-testid={getBatchVerifyModelCheckboxTestId(row.item.key)}
+            className="mt-0.5"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <div className="dark:text-dark-text-primary min-w-0 truncate text-sm font-medium text-gray-900">
+                {row.item.modelId}
+              </div>
+              <Badge
+                variant="outline"
+                size="sm"
+                className="max-w-full min-w-0"
+                title={sourceLabel.title ?? sourceLabel.label}
+              >
+                <span className="min-w-0 truncate">{sourceLabel.label}</span>
+              </Badge>
+              <Badge variant={statusVariant(row.status)} size="sm">
+                {row.status === BATCH_VERIFY_ROW_STATUSES.PASS
+                  ? t("modelList:batchVerify.status.pass")
+                  : row.status === BATCH_VERIFY_ROW_STATUSES.FAIL
+                    ? t("modelList:batchVerify.status.fail")
+                    : row.status === BATCH_VERIFY_ROW_STATUSES.SKIPPED
+                      ? t("modelList:batchVerify.status.skipped")
+                      : row.status === BATCH_VERIFY_ROW_STATUSES.RUNNING
+                        ? t("modelList:batchVerify.status.running")
+                        : t("modelList:batchVerify.status.pending")}
+              </Badge>
+              <span className="dark:text-dark-text-tertiary text-xs text-gray-500">
+                {formatLatency(row.latencyMs)}
+              </span>
             </div>
-            <Badge variant={statusVariant(row.status)} size="sm">
-              {row.status === BATCH_VERIFY_ROW_STATUSES.PASS
-                ? t("modelList:batchVerify.status.pass")
-                : row.status === BATCH_VERIFY_ROW_STATUSES.FAIL
-                  ? t("modelList:batchVerify.status.fail")
-                  : row.status === BATCH_VERIFY_ROW_STATUSES.SKIPPED
-                    ? t("modelList:batchVerify.status.skipped")
-                    : row.status === BATCH_VERIFY_ROW_STATUSES.RUNNING
-                      ? t("modelList:batchVerify.status.running")
-                      : t("modelList:batchVerify.status.pending")}
-            </Badge>
-            <span className="dark:text-dark-text-tertiary text-xs text-gray-500">
-              {formatLatency(row.latencyMs)}
-            </span>
+            <div className="dark:text-dark-text-secondary mt-1 text-xs text-gray-600">
+              {row.summary || t("modelList:batchVerify.messages.pending")}
+            </div>
+            {row.tokenName ? (
+              <div className="dark:text-dark-text-tertiary mt-1 text-xs text-gray-500">
+                {t("modelList:batchVerify.tokenUsed", {
+                  name: row.tokenName,
+                })}
+              </div>
+            ) : null}
+            {row.results.length > 0 ? (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {row.results.map((result) => (
+                  <Badge
+                    key={result.id}
+                    variant={statusVariant(
+                      result.status === "unsupported"
+                        ? BATCH_VERIFY_ROW_STATUSES.SKIPPED
+                        : result.status,
+                    )}
+                    size="sm"
+                  >
+                    {getApiVerificationProbeLabel(t, result.id)}
+                    {" · "}
+                    {result.status === "pass"
+                      ? t("modelList:batchVerify.status.pass")
+                      : result.status === "fail"
+                        ? t("modelList:batchVerify.status.fail")
+                        : t(
+                            "aiApiVerification:verifyDialog.status.unsupported",
+                          )}
+                    {" · "}
+                    {formatLatency(result.latencyMs)}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
           </div>
-          <div className="dark:text-dark-text-secondary mt-1 text-xs text-gray-600">
-            {row.summary || t("modelList:batchVerify.messages.pending")}
-          </div>
-          {row.tokenName ? (
-            <div className="dark:text-dark-text-tertiary mt-1 text-xs text-gray-500">
-              {t("modelList:batchVerify.tokenUsed", {
-                name: row.tokenName,
-              })}
-            </div>
-          ) : null}
-          {row.results.length > 0 ? (
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {row.results.map((result) => (
-                <Badge
-                  key={result.id}
-                  variant={statusVariant(
-                    result.status === "unsupported"
-                      ? BATCH_VERIFY_ROW_STATUSES.SKIPPED
-                      : result.status,
-                  )}
-                  size="sm"
-                >
-                  {getApiVerificationProbeLabel(t, result.id)}
-                  {" · "}
-                  {result.status === "pass"
-                    ? t("modelList:batchVerify.status.pass")
-                    : result.status === "fail"
-                      ? t("modelList:batchVerify.status.fail")
-                      : t("aiApiVerification:verifyDialog.status.unsupported")}
-                  {" · "}
-                  {formatLatency(result.latencyMs)}
-                </Badge>
-              ))}
-            </div>
-          ) : null}
         </div>
       </div>
-    </div>
-  )
+    )
+  }
 
   const header = (
     <div className="min-w-0">

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -13,6 +13,7 @@ import type {
   ModelManagementSourceCapabilities,
 } from "~/features/ModelList/modelManagementSources"
 import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
+import { formatModelListSourceLabel } from "~/features/ModelList/sourceLabels"
 import type { ModelPricing } from "~/services/apiService/common/type"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
 import type { CalculatedPrice } from "~/services/models/utils/modelPricing"
@@ -26,9 +27,9 @@ import type { ApiVerificationHistorySummary } from "~/services/verification/veri
 import { createTab } from "~/utils/browser/browserApi"
 import { isProdBuild } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
+import { tryParseUrl } from "~/utils/core/urlParsing"
 
 import { formatGroupLabelFromRatios } from "../../groupLabels"
-import { formatModelListSourceLabel } from "../../sourceLabels"
 import { ModelItemDescription } from "./ModelItemDescription"
 import { ModelItemDetails } from "./ModelItemDetails"
 import { ModelItemExpandButton } from "./ModelItemExpandButton"
@@ -152,6 +153,10 @@ export default function ModelItem(props: ModelItemProps) {
       ? source.account.baseUrl?.trim()
       : source.profile.baseUrl.trim()
   const canUseSourceUrl = Boolean(sourceBaseUrl)
+  const parsedSourceUrl = tryParseUrl(sourceBaseUrl)
+  const canOpenSourceUrl =
+    parsedSourceUrl?.protocol === "http:" ||
+    parsedSourceUrl?.protocol === "https:"
 
   const handleCopySourceUrl = async () => {
     if (!sourceBaseUrl) return
@@ -165,9 +170,9 @@ export default function ModelItem(props: ModelItemProps) {
   }
 
   const handleOpenSourceUrl = () => {
-    if (!sourceBaseUrl) return
+    if (!canOpenSourceUrl || !parsedSourceUrl) return
 
-    void createTab(sourceBaseUrl, true)
+    void createTab(parsedSourceUrl.toString(), true)
   }
 
   const sourceLabel = formatModelListSourceLabel(source, {
@@ -264,21 +269,23 @@ export default function ModelItem(props: ModelItemProps) {
       >
         <Copy className="h-3 w-3 text-gray-600 sm:h-3.5 sm:w-3.5 dark:text-gray-300" />
       </IconButton>
-      <IconButton
-        variant="ghost"
-        size="sm"
-        onClick={handleOpenSourceUrl}
-        title={t("actions.openSite")}
-        aria-label={t("actions.openSite")}
-        className="shrink-0"
-        analyticsAction={
-          source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
-            ? PRODUCT_ANALYTICS_ACTION_IDS.OpenAccountSite
-            : undefined
-        }
-      >
-        <ExternalLink className="h-3 w-3 text-gray-600 sm:h-3.5 sm:w-3.5 dark:text-gray-300" />
-      </IconButton>
+      {canOpenSourceUrl ? (
+        <IconButton
+          variant="ghost"
+          size="sm"
+          onClick={handleOpenSourceUrl}
+          title={t("actions.openSite")}
+          aria-label={t("actions.openSite")}
+          className="shrink-0"
+          analyticsAction={
+            source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
+              ? PRODUCT_ANALYTICS_ACTION_IDS.OpenAccountSite
+              : undefined
+          }
+        >
+          <ExternalLink className="h-3 w-3 text-gray-600 sm:h-3.5 sm:w-3.5 dark:text-gray-300" />
+        </IconButton>
+      ) : null}
     </>
   ) : null
 

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -1,8 +1,9 @@
+import { Copy, ExternalLink } from "lucide-react"
 import { useEffect, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
-import { Badge, Card, CardContent } from "~/components/ui"
+import { Badge, Card, CardContent, IconButton } from "~/components/ui"
 import {
   MODEL_LIST_GROUP_SELECTION_SCOPES,
   type ModelListGroupSelectionScope,
@@ -22,11 +23,12 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
 import type { ApiVerificationHistorySummary } from "~/services/verification/verificationResultHistory"
+import { createTab } from "~/utils/browser/browserApi"
 import { isProdBuild } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
-import { tryParseUrl } from "~/utils/core/urlParsing"
 
 import { formatGroupLabelFromRatios } from "../../groupLabels"
+import { formatModelListSourceLabel } from "../../sourceLabels"
 import { ModelItemDescription } from "./ModelItemDescription"
 import { ModelItemDetails } from "./ModelItemDetails"
 import { ModelItemExpandButton } from "./ModelItemExpandButton"
@@ -145,21 +147,33 @@ export default function ModelItem(props: ModelItemProps) {
     }
   }
 
-  const profileBaseUrl =
-    source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE
-      ? source.profile.baseUrl.trim()
-      : ""
-  const profileHost =
-    source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE
-      ? tryParseUrl(source.profile.baseUrl)?.host || profileBaseUrl || undefined
-      : undefined
-  const sourceLabel =
-    source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE
-      ? t("sourceLabels.profileBadge", {
-          name: source.profile.name,
-          host: profileHost,
-        })
-      : source.account.name
+  const sourceBaseUrl =
+    source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
+      ? source.account.baseUrl?.trim()
+      : source.profile.baseUrl.trim()
+  const canUseSourceUrl = Boolean(sourceBaseUrl)
+
+  const handleCopySourceUrl = async () => {
+    if (!sourceBaseUrl) return
+
+    try {
+      await navigator.clipboard.writeText(sourceBaseUrl)
+      toast.success(t("messages.siteUrlCopied"))
+    } catch {
+      toast.error(t("messages.copyFailed"))
+    }
+  }
+
+  const handleOpenSourceUrl = () => {
+    if (!sourceBaseUrl) return
+
+    void createTab(sourceBaseUrl, true)
+  }
+
+  const sourceLabel = formatModelListSourceLabel(source, {
+    formatProfileLabel: ({ name, host }) =>
+      t("sourceLabels.profileBadge", { name, host }),
+  })
   const handleFilterAccount =
     source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT && onFilterAccount
       ? () => onFilterAccount(source.account.id)
@@ -178,18 +192,12 @@ export default function ModelItem(props: ModelItemProps) {
     supportsAccountSummary:
       source.capabilities.supportsAccountSummary &&
       displayCapabilities.supportsAccountSummary,
-    supportsTokenCompatibility:
-      source.capabilities.supportsTokenCompatibility &&
-      displayCapabilities.supportsTokenCompatibility,
+    supportsTokenCompatibility: source.capabilities.supportsTokenCompatibility,
     supportsCredentialVerification:
-      source.capabilities.supportsCredentialVerification &&
-      displayCapabilities.supportsCredentialVerification,
+      source.capabilities.supportsCredentialVerification,
     supportsBatchCredentialVerification:
-      source.capabilities.supportsBatchCredentialVerification &&
-      displayCapabilities.supportsBatchCredentialVerification,
-    supportsCliVerification:
-      source.capabilities.supportsCliVerification &&
-      displayCapabilities.supportsCliVerification,
+      source.capabilities.supportsBatchCredentialVerification,
+    supportsCliVerification: source.capabilities.supportsCliVerification,
   }
 
   const showPricing =
@@ -210,7 +218,7 @@ export default function ModelItem(props: ModelItemProps) {
         ? activeGroups.some((group) => model.enable_groups.includes(group))
         : true
 
-  const sourceBadge = sourceLabel ? (
+  const sourceBadge = sourceLabel.label ? (
     handleFilterAccount ? (
       <Badge
         asChild
@@ -221,18 +229,57 @@ export default function ModelItem(props: ModelItemProps) {
         <button
           type="button"
           onClick={handleFilterAccount}
-          title={sourceLabel}
-          aria-label={sourceLabel}
+          title={sourceLabel.title ?? sourceLabel.label}
+          aria-label={sourceLabel.label}
           className="max-w-full min-w-0 cursor-pointer hover:border-blue-300 hover:text-blue-700 dark:hover:border-blue-400 dark:hover:text-blue-300"
         >
-          <span className="min-w-0 truncate">{sourceLabel}</span>
+          <span className="min-w-0 truncate">{sourceLabel.label}</span>
         </button>
       </Badge>
     ) : (
-      <Badge variant="outline" size="default" className="max-w-full min-w-0">
-        <span className="min-w-0 truncate">{sourceLabel}</span>
+      <Badge
+        variant="outline"
+        size="default"
+        className="max-w-full min-w-0"
+        title={sourceLabel.title ?? sourceLabel.label}
+      >
+        <span className="min-w-0 truncate">{sourceLabel.label}</span>
       </Badge>
     )
+  ) : null
+  const sourceUrlActions = canUseSourceUrl ? (
+    <>
+      <IconButton
+        variant="ghost"
+        size="sm"
+        onClick={handleCopySourceUrl}
+        title={t("actions.copySiteUrl")}
+        aria-label={t("actions.copySiteUrl")}
+        className="shrink-0"
+        analyticsAction={
+          source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
+            ? PRODUCT_ANALYTICS_ACTION_IDS.CopyAccountSiteUrl
+            : PRODUCT_ANALYTICS_ACTION_IDS.CopyBaseUrl
+        }
+      >
+        <Copy className="h-3 w-3 text-gray-600 sm:h-3.5 sm:w-3.5 dark:text-gray-300" />
+      </IconButton>
+      <IconButton
+        variant="ghost"
+        size="sm"
+        onClick={handleOpenSourceUrl}
+        title={t("actions.openSite")}
+        aria-label={t("actions.openSite")}
+        className="shrink-0"
+        analyticsAction={
+          source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
+            ? PRODUCT_ANALYTICS_ACTION_IDS.OpenAccountSite
+            : undefined
+        }
+      >
+        <ExternalLink className="h-3 w-3 text-gray-600 sm:h-3.5 sm:w-3.5 dark:text-gray-300" />
+      </IconButton>
+    </>
   ) : null
 
   return (
@@ -278,9 +325,10 @@ export default function ModelItem(props: ModelItemProps) {
                 : undefined
             }
             trailingContent={
-              sourceBadge || canExpand ? (
+              sourceBadge || sourceUrlActions || canExpand ? (
                 <>
                   {sourceBadge}
+                  {sourceUrlActions}
                   {canExpand && (
                     <ModelItemExpandButton
                       isExpanded={isExpanded}

--- a/src/features/ModelList/sourceLabels.ts
+++ b/src/features/ModelList/sourceLabels.ts
@@ -1,0 +1,42 @@
+import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
+import type { ModelManagementItemSource } from "~/features/ModelList/modelManagementSources"
+import { tryParseUrl } from "~/utils/core/urlParsing"
+
+type ModelListSourceLabel = {
+  label: string
+  title?: string
+}
+
+type FormatModelListSourceLabelOptions = {
+  formatProfileLabel: (params: { name: string; host?: string }) => string
+}
+
+/**
+ * Formats the model-row source so multi-account views expose both the account
+ * name and the site host without repeating URL parsing in every row surface.
+ */
+export function formatModelListSourceLabel(
+  source: ModelManagementItemSource,
+  options: FormatModelListSourceLabelOptions,
+): ModelListSourceLabel {
+  if (source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE) {
+    const baseUrl = source.profile.baseUrl.trim()
+    const host = tryParseUrl(baseUrl)?.host || baseUrl || undefined
+
+    return {
+      label: options.formatProfileLabel({
+        name: source.profile.name,
+        host,
+      }),
+      title: baseUrl || undefined,
+    }
+  }
+
+  const baseUrl = source.account.baseUrl?.trim() ?? ""
+  const host = tryParseUrl(baseUrl)?.host || baseUrl || undefined
+
+  return {
+    label: host ? `${source.account.name} · ${host}` : source.account.name,
+    title: baseUrl || undefined,
+  }
+}

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -21,7 +21,9 @@
   },
   "actions": {
     "copyModelName": "Copy model name",
+    "copySiteUrl": "Copy site URL",
     "keyForModel": "Key for this model",
+    "openSite": "Open site",
     "verifyApi": "Verify API",
     "verifyCliSupport": "Verify CLI Support"
   },
@@ -148,7 +150,8 @@
   "messages": {
     "copyFailed": "Copy failed",
     "modelNameCopied": "Model name copied",
-    "modelNamesCopied": "Model names copied"
+    "modelNamesCopied": "Model names copied",
+    "siteUrlCopied": "Site URL copied"
   },
   "noMatchingModels": "No matching models found",
   "noSourcesDescription": "Add a site account or API credential before viewing the model list.",

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -19,7 +19,9 @@
   },
   "actions": {
     "copyModelName": "モデル名をコピー",
+    "copySiteUrl": "サイト URL をコピー",
     "keyForModel": "このモデル用のキー",
+    "openSite": "サイトを開く",
     "verifyApi": "API を検証",
     "verifyCliSupport": "CLI 対応を検証"
   },
@@ -142,7 +144,8 @@
   "messages": {
     "copyFailed": "コピーに失敗しました",
     "modelNameCopied": "モデル名をコピーしました",
-    "modelNamesCopied": "モデル名をコピーしました"
+    "modelNamesCopied": "モデル名をコピーしました",
+    "siteUrlCopied": "サイト URL をコピーしました"
   },
   "noMatchingModels": "一致するモデルが見つかりません",
   "noSourcesDescription": "モデル一覧を表示するには、先にサイトアカウントまたは API 認証情報を追加してください。",

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -19,7 +19,9 @@
   },
   "actions": {
     "copyModelName": "Sao chép tên mô hình",
+    "copySiteUrl": "Sao chép URL trang",
     "keyForModel": "Khóa tương ứng với mô hình",
+    "openSite": "Mở trang",
     "verifyApi": "Xác minh API",
     "verifyCliSupport": "Xác minh khả năng tương thích CLI"
   },
@@ -142,7 +144,8 @@
   "messages": {
     "copyFailed": "Sao chép thất bại",
     "modelNameCopied": "Đã sao chép tên mô hình",
-    "modelNamesCopied": "Đã sao chép tên các mô hình"
+    "modelNamesCopied": "Đã sao chép tên các mô hình",
+    "siteUrlCopied": "Đã sao chép URL trang"
   },
   "noMatchingModels": "Không tìm thấy mô hình nào phù hợp",
   "noSourcesDescription": "Vui lòng thêm tài khoản trang web hoặc thông tin xác thực API trước, sau đó xem danh sách mô hình.",

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -19,7 +19,9 @@
   },
   "actions": {
     "copyModelName": "复制模型名称",
+    "copySiteUrl": "复制站点 URL",
     "keyForModel": "模型对应密钥",
+    "openSite": "打开站点",
     "verifyApi": "验证接口",
     "verifyCliSupport": "验证 CLI 兼容性"
   },
@@ -142,7 +144,8 @@
   "messages": {
     "copyFailed": "复制失败",
     "modelNameCopied": "模型名称已复制",
-    "modelNamesCopied": "模型名称已复制"
+    "modelNamesCopied": "模型名称已复制",
+    "siteUrlCopied": "站点 URL 已复制"
   },
   "noMatchingModels": "没有找到匹配的模型",
   "noSourcesDescription": "请先添加站点账号或 API 凭据，然后查看模型列表。",

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -19,7 +19,9 @@
   },
   "actions": {
     "copyModelName": "複製模型名稱",
+    "copySiteUrl": "複製站點 URL",
     "keyForModel": "模型對應金鑰",
+    "openSite": "打開站點",
     "verifyApi": "驗證介面",
     "verifyCliSupport": "驗證 CLI 相容性"
   },
@@ -142,7 +144,8 @@
   "messages": {
     "copyFailed": "複製失敗",
     "modelNameCopied": "模型名稱已複製",
-    "modelNamesCopied": "模型名稱已複製"
+    "modelNamesCopied": "模型名稱已複製",
+    "siteUrlCopied": "站點 URL 已複製"
   },
   "noMatchingModels": "沒有找到匹配的模型",
   "noSourcesDescription": "請先新增站點帳號或 API 憑據，然後查看模型列表。",

--- a/tests/entrypoints/options/pages/ModelList/ModelItem.profileActions.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelItem.profileActions.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import ModelItem from "~/features/ModelList/components/ModelItem"
 import {
@@ -16,7 +16,23 @@ import {
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
 import { render, screen } from "~~/tests/test-utils/render"
 
+const mockCreateTab = vi.hoisted(() => vi.fn())
+
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/utils/browser/browserApi")>()
+
+  return {
+    ...actual,
+    createTab: mockCreateTab,
+  }
+})
+
 describe("ModelItem profile actions", () => {
+  beforeEach(() => {
+    mockCreateTab.mockReset()
+  })
+
   it("exposes credential-based API and CLI verification for profile-backed rows", async () => {
     const user = userEvent.setup()
     const onVerifyModel = vi.fn()
@@ -235,6 +251,13 @@ describe("ModelItem profile actions", () => {
   })
 
   it("falls back to the raw profile baseUrl when the URL is malformed", async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    })
+
     const profileSource = createProfileSource({
       id: "profile-legacy",
       name: "Legacy Key",
@@ -278,6 +301,25 @@ describe("ModelItem profile actions", () => {
     expect(
       await screen.findByText("modelList:sourceLabels.profileBadge"),
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "modelList:actions.copySiteUrl",
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "modelList:actions.openSite",
+      }),
+    ).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "modelList:actions.copySiteUrl",
+      }),
+    )
+
+    expect(writeText).toHaveBeenCalledWith("not-a-valid-url")
+    expect(mockCreateTab).not.toHaveBeenCalled()
   })
 
   it("shows the owning account name as the source badge for account-backed rows", async () => {
@@ -327,8 +369,12 @@ describe("ModelItem profile actions", () => {
       />,
     )
 
-    const sourceBadge = await screen.findByText("Example Account")
+    const sourceBadge = await screen.findByText("Example Account · example.com")
     expect(sourceBadge).toBeInTheDocument()
+    expect(sourceBadge.closest("[data-slot]")).toHaveAttribute(
+      "title",
+      "https://example.com",
+    )
     expect(sourceBadge.closest("button")).toBeNull()
   })
 
@@ -384,9 +430,10 @@ describe("ModelItem profile actions", () => {
     )
 
     const sourceBadgeButton = (
-      await screen.findByText("Example Account")
+      await screen.findByText("Example Account · example.com")
     ).closest("button")
     expect(sourceBadgeButton).not.toBeNull()
+    expect(sourceBadgeButton).toHaveAttribute("title", "https://example.com")
 
     await user.click(sourceBadgeButton!)
 

--- a/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
+++ b/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
@@ -233,6 +233,23 @@ describe("BatchVerifyModelsDialog", () => {
     ).toBeInTheDocument()
   })
 
+  it("shows each row source account and site host before running", async () => {
+    renderDialog([
+      {
+        key: "account:acc-1:model:gpt-4o",
+        modelId: "gpt-4o",
+        enableGroups: ["default"],
+        source: { kind: "account", account },
+      },
+    ])
+
+    const row = await screen.findByTestId(
+      getBatchVerifyRowTestId("account:acc-1:model:gpt-4o"),
+    )
+
+    expect(row).toHaveTextContent("Account One · api.example.com")
+  })
+
   it("shrinks the virtual row container to the measured content height", async () => {
     renderDialog([
       {

--- a/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
+++ b/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
@@ -248,6 +248,10 @@ describe("BatchVerifyModelsDialog", () => {
     )
 
     expect(row).toHaveTextContent("Account One · api.example.com")
+    const sourceBadge = row.querySelector(
+      '[data-slot="badge"][title="https://api.example.com"]',
+    )
+    expect(sourceBadge).toHaveTextContent("Account One · api.example.com")
   })
 
   it("shrinks the virtual row container to the measured content height", async () => {
@@ -1566,9 +1570,9 @@ describe("BatchVerifyModelsDialog", () => {
     const row = await screen.findByTestId(
       getBatchVerifyRowTestId("profile:profile-1:model:claude-3-5-sonnet"),
     )
-    const sourceBadge = row
-      .querySelector('[title="https://anthropic.example.com"]')
-      ?.closest("[data-slot]")
+    const sourceBadge = row.querySelector(
+      '[data-slot="badge"][title="https://anthropic.example.com"]',
+    )
     expect(sourceBadge).toHaveTextContent("modelList:sourceLabels.profileBadge")
     expect(sourceBadge).toHaveAttribute(
       "title",

--- a/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
+++ b/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
@@ -1563,6 +1563,18 @@ describe("BatchVerifyModelsDialog", () => {
       },
     ])
 
+    const row = await screen.findByTestId(
+      getBatchVerifyRowTestId("profile:profile-1:model:claude-3-5-sonnet"),
+    )
+    const sourceBadge = row
+      .querySelector('[title="https://anthropic.example.com"]')
+      ?.closest("[data-slot]")
+    expect(sourceBadge).toHaveTextContent("modelList:sourceLabels.profileBadge")
+    expect(sourceBadge).toHaveAttribute(
+      "title",
+      "https://anthropic.example.com",
+    )
+
     fireEvent.click(
       await screen.findByRole("button", {
         name: "modelList:batchVerify.actions.start",

--- a/tests/features/ModelList/components/ModelItem.test.tsx
+++ b/tests/features/ModelList/components/ModelItem.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type React from "react"
+import toast from "react-hot-toast"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import ModelItem from "~/features/ModelList/components/ModelItem"
@@ -13,6 +14,7 @@ import {
   PRODUCT_ANALYTICS_FEATURE_IDS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
+import { createTab } from "~/utils/browser/browserApi"
 
 const { loggerWarnSpy } = vi.hoisted(() => ({
   loggerWarnSpy: vi.fn(),
@@ -368,7 +370,14 @@ describe("ModelItem", () => {
     )
   })
 
-  it("keeps source controls in the header trailing area", () => {
+  it("keeps source controls in the header trailing area", async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard denied"))
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    })
+
     render(
       <ModelItem
         {...createDefaultProps()}
@@ -398,6 +407,15 @@ describe("ModelItem", () => {
     expect(
       screen.getByRole("button", { name: "actions.openSite" }),
     ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "actions.openSite" }))
+    expect(createTab).toHaveBeenCalledWith("https://api.example.com/", true)
+
+    await user.click(
+      screen.getByRole("button", { name: "actions.copySiteUrl" }),
+    )
+    expect(writeText).toHaveBeenCalledWith("https://api.example.com")
+    expect(toast.error).toHaveBeenCalledWith("messages.copyFailed")
   })
 
   it("treats expansion as controlled only when both props are provided", async () => {

--- a/tests/features/ModelList/components/ModelItem.test.tsx
+++ b/tests/features/ModelList/components/ModelItem.test.tsx
@@ -29,6 +29,10 @@ vi.mock("react-hot-toast", () => ({
   },
 }))
 
+vi.mock("~/utils/browser/browserApi", () => ({
+  createTab: vi.fn(),
+}))
+
 vi.mock("~/utils/core/logger", () => ({
   createLogger: () => ({
     debug: vi.fn(),
@@ -66,12 +70,33 @@ vi.mock("~/features/ModelList/components/ModelItem/ModelItemHeader", () => ({
   ModelItemHeader: ({
     model,
     trailingContent,
+    onOpenKeyDialog,
+    onVerifyApi,
+    onVerifyCliSupport,
   }: {
     model: { model_name: string }
     trailingContent?: React.ReactNode
+    onOpenKeyDialog?: () => void
+    onVerifyApi?: () => void
+    onVerifyCliSupport?: () => void
   }) => (
     <div>
       {model.model_name}
+      {onOpenKeyDialog ? (
+        <button type="button" onClick={onOpenKeyDialog}>
+          key
+        </button>
+      ) : null}
+      {onVerifyApi ? (
+        <button type="button" onClick={onVerifyApi}>
+          verify-api
+        </button>
+      ) : null}
+      {onVerifyCliSupport ? (
+        <button type="button" onClick={onVerifyCliSupport}>
+          verify-cli
+        </button>
+      ) : null}
       {trailingContent ? (
         <div className="flex min-w-0 flex-wrap items-center gap-2 sm:ml-auto">
           {trailingContent}
@@ -260,6 +285,60 @@ describe("ModelItem", () => {
     )
   })
 
+  it("keeps row-level account actions available when an aggregate display source disables them", async () => {
+    const user = userEvent.setup()
+    const onOpenModelKeyDialog = vi.fn()
+    const onVerifyModel = vi.fn()
+    const onVerifyCliSupport = vi.fn()
+    const props = createDefaultProps()
+
+    render(
+      <ModelItem
+        {...props}
+        source={{
+          ...props.source,
+          capabilities: {
+            ...props.source.capabilities,
+            supportsTokenCompatibility: true,
+            supportsCredentialVerification: true,
+            supportsCliVerification: true,
+          },
+        }}
+        displayCapabilities={{
+          supportsPricing: true,
+          supportsRatioDisplay: true,
+          supportsGroupFiltering: true,
+          supportsAccountSummary: true,
+          supportsTokenCompatibility: false,
+          supportsCredentialVerification: false,
+          supportsBatchCredentialVerification: true,
+          supportsCliVerification: false,
+        }}
+        onOpenModelKeyDialog={onOpenModelKeyDialog}
+        onVerifyModel={onVerifyModel}
+        onVerifyCliSupport={onVerifyCliSupport}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "key" }))
+    await user.click(screen.getByRole("button", { name: "verify-api" }))
+    await user.click(screen.getByRole("button", { name: "verify-cli" }))
+
+    expect(onOpenModelKeyDialog).toHaveBeenCalledWith(
+      props.source.account,
+      props.model.model_name,
+      props.model.enable_groups,
+    )
+    expect(onVerifyModel).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "account" }),
+      props.model.model_name,
+    )
+    expect(onVerifyCliSupport).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "account" }),
+      props.model.model_name,
+    )
+  })
+
   it("uses internal expansion state when expansion props are omitted", async () => {
     const user = userEvent.setup()
 
@@ -290,15 +369,35 @@ describe("ModelItem", () => {
   })
 
   it("keeps source controls in the header trailing area", () => {
-    render(<ModelItem {...createDefaultProps()} />)
+    render(
+      <ModelItem
+        {...createDefaultProps()}
+        source={{
+          ...createDefaultProps().source,
+          account: {
+            ...createDefaultProps().source.account,
+            baseUrl: "https://api.example.com",
+          },
+        }}
+      />,
+    )
 
-    const sourceBadge = screen.getByText("Account One").closest("[data-slot]")
+    const sourceBadge = screen
+      .getByText("Account One · api.example.com")
+      .closest("[data-slot]")
     expect(sourceBadge).toHaveClass("max-w-full", "min-w-0")
     expect(sourceBadge?.parentElement).toHaveClass(
       "flex-wrap",
       "items-center",
       "sm:ml-auto",
     )
+    expect(sourceBadge).toHaveAttribute("title", "https://api.example.com")
+    expect(
+      screen.getByRole("button", { name: "actions.copySiteUrl" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "actions.openSite" }),
+    ).toBeInTheDocument()
   })
 
   it("treats expansion as controlled only when both props are provided", async () => {


### PR DESCRIPTION
## Summary
- Restore per-row model key creation, single API verification, and CLI verification actions in aggregate model-list views.
- Show account/profile source labels with site hosts in model cards and batch verification rows.
- Add localized copy plus regression coverage for restored row actions and source visibility.

## Root Cause
The recent model-list capability merge from #857 introduced an `effectiveCapabilities` path that applied the selected list source capabilities to every rendered row. In the `all-accounts` view, the aggregate source intentionally disables single-account actions such as key creation, single API verification, and CLI verification. Each row still had its concrete account source with those capabilities, but the row actions were gated by the aggregate display source, so the action callbacks became unavailable and the header buttons disappeared.

Batch verification had a separate visibility gap: result rows showed the model/status/latency/token but not the owning account or site URL, so users could not tell which site a batch result belonged to.

## Fix
- Keep display-only capabilities such as pricing, ratio display, group filtering, and account summary scoped to the selected display source.
- Gate row-level actions from the concrete row `source.capabilities`, preserving source-specific downgrades such as AIHubMix unsupported actions.
- Add shared source label formatting so model rows and batch verification rows can show account/profile names with the site host.
- Add copy/open site URL actions back to model rows.

## Linked Issues / PRs
Fixes #943
Related to #857

## Test Plan
- pnpm vitest --run tests/features/ModelList/components/ModelItem.test.tsx tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
- pnpm run i18n:extract:ci
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy and open site URL actions added to model list rows; trailing header shows site actions when badge, URL actions, or expandable details are present.
  * Source badges now include hostname info and show full site URL as a tooltip/title.
  * Verification/token indicators now reflect the source's reported capabilities (affecting which row-level actions appear).

* **Localization**
  * Added localized labels/messages for site URL actions and copy confirmations.

* **Tests**
  * Added/updated tests for site URL actions and enhanced source badge rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->