### PR TITLE
feat(feedback): add language request entry points

### DIFF
--- a/.github/ISSUE_TEMPLATE/language_request.yml
+++ b/.github/ISSUE_TEMPLATE/language_request.yml
@@ -1,0 +1,41 @@
+name: Language Request / 语言请求
+description: Request a new language or help improve an existing translation / 请求新增语言或协助改进现有翻译
+title: "[Language]: "
+labels: ["enhancement", "i18n"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping All API Hub work better in more languages. Please tell us which language you need and whether you can help review translations.
+
+        感谢您帮助 All API Hub 支持更多语言。请告诉我们您需要哪种语言，以及是否愿意协助校对翻译。
+
+  - type: input
+    id: language
+    attributes:
+      label: Requested Language / 期望支持的语言
+      description: Which language or locale would you like All API Hub to support? / 您希望 All API Hub 支持哪种语言或地区变体？
+      placeholder: e.g., French / Français, Korean / 한국어, zh-HK
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Can you help review translations? / 是否愿意协助校对？
+      description: Translation review from native or fluent speakers helps avoid awkward wording. / 母语或熟练使用者的校对能帮助我们避免生硬翻译。
+      options:
+        - Yes, I can help review / 可以，我愿意协助校对
+        - Maybe, please contact me first / 可能可以，请先联系我
+        - No, I am only requesting support / 暂时不能，只是提出请求
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: Preferred wording or references / 偏好的术语或参考
+      description: Share any terminology, screenshots, or product references that would help us localize naturally. / 如果有偏好的术语、截图或产品参考，可在这里补充，帮助我们写得更自然。
+      placeholder: |
+        Terms that should be translated carefully...
+        需要特别注意的术语...

--- a/src/components/FeedbackDropdownMenu.tsx
+++ b/src/components/FeedbackDropdownMenu.tsx
@@ -1,6 +1,7 @@
 import {
   BugAntIcon,
   ChatBubbleLeftEllipsisIcon,
+  LanguageIcon,
   LightBulbIcon,
   PuzzlePieceIcon,
   UsersIcon,
@@ -19,6 +20,7 @@ import {
   openBugReportPage,
   openCommunityPage,
   openFeatureRequestPage,
+  openLanguageRequestPage,
   openSiteSupportRequestPage,
 } from "~/utils/navigation"
 
@@ -63,6 +65,10 @@ export function FeedbackDropdownMenu({
         <DropdownMenuItem onClick={() => void openSiteSupportRequestPage()}>
           <PuzzlePieceIcon className="h-4 w-4" />
           {t("feedback.siteSupportRequest")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => void openLanguageRequestPage()}>
+          <LanguageIcon className="h-4 w-4" />
+          {t("feedback.languageRequest")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => void openCommunityPage(language)}>
           <UsersIcon className="h-4 w-4" />

--- a/src/components/RootErrorBoundary.tsx
+++ b/src/components/RootErrorBoundary.tsx
@@ -1,0 +1,94 @@
+import { AlertTriangle, ExternalLink, RefreshCw } from "lucide-react"
+import { Component, type ErrorInfo, type ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "~/components/ui/button"
+import { createLogger } from "~/utils/core/logger"
+import { getFeedbackDestinationUrls } from "~/utils/navigation/feedbackLinks"
+
+const logger = createLogger("RootErrorBoundary")
+
+type RootErrorBoundaryProps = {
+  children: ReactNode
+  reloadPage?: () => void
+}
+
+type RootErrorBoundaryState = {
+  hasError: boolean
+}
+
+/**
+ * Reloads the current extension page so users can recover from a root render crash.
+ */
+function reloadCurrentPage() {
+  window.location.reload()
+}
+
+/**
+ * Renders a small recovery surface when the React root cannot render normally.
+ */
+function RootErrorFallback({
+  reloadPage = reloadCurrentPage,
+}: Pick<RootErrorBoundaryProps, "reloadPage">) {
+  const { t } = useTranslation("common")
+  const languageRequestUrl = getFeedbackDestinationUrls().languageRequest
+
+  return (
+    <main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4 py-8">
+      <section className="bg-card w-full max-w-md rounded-lg border p-6 text-center shadow-sm">
+        <div className="bg-destructive/10 text-destructive mx-auto mb-4 flex size-12 items-center justify-center rounded-full">
+          <AlertTriangle className="size-6" aria-hidden="true" />
+        </div>
+        <h1 className="text-lg font-semibold">
+          {t("rootErrorBoundary.title")}
+        </h1>
+        <p className="text-muted-foreground mt-3 text-sm leading-6">
+          {t("rootErrorBoundary.description")}
+        </p>
+        <div className="mt-5 flex flex-col items-center justify-center gap-2 sm:flex-row">
+          <Button
+            type="button"
+            leftIcon={<RefreshCw className="size-4" aria-hidden="true" />}
+            onClick={reloadPage}
+          >
+            {t("rootErrorBoundary.reload")}
+          </Button>
+          <Button
+            asChild
+            variant="outline"
+            leftIcon={<ExternalLink className="size-4" aria-hidden="true" />}
+          >
+            <a href={languageRequestUrl} target="_blank" rel="noreferrer">
+              {t("rootErrorBoundary.requestLanguage")}
+            </a>
+          </Button>
+        </div>
+      </section>
+    </main>
+  )
+}
+
+export class RootErrorBoundary extends Component<
+  RootErrorBoundaryProps,
+  RootErrorBoundaryState
+> {
+  state: RootErrorBoundaryState = {
+    hasError: false,
+  }
+
+  static getDerivedStateFromError(): RootErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
+    logger.error("Root UI crashed", { error, componentStack: errorInfo })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <RootErrorFallback reloadPage={this.props.reloadPage} />
+    }
+
+    return this.props.children
+  }
+}

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html>
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom/client"
 
 import "~/utils/i18n"
 
+import { RootErrorBoundary } from "~/components/RootErrorBoundary"
 import { t } from "~/utils/i18n/core"
 import { setDocumentTitle } from "~/utils/navigation/documentTitle"
 
@@ -15,10 +16,12 @@ const queryClient = new QueryClient()
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <Suspense fallback={<div>{t("common:status.loading")}</div>}>
-        <App />
-      </Suspense>
-    </QueryClientProvider>
+    <RootErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <Suspense fallback={<div>{t("common:status.loading")}</div>}>
+          <App />
+        </Suspense>
+      </QueryClientProvider>
+    </RootErrorBoundary>
   </React.StrictMode>,
 )

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html>
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client"
 
 import "~/utils/i18n" // Import the i18n configuration
 
+import { RootErrorBoundary } from "~/components/RootErrorBoundary"
 import { t } from "~/utils/i18n/core"
 import { setDocumentTitle } from "~/utils/navigation/documentTitle"
 
@@ -13,8 +14,10 @@ setDocumentTitle("popup")
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <Suspense fallback={<div>{t("common:status.loading")}</div>}>
-      <App />
-    </Suspense>
+    <RootErrorBoundary>
+      <Suspense fallback={<div>{t("common:status.loading")}</div>}>
+        <App />
+      </Suspense>
+    </RootErrorBoundary>
   </React.StrictMode>,
 )

--- a/src/entrypoints/sidepanel/index.html
+++ b/src/entrypoints/sidepanel/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/src/entrypoints/sidepanel/index.html
+++ b/src/entrypoints/sidepanel/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html>
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client"
 
 import "~/utils/i18n" // Import the i18n configuration
 
+import { RootErrorBoundary } from "~/components/RootErrorBoundary"
 import { t } from "~/utils/i18n/core"
 import { setDocumentTitle } from "~/utils/navigation/documentTitle"
 
@@ -13,8 +14,10 @@ setDocumentTitle("sidepanel")
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <Suspense fallback={<div>{t("common:status.loading")}</div>}>
-      <App />
-    </Suspense>
+    <RootErrorBoundary>
+      <Suspense fallback={<div>{t("common:status.loading")}</div>}>
+        <App />
+      </Suspense>
+    </RootErrorBoundary>
   </React.StrictMode>,
 )

