### PR TITLE
feat(model-list): load Sub2API runtime models with estimated pricing

### DIFF
--- a/docs/superpowers/plans/2026-06-14-sub2api-model-list-price-estimation.md
+++ b/docs/superpowers/plans/2026-06-14-sub2api-model-list-price-estimation.md
@@ -1,0 +1,374 @@
+# Sub2API Model List Price Estimation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show key-scoped Sub2API runtime models from `/v1/models`, represent unavailable prices truthfully, and add guarded estimated prices only when dashboard group-rate and price-table inputs are available.
+
+**Architecture:** Keep `ApiServiceCapabilities.modelPricing` false for Sub2API until Model List has separate runtime-model-list and price-precision semantics. Add row-level catalog metadata so model-only rows can render without treating unknown prices as zero, then route Sub2API selected-key runtime models through the existing account-token fallback path. Add JWT-backed estimation as a second slice by joining the resolved key group, Sub2API group rates, and a synthetic-test-covered LiteLLM-style price table; keep channel pricing out of the first implementation path.
+
+**Tech Stack:** TypeScript, React, WXT, TanStack Query, Vitest, Testing Library, existing `~/services/apiService`, `~/services/apiCredentialProfiles`, and `~/features/ModelList` modules.
+
+---
+
+### Task 1: Add Model List Source And Price Precision Contracts
+
+**Files:**
+- Modify: `src/services/apiService/common/type.ts`
+- Modify: `src/features/ModelList/modelManagementSources.ts`
+- Test: `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`
+- Test: `tests/features/ModelList/components/ModelItemPricing.test.tsx`
+
+- [ ] **Step 1: Write failing tests for unavailable-price rows**
+
+  Add tests proving that a row marked as model-list-only is displayed but is not treated as a free model. In `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`, create a `PricingResponse` with one row whose pricing precision is unavailable and assert that price sort leaves that row out of priced comparisons while keeping it in the result set. In `tests/features/ModelList/components/ModelItemPricing.test.tsx`, render the pricing component with unavailable metadata and assert that it shows a localized unavailable-price state, not `$0`, `¥0`, or a ratio-derived price.
+
+  Run: `pnpm vitest run tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts tests/features/ModelList/components/ModelItemPricing.test.tsx`
+
+  Expected: FAIL because the type metadata and UI branch do not exist yet.
+
+- [ ] **Step 2: Extend shared pricing metadata types**
+
+  In `src/services/apiService/common/type.ts`, add constants and exported types for model-list and row-level pricing semantics:
+
+  - `MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY = "sub2api-runtime-key"`
+  - `MODEL_PRICE_SOURCE_KINDS.NONE = "none"`
+  - `MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE = "official-rate-estimate"`
+  - `MODEL_PRICE_SOURCE_KINDS.CHANNEL_PRICING = "channel-pricing"` for future use only
+  - `MODEL_PRICE_PRECISION_KINDS.EXACT = "exact"`
+  - `MODEL_PRICE_PRECISION_KINDS.ESTIMATED = "estimated"`
+  - `MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE = "unavailable"`
+  - `MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY = "model-list-only"`
+  - `MODEL_UNAVAILABLE_PRICE_REASONS.KEY_GROUP_UNKNOWN = "key-group-unknown"`
+  - `MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING = "official-price-missing"`
+  - `MODEL_UNAVAILABLE_PRICE_REASONS.PRICING_SOURCE_UNAVAILABLE = "pricing-source-unavailable"`
+
+  Add an optional `price_metadata` field to `ModelPricing` with source, precision, unavailable reason, optional source date, and optional unmatched model count fields. Extend `ModelListSourceInfo` with optional booleans `supportsRuntimeModelList` and `supportsPricing`. Keep existing fields optional for backward compatibility.
+
+- [ ] **Step 3: Extend Model List source capabilities without changing Sub2API service pricing**
+
+  In `src/features/ModelList/modelManagementSources.ts`, keep existing source capability defaults intact, and add a derived capability or helper that can read `PricingResponse.model_list_source.supportsRuntimeModelList` and `supportsPricing` for display behavior. This must not require changing `src/services/apiService/index.ts` Sub2API `modelPricing: false`.
+
+- [ ] **Step 4: Run contract tests**
+
+  Run: `pnpm vitest run tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts tests/features/ModelList/components/ModelItemPricing.test.tsx`
+
+  Expected: PASS for the new unavailable-price contract tests and existing tests in those files.
+
+- [ ] **Step 5: Commit**
+
+  Commit message: `feat(model-list): add price precision metadata`
+
+  Commit files: `src/services/apiService/common/type.ts`, `src/features/ModelList/modelManagementSources.ts`, `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`, `tests/features/ModelList/components/ModelItemPricing.test.tsx`
+
+### Task 2: Make Model List Treat Unknown Prices As Missing, Never Zero
+
+**Files:**
+- Modify: `src/services/models/utils/modelPricing.ts`
+- Modify: `src/features/ModelList/hooks/useFilteredModels.ts`
+- Modify: `src/features/ModelList/components/ModelItem/ModelItemPricing.tsx`
+- Modify: `src/features/ModelList/components/ModelItem/ModelItemDetails.tsx`
+- Modify: `src/features/ModelList/components/ModelItem/index.tsx`
+- Modify: `src/locales/zh-CN/modelList.json`
+- Modify: sibling locale files under `src/locales/**/modelList.json` only through the repo i18n extraction/check workflow
+- Test: `tests/utils/modelPricing.test.ts`
+- Test: `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`
+- Test: `tests/features/ModelList/components/ModelItemPricing.test.tsx`
+- Test: `tests/features/ModelList/components/ModelItemDetails.test.tsx`
+
+- [ ] **Step 1: Write failing tests for price-missing calculations and rendering**
+
+  Add tests that cover:
+
+  - `calculateModelPrice` returns an explicit missing-price result when `model.price_metadata.precision` is `unavailable`.
+  - billing-mode filters do not hide model-list-only rows merely because the current UI filter is token-based or per-call.
+  - price sorting compares priced rows and leaves unavailable rows stable instead of treating them as zero.
+  - row UI renders a local unavailable-price explanation and no numeric zero price.
+
+  Use synthetic names such as `example-runtime-model` and `example-priced-model`; do not encode real provider prices in tests.
+
+  Run: `pnpm vitest run tests/utils/modelPricing.test.ts tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts tests/features/ModelList/components/ModelItemPricing.test.tsx tests/features/ModelList/components/ModelItemDetails.test.tsx`
+
+  Expected: FAIL because the current utilities always produce numeric prices from ratio defaults.
+
+- [ ] **Step 2: Add missing-price calculation semantics**
+
+  In `src/services/models/utils/modelPricing.ts`, extend `CalculatedPrice` with a discriminant or optional metadata that tells consumers whether pricing is available. When `ModelPricing.price_metadata.precision === "unavailable"`, return a result that has no comparable numeric price. Do not represent unknown prices as `0`; zero remains a valid price only when a provider explicitly supplies zero.
+
+- [ ] **Step 3: Update filtering and sorting**
+
+  In `src/features/ModelList/hooks/useFilteredModels.ts`, update `getComparablePriceKey`, billing-mode filtering, lowest-price detection, and count helpers so unavailable-price rows remain visible for model discovery but do not participate in cheapest/most-expensive comparisons or lowest-price badges. Preserve current behavior for exact and estimated priced rows.
+
+- [ ] **Step 4: Update row UI and details**
+
+  In the Model Item components, render unavailable-price metadata as a concise local status. Use copy under the `modelList` namespace such as:
+
+  - model-list-only: "Models are available for this key. Prices are unavailable."
+  - key-group-unknown: "Prices are unavailable because this key's Sub2API group could not be resolved."
+  - official-price-missing: "This model is not in the price table."
+  - pricing-source-unavailable: "Price data is unavailable for this source."
+
+  If UI copy is added, run the repo i18n extraction/check flow and keep sibling locale shapes consistent. Do not manually drift one locale into a different key shape.
+
+- [ ] **Step 5: Run focused tests and i18n check**
+
+  Run: `pnpm vitest run tests/utils/modelPricing.test.ts tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts tests/features/ModelList/components/ModelItemPricing.test.tsx tests/features/ModelList/components/ModelItemDetails.test.tsx`
+
+  Expected: PASS, including tests that prove unknown prices are not rendered or sorted as zero.
+
+  Run: `pnpm run i18n:extract:ci`
+
+  Expected: PASS with no unexpected locale shape updates. If extraction updates locale JSON for the new copy, inspect the diff and keep the generated sibling locale changes.
+
+- [ ] **Step 6: Commit**
+
+  Commit message: `feat(model-list): support unavailable model prices`
+
+  Commit files: model pricing utility, Model List hook/components, locale JSON generated by i18n extraction, and the focused tests changed in this task.
+
+### Task 3: Add Sub2API Runtime `/v1/models` Helper Without Pricing
+
+**Files:**
+- Modify: `src/services/apiService/sub2api/index.ts`
+- Optionally create: `src/services/apiService/sub2api/runtimeModels.ts` if keeping the helper out of the large adapter file improves readability
+- Test: `tests/services/apiService/sub2api/index.test.ts`
+- Test: `tests/services/apiService/sub2api/keyManagement.test.ts`
+
+- [ ] **Step 1: Write failing Sub2API runtime model tests**
+
+  Add tests for a new exported helper, named during implementation as `fetchSub2ApiRuntimeModels` or a nearby repo-consistent equivalent, that:
+
+  - calls `GET {baseUrl}/v1/models`
+  - sends `Authorization: Bearer <api key>`
+  - accepts OpenAI-style `data[].id` responses with numeric `created`
+  - accepts Sub2API-style `data[].id`, `display_name`, and `created_at`
+  - returns normalized model IDs
+  - returns an empty array for a valid empty `data` list
+  - rejects malformed payloads with a validation error
+  - treats 401/403 as an API-key runtime auth failure
+
+  Also keep the existing `fetchAccountAvailableModels` tests intact and add an assertion that this key-creation helper still returns `[]` for Sub2API forms where it currently does so.
+
+  Run: `pnpm vitest run tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts`
+
+  Expected: FAIL because the runtime helper is not implemented/exported yet.
+
+- [ ] **Step 2: Implement the runtime helper**
+
+  Add the helper in `src/services/apiService/sub2api/index.ts` or `src/services/apiService/sub2api/runtimeModels.ts`. Use the existing Sub2API request/error/redaction style. Add a concise upstream contract comment near the request:
+
+  `Source: https://github.com/Wei-Shaw/sub2api - gateway /v1/models uses runtime API-key auth and returns models visible to that key's group/platform.`
+
+  Do not use dashboard JWT as the `/v1/models` credential. Do not call `/api/v1/channels/available`. Do not fall back to common `/api/pricing`.
+
+- [ ] **Step 3: Run focused adapter tests**
+
+  Run: `pnpm vitest run tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts`
+
+  Expected: PASS with existing key-management behavior preserved.
+
+- [ ] **Step 4: Commit**
+
+  Commit message: `feat(sub2api): fetch runtime key models`
+
+  Commit files: Sub2API runtime helper file(s) and Sub2API adapter tests.
+
+### Task 4: Route Sub2API Runtime Models Through Selected-Key Fallback
+
+**Files:**
+- Modify: `src/services/apiCredentialProfiles/modelCatalog.ts`
+- Modify: `src/features/ModelList/hooks/useModelData.ts`
+- Modify: `src/features/ModelList/modelManagementSources.ts` if source capabilities need response metadata
+- Test: `tests/services/apiCredentialProfiles/modelCatalog.test.ts`
+- Test: `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
+
+- [ ] **Step 1: Write failing fallback integration tests**
+
+  In `tests/services/apiCredentialProfiles/modelCatalog.test.ts`, add a Sub2API selected-token test proving that `loadAccountTokenFallbackPricingResponse` resolves the real token secret with `resolveDisplayAccountTokenForSecret`, calls the Sub2API runtime model helper with that secret, and returns a `PricingResponse` whose rows have:
+
+  - `model_list_source.kind = "sub2api-runtime-key"`
+  - `model_list_source.supportsRuntimeModelList = true`
+  - `model_list_source.supportsPricing = false`
+  - row `price_metadata.source = "none"`
+  - row `price_metadata.precision = "unavailable"`
+  - row unavailable reason `model-list-only`
+
+  In `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`, add a test proving Sub2API still has `capabilities.modelPricing = false`, the direct account query does not call `fetchModelPricing`, and the selected-key fallback can load runtime models without enabling common pricing.
+
+  Run: `pnpm vitest run tests/services/apiCredentialProfiles/modelCatalog.test.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
+
+  Expected: FAIL because Sub2API still uses the generic OpenAI-compatible fallback builder and zero-priced rows.
+
+- [ ] **Step 2: Build Sub2API model-only pricing response**
+
+  In `src/services/apiCredentialProfiles/modelCatalog.ts`, add a Sub2API branch before the generic OpenAI-compatible fallback. Resolve the token secret, call the new Sub2API runtime helper, and build model-only `PricingResponse` rows with unavailable-price metadata. Reuse the existing fallback error sanitization and make sure base URL, token key, and resolved secret are redacted from thrown messages.
+
+- [ ] **Step 3: Keep generic profile fallback behavior compatible**
+
+  Update `buildApiCredentialProfilePricingResponse` only as much as needed to avoid using zero for unknown prices when the response is a model-only catalog. Existing profile-backed OpenAI-compatible catalogs can remain marked as model-list-only unless they have a real price source. Do not silently reinterpret unknown profile prices as exact zero.
+
+- [ ] **Step 4: Update Model List fallback state if needed**
+
+  In `src/features/ModelList/hooks/useModelData.ts`, ensure the fallback load state, cache behavior, success toast, and analytics still work with a `PricingResponse` whose `model_list_source.supportsPricing` is false. Keep direct account Sub2API loading gated by `service.capabilities.modelPricing === false`.
+
+- [ ] **Step 5: Run focused fallback tests**
+
+  Run: `pnpm vitest run tests/services/apiCredentialProfiles/modelCatalog.test.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`
+
+  Expected: PASS. Assertions must prove Sub2API does not call common `fetchModelPricing` and unknown prices are unavailable, not zero.
+
+- [ ] **Step 6: Commit**
+
+  Commit message: `feat(model-list): load sub2api key runtime models`
+
+  Commit files: `src/services/apiCredentialProfiles/modelCatalog.ts`, `src/features/ModelList/hooks/useModelData.ts` if changed, `src/features/ModelList/modelManagementSources.ts` if changed, and focused fallback tests.
+
+### Task 5: Add Optional JWT Group Resolution And Estimated Prices
+
+**Files:**
+- Modify: `src/services/apiService/sub2api/index.ts`
+- Modify: `src/services/apiService/sub2api/parsing.ts`
+- Modify: `src/services/apiService/sub2api/type.ts`
+- Modify: `src/services/apiCredentialProfiles/modelCatalog.ts`
+- Create: `src/services/apiCredentialProfiles/sub2apiPriceEstimation.ts`
+- Create: `src/services/apiCredentialProfiles/modelPriceTable.ts`
+- Test: `tests/services/apiService/sub2api/keyManagement.test.ts`
+- Test: `tests/services/apiCredentialProfiles/modelCatalog.test.ts`
+- Test: `tests/services/apiCredentialProfiles/sub2apiPriceEstimation.test.ts`
+
+- [ ] **Step 1: Write failing key-group resolution tests**
+
+  Cover conservative group resolution in `tests/services/apiService/sub2api/keyManagement.test.ts` and `tests/services/apiCredentialProfiles/sub2apiPriceEstimation.test.ts`:
+
+  - exact unmasked key match resolves the backend key's stable group id when present
+  - stored stable group id is preferred if the implementation extends normalized token/storage shape to preserve it
+  - stored group name resolves only when exactly one available group has that exact name
+  - masked key values, no match, no stored group, or multiple same-name matches disable estimation
+  - current normalized `ApiToken.group` is treated as a name-like value, not a stable `group_id`
+
+  Run: `pnpm vitest run tests/services/apiService/sub2api/keyManagement.test.ts tests/services/apiCredentialProfiles/sub2apiPriceEstimation.test.ts`
+
+  Expected: FAIL because group resolution and estimation helpers do not exist yet.
+
+- [ ] **Step 2: Preserve stable group id only if supported by backend DTOs**
+
+  Inspect current Sub2API key DTO parsing in `src/services/apiService/sub2api/parsing.ts` before editing. If backend key list/detail DTOs expose a stable `group_id`, extend local normalization and types to preserve it with a narrow optional field. If only a group name is available, keep the type name-like and let the estimator use exact-name matching only. Do not guess a group from first, cheapest, or default available group.
+
+- [ ] **Step 3: Add dashboard-JWT group and rate helpers**
+
+  Add or expose helpers that use existing Sub2API dashboard auth mechanisms to call:
+
+  - `GET /api/v1/groups/available`
+  - `GET /api/v1/groups/rates`
+  - key list lookup through the existing `fetchAccountTokens` path when an exact key match is needed
+
+  These calls must use dashboard JWT/refresh-token auth, never the runtime API key. Reuse existing Sub2API auth refresh/error handling. If dashboard auth is unavailable or invalid, return the runtime model list without prices.
+
+- [ ] **Step 4: Add synthetic official price table loader**
+
+  In `src/services/apiCredentialProfiles/modelPriceTable.ts`, add a loader for a LiteLLM-style price table shape with source metadata. The first implementation can use a bundled static snapshot if product policy allows it; tests must inject a tiny synthetic table with `example-priced-model`, `example-cache-model`, and `example-unpriced-model`. Do not store real provider prices in tests, fixtures, comments, or snapshots.
+
+- [ ] **Step 5: Implement estimation formula**
+
+  In `src/services/apiCredentialProfiles/sub2apiPriceEstimation.ts`, join runtime model IDs to the price table and apply:
+
+  - `effectiveRate = userGroupRate[groupId] ?? group.rate_multiplier ?? 1`
+  - `estimatedInput = officialInput * effectiveRate`
+  - `estimatedOutput = officialOutput * effectiveRate`
+  - `estimatedCacheRead = officialCacheRead * effectiveRate`
+  - `estimatedCacheWrite = officialCacheWrite * effectiveRate`
+
+  Convert to the repository's existing display units through `ModelPricing.token_price_usd_per_million` where possible. Mark priced rows with `price_metadata.source = "official-rate-estimate"` and `precision = "estimated"`. Keep unmatched models in the response with unavailable reason `official-price-missing`.
+
+- [ ] **Step 6: Integrate optional estimation into selected-key fallback**
+
+  In `src/services/apiCredentialProfiles/modelCatalog.ts`, after Sub2API `/v1/models` succeeds, attempt the JWT/group/rate/price-table path only when dashboard auth data is available for the same account. If any estimation prerequisite fails, keep the model-only response and set a non-secret unavailable reason. Do not fail the model list because price estimation failed.
+
+- [ ] **Step 7: Run estimation tests**
+
+  Run: `pnpm vitest run tests/services/apiService/sub2api/keyManagement.test.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts tests/services/apiCredentialProfiles/sub2apiPriceEstimation.test.ts tests/utils/modelPricing.test.ts`
+
+  Expected: PASS. Tests must prove user-specific group rate overrides default group rate, unknown group disables estimation, unmatched official prices stay visible as unavailable, and estimated rows are labeled estimated.
+
+- [ ] **Step 8: Commit**
+
+  Commit message: `feat(sub2api): estimate key model prices`
+
+  Commit files: Sub2API parsing/type changes, `modelCatalog.ts`, new estimation and price-table modules, and focused tests.
+
+### Task 6: Final UI, Telemetry, And Validation
+
+**Files:**
+- Modify: `src/services/productAnalytics/events.ts` only if new telemetry fields are needed
+- Modify: `src/services/productAnalytics/modelListDiagnostics.ts` only if new telemetry fields are needed
+- Modify: `src/features/ModelList/components/StatusIndicator.tsx` if source state needs a visible status
+- Modify: `src/features/ModelList/sourceLabels.ts` if source labels need Sub2API runtime wording
+- Test: `tests/entrypoints/options/pages/ModelList/StatusIndicator.test.tsx`
+- Test: `tests/services/productAnalytics/modelListDiagnostics.test.ts` if telemetry changes
+
+- [ ] **Step 1: Decide telemetry scope**
+
+  If implementation already touches Model List refresh analytics, add sanitized result/summary fields only:
+
+  - source site type: `sub2api`
+  - runtime model list status: success/error/empty
+  - estimated pricing status: success/unavailable/error
+  - key group resolution status: matched/stored/missing
+  - counts: model count, priced model count, unpriced model count
+
+  Do not record base URL, model IDs, API keys, JWTs, group names, group IDs, raw backend messages, or stack traces. If analytics is not already touched, document telemetry decision as `none` in the final handoff because the feature is primarily represented by existing Model List refresh analytics.
+
+- [ ] **Step 2: Add final visible source state tests if UI changed**
+
+  If status/source UI changes, add tests proving:
+
+  - model-only Sub2API rows show a key runtime model-list source and prices unavailable
+  - estimated rows show estimated price source text
+  - mixed priced/unpriced rows render without overflow-prone long technical text
+
+  Run: `pnpm vitest run tests/entrypoints/options/pages/ModelList/StatusIndicator.test.tsx tests/features/ModelList/components/ModelItemPricing.test.tsx`
+
+  Expected: PASS when source state UI is changed. Skip this command only if no status/source UI file changed.
+
+- [ ] **Step 3: Run focused validation**
+
+  Run: `pnpm vitest run tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts tests/services/apiCredentialProfiles/sub2apiPriceEstimation.test.ts tests/utils/modelPricing.test.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts tests/features/ModelList/components/ModelItemPricing.test.tsx tests/features/ModelList/components/ModelItemDetails.test.tsx`
+
+  Expected: PASS for all focused service, hook, utility, and component coverage.
+
+- [ ] **Step 4: Run i18n check if copy changed**
+
+  Run: `pnpm run i18n:extract:ci`
+
+  Expected: PASS with no unexpected extraction diff. If it reports locale updates, inspect the diff, keep intended sibling locale changes, and rerun until clean.
+
+- [ ] **Step 5: Run commit gate**
+
+  Stage only task-scoped files for the current implementation slice.
+
+  Run: `pnpm run validate:staged`
+
+  Expected: PASS on staged task-scoped files.
+
+- [ ] **Step 6: Run push gate only if required by changed surface**
+
+  Run `pnpm run validate:push` if the implementation touches shared exports, dependency graph wiring, build configuration, or cross-module type contracts. This plan likely touches shared exported types, so expect to run it before pushing or opening a PR.
+
+  Expected: PASS. If it fails, classify the failure as code, tooling, environment, auth, network, or permission before changing code.
+
+- [ ] **Step 7: Commit final integration**
+
+  Commit message: `feat(model-list): label sub2api price precision`
+
+  Commit files: telemetry/status/source-label changes, locale changes generated by i18n extraction, and final UI tests changed in this task.
+
+### E2E Decision
+
+- [ ] **Step 1: Keep E2E out of the first implementation unless browser runtime behavior changes**
+
+  No Playwright E2E is required for the first implementation because the main risk is adapter normalization, selected-key data flow, price-source metadata, and rendering semantics covered by Vitest and Testing Library. Add or update Playwright only if implementation changes cross-entrypoint browser-session recovery, extension storage migration, route/deep-link behavior, or a new interactive setup flow.
+
+### Channel Pricing Future Work Boundary
+
+- [ ] **Step 1: Preserve the channel-free first path**
+
+  Do not use `/api/v1/channels/available` in this implementation. Document channel pricing only as a future enhancement after runtime model list and estimated group-rate pricing are stable. A future channel-pricing slice must map channel rows to the saved key's resolved group, platform, and model before setting `price_metadata.source = "channel-pricing"`.

