### PR TITLE
fix(webdav): avoid hidden temp backup names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,3 +86,10 @@ VITE_PUBLIC_POSTHOG_HOST=
 # AAH_E2E_NUTSTORE_WEBDAV_URL=https://dav.jianguoyun.com/dav/all-api-hub-e2e/all-api-hub-nutstore-move.json
 # AAH_E2E_NUTSTORE_WEBDAV_USERNAME=test-user@example.com
 # AAH_E2E_NUTSTORE_WEBDAV_PASSWORD=replace-with-nutstore-app-password
+
+# CTFile WebDAV real-site E2E
+# Use a dedicated low-value CTFile test file URL.
+# Run locally with: pnpm e2e:real-site:ctfile
+# AAH_E2E_CTFILE_WEBDAV_URL=https://dav.ctfile.com/test-space/all-api-hub-e2e/all-api-hub-ctfile.json
+# AAH_E2E_CTFILE_WEBDAV_USERNAME=test-user
+# AAH_E2E_CTFILE_WEBDAV_PASSWORD=replace-with-ctfile-password

--- a/.github/workflows/e2e-real-site.yml
+++ b/.github/workflows/e2e-real-site.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Account-backed real-site flows.
           - label: New API
             env_prefix: NEW_API
             spec: e2e/realSite/newApiAccountAdd.spec.ts
@@ -37,6 +38,7 @@ jobs:
           - label: Sub2API
             env_prefix: SUB2API
             spec: e2e/realSite/sub2apiAccountAdd.spec.ts
+          # WebDAV provider compatibility flows.
           - label: Nutstore WebDAV
             env_prefix: NUTSTORE_WEBDAV
             kind: webdav

--- a/.github/workflows/e2e-real-site.yml
+++ b/.github/workflows/e2e-real-site.yml
@@ -43,6 +43,12 @@ jobs:
             provider_name: Nutstore
             provider_account_prefix: nutstore
             spec: e2e/realSite/webdavProviderFlow.spec.ts
+          - label: CTFile WebDAV
+            env_prefix: CTFILE_WEBDAV
+            kind: webdav
+            provider_name: CTFile
+            provider_account_prefix: ctfile
+            spec: e2e/realSite/webdavProviderFlow.spec.ts
 
     steps:
       - name: Checkout code

