### PR TITLE
feat(key-management): batch import keys to CLIProxyAPI

### DIFF
--- a/src/features/KeyManagement/components/BatchCliProxyExportDialog.tsx
+++ b/src/features/KeyManagement/components/BatchCliProxyExportDialog.tsx
@@ -1,0 +1,474 @@
+import { Loader2 } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { CliProxyIcon } from "~/components/icons/CliProxyIcon"
+import {
+  Badge,
+  Button,
+  FormField,
+  Input,
+  Modal,
+  ModelListInput,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui"
+import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  buildDefaultCliProxyProviderBaseUrl,
+  CLI_PROXY_PROVIDER_TYPES,
+  getCliProxyProviderTypeDescription,
+  getCliProxyProviderTypeLabel,
+  normalizeCliProxyProviderBaseUrl,
+  type CliProxyModelMapping,
+  type CliProxyProviderType,
+} from "~/services/integrations/cliProxyProviderTypes"
+import { importToCliProxy } from "~/services/integrations/cliProxyService"
+import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_RESULTS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+} from "~/services/productAnalytics/events"
+import type { AccountToken, DisplaySiteData } from "~/types"
+import { getErrorMessage } from "~/utils/core/error"
+import { showResultToast } from "~/utils/core/toastHelpers"
+
+import { buildTokenIdentityKey } from "../utils"
+
+interface BatchCliProxyExportDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  items: Array<{
+    account: DisplaySiteData
+    token: AccountToken
+  }>
+}
+
+type ExecutionStatus = "pending" | "running" | "success" | "failed"
+
+interface ExecutionState {
+  status: ExecutionStatus
+  message?: string
+}
+
+/**
+ * Builds a CLIProxyAPI provider name from account metadata.
+ */
+function buildProviderName(account: DisplaySiteData) {
+  return account.name || account.baseUrl
+}
+
+/**
+ * Normalizes edited model mappings before they are shared across the batch.
+ */
+function normalizeModels(
+  models: React.ComponentProps<typeof ModelListInput>["value"],
+): CliProxyModelMapping[] {
+  return models
+    .map((item) => {
+      const name = item.name.trim()
+      const alias = item.alias.trim()
+      return {
+        name,
+        alias: alias || undefined,
+      }
+    })
+    .filter((item) => item.name.length > 0)
+}
+
+/**
+ * Maps batch execution states to existing badge styles.
+ */
+function getResultBadgeVariant(status: ExecutionStatus) {
+  switch (status) {
+    case "success":
+      return "success" as const
+    case "failed":
+      return "danger" as const
+    case "running":
+      return "info" as const
+    case "pending":
+    default:
+      return "secondary" as const
+  }
+}
+
+/**
+ * Resolves static translation keys for batch execution states.
+ */
+function getResultStatusText(
+  t: ReturnType<typeof useTranslation>["t"],
+  status: ExecutionStatus,
+) {
+  switch (status) {
+    case "success":
+      return t("keyManagement:batchCliProxyExport.results.success")
+    case "failed":
+      return t("keyManagement:batchCliProxyExport.results.failed")
+    case "running":
+      return t("keyManagement:batchCliProxyExport.results.running")
+    case "pending":
+    default:
+      return t("keyManagement:batchCliProxyExport.results.pending")
+  }
+}
+
+/**
+ * Imports selected Key Management tokens into CLIProxyAPI with shared settings.
+ */
+export function BatchCliProxyExportDialog({
+  isOpen,
+  onClose,
+  items,
+}: BatchCliProxyExportDialogProps) {
+  const { t } = useTranslation(["keyManagement", "ui", "common", "messages"])
+  const [providerType, setProviderType] = useState<CliProxyProviderType>(
+    CLI_PROXY_PROVIDER_TYPES.OPENAI_COMPATIBILITY,
+  )
+  const [proxyUrl, setProxyUrl] = useState("")
+  const [models, setModels] = useState<
+    React.ComponentProps<typeof ModelListInput>["value"]
+  >([])
+  const [hasEditedModels, setHasEditedModels] = useState(false)
+  const [isRunning, setIsRunning] = useState(false)
+  const [executionStateById, setExecutionStateById] = useState<
+    Record<string, ExecutionState>
+  >({})
+  const providerTypeDescription = `${t("ui:dialog.cliproxy.descriptions.providerType")} ${getCliProxyProviderTypeDescription(t, providerType)}`
+
+  useEffect(() => {
+    if (!isOpen) {
+      setProviderType(CLI_PROXY_PROVIDER_TYPES.OPENAI_COMPATIBILITY)
+      setProxyUrl("")
+      setModels([])
+      setHasEditedModels(false)
+      setIsRunning(false)
+      setExecutionStateById({})
+      return
+    }
+
+    setExecutionStateById({})
+  }, [isOpen])
+
+  const previewItems = useMemo(
+    () =>
+      items.map((item) => {
+        const id = buildTokenIdentityKey(item.token.accountId, item.token.id)
+        return {
+          ...item,
+          id,
+          providerName: buildProviderName(item.account),
+          providerBaseUrl: buildDefaultCliProxyProviderBaseUrl(
+            providerType,
+            item.account,
+          ),
+        }
+      }),
+    [items, providerType],
+  )
+
+  const statusCounts = useMemo(() => {
+    return previewItems.reduce(
+      (counts, item) => {
+        const status = executionStateById[item.id]?.status ?? "pending"
+        counts[status] += 1
+        return counts
+      },
+      {
+        pending: 0,
+        running: 0,
+        success: 0,
+        failed: 0,
+      } satisfies Record<ExecutionStatus, number>,
+    )
+  }, [executionStateById, previewItems])
+
+  const handleProviderTypeChange = (nextProviderType: string) => {
+    setProviderType(nextProviderType as CliProxyProviderType)
+  }
+
+  const handleStart = async () => {
+    if (isRunning || previewItems.length === 0) return
+
+    const tracker = startProductAnalyticsAction({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ImportExport,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.ExportAccountTokensToCliProxy,
+      surfaceId:
+        PRODUCT_ANALYTICS_SURFACE_IDS.AccountTokenThirdPartyExportDialog,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    })
+    const normalizedModels = hasEditedModels
+      ? normalizeModels(models)
+      : undefined
+    let successCount = 0
+    let failureCount = 0
+
+    setIsRunning(true)
+    setExecutionStateById(
+      Object.fromEntries(
+        previewItems.map((item) => [
+          item.id,
+          { status: "pending" satisfies ExecutionStatus },
+        ]),
+      ),
+    )
+
+    for (const item of previewItems) {
+      setExecutionStateById((current) => ({
+        ...current,
+        [item.id]: { status: "running" },
+      }))
+
+      try {
+        const resolvedToken = await resolveDisplayAccountTokenForSecret(
+          item.account,
+          item.token,
+        )
+        const result = await importToCliProxy({
+          account: item.account,
+          token: resolvedToken,
+          providerType,
+          providerName: item.providerName,
+          providerBaseUrl:
+            normalizeCliProxyProviderBaseUrl(
+              providerType,
+              item.providerBaseUrl,
+            ) || undefined,
+          proxyUrl: proxyUrl.trim(),
+          models: normalizedModels,
+        })
+
+        showResultToast(result)
+
+        if (result.success) {
+          successCount += 1
+          setExecutionStateById((current) => ({
+            ...current,
+            [item.id]: { status: "success", message: result.message },
+          }))
+        } else {
+          failureCount += 1
+          setExecutionStateById((current) => ({
+            ...current,
+            [item.id]: { status: "failed", message: result.message },
+          }))
+        }
+      } catch (error) {
+        const message = getErrorMessage(error)
+        failureCount += 1
+        setExecutionStateById((current) => ({
+          ...current,
+          [item.id]: { status: "failed", message },
+        }))
+        showResultToast({
+          success: false,
+          message: t("messages:errors.operation.failed", {
+            error: message,
+          }),
+        })
+      }
+    }
+
+    const result =
+      failureCount === 0
+        ? PRODUCT_ANALYTICS_RESULTS.Success
+        : PRODUCT_ANALYTICS_RESULTS.Failure
+
+    tracker.complete(result, {
+      insights: {
+        itemCount: previewItems.length,
+        successCount,
+        failureCount,
+      },
+    })
+    setIsRunning(false)
+  }
+
+  const footer = (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="text-muted-foreground text-sm" aria-live="polite">
+        {t("keyManagement:batchCliProxyExport.summary", {
+          total: previewItems.length,
+          success: statusCounts.success,
+          failed: statusCounts.failed,
+        })}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onClose}
+          disabled={isRunning}
+        >
+          {t("common:actions.cancel")}
+        </Button>
+        <Button
+          type="button"
+          disabled={isRunning || previewItems.length === 0}
+          leftIcon={
+            isRunning ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
+          }
+          onClick={() => void handleStart()}
+        >
+          {isRunning
+            ? t("keyManagement:batchCliProxyExport.actions.running")
+            : t("keyManagement:batchCliProxyExport.actions.start")}
+        </Button>
+      </div>
+    </div>
+  )
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      closeOnBackdropClick={!isRunning}
+      closeOnEsc={!isRunning}
+      showCloseButton={!isRunning}
+      size="lg"
+      header={
+        <div className="flex items-center gap-2">
+          <CliProxyIcon size="lg" />
+          <div>
+            <div className="text-base font-semibold">
+              {t("keyManagement:batchCliProxyExport.title")}
+            </div>
+            <p className="text-muted-foreground text-sm">
+              {t("keyManagement:batchCliProxyExport.description", {
+                selectedCount: previewItems.length,
+              })}
+            </p>
+          </div>
+        </div>
+      }
+      footer={footer}
+    >
+      <div className="space-y-4">
+        <div className="grid gap-3 rounded-md border p-3 md:grid-cols-2">
+          <FormField
+            label={t("ui:dialog.cliproxy.fields.providerType")}
+            description={providerTypeDescription}
+          >
+            <Select
+              value={providerType}
+              onValueChange={handleProviderTypeChange}
+              disabled={isRunning}
+            >
+              <SelectTrigger
+                aria-label={t("ui:dialog.cliproxy.fields.providerType")}
+              >
+                <SelectValue
+                  placeholder={t(
+                    "ui:dialog.cliproxy.placeholders.providerType",
+                  )}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.values(CLI_PROXY_PROVIDER_TYPES).map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {getCliProxyProviderTypeLabel(t, value)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormField>
+
+          <FormField
+            label={t("ui:dialog.cliproxy.fields.proxyUrl")}
+            description={t("ui:dialog.cliproxy.descriptions.proxyUrl")}
+          >
+            <Input
+              aria-label={t("ui:dialog.cliproxy.fields.proxyUrl")}
+              value={proxyUrl}
+              disabled={isRunning}
+              onChange={(event) => setProxyUrl(event.target.value)}
+              placeholder={t("ui:dialog.cliproxy.placeholders.proxyUrl")}
+            />
+          </FormField>
+
+          <div className="md:col-span-2">
+            <FormField
+              label={t("ui:dialog.cliproxy.fields.models")}
+              description={t("ui:dialog.cliproxy.descriptions.modelsManual")}
+            >
+              <ModelListInput
+                value={models}
+                onChange={(nextModels) => {
+                  setHasEditedModels(true)
+                  setModels(nextModels)
+                }}
+                showHeader={false}
+                strings={{
+                  addLabel: t("ui:dialog.cliproxy.actions.addModel"),
+                  removeLabel: t("ui:dialog.cliproxy.actions.removeModel"),
+                  dragHandleLabel: t("ui:dialog.cliproxy.actions.reorderModel"),
+                  namePlaceholder: t(
+                    "ui:dialog.cliproxy.placeholders.modelName",
+                  ),
+                  aliasPlaceholder: t(
+                    "ui:dialog.cliproxy.placeholders.modelAlias",
+                  ),
+                }}
+              />
+            </FormField>
+          </div>
+        </div>
+
+        <div className="max-h-[45vh] space-y-2 overflow-y-auto rounded-md border p-3">
+          {previewItems.map((item) => {
+            const state = executionStateById[item.id] ?? { status: "pending" }
+            return (
+              <div key={item.id} className="space-y-1 rounded-md border p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">
+                      {item.token.name}
+                    </div>
+                    <div className="text-muted-foreground truncate text-xs">
+                      {item.account.name}
+                    </div>
+                  </div>
+                  <Badge
+                    variant={getResultBadgeVariant(state.status)}
+                    size="sm"
+                  >
+                    {getResultStatusText(t, state.status)}
+                  </Badge>
+                </div>
+                <div className="grid gap-1 text-xs md:grid-cols-2">
+                  <div className="min-w-0">
+                    <span className="text-muted-foreground">
+                      {t("ui:dialog.cliproxy.fields.name")}
+                    </span>
+                    <span className="ml-2 break-words">
+                      {item.providerName}
+                    </span>
+                  </div>
+                  <div className="min-w-0">
+                    <span className="text-muted-foreground">
+                      {t("ui:dialog.cliproxy.fields.baseUrl")}
+                    </span>
+                    <span className="ml-2 break-all">
+                      {item.providerBaseUrl || "-"}
+                    </span>
+                  </div>
+                </div>
+                {state.message ? (
+                  <div className="text-muted-foreground text-xs break-words">
+                    {state.message}
+                  </div>
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/features/KeyManagement/components/BatchCliProxyExportDialog.tsx
+++ b/src/features/KeyManagement/components/BatchCliProxyExportDialog.tsx
@@ -50,7 +50,15 @@ interface BatchCliProxyExportDialogProps {
   }>
 }
 
-type ExecutionStatus = "pending" | "running" | "success" | "failed"
+const EXECUTION_STATUSES = {
+  Pending: "pending",
+  Running: "running",
+  Success: "success",
+  Failed: "failed",
+} as const
+
+type ExecutionStatus =
+  (typeof EXECUTION_STATUSES)[keyof typeof EXECUTION_STATUSES]
 
 interface ExecutionState {
   status: ExecutionStatus
@@ -87,13 +95,13 @@ function normalizeModels(
  */
 function getResultBadgeVariant(status: ExecutionStatus) {
   switch (status) {
-    case "success":
+    case EXECUTION_STATUSES.Success:
       return "success" as const
-    case "failed":
+    case EXECUTION_STATUSES.Failed:
       return "danger" as const
-    case "running":
+    case EXECUTION_STATUSES.Running:
       return "info" as const
-    case "pending":
+    case EXECUTION_STATUSES.Pending:
     default:
       return "secondary" as const
   }
@@ -107,13 +115,13 @@ function getResultStatusText(
   status: ExecutionStatus,
 ) {
   switch (status) {
-    case "success":
+    case EXECUTION_STATUSES.Success:
       return t("keyManagement:batchCliProxyExport.results.success")
-    case "failed":
+    case EXECUTION_STATUSES.Failed:
       return t("keyManagement:batchCliProxyExport.results.failed")
-    case "running":
+    case EXECUTION_STATUSES.Running:
       return t("keyManagement:batchCliProxyExport.results.running")
-    case "pending":
+    case EXECUTION_STATUSES.Pending:
     default:
       return t("keyManagement:batchCliProxyExport.results.pending")
   }
@@ -176,7 +184,8 @@ export function BatchCliProxyExportDialog({
   const statusCounts = useMemo(() => {
     return previewItems.reduce(
       (counts, item) => {
-        const status = executionStateById[item.id]?.status ?? "pending"
+        const status =
+          executionStateById[item.id]?.status ?? EXECUTION_STATUSES.Pending
         counts[status] += 1
         return counts
       },
@@ -214,7 +223,7 @@ export function BatchCliProxyExportDialog({
       Object.fromEntries(
         previewItems.map((item) => [
           item.id,
-          { status: "pending" satisfies ExecutionStatus },
+          { status: EXECUTION_STATUSES.Pending },
         ]),
       ),
     )
@@ -222,7 +231,7 @@ export function BatchCliProxyExportDialog({
     for (const item of previewItems) {
       setExecutionStateById((current) => ({
         ...current,
-        [item.id]: { status: "running" },
+        [item.id]: { status: EXECUTION_STATUSES.Running },
       }))
 
       try {
@@ -250,13 +259,19 @@ export function BatchCliProxyExportDialog({
           successCount += 1
           setExecutionStateById((current) => ({
             ...current,
-            [item.id]: { status: "success", message: result.message },
+            [item.id]: {
+              status: EXECUTION_STATUSES.Success,
+              message: result.message,
+            },
           }))
         } else {
           failureCount += 1
           setExecutionStateById((current) => ({
             ...current,
-            [item.id]: { status: "failed", message: result.message },
+            [item.id]: {
+              status: EXECUTION_STATUSES.Failed,
+              message: result.message,
+            },
           }))
         }
       } catch (error) {
@@ -264,7 +279,7 @@ export function BatchCliProxyExportDialog({
         failureCount += 1
         setExecutionStateById((current) => ({
           ...current,
-          [item.id]: { status: "failed", message },
+          [item.id]: { status: EXECUTION_STATUSES.Failed, message },
         }))
         showResultToast({
           success: false,
@@ -422,7 +437,9 @@ export function BatchCliProxyExportDialog({
 
         <div className="max-h-[45vh] space-y-2 overflow-y-auto rounded-md border p-3">
           {previewItems.map((item) => {
-            const state = executionStateById[item.id] ?? { status: "pending" }
+            const state = executionStateById[item.id] ?? {
+              status: EXECUTION_STATUSES.Pending,
+            }
             return (
               <div key={item.id} className="space-y-1 rounded-md border p-3">
                 <div className="flex items-start justify-between gap-3">

--- a/src/features/KeyManagement/components/TokenList.tsx
+++ b/src/features/KeyManagement/components/TokenList.tsx
@@ -7,7 +7,7 @@ import {
   KeyIcon,
   PlusIcon,
 } from "@heroicons/react/24/outline"
-import { SendToBack } from "lucide-react"
+import { Network, SendToBack } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -28,6 +28,7 @@ import { createTab } from "~/utils/browser/browserApi"
 
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "../constants"
 import { buildTokenIdentityKey } from "../utils"
+import { BatchCliProxyExportDialog } from "./BatchCliProxyExportDialog"
 import { ManagedSiteTokenBatchExportDialog } from "./ManagedSiteTokenBatchExportDialog"
 import { TokenListItem } from "./TokenListItem"
 
@@ -282,6 +283,10 @@ export function TokenList(props: TokenListProps) {
   const [batchExportItems, setBatchExportItems] = useState<
     ManagedSiteTokenBatchExportItemInput[]
   >([])
+  const [batchCliProxyExportOpen, setBatchCliProxyExportOpen] = useState(false)
+  const [batchCliProxyExportItems, setBatchCliProxyExportItems] = useState<
+    ManagedSiteTokenBatchExportItemInput[]
+  >([])
   const [selectedTokenIds, setSelectedTokenIds] = useState<Set<string>>(
     () => new Set(),
   )
@@ -515,6 +520,16 @@ export function TokenList(props: TokenListProps) {
     setBatchExportItems([])
   }
 
+  const openBatchCliProxyExportDialog = () => {
+    setBatchCliProxyExportItems(selectedBatchItems)
+    setBatchCliProxyExportOpen(true)
+  }
+
+  const closeBatchCliProxyExportDialog = () => {
+    setBatchCliProxyExportOpen(false)
+    setBatchCliProxyExportItems([])
+  }
+
   const handleBatchExportCompleted = (
     result: ManagedSiteTokenBatchExportExecutionResult,
   ) => {
@@ -588,6 +603,18 @@ export function TokenList(props: TokenListProps) {
             onClick={clearSelection}
           >
             {t("batchManagedSiteExport.actions.clearSelection")}
+          </Button>
+          <Button
+            size="sm"
+            type="button"
+            disabled={selectedBatchItems.length === 0}
+            variant="outline"
+            onClick={openBatchCliProxyExportDialog}
+            leftIcon={<Network className="h-4 w-4" />}
+          >
+            {t("batchCliProxyExport.actions.open", {
+              selectedCount: selectedBatchItems.length,
+            })}
           </Button>
           <Button
             size="sm"
@@ -821,6 +848,12 @@ export function TokenList(props: TokenListProps) {
           token={ccSwitchContext.token}
         />
       )}
+
+      <BatchCliProxyExportDialog
+        isOpen={batchCliProxyExportOpen}
+        onClose={closeBatchCliProxyExportDialog}
+        items={batchCliProxyExportItems}
+      />
 
       <ManagedSiteTokenBatchExportDialog
         isOpen={batchExportOpen}

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -30,6 +30,22 @@
   "allAccountsLoading_one": "{{count}} loading",
   "allAccountsLoading_other": "{{count}} loading",
   "allAccountsProgress": "{{loaded}}/{{total}} accounts loaded",
+  "batchCliProxyExport": {
+    "actions": {
+      "open": "Batch import to CLIProxyAPI ({{selectedCount}})",
+      "running": "Importing...",
+      "start": "Start import"
+    },
+    "description": "Import {{selectedCount}} selected keys to CLIProxyAPI with one provider policy.",
+    "results": {
+      "failed": "Failed",
+      "pending": "Pending",
+      "running": "Importing",
+      "success": "Success"
+    },
+    "summary": "{{total}} total, {{success}} succeeded, {{failed}} failed.",
+    "title": "Batch import to CLIProxyAPI"
+  },
   "batchManagedSiteExport": {
     "actions": {
       "clearSelection": "Clear selection",

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -27,6 +27,22 @@
   "allAccountsFailed_other": "{{count}} 件失敗",
   "allAccountsLoading_other": "{{count}} 件読み込み中",
   "allAccountsProgress": "{{loaded}}/{{total}} アカウントを読み込み済み",
+  "batchCliProxyExport": {
+    "actions": {
+      "open": "CLIProxyAPI に一括インポート（{{selectedCount}}）",
+      "running": "インポート中...",
+      "start": "インポート開始"
+    },
+    "description": "{{selectedCount}} 件の選択済みキーを、同じ Provider ルールで CLIProxyAPI にインポートします。",
+    "results": {
+      "failed": "失敗",
+      "pending": "待機中",
+      "running": "インポート中",
+      "success": "成功"
+    },
+    "summary": "合計 {{total}} 件、成功 {{success}} 件、失敗 {{failed}} 件。",
+    "title": "CLIProxyAPI に一括インポート"
+  },
   "batchManagedSiteExport": {
     "actions": {
       "clearSelection": "選択をクリア",

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -27,6 +27,22 @@
   "allAccountsFailed_other": "{{count}} thất bại",
   "allAccountsLoading_other": "{{count}} đang tải",
   "allAccountsProgress": "Đã tải {{loaded}}/{{total}} tài khoản",
+  "batchCliProxyExport": {
+    "actions": {
+      "open": "Nhập hàng loạt vào CLIProxyAPI ({{selectedCount}})",
+      "running": "Đang nhập...",
+      "start": "Bắt đầu nhập"
+    },
+    "description": "Nhập {{selectedCount}} khóa đã chọn vào CLIProxyAPI với cùng một quy tắc Provider.",
+    "results": {
+      "failed": "Thất bại",
+      "pending": "Chờ nhập",
+      "running": "Đang nhập",
+      "success": "Thành công"
+    },
+    "summary": "Tổng {{total}}, thành công {{success}}, thất bại {{failed}}.",
+    "title": "Nhập hàng loạt vào CLIProxyAPI"
+  },
   "batchManagedSiteExport": {
     "actions": {
       "clearSelection": "Xóa lựa chọn",

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -27,6 +27,22 @@
   "allAccountsFailed": "{{count}} 个失败",
   "allAccountsLoading": "{{count}} 个加载中",
   "allAccountsProgress": "已加载 {{loaded}}/{{total}} 个账号",
+  "batchCliProxyExport": {
+    "actions": {
+      "open": "批量导入到 CLIProxyAPI（{{selectedCount}}）",
+      "running": "正在导入...",
+      "start": "开始导入"
+    },
+    "description": "将 {{selectedCount}} 个已选择密钥按统一 Provider 规则导入到 CLIProxyAPI。",
+    "results": {
+      "failed": "失败",
+      "pending": "待导入",
+      "running": "导入中",
+      "success": "成功"
+    },
+    "summary": "共 {{total}} 个，成功 {{success}} 个，失败 {{failed}} 个。",
+    "title": "批量导入到 CLIProxyAPI"
+  },
   "batchManagedSiteExport": {
     "actions": {
       "clearSelection": "清空选择",

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -27,6 +27,22 @@
   "allAccountsFailed_other": "{{count}} 個失敗",
   "allAccountsLoading_other": "{{count}} 個載入中",
   "allAccountsProgress": "已載入 {{loaded}}/{{total}} 個帳號",
+  "batchCliProxyExport": {
+    "actions": {
+      "open": "批次匯入到 CLIProxyAPI（{{selectedCount}}）",
+      "running": "正在匯入...",
+      "start": "開始匯入"
+    },
+    "description": "將 {{selectedCount}} 個已選金鑰依同一 Provider 規則匯入到 CLIProxyAPI。",
+    "results": {
+      "failed": "失敗",
+      "pending": "待匯入",
+      "running": "匯入中",
+      "success": "成功"
+    },
+    "summary": "共 {{total}} 個，成功 {{success}} 個，失敗 {{failed}} 個。",
+    "title": "批次匯入到 CLIProxyAPI"
+  },
   "batchManagedSiteExport": {
     "actions": {
       "clearSelection": "清除選取",

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -375,6 +375,7 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
   ExportAccountTokenToClaudeCodeRouter:
     "export_account_token_to_claude_code_router",
   ExportAccountTokenToCliProxy: "export_account_token_to_cli_proxy",
+  ExportAccountTokensToCliProxy: "export_account_tokens_to_cli_proxy",
   ExportKiloCodeAccountSettingsFile: "export_kilo_code_account_settings_file",
   CancelRedemptionAccountSelection: "cancel_redemption_account_selection",
   CancelRedemptionPrompt: "cancel_redemption_prompt",

--- a/tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx
@@ -484,6 +484,14 @@ describe("TokenList batch export selection", () => {
     expect(
       screen.getByTestId("batch-cli-proxy-export-item-count"),
     ).toHaveTextContent("2")
+
+    await user.click(
+      screen.getByRole("button", { name: "Close batch CLIProxy import" }),
+    )
+
+    expect(
+      screen.queryByTestId("batch-cli-proxy-export-dialog"),
+    ).not.toBeInTheDocument()
   })
 
   it("skips rendering flat-list tokens whose account metadata is missing", async () => {

--- a/tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx
@@ -62,6 +62,31 @@ vi.mock("~/components/CCSwitchExportDialog", () => ({
 }))
 
 vi.mock(
+  "~/features/KeyManagement/components/BatchCliProxyExportDialog",
+  () => ({
+    BatchCliProxyExportDialog: ({
+      isOpen,
+      items,
+      onClose,
+    }: {
+      isOpen: boolean
+      items: Array<{ token: { accountId: string; id: number } }>
+      onClose: () => void
+    }) =>
+      isOpen ? (
+        <div data-testid="batch-cli-proxy-export-dialog">
+          <div data-testid="batch-cli-proxy-export-item-count">
+            {items.length}
+          </div>
+          <button type="button" onClick={onClose}>
+            Close batch CLIProxy import
+          </button>
+        </div>
+      ) : null,
+  }),
+)
+
+vi.mock(
   "~/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog",
   () => ({
     ManagedSiteTokenBatchExportDialog: ({
@@ -430,6 +455,35 @@ describe("TokenList batch export selection", () => {
     expect(screen.getByTestId("cc-switch-export-dialog")).toHaveTextContent(
       "CC Switch export for Account 1",
     )
+  })
+
+  it("opens the batch CLIProxyAPI dialog with the frozen selected tokens", async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderTokenList()
+
+    await user.click(await screen.findByRole("checkbox", { name: "Token 1" }))
+    await user.click(await screen.findByRole("checkbox", { name: "Token 2" }))
+    await user.click(
+      screen.getByRole("button", {
+        name: /keyManagement:batchCliProxyExport.actions.open/,
+      }),
+    )
+
+    expect(
+      screen.getByTestId("batch-cli-proxy-export-item-count"),
+    ).toHaveTextContent("2")
+
+    rerender(
+      <TokenList
+        {...(defaultProps as any)}
+        tokens={[token2] as any}
+        filteredTokens={[token2] as any}
+      />,
+    )
+
+    expect(
+      screen.getByTestId("batch-cli-proxy-export-item-count"),
+    ).toHaveTextContent("2")
   })
 
   it("skips rendering flat-list tokens whose account metadata is missing", async () => {

--- a/tests/features/KeyManagement/components/BatchCliProxyExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/BatchCliProxyExportDialog.test.tsx
@@ -209,4 +209,146 @@ describe("BatchCliProxyExportDialog", () => {
       },
     )
   })
+
+  it("normalizes edited model mappings and provider settings before import", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <BatchCliProxyExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        items={[{ account, token: token1 }]}
+      />,
+    )
+
+    await screen.findByRole("dialog")
+    await user.click(
+      screen.getByLabelText("ui:dialog.cliproxy.fields.providerType"),
+    )
+    await user.click(
+      await screen.findByText(
+        "ui:dialog.cliproxy.providerTypes.geminiApiKey.label",
+      ),
+    )
+    await user.type(
+      screen.getByLabelText("ui:dialog.cliproxy.fields.proxyUrl"),
+      "  http://localhost:4141  ",
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.cliproxy.actions.addModel",
+      }),
+    )
+    await user.type(
+      screen.getByPlaceholderText("ui:dialog.cliproxy.placeholders.modelName"),
+      "  gemini-2.5-pro  ",
+    )
+    await user.type(
+      screen.getByPlaceholderText("ui:dialog.cliproxy.placeholders.modelAlias"),
+      "  smart  ",
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchCliProxyExport.actions.start",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockImportToCliProxy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerType: CLI_PROXY_PROVIDER_TYPES.GEMINI_API_KEY,
+          providerBaseUrl: "https://one.example.invalid/api",
+          proxyUrl: "http://localhost:4141",
+          models: [{ name: "gemini-2.5-pro", alias: "smart" }],
+        }),
+      )
+    })
+  })
+
+  it("keeps nameless model mappings out of the batch import payload", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <BatchCliProxyExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        items={[{ account, token: token1 }]}
+      />,
+    )
+
+    await screen.findByRole("dialog")
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.cliproxy.actions.addModel",
+      }),
+    )
+    await user.type(
+      screen.getByPlaceholderText("ui:dialog.cliproxy.placeholders.modelAlias"),
+      "alias-only",
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchCliProxyExport.actions.start",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockImportToCliProxy).toHaveBeenCalledWith(
+        expect.objectContaining({ models: [] }),
+      )
+    })
+  })
+
+  it("reports token resolution failures without importing that token", async () => {
+    const user = userEvent.setup()
+    mockResolveDisplayAccountTokenForSecret
+      .mockRejectedValueOnce(new Error("token is hidden"))
+      .mockImplementationOnce(async (_account, token) => ({
+        ...token,
+        key: `resolved-${token.id}`,
+      }))
+
+    render(
+      <BatchCliProxyExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        items={[
+          { account, token: token1 },
+          { account, token: token2 },
+        ]}
+      />,
+    )
+
+    await screen.findByRole("dialog")
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchCliProxyExport.actions.start",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("token is hidden")).toBeInTheDocument()
+    })
+    expect(mockImportToCliProxy).toHaveBeenCalledTimes(1)
+    expect(mockImportToCliProxy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining({ id: token2.id, key: "resolved-2" }),
+      }),
+    )
+    expect(mockShowResultToast).toHaveBeenCalledWith({
+      success: false,
+      message: "messages:errors.operation.failed",
+    })
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      {
+        insights: {
+          itemCount: 2,
+          successCount: 1,
+          failureCount: 1,
+        },
+      },
+    )
+  })
 })

--- a/tests/features/KeyManagement/components/BatchCliProxyExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/BatchCliProxyExportDialog.test.tsx
@@ -1,0 +1,212 @@
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { BatchCliProxyExportDialog } from "~/features/KeyManagement/components/BatchCliProxyExportDialog"
+import { CLI_PROXY_PROVIDER_TYPES } from "~/services/integrations/cliProxyProviderTypes"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_RESULTS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+} from "~/services/productAnalytics/events"
+import { render, screen, waitFor } from "~~/tests/test-utils/render"
+import {
+  createAccount,
+  createToken,
+} from "~~/tests/utils/keyManagementFactories"
+
+const mockResolveDisplayAccountTokenForSecret = vi.fn()
+const mockImportToCliProxy = vi.fn()
+const mockShowResultToast = vi.fn()
+const { startProductAnalyticsActionMock, completeProductAnalyticsActionMock } =
+  vi.hoisted(() => ({
+    startProductAnalyticsActionMock: vi.fn(),
+    completeProductAnalyticsActionMock: vi.fn(),
+  }))
+
+vi.mock(
+  "~/services/accounts/utils/apiServiceRequest",
+  async (importOriginal) => {
+    const original =
+      await importOriginal<
+        typeof import("~/services/accounts/utils/apiServiceRequest")
+      >()
+    return {
+      ...original,
+      resolveDisplayAccountTokenForSecret: (...args: any[]) =>
+        mockResolveDisplayAccountTokenForSecret(...args),
+    }
+  },
+)
+
+vi.mock("~/services/integrations/cliProxyService", () => ({
+  importToCliProxy: (...args: any[]) => mockImportToCliProxy(...args),
+}))
+
+vi.mock("~/utils/core/toastHelpers", () => ({
+  showResultToast: (...args: any[]) => mockShowResultToast(...args),
+}))
+
+vi.mock("~/services/productAnalytics/actions", () => ({
+  startProductAnalyticsAction: startProductAnalyticsActionMock,
+}))
+
+describe("BatchCliProxyExportDialog", () => {
+  const account = createAccount({
+    id: "acc-1",
+    name: "Account 1",
+    baseUrl: "https://one.example.invalid/api",
+  })
+  const token1 = createToken({
+    id: 1,
+    accountId: account.id,
+    accountName: account.name,
+    name: "Token 1",
+    key: "masked-1",
+  })
+  const token2 = createToken({
+    id: 2,
+    accountId: account.id,
+    accountName: account.name,
+    name: "Token 2",
+    key: "masked-2",
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResolveDisplayAccountTokenForSecret.mockImplementation(
+      async (_account, token) => ({
+        ...token,
+        key: `resolved-${token.id}`,
+      }),
+    )
+    mockImportToCliProxy.mockResolvedValue({
+      success: true,
+      message: "ok",
+    })
+    startProductAnalyticsActionMock.mockReturnValue({
+      complete: completeProductAnalyticsActionMock,
+    })
+  })
+
+  it("imports each selected token to CLIProxyAPI with shared policy and per-token defaults", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <BatchCliProxyExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        items={[
+          { account, token: token1 },
+          { account, token: token2 },
+        ]}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:batchCliProxyExport.actions.start",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockImportToCliProxy).toHaveBeenCalledTimes(2)
+    })
+
+    expect(mockImportToCliProxy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        account,
+        token: expect.objectContaining({ key: "resolved-1" }),
+        providerType: CLI_PROXY_PROVIDER_TYPES.OPENAI_COMPATIBILITY,
+        providerName: "Account 1",
+        providerBaseUrl: "https://one.example.invalid/api/v1",
+        proxyUrl: "",
+        models: undefined,
+      }),
+    )
+    expect(mockImportToCliProxy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        token: expect.objectContaining({ key: "resolved-2" }),
+      }),
+    )
+    expect(screen.getByText("Token 1")).toBeInTheDocument()
+    expect(screen.getByText("Token 2")).toBeInTheDocument()
+    expect(
+      screen.getAllByText("keyManagement:batchCliProxyExport.results.success"),
+    ).toHaveLength(2)
+    expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ImportExport,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.ExportAccountTokensToCliProxy,
+      surfaceId:
+        PRODUCT_ANALYTICS_SURFACE_IDS.AccountTokenThirdPartyExportDialog,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    })
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Success,
+      {
+        insights: {
+          itemCount: 2,
+          successCount: 2,
+          failureCount: 0,
+        },
+      },
+    )
+
+    const analyticsCalls = JSON.stringify([
+      startProductAnalyticsActionMock.mock.calls,
+      completeProductAnalyticsActionMock.mock.calls,
+    ])
+    expect(analyticsCalls).not.toContain("resolved-1")
+    expect(analyticsCalls).not.toContain("resolved-2")
+    expect(analyticsCalls).not.toContain("https://one.example.invalid")
+    expect(analyticsCalls).not.toContain("Account 1")
+  })
+
+  it("continues after one token fails and reports a partial result", async () => {
+    const user = userEvent.setup()
+    mockImportToCliProxy
+      .mockResolvedValueOnce({ success: false, message: "rejected" })
+      .mockResolvedValueOnce({ success: true, message: "ok" })
+
+    render(
+      <BatchCliProxyExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        items={[
+          { account, token: token1 },
+          { account, token: token2 },
+        ]}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:batchCliProxyExport.actions.start",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockImportToCliProxy).toHaveBeenCalledTimes(2)
+    })
+
+    expect(
+      screen.getByText("keyManagement:batchCliProxyExport.results.failed"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("keyManagement:batchCliProxyExport.results.success"),
+    ).toBeInTheDocument()
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      {
+        insights: {
+          itemCount: 2,
+          successCount: 1,
+          failureCount: 1,
+        },
+      },
+    )
+  })
+})

--- a/tests/services/productAnalytics/events.test.ts
+++ b/tests/services/productAnalytics/events.test.ts
@@ -67,6 +67,7 @@ describe("product analytics event enums", () => {
       ExportAccountTokenToCherryStudio: "export_account_token_to_cherry_studio",
       ExportAccountTokenToCCSwitch: "export_account_token_to_cc_switch",
       ExportAccountTokenToCliProxy: "export_account_token_to_cli_proxy",
+      ExportAccountTokensToCliProxy: "export_account_tokens_to_cli_proxy",
       ExportAccountTokenToClaudeCodeRouter:
         "export_account_token_to_claude_code_router",
       CopyKiloCodeAccountExportConfig: "copy_kilo_code_account_export_config",


### PR DESCRIPTION
## Summary
- add a Key Management bulk action for importing selected keys into CLIProxyAPI
- reuse the existing CLIProxyAPI import service for each selected token with shared provider settings
- add per-item results, localized copy, privacy-safe analytics, and focused tests

Closes #954
#598 

## Validation
- pnpm exec vitest --run tests/features/KeyManagement/components/BatchCliProxyExportDialog.test.tsx tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx tests/components/CliProxyExportDialog.test.tsx tests/services/cliProxyService.test.ts tests/services/productAnalytics/events.test.ts
- pnpm compile
- pnpm run i18n:extract:ci
- pnpm run validate:push
- pnpm run validate:staged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch import dialog to export multiple tokens to CLIProxy with shared provider/model settings.
  * Per-token real-time statuses, preview list with badges, footer summary, and controls disabled while running.
  * Toolbar action to open the batch export flow.

* **Localization**
  * Added UI strings for the batch import flow in EN/JA/VI/ZH-CN/ZH-TW.

* **Tests**
  * New tests covering batch import scenarios and analytics assertions.

* **Chores**
  * Added analytics tracking for batch token exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->