### PR TITLE
feat(navigation): link account keys and models

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -7,6 +7,7 @@ interface PageHeaderProps {
   icon: ComponentType<{ className?: string }>
   title: ReactNode
   titleActions?: ReactNode
+  titleActionsTestId?: string
   description?: ReactNode
   actions?: ReactNode
   spacing?: "default" | "compact"
@@ -20,6 +21,7 @@ interface PageHeaderProps {
  * @param props.icon Icon component rendered next to the title.
  * @param props.title Header title node.
  * @param props.titleActions Optional compact action elements rendered next to the title.
+ * @param props.titleActionsTestId Optional test id for the title action container.
  * @param props.description Optional helper text shown below the title.
  * @param props.actions Optional action elements rendered on the right.
  * @param props.spacing Adjusts vertical spacing (default or compact).
@@ -30,6 +32,7 @@ export function PageHeader({
   icon: Icon,
   title,
   titleActions,
+  titleActionsTestId,
   description,
   actions,
   spacing = "default",
@@ -46,7 +49,10 @@ export function PageHeader({
               iconClassName,
             )}
           />
-          <div className="flex min-w-0 items-center gap-2">
+          <div
+            className="flex min-w-0 items-center gap-2"
+            data-testid={titleActionsTestId}
+          >
             <Heading2 className="dark:text-dark-text-primary text-gray-900">
               {title}
             </Heading2>

--- a/src/features/KeyManagement/KeyManagement.tsx
+++ b/src/features/KeyManagement/KeyManagement.tsx
@@ -20,7 +20,7 @@ import {
   type ManagedSiteTokenChannelStatus,
 } from "~/services/managedSites/tokenChannelStatus"
 import type { AccountToken } from "~/types"
-import { pushWithinOptionsPage } from "~/utils/navigation"
+import { openModelsPage, pushWithinOptionsPage } from "~/utils/navigation"
 
 import { AccountSelectorPanel } from "./components/AccountSelectorPanel"
 import { AccountSummaryBar } from "./components/AccountSummaryBar"
@@ -214,6 +214,17 @@ export default function KeyManagement(props: {
     pushWithinOptionsPage(`#${MENU_ITEM_IDS.ACCOUNT}`)
   }, [])
 
+  const handleOpenSelectedAccountModels = useCallback(() => {
+    if (
+      !selectedAccount ||
+      selectedAccount === KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE
+    ) {
+      return
+    }
+
+    void openModelsPage(selectedAccount)
+  }, [selectedAccount])
+
   const handleRequestAccountSelection = useCallback(() => {
     const selectorTrigger = accountSelectorTriggerRef.current
 
@@ -311,6 +322,12 @@ export default function KeyManagement(props: {
         onAddToken={handleAddToken}
         onRepairMissingKeys={handleRepairMissingKeys}
         onRefresh={() => selectedAccount && loadTokens()}
+        onOpenSelectedAccountModels={
+          selectedAccount &&
+          selectedAccount !== KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE
+            ? handleOpenSelectedAccountModels
+            : undefined
+        }
         onRefreshManagedSiteStatus={
           isManagedSiteChannelStatusSupported
             ? () => void refreshManagedSiteTokenStatuses()

--- a/src/features/KeyManagement/KeyManagement.tsx
+++ b/src/features/KeyManagement/KeyManagement.tsx
@@ -215,13 +215,6 @@ export default function KeyManagement(props: {
   }, [])
 
   const handleOpenSelectedAccountModels = useCallback(() => {
-    if (
-      !selectedAccount ||
-      selectedAccount === KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE
-    ) {
-      return
-    }
-
     void openModelsPage(selectedAccount)
   }, [selectedAccount])
 

--- a/src/features/KeyManagement/components/Header.tsx
+++ b/src/features/KeyManagement/components/Header.tsx
@@ -1,16 +1,25 @@
-import { KeyRound, Plus, RefreshCw, Wrench } from "lucide-react"
+import { Cpu, KeyRound, Plus, RefreshCw, Wrench } from "lucide-react"
 import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
 import { PageHeader } from "~/components/PageHeader"
-import { Button } from "~/components/ui"
+import Tooltip from "~/components/Tooltip"
+import { Button, IconButton } from "~/components/ui"
+import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+} from "~/services/productAnalytics/events"
 
 interface HeaderProps {
   selectedAccount: string
   onAddToken: () => void
   onRepairMissingKeys: () => void
   onRefresh: () => void
+  onOpenSelectedAccountModels?: () => void
   onRefreshManagedSiteStatus?: () => void
   managedSiteStatusHint?: string
   isLoading: boolean
@@ -27,6 +36,7 @@ export function Header({
   onAddToken,
   onRepairMissingKeys,
   onRefresh,
+  onOpenSelectedAccountModels,
   onRefreshManagedSiteStatus,
   managedSiteStatusHint,
   isLoading,
@@ -52,53 +62,80 @@ export function Header({
 
   return (
     <div className="mb-8">
-      <PageHeader
-        icon={KeyRound}
-        title={t("title")}
-        description={description}
-        actions={
-          <>
-            <Button
-              onClick={onAddToken}
-              disabled={isAddTokenDisabled}
-              size="sm"
-              variant="success"
-              leftIcon={<Plus className="h-4 w-4" />}
-              data-testid={KEY_MANAGEMENT_TEST_IDS.addTokenButton}
-            >
-              {t("dialog.addToken")}
-            </Button>
-            <Button
-              onClick={onRepairMissingKeys}
-              disabled={isRepairDisabled}
-              size="sm"
-              variant="outline"
-              leftIcon={<Wrench className="h-4 w-4" />}
-            >
-              {t("repairMissingKeys.action")}
-            </Button>
-            {onRefreshManagedSiteStatus ? (
+      <ProductAnalyticsScope
+        entrypoint={PRODUCT_ANALYTICS_ENTRYPOINTS.Options}
+        featureId={PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement}
+        surfaceId={PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementHeader}
+      >
+        <PageHeader
+          icon={KeyRound}
+          title={t("title")}
+          titleActions={
+            onOpenSelectedAccountModels ? (
+              <Tooltip content={t("actions.openSelectedAccountModels")}>
+                <IconButton
+                  type="button"
+                  onClick={onOpenSelectedAccountModels}
+                  size="sm"
+                  variant="outline"
+                  aria-label={t("actions.openSelectedAccountModels")}
+                  data-testid={
+                    KEY_MANAGEMENT_TEST_IDS.openSelectedAccountModelsButton
+                  }
+                  analyticsAction={
+                    PRODUCT_ANALYTICS_ACTION_IDS.OpenAccountModelListFromKeyManagement
+                  }
+                >
+                  <Cpu className="h-4 w-4" />
+                </IconButton>
+              </Tooltip>
+            ) : undefined
+          }
+          description={description}
+          actions={
+            <>
               <Button
-                onClick={onRefreshManagedSiteStatus}
-                disabled={isManagedSiteStatusRefreshDisabled}
+                onClick={onAddToken}
+                disabled={isAddTokenDisabled}
+                size="sm"
+                variant="success"
+                leftIcon={<Plus className="h-4 w-4" />}
+                data-testid={KEY_MANAGEMENT_TEST_IDS.addTokenButton}
+              >
+                {t("dialog.addToken")}
+              </Button>
+              <Button
+                onClick={onRepairMissingKeys}
+                disabled={isRepairDisabled}
                 size="sm"
                 variant="outline"
-                loading={isManagedSiteStatusRefreshing}
-                leftIcon={<RefreshCw className="h-4 w-4" />}
+                leftIcon={<Wrench className="h-4 w-4" />}
               >
-                {isManagedSiteStatusRefreshing
-                  ? t("managedSiteStatus.actions.refreshing")
-                  : t("managedSiteStatus.actions.refresh")}
+                {t("repairMissingKeys.action")}
               </Button>
-            ) : null}
-            <Button onClick={onRefresh} disabled={isLoading} size="sm">
-              {isLoading && selectedAccount
-                ? t("common:status.refreshing")
-                : t("refreshTokenList")}
-            </Button>
-          </>
-        }
-      />
+              {onRefreshManagedSiteStatus ? (
+                <Button
+                  onClick={onRefreshManagedSiteStatus}
+                  disabled={isManagedSiteStatusRefreshDisabled}
+                  size="sm"
+                  variant="outline"
+                  loading={isManagedSiteStatusRefreshing}
+                  leftIcon={<RefreshCw className="h-4 w-4" />}
+                >
+                  {isManagedSiteStatusRefreshing
+                    ? t("managedSiteStatus.actions.refreshing")
+                    : t("managedSiteStatus.actions.refresh")}
+                </Button>
+              ) : null}
+              <Button onClick={onRefresh} disabled={isLoading} size="sm">
+                {isLoading && selectedAccount
+                  ? t("common:status.refreshing")
+                  : t("refreshTokenList")}
+              </Button>
+            </>
+          }
+        />
+      </ProductAnalyticsScope>
     </div>
   )
 }

--- a/src/features/KeyManagement/components/Header.tsx
+++ b/src/features/KeyManagement/components/Header.tsx
@@ -70,6 +70,7 @@ export function Header({
         <PageHeader
           icon={KeyRound}
           title={t("title")}
+          titleActionsTestId={KEY_MANAGEMENT_TEST_IDS.titleActions}
           titleActions={
             onOpenSelectedAccountModels ? (
               <Tooltip content={t("actions.openSelectedAccountModels")}>

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -5,6 +5,8 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   saveToApiProfilesButton: "key-management-save-to-api-profiles-button",
   tokenRowActions: "key-management-token-row-actions",
   openApiProfilesToastButton: "key-management-open-api-profiles-toast-button",
+  openSelectedAccountModelsButton:
+    "key-management-open-selected-account-models-button",
   addTokenSubmitButton: "key-management-add-token-submit-button",
   oneTimeKeyCloseButton: "key-management-one-time-key-close-button",
   oneTimeKeySaveButton: "key-management-one-time-key-save-button",

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -7,6 +7,7 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   openApiProfilesToastButton: "key-management-open-api-profiles-toast-button",
   openSelectedAccountModelsButton:
     "key-management-open-selected-account-models-button",
+  titleActions: "key-management-title-actions",
   addTokenSubmitButton: "key-management-add-token-submit-button",
   oneTimeKeyCloseButton: "key-management-one-time-key-close-button",
   oneTimeKeySaveButton: "key-management-one-time-key-save-button",

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -1,13 +1,14 @@
 import { Tab } from "@headlessui/react"
 import { ArrowPathIcon } from "@heroicons/react/24/outline"
-import { Cpu } from "lucide-react"
+import { Cpu, KeyRound } from "lucide-react"
 import { useCallback, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { VerifyApiDialog } from "~/components/dialogs/VerifyApiDialog"
 import { VerifyCliSupportDialog } from "~/components/dialogs/VerifyCliSupportDialog"
 import { PageHeader } from "~/components/PageHeader"
-import { Alert, Button, EmptyState } from "~/components/ui"
+import Tooltip from "~/components/Tooltip"
+import { Alert, Button, EmptyState, IconButton } from "~/components/ui"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import { VerifyApiCredentialProfileDialog } from "~/features/ApiCredentialProfiles/components/VerifyApiCredentialProfileDialog"
@@ -35,7 +36,7 @@ import {
 } from "~/services/verification/verificationResultHistory"
 import type { DisplaySiteData } from "~/types"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
-import { pushWithinOptionsPage } from "~/utils/navigation"
+import { openKeysPage, pushWithinOptionsPage } from "~/utils/navigation"
 
 import { sortModelListAccounts } from "./accountOrdering"
 import { AccountSelector } from "./components/AccountSelector"
@@ -328,6 +329,14 @@ export default function ModelList(props: {
     pushWithinOptionsPage(`#${MENU_ITEM_IDS.API_CREDENTIAL_PROFILES}`)
   }, [])
 
+  const handleOpenSelectedAccountKeys = useCallback(() => {
+    if (selectedSource?.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT) {
+      return
+    }
+
+    void openKeysPage(selectedSource.account.id)
+  }, [selectedSource])
+
   const handleRequestSourceSelection = useCallback(() => {
     const selectorTrigger = sourceSelectorTriggerRef.current
 
@@ -358,6 +367,33 @@ export default function ModelList(props: {
       <PageHeader
         icon={Cpu}
         title={t("title")}
+        titleActions={
+          selectedSource?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT ? (
+            <ProductAnalyticsScope
+              entrypoint={PRODUCT_ANALYTICS_ENTRYPOINTS.Options}
+              featureId={PRODUCT_ANALYTICS_FEATURE_IDS.ModelList}
+              surfaceId={PRODUCT_ANALYTICS_SURFACE_IDS.OptionsModelListPage}
+            >
+              <Tooltip content={t("actions.openSelectedAccountKeys")}>
+                <IconButton
+                  type="button"
+                  onClick={handleOpenSelectedAccountKeys}
+                  size="sm"
+                  variant="outline"
+                  aria-label={t("actions.openSelectedAccountKeys")}
+                  data-testid={
+                    MODEL_LIST_TEST_IDS.openSelectedAccountKeysButton
+                  }
+                  analyticsAction={
+                    PRODUCT_ANALYTICS_ACTION_IDS.OpenAccountKeyManagementFromModel
+                  }
+                >
+                  <KeyRound className="h-4 w-4" />
+                </IconButton>
+              </Tooltip>
+            </ProductAnalyticsScope>
+          ) : undefined
+        }
         description={t("description")}
         actions={
           selectedSource && hasModelData ? (

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -329,13 +329,9 @@ export default function ModelList(props: {
     pushWithinOptionsPage(`#${MENU_ITEM_IDS.API_CREDENTIAL_PROFILES}`)
   }, [])
 
-  const handleOpenSelectedAccountKeys = useCallback(() => {
-    if (selectedSource?.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT) {
-      return
-    }
-
-    void openKeysPage(selectedSource.account.id)
-  }, [selectedSource])
+  const handleOpenSelectedAccountKeys = useCallback((accountId: string) => {
+    void openKeysPage(accountId)
+  }, [])
 
   const handleRequestSourceSelection = useCallback(() => {
     const selectorTrigger = sourceSelectorTriggerRef.current
@@ -367,6 +363,7 @@ export default function ModelList(props: {
       <PageHeader
         icon={Cpu}
         title={t("title")}
+        titleActionsTestId={MODEL_LIST_TEST_IDS.titleActions}
         titleActions={
           selectedSource?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT ? (
             <ProductAnalyticsScope
@@ -377,7 +374,9 @@ export default function ModelList(props: {
               <Tooltip content={t("actions.openSelectedAccountKeys")}>
                 <IconButton
                   type="button"
-                  onClick={handleOpenSelectedAccountKeys}
+                  onClick={() =>
+                    handleOpenSelectedAccountKeys(selectedSource.account.id)
+                  }
                   size="sm"
                   variant="outline"
                   aria-label={t("actions.openSelectedAccountKeys")}

--- a/src/features/ModelList/testIds.ts
+++ b/src/features/ModelList/testIds.ts
@@ -9,6 +9,7 @@ export const MODEL_LIST_TEST_IDS = {
   createCustomKeyButton: "model-list-create-custom-key-button",
   openKeyManagementButton: "model-list-open-key-management-button",
   openSelectedAccountKeysButton: "model-list-open-selected-account-keys-button",
+  titleActions: "model-list-title-actions",
 } as const
 
 /**

--- a/src/features/ModelList/testIds.ts
+++ b/src/features/ModelList/testIds.ts
@@ -8,6 +8,7 @@ export const MODEL_LIST_TEST_IDS = {
   modelKeyDialog: "model-list-model-key-dialog",
   createCustomKeyButton: "model-list-create-custom-key-button",
   openKeyManagementButton: "model-list-open-key-management-button",
+  openSelectedAccountKeysButton: "model-list-open-selected-account-keys-button",
 } as const
 
 /**

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -19,6 +19,7 @@
     "importToCliProxy": "Import to CLIProxyAPI",
     "importToManagedSite": "Import to {{site}}",
     "openApiProfiles": "Open API credential library",
+    "openSelectedAccountModels": "View account models",
     "retryFailed": "Retry failed",
     "saveToApiProfiles": "Save to API credential library",
     "showKey": "Show Key",

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -23,6 +23,7 @@
     "copyModelName": "Copy model name",
     "copySiteUrl": "Copy site URL",
     "keyForModel": "Key for this model",
+    "openSelectedAccountKeys": "Manage account keys",
     "openSite": "Open site",
     "verifyApi": "Verify API",
     "verifyCliSupport": "Verify CLI Support"

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -18,6 +18,7 @@
     "importToCliProxy": "CLIProxyAPI にインポート",
     "importToManagedSite": "{{site}} にインポート",
     "openApiProfiles": "API 認証情報庫を開く",
+    "openSelectedAccountModels": "アカウントモデルを見る",
     "retryFailed": "失敗を再試行",
     "saveToApiProfiles": "API 認証情報庫に保存",
     "showKey": "キーを表示",

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -21,6 +21,7 @@
     "copyModelName": "モデル名をコピー",
     "copySiteUrl": "サイト URL をコピー",
     "keyForModel": "このモデル用のキー",
+    "openSelectedAccountKeys": "アカウントキーを管理",
     "openSite": "サイトを開く",
     "verifyApi": "API を検証",
     "verifyCliSupport": "CLI 対応を検証"

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -18,6 +18,7 @@
     "importToCliProxy": "Nhập vào CLIProxyAPI",
     "importToManagedSite": "Nhập vào {{site}}",
     "openApiProfiles": "Mở Hồ sơ API",
+    "openSelectedAccountModels": "Xem mô hình tài khoản",
     "retryFailed": "Thử lại tài khoản thất bại",
     "saveToApiProfiles": "Lưu vào Hồ sơ API",
     "showKey": "Hiển thị khóa",

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -21,6 +21,7 @@
     "copyModelName": "Sao chép tên mô hình",
     "copySiteUrl": "Sao chép URL trang",
     "keyForModel": "Khóa tương ứng với mô hình",
+    "openSelectedAccountKeys": "Quản lý khóa tài khoản",
     "openSite": "Mở trang",
     "verifyApi": "Xác minh API",
     "verifyCliSupport": "Xác minh khả năng tương thích CLI"

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -18,6 +18,7 @@
     "importToCliProxy": "导入到 CLIProxyAPI",
     "importToManagedSite": "导入到 {{site}}",
     "openApiProfiles": "打开 API 凭据库",
+    "openSelectedAccountModels": "查看账号模型",
     "retryFailed": "重试失败账号",
     "saveToApiProfiles": "保存到 API 凭据库",
     "showKey": "显示密钥",

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -21,6 +21,7 @@
     "copyModelName": "复制模型名称",
     "copySiteUrl": "复制站点 URL",
     "keyForModel": "模型对应密钥",
+    "openSelectedAccountKeys": "管理账号密钥",
     "openSite": "打开站点",
     "verifyApi": "验证接口",
     "verifyCliSupport": "验证 CLI 兼容性"

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -18,6 +18,7 @@
     "importToCliProxy": "匯入到 CLIProxyAPI",
     "importToManagedSite": "匯入到 {{site}}",
     "openApiProfiles": "開啟 API 憑據庫",
+    "openSelectedAccountModels": "查看帳號模型",
     "retryFailed": "重試失敗帳號",
     "saveToApiProfiles": "儲存到 API 憑據庫",
     "showKey": "顯示金鑰",

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -21,6 +21,7 @@
     "copyModelName": "複製模型名稱",
     "copySiteUrl": "複製站點 URL",
     "keyForModel": "模型對應金鑰",
+    "openSelectedAccountKeys": "管理帳號金鑰",
     "openSite": "打開站點",
     "verifyApi": "驗證介面",
     "verifyCliSupport": "驗證 CLI 相容性"

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -425,6 +425,8 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
   OpenCreateApiCredentialProfileDialog:
     "open_create_api_credential_profile_dialog",
   OpenAccountKeyManagementFromModel: "open_account_key_management_from_model",
+  OpenAccountModelListFromKeyManagement:
+    "open_account_model_list_from_key_management",
   OpenFailedAutoCheckinManualSignIns:
     "open_failed_auto_checkin_manual_sign_ins",
   OpenFilteredManagedSiteChannelMigration:

--- a/tests/entrypoints/options/pages/KeyManagement/KeyManagement.emptyStateActions.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/KeyManagement.emptyStateActions.test.tsx
@@ -299,19 +299,35 @@ describe("KeyManagement empty-state actions", () => {
 
     render(<KeyManagement />)
 
-    const pageTitle = await screen.findByRole("heading", {
-      name: "keyManagement:title",
-    })
-    const titleActionContainer = pageTitle.parentElement
-    expect(titleActionContainer).not.toBeNull()
-
     await user.click(
-      within(titleActionContainer as HTMLElement).getByTestId(
-        KEY_MANAGEMENT_TEST_IDS.openSelectedAccountModelsButton,
-      ),
+      within(
+        await screen.findByTestId(KEY_MANAGEMENT_TEST_IDS.titleActions),
+      ).getByTestId(KEY_MANAGEMENT_TEST_IDS.openSelectedAccountModelsButton),
     )
 
     expect(openModelsPageMock).toHaveBeenCalledWith(account.id)
+  })
+
+  it("does not show the model-list title shortcut while viewing all accounts", async () => {
+    const account = createAccount({
+      id: "acc-1",
+      name: "Account 1",
+    })
+
+    useKeyManagementMock.mockReturnValue(
+      createHookResult({
+        displayData: [account],
+        selectedAccount: KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE,
+      }),
+    )
+
+    render(<KeyManagement />)
+
+    expect(
+      within(
+        await screen.findByTestId(KEY_MANAGEMENT_TEST_IDS.titleActions),
+      ).queryByTestId(KEY_MANAGEMENT_TEST_IDS.openSelectedAccountModelsButton),
+    ).not.toBeInTheDocument()
   })
 
   it("uses the destructive confirmation dialog before deleting a token", async () => {

--- a/tests/entrypoints/options/pages/KeyManagement/KeyManagement.emptyStateActions.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/KeyManagement.emptyStateActions.test.tsx
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import KeyManagement from "~/entrypoints/options/pages/KeyManagement"
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "~/features/KeyManagement/constants"
-import { render, screen, waitFor } from "~~/tests/test-utils/render"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
+import { render, screen, waitFor, within } from "~~/tests/test-utils/render"
 import {
   createAccount,
   createToken,
@@ -14,6 +15,7 @@ const {
   tokenListPropsSpy,
   useKeyManagementMock,
   pushWithinOptionsPageMock,
+  openModelsPageMock,
   mockedUseUserPreferencesContext,
   addTokenDialogPropsSpy,
   accountSummaryBarPropsSpy,
@@ -22,6 +24,7 @@ const {
   tokenListPropsSpy: vi.fn(),
   useKeyManagementMock: vi.fn(),
   pushWithinOptionsPageMock: vi.fn(),
+  openModelsPageMock: vi.fn(),
   mockedUseUserPreferencesContext: vi.fn(),
   addTokenDialogPropsSpy: vi.fn(),
   accountSummaryBarPropsSpy: vi.fn(),
@@ -43,6 +46,7 @@ vi.mock("~/utils/navigation", async (importOriginal) => {
   return {
     ...actual,
     pushWithinOptionsPage: pushWithinOptionsPageMock,
+    openModelsPage: openModelsPageMock,
   }
 })
 
@@ -219,6 +223,7 @@ describe("KeyManagement empty-state actions", () => {
     tokenListPropsSpy.mockReset()
     useKeyManagementMock.mockReset()
     pushWithinOptionsPageMock.mockReset()
+    openModelsPageMock.mockReset()
     addTokenDialogPropsSpy.mockReset()
     accountSummaryBarPropsSpy.mockReset()
     mockedUseUserPreferencesContext.mockReturnValue({
@@ -276,6 +281,37 @@ describe("KeyManagement empty-state actions", () => {
     await waitFor(() =>
       expect(selectorTrigger).toHaveAttribute("aria-expanded", "true"),
     )
+  })
+
+  it("opens the model list for the selected account from the title action", async () => {
+    const user = userEvent.setup()
+    const account = createAccount({
+      id: "acc-1",
+      name: "Account 1",
+    })
+
+    useKeyManagementMock.mockReturnValue(
+      createHookResult({
+        displayData: [account],
+        selectedAccount: account.id,
+      }),
+    )
+
+    render(<KeyManagement />)
+
+    const pageTitle = await screen.findByRole("heading", {
+      name: "keyManagement:title",
+    })
+    const titleActionContainer = pageTitle.parentElement
+    expect(titleActionContainer).not.toBeNull()
+
+    await user.click(
+      within(titleActionContainer as HTMLElement).getByTestId(
+        KEY_MANAGEMENT_TEST_IDS.openSelectedAccountModelsButton,
+      ),
+    )
+
+    expect(openModelsPageMock).toHaveBeenCalledWith(account.id)
   })
 
   it("uses the destructive confirmation dialog before deleting a token", async () => {

--- a/tests/features/ModelList/ModelList.test.tsx
+++ b/tests/features/ModelList/ModelList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -7,8 +7,9 @@ import ModelList from "~/features/ModelList/ModelList"
 import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
 import { MODEL_LIST_TEST_IDS } from "~/features/ModelList/testIds"
 
-const { mockUseModelListData } = vi.hoisted(() => ({
+const { mockUseModelListData, openKeysPageMock } = vi.hoisted(() => ({
   mockUseModelListData: vi.fn(),
+  openKeysPageMock: vi.fn(),
 }))
 
 vi.mock("react-i18next", async (importOriginal) => {
@@ -36,6 +37,15 @@ vi.mock("@headlessui/react", () => ({
 vi.mock("~/features/ModelList/hooks/useModelListData", () => ({
   useModelListData: (...args: unknown[]) => mockUseModelListData(...args),
 }))
+
+vi.mock("~/utils/navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/navigation")>()
+
+  return {
+    ...actual,
+    openKeysPage: openKeysPageMock,
+  }
+})
 
 vi.mock(
   "~/services/verification/verificationResultHistory",
@@ -253,6 +263,24 @@ describe("ModelList", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseModelListData.mockReturnValue(createModelListData())
+  })
+
+  it("opens key management for the selected account from the title action", async () => {
+    const user = userEvent.setup()
+
+    render(<ModelList />)
+
+    const pageTitle = screen.getByRole("heading", { name: "title" })
+    const titleActionContainer = pageTitle.parentElement
+    expect(titleActionContainer).not.toBeNull()
+
+    await user.click(
+      within(titleActionContainer as HTMLElement).getByTestId(
+        MODEL_LIST_TEST_IDS.openSelectedAccountKeysButton,
+      ),
+    )
+
+    expect(openKeysPageMock).toHaveBeenCalledWith(ACCOUNT.id)
   })
 
   it("opens the model key dialog from an incompatible API verification token state", async () => {

--- a/tests/features/ModelList/ModelList.test.tsx
+++ b/tests/features/ModelList/ModelList.test.tsx
@@ -270,17 +270,36 @@ describe("ModelList", () => {
 
     render(<ModelList />)
 
-    const pageTitle = screen.getByRole("heading", { name: "title" })
-    const titleActionContainer = pageTitle.parentElement
-    expect(titleActionContainer).not.toBeNull()
-
     await user.click(
-      within(titleActionContainer as HTMLElement).getByTestId(
+      within(screen.getByTestId(MODEL_LIST_TEST_IDS.titleActions)).getByTestId(
         MODEL_LIST_TEST_IDS.openSelectedAccountKeysButton,
       ),
     )
 
     expect(openKeysPageMock).toHaveBeenCalledWith(ACCOUNT.id)
+  })
+
+  it("does not show the key-management title shortcut for non-account sources", () => {
+    mockUseModelListData.mockReturnValue({
+      ...createModelListData(),
+      selectedSource: {
+        kind: MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS,
+        value: "all-accounts",
+        capabilities: CAPABILITIES,
+      },
+      selectedSourceValue: "all-accounts",
+      currentAccount: null,
+      pricingContexts: [],
+      pricingData: null,
+    })
+
+    render(<ModelList />)
+
+    expect(
+      within(
+        screen.getByTestId(MODEL_LIST_TEST_IDS.titleActions),
+      ).queryByTestId(MODEL_LIST_TEST_IDS.openSelectedAccountKeysButton),
+    ).not.toBeInTheDocument()
   })
 
   it("opens the model key dialog from an incompatible API verification token state", async () => {


### PR DESCRIPTION
## Summary
- Add account-scoped shortcuts between Model List and Key Management.
- Keep the shortcuts title-adjacent so navigation is separated from page actions.
- Add localized labels, telemetry action coverage, and focused component tests.

## Test Plan
- pnpm vitest --run tests/features/ModelList/ModelList.test.tsx tests/entrypoints/options/pages/KeyManagement/KeyManagement.emptyStateActions.test.tsx tests/services/productAnalytics/events.test.ts tests/services/productAnalytics/privacy.test.ts tests/components/Button.test.tsx tests/components/IconButton.test.tsx
- pnpm run i18n:extract:ci
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“View account models”** shortcut to Key Management to jump to the selected account’s models.
  * Added a **“Manage account keys”** shortcut to Model List to jump to the selected account’s keys.
  * These shortcuts appear only when viewing an individual account (not when viewing all accounts).
* **Localization**
  * Added/updated the new action labels in English, Japanese, Vietnamese, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->