### PR TITLE
fix(settings): improve setup guidance destinations

### DIFF
--- a/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
+++ b/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
@@ -38,7 +38,10 @@ import {
   getHealthStatusDisplay,
   getStatusIndicatorColor,
 } from "~/features/AccountManagement/utils/healthStatusUtils"
-import { getTempWindowFallbackSettingsTab } from "~/features/AccountManagement/utils/tempWindowFallbackReminder"
+import {
+  getTempWindowFallbackSettingsAnchor,
+  getTempWindowFallbackSettingsTab,
+} from "~/features/AccountManagement/utils/tempWindowFallbackReminder"
 import { useLdohSiteLookupContext } from "~/features/LdohSiteLookup/hooks/LdohSiteLookupContext"
 import { getDayKeyFromUnixSeconds } from "~/services/history/usageHistory/core"
 import {
@@ -143,6 +146,10 @@ export default function SiteInfo({
     canOpenHealthSettings && healthCode
       ? getTempWindowFallbackSettingsTab(healthCode)
       : null
+  const healthSettingsAnchor =
+    canOpenHealthSettings && healthCode
+      ? getTempWindowFallbackSettingsAnchor(healthCode)
+      : undefined
 
   const handleOpenAccountSite = async (e: React.MouseEvent) => {
     e.preventDefault()
@@ -415,6 +422,7 @@ export default function SiteInfo({
                         e.preventDefault()
                         e.stopPropagation()
                         void openSettingsTab(healthSettingsTab, {
+                          anchor: healthSettingsAnchor,
                           preserveHistory: true,
                         }).catch((error) => {
                           const errorMessage = getErrorMessage(

--- a/src/features/AccountManagement/components/TempWindowFallbackReminderDialog.tsx
+++ b/src/features/AccountManagement/components/TempWindowFallbackReminderDialog.tsx
@@ -81,8 +81,11 @@ export function TempWindowFallbackReminderDialog({
 
   const handleOpenSettings = useCallback(async () => {
     onClose()
-    await openSettingsTab(issue.settingsTab, { preserveHistory: true })
-  }, [issue.settingsTab, onClose])
+    await openSettingsTab(issue.settingsTab, {
+      anchor: issue.settingsAnchor,
+      preserveHistory: true,
+    })
+  }, [issue.settingsAnchor, issue.settingsTab, onClose])
 
   const handleNeverRemind = useCallback(async () => {
     await onNeverRemind()

--- a/src/features/AccountManagement/utils/tempWindowFallbackReminder.ts
+++ b/src/features/AccountManagement/utils/tempWindowFallbackReminder.ts
@@ -5,12 +5,14 @@ import {
 } from "~/types"
 
 export type TempWindowFallbackSettingsTab = "refresh" | "permissions"
+export type TempWindowFallbackSettingsAnchor = "shield-settings"
 
 export interface TempWindowFallbackIssue {
   code: HealthStatusCode
   accountId: string
   accountName: string
   settingsTab: TempWindowFallbackSettingsTab
+  settingsAnchor?: TempWindowFallbackSettingsAnchor
 }
 
 /**
@@ -23,6 +25,19 @@ export function getTempWindowFallbackSettingsTab(
     return "permissions"
   }
   return "refresh"
+}
+
+/**
+ * Maps a health status code to the most relevant in-tab Settings anchor.
+ */
+export function getTempWindowFallbackSettingsAnchor(
+  code: HealthStatusCode,
+): TempWindowFallbackSettingsAnchor | undefined {
+  if (code === TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED) {
+    return "shield-settings"
+  }
+
+  return undefined
 }
 
 /**
@@ -48,6 +63,7 @@ export function getTempWindowFallbackIssue(
       accountId: site.id,
       accountName: site.name,
       settingsTab: getTempWindowFallbackSettingsTab(code),
+      settingsAnchor: getTempWindowFallbackSettingsAnchor(code),
     }
   }
 

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -214,7 +214,9 @@ const getManagedSiteStatusDescription = (
 
   switch (managedSiteStatus.reason) {
     case MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.CONFIG_MISSING:
-      return t("keyManagement:managedSiteStatus.descriptions.configMissing")
+      return t(
+        "keyManagement:managedSiteStatus.descriptions.configMissingOptional",
+      )
     case MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.INPUT_PREPARATION_FAILED:
       return t(
         "keyManagement:managedSiteStatus.descriptions.inputPreparationFailed",
@@ -616,8 +618,13 @@ export function TokenHeader({
       managedSiteStatus &&
       onManagedSiteVerificationRetry,
   )
+  const isManagedSiteConfigMissing =
+    managedSiteStatus?.status === MANAGED_SITE_TOKEN_CHANNEL_STATUSES.UNKNOWN &&
+    managedSiteStatus.reason ===
+      MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.CONFIG_MISSING
   const shouldShowManagedSiteSettingsAction = Boolean(
-    managedSiteRecovery && !canRetryManagedSiteVerification,
+    (managedSiteRecovery && !canRetryManagedSiteVerification) ||
+      isManagedSiteConfigMissing,
   )
   const managedSiteRecoveryMessage = managedSiteRecovery
     ? canRetryManagedSiteVerification
@@ -652,8 +659,12 @@ export function TokenHeader({
   }
 
   const handleOpenManagedSiteSettings = () => {
-    void openSettingsTab("managedSite", { preserveHistory: true }).catch(
-      (error) => logger.error("Failed to open managed-site settings", error),
+    void Promise.resolve(
+      openSettingsTab("managedSite", {
+        preserveHistory: true,
+      }),
+    ).catch((error) =>
+      logger.error("Failed to open managed-site settings", error),
     )
   }
 
@@ -784,7 +795,9 @@ export function TokenHeader({
                 onClick={handleOpenManagedSiteSettings}
                 title={managedSiteRecoveryMessage ?? undefined}
               >
-                {t("common:labels.settings")}
+                {isManagedSiteConfigMissing
+                  ? t("managedSiteStatus.actions.configureChecks")
+                  : t("common:labels.settings")}
               </WorkflowTransitionButton>
             ) : null}
           </div>

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -164,6 +164,7 @@
   },
   "managedSiteStatus": {
     "actions": {
+      "configureChecks": "Configure managed-site checks",
       "refresh": "Refresh Managed-Site Channel Status",
       "refreshing": "Refreshing Managed-Site Channel Status",
       "reviewChannels": "Review channels",
@@ -182,7 +183,7 @@
     "descriptions": {
       "backendSearchFailed": "Managed-site checks could not be completed.",
       "baseUrlSearchUnsupported": "This feature is not supported on the current managed site because it does not support base URL search for channel lookup.",
-      "configMissing": "Configure managed-site admin credentials before checks can run.",
+      "configMissingOptional": "Optional managed-site channel checks are not enabled yet. Viewing, copying, and creating keys still work.",
       "inputPreparationFailed": "Verification could not prepare comparable channel inputs.",
       "newApiRetrieveKeyHint": "For New API, full key comparison depends on the channel key, and viewing that channel key itself requires 2FA verification, so full key comparison is currently unavailable."
     },

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -159,6 +159,7 @@
   },
   "managedSiteStatus": {
     "actions": {
+      "configureChecks": "管理対象サイト確認を設定",
       "refresh": "管理対象サイトのチャネル状態を更新",
       "refreshing": "管理対象サイトのチャネル状態を更新中",
       "reviewChannels": "チャネルを確認",
@@ -177,7 +178,7 @@
     "descriptions": {
       "backendSearchFailed": "管理対象サイトの確認を完了できませんでした。",
       "baseUrlSearchUnsupported": "現在の管理対象サイトはチャネル検索時の Base URL 検索をサポートしていないため、この機能は利用できません。",
-      "configMissing": "確認を実行する前に、管理対象サイトの管理者認証情報を設定してください。",
+      "configMissingOptional": "任意の管理対象サイトのチャネル確認はまだ有効化されていません。キーの表示、コピー、作成は引き続き利用できます。",
       "inputPreparationFailed": "検証に必要な比較用チャネル入力を準備できませんでした。",
       "newApiRetrieveKeyHint": "New API では完全なキー比較がチャネルキーに依存しますが、そのチャネルキー自体の表示に 2FA 認証が必要なため、現時点では完全なキー比較は利用できません。"
     },

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -159,6 +159,7 @@
   },
   "managedSiteStatus": {
     "actions": {
+      "configureChecks": "Cấu hình kiểm tra trang web quản lý",
       "refresh": "Làm mới trạng thái kênh trang web quản lý",
       "refreshing": "Đang làm mới trạng thái kênh trang web quản lý",
       "reviewChannels": "Xem các kênh ứng viên",
@@ -177,7 +178,7 @@
     "descriptions": {
       "backendSearchFailed": "Kiểm tra trang web quản lý tạm thời không thể hoàn tất.",
       "baseUrlSearchUnsupported": "Tính năng này không được hỗ trợ trên trang web lưu trữ hiện tại vì trang web lưu trữ hiện tại không hỗ trợ tìm kiếm kênh theo địa chỉ cơ sở.",
-      "configMissing": "Vui lòng định cấu hình thông tin xác thực quản trị viên của trang web quản lý trước khi kiểm tra.",
+      "configMissingOptional": "Kiểm tra kênh trang web quản lý là tùy chọn và chưa được bật; việc xem, sao chép hoặc tạo khóa vẫn hoạt động.",
       "inputPreparationFailed": "Không thể chuẩn bị dữ liệu nhập kênh có thể so sánh, tạm thời không thể hoàn tất kiểm tra.",
       "newApiRetrieveKeyHint": "Đối với New API, việc so sánh toàn bộ key phụ thuộc vào key kênh, và việc xem key kênh yêu cầu phải hoàn tất xác minh 2FA trước, do đó hiện tại chưa thể hoàn tất so sánh toàn bộ key."
     },

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -159,6 +159,7 @@
   },
   "managedSiteStatus": {
     "actions": {
+      "configureChecks": "配置管理站点校验",
       "refresh": "刷新管理站点渠道状态",
       "refreshing": "正在刷新管理站点渠道状态",
       "reviewChannels": "查看候选渠道",
@@ -177,7 +178,7 @@
     "descriptions": {
       "backendSearchFailed": "管理站点校验暂时无法完成。",
       "baseUrlSearchUnsupported": "该功能在当前托管站点上不受支持，因为当前托管站点不支持按基础地址搜索渠道。",
-      "configMissing": "请先配置管理站点管理员凭据后再进行校验。",
+      "configMissingOptional": "可选的管理站点渠道校验尚未启用；不影响密钥查看、复制或创建。",
       "inputPreparationFailed": "无法准备可比对的渠道输入，暂时无法完成校验。",
       "newApiRetrieveKeyHint": "对于 New API，完整的 key 比对依赖渠道 key，而查看渠道 key 本身需要先完成 2FA 验证，因此当前暂无法完成完整 key 比对。"
     },

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -159,6 +159,7 @@
   },
   "managedSiteStatus": {
     "actions": {
+      "configureChecks": "設定管理站點校驗",
       "refresh": "重新整理管理站點渠道狀態",
       "refreshing": "正在重新整理管理站點渠道狀態",
       "reviewChannels": "檢視候選渠道",
@@ -177,7 +178,7 @@
     "descriptions": {
       "backendSearchFailed": "管理站點校驗暫時無法完成。",
       "baseUrlSearchUnsupported": "該功能在目前的託管站點上不受支援，因為目前的託管站點不支援按基礎地址搜尋渠道。",
-      "configMissing": "請先配置管理站點管理員憑據後再進行校驗。",
+      "configMissingOptional": "可選的管理站點渠道校驗尚未啟用；不影響金鑰檢視、複製或建立。",
       "inputPreparationFailed": "無法準備可比對的渠道輸入，暫時無法完成校驗。",
       "newApiRetrieveKeyHint": "對於 New API，完整的 key 比對依賴渠道 key，而檢視渠道 key 本身需要先完成 2FA 驗證，因此當前暫無法完成完整 key 比對。"
     },

--- a/tests/entrypoints/options/pages/KeyManagement/TokenHeader.saveToApiProfiles.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/TokenHeader.saveToApiProfiles.test.tsx
@@ -886,6 +886,71 @@ describe("TokenHeader save to API profiles", () => {
     ).toBeInTheDocument()
   })
 
+  it("explains missing managed-site admin credentials as an optional check and opens the setup anchor", async () => {
+    const user = userEvent.setup()
+    const account = createAccountStub()
+
+    const token = {
+      id: 9_2,
+      user_id: 1,
+      key: "sk-managed-site-config-missing",
+      status: 1,
+      name: "Managed Site Config Missing Token",
+      created_time: 0,
+      accessed_time: 0,
+      expired_time: 0,
+      remain_quota: 0,
+      unlimited_quota: false,
+      used_quota: 0,
+      accountId: account.id,
+      accountName: account.name,
+    }
+
+    render(
+      <TokenHeader
+        token={token as any}
+        copyKey={vi.fn()}
+        handleEditToken={vi.fn()}
+        handleDeleteToken={vi.fn()}
+        account={account}
+        managedSiteStatus={{
+          status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.UNKNOWN,
+          reason:
+            MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.CONFIG_MISSING,
+        }}
+      />,
+    )
+
+    expect(
+      screen.getByText("keyManagement:managedSiteStatus.badges.configMissing"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "keyManagement:managedSiteStatus.descriptions.configMissingOptional",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        "keyManagement:managedSiteStatus.descriptions.configMissing",
+      ),
+    ).toBeNull()
+    expect(
+      screen.queryByRole("button", {
+        name: "keyManagement:managedSiteStatus.actions.verifyNow",
+      }),
+    ).toBeNull()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:managedSiteStatus.actions.configureChecks",
+      }),
+    )
+
+    expect(mockOpenSettingsTab).toHaveBeenCalledWith("managedSite", {
+      preserveHistory: true,
+    })
+  })
+
   it("logs a settings navigation failure instead of leaving the rejection unhandled", async () => {
     const user = userEvent.setup()
     const account = createAccountStub()

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -337,6 +337,39 @@ describe("SiteInfo", () => {
     })
   })
 
+  it("opens the shield settings anchor from the disabled temp-window health reason", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <SiteInfo
+        site={buildSite({
+          health: {
+            status: "warning",
+            code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
+            reason: "Temp window fallback disabled",
+          },
+        })}
+      />,
+    )
+
+    await user.hover(
+      screen.getByRole("button", {
+        name: "account:list.site.refreshHealthStatus",
+      }),
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Temp window fallback disabled",
+      }),
+    )
+
+    expect(mockOpenSettingsTab).toHaveBeenCalledWith("refresh", {
+      anchor: "shield-settings",
+      preserveHistory: true,
+    })
+  })
+
   it("shows a toast when opening the related settings tab fails", async () => {
     const user = userEvent.setup()
     mockOpenSettingsTab.mockRejectedValueOnce(new Error("settings page failed"))

--- a/tests/features/AccountManagement/components/TempWindowFallbackReminderDialog.test.tsx
+++ b/tests/features/AccountManagement/components/TempWindowFallbackReminderDialog.test.tsx
@@ -172,6 +172,7 @@ describe("TempWindowFallbackReminderDialog", () => {
           accountId: "acc-2",
           accountName: "Blocked account",
           settingsTab: "refresh",
+          settingsAnchor: "shield-settings",
         }}
         onClose={onClose}
         onNeverRemind={onNeverRemind}
@@ -219,6 +220,41 @@ describe("TempWindowFallbackReminderDialog", () => {
     expect(openSettingsTabMock).not.toHaveBeenCalled()
   })
 
+  it("opens the shield settings anchor when temp-window fallback is disabled", async () => {
+    const onClose = vi.fn()
+
+    render(
+      <TempWindowFallbackReminderDialog
+        isOpen
+        issue={{
+          code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
+          accountId: "acc-4",
+          accountName: "Blocked account",
+          settingsTab: "refresh",
+          settingsAnchor: "shield-settings",
+        }}
+        onClose={onClose}
+        onNeverRemind={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: JSON.stringify({
+          key: "ui:dialog.tempWindowFallbackReminder.actions.openSettings",
+        }),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(openSettingsTabMock).toHaveBeenCalledWith("refresh", {
+        anchor: "shield-settings",
+        preserveHistory: true,
+      })
+    })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   it.each([
     {
       issueCode: TEMP_WINDOW_HEALTH_STATUS_CODES.PERMISSION_REQUIRED,
@@ -251,6 +287,10 @@ describe("TempWindowFallbackReminderDialog", () => {
               issueCode === TEMP_WINDOW_HEALTH_STATUS_CODES.PERMISSION_REQUIRED
                 ? "permissions"
                 : "refresh",
+            settingsAnchor:
+              issueCode === TEMP_WINDOW_HEALTH_STATUS_CODES.PERMISSION_REQUIRED
+                ? undefined
+                : "shield-settings",
           }}
           onClose={vi.fn()}
           onNeverRemind={vi.fn()}

--- a/tests/features/AccountManagement/utils/tempWindowFallbackReminder.test.ts
+++ b/tests/features/AccountManagement/utils/tempWindowFallbackReminder.test.ts
@@ -53,7 +53,7 @@ describe("tempWindowFallbackReminder", () => {
     expect(issue).toBeNull()
   })
 
-  it("returns an issue for TEMP_WINDOW_DISABLED and maps to refresh tab", () => {
+  it("returns an issue for TEMP_WINDOW_DISABLED and maps to the shield settings anchor", () => {
     const issue = getTempWindowFallbackIssue([
       makeSite({
         id: "acc-2",
@@ -68,6 +68,7 @@ describe("tempWindowFallbackReminder", () => {
 
     expect(issue).not.toBeNull()
     expect(issue?.settingsTab).toBe("refresh")
+    expect(issue?.settingsAnchor).toBe("shield-settings")
     expect(issue?.accountName).toBe("Relay")
   })
 
@@ -86,6 +87,7 @@ describe("tempWindowFallbackReminder", () => {
 
     expect(issue).not.toBeNull()
     expect(issue?.settingsTab).toBe("permissions")
+    expect(issue?.settingsAnchor).toBeUndefined()
   })
 
   it("returns the first matching issue when multiple sites are blocked", () => {
@@ -115,6 +117,7 @@ describe("tempWindowFallbackReminder", () => {
       accountId: "acc-10",
       accountName: "First blocked",
       settingsTab: "refresh",
+      settingsAnchor: "shield-settings",
     })
   })
 })


### PR DESCRIPTION
## Summary
- Clarify that managed-site token verification is optional when no managed-site admin credentials are configured, and route the setup action to the generic managed-site settings tab.
- Point temp-window fallback guidance directly at the shield settings section when the fallback is disabled.
- Add focused coverage for both setup destinations.

Closes #948

## Test Plan
- pnpm vitest run tests/entrypoints/options/pages/KeyManagement/TokenHeader.saveToApiProfiles.test.tsx
- pnpm vitest run tests/features/AccountManagement/utils/tempWindowFallbackReminder.test.ts tests/features/AccountManagement/components/TempWindowFallbackReminderDialog.test.tsx tests/features/AccountManagement/components/SiteInfo.test.tsx
- pnpm run i18n:extract:ci
- pnpm compile
- pnpm run validate:staged
- pre-push: pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings navigation now supports anchored positioning for targeted tab access.
  * Added "Configure Checks" action for managed-site configuration.

* **Improvements**
  * Updated messaging for optional managed-site channel checks configuration.
  * Enhanced status handling for missing managed-site configuration scenarios.

* **Localization**
  * Updated UI text in English, Japanese, Vietnamese, Simplified Chinese, and Traditional Chinese.

* **Tests**
  * Added test coverage for settings navigation and managed-site configuration behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->