--- a/src/features/About/About.tsx
+++ b/src/features/About/About.tsx
@@ -4,6 +4,7 @@ import {
   ChatBubbleLeftEllipsisIcon,
   CodeBracketIcon,
   GlobeAltIcon,
+  LanguageIcon,
   LightBulbIcon,
   StarIcon,
   UsersIcon,
@@ -154,6 +155,15 @@ export default function About() {
               buttonText={t("feedbackSection.featureRequest.button")}
               buttonVariant="secondary"
               iconClass="text-amber-500 dark:text-amber-400"
+            />
+            <LinkCard
+              Icon={LanguageIcon}
+              title={t("ui:feedback.languageRequest")}
+              description={t("feedbackSection.languageRequest.description")}
+              href={feedbackDestinations.languageRequest}
+              buttonText={t("feedbackSection.languageRequest.button")}
+              buttonVariant="secondary"
+              iconClass="text-indigo-600 dark:text-indigo-400"
             />
             <LinkCard
               Icon={UsersIcon}

--- a/src/features/OptionsOverview/components/dialogs/PermissionOnboardingDialog.tsx
+++ b/src/features/OptionsOverview/components/dialogs/PermissionOnboardingDialog.tsx
@@ -23,6 +23,7 @@ import {
 import { trackOptionalPermissionRequestResult } from "~/services/productAnalytics/permissions"
 import { createLogger } from "~/utils/core/logger"
 import { showResultToast } from "~/utils/core/toastHelpers"
+import { openLanguageRequestPage } from "~/utils/navigation"
 
 /**
  * Unified logger scoped to the optional-permissions onboarding dialog.
@@ -195,6 +196,10 @@ export function PermissionOnboardingDialog({
     window.open(GITHUB_URL, "_blank", "noopener,noreferrer")
   }, [])
 
+  const handleOpenLanguageRequest = useCallback(() => {
+    void openLanguageRequestPage()
+  }, [])
+
   const permissionList = useMemo(() => {
     return OPTIONAL_PERMISSION_DEFINITIONS.map((permission) => ({
       ...permission,
@@ -270,13 +275,26 @@ export function PermissionOnboardingDialog({
               {t("appearanceLanguage.onboardingHelper")}
             </BodySmall>
           </CardHeader>
-          <CardContent padding="sm" spacing="sm" className="space-y-3">
+          <CardContent
+            padding="sm"
+            spacing="none"
+            className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+          >
             <LanguageSwitcher
               variant="select"
               compact
               showIcon={false}
               className="w-full sm:w-40"
             />
+            <Button
+              type="button"
+              variant="link"
+              size="sm"
+              onClick={handleOpenLanguageRequest}
+              className="h-auto justify-start px-0 py-0 text-xs font-normal sm:justify-center"
+            >
+              {t("appearanceLanguage.onboardingLanguageRequest")}
+            </Button>
           </CardContent>
         </Card>
 

--- a/src/locales/en/about.json
+++ b/src/locales/en/about.json
@@ -19,6 +19,10 @@
       "button": "Open feature request",
       "description": "Share an improvement idea or workflow request through the feature-request template."
     },
+    "languageRequest": {
+      "button": "Open language request",
+      "description": "Ask us to support a new interface language for All API Hub."
+    },
     "title": "Feedback & Support"
   },
   "githubDesc": "View source code, submit issues or participate in project development",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -31,6 +31,12 @@
   "quota": {
     "unlimited": "Unlimited"
   },
+  "rootErrorBoundary": {
+    "description": "The page could not be displayed correctly. Reload first. If this keeps happening, turn off automatic translation for this page or switch to the language you need in extension settings.",
+    "reload": "Reload page",
+    "requestLanguage": "Request a language",
+    "title": "Page display failed"
+  },
   "status": {
     "configurationRequired": "Configuration required",
     "creating": "Creating...",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -21,6 +21,7 @@
     "languageDesc": "Choose your preferred language",
     "onboardingHelper": "Update the onboarding text immediately and keep this language for later settings pages.",
     "onboardingLabel": "Choose your language",
+    "onboardingLanguageRequest": "Don't see your language? Tell us what to add",
     "switcher": {
       "currentLanguage": "Current interface language: {{language}}",
       "groupLabel": "Interface language selector",

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -322,6 +322,7 @@
     "community": "Community groups",
     "discussion": "Start a discussion",
     "featureRequest": "Request a feature",
+    "languageRequest": "Request a new language",
     "siteSupportRequest": "Request site support",
     "trigger": "Feedback",
     "triggerTooltip": "Open feedback shortcuts"

--- a/src/locales/ja/about.json
+++ b/src/locales/ja/about.json
@@ -19,6 +19,10 @@
       "button": "機能要望を開く",
       "description": "feature-request テンプレートを通じて、改善案やワークフロー要望を共有してください。"
     },
+    "languageRequest": {
+      "button": "言語要望を開く",
+      "description": "All API Hub で新しい表示言語の対応をリクエストできます。"
+    },
     "title": "フィードバックとサポート"
   },
   "githubDesc": "ソースコードの確認、Issue の報告、プロジェクト開発への参加ができます",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -31,6 +31,12 @@
   "quota": {
     "unlimited": "無制限"
   },
+  "rootErrorBoundary": {
+    "description": "ページを正しく表示できませんでした。まずページを再読み込みしてください。繰り返し発生する場合は、このページの自動翻訳をオフにするか、拡張機能の設定で必要な言語に切り替えてください。",
+    "reload": "ページを再読み込み",
+    "requestLanguage": "言語サポートをリクエスト",
+    "title": "ページを表示できません"
+  },
   "status": {
     "configurationRequired": "設定が必要です",
     "creating": "作成中...",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -21,6 +21,7 @@
     "languageDesc": "表示に使用する言語を選択します",
     "onboardingHelper": "切り替えると案内文がすぐに更新され、以後の設定ページでもこの言語が使われます。",
     "onboardingLabel": "言語を選択",
+    "onboardingLanguageRequest": "表示したい言語がありませんか？追加希望をお知らせください",
     "switcher": {
       "currentLanguage": "現在の表示言語: {{language}}",
       "groupLabel": "表示言語セレクター",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -317,6 +317,7 @@
     "community": "コミュニティグループ",
     "discussion": "ディスカッションを開始",
     "featureRequest": "機能要望を送る",
+    "languageRequest": "新しい言語をリクエスト",
     "siteSupportRequest": "サイト対応を依頼",
     "trigger": "フィードバック",
     "triggerTooltip": "フィードバックショートカットを開く"

--- a/src/locales/vi/about.json
+++ b/src/locales/vi/about.json
@@ -19,6 +19,10 @@
       "button": "Mở yêu cầu tính năng",
       "description": "Chia sẻ ý tưởng cải tiến hoặc nhu cầu sử dụng của bạn thông qua mẫu yêu cầu tính năng."
     },
+    "languageRequest": {
+      "button": "Mở yêu cầu ngôn ngữ mới",
+      "description": "Yêu cầu All API Hub hỗ trợ thêm ngôn ngữ giao diện mới."
+    },
     "title": "Phản hồi và hỗ trợ"
   },
   "githubDesc": "Xem mã nguồn, gửi vấn đề hoặc tham gia phát triển dự án",

--- a/src/locales/vi/common.json
+++ b/src/locales/vi/common.json
@@ -31,6 +31,12 @@
   "quota": {
     "unlimited": "Không giới hạn"
   },
+  "rootErrorBoundary": {
+    "description": "Không thể hiển thị trang chính xác. Trước tiên hãy tải lại trang. Nếu lỗi lặp lại, hãy tắt tự động dịch cho trang này hoặc chuyển sang ngôn ngữ bạn cần trong cài đặt tiện ích.",
+    "reload": "Tải lại trang",
+    "requestLanguage": "Yêu cầu ngôn ngữ",
+    "title": "Không hiển thị được trang"
+  },
   "status": {
     "configurationRequired": "Yêu cầu cấu hình",
     "creating": "Đang tạo...",

--- a/src/locales/vi/settings.json
+++ b/src/locales/vi/settings.json
@@ -21,6 +21,7 @@
     "languageDesc": "Chọn ngôn ngữ hiển thị bạn muốn dùng",
     "onboardingHelper": "Sau khi chuyển, nội dung hướng dẫn sẽ cập nhật ngay và được dùng làm ngôn ngữ hiển thị cho trang cài đặt sau này.",
     "onboardingLabel": "Chọn ngôn ngữ giao diện",
+    "onboardingLanguageRequest": "Không thấy ngôn ngữ của bạn? Hãy cho chúng tôi biết cần thêm gì",
     "switcher": {
       "currentLanguage": "Ngôn ngữ giao diện hiện tại: {{language}}",
       "groupLabel": "Chọn ngôn ngữ giao diện",

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -317,6 +317,7 @@
     "community": "Nhóm cộng đồng",
     "discussion": "Tham gia thảo luận",
     "featureRequest": "Đề xuất tính năng",
+    "languageRequest": "Yêu cầu ngôn ngữ mới",
     "siteSupportRequest": "Phản hồi trang web chưa được hỗ trợ",
     "trigger": "Phản hồi",
     "triggerTooltip": "Mở lối tắt phản hồi"

--- a/src/locales/zh-CN/about.json
+++ b/src/locales/zh-CN/about.json
@@ -19,6 +19,10 @@
       "button": "打开功能建议",
       "description": "通过功能建议模板分享你的改进想法或使用场景需求。"
     },
+    "languageRequest": {
+      "button": "打开新语言请求",
+      "description": "请求 All API Hub 支持新的界面语言。"
+    },
     "title": "反馈与支持"
   },
   "githubDesc": "查看源代码、提交问题或参与项目开发",

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -31,6 +31,12 @@
   "quota": {
     "unlimited": "无限额度"
   },
+  "rootErrorBoundary": {
+    "description": "页面显示异常。请先刷新页面；如果反复出现，请关闭此页面的自动翻译，或在扩展设置中切换到需要的语言。",
+    "reload": "刷新页面",
+    "requestLanguage": "请求支持新语言",
+    "title": "页面显示失败"
+  },
   "status": {
     "configurationRequired": "缺少配置",
     "creating": "创建中...",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -21,6 +21,7 @@
     "languageDesc": "选择您偏好的显示语言",
     "onboardingHelper": "切换后会立即更新引导内容，并作为后续设置页面的显示语言。",
     "onboardingLabel": "选择界面语言",
+    "onboardingLanguageRequest": "没找到你的语言？告诉我们希望支持哪种",
     "switcher": {
       "currentLanguage": "当前界面语言：{{language}}",
       "groupLabel": "界面语言选择",

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -317,6 +317,7 @@
     "community": "社区交流群",
     "discussion": "参与讨论",
     "featureRequest": "提出功能建议",
+    "languageRequest": "请求支持新语言",
     "siteSupportRequest": "反馈未适配站点",
     "trigger": "反馈",
     "triggerTooltip": "打开反馈快捷入口"

--- a/src/locales/zh-TW/about.json
+++ b/src/locales/zh-TW/about.json
@@ -19,6 +19,10 @@
       "button": "開啟功能建議",
       "description": "透過功能建議模板分享你的改進想法或使用場景需求。"
     },
+    "languageRequest": {
+      "button": "開啟新語言請求",
+      "description": "請求 All API Hub 支援新的介面語言。"
+    },
     "title": "反饋與支援"
   },
   "githubDesc": "檢視原始碼、提交問題或參與專案開發",

--- a/src/locales/zh-TW/common.json
+++ b/src/locales/zh-TW/common.json
@@ -31,6 +31,12 @@
   "quota": {
     "unlimited": "無限額度"
   },
+  "rootErrorBoundary": {
+    "description": "頁面顯示異常。請先重新整理頁面；如果反覆出現，請關閉此頁面的自動翻譯，或在擴充功能設定中切換到需要的語言。",
+    "reload": "重新整理頁面",
+    "requestLanguage": "請求支援新語言",
+    "title": "頁面顯示失敗"
+  },
   "status": {
     "configurationRequired": "缺少配置",
     "creating": "建立中...",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -21,6 +21,7 @@
     "languageDesc": "選擇您偏好的顯示語言",
     "onboardingHelper": "切換後會立即更新引導內容，並作為後續設定頁面的顯示語言。",
     "onboardingLabel": "選擇介面語言",
+    "onboardingLanguageRequest": "找不到你的語言？告訴我們希望支援哪一種",
     "switcher": {
       "currentLanguage": "當前介面語言：{{language}}",
       "groupLabel": "介面語言選擇",

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -317,6 +317,7 @@
     "community": "社羣交流群",
     "discussion": "參與討論",
     "featureRequest": "提出功能建議",
+    "languageRequest": "請求支援新語言",
     "siteSupportRequest": "反饋未適配站點",
     "trigger": "反饋",
     "triggerTooltip": "開啟反饋快捷入口"

--- a/src/utils/i18n/index.ts
+++ b/src/utils/i18n/index.ts
@@ -14,8 +14,19 @@ import { userPreferences } from "~/services/preferences/userPreferences"
 import { isDevBuild } from "~/utils/core/environment"
 
 import i18n from "./core"
-import { resolveInitialAppLanguage } from "./language"
+import { normalizeAppLanguage, resolveInitialAppLanguage } from "./language"
 import { mapToDayjsLocale, resources } from "./resources"
+
+/**
+ * Keep the extension page root language aligned with the active UI locale.
+ */
+function syncDocumentLanguage(language: string) {
+  if (typeof document === "undefined") {
+    return
+  }
+
+  document.documentElement.lang = normalizeAppLanguage(language) ?? language
+}
 
 i18n
   .use(LanguageDetector)
@@ -53,10 +64,12 @@ i18n
     }
 
     dayjs.locale(mapToDayjsLocale(initialLanguage))
+    syncDocumentLanguage(initialLanguage)
   })
 
 export default i18n
 
 i18n.on("languageChanged", async (lng) => {
   dayjs.locale(mapToDayjsLocale(lng))
+  syncDocumentLanguage(lng)
 })

