### PR TITLE
feat(model-list): show group count badges

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -58,4 +58,20 @@ function Badge({
   )
 }
 
-export { Badge, badgeVariants }
+/**
+ * BadgeAdornment renders short secondary metadata inside a Badge.
+ */
+function BadgeAdornment({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="badge-adornment"
+      className={cn(
+        "shrink-0 rounded-full bg-current/10 px-1.5 text-[0.85em] font-medium tabular-nums",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Badge, BadgeAdornment, badgeVariants }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -25,7 +25,7 @@ export { CardList } from "./CardList"
 export { Label, labelVariants } from "./label"
 export { Alert, AlertTitle, AlertDescription } from "./Alert"
 export { Notice, type NoticeProps } from "./Notice"
-export { Badge, badgeVariants } from "./badge"
+export { Badge, BadgeAdornment, badgeVariants } from "./badge"
 export {
   Select,
   SelectContent,

--- a/src/features/ModelList/components/ModelItem/ModelItemHeader.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemHeader.tsx
@@ -8,7 +8,7 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 
 import { VerificationHistorySummary } from "~/components/dialogs/VerifyApiDialog/VerificationHistorySummary"
-import { Badge, IconButton } from "~/components/ui"
+import { Badge, BadgeAdornment, IconButton } from "~/components/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import type { ModelPricing } from "~/services/apiService/common/type"
 import { getBillingModeText } from "~/services/models/utils/modelPricing"
@@ -28,7 +28,11 @@ interface ModelItemHeaderProps {
   isAvailableForUser: boolean
   handleCopyModelName: () => void
   showPricingMetadata: boolean
-  showAvailabilityBadge: boolean
+  groupSummary?: {
+    label: string
+    overflowCount?: number
+    title: string
+  }
   verificationSummary?: ApiVerificationHistorySummary | null
   onOpenKeyDialog?: () => void
   onVerifyApi?: () => void
@@ -45,7 +49,7 @@ export const ModelItemHeader: React.FC<ModelItemHeaderProps> = ({
   isAvailableForUser,
   handleCopyModelName,
   showPricingMetadata,
-  showAvailabilityBadge,
+  groupSummary,
   verificationSummary,
   onOpenKeyDialog,
   onVerifyApi,
@@ -162,15 +166,20 @@ export const ModelItemHeader: React.FC<ModelItemHeaderProps> = ({
             </Badge>
           )}
 
-          {showAvailabilityBadge && (
+          {groupSummary && (
             <Badge
-              variant={isAvailableForUser ? "success" : "secondary"}
+              variant="secondary"
               size="sm"
-              className="text-[10px] sm:text-xs"
+              className="max-w-[9rem] min-w-0 text-[10px] sm:text-xs"
+              title={groupSummary.title}
+              aria-label={groupSummary.title}
             >
-              {isAvailableForUser
-                ? t("modelList:available")
-                : t("modelList:unavailable")}
+              <span className="min-w-0 truncate">{groupSummary.label}</span>
+              {typeof groupSummary.overflowCount === "number" && (
+                <BadgeAdornment aria-hidden="true">
+                  +{groupSummary.overflowCount}
+                </BadgeAdornment>
+              )}
             </Badge>
           )}
         </div>

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -233,6 +233,22 @@ export default function ModelItem(props: ModelItemProps) {
       : showGroupDetails
         ? activeGroups.some((group) => model.enable_groups.includes(group))
         : true
+  const groupLabels = model.enable_groups.map((group) =>
+    formatGroupLabelFromRatios(group, groupRatios),
+  )
+  const groupSummary =
+    showGroupDetails && groupLabels.length > 0
+      ? {
+          label:
+            groupLabels.length === 1
+              ? groupLabels[0]
+              : formatGroupLabelFromRatios(model.enable_groups[0], groupRatios),
+          ...(groupLabels.length > 1
+            ? { overflowCount: groupLabels.length - 1 }
+            : {}),
+          title: `${t("availableGroups")}: ${groupLabels.join(", ")}`,
+        }
+      : undefined
 
   const modelActionEnableGroups = effectiveGroup
     ? [effectiveGroup]
@@ -322,7 +338,7 @@ export default function ModelItem(props: ModelItemProps) {
             isAvailableForUser={isAvailableForUser}
             handleCopyModelName={handleCopyModelName}
             showPricingMetadata={showPricing}
-            showAvailabilityBadge={showGroupDetails}
+            groupSummary={groupSummary}
             verificationSummary={verificationSummary}
             onOpenKeyDialog={
               source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT &&

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -36,7 +36,6 @@
   "allBillingModes": "All Billing Modes",
   "allGroups": "All Groups",
   "allProviders": "All Providers",
-  "available": "Available",
   "availableGroups": "Available Groups",
   "batchVerify": {
     "actions": {

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -34,7 +34,6 @@
   "allBillingModes": "すべての課金方式",
   "allGroups": "すべてのグループ",
   "allProviders": "すべてのプロバイダー",
-  "available": "利用可能",
   "availableGroups": "利用可能なグループ",
   "batchVerify": {
     "actions": {

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -34,7 +34,6 @@
   "allBillingModes": "Tất cả phương thức tính phí",
   "allGroups": "Tất cả các nhóm",
   "allProviders": "Tất cả nhà cung cấp",
-  "available": "Khả dụng",
   "availableGroups": "Nhóm khả dụng",
   "batchVerify": {
     "actions": {

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -34,7 +34,6 @@
   "allBillingModes": "所有计费方式",
   "allGroups": "所有分组",
   "allProviders": "所有厂商",
-  "available": "可用",
   "availableGroups": "可用分组",
   "batchVerify": {
     "actions": {

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -34,7 +34,6 @@
   "allBillingModes": "所有計費方式",
   "allGroups": "所有分組",
   "allProviders": "所有廠商",
-  "available": "可用",
   "availableGroups": "可用分組",
   "batchVerify": {
     "actions": {

--- a/tests/entrypoints/options/pages/ModelList/ModelItem.profileActions.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelItem.profileActions.test.tsx
@@ -575,7 +575,7 @@ describe("ModelItem profile actions", () => {
       ),
     ).toBeInTheDocument()
 
-    expect(screen.getByText("modelList:available")).toBeInTheDocument()
+    expect(screen.queryByText("modelList:available")).not.toBeInTheDocument()
     expect(screen.queryByText("modelList:unavailable")).not.toBeInTheDocument()
     expect(
       screen.queryByText(/modelList:clickSwitchGroup/),

--- a/tests/features/ModelList/components/ModelItem.test.tsx
+++ b/tests/features/ModelList/components/ModelItem.test.tsx
@@ -55,9 +55,14 @@ vi.mock("react-i18next", async (importOriginal) => {
   return {
     ...actual,
     useTranslation: () => ({
-      t: (key: string, options?: { group?: string; name?: string }) => {
+      t: (
+        key: string,
+        options?: { group?: string; name?: string; remainingCount?: number },
+      ) => {
         if (options?.group) {
-          return `${key}:${options.group}`
+          return options.remainingCount
+            ? `${key}:${options.group}+${options.remainingCount}`
+            : `${key}:${options.group}`
         }
         if (options?.name) {
           return `${key}:${options.name}`
@@ -75,15 +80,29 @@ vi.mock("~/features/ModelList/components/ModelItem/ModelItemHeader", () => ({
     onOpenKeyDialog,
     onVerifyApi,
     onVerifyCliSupport,
+    groupSummary,
   }: {
     model: { model_name: string }
     trailingContent?: React.ReactNode
     onOpenKeyDialog?: () => void
     onVerifyApi?: () => void
     onVerifyCliSupport?: () => void
+    groupSummary?: {
+      label: string
+      overflowCount?: number
+      title: string
+    }
   }) => (
     <div>
       {model.model_name}
+      {groupSummary ? (
+        <span title={groupSummary.title}>
+          {groupSummary.label}
+          {typeof groupSummary.overflowCount === "number"
+            ? `+${groupSummary.overflowCount}`
+            : ""}
+        </span>
+      ) : null}
       {onOpenKeyDialog ? (
         <button type="button" onClick={onOpenKeyDialog}>
           key
@@ -239,6 +258,34 @@ describe("ModelItem", () => {
     expect(
       screen.queryByText("availableGroups: vip (1x)"),
     ).not.toBeInTheDocument()
+  })
+
+  it("summarizes model groups in the row header without showing availability status", () => {
+    const props = createDefaultProps()
+
+    render(
+      <ModelItem
+        {...props}
+        model={{
+          ...props.model,
+          enable_groups: ["default", "vip", "private"],
+        }}
+        groupRatios={{
+          default: 1,
+          vip: 2,
+          private: 3,
+        }}
+        selectedGroups={[]}
+        availableGroups={["default", "vip", "private"]}
+      />,
+    )
+
+    const groupSummary = screen.getByText("default (1x)+2")
+    expect(groupSummary).toHaveAttribute(
+      "title",
+      "availableGroups: default (1x), vip (2x), private (3x)",
+    )
+    expect(screen.queryByText("available")).not.toBeInTheDocument()
   })
 
   it("suppresses the ratio column when either the row or display capabilities do not support ratios", () => {

--- a/tests/features/ModelList/components/ModelItemHeader.test.tsx
+++ b/tests/features/ModelList/components/ModelItemHeader.test.tsx
@@ -94,7 +94,6 @@ function renderModelItemHeader(quotaType: number) {
       isAvailableForUser={true}
       handleCopyModelName={vi.fn()}
       showPricingMetadata={true}
-      showAvailabilityBadge={false}
     />,
   )
 }
@@ -112,7 +111,6 @@ describe("ModelItemHeader", () => {
         isAvailableForUser={true}
         handleCopyModelName={vi.fn()}
         showPricingMetadata={true}
-        showAvailabilityBadge={false}
         onOpenKeyDialog={vi.fn()}
         onVerifyApi={vi.fn()}
         onVerifyCliSupport={vi.fn()}
@@ -175,5 +173,71 @@ describe("ModelItemHeader", () => {
       "flex-[1_1_10rem]",
       "items-center",
     )
+  })
+
+  it("renders available groups as neutral metadata instead of availability status", () => {
+    render(
+      <ModelItemHeader
+        model={
+          {
+            model_name: "gpt-private-model",
+            quota_type: 0,
+          } as any
+        }
+        isAvailableForUser={true}
+        handleCopyModelName={vi.fn()}
+        showPricingMetadata={true}
+        groupSummary={{
+          label: "default (1x)",
+          overflowCount: 1,
+          title: "modelList:availableGroups: default (1x), vip (2x)",
+        }}
+      />,
+    )
+
+    const groupBadge = screen.getByText("default (1x)").closest("[data-slot]")
+    expect(groupBadge).toBeInTheDocument()
+    expect(groupBadge).toHaveAttribute(
+      "title",
+      "modelList:availableGroups: default (1x), vip (2x)",
+    )
+    expect(groupBadge).toHaveAttribute(
+      "aria-label",
+      "modelList:availableGroups: default (1x), vip (2x)",
+    )
+    expect(groupBadge).toHaveClass("bg-secondary")
+    const overflowCount = screen.getByText("+1")
+    expect(overflowCount).toHaveClass(
+      "shrink-0",
+      "rounded-full",
+      "bg-current/10",
+      "px-1.5",
+      "text-[0.85em]",
+      "tabular-nums",
+    )
+    expect(screen.queryByText("modelList:available")).not.toBeInTheDocument()
+  })
+
+  it("omits the count adornment for single-group summaries", () => {
+    render(
+      <ModelItemHeader
+        model={
+          {
+            model_name: "gpt-private-model",
+            quota_type: 0,
+          } as any
+        }
+        isAvailableForUser={true}
+        handleCopyModelName={vi.fn()}
+        showPricingMetadata={true}
+        groupSummary={{
+          label: "default (1x)",
+          title: "modelList:availableGroups: default (1x)",
+        }}
+      />,
+    )
+
+    expect(screen.getByText("default (1x)")).toBeInTheDocument()
+    expect(screen.queryByText(/^\+\d+$/)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Replace the model row availability badge with a neutral group summary badge.
- Add a reusable BadgeAdornment for compact count metadata inside badges.
- Keep full available-group context in title/aria-label and remove the unused availability copy.

## Test Plan
- pnpm vitest run tests/features/ModelList/components/ModelItemHeader.test.tsx tests/features/ModelList/components/ModelItem.test.tsx
- pnpm run i18n:extract:ci
- pnpm compile
- pnpm run validate:push
- pnpm run validate:staged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new badge adornment component to display secondary pill-style metadata.

* **Improvements**
  * Updated model listing row headers to show group availability as a neutral metadata badge.
  * When multiple groups apply, the UI now includes an overflow count indicator (e.g., “+n”) and a helpful tooltip title.

* **Localization**
  * Updated supported languages by removing the prior “available” label and introducing “available groups” wording.

* **Tests**
  * Adjusted and expanded coverage for the updated group badge behavior and locale expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->