### PR TITLE
feat(key-management): audit group key coverage

### DIFF
--- a/docs/superpowers/plans/2026-06-12-key-coverage-audit.md
+++ b/docs/superpowers/plans/2026-06-12-key-coverage-audit.md
@@ -1,0 +1,1860 @@
+# Key Coverage Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-key-coverage-audit-design.md`
+
+**Goal:** Replace the existing one-key repair flow with a manual key coverage audit that can backfill missing group keys, list invalid group keys, and delete selected invalid keys after explicit confirmation.
+
+**Architecture:** Keep the current Key Management header entrypoint and `RepairMissingKeysDialog`, but make the header action open the tool without starting remote writes. Add a group-aware account audit helper, extend the existing repair runner progress model compatibly, add a typed delete-invalid-keys message, and split the dialog result area into `账号覆盖` and `异常密钥` views.
+
+**Tech Stack:** TypeScript, React, WXT extension messaging, Vitest, Testing Library, existing shared UI primitives.
+
+---
+
+## File Structure
+
+- Create `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+  - Owns group-aware coverage calculation for one account.
+  - Fetches tokens and groups.
+  - Creates missing group keys.
+  - Returns account-level coverage plus invalid-token findings.
+
+- Modify `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+  - Export helper constants and token request builder for group-specific default keys.
+  - Keep `ensureDefaultApiTokenForAccount` behavior stable.
+
+- Modify `src/types/accountKeyAutoProvisioning.ts`
+  - Add coverage and invalid-token result types.
+  - Extend progress summary compatibly with optional count fields.
+  - Add batch-delete request/result types.
+
+- Modify `src/services/accounts/accountKeyAutoProvisioning/messaging.ts`
+  - Add `DeleteInvalidTokens` message.
+
+- Modify `src/services/accounts/accountKeyAutoProvisioning/repair.ts`
+  - Call the new group-aware helper for eligible accounts.
+  - Preserve existing skip behavior.
+  - Add delete-invalid-token handler with serial `for...of await` deletion.
+  - Update progress and summary counts after deletion.
+
+- Modify `src/features/KeyManagement/KeyManagement.tsx`
+  - Change header action so it opens the dialog without auto-start.
+  - Keep auto-open behavior for already-running jobs.
+
+- Modify `src/features/KeyManagement/components/Header.tsx`
+  - Rename action copy through locale key only.
+  - Keep the same button position and icon.
+
+- Modify `src/features/KeyManagement/components/RepairMissingKeysDialog.tsx`
+  - Add initial explanation and explicit start button.
+  - Add view switch for account coverage vs invalid keys.
+  - Add invalid-key selection, bulk delete confirmation, serial delete progress, and partial-success rendering.
+
+- Modify `src/locales/zh-CN/keyManagement.json`
+  - Update Chinese source copy for the renamed audit flow and new invalid-key UI.
+
+- Modify sibling locale files under `src/locales/{en,ja,vi,zh-TW}/keyManagement.json`
+  - Keep key shapes consistent.
+  - Use clear direct copy; do not rely on extraction to invent placeholder copy.
+
+- Modify `src/services/productAnalytics/events.ts` only if a separate destructive action id is needed.
+  - Prefer adding `DeleteInvalidAccountTokens: "delete_invalid_account_tokens"` if existing `DeleteAccountToken` cannot distinguish batch invalid-key deletion.
+
+- Modify `src/services/productAnalytics/privacy.ts` only if new analytics fields are added.
+  - Counts only; no names, ids, URLs, origins, group names, or backend messages.
+
+- Modify `tests/services/accountKeyRepair.test.ts`
+  - Add service/runner tests for group coverage and invalid-key deletion.
+
+- Modify `tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx`
+  - Add UI tests for explicit start, view switch, invalid-key selection, confirmation, and partial delete results.
+
+## Shared Type Shape
+
+Use this concrete shape as the implementation target. Keep fields optional where older stored progress blobs may exist.
+
+```ts
+export interface AccountKeyRepairInvalidToken {
+  accountId: string
+  accountName: string
+  siteType: AccountSiteType
+  siteUrlOrigin: string
+  tokenId: number
+  tokenName: string
+  group: string
+  reason: "groupUnavailable"
+  errorMessage?: string
+}
+
+export interface AccountKeyRepairDeletedInvalidToken
+  extends AccountKeyRepairInvalidToken {
+  deletedAt: number
+}
+
+export interface AccountKeyRepairFailedInvalidTokenDelete
+  extends AccountKeyRepairInvalidToken {
+  errorMessage: string
+}
+
+export interface AccountKeyRepairDeleteInvalidTokensRequest {
+  tokens: AccountKeyRepairInvalidToken[]
+}
+
+export interface AccountKeyRepairDeleteInvalidTokensResult {
+  deleted: AccountKeyRepairDeletedInvalidToken[]
+  failed: AccountKeyRepairFailedInvalidTokenDelete[]
+}
+```
+
+Extend `AccountKeyRepairAccountResult`:
+
+```ts
+export interface AccountKeyRepairAccountResult {
+  accountId: string
+  accountName: string
+  siteType: AccountSiteType
+  siteUrlOrigin: string
+  outcome: AccountKeyRepairOutcome
+  skipReason?: AccountKeyRepairSkipReason
+  errorMessage?: string
+  finishedAt: number
+  availableGroups?: string[]
+  coveredGroups?: string[]
+  createdGroups?: string[]
+  missingGroups?: string[]
+  invalidTokens?: AccountKeyRepairInvalidToken[]
+}
+```
+
+Extend `summary`:
+
+```ts
+summary: {
+  created: number
+  alreadyHad: number
+  skipped: number
+  failed: number
+  availableGroups?: number
+  coveredGroups?: number
+  createdKeys?: number
+  invalidKeys?: number
+  deletedKeys?: number
+  deleteFailed?: number
+}
+```
+
+## Task 1: Add Group Coverage Helper
+
+**Files:**
+- Create: `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+- Modify: `src/types/accountKeyAutoProvisioning.ts`
+- Test: `tests/services/accountKeyRepair.test.ts`
+
+- [ ] **Step 1: Add failing tests for group coverage creation and invalid-key detection**
+
+In `tests/services/accountKeyRepair.test.ts`, update the hoisted mocks so the `ensureDefaultToken` mock also exposes the new helper:
+
+```ts
+const mocks = vi.hoisted(() => {
+  const storageMap = new Map<string, unknown>()
+
+  class StorageMock {
+    async get(key: string) {
+      return storageMap.get(key)
+    }
+
+    async set(key: string, value: unknown) {
+      storageMap.set(key, value)
+    }
+  }
+
+  return {
+    storageMap,
+    StorageMock,
+    getAllAccounts: vi.fn(),
+    convertToDisplayData: vi.fn(),
+    ensureDefaultApiTokenForAccount: vi.fn(),
+    ensureAccountKeysForAvailableGroups: vi.fn(),
+    deleteInvalidAccountToken: vi.fn(),
+    sendRuntimeMessage: vi.fn(),
+    safeRandomUUID: vi.fn(() => "job-123"),
+  }
+})
+```
+
+Update the module mock:
+
+```ts
+vi.mock(
+  "~/services/accounts/accountKeyAutoProvisioning/groupCoverage",
+  () => ({
+    ensureAccountKeysForAvailableGroups:
+      mocks.ensureAccountKeysForAvailableGroups,
+    deleteInvalidAccountToken: mocks.deleteInvalidAccountToken,
+  }),
+)
+```
+
+Then add this test under `describe("accountKeyRepair", ...)`:
+
+```ts
+it("records group coverage and invalid keys from the group-aware audit helper", async () => {
+  const account = buildSiteAccount({
+    id: "new-api-1",
+    site_type: "new-api",
+    site_url: "https://relay.example.com",
+    authType: AuthTypeEnum.AccessToken,
+    disabled: false,
+    account_info: {
+      id: "101",
+      access_token: "access-token",
+      username: "valid",
+      quota: 0,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+    },
+  })
+
+  mocks.getAllAccounts.mockResolvedValue([account])
+  mocks.convertToDisplayData.mockReturnValue([
+    buildDisplaySiteData({
+      id: account.id,
+      name: "Relay Account",
+      baseUrl: account.site_url,
+      siteType: "new-api",
+      authType: AuthTypeEnum.AccessToken,
+      userId: "101",
+      token: "access-token",
+    }),
+  ])
+  mocks.ensureAccountKeysForAvailableGroups.mockResolvedValueOnce({
+    created: true,
+    availableGroups: ["default", "vip"],
+    coveredGroups: ["default", "vip"],
+    createdGroups: ["vip"],
+    missingGroups: [],
+    invalidTokens: [
+      {
+        accountId: "new-api-1",
+        accountName: "Relay Account",
+        siteType: "new-api",
+        siteUrlOrigin: "https://relay.example.com",
+        tokenId: 9,
+        tokenName: "old group key",
+        group: "old",
+        reason: "groupUnavailable",
+      },
+    ],
+  })
+
+  const { accountKeyRepairRunner } = await import(
+    "~/services/accounts/accountKeyAutoProvisioning/repair"
+  )
+
+  await accountKeyRepairRunner.start()
+
+  await vi.waitFor(async () => {
+    const progress = await accountKeyRepairRunner.getProgress()
+    expect(progress.state).toBe("completed")
+  })
+
+  const progress = await accountKeyRepairRunner.getProgress()
+  expect(progress.summary).toMatchObject({
+    created: 1,
+    alreadyHad: 0,
+    skipped: 0,
+    failed: 0,
+    availableGroups: 2,
+    coveredGroups: 2,
+    createdKeys: 1,
+    invalidKeys: 1,
+  })
+  expect(progress.results).toEqual([
+    expect.objectContaining({
+      accountId: "new-api-1",
+      outcome: "created",
+      availableGroups: ["default", "vip"],
+      coveredGroups: ["default", "vip"],
+      createdGroups: ["vip"],
+      invalidTokens: [
+        expect.objectContaining({
+          tokenId: 9,
+          tokenName: "old group key",
+          group: "old",
+          reason: "groupUnavailable",
+        }),
+      ],
+    }),
+  ])
+})
+```
+
+- [ ] **Step 2: Run the failing repair test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountKeyRepair.test.ts
+```
+
+Expected: FAIL because `groupCoverage` helper does not exist and `repair.ts` still imports `ensureDefaultApiTokenForAccount`.
+
+- [ ] **Step 3: Extend the progress types**
+
+In `src/types/accountKeyAutoProvisioning.ts`, add the invalid-token and delete-result interfaces from the "Shared Type Shape" section above.
+
+Keep existing fields and add optional fields to `AccountKeyRepairAccountResult` and `AccountKeyRepairProgress["summary"]`.
+
+- [ ] **Step 4: Create the group coverage helper**
+
+Create `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import { getApiService } from "~/services/apiService"
+import { API_ERROR_CODES } from "~/services/apiService/common/errors"
+import type { CreateTokenRequest } from "~/services/apiService/common/type"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
+import type {
+  AccountKeyRepairInvalidToken,
+  AccountKeyRepairDeleteInvalidTokensResult,
+} from "~/types/accountKeyAutoProvisioning"
+import { getErrorMessage } from "~/utils/core/error"
+import { t } from "~/utils/i18n/core"
+
+import {
+  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+  generateDefaultTokenRequest,
+} from "./ensureDefaultToken"
+
+export interface AccountKeyCoverageResult {
+  created: boolean
+  availableGroups: string[]
+  coveredGroups: string[]
+  createdGroups: string[]
+  missingGroups: string[]
+  invalidTokens: AccountKeyRepairInvalidToken[]
+}
+
+const normalizeGroupName = (value: unknown) =>
+  typeof value === "string" ? value.trim() : ""
+
+const isFeatureUnsupportedError = (error: unknown) =>
+  !!error &&
+  typeof error === "object" &&
+  "code" in error &&
+  (error as { code?: unknown }).code === API_ERROR_CODES.FEATURE_UNSUPPORTED
+
+export function buildGroupDefaultTokenRequest(group: string): CreateTokenRequest {
+  return {
+    ...generateDefaultTokenRequest(),
+    name:
+      group && group !== "default"
+        ? `${group} group (auto)`
+        : DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+    group,
+  }
+}
+
+export function createAccountApiRequest(
+  account: SiteAccount,
+  displaySiteData: DisplaySiteData,
+): ApiServiceRequest {
+  return {
+    baseUrl: displaySiteData.baseUrl || account.site_url,
+    accountId: displaySiteData.id || account.id,
+    auth: {
+      authType: displaySiteData.authType,
+      userId: displaySiteData.userId,
+      accessToken: displaySiteData.token,
+      cookie: displaySiteData.cookieAuthSessionCookie,
+    },
+  }
+}
+
+export async function ensureAccountKeysForAvailableGroups(params: {
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+  accountName: string
+  siteUrlOrigin: string
+}): Promise<AccountKeyCoverageResult> {
+  const { account, displaySiteData, accountName, siteUrlOrigin } = params
+  const service = getApiService(displaySiteData.siteType)
+  const request = createAccountApiRequest(account, displaySiteData)
+
+  const tokens = await service.fetchAccountTokens(request)
+  let groups: string[]
+
+  try {
+    const groupsData = await service.fetchUserGroups(request)
+    groups = Object.keys(groupsData)
+      .map(normalizeGroupName)
+      .filter(Boolean)
+  } catch (error) {
+    if (!isFeatureUnsupportedError(error)) {
+      throw error
+    }
+    groups = []
+  }
+
+  const uniqueGroups = Array.from(new Set(groups))
+
+  if (uniqueGroups.length === 0) {
+    if (tokens.length > 0) {
+      return {
+        created: false,
+        availableGroups: [],
+        coveredGroups: [],
+        createdGroups: [],
+        missingGroups: [],
+        invalidTokens: [],
+      }
+    }
+
+    if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
+      throw new Error(t("messages:sub2api.createRequiresGroup"))
+    }
+
+    if (displaySiteData.siteType === SITE_TYPES.AIHUBMIX) {
+      throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
+    }
+
+    await service.createApiToken(request, generateDefaultTokenRequest())
+    return {
+      created: true,
+      availableGroups: [],
+      coveredGroups: [],
+      createdGroups: [""],
+      missingGroups: [],
+      invalidTokens: [],
+    }
+  }
+
+  const availableGroupSet = new Set(uniqueGroups)
+  const coveredGroupSet = new Set<string>()
+  const invalidTokens: AccountKeyRepairInvalidToken[] = []
+
+  for (const token of tokens) {
+    const group = normalizeGroupName(token.group)
+    if (!group) continue
+    if (availableGroupSet.has(group)) {
+      coveredGroupSet.add(group)
+      continue
+    }
+
+    invalidTokens.push({
+      accountId: displaySiteData.id,
+      accountName,
+      siteType: displaySiteData.siteType,
+      siteUrlOrigin,
+      tokenId: token.id,
+      tokenName: token.name,
+      group,
+      reason: "groupUnavailable",
+    })
+  }
+
+  const createdGroups: string[] = []
+  const missingGroups: string[] = []
+
+  for (const group of uniqueGroups) {
+    if (coveredGroupSet.has(group)) continue
+    try {
+      await service.createApiToken(request, buildGroupDefaultTokenRequest(group))
+      coveredGroupSet.add(group)
+      createdGroups.push(group)
+    } catch (error) {
+      missingGroups.push(group)
+      const message = getErrorMessage(error)
+      if (message) {
+        invalidTokens.push({
+          accountId: displaySiteData.id,
+          accountName,
+          siteType: displaySiteData.siteType,
+          siteUrlOrigin,
+          tokenId: -1,
+          tokenName: group,
+          group,
+          reason: "groupUnavailable",
+          errorMessage: message,
+        })
+      }
+    }
+  }
+
+  return {
+    created: createdGroups.length > 0,
+    availableGroups: uniqueGroups,
+    coveredGroups: uniqueGroups.filter((group) => coveredGroupSet.has(group)),
+    createdGroups,
+    missingGroups,
+    invalidTokens: invalidTokens.filter((token) => token.tokenId >= 0),
+  }
+}
+
+export async function deleteInvalidAccountToken(params: {
+  token: AccountKeyRepairInvalidToken
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+}): Promise<AccountKeyRepairDeleteInvalidTokensResult["deleted"][number]> {
+  const { token, account, displaySiteData } = params
+  const service = getApiService(displaySiteData.siteType)
+  const request = createAccountApiRequest(account, displaySiteData)
+  await service.deleteApiToken(request, token.tokenId)
+  return {
+    ...token,
+    deletedAt: Date.now(),
+  }
+}
+```
+
+- [ ] **Step 5: Update repair runner to call the new helper**
+
+In `src/services/accounts/accountKeyAutoProvisioning/repair.ts`, replace the import:
+
+```ts
+import {
+  deleteInvalidAccountToken,
+  ensureAccountKeysForAvailableGroups,
+} from "./groupCoverage"
+```
+
+In `processEligibleAccount`, replace the call to `ensureDefaultApiTokenForAccount` with:
+
+```ts
+const result = await ensureAccountKeysForAvailableGroups({
+  account,
+  displaySiteData,
+  accountName,
+  siteUrlOrigin: originKey,
+})
+
+await this.recordResult({
+  accountId: account.id,
+  accountName,
+  siteType: account.site_type,
+  siteUrlOrigin: originKey,
+  outcome: result.created ? "created" : "alreadyHad",
+  availableGroups: result.availableGroups,
+  coveredGroups: result.coveredGroups,
+  createdGroups: result.createdGroups,
+  missingGroups: result.missingGroups,
+  invalidTokens: result.invalidTokens,
+  finishedAt: Date.now(),
+})
+```
+
+Update `recordResult` to increment optional summary counts:
+
+```ts
+const availableGroupCount = result.availableGroups?.length ?? 0
+const coveredGroupCount = result.coveredGroups?.length ?? 0
+const createdKeyCount = result.createdGroups?.length ?? 0
+const invalidKeyCount = result.invalidTokens?.length ?? 0
+
+return {
+  ...prev,
+  results: nextResults,
+  summary: {
+    ...nextSummary,
+    availableGroups: (prev.summary.availableGroups ?? 0) + availableGroupCount,
+    coveredGroups: (prev.summary.coveredGroups ?? 0) + coveredGroupCount,
+    createdKeys: (prev.summary.createdKeys ?? 0) + createdKeyCount,
+    invalidKeys: (prev.summary.invalidKeys ?? 0) + invalidKeyCount,
+    deletedKeys: prev.summary.deletedKeys ?? 0,
+    deleteFailed: prev.summary.deleteFailed ?? 0,
+  },
+  totals: {
+    ...prev.totals,
+    processedAccounts: isEligibleOutcome
+      ? prev.totals.processedAccounts + 1
+      : prev.totals.processedAccounts,
+    processedEligibleAccounts: nextProcessedEligibleAccounts,
+  },
+}
+```
+
+- [ ] **Step 6: Update existing tests to mock the new helper**
+
+Where existing tests expected `ensureDefaultApiTokenForAccount`, update expectations to `ensureAccountKeysForAvailableGroups`.
+
+For created result mocks, return:
+
+```ts
+mocks.ensureAccountKeysForAvailableGroups.mockResolvedValueOnce({
+  created: true,
+  availableGroups: [],
+  coveredGroups: [],
+  createdGroups: [""],
+  missingGroups: [],
+  invalidTokens: [],
+})
+```
+
+For already-had result mocks, return:
+
+```ts
+mocks.ensureAccountKeysForAvailableGroups.mockResolvedValueOnce({
+  created: false,
+  availableGroups: [],
+  coveredGroups: [],
+  createdGroups: [],
+  missingGroups: [],
+  invalidTokens: [],
+})
+```
+
+- [ ] **Step 7: Run service tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountKeyRepair.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit service helper**
+
+```powershell
+git add src/types/accountKeyAutoProvisioning.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts src/services/accounts/accountKeyAutoProvisioning/repair.ts tests/services/accountKeyRepair.test.ts
+git commit -m "feat(key-management): audit group key coverage"
+```
+
+## Task 2: Add Typed Invalid-Key Delete Message
+
+**Files:**
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/messaging.ts`
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/repair.ts`
+- Test: `tests/services/accountKeyRepair.test.ts`
+
+- [ ] **Step 1: Add failing delete message test**
+
+Add this test to `tests/services/accountKeyRepair.test.ts`:
+
+```ts
+it("deletes selected invalid tokens serially and records partial failure", async () => {
+  const account = buildSiteAccount({
+    id: "new-api-1",
+    site_type: "new-api",
+    site_url: "https://relay.example.com",
+    authType: AuthTypeEnum.AccessToken,
+    disabled: false,
+    account_info: {
+      id: "101",
+      access_token: "access-token",
+      username: "valid",
+      quota: 0,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+    },
+  })
+  const displayAccount = buildDisplaySiteData({
+    id: account.id,
+    name: "Relay Account",
+    baseUrl: account.site_url,
+    siteType: "new-api",
+    authType: AuthTypeEnum.AccessToken,
+    userId: "101",
+    token: "access-token",
+  })
+  const invalidTokens = [
+    {
+      accountId: "new-api-1",
+      accountName: "Relay Account",
+      siteType: "new-api",
+      siteUrlOrigin: "https://relay.example.com",
+      tokenId: 9,
+      tokenName: "old one",
+      group: "old",
+      reason: "groupUnavailable" as const,
+    },
+    {
+      accountId: "new-api-1",
+      accountName: "Relay Account",
+      siteType: "new-api",
+      siteUrlOrigin: "https://relay.example.com",
+      tokenId: 10,
+      tokenName: "old two",
+      group: "old-2",
+      reason: "groupUnavailable" as const,
+    },
+  ]
+
+  mocks.getAllAccounts.mockResolvedValue([account])
+  mocks.convertToDisplayData.mockReturnValue([displayAccount])
+  mocks.deleteInvalidAccountToken
+    .mockResolvedValueOnce({ ...invalidTokens[0], deletedAt: 123 })
+    .mockRejectedValueOnce(new Error("delete boom"))
+
+  const { deleteInvalidAccountTokens } = await import(
+    "~/services/accounts/accountKeyAutoProvisioning/repair"
+  )
+
+  await expect(
+    deleteInvalidAccountTokens({ tokens: invalidTokens }),
+  ).resolves.toEqual({
+    success: true,
+    data: {
+      deleted: [{ ...invalidTokens[0], deletedAt: 123 }],
+      failed: [{ ...invalidTokens[1], errorMessage: "delete boom" }],
+    },
+  })
+
+  expect(mocks.deleteInvalidAccountToken.mock.calls.map((call) => call[0].token.tokenId)).toEqual([9, 10])
+})
+```
+
+- [ ] **Step 2: Run the failing delete test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountKeyRepair.test.ts -t "deletes selected invalid tokens"
+```
+
+Expected: FAIL because delete message/handler is not implemented.
+
+- [ ] **Step 3: Extend messaging protocol**
+
+In `src/services/accounts/accountKeyAutoProvisioning/messaging.ts`, import delete types:
+
+```ts
+import type {
+  AccountKeyRepairDeleteInvalidTokensRequest,
+  AccountKeyRepairDeleteInvalidTokensResult,
+  AccountKeyRepairProgress,
+} from "~/types/accountKeyAutoProvisioning"
+```
+
+Add message type:
+
+```ts
+DeleteInvalidTokens: "accountKeyRepair:deleteInvalidTokens",
+```
+
+Update protocol map:
+
+```ts
+[AccountKeyRepairMessageTypes.DeleteInvalidTokens](
+  request: AccountKeyRepairDeleteInvalidTokensRequest,
+): RuntimeMessageResponse<AccountKeyRepairDeleteInvalidTokensResult>
+```
+
+- [ ] **Step 4: Implement delete handler in repair service**
+
+In `repair.ts`, export:
+
+```ts
+export async function deleteInvalidAccountTokens(
+  request: AccountKeyRepairDeleteInvalidTokensRequest,
+) {
+  const allAccounts = await accountStorage.getAllAccounts()
+  const displaySiteDataById = new Map(
+    accountStorage
+      .convertToDisplayData(allAccounts, allAccounts)
+      .map((account) => [account.id, account] as const),
+  )
+  const accountById = new Map(allAccounts.map((account) => [account.id, account]))
+  const deleted: AccountKeyRepairDeleteInvalidTokensResult["deleted"] = []
+  const failed: AccountKeyRepairDeleteInvalidTokensResult["failed"] = []
+
+  for (const token of request.tokens) {
+    const account = accountById.get(token.accountId)
+    const displaySiteData = displaySiteDataById.get(token.accountId)
+    if (!account || !displaySiteData) {
+      failed.push({
+        ...token,
+        errorMessage: "account_not_found",
+      })
+      continue
+    }
+
+    try {
+      const result = await deleteInvalidAccountToken({
+        token,
+        account,
+        displaySiteData,
+      })
+      deleted.push(result)
+    } catch (error) {
+      failed.push({
+        ...token,
+        errorMessage: getErrorMessage(error) || "delete_failed",
+      })
+    }
+  }
+
+  accountKeyRepairRunner.recordInvalidTokenDeletionResultForCurrentProgress({
+    deleted,
+    failed,
+  })
+
+  return { success: true as const, data: { deleted, failed } }
+}
+```
+
+Expose a public method on `AccountKeyRepairRunner`:
+
+```ts
+async recordInvalidTokenDeletionResultForCurrentProgress(
+  result: AccountKeyRepairDeleteInvalidTokensResult,
+) {
+  await this.queueProgressUpdate((prev) => {
+    const deletedIds = new Set(result.deleted.map((token) => `${token.accountId}:${token.tokenId}`))
+    return {
+      ...prev,
+      results: prev.results.map((accountResult) => ({
+        ...accountResult,
+        invalidTokens: accountResult.invalidTokens?.filter(
+          (token) => !deletedIds.has(`${token.accountId}:${token.tokenId}`),
+        ),
+      })),
+      summary: {
+        ...prev.summary,
+        invalidKeys: Math.max(
+          0,
+          (prev.summary.invalidKeys ?? 0) - result.deleted.length,
+        ),
+        deletedKeys: (prev.summary.deletedKeys ?? 0) + result.deleted.length,
+        deleteFailed: (prev.summary.deleteFailed ?? 0) + result.failed.length,
+      },
+    }
+  })
+}
+```
+
+- [ ] **Step 5: Register delete message listener**
+
+In `setupAccountKeyRepairMessagingListeners`, add:
+
+```ts
+onAccountKeyRepairMessage(
+  AccountKeyRepairMessageTypes.DeleteInvalidTokens,
+  async (request) => {
+    try {
+      return await deleteInvalidAccountTokens(request)
+    } catch (error) {
+      return toAccountKeyRepairFailure(error)
+    }
+  },
+),
+```
+
+- [ ] **Step 6: Run service tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountKeyRepair.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit delete message**
+
+```powershell
+git add src/types/accountKeyAutoProvisioning.ts src/services/accounts/accountKeyAutoProvisioning/messaging.ts src/services/accounts/accountKeyAutoProvisioning/repair.ts tests/services/accountKeyRepair.test.ts
+git commit -m "feat(key-management): delete invalid group keys"
+```
+
+## Task 3: Make Dialog Manual-Start And Rename Entry Point
+
+**Files:**
+- Modify: `src/features/KeyManagement/KeyManagement.tsx`
+- Modify: `src/features/KeyManagement/components/Header.tsx`
+- Modify: `src/features/KeyManagement/components/RepairMissingKeysDialog.tsx`
+- Modify: `src/locales/zh-CN/keyManagement.json`
+- Modify: `src/locales/en/keyManagement.json`
+- Modify: `src/locales/ja/keyManagement.json`
+- Modify: `src/locales/vi/keyManagement.json`
+- Modify: `src/locales/zh-TW/keyManagement.json`
+- Test: `tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx`
+
+- [ ] **Step 1: Add failing manual-start UI test**
+
+In `tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx`, update the first test or add a new one:
+
+```tsx
+it("opens the key check dialog without starting until the user confirms", async () => {
+  sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+    if (message === AccountKeyRepairMessageTypes.GetProgress) {
+      return { success: true, data: idleProgress }
+    }
+    if (message === AccountKeyRepairMessageTypes.Start) {
+      return { success: true, data: startProgress }
+    }
+    return { success: false }
+  })
+
+  render(<KeyManagement />)
+
+  fireEvent.click(
+    await screen.findByRole("button", {
+      name: "keyManagement:repairMissingKeys.action",
+    }),
+  )
+
+  expect(
+    screen.getByText("keyManagement:repairMissingKeys.initialNotice"),
+  ).toBeInTheDocument()
+  expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
+    AccountKeyRepairMessageTypes.GetProgress,
+    undefined,
+  )
+  expect(sendRuntimeActionMessageMock).not.toHaveBeenCalledWith(
+    AccountKeyRepairMessageTypes.Start,
+    undefined,
+  )
+
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: "keyManagement:repairMissingKeys.actions.start",
+    }),
+  )
+
+  await waitFor(() => {
+    expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.Start,
+      undefined,
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run failing UI test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx -t "opens the key check dialog"
+```
+
+Expected: FAIL because opening currently starts the repair.
+
+- [ ] **Step 3: Stop auto-starting from the header button**
+
+In `src/features/KeyManagement/KeyManagement.tsx`, change:
+
+```ts
+const handleRepairMissingKeys = () => {
+  setRepairStartOnOpen(true)
+  setIsRepairOpen(true)
+}
+```
+
+to:
+
+```ts
+const handleRepairMissingKeys = () => {
+  setRepairStartOnOpen(false)
+  setIsRepairOpen(true)
+}
+```
+
+Keep the existing page-load running-job recovery as:
+
+```ts
+if (response.data.state === "running") {
+  setRepairStartOnOpen(false)
+  setIsRepairOpen(true)
+}
+```
+
+- [ ] **Step 4: Add explicit start action to dialog**
+
+In `RepairMissingKeysDialog.tsx`, add:
+
+```ts
+const [isStarting, setIsStarting] = useState(false)
+
+const handleStartAudit = async () => {
+  setIsStarting(true)
+  setError("")
+  try {
+    const response = await sendAccountKeyRepairMessage(
+      AccountKeyRepairMessageTypes.Start,
+    )
+    if (response?.success && response.data) {
+      startedAnalyticsJobIdRef.current = response.data.jobId
+      void trackProductAnalyticsActionStarted(repairMissingKeysAnalyticsContext)
+      setProgress(response.data)
+      return
+    }
+
+    void trackProductAnalyticsActionCompleted({
+      ...repairMissingKeysAnalyticsContext,
+      result: PRODUCT_ANALYTICS_RESULTS.Failure,
+      errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      insights: getRepairStartFailureInsights(
+        progressRef.current,
+        accountsRef.current,
+      ),
+    })
+    setError(t("repairMissingKeys.messages.startFailed"))
+  } catch {
+    void trackProductAnalyticsActionCompleted({
+      ...repairMissingKeysAnalyticsContext,
+      result: PRODUCT_ANALYTICS_RESULTS.Failure,
+      errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      insights: getRepairStartFailureInsights(
+        progressRef.current,
+        accountsRef.current,
+      ),
+    })
+    setError(t("repairMissingKeys.messages.startFailed"))
+  } finally {
+    setIsStarting(false)
+  }
+}
+```
+
+Replace the `startOnOpen` effect body with:
+
+```ts
+if (isOpen && startOnOpen) {
+  void handleStartAudit()
+}
+```
+
+Render the initial state when progress is idle:
+
+```tsx
+{!progress || progress.state === "idle" ? (
+  <Card>
+    <CardContent padding="md" className="space-y-3">
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        {t("repairMissingKeys.initialNotice")}
+      </p>
+      <Alert description={t("repairMissingKeys.remoteWriteNotice")} />
+      <Button
+        type="button"
+        onClick={() => void handleStartAudit()}
+        loading={isStarting}
+      >
+        {t("repairMissingKeys.actions.start")}
+      </Button>
+    </CardContent>
+  </Card>
+) : null}
+```
+
+- [ ] **Step 5: Update locale keys**
+
+In every `src/locales/*/keyManagement.json`, add these keys under `repairMissingKeys`:
+
+```json
+{
+  "action": "密钥检查",
+  "title": "密钥覆盖检查",
+  "description": "检查每个账号的可用分组，为缺少密钥的分组创建默认密钥，并列出分组不可用的异常密钥。",
+  "initialNotice": "开始后会检查已保存账号的可用分组，并为缺少密钥的分组创建默认密钥。",
+  "remoteWriteNotice": "此操作可能会在对应网站创建新密钥；不会自动删除任何密钥。",
+  "actions": {
+    "start": "开始检查并补齐",
+    "rerun": "重新检查"
+  }
+}
+```
+
+Use localized equivalents in non-Chinese files while keeping the same key shape.
+
+- [ ] **Step 6: Update old tests that assumed start-on-open**
+
+In existing `KeyManagementRepairMissingKeys.test.tsx` tests, after opening the dialog, click the new start button before expecting `AccountKeyRepairMessageTypes.Start`:
+
+```ts
+fireEvent.click(
+  screen.getByRole("button", {
+    name: "keyManagement:repairMissingKeys.actions.start",
+  }),
+)
+```
+
+- [ ] **Step 7: Run UI test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run i18n staged check after locale edits**
+
+Run:
+
+```powershell
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS with no unexpected locale updates.
+
+- [ ] **Step 9: Commit manual-start UI**
+
+```powershell
+git add src/features/KeyManagement/KeyManagement.tsx src/features/KeyManagement/components/Header.tsx src/features/KeyManagement/components/RepairMissingKeysDialog.tsx src/locales/zh-CN/keyManagement.json src/locales/en/keyManagement.json src/locales/ja/keyManagement.json src/locales/vi/keyManagement.json src/locales/zh-TW/keyManagement.json tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+git commit -m "feat(key-management): require explicit key check start"
+```
+
+## Task 4: Add Account Coverage And Invalid-Key Views
+
+**Files:**
+- Modify: `src/features/KeyManagement/components/RepairMissingKeysDialog.tsx`
+- Modify: `src/locales/*/keyManagement.json`
+- Test: `tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx`
+
+- [ ] **Step 1: Add failing view-switch test**
+
+Add test data:
+
+```ts
+const coverageProgress: AccountKeyRepairProgress = {
+  jobId: "job-coverage",
+  state: "completed",
+  startedAt: 1,
+  updatedAt: 2,
+  finishedAt: 2,
+  totals: {
+    enabledAccounts: 1,
+    eligibleAccounts: 1,
+    processedAccounts: 1,
+    processedEligibleAccounts: 1,
+  },
+  summary: {
+    created: 1,
+    alreadyHad: 0,
+    skipped: 0,
+    failed: 0,
+    availableGroups: 2,
+    coveredGroups: 2,
+    createdKeys: 1,
+    invalidKeys: 1,
+  },
+  results: [
+    {
+      accountId: "account-enabled",
+      accountName: "Enabled Site",
+      siteType: "new-api",
+      siteUrlOrigin: "https://enabled.example.com",
+      outcome: "created",
+      availableGroups: ["default", "vip"],
+      coveredGroups: ["default", "vip"],
+      createdGroups: ["vip"],
+      missingGroups: [],
+      invalidTokens: [
+        {
+          accountId: "account-enabled",
+          accountName: "Enabled Site",
+          siteType: "new-api",
+          siteUrlOrigin: "https://enabled.example.com",
+          tokenId: 9,
+          tokenName: "old group key",
+          group: "old",
+          reason: "groupUnavailable",
+        },
+      ],
+      finishedAt: 2,
+    },
+  ],
+}
+```
+
+Add test:
+
+```tsx
+it("switches between account coverage and invalid key views", async () => {
+  sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+    if (message === AccountKeyRepairMessageTypes.GetProgress) {
+      return { success: true, data: coverageProgress }
+    }
+    return { success: false }
+  })
+
+  render(<KeyManagement />)
+
+  fireEvent.click(
+    await screen.findByRole("button", {
+      name: "keyManagement:repairMissingKeys.action",
+    }),
+  )
+
+  expect(screen.getByRole("button", {
+    name: "keyManagement:repairMissingKeys.views.accountCoverage",
+  })).toHaveAttribute("aria-pressed", "true")
+  expect(screen.getByText("vip")).toBeInTheDocument()
+  expect(screen.queryByText("old group key")).not.toBeInTheDocument()
+
+  fireEvent.click(screen.getByRole("button", {
+    name: "keyManagement:repairMissingKeys.views.invalidKeys",
+  }))
+
+  expect(screen.getByText("old group key")).toBeInTheDocument()
+  expect(screen.getByText("old")).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run failing view-switch test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx -t "switches between account coverage"
+```
+
+Expected: FAIL because no view switch exists.
+
+- [ ] **Step 3: Add view state and derived invalid tokens**
+
+In `RepairMissingKeysDialog.tsx`, add:
+
+```ts
+type RepairResultView = "accountCoverage" | "invalidKeys"
+
+const [activeView, setActiveView] =
+  useState<RepairResultView>("accountCoverage")
+
+const invalidTokens = useMemo(() => {
+  return visibleResults.flatMap((result) => result.invalidTokens ?? [])
+}, [visibleResults])
+```
+
+Reset on close:
+
+```ts
+if (!isOpen) {
+  setSearchTerm("")
+  setOutcomeFilter(null)
+  setActiveView("accountCoverage")
+}
+```
+
+- [ ] **Step 4: Render compact segmented view switch**
+
+Add below summary cards:
+
+```tsx
+<div className="flex flex-wrap gap-2" role="group" aria-label={t("repairMissingKeys.views.label")}>
+  {(["accountCoverage", "invalidKeys"] as const).map((view) => (
+    <Button
+      key={view}
+      type="button"
+      size="sm"
+      variant={activeView === view ? "default" : "outline"}
+      aria-pressed={activeView === view}
+      onClick={() => setActiveView(view)}
+    >
+      {t(`repairMissingKeys.views.${view}`)}
+      {view === "invalidKeys" && invalidTokens.length > 0 ? (
+        <Badge variant="warning" size="sm" className="ml-2">
+          {invalidTokens.length}
+        </Badge>
+      ) : null}
+    </Button>
+  ))}
+</div>
+```
+
+- [ ] **Step 5: Render coverage details in account rows**
+
+Inside account result rows, add details when present:
+
+```tsx
+{result.availableGroups ? (
+  <div className="mt-2 flex flex-wrap gap-2 text-xs">
+    <Badge variant="outline" size="sm">
+      {t("repairMissingKeys.coverage.groupsCovered", {
+        covered: result.coveredGroups?.length ?? 0,
+        total: result.availableGroups.length,
+      })}
+    </Badge>
+    {(result.createdGroups ?? []).map((group) => (
+      <Badge key={group} variant="success" size="sm">
+        {t("repairMissingKeys.coverage.createdGroup", { group })}
+      </Badge>
+    ))}
+    {(result.missingGroups ?? []).map((group) => (
+      <Badge key={group} variant="warning" size="sm">
+        {t("repairMissingKeys.coverage.missingGroup", { group })}
+      </Badge>
+    ))}
+  </div>
+) : null}
+```
+
+- [ ] **Step 6: Render invalid-key list**
+
+When `activeView === "invalidKeys"`, render:
+
+```tsx
+{invalidTokens.length === 0 ? (
+  <EmptyState
+    icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+    title={t("repairMissingKeys.invalidKeys.emptyTitle")}
+    description={t("repairMissingKeys.invalidKeys.emptyDescription")}
+    className="py-10"
+  />
+) : (
+  <ul className="dark:divide-dark-bg-tertiary divide-y">
+    {invalidTokens.map((token) => (
+      <li key={`${token.accountId}-${token.tokenId}`} className="px-4 py-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 space-y-1">
+            <div className="truncate text-sm font-medium">{token.tokenName}</div>
+            <div className="dark:text-dark-text-secondary truncate text-xs text-gray-500">
+              {token.accountName} · {token.siteUrlOrigin}
+            </div>
+            <div className="text-xs text-amber-700 dark:text-amber-300">
+              {t("repairMissingKeys.invalidKeys.groupUnavailable", {
+                group: token.group,
+              })}
+            </div>
+          </div>
+          <Badge variant="warning" size="sm" className="shrink-0">
+            {t("repairMissingKeys.invalidKeys.badge")}
+          </Badge>
+        </div>
+      </li>
+    ))}
+  </ul>
+)}
+```
+
+- [ ] **Step 7: Add locale keys**
+
+Under `repairMissingKeys`, add:
+
+```json
+"views": {
+  "label": "结果视图",
+  "accountCoverage": "账号覆盖",
+  "invalidKeys": "异常密钥"
+},
+"coverage": {
+  "groupsCovered": "已覆盖 {{covered}}/{{total}} 个分组",
+  "createdGroup": "已创建：{{group}}",
+  "missingGroup": "未补齐：{{group}}"
+},
+"invalidKeys": {
+  "badge": "异常",
+  "emptyTitle": "没有异常密钥",
+  "emptyDescription": "本次检查未发现分组不可用的密钥。",
+  "groupUnavailable": "分组 {{group}} 当前不可用"
+}
+```
+
+Update sibling locales with the same key shape.
+
+- [ ] **Step 8: Run UI and i18n checks**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit view split**
+
+```powershell
+git add src/features/KeyManagement/components/RepairMissingKeysDialog.tsx src/locales/zh-CN/keyManagement.json src/locales/en/keyManagement.json src/locales/ja/keyManagement.json src/locales/vi/keyManagement.json src/locales/zh-TW/keyManagement.json tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+git commit -m "feat(key-management): split audit result views"
+```
+
+## Task 5: Add Invalid-Key Selection And Batch Delete UI
+
+**Files:**
+- Modify: `src/features/KeyManagement/components/RepairMissingKeysDialog.tsx`
+- Modify: `src/locales/*/keyManagement.json`
+- Test: `tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx`
+
+- [ ] **Step 1: Add failing batch-delete UI test**
+
+Add:
+
+```tsx
+it("deletes selected invalid keys after destructive confirmation", async () => {
+  sendRuntimeActionMessageMock.mockImplementation(async (message: any, data: any) => {
+    if (message === AccountKeyRepairMessageTypes.GetProgress) {
+      return { success: true, data: coverageProgress }
+    }
+    if (message === AccountKeyRepairMessageTypes.DeleteInvalidTokens) {
+      return {
+        success: true,
+        data: {
+          deleted: [{ ...data.tokens[0], deletedAt: 123 }],
+          failed: [],
+        },
+      }
+    }
+    return { success: false }
+  })
+
+  render(<KeyManagement />)
+
+  fireEvent.click(
+    await screen.findByRole("button", {
+      name: "keyManagement:repairMissingKeys.action",
+    }),
+  )
+  fireEvent.click(screen.getByRole("button", {
+    name: "keyManagement:repairMissingKeys.views.invalidKeys",
+  }))
+  fireEvent.click(screen.getByRole("checkbox", {
+    name: "old group key",
+  }))
+
+  fireEvent.click(screen.getByRole("button", {
+    name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+  }))
+
+  expect(screen.getByText("keyManagement:repairMissingKeys.deleteConfirm.description")).toBeInTheDocument()
+
+  fireEvent.click(screen.getByTestId("repair-invalid-keys-confirm-delete"))
+
+  await waitFor(() => {
+    expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.DeleteInvalidTokens,
+      {
+        tokens: [
+          expect.objectContaining({
+            tokenId: 9,
+            tokenName: "old group key",
+          }),
+        ],
+      },
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run failing batch-delete UI test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx -t "deletes selected invalid keys"
+```
+
+Expected: FAIL because selection and delete UI do not exist.
+
+- [ ] **Step 3: Add selection state**
+
+In `RepairMissingKeysDialog.tsx`, import `Checkbox` and `DestructiveConfirmDialog` from shared UI.
+
+Add:
+
+```ts
+const [selectedInvalidTokenKeys, setSelectedInvalidTokenKeys] = useState<Set<string>>(
+  () => new Set(),
+)
+const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
+const [isDeletingInvalidKeys, setIsDeletingInvalidKeys] = useState(false)
+const [deleteResultMessage, setDeleteResultMessage] = useState("")
+
+const getInvalidTokenKey = (token: AccountKeyRepairInvalidToken) =>
+  `${token.accountId}:${token.tokenId}`
+
+const selectedInvalidTokens = useMemo(() => {
+  return invalidTokens.filter((token) =>
+    selectedInvalidTokenKeys.has(getInvalidTokenKey(token)),
+  )
+}, [invalidTokens, selectedInvalidTokenKeys])
+```
+
+- [ ] **Step 4: Add invalid-key toolbar controls**
+
+Above the invalid-key list, render:
+
+```tsx
+<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+  <label className="flex items-center gap-2 text-sm">
+    <Checkbox
+      checked={
+        invalidTokens.length > 0 &&
+        selectedInvalidTokens.length === invalidTokens.length
+      }
+      onCheckedChange={(checked) => {
+        setSelectedInvalidTokenKeys(
+          checked
+            ? new Set(invalidTokens.map(getInvalidTokenKey))
+            : new Set(),
+        )
+      }}
+      aria-label={t("repairMissingKeys.invalidKeys.selectAll")}
+    />
+    {t("repairMissingKeys.invalidKeys.selectAll")}
+  </label>
+  <div className="flex items-center gap-2">
+    <span className="text-xs text-gray-500 dark:text-gray-400">
+      {t("repairMissingKeys.invalidKeys.selectedCount", {
+        count: selectedInvalidTokens.length,
+      })}
+    </span>
+    <Button
+      type="button"
+      size="sm"
+      variant="destructive"
+      disabled={selectedInvalidTokens.length === 0}
+      onClick={() => setIsDeleteConfirmOpen(true)}
+    >
+      {t("repairMissingKeys.invalidKeys.deleteSelected")}
+    </Button>
+  </div>
+</div>
+```
+
+- [ ] **Step 5: Add per-row checkboxes**
+
+Inside each invalid-key row:
+
+```tsx
+<Checkbox
+  checked={selectedInvalidTokenKeys.has(getInvalidTokenKey(token))}
+  onCheckedChange={(checked) => {
+    const key = getInvalidTokenKey(token)
+    setSelectedInvalidTokenKeys((prev) => {
+      const next = new Set(prev)
+      if (checked) {
+        next.add(key)
+      } else {
+        next.delete(key)
+      }
+      return next
+    })
+  }}
+  aria-label={token.tokenName}
+/>
+```
+
+- [ ] **Step 6: Add destructive confirmation and delete handler**
+
+Add:
+
+```ts
+const handleConfirmDeleteInvalidKeys = async () => {
+  if (selectedInvalidTokens.length === 0) return
+  setIsDeletingInvalidKeys(true)
+  setDeleteResultMessage("")
+  try {
+    const response = await sendAccountKeyRepairMessage(
+      AccountKeyRepairMessageTypes.DeleteInvalidTokens,
+      { tokens: selectedInvalidTokens },
+    )
+    if (!response?.success || !response.data) {
+      setDeleteResultMessage(t("repairMissingKeys.invalidKeys.deleteFailed"))
+      return
+    }
+
+    const deletedKeys = new Set(response.data.deleted.map(getInvalidTokenKey))
+    setSelectedInvalidTokenKeys((prev) => {
+      const next = new Set(prev)
+      for (const key of deletedKeys) next.delete(key)
+      return next
+    })
+    setProgress((current) => {
+      if (!current) return current
+      return {
+        ...current,
+        results: current.results.map((result) => ({
+          ...result,
+          invalidTokens: result.invalidTokens?.filter(
+            (token) => !deletedKeys.has(getInvalidTokenKey(token)),
+          ),
+        })),
+        summary: {
+          ...current.summary,
+          invalidKeys: Math.max(
+            0,
+            (current.summary.invalidKeys ?? 0) - response.data.deleted.length,
+          ),
+          deletedKeys:
+            (current.summary.deletedKeys ?? 0) + response.data.deleted.length,
+          deleteFailed:
+            (current.summary.deleteFailed ?? 0) + response.data.failed.length,
+        },
+      }
+    })
+    setDeleteResultMessage(
+      response.data.failed.length > 0
+        ? t("repairMissingKeys.invalidKeys.deletePartial", {
+            deleted: response.data.deleted.length,
+            failed: response.data.failed.length,
+          })
+        : t("repairMissingKeys.invalidKeys.deleteSuccess", {
+            count: response.data.deleted.length,
+          }),
+    )
+    setIsDeleteConfirmOpen(false)
+  } finally {
+    setIsDeletingInvalidKeys(false)
+  }
+}
+```
+
+Render:
+
+```tsx
+<DestructiveConfirmDialog
+  isOpen={isDeleteConfirmOpen}
+  onClose={() => setIsDeleteConfirmOpen(false)}
+  title={t("repairMissingKeys.deleteConfirm.title", {
+    count: selectedInvalidTokens.length,
+  })}
+  description={t("repairMissingKeys.deleteConfirm.description")}
+  cancelLabel={t("common:actions.cancel")}
+  confirmLabel={t("repairMissingKeys.deleteConfirm.confirm")}
+  confirmButtonTestId="repair-invalid-keys-confirm-delete"
+  isWorking={isDeletingInvalidKeys}
+  size="md"
+  details={
+    <ul className="max-h-40 space-y-1 overflow-y-auto text-xs text-gray-600 dark:text-gray-400">
+      {selectedInvalidTokens.slice(0, 5).map((token) => (
+        <li key={getInvalidTokenKey(token)}>
+          {token.tokenName} · {token.accountName}
+        </li>
+      ))}
+      {selectedInvalidTokens.length > 5 ? (
+        <li>
+          {t("repairMissingKeys.deleteConfirm.more", {
+            count: selectedInvalidTokens.length - 5,
+          })}
+        </li>
+      ) : null}
+    </ul>
+  }
+  onConfirm={() => void handleConfirmDeleteInvalidKeys()}
+/>
+```
+
+- [ ] **Step 7: Add locale keys**
+
+Under `repairMissingKeys.invalidKeys`, add:
+
+```json
+"selectAll": "全选当前结果",
+"selectedCount": "已选择 {{count}} 个异常密钥",
+"deleteSelected": "删除所选",
+"deleteSuccess": "已删除 {{count}} 个异常密钥",
+"deletePartial": "已删除 {{deleted}} 个，{{failed}} 个删除失败",
+"deleteFailed": "删除异常密钥失败"
+```
+
+Under `repairMissingKeys`, add:
+
+```json
+"deleteConfirm": {
+  "title": "删除 {{count}} 个异常密钥？",
+  "description": "这些密钥会同时从对应网站删除，无法通过扩展恢复。请确认它们的分组已不再使用。",
+  "confirm": "删除所选密钥",
+  "more": "以及另外 {{count}} 个"
+}
+```
+
+Update sibling locales with the same key shape.
+
+- [ ] **Step 8: Run UI and i18n checks**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit invalid-key delete UI**
+
+```powershell
+git add src/features/KeyManagement/components/RepairMissingKeysDialog.tsx src/locales/zh-CN/keyManagement.json src/locales/en/keyManagement.json src/locales/ja/keyManagement.json src/locales/vi/keyManagement.json src/locales/zh-TW/keyManagement.json tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+git commit -m "feat(key-management): confirm batch invalid key deletion"
+```
+
+## Task 6: Analytics And Final Validation
+
+**Files:**
+- Modify: `src/services/productAnalytics/events.ts`
+- Modify: `src/services/productAnalytics/privacy.ts`
+- Modify: `src/features/KeyManagement/components/RepairMissingKeysDialog.tsx`
+- Test: `tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx`
+
+- [ ] **Step 1: Decide whether a new analytics action id is needed**
+
+If batch invalid-key deletion currently completes under `RepairMissingAccountKeys`, add a separate action id.
+
+In `src/services/productAnalytics/events.ts`, add:
+
+```ts
+DeleteInvalidAccountTokens: "delete_invalid_account_tokens",
+```
+
+No new privacy allow-list entries are required if the implementation only uses existing insight fields:
+
+- `itemCount`
+- `selectedCount`
+- `successCount`
+- `failureCount`
+- `statusKind`
+
+- [ ] **Step 2: Track invalid-key delete completion**
+
+In `RepairMissingKeysDialog.tsx`, add context:
+
+```ts
+const deleteInvalidKeysAnalyticsContext = {
+  featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+  actionId: PRODUCT_ANALYTICS_ACTION_IDS.DeleteInvalidAccountTokens,
+  surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRepairDialog,
+  entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+}
+```
+
+At delete start:
+
+```ts
+void trackProductAnalyticsActionStarted(deleteInvalidKeysAnalyticsContext)
+```
+
+At delete completion:
+
+```ts
+void trackProductAnalyticsActionCompleted({
+  ...deleteInvalidKeysAnalyticsContext,
+  result:
+    response.data.failed.length > 0
+      ? PRODUCT_ANALYTICS_RESULTS.Failure
+      : PRODUCT_ANALYTICS_RESULTS.Success,
+  insights: {
+    itemCount: selectedInvalidTokens.length,
+    selectedCount: selectedInvalidTokens.length,
+    successCount: response.data.deleted.length,
+    failureCount: response.data.failed.length,
+    statusKind:
+      response.data.failed.length > 0
+        ? PRODUCT_ANALYTICS_STATUS_KINDS.Warning
+        : PRODUCT_ANALYTICS_STATUS_KINDS.Healthy,
+  },
+})
+```
+
+On thrown/immediate failure:
+
+```ts
+void trackProductAnalyticsActionCompleted({
+  ...deleteInvalidKeysAnalyticsContext,
+  result: PRODUCT_ANALYTICS_RESULTS.Failure,
+  errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+  insights: {
+    itemCount: selectedInvalidTokens.length,
+    selectedCount: selectedInvalidTokens.length,
+    successCount: 0,
+    failureCount: selectedInvalidTokens.length,
+    statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
+  },
+})
+```
+
+- [ ] **Step 3: Add analytics test**
+
+In `KeyManagementRepairMissingKeys.test.tsx`, extend the batch-delete test:
+
+```ts
+await waitFor(() => {
+  expect(mockTrackProductAnalyticsActionCompleted).toHaveBeenCalledWith(
+    expect.objectContaining({
+      actionId: "delete_invalid_account_tokens",
+      result: PRODUCT_ANALYTICS_RESULTS.Success,
+      insights: expect.objectContaining({
+        itemCount: 1,
+        selectedCount: 1,
+        successCount: 1,
+        failureCount: 0,
+      }),
+    }),
+  )
+})
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountKeyRepair.test.ts tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run related tests**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/accounts/accountKeyAutoProvisioning/repair.ts src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/features/KeyManagement/components/RepairMissingKeysDialog.tsx src/features/KeyManagement/KeyManagement.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run i18n validation**
+
+Run:
+
+```powershell
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run commit gate**
+
+Stage only task-scoped files:
+
+```powershell
+git add src/services/accounts/accountKeyAutoProvisioning src/types/accountKeyAutoProvisioning.ts src/features/KeyManagement src/locales/zh-CN/keyManagement.json src/locales/en/keyManagement.json src/locales/ja/keyManagement.json src/locales/vi/keyManagement.json src/locales/zh-TW/keyManagement.json src/services/productAnalytics/events.ts src/services/productAnalytics/privacy.ts tests/services/accountKeyRepair.test.ts tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit final analytics/validation cleanup**
+
+```powershell
+git commit -m "chore(key-management): validate key coverage audit"
+```
+
+## Self-Review Notes
+
+- Spec coverage:
+  - Manual start: Task 3.
+  - Existing dialog shell reuse: Tasks 3-5.
+  - Group-aware coverage and invalid-token detection: Task 1.
+  - Bulk invalid-key deletion with explicit confirmation: Tasks 2 and 5.
+  - Serial deletion: Task 2 service handler.
+  - Unsupported site boundaries: Task 1 tests and helper behavior.
+  - Privacy-safe telemetry: Task 6.
+  - No new sidebar/page-level tab/scheduler: preserved by all UI tasks.
+
+- E2E decision:
+  - No E2E is planned. This feature's first-version risks are service branching,
+    dialog state, confirmation copy, and partial success, all covered by focused
+    Vitest and Testing Library tests.
+
+- Implementation guardrails:
+  - Do not add a new concurrency setting.
+  - Do not make the header button start the audit.
+  - Do not automatically delete invalid keys.
+  - Do not record key names, group names, token ids, account ids, URLs, origins,
+    or backend error text in analytics.

--- a/docs/superpowers/specs/2026-06-12-key-coverage-audit-design.md
+++ b/docs/superpowers/specs/2026-06-12-key-coverage-audit-design.md
@@ -1,0 +1,436 @@
+# Key Coverage Audit Design
+
+Date: 2026-06-12
+
+## Purpose
+
+Evolve the existing Key Management "ensure at least one key" repair flow into
+a manual key coverage audit that can:
+
+- detect each saved account's currently available groups
+- create default keys for available groups that have no key
+- list keys whose assigned group is no longer available
+- let users explicitly delete selected invalid keys after confirmation
+
+The feature should remain a low-friction maintenance tool inside Key
+Management. It should not become a new sidebar entry, a page-level dashboard,
+or a background scheduler in the first version.
+
+## Current Context
+
+`src/features/KeyManagement/KeyManagement.tsx` already owns a header action that
+opens `RepairMissingKeysDialog`. The dialog is backed by a background repair
+runner in `src/services/accounts/accountKeyAutoProvisioning/repair.ts`.
+
+The current repair runner:
+
+- scans enabled accounts
+- skips known unsupported accounts such as Sub2API and AIHubMix
+- calls `ensureDefaultApiTokenForAccount`
+- creates one default key only when an account has no keys
+- persists progress and sends runtime progress updates
+
+The existing dialog already has the right shell for a manual maintenance task:
+
+- modal header and status badge
+- progress bar
+- summary counts
+- search
+- outcome filters
+- per-account result rows
+- Sub2API manual create-key affordance for skipped rows
+
+The key change is semantic: the old unit of coverage was "account has at least
+one key"; the new unit is "each available group has at least one key".
+
+## Problem
+
+Relay-site groups can change over time. A previously useful key can point to a
+group that no longer exists, and a newly available group can have no key. Users
+currently have to inspect accounts and keys one by one to notice these gaps.
+
+The feature also includes a destructive path: deleting a key in the extension
+deletes the key on the remote site. The UI must make that boundary explicit and
+must not make deletion look like part of the automatic repair step.
+
+The current button label also risks becoming misleading if clicking it
+immediately starts a larger operation. The first version should distinguish
+between opening the audit tool and starting remote writes.
+
+## Goals
+
+- Reuse the existing Key Management repair entrypoint and dialog shell.
+- Rename the entrypoint so it opens a key audit tool rather than implying a
+  single missing-key repair.
+- Require an explicit "start" action inside the dialog before scanning and
+  creating keys.
+- Use available user groups as the source of truth for group coverage.
+- Create default keys only for missing available groups.
+- List invalid keys separately from account coverage results.
+- Support selected and bulk deletion for invalid keys with strong
+  confirmation.
+- Keep deletion serial and partial-success aware.
+- Preserve existing unsupported-site skips and manual affordances.
+
+## Non-Goals
+
+- Do not add a new sidebar entry.
+- Do not add a page-level tab to Key Management in the first version.
+- Do not add scheduled or automatic background audits.
+- Do not automatically delete invalid keys.
+- Do not add a user-facing concurrency setting.
+- Do not redesign the whole Key Management page.
+- Do not broaden the first version into Sub2API or AIHubMix group semantics.
+- Do not manually edit translated docs or generated locale output outside the
+  normal repo workflow.
+
+## Information Architecture
+
+The Key Management header should keep a single maintenance action, renamed from
+the current "ensure at least one key" wording.
+
+Recommended Chinese copy:
+
+- Header button: `密钥检查`
+- Dialog title: `密钥覆盖检查`
+- Start action: `开始检查并补齐`
+
+Recommended English intent:
+
+- Header button: `Key Check`
+- Dialog title: `Key Coverage Check`
+- Start action: `Start Check and Backfill`
+
+The header button opens the dialog only. It should not start a new audit by
+itself. This prevents a user from accidentally triggering remote key creation
+before they understand the operation.
+
+If an audit job is already running when the page loads, the dialog may open
+automatically to show progress. That is a recovery/view behavior, not a new
+execution.
+
+## Dialog Layout
+
+The dialog should keep the existing repair modal structure and extend the
+result area.
+
+Top to bottom:
+
+1. Header
+   - title
+   - running/completed/failed status badge
+   - short description
+2. Intro or progress area
+   - initial state explains what will happen
+   - running state shows progress and current status
+   - completed state shows the latest run summary
+3. Summary metrics
+   - enabled accounts
+   - eligible accounts
+   - processed accounts
+   - groups covered / total available groups when known
+   - created keys
+   - invalid keys
+   - failed accounts or failed delete count when relevant
+4. Result view switch
+   - `账号覆盖`
+   - `异常密钥`
+5. View-specific toolbar
+   - account coverage: search and outcome filter
+   - invalid keys: search, select current result, selected count, delete
+     selected
+6. Scrollable result list
+7. Footer note
+   - audit runs in the background after it starts
+   - deletion removes keys from the remote site
+
+Use a compact segmented control for the two result views. Do not make these
+page-level tabs. The results are a session snapshot, not a persistent top-level
+section.
+
+## Initial State
+
+When opened with no running job, the dialog should show:
+
+- explanation of the operation
+- note that it may create default keys on remote sites
+- note that it will not automatically delete keys
+- primary button: `开始检查并补齐`
+- optional secondary content showing the last completed result, if available
+
+The user must click the start button before the runner scans groups or creates
+keys.
+
+## Account Coverage View
+
+This is the default result view.
+
+Each row represents one account and should keep the existing row rhythm:
+
+- account name
+- site type badge
+- site origin
+- outcome badge
+- coverage details
+- relevant action, such as manual key creation for skipped Sub2API accounts
+
+Coverage details should show:
+
+- available group count
+- covered group count
+- created group keys
+- missing groups that could not be created
+- error message when group detection or key creation failed
+
+Rows should remain searchable by account name, origin, site type, and group
+name when group details are available.
+
+Outcome filters should remain secondary to the view switch. They filter account
+coverage rows only; they should not filter the invalid-key view.
+
+## Invalid Keys View
+
+This view lists existing keys whose assigned group is no longer present in the
+account's current available group set.
+
+Each row should show:
+
+- checkbox
+- key name
+- account name
+- site type badge
+- site origin
+- invalid group name
+- reason, such as `分组当前不可用`
+- per-row delete action
+
+The view should support:
+
+- search by key name, account name, origin, site type, and group name
+- select all current filtered results
+- selected count
+- `删除所选` button enabled only when at least one invalid key is selected
+
+Invalid keys should be based on the latest audit snapshot. They should not be
+shown as a permanent real-time state unless the user reruns the check.
+
+## Bulk Delete Behavior
+
+Bulk deletion is allowed only from the `异常密钥` view and only for selected
+invalid keys from the current audit result.
+
+Deletion must require a destructive confirmation dialog.
+
+The confirmation should include:
+
+- selected key count
+- explicit remote-site deletion warning
+- a short preview of selected key names and account names
+- overflow text for additional selected keys
+- destructive confirm label such as `删除所选密钥`
+
+Recommended Chinese warning intent:
+
+> 这些密钥会同时从对应网站删除，无法通过扩展恢复。请确认它们的分组已不再使用。
+
+Bulk deletion should execute serially with a normal `for...of await` loop. Do
+not add a new worker pool or user-facing concurrency control. The transport
+layer already applies per-site request limiting, and serial deletion produces a
+clearer partial-success story for a destructive operation.
+
+After deletion:
+
+- successfully deleted keys should be removed from the invalid-key list or
+  marked deleted
+- failed keys should remain visible with an error message
+- the dialog should show a partial-success summary when any deletion fails
+- the audit should not automatically rerun after deletion
+- a `重新检查` action should remain available
+
+## Service Design
+
+The current `ensureDefaultApiTokenForAccount` can remain as the narrow legacy
+helper for the old "one key per account" semantics.
+
+The group-aware audit should use a new service-level helper with a clearer
+contract, for example:
+
+```ts
+ensureAccountKeysForAvailableGroups(params)
+```
+
+The helper should:
+
+1. fetch current tokens
+2. fetch current user groups
+3. normalize available group names
+4. compute covered groups from token `group` fields
+5. create default tokens for uncovered available groups
+6. compute invalid tokens whose group is non-empty and not available
+7. return structured coverage and invalid-key data
+
+If group fetching is unsupported or returns no groups, the service should fall
+back to the existing "account has at least one key" behavior rather than
+blocking compatible sites that do not expose group inventory.
+
+Creation should reuse the existing default token request shape, overriding only
+the group and a predictable default name when a group-specific key is created.
+
+## Progress Model
+
+The repair progress type should be extended compatibly. New fields should be
+optional where older stored progress blobs may exist.
+
+Account result additions may include:
+
+- `availableGroups`
+- `coveredGroups`
+- `createdGroups`
+- `missingGroups`
+- `invalidTokens`
+- `groupCoverageStatus`
+
+Summary additions may include:
+
+- `availableGroups`
+- `coveredGroups`
+- `createdKeys`
+- `invalidKeys`
+- `deletedKeys`
+- `deleteFailed`
+
+Existing outcome values may remain for account-level filtering:
+
+- `created`
+- `alreadyHad`
+- `skipped`
+- `failed`
+
+If an account both creates missing group keys and detects invalid keys, the
+account coverage outcome should still reflect the coverage repair result, while
+invalid keys appear in the separate invalid-key view.
+
+## Unsupported Sites
+
+Keep the current conservative unsupported-site behavior in the first version:
+
+- Sub2API remains skipped for automatic repair because key creation requires
+  explicit group selection through its own flow.
+- AIHubMix remains skipped because key creation has one-time-secret behavior
+  and no One-API-style group semantics.
+- none-auth accounts remain skipped.
+
+The existing Sub2API manual create-token affordance should remain available in
+skipped account rows.
+
+## Error Handling
+
+Failures should be scoped to the account or key being processed when possible.
+
+Audit failures:
+
+- group fetch unsupported: fall back to one-key behavior
+- group fetch failed due to network/auth: mark account failed
+- token fetch failed: mark account failed
+- key creation failed for one group: keep processing other groups only if the
+  service can do so without hiding the failure
+
+Delete failures:
+
+- keep failed rows selected or visible
+- show per-key error message
+- show aggregate partial-success feedback
+- do not roll back successful remote deletions
+
+User-facing messages must not rely only on backend messages. Provide local
+fallback copy for empty or unsuitable backend errors.
+
+## Telemetry Decision
+
+Reuse the existing Key Management repair analytics action for the audit start
+and completion path if the event remains semantically correct.
+
+If the payload needs more detail, add privacy-safe counts only:
+
+- eligible account count
+- processed account count
+- created key count
+- invalid key count
+- deleted key count
+- delete failure count
+- coarse status kind
+
+Do not record key names, group names, origins, URLs, token ids, raw backend
+messages, or account identifiers.
+
+Bulk invalid-key deletion is a user-visible destructive action. It should have
+its own action id or a clearly distinguishable action detail if the analytics
+schema already supports that pattern.
+
+## Settings Search And Deep Links
+
+This change does not add a settings page or a new persistent configuration
+control. It does not need a new settings search target.
+
+If the header action is later exposed as a deep-link target, add a stable target
+id then. That is out of scope for the first version.
+
+## Testing Strategy
+
+Service tests should cover:
+
+- existing one-key fallback remains stable
+- available groups are fetched and normalized
+- keys are created for missing available groups
+- existing keys satisfy their own group
+- invalid tokens are detected when their group is not available
+- empty or unsupported groups fall back to the existing one-key behavior
+- Sub2API, AIHubMix, and none-auth skip behavior remains unchanged
+- partial group creation failures are reported
+- bulk delete succeeds serially and reports deleted keys
+- bulk delete partial failure keeps failed keys visible
+
+Component tests should cover:
+
+- header button opens the dialog without starting a new audit
+- initial dialog explains remote key creation and no automatic deletion
+- start button sends the start message
+- running progress still opens automatically when a job is already running
+- account coverage and invalid-key views switch correctly
+- invalid-key selection, select current results, and selected count
+- delete selected button disabled until selection exists
+- destructive confirmation copy mentions remote deletion
+- partial delete result is rendered
+
+E2E is not required for the first version. The main risks are service behavior,
+state transitions, and destructive confirmation copy, which are better covered
+with focused Vitest and Testing Library tests.
+
+## Validation Plan
+
+Focused validation should include:
+
+```powershell
+pnpm vitest run tests/services/accountKeyRepair.test.ts tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+```
+
+Related validation should include:
+
+```powershell
+pnpm vitest related --run src/services/accounts/accountKeyAutoProvisioning/repair.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/features/KeyManagement/components/RepairMissingKeysDialog.tsx src/features/KeyManagement/KeyManagement.tsx
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+## Rollout Notes
+
+This is a user-facing behavior change. The changelog should describe it as a
+manual key coverage check that can backfill missing group keys and identify
+invalid group keys for cleanup.
+
+The docs should avoid implying automatic deletion or scheduled monitoring.
+Deletion must be described as explicit and confirmed by the user.

--- a/src/components/ResponsiveButtonGroup.tsx
+++ b/src/components/ResponsiveButtonGroup.tsx
@@ -10,7 +10,7 @@ import { cn } from "~/lib/utils"
 type ResponsiveButtonGroupVariant = "segmented" | "plain"
 
 export const responsiveButtonGroupItemClassName =
-  "min-w-fit flex-1 [@container(min-width:42rem)]:flex-none"
+  "min-w-fit flex-1 scale-100 [@container(min-width:42rem)]:flex-none"
 
 interface ResponsiveButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode

--- a/src/features/KeyManagement/KeyManagement.tsx
+++ b/src/features/KeyManagement/KeyManagement.tsx
@@ -179,7 +179,7 @@ export default function KeyManagement(props: {
   }, [])
 
   const handleRepairMissingKeys = () => {
-    setRepairStartOnOpen(true)
+    setRepairStartOnOpen(false)
     setIsRepairOpen(true)
   }
 

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -1,17 +1,22 @@
 import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { ShieldCheck, TriangleAlert } from "lucide-react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
+import { ResponsiveToggleGroup } from "~/components/ResponsiveButtonGroup"
 import {
   Alert,
   Badge,
   Button,
   Card,
   CardContent,
+  CardFooter,
   CardHeader,
   CardTitle,
+  Checkbox,
+  DestructiveConfirmDialog,
   EmptyState,
   Input,
   Label,
@@ -39,6 +44,7 @@ import {
 } from "~/services/productAnalytics/events"
 import type { DisplaySiteData } from "~/types"
 import type {
+  AccountKeyRepairInvalidToken,
   AccountKeyRepairOutcome,
   AccountKeyRepairProgress,
   AccountKeyRepairSkipReason,
@@ -48,6 +54,13 @@ import { onRuntimeMessage } from "~/utils/browser/browserApi"
 const repairMissingKeysAnalyticsContext = {
   featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
   actionId: PRODUCT_ANALYTICS_ACTION_IDS.RepairMissingAccountKeys,
+  surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRepairDialog,
+  entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+}
+
+const deleteInvalidKeysAnalyticsContext = {
+  featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+  actionId: PRODUCT_ANALYTICS_ACTION_IDS.DeleteInvalidAccountTokens,
   surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRepairDialog,
   entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
 }
@@ -103,6 +116,7 @@ function getSkipReasonLabel(
 }
 
 type BadgeVariant = React.ComponentProps<typeof Badge>["variant"]
+type RepairResultView = "accountCoverage" | "invalidKeys"
 
 const OUTCOME_BADGE_VARIANTS: Record<AccountKeyRepairOutcome, BadgeVariant> = {
   created: "success",
@@ -125,6 +139,67 @@ function getRepairOutcomeLabel(t: TFunction, outcome: AccountKeyRepairOutcome) {
     case "failed":
       return t("keyManagement:repairMissingKeys.outcomes.failed")
   }
+}
+
+/**
+ * Returns the localized view switch label.
+ */
+function getRepairResultViewLabel(t: TFunction, view: RepairResultView) {
+  switch (view) {
+    case "accountCoverage":
+      return t("keyManagement:repairMissingKeys.views.accountCoverage")
+    case "invalidKeys":
+      return t("keyManagement:repairMissingKeys.views.invalidKeys")
+  }
+}
+
+/**
+ * Keeps group names visible if i18n returns the missing-key fallback instead of
+ * interpolated copy.
+ */
+function getCoverageGroupLabel(
+  t: TFunction,
+  key: "createdGroup" | "missingGroup",
+  group: string,
+) {
+  const [translationKey, label] =
+    key === "createdGroup"
+      ? [
+          "keyManagement:repairMissingKeys.coverage.createdGroup",
+          t("keyManagement:repairMissingKeys.coverage.createdGroup", {
+            group,
+          }),
+        ]
+      : [
+          "keyManagement:repairMissingKeys.coverage.missingGroup",
+          t("keyManagement:repairMissingKeys.coverage.missingGroup", {
+            group,
+          }),
+        ]
+
+  return label === translationKey ? group : label
+}
+
+/**
+ * Returns the localized reason shown for invalid keys.
+ */
+function getInvalidTokenReasonLabel(
+  t: TFunction,
+  token: AccountKeyRepairInvalidToken,
+) {
+  switch (token.reason) {
+    case "groupUnavailable":
+      return t("keyManagement:repairMissingKeys.invalidKeys.groupUnavailable", {
+        group: token.group,
+      })
+  }
+}
+
+/**
+ * Builds a stable selection key for an invalid token within an account.
+ */
+function getInvalidTokenKey(token: AccountKeyRepairInvalidToken) {
+  return `${token.accountId}:${token.tokenId}`
 }
 
 /**
@@ -182,13 +257,27 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
   const [searchTerm, setSearchTerm] = useState("")
   const [outcomeFilter, setOutcomeFilter] =
     useState<AccountKeyRepairOutcome | null>(null)
+  const [activeView, setActiveView] =
+    useState<RepairResultView>("accountCoverage")
   const [openingSub2ApiAccountId, setOpeningSub2ApiAccountId] = useState<
     string | null
   >(null)
+  const [selectedInvalidTokenKeys, setSelectedInvalidTokenKeys] = useState<
+    Set<string>
+  >(() => new Set())
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
+  const [isDeletingInvalidKeys, setIsDeletingInvalidKeys] = useState(false)
+  const [deleteResultMessage, setDeleteResultMessage] = useState("")
+  const [isStarting, setIsStarting] = useState(false)
   const startedAnalyticsJobIdRef = useRef<string | null>(null)
   const completedAnalyticsJobIdRef = useRef<string | null>(null)
   const progressRef = useRef<AccountKeyRepairProgress | null>(null)
   const accountsRef = useRef(accounts)
+  const isDialogOpenRef = useRef(isOpen)
+  const startInFlightRef = useRef(false)
+  const startRequestIdRef = useRef(0)
+
+  isDialogOpenRef.current = isOpen
 
   const disabledAccountIds = useMemo(() => {
     return new Set(
@@ -207,9 +296,14 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     )
   }, [disabledAccountIds, progress])
 
+  const invalidTokens = useMemo(() => {
+    return visibleResults.flatMap((result) => result.invalidTokens ?? [])
+  }, [visibleResults])
+
   /**
    * Filters visible repair results by free-text search and an optional outcome filter.
-   * Search matches account name, site origin, and site type (case-insensitive).
+   * Search matches account name, site origin, site type, and group coverage
+   * details (case-insensitive).
    */
   const filteredResults = useMemo(() => {
     let results = visibleResults
@@ -224,13 +318,188 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     }
 
     return results.filter((result) => {
+      const groupNames = [
+        ...(result.availableGroups ?? []),
+        ...(result.coveredGroups ?? []),
+        ...(result.createdGroups ?? []),
+        ...(result.missingGroups ?? []),
+      ]
+
       return (
         result.accountName.toLowerCase().includes(keyword) ||
         result.siteUrlOrigin.toLowerCase().includes(keyword) ||
-        result.siteType.toLowerCase().includes(keyword)
+        result.siteType.toLowerCase().includes(keyword) ||
+        groupNames.some((group) => group.toLowerCase().includes(keyword))
       )
     })
   }, [outcomeFilter, searchTerm, visibleResults])
+
+  const filteredInvalidTokens = useMemo(() => {
+    const keyword = searchTerm.trim().toLowerCase()
+    if (!keyword) {
+      return invalidTokens
+    }
+
+    return invalidTokens.filter((token) => {
+      return (
+        token.accountName.toLowerCase().includes(keyword) ||
+        token.siteUrlOrigin.toLowerCase().includes(keyword) ||
+        token.siteType.toLowerCase().includes(keyword) ||
+        token.tokenName.toLowerCase().includes(keyword) ||
+        token.group.toLowerCase().includes(keyword)
+      )
+    })
+  }, [invalidTokens, searchTerm])
+
+  const selectedInvalidTokens = useMemo(() => {
+    return filteredInvalidTokens.filter((token) =>
+      selectedInvalidTokenKeys.has(getInvalidTokenKey(token)),
+    )
+  }, [filteredInvalidTokens, selectedInvalidTokenKeys])
+
+  const deleteConfirmDetails = useMemo(() => {
+    const previewTokens = selectedInvalidTokens.slice(0, 5)
+    const hiddenCount = selectedInvalidTokens.length - previewTokens.length
+
+    return (
+      <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-tertiary/40 rounded-md border border-gray-200 bg-gray-50 p-3">
+        <ul className="space-y-2 text-sm">
+          {previewTokens.map((token) => (
+            <li
+              key={getInvalidTokenKey(token)}
+              className="min-w-0 text-gray-700 dark:text-gray-300"
+            >
+              <span className="font-medium">{token.tokenName}</span>
+              <span className="dark:text-dark-text-secondary text-gray-500">
+                {" "}
+                · {token.accountName}
+              </span>
+            </li>
+          ))}
+        </ul>
+        {hiddenCount > 0 ? (
+          <p className="dark:text-dark-text-secondary mt-2 text-xs text-gray-500">
+            {t("repairMissingKeys.deleteConfirm.more", {
+              count: hiddenCount,
+            })}
+          </p>
+        ) : null}
+      </div>
+    )
+  }, [selectedInvalidTokens, t])
+
+  const handleDeleteInvalidKeys = async () => {
+    const tokensToDelete = selectedInvalidTokens
+    if (tokensToDelete.length === 0) {
+      return
+    }
+
+    setIsDeletingInvalidKeys(true)
+    setDeleteResultMessage("")
+    void trackProductAnalyticsActionStarted(deleteInvalidKeysAnalyticsContext)
+    try {
+      const response = await sendAccountKeyRepairMessage(
+        AccountKeyRepairMessageTypes.DeleteInvalidTokens,
+        { tokens: tokensToDelete },
+      )
+
+      if (!response?.success || !response.data) {
+        setDeleteResultMessage(t("repairMissingKeys.invalidKeys.deleteFailed"))
+        setIsDeleteConfirmOpen(false)
+        void trackProductAnalyticsActionCompleted({
+          ...deleteInvalidKeysAnalyticsContext,
+          result: PRODUCT_ANALYTICS_RESULTS.Failure,
+          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+          insights: {
+            itemCount: tokensToDelete.length,
+            selectedCount: tokensToDelete.length,
+            successCount: 0,
+            failureCount: tokensToDelete.length,
+            statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
+          },
+        })
+        return
+      }
+
+      const deletedKeys = new Set(response.data.deleted.map(getInvalidTokenKey))
+      setSelectedInvalidTokenKeys((previous) => {
+        const next = new Set(previous)
+        for (const key of deletedKeys) {
+          next.delete(key)
+        }
+        return next
+      })
+      setProgress((current) => {
+        if (!current) return current
+
+        return {
+          ...current,
+          summary: {
+            ...current.summary,
+            invalidKeys: Math.max(
+              0,
+              (current.summary.invalidKeys ?? 0) - response.data.deleted.length,
+            ),
+            deletedKeys:
+              (current.summary.deletedKeys ?? 0) + response.data.deleted.length,
+            deleteFailed:
+              (current.summary.deleteFailed ?? 0) + response.data.failed.length,
+          },
+          results: current.results.map((result) => ({
+            ...result,
+            invalidTokens: result.invalidTokens?.filter(
+              (token) => !deletedKeys.has(getInvalidTokenKey(token)),
+            ),
+          })),
+        }
+      })
+      setDeleteResultMessage(
+        response.data.failed.length > 0
+          ? t("repairMissingKeys.invalidKeys.deletePartial", {
+              deleted: response.data.deleted.length,
+              failed: response.data.failed.length,
+            })
+          : t("repairMissingKeys.invalidKeys.deleteSuccess", {
+              count: response.data.deleted.length,
+            }),
+      )
+      setIsDeleteConfirmOpen(false)
+      void trackProductAnalyticsActionCompleted({
+        ...deleteInvalidKeysAnalyticsContext,
+        result:
+          response.data.failed.length > 0
+            ? PRODUCT_ANALYTICS_RESULTS.Failure
+            : PRODUCT_ANALYTICS_RESULTS.Success,
+        insights: {
+          itemCount: tokensToDelete.length,
+          selectedCount: tokensToDelete.length,
+          successCount: response.data.deleted.length,
+          failureCount: response.data.failed.length,
+          statusKind:
+            response.data.failed.length > 0
+              ? PRODUCT_ANALYTICS_STATUS_KINDS.Warning
+              : PRODUCT_ANALYTICS_STATUS_KINDS.Healthy,
+        },
+      })
+    } catch {
+      setDeleteResultMessage(t("repairMissingKeys.invalidKeys.deleteFailed"))
+      setIsDeleteConfirmOpen(false)
+      void trackProductAnalyticsActionCompleted({
+        ...deleteInvalidKeysAnalyticsContext,
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        insights: {
+          itemCount: tokensToDelete.length,
+          selectedCount: tokensToDelete.length,
+          successCount: 0,
+          failureCount: tokensToDelete.length,
+          statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
+        },
+      })
+    } finally {
+      setIsDeletingInvalidKeys(false)
+    }
+  }
 
   const handleOpenSub2ApiTokenDialog = async (accountId: string) => {
     const account = accountById.get(accountId)
@@ -292,6 +561,87 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     return "bg-blue-600 dark:bg-blue-500"
   }, [progress])
 