--- a/e2e/alarmSchedulers.spec.ts
+++ b/e2e/alarmSchedulers.spec.ts
@@ -412,16 +412,20 @@ async function stubWebdavBackupRoutes(
   const uploadedPayloads: unknown[] = []
   const tempDeleteUrls: string[] = []
   const backupFileUrl = new URL(options.backupFileUrl)
+  const backupDirectoryPath = backupFileUrl.pathname.replace(/\/[^/]*$/, "")
+  const backupFileName = backupFileUrl.pathname.split("/").pop() ?? ""
 
   await context.route(`${backupFileUrl.origin}/**`, async (route: Route) => {
     const request = route.request()
     const method = request.method()
     const url = new URL(request.url())
     const isBackupFile = url.href === options.backupFileUrl
+    const requestDirectoryPath = url.pathname.replace(/\/[^/]*$/, "")
+    const requestFileName = url.pathname.split("/").pop() ?? ""
     const isTempBackupFile =
-      url.pathname.startsWith(
-        `${backupFileUrl.pathname.replace(/\/[^/]*$/, "")}/.`,
-      ) && url.pathname.includes(".tmp.")
+      requestDirectoryPath === backupDirectoryPath &&
+      (requestFileName.startsWith(`${backupFileName}.tmp.`) ||
+        requestFileName.startsWith(`.${backupFileName}.tmp.`))
 
     if (method === "GET" && (isBackupFile || isTempBackupFile)) {
       const body = isTempBackupFile ? stagedBackups.get(url.href) : remoteBackup

--- a/e2e/importExportCommonFlows.spec.ts
+++ b/e2e/importExportCommonFlows.spec.ts
@@ -1133,13 +1133,23 @@ test("uploads a WebDAV backup and restores it through the WebDAV download flow",
   const stagedBackups = new Map<string, string>()
   const tempDeleteUrls: string[] = []
   let remoteBackup = ""
+  const webdavBackupFile = new URL(webdavFileUrl)
+  const webdavBackupDirectoryPath = webdavBackupFile.pathname.replace(
+    /\/[^/]*$/,
+    "",
+  )
+  const webdavBackupFileName = webdavBackupFile.pathname.split("/").pop() ?? ""
 
   await context.route("https://webdav.example.com/**", async (route) => {
     const method = route.request().method()
     const url = new URL(route.request().url())
     const isBackupFile = url.href === webdavFileUrl
+    const requestDirectoryPath = url.pathname.replace(/\/[^/]*$/, "")
+    const requestFileName = url.pathname.split("/").pop() ?? ""
     const isTempBackupFile =
-      url.pathname.startsWith("/.") && url.pathname.includes(".tmp.")
+      requestDirectoryPath === webdavBackupDirectoryPath &&
+      (requestFileName.startsWith(`${webdavBackupFileName}.tmp.`) ||
+        requestFileName.startsWith(`.${webdavBackupFileName}.tmp.`))
 
     if (method === "GET" && (isBackupFile || isTempBackupFile)) {
       const body = isTempBackupFile ? stagedBackups.get(url.href) : remoteBackup

--- a/e2e/realSite/README.md
+++ b/e2e/realSite/README.md
@@ -20,7 +20,9 @@ Provider compatibility checks:
 
 - WebDAV providers: verify the live provider's UI-driven save, connection
   test, upload overwrite, and download/import flow. Nutstore is included as a
-  regression target for existing-file `MOVE` compatibility.
+  regression target for existing-file `MOVE` compatibility. CTFile is included
+  as a regression target for providers that reject hidden temporary upload
+  names.
 
 For current coverage details, inspect the specs in this directory and the shared
 helpers under `e2e/scenarios/`.
@@ -40,6 +42,7 @@ Run the shared WebDAV provider flow locally:
 
 ```bash
 pnpm e2e:real-site:nutstore
+pnpm e2e:real-site:ctfile
 pnpm e2e:real-site:webdav
 ```
 
@@ -136,6 +139,19 @@ runner selects these variables by default.
 AAH_E2E_NUTSTORE_WEBDAV_URL=https://dav.jianguoyun.com/dav/all-api-hub-e2e/all-api-hub-nutstore-move.json
 AAH_E2E_NUTSTORE_WEBDAV_USERNAME=test-user@example.com
 AAH_E2E_NUTSTORE_WEBDAV_PASSWORD=replace-with-nutstore-app-password
+```
+
+## CTFile WebDAV
+
+Use a dedicated low-value CTFile test file URL. The shared provider flow uploads
+through the extension UI, overwrites the same JSON file, imports it back, and
+deletes the exact test file before and after the run. This provider covers
+WebDAV servers that reject hidden `PUT` target names.
+
+```env
+AAH_E2E_CTFILE_WEBDAV_URL=https://dav.ctfile.com/test-space/all-api-hub-e2e/all-api-hub-ctfile.json
+AAH_E2E_CTFILE_WEBDAV_USERNAME=test-user
+AAH_E2E_CTFILE_WEBDAV_PASSWORD=replace-with-ctfile-password
 ```
 
 ## Additional WebDAV Providers

--- a/e2e/realSite/webdavProviderFlow.spec.ts
+++ b/e2e/realSite/webdavProviderFlow.spec.ts
@@ -258,7 +258,7 @@ test.describe("real-site E2E: WebDAV provider flow", () => {
   test.beforeEach(async ({ context, page }) => {
     installExtensionPageGuards(page, {
       ignoreConsoleErrorPatterns: [
-        /Failed to load resource: .*status of (404|409)/u,
+        /Failed to load resource: .*status of (404|405|409)/u,
       ],
     })
     await forceExtensionLanguage(page, "en")

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "e2e:default": "playwright test",
     "e2e:dnr-required": "playwright test e2e/dnrRequired --project=chromium --workers=1 --timeout=120000",
     "e2e:real-site": "playwright test e2e/realSite",
+    "e2e:real-site:ctfile": "node scripts/e2e-webdav-provider.mjs ctfile",
     "e2e:real-site:nutstore": "node scripts/e2e-webdav-provider.mjs nutstore",
     "e2e:real-site:webdav": "node scripts/e2e-webdav-provider.mjs",
     "e2e:diagnostics": "node scripts/diagnostics/e2e-diagnostics.mjs",

--- a/scripts/e2e-webdav-provider.mjs
+++ b/scripts/e2e-webdav-provider.mjs
@@ -14,6 +14,14 @@ const providerAliases = new Map([
       accountPrefix: "nutstore",
     },
   ],
+  [
+    "ctfile",
+    {
+      providerPrefix: "CTFILE_WEBDAV",
+      providerName: "CTFile",
+      accountPrefix: "ctfile",
+    },
+  ],
 ])
 
 const { providerArg, extraPlaywrightArgs } = parseArgs(process.argv.slice(2))
@@ -133,7 +141,9 @@ function printUsage() {
   console.log(`Usage:
   pnpm e2e:real-site:webdav
   pnpm e2e:real-site:webdav nutstore
+  pnpm e2e:real-site:webdav ctfile
   pnpm e2e:real-site:nutstore
+  pnpm e2e:real-site:ctfile
   pnpm e2e:real-site:webdav CUSTOM_WEBDAV -- --headed
 
 The provider argument selects AAH_E2E_<PROVIDER>_URL, USERNAME, and PASSWORD

--- a/src/services/webdav/webdavService.ts
+++ b/src/services/webdav/webdavService.ts
@@ -166,7 +166,14 @@ function createTimestampForTempFile(now: number = Date.now()) {
 function createSafeCommitTempPrefix(targetUrl: string) {
   const officialName =
     getBackupFileName(targetUrl) || `${PROGRAM_NAME}-${CONFIG_VERSION}.json`
-  return `.${officialName}.tmp.`
+  return `${officialName}.tmp.`
+}
+
+/**
+ * Creates the hidden temp prefix used by older builds.
+ */
+function createLegacySafeCommitTempPrefix(targetUrl: string) {
+  return `.${createSafeCommitTempPrefix(targetUrl)}`
 }
 
 /**
@@ -522,7 +529,7 @@ function resolveHrefToCollectionUrl(collectionUrl: string, href: string) {
  */
 async function cleanupStaleTempBackupsBestEffort(params: {
   collectionUrl: string
-  tempPrefix: string
+  tempPrefixes: string[]
   username: string
   password: string
   now?: number
@@ -545,11 +552,15 @@ async function cleanupStaleTempBackupsBestEffort(params: {
       const fileName = decodeURIComponent(
         href.split("/").filter(Boolean).pop() || "",
       )
-      const createdAt = parseTempTimestampFromFileName({
-        fileName,
-        tempPrefix: params.tempPrefix,
-      })
-      if (createdAt === null || now - createdAt <= STALE_TEMP_MAX_AGE_MS) {
+      const createdAt = params.tempPrefixes
+        .map((tempPrefix) =>
+          parseTempTimestampFromFileName({
+            fileName,
+            tempPrefix,
+          }),
+        )
+        .find((value): value is number => value !== null)
+      if (createdAt === undefined || now - createdAt <= STALE_TEMP_MAX_AGE_MS) {
         continue
       }
 
@@ -768,7 +779,10 @@ export async function uploadBackup(
   await prepareWebdavBackupTargetForWrite(context)
   void cleanupStaleTempBackupsBestEffort({
     collectionUrl: getBackupDirUrl(targetUrl),
-    tempPrefix: createSafeCommitTempPrefix(targetUrl),
+    tempPrefixes: [
+      createSafeCommitTempPrefix(targetUrl),
+      createLegacySafeCommitTempPrefix(targetUrl),
+    ],
     username: cfg.username,
     password: cfg.password,
   }).catch(() => {

--- a/tests/services/webdavService.test.ts
+++ b/tests/services/webdavService.test.ts
@@ -565,7 +565,27 @@ describe("webdavService", () => {
       await expect(uploadBackup('{"random":true}')).resolves.toBe(true)
 
       expect(globalAny.fetch.mock.calls[2][0]).toBe(
-        "https://example.com/webdav/all-api-hub-backup/.all-api-hub-1-0.json.tmp.20260531T041500Z.4fzzzxjylrx",
+        "https://example.com/webdav/all-api-hub-backup/all-api-hub-1-0.json.tmp.20260531T041500Z.4fzzzxjylrx",
+      )
+    })
+
+    it("uses non-hidden temp file names for provider compatibility", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
+
+      globalAny.fetch
+        .mockResolvedValueOnce({ status: 201 })
+        .mockResolvedValueOnce({ status: 405 })
+        .mockResolvedValueOnce({ status: 204 })
+        .mockResolvedValueOnce({
+          status: 200,
+          text: vi.fn().mockResolvedValue('{"visibleTemp":true}'),
+        })
+        .mockResolvedValueOnce({ status: 201 })
+
+      await expect(uploadBackup('{"visibleTemp":true}')).resolves.toBe(true)
+
+      expect(globalAny.fetch.mock.calls[2][0]).toMatch(
+        /^https:\/\/example\.com\/webdav\/all-api-hub-backup\/all-api-hub-1-0\.json\.tmp\.\d{8}T\d{6}Z\.[a-z0-9]+$/,
       )
     })
 
@@ -581,7 +601,7 @@ describe("webdavService", () => {
             .mockResolvedValue(`<?xml version="1.0" encoding="utf-8"?>
         <d:multistatus xmlns:d="DAV:">
           <d:response>
-            <d:href>/webdav/all-api-hub-backup/.all-api-hub-1-0.json.tmp.20260231T000000Z.invaliddate</d:href>
+            <d:href>/webdav/all-api-hub-backup/.all-api-hub-1-0.json.tmp.20261301T000000Z.invaliddate</d:href>
           </d:response>
         </d:multistatus>`),
         })
@@ -597,7 +617,7 @@ describe("webdavService", () => {
       expect(
         globalAny.fetch.mock.calls.some(
           ([url, init]: [unknown, RequestInit]) =>
-            String(url).includes("20260231T000000Z.invaliddate") &&
+            String(url).includes("20261301T000000Z.invaliddate") &&
             init?.method === "DELETE",
         ),
       ).toBe(false)
@@ -777,7 +797,7 @@ describe("webdavService", () => {
       expect((putInit as RequestInit).method).toBe("PUT")
       expect((putInit as RequestInit).body).toBe('{"foo":"bar"}')
       expect(String(tempUrl)).toMatch(
-        /^https:\/\/example\.com\/webdav\/all-api-hub-backup\/\.all-api-hub-1-0\.json\.tmp\.\d{8}T\d{6}Z\.[a-z0-9]+$/,
+        /^https:\/\/example\.com\/webdav\/all-api-hub-backup\/all-api-hub-1-0\.json\.tmp\.\d{8}T\d{6}Z\.[a-z0-9]+$/,
       )
       expect(putUrl).toBe(tempUrl)
       expect((getInit as RequestInit).method).toBe("GET")
@@ -1305,7 +1325,7 @@ describe("webdavService", () => {
         "https://example.com/custom-backups/",
       )
       expect(globalAny.fetch.mock.calls[3][0]).toMatch(
-        /^https:\/\/example\.com\/custom-backups\/\.custom\.json\.tmp\.\d{8}T\d{6}Z\.[a-z0-9]+$/,
+        /^https:\/\/example\.com\/custom-backups\/custom\.json\.tmp\.\d{8}T\d{6}Z\.[a-z0-9]+$/,
       )
       expect(globalAny.fetch.mock.calls[5][0]).toBe(
         globalAny.fetch.mock.calls[3][0],


### PR DESCRIPTION
## Summary
- Change WebDAV safe-commit temp uploads to use visible temp file names for providers that reject dot-prefixed PUT targets.
- Keep stale cleanup compatible with hidden temp files left by older builds.
- Add CTFile as a WebDAV real-site provider in the shared Playwright flow and CI matrix.

## Root Cause
CTFile accepted WebDAV directory and read requests, but rejected PUT requests to hidden dot-prefixed temp files such as .all-api-hub-1-0.json.tmp.* with 403. The safe-commit upload flow failed before reaching MOVE overwrite handling.

## Test Plan
- pnpm vitest run tests/services/webdavService.test.ts
- pnpm e2e:real-site:ctfile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CTFile WebDAV provider to real-site E2E testing.

* **Tests**
  * Extended real-site E2E coverage and added a dedicated CTFile test command.
  * Improved test handling of provider temp-file patterns and suppressed additional HTTP 405 console noise.

* **Chores**
  * Updated example environment configuration and documentation for CTFile.
  * Broadened temporary-file cleanup compatibility to cover legacy and current temp filename formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->