--- a/src/utils/navigation/feedbackLinks.ts
+++ b/src/utils/navigation/feedbackLinks.ts
@@ -3,6 +3,7 @@ import { getRepository } from "~/utils/navigation/packageMeta"
 
 const BUG_REPORT_TEMPLATE = "bug_report.yml"
 const FEATURE_REQUEST_TEMPLATE = "feature_request.yml"
+const LANGUAGE_REQUEST_TEMPLATE = "language_request.yml"
 const SITE_SUPPORT_REQUEST_TEMPLATE = "site_support_request.yml"
 
 export interface SiteSupportRequestContext {
@@ -15,6 +16,7 @@ interface FeedbackDestinationUrls {
   repository: string
   bugReport: string
   featureRequest: string
+  languageRequest: string
   siteSupportRequest: string
   discussions: string
   community: string
@@ -51,6 +53,10 @@ export const getFeedbackDestinationUrls = (
     repository,
     bugReport: buildIssueTemplateUrl(repository, BUG_REPORT_TEMPLATE),
     featureRequest: buildIssueTemplateUrl(repository, FEATURE_REQUEST_TEMPLATE),
+    languageRequest: buildIssueTemplateUrl(
+      repository,
+      LANGUAGE_REQUEST_TEMPLATE,
+    ),
     siteSupportRequest: buildIssueTemplateUrl(
       repository,
       SITE_SUPPORT_REQUEST_TEMPLATE,

--- a/src/utils/navigation/index.ts
+++ b/src/utils/navigation/index.ts
@@ -512,6 +512,13 @@ const _openFeatureRequestPage = async () => {
 }
 
 /**
+ * Opens the repository language-request template in a new browser tab.
+ */
+const _openLanguageRequestPage = async () => {
+  await createActiveTab(getFeedbackDestinationUrls().languageRequest)
+}
+
+/**
  * Opens the site-support request issue form in a new browser tab.
  */
 const _openSiteSupportRequestPage = async (
@@ -846,6 +853,11 @@ export const openBugReportPage = withPopupClose(_openBugReportPage)
  * Open the feature-request issue template and close the popup afterward when needed.
  */
 export const openFeatureRequestPage = withPopupClose(_openFeatureRequestPage)
+
+/**
+ * Open the language-request issue template and close the popup afterward when needed.
+ */
+export const openLanguageRequestPage = withPopupClose(_openLanguageRequestPage)
 
 /**
  * Open the site-support issue template and close the popup afterward when needed.

--- a/tests/components/RootErrorBoundary.test.tsx
+++ b/tests/components/RootErrorBoundary.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { createInstance } from "i18next"
+import type { ReactNode } from "react"
+import { I18nextProvider, initReactI18next } from "react-i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import { RootErrorBoundary } from "~/components/RootErrorBoundary"
+
+const { loggerErrorMock } = vi.hoisted(() => ({
+  loggerErrorMock: vi.fn(),
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: loggerErrorMock,
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}))
+
+const i18n = createInstance()
+
+await i18n.use(initReactI18next).init({
+  lng: "en",
+  fallbackLng: "en",
+  ns: ["common"],
+  defaultNS: "common",
+  resources: {
+    en: {
+      common: {
+        rootErrorBoundary: {
+          description:
+            "The page could not be displayed correctly. Reload first. If this keeps happening, turn off automatic translation for this page or switch to the language you need in extension settings.",
+          reload: "Reload page",
+          requestLanguage: "Request a language",
+          title: "Page display failed",
+        },
+      },
+    },
+  },
+  react: { useSuspense: false },
+})
+
+function BrokenChild(): ReactNode {
+  throw new Error("Simulated root render failure")
+}
+
+describe("RootErrorBoundary", () => {
+  it("shows recovery guidance and reloads the page after a root render failure", async () => {
+    const user = userEvent.setup()
+    const reload = vi.fn()
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+
+    try {
+      loggerErrorMock.mockClear()
+      render(
+        <I18nextProvider i18n={i18n}>
+          <RootErrorBoundary reloadPage={reload}>
+            <BrokenChild />
+          </RootErrorBoundary>
+        </I18nextProvider>,
+      )
+
+      expect(
+        screen.getByRole("heading", { name: "Page display failed" }),
+      ).toBeVisible()
+      expect(
+        screen.getByText(
+          "The page could not be displayed correctly. Reload first. If this keeps happening, turn off automatic translation for this page or switch to the language you need in extension settings.",
+        ),
+      ).toBeVisible()
+      expect(
+        screen.getByRole("link", { name: "Request a language" }),
+      ).toHaveAttribute(
+        "href",
+        "https://github.com/qixing-jk/all-api-hub/issues/new?template=language_request.yml",
+      )
+
+      await user.click(screen.getByRole("button", { name: "Reload page" }))
+
+      expect(reload).toHaveBeenCalledTimes(1)
+      expect(loggerErrorMock).toHaveBeenCalledWith(
+        "Root UI crashed",
+        expect.objectContaining({
+          componentStack: expect.any(Object),
+          error: expect.any(Error),
+        }),
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+})

--- a/tests/components/RootErrorBoundary.test.tsx
+++ b/tests/components/RootErrorBoundary.test.tsx
@@ -48,6 +48,44 @@ function BrokenChild(): ReactNode {
 }
 
 describe("RootErrorBoundary", () => {
+  it("uses the browser reload function when no custom reload handler is provided", async () => {
+    const user = userEvent.setup()
+    const reload = vi.fn()
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+
+    const originalLocation = window.location
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        reload,
+      },
+    })
+
+    try {
+      loggerErrorMock.mockClear()
+      render(
+        <I18nextProvider i18n={i18n}>
+          <RootErrorBoundary>
+            <BrokenChild />
+          </RootErrorBoundary>
+        </I18nextProvider>,
+      )
+
+      await user.click(screen.getByRole("button", { name: "Reload page" }))
+
+      expect(reload).toHaveBeenCalledTimes(1)
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      })
+      consoleError.mockRestore()
+    }
+  })
+
   it("shows recovery guidance and reloads the page after a root render failure", async () => {
     const user = userEvent.setup()
     const reload = vi.fn()

--- a/tests/entrypoints/options/Header.test.tsx
+++ b/tests/entrypoints/options/Header.test.tsx
@@ -7,6 +7,7 @@ import {
   openBugReportPage,
   openCommunityPage,
   openFeatureRequestPage,
+  openLanguageRequestPage,
   openPermissionsOnboardingPage,
   openSiteSupportRequestPage,
 } from "~/utils/navigation"
@@ -62,6 +63,7 @@ vi.mock("~/utils/navigation", async (importOriginal) => {
     openBugReportPage: vi.fn(),
     openCommunityPage: vi.fn(),
     openFeatureRequestPage: vi.fn(),
+    openLanguageRequestPage: vi.fn(),
     openPermissionsOnboardingPage: vi.fn(),
     openSiteSupportRequestPage: vi.fn(),
   }
@@ -70,6 +72,7 @@ vi.mock("~/utils/navigation", async (importOriginal) => {
 const mockedOpenBugReportPage = vi.mocked(openBugReportPage)
 const mockedOpenCommunityPage = vi.mocked(openCommunityPage)
 const mockedOpenFeatureRequestPage = vi.mocked(openFeatureRequestPage)
+const mockedOpenLanguageRequestPage = vi.mocked(openLanguageRequestPage)
 const mockedOpenPermissionsOnboardingPage = vi.mocked(
   openPermissionsOnboardingPage,
 )
@@ -145,6 +148,16 @@ describe("options Header", () => {
       }),
     )
     expect(mockedOpenSiteSupportRequestPage).toHaveBeenCalledTimes(1)
+
+    await user.click(
+      await screen.findByRole("button", { name: "ui:feedback.trigger" }),
+    )
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: "ui:feedback.languageRequest",
+      }),
+    )
+    expect(mockedOpenLanguageRequestPage).toHaveBeenCalledTimes(1)
 
     await user.click(
       await screen.findByRole("button", { name: "ui:feedback.trigger" }),

--- a/tests/entrypoints/popup/HeaderSection.test.tsx
+++ b/tests/entrypoints/popup/HeaderSection.test.tsx
@@ -27,6 +27,7 @@ import {
   openFeatureRequestPage,
   openFullAccountManagerPage,
   openFullBookmarkManagerPage,
+  openLanguageRequestPage,
   openPermissionsOnboardingPage,
   openSettingsPage,
   openSidePanelPage,
@@ -99,6 +100,7 @@ vi.mock("~/utils/navigation", () => ({
   openFeatureRequestPage: vi.fn(),
   openFullAccountManagerPage: vi.fn(),
   openFullBookmarkManagerPage: vi.fn(),
+  openLanguageRequestPage: vi.fn(),
   openPermissionsOnboardingPage: vi.fn(),
   openSettingsPage: vi.fn(),
   openSidePanelPage: vi.fn(),
@@ -141,6 +143,7 @@ const mockedOpenCommunityPage = vi.mocked(openCommunityPage)
 const mockedOpenFeatureRequestPage = vi.mocked(openFeatureRequestPage)
 const mockedOpenFullAccountManagerPage = vi.mocked(openFullAccountManagerPage)
 const mockedOpenFullBookmarkManagerPage = vi.mocked(openFullBookmarkManagerPage)
+const mockedOpenLanguageRequestPage = vi.mocked(openLanguageRequestPage)
 const mockedOpenPermissionsOnboardingPage = vi.mocked(
   openPermissionsOnboardingPage,
 )
@@ -410,6 +413,17 @@ describe("popup HeaderSection", () => {
     )
 
     expect(mockedOpenSiteSupportRequestPage).toHaveBeenCalledTimes(1)
+
+    await user.click(
+      await screen.findByRole("button", { name: "ui:feedback.trigger" }),
+    )
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: "ui:feedback.languageRequest",
+      }),
+    )
+
+    expect(mockedOpenLanguageRequestPage).toHaveBeenCalledTimes(1)
 
     await user.click(
       await screen.findByRole("button", { name: "ui:feedback.trigger" }),

--- a/tests/features/About/About.test.tsx
+++ b/tests/features/About/About.test.tsx
@@ -35,6 +35,11 @@ describe("About", () => {
         name: "about:feedbackSection.featureRequest.button",
       }),
     ).toHaveAttribute("href", feedbackUrls.featureRequest)
+    expect(
+      await screen.findByRole("link", {
+        name: "about:feedbackSection.languageRequest.button",
+      }),
+    ).toHaveAttribute("href", feedbackUrls.languageRequest)
     const communityLink = await screen.findByRole("link", {
       name: "about:feedbackSection.community.button",
     })

--- a/tests/features/OptionsOverview/PermissionOnboardingDialog.languageSelection.test.tsx
+++ b/tests/features/OptionsOverview/PermissionOnboardingDialog.languageSelection.test.tsx
@@ -40,6 +40,10 @@ const analyticsMocks = vi.hoisted(() => ({
   trackProductAnalyticsEvent: vi.fn(),
 }))
 
+const navigationMocks = vi.hoisted(() => ({
+  openLanguageRequestPage: vi.fn(),
+}))
+
 vi.mock("~/services/permissions/permissionManager", () => {
   const OPTIONAL_PERMISSIONS = [
     "cookies",
@@ -80,6 +84,10 @@ vi.mock("~/services/productAnalytics/events", async (importOriginal) => {
     trackProductAnalyticsEvent: analyticsMocks.trackProductAnalyticsEvent,
   }
 })
+
+vi.mock("~/utils/navigation", () => ({
+  openLanguageRequestPage: navigationMocks.openLanguageRequestPage,
+}))
 
 vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
   const actual =
@@ -235,6 +243,7 @@ describe("PermissionOnboardingDialog language selection", () => {
     preferenceMocks.setLanguage.mockReset()
     toastHelperMocks.showResultToast.mockReset()
     analyticsMocks.trackProductAnalyticsEvent.mockReset()
+    navigationMocks.openLanguageRequestPage.mockReset()
   })
 
   it("renders the onboarding selector and updates onboarding copy immediately when the language changes", async () => {
@@ -294,6 +303,23 @@ describe("PermissionOnboardingDialog language selection", () => {
     expect(
       screen.getByRole("heading", { name: "Welcome to All API Hub" }),
     ).toBeInTheDocument()
+  })
+
+  it("opens the language request page from the onboarding language selector", async () => {
+    const user = userEvent.setup()
+    const i18n = await createSettingsI18n("en")
+
+    navigationMocks.openLanguageRequestPage.mockResolvedValue(undefined)
+
+    renderWithI18n(<PermissionOnboardingDialog open onClose={vi.fn()} />, i18n)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: i18n.t("appearanceLanguage.onboardingLanguageRequest"),
+      }),
+    )
+
+    expect(navigationMocks.openLanguageRequestPage).toHaveBeenCalledTimes(1)
   })
 
   it("uses the persisted onboarding language in later settings renders and localizes shared switcher accessibility labels", async () => {

--- a/tests/utils/i18nIndex.node.test.ts
+++ b/tests/utils/i18nIndex.node.test.ts
@@ -1,0 +1,107 @@
+import dayjs from "dayjs"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { DEFAULT_LANG } from "~/constants"
+import { I18NEXT_LANGUAGE_STORAGE_KEY } from "~/services/core/storageKeys"
+
+const {
+  getLanguageMock,
+  i18nCoreMock,
+  languageDetectorPlugin,
+  mapToDayjsLocaleMock,
+  reactI18nextPlugin,
+  resolveInitialAppLanguageMock,
+} = vi.hoisted(() => ({
+  getLanguageMock: vi.fn(),
+  i18nCoreMock: {
+    use: vi.fn(),
+    init: vi.fn(),
+    changeLanguage: vi.fn(),
+    on: vi.fn(),
+    language: "en",
+    resolvedLanguage: "en" as string | undefined,
+  },
+  languageDetectorPlugin: { type: "languageDetector" },
+  mapToDayjsLocaleMock: vi.fn(),
+  reactI18nextPlugin: { type: "3rdParty" },
+  resolveInitialAppLanguageMock: vi.fn(),
+}))
+
+vi.mock("~/utils/i18n/core", () => ({
+  default: i18nCoreMock,
+}))
+
+vi.mock("~/services/preferences/userPreferences", () => ({
+  userPreferences: {
+    getLanguage: getLanguageMock,
+  },
+}))
+
+vi.mock("~/utils/i18n/language", () => ({
+  normalizeAppLanguage: (language?: string | null) => language ?? undefined,
+  resolveInitialAppLanguage: resolveInitialAppLanguageMock,
+}))
+
+vi.mock("~/utils/i18n/resources", () => ({
+  mapToDayjsLocale: mapToDayjsLocaleMock,
+  resources: {
+    en: { common: { greeting: "Hello" } },
+  },
+}))
+
+vi.mock("i18next-browser-languagedetector", () => ({
+  default: languageDetectorPlugin,
+}))
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: reactI18nextPlugin,
+}))
+
+describe("app i18n initialization without a document", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+
+    i18nCoreMock.use.mockReset()
+    i18nCoreMock.use.mockImplementation(() => i18nCoreMock)
+    i18nCoreMock.init.mockReset()
+    i18nCoreMock.init.mockResolvedValue(undefined)
+    i18nCoreMock.changeLanguage.mockReset()
+    i18nCoreMock.changeLanguage.mockResolvedValue(undefined)
+    i18nCoreMock.on.mockReset()
+
+    getLanguageMock.mockReset()
+    resolveInitialAppLanguageMock.mockReset()
+    mapToDayjsLocaleMock.mockReset()
+    mapToDayjsLocaleMock.mockImplementation((language: string) => language)
+
+    i18nCoreMock.language = "en"
+    i18nCoreMock.resolvedLanguage = "en"
+  })
+
+  it("keeps initialization working when no DOM document exists", async () => {
+    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("ja")
+    getLanguageMock.mockResolvedValueOnce(undefined)
+    resolveInitialAppLanguageMock.mockReturnValueOnce("ja")
+
+    try {
+      await import("~/utils/i18n/index")
+
+      await vi.waitFor(() => {
+        expect(getLanguageMock).toHaveBeenCalledTimes(1)
+      })
+
+      expect(i18nCoreMock.init).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fallbackLng: DEFAULT_LANG,
+          detection: {
+            lookupLocalStorage: I18NEXT_LANGUAGE_STORAGE_KEY,
+          },
+        }),
+      )
+      expect(localeSpy).toHaveBeenCalledWith("ja")
+    } finally {
+      localeSpy.mockRestore()
+    }
+  })
+})

--- a/tests/utils/i18nIndex.test.ts
+++ b/tests/utils/i18nIndex.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import dayjs from "dayjs"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -38,6 +40,19 @@ vi.mock("~/services/preferences/userPreferences", () => ({
 }))
 
 vi.mock("~/utils/i18n/language", () => ({
+  normalizeAppLanguage: (language?: string | null) => {
+    const normalized = language?.trim().replace(/_/g, "-")
+    if (!normalized) return undefined
+
+    const languageFamily = normalized.toLowerCase().split("-")[0]
+    if (languageFamily === "en") return "en"
+    if (languageFamily === "ja") return "ja"
+    if (languageFamily === "vi") return "vi"
+    if (normalized.toLowerCase() === "zh-tw") return "zh-TW"
+    if (languageFamily === "zh") return "zh-CN"
+
+    return undefined
+  },
   resolveInitialAppLanguage: resolveInitialAppLanguageMock,
 }))
 
@@ -61,6 +76,7 @@ describe("app i18n initialization", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.unstubAllEnvs()
+    document.documentElement.lang = "en"
 
     i18nCoreMock.use.mockReset()
     i18nCoreMock.use.mockImplementation(() => i18nCoreMock)
@@ -130,6 +146,7 @@ describe("app i18n initialization", () => {
       })
       expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
       expect(localeSpy).toHaveBeenCalledWith("ja")
+      expect(document.documentElement.lang).toBe("ja")
 
       const languageChangedHandler = i18nCoreMock.on.mock.calls.find(
         ([eventName]) => eventName === "languageChanged",
@@ -139,6 +156,7 @@ describe("app i18n initialization", () => {
       languageChangedHandler?.("zh_TW")
 
       expect(localeSpy).toHaveBeenLastCalledWith("zh-tw")
+      expect(document.documentElement.lang).toBe("zh-TW")
     } finally {
       localeSpy.mockRestore()
     }
@@ -186,6 +204,7 @@ describe("app i18n initialization", () => {
       )
       expect(i18nCoreMock.changeLanguage).not.toHaveBeenCalled()
       expect(localeSpy).toHaveBeenCalledWith("ja")
+      expect(document.documentElement.lang).toBe("ja")
     } finally {
       localeSpy.mockRestore()
     }

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -28,6 +28,7 @@ import {
   openFullAccountManagerPage,
   openFullBookmarkManagerPage,
   openKeysPage,
+  openLanguageRequestPage,
   openManagedSiteChannelsForChannel,
   openManagedSiteChannelsPage,
   openManagedSiteModelSyncForChannel,
@@ -104,6 +105,7 @@ vi.mock("~/utils/navigation/feedbackLinks", () => ({
   getFeedbackDestinationUrls: vi.fn((language?: string) => ({
     bugReport: "https://feedback.example/bug",
     featureRequest: "https://feedback.example/feature",
+    languageRequest: "https://feedback.example/language",
     siteSupportRequest: "https://feedback.example/site-support",
     discussions: "https://feedback.example/discussions",
     community: language
@@ -939,6 +941,7 @@ describe("navigation utilities", () => {
     await openAboutPage()
     await openBugReportPage()
     await openFeatureRequestPage()
+    await openLanguageRequestPage()
     await openSiteSupportRequestPage({
       siteUrl: "https://relay.example.com/console",
     })
@@ -959,6 +962,10 @@ describe("navigation utilities", () => {
     )
     expect(mockedCreateTab).toHaveBeenCalledWith(
       "https://feedback.example/feature",
+      true,
+    )
+    expect(mockedCreateTab).toHaveBeenCalledWith(
+      "https://feedback.example/language",
       true,
     )
     expect(mockedCreateTab).toHaveBeenCalledWith(

--- a/tests/utils/packageMeta.test.ts
+++ b/tests/utils/packageMeta.test.ts
@@ -126,6 +126,8 @@ describe("packageMeta", () => {
           "https://github.com/qixing-jk/all-api-hub/issues/new?template=bug_report.yml",
         featureRequest:
           "https://github.com/qixing-jk/all-api-hub/issues/new?template=feature_request.yml",
+        languageRequest:
+          "https://github.com/qixing-jk/all-api-hub/issues/new?template=language_request.yml",
         siteSupportRequest:
           "https://github.com/qixing-jk/all-api-hub/issues/new?template=site_support_request.yml",
         discussions: "https://github.com/qixing-jk/all-api-hub/discussions",
@@ -163,6 +165,8 @@ describe("packageMeta", () => {
           "https://github.com/example/project/issues/new?template=bug_report.yml",
         featureRequest:
           "https://github.com/example/project/issues/new?template=feature_request.yml",
+        languageRequest:
+          "https://github.com/example/project/issues/new?template=language_request.yml",
         siteSupportRequest:
           "https://github.com/example/project/issues/new?template=site_support_request.yml",
         discussions: "https://github.com/example/project/discussions",


### PR DESCRIPTION
## Summary
- add a GitHub language request issue template and expose language request shortcuts from feedback/About surfaces
- add a language request CTA to the permission onboarding language selection step
- add root render crash recovery and keep extension document lang in sync with i18n state

## Test Plan
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add language request flow across UI (feedback menu, About, onboarding) and a new error boundary with a recovery UI linking to language requests.

* **Localization**
  * Add/extend translations for en, ja, vi, zh-CN, zh-TW and surface a new localized copy for language-request and error UI.

* **Accessibility / Behavior**
  * Keep document language attribute in sync with the active app language.

* **Tests**
  * Add/extend tests for error boundary, i18n document-lang sync, and language-request navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->