+  const handleStartAudit = useCallback(async () => {
+    if (startInFlightRef.current) {
+      return
+    }
+
+    startInFlightRef.current = true
+    const requestId = startRequestIdRef.current + 1
+    startRequestIdRef.current = requestId
+
+    setIsStarting(true)
+    setError("")
+    try {
+      const response = await sendAccountKeyRepairMessage(
+        AccountKeyRepairMessageTypes.Start,
+      )
+      if (response?.success && response.data) {
+        startedAnalyticsJobIdRef.current = response.data.jobId
+        void trackProductAnalyticsActionStarted(
+          repairMissingKeysAnalyticsContext,
+        )
+        if (
+          isDialogOpenRef.current &&
+          startRequestIdRef.current === requestId
+        ) {
+          setProgress(response.data)
+        }
+        return
+      }
+
+      void trackProductAnalyticsActionCompleted({
+        ...repairMissingKeysAnalyticsContext,
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        insights: getRepairStartFailureInsights(
+          progressRef.current,
+          accountsRef.current,
+        ),
+      })
+      if (isDialogOpenRef.current && startRequestIdRef.current === requestId) {
+        setError(t("repairMissingKeys.messages.startFailed"))
+      }
+    } catch {
+      void trackProductAnalyticsActionCompleted({
+        ...repairMissingKeysAnalyticsContext,
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        insights: getRepairStartFailureInsights(
+          progressRef.current,
+          accountsRef.current,
+        ),
+      })
+      if (isDialogOpenRef.current && startRequestIdRef.current === requestId) {
+        setError(t("repairMissingKeys.messages.startFailed"))
+      }
+    } finally {
+      if (startRequestIdRef.current === requestId) {
+        startInFlightRef.current = false
+        if (isDialogOpenRef.current) {
+          setIsStarting(false)
+        }
+      }
+    }
+  }, [t])
+
+  useEffect(() => {
+    isDialogOpenRef.current = isOpen
+    if (isOpen) {
+      setIsStarting(startInFlightRef.current)
+    } else {
+      setIsStarting(false)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    return () => {
+      isDialogOpenRef.current = false
+      startRequestIdRef.current += 1
+      startInFlightRef.current = false
+    }
+  }, [])
+
   useEffect(() => {
     if (!isOpen) {
       startedAnalyticsJobIdRef.current = null
@@ -303,8 +653,30 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     if (!isOpen) {
       setSearchTerm("")
       setOutcomeFilter(null)
+      setActiveView("accountCoverage")
+      setSelectedInvalidTokenKeys(new Set())
+      setIsDeleteConfirmOpen(false)
+      setDeleteResultMessage("")
     }
   }, [isOpen])
+
+  useEffect(() => {
+    const currentInvalidTokenKeys = new Set(
+      invalidTokens.map(getInvalidTokenKey),
+    )
+    setSelectedInvalidTokenKeys((previous) => {
+      const next = new Set(
+        [...previous].filter((key) => currentInvalidTokenKeys.has(key)),
+      )
+      return next.size === previous.size ? previous : next
+    })
+  }, [invalidTokens])
+
+  useEffect(() => {
+    if (isDeleteConfirmOpen && selectedInvalidTokens.length === 0) {
+      setIsDeleteConfirmOpen(false)
+    }
+  }, [isDeleteConfirmOpen, selectedInvalidTokens.length])
 
   useEffect(() => {
     progressRef.current = progress
@@ -356,52 +728,8 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     if (!isOpen) return
     if (!startOnOpen) return
 
-    let cancelled = false
-
-    void (async () => {
-      try {
-        const response = await sendAccountKeyRepairMessage(
-          AccountKeyRepairMessageTypes.Start,
-        )
-        if (cancelled) return
-        if (response?.success && response.data) {
-          startedAnalyticsJobIdRef.current = response.data.jobId
-          void trackProductAnalyticsActionStarted(
-            repairMissingKeysAnalyticsContext,
-          )
-          setProgress(response.data)
-        } else {
-          void trackProductAnalyticsActionCompleted({
-            ...repairMissingKeysAnalyticsContext,
-            result: PRODUCT_ANALYTICS_RESULTS.Failure,
-            errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-            insights: getRepairStartFailureInsights(
-              progressRef.current,
-              accountsRef.current,
-            ),
-          })
-          setError(t("repairMissingKeys.messages.startFailed"))
-        }
-      } catch {
-        if (!cancelled) {
-          void trackProductAnalyticsActionCompleted({
-            ...repairMissingKeysAnalyticsContext,
-            result: PRODUCT_ANALYTICS_RESULTS.Failure,
-            errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-            insights: getRepairStartFailureInsights(
-              progressRef.current,
-              accountsRef.current,
-            ),
-          })
-          setError(t("repairMissingKeys.messages.startFailed"))
-        }
-      }
-    })()
-
-    return () => {
-      cancelled = true
-    }
-  }, [isOpen, startOnOpen, t])
+    void handleStartAudit()
+  }, [handleStartAudit, isOpen, startOnOpen])
 
   useEffect(() => {
     if (!progress) return
@@ -477,16 +805,72 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     >
       {error ? <Alert variant="destructive" description={error} /> : null}
 
-      {progress ? (
+      {!progress || progress.state === "idle" ? (
+        <Card variant="outlined" className="overflow-hidden">
+          <CardContent padding="default" className="space-y-4">
+            <div className="flex items-start gap-3">
+              <div className="shrink-0 rounded-lg bg-blue-50 p-2 text-blue-600 dark:bg-blue-900/30 dark:text-blue-300">
+                <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <p className="pt-1 text-sm leading-6 text-gray-700 dark:text-gray-300">
+                {t("repairMissingKeys.initialNotice")}
+              </p>
+            </div>
+            <Alert
+              variant="info"
+              compact
+              description={t("repairMissingKeys.remoteWriteNotice")}
+            />
+          </CardContent>
+          <CardFooter
+            padding="sm"
+            className="dark:bg-dark-bg-primary/40 justify-start bg-gray-50/80"
+          >
+            <Button
+              type="button"
+              onClick={() => void handleStartAudit()}
+              disabled={isStarting}
+              loading={isStarting}
+              className="w-full sm:w-auto"
+            >
+              {t("repairMissingKeys.actions.start")}
+            </Button>
+          </CardFooter>
+        </Card>
+      ) : null}
+
+      {progress && progress.state !== "idle" ? (
         <div className="space-y-4">
           <Card>
             <CardContent padding="md" spacing="none" className="space-y-4">
               <div className="space-y-2">
-                <div className="flex items-center justify-between gap-2 text-xs text-gray-600 dark:text-gray-400">
-                  <span>{t("repairMissingKeys.progressLabel")}</span>
-                  <span>
-                    {processedTotal}/{eligibleTotal} ({progressPercent}%)
-                  </span>
+                <div
+                  data-testid="repair-missing-keys-progress-header"
+                  className="flex flex-wrap items-center justify-between gap-2"
+                >
+                  <div className="min-w-0 text-xs text-gray-600 dark:text-gray-400">
+                    <span>{t("repairMissingKeys.progressLabel")}</span>
+                  </div>
+                  <div
+                    data-testid="repair-missing-keys-progress-actions"
+                    className="flex flex-wrap items-center justify-end gap-3 text-xs text-gray-600 dark:text-gray-400"
+                  >
+                    <span>
+                      {processedTotal}/{eligibleTotal} ({progressPercent}%)
+                    </span>
+                    {progress.state !== "running" ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void handleStartAudit()}
+                        disabled={isStarting}
+                        loading={isStarting}
+                      >
+                        {t("repairMissingKeys.actions.rerun")}
+                      </Button>
+                    ) : null}
+                  </div>
                 </div>
                 <div
                   className="dark:bg-dark-bg-tertiary h-2 w-full rounded-full bg-gray-100"
@@ -568,22 +952,78 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
             </CardContent>
           </Card>
 
+          <ResponsiveToggleGroup
+            aria-label={t("repairMissingKeys.views.label")}
+            value={activeView}
+            onValueChange={setActiveView}
+            buttonSize="sm"
+            className="w-full"
+            options={[
+              {
+                value: "accountCoverage",
+                label: getRepairResultViewLabel(t, "accountCoverage"),
+                leftIcon: (
+                  <ShieldCheck
+                    aria-hidden="true"
+                    data-testid="repair-missing-keys-account-coverage-view-icon"
+                    className="h-4 w-4"
+                  />
+                ),
+              },
+              {
+                value: "invalidKeys",
+                label: (
+                  <>
+                    {getRepairResultViewLabel(t, "invalidKeys")}
+                    {invalidTokens.length > 0 ? (
+                      <Badge
+                        variant="warning"
+                        size="sm"
+                        className="ml-2"
+                        aria-hidden="true"
+                      >
+                        {invalidTokens.length}
+                      </Badge>
+                    ) : null}
+                  </>
+                ),
+                leftIcon: (
+                  <TriangleAlert
+                    aria-hidden="true"
+                    data-testid="repair-missing-keys-invalid-keys-view-icon"
+                    className="h-4 w-4"
+                  />
+                ),
+              },
+            ]}
+          />
+
           <Card>
             <CardHeader
+              data-testid="repair-missing-keys-results-header"
               padding="sm"
-              className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+              className="flex flex-col gap-2 space-y-0 sm:flex-row sm:items-center sm:justify-between"
             >
-              <div className="flex items-center gap-2">
-                <CardTitle className="text-sm">
-                  {t("repairMissingKeys.resultsTitle")}
-                </CardTitle>
-                <Badge
-                  variant="outline"
-                  size="sm"
-                  className="border-transparent"
+              <div
+                data-testid="repair-missing-keys-result-heading-row"
+                className="flex h-9 items-center"
+              >
+                <div
+                  data-testid="repair-missing-keys-result-heading"
+                  className="flex items-baseline gap-2"
                 >
-                  {filteredResults.length}/{visibleResults.length}
-                </Badge>
+                  <CardTitle className="text-sm">
+                    {t("repairMissingKeys.resultsTitle")}
+                  </CardTitle>
+                  <span
+                    data-testid="repair-missing-keys-result-count"
+                    className="text-xs leading-none text-gray-500 tabular-nums dark:text-gray-400"
+                  >
+                    {activeView === "accountCoverage"
+                      ? `${filteredResults.length}/${visibleResults.length}`
+                      : `${filteredInvalidTokens.length}/${invalidTokens.length}`}
+                  </span>
+                </div>
               </div>
 
               <div className="w-full sm:w-80">
@@ -615,57 +1055,208 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
               </div>
             </CardHeader>
 
-            <CardContent
-              padding="sm"
-              spacing="none"
-              className="dark:border-dark-bg-tertiary border-b border-gray-200"
-            >
-              <div className="space-y-2">
-                <div>
-                  <Label className="text-sm font-medium">
-                    {t("repairMissingKeys.outcomeLabel")}
-                  </Label>
+            {activeView === "accountCoverage" ? (
+              <CardContent
+                padding="sm"
+                spacing="none"
+                className="dark:border-dark-bg-tertiary border-b border-gray-200"
+              >
+                <div className="space-y-2">
+                  <TagFilter
+                    mode="single"
+                    value={outcomeFilter}
+                    onChange={(value) =>
+                      setOutcomeFilter(value as AccountKeyRepairOutcome | null)
+                    }
+                    allCount={visibleResults.length}
+                    options={[
+                      {
+                        value: "created",
+                        label: t("repairMissingKeys.outcomes.created"),
+                        count: outcomeCounts.created,
+                        variant: "success",
+                      },
+                      {
+                        value: "alreadyHad",
+                        label: t("repairMissingKeys.outcomes.alreadyHad"),
+                        count: outcomeCounts.alreadyHad,
+                        variant: "info",
+                      },
+                      {
+                        value: "skipped",
+                        label: t("repairMissingKeys.outcomes.skipped"),
+                        count: outcomeCounts.skipped,
+                        variant: "warning",
+                      },
+                      {
+                        value: "failed",
+                        label: t("repairMissingKeys.outcomes.failed"),
+                        count: outcomeCounts.failed,
+                        variant: "danger",
+                      },
+                    ]}
+                  />
                 </div>
-                <TagFilter
-                  mode="single"
-                  value={outcomeFilter}
-                  onChange={(value) =>
-                    setOutcomeFilter(value as AccountKeyRepairOutcome | null)
-                  }
-                  allCount={visibleResults.length}
-                  options={[
-                    {
-                      value: "created",
-                      label: t("repairMissingKeys.outcomes.created"),
-                      count: outcomeCounts.created,
-                      variant: "success",
-                    },
-                    {
-                      value: "alreadyHad",
-                      label: t("repairMissingKeys.outcomes.alreadyHad"),
-                      count: outcomeCounts.alreadyHad,
-                      variant: "info",
-                    },
-                    {
-                      value: "skipped",
-                      label: t("repairMissingKeys.outcomes.skipped"),
-                      count: outcomeCounts.skipped,
-                      variant: "warning",
-                    },
-                    {
-                      value: "failed",
-                      label: t("repairMissingKeys.outcomes.failed"),
-                      count: outcomeCounts.failed,
-                      variant: "danger",
-                    },
-                  ]}
-                />
-              </div>
-            </CardContent>
+              </CardContent>
+            ) : null}
 
             <CardContent padding="none" spacing="none">
               <div className="max-h-[60vh] overflow-y-auto md:max-h-[min(70vh,48rem)]">
-                {filteredResults.length === 0 ? (
+                {activeView === "invalidKeys" ? (
+                  <div>
+                    {deleteResultMessage ? (
+                      <div className="px-4 pt-4">
+                        <Alert description={deleteResultMessage} />
+                      </div>
+                    ) : null}
+
+                    {invalidTokens.length === 0 ? (
+                      <EmptyState
+                        icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+                        title={t("repairMissingKeys.invalidKeys.emptyTitle")}
+                        description={t(
+                          "repairMissingKeys.invalidKeys.emptyDescription",
+                        )}
+                        className="py-10"
+                      />
+                    ) : filteredInvalidTokens.length === 0 ? (
+                      <EmptyState
+                        icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+                        title={t("repairMissingKeys.noMatchingResults")}
+                        className="py-10"
+                      />
+                    ) : (
+                      <>
+                        <div className="dark:border-dark-bg-tertiary space-y-2 border-b border-gray-200 px-4 py-3">
+                          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <label className="flex items-center gap-2 text-sm">
+                              <Checkbox
+                                checked={
+                                  filteredInvalidTokens.length > 0 &&
+                                  selectedInvalidTokens.length ===
+                                    filteredInvalidTokens.length
+                                }
+                                onCheckedChange={(checked) => {
+                                  setSelectedInvalidTokenKeys(
+                                    checked
+                                      ? new Set(
+                                          filteredInvalidTokens.map(
+                                            getInvalidTokenKey,
+                                          ),
+                                        )
+                                      : new Set(),
+                                  )
+                                }}
+                                aria-label={t(
+                                  "repairMissingKeys.invalidKeys.selectAll",
+                                )}
+                              />
+                              {t("repairMissingKeys.invalidKeys.selectAll")}
+                            </label>
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs text-gray-500 dark:text-gray-400">
+                                {t(
+                                  "repairMissingKeys.invalidKeys.selectedCount",
+                                  {
+                                    count: selectedInvalidTokens.length,
+                                  },
+                                )}
+                              </span>
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="destructive"
+                                disabled={selectedInvalidTokens.length === 0}
+                                onClick={() => setIsDeleteConfirmOpen(true)}
+                              >
+                                {t(
+                                  "repairMissingKeys.invalidKeys.deleteSelected",
+                                )}
+                              </Button>
+                            </div>
+                          </div>
+                        </div>
+
+                        <ul className="dark:divide-dark-bg-tertiary divide-y">
+                          {filteredInvalidTokens.map((token) => {
+                            const tokenKey = getInvalidTokenKey(token)
+
+                            return (
+                              <li
+                                key={`${token.accountId}-${token.tokenId}-${token.group}`}
+                                className="px-4 py-3"
+                              >
+                                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                  <div className="flex min-w-0 gap-3">
+                                    <Checkbox
+                                      checked={selectedInvalidTokenKeys.has(
+                                        tokenKey,
+                                      )}
+                                      onCheckedChange={(checked) => {
+                                        setSelectedInvalidTokenKeys(
+                                          (previous) => {
+                                            const next = new Set(previous)
+                                            if (checked) {
+                                              next.add(tokenKey)
+                                            } else {
+                                              next.delete(tokenKey)
+                                            }
+                                            return next
+                                          },
+                                        )
+                                      }}
+                                      aria-label={token.tokenName}
+                                      className="mt-0.5 shrink-0"
+                                    />
+                                    <div className="min-w-0 space-y-1">
+                                      <div className="flex min-w-0 flex-wrap items-center gap-2">
+                                        <div className="truncate text-sm font-medium">
+                                          {token.tokenName}
+                                        </div>
+                                        <Badge
+                                          variant="warning"
+                                          size="sm"
+                                          className="shrink-0 border-transparent"
+                                        >
+                                          {t(
+                                            "repairMissingKeys.invalidKeys.badge",
+                                          )}
+                                        </Badge>
+                                        <Badge
+                                          variant="outline"
+                                          size="sm"
+                                          className="dark:border-dark-bg-tertiary shrink-0 border-gray-200 px-2 py-0.5 text-[11px] font-medium"
+                                          title={token.group}
+                                        >
+                                          {token.group}
+                                        </Badge>
+                                      </div>
+                                      <div className="dark:text-dark-text-secondary truncate text-xs text-gray-500">
+                                        {token.accountName} ·{" "}
+                                        {token.siteUrlOrigin}
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <Badge
+                                    variant="outline"
+                                    size="sm"
+                                    className="dark:border-dark-bg-tertiary shrink-0 border-gray-200 px-2 py-0.5 text-[11px] font-medium"
+                                    title={token.siteType}
+                                  >
+                                    {token.siteType}
+                                  </Badge>
+                                </div>
+                                <div className="mt-2 text-xs text-amber-700 dark:text-amber-200">
+                                  {getInvalidTokenReasonLabel(t, token)}
+                                </div>
+                              </li>
+                            )
+                          })}
+                        </ul>
+                      </>
+                    )}
+                  </div>
+                ) : filteredResults.length === 0 ? (
                   <EmptyState
                     icon={<MagnifyingGlassIcon className="h-12 w-12" />}
                     title={t("repairMissingKeys.noMatchingResults")}
@@ -760,6 +1351,35 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
                               {details}
                             </div>
                           ) : null}
+
+                          {result.availableGroups ? (
+                            <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                              <Badge variant="outline" size="sm">
+                                {t("repairMissingKeys.coverage.groupsCovered", {
+                                  covered: result.coveredGroups?.length ?? 0,
+                                  total: result.availableGroups.length,
+                                })}
+                              </Badge>
+                              {(result.createdGroups ?? []).map((group) => (
+                                <Badge key={group} variant="success" size="sm">
+                                  {getCoverageGroupLabel(
+                                    t,
+                                    "createdGroup",
+                                    group,
+                                  )}
+                                </Badge>
+                              ))}
+                              {(result.missingGroups ?? []).map((group) => (
+                                <Badge key={group} variant="warning" size="sm">
+                                  {getCoverageGroupLabel(
+                                    t,
+                                    "missingGroup",
+                                    group,
+                                  )}
+                                </Badge>
+                              ))}
+                            </div>
+                          ) : null}
                         </li>
                       )
                     })}
@@ -769,12 +1389,23 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
             </CardContent>
           </Card>
         </div>
-      ) : (
-        <div className="dark:text-dark-text-secondary flex items-center justify-center gap-3 py-10 text-sm text-gray-500">
-          <Spinner size="sm" />
-          {t("common:status.loading")}
-        </div>
-      )}
+      ) : null}
+
+      <DestructiveConfirmDialog
+        isOpen={isDeleteConfirmOpen}
+        onClose={() => setIsDeleteConfirmOpen(false)}
+        onConfirm={() => void handleDeleteInvalidKeys()}
+        title={t("repairMissingKeys.deleteConfirm.title", {
+          count: selectedInvalidTokens.length,
+        })}
+        description={t("repairMissingKeys.deleteConfirm.description")}
+        confirmLabel={t("repairMissingKeys.deleteConfirm.confirm")}
+        cancelLabel={t("common:actions.cancel")}
+        details={deleteConfirmDetails}
+        isWorking={isDeletingInvalidKeys}
+        size="md"
+        confirmButtonTestId="repair-invalid-keys-confirm-delete"
+      />
     </Modal>
   )
 }

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -116,7 +116,13 @@ function getSkipReasonLabel(
 }
 
 type BadgeVariant = React.ComponentProps<typeof Badge>["variant"]