--- a/docs/superpowers/specs/2026-06-14-sub2api-model-list-price-estimation-design.md
+++ b/docs/superpowers/specs/2026-06-14-sub2api-model-list-price-estimation-design.md
@@ -1,0 +1,457 @@
+# Sub2API Model List And Price Estimation Design
+
+Date: 2026-06-14
+
+## Purpose
+
+Add a correct Sub2API model-list path and define a guarded price-estimation
+path for Model List without reintroducing incompatible One-API/New-API common
+pricing behavior.
+
+Sub2API is not One-API/New-API compatible. Its runtime model list is keyed by
+the API key's group, while its dashboard user APIs expose group visibility and
+user-specific group rates. The first implementation should use those contracts
+directly and label derived prices as estimates.
+
+## Current Context
+
+The adapter capability contract currently marks Sub2API model pricing as
+unsupported. That is correct for full, backend-accurate model pricing because
+Sub2API does not expose a key-scoped pricing endpoint equivalent to common
+`/api/pricing` surfaces.
+
+Upstream Sub2API does provide two relevant data paths:
+
+- API-key runtime model discovery:
+  - `GET /v1/models`
+  - `Authorization: Bearer <api key>`
+  - returns the models visible to that API key.
+- Dashboard user group pricing inputs:
+  - `GET /api/v1/groups/available`
+  - `GET /api/v1/groups/rates`
+  - `Authorization: Bearer <dashboard JWT>`
+  - returns user-visible groups and user-specific group-rate overrides.
+
+The related Price-Monitor-AI-Api project uses the same user group inputs plus a
+LiteLLM-style official price table to produce price rows. Its README explicitly
+states that `/v1/models` is only a model-probe source and not a complete price
+directory. Its Sub2API user-price logic multiplies official model prices by the
+effective group rate.
+
+## Verified Sub2API Behavior
+
+### Runtime Model List
+
+Sub2API registers `/v1/models` on the gateway route with API-key auth. The
+handler resolves the API key from context, reads its group and platform, then
+calls `GatewayService.GetAvailableModels(groupID, platform)`.
+
+The returned list is key-scoped through the key's group:
+
+- API key auth validates the key and loads `APIKey`, `User`, and `Group`.
+- `Models` uses `apiKey.Group.ID` and `apiKey.Group.Platform`.
+- `GetAvailableModels` lists schedulable accounts in that group/platform and
+  collects model names from account model mappings.
+- If the group enables a custom model list, the handler filters by that list.
+- If no mapped models are available, the handler falls back to default platform
+  model catalogs.
+
+This means the correct model-list source for a saved Sub2API API key is the
+runtime `/v1/models` endpoint, not `/api/v1/channels/available`.
+
+### Dashboard Group Rates
+
+Sub2API user routes expose:
+
+- `GET /api/v1/groups/available`, handled by
+  `APIKeyHandler.GetAvailableGroups`, returning groups the authenticated user
+  may bind to.
+- `GET /api/v1/groups/rates`, handled by
+  `APIKeyHandler.GetUserGroupRates`, returning `map[groupID]rateMultiplier`
+  for user-specific group-rate overrides.
+
+These endpoints require dashboard JWT auth. They do not accept the runtime API
+key as a substitute.
+
+### Billing Calculation
+
+For OpenAI-compatible requests, Sub2API usage recording resolves a rate
+multiplier before calculating cost:
+
+- start with configured/default rate
+- when the API key has a group, resolve the effective user/group rate with
+  `userGroupRateResolver.Resolve(userID, groupID, group.RateMultiplier)`
+- pass that multiplier into `BillingService.CalculateCostUnified`
+
+The base model pricing is resolved by `ModelPricingResolver`:
+
+- channel pricing override
+- LiteLLM/dynamic model price
+- fallback price
+
+For token pricing without channel overrides, the high-level relationship is:
+
+```text
+model base price * effective group rate
+```
+
+The Price-Monitor-AI-Api approach is therefore faithful to the simple/default
+rate-multiplier part of Sub2API billing, but it is an estimate rather than a
+complete billing replica.
+
+## Problem
+
+The product needs two related but distinct capabilities:
+
+1. show the models a saved Sub2API key can actually use
+2. show a useful price comparison when enough dashboard data is available
+
+Treating these as one `fetchModelPricing` capability creates false precision:
+
+- `/v1/models` is key-scoped but has no prices.
+- `/api/v1/groups/available` and `/api/v1/groups/rates` provide rate inputs,
+  but do not prove which group a specific key uses unless key metadata is
+  also read.
+- `official price * effective rate` misses Sub2API channel pricing overrides,
+  interval pricing, image/per-request pricing, and model mapping choices.
+- `/api/v1/channels/available` may contain channel pricing, but it is
+  feature-gated, dashboard-scoped, and not a reliable key-scoped model-list
+  source.
+
+## Goals
+
+- Add a Sub2API model-list path that uses the saved API key against
+  `/v1/models`.
+- Keep model-list availability separate from price-estimation availability.
+- When dashboard JWT data is available, estimate model prices from the key's
+  group, user group rates, and an official/LiteLLM price table.
+- Mark estimated prices as estimated in the returned data and UI state.
+- Avoid claiming support for exact Sub2API billing prices.
+- Keep `/api/v1/channels/available` out of the first implementation's required
+  path.
+- Preserve strict adapter behavior for unsupported full model-pricing calls
+  until the new estimated-price capability is explicitly modeled.
+
+## Non-Goals
+
+- Do not implement exact Sub2API usage-billing replication.
+- Do not depend on `/api/v1/channels/available` for the first implementation.
+- Do not scrape dashboard pages.
+- Do not require a dashboard JWT just to show the API key's model list.
+- Do not store or ship real provider prices in tests or fixtures; use reserved
+  examples or tiny synthetic tables in tests.
+- Do not change Sub2API key creation, refresh-token import, or browser-session
+  recovery behavior outside the data needed for this feature.
+
+## Design
+
+### 1. Split Capability Semantics
+
+Sub2API should not simply flip `capabilities.modelPricing` to `true` for the
+first slice. That field currently implies a full account pricing response,
+which would be misleading for estimated data.
+
+Before Sub2API `/v1/models` rows flow through `PricingResponse`, the Model List
+data model must represent price precision and unavailable prices explicitly.
+Returning model-only rows with zero prices is not acceptable because current
+filtering and sorting logic treats numeric zero as a real price.
+
+Add explicit semantics at the model-list layer, either by extending
+`PricingResponse.model_list_source`, adding pricing metadata to `ModelPricing`,
+or adding source capability flags in the Model List data model:
+
+- model list source: `sub2api-runtime-key`
+- price source: `none`, `official-rate-estimate`, or future
+  `channel-pricing`
+- precision: `exact`, `estimated`, or `unavailable`
+- unavailable-price reason: `model-list-only`, `key-group-unknown`,
+  `official-price-missing`, or `pricing-source-unavailable`
+
+The first implementation should expose:
+
+- `supportsRuntimeModelList: true`
+- `supportsPricing: false` when only `/v1/models` succeeds
+- `supportsPricing: true` with `precision: estimated` only when the
+  JWT/rate/official-price path succeeds
+
+### 2. Runtime Model List
+
+Add a Sub2API helper that calls:
+
+```http
+GET {baseUrl}/v1/models
+Authorization: Bearer <apiKey>
+Accept: application/json
+```
+
+Normalize both common OpenAI-style numeric `created` payloads and Sub2API's
+observed `created_at` payload:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "example-model",
+      "type": "model",
+      "display_name": "example-model",
+      "created_at": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+The normalized model rows should have no price fields unless the estimation
+path can join prices later.
+
+Failure behavior:
+
+- 401/403: surface an API-key-specific model-list auth error.
+- empty `data`: return an empty catalog with a clear empty state.
+- malformed payload: fail the Sub2API account source and avoid falling back to
+  common `/api/pricing`.
+
+### 3. Key-Scoped Group Resolution
+
+When dashboard JWT auth is available, resolve the saved API key's group before
+estimating price.
+
+Data sources:
+
+- `GET /api/v1/keys` to list current user's keys.
+- match the saved runtime key to a key DTO when possible.
+- read its group id/name from the matched key.
+- `GET /api/v1/groups/available` for group default metadata.
+- `GET /api/v1/groups/rates` for user-specific rate overrides.
+
+Implementation note: current local Sub2API key normalization maps backend key
+DTOs into the existing `ApiToken` shape and preserves the group as `group`.
+It does not currently preserve a separate stable `group_id`. The
+implementation must either extend that normalized/storage shape to carry
+`group_id`, or treat stored group information as a name and resolve it
+conservatively against `/api/v1/groups/available`.
+
+Matching must be conservative because some deployments may mask key values in
+list responses:
+
+- If the exact key cannot be matched, do not estimate by guessing the cheapest
+  or first group.
+- If the account already stores a Sub2API group selected during key creation,
+  prefer a stored group id only if the implementation extends the normalized
+  token/storage shape to preserve that id. The current token normalization
+  preserves the group as a name-like value, not a stable `group_id`.
+- If only a stored group name is available, resolve it conservatively against
+  current available groups. A single exact name match may be used; no match or
+  multiple matches must disable estimation.
+- If neither exact key match nor conservative stored-group resolution is
+  available, return the model list without prices and explain that the key
+  group is unknown.
+
+### 4. Official Price Table
+
+Use an official/LiteLLM-style price table as the base price source, following
+the Price-Monitor-AI-Api pattern.
+
+Initial source options:
+
+- bundled static snapshot for offline reliability
+- optional remote refresh from a known model-price source when network access
+  and project policy allow it
+
+The implementation must preserve source metadata:
+
+- price table source
+- fetched-at or bundled snapshot date when available
+- unmatched models count
+
+Tests should use synthetic model names and prices.
+
+### 5. Estimation Formula
+
+For token models where the official table has token prices:
+
+```text
+effectiveRate = userGroupRate[groupId] ?? group.rate_multiplier ?? 1
+estimatedInput = officialInput * effectiveRate
+estimatedOutput = officialOutput * effectiveRate
+estimatedCacheRead = officialCacheRead * effectiveRate
+estimatedCacheWrite = officialCacheWrite * effectiveRate
+```
+
+Convert official per-token prices to this repository's existing
+`ModelPricing`/display units consistently with existing `modelPricing` helpers.
+
+When the official table lacks a model, include the model without pricing and
+mark the price as unavailable. Do not synthesize zero-valued price fields for
+unknown prices.
+
+### 6. Channel Pricing Treatment
+
+The spec must document channel pricing as a known accuracy gap.
+
+Sub2API's real serving and billing can involve channel state. Channels are not
+the base model-list source, but they can affect model mapping, restrictions,
+and pricing. Sub2API's real billing resolves pricing through:
+
+```text
+channel pricing -> LiteLLM/base price -> fallback
+```
+
+Channel pricing can override token prices, define intervals, or use
+per-request/image billing. The first implementation should not depend on
+`/api/v1/channels/available` because:
+
+- the endpoint is dashboard-scoped, not API-key runtime scoped
+- the feature is opt-in and can return an empty list when disabled
+- channel rows can span multiple groups/platforms and require careful mapping
+- using it incorrectly can be worse than showing no price
+
+Future enhancement:
+
+- probe `/api/v1/channels/available` only when dashboard JWT is available
+- use channel pricing only when it can be mapped to the saved key's resolved
+  group, platform, and model
+- mark source as `channel-pricing`
+- keep fallback estimated prices visible only when the source is clearly
+  labeled
+
+## Data Flow
+
+### Model List Only
+
+1. User opens Model List for a Sub2API account.
+2. App resolves the saved runtime API key.
+3. Sub2API adapter calls `/v1/models` with API-key auth.
+4. App displays key-scoped models with no price fields.
+5. UI shows a source note: key runtime model list, prices unavailable.
+
+### Model List With Estimated Prices
+
+1. Runtime model list succeeds.
+2. App checks whether dashboard JWT/refresh-token auth is available for the
+   same Sub2API account.
+3. App resolves dashboard JWT using existing Sub2API auth helpers.
+4. App resolves the key's group via exact key match or stored group id.
+5. App loads available groups and user group rates.
+6. App loads official price table.
+7. App joins visible runtime model ids to official price rows.
+8. App applies effective group rate.
+9. UI shows estimated prices with source and precision metadata.
+
+## UI Requirements
+
+- Do not label estimated data as exact pricing.
+- Show model rows even when price estimation fails.
+- When prices are estimated, display a short source state such as:
+  "Estimated from official model prices and Sub2API group rate."
+- When some models lack official prices, show those models as price
+  unavailable rather than hiding them.
+- When key group resolution fails, show prices unavailable with a local
+  explanation.
+- Avoid using raw backend error text directly for user-visible status.
+
+## Telemetry
+
+Telemetry decision: add result/summary event fields only if the implementation
+already touches Model List refresh analytics.
+
+Safe fields:
+
+- source site type: `sub2api`
+- runtime model list status: success/error/empty
+- estimated pricing status: success/unavailable/error
+- key group resolution status: matched/stored/missing
+- counts: model count, priced model count, unpriced model count
+
+Do not record:
+
+- base URL
+- model ids
+- API keys
+- JWTs
+- group names or ids
+- raw backend messages
+
+## Testing Strategy
+
+Unit tests:
+
+- normalize Sub2API `/v1/models` payload with `created_at`.
+- reject malformed runtime model-list payloads.
+- join exact key or stored group id to available group metadata.
+- refuse estimation when key group is unknown.
+- apply user-specific group rate over default group rate.
+- keep unpriced models when the official table lacks entries.
+- label estimated price source and precision.
+- do not call common `fetchModelPricing` for Sub2API runtime model list.
+
+Hook/service tests:
+
+- Model List displays Sub2API runtime models without prices when only API key
+  auth is available.
+- Model List displays estimated prices when dashboard auth and official prices
+  are available.
+- Cached estimated responses do not masquerade as exact pricing.
+
+No Playwright E2E is required for the first implementation because the main
+risk is adapter/data normalization and pricing-source semantics. Add E2E only
+if implementation changes cross-entrypoint browser-session recovery or a new
+interactive setup flow.
+
+## Validation
+
+Focused validation should include:
+
+- affected Sub2API adapter tests
+- affected Model List hook tests
+- pricing utility tests for any new conversion helpers
+
+Before handoff or commit:
+
+- `pnpm run validate:staged`
+
+Run broader `pnpm run validate:push` only if the implementation touches shared
+exports, dependency graph wiring, or build configuration.
+
+## Rollout
+
+Implement in two phases:
+
+1. Runtime model-list source:
+   - add Sub2API `/v1/models` API-key helper
+   - show models without prices
+   - keep full `modelPricing` capability disabled
+2. Estimated pricing enhancement:
+   - resolve key group with dashboard JWT
+   - load group rates and official price table
+   - join estimated prices to runtime models
+   - label source and precision
+
+Channel pricing should remain a documented future enhancement until the mapping
+from user-visible channel data to a specific key's resolved billing source is
+verified and tested.
+
+## Source References
+
+Sub2API upstream:
+
+- `backend/internal/server/routes/gateway.go`
+- `backend/internal/handler/gateway_handler.go`
+- `backend/internal/service/gateway_service.go`
+- `backend/internal/handler/api_key_handler.go`
+- `backend/internal/service/api_key_service.go`
+- `backend/internal/service/openai_gateway_service.go`
+- `backend/internal/service/model_pricing_resolver.go`
+- `backend/internal/handler/available_channel_handler.go`
+
+Price-Monitor-AI-Api reference:
+
+- `README.md`
+- `internal/app/model_probe.go`
+- `internal/app/sub2api_prices.go`
+- `internal/app/sub2api.go`
+
+Existing repo context:
+
+- `docs/superpowers/specs/2026-06-08-sub2api-adapter-seam-separation-design.md`
+- `docs/superpowers/specs/2026-06-10-api-service-capabilities-design.md`

--- a/src/features/ModelList/components/ModelItem/ModelItemDetails.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemDetails.tsx
@@ -20,6 +20,8 @@ import {
   type CalculatedPrice,
 } from "~/services/models/utils/modelPricing"
 
+import { getUnavailablePriceReasonText } from "./ModelItemPricing"
+
 interface ModelItemDetailsProps {
   model: ModelPricing
   calculatedPrice: CalculatedPrice
@@ -46,6 +48,8 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
   if (!showGroupDetails && !showEndpointTypes && !showPricingDetails) {
     return null
   }
+
+  const priceUnavailable = calculatedPrice.priceAvailability === "unavailable"
 
   return (
     <>
@@ -130,30 +134,40 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
                 {t("detailedPricing")}
               </span>
             </div>
-            <div className="grid grid-cols-2 gap-4 text-xs">
-              <div className="space-y-1">
-                <div className="dark:text-dark-text-tertiary text-gray-500">
-                  {t("input1MTokens")}
+            {priceUnavailable ? (
+              <div className="dark:text-dark-text-secondary text-xs leading-snug text-gray-600">
+                {getUnavailablePriceReasonText(
+                  t,
+                  calculatedPrice.unavailableReason ??
+                    model.price_metadata?.unavailable_reason,
+                )}
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-4 text-xs">
+                <div className="space-y-1">
+                  <div className="dark:text-dark-text-tertiary text-gray-500">
+                    {t("input1MTokens")}
+                  </div>
+                  <div className="dark:text-dark-text-primary font-medium text-gray-900">
+                    USD: {formatPrice(calculatedPrice.inputUSD, "USD")}
+                  </div>
+                  <div className="dark:text-dark-text-primary font-medium text-gray-900">
+                    CNY: {formatPrice(calculatedPrice.inputCNY, "CNY")}
+                  </div>
                 </div>
-                <div className="dark:text-dark-text-primary font-medium text-gray-900">
-                  USD: {formatPrice(calculatedPrice.inputUSD, "USD")}
-                </div>
-                <div className="dark:text-dark-text-primary font-medium text-gray-900">
-                  CNY: {formatPrice(calculatedPrice.inputCNY, "CNY")}
+                <div className="space-y-1">
+                  <div className="dark:text-dark-text-tertiary text-gray-500">
+                    {t("output1MTokens")}
+                  </div>
+                  <div className="dark:text-dark-text-primary font-medium text-gray-900">
+                    USD: {formatPrice(calculatedPrice.outputUSD, "USD")}
+                  </div>
+                  <div className="dark:text-dark-text-primary font-medium text-gray-900">
+                    CNY: {formatPrice(calculatedPrice.outputCNY, "CNY")}
+                  </div>
                 </div>
               </div>
-              <div className="space-y-1">
-                <div className="dark:text-dark-text-tertiary text-gray-500">
-                  {t("output1MTokens")}
-                </div>
-                <div className="dark:text-dark-text-primary font-medium text-gray-900">
-                  USD: {formatPrice(calculatedPrice.outputUSD, "USD")}
-                </div>
-                <div className="dark:text-dark-text-primary font-medium text-gray-900">
-                  CNY: {formatPrice(calculatedPrice.outputCNY, "CNY")}
-                </div>
-              </div>
-            </div>
+            )}
           </div>
         )}
       </div>

--- a/src/features/ModelList/components/ModelItem/ModelItemDetails.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemDetails.tsx
@@ -22,6 +22,7 @@ import {
 
 import {
   getUnavailablePriceReasonText,
+  isAvailableCalculatedPrice,
   resolveUnavailablePriceReason,
 } from "./ModelItemPricing"
 
@@ -144,7 +145,7 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
               <div className="dark:text-dark-text-secondary text-xs leading-snug text-gray-600">
                 {getUnavailablePriceReasonText(t, unavailableReason)}
               </div>
-            ) : (
+            ) : isAvailableCalculatedPrice(calculatedPrice) ? (
               <div className="grid grid-cols-2 gap-4 text-xs">
                 <div className="space-y-1">
                   <div className="dark:text-dark-text-tertiary text-gray-500">
@@ -169,7 +170,7 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
                   </div>
                 </div>
               </div>
-            )}
+            ) : null}
           </div>
         )}
       </div>

--- a/src/features/ModelList/components/ModelItem/ModelItemDetails.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemDetails.tsx
@@ -20,7 +20,10 @@ import {
   type CalculatedPrice,
 } from "~/services/models/utils/modelPricing"
 
-import { getUnavailablePriceReasonText } from "./ModelItemPricing"
+import {
+  getUnavailablePriceReasonText,
+  resolveUnavailablePriceReason,
+} from "./ModelItemPricing"
 
 interface ModelItemDetailsProps {
   model: ModelPricing
@@ -49,7 +52,10 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
     return null
   }
 
