### PR TITLE
fix(webdav): persist dirty settings before testing

### DIFF
--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -218,7 +218,6 @@ export default function WebDAVSettings() {
     draft: localConfig,
     setDraft: setLocalConfig,
     isDirty: webdavConfigDirty,
-    expectedLastUpdated,
   } = usePreferenceDraft({
     savedValue: savedConfig,
     savedVersion: preferences.lastUpdated,
@@ -306,7 +305,7 @@ export default function WebDAVSettings() {
     try {
       success = await updateWebdavSettings(updates, {
         expectedLastUpdated:
-          options?.expectedLastUpdated ?? expectedLastUpdated,
+          options?.expectedLastUpdated ?? preferences.lastUpdated,
       })
     } catch (error) {
       throw new PersistWebdavConfigError(error)
@@ -365,7 +364,7 @@ export default function WebDAVSettings() {
       logger.error("WebDAV connection test failed", e)
       toast.error(
         e instanceof PersistWebdavConfigError
-          ? t("webdav.testFailed")
+          ? t("settings:messages.saveSettingsFailed")
           : e?.message || t("webdav.testFailed"),
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -513,7 +512,7 @@ export default function WebDAVSettings() {
       logger.error("Failed to upload backup to WebDAV", e)
       toast.error(
         e instanceof PersistWebdavConfigError
-          ? t("webdav.uploadFailed")
+          ? t("settings:messages.saveSettingsFailed")
           : e?.message || t("webdav.uploadFailed"),
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -676,7 +675,7 @@ export default function WebDAVSettings() {
       logger.error("Failed to download/import WebDAV backup", e)
       toast.error(
         e instanceof PersistWebdavConfigError
-          ? t("importExport:import.downloadImportFailed")
+          ? t("settings:messages.saveSettingsFailed")
           : e?.message || t("importExport:import.downloadImportFailed"),
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {

--- a/src/services/webdav/webdavService.ts
+++ b/src/services/webdav/webdavService.ts
@@ -122,9 +122,13 @@ function ensureFilename(url: string, version: string = CONFIG_VERSION) {
  * For directory-style settings, probe the configured collection itself instead
  * of the generated backup file path so first-time valid endpoints are not
  * rejected before the backup file exists.
+ *
+ * Both directory-style URLs (e.g., "http://host/webdav/") and file-style URLs
+ * (e.g., "http://host/webdav/backup.json") are returned unchanged, ensuring
+ * connection tests probe the user's exact configuration.
  */
 function resolveConnectionTestUrl(url: string) {
-  return /\.json($|\?)/i.test(url) ? ensureFilename(url) : url
+  return url
 }
 
 /**

--- a/src/services/webdav/webdavService.ts
+++ b/src/services/webdav/webdavService.ts
@@ -117,6 +117,17 @@ function ensureFilename(url: string, version: string = CONFIG_VERSION) {
 }
 
 /**
+ * Resolves the endpoint used for connection checks.
+ *
+ * For directory-style settings, probe the configured collection itself instead
+ * of the generated backup file path so first-time valid endpoints are not
+ * rejected before the backup file exists.
+ */
+function resolveConnectionTestUrl(url: string) {
+  return /\.json($|\?)/i.test(url) ? ensureFilename(url) : url
+}
+
+/**
  * Derives the backup directory URL from a fully-qualified backup target URL.
  *
  * Used so we can create the collection via `MKCOL` before uploading.
@@ -629,7 +640,8 @@ async function getWebdavEncryptionConfig() {
  * errors.
  */
 export async function testWebdavConnection(custom?: Partial<WebDAVConfig>) {
-  const { cfg, targetUrl } = await resolveWebdavBackupRequestContext(custom)
+  const { cfg } = await resolveWebdavBackupRequestContext(custom)
+  const targetUrl = resolveConnectionTestUrl(cfg.url)
 
   const res = await fetch(targetUrl, {
     method: "GET",

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -1197,6 +1197,64 @@ describe("WebDAVSettings", () => {
     )
   })
 
+  it("saves dirty WebDAV settings after unrelated preference timestamp changes before testing", async () => {
+    render(
+      <>
+        <WebDAVSettings />
+        <WebDAVAutoSyncSettings />
+      </>,
+    )
+
+    const webdavUrlInput = (await screen.findByDisplayValue(
+      "https://dav.example.com/backup.json",
+    )) as HTMLInputElement
+
+    fireEvent.change(webdavUrlInput, {
+      target: {
+        value: "http://127.0.0.1:1900/configSync/ALL-API-HUB",
+      },
+    })
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "importExport:webdav.autoSync.syncNow",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("custom sync ok")
+    })
+
+    clickWebdavAction("webdav-test-connection")
+
+    await waitFor(() => {
+      expect(
+        mockUserPreferences.savePreferencesWithResult,
+      ).toHaveBeenCalledWith(
+        {
+          webdav: expect.objectContaining({
+            url: "http://127.0.0.1:1900/configSync/ALL-API-HUB",
+            username: "alice",
+            password: "pw",
+          }),
+        },
+        {
+          expectedLastUpdated: 1,
+        },
+      )
+      expect(mockTestWebdavConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "http://127.0.0.1:1900/configSync/ALL-API-HUB",
+          username: "alice",
+          password: "pw",
+        }),
+      )
+    })
+    expect(toast.success).toHaveBeenCalledWith(
+      "importExport:webdav.testSuccess",
+    )
+  })
+
   it("explains when manual WebDAV actions will save draft changes first", async () => {
     render(<WebDAVSettings />)
 
@@ -1385,7 +1443,7 @@ describe("WebDAVSettings", () => {
     )
   })
 
-  it("shows the action-specific connection failure message when persisting settings fails", async () => {
+  it("shows a local save failure when persisting settings before connection test fails", async () => {
     mockUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
 
     render(<WebDAVSettings />)
@@ -1398,12 +1456,14 @@ describe("WebDAVSettings", () => {
     clickWebdavAction("webdav-test-connection")
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("importExport:webdav.testFailed")
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings:messages.saveSettingsFailed",
+      )
     })
     expect(mockTestWebdavConnection).not.toHaveBeenCalled()
   })
 
-  it("shows the action-specific upload failure message when persisting settings fails", async () => {
+  it("shows a local save failure when persisting settings before upload fails", async () => {
     mockUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
 
     render(<WebDAVSettings />)
@@ -1417,7 +1477,7 @@ describe("WebDAVSettings", () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        "importExport:webdav.uploadFailed",
+        "settings:messages.saveSettingsFailed",
       )
     })
     expect(mockUploadBackup).not.toHaveBeenCalled()

--- a/tests/services/webdavService.test.ts
+++ b/tests/services/webdavService.test.ts
@@ -145,6 +145,26 @@ describe("webdavService", () => {
       expect((init as RequestInit).method).toBe("GET")
     })
 
+    it("tests directory-like WebDAV URLs without expanding them to backup files", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue({
+        webdav: {
+          ...basePrefs.webdav,
+          url: "http://127.0.0.1:1900/configSync/ALL-API-HUB",
+        },
+      })
+      globalAny.fetch.mockResolvedValue({ status: 200 })
+
+      const ok = await testWebdavConnection()
+
+      expect(ok).toBe(true)
+      expect(globalAny.fetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:1900/configSync/ALL-API-HUB",
+        expect.objectContaining({
+          method: "GET",
+        }),
+      )
+    })
+
     it("returns true when status is 404 (file missing but auth ok)", async () => {
       mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
       globalAny.fetch.mockResolvedValue({ status: 404 })


### PR DESCRIPTION
## Summary
- Persist dirty WebDAV settings against the latest preference snapshot before test/upload/download actions.
- Test directory-style WebDAV URLs at the configured collection instead of expanding them to a generated backup file path.
- Show the local settings-save failure message when save-before-action fails.

## Root Cause
The WebDAV settings form kept using the draft's stale `expectedLastUpdated` baseline when saving before a connection test. If another preference write, such as auto-sync metadata, bumped the global preferences timestamp after the form mounted, the save was rejected as stale. That left `user_preferences.webdav` unchanged and made a valid endpoint look like it could not be saved or tested.

`testWebdavConnection` also probed directory-like WebDAV URLs by expanding them through the backup filename path, which could fail on servers that accepted the configured collection endpoint but rejected generated backup-file probes.

Closes #953

## Test Plan
- `pnpm exec vitest run tests/features/ImportExport/components/WebDAVSettings.test.tsx`
- `pnpm exec vitest run tests/services/webdavService.test.ts`
- `pnpm run validate:push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebDAV connection testing to correctly handle directory-style URLs.
  * Standardized error messaging when WebDAV configuration changes fail to save.
  * Ensured draft WebDAV changes are reliably persisted even if unrelated preference timestamps change before syncing/testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->