-type RepairResultView = "accountCoverage" | "invalidKeys"
+const REPAIR_RESULT_VIEWS = {
+  AccountCoverage: "accountCoverage",
+  InvalidKeys: "invalidKeys",
+} as const
+
+type RepairResultView =
+  (typeof REPAIR_RESULT_VIEWS)[keyof typeof REPAIR_RESULT_VIEWS]
 
 const OUTCOME_BADGE_VARIANTS: Record<AccountKeyRepairOutcome, BadgeVariant> = {
   created: "success",
@@ -146,9 +152,9 @@ function getRepairOutcomeLabel(t: TFunction, outcome: AccountKeyRepairOutcome) {
  */
 function getRepairResultViewLabel(t: TFunction, view: RepairResultView) {
   switch (view) {
-    case "accountCoverage":
+    case REPAIR_RESULT_VIEWS.AccountCoverage:
       return t("keyManagement:repairMissingKeys.views.accountCoverage")
-    case "invalidKeys":
+    case REPAIR_RESULT_VIEWS.InvalidKeys:
       return t("keyManagement:repairMissingKeys.views.invalidKeys")
   }
 }
@@ -257,8 +263,9 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
   const [searchTerm, setSearchTerm] = useState("")
   const [outcomeFilter, setOutcomeFilter] =
     useState<AccountKeyRepairOutcome | null>(null)
-  const [activeView, setActiveView] =
-    useState<RepairResultView>("accountCoverage")
+  const [activeView, setActiveView] = useState<RepairResultView>(
+    REPAIR_RESULT_VIEWS.AccountCoverage,
+  )
   const [openingSub2ApiAccountId, setOpeningSub2ApiAccountId] = useState<
     string | null
   >(null)
@@ -432,25 +439,36 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
       setProgress((current) => {
         if (!current) return current
 
+        let removedInvalidTokenCount = 0
+        const nextResults = current.results.map((result) => {
+          const nextInvalidTokens = result.invalidTokens?.filter((token) => {
+            const shouldRemove = deletedKeys.has(getInvalidTokenKey(token))
+            if (shouldRemove) {
+              removedInvalidTokenCount += 1
+            }
+            return !shouldRemove
+          })
+
+          return {
+            ...result,
+            invalidTokens: nextInvalidTokens,
+          }
+        })
+
         return {
           ...current,
           summary: {
             ...current.summary,
             invalidKeys: Math.max(
               0,
-              (current.summary.invalidKeys ?? 0) - response.data.deleted.length,
+              (current.summary.invalidKeys ?? 0) - removedInvalidTokenCount,
             ),
             deletedKeys:
               (current.summary.deletedKeys ?? 0) + response.data.deleted.length,
             deleteFailed:
               (current.summary.deleteFailed ?? 0) + response.data.failed.length,
           },
-          results: current.results.map((result) => ({
-            ...result,
-            invalidTokens: result.invalidTokens?.filter(
-              (token) => !deletedKeys.has(getInvalidTokenKey(token)),
-            ),
-          })),
+          results: nextResults,
         }
       })
       setDeleteResultMessage(
@@ -653,7 +671,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     if (!isOpen) {
       setSearchTerm("")
       setOutcomeFilter(null)
-      setActiveView("accountCoverage")
+      setActiveView(REPAIR_RESULT_VIEWS.AccountCoverage)
       setSelectedInvalidTokenKeys(new Set())
       setIsDeleteConfirmOpen(false)
       setDeleteResultMessage("")
@@ -960,8 +978,11 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
             className="w-full"
             options={[
               {
-                value: "accountCoverage",
-                label: getRepairResultViewLabel(t, "accountCoverage"),
+                value: REPAIR_RESULT_VIEWS.AccountCoverage,
+                label: getRepairResultViewLabel(
+                  t,
+                  REPAIR_RESULT_VIEWS.AccountCoverage,
+                ),
                 leftIcon: (
                   <ShieldCheck
                     aria-hidden="true"
@@ -971,10 +992,13 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
                 ),
               },
               {
-                value: "invalidKeys",
+                value: REPAIR_RESULT_VIEWS.InvalidKeys,
                 label: (
                   <>
-                    {getRepairResultViewLabel(t, "invalidKeys")}
+                    {getRepairResultViewLabel(
+                      t,
+                      REPAIR_RESULT_VIEWS.InvalidKeys,
+                    )}
                     {invalidTokens.length > 0 ? (
                       <Badge
                         variant="warning"
@@ -1019,7 +1043,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
                     data-testid="repair-missing-keys-result-count"
                     className="text-xs leading-none text-gray-500 tabular-nums dark:text-gray-400"
                   >
-                    {activeView === "accountCoverage"
+                    {activeView === REPAIR_RESULT_VIEWS.AccountCoverage
                       ? `${filteredResults.length}/${visibleResults.length}`
                       : `${filteredInvalidTokens.length}/${invalidTokens.length}`}
                   </span>
@@ -1055,7 +1079,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
               </div>
             </CardHeader>
 
-            {activeView === "accountCoverage" ? (
+            {activeView === REPAIR_RESULT_VIEWS.AccountCoverage ? (
               <CardContent
                 padding="sm"
                 spacing="none"
@@ -1102,7 +1126,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
 
             <CardContent padding="none" spacing="none">
               <div className="max-h-[60vh] overflow-y-auto md:max-h-[min(70vh,48rem)]">
-                {activeView === "invalidKeys" ? (
+                {activeView === REPAIR_RESULT_VIEWS.InvalidKeys ? (
                   <div>
                     {deleteResultMessage ? (
                       <div className="px-4 pt-4">

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -256,14 +256,45 @@
   "pleaseSelectAccount": "Please select account",
   "refreshTokenList": "Refresh Key List",
   "repairMissingKeys": {
-    "action": "Ensure at least one key",
-    "description": "Scan stored accounts and create a default key for any eligible account with no keys, ensuring each eligible account has at least one key.",
+    "action": "Key check",
+    "actions": {
+      "rerun": "Check again",
+      "start": "Start check and fill gaps"
+    },
+    "coverage": {
+      "createdGroup": "Created: {{group}}",
+      "groupsCovered": "Covered {{covered}}/{{total}} groups",
+      "missingGroup": "Missing: {{group}}"
+    },
+    "deleteConfirm": {
+      "confirm": "Delete selected keys",
+      "description": "These keys will also be deleted from the corresponding sites and cannot be restored through the extension. Confirm their groups are no longer used.",
+      "more_one": "And {{count}} more",
+      "more_other": "And {{count}} more",
+      "title_one": "Delete {{count}} invalid key?",
+      "title_other": "Delete {{count}} invalid keys?"
+    },
+    "description": "Check each account's available groups, create default keys for groups without keys, and list unusual keys whose groups are unavailable.",
+    "initialNotice": "After starting, saved accounts will be checked for available groups, and default keys will be created for groups without keys.",
+    "invalidKeys": {
+      "badge": "Invalid",
+      "deleteFailed": "Failed to delete invalid keys",
+      "deletePartial": "Deleted {{deleted}}, {{failed}} failed",
+      "deleteSelected": "Delete selected",
+      "deleteSuccess_one": "Deleted {{count}} invalid key",
+      "deleteSuccess_other": "Deleted {{count}} invalid keys",
+      "emptyDescription": "This check did not find any keys whose groups are unavailable.",
+      "emptyTitle": "No invalid keys",
+      "groupUnavailable": "Group {{group}} is currently unavailable",
+      "selectAll": "Select all current results",
+      "selectedCount_one": "{{count}} invalid key selected",
+      "selectedCount_other": "{{count}} invalid keys selected"
+    },
     "messages": {
       "loadFailed": "Failed to load repair progress",
       "startFailed": "Failed to start repair job"
     },
     "noMatchingResults": "No matching results",
-    "outcomeLabel": "Outcome",
     "outcomes": {
       "alreadyHad": "Already had keys",
       "created": "Created",
@@ -271,6 +302,7 @@
       "skipped": "Skipped"
     },
     "progressLabel": "Progress",
+    "remoteWriteNotice": "This action may create new keys on the corresponding sites. It will not automatically delete any keys.",
     "resultsTitle": "Results",
     "runningNote": "This job runs in the background. Closing this dialog will not cancel it.",
     "searchLabel": "Search",
@@ -280,11 +312,16 @@
       "noneAuth": "No credentials (auth type: none)",
       "sub2api": "Requires selecting a Sub2API group; create the key manually"
     },
-    "title": "Ensure at least one key",
+    "title": "Key coverage check",
     "totalsLabels": {
       "eligibleAccounts": "Eligible accounts",
       "enabledAccounts": "Enabled accounts",
       "processedAccounts": "Processed"
+    },
+    "views": {
+      "accountCoverage": "Account coverage",
+      "invalidKeys": "Invalid keys",
+      "label": "Result view"
     }
   },
   "searchPlaceholder": "Search key name...",

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -250,14 +250,41 @@
   "pleaseSelectAccount": "アカウントを選択してください",
   "refreshTokenList": "キー一覧を更新",
   "repairMissingKeys": {
-    "action": "少なくとも 1 つのキーを確保",
-    "description": "保存済みアカウントを走査し、キーを持たない対象アカウントに既定キーを作成して、各対象アカウントに少なくとも 1 つのキーがある状態を保証します。",
+    "action": "キーをチェック",
+    "actions": {
+      "rerun": "再チェック",
+      "start": "チェックして不足分を補完"
+    },
+    "coverage": {
+      "createdGroup": "作成済み：{{group}}",
+      "groupsCovered": "{{covered}}/{{total}} グループをカバー済み",
+      "missingGroup": "未補完：{{group}}"
+    },
+    "deleteConfirm": {
+      "confirm": "選択したキーを削除",
+      "description": "これらのキーは対応するサイトからも削除され、拡張機能からは復元できません。対象グループがもう使われていないことを確認してください。",
+      "more_other": "ほか {{count}} 件",
+      "title_other": "{{count}} 件の例外キーを削除しますか？"
+    },
+    "description": "各アカウントの利用可能なグループを確認し、キーがないグループには既定キーを作成し、グループを利用できない例外キーを一覧表示します。",
+    "initialNotice": "開始すると、保存済みアカウントの利用可能なグループを確認し、キーがないグループには既定キーを作成します。",
+    "invalidKeys": {
+      "badge": "例外",
+      "deleteFailed": "例外キーの削除に失敗しました",
+      "deletePartial": "{{deleted}} 件を削除、{{failed}} 件は削除失敗",
+      "deleteSelected": "選択項目を削除",
+      "deleteSuccess_other": "{{count}} 件の例外キーを削除しました",
+      "emptyDescription": "今回のチェックでは、グループを利用できないキーは見つかりませんでした。",
+      "emptyTitle": "例外キーはありません",
+      "groupUnavailable": "グループ {{group}} は現在利用できません",
+      "selectAll": "現在の結果をすべて選択",
+      "selectedCount_other": "{{count}} 件の例外キーを選択中"
+    },
     "messages": {
       "loadFailed": "修復進捗の読み込みに失敗しました",
       "startFailed": "修復ジョブの開始に失敗しました"
     },
     "noMatchingResults": "一致する結果がありません",
-    "outcomeLabel": "結果",
     "outcomes": {
       "alreadyHad": "既にキーあり",
       "created": "作成済み",
@@ -265,6 +292,7 @@
       "skipped": "スキップ"
     },
     "progressLabel": "進捗",
+    "remoteWriteNotice": "この操作により、対応するサイトで新しいキーが作成される場合があります。キーが自動的に削除されることはありません。",
     "resultsTitle": "結果",
     "runningNote": "このジョブはバックグラウンドで実行されます。このダイアログを閉じてもキャンセルされません。",
     "searchLabel": "検索",
@@ -274,11 +302,16 @@
       "noneAuth": "認証情報なし（auth type: none）",
       "sub2api": "Sub2API グループの選択が必要です。手動でキーを作成してください"
     },
-    "title": "少なくとも 1 つのキーを確保",
+    "title": "キー網羅性チェック",
     "totalsLabels": {
       "eligibleAccounts": "対象アカウント",
       "enabledAccounts": "有効アカウント",
       "processedAccounts": "処理済み"
+    },
+    "views": {
+      "accountCoverage": "アカウント網羅",
+      "invalidKeys": "例外キー",
+      "label": "結果ビュー"
     }
   },
   "searchPlaceholder": "キー名を検索...",

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -250,14 +250,41 @@
   "pleaseSelectAccount": "Vui lòng chọn tài khoản",
   "refreshTokenList": "Làm mới danh sách khóa",
   "repairMissingKeys": {
-    "action": "Đảm bảo có ít nhất một khóa",
-    "description": "Quét các tài khoản đã lưu và tự động tạo một khóa mặc định cho các tài khoản đủ điều kiện và chưa có khóa, đảm bảo mỗi tài khoản đủ điều kiện có ít nhất một khóa.",
+    "action": "Kiểm tra khóa",
+    "actions": {
+      "rerun": "Kiểm tra lại",
+      "start": "Bắt đầu kiểm tra và bổ sung"
+    },
+    "coverage": {
+      "createdGroup": "Đã tạo: {{group}}",
+      "groupsCovered": "Đã phủ {{covered}}/{{total}} nhóm",
+      "missingGroup": "Chưa bổ sung: {{group}}"
+    },
+    "deleteConfirm": {
+      "confirm": "Xóa khóa đã chọn",
+      "description": "Các khóa này cũng sẽ bị xóa khỏi trang web tương ứng và không thể khôi phục bằng tiện ích. Hãy xác nhận rằng các nhóm của chúng không còn được sử dụng.",
+      "more_other": "Và {{count}} mục khác",
+      "title_other": "Xóa {{count}} khóa bất thường?"
+    },
+    "description": "Kiểm tra các nhóm khả dụng của từng tài khoản, tạo khóa mặc định cho nhóm còn thiếu khóa và liệt kê các khóa bất thường có nhóm không khả dụng.",
+    "initialNotice": "Sau khi bắt đầu, các nhóm khả dụng của tài khoản đã lưu sẽ được kiểm tra và khóa mặc định sẽ được tạo cho các nhóm còn thiếu khóa.",
+    "invalidKeys": {
+      "badge": "Bất thường",
+      "deleteFailed": "Xóa khóa bất thường thất bại",
+      "deletePartial": "Đã xóa {{deleted}}, {{failed}} mục xóa thất bại",
+      "deleteSelected": "Xóa mục đã chọn",
+      "deleteSuccess_other": "Đã xóa {{count}} khóa bất thường",
+      "emptyDescription": "Lần kiểm tra này không phát hiện khóa nào có nhóm không khả dụng.",
+      "emptyTitle": "Không có khóa bất thường",
+      "groupUnavailable": "Nhóm {{group}} hiện không khả dụng",
+      "selectAll": "Chọn tất cả kết quả hiện tại",
+      "selectedCount_other": "Đã chọn {{count}} khóa bất thường"
+    },
     "messages": {
       "loadFailed": "Tải tiến trình sửa chữa thất bại",
       "startFailed": "Bắt đầu tác vụ sửa chữa thất bại"
     },
     "noMatchingResults": "Không có kết quả khớp",
-    "outcomeLabel": "Kết quả",
     "outcomes": {
       "alreadyHad": "Đã tồn tại",
       "created": "Đã tạo",
@@ -265,6 +292,7 @@
       "skipped": "Đã bỏ qua"
     },
     "progressLabel": "Tiến trình",
+    "remoteWriteNotice": "Thao tác này có thể tạo khóa mới trên các trang web tương ứng; sẽ không tự động xóa bất kỳ khóa nào.",
     "resultsTitle": "Kết quả",
     "runningNote": "Tác vụ đang chạy trong nền, việc đóng hộp thoại này sẽ không hủy tác vụ.",
     "searchLabel": "Tìm kiếm",
@@ -274,11 +302,16 @@
       "noneAuth": "Không có thông tin xác thực (Phương thức xác thực: Không có)",
       "sub2api": "Cần chọn nhóm Sub2API; hãy tạo khóa thủ công"
     },
-    "title": "Đảm bảo có ít nhất một khóa",
+    "title": "Kiểm tra phạm vi khóa",
     "totalsLabels": {
       "eligibleAccounts": "Tài khoản đủ điều kiện",
       "enabledAccounts": "Tài khoản đã kích hoạt",
       "processedAccounts": "Đã xử lý"
+    },
+    "views": {
+      "accountCoverage": "Phạm vi tài khoản",
+      "invalidKeys": "Khóa bất thường",
+      "label": "Chế độ xem kết quả"
     }
   },
   "searchPlaceholder": "Tìm kiếm tên khóa...",

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -250,14 +250,41 @@
   "pleaseSelectAccount": "请选择账号",
   "refreshTokenList": "刷新密钥列表",
   "repairMissingKeys": {
-    "action": "确保至少有一个密钥",
-    "description": "扫描已保存账号，为符合条件且没有密钥的账号自动创建一个默认密钥，确保每个符合条件的账号至少有一个密钥。",
+    "action": "密钥检查",
+    "actions": {
+      "rerun": "重新检查",
+      "start": "开始检查并补齐"
+    },
+    "coverage": {
+      "createdGroup": "已创建：{{group}}",
+      "groupsCovered": "已覆盖 {{covered}}/{{total}} 个分组",
+      "missingGroup": "未补齐：{{group}}"
+    },
+    "deleteConfirm": {
+      "confirm": "删除所选密钥",
+      "description": "这些密钥会同时从对应网站删除，无法通过扩展恢复。请确认它们的分组已不再使用。",
+      "more": "以及另外 {{count}} 个",
+      "title": "删除 {{count}} 个异常密钥？"
+    },
+    "description": "检查每个账号的可用分组，为缺少密钥的分组创建默认密钥，并列出分组不可用的异常密钥。",
+    "initialNotice": "开始后会检查已保存账号的可用分组，并为缺少密钥的分组创建默认密钥。",
+    "invalidKeys": {
+      "badge": "异常",
+      "deleteFailed": "删除异常密钥失败",
+      "deletePartial": "已删除 {{deleted}} 个，{{failed}} 个删除失败",
+      "deleteSelected": "删除所选",
+      "deleteSuccess": "已删除 {{count}} 个异常密钥",
+      "emptyDescription": "本次检查未发现分组不可用的密钥。",
+      "emptyTitle": "没有异常密钥",
+      "groupUnavailable": "分组 {{group}} 当前不可用",
+      "selectAll": "全选当前结果",
+      "selectedCount": "已选择 {{count}} 个异常密钥"
+    },
     "messages": {
       "loadFailed": "加载修复进度失败",
       "startFailed": "启动修复任务失败"
     },
     "noMatchingResults": "没有匹配的结果",
-    "outcomeLabel": "结果",
     "outcomes": {
       "alreadyHad": "已存在",
       "created": "已创建",
@@ -265,6 +292,7 @@
       "skipped": "已跳过"
     },
     "progressLabel": "进度",
+    "remoteWriteNotice": "此操作可能会在对应网站创建新密钥；不会自动删除任何密钥。",
     "resultsTitle": "结果",
     "runningNote": "任务在后台运行，关闭此对话框不会取消任务。",
     "searchLabel": "搜索",
@@ -274,11 +302,16 @@
       "noneAuth": "无凭据（认证方式：无）",
       "sub2api": "需要选择 Sub2API 分组，请手动创建密钥"
     },
-    "title": "确保至少有一个密钥",
+    "title": "密钥覆盖检查",
     "totalsLabels": {
       "eligibleAccounts": "符合条件账号",
       "enabledAccounts": "已启用账号",
       "processedAccounts": "已处理"
+    },
+    "views": {
+      "accountCoverage": "账号覆盖",
+      "invalidKeys": "异常密钥",
+      "label": "结果视图"
     }
   },
   "searchPlaceholder": "搜索密钥名称...",

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -300,7 +300,7 @@
     "skipReasons": {
       "aihubmixOneTimeKey": "AIHubMix 金鑰僅可查看一次，請手動建立並立即保存完整金鑰",
       "noneAuth": "無憑據（認證方式：無）",
-      "sub2api": "需要選擇 Sub2API 分組，請手動建立密鑰"
+      "sub2api": "需要選擇 Sub2API 分組，請手動建立金鑰"
     },
     "title": "金鑰覆蓋檢查",
     "totalsLabels": {

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -250,14 +250,41 @@
   "pleaseSelectAccount": "請選擇帳號",
   "refreshTokenList": "重新整理金鑰列表",
   "repairMissingKeys": {
-    "action": "確保至少有一個金鑰",
-    "description": "掃描已儲存帳號，為符合條件且沒有金鑰的帳號自動建立一個預設金鑰，確保每個符合條件的帳號至少有一個金鑰。",
+    "action": "金鑰檢查",
+    "actions": {
+      "rerun": "重新檢查",
+      "start": "開始檢查並補齊"
+    },
+    "coverage": {
+      "createdGroup": "已建立：{{group}}",
+      "groupsCovered": "已覆蓋 {{covered}}/{{total}} 個分組",
+      "missingGroup": "未補齊：{{group}}"
+    },
+    "deleteConfirm": {
+      "confirm": "刪除所選金鑰",
+      "description": "這些金鑰會同時從對應網站刪除，無法透過擴充功能恢復。請確認它們的分組已不再使用。",
+      "more_other": "以及另外 {{count}} 個",
+      "title_other": "刪除 {{count}} 個異常金鑰？"
+    },
+    "description": "檢查每個帳號的可用分組，為缺少金鑰的分組建立預設金鑰，並列出分組不可用的異常金鑰。",
+    "initialNotice": "開始後會檢查已儲存帳號的可用分組，並為缺少金鑰的分組建立預設金鑰。",
+    "invalidKeys": {
+      "badge": "異常",
+      "deleteFailed": "刪除異常金鑰失敗",
+      "deletePartial": "已刪除 {{deleted}} 個，{{failed}} 個刪除失敗",
+      "deleteSelected": "刪除所選",
+      "deleteSuccess_other": "已刪除 {{count}} 個異常金鑰",
+      "emptyDescription": "本次檢查未發現分組不可用的金鑰。",
+      "emptyTitle": "沒有異常金鑰",
+      "groupUnavailable": "分組 {{group}} 目前不可用",
+      "selectAll": "全選目前結果",
+      "selectedCount_other": "已選擇 {{count}} 個異常金鑰"
+    },
     "messages": {
       "loadFailed": "載入修復進度失敗",
       "startFailed": "啟動修復任務失敗"
     },
     "noMatchingResults": "沒有匹配的結果",
-    "outcomeLabel": "結果",
     "outcomes": {
       "alreadyHad": "已存在",
       "created": "已建立",
@@ -265,6 +292,7 @@
       "skipped": "已跳過"
     },
     "progressLabel": "進度",
+    "remoteWriteNotice": "此操作可能會在對應網站建立新金鑰；不會自動刪除任何金鑰。",
     "resultsTitle": "結果",
     "runningNote": "任務在後臺執行，關閉此對話方塊不會取消任務。",
     "searchLabel": "搜尋",
@@ -274,11 +302,16 @@
       "noneAuth": "無憑據（認證方式：無）",
       "sub2api": "需要選擇 Sub2API 分組，請手動建立密鑰"
     },
-    "title": "確保至少有一個金鑰",
+    "title": "金鑰覆蓋檢查",
     "totalsLabels": {
       "eligibleAccounts": "符合條件帳號",
       "enabledAccounts": "已啟用帳號",
       "processedAccounts": "已處理"
+    },
+    "views": {
+      "accountCoverage": "帳號覆蓋",
+      "invalidKeys": "異常金鑰",
+      "label": "結果視圖"
     }
   },
   "searchPlaceholder": "搜尋金鑰名稱...",

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -4,9 +4,10 @@ import { API_ERROR_CODES } from "~/services/apiService/common/errors"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { DisplaySiteData, SiteAccount } from "~/types"
-import type {
-  AccountKeyRepairDeleteInvalidTokensResult,
-  AccountKeyRepairInvalidToken,
+import {
+  ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
+  type AccountKeyRepairDeleteInvalidTokensResult,
+  type AccountKeyRepairInvalidToken,
 } from "~/types/accountKeyAutoProvisioning"
 import { t } from "~/utils/i18n/core"
 
@@ -151,7 +152,7 @@ export async function ensureAccountKeysForAvailableGroups(params: {
       tokenId: token.id,
       tokenName: token.name,
       group,
-      reason: "groupUnavailable",
+      reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
     })
   }
 

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -60,9 +60,11 @@ function createAccountApiRequest(
   account: SiteAccount,
   displaySiteData: DisplaySiteData,
 ): ApiServiceRequest {
+  const accountId = displaySiteData.id || account.id
+
   return {
     baseUrl: displaySiteData.baseUrl || account.site_url,
-    accountId: displaySiteData.id || account.id,
+    accountId,
     auth: {
       authType: displaySiteData.authType,
       userId: displaySiteData.userId,
@@ -84,6 +86,7 @@ export async function ensureAccountKeysForAvailableGroups(params: {
   const { account, displaySiteData, accountName, siteUrlOrigin } = params
   const service = getApiService(displaySiteData.siteType)
   const request = createAccountApiRequest(account, displaySiteData)
+  const accountId = displaySiteData.id || account.id
 
   const tokens = await service.fetchAccountTokens(request)
   let groups: string[]
@@ -145,7 +148,7 @@ export async function ensureAccountKeysForAvailableGroups(params: {
     }
 
     invalidTokens.push({
-      accountId: displaySiteData.id,
+      accountId,
       accountName,
       siteType: displaySiteData.siteType,
       siteUrlOrigin,

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -1,0 +1,202 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import { getApiService } from "~/services/apiService"
+import { API_ERROR_CODES } from "~/services/apiService/common/errors"
+import type { CreateTokenRequest } from "~/services/apiService/common/type"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type { DisplaySiteData, SiteAccount } from "~/types"
+import type {
+  AccountKeyRepairDeleteInvalidTokensResult,
+  AccountKeyRepairInvalidToken,
+} from "~/types/accountKeyAutoProvisioning"
+import { t } from "~/utils/i18n/core"
+
+import {
+  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+  generateDefaultTokenRequest,
+} from "./ensureDefaultToken"
+
+interface AccountKeyCoverageResult {
+  created: boolean
+  availableGroups: string[]
+  coveredGroups: string[]
+  createdGroups: string[]
+  missingGroups: string[]
+  invalidTokens: AccountKeyRepairInvalidToken[]
+}
+
+const normalizeGroupName = (value: unknown) =>
+  typeof value === "string" ? value.trim() : ""
+
+const isFeatureUnsupportedError = (error: unknown) =>
+  !!error &&
+  typeof error === "object" &&
+  "code" in error &&
+  (error as { code?: unknown }).code === API_ERROR_CODES.FEATURE_UNSUPPORTED
+
+/**
+ * Builds the default auto-provision token payload for one user group.
+ */
+export function buildGroupDefaultTokenRequest(
+  group: string,
+): CreateTokenRequest {
+  return {
+    ...generateDefaultTokenRequest(),
+    name:
+      group && group !== "default"
+        ? `${group} group (auto)`
+        : DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+    group,
+  }
+}
+
+/**
+ * Builds the normalized API-service request for account key audit calls.
+ *
+ * This helper accepts the stored account too so repair fallback paths can still
+ * build a request when display data is missing URL/id fields.
+ */
+function createAccountApiRequest(
+  account: SiteAccount,
+  displaySiteData: DisplaySiteData,
+): ApiServiceRequest {
+  return {
+    baseUrl: displaySiteData.baseUrl || account.site_url,
+    accountId: displaySiteData.id || account.id,
+    auth: {
+      authType: displaySiteData.authType,
+      userId: displaySiteData.userId,
+      accessToken: displaySiteData.token,
+      cookie: displaySiteData.cookieAuthSessionCookie,
+    },
+  }
+}
+
+/**
+ * Ensures one account has API keys for every currently available user group.
+ */
+export async function ensureAccountKeysForAvailableGroups(params: {
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+  accountName: string
+  siteUrlOrigin: string
+}): Promise<AccountKeyCoverageResult> {
+  const { account, displaySiteData, accountName, siteUrlOrigin } = params
+  const service = getApiService(displaySiteData.siteType)
+  const request = createAccountApiRequest(account, displaySiteData)
+
+  const tokens = await service.fetchAccountTokens(request)
+  let groups: string[]
+
+  try {
+    const groupsData = await service.fetchUserGroups(request)
+    groups = Object.keys(groupsData).map(normalizeGroupName).filter(Boolean)
+  } catch (error) {
+    if (!isFeatureUnsupportedError(error)) {
+      throw error
+    }
+    groups = []
+  }
+
+  const uniqueGroups = Array.from(new Set(groups))
+
+  if (uniqueGroups.length === 0) {
+    if (tokens.length > 0) {
+      return {
+        created: false,
+        availableGroups: [],
+        coveredGroups: [],
+        createdGroups: [],
+        missingGroups: [],
+        invalidTokens: [],
+      }
+    }
+
+    if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
+      throw new Error(t("messages:sub2api.createRequiresGroup"))
+    }
+
+    if (displaySiteData.siteType === SITE_TYPES.AIHUBMIX) {
+      throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
+    }
+
+    await service.createApiToken(request, generateDefaultTokenRequest())
+    return {
+      created: true,
+      availableGroups: [],
+      coveredGroups: [],
+      createdGroups: [""],
+      missingGroups: [],
+      invalidTokens: [],
+    }
+  }
+
+  const availableGroupSet = new Set(uniqueGroups)
+  const coveredGroupSet = new Set<string>()
+  const invalidTokens: AccountKeyRepairInvalidToken[] = []
+
+  for (const token of tokens) {
+    const group = normalizeGroupName(token.group)
+    if (!group) continue
+
+    if (availableGroupSet.has(group)) {
+      coveredGroupSet.add(group)
+      continue
+    }
+
+    invalidTokens.push({
+      accountId: displaySiteData.id,
+      accountName,
+      siteType: displaySiteData.siteType,
+      siteUrlOrigin,
+      tokenId: token.id,
+      tokenName: token.name,
+      group,
+      reason: "groupUnavailable",
+    })
+  }
+
+  const createdGroups: string[] = []
+  const missingGroups: string[] = []
+
+  for (const group of uniqueGroups) {
+    if (coveredGroupSet.has(group)) continue
+
+    try {
+      await service.createApiToken(
+        request,
+        buildGroupDefaultTokenRequest(group),
+      )
+      coveredGroupSet.add(group)
+      createdGroups.push(group)
+    } catch {
+      missingGroups.push(group)
+    }
+  }
+
+  return {
+    created: createdGroups.length > 0,
+    availableGroups: uniqueGroups,
+    coveredGroups: uniqueGroups.filter((group) => coveredGroupSet.has(group)),
+    createdGroups,
+    missingGroups,
+    invalidTokens,
+  }
+}
+
+/**
+ * Deletes one invalid account token and returns the typed deletion record.
+ */
+export async function deleteInvalidAccountToken(params: {
+  token: AccountKeyRepairInvalidToken
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+}): Promise<AccountKeyRepairDeleteInvalidTokensResult["deleted"][number]> {
+  const { token, account, displaySiteData } = params
+  const service = getApiService(displaySiteData.siteType)
+  const request = createAccountApiRequest(account, displaySiteData)
+  await service.deleteApiToken(request, token.tokenId)
+  return {
+    ...token,
+    deletedAt: Date.now(),
+  }
+}

--- a/src/services/accounts/accountKeyAutoProvisioning/messaging.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/messaging.ts
@@ -1,16 +1,24 @@
 import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
-import type { AccountKeyRepairProgress } from "~/types/accountKeyAutoProvisioning"
+import type {
+  AccountKeyRepairDeleteInvalidTokensRequest,
+  AccountKeyRepairDeleteInvalidTokensResult,
+  AccountKeyRepairProgress,
+} from "~/types/accountKeyAutoProvisioning"
 
 export const AccountKeyRepairMessageTypes = {
   Start: "accountKeyRepair:start",
   GetProgress: "accountKeyRepair:getProgress",
+  DeleteInvalidTokens: "accountKeyRepair:deleteInvalidTokens",
 } as const
 
 interface AccountKeyRepairProtocolMap {
   [AccountKeyRepairMessageTypes.Start](): RuntimeMessageResponse<AccountKeyRepairProgress>
   [AccountKeyRepairMessageTypes.GetProgress](): RuntimeMessageResponse<AccountKeyRepairProgress>
+  [AccountKeyRepairMessageTypes.DeleteInvalidTokens](
+    request: AccountKeyRepairDeleteInvalidTokensRequest,
+  ): RuntimeMessageResponse<AccountKeyRepairDeleteInvalidTokensResult>
 }
 
 export const {

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -291,7 +291,12 @@ class AccountKeyRepairRunner {
         accountName: resolvedAccountName,
         siteType: account.site_type,
         siteUrlOrigin: originKey,
-        outcome: result.created ? "created" : "alreadyHad",
+        outcome:
+          !result.created && result.missingGroups.length > 0
+            ? "failed"
+            : result.created
+              ? "created"
+              : "alreadyHad",
         availableGroups: result.availableGroups,
         coveredGroups: result.coveredGroups,
         createdGroups: result.createdGroups,
@@ -388,20 +393,33 @@ class AccountKeyRepairRunner {
       const deletedIds = new Set(
         result.deleted.map((token) => `${token.accountId}:${token.tokenId}`),
       )
+      let removedInvalidTokenCount = 0
 
       return {
         ...prev,
-        results: prev.results.map((accountResult) => ({
-          ...accountResult,
-          invalidTokens: accountResult.invalidTokens?.filter(
-            (token) => !deletedIds.has(`${token.accountId}:${token.tokenId}`),
-          ),
-        })),
+        results: prev.results.map((accountResult) => {
+          const nextInvalidTokens = accountResult.invalidTokens?.filter(
+            (token) => {
+              const shouldRemove = deletedIds.has(
+                `${token.accountId}:${token.tokenId}`,
+              )
+              if (shouldRemove) {
+                removedInvalidTokenCount += 1
+              }
+              return !shouldRemove
+            },
+          )
+
+          return {
+            ...accountResult,
+            invalidTokens: nextInvalidTokens,
+          }
+        }),
         summary: {
           ...prev.summary,
           invalidKeys: Math.max(
             0,
-            (prev.summary.invalidKeys ?? 0) - result.deleted.length,
+            (prev.summary.invalidKeys ?? 0) - removedInvalidTokenCount,
           ),
           deletedKeys: (prev.summary.deletedKeys ?? 0) + result.deleted.length,
           deleteFailed: (prev.summary.deleteFailed ?? 0) + result.failed.length,

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -8,6 +8,8 @@ import type { DisplaySiteData, SiteAccount } from "~/types"
 import { AuthTypeEnum } from "~/types"
 import type {
   AccountKeyRepairAccountResult,
+  AccountKeyRepairDeleteInvalidTokensRequest,
+  AccountKeyRepairDeleteInvalidTokensResult,
   AccountKeyRepairProgress,
   AccountKeyRepairSkipReason,
 } from "~/types/accountKeyAutoProvisioning"
@@ -17,7 +19,10 @@ import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
 
-import { ensureDefaultApiTokenForAccount } from "./ensureDefaultToken"
+import {
+  deleteInvalidAccountToken,
+  ensureAccountKeysForAvailableGroups,
+} from "./groupCoverage"
 import {
   AccountKeyRepairMessageTypes,
   onAccountKeyRepairMessage,
@@ -249,6 +254,7 @@ class AccountKeyRepairRunner {
       const displaySiteData: DisplaySiteData =
         displaySiteDataById.get(account.id) ??
         accountStorage.convertToDisplayData(account)
+      const resolvedAccountName = displaySiteData.name || accountName
       const hasToken =
         typeof displaySiteData?.token === "string" &&
         displaySiteData.token.trim().length > 0
@@ -273,17 +279,24 @@ class AccountKeyRepairRunner {
         throw new Error("invalid_display_site_data")
       }
 
-      const result = await ensureDefaultApiTokenForAccount({
+      const result = await ensureAccountKeysForAvailableGroups({
         account,
         displaySiteData,
+        accountName: resolvedAccountName,
+        siteUrlOrigin: originKey,
       })
 
       await this.recordResult({
         accountId: account.id,
-        accountName,
+        accountName: resolvedAccountName,
         siteType: account.site_type,
         siteUrlOrigin: originKey,
         outcome: result.created ? "created" : "alreadyHad",
+        availableGroups: result.availableGroups,
+        coveredGroups: result.coveredGroups,
+        createdGroups: result.createdGroups,
+        missingGroups: result.missingGroups,
+        invalidTokens: result.invalidTokens,
         finishedAt: Date.now(),
       })
     } catch (error) {
@@ -334,6 +347,10 @@ class AccountKeyRepairRunner {
       }
 
       const isEligibleOutcome = result.outcome !== "skipped"
+      const availableGroupCount = result.availableGroups?.length ?? 0
+      const coveredGroupCount = result.coveredGroups?.length ?? 0
+      const createdKeyCount = result.createdGroups?.length ?? 0
+      const invalidKeyCount = result.invalidTokens?.length ?? 0
       const nextProcessedEligibleAccounts = isEligibleOutcome
         ? (prev.totals.processedEligibleAccounts ??
             prev.totals.processedAccounts) + 1
@@ -342,13 +359,52 @@ class AccountKeyRepairRunner {
       return {
         ...prev,
         results: nextResults,
-        summary: nextSummary,
+        summary: {
+          ...nextSummary,
+          availableGroups:
+            (prev.summary.availableGroups ?? 0) + availableGroupCount,
+          coveredGroups: (prev.summary.coveredGroups ?? 0) + coveredGroupCount,
+          createdKeys: (prev.summary.createdKeys ?? 0) + createdKeyCount,
+          invalidKeys: (prev.summary.invalidKeys ?? 0) + invalidKeyCount,
+          deletedKeys: prev.summary.deletedKeys ?? 0,
+          deleteFailed: prev.summary.deleteFailed ?? 0,
+        },
         totals: {
           ...prev.totals,
           processedAccounts: isEligibleOutcome
             ? prev.totals.processedAccounts + 1
             : prev.totals.processedAccounts,
           processedEligibleAccounts: nextProcessedEligibleAccounts,
+        },
+      }
+    })
+  }
+
+  async recordInvalidTokenDeletionResultForCurrentProgress(
+    result: AccountKeyRepairDeleteInvalidTokensResult,
+  ) {
+    await this.getProgress()
+    await this.queueProgressUpdate((prev) => {
+      const deletedIds = new Set(
+        result.deleted.map((token) => `${token.accountId}:${token.tokenId}`),
+      )
+
+      return {
+        ...prev,
+        results: prev.results.map((accountResult) => ({
+          ...accountResult,
+          invalidTokens: accountResult.invalidTokens?.filter(
+            (token) => !deletedIds.has(`${token.accountId}:${token.tokenId}`),
+          ),
+        })),
+        summary: {
+          ...prev.summary,
+          invalidKeys: Math.max(
+            0,
+            (prev.summary.invalidKeys ?? 0) - result.deleted.length,
+          ),
+          deletedKeys: (prev.summary.deletedKeys ?? 0) + result.deleted.length,
+          deleteFailed: (prev.summary.deleteFailed ?? 0) + result.failed.length,
         },
       }
     })
@@ -411,6 +467,60 @@ export async function getAccountKeyRepairProgress() {
 }
 
 /**
+ * Delete selected invalid account tokens and update the current repair progress.
+ */
+export async function deleteInvalidAccountTokens(
+  request: AccountKeyRepairDeleteInvalidTokensRequest,
+) {
+  const allAccounts = await accountStorage.getAllAccounts()
+  const displaySiteDataById = new Map(
+    accountStorage
+      .convertToDisplayData(allAccounts, allAccounts)
+      .map((account) => [account.id, account] as const),
+  )
+  const accountById = new Map(
+    allAccounts.map((account) => [account.id, account]),
+  )
+  const deleted: AccountKeyRepairDeleteInvalidTokensResult["deleted"] = []
+  const failed: AccountKeyRepairDeleteInvalidTokensResult["failed"] = []
+
+  for (const token of request.tokens) {
+    const account = accountById.get(token.accountId)
+    const displaySiteData = displaySiteDataById.get(token.accountId)
+    if (!account || !displaySiteData) {
+      failed.push({
+        ...token,
+        errorMessage: "account_not_found",
+      })
+      continue
+    }
+
+    try {
+      const result = await deleteInvalidAccountToken({
+        token,
+        account,
+        displaySiteData,
+      })
+      deleted.push(result)
+    } catch (error) {
+      failed.push({
+        ...token,
+        errorMessage: getErrorMessage(error) || "delete_failed",
+      })
+    }
+  }
+
+  await accountKeyRepairRunner.recordInvalidTokenDeletionResultForCurrentProgress(
+    {
+      deleted,
+      failed,
+    },
+  )
+
+  return { success: true as const, data: { deleted, failed } }
+}
+
+/**
  * Convert account-key repair listener errors into runtime responses.
  */
 function toAccountKeyRepairFailure(error: unknown) {
@@ -441,6 +551,16 @@ export function setupAccountKeyRepairMessagingListeners() {
       async () => {
         try {
           return await getAccountKeyRepairProgress()
+        } catch (error) {
+          return toAccountKeyRepairFailure(error)
+        }
+      },
+    ),
+    onAccountKeyRepairMessage(
+      AccountKeyRepairMessageTypes.DeleteInvalidTokens,
+      async ({ data }) => {
+        try {
+          return await deleteInvalidAccountTokens(data)
         } catch (error) {
           return toAccountKeyRepairFailure(error)
         }

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -351,6 +351,7 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
   DeleteApiCredentialProfile: "delete_api_credential_profile",
   DeleteAutoCheckinAccount: "delete_auto_checkin_account",
   DeleteBookmark: "delete_bookmark",
+  DeleteInvalidAccountTokens: "delete_invalid_account_tokens",
   DeleteManagedSiteChannel: "delete_managed_site_channel",
   DeleteSelectedManagedSiteChannels: "delete_selected_managed_site_channels",
   DisableSelectedAccounts: "disable_selected_accounts",

--- a/src/types/accountKeyAutoProvisioning.ts
+++ b/src/types/accountKeyAutoProvisioning.ts
@@ -17,6 +17,13 @@ export type AccountKeyRepairSkipReason =
   | "aihubmixOneTimeKey"
   | "noneAuth"
 
+export const ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS = {
+  GroupUnavailable: "groupUnavailable",
+} as const
+
+export type AccountKeyRepairInvalidTokenReason =
+  (typeof ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS)[keyof typeof ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS]
+
 export interface AccountKeyRepairInvalidToken {
   accountId: string
   accountName: string
@@ -25,7 +32,7 @@ export interface AccountKeyRepairInvalidToken {
   tokenId: number
   tokenName: string
   group: string
-  reason: "groupUnavailable"
+  reason: AccountKeyRepairInvalidTokenReason
   errorMessage?: string
 }
 

--- a/src/types/accountKeyAutoProvisioning.ts
+++ b/src/types/accountKeyAutoProvisioning.ts
@@ -17,6 +17,37 @@ export type AccountKeyRepairSkipReason =
   | "aihubmixOneTimeKey"
   | "noneAuth"
 
+export interface AccountKeyRepairInvalidToken {
+  accountId: string
+  accountName: string
+  siteType: AccountSiteType
+  siteUrlOrigin: string
+  tokenId: number
+  tokenName: string
+  group: string
+  reason: "groupUnavailable"
+  errorMessage?: string
+}
+
+export interface AccountKeyRepairDeletedInvalidToken
+  extends AccountKeyRepairInvalidToken {
+  deletedAt: number
+}
+
+export interface AccountKeyRepairFailedInvalidTokenDelete
+  extends AccountKeyRepairInvalidToken {
+  errorMessage: string
+}
+
+export interface AccountKeyRepairDeleteInvalidTokensRequest {
+  tokens: AccountKeyRepairInvalidToken[]
+}
+
+export interface AccountKeyRepairDeleteInvalidTokensResult {
+  deleted: AccountKeyRepairDeletedInvalidToken[]
+  failed: AccountKeyRepairFailedInvalidTokenDelete[]
+}
+
 export interface AccountKeyRepairAccountResult {
   accountId: string
   accountName: string
@@ -25,6 +56,11 @@ export interface AccountKeyRepairAccountResult {
   outcome: AccountKeyRepairOutcome
   skipReason?: AccountKeyRepairSkipReason
   errorMessage?: string
+  availableGroups?: string[]
+  coveredGroups?: string[]
+  createdGroups?: string[]
+  missingGroups?: string[]
+  invalidTokens?: AccountKeyRepairInvalidToken[]
   finishedAt: number
 }
 
@@ -50,6 +86,12 @@ export interface AccountKeyRepairProgress {
     alreadyHad: number
     skipped: number
     failed: number
+    availableGroups?: number
+    coveredGroups?: number
+    createdKeys?: number
+    invalidKeys?: number
+    deletedKeys?: number
+    deleteFailed?: number
   }
   results: AccountKeyRepairAccountResult[]
   lastError?: string

--- a/tests/components/ResponsiveButtonGroup.test.tsx
+++ b/tests/components/ResponsiveButtonGroup.test.tsx
@@ -71,7 +71,9 @@ describe("ResponsiveToggleGroup", () => {
       "min-w-fit",
       "flex-1",
       "[@container(min-width:42rem)]:flex-none",
+      "scale-100",
     )
+    expect(usdButton).not.toHaveClass("scale-105")
     expect(usdButton).toHaveAttribute("aria-pressed", "true")
 
     fireEvent.click(cnyButton)

--- a/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+++ b/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
@@ -471,6 +471,31 @@ const coverageProgress: AccountKeyRepairProgress = {
   ],
 }
 
+const multiInvalidKeysProgress: AccountKeyRepairProgress = {
+  ...coverageProgress,
+  jobId: "job-many-invalid",
+  summary: {
+    ...coverageProgress.summary,
+    invalidKeys: 6,
+  },
+  results: [
+    {
+      ...coverageProgress.results[0],
+      invalidTokens: Array.from({ length: 6 }, (_, index) => ({
+        accountId: "account-enabled",
+        accountName: "Enabled Site",
+        siteType: "new-api",
+        siteUrlOrigin: "https://enabled.example.com",
+        tokenId: index + 1,
+        tokenName: `old group key ${index + 1}`,
+        group: `old-${index + 1}`,
+        reason: "groupUnavailable",
+      })),
+      missingGroups: ["legacy"],
+    },
+  ],
+}
+
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
   let reject!: (reason?: unknown) => void
@@ -1026,6 +1051,48 @@ describe("KeyManagement repair missing keys entry point", () => {
     expect(screen.getByText("old")).toBeInTheDocument()
   })
 
+  it("shows missing groups and bulk-selects invalid keys", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: multiInvalidKeysProgress }
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    expect(await screen.findByText("Enabled Site")).toBeInTheDocument()
+    expect(screen.getByText("legacy")).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.selectAll",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    )
+
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.deleteConfirm.more"),
+    ).toBeInTheDocument()
+  })
+
   it("shows a search no-match state when invalid keys are filtered out", async () => {
     sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
       if (message === AccountKeyRepairMessageTypes.GetProgress) {
@@ -1285,6 +1352,63 @@ describe("KeyManagement repair missing keys entry point", () => {
     expect(screen.getByText("old group key")).toBeInTheDocument()
   })
 
+  it("closes confirmation and shows delete failure feedback when the delete request throws", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: coverageProgress }
+      }
+      if (message === AccountKeyRepairMessageTypes.DeleteInvalidTokens) {
+        throw new Error("delete request failed")
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    )
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "old group key",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    )
+    fireEvent.click(screen.getByTestId("repair-invalid-keys-confirm-delete"))
+
+    expect(
+      await screen.findByText(
+        "keyManagement:repairMissingKeys.invalidKeys.deleteFailed",
+      ),
+    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "keyManagement:repairMissingKeys.deleteConfirm.description",
+        ),
+      ).not.toBeInTheDocument()
+    })
+    expect(mockTrackProductAnalyticsActionCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "delete_invalid_account_tokens",
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      }),
+    )
+  })
+
   it("closes delete confirmation when selected invalid keys are pruned", async () => {
     sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
       if (message === AccountKeyRepairMessageTypes.GetProgress) {
@@ -1520,6 +1644,56 @@ describe("KeyManagement repair missing keys entry point", () => {
       })
     })
     expect(mockTrackProductAnalyticsActionStarted).not.toHaveBeenCalled()
+    expect(
+      mockTrackProductAnalyticsActionCompleted.mock.calls[0]?.[0],
+    ).not.toHaveProperty("error")
+  })
+
+  it("tracks thrown start failures without raw error details", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: idleProgress }
+      }
+      if (message === AccountKeyRepairMessageTypes.Start) {
+        throw new Error("raw backend detail")
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockTrackProductAnalyticsActionCompleted).toHaveBeenCalledWith({
+        featureId: "key_management",
+        actionId: "repair_missing_account_keys",
+        surfaceId: "options_key_management_repair_dialog",
+        entrypoint: "options",
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        insights: {
+          itemCount: 2,
+          selectedCount: 0,
+          successCount: 0,
+          failureCount: 0,
+          statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
+        },
+      })
+    })
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.messages.startFailed"),
+    ).toBeInTheDocument()
     expect(
       mockTrackProductAnalyticsActionCompleted.mock.calls[0]?.[0],
     ).not.toHaveProperty("error")

--- a/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+++ b/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
@@ -1172,6 +1172,68 @@ describe("KeyManagement repair missing keys entry point", () => {
     })
   })
 
+  it("keeps the invalid key summary aligned with actually visible deleted keys", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(
+      async (message: any, data: any) => {
+        if (message === AccountKeyRepairMessageTypes.GetProgress) {
+          return { success: true, data: coverageProgress }
+        }
+        if (message === AccountKeyRepairMessageTypes.DeleteInvalidTokens) {
+          return {
+            success: true,
+            data: {
+              deleted: [
+                { ...data.tokens[0], deletedAt: 123 },
+                {
+                  ...data.tokens[0],
+                  tokenId: 99,
+                  tokenName: "already removed",
+                  deletedAt: 124,
+                },
+              ],
+              failed: [],
+            },
+          }
+        }
+        return { success: false }
+      },
+    )
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    )
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "old group key",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    )
+    fireEvent.click(screen.getByTestId("repair-invalid-keys-confirm-delete"))
+
+    expect(
+      await screen.findByText(
+        "keyManagement:repairMissingKeys.invalidKeys.deleteSuccess",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId("repair-missing-keys-result-count"),
+    ).toHaveTextContent("0/0")
+  })
+
   it("closes confirmation and shows delete failure feedback when invalid key deletion fails", async () => {
     sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
       if (message === AccountKeyRepairMessageTypes.GetProgress) {

--- a/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+++ b/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
@@ -421,11 +421,269 @@ const aihubmixSkippedProgress: AccountKeyRepairProgress = {
   ],
 }
 
+const coverageProgress: AccountKeyRepairProgress = {
+  jobId: "job-coverage",
+  state: "completed",
+  startedAt: 1,
+  updatedAt: 2,
+  finishedAt: 2,
+  totals: {
+    enabledAccounts: 1,
+    eligibleAccounts: 1,
+    processedAccounts: 1,
+    processedEligibleAccounts: 1,
+  },
+  summary: {
+    created: 1,
+    alreadyHad: 0,
+    skipped: 0,
+    failed: 0,
+    availableGroups: 2,
+    coveredGroups: 2,
+    createdKeys: 1,
+    invalidKeys: 1,
+  },
+  results: [
+    {
+      accountId: "account-enabled",
+      accountName: "Enabled Site",
+      siteType: "new-api",
+      siteUrlOrigin: "https://enabled.example.com",
+      outcome: "created",
+      availableGroups: ["default", "vip"],
+      coveredGroups: ["default", "vip"],
+      createdGroups: ["vip"],
+      missingGroups: [],
+      invalidTokens: [
+        {
+          accountId: "account-enabled",
+          accountName: "Enabled Site",
+          siteType: "new-api",
+          siteUrlOrigin: "https://enabled.example.com",
+          tokenId: 9,
+          tokenName: "old group key",
+          group: "old",
+          reason: "groupUnavailable",
+        },
+      ],
+      finishedAt: 2,
+    },
+  ],
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, resolve, reject }
+}
+
 describe("KeyManagement repair missing keys entry point", () => {
   beforeEach(() => {
     mockOpenSub2ApiTokenCreationDialog.mockReset()
     mockTrackProductAnalyticsActionCompleted.mockReset()
     mockTrackProductAnalyticsActionStarted.mockReset()
+  })
+
+  it("opens the key check dialog without starting until the user confirms", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: idleProgress }
+      }
+      if (message === AccountKeyRepairMessageTypes.Start) {
+        return { success: true, data: startProgress }
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.initialNotice"),
+    ).toBeInTheDocument()
+    expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.GetProgress,
+      undefined,
+    )
+    expect(sendRuntimeActionMessageMock).not.toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.Start,
+      undefined,
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
+        AccountKeyRepairMessageTypes.Start,
+        undefined,
+      )
+    })
+  })
+
+  it("ignores repeated start clicks while the first start request is pending", async () => {
+    const startRequest = createDeferred<{
+      success: true
+      data: AccountKeyRepairProgress
+    }>()
+
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: idleProgress }
+      }
+      if (message === AccountKeyRepairMessageTypes.Start) {
+        return startRequest.promise
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    const startButton = screen.getByRole("button", {
+      name: "keyManagement:repairMissingKeys.actions.start",
+    })
+
+    fireEvent.click(startButton)
+    fireEvent.click(startButton)
+
+    await waitFor(() => {
+      expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
+        AccountKeyRepairMessageTypes.Start,
+        undefined,
+      )
+    })
+    expect(
+      sendRuntimeActionMessageMock.mock.calls.filter(
+        ([message]) => message === AccountKeyRepairMessageTypes.Start,
+      ),
+    ).toHaveLength(1)
+
+    await act(async () => {
+      startRequest.resolve({ success: true, data: startProgress })
+      await startRequest.promise
+    })
+  })
+
+  it("keeps the start guard when closing and reopening during a pending start", async () => {
+    const startRequest = createDeferred<{
+      success: true
+      data: AccountKeyRepairProgress
+    }>()
+
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: idleProgress }
+      }
+      if (message === AccountKeyRepairMessageTypes.Start) {
+        return startRequest.promise
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    const repairButton = await screen.findByRole("button", {
+      name: "keyManagement:repairMissingKeys.action",
+    })
+
+    fireEvent.click(repairButton)
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /keyManagement:repairMissingKeys\.actions\.start/,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
+        AccountKeyRepairMessageTypes.Start,
+        undefined,
+      )
+    })
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "common:actions.close",
+      }),
+    )
+
+    fireEvent.click(repairButton)
+    const pendingStartButton = screen.getByRole("button", {
+      name: /keyManagement:repairMissingKeys\.actions\.start/,
+    })
+    expect(pendingStartButton).toBeDisabled()
+    fireEvent.click(pendingStartButton)
+
+    expect(
+      sendRuntimeActionMessageMock.mock.calls.filter(
+        ([message]) => message === AccountKeyRepairMessageTypes.Start,
+      ),
+    ).toHaveLength(1)
+
+    await act(async () => {
+      startRequest.resolve({ success: true, data: completedProgress })
+      await startRequest.promise
+    })
+
+    const rerunButton = screen.getByRole("button", {
+      name: "keyManagement:repairMissingKeys.actions.rerun",
+    })
+    const progressHeader = screen.getByTestId(
+      "repair-missing-keys-progress-header",
+    )
+    const progressActions = screen.getByTestId(
+      "repair-missing-keys-progress-actions",
+    )
+    expect(progressHeader).toHaveClass(
+      "flex",
+      "flex-wrap",
+      "items-center",
+      "justify-between",
+    )
+    expect(progressHeader).not.toHaveClass("flex-col", "sm:flex-row")
+    expect(progressActions).toHaveClass(
+      "flex-wrap",
+      "items-center",
+      "justify-end",
+    )
+    expect(progressActions).toHaveTextContent("2/2 (100%)")
+    expect(progressActions).toContainElement(rerunButton)
+
+    const enabledAccountsLabel = screen.getByText(
+      "keyManagement:repairMissingKeys.totalsLabels.enabledAccounts",
+    )
+    expect(
+      rerunButton.compareDocumentPosition(enabledAccountsLabel) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+
+    fireEvent.click(rerunButton)
+
+    await waitFor(() => {
+      expect(
+        sendRuntimeActionMessageMock.mock.calls.filter(
+          ([message]) => message === AccountKeyRepairMessageTypes.Start,
+        ),
+      ).toHaveLength(2)
+    })
   })
 
   it("opens dialog, subscribes to progress, and hides disabled accounts", async () => {
@@ -449,6 +707,12 @@ describe("KeyManagement repair missing keys entry point", () => {
     expect(
       screen.getByText("keyManagement:repairMissingKeys.description"),
     ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
+      }),
+    )
 
     await waitFor(() => {
       expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
@@ -510,6 +774,12 @@ describe("KeyManagement repair missing keys entry point", () => {
       }),
     )
 
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
+      }),
+    )
+
     await waitFor(() => {
       expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
         AccountKeyRepairMessageTypes.Start,
@@ -544,6 +814,12 @@ describe("KeyManagement repair missing keys entry point", () => {
     fireEvent.click(
       await screen.findByRole("button", {
         name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
       }),
     )
 
@@ -621,6 +897,12 @@ describe("KeyManagement repair missing keys entry point", () => {
       }),
     )
 
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
+      }),
+    )
+
     await waitFor(() => {
       expect(screen.getByText("Another Site")).toBeInTheDocument()
     })
@@ -661,6 +943,12 @@ describe("KeyManagement repair missing keys entry point", () => {
       }),
     )
 
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
+      }),
+    )
+
     expect((await screen.findAllByText("AIHubMix"))[0]).toBeInTheDocument()
     expect(
       screen.getByText(
@@ -675,7 +963,395 @@ describe("KeyManagement repair missing keys entry point", () => {
     expect(mockOpenSub2ApiTokenCreationDialog).not.toHaveBeenCalled()
   })
 
-  it("tracks started and successful completion analytics for start-on-open repair", async () => {
+  it("switches between account coverage and invalid key views", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: coverageProgress }
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    const viewSwitch = await screen.findByRole("group", {
+      name: "keyManagement:repairMissingKeys.views.label",
+    })
+    expect(viewSwitch).toHaveClass("w-full", "rounded-lg", "p-1")
+    expect(
+      screen.getByTestId("repair-missing-keys-account-coverage-view-icon"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId("repair-missing-keys-invalid-keys-view-icon"),
+    ).toBeInTheDocument()
+    const resultCount = screen.getByTestId("repair-missing-keys-result-count")
+    expect(
+      screen.getByTestId("repair-missing-keys-results-header"),
+    ).toHaveClass("space-y-0")
+    expect(
+      screen.getByTestId("repair-missing-keys-result-heading-row"),
+    ).toHaveClass("h-9", "items-center")
+    expect(
+      screen.getByTestId("repair-missing-keys-result-heading"),
+    ).toHaveClass("items-baseline")
+    expect(resultCount).toHaveTextContent("1/1")
+    expect(resultCount).toHaveClass("leading-none", "tabular-nums")
+    expect(resultCount).not.toHaveClass("rounded-full")
+    const accountCoverageButton = screen.getByRole("button", {
+      name: "keyManagement:repairMissingKeys.views.accountCoverage",
+    })
+    expect(accountCoverageButton).toHaveClass("scale-100")
+    expect(accountCoverageButton).not.toHaveClass("scale-105")
+    expect(accountCoverageButton).toHaveAttribute("aria-pressed", "true")
+    expect(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    ).toHaveAttribute("aria-pressed", "false")
+    expect(screen.getByText("vip")).toBeInTheDocument()
+    expect(screen.queryByText("old group key")).not.toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    )
+
+    expect(screen.getByText("old group key")).toBeInTheDocument()
+    expect(screen.getByText("old")).toBeInTheDocument()
+  })
+
+  it("shows a search no-match state when invalid keys are filtered out", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: coverageProgress }
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    )
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "keyManagement:repairMissingKeys.searchPlaceholder",
+      ),
+      { target: { value: "does-not-match-invalid-keys" } },
+    )
+
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.noMatchingResults"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        "keyManagement:repairMissingKeys.invalidKeys.emptyTitle",
+      ),
+    ).not.toBeInTheDocument()
+  })
+
+  it("deletes selected invalid keys after destructive confirmation", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(
+      async (message: any, data: any) => {
+        if (message === AccountKeyRepairMessageTypes.GetProgress) {
+          return { success: true, data: coverageProgress }
+        }
+        if (message === AccountKeyRepairMessageTypes.DeleteInvalidTokens) {
+          return {
+            success: true,
+            data: {
+              deleted: [{ ...data.tokens[0], deletedAt: 123 }],
+              failed: [],
+            },
+          }
+        }
+        return { success: false }
+      },
+    )
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    )
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "old group key",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    )
+
+    expect(
+      screen.getByText(
+        "keyManagement:repairMissingKeys.deleteConfirm.description",
+      ),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId("repair-invalid-keys-confirm-delete"))
+
+    await waitFor(() => {
+      expect(sendRuntimeActionMessageMock).toHaveBeenCalledWith(
+        AccountKeyRepairMessageTypes.DeleteInvalidTokens,
+        {
+          tokens: [
+            expect.objectContaining({
+              tokenId: 9,
+              tokenName: "old group key",
+            }),
+          ],
+        },
+      )
+    })
+
+    expect(
+      await screen.findByText(
+        "keyManagement:repairMissingKeys.invalidKeys.deleteSuccess",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "keyManagement:repairMissingKeys.invalidKeys.emptyTitle",
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("old group key")).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "keyManagement:repairMissingKeys.deleteConfirm.description",
+        ),
+      ).not.toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(mockTrackProductAnalyticsActionStarted).toHaveBeenCalledWith({
+        featureId: "key_management",
+        actionId: "delete_invalid_account_tokens",
+        surfaceId: "options_key_management_repair_dialog",
+        entrypoint: "options",
+      })
+    })
+    await waitFor(() => {
+      expect(mockTrackProductAnalyticsActionCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionId: "delete_invalid_account_tokens",
+          result: PRODUCT_ANALYTICS_RESULTS.Success,
+          insights: expect.objectContaining({
+            itemCount: 1,
+            selectedCount: 1,
+            successCount: 1,
+            failureCount: 0,
+          }),
+        }),
+      )
+    })
+  })
+
+  it("closes confirmation and shows delete failure feedback when invalid key deletion fails", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: coverageProgress }
+      }
+      if (message === AccountKeyRepairMessageTypes.DeleteInvalidTokens) {
+        return { success: false }
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    )
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "old group key",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    )
+    fireEvent.click(screen.getByTestId("repair-invalid-keys-confirm-delete"))
+
+    expect(
+      await screen.findByText(
+        "keyManagement:repairMissingKeys.invalidKeys.deleteFailed",
+      ),
+    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "keyManagement:repairMissingKeys.deleteConfirm.description",
+        ),
+      ).not.toBeInTheDocument()
+    })
+    expect(screen.getByText("old group key")).toBeInTheDocument()
+  })
+
+  it("closes delete confirmation when selected invalid keys are pruned", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: coverageProgress }
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    )
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "old group key",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    )
+
+    expect(
+      screen.getByText(
+        "keyManagement:repairMissingKeys.deleteConfirm.description",
+      ),
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      runtimeMessageState.listener?.({
+        type: RuntimeMessageTypes.AccountKeyRepairProgress,
+        payload: {
+          ...coverageProgress,
+          summary: {
+            ...coverageProgress.summary,
+            invalidKeys: 0,
+          },
+          results: coverageProgress.results.map((result) => ({
+            ...result,
+            invalidTokens: [],
+          })),
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "keyManagement:repairMissingKeys.deleteConfirm.description",
+        ),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("keeps invalid key delete feedback visible when search has no matches", async () => {
+    sendRuntimeActionMessageMock.mockImplementation(
+      async (message: any, data: any) => {
+        if (message === AccountKeyRepairMessageTypes.GetProgress) {
+          return { success: true, data: coverageProgress }
+        }
+        if (message === AccountKeyRepairMessageTypes.DeleteInvalidTokens) {
+          return {
+            success: true,
+            data: {
+              deleted: [],
+              failed: [{ ...data.tokens[0], errorMessage: "delete failed" }],
+            },
+          }
+        }
+        return { success: false }
+      },
+    )
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.invalidKeys",
+      }),
+    )
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "old group key",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    )
+    fireEvent.click(screen.getByTestId("repair-invalid-keys-confirm-delete"))
+
+    expect(
+      await screen.findByText(
+        "keyManagement:repairMissingKeys.invalidKeys.deletePartial",
+      ),
+    ).toBeInTheDocument()
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "keyManagement:repairMissingKeys.searchPlaceholder",
+      ),
+      { target: { value: "does-not-match-invalid-keys" } },
+    )
+
+    expect(
+      screen.getByText(
+        "keyManagement:repairMissingKeys.invalidKeys.deletePartial",
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("tracks started and successful completion analytics for manual repair start", async () => {
     sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
       if (message === AccountKeyRepairMessageTypes.GetProgress) {
         return { success: true, data: idleProgress }
@@ -691,6 +1367,12 @@ describe("KeyManagement repair missing keys entry point", () => {
     fireEvent.click(
       await screen.findByRole("button", {
         name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
       }),
     )
 
@@ -752,6 +1434,12 @@ describe("KeyManagement repair missing keys entry point", () => {
       }),
     )
 
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
+      }),
+    )
+
     await waitFor(() => {
       expect(mockTrackProductAnalyticsActionCompleted).toHaveBeenCalledWith({
         featureId: "key_management",
@@ -791,6 +1479,12 @@ describe("KeyManagement repair missing keys entry point", () => {
     fireEvent.click(
       await screen.findByRole("button", {
         name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
       }),
     )
 

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -7,10 +7,12 @@ import {
 } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
   buildGroupDefaultTokenRequest,
+  deleteInvalidAccountToken,
   ensureAccountKeysForAvailableGroups,
 } from "~/services/accounts/accountKeyAutoProvisioning/groupCoverage"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import { AuthTypeEnum } from "~/types"
+import { ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS } from "~/types/accountKeyAutoProvisioning"
 import {
   buildApiToken,
   buildDisplaySiteData,
@@ -113,7 +115,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
           tokenId: 9,
           tokenName: "old group key",
           group: "old",
-          reason: "groupUnavailable",
+          reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
         },
       ],
     })
@@ -221,6 +223,48 @@ describe("ensureAccountKeysForAvailableGroups", () => {
       2,
       expect.any(Object),
       buildGroupDefaultTokenRequest("beta"),
+    )
+  })
+
+  it("deletes an invalid account token and returns a deletion record", async () => {
+    mocks.deleteApiToken.mockResolvedValue(true)
+
+    const result = await deleteInvalidAccountToken({
+      account,
+      displaySiteData,
+      token: {
+        accountId: "new-api-1",
+        accountName: "Relay Account",
+        siteType: SITE_TYPES.NEW_API,
+        siteUrlOrigin: "https://relay.example.com",
+        tokenId: 9,
+        tokenName: "old group key",
+        group: "old",
+        reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+      },
+    })
+
+    expect(mocks.deleteApiToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://relay.example.com",
+        accountId: "new-api-1",
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.AccessToken,
+          userId: "101",
+          accessToken: "access-token",
+        }),
+      }),
+      9,
+    )
+    expect(result).toEqual(
+      expect.objectContaining({
+        accountId: "new-api-1",
+        tokenId: 9,
+        tokenName: "old group key",
+        group: "old",
+        reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+        deletedAt: expect.any(Number),
+      }),
     )
   })
 })

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -133,6 +133,42 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     )
   })
 