-  const priceUnavailable = calculatedPrice.priceAvailability === "unavailable"
+  const unavailableReason = resolveUnavailablePriceReason(
+    model,
+    calculatedPrice,
+  )
 
   return (
     <>
@@ -134,13 +140,9 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
                 {t("detailedPricing")}
               </span>
             </div>
-            {priceUnavailable ? (
+            {unavailableReason ? (
               <div className="dark:text-dark-text-secondary text-xs leading-snug text-gray-600">
-                {getUnavailablePriceReasonText(
-                  t,
-                  calculatedPrice.unavailableReason ??
-                    model.price_metadata?.unavailable_reason,
-                )}
+                {getUnavailablePriceReasonText(t, unavailableReason)}
               </div>
             ) : (
               <div className="grid grid-cols-2 gap-4 text-xs">

--- a/src/features/ModelList/components/ModelItem/ModelItemPerCallPricingView.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemPerCallPricingView.tsx
@@ -1,6 +1,6 @@
 import {
   formatPriceCompact,
-  type CalculatedPrice,
+  type AvailableCalculatedPrice,
   type PerCallPrice,
 } from "~/services/models/utils/modelPricing"
 
@@ -34,7 +34,8 @@ export const ModelItemPerCallPricingView = ({
       </span>
     )
   } else {
-    const calculatedPrice: CalculatedPrice = {
+    const calculatedPrice: AvailableCalculatedPrice = {
+      priceAvailability: "available",
       inputUSD: perCallPrice.input,
       inputCNY: perCallPrice.input * exchangeRate,
       outputUSD: perCallPrice.output,

--- a/src/features/ModelList/components/ModelItem/ModelItemPicingView.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemPicingView.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from "react-i18next"
 
-import { CalculatedPrice } from "~/services/models/utils/modelPricing"
+import type { AvailableCalculatedPrice } from "~/services/models/utils/modelPricing"
 import { CurrencyType } from "~/types"
 
 interface PriceViewProps {
-  calculatedPrice: CalculatedPrice
+  calculatedPrice: AvailableCalculatedPrice
   showRealPrice: boolean
   tokenBillingType: boolean
   isAvailableForUser: boolean

--- a/src/features/ModelList/components/ModelItem/ModelItemPricing.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemPricing.tsx
@@ -1,13 +1,24 @@
+import type { TFunction } from "i18next"
 import React from "react"
 import { useTranslation } from "react-i18next"
 
 import { Badge } from "~/components/ui"
-import { formatGroupLabelFromRatios } from "~/features/ModelList/groupLabels"
+import {
+  formatGroupLabelFromRatios,
+  resolveGroupRatio,
+} from "~/features/ModelList/groupLabels"
 import {
   MODEL_LIST_GROUP_SELECTION_SCOPES,
   type ModelListGroupSelectionScope,
 } from "~/features/ModelList/groupSelectionScopes"
-import type { ModelPricing } from "~/services/apiService/common/type"
+import {
+  isModelPriceUnavailable,
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
+  type ModelPricing,
+  type ModelUnavailablePriceReason,
+} from "~/services/apiService/common/type"
 import {
   formatPriceCompact,
   isTokenBillingType,
@@ -35,6 +46,26 @@ interface ModelItemPricingProps {
 interface PriceMetaBadgeViewModel {
   kind: "optimal-group" | "lowest-price"
   variant: "success" | "secondary"
+}
+
+/**
+ * Maps unavailable-price metadata to local model-list copy.
+ */
+export function getUnavailablePriceReasonText(
+  t: TFunction<"modelList">,
+  reason?: ModelUnavailablePriceReason,
+) {
+  switch (reason) {
+    case MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY:
+      return t("unavailablePriceReasons.modelListOnly")
+    case MODEL_UNAVAILABLE_PRICE_REASONS.KEY_GROUP_UNKNOWN:
+      return t("unavailablePriceReasons.keyGroupUnknown")
+    case MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING:
+      return t("unavailablePriceReasons.officialPriceMissing")
+    case MODEL_UNAVAILABLE_PRICE_REASONS.PRICING_SOURCE_UNAVAILABLE:
+    default:
+      return t("unavailablePriceReasons.pricingSourceUnavailable")
+  }
 }
 
 /**
@@ -87,8 +118,19 @@ export const ModelItemPricing: React.FC<ModelItemPricingProps> = ({
     return null
   }
 
+  const priceUnavailable =
+    isModelPriceUnavailable(model) ||
+    calculatedPrice.priceAvailability === "unavailable"
   const tokenBillingType = isTokenBillingType(model.quota_type)
   const perCallPrice = calculatedPrice.perCallPrice
+  const estimatedPriceUsesDirectTokenPrice =
+    model.price_metadata?.source ===
+      MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE &&
+    model.price_metadata?.precision === MODEL_PRICE_PRECISION_KINDS.ESTIMATED
+  const displayRatio =
+    estimatedPriceUsesDirectTokenPrice && effectiveGroup
+      ? resolveGroupRatio(effectiveGroup, groupRatios)
+      : model.model_ratio
   const effectiveGroupLabel = effectiveGroup
     ? formatGroupLabelFromRatios(effectiveGroup, groupRatios)
     : undefined
@@ -137,6 +179,40 @@ export const ModelItemPricing: React.FC<ModelItemPricingProps> = ({
       {priceMetaLabel}
     </Badge>
   ) : null
+  const estimatedPriceMeta =
+    model.price_metadata?.precision ===
+    MODEL_PRICE_PRECISION_KINDS.ESTIMATED ? (
+      <Badge
+        variant="warning"
+        size="sm"
+        className="shrink-0 text-[10px] sm:text-xs"
+        title={t("estimatedPriceTitle")}
+      >
+        {t("estimatedPrice")}
+      </Badge>
+    ) : null
+
+  if (priceUnavailable) {
+    const unavailableReason =
+      model.price_metadata?.unavailable_reason ??
+      (calculatedPrice.priceAvailability === "unavailable"
+        ? calculatedPrice.unavailableReason
+        : undefined)
+
+    return (
+      <div className="mt-2">
+        <span
+          className={`block max-w-full text-xs leading-snug font-medium sm:text-sm ${
+            isAvailableForUser
+              ? "dark:text-dark-text-secondary text-gray-600"
+              : "dark:text-dark-text-tertiary text-gray-500"
+          }`}
+        >
+          {getUnavailablePriceReasonText(t, unavailableReason)}
+        </span>
+      </div>
+    )
+  }
 
   return (
     <div className="mt-2">
@@ -150,7 +226,7 @@ export const ModelItemPricing: React.FC<ModelItemPricingProps> = ({
             formatPriceCompact={formatPriceCompact}
           />
 
-          {(showRatioColumn || priceMeta) && (
+          {(showRatioColumn || priceMeta || estimatedPriceMeta) && (
             <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
               {showRatioColumn && (
                 <>
@@ -164,16 +240,17 @@ export const ModelItemPricing: React.FC<ModelItemPricingProps> = ({
                         : "dark:text-dark-text-tertiary text-gray-500"
                     }`}
                   >
-                    {model.model_ratio}x
+                    {displayRatio}x
                   </span>
                 </>
               )}
               {priceMeta}
+              {estimatedPriceMeta}
             </div>
           )}
         </div>
       ) : (
-        perCallPrice && (
+        perCallPrice !== undefined && (
           <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
             <span className="dark:text-dark-text-secondary text-xs whitespace-nowrap text-gray-600 sm:text-sm">
               {t("perCall")}
@@ -186,6 +263,7 @@ export const ModelItemPricing: React.FC<ModelItemPricingProps> = ({
               tokenBillingType={tokenBillingType}
             />
             {priceMeta}
+            {estimatedPriceMeta}
           </div>
         )
       )}

--- a/src/features/ModelList/components/ModelItem/ModelItemPricing.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemPricing.tsx
@@ -69,6 +69,28 @@ export function getUnavailablePriceReasonText(
 }
 
 /**
+ * Resolves the shared unavailable-price state used by collapsed and expanded rows.
+ */
+export function resolveUnavailablePriceReason(
+  model: ModelPricing,
+  calculatedPrice: CalculatedPrice,
+): ModelUnavailablePriceReason | undefined {
+  if (
+    !isModelPriceUnavailable(model) &&
+    calculatedPrice.priceAvailability !== "unavailable"
+  ) {
+    return undefined
+  }
+
+  return (
+    model.price_metadata?.unavailable_reason ??
+    (calculatedPrice.priceAvailability === "unavailable"
+      ? calculatedPrice.unavailableReason
+      : undefined)
+  )
+}
+
+/**
  * Resolves which pricing metadata badge should be rendered for the model row.
  */
 function resolvePriceMetaBadge(params: {
@@ -118,9 +140,10 @@ export const ModelItemPricing: React.FC<ModelItemPricingProps> = ({
     return null
   }
 
-  const priceUnavailable =
-    isModelPriceUnavailable(model) ||
-    calculatedPrice.priceAvailability === "unavailable"
+  const unavailableReason = resolveUnavailablePriceReason(
+    model,
+    calculatedPrice,
+  )
   const tokenBillingType = isTokenBillingType(model.quota_type)
   const perCallPrice = calculatedPrice.perCallPrice
   const estimatedPriceUsesDirectTokenPrice =
@@ -192,13 +215,7 @@ export const ModelItemPricing: React.FC<ModelItemPricingProps> = ({
       </Badge>
     ) : null
 
-  if (priceUnavailable) {
-    const unavailableReason =
-      model.price_metadata?.unavailable_reason ??
-      (calculatedPrice.priceAvailability === "unavailable"
-        ? calculatedPrice.unavailableReason
-        : undefined)
-
+  if (unavailableReason) {
     return (
       <div className="mt-2">
         <span

--- a/src/features/ModelList/components/ModelItem/ModelItemPricing.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemPricing.tsx
@@ -22,6 +22,7 @@ import {
 import {
   formatPriceCompact,
   isTokenBillingType,
+  type AvailableCalculatedPrice,
   type CalculatedPrice,
 } from "~/services/models/utils/modelPricing"
 
@@ -86,8 +87,18 @@ export function resolveUnavailablePriceReason(
     model.price_metadata?.unavailable_reason ??
     (calculatedPrice.priceAvailability === "unavailable"
       ? calculatedPrice.unavailableReason
-      : undefined)
+      : undefined) ??
+    MODEL_UNAVAILABLE_PRICE_REASONS.PRICING_SOURCE_UNAVAILABLE
   )
+}
+
+/**
+ * Narrows calculated pricing to rows that can render numeric price values.
+ */
+export function isAvailableCalculatedPrice(
+  calculatedPrice: CalculatedPrice,
+): calculatedPrice is AvailableCalculatedPrice {
+  return calculatedPrice.priceAvailability !== "unavailable"
 }
 
 /**
@@ -229,6 +240,10 @@ export const ModelItemPricing: React.FC<ModelItemPricingProps> = ({
         </span>
       </div>
     )
+  }
+
+  if (!isAvailableCalculatedPrice(calculatedPrice)) {
+    return null
   }
 
   return (

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -14,7 +14,10 @@ import type {
 } from "~/features/ModelList/modelManagementSources"
 import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
 import { formatModelListSourceLabel } from "~/features/ModelList/sourceLabels"
-import type { ModelPricing } from "~/services/apiService/common/type"
+import {
+  isModelPriceUnavailable,
+  type ModelPricing,
+} from "~/services/apiService/common/type"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
 import type { CalculatedPrice } from "~/services/models/utils/modelPricing"
 import {
@@ -216,7 +219,11 @@ export default function ModelItem(props: ModelItemProps) {
 
   const activeGroups =
     selectedGroups.length > 0 ? selectedGroups : availableGroups
+  const hasRuntimeDiscoveredPricingGap =
+    isModelPriceUnavailable(model) ||
+    calculatedPrice.priceAvailability === "unavailable"
   const isAvailableForUser =
+    hasRuntimeDiscoveredPricingGap ||
     groupSelectionScope === MODEL_LIST_GROUP_SELECTION_SCOPES.ALL_ACCOUNTS
       ? true
       : showGroupDetails

--- a/src/features/ModelList/components/StatusIndicator.tsx
+++ b/src/features/ModelList/components/StatusIndicator.tsx
@@ -14,6 +14,7 @@ import {
   Spinner,
   WorkflowTransitionButton,
 } from "~/components/ui"
+import { SITE_TYPES } from "~/constants/siteType"
 import type { AccountFallbackControls } from "~/features/ModelList/hooks/useModelData"
 import {
   MODEL_MANAGEMENT_SOURCE_KINDS,
@@ -74,6 +75,12 @@ export function StatusIndicator({
     )
   }
 
+  const isSub2ApiKeyScopedStatus =
+    selectedSource.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT &&
+    currentAccount?.siteType === SITE_TYPES.SUB2API &&
+    accountFallback?.isAvailable === true &&
+    !accountFallback.isActive
+
   const renderAccountFallbackSection = () => {
     if (!currentAccount || !accountFallback?.isAvailable) {
       return null
@@ -86,13 +93,17 @@ export function StatusIndicator({
       (!requiresExplicitSelection || accountFallback.selectedTokenId !== null)
 
     return (
-      <div className="dark:border-dark-bg-tertiary mt-4 space-y-4 border-t border-red-100 pt-4">
+      <div className="dark:border-dark-bg-tertiary mt-4 space-y-4 border-t border-gray-200 pt-4">
         <div>
           <h4 className="dark:text-dark-text-primary text-sm font-semibold text-gray-900">
-            {t("status.fallback.title")}
+            {isSub2ApiKeyScopedStatus
+              ? t("status.sub2apiKeyScopedFallbackTitle")
+              : t("status.fallback.title")}
           </h4>
           <p className="dark:text-dark-text-secondary mt-1 text-sm text-gray-600">
-            {t("status.fallback.description")}
+            {isSub2ApiKeyScopedStatus
+              ? t("status.sub2apiKeyScopedFallbackDescription")
+              : t("status.fallback.description")}
           </p>
         </div>
 
@@ -237,6 +248,20 @@ export function StatusIndicator({
           </div>
         ) : null}
       </div>
+    )
+  }
+
+  if (isSub2ApiKeyScopedStatus) {
+    return (
+      <Alert
+        variant="info"
+        className="mb-6"
+        title={t("status.sub2apiKeyScopedTitle")}
+        description={t("status.sub2apiKeyScopedDescription")}
+        aria-live="polite"
+      >
+        {renderAccountFallbackSection()}
+      </Alert>
     )
   }
 

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -4,6 +4,7 @@ import { UI_CONSTANTS } from "~/constants/ui"
 import { applyAihubmixModelListCapabilities } from "~/features/ModelList/aihubmixModelList"
 import {
   createAccountSource,
+  deriveModelListSourceCapabilities,
   MODEL_MANAGEMENT_SOURCE_KINDS,
   type ModelManagementSource,
 } from "~/features/ModelList/modelManagementSources"
@@ -11,7 +12,10 @@ import {
   MODEL_LIST_SORT_MODES,
   type ModelListSortMode,
 } from "~/features/ModelList/sortModes"
-import type { PricingResponse } from "~/services/apiService/common/type"
+import {
+  isModelPriceUnavailable,
+  type PricingResponse,
+} from "~/services/apiService/common/type"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
 import {
   calculateModelPrice,
@@ -111,6 +115,17 @@ function getComparablePriceKey(
   item: Pick<CalculatedModelItem, "model" | "calculatedPrice" | "source">,
   showRealPrice: boolean,
 ): ComparablePriceKey {
+  if (
+    isModelPriceUnavailable(item.model) ||
+    item.calculatedPrice.priceAvailability === "unavailable"
+  ) {
+    return {
+      billingMode: getModelBillingMode(item.model.quota_type),
+      primary: null,
+      secondary: null,
+    }
+  }
+
   if (isTokenBillingType(item.model.quota_type)) {
     const inputPrice = showRealPrice
       ? item.calculatedPrice.inputCNY
@@ -156,12 +171,16 @@ function getComparablePriceKey(
 }
 
 /** Orders nullable numbers with finite values before missing ones. */
-function compareNullableNumber(a: number | null, b: number | null) {
+function compareNullableNumber(
+  a: number | null,
+  b: number | null,
+  direction: 1 | -1,
+) {
   const aValid = isFiniteNumber(a)
   const bValid = isFiniteNumber(b)
 
   if (aValid && bValid) {
-    return a - b
+    return (a - b) * direction
   }
 
   if (aValid) {
@@ -181,17 +200,30 @@ function comparePriceKeys(
   b: ComparablePriceKey,
   direction: 1 | -1,
 ) {
-  const primaryComparison = compareNullableNumber(a.primary, b.primary)
+  const primaryComparison = compareNullableNumber(
+    a.primary,
+    b.primary,
+    direction,
+  )
   if (primaryComparison !== 0) {
-    return primaryComparison * direction
+    return primaryComparison
   }
 
-  const secondaryComparison = compareNullableNumber(a.secondary, b.secondary)
+  const secondaryComparison = compareNullableNumber(
+    a.secondary,
+    b.secondary,
+    direction,
+  )
   if (secondaryComparison !== 0) {
-    return secondaryComparison * direction
+    return secondaryComparison
   }
 
   return 0
+}
+
+/** Returns true when a price key has at least one finite comparable value. */
+function hasComparablePriceValue(priceKey: ComparablePriceKey) {
+  return isFiniteNumber(priceKey.primary) || isFiniteNumber(priceKey.secondary)
 }
 
 /** Creates a stable identifier for a calculated model item. */
@@ -254,8 +286,12 @@ function getModelBillingMode(quotaType: number): PricingBillingMode {
 
 /** Returns true when row pricing metadata should affect filters and sorting. */
 function supportsPricingDerivedBehavior(
-  item: Pick<CalculatedModelItem, "source">,
+  item: Pick<CalculatedModelItem, "model" | "source">,
 ) {
+  if (isModelPriceUnavailable(item.model)) {
+    return false
+  }
+
   return (
     item.source.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT ||
     item.source.capabilities.supportsPricing
@@ -275,7 +311,11 @@ function resolveBestCalculatedItem(
     supportsGroupFiltering,
   )
 
-  if (supportsGroupFiltering && candidateGroups.length === 0) {
+  if (
+    supportsGroupFiltering &&
+    candidateGroups.length === 0 &&
+    supportsPricingDerivedBehavior(rawItem)
+  ) {
     return null
   }
 
@@ -409,7 +449,13 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
           },
         }
         const source = applyAihubmixModelListCapabilities(
-          allAccountsRowSource,
+          {
+            ...allAccountsRowSource,
+            capabilities: deriveModelListSourceCapabilities({
+              capabilities: allAccountsRowSource.capabilities,
+              modelListSource: pricing.model_list_source,
+            }),
+          },
           pricing,
         )
 
@@ -446,7 +492,13 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
         : UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
 
     const source = applyAihubmixModelListCapabilities(
-      selectedSource,
+      {
+        ...selectedSource,
+        capabilities: deriveModelListSourceCapabilities({
+          capabilities: selectedSource.capabilities,
+          modelListSource: pricingData.model_list_source,
+        }),
+      },
       pricingData,
     )
 
@@ -689,6 +741,10 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
 
       if (supportsGroupFiltering) {
         filtered = filtered.filter((item) => {
+          if (!supportsPricingDerivedBehavior(item)) {
+            return true
+          }
+
           const itemSupportsGroupFiltering =
             item.source.capabilities.supportsGroupFiltering
           return (
@@ -843,6 +899,12 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     const priceKeys = new Map<string, ComparablePriceKey>()
     providerFilteredModels.forEach((item) => {
       if (!supportsPricingDerivedBehavior(item)) {
+        if (isModelPriceUnavailable(item.model)) {
+          priceKeys.set(
+            getModelItemKey(item),
+            getComparablePriceKey(item, showRealPrice),
+          )
+        }
         return
       }
 
@@ -871,11 +933,7 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
       groups.forEach((groupItems) => {
         const comparableItems = groupItems.filter((item) => {
           const priceKey = priceKeys.get(getModelItemKey(item))
-          return (
-            priceKey &&
-            (isFiniteNumber(priceKey.primary) ||
-              isFiniteNumber(priceKey.secondary))
-          )
+          return priceKey && hasComparablePriceValue(priceKey)
         })
 
         if (comparableItems.length === 0) {
@@ -990,20 +1048,15 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
                   item,
                 ): item is (typeof indexedItems)[number] & {
                   priceKey: ComparablePriceKey
-                } => !!item.priceKey,
+                } => !!item.priceKey && hasComparablePriceValue(item.priceKey),
               )
               .sort(comparePricedRows)
 
-            let pricedIndex = 0
-            return indexedItems.map((item) => {
-              if (!item.priceKey) {
-                return item
-              }
-
-              const nextPricedItem = pricedItems[pricedIndex]
-              pricedIndex += 1
-              return nextPricedItem ?? item
-            })
+            const missingPriceItems = indexedItems.filter(
+              (item) =>
+                !item.priceKey || !hasComparablePriceValue(item.priceKey),
+            )
+            return [...pricedItems, ...missingPriceItems]
           })()
 
     return sortedWithIndices.map(({ item, itemKey }) => ({

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import {
   MODEL_MANAGEMENT_SOURCE_KINDS,
   type ModelManagementSource,
@@ -111,8 +112,13 @@ function createInvalidFormatError() {
   return error
 }
 
+const MODEL_PRICING_UNSUPPORTED_ERROR = "model_pricing_unsupported"
+
 const createUnsupportedModelPricingError = () =>
-  new Error("model_pricing_unsupported")
+  new Error(MODEL_PRICING_UNSUPPORTED_ERROR)
+
+const isUnsupportedModelPricingError = (error: unknown) =>
+  error instanceof Error && error.message === MODEL_PRICING_UNSUPPORTED_ERROR
 
 /** Counts only valid model rows so analytics never includes raw model ids. */
 function getPricingModelCount(pricing: PricingResponse | null | undefined) {
@@ -733,6 +739,40 @@ function useSingleAccountModelData(params: {
       selectedSource?.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT ||
       !currentAccount
     ) {
+      return
+    }
+    if (!fallbackAvailable) return
+    if (currentAccount.siteType !== SITE_TYPES.SUB2API) return
+    if (!query.isError) return
+    if (!isUnsupportedModelPricingError(query.error)) return
+    if (!scopedHasLoadedFallbackTokens) return
+    if (scopedFallbackTokens.length !== 1) return
+    if (!selectedFallbackToken) return
+    if (scopedFallbackPricingData) return
+    if (scopedIsLoadingFallbackCatalog) return
+    if (scopedFallbackCatalogLoadErrorMessage) return
+
+    void loadFallbackCatalog()
+  }, [
+    currentAccount,
+    fallbackAvailable,
+    loadFallbackCatalog,
+    query.error,
+    query.isError,
+    scopedFallbackCatalogLoadErrorMessage,
+    scopedFallbackPricingData,
+    scopedFallbackTokens.length,
+    scopedHasLoadedFallbackTokens,
+    scopedIsLoadingFallbackCatalog,
+    selectedFallbackToken,
+    selectedSource?.kind,
+  ])
+
+  useEffect(() => {
+    if (
+      selectedSource?.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT ||
+      !currentAccount
+    ) {
       setDataFormatError(false)
       setLoadErrorMessage(null)
       return
@@ -789,6 +829,15 @@ function useSingleAccountModelData(params: {
       }
 
       setDataFormatError(false)
+      if (
+        currentAccount.siteType === SITE_TYPES.SUB2API &&
+        isUnsupportedModelPricingError(query.error) &&
+        fallbackAvailable
+      ) {
+        setLoadErrorMessage(null)
+        return
+      }
+
       const message = t("status.loadFailed")
       setLoadErrorMessage(message)
       toast.error(message)
@@ -816,6 +865,7 @@ function useSingleAccountModelData(params: {
     query.errorUpdatedAt,
     currentAccount,
     currentAccountScopeKey,
+    fallbackAvailable,
     selectedSource?.kind,
     t,
     resetFallbackState,
@@ -823,11 +873,22 @@ function useSingleAccountModelData(params: {
 
   const loadPricingData = useCallback(async () => {
     if (!currentAccount) return
+    if (scopedFallbackPricingData && selectedFallbackToken) {
+      await loadFallbackCatalog()
+      return
+    }
+
     await modelPricingCache.invalidate(
       createModelPricingCacheKey(currentAccount),
     )
     await query.refetch()
-  }, [currentAccount, query])
+  }, [
+    currentAccount,
+    loadFallbackCatalog,
+    query,
+    scopedFallbackPricingData,
+    selectedFallbackToken,
+  ])
 
   const pricingData = query.data ?? scopedFallbackPricingData ?? null
   const isFallbackCatalogActive = Boolean(
@@ -884,7 +945,7 @@ function useSingleAccountModelData(params: {
   return {
     pricingData,
     pricingContexts,
-    isLoading: query.isFetching,
+    isLoading: query.isFetching || scopedIsLoadingFallbackCatalog,
     dataFormatError,
     accountQueryStates: [],
     loadPricingData,

--- a/src/features/ModelList/hooks/useModelListData.ts
+++ b/src/features/ModelList/hooks/useModelListData.ts
@@ -8,6 +8,7 @@ import {
   isAihubmixModelListPricing,
 } from "../aihubmixModelList"
 import {
+  deriveModelListSourceCapabilities,
   EMPTY_MODEL_MANAGEMENT_CAPABILITIES,
   isProfileSourceValue,
   MODEL_MANAGEMENT_SOURCE_KINDS,
@@ -208,15 +209,25 @@ export function useModelListData(routeParams?: Record<string, string>) {
       return toAihubmixModelListCapabilities(baseCapabilities)
     }
 
+    const responseDerivedCapabilities = deriveModelListSourceCapabilities({
+      capabilities: baseCapabilities,
+      modelListSource: modelData.pricingData?.model_list_source,
+    })
+
     // Account-key fallback keeps the same owning account selected, but the
     // rendered catalog is no longer pricing-authoritative.
-    return isFallbackCatalogActive
-      ? toCatalogOnlyCapabilities(baseCapabilities)
-      : baseCapabilities
+    const shouldDowngradeFallbackCatalog =
+      isFallbackCatalogActive &&
+      modelData.pricingData?.model_list_source?.supportsPricing !== true
+
+    return shouldDowngradeFallbackCatalog
+      ? toCatalogOnlyCapabilities(responseDerivedCapabilities)
+      : responseDerivedCapabilities
   }, [
     isFallbackCatalogActive,
     isSelectedAccountAihubmixCatalogFallback,
     isSelectedAccountAihubmixModelList,
+    modelData.pricingData?.model_list_source,
     selectedSource?.capabilities,
   ])
 

--- a/src/features/ModelList/modelManagementSources.ts
+++ b/src/features/ModelList/modelManagementSources.ts
@@ -1,3 +1,4 @@
+import type { ModelListSourceInfo } from "~/services/apiService/common/type"
 import type { DisplaySiteData } from "~/types"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 
@@ -16,6 +17,7 @@ const MODEL_MANAGEMENT_SOURCE_VALUE_PREFIXES = {
 } as const
 
 export type ModelManagementSourceCapabilities = {
+  supportsRuntimeModelList?: boolean
   supportsPricing: boolean
   supportsRatioDisplay: boolean
   supportsGroupFiltering: boolean
@@ -159,6 +161,33 @@ export function toAihubmixCatalogFallbackCapabilities(
   return {
     ...toAihubmixModelListCapabilities(capabilities),
     supportsAccountSummary: false,
+  }
+}
+
+/**
+ * Applies response-level model-list source capability overrides for display.
+ */
+export function deriveModelListSourceCapabilities(params: {
+  capabilities: ModelManagementSourceCapabilities
+  modelListSource?: Pick<
+    ModelListSourceInfo,
+    "supportsRuntimeModelList" | "supportsPricing"
+  >
+}): ModelManagementSourceCapabilities {
+  const { capabilities, modelListSource } = params
+
+  if (!modelListSource) return capabilities
+
+  const pricingCapabilities =
+    modelListSource.supportsPricing === false
+      ? toCatalogOnlyCapabilities(capabilities)
+      : capabilities
+
+  return {
+    ...pricingCapabilities,
+    ...(typeof modelListSource.supportsRuntimeModelList === "boolean"
+      ? { supportsRuntimeModelList: modelListSource.supportsRuntimeModelList }
+      : {}),
   }
 }
 

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -102,6 +102,8 @@
   "displayOptions": "Display Options:",
   "endpointType": "Endpoint Type",
   "endpointTypes": "Endpoint Types",
+  "estimatedPrice": "Estimated",
+  "estimatedPriceTitle": "Estimated from the official price table and this key's Sub2API group rate.",
   "expandDetails": "Expand details",
   "fallbackSourceNotice": {
     "description": "This catalog is currently loaded through an account-key fallback, so it only supports model discovery and verification. Refresh Data will retry the direct account route.",
@@ -226,11 +228,21 @@
     "loading": "Loading model data...",
     "profileLoadFailed": "Failed to load models for this API credential: {{errorMessage}}",
     "profileLoadFailedTitle": "Failed to load models for this API credential",
-    "retryLoad": "Retry Load"
+    "retryLoad": "Retry Load",
+    "sub2apiKeyScopedDescription": "Sub2API does not provide an account-level model list. The extension fetches the models available to this account through its API keys.",
+    "sub2apiKeyScopedFallbackDescription": "Select an API key. If only one available key exists, the extension will use it automatically.",
+    "sub2apiKeyScopedFallbackTitle": "Fetch models through a key",
+    "sub2apiKeyScopedTitle": "Fetching the model list through an API key"
   },
   "title": "Model List",
   "totalModels_one": "Total {{count}} model",
   "totalModels_other": "Total {{count}} models",
   "unavailable": "Unavailable",
+  "unavailablePriceReasons": {
+    "keyGroupUnknown": "Prices are unavailable because this key's Sub2API group could not be resolved.",
+    "modelListOnly": "Models are available for this key. Prices are unavailable.",
+    "officialPriceMissing": "This model is not in the price table.",
+    "pricingSourceUnavailable": "Price data is unavailable for this source."
+  },
   "userGroup": "User Group"
 }

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -96,6 +96,8 @@
   "displayOptions": "表示オプション:",
   "endpointType": "エンドポイント種別",
   "endpointTypes": "エンドポイント種別",
+  "estimatedPrice": "推定",
+  "estimatedPriceTitle": "公式価格表とこのキーの Sub2API グループ倍率から推定しています。",
   "expandDetails": "詳細を展開",
   "fallbackSourceNotice": {
     "description": "このカタログは現在アカウントキーのフォールバック経由で読み込まれているため、モデル検出と検証のみ利用できます。[データを更新] を押すと直接のアカウント経路を再試行します。",
@@ -219,10 +221,20 @@
     "loading": "モデルデータを読み込み中...",
     "profileLoadFailed": "この API 認証情報のモデル読み込みに失敗しました: {{errorMessage}}",
     "profileLoadFailedTitle": "この API 認証情報のモデル読み込みに失敗しました",
-    "retryLoad": "再読み込み"
+    "retryLoad": "再読み込み",
+    "sub2apiKeyScopedDescription": "Sub2API はアカウント単位のモデル一覧を提供していません。拡張機能は、このアカウントの API キーを使って実際に利用できるモデルを取得します。",
+    "sub2apiKeyScopedFallbackDescription": "API キーを選択してください。利用可能なキーが 1 つだけの場合は、拡張機能が自動的にそのキーでモデルを読み込みます。",
+    "sub2apiKeyScopedFallbackTitle": "キーでモデルを取得",
+    "sub2apiKeyScopedTitle": "API キーでモデル一覧を取得しています"
   },
   "title": "モデル一覧",
   "totalModels_other": "合計 {{count}} モデル",
   "unavailable": "利用不可",
+  "unavailablePriceReasons": {
+    "keyGroupUnknown": "このキーの Sub2API グループを解決できないため、料金は利用できません。",
+    "modelListOnly": "このキーではモデルを利用できますが、料金は利用できません。",
+    "officialPriceMissing": "このモデルは料金表にありません。",
+    "pricingSourceUnavailable": "このソースの料金データは利用できません。"
+  },
   "userGroup": "ユーザーグループ"
 }

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -96,6 +96,8 @@
   "displayOptions": "Tùy chọn hiển thị:",
   "endpointType": "Loại endpoint",
   "endpointTypes": "Loại endpoint",
+  "estimatedPrice": "Ước tính",
+  "estimatedPriceTitle": "Ước tính từ bảng giá chính thức và tỷ lệ nhóm Sub2API của khóa này.",
   "expandDetails": "Mở rộng chi tiết",
   "fallbackSourceNotice": {
     "description": "Thư mục mô hình hiện tại được tải dự phòng thông qua khóa tài khoản, chỉ hỗ trợ phát hiện và xác minh mô hình. Nhấp vào làm mới dữ liệu sẽ thử lại API của tài khoản.",
@@ -219,10 +221,20 @@
     "loading": "Đang tải dữ liệu mô hình...",
     "profileLoadFailed": "Tải mô hình của thông tin xác thực API này thất bại: {{errorMessage}}",
     "profileLoadFailedTitle": "Tải mô hình của thông tin xác thực API này thất bại",
-    "retryLoad": "Thử tải lại"
+    "retryLoad": "Thử tải lại",
+    "sub2apiKeyScopedDescription": "Sub2API không cung cấp danh sách mô hình ở cấp tài khoản. Tiện ích sẽ dùng API key của tài khoản này để lấy các mô hình thực sự có thể sử dụng.",
+    "sub2apiKeyScopedFallbackDescription": "Chọn một API key. Nếu chỉ có một key khả dụng, tiện ích sẽ tự động dùng key đó để tải mô hình.",
+    "sub2apiKeyScopedFallbackTitle": "Lấy mô hình qua key",
+    "sub2apiKeyScopedTitle": "Đang lấy danh sách mô hình qua API key"
   },
   "title": "Danh sách mô hình",
   "totalModels_other": "Tổng cộng {{count}} mô hình",
   "unavailable": "Không khả dụng",
+  "unavailablePriceReasons": {
+    "keyGroupUnknown": "Không có giá vì không thể xác định nhóm Sub2API của khóa này.",
+    "modelListOnly": "Các mô hình này khả dụng cho khóa này. Không có dữ liệu giá.",
+    "officialPriceMissing": "Mô hình này không có trong bảng giá.",
+    "pricingSourceUnavailable": "Dữ liệu giá không khả dụng cho nguồn này."
+  },
   "userGroup": "Nhóm người dùng"
 }

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -96,6 +96,8 @@
   "displayOptions": "显示选项:",
   "endpointType": "端点类型",
   "endpointTypes": "端点类型",
+  "estimatedPrice": "估算价",
+  "estimatedPriceTitle": "基于官方价格表和此密钥的 Sub2API 分组倍率估算。",
   "expandDetails": "展开详细信息",
   "fallbackSourceNotice": {
     "description": "当前模型目录通过账号密钥回退加载，仅支持模型发现与验证。点击刷新数据会重新尝试账号接口。",
@@ -219,10 +221,20 @@
     "loading": "正在加载模型数据...",
     "profileLoadFailed": "加载该 API 凭据的模型失败：{{errorMessage}}",
     "profileLoadFailedTitle": "加载该 API 凭据的模型失败",
-    "retryLoad": "重新尝试加载"
+    "retryLoad": "重新尝试加载",
+    "sub2apiKeyScopedDescription": "Sub2API 不提供账号级模型列表。插件会通过该账号下的 API 密钥获取实际可用模型。",
+    "sub2apiKeyScopedFallbackDescription": "请选择一个 API 密钥；如果只有一个可用密钥，插件会自动使用它加载模型。",
+    "sub2apiKeyScopedFallbackTitle": "通过密钥获取模型",
+    "sub2apiKeyScopedTitle": "正在通过 API 密钥获取模型列表"
   },
   "title": "模型列表",
   "totalModels": "总计 {{count}} 个模型",
   "unavailable": "不可用",
+  "unavailablePriceReasons": {
+    "keyGroupUnknown": "价格不可用，因为无法解析此密钥的 Sub2API 分组。",
+    "modelListOnly": "此密钥可使用这些模型，但价格不可用。",
+    "officialPriceMissing": "此模型不在价格表中。",
+    "pricingSourceUnavailable": "此来源的价格数据不可用。"
+  },
   "userGroup": "用户分组"
 }

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -96,6 +96,8 @@
   "displayOptions": "顯示選項:",
   "endpointType": "端點型別",
   "endpointTypes": "端點型別",
+  "estimatedPrice": "估算價",
+  "estimatedPriceTitle": "基於官方價格表和此金鑰的 Sub2API 分組倍率估算。",
   "expandDetails": "展開詳細資訊",
   "fallbackSourceNotice": {
     "description": "目前模型目錄是透過帳號金鑰回退載入，僅支援模型發現與驗證。點擊重新整理資料會重新嘗試帳號介面。",
@@ -219,10 +221,20 @@
     "loading": "正在載入模型資料...",
     "profileLoadFailed": "載入該 API 憑據的模型失敗：{{errorMessage}}",
     "profileLoadFailedTitle": "載入該 API 憑據的模型失敗",
-    "retryLoad": "重新嘗試載入"
+    "retryLoad": "重新嘗試載入",
+    "sub2apiKeyScopedDescription": "Sub2API 不提供帳號級模型列表。擴充功能會透過該帳號下的 API 密鑰取得實際可用模型。",
+    "sub2apiKeyScopedFallbackDescription": "請選擇一個 API 密鑰；如果只有一個可用密鑰，擴充功能會自動使用它載入模型。",
+    "sub2apiKeyScopedFallbackTitle": "透過密鑰取得模型",
+    "sub2apiKeyScopedTitle": "正在透過 API 密鑰取得模型列表"
   },
   "title": "模型列表",
   "totalModels_other": "總計 {{count}} 個模型",
   "unavailable": "不可用",
+  "unavailablePriceReasons": {
+    "keyGroupUnknown": "價格不可用，因為無法解析此金鑰的 Sub2API 分組。",
+    "modelListOnly": "此金鑰可使用這些模型，但價格不可用。",
+    "officialPriceMissing": "此模型不在價格表中。",
+    "pricingSourceUnavailable": "此來源的價格資料不可用。"
+  },
   "userGroup": "使用者分組"
 }

--- a/src/services/apiCredentialProfiles/modelCatalog.ts
+++ b/src/services/apiCredentialProfiles/modelCatalog.ts
@@ -3,17 +3,33 @@ import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/a
 import { fetchAnthropicModelIds } from "~/services/aiApi/anthropic"
 import { fetchGoogleModelIds } from "~/services/aiApi/google"
 import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
+import { loadModelPriceTable } from "~/services/apiCredentialProfiles/modelPriceTable"
+import {
+  applySub2ApiPriceEstimates,
+  resolveSub2ApiKeyGroupForPriceEstimation,
+} from "~/services/apiCredentialProfiles/sub2apiPriceEstimation"
 import { getApiService } from "~/services/apiService"
-import type {
-  ModelPricing,
-  PricingResponse,
+import {
+  MODEL_LIST_SOURCE_KINDS,
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
+  type ModelPricing,
+  type PricingResponse,
 } from "~/services/apiService/common/type"
+import {
+  fetchAccountTokens,
+  fetchSub2ApiAvailableGroups,
+  fetchSub2ApiGroupRates,
+  fetchSub2ApiRuntimeModels,
+} from "~/services/apiService/sub2api"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import {
   API_TYPES,
   type ApiVerificationApiType,
 } from "~/services/verification/aiApiVerification"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
-import type { ApiToken, DisplaySiteData } from "~/types"
+import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { parseDelimitedList } from "~/utils/core/string"
 
 type FetchApiCredentialModelCatalogParams = {
@@ -103,6 +119,30 @@ export async function loadAccountTokenFallbackPricingResponse(
     )
     resolvedTokenKey = resolvedToken.key
 
+    if (params.account.siteType === SITE_TYPES.SUB2API) {
+      const runtimeModelIds = await fetchSub2ApiRuntimeModels({
+        baseUrl: params.account.baseUrl,
+        accountId: params.account.id,
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          apiKey: resolvedToken.key,
+        },
+      } as ApiServiceRequest & {
+        auth: ApiServiceRequest["auth"] & { apiKey: string }
+      })
+
+      const modelOnlyResponse =
+        buildSub2ApiRuntimePricingResponse(runtimeModelIds)
+
+      return await loadSub2ApiEstimatedPricingResponse({
+        account: params.account,
+        selectedToken: params.token,
+        resolvedKey: resolvedToken.key,
+        runtimeModelIds,
+        fallbackResponse: modelOnlyResponse,
+      })
+    }
+
     let upstreamModelIds: string[] = []
     try {
       upstreamModelIds = await fetchApiCredentialModelIds({
@@ -151,12 +191,20 @@ export function normalizeApiCredentialModelIds(modelIds: unknown[]) {
 /**
  * Convert a raw model id into the minimal pricing-model shape used by Model List.
  */
-function createProfileCatalogModel(modelId: string): ModelPricing {
+function createProfileCatalogModel(
+  modelId: string,
+  unavailableReason: (typeof MODEL_UNAVAILABLE_PRICE_REASONS)[keyof typeof MODEL_UNAVAILABLE_PRICE_REASONS] = MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+): ModelPricing {
   return {
     model_name: modelId,
     quota_type: 0,
     model_ratio: 0,
     model_price: 0,
+    price_metadata: {
+      source: MODEL_PRICE_SOURCE_KINDS.NONE,
+      precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+      unavailable_reason: unavailableReason,
+    },
     completion_ratio: 1,
     enable_groups: [],
     supported_endpoint_types: [],
@@ -174,7 +222,98 @@ export function buildApiCredentialProfilePricingResponse(
       createProfileCatalogModel(modelId),
     ),
     group_ratio: {},
+    model_list_source: {
+      kind: MODEL_LIST_SOURCE_KINDS.CATALOG_FALLBACK,
+      supportsPricing: false,
+    },
     success: true,
     usable_group: {},
+  }
+}
+
+/**
+ * Build a Sub2API runtime-key model catalog where model visibility is known
+ * but no JWT/group pricing estimate has been applied yet.
+ */
+function buildSub2ApiRuntimePricingResponse(
+  modelIds: string[],
+  unavailableReason: (typeof MODEL_UNAVAILABLE_PRICE_REASONS)[keyof typeof MODEL_UNAVAILABLE_PRICE_REASONS] = MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+): PricingResponse {
+  return {
+    data: normalizeApiCredentialModelIds(modelIds).map((modelId) =>
+      createProfileCatalogModel(modelId, unavailableReason),
+    ),
+    group_ratio: {},
+    model_list_source: {
+      kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+      provider: SITE_TYPES.SUB2API,
+      supportsRuntimeModelList: true,
+      supportsPricing: false,
+    },
+    success: true,
+    usable_group: {},
+  }
+}
+
+const hasSub2ApiDashboardAuth = (
+  account: LoadAccountTokenFallbackPricingParams["account"],
+): boolean => {
+  return (
+    account.authType === AuthTypeEnum.AccessToken &&
+    typeof account.token === "string" &&
+    account.token.trim().length > 0
+  )
+}
+
+const createSub2ApiDashboardRequest = (
+  account: LoadAccountTokenFallbackPricingParams["account"],
+): ApiServiceRequest => ({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+
+const loadSub2ApiEstimatedPricingResponse = async (params: {
+  account: LoadAccountTokenFallbackPricingParams["account"]
+  selectedToken: ApiToken
+  resolvedKey: string
+  runtimeModelIds: string[]
+  fallbackResponse: PricingResponse
+}): Promise<PricingResponse> => {
+  if (!hasSub2ApiDashboardAuth(params.account)) {
+    return params.fallbackResponse
+  }
+
+  try {
+    const dashboardRequest = createSub2ApiDashboardRequest(params.account)
+    const [groups, groupRates, accountTokens, priceTable] = await Promise.all([
+      fetchSub2ApiAvailableGroups(dashboardRequest),
+      fetchSub2ApiGroupRates(dashboardRequest),
+      fetchAccountTokens(dashboardRequest),
+      loadModelPriceTable(),
+    ])
+    const group = resolveSub2ApiKeyGroupForPriceEstimation({
+      selectedToken: params.selectedToken,
+      resolvedKey: params.resolvedKey,
+      accountTokens,
+      groups,
+    })
+
+    return applySub2ApiPriceEstimates({
+      modelIds: params.runtimeModelIds,
+      group,
+      groupRates,
+      priceTable,
+    })
+  } catch {
+    return buildSub2ApiRuntimePricingResponse(
+      params.runtimeModelIds,
+      MODEL_UNAVAILABLE_PRICE_REASONS.PRICING_SOURCE_UNAVAILABLE,
+    )
   }
 }

--- a/src/services/apiCredentialProfiles/modelPriceTable.ts
+++ b/src/services/apiCredentialProfiles/modelPriceTable.ts
@@ -18,8 +18,10 @@ type LiteLlmPriceTableEntry = {
   cache_creation_input_token_cost?: unknown
 }
 
-const LITELLM_MODEL_PRICE_TABLE_URL =
+export const LITELLM_MODEL_PRICE_TABLE_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+
+export const MODEL_PRICE_TABLE_FETCH_TIMEOUT_MS = 10_000
 
 const USD_PER_TOKEN_TO_USD_PER_MILLION = 1_000_000
 
@@ -87,7 +89,29 @@ const normalizeLiteLlmPriceTable = (payload: unknown): ModelPriceTable => {
  * token and are normalized to this app's USD-per-1M-token display units.
  */
 export async function loadModelPriceTable(): Promise<ModelPriceTable> {
-  const response = await fetch(LITELLM_MODEL_PRICE_TABLE_URL)
+  const controller = new AbortController()
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    MODEL_PRICE_TABLE_FETCH_TIMEOUT_MS,
+  )
+  let response: Response
+
+  try {
+    response = await fetch(LITELLM_MODEL_PRICE_TABLE_URL, {
+      signal: controller.signal,
+    })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error("Timed out loading LiteLLM price table", {
+        cause: error,
+      })
+    }
+
+    throw new Error("Failed to load LiteLLM price table", { cause: error })
+  } finally {
+    clearTimeout(timeoutId)
+  }
+
   if (!response.ok) {
     throw new Error("Failed to load LiteLLM price table")
   }

--- a/src/services/apiCredentialProfiles/modelPriceTable.ts
+++ b/src/services/apiCredentialProfiles/modelPriceTable.ts
@@ -1,0 +1,96 @@
+export type ModelPriceTableEntry = {
+  input?: number | string | null
+  output?: number | string | null
+  cache_read?: number | string | null
+  cache_write?: number | string | null
+}
+
+export type ModelPriceTable = {
+  source: string
+  source_date?: string
+  models: Record<string, ModelPriceTableEntry>
+}
+
+type LiteLlmPriceTableEntry = {
+  input_cost_per_token?: unknown
+  output_cost_per_token?: unknown
+  cache_read_input_token_cost?: unknown
+  cache_creation_input_token_cost?: unknown
+}
+
+const LITELLM_MODEL_PRICE_TABLE_URL =
+  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+
+const USD_PER_TOKEN_TO_USD_PER_MILLION = 1_000_000
+
+const toFiniteNonNegativeNumber = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+  }
+
+  return undefined
+}
+
+const toUsdPerMillion = (value: unknown): number | undefined => {
+  const pricePerToken = toFiniteNonNegativeNumber(value)
+  return typeof pricePerToken === "number"
+    ? pricePerToken * USD_PER_TOKEN_TO_USD_PER_MILLION
+    : undefined
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const normalizeLiteLlmPriceTable = (payload: unknown): ModelPriceTable => {
+  if (!isRecord(payload)) {
+    throw new Error("Invalid LiteLLM price table payload")
+  }
+
+  const models = Object.fromEntries(
+    Object.entries(payload).flatMap(([modelId, value]) => {
+      if (modelId === "sample_spec" || !isRecord(value)) {
+        return []
+      }
+
+      const entry = value as LiteLlmPriceTableEntry
+      const normalized: ModelPriceTableEntry = {
+        input: toUsdPerMillion(entry.input_cost_per_token),
+        output: toUsdPerMillion(entry.output_cost_per_token),
+        cache_read: toUsdPerMillion(entry.cache_read_input_token_cost),
+        cache_write: toUsdPerMillion(entry.cache_creation_input_token_cost),
+      }
+      const cleaned = Object.fromEntries(
+        Object.entries(normalized).filter(
+          ([, price]) => typeof price === "number",
+        ),
+      ) as ModelPriceTableEntry
+
+      return Object.keys(cleaned).length > 0 ? [[modelId, cleaned]] : []
+    }),
+  )
+
+  return {
+    source: LITELLM_MODEL_PRICE_TABLE_URL,
+    models,
+  }
+}
+
+/**
+ * Loads the official-price snapshot used by optional catalog estimation.
+ *
+ * Source: LiteLLM model_prices_and_context_window.json. Values are USD per
+ * token and are normalized to this app's USD-per-1M-token display units.
+ */
+export async function loadModelPriceTable(): Promise<ModelPriceTable> {
+  const response = await fetch(LITELLM_MODEL_PRICE_TABLE_URL)
+  if (!response.ok) {
+    throw new Error("Failed to load LiteLLM price table")
+  }
+
+  return normalizeLiteLlmPriceTable(await response.json())
+}

--- a/src/services/apiCredentialProfiles/sub2apiPriceEstimation.ts
+++ b/src/services/apiCredentialProfiles/sub2apiPriceEstimation.ts
@@ -1,0 +1,292 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import type { ModelPriceTable } from "~/services/apiCredentialProfiles/modelPriceTable"
+import {
+  isMaskedApiTokenKey,
+  normalizeApiTokenKeyValue,
+} from "~/services/apiService/common/apiKey"
+import {
+  MODEL_LIST_SOURCE_KINDS,
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
+  type ModelPricing,
+  type PricingResponse,
+} from "~/services/apiService/common/type"
+import { parseSub2ApiGroupRates } from "~/services/apiService/sub2api/parsing"
+import type { ApiToken } from "~/types"
+
+type Sub2ApiGroupLike = {
+  id?: number | string | null
+  name?: string | null
+  rate_multiplier?: number | string | null
+}
+
+type ResolvedSub2ApiPriceGroup = {
+  groupId: string
+  groupName: string
+  rate_multiplier?: number
+}
+
+type ResolveSub2ApiKeyGroupParams = {
+  selectedToken: ApiToken
+  resolvedKey: string
+  accountTokens: ApiToken[]
+  groups: unknown[]
+}
+
+type ApplySub2ApiPriceEstimatesParams = {
+  modelIds: string[]
+  group: ResolvedSub2ApiPriceGroup | null
+  groupRates: Record<string, number>
+  priceTable: ModelPriceTable
+}
+
+const toTrimmedString = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : ""
+
+const toFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+const toSafeRateMultiplier = (value: unknown): number => {
+  const parsed = toFiniteNumber(value)
+  return parsed && parsed > 0 ? parsed : 1
+}
+
+const toFiniteGroupId = (value: unknown): number | undefined => {
+  const parsed = toFiniteNumber(value)
+  return typeof parsed === "number" && Number.isInteger(parsed)
+    ? parsed
+    : undefined
+}
+
+const normalizeGroup = (
+  group: Sub2ApiGroupLike,
+): ResolvedSub2ApiPriceGroup | null => {
+  const id = toFiniteGroupId(group.id)
+  const name = toTrimmedString(group.name)
+  if (id === undefined || !name) return null
+
+  return {
+    groupId: String(id),
+    groupName: name,
+    rate_multiplier: toSafeRateMultiplier(group.rate_multiplier),
+  }
+}
+
+const normalizeGroups = (
+  groups: Sub2ApiGroupLike[],
+): ResolvedSub2ApiPriceGroup[] =>
+  groups
+    .map(normalizeGroup)
+    .filter((group): group is ResolvedSub2ApiPriceGroup => Boolean(group))
+
+const findGroupByStableId = (
+  groups: ResolvedSub2ApiPriceGroup[],
+  groupId: unknown,
+): ResolvedSub2ApiPriceGroup | null => {
+  const normalizedGroupId = toFiniteGroupId(groupId)
+  if (normalizedGroupId === undefined) return null
+
+  return (
+    groups.find((group) => group.groupId === String(normalizedGroupId)) ?? null
+  )
+}
+
+const findSingleGroupByName = (
+  groups: ResolvedSub2ApiPriceGroup[],
+  groupName: string | undefined,
+): ResolvedSub2ApiPriceGroup | null => {
+  const normalizedGroupName = toTrimmedString(groupName)
+  if (!normalizedGroupName) return null
+
+  const matches = groups.filter(
+    (group) => group.groupName === normalizedGroupName,
+  )
+  return matches.length === 1 ? matches[0] : null
+}
+
+const findExactUnmaskedTokenMatch = (
+  accountTokens: ApiToken[],
+  resolvedKey: string,
+): ApiToken | null => {
+  const normalizedResolvedKey = normalizeApiTokenKeyValue(resolvedKey)
+  if (!normalizedResolvedKey || isMaskedApiTokenKey(normalizedResolvedKey)) {
+    return null
+  }
+
+  return (
+    accountTokens.find((token) => {
+      const normalizedTokenKey = normalizeApiTokenKeyValue(token.key ?? "")
+      return (
+        normalizedTokenKey === normalizedResolvedKey &&
+        !isMaskedApiTokenKey(normalizedTokenKey)
+      )
+    }) ?? null
+  )
+}
+
+/**
+ * Resolve the selected Sub2API key's stable group for optional price estimation.
+ */
+export function resolveSub2ApiKeyGroupForPriceEstimation(
+  params: ResolveSub2ApiKeyGroupParams,
+): ResolvedSub2ApiPriceGroup | null {
+  const groups = normalizeGroups(params.groups as Sub2ApiGroupLike[])
+
+  const selectedStableGroup = findGroupByStableId(
+    groups,
+    params.selectedToken.sub2api_group_id,
+  )
+  if (selectedStableGroup) return selectedStableGroup
+
+  if (params.accountTokens.length > 0) {
+    const matchedToken = findExactUnmaskedTokenMatch(
+      params.accountTokens,
+      params.resolvedKey,
+    )
+    if (!matchedToken) return null
+
+    return (
+      findGroupByStableId(groups, matchedToken.sub2api_group_id) ??
+      findSingleGroupByName(groups, matchedToken.group)
+    )
+  }
+
+  return findSingleGroupByName(groups, params.selectedToken.group)
+}
+
+const normalizeModelIds = (modelIds: string[]): string[] =>
+  Array.from(
+    new Set(
+      modelIds
+        .map((modelId) => modelId.trim())
+        .filter((modelId) => modelId.length > 0),
+    ),
+  )
+
+const createUnavailableModel = (
+  modelId: string,
+  reason: (typeof MODEL_UNAVAILABLE_PRICE_REASONS)[keyof typeof MODEL_UNAVAILABLE_PRICE_REASONS],
+): ModelPricing => ({
+  model_name: modelId,
+  quota_type: 0,
+  model_ratio: 0,
+  model_price: 0,
+  price_metadata: {
+    source: MODEL_PRICE_SOURCE_KINDS.NONE,
+    precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+    unavailable_reason: reason,
+  },
+  completion_ratio: 1,
+  enable_groups: [],
+  supported_endpoint_types: [],
+})
+
+const hasFinitePrice = (value: number | undefined): value is number =>
+  typeof value === "number" && Number.isFinite(value)
+
+const createEstimatedModel = (
+  modelId: string,
+  group: ResolvedSub2ApiPriceGroup,
+  effectiveRate: number,
+  priceTable: ModelPriceTable,
+): ModelPricing => {
+  const officialPrice = priceTable.models[modelId]
+  const input = toFiniteNumber(officialPrice?.input)
+  const output = toFiniteNumber(officialPrice?.output)
+  const cacheRead = toFiniteNumber(officialPrice?.cache_read)
+  const cacheWrite = toFiniteNumber(officialPrice?.cache_write)
+
+  if (!hasFinitePrice(input) || !hasFinitePrice(output)) {
+    return createUnavailableModel(
+      modelId,
+      MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
+    )
+  }
+
+  return {
+    model_name: modelId,
+    quota_type: 0,
+    model_ratio: 0,
+    model_price: 0,
+    token_price_usd_per_million: {
+      ...(hasFinitePrice(input) ? { input: input * effectiveRate } : {}),
+      ...(hasFinitePrice(output) ? { output: output * effectiveRate } : {}),
+      ...(hasFinitePrice(cacheRead)
+        ? { cache_read: cacheRead * effectiveRate }
+        : {}),
+      ...(hasFinitePrice(cacheWrite)
+        ? { cache_write: cacheWrite * effectiveRate }
+        : {}),
+    },
+    price_metadata: {
+      source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+      precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+      ...(priceTable.source_date
+        ? { source_date: priceTable.source_date }
+        : {}),
+    },
+    completion_ratio: 0,
+    enable_groups: [group.groupName],
+    supported_endpoint_types: [],
+  }
+}
+
+/**
+ * Build a Sub2API runtime-model pricing response using official prices and the key's group rate.
+ */
+export function applySub2ApiPriceEstimates(
+  params: ApplySub2ApiPriceEstimatesParams,
+): PricingResponse {
+  const modelIds = normalizeModelIds(params.modelIds)
+
+  if (!params.group) {
+    return {
+      success: true,
+      group_ratio: {},
+      usable_group: {},
+      model_list_source: {
+        kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+        provider: SITE_TYPES.SUB2API,
+        supportsRuntimeModelList: true,
+        supportsPricing: false,
+      },
+      data: modelIds.map((modelId) =>
+        createUnavailableModel(
+          modelId,
+          MODEL_UNAVAILABLE_PRICE_REASONS.KEY_GROUP_UNKNOWN,
+        ),
+      ),
+    }
+  }
+
+  const group = params.group
+  const groupRates = parseSub2ApiGroupRates(params.groupRates, "sub2api-rates")
+  const effectiveRate =
+    groupRates[group.groupId] ?? toSafeRateMultiplier(group.rate_multiplier)
+
+  return {
+    success: true,
+    group_ratio: {
+      [group.groupName]: effectiveRate,
+    },
+    usable_group: {
+      [group.groupName]: group.groupName,
+    },
+    model_list_source: {
+      kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+      provider: SITE_TYPES.SUB2API,
+      supportsRuntimeModelList: true,
+      supportsPricing: true,
+    },
+    data: modelIds.map((modelId) =>
+      createEstimatedModel(modelId, group, effectiveRate, params.priceTable),
+    ),
+  }
+}

--- a/src/services/apiCredentialProfiles/sub2apiPriceEstimation.ts
+++ b/src/services/apiCredentialProfiles/sub2apiPriceEstimation.ts
@@ -150,12 +150,13 @@ export function resolveSub2ApiKeyGroupForPriceEstimation(
       params.accountTokens,
       params.resolvedKey,
     )
-    if (!matchedToken) return null
 
-    return (
-      findGroupByStableId(groups, matchedToken.sub2api_group_id) ??
-      findSingleGroupByName(groups, matchedToken.group)
-    )
+    if (matchedToken) {
+      return (
+        findGroupByStableId(groups, matchedToken.sub2api_group_id) ??
+        findSingleGroupByName(groups, matchedToken.group)
+      )
+    }
   }
 
   return findSingleGroupByName(groups, params.selectedToken.group)

--- a/src/services/apiService/common/type.ts
+++ b/src/services/apiService/common/type.ts
@@ -163,7 +163,9 @@ export interface ModelPricing {
     input?: number
     output?: number
     cache_read?: number
+    cache_write?: number
   }
+  price_metadata?: ModelPriceMetadata
   owner_by?: string
   completion_ratio: number
   enable_groups: string[]
@@ -173,14 +175,64 @@ export interface ModelPricing {
 export const MODEL_LIST_SOURCE_KINDS = {
   USER_SCOPED: "user-scoped",
   CATALOG_FALLBACK: "catalog-fallback",
+  SUB2API_RUNTIME_KEY: "sub2api-runtime-key",
 } as const
 
 export type ModelListSourceKind =
   (typeof MODEL_LIST_SOURCE_KINDS)[keyof typeof MODEL_LIST_SOURCE_KINDS]
 
+export const MODEL_PRICE_SOURCE_KINDS = {
+  NONE: "none",
+  OFFICIAL_RATE_ESTIMATE: "official-rate-estimate",
+  CHANNEL_PRICING: "channel-pricing",
+} as const
+
+export type ModelPriceSourceKind =
+  (typeof MODEL_PRICE_SOURCE_KINDS)[keyof typeof MODEL_PRICE_SOURCE_KINDS]
+
+export const MODEL_PRICE_PRECISION_KINDS = {
+  EXACT: "exact",
+  ESTIMATED: "estimated",
+  UNAVAILABLE: "unavailable",
+} as const
+
+export type ModelPricePrecisionKind =
+  (typeof MODEL_PRICE_PRECISION_KINDS)[keyof typeof MODEL_PRICE_PRECISION_KINDS]
+
+export const MODEL_UNAVAILABLE_PRICE_REASONS = {
+  MODEL_LIST_ONLY: "model-list-only",
+  KEY_GROUP_UNKNOWN: "key-group-unknown",
+  OFFICIAL_PRICE_MISSING: "official-price-missing",
+  PRICING_SOURCE_UNAVAILABLE: "pricing-source-unavailable",
+} as const
+
+export type ModelUnavailablePriceReason =
+  (typeof MODEL_UNAVAILABLE_PRICE_REASONS)[keyof typeof MODEL_UNAVAILABLE_PRICE_REASONS]
+
+export interface ModelPriceMetadata {
+  source: ModelPriceSourceKind
+  precision: ModelPricePrecisionKind
+  unavailable_reason?: ModelUnavailablePriceReason
+  source_date?: string
+  unmatched_model_count?: number
+}
+
 export interface ModelListSourceInfo {
   kind: ModelListSourceKind
   provider?: AccountSiteType
+  supportsRuntimeModelList?: boolean
+  supportsPricing?: boolean
+}
+
+/**
+ * Returns whether a model row intentionally lacks usable pricing data.
+ */
+export function isModelPriceUnavailable(
+  model: Pick<ModelPricing, "price_metadata">,
+) {
+  return (
+    model.price_metadata?.precision === MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE
+  )
 }
 
 // 模型定价响应类型

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -43,6 +43,7 @@ import {
   buildSub2ApiUserGroups,
   extractSub2ApiKeyItems,
   parseSub2ApiEnvelope,
+  parseSub2ApiGroupRates,
   parseSub2ApiKey,
   parseSub2ApiUserIdentity,
   resolveSub2ApiGroupId,
@@ -75,6 +76,7 @@ import {
 const logger = createLogger("ApiService.Sub2API")
 const DEFAULT_KEYS_PAGE = 1
 const DEFAULT_KEYS_PAGE_SIZE = 100
+const SUB2API_RUNTIME_MODELS_ENDPOINT = "/v1/models"
 const sub2ApiAuthMutationLocks = new Map<string, Promise<void>>()
 
 const isCloseToExpiry = (tokenExpiresAt: number): boolean => {
@@ -87,6 +89,11 @@ const normalizeAccessToken = (value: unknown): string =>
 
 const normalizeRefreshToken = (value: unknown): string =>
   normalizeAccessToken(value)
+
+const normalizeRuntimeApiKey = (request: ApiServiceRequest): string => {
+  const auth = request.auth as typeof request.auth & { apiKey?: unknown }
+  return normalizeAccessToken(auth.apiKey)
+}
 
 const normalizeTokenExpiresAt = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? value : undefined
@@ -608,6 +615,99 @@ const fetchSub2ApiData = async <T>(
   return result.data
 }
 
+const createInvalidRuntimeModelsPayloadError = () =>
+  new ApiError(
+    t("messages:errors.api.invalidResponseFormat"),
+    undefined,
+    SUB2API_RUNTIME_MODELS_ENDPOINT,
+    API_ERROR_CODES.BUSINESS_ERROR,
+  )
+
+const createRuntimeApiKeyAuthError = () =>
+  new ApiError(
+    t("messages:sub2api.loginRequired"),
+    401,
+    SUB2API_RUNTIME_MODELS_ENDPOINT,
+    API_ERROR_CODES.HTTP_401,
+  )
+
+const createSub2ApiRuntimeBusinessError = (
+  payload: unknown,
+): ApiError | null => {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null
+  }
+
+  const code = (payload as { code?: unknown }).code
+  if (
+    (typeof code !== "string" || !code.trim()) &&
+    (typeof code !== "number" || code === 0)
+  ) {
+    return null
+  }
+
+  const message = (payload as { message?: unknown }).message
+  if (typeof message !== "string" || !message.trim()) {
+    return null
+  }
+
+  return new ApiError(
+    message.trim(),
+    undefined,
+    SUB2API_RUNTIME_MODELS_ENDPOINT,
+    API_ERROR_CODES.BUSINESS_ERROR,
+  )
+}
+
+const normalizeRuntimeModelId = (item: unknown): string => {
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    throw createInvalidRuntimeModelsPayloadError()
+  }
+
+  const id = (item as { id?: unknown }).id
+  if (typeof id !== "string" || !id.trim()) {
+    throw createInvalidRuntimeModelsPayloadError()
+  }
+
+  return id.trim()
+}
+
+const parseSub2ApiRuntimeModelIds = (payload: unknown): string[] => {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw createInvalidRuntimeModelsPayloadError()
+  }
+
+  const data = (payload as { data?: unknown }).data
+  if (!Array.isArray(data)) {
+    throw createInvalidRuntimeModelsPayloadError()
+  }
+
+  return data.map(normalizeRuntimeModelId)
+}
+
+const readRuntimeModelsPayload = async (
+  response: Response,
+): Promise<unknown> => {
+  try {
+    return await response.json()
+  } catch {
+    throw createInvalidRuntimeModelsPayloadError()
+  }
+}
+
+const readRuntimeModelsBusinessError = async (
+  response: Response,
+): Promise<ApiError | null> => {
+  try {
+    return createSub2ApiRuntimeBusinessError(await response.clone().json())
+  } catch {
+    return null
+  }
+}
+
+const createRuntimeModelsUrl = (baseUrl: string): string =>
+  `${baseUrl.replace(/\/+$/, "")}${SUB2API_RUNTIME_MODELS_ENDPOINT}`
+
 const fetchAvailableGroupsInternal = async (request: ApiServiceRequest) =>
   fetchSub2ApiData<unknown[]>(request, SUB2API_AVAILABLE_GROUPS_ENDPOINT, {
     method: "GET",
@@ -615,14 +715,16 @@ const fetchAvailableGroupsInternal = async (request: ApiServiceRequest) =>
   })
 
 const fetchGroupRatesInternal = async (request: ApiServiceRequest) =>
-  fetchSub2ApiData<Record<string, number>>(
-    request,
-    SUB2API_GROUP_RATES_ENDPOINT,
-    {
-      method: "GET",
-      cache: "no-store",
-    },
+  fetchSub2ApiData<unknown>(request, SUB2API_GROUP_RATES_ENDPOINT, {
+    method: "GET",
+    cache: "no-store",
+  }).then((rates) =>
+    parseSub2ApiGroupRates(rates, SUB2API_GROUP_RATES_ENDPOINT),
   )
+
+export const fetchSub2ApiAvailableGroups = fetchAvailableGroupsInternal
+
+export const fetchSub2ApiGroupRates = fetchGroupRatesInternal
 
 const normalizePositiveInteger = (value: number, fallback: number): number =>
   Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback
@@ -1357,6 +1459,62 @@ export async function fetchUserGroups(
   } catch (error) {
     logger.error("Failed to fetch Sub2API groups", {
       accountId: request.accountId,
+      error: getSafeErrorMessage(error),
+    })
+    throw error
+  }
+}
+
+/**
+ * Source: https://github.com/Wei-Shaw/sub2api - gateway /v1/models uses
+ * runtime API-key auth and returns models visible to that key's group/platform.
+ */
+export async function fetchSub2ApiRuntimeModels(
+  request: ApiServiceRequest,
+): Promise<string[]> {
+  const apiKey = normalizeRuntimeApiKey(request)
+  if (!apiKey) {
+    throw createRuntimeApiKeyAuthError()
+  }
+
+  const endpointUrl = createRuntimeModelsUrl(request.baseUrl)
+
+  try {
+    const response = await fetch(endpointUrl, {
+      method: "GET",
+      cache: "no-store",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+
+    if (response.status === 401 || response.status === 403) {
+      const businessError = await readRuntimeModelsBusinessError(response)
+      if (businessError) {
+        throw businessError
+      }
+
+      throw createRuntimeApiKeyAuthError()
+    }
+
+    if (!response.ok) {
+      throw new ApiError(
+        response.statusText || "Sub2API runtime model request failed",
+        response.status,
+        SUB2API_RUNTIME_MODELS_ENDPOINT,
+        API_ERROR_CODES.HTTP_OTHER,
+      )
+    }
+
+    return parseSub2ApiRuntimeModelIds(await readRuntimeModelsPayload(response))
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error
+    }
+
+    logger.error("Failed to fetch Sub2API runtime models", {
+      accountId: request.accountId,
+      endpoint: SUB2API_RUNTIME_MODELS_ENDPOINT,
       error: getSafeErrorMessage(error),
     })
     throw error

--- a/src/services/apiService/sub2api/parsing.ts
+++ b/src/services/apiService/sub2api/parsing.ts
@@ -155,6 +155,17 @@ const parseSub2ApiKeyGroup = (payload: Partial<Sub2ApiKeyData>): string => {
   return ""
 }
 
+const parseSub2ApiKeyGroupId = (
+  payload: Partial<Sub2ApiKeyData>,
+): number | undefined => {
+  const explicitGroupId = toFiniteIntegerOrNull(payload.group_id)
+  if (explicitGroupId !== null) {
+    return explicitGroupId
+  }
+
+  return undefined
+}
+
 /**
  * Convert a USD balance (Sub2API) into the extension's internal quota unit.
  */
@@ -317,6 +328,7 @@ export const parseSub2ApiKey = (
     allow_ips: normalizeIpWhitelist(data.ip_whitelist).join(","),
     used_quota: convertUsdBalanceToQuota(usedQuotaUsd),
     group: parseSub2ApiKeyGroup(data),
+    sub2api_group_id: parseSub2ApiKeyGroupId(data),
   })
 }
 
@@ -336,7 +348,7 @@ const parseSub2ApiGroupList = (
   })
 }
 
-const parseSub2ApiGroupRates = (
+export const parseSub2ApiGroupRates = (
   payload: unknown,
   endpoint: string,
 ): Record<string, number> => {
@@ -345,7 +357,7 @@ const parseSub2ApiGroupRates = (
   return Object.entries(rates).reduce(
     (accumulator, [key, value]) => {
       const numericValue = toFiniteNumberOrZero(value)
-      accumulator[key] = numericValue || 1
+      accumulator[key] = numericValue > 0 ? numericValue : 1
       return accumulator
     },
     {} as Record<string, number>,

--- a/src/services/models/utils/modelPricing.ts
+++ b/src/services/models/utils/modelPricing.ts
@@ -2,17 +2,36 @@
  * 模型定价计算工具
  */
 
-import type { ModelPricing } from "~/services/apiService/common/type"
+import {
+  isModelPriceUnavailable,
+  type ModelPricing,
+  type ModelUnavailablePriceReason,
+} from "~/services/apiService/common/type"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
 import type { CurrencyType } from "~/types"
 import { t } from "~/utils/i18n/core"
 
-export interface CalculatedPrice {
+export type CalculatedPrice =
+  | AvailableCalculatedPrice
+  | UnavailableCalculatedPrice
+
+export interface AvailableCalculatedPrice {
+  priceAvailability?: "available"
   inputUSD: number // 每1M token输入价格（美元）
   outputUSD: number // 每1M token输出价格（美元）
   inputCNY: number // 每1M token输入价格（人民币）
   outputCNY: number // 每1M token输出价格（人民币）
   perCallPrice?: PerCallPrice // 按次计费时每次调用的价格
+}
+
+export interface UnavailableCalculatedPrice {
+  priceAvailability: "unavailable"
+  unavailableReason?: ModelUnavailablePriceReason
+  inputUSD?: undefined
+  outputUSD?: undefined
+  inputCNY?: undefined
+  outputCNY?: undefined
+  perCallPrice?: undefined
 }
 
 export type PerCallPrice = number | { input: number; output: number }
@@ -22,7 +41,7 @@ const TOKEN_PRICE_UNIT_TOKENS = 1_000_000
 const NEW_API_RATIO_BASE_USD_PER_MILLION_TOKENS =
   TOKEN_PRICE_UNIT_TOKENS / NEW_API_QUOTA_PER_USD
 
-type TokenPriceUSD = Pick<CalculatedPrice, "inputUSD" | "outputUSD">
+type TokenPriceUSD = Pick<AvailableCalculatedPrice, "inputUSD" | "outputUSD">
 type PartialTokenPriceUSD = Partial<TokenPriceUSD>
 
 /**
@@ -80,6 +99,13 @@ export const calculateModelPrice = (
   exchangeRate: number,
   userGroup: string = DEFAULT_MODEL_GROUP,
 ): CalculatedPrice => {
+  if (isModelPriceUnavailable(model)) {
+    return {
+      priceAvailability: "unavailable",
+      unavailableReason: model.price_metadata?.unavailable_reason,
+    }
+  }
+
   // 获取用户分组的倍率，默认为1
   const groupMultiplier = groupRatio[userGroup] || 1
 
@@ -93,6 +119,7 @@ export const calculateModelPrice = (
     const outputUSD = directPrice.outputUSD ?? ratioPrice.outputUSD
 
     return {
+      priceAvailability: "available",
       inputUSD,
       outputUSD,
       inputCNY: inputUSD * exchangeRate,
@@ -106,6 +133,7 @@ export const calculateModelPrice = (
     )
 
     return {
+      priceAvailability: "available",
       inputUSD: 0,
       outputUSD: 0,
       inputCNY: 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -512,6 +512,12 @@ export interface ApiToken {
   allow_ips?: string
   used_quota: number
   group?: string // 可选字段，某些站点可能没有
+  /**
+   * Stable Sub2API backend group id, when the key DTO exposes it.
+   *
+   * `group` remains the display/group name and must not be interpreted as this id.
+   */
+  sub2api_group_id?: number
   DeletedAt?: null
   /**
    * Token-scoped model allow-list / restriction field returned by some backends.

--- a/tests/entrypoints/options/pages/ModelList/ModelItem.profileActions.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelItem.profileActions.test.tsx
@@ -8,6 +8,11 @@ import {
   toAihubmixCatalogFallbackCapabilities,
   toCatalogOnlyCapabilities,
 } from "~/features/ModelList/modelManagementSources"
+import {
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
+} from "~/services/apiService/common/type"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import {
   createProfileModelVerificationHistoryTarget,
@@ -509,6 +514,75 @@ describe("ModelItem profile actions", () => {
         name: "modelList:expandDetails",
       }),
     ).not.toBeInTheDocument()
+  })
+
+  it("keeps model-list-only rows visually available while showing unavailable pricing copy", async () => {
+    const accountSource = createAccountSource({
+      id: "account-model-list-only",
+      name: "Example Account",
+      username: "tester",
+      balance: { USD: 0, CNY: 0 },
+      todayConsumption: { USD: 0, CNY: 0 },
+      todayIncome: { USD: 0, CNY: 0 },
+      todayTokens: { upload: 0, download: 0 },
+      health: { status: SiteHealthStatus.Healthy },
+      siteType: "new-api",
+      baseUrl: "https://example.com",
+      token: "token",
+      userId: "1",
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: { enableDetection: false },
+    })
+
+    render(
+      <ModelItem
+        model={{
+          model_name: "example-runtime-model",
+          quota_type: 0,
+          model_ratio: 0,
+          model_price: 0,
+          completion_ratio: 0,
+          enable_groups: [],
+          supported_endpoint_types: [],
+          price_metadata: {
+            source: MODEL_PRICE_SOURCE_KINDS.NONE,
+            precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+            unavailable_reason: MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+          },
+        }}
+        calculatedPrice={{
+          priceAvailability: "unavailable",
+          unavailableReason: MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+        }}
+        exchangeRate={1}
+        showRealPrice={false}
+        showRatioColumn={true}
+        showEndpointTypes={true}
+        groupRatios={{ default: 1 }}
+        selectedGroups={["default"]}
+        availableGroups={["default"]}
+        source={accountSource}
+      />,
+    )
+
+    expect(
+      await screen.findByText(
+        "modelList:unavailablePriceReasons.modelListOnly",
+      ),
+    ).toBeInTheDocument()
+
+    expect(screen.getByText("modelList:available")).toBeInTheDocument()
+    expect(screen.queryByText("modelList:unavailable")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/modelList:clickSwitchGroup/),
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.getByRole("heading", { name: "example-runtime-model" }),
+    ).toHaveClass("text-gray-900")
+    expect(
+      screen.getByRole("heading", { name: "example-runtime-model" }),
+    ).not.toHaveClass("text-gray-500")
   })
 
   it("hides the model-key action for account catalog fallback rows without token compatibility", async () => {

--- a/tests/entrypoints/options/pages/ModelList/StatusIndicator.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/StatusIndicator.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import { StatusIndicator } from "~/features/ModelList/components/StatusIndicator"
 import {
   createAccountSource,
@@ -27,6 +28,49 @@ const ACCOUNT = {
 } as const
 
 describe("StatusIndicator", () => {
+  it("shows Sub2API key-scoped model loading as an expected info state", async () => {
+    const sub2apiAccount = {
+      ...ACCOUNT,
+      siteType: SITE_TYPES.SUB2API,
+    }
+
+    render(
+      <StatusIndicator
+        selectedSource={createAccountSource(sub2apiAccount as any)}
+        isLoading={false}
+        dataFormatError={false}
+        loadErrorMessage={null}
+        currentAccount={sub2apiAccount as any}
+        loadPricingData={vi.fn()}
+        accountFallback={{
+          isAvailable: true,
+          isActive: false,
+          hasLoadedTokens: false,
+          isLoadingTokens: true,
+          isLoadingCatalog: false,
+          tokenLoadErrorMessage: null,
+          catalogLoadErrorMessage: null,
+          tokens: [],
+          selectedTokenId: null,
+          activeTokenName: null,
+          loadTokens: vi.fn(),
+          setSelectedTokenId: vi.fn(),
+          loadCatalog: vi.fn(),
+        }}
+      />,
+    )
+
+    expect(
+      await screen.findByText("modelList:status.sub2apiKeyScopedTitle"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelList:status.sub2apiKeyScopedDescription"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("modelList:status.genericLoadFailedTitle"),
+    ).not.toBeInTheDocument()
+  })
+
   it("shows automatic key loading feedback before the fallback list is ready", async () => {
     render(
       <StatusIndicator

--- a/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
@@ -12,6 +12,9 @@ import {
 import { MODEL_LIST_SORT_MODES } from "~/features/ModelList/sortModes"
 import {
   MODEL_LIST_SOURCE_KINDS,
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
   type PricingResponse,
 } from "~/services/apiService/common/type"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
@@ -1774,6 +1777,244 @@ describe("useFilteredModels", () => {
       expect(
         result.current.filteredModels.map((item) => item.model.model_name),
       ).toEqual(["per-call-a", "per-call-b"])
+    })
+  })
+
+  it("sorts model-list-only rows after comparable priced rows", async () => {
+    const account = createDisplayAccount({
+      id: "account-model-list-only-pricing",
+      balance: { USD: 10, CNY: 70 },
+    })
+
+    const pricingData = createPricingResponse([
+      {
+        model_name: "priced-expensive-model",
+        model_ratio: 4,
+        completion_ratio: 1,
+        enable_groups: ["default"],
+      },
+      {
+        model_name: "example-runtime-model",
+        model_ratio: 0,
+        completion_ratio: 0,
+        enable_groups: [],
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason: MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+        },
+      },
+      {
+        model_name: "priced-cheap-model",
+        model_ratio: 1,
+        completion_ratio: 1,
+        enable_groups: ["default"],
+      },
+    ])
+
+    const { result, rerender } = renderUseFilteredModels({
+      pricingData,
+      selectedSource: createAccountSource(account),
+      sortMode: MODEL_LIST_SORT_MODES.PRICE_ASC,
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual([
+        "priced-cheap-model",
+        "priced-expensive-model",
+        "example-runtime-model",
+      ])
+    })
+
+    rerender({
+      pricingData,
+      selectedSource: createAccountSource(account),
+      sortMode: MODEL_LIST_SORT_MODES.PRICE_DESC,
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual([
+        "priced-expensive-model",
+        "priced-cheap-model",
+        "example-runtime-model",
+      ])
+    })
+  })
+
+  it("keeps unavailable-price model-list-only rows visible for token and per-call billing filters", async () => {
+    const account = createDisplayAccount({
+      id: "account-model-list-only-filters",
+      balance: { USD: 10, CNY: 70 },
+    })
+
+    const pricingData = createPricingResponse([
+      {
+        model_name: "example-runtime-model",
+        quota_type: 0,
+        model_ratio: 0,
+        completion_ratio: 0,
+        enable_groups: [],
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason: MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+        },
+      },
+      {
+        model_name: "example-priced-model",
+        quota_type: 0,
+        model_ratio: 1,
+        completion_ratio: 1,
+        enable_groups: ["default"],
+      },
+    ])
+
+    const source = createAccountSource(account)
+
+    const { result, rerender } = renderUseFilteredModels({
+      pricingData,
+      selectedSource: source,
+      selectedBillingMode: MODEL_LIST_BILLING_MODES.TOKEN_BASED,
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual(["example-runtime-model", "example-priced-model"])
+    })
+
+    rerender({
+      pricingData,
+      selectedSource: source,
+      selectedBillingMode: MODEL_LIST_BILLING_MODES.PER_CALL,
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual(["example-runtime-model"])
+    })
+  })
+
+  it("keeps unavailable-price rows stable after sorting comparable priced rows", async () => {
+    const account = createDisplayAccount({
+      id: "account-stable-unavailable",
+      balance: { USD: 10, CNY: 70 },
+    })
+
+    const pricingData = createPricingResponse([
+      {
+        model_name: "priced-expensive-model",
+        model_ratio: 4,
+        completion_ratio: 1,
+        enable_groups: ["default"],
+      },
+      {
+        model_name: "example-runtime-model-a",
+        model_ratio: 0,
+        completion_ratio: 0,
+        enable_groups: [],
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason: MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+        },
+      },
+      {
+        model_name: "priced-cheap-model",
+        model_ratio: 1,
+        completion_ratio: 1,
+        enable_groups: ["default"],
+      },
+      {
+        model_name: "example-runtime-model-b",
+        model_ratio: 0,
+        completion_ratio: 0,
+        enable_groups: [],
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason:
+            MODEL_UNAVAILABLE_PRICE_REASONS.PRICING_SOURCE_UNAVAILABLE,
+        },
+      },
+    ])
+
+    const { result } = renderUseFilteredModels({
+      pricingData,
+      selectedSource: createAccountSource(account),
+      sortMode: MODEL_LIST_SORT_MODES.PRICE_ASC,
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual([
+        "priced-cheap-model",
+        "priced-expensive-model",
+        "example-runtime-model-a",
+        "example-runtime-model-b",
+      ])
+    })
+
+    expect(
+      result.current.filteredModels.map((item) => [
+        item.model.model_name,
+        item.calculatedPrice.priceAvailability,
+        item.isLowestPrice,
+      ]),
+    ).toEqual([
+      ["priced-cheap-model", "available", false],
+      ["priced-expensive-model", "available", false],
+      ["example-runtime-model-a", "unavailable", false],
+      ["example-runtime-model-b", "unavailable", false],
+    ])
+  })
+
+  it("ignores stale pricing filters when response metadata disables pricing", async () => {
+    const account = createDisplayAccount({
+      id: "account-runtime-list-only",
+      balance: { USD: 10, CNY: 70 },
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingData: createPricingResponse(
+        [
+          {
+            model_name: "example-runtime-token-model",
+            quota_type: 0,
+            model_ratio: 1,
+            completion_ratio: 1,
+            enable_groups: ["default"],
+          },
+          {
+            model_name: "example-runtime-call-model",
+            quota_type: 1,
+            model_price: 1,
+            enable_groups: ["default"],
+          },
+        ],
+        {
+          model_list_source: {
+            kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+            supportsRuntimeModelList: true,
+            supportsPricing: false,
+          },
+        },
+      ),
+      selectedSource: createAccountSource(account),
+      selectedBillingMode: MODEL_LIST_BILLING_MODES.PER_CALL,
+      selectedGroups: ["stale-group"],
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual(["example-runtime-token-model", "example-runtime-call-model"])
     })
   })
 })

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -17,6 +17,12 @@ import {
   type ApiServiceCapabilities,
 } from "~/services/apiService"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
+import {
+  MODEL_LIST_SOURCE_KINDS,
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
+} from "~/services/apiService/common/type"
 import { modelPricingCache } from "~/services/models/modelPricingCache"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -376,6 +382,7 @@ describe("useModelData all-accounts loading", () => {
       siteType: SITE_TYPES.SUB2API,
       userId: "sub2api-user",
     })
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce([])
 
     const { result } = renderHook(
       () =>
@@ -388,12 +395,11 @@ describe("useModelData all-accounts loading", () => {
 
     await waitFor(
       () => {
-        expect(result.current.loadErrorMessage).toBe(
-          "modelList:status.loadFailed",
-        )
+        expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(account)
       },
       { timeout: 3000 },
     )
+    expect(result.current.loadErrorMessage).toBeNull()
     expect(fetchModelPricing).not.toHaveBeenCalled()
   })
 
@@ -1247,17 +1253,358 @@ describe("useModelData all-accounts loading", () => {
 
       await waitFor(
         () => {
-          expect(result.current.loadErrorMessage).toBe(
-            "modelList:status.loadFailed",
-          )
+          expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(account)
         },
         { timeout: 3000 },
       )
+      expect(result.current.loadErrorMessage).toBeNull()
       expect(fetchModelPricing).not.toHaveBeenCalled()
       expect(result.current.pricingData).toBeNull()
     } finally {
       await modelPricingCache.invalidate(cacheKey)
     }
+  })
+
+  it("loads Sub2API selected-key fallback runtime models without enabling common pricing", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    const fetchModelPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("common pricing should not be called"))
+    const sub2apiService = createMockApiService(fetchModelPricing, {
+      capabilities: { modelPricing: false },
+    })
+    vi.mocked(getApiService).mockReturnValue(sub2apiService)
+
+    const account = createDisplayAccount({
+      id: "sub2api-runtime-fallback-account",
+      baseUrl: "https://sub2api.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+      userId: "sub2api-runtime-user",
+    })
+    const fallbackTokens = [
+      {
+        id: 17,
+        user_id: 17,
+        key: "sk-sub2api-other-masked",
+        status: 1,
+        name: "Other runtime key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+      {
+        id: 18,
+        user_id: 18,
+        key: "sk-sub2api-masked",
+        status: 1,
+        name: "Runtime key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ]
+
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce(fallbackTokens)
+    mockLoadAccountTokenFallbackPricingResponse.mockResolvedValueOnce({
+      data: [
+        {
+          model_name: "example-runtime-model",
+          quota_type: 0,
+          model_ratio: 0,
+          model_price: 0,
+          completion_ratio: 1,
+          enable_groups: [],
+          supported_endpoint_types: [],
+          price_metadata: {
+            source: MODEL_PRICE_SOURCE_KINDS.NONE,
+            precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+            unavailable_reason: MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+          },
+        },
+      ],
+      group_ratio: {},
+      success: true,
+      usable_group: {},
+      model_list_source: {
+        kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+        provider: SITE_TYPES.SUB2API,
+        supportsRuntimeModelList: true,
+        supportsPricing: false,
+      },
+    })
+
+    const selectedSource = createAccountSource(account)
+    expect(sub2apiService.capabilities.modelPricing).toBe(false)
+    expect(selectedSource.capabilities.supportsPricing).toBe(true)
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource,
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(account)
+      },
+      { timeout: 3000 },
+    )
+    expect(result.current.loadErrorMessage).toBeNull()
+    expect(fetchModelPricing).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(result.current.accountFallback?.selectedTokenId).toBeNull()
+    })
+
+    expect(mockLoadAccountTokenFallbackPricingResponse).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.accountFallback?.setSelectedTokenId(18)
+    })
+
+    await act(async () => {
+      await result.current.accountFallback?.loadCatalog()
+    })
+
+    await waitFor(() => {
+      expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith({
+        account,
+        token: fallbackTokens[1],
+      })
+      expect(result.current.accountFallback?.isActive).toBe(true)
+    })
+    expect(result.current.pricingData).toEqual(
+      expect.objectContaining({
+        model_list_source: {
+          kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+          provider: SITE_TYPES.SUB2API,
+          supportsRuntimeModelList: true,
+          supportsPricing: false,
+        },
+        data: [
+          expect.objectContaining({
+            model_name: "example-runtime-model",
+            price_metadata: {
+              source: MODEL_PRICE_SOURCE_KINDS.NONE,
+              precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+              unavailable_reason:
+                MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+            },
+          }),
+        ],
+      }),
+    )
+  })
+
+  it("auto-loads Sub2API runtime models when a single fallback key is available", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    const fetchModelPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("common pricing should not be called"))
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-auto-runtime-account",
+      baseUrl: "https://sub2api-auto.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+      userId: "sub2api-auto-user",
+    })
+    const fallbackToken = {
+      id: 19,
+      user_id: 19,
+      key: "sk-sub2api-auto-masked",
+      status: 1,
+      name: "Only runtime key",
+      created_time: 0,
+      accessed_time: 0,
+      expired_time: -1,
+      remain_quota: 0,
+      unlimited_quota: true,
+      used_quota: 0,
+    }
+    const fallbackPricing = {
+      data: [
+        {
+          model_name: "example-runtime-auto-model",
+          quota_type: 0,
+          model_ratio: 0,
+          model_price: 0,
+          completion_ratio: 1,
+          enable_groups: [],
+          supported_endpoint_types: [],
+          price_metadata: {
+            source: MODEL_PRICE_SOURCE_KINDS.NONE,
+            precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+            unavailable_reason: MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+          },
+        },
+      ],
+      group_ratio: {},
+      success: true,
+      usable_group: {},
+      model_list_source: {
+        kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+        provider: SITE_TYPES.SUB2API,
+        supportsRuntimeModelList: true,
+        supportsPricing: false,
+      },
+    }
+
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce([fallbackToken])
+    mockLoadAccountTokenFallbackPricingResponse.mockResolvedValueOnce(
+      fallbackPricing,
+    )
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAccountSource(account),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(account)
+      },
+      { timeout: 3000 },
+    )
+
+    await waitFor(
+      () => {
+        expect(
+          mockLoadAccountTokenFallbackPricingResponse,
+        ).toHaveBeenCalledWith({
+          account,
+          token: fallbackToken,
+        })
+      },
+      { timeout: 3000 },
+    )
+
+    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(result.current.loadErrorMessage).toBeNull()
+    expect(result.current.accountFallback?.isActive).toBe(true)
+    expect(result.current.pricingData).toEqual(fallbackPricing)
+  })
+
+  it("refreshes an active Sub2API runtime fallback catalog with the selected key", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    const fetchModelPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("common pricing should not be called"))
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-refresh-runtime-account",
+      baseUrl: "https://sub2api-refresh.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+      userId: "sub2api-refresh-user",
+    })
+    const fallbackToken = {
+      id: 20,
+      user_id: 20,
+      key: "sk-sub2api-refresh-masked",
+      status: 1,
+      name: "Runtime refresh key",
+      created_time: 0,
+      accessed_time: 0,
+      expired_time: -1,
+      remain_quota: 0,
+      unlimited_quota: true,
+      used_quota: 0,
+    }
+    const createFallbackPricing = (modelName: string) => ({
+      data: [
+        {
+          model_name: modelName,
+          quota_type: 0,
+          model_ratio: 0,
+          model_price: 0,
+          completion_ratio: 1,
+          enable_groups: [],
+          supported_endpoint_types: [],
+        },
+      ],
+      group_ratio: {},
+      success: true,
+      usable_group: {},
+      model_list_source: {
+        kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+        provider: SITE_TYPES.SUB2API,
+        supportsRuntimeModelList: true,
+        supportsPricing: false,
+      },
+    })
+
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce([fallbackToken])
+    mockLoadAccountTokenFallbackPricingResponse
+      .mockResolvedValueOnce(createFallbackPricing("stale-runtime-model"))
+      .mockResolvedValueOnce(createFallbackPricing("fresh-runtime-model"))
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAccountSource(account),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(
+          mockLoadAccountTokenFallbackPricingResponse,
+        ).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 3000 },
+    )
+    expect(result.current.pricingData?.data[0]?.model_name).toBe(
+      "stale-runtime-model",
+    )
+
+    await act(async () => {
+      await result.current.loadPricingData()
+    })
+
+    await waitFor(() => {
+      expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledTimes(
+        2,
+      )
+    })
+    expect(
+      mockLoadAccountTokenFallbackPricingResponse,
+    ).toHaveBeenLastCalledWith({
+      account,
+      token: fallbackToken,
+    })
+    expect(result.current.pricingData?.data[0]?.model_name).toBe(
+      "fresh-runtime-model",
+    )
+    expect(fetchModelPricing).not.toHaveBeenCalled()
   })
 
   it("marks all-account queries as loading before each account returns data", async () => {
@@ -1575,7 +1922,7 @@ describe("useModelData all-accounts loading", () => {
     ).toEqual(["gpt-4o-mini"])
   })
 
-  it("clears fallback state after a successful direct-account retry", async () => {
+  it("refreshes an active account-key fallback catalog instead of retrying direct pricing", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
@@ -1583,22 +1930,6 @@ describe("useModelData all-accounts loading", () => {
       .fn()
       .mockRejectedValueOnce(new Error("boom"))
       .mockRejectedValueOnce(new Error("boom"))
-      .mockResolvedValueOnce({
-        data: [
-          {
-            model_name: "account-model",
-            quota_type: 0,
-            model_ratio: 1,
-            model_price: 1,
-            completion_ratio: 1,
-            enable_groups: ["default"],
-            supported_endpoint_types: [],
-          },
-        ],
-        group_ratio: { default: 1 },
-        success: true,
-        usable_group: { default: true },
-      })
     vi.mocked(getApiService).mockReturnValue(
       createMockApiService(fetchModelPricing),
     )
@@ -1624,10 +1955,10 @@ describe("useModelData all-accounts loading", () => {
     }
 
     mockFetchDisplayAccountTokens.mockResolvedValueOnce([fallbackToken])
-    mockLoadAccountTokenFallbackPricingResponse.mockResolvedValueOnce({
+    const createFallbackPricing = (modelName: string) => ({
       data: [
         {
-          model_name: "fallback-model",
+          model_name: modelName,
           quota_type: 0,
           model_ratio: 0,
           model_price: 0,
@@ -1640,6 +1971,9 @@ describe("useModelData all-accounts loading", () => {
       success: true,
       usable_group: {},
     })
+    mockLoadAccountTokenFallbackPricingResponse
+      .mockResolvedValueOnce(createFallbackPricing("stale-fallback-model"))
+      .mockResolvedValueOnce(createFallbackPricing("fresh-fallback-model"))
 
     const { result } = renderHook(
       () =>
@@ -1677,19 +2011,29 @@ describe("useModelData all-accounts loading", () => {
     await waitFor(() => {
       expect(result.current.accountFallback?.isActive).toBe(true)
     })
+    expect(result.current.pricingData?.data[0]?.model_name).toBe(
+      "stale-fallback-model",
+    )
+    const pricingCallCountBeforeRefresh = fetchModelPricing.mock.calls.length
 
     await act(async () => {
       await result.current.loadPricingData()
     })
 
     await waitFor(() => {
-      expect(result.current.accountFallback?.isActive).toBe(false)
+      expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledTimes(
+        2,
+      )
     })
 
     expect(result.current.loadErrorMessage).toBeNull()
+    expect(result.current.accountFallback?.isActive).toBe(true)
     expect(
       result.current.pricingData?.data.map((item) => item.model_name),
-    ).toEqual(["account-model"])
+    ).toEqual(["fresh-fallback-model"])
+    expect(fetchModelPricing).toHaveBeenCalledTimes(
+      pricingCallCountBeforeRefresh,
+    )
   })
 
   it("discards stale fallback token results after switching accounts", async () => {

--- a/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
@@ -472,6 +472,129 @@ describe("useModelListData", () => {
     })
   })
 
+  it("derives runtime model-list display capabilities from response metadata", async () => {
+    mockUseModelData.mockReturnValue({
+      pricingData: {
+        data: [],
+        group_ratio: {},
+        success: true,
+        usable_group: {},
+        model_list_source: {
+          kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+          provider: SITE_TYPES.SUB2API,
+          supportsRuntimeModelList: true,
+          supportsPricing: false,
+        },
+      },
+      pricingContexts: [],
+      isLoading: false,
+      dataFormatError: false,
+      accountQueryStates: [],
+      loadPricingData: vi.fn(),
+      loadErrorMessage: null,
+      accountFallback: null,
+    })
+
+    const { result } = renderHook(() => useModelListData())
+
+    act(() => {
+      result.current.setSelectedSourceValue(toAccountSourceValue(ACCOUNT.id))
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedSource?.kind).toBe(
+        MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT,
+      )
+    })
+
+    expect(result.current.sourceCapabilities).toMatchObject({
+      supportsRuntimeModelList: true,
+      supportsPricing: false,
+      supportsRatioDisplay: false,
+      supportsGroupFiltering: false,
+      supportsAccountSummary: false,
+      supportsTokenCompatibility: true,
+      supportsCredentialVerification: true,
+      supportsBatchCredentialVerification: true,
+      supportsCliVerification: true,
+    })
+  })
+
+  it("keeps Sub2API fallback estimated pricing and group ratio display enabled", async () => {
+    mockUseAccountData.mockReturnValue({
+      enabledDisplayData: [
+        {
+          ...ACCOUNT,
+          siteType: SITE_TYPES.SUB2API,
+        },
+      ],
+    })
+    mockUseModelData.mockReturnValue({
+      pricingData: {
+        data: [],
+        group_ratio: {
+          default: 1,
+        },
+        success: true,
+        usable_group: {
+          default: "default",
+        },
+        model_list_source: {
+          kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+          provider: SITE_TYPES.SUB2API,
+          supportsRuntimeModelList: true,
+          supportsPricing: true,
+        },
+      },
+      pricingContexts: [],
+      isLoading: false,
+      dataFormatError: false,
+      accountQueryStates: [],
+      loadPricingData: vi.fn(),
+      loadErrorMessage: null,
+      accountFallback: {
+        isAvailable: true,
+        isActive: true,
+        hasLoadedTokens: true,
+        isLoadingTokens: false,
+        isLoadingCatalog: false,
+        tokenLoadErrorMessage: null,
+        catalogLoadErrorMessage: null,
+        tokens: [],
+        selectedTokenId: null,
+        activeTokenName: "Runtime key",
+        loadTokens: vi.fn(),
+        setSelectedTokenId: vi.fn(),
+        loadCatalog: vi.fn(),
+      },
+    })
+
+    const { result } = renderHook(() => useModelListData())
+
+    act(() => {
+      result.current.setSelectedSourceValue(toAccountSourceValue(ACCOUNT.id))
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedSource?.kind).toBe(
+        MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT,
+      )
+    })
+
+    expect(result.current.isFallbackCatalogActive).toBe(true)
+    expect(result.current.sourceCapabilities).toMatchObject({
+      supportsRuntimeModelList: true,
+      supportsPricing: true,
+      supportsRatioDisplay: true,
+      supportsGroupFiltering: true,
+      supportsAccountSummary: false,
+      supportsTokenCompatibility: true,
+      supportsCredentialVerification: true,
+      supportsBatchCredentialVerification: true,
+      supportsCliVerification: true,
+    })
+  })
+
   it("exposes AIHubMix catalog fallback notice state without globally downgrading all-accounts capabilities", async () => {
     const aihubmixAccount: DisplaySiteData = {
       ...ACCOUNT,

--- a/tests/features/ModelList/components/ModelDisplay.test.tsx
+++ b/tests/features/ModelList/components/ModelDisplay.test.tsx
@@ -168,7 +168,9 @@ const PROFILE_SOURCE = {
 
 type CalculatedModelOverrides = {
   model?: Partial<ModelPricing>
-  calculatedPrice?: Partial<CalculatedPrice>
+  calculatedPrice?: Partial<
+    Extract<CalculatedPrice, { priceAvailability?: "available" }>
+  >
   source?: CalculatedModelItem["source"]
   effectiveGroup?: string
 }

--- a/tests/features/ModelList/components/ModelItemDetails.test.tsx
+++ b/tests/features/ModelList/components/ModelItemDetails.test.tsx
@@ -3,6 +3,11 @@ import React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ModelItemDetails } from "~/features/ModelList/components/ModelItem/ModelItemDetails"
+import {
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
+} from "~/services/apiService/common/type"
 import { render, screen } from "~~/tests/test-utils/render"
 
 const { formatPriceMock, getEndpointTypesTextMock, isTokenBillingTypeMock } =
@@ -246,6 +251,46 @@ describe("ModelItemDetails", () => {
     expect(screen.getByText("USD: USD:2.5")).toBeInTheDocument()
     expect(screen.getByText("CNY: CNY:17.5")).toBeInTheDocument()
     expect(formatPriceMock).toHaveBeenCalledTimes(4)
+  })
+
+  it("shows an unavailable-price explanation instead of zero details", async () => {
+    render(
+      <ModelItemDetails
+        model={
+          {
+            enable_groups: ["default"],
+            supported_endpoint_types: ["chat"],
+            quota_type: 0,
+            price_metadata: {
+              source: MODEL_PRICE_SOURCE_KINDS.NONE,
+              precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+              unavailable_reason:
+                MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
+            },
+          } as any
+        }
+        calculatedPrice={
+          {
+            priceAvailability: "unavailable",
+            unavailableReason:
+              MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
+          } as any
+        }
+        showEndpointTypes={false}
+        groupRatios={{}}
+        effectiveGroup="default"
+        showGroupDetails={false}
+        showPricingDetails={true}
+      />,
+    )
+
+    expect(await screen.findByText("detailedPricing")).toBeInTheDocument()
+    expect(
+      screen.getByText("unavailablePriceReasons.officialPriceMissing"),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/^USD:/)).toBeNull()
+    expect(screen.queryByText(/^CNY:/)).toBeNull()
+    expect(formatPriceMock).not.toHaveBeenCalled()
   })
 
   it("falls back to a 1x tooltip when group ratios are missing", async () => {

--- a/tests/features/ModelList/components/ModelItemDetails.test.tsx
+++ b/tests/features/ModelList/components/ModelItemDetails.test.tsx
@@ -293,6 +293,85 @@ describe("ModelItemDetails", () => {
     expect(formatPriceMock).not.toHaveBeenCalled()
   })
 
+  it("uses model unavailable metadata before calculated fallback details", async () => {
+    render(
+      <ModelItemDetails
+        model={
+          {
+            enable_groups: ["default"],
+            supported_endpoint_types: ["chat"],
+            quota_type: 0,
+            price_metadata: {
+              source: MODEL_PRICE_SOURCE_KINDS.NONE,
+              precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+              unavailable_reason:
+                MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+            },
+          } as any
+        }
+        calculatedPrice={
+          {
+            priceAvailability: "unavailable",
+            unavailableReason:
+              MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
+          } as any
+        }
+        showEndpointTypes={false}
+        groupRatios={{}}
+        effectiveGroup="default"
+        showGroupDetails={false}
+        showPricingDetails={true}
+      />,
+    )
+
+    expect(await screen.findByText("detailedPricing")).toBeInTheDocument()
+    expect(
+      screen.getByText("unavailablePriceReasons.modelListOnly"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("unavailablePriceReasons.officialPriceMissing"),
+    ).toBeNull()
+  })
+
+  it("uses model unavailable metadata even when calculated prices are otherwise available", async () => {
+    render(
+      <ModelItemDetails
+        model={
+          {
+            enable_groups: ["default"],
+            supported_endpoint_types: ["chat"],
+            quota_type: 0,
+            price_metadata: {
+              source: MODEL_PRICE_SOURCE_KINDS.NONE,
+              precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+              unavailable_reason:
+                MODEL_UNAVAILABLE_PRICE_REASONS.PRICING_SOURCE_UNAVAILABLE,
+            },
+          } as any
+        }
+        calculatedPrice={
+          {
+            inputUSD: 1,
+            outputUSD: 2,
+            inputCNY: 7,
+            outputCNY: 14,
+          } as any
+        }
+        showEndpointTypes={false}
+        groupRatios={{}}
+        effectiveGroup="default"
+        showGroupDetails={false}
+        showPricingDetails={true}
+      />,
+    )
+
+    expect(await screen.findByText("detailedPricing")).toBeInTheDocument()
+    expect(
+      screen.getByText("unavailablePriceReasons.pricingSourceUnavailable"),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/^USD:/)).toBeNull()
+  })
+
   it("falls back to a 1x tooltip when group ratios are missing", async () => {
     render(
       <ModelItemDetails

--- a/tests/features/ModelList/components/ModelItemPricing.test.tsx
+++ b/tests/features/ModelList/components/ModelItemPricing.test.tsx
@@ -6,6 +6,11 @@ import { ModelItemPerCallPricingView } from "~/features/ModelList/components/Mod
 import { PriceView } from "~/features/ModelList/components/ModelItem/ModelItemPicingView"
 import { ModelItemPricing } from "~/features/ModelList/components/ModelItem/ModelItemPricing"
 import { MODEL_LIST_GROUP_SELECTION_SCOPES } from "~/features/ModelList/groupSelectionScopes"
+import {
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
+} from "~/services/apiService/common/type"
 
 const { formatPriceCompactMock, isTokenBillingTypeMock } = vi.hoisted(() => ({
   formatPriceCompactMock: vi.fn(
@@ -296,7 +301,7 @@ describe("Model item pricing and description", () => {
       expect(screen.queryByText("ratio")).toBeNull()
     })
 
-    it("omits the pricing body when a per-call model has no computed per-call price", () => {
+    it("renders explicit zero per-call prices instead of treating them as missing", () => {
       isTokenBillingTypeMock.mockReturnValue(false)
 
       render(
@@ -312,7 +317,8 @@ describe("Model item pricing and description", () => {
         />,
       )
 
-      expect(screen.queryByText("perCall")).toBeNull()
+      expect(screen.getByText("perCall")).toBeInTheDocument()
+      expect(screen.getByText("USD:0")).toBeInTheDocument()
       expect(screen.queryByText("ratio")).toBeNull()
     })
 
@@ -419,6 +425,160 @@ describe("Model item pricing and description", () => {
         "lowestPriceWithinAccountFilters",
       )
       expect(screen.queryByText(/^optimalGroup:/)).toBeNull()
+    })
+
+    it("shows unavailable pricing metadata without formatting a zero price or ratio", () => {
+      isTokenBillingTypeMock.mockReturnValue(true)
+
+      render(
+        <ModelItemPricing
+          model={createModel({
+            model_ratio: 0,
+            completion_ratio: 0,
+            price_metadata: {
+              source: MODEL_PRICE_SOURCE_KINDS.NONE,
+              precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+              unavailable_reason:
+                MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+            },
+          })}
+          calculatedPrice={createCalculatedPrice({
+            inputUSD: 0,
+            inputCNY: 0,
+            outputUSD: 0,
+            outputCNY: 0,
+          })}
+          exchangeRate={7}
+          showRealPrice={false}
+          showPricing={true}
+          showRatioColumn={true}
+          isAvailableForUser={true}
+          groupRatios={{}}
+        />,
+      )
+
+      expect(
+        screen.getByText("unavailablePriceReasons.modelListOnly"),
+      ).toBeInTheDocument()
+      expect(screen.queryByText("USD:0/M")).toBeNull()
+      expect(screen.queryByText("CNY:0/M")).toBeNull()
+      expect(screen.queryByText("0x")).toBeNull()
+      expect(formatPriceCompactMock).not.toHaveBeenCalled()
+    })
+
+    it("shows the key-group unavailable reason when Sub2API group resolution is missing", () => {
+      isTokenBillingTypeMock.mockReturnValue(true)
+
+      render(
+        <ModelItemPricing
+          model={createModel({
+            model_name: "example-runtime-model",
+            price_metadata: {
+              source: MODEL_PRICE_SOURCE_KINDS.NONE,
+              precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+              unavailable_reason:
+                MODEL_UNAVAILABLE_PRICE_REASONS.KEY_GROUP_UNKNOWN,
+            },
+          })}
+          calculatedPrice={createCalculatedPrice({
+            priceAvailability: "unavailable",
+            unavailableReason:
+              MODEL_UNAVAILABLE_PRICE_REASONS.KEY_GROUP_UNKNOWN,
+          })}
+          exchangeRate={7}
+          showRealPrice={false}
+          showPricing={true}
+          showRatioColumn={true}
+          isAvailableForUser={true}
+          groupRatios={{}}
+        />,
+      )
+
+      expect(
+        screen.getByText("unavailablePriceReasons.keyGroupUnknown"),
+      ).toBeInTheDocument()
+      expect(formatPriceCompactMock).not.toHaveBeenCalled()
+    })
+
+    it("labels estimated Sub2API prices with short source text", () => {
+      isTokenBillingTypeMock.mockReturnValue(true)
+
+      render(
+        <ModelItemPricing
+          model={createModel({
+            model_ratio: 0,
+            completion_ratio: 0,
+            token_price_usd_per_million: {
+              input: 0.25,
+              output: 1,
+            },
+            price_metadata: {
+              source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+              precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+              source_date: "2026-06-14",
+            },
+          })}
+          calculatedPrice={createCalculatedPrice({
+            inputUSD: 0.25,
+            inputCNY: 1.75,
+            outputUSD: 1,
+            outputCNY: 7,
+          })}
+          exchangeRate={7}
+          showRealPrice={false}
+          showPricing={true}
+          showRatioColumn={false}
+          isAvailableForUser={true}
+          groupRatios={{ default: 1 }}
+        />,
+      )
+
+      expect(screen.getByText("estimatedPrice")).toHaveAttribute(
+        "title",
+        "estimatedPriceTitle",
+      )
+      expect(screen.getByText("estimatedPrice")).toHaveClass("shrink-0")
+      expect(screen.getByText("USD:0.25/M")).toBeInTheDocument()
+      expect(screen.queryByText("official-rate-estimate")).toBeNull()
+      expect(screen.queryByText("2026-06-14")).toBeNull()
+    })
+
+    it("shows the effective group ratio for estimated Sub2API prices", () => {
+      isTokenBillingTypeMock.mockReturnValue(true)
+
+      render(
+        <ModelItemPricing
+          model={createModel({
+            model_ratio: 0,
+            completion_ratio: 0,
+            token_price_usd_per_million: {
+              input: 0.25,
+              output: 1,
+            },
+            price_metadata: {
+              source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+              precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+            },
+          })}
+          calculatedPrice={createCalculatedPrice({
+            inputUSD: 0.25,
+            inputCNY: 1.75,
+            outputUSD: 1,
+            outputCNY: 7,
+          })}
+          exchangeRate={7}
+          showRealPrice={false}
+          showPricing={true}
+          showRatioColumn={true}
+          isAvailableForUser={true}
+          effectiveGroup="vip"
+          groupRatios={{ vip: 2 }}
+        />,
+      )
+
+      expect(screen.getByText("ratio")).toBeInTheDocument()
+      expect(screen.getByText("2x")).toBeInTheDocument()
+      expect(screen.queryByText("0x")).toBeNull()
     })
 
     it("uses account-filter copy for all-accounts auto-picked groups", () => {

--- a/tests/services/apiCredentialProfiles/modelCatalog.test.ts
+++ b/tests/services/apiCredentialProfiles/modelCatalog.test.ts
@@ -450,6 +450,45 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     ])
   })
 
+  it("keeps Sub2API runtime rows without pricing when dashboard auth is unavailable", async () => {
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
+      ...TOKEN,
+      key: "sk-real-sub2api-secret",
+    })
+    fetchSub2ApiRuntimeModelsMock.mockResolvedValueOnce([
+      "example-runtime-model",
+    ])
+
+    const result = await loadAccountTokenFallbackPricingResponse({
+      account: {
+        ...ACCOUNT,
+        siteType: SITE_TYPES.SUB2API,
+        baseUrl: "https://sub2api.example.invalid",
+        token: "",
+      },
+      token: {
+        ...TOKEN,
+        key: "sk-masked-sub2api",
+      },
+    })
+
+    expect(fetchSub2ApiAvailableGroupsMock).not.toHaveBeenCalled()
+    expect(loadModelPriceTableMock).not.toHaveBeenCalled()
+    expect(result.model_list_source).toMatchObject({
+      kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+      provider: SITE_TYPES.SUB2API,
+      supportsPricing: false,
+    })
+    expect(result.data).toEqual([
+      expect.objectContaining({
+        model_name: "example-runtime-model",
+        price_metadata: expect.objectContaining({
+          unavailable_reason: MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+        }),
+      }),
+    ])
+  })
+
   it("redacts the resolved key and base URL when fallback loading fails", async () => {
     resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
       ...TOKEN,

--- a/tests/services/apiCredentialProfiles/modelCatalog.test.ts
+++ b/tests/services/apiCredentialProfiles/modelCatalog.test.ts
@@ -11,6 +11,9 @@ import {
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import {
   MODEL_LIST_SOURCE_KINDS,
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
   type PricingResponse,
 } from "~/services/apiService/common/type"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
@@ -20,13 +23,23 @@ const {
   fetchAnthropicModelIdsMock,
   fetchGoogleModelIdsMock,
   fetchOpenAICompatibleModelIdsMock,
+  fetchAccountTokensMock,
+  fetchSub2ApiAvailableGroupsMock,
+  fetchSub2ApiGroupRatesMock,
+  fetchSub2ApiRuntimeModelsMock,
   getApiServiceMock,
+  loadModelPriceTableMock,
   resolveDisplayAccountTokenForSecretMock,
 } = vi.hoisted(() => ({
   fetchAnthropicModelIdsMock: vi.fn(),
   fetchGoogleModelIdsMock: vi.fn(),
   fetchOpenAICompatibleModelIdsMock: vi.fn(),
+  fetchAccountTokensMock: vi.fn(),
+  fetchSub2ApiAvailableGroupsMock: vi.fn(),
+  fetchSub2ApiGroupRatesMock: vi.fn(),
+  fetchSub2ApiRuntimeModelsMock: vi.fn(),
   getApiServiceMock: vi.fn(),
+  loadModelPriceTableMock: vi.fn(),
   resolveDisplayAccountTokenForSecretMock: vi.fn(),
 }))
 
@@ -46,6 +59,20 @@ vi.mock("~/services/aiApi/google", () => ({
 vi.mock("~/services/aiApi/openaiCompatible", () => ({
   fetchOpenAICompatibleModelIds: (...args: unknown[]) =>
     fetchOpenAICompatibleModelIdsMock(...args),
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchAccountTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+  fetchSub2ApiAvailableGroups: (...args: unknown[]) =>
+    fetchSub2ApiAvailableGroupsMock(...args),
+  fetchSub2ApiGroupRates: (...args: unknown[]) =>
+    fetchSub2ApiGroupRatesMock(...args),
+  fetchSub2ApiRuntimeModels: (...args: unknown[]) =>
+    fetchSub2ApiRuntimeModelsMock(...args),
+}))
+
+vi.mock("~/services/apiCredentialProfiles/modelPriceTable", () => ({
+  loadModelPriceTable: (...args: unknown[]) => loadModelPriceTableMock(...args),
 }))
 
 vi.mock(
@@ -101,11 +128,25 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     fetchAnthropicModelIdsMock.mockReset()
     fetchGoogleModelIdsMock.mockReset()
     fetchOpenAICompatibleModelIdsMock.mockReset()
+    fetchAccountTokensMock.mockReset()
+    fetchSub2ApiAvailableGroupsMock.mockReset()
+    fetchSub2ApiGroupRatesMock.mockReset()
+    fetchSub2ApiRuntimeModelsMock.mockReset()
     getApiServiceMock.mockReset()
+    loadModelPriceTableMock.mockReset()
     resolveDisplayAccountTokenForSecretMock.mockReset()
     resolveDisplayAccountTokenForSecretMock.mockImplementation(
       async (_account, token) => token,
     )
+    fetchSub2ApiAvailableGroupsMock.mockRejectedValue(
+      new Error("dashboard auth unavailable"),
+    )
+    fetchSub2ApiGroupRatesMock.mockResolvedValue({})
+    fetchAccountTokensMock.mockResolvedValue([])
+    loadModelPriceTableMock.mockResolvedValue({
+      source: "synthetic-test",
+      models: {},
+    })
   })
 
   it("routes profile model-id lookups to the provider-specific fetcher", async () => {
@@ -264,6 +305,151 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     expect(fetchOpenAICompatibleModelIdsMock).not.toHaveBeenCalled()
   })
 
+  it("loads Sub2API selected-key runtime models as model-list-only rows", async () => {
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
+      ...TOKEN,
+      key: "sk-real-sub2api-secret",
+    })
+    fetchSub2ApiRuntimeModelsMock.mockResolvedValueOnce([
+      "example-runtime-model",
+    ])
+
+    const result = await loadAccountTokenFallbackPricingResponse({
+      account: {
+        ...ACCOUNT,
+        siteType: SITE_TYPES.SUB2API,
+        baseUrl: "https://sub2api.example.invalid",
+      },
+      token: {
+        ...TOKEN,
+        key: "sk-masked-sub2api",
+      },
+    })
+
+    expect(resolveDisplayAccountTokenForSecretMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteType: SITE_TYPES.SUB2API,
+        baseUrl: "https://sub2api.example.invalid",
+      }),
+      expect.objectContaining({
+        key: "sk-masked-sub2api",
+      }),
+    )
+    expect(fetchSub2ApiRuntimeModelsMock).toHaveBeenCalledWith({
+      baseUrl: "https://sub2api.example.invalid",
+      accountId: "account-1",
+      auth: expect.objectContaining({
+        authType: AuthTypeEnum.AccessToken,
+        apiKey: "sk-real-sub2api-secret",
+      }),
+    })
+    expect(fetchOpenAICompatibleModelIdsMock).not.toHaveBeenCalled()
+    expect(fetchSub2ApiAvailableGroupsMock).toHaveBeenCalledWith({
+      baseUrl: "https://sub2api.example.invalid",
+      accountId: "account-1",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        userId: "1",
+        accessToken: "account-token",
+        cookie: undefined,
+      },
+    })
+    expect(result.model_list_source).toEqual({
+      kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+      provider: SITE_TYPES.SUB2API,
+      supportsRuntimeModelList: true,
+      supportsPricing: false,
+    })
+    expect(result.data).toEqual([
+      expect.objectContaining({
+        model_name: "example-runtime-model",
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason:
+            MODEL_UNAVAILABLE_PRICE_REASONS.PRICING_SOURCE_UNAVAILABLE,
+        },
+      }),
+    ])
+  })
+
+  it("adds estimated Sub2API prices when dashboard group and price-table data are available", async () => {
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
+      ...TOKEN,
+      key: "sk-real-sub2api-secret",
+    })
+    fetchSub2ApiRuntimeModelsMock.mockResolvedValueOnce([
+      "example-priced-model",
+      "example-unpriced-model",
+    ])
+    fetchSub2ApiAvailableGroupsMock.mockResolvedValueOnce([
+      { id: 9, name: "vip", rate_multiplier: 1.5 },
+    ])
+    fetchSub2ApiGroupRatesMock.mockResolvedValueOnce({ "9": 2 })
+    fetchAccountTokensMock.mockResolvedValueOnce([
+      {
+        ...TOKEN,
+        id: 99,
+        key: "sk-real-sub2api-secret",
+        group: "vip",
+        sub2api_group_id: 9,
+      },
+    ])
+    loadModelPriceTableMock.mockResolvedValueOnce({
+      source: "synthetic-test",
+      source_date: "2026-06-14",
+      models: {
+        "example-priced-model": {
+          input: 2,
+          output: 6,
+        },
+        "example-unpriced-model": {},
+      },
+    })
+
+    const result = await loadAccountTokenFallbackPricingResponse({
+      account: {
+        ...ACCOUNT,
+        siteType: SITE_TYPES.SUB2API,
+        baseUrl: "https://sub2api.example.invalid",
+      },
+      token: {
+        ...TOKEN,
+        key: "sk-masked-sub2api",
+      },
+    })
+
+    expect(result.model_list_source).toEqual({
+      kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+      provider: SITE_TYPES.SUB2API,
+      supportsRuntimeModelList: true,
+      supportsPricing: true,
+    })
+    expect(result.data).toEqual([
+      expect.objectContaining({
+        model_name: "example-priced-model",
+        token_price_usd_per_million: {
+          input: 4,
+          output: 12,
+        },
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+          precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+          source_date: "2026-06-14",
+        },
+      }),
+      expect.objectContaining({
+        model_name: "example-unpriced-model",
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason:
+            MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
+        },
+      }),
+    ])
+  })
+
   it("redacts the resolved key and base URL when fallback loading fails", async () => {
     resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
       ...TOKEN,
@@ -328,6 +514,37 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     expect(
       caughtError instanceof Error ? caughtError.message : "",
     ).not.toContain("sk-real-secret")
+  })
+
+  it("surfaces Sub2API runtime key business errors for fallback catalog loading", async () => {
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
+      ...TOKEN,
+      key: "sk-real-sub2api-secret",
+    })
+    const groupDeletedError = new ApiError(
+      "API Key 所属分组已删除",
+      undefined,
+      "/v1/models",
+      API_ERROR_CODES.BUSINESS_ERROR,
+    )
+    fetchSub2ApiRuntimeModelsMock.mockRejectedValueOnce(groupDeletedError)
+
+    await expect(
+      loadAccountTokenFallbackPricingResponse({
+        account: {
+          ...ACCOUNT,
+          siteType: SITE_TYPES.SUB2API,
+          baseUrl: "https://sub2api.example.invalid",
+        },
+        token: {
+          ...TOKEN,
+          key: "sk-masked-sub2api",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "API Key 所属分组已删除",
+      cause: groupDeletedError,
+    })
   })
 
   it("normalizes, filters, and de-duplicates raw model ids when building profile catalogs", () => {

--- a/tests/services/apiCredentialProfiles/modelPriceTable.test.ts
+++ b/tests/services/apiCredentialProfiles/modelPriceTable.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { loadModelPriceTable } from "~/services/apiCredentialProfiles/modelPriceTable"
+import {
+  LITELLM_MODEL_PRICE_TABLE_URL,
+  loadModelPriceTable,
+  MODEL_PRICE_TABLE_FETCH_TIMEOUT_MS,
+} from "~/services/apiCredentialProfiles/modelPriceTable"
 
 describe("loadModelPriceTable", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.useRealTimers()
   })
 
   it("loads and normalizes LiteLLM token prices into USD-per-million units", async () => {
@@ -27,8 +32,7 @@ describe("loadModelPriceTable", () => {
     vi.stubGlobal("fetch", fetchMock)
 
     await expect(loadModelPriceTable()).resolves.toEqual({
-      source:
-        "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+      source: LITELLM_MODEL_PRICE_TABLE_URL,
       models: {
         "example-priced-model": {
           input: 2,
@@ -38,9 +42,9 @@ describe("loadModelPriceTable", () => {
         },
       },
     })
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
-    )
+    expect(fetchMock).toHaveBeenCalledWith(LITELLM_MODEL_PRICE_TABLE_URL, {
+      signal: expect.any(AbortSignal),
+    })
   })
 
   it("rejects failed or malformed price-table responses", async () => {
@@ -67,5 +71,32 @@ describe("loadModelPriceTable", () => {
     await expect(loadModelPriceTable()).rejects.toThrow(
       "Invalid LiteLLM price table payload",
     )
+  })
+
+  it("aborts hung LiteLLM price-table requests", async () => {
+    vi.useFakeTimers()
+    let abortSignal: AbortSignal | undefined
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        abortSignal = init?.signal
+
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted", "AbortError"))
+          })
+        })
+      }),
+    )
+
+    const loading = loadModelPriceTable()
+    const loadingExpectation = expect(loading).rejects.toThrow(
+      "Timed out loading LiteLLM price table",
+    )
+
+    await vi.advanceTimersByTimeAsync(MODEL_PRICE_TABLE_FETCH_TIMEOUT_MS)
+
+    expect(abortSignal?.aborted).toBe(true)
+    await loadingExpectation
   })
 })

--- a/tests/services/apiCredentialProfiles/modelPriceTable.test.ts
+++ b/tests/services/apiCredentialProfiles/modelPriceTable.test.ts
@@ -79,7 +79,7 @@ describe("loadModelPriceTable", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn((_url: string, init?: RequestInit) => {
-        abortSignal = init?.signal
+        abortSignal = init?.signal ?? undefined
 
         return new Promise((_resolve, reject) => {
           init?.signal?.addEventListener("abort", () => {

--- a/tests/services/apiCredentialProfiles/modelPriceTable.test.ts
+++ b/tests/services/apiCredentialProfiles/modelPriceTable.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { loadModelPriceTable } from "~/services/apiCredentialProfiles/modelPriceTable"
+
+describe("loadModelPriceTable", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("loads and normalizes LiteLLM token prices into USD-per-million units", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        "example-priced-model": {
+          input_cost_per_token: 0.000002,
+          output_cost_per_token: "0.000006",
+          cache_read_input_token_cost: 0.00000025,
+          cache_creation_input_token_cost: "0.0000005",
+        },
+        "example-empty-model": {},
+        sample_spec: {
+          input_cost_per_token: 1,
+          output_cost_per_token: 1,
+        },
+      }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(loadModelPriceTable()).resolves.toEqual({
+      source:
+        "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+      models: {
+        "example-priced-model": {
+          input: 2,
+          output: 6,
+          cache_read: 0.25,
+          cache_write: 0.5,
+        },
+      },
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+    )
+  })
+
+  it("rejects failed or malformed price-table responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: vi.fn(),
+      }),
+    )
+
+    await expect(loadModelPriceTable()).rejects.toThrow(
+      "Failed to load LiteLLM price table",
+    )
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(null),
+      }),
+    )
+
+    await expect(loadModelPriceTable()).rejects.toThrow(
+      "Invalid LiteLLM price table payload",
+    )
+  })
+})

--- a/tests/services/apiCredentialProfiles/sub2apiPriceEstimation.test.ts
+++ b/tests/services/apiCredentialProfiles/sub2apiPriceEstimation.test.ts
@@ -108,6 +108,27 @@ describe("resolveSub2ApiKeyGroupForPriceEstimation", () => {
     ).toEqual(expect.objectContaining({ groupId: "9", groupName: "vip" }))
   })
 
+  it("falls back to the selected key group name when account tokens do not reveal an exact key match", () => {
+    expect(
+      resolveSub2ApiKeyGroupForPriceEstimation({
+        selectedToken: createToken({
+          key: "masked********key",
+          group: "vip",
+        }),
+        resolvedKey: "sub2api-full-secret",
+        accountTokens: [
+          createToken({
+            id: 1,
+            key: "different-sub2api-secret",
+            group: "default",
+            sub2api_group_id: 1,
+          }),
+        ],
+        groups,
+      }),
+    ).toEqual(expect.objectContaining({ groupId: "9", groupName: "vip" }))
+  })
+
   it("disables estimation for masked matches, no match, no stored group, or multiple same-name matches", () => {
     const baseParams = {
       resolvedKey: "stored-key",
@@ -117,7 +138,7 @@ describe("resolveSub2ApiKeyGroupForPriceEstimation", () => {
     expect(
       resolveSub2ApiKeyGroupForPriceEstimation({
         ...baseParams,
-        selectedToken: createToken({ group: "vip" }),
+        selectedToken: createToken({ group: "" }),
         accountTokens: [
           createToken({
             key: "stored********key",

--- a/tests/services/apiCredentialProfiles/sub2apiPriceEstimation.test.ts
+++ b/tests/services/apiCredentialProfiles/sub2apiPriceEstimation.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  applySub2ApiPriceEstimates,
+  resolveSub2ApiKeyGroupForPriceEstimation,
+} from "~/services/apiCredentialProfiles/sub2apiPriceEstimation"
+import {
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+
+const createToken = (overrides: Partial<ApiToken> = {}): ApiToken => ({
+  id: 10,
+  user_id: 1,
+  key: "stored-key",
+  status: 1,
+  name: "Fallback Key",
+  created_time: 0,
+  accessed_time: 0,
+  expired_time: -1,
+  remain_quota: 0,
+  unlimited_quota: true,
+  used_quota: 0,
+  models: "",
+  ...overrides,
+})
+
+const groups = [
+  { id: 1, name: "default", rate_multiplier: 1 },
+  { id: 9, name: "vip", rate_multiplier: 1.5 },
+  { id: 10, name: "duplicate", rate_multiplier: 2 },
+  { id: 11, name: "duplicate", rate_multiplier: 3 },
+]
+
+const priceTable = {
+  source: "synthetic-test",
+  source_date: "2026-06-14",
+  models: {
+    "example-priced-model": {
+      input: 2,
+      output: 6,
+    },
+    "example-cache-model": {
+      input: 1,
+      output: 3,
+      cache_read: 0.25,
+      cache_write: 0.5,
+    },
+    "example-input-only-model": {
+      input: 2,
+    },
+    "example-output-only-model": {
+      output: 6,
+    },
+    "example-unpriced-model": {},
+  },
+}
+
+describe("resolveSub2ApiKeyGroupForPriceEstimation", () => {
+  it("resolves an exact unmasked backend key match to the backend key's stable group id", () => {
+    expect(
+      resolveSub2ApiKeyGroupForPriceEstimation({
+        selectedToken: createToken({
+          key: "masked********key",
+          group: "vip",
+        }),
+        resolvedKey: "sub2api-full-secret",
+        accountTokens: [
+          createToken({
+            id: 1,
+            key: "sub2api-full-secret",
+            group: "vip",
+            sub2api_group_id: 9,
+          }),
+        ],
+        groups,
+      }),
+    ).toEqual(expect.objectContaining({ groupId: "9", groupName: "vip" }))
+  })
+
+  it("prefers a stored stable group id over name matching", () => {
+    expect(
+      resolveSub2ApiKeyGroupForPriceEstimation({
+        selectedToken: createToken({
+          key: "stored-key",
+          group: "duplicate",
+          sub2api_group_id: 9,
+        }),
+        resolvedKey: "stored-key",
+        accountTokens: [],
+        groups,
+      }),
+    ).toEqual(expect.objectContaining({ groupId: "9", groupName: "vip" }))
+  })
+
+  it("resolves a stored group name only when exactly one available group has that name", () => {
+    expect(
+      resolveSub2ApiKeyGroupForPriceEstimation({
+        selectedToken: createToken({
+          group: "vip",
+        }),
+        resolvedKey: "stored-key",
+        accountTokens: [],
+        groups,
+      }),
+    ).toEqual(expect.objectContaining({ groupId: "9", groupName: "vip" }))
+  })
+
+  it("disables estimation for masked matches, no match, no stored group, or multiple same-name matches", () => {
+    const baseParams = {
+      resolvedKey: "stored-key",
+      groups,
+    }
+
+    expect(
+      resolveSub2ApiKeyGroupForPriceEstimation({
+        ...baseParams,
+        selectedToken: createToken({ group: "vip" }),
+        accountTokens: [
+          createToken({
+            key: "stored********key",
+            group: "vip",
+            sub2api_group_id: 9,
+          }),
+        ],
+      }),
+    ).toBeNull()
+    expect(
+      resolveSub2ApiKeyGroupForPriceEstimation({
+        ...baseParams,
+        selectedToken: createToken({ group: "" }),
+        accountTokens: [createToken({ key: "other-key", group: "vip" })],
+      }),
+    ).toBeNull()
+    expect(
+      resolveSub2ApiKeyGroupForPriceEstimation({
+        ...baseParams,
+        selectedToken: createToken({ group: "" }),
+        accountTokens: [],
+      }),
+    ).toBeNull()
+    expect(
+      resolveSub2ApiKeyGroupForPriceEstimation({
+        ...baseParams,
+        selectedToken: createToken({ group: "duplicate" }),
+        accountTokens: [],
+      }),
+    ).toBeNull()
+  })
+
+  it("treats normalized ApiToken.group as a name-like value, not a stable group id", () => {
+    expect(
+      resolveSub2ApiKeyGroupForPriceEstimation({
+        selectedToken: createToken({ group: "9" }),
+        resolvedKey: "stored-key",
+        accountTokens: [],
+        groups,
+      }),
+    ).toBeNull()
+  })
+})
+
+describe("applySub2ApiPriceEstimates", () => {
+  it("uses user-specific group rates before the default group rate", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-priced-model"],
+      group: { groupId: "9", groupName: "vip", rate_multiplier: 1.5 },
+      groupRates: { "9": 2 },
+      priceTable,
+    })
+
+    expect(result.data[0]).toMatchObject({
+      model_name: "example-priced-model",
+      token_price_usd_per_million: {
+        input: 4,
+        output: 12,
+      },
+      price_metadata: {
+        source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+        precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+        source_date: "2026-06-14",
+      },
+    })
+    expect(result.group_ratio).toEqual({ vip: 2 })
+    expect(result.model_list_source?.supportsPricing).toBe(true)
+  })
+
+  it("normalizes invalid and zero group rates before estimating prices", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-priced-model", "example-cache-model"],
+      group: { groupId: "9", groupName: "vip", rate_multiplier: 1.5 },
+      groupRates: { "9": "invalid", "10": 0 } as any,
+      priceTable,
+    })
+
+    expect(result.data[0]?.token_price_usd_per_million).toEqual({
+      input: 2,
+      output: 6,
+    })
+    expect(result.data[1]?.token_price_usd_per_million).toEqual({
+      input: 1,
+      output: 3,
+      cache_read: 0.25,
+      cache_write: 0.5,
+    })
+  })
+
+  it("normalizes negative user-specific group rates before estimating prices", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-priced-model"],
+      group: { groupId: "9", groupName: "vip", rate_multiplier: 1.5 },
+      groupRates: { "9": -2 },
+      priceTable,
+    })
+
+    expect(result.data[0]?.token_price_usd_per_million).toEqual({
+      input: 2,
+      output: 6,
+    })
+  })
+
+  it("normalizes zero group rate multipliers before estimating prices", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-priced-model"],
+      group: { groupId: "9", groupName: "vip", rate_multiplier: 0 },
+      groupRates: {},
+      priceTable,
+    })
+
+    expect(result.data[0]?.token_price_usd_per_million).toEqual({
+      input: 2,
+      output: 6,
+    })
+  })
+
+  it("normalizes negative group rate multipliers before estimating prices", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-priced-model"],
+      group: { groupId: "9", groupName: "vip", rate_multiplier: -1.5 },
+      groupRates: {},
+      priceTable,
+    })
+
+    expect(result.data[0]?.token_price_usd_per_million).toEqual({
+      input: 2,
+      output: 6,
+    })
+  })
+
+  it("normalizes invalid group rate multipliers before estimating prices", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-priced-model"],
+      group: {
+        groupId: "9",
+        groupName: "vip",
+        rate_multiplier: "invalid" as any,
+      },
+      groupRates: {},
+      priceTable,
+    })
+
+    expect(result.data[0]?.token_price_usd_per_million).toEqual({
+      input: 2,
+      output: 6,
+    })
+  })
+
+  it("keeps unmatched official prices visible as unavailable model rows", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-unpriced-model", "missing-from-table"],
+      group: { groupId: "9", groupName: "vip", rate_multiplier: 1.5 },
+      groupRates: {},
+      priceTable,
+    })
+
+    expect(result.data).toEqual([
+      expect.objectContaining({
+        model_name: "example-unpriced-model",
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason:
+            MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
+        },
+      }),
+      expect.objectContaining({
+        model_name: "missing-from-table",
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason:
+            MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
+        },
+      }),
+    ])
+  })
+
+  it("treats partial official token price rows as unavailable", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-input-only-model", "example-output-only-model"],
+      group: { groupId: "9", groupName: "vip", rate_multiplier: 1.5 },
+      groupRates: {},
+      priceTable,
+    })
+
+    expect(result.data).toEqual([
+      expect.objectContaining({
+        model_name: "example-input-only-model",
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason:
+            MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
+        },
+      }),
+      expect.objectContaining({
+        model_name: "example-output-only-model",
+        price_metadata: {
+          source: MODEL_PRICE_SOURCE_KINDS.NONE,
+          precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+          unavailable_reason:
+            MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
+        },
+      }),
+    ])
+    expect(result.data[0]?.token_price_usd_per_million).toBeUndefined()
+    expect(result.data[1]?.token_price_usd_per_million).toBeUndefined()
+  })
+
+  it("applies cache read and cache write estimates when official prices include them", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-cache-model"],
+      group: { groupId: "9", groupName: "vip", rate_multiplier: 1.5 },
+      groupRates: {},
+      priceTable,
+    })
+
+    expect(result.data[0]?.token_price_usd_per_million).toEqual({
+      input: 1.5,
+      output: 4.5,
+      cache_read: 0.375,
+      cache_write: 0.75,
+    })
+  })
+
+  it("disables estimation when the selected key group is unknown", () => {
+    const result = applySub2ApiPriceEstimates({
+      modelIds: ["example-priced-model"],
+      group: null,
+      groupRates: {},
+      priceTable,
+    })
+
+    expect(result.data[0]).toMatchObject({
+      model_name: "example-priced-model",
+      price_metadata: {
+        source: MODEL_PRICE_SOURCE_KINDS.NONE,
+        precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+        unavailable_reason: MODEL_UNAVAILABLE_PRICE_REASONS.KEY_GROUP_UNKNOWN,
+      },
+    })
+    expect(result.model_list_source?.supportsPricing).toBe(false)
+  })
+})

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -18,6 +18,7 @@ import {
   fetchCurrentUser,
   fetchSiteStatus,
   fetchSub2ApiAnnouncements,
+  fetchSub2ApiRuntimeModels,
   fetchSupportCheckIn,
   fetchTodayIncome,
   fetchTodayUsage,
@@ -1750,6 +1751,193 @@ describe("apiService sub2api exported operations", () => {
     await expect(
       fetchAccountAvailableModels(baseRequest as any),
     ).resolves.toEqual([])
+  })
+
+  describe("fetchSub2ApiRuntimeModels", () => {
+    const createRuntimeRequest = (
+      overrides: Partial<ApiServiceAccountRequest> = {},
+    ): ApiServiceAccountRequest =>
+      ({
+        baseUrl: "https://sub2.example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          apiKey: "runtime-api-key",
+        },
+        ...overrides,
+      }) as ApiServiceAccountRequest
+
+    it("fetches OpenAI-style runtime models with bearer API-key auth", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [
+              {
+                id: "example-runtime-model",
+                object: "model",
+                created: 1_700_000_000,
+                owned_by: "example",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+      ).resolves.toEqual(["example-runtime-model"])
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://sub2.example.com/v1/models",
+        expect.objectContaining({
+          method: "GET",
+          cache: "no-store",
+          headers: expect.objectContaining({
+            Authorization: "Bearer runtime-api-key",
+          }),
+        }),
+      )
+      expect(fetchApi).not.toHaveBeenCalled()
+      expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+    })
+
+    it("fetches Sub2API-style runtime models and normalizes IDs", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "example-runtime-model",
+                display_name: "Example Runtime Model",
+                created_at: "2026-06-14T00:00:00.000Z",
+              },
+              {
+                id: " second-runtime-model ",
+                display_name: "Second Runtime Model",
+                created_at: 1_700_000_000,
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+      ).resolves.toEqual(["example-runtime-model", "second-runtime-model"])
+    })
+
+    it("returns an empty list when the runtime model data list is empty", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+      ).resolves.toEqual([])
+    })
+
+    it("rejects malformed runtime model payloads with a validation error", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ data: [{ id: "" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+      ).rejects.toMatchObject({
+        message: "messages:errors.api.invalidResponseFormat",
+        code: API_ERROR_CODES.BUSINESS_ERROR,
+      })
+    })
+
+    it("rejects invalid JSON runtime model responses with a validation error", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response("<html>not json</html>", {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+      )
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+      ).rejects.toMatchObject({
+        message: "messages:errors.api.invalidResponseFormat",
+        code: API_ERROR_CODES.BUSINESS_ERROR,
+      })
+    })
+
+    it("treats runtime 401 and 403 responses as API-key auth failures", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response("Unauthorized", { status: 401 }))
+        .mockResolvedValueOnce(new Response("Forbidden", { status: 403 }))
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+      ).rejects.toMatchObject({
+        code: API_ERROR_CODES.HTTP_401,
+      })
+
+      await expect(
+        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+      ).rejects.toMatchObject({
+        code: API_ERROR_CODES.HTTP_401,
+      })
+    })
+
+    it("surfaces Sub2API runtime business errors before auth fallbacks", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: "GROUP_DELETED",
+            message: "API Key 所属分组已删除",
+          }),
+          { status: 403, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+      ).rejects.toMatchObject({
+        message: "API Key 所属分组已删除",
+        code: API_ERROR_CODES.BUSINESS_ERROR,
+        endpoint: "/v1/models",
+      })
+    })
+
+    it("rejects dashboard access tokens without calling the runtime model endpoint", async () => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(
+          createRuntimeRequest({
+            auth: {
+              authType: AuthTypeEnum.AccessToken,
+              accessToken: "dashboard-jwt",
+            },
+          }),
+        ),
+      ).rejects.toMatchObject({
+        code: API_ERROR_CODES.HTTP_401,
+      })
+
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
   })
 
   it("reuses newer stored auth instead of refreshing again when account storage already rotated the JWT", async () => {

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -1898,6 +1898,39 @@ describe("apiService sub2api exported operations", () => {
       })
     })
 
+    it("surfaces non-auth runtime model HTTP failures with endpoint context", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response("Gateway timeout", {
+          status: 504,
+          statusText: "",
+        }),
+      )
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+      ).rejects.toMatchObject({
+        message: "Sub2API runtime model request failed",
+        statusCode: 504,
+        code: API_ERROR_CODES.HTTP_OTHER,
+        endpoint: "/v1/models",
+      })
+    })
+
+    it("logs and rethrows network failures from the runtime model endpoint", async () => {
+      const networkError = new Error("network down")
+      const fetchMock = vi.fn().mockRejectedValueOnce(networkError)
+      vi.stubGlobal("fetch", fetchMock as any)
+
+      await expect(
+        fetchSub2ApiRuntimeModels(
+          createRuntimeRequest({
+            accountId: "account-runtime",
+          }),
+        ),
+      ).rejects.toBe(networkError)
+    })
+
     it("surfaces Sub2API runtime business errors before auth fallbacks", async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         new Response(

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -10,6 +10,7 @@ import {
   createApiToken,
   fetchAccountAvailableModels,
   fetchAccountTokens,
+  fetchSub2ApiGroupRates,
   fetchTokenById,
   fetchUserGroups,
   resolveApiTokenKey,
@@ -103,8 +104,50 @@ describe("apiService sub2api key management parsing", () => {
     expect(token.used_quota).toBe(Math.round(1.25 * 500000))
     expect(token.allow_ips).toBe("1.1.1.1,2.2.2.2")
     expect(token.group).toBe("vip")
+    expect(token.sub2api_group_id).toBeUndefined()
     expect(token.unlimited_quota).toBe(false)
     expect(token.expired_time).toBe(1772971200)
+  })
+
+  it("treats nested Sub2API group ids as group metadata, not stable key group ids", () => {
+    const token = parseSub2ApiKey({
+      id: "7",
+      user_id: "5",
+      key: "test-key",
+      name: "VIP Key",
+      status: "active",
+      quota: 2.5,
+      quota_used: 1.25,
+      expires_at: null,
+      created_at: "2026-03-01T08:30:00.000Z",
+      updated_at: "2026-03-02T09:45:00.000Z",
+      ip_whitelist: [],
+      group: { id: 9, name: "vip" },
+    })
+
+    expect(token.group).toBe("vip")
+    expect(token.sub2api_group_id).toBeUndefined()
+  })
+
+  it("preserves a stable Sub2API key group id when the backend exposes group_id", () => {
+    const token = parseSub2ApiKey({
+      id: "7",
+      user_id: "5",
+      key: "test-key",
+      name: "VIP Key",
+      status: "active",
+      quota: 2.5,
+      quota_used: 1.25,
+      expires_at: null,
+      created_at: "2026-03-01T08:30:00.000Z",
+      updated_at: "2026-03-02T09:45:00.000Z",
+      ip_whitelist: [],
+      group_id: "11",
+      group: { id: 9, name: "vip" },
+    })
+
+    expect(token.group).toBe("vip")
+    expect(token.sub2api_group_id).toBe(11)
   })
 
   it("treats non-positive numeric strings like numeric expiries", () => {
@@ -185,10 +228,43 @@ describe("apiService sub2api key management service", () => {
     })
   })
 
+  it("normalizes raw Sub2API group rates for estimator callers", async () => {
+    fetchApiMock.mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: {
+        "1": "0",
+        "9": "invalid",
+        "10": "2.5",
+      },
+    })
+
+    await expect(fetchSub2ApiGroupRates(createRequest())).resolves.toEqual({
+      "1": 1,
+      "9": 1,
+      "10": 2.5,
+    })
+  })
+
   it("returns no available models so Sub2API form hides model-limit controls", async () => {
     await expect(fetchAccountAvailableModels(createRequest())).resolves.toEqual(
       [],
     )
+  })
+
+  it("keeps key-creation available models empty even with Sub2API form metadata", async () => {
+    await expect(
+      fetchAccountAvailableModels(
+        createRequest({
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            apiKey: "runtime-api-key",
+            accessToken: "dashboard-jwt",
+          } as ApiServiceRequest["auth"] & { apiKey: string },
+        }),
+      ),
+    ).resolves.toEqual([])
+    expect(fetchApiMock).not.toHaveBeenCalled()
   })
 
   it("resolves usable inventory keys without calling unsupported compatible reveal endpoints", async () => {

--- a/tests/utils/modelPricing.test.ts
+++ b/tests/utils/modelPricing.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest"
 
 import type { ModelPricing } from "~/services/apiService/common/type"
 import {
+  MODEL_PRICE_PRECISION_KINDS,
+  MODEL_PRICE_SOURCE_KINDS,
+  MODEL_UNAVAILABLE_PRICE_REASONS,
+} from "~/services/apiService/common/type"
+import {
   calculateModelPrice,
   formatPrice,
   formatPriceCompact,
@@ -199,6 +204,39 @@ describe("modelPricing utils", () => {
           inputCNY: 42,
           outputCNY: 63,
         })
+      })
+
+      it("returns missing-price metadata for unavailable price rows", () => {
+        const result = calculateModelPrice(
+          {
+            ...tokenModel,
+            model_name: "example-runtime-model",
+            model_ratio: 0,
+            completion_ratio: 0,
+            price_metadata: {
+              source: MODEL_PRICE_SOURCE_KINDS.NONE,
+              precision: MODEL_PRICE_PRECISION_KINDS.UNAVAILABLE,
+              unavailable_reason:
+                MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+            },
+          },
+          baseGroupRatio,
+          exchangeRate,
+          "default",
+        )
+
+        expect(result.priceAvailability).toBe("unavailable")
+        if (result.priceAvailability !== "unavailable") {
+          throw new Error("Expected unavailable price result")
+        }
+        expect(result.unavailableReason).toBe(
+          MODEL_UNAVAILABLE_PRICE_REASONS.MODEL_LIST_ONLY,
+        )
+        expect(result.inputUSD).toBeUndefined()
+        expect(result.outputUSD).toBeUndefined()
+        expect(result.inputCNY).toBeUndefined()
+        expect(result.outputCNY).toBeUndefined()
+        expect(result.perCallPrice).toBeUndefined()
       })
     })
 


### PR DESCRIPTION
## Summary
- Add Sub2API runtime /v1/models loading through selected API credential keys.
- Add optional Sub2API estimated pricing from resolved key group rates plus LiteLLM-style model price data.
- Update Model List source metadata, pricing badges, filtering, sorting, and localized unavailable/estimated price copy.

## Test Plan
- pnpm run i18n:extract:ci
- pnpm run validate:staged
- pnpm run validate:push

## Notes
- Branch was tidied into three reviewable commits: docs, service/runtime pricing, and Model List UI state.
- Existing unrelated untracked local files were left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Sub2API runtime model list discovery, with estimated pricing computed from runtime group rates.
  * Added “estimated price” labels and UI badges where estimates apply.
  * Added Sub2API key-scoped loading/status messaging and clearer fallback behavior.
* **Bug Fixes**
  * Improved handling of unavailable pricing so unknown prices no longer display as zero; unavailable rows show specific reason text.
  * Updated model sorting/filtering to treat unavailable pricing as uncomparable.
* **Documentation**
  * Added Sub2API model list price estimation planning/design docs.
* **Localization**
  * Added estimated pricing and per-reason unavailable pricing UI strings across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->