### PR TITLE
fix(account): allow string user ids

### DIFF
--- a/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
@@ -33,7 +33,6 @@ import {
 import type { AccountDialogDraft } from "~/features/AccountManagement/components/AccountDialog/models"
 import { TagPicker } from "~/features/AccountManagement/components/TagPicker"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
-import { requiresNumericManualAccountIdentity } from "~/services/accounts/accountIdentity"
 import { isValidExchangeRate } from "~/services/accounts/accountOperations"
 import { AuthTypeEnum, type CheckInConfig, type Tag } from "~/types"
 import { formatLocaleDateTime } from "~/utils/core/formatters"
@@ -137,7 +136,6 @@ export default function AccountForm({
     siteType,
   } = draft
   const isSub2Api = siteType === SITE_TYPES.SUB2API
-  const requiresNumericUserId = requiresNumericManualAccountIdentity(siteType)
 
   return (
     <div className="space-y-3">
@@ -245,13 +243,12 @@ export default function AccountForm({
 
         <FormField label={t("form.userId")} required>
           <Input
-            type={requiresNumericUserId ? "number" : "text"}
+            // Compatible account sites may expose alphanumeric user IDs. Reference: https://github.com/qixing-jk/all-api-hub/issues/964
+            type="text"
             autoComplete="off"
             value={userId}
             onChange={(e) => onUserIdChange(e.target.value)}
-            placeholder={
-              requiresNumericUserId ? t("form.userIdNumber") : t("form.userId")
-            }
+            placeholder={t("form.userId")}
             leftIcon={<span className="font-mono text-sm">#</span>}
             data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.userIdInput}
             required

--- a/src/locales/en/accountDialog.json
+++ b/src/locales/en/accountDialog.json
@@ -94,7 +94,6 @@
     "tagsSelectedCount_one": "{{count}} tag selected",
     "tagsSelectedCount_other": "{{count}} tags selected",
     "userId": "User ID",
-    "userIdNumber": "User ID (number)",
     "username": "Username",
     "validRateError": "Please enter a valid exchange rate, greater than 0"
   },

--- a/src/locales/ja/accountDialog.json
+++ b/src/locales/ja/accountDialog.json
@@ -93,7 +93,6 @@
     "tagsSearchPlaceholder": "タグを検索...",
     "tagsSelectedCount_other": "{{count}} 個のタグを選択中",
     "userId": "ユーザー ID",
-    "userIdNumber": "ユーザー ID（数値）",
     "username": "ユーザー名",
     "validRateError": "0 より大きい有効な為替レートを入力してください"
   },

--- a/src/locales/vi/accountDialog.json
+++ b/src/locales/vi/accountDialog.json
@@ -93,7 +93,6 @@
     "tagsSearchPlaceholder": "Tìm kiếm thẻ…",
     "tagsSelectedCount_other": "Đã chọn {{count}} thẻ",
     "userId": "User ID",
-    "userIdNumber": "User ID (Số)",
     "username": "Tên người dùng",
     "validRateError": "Vui lòng nhập tỷ giá hợp lệ, lớn hơn 0"
   },

--- a/src/locales/zh-CN/accountDialog.json
+++ b/src/locales/zh-CN/accountDialog.json
@@ -93,7 +93,6 @@
     "tagsSearchPlaceholder": "搜索标签…",
     "tagsSelectedCount": "已选择 {{count}} 个标签",
     "userId": "用户 ID",
-    "userIdNumber": "用户 ID（数字）",
     "username": "用户名",
     "validRateError": "请输入有效的汇率，大于 0"
   },

--- a/src/locales/zh-TW/accountDialog.json
+++ b/src/locales/zh-TW/accountDialog.json
@@ -93,7 +93,6 @@
     "tagsSearchPlaceholder": "搜尋標籤…",
     "tagsSelectedCount_other": "已選擇 {{count}} 個標籤",
     "userId": "使用者 ID",
-    "userIdNumber": "使用者 ID（數字）",
     "username": "使用者名稱",
     "validRateError": "請輸入有效的匯率，大於 0"
   },