+  it("uses the stored account id for invalid tokens when display data has no id", async () => {
+    mocks.fetchAccountTokens.mockResolvedValue([
+      buildApiToken({
+        id: 9,
+        name: "old group key",
+        group: "old",
+      }),
+    ])
+    mocks.fetchUserGroups.mockResolvedValue({
+      default: { desc: "Default", ratio: 1 },
+    })
+    mocks.createApiToken.mockResolvedValue(true)
+
+    const result = await ensureAccountKeysForAvailableGroups({
+      account,
+      displaySiteData: {
+        ...displaySiteData,
+        id: "",
+      },
+      accountName: "Relay Account",
+      siteUrlOrigin: "https://relay.example.com",
+    })
+
+    expect(mocks.fetchAccountTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "new-api-1",
+      }),
+    )
+    expect(result.invalidTokens).toEqual([
+      expect.objectContaining({
+        accountId: "new-api-1",
+        tokenId: 9,
+      }),
+    ])
+  })
+
   it("falls back to one-key behavior when group lookup is unsupported", async () => {
     mocks.fetchAccountTokens.mockResolvedValue([])
     mocks.fetchUserGroups.mockRejectedValue(

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+  generateDefaultTokenRequest,
+} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import {
+  buildGroupDefaultTokenRequest,
+  ensureAccountKeysForAvailableGroups,
+} from "~/services/accounts/accountKeyAutoProvisioning/groupCoverage"
+import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
+import { AuthTypeEnum } from "~/types"
+import {
+  buildApiToken,
+  buildDisplaySiteData,
+  buildSiteAccount,
+} from "~~/tests/test-utils/factories"
+
+const mocks = vi.hoisted(() => ({
+  fetchAccountTokens: vi.fn(),
+  fetchUserGroups: vi.fn(),
+  createApiToken: vi.fn(),
+  deleteApiToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => mocks),
+  }
+})
+
+const account = buildSiteAccount({
+  id: "new-api-1",
+  site_name: "Relay Account",
+  site_type: SITE_TYPES.NEW_API,
+  site_url: "https://relay.example.com",
+  authType: AuthTypeEnum.AccessToken,
+  account_info: {
+    id: "101",
+    access_token: "access-token",
+    username: "valid",
+    quota: 0,
+    today_prompt_tokens: 0,
+    today_completion_tokens: 0,
+    today_quota_consumption: 0,
+    today_requests_count: 0,
+    today_income: 0,
+  },
+})
+
+const displaySiteData = buildDisplaySiteData({
+  id: account.id,
+  name: "Relay Account",
+  baseUrl: account.site_url,
+  siteType: SITE_TYPES.NEW_API,
+  authType: AuthTypeEnum.AccessToken,
+  userId: "101",
+  token: "access-token",
+})
+
+const runCoverage = () =>
+  ensureAccountKeysForAvailableGroups({
+    account,
+    displaySiteData,
+    accountName: "Relay Account",
+    siteUrlOrigin: "https://relay.example.com",
+  })
+
+describe("ensureAccountKeysForAvailableGroups", () => {
+  beforeEach(() => {
+    mocks.fetchAccountTokens.mockReset()
+    mocks.fetchUserGroups.mockReset()
+    mocks.createApiToken.mockReset()
+    mocks.deleteApiToken.mockReset()
+  })
+
+  it("creates missing group keys and reports tokens tied to unavailable groups", async () => {
+    mocks.fetchAccountTokens.mockResolvedValue([
+      buildApiToken({
+        id: 1,
+        name: "default key",
+        group: "default",
+      }),
+      buildApiToken({
+        id: 9,
+        name: "old group key",
+        group: "old",
+      }),
+    ])
+    mocks.fetchUserGroups.mockResolvedValue({
+      default: { desc: "Default", ratio: 1 },
+      vip: { desc: "VIP", ratio: 1 },
+    })
+    mocks.createApiToken.mockResolvedValue(true)
+
+    const result = await runCoverage()
+
+    expect(result).toEqual({
+      created: true,
+      availableGroups: ["default", "vip"],
+      coveredGroups: ["default", "vip"],
+      createdGroups: ["vip"],
+      missingGroups: [],
+      invalidTokens: [
+        {
+          accountId: "new-api-1",
+          accountName: "Relay Account",
+          siteType: SITE_TYPES.NEW_API,
+          siteUrlOrigin: "https://relay.example.com",
+          tokenId: 9,
+          tokenName: "old group key",
+          group: "old",
+          reason: "groupUnavailable",
+        },
+      ],
+    })
+    expect(mocks.createApiToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://relay.example.com",
+        accountId: "new-api-1",
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.AccessToken,
+          userId: "101",
+          accessToken: "access-token",
+        }),
+      }),
+      buildGroupDefaultTokenRequest("vip"),
+    )
+  })
+
+  it("falls back to one-key behavior when group lookup is unsupported", async () => {
+    mocks.fetchAccountTokens.mockResolvedValue([])
+    mocks.fetchUserGroups.mockRejectedValue(
+      new ApiError(
+        "unsupported",
+        undefined,
+        "/api/user/self/groups",
+        API_ERROR_CODES.FEATURE_UNSUPPORTED,
+      ),
+    )
+    mocks.createApiToken.mockResolvedValue(true)
+
+    const result = await runCoverage()
+
+    expect(result).toEqual({
+      created: true,
+      availableGroups: [],
+      coveredGroups: [],
+      createdGroups: [""],
+      missingGroups: [],
+      invalidTokens: [],
+    })
+    expect(mocks.createApiToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://relay.example.com",
+        accountId: "new-api-1",
+      }),
+      generateDefaultTokenRequest(),
+    )
+  })
+
+  it("treats empty group responses as legacy one-key coverage when a token already exists", async () => {
+    mocks.fetchAccountTokens.mockResolvedValue([
+      buildApiToken({
+        id: 1,
+        name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: "",
+      }),
+    ])
+    mocks.fetchUserGroups.mockResolvedValue({})
+
+    const result = await runCoverage()
+
+    expect(result).toEqual({
+      created: false,
+      availableGroups: [],
+      coveredGroups: [],
+      createdGroups: [],
+      missingGroups: [],
+      invalidTokens: [],
+    })
+    expect(mocks.createApiToken).not.toHaveBeenCalled()
+  })
+
+  it("records failed group creation as missing and continues with later groups", async () => {
+    mocks.fetchAccountTokens.mockResolvedValue([
+      buildApiToken({
+        id: 1,
+        name: "default key",
+        group: "default",
+      }),
+    ])
+    mocks.fetchUserGroups.mockResolvedValue({
+      default: { desc: "Default", ratio: 1 },
+      vip: { desc: "VIP", ratio: 1 },
+      beta: { desc: "Beta", ratio: 1 },
+    })
+    mocks.createApiToken
+      .mockRejectedValueOnce(new Error("vip failed"))
+      .mockResolvedValueOnce(true)
+
+    const result = await runCoverage()
+
+    expect(result).toEqual({
+      created: true,
+      availableGroups: ["default", "vip", "beta"],
+      coveredGroups: ["default", "beta"],
+      createdGroups: ["beta"],
+      missingGroups: ["vip"],
+      invalidTokens: [],
+    })
+    expect(mocks.createApiToken).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Object),
+      buildGroupDefaultTokenRequest("vip"),
+    )
+    expect(mocks.createApiToken).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Object),
+      buildGroupDefaultTokenRequest("beta"),
+    )
+  })
+})

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -27,6 +27,8 @@ const mocks = vi.hoisted(() => {
     getAllAccounts: vi.fn(),
     convertToDisplayData: vi.fn(),
     ensureDefaultApiTokenForAccount: vi.fn(),
+    ensureAccountKeysForAvailableGroups: vi.fn(),
+    deleteInvalidAccountToken: vi.fn(),
     sendRuntimeMessage: vi.fn(),
     safeRandomUUID: vi.fn(() => "job-123"),
   }
@@ -43,12 +45,11 @@ vi.mock("~/services/accounts/accountStorage", () => ({
   },
 }))
 
-vi.mock(
-  "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken",
-  () => ({
-    ensureDefaultApiTokenForAccount: mocks.ensureDefaultApiTokenForAccount,
-  }),
-)
+vi.mock("~/services/accounts/accountKeyAutoProvisioning/groupCoverage", () => ({
+  ensureAccountKeysForAvailableGroups:
+    mocks.ensureAccountKeysForAvailableGroups,
+  deleteInvalidAccountToken: mocks.deleteInvalidAccountToken,
+}))
 
 vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   const actual =
@@ -215,7 +216,7 @@ describe("accountKeyRepair", () => {
         id: validAccount.id,
         name: "Valid Account",
         baseUrl: validAccount.site_url,
-        siteType: "new-api",
+        siteType: SITE_TYPES.NEW_API,
         authType: AuthTypeEnum.AccessToken,
         userId: "101",
         token: "access-token",
@@ -224,16 +225,20 @@ describe("accountKeyRepair", () => {
         id: invalidDisplayAccount.id,
         name: "Broken Cookie Account",
         baseUrl: invalidDisplayAccount.site_url,
-        siteType: "new-api",
+        siteType: SITE_TYPES.NEW_API,
         authType: AuthTypeEnum.Cookie,
         userId: "202",
         token: "",
         cookieAuthSessionCookie: "",
       }),
     ])