--- a/src/services/accounts/accountIdentity.ts
+++ b/src/services/accounts/accountIdentity.ts
@@ -1,25 +1,6 @@
 import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 import type { AccountIdentity } from "~/types"
 
-const NUMERIC_MANUAL_ACCOUNT_ID_SITE_TYPES: ReadonlySet<AccountSiteType> =
-  new Set([
-    SITE_TYPES.ONE_API,
-    SITE_TYPES.NEW_API,
-    SITE_TYPES.ANYROUTER,
-    SITE_TYPES.VELOERA,
-    SITE_TYPES.ONE_HUB,
-    SITE_TYPES.DONE_HUB,
-    SITE_TYPES.V_API,
-    SITE_TYPES.VO_API,
-    SITE_TYPES.SUPER_API,
-    SITE_TYPES.RIX_API,
-    SITE_TYPES.NEO_API,
-    SITE_TYPES.WONG_GONGYI,
-    SITE_TYPES.UNKNOWN,
-  ])
-
-const POSITIVE_INTEGER_ID_PATTERN = /^[1-9]\d*$/
-
 type StoredAccountUserIdentity = {
   userId: AccountIdentity
   user: Record<string, unknown>
@@ -27,6 +8,8 @@ type StoredAccountUserIdentity = {
 
 /**
  * Normalizes account identity values from storage, auto-detect, and adapters.
+ * Account-site identities are persisted as strings because compatible
+ * deployments may expose alphanumeric IDs.
  */
 export function normalizeAccountIdentity(
   value: unknown,
@@ -73,28 +56,4 @@ export function coerceAccountIdentity(
   fallback: AccountIdentity,
 ): AccountIdentity {
   return normalizeAccountIdentity(value) ?? fallback
-}
-
-/**
- * Returns whether manually entered identities must be numeric for the site.
- */
-export function requiresNumericManualAccountIdentity(
-  siteType: AccountSiteType,
-): boolean {
-  return NUMERIC_MANUAL_ACCOUNT_ID_SITE_TYPES.has(siteType)
-}
-
-/**
- * Validates manual account identity using the site-specific input strategy.
- */
-export function isValidManualAccountIdentity(
-  identity: AccountIdentity,
-  siteType: AccountSiteType,
-): boolean {
-  const normalizedIdentity = normalizeAccountIdentity(identity)
-  if (!normalizedIdentity) return false
-
-  if (!requiresNumericManualAccountIdentity(siteType)) return true
-
-  return POSITIVE_INTEGER_ID_PATTERN.test(normalizedIdentity)
 }

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -15,10 +15,7 @@ import {
 } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
-import {
-  isValidManualAccountIdentity,
-  normalizeAccountIdentity,
-} from "~/services/accounts/accountIdentity"
+import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import {
   ensureDefaultApiTokenForAccount,
   generateDefaultTokenRequest,
@@ -69,24 +66,6 @@ import { t } from "~/utils/i18n/core"
 const logger = createLogger("AccountOperations")
 
 export const MANUAL_ADD_ACCOUNT_DATA_FETCH_TIMEOUT_MS = 20000
-
-/**
- * Keeps legacy numeric-id validation at the explicit manual-input boundary only.
- */
-function validateManualAccountIdentity(
-  userId: string,
-  siteType: AccountSiteType,
-): AccountSaveResponse | null {
-  const identity = normalizeAccountIdentity(userId)
-  if (!identity || !isValidManualAccountIdentity(identity, siteType)) {
-    return {
-      success: false,
-      message: t("messages:errors.validation.userIdNumeric"),
-    }
-  }
-
-  return null
-}
 
 const isCreatedApiToken = (value: unknown): value is ApiToken =>
   !!value &&
@@ -813,11 +792,6 @@ export async function validateAndSaveAccount(
   }
 
   const accountIdentity = normalizeAccountIdentity(userId) ?? ""
-  const identityValidationError = validateManualAccountIdentity(
-    accountIdentity,
-    normalizedSiteType,
-  )
-  if (identityValidationError) return identityValidationError
 
   let shouldAutoProvisionKeyOnAccountAdd =
     DEFAULT_PREFERENCES.autoProvisionKeyOnAccountAdd ?? false
@@ -1085,11 +1059,6 @@ export async function validateAndUpdateAccount(
   }
 
   const accountIdentity = normalizeAccountIdentity(userId) ?? ""
-  const identityValidationError = validateManualAccountIdentity(
-    accountIdentity,
-    normalizedSiteType,
-  )
-  if (identityValidationError) return identityValidationError
 
   const manualQuota = parseManualQuotaFromUsd(manualBalanceUsd)
   const normalizedManualBalanceUsd =

--- a/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
@@ -154,9 +154,7 @@ describe("AccountDialog AccountForm", () => {
     ).toBeInTheDocument()
     expect(within(authSection).getByDisplayValue("alice")).toBeInTheDocument()
     expect(
-      within(authSection).getByPlaceholderText(
-        "accountDialog:form.userIdNumber",
-      ),
+      within(authSection).getByPlaceholderText("accountDialog:form.userId"),
     ).toBeInTheDocument()
     expect(
       within(authSection).getByDisplayValue("secret-token"),
@@ -181,14 +179,20 @@ describe("AccountDialog AccountForm", () => {
     expect(props.onAuthTypeChange).toHaveBeenCalledWith(AuthTypeEnum.Cookie)
   })
 
-  it("uses the site-specific account identity input strategy", async () => {
+  it("uses text input for manual account identities across account site types", async () => {
     const props = createProps()
 
     const { rerender } = render(<AccountForm {...props} />)
 
-    expect(
-      await screen.findByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.userIdInput),
-    ).toHaveAttribute("type", "number")
+    const newApiUserIdInput = await screen.findByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.userIdInput,
+    )
+    expect(newApiUserIdInput).toHaveAttribute("type", "text")
+    expect(newApiUserIdInput).toHaveAttribute("autocomplete", "off")
+    expect(newApiUserIdInput).toHaveAttribute(
+      "placeholder",
+      "accountDialog:form.userId",
+    )
 
     props.draft.siteType = SITE_TYPES.AIHUBMIX
     props.draft.userId = "aihubmix-user"
@@ -339,12 +343,9 @@ describe("AccountDialog AccountForm", () => {
     fireEvent.change(screen.getByDisplayValue("alice"), {
       target: { value: "alice cooper" },
     })
-    fireEvent.change(
-      screen.getByPlaceholderText("accountDialog:form.userIdNumber"),
-      {
-        target: { value: "77" },
-      },
-    )
+    fireEvent.change(screen.getByPlaceholderText("accountDialog:form.userId"), {
+      target: { value: "77" },
+    })
     fireEvent.change(accessTokenInput, {
       target: { value: "secret-token next" },
     })

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -417,13 +417,23 @@ describe("accountOperations validateAndSaveAccount", () => {
     )
   })
 
-  it("rejects non-numeric user ids before fetching remote data", async () => {
+  it("allows unknown account sites to save stable string user ids", async () => {
+    fetchAccountDataMock.mockResolvedValueOnce({
+      quota: 12,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+      checkIn: CHECK_IN_DISABLED,
+    })
+
     const result = await validateAndSaveAccount(
       "https://api.example.com",
       "Test Site",
       "tester",
       "token",
-      "not-a-number",
+      "user-abc-123",
       "7.0",
       "",
       [],
@@ -433,15 +443,30 @@ describe("accountOperations validateAndSaveAccount", () => {
       "",
     )
 
-    expect(result).toEqual({
-      success: false,
-      message: "messages:errors.validation.userIdNumeric",
-    })
-    expect(fetchAccountDataMock).not.toHaveBeenCalled()
+    expect(result.success).toBe(true)
+    const saved = await accountStorage.getAccountById(result.accountId!)
+    expect(saved?.account_info.id).toBe("user-abc-123")
+    expect(fetchAccountDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          userId: "user-abc-123",
+        }),
+      }),
+    )
   })
 
-  it("rejects non-canonical numeric user ids before fetching remote data", async () => {
+  it("allows New API-family account sites to save non-canonical string user ids", async () => {
     for (const userId of ["1.5", "1e3", "-1", "0", "001"]) {
+      fetchAccountDataMock.mockResolvedValueOnce({
+        quota: 12,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+        checkIn: CHECK_IN_DISABLED,
+      })
+
       const result = await validateAndSaveAccount(
         "https://api.example.com",
         "Test Site",
@@ -457,13 +482,12 @@ describe("accountOperations validateAndSaveAccount", () => {
         "",
       )
 
-      expect(result).toEqual({
-        success: false,
-        message: "messages:errors.validation.userIdNumeric",
-      })
+      expect(result.success).toBe(true)
+      const saved = await accountStorage.getAccountById(result.accountId!)
+      expect(saved?.account_info.id).toBe(userId)
     }
 
-    expect(fetchAccountDataMock).not.toHaveBeenCalled()
+    expect(fetchAccountDataMock).toHaveBeenCalledTimes(5)
   })
 
   it("allows AIHubMix to save a stable username identity", async () => {

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -490,6 +490,76 @@ describe("accountOperations validateAndSaveAccount", () => {
     expect(fetchAccountDataMock).toHaveBeenCalledTimes(5)
   })
 
+  it("allows New API-family account sites to update non-canonical string user ids", async () => {
+    for (const userId of ["1.5", "1e3", "-1", "0", "001"]) {
+      const accountId = await accountStorage.addAccount({
+        site_name: "Test Site",
+        site_url: "https://api.example.com",
+        site_type: SITE_TYPES.NEW_API,
+        health: { status: SiteHealthStatus.Healthy },
+        authType: AuthTypeEnum.AccessToken,
+        disabled: false,
+        excludeFromTotalBalance: false,
+        excludeFromTodayIncome: false,
+        exchange_rate: 7,
+        notes: "",
+        tagIds: [],
+        checkIn: CHECK_IN_DISABLED,
+        account_info: {
+          id: "previous-id",
+          access_token: "old-token",
+          username: "tester",
+          quota: 0,
+          today_prompt_tokens: 0,
+          today_completion_tokens: 0,
+          today_quota_consumption: 0,
+          today_requests_count: 0,
+          today_income: 0,
+        },
+        last_sync_time: 0,
+      })
+
+      fetchAccountDataMock.mockResolvedValueOnce({
+        quota: 12,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+        checkIn: CHECK_IN_DISABLED,
+      })
+
+      const result = await validateAndUpdateAccount(
+        accountId,
+        "https://api.example.com",
+        "Test Site",
+        "tester",
+        "token",
+        userId,
+        "7.0",
+        "",
+        [],
+        CHECK_IN_DISABLED,
+        SITE_TYPES.NEW_API,
+        AuthTypeEnum.AccessToken,
+        "",
+      )
+
+      expect(result.success).toBe(true)
+      const saved = await accountStorage.getAccountById(accountId)
+      expect(saved?.account_info.id).toBe(userId)
+      expect(fetchAccountDataMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          auth: expect.objectContaining({
+            userId,
+          }),
+        }),
+      )
+    }
+
+    expect(fetchAccountDataMock).toHaveBeenCalledTimes(5)
+  })
+
   it("allows AIHubMix to save a stable username identity", async () => {
     fetchAccountDataMock.mockResolvedValueOnce({
       quota: 12,

--- a/tests/services/accounts/accountIdentity.test.ts
+++ b/tests/services/accounts/accountIdentity.test.ts
@@ -3,15 +3,16 @@ import { describe, expect, it } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   coerceAccountIdentity,
-  isValidManualAccountIdentity,
   normalizeAccountIdentity,
-  requiresNumericManualAccountIdentity,
   resolveStoredAccountUserIdentity,
 } from "~/services/accounts/accountIdentity"
 
 describe("accountIdentity", () => {
   it("normalizes string and numeric identities to non-empty strings", () => {
     expect(normalizeAccountIdentity(" user-name ")).toBe("user-name")
+    expect(normalizeAccountIdentity("new-api-user-123")).toBe(
+      "new-api-user-123",
+    )
     expect(normalizeAccountIdentity(42)).toBe("42")
   })
 
@@ -21,34 +22,6 @@ describe("accountIdentity", () => {
     expect(normalizeAccountIdentity(Number.POSITIVE_INFINITY)).toBeNull()
     expect(normalizeAccountIdentity({ id: 1 })).toBeNull()
     expect(coerceAccountIdentity(null, "")).toBe("")
-  })
-
-  it("keeps numeric manual validation scoped to compatible site types", () => {
-    expect(requiresNumericManualAccountIdentity(SITE_TYPES.NEW_API)).toBe(true)
-    expect(requiresNumericManualAccountIdentity(SITE_TYPES.AIHUBMIX)).toBe(
-      false,
-    )
-  })
-
-  it("allows username identities only for site types that do not require numeric manual ids", () => {
-    expect(
-      isValidManualAccountIdentity("aihubmix-user", SITE_TYPES.AIHUBMIX),
-    ).toBe(true)
-    expect(isValidManualAccountIdentity("", SITE_TYPES.AIHUBMIX)).toBe(false)
-    expect(isValidManualAccountIdentity("  ", SITE_TYPES.NEW_API)).toBe(false)
-    expect(
-      isValidManualAccountIdentity("not-a-number", SITE_TYPES.NEW_API),
-    ).toBe(false)
-    expect(isValidManualAccountIdentity("123", SITE_TYPES.NEW_API)).toBe(true)
-  })
-
-  it("requires positive integer strings for numeric manual account identities", () => {
-    expect(isValidManualAccountIdentity("1.5", SITE_TYPES.NEW_API)).toBe(false)
-    expect(isValidManualAccountIdentity("1e3", SITE_TYPES.NEW_API)).toBe(false)
-    expect(isValidManualAccountIdentity("-1", SITE_TYPES.NEW_API)).toBe(false)
-    expect(isValidManualAccountIdentity("0", SITE_TYPES.NEW_API)).toBe(false)
-    expect(isValidManualAccountIdentity("001", SITE_TYPES.NEW_API)).toBe(false)
-    expect(isValidManualAccountIdentity("1", SITE_TYPES.NEW_API)).toBe(true)
   })
 
   it("resolves stored user identities from the site-specific identity field", () => {


### PR DESCRIPTION
Closes #964.

## Summary
- Allow account-site user IDs to be entered and stored as stable strings.
- Remove the account-dialog numeric-only placeholder and stale account ID helper functions.
- Leave managed-site user ID validation unchanged.

## Root Cause
Manual account entry treated several account site types as numeric-only even though compatible deployments can expose alphanumeric user IDs.

## Validation
- `pnpm vitest run tests/services/accounts/accountIdentity.test.ts tests/services/accountOperations.validateAndSaveAccount.test.ts tests/features/AccountManagement/components/AccountDialogForm.test.tsx`
- `pnpm vitest run tests/entrypoints/options/BasicSettingsTabs.test.tsx tests/entrypoints/options/DoneHubSettings.test.tsx tests/entrypoints/options/VeloeraSettings.test.tsx tests/services/newApiService/newApiService.test.ts tests/services/doneHubService/doneHubService.more.test.ts tests/services/veloeraService/veloeraService.more.test.ts`
- `pnpm run i18n:extract:ci`
- `pnpm run validate:push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified user ID handling to accept alphanumeric values across all account types.
  * Updated the account dialog’s User ID input to use a consistent text entry experience (including placeholder behavior).
  * Streamlined create/update validation by removing legacy numeric-specific checks.

* **Localization**
  * Updated account dialog User ID labels across supported languages to remove numeric-specific wording.

* **Tests**
  * Adjusted and expanded unit tests to match the new User ID validation and placeholder expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->