-    mocks.ensureDefaultApiTokenForAccount.mockResolvedValueOnce({
-      token: { id: 1, key: "created-token" },
+    mocks.ensureAccountKeysForAvailableGroups.mockResolvedValueOnce({
       created: true,
+      availableGroups: [],
+      coveredGroups: [],
+      createdGroups: [""],
+      missingGroups: [],
+      invalidTokens: [],
     })
     mocks.sendRuntimeMessage.mockResolvedValue(undefined)
 
@@ -264,6 +269,12 @@ describe("accountKeyRepair", () => {
       alreadyHad: 0,
       skipped: 2,
       failed: 1,
+      availableGroups: 0,
+      coveredGroups: 0,
+      createdKeys: 1,
+      invalidKeys: 0,
+      deletedKeys: 0,
+      deleteFailed: 0,
     })
     expect(progress.results).toEqual(
       expect.arrayContaining([
@@ -292,7 +303,7 @@ describe("accountKeyRepair", () => {
         }),
       ]),
     )
-    expect(mocks.ensureDefaultApiTokenForAccount).toHaveBeenCalledTimes(1)
+    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(1)
     expect(mocks.sendRuntimeMessage).toHaveBeenCalledWith(
       {
         type: RuntimeMessageTypes.AccountKeyRepairProgress,
@@ -300,6 +311,352 @@ describe("accountKeyRepair", () => {
       },
       { maxAttempts: 1 },
     )
+  })
+
+  it("records group coverage and invalid keys from the group-aware audit helper", async () => {
+    const account = buildSiteAccount({
+      id: "new-api-1",
+      site_type: "new-api",
+      site_url: "https://relay.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "101",
+        access_token: "access-token",
+        username: "valid",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+
+    mocks.getAllAccounts.mockResolvedValue([account])
+    mocks.convertToDisplayData.mockReturnValue([
+      buildDisplaySiteData({
+        id: account.id,
+        name: "Relay Account",
+        baseUrl: account.site_url,
+        siteType: SITE_TYPES.NEW_API,
+        authType: AuthTypeEnum.AccessToken,
+        userId: "101",
+        token: "access-token",
+      }),
+    ])
+    mocks.ensureAccountKeysForAvailableGroups.mockResolvedValueOnce({
+      created: true,
+      availableGroups: ["default", "vip"],
+      coveredGroups: ["default", "vip"],
+      createdGroups: ["vip"],
+      missingGroups: [],
+      invalidTokens: [
+        {
+          accountId: "new-api-1",
+          accountName: "Relay Account",
+          siteType: SITE_TYPES.NEW_API,
+          siteUrlOrigin: "https://relay.example.com",
+          tokenId: 9,
+          tokenName: "old group key",
+          group: "old",
+          reason: "groupUnavailable",
+        },
+      ],
+    })
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await accountKeyRepairRunner.start()
+
+    await vi.waitFor(async () => {
+      const progress = await accountKeyRepairRunner.getProgress()
+      expect(progress.state).toBe("completed")
+    })
+
+    const progress = await accountKeyRepairRunner.getProgress()
+    expect(progress.summary).toMatchObject({
+      created: 1,
+      alreadyHad: 0,
+      skipped: 0,
+      failed: 0,
+      availableGroups: 2,
+      coveredGroups: 2,
+      createdKeys: 1,
+      invalidKeys: 1,
+    })
+    expect(progress.results).toEqual([
+      expect.objectContaining({
+        accountId: "new-api-1",
+        outcome: "created",
+        availableGroups: ["default", "vip"],
+        coveredGroups: ["default", "vip"],
+        createdGroups: ["vip"],
+        invalidTokens: [
+          expect.objectContaining({
+            tokenId: 9,
+            tokenName: "old group key",
+            group: "old",
+            reason: "groupUnavailable",
+          }),
+        ],
+      }),
+    ])
+  })
+
+  it("deletes selected invalid tokens serially and records partial failure", async () => {
+    const account = buildSiteAccount({
+      id: "new-api-1",
+      site_type: "new-api",
+      site_url: "https://relay.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "101",
+        access_token: "access-token",
+        username: "valid",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const displayAccount = buildDisplaySiteData({
+      id: account.id,
+      name: "Relay Account",
+      baseUrl: account.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "101",
+      token: "access-token",
+    })
+    const invalidTokens = [
+      {
+        accountId: "new-api-1",
+        accountName: "Relay Account",
+        siteType: SITE_TYPES.NEW_API,
+        siteUrlOrigin: "https://relay.example.com",
+        tokenId: 9,
+        tokenName: "old one",
+        group: "old",
+        reason: "groupUnavailable" as const,
+      },
+      {
+        accountId: "new-api-1",
+        accountName: "Relay Account",
+        siteType: SITE_TYPES.NEW_API,
+        siteUrlOrigin: "https://relay.example.com",
+        tokenId: 10,
+        tokenName: "old two",
+        group: "old-2",
+        reason: "groupUnavailable" as const,
+      },
+    ]
+
+    mocks.getAllAccounts.mockResolvedValue([account])
+    mocks.convertToDisplayData.mockReturnValue([displayAccount])
+    let resolveFirstDelete!: (
+      value: (typeof invalidTokens)[number] & { deletedAt: number },
+    ) => void
+    mocks.deleteInvalidAccountToken
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstDelete = resolve
+          }),
+      )
+      .mockRejectedValueOnce(new Error("delete boom"))
+
+    const { deleteInvalidAccountTokens } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    const deleteResult = deleteInvalidAccountTokens({ tokens: invalidTokens })
+
+    await vi.waitFor(() => {
+      expect(mocks.deleteInvalidAccountToken).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      mocks.deleteInvalidAccountToken.mock.calls[0]?.[0].token.tokenId,
+    ).toBe(9)
+
+    resolveFirstDelete({ ...invalidTokens[0], deletedAt: 123 })
+
+    await vi.waitFor(() => {
+      expect(mocks.deleteInvalidAccountToken).toHaveBeenCalledTimes(2)
+    })
+
+    await expect(deleteResult).resolves.toEqual({
+      success: true,
+      data: {
+        deleted: [{ ...invalidTokens[0], deletedAt: 123 }],
+        failed: [{ ...invalidTokens[1], errorMessage: "delete boom" }],
+      },
+    })
+
+    expect(
+      mocks.deleteInvalidAccountToken.mock.calls.map(
+        (call) => call[0].token.tokenId,
+      ),
+    ).toEqual([9, 10])
+  })
+
+  it("preserves stored audit progress when deleting after a cold start", async () => {
+    const account = buildSiteAccount({
+      id: "new-api-1",
+      site_type: "new-api",
+      site_url: "https://relay.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "101",
+        access_token: "access-token",
+        username: "valid",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const displayAccount = buildDisplaySiteData({
+      id: account.id,
+      name: "Relay Account",
+      baseUrl: account.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "101",
+      token: "access-token",
+    })
+    const invalidTokens = [
+      {
+        accountId: "new-api-1",
+        accountName: "Relay Account",
+        siteType: SITE_TYPES.NEW_API,
+        siteUrlOrigin: "https://relay.example.com",
+        tokenId: 9,
+        tokenName: "old one",
+        group: "old",
+        reason: "groupUnavailable" as const,
+      },
+      {
+        accountId: "new-api-1",
+        accountName: "Relay Account",
+        siteType: SITE_TYPES.NEW_API,
+        siteUrlOrigin: "https://relay.example.com",
+        tokenId: 10,
+        tokenName: "old two",
+        group: "old-2",
+        reason: "groupUnavailable" as const,
+      },
+    ]
+
+    mocks.storageMap.set("accountKeyRepair_progress", {
+      jobId: "job-stored",
+      state: "completed",
+      startedAt: 100,
+      updatedAt: 200,
+      finishedAt: 300,
+      totals: {
+        enabledAccounts: 1,
+        eligibleAccounts: 1,
+        processedAccounts: 1,
+        processedEligibleAccounts: 1,
+      },
+      summary: {
+        created: 1,
+        alreadyHad: 0,
+        skipped: 0,
+        failed: 0,
+        availableGroups: 2,
+        coveredGroups: 2,
+        createdKeys: 1,
+        invalidKeys: 2,
+        deletedKeys: 0,
+        deleteFailed: 0,
+      },
+      results: [
+        {
+          accountId: "new-api-1",
+          accountName: "Relay Account",
+          siteType: SITE_TYPES.NEW_API,
+          siteUrlOrigin: "https://relay.example.com",
+          outcome: "created",
+          availableGroups: ["default", "vip"],
+          coveredGroups: ["default", "vip"],
+          createdGroups: ["vip"],
+          invalidTokens,
+          finishedAt: 300,
+        },
+      ],
+    })
+    mocks.getAllAccounts.mockResolvedValue([account])
+    mocks.convertToDisplayData.mockReturnValue([displayAccount])
+    mocks.deleteInvalidAccountToken.mockResolvedValueOnce({
+      ...invalidTokens[0],
+      deletedAt: 123,
+    })
+
+    const { accountKeyRepairRunner, deleteInvalidAccountTokens } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await expect(
+      deleteInvalidAccountTokens({ tokens: [invalidTokens[0]] }),
+    ).resolves.toEqual({
+      success: true,
+      data: {
+        deleted: [{ ...invalidTokens[0], deletedAt: 123 }],
+        failed: [],
+      },
+    })
+
+    expect(mocks.storageMap.get("accountKeyRepair_progress")).toMatchObject({
+      jobId: "job-stored",
+      state: "completed",
+      totals: {
+        enabledAccounts: 1,
+        eligibleAccounts: 1,
+        processedAccounts: 1,
+        processedEligibleAccounts: 1,
+      },
+      summary: {
+        created: 1,
+        alreadyHad: 0,
+        skipped: 0,
+        failed: 0,
+        availableGroups: 2,
+        coveredGroups: 2,
+        createdKeys: 1,
+        invalidKeys: 1,
+        deletedKeys: 1,
+        deleteFailed: 0,
+      },
+      results: [
+        expect.objectContaining({
+          accountId: "new-api-1",
+          outcome: "created",
+          invalidTokens: [invalidTokens[1]],
+        }),
+      ],
+    })
+    await expect(accountKeyRepairRunner.getProgress()).resolves.toMatchObject({
+      jobId: "job-stored",
+      summary: {
+        invalidKeys: 1,
+        deletedKeys: 1,
+      },
+      results: [
+        expect.objectContaining({
+          invalidTokens: [invalidTokens[1]],
+        }),
+      ],
+    })
   })
 
   it("skips none-auth accounts, ignores disabled accounts, and falls back to per-account display conversion", async () => {
@@ -348,7 +705,7 @@ describe("accountKeyRepair", () => {
             id: noneAuthAccount.id,
             name: "None Auth",
             baseUrl: noneAuthAccount.site_url,
-            siteType: "new-api",
+            siteType: SITE_TYPES.NEW_API,
             authType: AuthTypeEnum.None,
             userId: "1",
           }),
@@ -359,16 +716,20 @@ describe("accountKeyRepair", () => {
         id: cookieAccount.id,
         name: "Cookie Fallback",
         baseUrl: cookieAccount.site_url,
-        siteType: "new-api",
+        siteType: SITE_TYPES.NEW_API,
         authType: AuthTypeEnum.Cookie,
         userId: "404",
         token: "",
         cookieAuthSessionCookie: "session=abc",
       })
     })
-    mocks.ensureDefaultApiTokenForAccount.mockResolvedValueOnce({
-      token: { id: 3, key: "cookie-created" },
+    mocks.ensureAccountKeysForAvailableGroups.mockResolvedValueOnce({
       created: false,
+      availableGroups: [],
+      coveredGroups: [],
+      createdGroups: [],
+      missingGroups: [],
+      invalidTokens: [],
     })
 
     const { accountKeyRepairRunner } = await import(
@@ -394,6 +755,12 @@ describe("accountKeyRepair", () => {
       alreadyHad: 1,
       skipped: 1,
       failed: 0,
+      availableGroups: 0,
+      coveredGroups: 0,
+      createdKeys: 0,
+      invalidKeys: 0,
+      deletedKeys: 0,
+      deleteFailed: 0,
     })
     expect(progress.results).toEqual(
       expect.arrayContaining([
@@ -410,13 +777,15 @@ describe("accountKeyRepair", () => {
       ]),
     )
     expect(mocks.convertToDisplayData).toHaveBeenCalledWith(cookieAccount)
-    expect(mocks.ensureDefaultApiTokenForAccount).toHaveBeenCalledWith({
+    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledWith({
       account: cookieAccount,
       displaySiteData: expect.objectContaining({
         id: "cookie-1",
         authType: AuthTypeEnum.Cookie,
         cookieAuthSessionCookie: "session=abc",
       }),
+      accountName: "Cookie Fallback",
+      siteUrlOrigin: "https://cookie.example.com",
     })
   })
 
@@ -448,19 +817,23 @@ describe("accountKeyRepair", () => {
         id: "queued-1",
         name: "Queued Account",
         baseUrl: "https://queued.example.com",
-        siteType: "new-api",
+        siteType: SITE_TYPES.NEW_API,
         authType: AuthTypeEnum.AccessToken,
         userId: "303",
         token: "queued-token",
       }),
     ])
-    mocks.ensureDefaultApiTokenForAccount.mockImplementation(
+    mocks.ensureAccountKeysForAvailableGroups.mockImplementation(
       () =>
         new Promise((resolve) => {
           resolvers.push(() =>
             resolve({
-              token: { id: 2, key: "queued-token-created" },
               created: false,
+              availableGroups: [],
+              coveredGroups: [],
+              createdGroups: [],
+              missingGroups: [],
+              invalidTokens: [],
             }),
           )
         }),

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import { AuthTypeEnum } from "~/types"
+import { ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS } from "~/types/accountKeyAutoProvisioning"
 import {
   buildDisplaySiteData,
   buildSiteAccount,
@@ -360,7 +361,7 @@ describe("accountKeyRepair", () => {
           tokenId: 9,
           tokenName: "old group key",
           group: "old",
-          reason: "groupUnavailable",
+          reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
         },
       ],
     })
@@ -399,9 +400,81 @@ describe("accountKeyRepair", () => {
             tokenId: 9,
             tokenName: "old group key",
             group: "old",
-            reason: "groupUnavailable",
+            reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
           }),
         ],
+      }),
+    ])
+  })
+
+  it("marks unresolved group provisioning as failed instead of already covered", async () => {
+    const account = buildSiteAccount({
+      id: "new-api-1",
+      site_type: "new-api",
+      site_url: "https://relay.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "101",
+        access_token: "access-token",
+        username: "valid",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+
+    mocks.getAllAccounts.mockResolvedValue([account])
+    mocks.convertToDisplayData.mockReturnValue([
+      buildDisplaySiteData({
+        id: account.id,
+        name: "Relay Account",
+        baseUrl: account.site_url,
+        siteType: SITE_TYPES.NEW_API,
+        authType: AuthTypeEnum.AccessToken,
+        userId: "101",
+        token: "access-token",
+      }),
+    ])
+    mocks.ensureAccountKeysForAvailableGroups.mockResolvedValueOnce({
+      created: false,
+      availableGroups: ["default", "vip"],
+      coveredGroups: ["default"],
+      createdGroups: [],
+      missingGroups: ["vip"],
+      invalidTokens: [],
+    })
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await accountKeyRepairRunner.start()
+
+    await vi.waitFor(async () => {
+      const progress = await accountKeyRepairRunner.getProgress()
+      expect(progress.state).toBe("completed")
+    })
+
+    const progress = await accountKeyRepairRunner.getProgress()
+    expect(progress.summary).toMatchObject({
+      created: 0,
+      alreadyHad: 0,
+      failed: 1,
+      availableGroups: 2,
+      coveredGroups: 1,
+      createdKeys: 0,
+    })
+    expect(progress.results).toEqual([
+      expect.objectContaining({
+        accountId: "new-api-1",
+        outcome: "failed",
+        availableGroups: ["default", "vip"],
+        coveredGroups: ["default"],
+        missingGroups: ["vip"],
       }),
     ])
   })
@@ -443,7 +516,7 @@ describe("accountKeyRepair", () => {
         tokenId: 9,
         tokenName: "old one",
         group: "old",
-        reason: "groupUnavailable" as const,
+        reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
       },
       {
         accountId: "new-api-1",
@@ -453,7 +526,7 @@ describe("accountKeyRepair", () => {
         tokenId: 10,
         tokenName: "old two",
         group: "old-2",
-        reason: "groupUnavailable" as const,
+        reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
       },
     ]
 
@@ -542,7 +615,7 @@ describe("accountKeyRepair", () => {
         tokenId: 9,
         tokenName: "old one",
         group: "old",
-        reason: "groupUnavailable" as const,
+        reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
       },
       {
         accountId: "new-api-1",
@@ -552,7 +625,7 @@ describe("accountKeyRepair", () => {
         tokenId: 10,
         tokenName: "old two",
         group: "old-2",
-        reason: "groupUnavailable" as const,
+        reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
       },
     ]
 
@@ -654,6 +727,145 @@ describe("accountKeyRepair", () => {
       results: [
         expect.objectContaining({
           invalidTokens: [invalidTokens[1]],
+        }),
+      ],
+    })
+  })
+
+  it("decrements invalid key summary by tokens removed from stored results", async () => {
+    const account = buildSiteAccount({
+      id: "new-api-1",
+      site_type: "new-api",
+      site_url: "https://relay.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "101",
+        access_token: "access-token",
+        username: "valid",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const displayAccount = buildDisplaySiteData({
+      id: account.id,
+      name: "Relay Account",
+      baseUrl: account.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "101",
+      token: "access-token",
+    })
+    const storedInvalidTokens = [
+      {
+        accountId: "new-api-1",
+        accountName: "Relay Account",
+        siteType: SITE_TYPES.NEW_API,
+        siteUrlOrigin: "https://relay.example.com",
+        tokenId: 9,
+        tokenName: "old one",
+        group: "old",
+        reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+      },
+      {
+        accountId: "new-api-1",
+        accountName: "Relay Account",
+        siteType: SITE_TYPES.NEW_API,
+        siteUrlOrigin: "https://relay.example.com",
+        tokenId: 10,
+        tokenName: "old two",
+        group: "old-2",
+        reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+      },
+    ]
+    const staleInvalidToken = {
+      accountId: "new-api-1",
+      accountName: "Relay Account",
+      siteType: SITE_TYPES.NEW_API,
+      siteUrlOrigin: "https://relay.example.com",
+      tokenId: 99,
+      tokenName: "already removed",
+      group: "legacy",
+      reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+    }
+
+    mocks.storageMap.set("accountKeyRepair_progress", {
+      jobId: "job-stored",
+      state: "completed",
+      startedAt: 100,
+      updatedAt: 200,
+      finishedAt: 300,
+      totals: {
+        enabledAccounts: 1,
+        eligibleAccounts: 1,
+        processedAccounts: 1,
+        processedEligibleAccounts: 1,
+      },
+      summary: {
+        created: 1,
+        alreadyHad: 0,
+        skipped: 0,
+        failed: 0,
+        availableGroups: 2,
+        coveredGroups: 2,
+        createdKeys: 1,
+        invalidKeys: 2,
+        deletedKeys: 0,
+        deleteFailed: 0,
+      },
+      results: [
+        {
+          accountId: "new-api-1",
+          accountName: "Relay Account",
+          siteType: SITE_TYPES.NEW_API,
+          siteUrlOrigin: "https://relay.example.com",
+          outcome: "created",
+          availableGroups: ["default", "vip"],
+          coveredGroups: ["default", "vip"],
+          createdGroups: ["vip"],
+          invalidTokens: storedInvalidTokens,
+          finishedAt: 300,
+        },
+      ],
+    })
+    mocks.getAllAccounts.mockResolvedValue([account])
+    mocks.convertToDisplayData.mockReturnValue([displayAccount])
+    mocks.deleteInvalidAccountToken
+      .mockResolvedValueOnce({ ...storedInvalidTokens[0], deletedAt: 123 })
+      .mockResolvedValueOnce({ ...staleInvalidToken, deletedAt: 124 })
+
+    const { deleteInvalidAccountTokens } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await expect(
+      deleteInvalidAccountTokens({
+        tokens: [storedInvalidTokens[0], staleInvalidToken],
+      }),
+    ).resolves.toEqual({
+      success: true,
+      data: {
+        deleted: [
+          { ...storedInvalidTokens[0], deletedAt: 123 },
+          { ...staleInvalidToken, deletedAt: 124 },
+        ],
+        failed: [],
+      },
+    })
+
+    expect(mocks.storageMap.get("accountKeyRepair_progress")).toMatchObject({
+      summary: {
+        invalidKeys: 1,
+        deletedKeys: 2,
+        deleteFailed: 0,
+      },
+      results: [
+        expect.objectContaining({
+          invalidTokens: [storedInvalidTokens[1]],
         }),
       ],
     })

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -871,6 +871,42 @@ describe("accountKeyRepair", () => {
     })
   })
 
+  it("records invalid token delete failures when the account is missing", async () => {
+    const invalidToken = {
+      accountId: "missing-account",
+      accountName: "Missing Account",
+      siteType: SITE_TYPES.NEW_API,
+      siteUrlOrigin: "https://missing.example.com",
+      tokenId: 9,
+      tokenName: "old one",
+      group: "old",
+      reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+    }
+
+    mocks.getAllAccounts.mockResolvedValue([])
+    mocks.convertToDisplayData.mockReturnValue([])
+
+    const { deleteInvalidAccountTokens } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await expect(
+      deleteInvalidAccountTokens({ tokens: [invalidToken] }),
+    ).resolves.toEqual({
+      success: true,
+      data: {
+        deleted: [],
+        failed: [
+          {
+            ...invalidToken,
+            errorMessage: "account_not_found",
+          },
+        ],
+      },
+    })
+    expect(mocks.deleteInvalidAccountToken).not.toHaveBeenCalled()
+  })
+
   it("skips none-auth accounts, ignores disabled accounts, and falls back to per-account display conversion", async () => {
     const noneAuthAccount = buildSiteAccount({
       id: "none-auth-1",

--- a/tests/services/runtimeTypedMessagingSetup.test.ts
+++ b/tests/services/runtimeTypedMessagingSetup.test.ts
@@ -320,6 +320,8 @@ describe("typed runtime messaging setup", () => {
   it("registers account key repair typed listeners once and wraps handler errors", async () => {
     const onAccountKeyRepairMessage: OnMessageMock = vi.fn(() => vi.fn())
     const storageGet = vi.fn().mockRejectedValue(new Error("repair failed"))
+    const getAllAccounts = vi.fn().mockResolvedValue([])
+    const convertToDisplayData = vi.fn().mockReturnValue([])
 
     vi.doMock(
       "~/services/accounts/accountKeyAutoProvisioning/messaging",
@@ -327,10 +329,17 @@ describe("typed runtime messaging setup", () => {
         AccountKeyRepairMessageTypes: {
           Start: "accountKeyRepair:start",
           GetProgress: "accountKeyRepair:getProgress",
+          DeleteInvalidTokens: "accountKeyRepair:deleteInvalidTokens",
         },
         onAccountKeyRepairMessage,
       }),
     )
+    vi.doMock("~/services/accounts/accountStorage", () => ({
+      accountStorage: {
+        getAllAccounts,
+        convertToDisplayData,
+      },
+    }))
     vi.doMock("@plasmohq/storage", () => ({
       Storage: class {
         get = storageGet
@@ -345,7 +354,7 @@ describe("typed runtime messaging setup", () => {
     repair.setupAccountKeyRepairMessagingListeners()
     repair.setupAccountKeyRepairMessagingListeners()
 
-    expect(onAccountKeyRepairMessage).toHaveBeenCalledTimes(2)
+    expect(onAccountKeyRepairMessage).toHaveBeenCalledTimes(3)
     const getProgressHandler = onAccountKeyRepairMessage.mock.calls.find(
       ([type]) => type === "accountKeyRepair:getProgress",
     )?.[1]
@@ -354,6 +363,17 @@ describe("typed runtime messaging setup", () => {
       success: false,
       error: "repair failed",
     })
+
+    const deleteHandler = getRegisteredHandler(
+      onAccountKeyRepairMessage,
+      "accountKeyRepair:deleteInvalidTokens",
+    )
+    await expect(deleteHandler({ data: { tokens: [] } })).resolves.toEqual({
+      success: false,
+      error: "repair failed",
+    })
+    expect(getAllAccounts).toHaveBeenCalledTimes(1)
+    expect(convertToDisplayData).toHaveBeenCalledWith([], [])
   })
 
   it("routes WebDAV auto-sync typed listeners through runtime resolvers", async () => {


### PR DESCRIPTION
## Summary
- Adds a manual Key Management audit that creates missing per-group API keys where supported.
- Surfaces invalid group-bound keys with filtering, confirmation, deletion, and failure feedback.
- Updates localized Key Management copy, typed runtime messaging, analytics metadata, and focused coverage.

## Root Cause
Issue #951 needs key repair to account for group-specific token coverage instead of only checking whether an account has any key.

## Test Plan
- pnpm run validate:push

Closes #951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Key Coverage Audit: manual audit to backfill missing per-group keys, view account coverage vs invalid keys, search/select invalid keys, and confirm serial bulk deletion with progress and partial-result handling.

* **Documentation**
  * Added plan and design spec for the Key Coverage Audit workflow.

* **Localization**
  * Updated copy for this flow in en/ja/vi/zh-CN/zh-TW.

* **Style**
  * Minor responsive button-group styling tweak.

* **Tests**
  * Expanded unit and UI tests covering audit, multi-view behavior, deletion flows, and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->