### PR TITLE
feat(model-list): compare all Sub2API keys

### DIFF
--- a/docs/superpowers/plans/2026-06-16-sub2api-all-key-model-comparison.md
+++ b/docs/superpowers/plans/2026-06-16-sub2api-all-key-model-comparison.md
@@ -1,0 +1,1532 @@
+# Sub2API All-Key Model Comparison Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Sub2API accounts in the all-accounts Model List load every usable saved runtime key and compare each key as its own source.
+
+**Architecture:** Keep Sub2API runtime-key catalog loading in the Model List data hook layer, while keeping `loadAccountTokenFallbackPricingResponse()` single-token scoped. Add a lightweight `sourceIdentity` metadata object to pricing contexts and calculated rows so key-scoped rows remain distinct for row keys, source labels, group candidates, sorting, and lowest-price badges without changing account-backed verification actions.
+
+**Tech Stack:** TypeScript, React hooks, TanStack Query `useQueries`, Vitest, Testing Library hook tests, existing Model List source/capability helpers.
+
+---
+
+## Files And Responsibilities
+
+- Modify `src/features/ModelList/modelManagementSources.ts`
+  - Own the shared `ModelListSourceIdentity` type and source-identity helper functions.
+- Modify `src/features/ModelList/hooks/useModelData.ts`
+  - Return account-level pricing query results as arrays of `AccountPricingContext`.
+  - Load all Sub2API account tokens with bounded per-account concurrency.
+  - Preserve partial key failures as account query state without blocking successful key contexts.
+- Modify `src/features/ModelList/hooks/useFilteredModels.ts`
+  - Carry `sourceIdentity` through raw/calculated rows.
+  - Use source identity for row keys, price-key maps, sort tie-breakers, and source-level group candidates.
+  - Keep account filters and account summary counts keyed by `account.id`.
+- Modify `src/features/ModelList/sourceLabels.ts`
+  - Include token names in row source labels when the row is token-scoped.
+- Modify `src/features/ModelList/components/ModelItem/index.tsx`
+  - Accept and pass token source identity to `formatModelListSourceLabel()`.
+- Modify `src/features/ModelList/components/ModelDisplay.tsx`
+  - Pass calculated-row source identity into `ModelItem`.
+- Inspect `src/features/ModelList/batchVerification.ts`
+  - It already calls `getModelItemKey(item)` on `CalculatedModelItem`; verify
+    token-scoped rows dedupe by token identity after `CalculatedModelItem`
+    carries `sourceIdentity`.
+- Modify `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
+  - Cover Sub2API all-key loading, partial failures, total failures, and refresh.
+- Modify `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`
+  - Cover row identity, lowest-price comparison, account filtering, and source-level group candidate isolation.
+- Create `tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts`
+  - Cover token source labels without raw key leakage.
+
+---
+
+### Task 1: Add Source Identity Plumbing
+
+**Files:**
+
+- Modify: `src/features/ModelList/modelManagementSources.ts`
+- Modify: `src/features/ModelList/hooks/useModelData.ts`
+- Modify: `src/features/ModelList/hooks/useFilteredModels.ts`
+- Test: `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`
+
+- [ ] **Step 1: Write the failing row-key test**
+
+Add this test near the existing all-accounts cheapest-sort tests in `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`:
+
+```ts
+  it("keeps same-account token sources distinct when they expose the same model", async () => {
+    const account = createDisplayAccount({
+      id: "account-sub2api-multi-key",
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2api.example.invalid",
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingContexts: [
+        {
+          account,
+          sourceIdentity: {
+            kind: "account-token",
+            id: "account-sub2api-multi-key:token:11",
+            tokenId: 11,
+            tokenName: "Default key",
+          },
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "shared-model",
+                quota_type: 0,
+                model_ratio: 0,
+                completion_ratio: 1,
+                enable_groups: ["default"],
+                token_price_usd_per_million: {
+                  input: 0.5,
+                  output: 1,
+                },
+                price_metadata: {
+                  source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+                  precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+                },
+              },
+            ],
+            {
+              group_ratio: { default: 1 },
+              model_list_source: {
+                kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+                provider: SITE_TYPES.SUB2API,
+                supportsRuntimeModelList: true,
+                supportsPricing: true,
+              },
+            },
+          ),
+        },
+        {
+          account,
+          sourceIdentity: {
+            kind: "account-token",
+            id: "account-sub2api-multi-key:token:12",
+            tokenId: 12,
+            tokenName: "VIP key",
+          },
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "shared-model",
+                quota_type: 0,
+                model_ratio: 0,
+                completion_ratio: 1,
+                enable_groups: ["vip"],
+                token_price_usd_per_million: {
+                  input: 0.25,
+                  output: 0.75,
+                },
+                price_metadata: {
+                  source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+                  precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+                },
+              },
+            ],
+            {
+              group_ratio: { vip: 0.5 },
+              model_list_source: {
+                kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+                provider: SITE_TYPES.SUB2API,
+                supportsRuntimeModelList: true,
+                supportsPricing: true,
+              },
+            },
+          ),
+        },
+      ],
+      selectedSource: createAllAccountsSource(),
+      sortMode: MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST,
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => [
+          item.source.kind === "account" ? item.source.account.id : "profile",
+          item.sourceIdentity?.id,
+          item.effectiveGroup,
+          item.calculatedPrice.inputUSD,
+          item.isLowestPrice,
+        ]),
+      ).toEqual([
+        [
+          "account-sub2api-multi-key",
+          "account-sub2api-multi-key:token:12",
+          "vip",
+          0.25,
+          true,
+        ],
+        [
+          "account-sub2api-multi-key",
+          "account-sub2api-multi-key:token:11",
+          "default",
+          0.5,
+          false,
+        ],
+      ])
+    })
+  })
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts -t "keeps same-account token sources distinct"
+```
+
+Expected: TypeScript or runtime failure because `sourceIdentity` is not part of `AccountPricingContext` or `CalculatedModelItem`, and current row identity collapses same-account token rows.
+
+- [ ] **Step 3: Add shared source identity types**
+
+Append these exports after `ModelManagementItemSource` in `src/features/ModelList/modelManagementSources.ts`:
+
+```ts
+export const MODEL_LIST_SOURCE_IDENTITY_KINDS = {
+  ACCOUNT: "account",
+  ACCOUNT_TOKEN: "account-token",
+} as const
+
+export type ModelListSourceIdentity =
+  | {
+      kind: typeof MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT
+      id: string
+    }
+  | {
+      kind: typeof MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN
+      id: string
+      tokenId: number
+      tokenName?: string
+    }
+
+export function createAccountModelListSourceIdentity(
+  accountId: string,
+): ModelListSourceIdentity {
+  return {
+    kind: MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT,
+    id: accountId,
+  }
+}
+
+export function createAccountTokenModelListSourceIdentity(params: {
+  accountId: string
+  tokenId: number
+  tokenName?: string
+}): ModelListSourceIdentity {
+  const tokenName = params.tokenName?.trim()
+
+  return {
+    kind: MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN,
+    id: `${params.accountId}:token:${params.tokenId}`,
+    tokenId: params.tokenId,
+    ...(tokenName ? { tokenName } : {}),
+  }
+}
+```
+
+- [ ] **Step 4: Extend pricing contexts**
+
+In `src/features/ModelList/hooks/useModelData.ts`, update the import from `modelManagementSources` and extend `AccountPricingContext`:
+
+```ts
+import {
+  createAccountModelListSourceIdentity,
+  MODEL_MANAGEMENT_SOURCE_KINDS,
+  type ModelListSourceIdentity,
+  type ModelManagementSource,
+} from "~/features/ModelList/modelManagementSources"
+
+export interface AccountPricingContext {
+  account: DisplaySiteData
+  pricing: PricingResponse
+  sourceIdentity?: ModelListSourceIdentity
+}
+```
+
+In the single-account `pricingContexts` memo, add account identity:
+
+```ts
+  const pricingContexts: AccountPricingContext[] = useMemo(
+    () =>
+      currentAccount && pricingData
+        ? [
+            {
+              account: currentAccount,
+              pricing: pricingData,
+              sourceIdentity: createAccountModelListSourceIdentity(
+                currentAccount.id,
+              ),
+            },
+          ]
+        : [],
+    [currentAccount, pricingData],
+  )
+```
+
+- [ ] **Step 5: Carry source identity through filtering**
+
+In `src/features/ModelList/hooks/useFilteredModels.ts`, import the type and add a helper:
+
+```ts
+import {
+  createAccountSource,
+  deriveModelListSourceCapabilities,
+  MODEL_MANAGEMENT_SOURCE_KINDS,
+  type ModelListSourceIdentity,
+  type ModelManagementSource,
+} from "~/features/ModelList/modelManagementSources"
+
+function getModelListSourceIdentityKey(params: {
+  source:
+    | ReturnType<typeof createAccountSource>
+    | Extract<
+        NonNullable<ModelManagementSource>,
+        { kind: typeof MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE }
+      >
+  sourceIdentity?: ModelListSourceIdentity
+}) {
+  return (
+    params.sourceIdentity?.id ??
+    (params.source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
+      ? params.source.account.id
+      : params.source.profile.id)
+  )
+}
+```
+
+Add `sourceIdentity?: ModelListSourceIdentity` to both `RawModelItem` and `CalculatedModelItem`.
+
+Update `getModelItemKey()`:
+
+```ts
+export function getModelItemKey(
+  item: Pick<CalculatedModelItem, "model" | "source" | "sourceIdentity">,
+) {
+  const sourceId = getModelListSourceIdentityKey({
+    source: item.source,
+    sourceIdentity: item.sourceIdentity,
+  })
+
+  return `${item.source.kind}:${sourceId}:${item.model.model_name}`
+}
+```
+
+When building raw rows from `pricingContexts`, preserve the context identity:
+
+```ts
+      return pricingContexts.flatMap(({ account, pricing, sourceIdentity }) => {
+        if (!pricing || !Array.isArray(pricing.data)) {
+          return []
+        }
+
+        const exchangeRate =
+          account.balance?.USD > 0
+            ? account.balance.CNY / account.balance.USD
+            : UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
+
+        const accountSource = createAccountSource(account)
+        const allAccountsRowSource = {
+          ...accountSource,
+          capabilities: {
+            ...accountSource.capabilities,
+            supportsAccountSummary: true,
+          },
+        }
+        const source = applyAihubmixModelListCapabilities(
+          {
+            ...allAccountsRowSource,
+            capabilities: deriveModelListSourceCapabilities({
+              capabilities: allAccountsRowSource.capabilities,
+              modelListSource: pricing.model_list_source,
+            }),
+          },
+          pricing,
+        )
+
+        return pricing.data.map((model) => ({
+          model,
+          source,
+          sourceIdentity,
+          groupRatios: pricing.group_ratio ?? {},
+          exchangeRate,
+        }))
+      })
+```
+
+When creating `candidateItem` in `resolveBestCalculatedItem()`, include:
+
+```ts
+      sourceIdentity: rawItem.sourceIdentity,
+```
+
+- [ ] **Step 6: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts -t "keeps same-account token sources distinct"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add src/features/ModelList/modelManagementSources.ts src/features/ModelList/hooks/useModelData.ts src/features/ModelList/hooks/useFilteredModels.ts tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+git commit -m "feat(model-list): add token source identity"
+```
+
+---
+
+### Task 2: Isolate Source-Level Group Candidates And Labels
+
+**Files:**
+
+- Modify: `src/features/ModelList/hooks/useFilteredModels.ts`
+- Modify: `src/features/ModelList/sourceLabels.ts`
+- Modify: `src/features/ModelList/components/ModelItem/index.tsx`
+- Modify: `src/features/ModelList/components/ModelDisplay.tsx`
+- Test: `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`
+- Create: `tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts`
+
+- [ ] **Step 1: Write the failing group-isolation test**
+
+Add this test near `"treats same-named groups on different accounts as unrelated filters"` in `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`:
+
+```ts
+  it("keeps token-scoped group candidates separate under the same account", async () => {
+    const account = createDisplayAccount({
+      id: "account-sub2api-token-groups",
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2api.example.invalid",
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingContexts: [
+        {
+          account,
+          sourceIdentity: {
+            kind: "account-token",
+            id: "account-sub2api-token-groups:token:31",
+            tokenId: 31,
+            tokenName: "Default key",
+          },
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "default-model",
+                model_ratio: 1,
+                completion_ratio: 1,
+                enable_groups: ["default"],
+              },
+            ],
+            {
+              group_ratio: { default: 1 },
+            },
+          ),
+        },
+        {
+          account,
+          sourceIdentity: {
+            kind: "account-token",
+            id: "account-sub2api-token-groups:token:32",
+            tokenId: 32,
+            tokenName: "VIP key",
+          },
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "vip-model",
+                model_ratio: 1,
+                completion_ratio: 1,
+                enable_groups: ["vip"],
+              },
+            ],
+            {
+              group_ratio: { vip: 0.5 },
+            },
+          ),
+        },
+      ],
+      selectedSource: createAllAccountsSource(),
+      sortMode: MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST,
+      allAccountsExcludedGroupsByAccountId: {
+        "account-sub2api-token-groups": ["vip"],
+      },
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => [
+          item.model.model_name,
+          item.sourceIdentity?.id,
+          item.effectiveGroup,
+        ]),
+      ).toEqual([
+        [
+          "default-model",
+          "account-sub2api-token-groups:token:31",
+          "default",
+        ],
+      ])
+    })
+
+    expect(result.current.availableAccountGroupsByAccountId).toEqual({
+      "account-sub2api-token-groups": ["default", "vip"],
+    })
+    expect(result.current.availableAccountGroupOptionsByAccountId).toEqual({
+      "account-sub2api-token-groups": [
+        { name: "default", ratio: 1 },
+        { name: "vip", ratio: 0.5 },
+      ],
+    })
+  })
+```
+
+- [ ] **Step 2: Write the failing source-label test**
+
+Create `tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  createAccountSource,
+  createAccountTokenModelListSourceIdentity,
+  createProfileSource,
+} from "~/features/ModelList/modelManagementSources"
+import { formatModelListSourceLabel } from "~/features/ModelList/sourceLabels"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
+import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
+
+const createDisplayAccount = (
+  overrides: Partial<DisplaySiteData>,
+): DisplaySiteData => ({
+  id: "account",
+  name: "Account",
+  username: "user",
+  balance: { USD: 0, CNY: 0 },
+  todayConsumption: { USD: 0, CNY: 0 },
+  todayIncome: { USD: 0, CNY: 0 },
+  todayTokens: { upload: 0, download: 0 },
+  health: { status: SiteHealthStatus.Healthy },
+  siteType: SITE_TYPES.UNKNOWN,
+  baseUrl: "https://example.com",
+  token: "token",
+  userId: "1",
+  authType: AuthTypeEnum.AccessToken,
+  checkIn: { enableDetection: false },
+  ...overrides,
+})
+
+const labelOptions = {
+  formatProfileLabel: ({ name, host }: { name: string; host?: string }) =>
+    host ? `${name} (${host})` : name,
+}
+
+describe("formatModelListSourceLabel", () => {
+  it("includes token names for account-token model-list sources", () => {
+    const account = createDisplayAccount({
+      id: "sub2api-account",
+      name: "Sub2API Account",
+      baseUrl: "https://sub2api.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+
+    const label = formatModelListSourceLabel(
+      createAccountSource(account),
+      labelOptions,
+      createAccountTokenModelListSourceIdentity({
+        accountId: account.id,
+        tokenId: 41,
+        tokenName: "VIP runtime key",
+      }),
+    )
+
+    expect(label).toEqual({
+      label: "Sub2API Account / VIP runtime key · sub2api.example.invalid",
+      title: "https://sub2api.example.invalid",
+    })
+    expect(label.label).not.toContain("sk-")
+  })
+
+  it("keeps profile labels unchanged", () => {
+    const source = createProfileSource({
+      id: "profile",
+      name: "Reusable Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://profile.example.invalid/v1",
+      apiKey: "sk-secret",
+      tagIds: [],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+
+    expect(formatModelListSourceLabel(source, labelOptions)).toEqual({
+      label: "Reusable Key (profile.example.invalid)",
+      title: "https://profile.example.invalid/v1",
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Run both focused tests and verify they fail**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts -t "keeps token-scoped group candidates separate"
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts
+```
+
+Expected: group test fails because current candidate maps are account-keyed only; label test fails because `formatModelListSourceLabel()` has no source identity parameter.
+
+- [ ] **Step 4: Add source-level group maps**
+
+In `src/features/ModelList/hooks/useFilteredModels.ts`, add a helper near `getModelListSourceIdentityKey()`:
+
+```ts
+function getRawItemSourceIdentityKey(item: Pick<RawModelItem, "source" | "sourceIdentity">) {
+  return getModelListSourceIdentityKey({
+    source: item.source,
+    sourceIdentity: item.sourceIdentity,
+  })
+}
+```
+
+Add a source-level group memo before `availableAccountGroupsByAccountId`:
+
+```ts
+  const availableGroupsBySourceId = useMemo(() => {
+    if (
+      !selectedSource?.capabilities.supportsGroupFiltering ||
+      selectedSource.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS
+    ) {
+      return {}
+    }
+
+    const groupsBySourceId = new Map<string, Set<string>>()
+
+    rawModelItems.forEach((item) => {
+      if (item.source.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT) {
+        return
+      }
+
+      const sourceId = getRawItemSourceIdentityKey(item)
+      const sourceGroups = groupsBySourceId.get(sourceId) ?? new Set<string>()
+
+      Object.keys(item.groupRatios).forEach((group) => {
+        if (group) {
+          sourceGroups.add(group)
+        }
+      })
+      addAvailableGroups(sourceGroups, item.model)
+
+      groupsBySourceId.set(sourceId, sourceGroups)
+    })
+
+    return Object.fromEntries(
+      Array.from(groupsBySourceId.entries()).map(([sourceId, groups]) => [
+        sourceId,
+        toUniqueGroups(groups),
+      ]),
+    ) as Record<string, string[]>
+  }, [
+    rawModelItems,
+    selectedSource?.capabilities.supportsGroupFiltering,
+    selectedSource?.kind,
+  ])
+```
+
+Keep `availableAccountGroupsByAccountId` and `availableAccountGroupOptionsByAccountId` account-keyed for UI, but compute group candidates from source ids:
+
+```ts
+  const includedAllAccountsGroupsBySourceId = useMemo(() => {
+    if (selectedSource?.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS) {
+      return {}
+    }
+
+    return Object.fromEntries(
+      rawModelItems.flatMap((item) => {
+        if (item.source.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT) {
+          return []
+        }
+
+        const sourceId = getRawItemSourceIdentityKey(item)
+        const groups = availableGroupsBySourceId[sourceId] ?? []
+        const excludedGroups = new Set(
+          toUniqueGroups(
+            allAccountsExcludedGroupsByAccountId[item.source.account.id] ?? [],
+          ),
+        )
+
+        return [
+          [
+            sourceId,
+            groups.filter((group) => !excludedGroups.has(group)),
+          ],
+        ]
+      }),
+    ) as Record<string, string[]>
+  }, [
+    allAccountsExcludedGroupsByAccountId,
+    availableGroupsBySourceId,
+    rawModelItems,
+    selectedSource?.kind,
+  ])
+```
+
+Update `getGroupCandidatesForRawItem()` to read `includedAllAccountsGroupsBySourceId[getRawItemSourceIdentityKey(item)]`.
+
+- [ ] **Step 5: Add token source labels**
+
+Update `src/features/ModelList/sourceLabels.ts`:
+
+```ts
+import {
+  MODEL_LIST_SOURCE_IDENTITY_KINDS,
+  MODEL_MANAGEMENT_SOURCE_KINDS,
+} from "~/features/ModelList/modelManagementSources"
+import type {
+  ModelListSourceIdentity,
+  ModelManagementItemSource,
+} from "~/features/ModelList/modelManagementSources"
+
+function formatAccountTokenName(sourceIdentity: ModelListSourceIdentity) {
+  if (sourceIdentity.kind !== MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN) {
+    return null
+  }
+
+  return sourceIdentity.tokenName?.trim() || `#${sourceIdentity.tokenId}`
+}
+```
+
+Change the function signature and account branch:
+
+```ts
+export function formatModelListSourceLabel(
+  source: ModelManagementItemSource,
+  options: FormatModelListSourceLabelOptions,
+  sourceIdentity?: ModelListSourceIdentity,
+): ModelListSourceLabel {
+  if (source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE) {
+    const baseUrl = source.profile.baseUrl.trim()
+    const host = tryParseUrl(baseUrl)?.host || baseUrl || undefined
+
+    return {
+      label: options.formatProfileLabel({
+        name: source.profile.name,
+        host,
+      }),
+      title: baseUrl || undefined,
+    }
+  }
+
+  const baseUrl = source.account.baseUrl?.trim() ?? ""
+  const host = tryParseUrl(baseUrl)?.host || baseUrl || undefined
+  const tokenName = sourceIdentity ? formatAccountTokenName(sourceIdentity) : null
+  const accountLabel = tokenName
+    ? `${source.account.name} / ${tokenName}`
+    : source.account.name
+
+  return {
+    label: host ? `${accountLabel} · ${host}` : accountLabel,
+    title: baseUrl || undefined,
+  }
+}
+```
+
+Update `ModelItemProps` in `src/features/ModelList/components/ModelItem/index.tsx`:
+
+```ts
+import type {
+  ModelListSourceIdentity,
+  ModelManagementItemSource,
+  ModelManagementSourceCapabilities,
+} from "~/features/ModelList/modelManagementSources"
+
+  sourceIdentity?: ModelListSourceIdentity
+```
+
+Destructure `sourceIdentity`, and pass it to label formatting:
+
+```ts
+  const sourceLabel = formatModelListSourceLabel(
+    source,
+    {
+      formatProfileLabel: ({ name, host }) =>
+        t("sourceLabels.profileBadge", { name, host }),
+    },
+    sourceIdentity,
+  )
+```
+
+In `src/features/ModelList/components/ModelDisplay.tsx`, pass it into `ModelItem`:
+
+```tsx
+              source={sourceForModel}
+              sourceIdentity={item.sourceIdentity}
+```
+
+- [ ] **Step 6: Run focused tests and verify they pass**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts -t "keeps token-scoped group candidates separate"
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 2**
+
+Run:
+
+```bash
+git add src/features/ModelList/hooks/useFilteredModels.ts src/features/ModelList/sourceLabels.ts src/features/ModelList/components/ModelItem/index.tsx src/features/ModelList/components/ModelDisplay.tsx tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts
+git commit -m "feat(model-list): distinguish token-scoped rows"
+```
+
+---
+
+### Task 3: Load All Sub2API Tokens In All-Accounts Mode
+
+**Files:**
+
+- Modify: `src/features/ModelList/hooks/useModelData.ts`
+- Test: `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
+
+- [ ] **Step 1: Write the failing all-key load test**
+
+Replace the existing `"loads Sub2API fallback pricing in all-accounts mode so it can be compared"` test in `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx` with:
+
+```ts
+  it("loads every Sub2API fallback key in all-accounts mode so each key can be compared", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    const fetchModelPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("common pricing should not be called"))
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-all-accounts",
+      name: "Sub2API Account",
+      baseUrl: "https://sub2api-all.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+      userId: "sub2api-all-user",
+    })
+    const fallbackTokens = [
+      {
+        id: 21,
+        user_id: 21,
+        key: "sk-sub2api-all-masked-a",
+        status: 1,
+        name: "Default runtime key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+      {
+        id: 22,
+        user_id: 21,
+        key: "sk-sub2api-all-masked-b",
+        status: 1,
+        name: "VIP runtime key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ]
+    const defaultPricing = {
+      data: [
+        {
+          model_name: "example-runtime-priced-model",
+          quota_type: 0,
+          model_ratio: 2,
+          model_price: 0,
+          completion_ratio: 1,
+          enable_groups: ["default"],
+          supported_endpoint_types: [],
+          price_metadata: {
+            source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+            precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+          },
+        },
+      ],
+      group_ratio: { default: 1 },
+      success: true,
+      usable_group: { default: "default" },
+      model_list_source: {
+        kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+        provider: SITE_TYPES.SUB2API,
+        supportsRuntimeModelList: true,
+        supportsPricing: true,
+      },
+    }
+    const vipPricing = {
+      ...defaultPricing,
+      data: [
+        {
+          ...defaultPricing.data[0],
+          model_name: "example-runtime-vip-model",
+          enable_groups: ["vip"],
+        },
+      ],
+      group_ratio: { vip: 0.5 },
+      usable_group: { vip: "vip" },
+    }
+
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce(fallbackTokens)
+    mockLoadAccountTokenFallbackPricingResponse
+      .mockResolvedValueOnce(defaultPricing)
+      .mockResolvedValueOnce(vipPricing)
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledTimes(2)
+      },
+      { timeout: 3000 },
+    )
+
+    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(result.current.loadErrorMessage).toBeNull()
+    expect(result.current.pricingContexts).toEqual([
+      {
+        account,
+        pricing: defaultPricing,
+        sourceIdentity: {
+          kind: "account-token",
+          id: "sub2api-all-accounts:token:21",
+          tokenId: 21,
+          tokenName: "Default runtime key",
+        },
+      },
+      {
+        account,
+        pricing: vipPricing,
+        sourceIdentity: {
+          kind: "account-token",
+          id: "sub2api-all-accounts:token:22",
+          tokenId: 22,
+          tokenName: "VIP runtime key",
+        },
+      },
+    ])
+  })
+```
+
+- [ ] **Step 2: Write the failing partial-failure test**
+
+Add this test in the same all-accounts describe block:
+
+```ts
+  it("keeps successful Sub2API token contexts when another token fails", async () => {
+    const fetchModelPricing = vi.fn()
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-partial",
+      name: "Sub2API Partial",
+      baseUrl: "https://sub2api-partial.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+    const tokens = [
+      {
+        id: 31,
+        user_id: 31,
+        key: "sk-success",
+        status: 1,
+        name: "Success key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+      {
+        id: 32,
+        user_id: 31,
+        key: "sk-failure",
+        status: 1,
+        name: "Failure key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ]
+    const pricing = {
+      data: [
+        {
+          model_name: "surviving-model",
+          quota_type: 0,
+          model_ratio: 1,
+          model_price: 0,
+          completion_ratio: 1,
+          enable_groups: ["default"],
+          supported_endpoint_types: [],
+        },
+      ],
+      group_ratio: { default: 1 },
+      success: true,
+      usable_group: { default: "default" },
+    }
+
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce(tokens)
+    mockLoadAccountTokenFallbackPricingResponse
+      .mockResolvedValueOnce(pricing)
+      .mockRejectedValueOnce(new Error("token failed"))
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.pricingContexts).toHaveLength(1)
+      },
+      { timeout: 3000 },
+    )
+
+    expect(result.current.loadErrorMessage).toBeNull()
+    expect(result.current.accountQueryStates).toEqual([
+      {
+        account,
+        isLoading: false,
+        hasData: true,
+        hasError: true,
+        errorType: "load-failed",
+      },
+    ])
+  })
+```
+
+- [ ] **Step 3: Write the failing all-failed test**
+
+Add:
+
+```ts
+  it("marks a Sub2API account failed when every fallback key fails", async () => {
+    const fetchModelPricing = vi.fn()
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-all-failed",
+      name: "Sub2API Failed",
+      baseUrl: "https://sub2api-failed.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+    const tokens = [
+      {
+        id: 41,
+        user_id: 41,
+        key: "sk-failed",
+        status: 1,
+        name: "Failed key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ]
+
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce(tokens)
+    mockLoadAccountTokenFallbackPricingResponse.mockRejectedValueOnce(
+      new Error("token failed"),
+    )
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.loadErrorMessage).toBe(
+          "modelList:status.loadFailed",
+        )
+      },
+      { timeout: 3000 },
+    )
+
+    expect(result.current.pricingContexts).toEqual([])
+    expect(result.current.accountQueryStates).toEqual([
+      {
+        account,
+        isLoading: false,
+        hasData: false,
+        hasError: true,
+        errorType: "load-failed",
+      },
+    ])
+  })
+```
+
+- [ ] **Step 4: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/useModelData.test.tsx -t "Sub2API"
+```
+
+Expected: new multi-key and partial-failure tests fail because the current all-accounts helper requires exactly one token and query data is a single `PricingResponse`.
+
+- [ ] **Step 5: Add query-result types and bounded concurrency**
+
+In `src/features/ModelList/hooks/useModelData.ts`, add imports:
+
+```ts
+import {
+  createAccountModelListSourceIdentity,
+  createAccountTokenModelListSourceIdentity,
+  MODEL_MANAGEMENT_SOURCE_KINDS,
+  type ModelListSourceIdentity,
+  type ModelManagementSource,
+} from "~/features/ModelList/modelManagementSources"
+```
+
+Add types near `AccountQueryState`:
+
+```ts
+interface AccountPricingQueryResult {
+  contexts: AccountPricingContext[]
+  partialFailureCount?: number
+}
+
+interface SettledContextResult {
+  context?: AccountPricingContext
+  error?: unknown
+}
+```
+
+Add helpers near `fetchSub2ApiAllAccountsFallbackPricing`:
+
+```ts
+const SUB2API_ALL_ACCOUNTS_TOKEN_CONCURRENCY = 4
+
+function hasValidPricingData(data: PricingResponse) {
+  return Array.isArray(data.data)
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+) {
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length)
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const currentIndex = nextIndex
+        nextIndex += 1
+        results[currentIndex] = await mapper(items[currentIndex])
+      }
+    }),
+  )
+
+  return results
+}
+
+async function loadSub2ApiTokenPricingContext(params: {
+  account: DisplaySiteData
+  token: ApiToken
+}): Promise<SettledContextResult> {
+  try {
+    const pricing = await loadAccountTokenFallbackPricingResponse(params)
+    if (!hasValidPricingData(pricing)) {
+      throw createInvalidFormatError()
+    }
+
+    return {
+      context: {
+        account: params.account,
+        pricing,
+        sourceIdentity: createAccountTokenModelListSourceIdentity({
+          accountId: params.account.id,
+          tokenId: params.token.id,
+          tokenName: params.token.name,
+        }),
+      },
+    }
+  } catch (error) {
+    return { error }
+  }
+}
+```
+
+Replace `fetchSub2ApiAllAccountsFallbackPricing()` with:
+
+```ts
+async function fetchSub2ApiAllAccountsFallbackPricingContexts(
+  account: DisplaySiteData,
+): Promise<AccountPricingQueryResult> {
+  const tokens = await fetchDisplayAccountTokens(account)
+  if (tokens.length === 0) {
+    throw createUnsupportedModelPricingError()
+  }
+
+  const settledResults = await mapWithConcurrency(
+    tokens,
+    SUB2API_ALL_ACCOUNTS_TOKEN_CONCURRENCY,
+    (token) => loadSub2ApiTokenPricingContext({ account, token }),
+  )
+  const contexts = settledResults.flatMap((result) =>
+    result.context ? [result.context] : [],
+  )
+  const errors = settledResults.flatMap((result) =>
+    result.error ? [result.error] : [],
+  )
+
+  if (contexts.length === 0) {
+    const invalidFormatError = errors.find((error) => {
+      const typedError = error as { code?: string } | null | undefined
+      return typedError?.code === MODEL_LIST_DATA_ERROR_CODES.INVALID_FORMAT
+    })
+    throw invalidFormatError ?? createUnsupportedModelPricingError()
+  }
+
+  return {
+    contexts,
+    ...(errors.length > 0 ? { partialFailureCount: errors.length } : {}),
+  }
+}
+```
+
+- [ ] **Step 6: Convert all-accounts queries to context arrays**
+
+In `useAllAccountsModelData()`, update `useQueries` query functions so every successful account returns `AccountPricingQueryResult`.
+
+For Sub2API unsupported common pricing:
+
+```ts
+          if (account.siteType === SITE_TYPES.SUB2API) {
+            return fetchSub2ApiAllAccountsFallbackPricingContexts(account)
+          }
+```
+
+For cached account-level pricing:
+
+```ts
+        if (cached && Array.isArray(cached.data)) {
+          return {
+            contexts: [
+              {
+                account,
+                pricing: cached,
+                sourceIdentity: createAccountModelListSourceIdentity(
+                  account.id,
+                ),
+              },
+            ],
+          }
+        }
+```
+
+For newly fetched account-level pricing:
+
+```ts
+        return {
+          contexts: [
+            {
+              account,
+              pricing: data,
+              sourceIdentity: createAccountModelListSourceIdentity(account.id),
+            },
+          ],
+        }
+```
+
+Update aggregate model count:
+
+```ts
+    const modelCount = queries.reduce(
+      (count, query) =>
+        count +
+        (query.data?.contexts.reduce(
+          (contextCount, context) =>
+            contextCount + getPricingModelCount(context.pricing),
+          0,
+        ) ?? 0),
+      0,
+    )
+```
+
+Update `pricingContexts` memo:
+
+```ts
+  const pricingContexts: AccountPricingContext[] = useMemo(() => {
+    return queries.flatMap((query) => query.data?.contexts ?? [])
+  }, [queries])
+```
+
+Update `accountQueryStates`:
+
+```ts
+        const hasData = (query?.data?.contexts.length ?? 0) > 0
+        const hasError =
+          !!query?.error || (query?.data?.partialFailureCount ?? 0) > 0
+```
+
+Keep the existing `errorType` rules and add:
+
+```ts
+        } else if (hasError) {
+          errorType = MODEL_LIST_ACCOUNT_ERROR_TYPES.LOAD_FAILED
+        }
+```
+
+- [ ] **Step 7: Update refresh invalidation**
+
+Keep account-level cache invalidation for common pricing and refetch each account query:
+
+```ts
+  const loadPricingData = useCallback(async () => {
+    await Promise.all(
+      safeDisplayData.map(async (account, index) => {
+        await modelPricingCache.invalidate(createModelPricingCacheKey(account))
+        const query = queries[index]
+        if (query) {
+          await query.refetch()
+        }
+      }),
+    )
+  }, [queries, safeDisplayData])
+```
+
+Do not add token-level cache in this task unless the implementation introduces a cache write for token contexts. `loadAccountTokenFallbackPricingResponse()` currently performs live fallback loading, so refetching the account query reloads the token sources.
+
+- [ ] **Step 8: Run focused tests and verify they pass**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/useModelData.test.tsx -t "Sub2API"
+```
+
+Expected: PASS for Sub2API all-accounts, single-account fallback, selected-key fallback, and refresh tests.
+
+- [ ] **Step 9: Commit Task 3**
+
+Run:
+
+```bash
+git add src/features/ModelList/hooks/useModelData.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+git commit -m "feat(model-list): load all sub2api keys for comparison"
+```
+
+---
+
+### Task 4: Final Integration And Validation
+
+**Files:**
+
+- Modify as needed: `src/features/ModelList/hooks/useFilteredModels.ts`
+- Modify as needed: `src/features/ModelList/hooks/useModelData.ts`
+- Modify as needed: `src/features/ModelList/batchVerification.ts`
+- Modify as needed: `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
+- Modify as needed: `tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`
+- Modify as needed: `tests/features/ModelList/batchVerification.test.ts`
+
+- [ ] **Step 1: Run all affected Model List hook tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+pnpm vitest --run tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Verify batch verification dedupe uses token identity**
+
+Add this case to `tests/features/ModelList/batchVerification.test.ts`:
+
+```ts
+  it("keeps same-account token rows separate for batch verification", () => {
+    const source = {
+      kind: MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT,
+      account: { id: "batch-sub2api-account" },
+      capabilities: { supportsBatchCredentialVerification: true },
+    } as any
+    const model = { model_name: "shared-model", enable_groups: ["default"] }
+
+    expect(
+      createBatchVerifyModelItems([
+        {
+          model,
+          source,
+          sourceIdentity: {
+            kind: "account-token",
+            id: "batch-sub2api-account:token:51",
+            tokenId: 51,
+            tokenName: "Default key",
+          },
+          groupRatios: { default: 1 },
+          effectiveGroup: "default",
+        },
+        {
+          model,
+          source,
+          sourceIdentity: {
+            kind: "account-token",
+            id: "batch-sub2api-account:token:52",
+            tokenId: 52,
+            tokenName: "Second key",
+          },
+          groupRatios: { default: 1 },
+          effectiveGroup: "default",
+        },
+      ] as any).map((item) => item.key),
+    ).toEqual([
+      "account:batch-sub2api-account:token:51:shared-model",
+      "account:batch-sub2api-account:token:52:shared-model",
+    ])
+  })
+```
+
+Run:
+
+```bash
+pnpm vitest --run tests/features/ModelList/batchVerification.test.ts -t "keeps same-account token rows separate"
+```
+
+Expected: PASS once `getModelItemKey()` uses `sourceIdentity.id`.
+
+- [ ] **Step 3: Fix type or behavior failures from the focused run**
+
+If failures occur, keep fixes within the task files above. The likely acceptable fixes are:
+
+```ts
+// useFilteredModels.ts dependency arrays must include new source-level maps.
+includedAllAccountsGroupsBySourceId
+availableGroupsBySourceId
+
+// useModelData.ts query data is now AccountPricingQueryResult in all-accounts mode.
+query.data?.contexts
+query.data?.partialFailureCount
+```
+
+Run the failed command again after each fix.
+
+- [ ] **Step 4: Inspect final diff for scope**
+
+Run:
+
+```bash
+git diff -- src/features/ModelList/modelManagementSources.ts src/features/ModelList/hooks/useModelData.ts src/features/ModelList/hooks/useFilteredModels.ts src/features/ModelList/sourceLabels.ts src/features/ModelList/components/ModelItem/index.tsx src/features/ModelList/components/ModelDisplay.tsx src/features/ModelList/batchVerification.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts tests/features/ModelList/batchVerification.test.ts
+git status --porcelain
+```
+
+Expected: diff contains only the all-key comparison implementation and focused tests.
+
+- [ ] **Step 5: Run staged validation**
+
+Stage only task-scoped files:
+
+```bash
+git add src/features/ModelList/modelManagementSources.ts src/features/ModelList/hooks/useModelData.ts src/features/ModelList/hooks/useFilteredModels.ts src/features/ModelList/sourceLabels.ts src/features/ModelList/components/ModelItem/index.tsx src/features/ModelList/components/ModelDisplay.tsx src/features/ModelList/batchVerification.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts tests/features/ModelList/batchVerification.test.ts
+pnpm run validate:staged
+```
+
+Expected: lint-staged, ESLint, Prettier, and staged i18n check pass.
+
+- [ ] **Step 6: Commit final validation fixes**
+
+If Task 4 changed files after Task 3, commit them:
+
+```bash
+git commit -m "test(model-list): cover sub2api token comparison"
+```
+
+If Task 4 only verified existing commits and staged validation did not change files, do not create an empty commit.
+
+- [ ] **Step 7: Handoff notes**
+
+Final handoff must include:
+
+```text
+Telemetry: reused existing Model List load-completion event; no new analytics schema fields were added because token counts would require broader diagnostics typing.
+E2E: not added; the risk is hook-level data identity, token loading orchestration, and row sorting, covered by Vitest.
+Validation: list exact commands and pass/fail results.
+Commit(s): list commit hashes.
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - all active Sub2API tokens load in all-accounts mode: Task 3
+  - each token is a distinct comparison source: Task 1 and Task 2
+  - one token failure does not block successful token rows: Task 3
+  - all-token failure reports account failure: Task 3
+  - row labels include token names without secrets: Task 2
+  - account filters and summaries remain account-keyed: Task 2
+  - group candidates and row keys use source identity: Task 1 and Task 2
+- Red-flag scan: no unresolved markers or vague test instructions.
+- Type consistency:
+  - `ModelListSourceIdentity` is defined once in `modelManagementSources.ts`.
+  - `AccountPricingContext.sourceIdentity` uses `ModelListSourceIdentity`.
+  - `RawModelItem` and `CalculatedModelItem` carry the same optional `sourceIdentity`.
+  - `getModelItemKey()` accepts `sourceIdentity` through `CalculatedModelItem`.

--- a/docs/superpowers/specs/2026-06-16-sub2api-all-key-comparison-design.md
+++ b/docs/superpowers/specs/2026-06-16-sub2api-all-key-comparison-design.md
@@ -1,0 +1,319 @@
+# Sub2API All-Key Model Comparison Design
+
+Date: 2026-06-16
+
+## Purpose
+
+Make Sub2API accounts with multiple saved runtime keys participate naturally in
+the all-accounts Model List comparison. Instead of requiring the user to choose
+one key first, the all-accounts view should load each usable Sub2API key as its
+own comparable source.
+
+## Current Context
+
+Sub2API does not expose account-level pricing compatible with One API or New
+API. The existing Sub2API Model List path correctly uses each runtime API key
+against `/v1/models` and then applies estimated pricing only when the key's
+group and model price table can be resolved.
+
+The current all-accounts integration is intentionally conservative:
+
+- `src/features/ModelList/hooks/useModelData.ts` returns Sub2API fallback
+  pricing only when `fetchDisplayAccountTokens(account)` returns exactly one
+  token.
+- `AccountPricingContext` currently carries `{ account, pricing }`, so the
+  downstream model row source only knows the owning account.
+- `src/features/ModelList/hooks/useFilteredModels.ts` builds row identity with
+  `getModelItemKey()` as `account:<accountId>:<modelName>` for account-backed
+  rows.
+- Model row source labels come from
+  `src/features/ModelList/sourceLabels.ts`, which formats account rows as
+  account name plus host.
+
+That shape is sufficient for one account-level catalog per account. It is not
+sufficient for Sub2API multi-key comparison because two keys under the same
+account may expose different model lists, groups, and estimated prices.
+
+## Decision
+
+In all-accounts mode, Sub2API should default to loading all active saved
+runtime keys and treating each loaded key as an independent comparison source.
+
+This is the same user-facing comparison idea as New API group-aware sorting:
+the user asks "which source is best for this model?", and the list evaluates
+all configured viable sources. The source unit differs by backend:
+
+- New API-family accounts: the account is the source, and groups are price
+  candidates inside that source.
+- Sub2API accounts: each runtime key is the source because model visibility and
+  group/rate context are key-scoped.
+
+The UI must make the key dimension visible. It must not silently merge multiple
+Sub2API keys under a single account row identity.
+
+## Goals
+
+- In all-accounts mode, load every active saved Sub2API token that can be used
+  for runtime model discovery.
+- Keep each Sub2API key distinct for sorting, lowest-price badges, row keys,
+  verification context, and source labels.
+- Preserve model rows when a key has model-list data but unavailable prices.
+- Allow one failing Sub2API key to fail independently without dropping the
+  whole Sub2API account.
+- Avoid exposing secrets, raw key values, backend messages, or group ids in UI
+  or telemetry.
+- Keep single-account fallback behavior unchanged unless implementation needs a
+  small shared helper.
+
+## Non-Goals
+
+- Do not add a user preference screen for key inclusion in the first version.
+- Do not make dashboard channel pricing a dependency.
+- Do not reclassify Sub2API as supporting exact account-level
+  `fetchModelPricing`.
+- Do not load disabled/deleted/unusable tokens when the token list exposes an
+  active/enabled flag.
+- Do not deduplicate keys by group or model list in the first version. Duplicate
+  rows are acceptable when they represent distinct configured keys.
+
+## Data Model
+
+Add explicit source identity metadata to all-account pricing contexts:
+
+```ts
+export interface AccountPricingContext {
+  account: DisplaySiteData
+  pricing: PricingResponse
+  sourceIdentity?: {
+    kind: "account" | "account-token"
+    id: string
+    tokenId?: number
+    tokenName?: string
+  }
+}
+```
+
+Default account-level contexts should use either no `sourceIdentity` or
+`{ kind: "account", id: account.id }`. Sub2API all-key contexts should use:
+
+```ts
+{
+  kind: "account-token",
+  id: `${account.id}:token:${token.id}`,
+  tokenId: token.id,
+  tokenName: token.name,
+}
+```
+
+The source identity is display and comparison metadata only. It must never
+store the raw token key.
+
+## Loading Design
+
+Replace the single-key-only all-accounts helper with a multi-source loader:
+
+```ts
+async function fetchSub2ApiAllAccountsFallbackPricingContexts(
+  account: DisplaySiteData,
+): Promise<AccountPricingContext[]> {
+  const tokens = await fetchDisplayAccountTokens(account)
+  const usableTokens = tokens.filter(isUsableSub2ApiRuntimeToken)
+  return mapWithConcurrency(usableTokens, 4, async (token) => ({
+    account,
+    pricing: await loadAccountTokenFallbackPricingResponse({ account, token }),
+    sourceIdentity: {
+      kind: "account-token",
+      id: `${account.id}:token:${token.id}`,
+      tokenId: token.id,
+      tokenName: token.name,
+    },
+  }))
+}
+```
+
+If the current `ApiToken` type does not expose a reliable active flag, the first
+implementation may treat all fetched tokens as usable and document that choice
+in a short helper comment.
+
+The helper should live near `useAllAccountsModelData()` at first because it is
+hook orchestration logic. If the code becomes difficult to test or grows beyond
+loading orchestration, split it into a focused module under
+`src/features/ModelList/hooks/` rather than moving React state concerns into
+`src/services/`.
+
+### Per-Key Error Handling
+
+Each token load should settle independently.
+
+- Success: include an `AccountPricingContext` for that key.
+- Invalid payload for one key: omit that key and record a key-source failure in
+  the account query summary.
+- Auth/network/business failure for one key: omit that key and record a
+  key-source failure in the account query summary.
+- All keys fail or no usable keys exist: treat the Sub2API account as failed or
+  unsupported for all-accounts data, using the existing all-account error state.
+
+The first implementation can keep the current aggregate account-level
+`AccountQueryState` shape if it only needs to say the account is partial or
+failed. Per-key partial-failure details are a separate UI refinement, not part
+of this first all-key comparison change.
+
+### Concurrency
+
+Use bounded concurrency for Sub2API keys inside one account. Four parallel key
+loads is a reasonable first limit because it avoids a large burst against a
+single deployment while still keeping all-accounts loading responsive.
+
+Do not add a new dependency for this. A tiny local helper that walks the token
+array with worker indexes is enough and avoids bundle cost.
+
+## Filtering And Comparison
+
+Update downstream row identity to use `sourceIdentity.id` when present:
+
+```ts
+export function getModelItemKey(
+  item: Pick<CalculatedModelItem, "model" | "source" | "sourceIdentity">,
+) {
+  const sourceId =
+    item.sourceIdentity?.id ??
+    (item.source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
+      ? item.source.account.id
+      : item.source.profile.id)
+
+  return `${item.source.kind}:${sourceId}:${item.model.model_name}`
+}
+```
+
+`RawModelItem` and `CalculatedModelItem` should carry the optional
+`sourceIdentity` alongside `source`. Lowest-price grouping should still group
+by model name and billing mode, not by key, so all Sub2API keys compete against
+each other and against other accounts.
+
+Account filters should remain account-level in the first version. Selecting or
+excluding an account includes or excludes all of that account's Sub2API key
+sources.
+
+Group-derived state needs a deliberate split:
+
+- account filter and account summary maps stay keyed by `account.id`
+- source-level group candidates, group exclusions, price keys, and row keys use
+  `sourceIdentity.id` when present
+
+This prevents two Sub2API keys under the same account from leaking group
+availability or exclusion state into each other while preserving the current
+account-level sidebar behavior.
+
+Account summary counts should remain account-level by default, summing all key
+rows for that account. This matches the current account list and avoids adding
+a new key-level sidebar surface. If duplicate model rows from multiple keys
+make the count surprising, a separate key-source count should be designed as a
+follow-up UI change.
+
+## Source Labels
+
+Extend model-row source labels to include token names when source identity is a
+Sub2API account-token source:
+
+```text
+Account name / Token name · host
+```
+
+If the token name is empty, use a local fallback such as "Runtime key". The
+label and title must not include the raw API key.
+
+The same source identity should be used only for display and comparison. Row
+actions that verify a model or open the key dialog should still receive the
+owning account and model id. The current code can keep using
+`source.account` for those actions.
+
+## Refresh And Caching
+
+All-accounts refresh should invalidate and reload each Sub2API key source for
+the account. The cache key for Sub2API all-key contexts must include the token
+id or source identity so two token catalogs under one account cannot overwrite
+each other.
+
+The existing `modelPricingCache` account-level cache should continue to apply
+to backends that truly return one account-level pricing response. Sub2API
+token-level fallback results need token-level cache identity if they are cached
+in this path.
+
+## UI Requirements
+
+- The all-accounts Model List should show multiple rows for the same model when
+  different Sub2API keys expose that model.
+- The source badge should identify the account and token.
+- Lowest-price badges should compare Sub2API token rows against other token
+  rows and other accounts.
+- Price-unavailable rows should still render, but should not win lowest-price
+  comparison.
+- A failed key should not show a blocking full-page error when at least one
+  other source loaded successfully.
+- No new manual selection control is required for the first version.
+
+## Telemetry
+
+Telemetry decision: reuse the existing Model List load-completion event and add
+safe aggregate counts only if diagnostics already has a natural field location.
+
+Safe new fields:
+
+- `sub2apiTokenSourceCount`
+- `sub2apiTokenSourceSuccessCount`
+- `sub2apiTokenSourceFailureCount`
+
+Do not record token ids, token names, group names, group ids, model ids, base
+URLs, API keys, JWTs, or raw backend messages.
+
+If adding those fields causes broad analytics schema churn, defer telemetry and
+state that the first implementation reuses existing account success/failure
+counts.
+
+## Testing Strategy
+
+Focused tests should cover:
+
+- `useModelData` all-accounts mode loads two Sub2API tokens and returns two
+  pricing contexts with distinct `sourceIdentity.id` values.
+- A single failed Sub2API token does not remove another successful token source.
+- All Sub2API tokens failing leaves the account in a load-failed state.
+- `useFilteredModels` keeps two same-account Sub2API rows for the same model
+  distinct and marks the cheapest comparable token as lowest price.
+- `getModelItemKey()` includes source identity so two token rows with the same
+  account and model do not collide.
+- Token-qualified group candidates and group exclusions do not leak between two
+  keys under the same account.
+- Source-label formatting includes token name and never includes a raw key.
+- Account filter still includes/excludes all token sources under the account.
+
+No Playwright E2E is required for the first implementation because the risk is
+data identity, loading orchestration, and sorting behavior. Vitest coverage at
+hook and formatter level is the right layer unless implementation introduces a
+new interactive control.
+
+## Validation
+
+Focused validation:
+
+- `pnpm vitest --run tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
+- `pnpm vitest --run tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts`
+
+Commit gate:
+
+- `pnpm run validate:staged`
+
+Run `pnpm run validate:push` only if the implementation changes shared exports,
+analytics event schema, dependency wiring, or build configuration.
+
+## Rollout
+
+Implement as one scoped feature branch with three small commits:
+
+1. Add source identity types and row identity/label tests.
+2. Add Sub2API all-key loading with bounded concurrency and hook tests.
+3. Add partial-failure diagnostics and final validation fixes.
+
+If the source identity change touches too many model-row action surfaces, split
+the identity plumbing into its own PR and keep the Sub2API loader change for a
+second PR.

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -201,6 +201,7 @@ export default function ModelList(props: {
           count: count ?? 0,
           isLoading: state.isLoading,
           errorType: state.errorType,
+          errorMessage: state.errorMessage,
         },
       ]
     })

--- a/src/features/ModelList/batchVerification.ts
+++ b/src/features/ModelList/batchVerification.ts
@@ -1,3 +1,8 @@
+import {
+  MODEL_LIST_SOURCE_IDENTITY_KINDS,
+  type ModelListSourceIdentity,
+  type ModelManagementItemSource,
+} from "~/features/ModelList/modelManagementSources"
 import { identifyProvider } from "~/services/models/utils/modelProviders"
 import { isTokenCompatibleWithModel } from "~/services/models/utils/tokenModelCompatibility"
 import {
@@ -10,11 +15,6 @@ import {
   getModelItemKey,
   type CalculatedModelItem,
 } from "./hooks/useFilteredModels"
-import {
-  MODEL_LIST_SOURCE_IDENTITY_KINDS,
-  type ModelListSourceIdentity,
-  type ModelManagementItemSource,
-} from "./modelManagementSources"
 
 export const MODEL_LIST_BATCH_VERIFY_CONCURRENCY = 5
 export const MODEL_LIST_BATCH_VERIFY_API_TYPE_MODES = {

--- a/src/features/ModelList/batchVerification.ts
+++ b/src/features/ModelList/batchVerification.ts
@@ -10,7 +10,11 @@ import {
   getModelItemKey,
   type CalculatedModelItem,
 } from "./hooks/useFilteredModels"
-import { type ModelManagementItemSource } from "./modelManagementSources"
+import {
+  MODEL_LIST_SOURCE_IDENTITY_KINDS,
+  type ModelListSourceIdentity,
+  type ModelManagementItemSource,
+} from "./modelManagementSources"
 
 export const MODEL_LIST_BATCH_VERIFY_CONCURRENCY = 5
 export const MODEL_LIST_BATCH_VERIFY_API_TYPE_MODES = {
@@ -26,6 +30,7 @@ export type BatchVerifyModelItem = {
   modelId: string
   enableGroups: string[] | null
   source: ModelManagementItemSource
+  sourceIdentity?: ModelListSourceIdentity
 }
 
 /**
@@ -60,6 +65,7 @@ export function createBatchVerifyModelItems(
           ? item.model.enable_groups
           : null,
       source: item.source,
+      sourceIdentity: item.sourceIdentity,
     })
   }
 
@@ -87,14 +93,26 @@ export function resolveBatchVerifyApiType(
  */
 export function pickBatchVerifyCompatibleToken(
   tokens: ApiToken[],
-  item: Pick<BatchVerifyModelItem, "modelId" | "enableGroups">,
+  item: Pick<
+    BatchVerifyModelItem,
+    "modelId" | "enableGroups" | "sourceIdentity"
+  >,
 ): ApiToken | null {
-  return (
-    tokens.find((token) =>
-      isTokenCompatibleWithModel(token, {
-        id: item.modelId,
-        enableGroups: item.enableGroups,
-      }),
-    ) ?? null
-  )
+  const isCompatible = (token: ApiToken) =>
+    isTokenCompatibleWithModel(token, {
+      id: item.modelId,
+      enableGroups: item.enableGroups,
+    })
+
+  if (
+    item.sourceIdentity?.kind === MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN
+  ) {
+    const sourceIdentity = item.sourceIdentity
+    const token = tokens.find(
+      (candidate) => candidate.id === sourceIdentity.tokenId,
+    )
+    return token && isCompatible(token) ? token : null
+  }
+
+  return tokens.find((token) => isCompatible(token)) ?? null
 }

--- a/src/features/ModelList/components/AccountSummaryBar.tsx
+++ b/src/features/ModelList/components/AccountSummaryBar.tsx
@@ -13,6 +13,7 @@ interface AccountSummaryItem {
   count: number
   isLoading?: boolean
   errorType?: ModelListAccountErrorType
+  errorMessage?: string
 }
 
 interface AccountSummaryBarProps {
@@ -24,6 +25,7 @@ interface AccountSummaryBarProps {
 interface StatusPresentation {
   label: string
   className: string
+  title?: string
 }
 
 /**
@@ -60,6 +62,7 @@ export function AccountSummaryBar({
       return {
         label: t("accountSummary.loadFailed"),
         className: "text-red-500 dark:text-red-400",
+        title: item.errorMessage,
       }
     }
 
@@ -67,6 +70,15 @@ export function AccountSummaryBar({
       return {
         label: t("accountSummary.incompatible"),
         className: "text-red-500 dark:text-red-400",
+        title: item.errorMessage,
+      }
+    }
+
+    if (item.errorType === MODEL_LIST_ACCOUNT_ERROR_TYPES.PARTIAL_LOAD_FAILED) {
+      return {
+        label: t("accountSummary.partialLoadFailed"),
+        className: "text-amber-600 dark:text-amber-300",
+        title: item.errorMessage,
       }
     }
 
@@ -97,6 +109,12 @@ export function AccountSummaryBar({
                   }
                   size="default"
                   className="cursor-pointer"
+                  title={statusPresentation.title}
+                  aria-label={
+                    statusPresentation.title
+                      ? `${item.name} ${statusPresentation.label} ${statusPresentation.title}`
+                      : undefined
+                  }
                   onClick={() => onAccountClick?.(item.accountId)}
                 >
                   <span className="truncate font-medium">{item.name}</span>

--- a/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
+++ b/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
@@ -887,10 +887,14 @@ export function BatchVerifyModelsDialog({
   }
 
   const renderRow = (row: BatchVerifyRow) => {
-    const sourceLabel = formatModelListSourceLabel(row.item.source, {
-      formatProfileLabel: ({ name, host }) =>
-        t("modelList:sourceLabels.profileBadge", { name, host }),
-    })
+    const sourceLabel = formatModelListSourceLabel(
+      row.item.source,
+      {
+        formatProfileLabel: ({ name, host }) =>
+          t("modelList:sourceLabels.profileBadge", { name, host }),
+      },
+      row.item.sourceIdentity,
+    )
 
     return (
       <div

--- a/src/features/ModelList/components/ModelDisplay.tsx
+++ b/src/features/ModelList/components/ModelDisplay.tsx
@@ -213,6 +213,7 @@ export function ModelDisplay(props: ModelDisplayProps) {
               groupSelectionScope={groupSelectionScope}
               isGroupSelectionInteractive={isGroupSelectionInteractive}
               source={sourceForModel}
+              sourceIdentity={item.sourceIdentity}
               displayCapabilities={displayCapabilities}
               verificationSummary={verificationSummary}
               onFilterAccount={onFilterAccount}

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -9,6 +9,7 @@ import {
   type ModelListGroupSelectionScope,
 } from "~/features/ModelList/groupSelectionScopes"
 import type {
+  ModelListSourceIdentity,
   ModelManagementItemSource,
   ModelManagementSourceCapabilities,
 } from "~/features/ModelList/modelManagementSources"
@@ -58,6 +59,7 @@ interface ModelItemProps {
   groupSelectionScope?: ModelListGroupSelectionScope
   isGroupSelectionInteractive?: boolean
   source: ModelManagementItemSource
+  sourceIdentity?: ModelListSourceIdentity
   displayCapabilities?: ModelManagementSourceCapabilities
   isLowestPrice?: boolean
   verificationSummary?: ApiVerificationHistorySummary | null
@@ -103,6 +105,7 @@ export default function ModelItem(props: ModelItemProps) {
     groupSelectionScope = MODEL_LIST_GROUP_SELECTION_SCOPES.SINGLE_SOURCE,
     isGroupSelectionInteractive = true,
     source,
+    sourceIdentity,
     displayCapabilities = source.capabilities,
     isLowestPrice = false,
     verificationSummary,
@@ -182,10 +185,14 @@ export default function ModelItem(props: ModelItemProps) {
     void createTab(parsedSourceUrl.toString(), true)
   }
 
-  const sourceLabel = formatModelListSourceLabel(source, {
-    formatProfileLabel: ({ name, host }) =>
-      t("sourceLabels.profileBadge", { name, host }),
-  })
+  const sourceLabel = formatModelListSourceLabel(
+    source,
+    {
+      formatProfileLabel: ({ name, host }) =>
+        t("sourceLabels.profileBadge", { name, host }),
+    },
+    sourceIdentity,
+  )
   const handleFilterAccount =
     source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT && onFilterAccount
       ? () => onFilterAccount(source.account.id)

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -6,6 +6,7 @@ import {
   createAccountSource,
   deriveModelListSourceCapabilities,
   MODEL_MANAGEMENT_SOURCE_KINDS,
+  type ModelListSourceIdentity,
   type ModelManagementSource,
 } from "~/features/ModelList/modelManagementSources"
 import {
@@ -66,6 +67,7 @@ interface RawModelItem {
         NonNullable<ModelManagementSource>,
         { kind: typeof MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE }
       >
+  sourceIdentity?: ModelListSourceIdentity
   groupRatios: Record<string, number>
   exchangeRate: number
 }
@@ -84,6 +86,7 @@ export type CalculatedModelItem = {
         NonNullable<ModelManagementSource>,
         { kind: typeof MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE }
       >
+  sourceIdentity?: ModelListSourceIdentity
   groupRatios: Record<string, number>
   effectiveGroup?: string
   hasAutoSelectedGroup?: boolean
@@ -226,14 +229,42 @@ function hasComparablePriceValue(priceKey: ComparablePriceKey) {
   return isFiniteNumber(priceKey.primary) || isFiniteNumber(priceKey.secondary)
 }
 
+/** Resolves the row identity used for source-scoped model-list comparisons. */
+function getModelListSourceIdentityKey(params: {
+  source:
+    | ReturnType<typeof createAccountSource>
+    | Extract<
+        NonNullable<ModelManagementSource>,
+        { kind: typeof MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE }
+      >
+  sourceIdentity?: ModelListSourceIdentity
+}) {
+  return (
+    params.sourceIdentity?.id ??
+    (params.source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
+      ? params.source.account.id
+      : params.source.profile.id)
+  )
+}
+
+/** Resolves the source-level group/filter key for a raw model item. */
+function getRawItemSourceIdentityKey(
+  item: Pick<RawModelItem, "source" | "sourceIdentity">,
+) {
+  return getModelListSourceIdentityKey({
+    source: item.source,
+    sourceIdentity: item.sourceIdentity,
+  })
+}
+
 /** Creates a stable identifier for a calculated model item. */
 export function getModelItemKey(
-  item: Pick<CalculatedModelItem, "model" | "source">,
+  item: Pick<CalculatedModelItem, "model" | "source" | "sourceIdentity">,
 ) {
-  const sourceId =
-    item.source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
-      ? item.source.account.id
-      : item.source.profile.id
+  const sourceId = getModelListSourceIdentityKey({
+    source: item.source,
+    sourceIdentity: item.sourceIdentity,
+  })
 
   return `${item.source.kind}:${sourceId}:${item.model.model_name}`
 }
@@ -336,6 +367,7 @@ function resolveBestCalculatedItem(
       model: rawItem.model,
       calculatedPrice,
       source: rawItem.source,
+      sourceIdentity: rawItem.sourceIdentity,
       groupRatios: rawItem.groupRatios,
       effectiveGroup: supportsGroupFiltering ? group : undefined,
       hasAutoSelectedGroup: groupsToEvaluate.length > 1,
@@ -430,7 +462,7 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
 
   const rawModelItems = useMemo<RawModelItem[]>(() => {
     if (pricingContexts && pricingContexts.length > 0) {
-      return pricingContexts.flatMap(({ account, pricing }) => {
+      return pricingContexts.flatMap(({ account, pricing, sourceIdentity }) => {
         if (!pricing || !Array.isArray(pricing.data)) {
           return []
         }
@@ -462,6 +494,7 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
         return pricing.data.map((model) => ({
           model,
           source,
+          sourceIdentity,
           groupRatios: pricing.group_ratio ?? {},
           exchangeRate,
         }))
@@ -530,6 +563,49 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     })
 
     return Array.from(groupSet)
+  }, [
+    rawModelItems,
+    selectedSource?.capabilities.supportsGroupFiltering,
+    selectedSource?.kind,
+  ])
+
+  const availableGroupsBySourceId = useMemo(() => {
+    if (
+      !selectedSource?.capabilities.supportsGroupFiltering ||
+      selectedSource.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS
+    ) {
+      return {}
+    }
+
+    const groupsBySourceId = new Map<string, Set<string>>()
+
+    rawModelItems.forEach((item) => {
+      if (item.source.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT) {
+        return
+      }
+
+      const sourceId = getRawItemSourceIdentityKey(item)
+      const sourceGroups = groupsBySourceId.get(sourceId) ?? new Set<string>()
+
+      const pricedGroups = Object.keys(item.groupRatios)
+      pricedGroups.forEach((group) => {
+        if (group) {
+          sourceGroups.add(group)
+        }
+      })
+      if (pricedGroups.length === 0) {
+        addAvailableGroups(sourceGroups, item.model)
+      }
+
+      groupsBySourceId.set(sourceId, sourceGroups)
+    })
+
+    return Object.fromEntries(
+      Array.from(groupsBySourceId.entries()).map(([sourceId, groups]) => [
+        sourceId,
+        toUniqueGroups(groups),
+      ]),
+    ) as Record<string, string[]>
   }, [
     rawModelItems,
     selectedSource?.capabilities.supportsGroupFiltering,
@@ -629,30 +705,34 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     selectedSource?.kind,
   ])
 
-  const includedAllAccountsGroupsByAccountId = useMemo(() => {
+  const includedAllAccountsGroupsBySourceId = useMemo(() => {
     if (selectedSource?.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS) {
       return {}
     }
 
     return Object.fromEntries(
-      Object.entries(availableAccountGroupsByAccountId).map(
-        ([accountId, groups]) => {
-          const excludedGroups = new Set(
-            toUniqueGroups(
-              allAccountsExcludedGroupsByAccountId[accountId] ?? [],
-            ),
-          )
+      rawModelItems.flatMap((item) => {
+        if (item.source.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT) {
+          return []
+        }
 
-          return [
-            accountId,
-            groups.filter((group) => !excludedGroups.has(group)),
-          ]
-        },
-      ),
+        const sourceId = getRawItemSourceIdentityKey(item)
+        const groups = availableGroupsBySourceId[sourceId] ?? []
+        const excludedGroups = new Set(
+          toUniqueGroups(
+            allAccountsExcludedGroupsByAccountId[item.source.account.id] ?? [],
+          ),
+        )
+
+        return [
+          [sourceId, groups.filter((group) => !excludedGroups.has(group))],
+        ]
+      }),
     ) as Record<string, string[]>
   }, [
     allAccountsExcludedGroupsByAccountId,
-    availableAccountGroupsByAccountId,
+    availableGroupsBySourceId,
+    rawModelItems,
     selectedSource?.kind,
   ])
 
@@ -698,7 +778,9 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
         item.source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
       ) {
         return (
-          includedAllAccountsGroupsByAccountId[item.source.account.id] ?? []
+          includedAllAccountsGroupsBySourceId[
+            getRawItemSourceIdentityKey(item)
+          ] ?? []
         )
       }
 
@@ -706,7 +788,7 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     },
     [
       getSingleSourceGroupCandidates,
-      includedAllAccountsGroupsByAccountId,
+      includedAllAccountsGroupsBySourceId,
       selectedGroups,
       selectedSource?.capabilities.supportsGroupFiltering,
       selectedSource?.kind,

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -1,4 +1,5 @@
 import { useQueries, useQuery } from "@tanstack/react-query"
+import type { TFunction } from "i18next"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -6,6 +7,7 @@ import { useTranslation } from "react-i18next"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   createAccountModelListSourceIdentity,
+  createAccountTokenModelListSourceIdentity,
   MODEL_MANAGEMENT_SOURCE_KINDS,
   type ModelListSourceIdentity,
   type ModelManagementSource,
@@ -78,6 +80,18 @@ interface AccountQueryState {
   hasData: boolean
   hasError: boolean
   errorType?: ModelListAccountErrorType
+  errorMessage?: string
+}
+
+interface AccountPricingQueryResult {
+  contexts: AccountPricingContext[]
+  partialFailureCount?: number
+  partialFailureErrors?: unknown[]
+}
+
+interface SettledContextResult {
+  context?: AccountPricingContext
+  error?: unknown
 }
 
 export interface AccountFallbackControls {
@@ -215,6 +229,35 @@ function getAggregateModelDataFailureDiagnostics(errors: unknown[]): {
   )
 }
 
+/** Returns a user-facing, non-secret reason for model-data load failures. */
+function getModelDataDisplayErrorReason(
+  error: unknown,
+  t: TFunction<"modelList">,
+) {
+  const code =
+    error && typeof error === "object"
+      ? (error as { code?: unknown }).code
+      : undefined
+
+  if (code === MODEL_LIST_DATA_ERROR_CODES.INVALID_FORMAT) {
+    return t("accountSummary.failureReasons.invalidFormat")
+  }
+
+  return getErrorMessage(error) || t("accountSummary.failureReasons.unknown")
+}
+
+/** Selects the first useful display reason from a set of load failures. */
+function getFirstModelDataDisplayErrorReason(
+  errors: unknown[],
+  t: TFunction<"modelList">,
+) {
+  return (
+    errors
+      .map((error) => getModelDataDisplayErrorReason(error, t))
+      .find(Boolean) ?? t("accountSummary.failureReasons.unknown")
+  )
+}
+
 const MODEL_DATA_ANALYTICS_CONTEXT = {
   featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ModelList,
   actionId: PRODUCT_ANALYTICS_ACTION_IDS.RefreshModelPricingData,
@@ -316,6 +359,24 @@ function createModelPricingQueryKey(
     : [MODEL_LIST_QUERY_KEYS.PRICING, MODEL_LIST_QUERY_SCOPE_VALUES.NONE]
 }
 
+/** Builds an all-accounts pricing query key without changing persistence cache scope. */
+function createAllAccountsModelPricingQueryKey(
+  account: Pick<
+    DisplaySiteData,
+    "id" | "baseUrl" | "userId" | "siteType" | "authType"
+  >,
+) {
+  return [
+    MODEL_LIST_QUERY_KEYS.PRICING,
+    MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS,
+    account.id,
+    account.baseUrl,
+    account.userId,
+    account.siteType,
+    account.authType,
+  ]
+}
+
 /** Builds the persisted pricing-cache key from non-secret account fields. */
 function createModelPricingCacheKey(
   account: Pick<
@@ -332,25 +393,108 @@ function createModelPricingCacheKey(
   ].join("|")
 }
 
-/** Loads the single-key Sub2API fallback catalog for all-accounts comparison. */
-async function fetchSub2ApiAllAccountsFallbackPricing(
-  account: DisplaySiteData,
+const SUB2API_ALL_ACCOUNTS_TOKEN_CONCURRENCY = 4
+
+/** Checks that a pricing response exposes the expected model row array. */
+function hasValidPricingData(data: PricingResponse) {
+  return Array.isArray(data.data)
+}
+
+/** Maps items through async workers while preserving input order. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
 ) {
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length)
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const currentIndex = nextIndex
+        nextIndex += 1
+        results[currentIndex] = await mapper(items[currentIndex])
+      }
+    }),
+  )
+
+  return results
+}
+
+/** Loads one Sub2API token fallback catalog as a row source context. */
+async function loadSub2ApiTokenPricingContext(params: {
+  account: DisplaySiteData
+  token: ApiToken
+}): Promise<SettledContextResult> {
+  try {
+    const pricing = await loadAccountTokenFallbackPricingResponse(params)
+    if (!hasValidPricingData(pricing)) {
+      throw createInvalidFormatError()
+    }
+
+    return {
+      context: {
+        account: params.account,
+        pricing,
+        sourceIdentity: createAccountTokenModelListSourceIdentity({
+          accountId: params.account.id,
+          tokenId: params.token.id,
+          tokenName: params.token.name,
+        }),
+      },
+    }
+  } catch (error) {
+    return { error }
+  }
+}
+
+/** Loads Sub2API fallback catalogs for every account token in comparison mode. */
+async function fetchSub2ApiAllAccountsFallbackPricingContexts(
+  account: DisplaySiteData,
+): Promise<AccountPricingQueryResult> {
   const tokens = await fetchDisplayAccountTokens(account)
-  if (tokens.length !== 1) {
+  if (tokens.length === 0) {
     throw createUnsupportedModelPricingError()
   }
 
-  const data = await loadAccountTokenFallbackPricingResponse({
-    account,
-    token: tokens[0],
-  })
+  const settledResults = await mapWithConcurrency(
+    tokens,
+    SUB2API_ALL_ACCOUNTS_TOKEN_CONCURRENCY,
+    (token) => loadSub2ApiTokenPricingContext({ account, token }),
+  )
+  const contexts = settledResults.flatMap((result) =>
+    result.context ? [result.context] : [],
+  )
+  const errors = settledResults.flatMap((result) =>
+    result.error ? [result.error] : [],
+  )
 
-  if (!Array.isArray(data.data)) {
-    throw createInvalidFormatError()
+  if (contexts.length === 0) {
+    const invalidFormatErrors = errors.filter((error) => {
+      const typedError = error as { code?: string } | null | undefined
+      return typedError?.code === MODEL_LIST_DATA_ERROR_CODES.INVALID_FORMAT
+    })
+    if (
+      invalidFormatErrors.length > 0 &&
+      invalidFormatErrors.length === errors.length
+    ) {
+      throw invalidFormatErrors[0]
+    }
+
+    const nonInvalidFormatError = errors.find((error) => {
+      const typedError = error as { code?: string } | null | undefined
+      return typedError?.code !== MODEL_LIST_DATA_ERROR_CODES.INVALID_FORMAT
+    })
+    throw nonInvalidFormatError ?? createUnsupportedModelPricingError()
   }
 
-  return data
+  return {
+    contexts,
+    ...(errors.length > 0 ? { partialFailureCount: errors.length } : {}),
+    ...(errors.length > 0 ? { partialFailureErrors: errors } : {}),
+  }
 }
 
 /** Builds the profile catalog query key from stable profile revision data. */
@@ -929,13 +1073,23 @@ function useSingleAccountModelData(params: {
             {
               account: currentAccount,
               pricing: pricingData,
-              sourceIdentity: createAccountModelListSourceIdentity(
-                currentAccount.id,
-              ),
+              sourceIdentity:
+                isFallbackCatalogActive && selectedFallbackToken
+                  ? createAccountTokenModelListSourceIdentity({
+                      accountId: currentAccount.id,
+                      tokenId: selectedFallbackToken.id,
+                      tokenName: selectedFallbackToken.name,
+                    })
+                  : createAccountModelListSourceIdentity(currentAccount.id),
             },
           ]
         : [],
-    [currentAccount, pricingData],
+    [
+      currentAccount,
+      isFallbackCatalogActive,
+      pricingData,
+      selectedFallbackToken,
+    ],
   )
 
   const accountFallback = useMemo<AccountFallbackControls | null>(() => {
@@ -1004,7 +1158,7 @@ function useAllAccountsModelData(
 
   const queries = useQueries({
     queries: safeDisplayData.map((account) => ({
-      queryKey: createModelPricingQueryKey(account),
+      queryKey: createAllAccountsModelPricingQueryKey(account),
       /**
        * Only load pricing when the UI is explicitly in "all accounts" mode.
        * This avoids triggering expensive background fetches while the user is
@@ -1018,7 +1172,7 @@ function useAllAccountsModelData(
         const service = getApiService(account.siteType)
         if (!service.capabilities.modelPricing) {
           if (account.siteType === SITE_TYPES.SUB2API) {
-            return fetchSub2ApiAllAccountsFallbackPricing(account)
+            return fetchSub2ApiAllAccountsFallbackPricingContexts(account)
           }
 
           throw createUnsupportedModelPricingError()
@@ -1027,7 +1181,17 @@ function useAllAccountsModelData(
         const cacheKey = createModelPricingCacheKey(account)
         const cached = await modelPricingCache.get(cacheKey)
         if (cached && Array.isArray(cached.data)) {
-          return cached
+          return {
+            contexts: [
+              {
+                account,
+                pricing: cached,
+                sourceIdentity: createAccountModelListSourceIdentity(
+                  account.id,
+                ),
+              },
+            ],
+          }
         }
 
         const data = await service.fetchModelPricing({
@@ -1047,7 +1211,15 @@ function useAllAccountsModelData(
 
         await modelPricingCache.set(cacheKey, data)
 
-        return data
+        return {
+          contexts: [
+            {
+              account,
+              pricing: data,
+              sourceIdentity: createAccountModelListSourceIdentity(account.id),
+            },
+          ],
+        }
       },
     })),
   })
@@ -1076,10 +1248,18 @@ function useAllAccountsModelData(
     if (!queries.every((query) => query.isSuccess || query.isError)) return
 
     const successCount = queries.filter((query) => query.isSuccess).length
-    const failedQueries = queries.filter((query) => query.isError)
+    const failedQueries = queries.filter(
+      (query) => query.isError || (query.data?.partialFailureCount ?? 0) > 0,
+    )
     const failureCount = failedQueries.length
     const modelCount = queries.reduce(
-      (count, query) => count + getPricingModelCount(query.data),
+      (count, query) =>
+        count +
+        (query.data?.contexts ?? []).reduce(
+          (contextCount, context) =>
+            contextCount + getPricingModelCount(context.pricing),
+          0,
+        ),
       0,
     )
     const trackingKey = queries
@@ -1087,6 +1267,7 @@ function useAllAccountsModelData(
         [
           safeDisplayData[index]?.id,
           query.isSuccess ? "success" : "failure",
+          query.data?.partialFailureCount ?? 0,
           query.dataUpdatedAt,
           query.errorUpdatedAt,
         ].join(":"),
@@ -1099,7 +1280,10 @@ function useAllAccountsModelData(
     const failureDiagnostics =
       failureCount > 0
         ? getAggregateModelDataFailureDiagnostics(
-            failedQueries.map((query) => query.error),
+            failedQueries.flatMap((query) => [
+              ...(query.error ? [query.error] : []),
+              ...(query.data?.partialFailureErrors ?? []),
+            ]),
           )
         : null
 
@@ -1128,17 +1312,8 @@ function useAllAccountsModelData(
   }, [enabled, queries, safeDisplayData])
 
   const pricingContexts: AccountPricingContext[] = useMemo(() => {
-    return safeDisplayData
-      .map((account, index) => {
-        const query = queries[index]
-        if (!query || !query.data) return null
-        return {
-          account,
-          pricing: query.data,
-        }
-      })
-      .filter((item): item is AccountPricingContext => item !== null)
-  }, [queries, safeDisplayData])
+    return queries.flatMap((query) => query.data?.contexts ?? [])
+  }, [queries])
 
   const isLoading = queries.some((query) => query.isFetching)
 
@@ -1164,16 +1339,32 @@ function useAllAccountsModelData(
       safeDisplayData.map((account, index) => {
         const query = queries[index]
         const error = query?.error as { code?: string } | null | undefined
-        const hasData = !!query?.data
-        const hasError = !!query?.error
+        const partialFailureCount = query?.data?.partialFailureCount ?? 0
+        const partialFailureErrors = query?.data?.partialFailureErrors ?? []
+        const hasData = (query?.data?.contexts.length ?? 0) > 0
+        const hasPartialFailure = hasData && partialFailureCount > 0
+        const hasError = !!query?.error || partialFailureCount > 0
         const isLoading =
           !hasData && Boolean(query?.isPending || query?.isFetching)
 
         let errorType: ModelListAccountErrorType | undefined
+        let errorMessage: string | undefined
         if (error?.code === MODEL_LIST_DATA_ERROR_CODES.INVALID_FORMAT) {
           errorType = MODEL_LIST_ACCOUNT_ERROR_TYPES.INVALID_FORMAT
+          errorMessage = t("accountSummary.failureReasons.invalidFormat")
+        } else if (hasPartialFailure) {
+          errorType = MODEL_LIST_ACCOUNT_ERROR_TYPES.PARTIAL_LOAD_FAILED
+          errorMessage = t("accountSummary.partialLoadFailedReason", {
+            reason: getFirstModelDataDisplayErrorReason(
+              partialFailureErrors,
+              t,
+            ),
+          })
         } else if (hasError) {
           errorType = MODEL_LIST_ACCOUNT_ERROR_TYPES.LOAD_FAILED
+          errorMessage = query?.error
+            ? getModelDataDisplayErrorReason(query.error, t)
+            : undefined
         }
 
         return {
@@ -1182,10 +1373,22 @@ function useAllAccountsModelData(
           hasData,
           hasError,
           errorType,
+          errorMessage,
         }
       }),
-    [queries, safeDisplayData],
+    [queries, safeDisplayData, t],
   )
+
+  const loadErrorMessage = useMemo(() => {
+    const failedQuery = queries.find((query) => query.isError)
+    if (!failedQuery?.error) {
+      return null
+    }
+
+    return t("status.loadFailedWithReason", {
+      reason: getModelDataDisplayErrorReason(failedQuery.error, t),
+    })
+  }, [queries, t])
 
   return {
     pricingData: null,
@@ -1194,9 +1397,7 @@ function useAllAccountsModelData(
     dataFormatError,
     accountQueryStates,
     loadPricingData,
-    loadErrorMessage: queries.some((query) => query.isError)
-      ? t("status.loadFailed")
-      : null,
+    loadErrorMessage,
     accountFallback: null,
   }
 }

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -5,7 +5,9 @@ import { useTranslation } from "react-i18next"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  createAccountModelListSourceIdentity,
   MODEL_MANAGEMENT_SOURCE_KINDS,
+  type ModelListSourceIdentity,
   type ModelManagementSource,
 } from "~/features/ModelList/modelManagementSources"
 import {
@@ -67,6 +69,7 @@ interface UseModelDataProps {
 export interface AccountPricingContext {
   account: DisplaySiteData
   pricing: PricingResponse
+  sourceIdentity?: ModelListSourceIdentity
 }
 
 interface AccountQueryState {
@@ -119,6 +122,9 @@ const createUnsupportedModelPricingError = () =>
 
 const isUnsupportedModelPricingError = (error: unknown) =>
   error instanceof Error && error.message === MODEL_PRICING_UNSUPPORTED_ERROR
+
+const shouldRetryModelPricingQuery = (failureCount: number, error: Error) =>
+  !isUnsupportedModelPricingError(error) && failureCount < 1
 
 /** Counts only valid model rows so analytics never includes raw model ids. */
 function getPricingModelCount(pricing: PricingResponse | null | undefined) {
@@ -326,6 +332,27 @@ function createModelPricingCacheKey(
   ].join("|")
 }
 
+/** Loads the single-key Sub2API fallback catalog for all-accounts comparison. */
+async function fetchSub2ApiAllAccountsFallbackPricing(
+  account: DisplaySiteData,
+) {
+  const tokens = await fetchDisplayAccountTokens(account)
+  if (tokens.length !== 1) {
+    throw createUnsupportedModelPricingError()
+  }
+
+  const data = await loadAccountTokenFallbackPricingResponse({
+    account,
+    token: tokens[0],
+  })
+
+  if (!Array.isArray(data.data)) {
+    throw createInvalidFormatError()
+  }
+
+  return data
+}
+
 /** Builds the profile catalog query key from stable profile revision data. */
 function createProfileCatalogQueryKey(profile?: {
   id: string
@@ -512,7 +539,7 @@ function useSingleAccountModelData(params: {
     enabled: !!currentAccount,
     staleTime: MODEL_PRICING_CACHE_TTL_MS,
     refetchOnWindowFocus: false,
-    retry: 1,
+    retry: shouldRetryModelPricingQuery,
     queryFn: async () => {
       if (!currentAccount) {
         throw new Error("No account selected")
@@ -898,7 +925,15 @@ function useSingleAccountModelData(params: {
   const pricingContexts: AccountPricingContext[] = useMemo(
     () =>
       currentAccount && pricingData
-        ? [{ account: currentAccount, pricing: pricingData }]
+        ? [
+            {
+              account: currentAccount,
+              pricing: pricingData,
+              sourceIdentity: createAccountModelListSourceIdentity(
+                currentAccount.id,
+              ),
+            },
+          ]
         : [],
     [currentAccount, pricingData],
   )
@@ -978,10 +1013,14 @@ function useAllAccountsModelData(
       enabled: enabled && safeDisplayData.length > 0,
       staleTime: MODEL_PRICING_CACHE_TTL_MS,
       refetchOnWindowFocus: false,
-      retry: 1,
+      retry: shouldRetryModelPricingQuery,
       queryFn: async () => {
         const service = getApiService(account.siteType)
         if (!service.capabilities.modelPricing) {
+          if (account.siteType === SITE_TYPES.SUB2API) {
+            return fetchSub2ApiAllAccountsFallbackPricing(account)
+          }
+
           throw createUnsupportedModelPricingError()
         }
 

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -454,7 +454,9 @@ async function loadSub2ApiTokenPricingContext(params: {
 async function fetchSub2ApiAllAccountsFallbackPricingContexts(
   account: DisplaySiteData,
 ): Promise<AccountPricingQueryResult> {
-  const tokens = await fetchDisplayAccountTokens(account)
+  const tokens = (await fetchDisplayAccountTokens(account)).filter(
+    (token) => token.status === 1,
+  )
   if (tokens.length === 0) {
     throw createUnsupportedModelPricingError()
   }

--- a/src/features/ModelList/modelDataStates.ts
+++ b/src/features/ModelList/modelDataStates.ts
@@ -16,6 +16,7 @@ export const MODEL_LIST_DATA_ERROR_CODES = {
 export const MODEL_LIST_ACCOUNT_ERROR_TYPES = {
   INVALID_FORMAT: "invalid-format",
   LOAD_FAILED: "load-failed",
+  PARTIAL_LOAD_FAILED: "partial-load-failed",
 } as const
 
 export type ModelListAccountErrorType =

--- a/src/features/ModelList/modelManagementSources.ts
+++ b/src/features/ModelList/modelManagementSources.ts
@@ -61,6 +61,49 @@ export type ModelManagementItemSource =
   | ModelManagementAccountSource
   | ModelManagementProfileSource
 
+export const MODEL_LIST_SOURCE_IDENTITY_KINDS = {
+  ACCOUNT: "account",
+  ACCOUNT_TOKEN: "account-token",
+} as const
+
+export type ModelListSourceIdentity =
+  | {
+      kind: typeof MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT
+      id: string
+    }
+  | {
+      kind: typeof MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN
+      id: string
+      tokenId: number
+      tokenName?: string
+    }
+
+/** Creates the default account-scoped source identity for model-list rows. */
+export function createAccountModelListSourceIdentity(
+  accountId: string,
+): ModelListSourceIdentity {
+  return {
+    kind: MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT,
+    id: accountId,
+  }
+}
+
+/** Creates a token-scoped account source identity for model-list rows. */
+export function createAccountTokenModelListSourceIdentity(params: {
+  accountId: string
+  tokenId: number
+  tokenName?: string
+}): ModelListSourceIdentity {
+  const tokenName = params.tokenName?.trim()
+
+  return {
+    kind: MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN,
+    id: `${params.accountId}:token:${params.tokenId}`,
+    tokenId: params.tokenId,
+    ...(tokenName ? { tokenName } : {}),
+  }
+}
+
 export const EMPTY_MODEL_MANAGEMENT_CAPABILITIES: ModelManagementSourceCapabilities =
   {
     supportsPricing: false,

--- a/src/features/ModelList/sourceLabels.ts
+++ b/src/features/ModelList/sourceLabels.ts
@@ -1,5 +1,11 @@
-import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
-import type { ModelManagementItemSource } from "~/features/ModelList/modelManagementSources"
+import {
+  MODEL_LIST_SOURCE_IDENTITY_KINDS,
+  MODEL_MANAGEMENT_SOURCE_KINDS,
+} from "~/features/ModelList/modelManagementSources"
+import type {
+  ModelListSourceIdentity,
+  ModelManagementItemSource,
+} from "~/features/ModelList/modelManagementSources"
 import { tryParseUrl } from "~/utils/core/urlParsing"
 
 type ModelListSourceLabel = {
@@ -11,6 +17,15 @@ type FormatModelListSourceLabelOptions = {
   formatProfileLabel: (params: { name: string; host?: string }) => string
 }
 
+/** Returns the display-safe token label for token-scoped account rows. */
+function formatAccountTokenName(sourceIdentity: ModelListSourceIdentity) {
+  if (sourceIdentity.kind !== MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN) {
+    return null
+  }
+
+  return sourceIdentity.tokenName?.trim() || `#${sourceIdentity.tokenId}`
+}
+
 /**
  * Formats the model-row source so multi-account views expose both the account
  * name and the site host without repeating URL parsing in every row surface.
@@ -18,6 +33,7 @@ type FormatModelListSourceLabelOptions = {
 export function formatModelListSourceLabel(
   source: ModelManagementItemSource,
   options: FormatModelListSourceLabelOptions,
+  sourceIdentity?: ModelListSourceIdentity,
 ): ModelListSourceLabel {
   if (source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE) {
     const baseUrl = source.profile.baseUrl.trim()
@@ -34,9 +50,15 @@ export function formatModelListSourceLabel(
 
   const baseUrl = source.account.baseUrl?.trim() ?? ""
   const host = tryParseUrl(baseUrl)?.host || baseUrl || undefined
+  const tokenName = sourceIdentity
+    ? formatAccountTokenName(sourceIdentity)
+    : null
+  const accountLabel = tokenName
+    ? `${source.account.name} / ${tokenName}`
+    : source.account.name
 
   return {
-    label: host ? `${source.account.name} · ${host}` : source.account.name,
+    label: host ? `${accountLabel} · ${host}` : accountLabel,
     title: baseUrl || undefined,
   }
 }

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -12,11 +12,17 @@
   "accountGroupFilterTriggerCount_one": "{{count}} account filtered",
   "accountGroupFilterTriggerCount_other": "{{count}} accounts filtered",
   "accountSummary": {
+    "failureReasons": {
+      "invalidFormat": "The model list returned an unsupported format.",
+      "unknown": "Unknown error"
+    },
     "incompatible": "format incompatible",
     "loadFailed": "load failed",
     "loading": "loading",
     "models_one": "{{count}} model",
     "models_other": "{{count}} models",
+    "partialLoadFailed": "partial",
+    "partialLoadFailedReason": "Some keys failed to load. First failure: {{reason}}",
     "title": "Accounts overview"
   },
   "actions": {
@@ -226,6 +232,7 @@
     "incompatibleDesc": "The model data interface of the current site does not conform to the standard specification, possibly due to secondary development of the site. The extension cannot parse the model pricing information of this site for the time being",
     "incompatibleFormat": "Data format incompatible",
     "loadFailed": "Failed to load model data, please try again later",
+    "loadFailedWithReason": "Failed to load model data: {{reason}}",
     "loading": "Loading model data...",
     "profileLoadFailed": "Failed to load models for this API credential: {{errorMessage}}",
     "profileLoadFailedTitle": "Failed to load models for this API credential",

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -11,10 +11,16 @@
   "accountGroupFilterTrigger": "アカウントグループを絞り込む",
   "accountGroupFilterTriggerCount_other": "{{count}} 件のアカウントを絞り込み中",
   "accountSummary": {
+    "failureReasons": {
+      "invalidFormat": "モデル一覧が対応していない形式で返されました。",
+      "unknown": "不明なエラー"
+    },
     "incompatible": "形式非互換",
     "loadFailed": "読み込み失敗",
     "loading": "読み込み中",
     "models_other": "{{count}} モデル",
+    "partialLoadFailed": "一部読み込み",
+    "partialLoadFailedReason": "一部のキーの読み込みに失敗しました。最初の理由: {{reason}}",
     "title": "アカウント概要"
   },
   "actions": {
@@ -219,6 +225,7 @@
     "incompatibleDesc": "現在のサイトのモデルデータインターフェースは標準仕様に準拠していません。サイト側の二次開発が原因の可能性があり、このサイトのモデル料金情報は現時点で解析できません。",
     "incompatibleFormat": "データ形式に互換性がありません",
     "loadFailed": "モデルデータの読み込みに失敗しました。しばらくしてからもう一度お試しください",
+    "loadFailedWithReason": "モデルデータの読み込みに失敗しました: {{reason}}",
     "loading": "モデルデータを読み込み中...",
     "profileLoadFailed": "この API 認証情報のモデル読み込みに失敗しました: {{errorMessage}}",
     "profileLoadFailedTitle": "この API 認証情報のモデル読み込みに失敗しました",

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -11,10 +11,16 @@
   "accountGroupFilterTrigger": "Lọc nhóm tài khoản",
   "accountGroupFilterTriggerCount_other": "{{count}} tài khoản",
   "accountSummary": {
+    "failureReasons": {
+      "invalidFormat": "Danh sách mô hình trả về định dạng không được hỗ trợ.",
+      "unknown": "Lỗi không xác định"
+    },
     "incompatible": "Định dạng không tương thích",
     "loadFailed": "Tải thất bại",
     "loading": "Đang tải",
     "models_other": "{{count}} mô hình",
+    "partialLoadFailed": "Tải một phần",
+    "partialLoadFailedReason": "Một số khóa tải thất bại. Lỗi đầu tiên: {{reason}}",
     "title": "Tổng quan tài khoản"
   },
   "actions": {
@@ -219,6 +225,7 @@
     "incompatibleDesc": "Định dạng trả về từ API dữ liệu mô hình của trang web hiện tại không tuân thủ tiêu chuẩn, có thể đây là một trang web đã được phát triển thứ cấp. Tiện ích mở rộng tạm thời không thể phân tích thông tin định giá mô hình của trang web này",
     "incompatibleFormat": "Định dạng dữ liệu không tương thích",
     "loadFailed": "Tải dữ liệu mô hình thất bại, vui lòng thử lại sau",
+    "loadFailedWithReason": "Tải dữ liệu mô hình thất bại: {{reason}}",
     "loading": "Đang tải dữ liệu mô hình...",
     "profileLoadFailed": "Tải mô hình của thông tin xác thực API này thất bại: {{errorMessage}}",
     "profileLoadFailedTitle": "Tải mô hình của thông tin xác thực API này thất bại",

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -11,10 +11,16 @@
   "accountGroupFilterTrigger": "筛选账号分组",
   "accountGroupFilterTriggerCount": "{{count}} 个账号",
   "accountSummary": {
+    "failureReasons": {
+      "invalidFormat": "模型列表返回格式不受支持。",
+      "unknown": "未知错误"
+    },
     "incompatible": "格式不兼容",
     "loadFailed": "加载失败",
     "loading": "加载中",
     "models": "{{count}} 个模型",
+    "partialLoadFailed": "部分加载",
+    "partialLoadFailedReason": "部分密钥加载失败。首个原因：{{reason}}",
     "title": "账号概览"
   },
   "actions": {
@@ -219,6 +225,7 @@
     "incompatibleDesc": "当前站点的模型数据接口返回格式不符合标准规范，可能是经过二次开发的站点。插件暂时无法解析该站点的模型定价信息",
     "incompatibleFormat": "数据格式不兼容",
     "loadFailed": "加载模型数据失败，请稍后重试",
+    "loadFailedWithReason": "加载模型数据失败：{{reason}}",
     "loading": "正在加载模型数据...",
     "profileLoadFailed": "加载该 API 凭据的模型失败：{{errorMessage}}",
     "profileLoadFailedTitle": "加载该 API 凭据的模型失败",

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -11,10 +11,16 @@
   "accountGroupFilterTrigger": "篩選帳號分組",
   "accountGroupFilterTriggerCount_other": "已篩選 {{count}} 個帳號",
   "accountSummary": {
+    "failureReasons": {
+      "invalidFormat": "模型列表返回格式不受支援。",
+      "unknown": "未知錯誤"
+    },
     "incompatible": "格式不相容",
     "loadFailed": "載入失敗",
     "loading": "載入中",
     "models_other": "{{count}} 個模型",
+    "partialLoadFailed": "部分載入",
+    "partialLoadFailedReason": "部分金鑰載入失敗。第一個原因：{{reason}}",
     "title": "帳號概覽"
   },
   "actions": {
@@ -219,6 +225,7 @@
     "incompatibleDesc": "當前站點的模型資料介面返回格式不符合標準規範，可能是經過二次開發的站點。外掛暫時無法解析該站點的模型定價資訊",
     "incompatibleFormat": "資料格式不相容",
     "loadFailed": "載入模型資料失敗，請稍後重試",
+    "loadFailedWithReason": "載入模型資料失敗：{{reason}}",
     "loading": "正在載入模型資料...",
     "profileLoadFailed": "載入該 API 憑據的模型失敗：{{errorMessage}}",
     "profileLoadFailedTitle": "載入該 API 憑據的模型失敗",

--- a/tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  createAccountSource,
+  createAccountTokenModelListSourceIdentity,
+  createProfileSource,
+} from "~/features/ModelList/modelManagementSources"
+import { formatModelListSourceLabel } from "~/features/ModelList/sourceLabels"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
+import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
+
+const createDisplayAccount = (
+  overrides: Partial<DisplaySiteData>,
+): DisplaySiteData => ({
+  id: "account",
+  name: "Account",
+  username: "user",
+  balance: { USD: 0, CNY: 0 },
+  todayConsumption: { USD: 0, CNY: 0 },
+  todayIncome: { USD: 0, CNY: 0 },
+  todayTokens: { upload: 0, download: 0 },
+  health: { status: SiteHealthStatus.Healthy },
+  siteType: SITE_TYPES.UNKNOWN,
+  baseUrl: "https://example.com",
+  token: "token",
+  userId: "1",
+  authType: AuthTypeEnum.AccessToken,
+  checkIn: { enableDetection: false },
+  ...overrides,
+})
+
+const labelOptions = {
+  formatProfileLabel: ({ name, host }: { name: string; host?: string }) =>
+    host ? `${name} (${host})` : name,
+}
+
+describe("formatModelListSourceLabel", () => {
+  it("includes token names for account-token model-list sources", () => {
+    const account = createDisplayAccount({
+      id: "sub2api-account",
+      name: "Sub2API Account",
+      baseUrl: "https://sub2api.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+
+    const label = formatModelListSourceLabel(
+      createAccountSource(account),
+      labelOptions,
+      createAccountTokenModelListSourceIdentity({
+        accountId: account.id,
+        tokenId: 41,
+        tokenName: "VIP runtime key",
+      }),
+    )
+
+    expect(label).toEqual({
+      label: "Sub2API Account / VIP runtime key · sub2api.example.invalid",
+      title: "https://sub2api.example.invalid",
+    })
+    expect(label.label).not.toContain("sk-")
+  })
+
+  it("keeps profile labels unchanged", () => {
+    const source = createProfileSource({
+      id: "profile",
+      name: "Reusable Key",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://profile.example.invalid/v1",
+      apiKey: "sk-secret",
+      tagIds: [],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 1,
+    })
+
+    expect(formatModelListSourceLabel(source, labelOptions)).toEqual({
+      label: "Reusable Key (profile.example.invalid)",
+      title: "https://profile.example.invalid/v1",
+    })
+  })
+})

--- a/tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/sourceLabels.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  createAccountModelListSourceIdentity,
   createAccountSource,
   createAccountTokenModelListSourceIdentity,
   createProfileSource,
@@ -59,6 +60,50 @@ describe("formatModelListSourceLabel", () => {
       title: "https://sub2api.example.invalid",
     })
     expect(label.label).not.toContain("sk-")
+  })
+
+  it("falls back to token ids when account-token source names are blank", () => {
+    const account = createDisplayAccount({
+      id: "sub2api-account",
+      name: "Sub2API Account",
+      baseUrl: "https://sub2api.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+
+    expect(
+      formatModelListSourceLabel(
+        createAccountSource(account),
+        labelOptions,
+        createAccountTokenModelListSourceIdentity({
+          accountId: account.id,
+          tokenId: 42,
+          tokenName: "  ",
+        }),
+      ),
+    ).toEqual({
+      label: "Sub2API Account / #42 · sub2api.example.invalid",
+      title: "https://sub2api.example.invalid",
+    })
+  })
+
+  it("ignores non-token source identities for account labels", () => {
+    const account = createDisplayAccount({
+      id: "sub2api-account",
+      name: "Sub2API Account",
+      baseUrl: "https://sub2api.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+
+    expect(
+      formatModelListSourceLabel(
+        createAccountSource(account),
+        labelOptions,
+        createAccountModelListSourceIdentity(account.id),
+      ),
+    ).toEqual({
+      label: "Sub2API Account · sub2api.example.invalid",
+      title: "https://sub2api.example.invalid",
+    })
   })
 
   it("keeps profile labels unchanged", () => {

--- a/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
@@ -6,8 +6,10 @@ import { MODEL_LIST_BILLING_MODES } from "~/features/ModelList/billingModes"
 import { useFilteredModels } from "~/features/ModelList/hooks/useFilteredModels"
 import {
   createAccountSource,
+  createAccountTokenModelListSourceIdentity,
   createAllAccountsSource,
   createProfileSource,
+  MODEL_LIST_SOURCE_IDENTITY_KINDS,
 } from "~/features/ModelList/modelManagementSources"
 import { MODEL_LIST_SORT_MODES } from "~/features/ModelList/sortModes"
 import {
@@ -1361,6 +1363,211 @@ describe("useFilteredModels", () => {
     })
   })
 
+  it("compares Sub2API estimated token prices against ratio-based accounts in all-accounts mode", async () => {
+    const sub2apiAccount = createDisplayAccount({
+      id: "account-sub2api-estimated",
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2api.example.invalid",
+    })
+    const ratioAccount = createDisplayAccount({
+      id: "account-ratio",
+      name: "Ratio Account",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://ratio.example.invalid",
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingContexts: [
+        {
+          account: sub2apiAccount,
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "shared-model",
+                quota_type: 0,
+                model_ratio: 0,
+                completion_ratio: 1,
+                enable_groups: ["default"],
+                token_price_usd_per_million: {
+                  input: 0.5,
+                  output: 2,
+                },
+                price_metadata: {
+                  source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+                  precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+                },
+              },
+            ],
+            {
+              group_ratio: { default: 1 },
+              model_list_source: {
+                kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+                provider: SITE_TYPES.SUB2API,
+                supportsRuntimeModelList: true,
+                supportsPricing: true,
+              },
+            },
+          ),
+        },
+        {
+          account: ratioAccount,
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "shared-model",
+                quota_type: 0,
+                model_ratio: 1,
+                completion_ratio: 3,
+                enable_groups: ["default"],
+              },
+            ],
+            {
+              group_ratio: { default: 1 },
+            },
+          ),
+        },
+      ],
+      selectedSource: createAllAccountsSource(),
+      sortMode: MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST,
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => [
+          item.source.kind === "account" ? item.source.account.id : "profile",
+          item.calculatedPrice.inputUSD,
+          item.calculatedPrice.outputUSD,
+          item.isLowestPrice,
+        ]),
+      ).toEqual([
+        ["account-sub2api-estimated", 0.5, 2, true],
+        ["account-ratio", 2, 6, false],
+      ])
+    })
+  })
+
+  it("keeps same-account token sources distinct when they expose the same model", async () => {
+    const account = createDisplayAccount({
+      id: "account-sub2api-multi-key",
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2api.example.invalid",
+    })
+    const defaultTokenSourceIdentity =
+      createAccountTokenModelListSourceIdentity({
+        accountId: account.id,
+        tokenId: 11,
+        tokenName: "Default key",
+      })
+    const vipTokenSourceIdentity = createAccountTokenModelListSourceIdentity({
+      accountId: account.id,
+      tokenId: 12,
+      tokenName: "VIP key",
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingContexts: [
+        {
+          account,
+          sourceIdentity: defaultTokenSourceIdentity,
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "shared-model",
+                quota_type: 0,
+                model_ratio: 0,
+                completion_ratio: 1,
+                enable_groups: ["default"],
+                token_price_usd_per_million: {
+                  input: 0.5,
+                  output: 1,
+                },
+                price_metadata: {
+                  source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+                  precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+                },
+              },
+            ],
+            {
+              group_ratio: { default: 1 },
+              model_list_source: {
+                kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+                provider: SITE_TYPES.SUB2API,
+                supportsRuntimeModelList: true,
+                supportsPricing: true,
+              },
+            },
+          ),
+        },
+        {
+          account,
+          sourceIdentity: vipTokenSourceIdentity,
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "shared-model",
+                quota_type: 0,
+                model_ratio: 0,
+                completion_ratio: 1,
+                enable_groups: ["vip"],
+                token_price_usd_per_million: {
+                  input: 0.25,
+                  output: 0.75,
+                },
+                price_metadata: {
+                  source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+                  precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+                },
+              },
+            ],
+            {
+              group_ratio: { vip: 0.5 },
+              model_list_source: {
+                kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+                provider: SITE_TYPES.SUB2API,
+                supportsRuntimeModelList: true,
+                supportsPricing: true,
+              },
+            },
+          ),
+        },
+      ],
+      selectedSource: createAllAccountsSource(),
+      sortMode: MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST,
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => [
+          item.source.kind === "account" ? item.source.account.id : "profile",
+          item.sourceIdentity?.id,
+          item.sourceIdentity?.kind,
+          item.effectiveGroup,
+          item.calculatedPrice.inputUSD,
+          item.isLowestPrice,
+        ]),
+      ).toEqual([
+        [
+          "account-sub2api-multi-key",
+          "account-sub2api-multi-key:token:12",
+          MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN,
+          "vip",
+          0.25,
+          true,
+        ],
+        [
+          "account-sub2api-multi-key",
+          "account-sub2api-multi-key:token:11",
+          MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN,
+          "default",
+          0.5,
+          false,
+        ],
+      ])
+    })
+  })
+
   it("treats same-named groups on different accounts as unrelated filters", async () => {
     const accountA = createDisplayAccount({
       id: "account-a",
@@ -1431,6 +1638,89 @@ describe("useFilteredModels", () => {
     expect(result.current.availableAccountGroupOptionsByAccountId).toEqual({
       "account-a": [{ name: "vip", ratio: 0.5 }],
       "account-b": [{ name: "vip", ratio: 0.8 }],
+    })
+  })
+
+  it("keeps token-scoped group candidates separate under the same account", async () => {
+    const account = createDisplayAccount({
+      id: "account-sub2api-token-groups",
+      name: "Sub2API",
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2api.example.invalid",
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingContexts: [
+        {
+          account,
+          sourceIdentity: createAccountTokenModelListSourceIdentity({
+            accountId: account.id,
+            tokenId: 31,
+            tokenName: "Default key",
+          }),
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "default-model",
+                model_ratio: 1,
+                completion_ratio: 1,
+                enable_groups: ["default"],
+              },
+            ],
+            {
+              group_ratio: { default: 1 },
+            },
+          ),
+        },
+        {
+          account,
+          sourceIdentity: createAccountTokenModelListSourceIdentity({
+            accountId: account.id,
+            tokenId: 32,
+            tokenName: "VIP key",
+          }),
+          pricing: createPricingResponse(
+            [
+              {
+                model_name: "vip-model",
+                model_ratio: 1,
+                completion_ratio: 1,
+                enable_groups: ["default", "vip"],
+              },
+            ],
+            {
+              group_ratio: { vip: 0.5 },
+            },
+          ),
+        },
+      ],
+      selectedSource: createAllAccountsSource(),
+      sortMode: MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST,
+      allAccountsExcludedGroupsByAccountId: {
+        "account-sub2api-token-groups": ["vip"],
+      },
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => [
+          item.model.model_name,
+          item.sourceIdentity?.id,
+          item.effectiveGroup,
+        ]),
+      ).toEqual([
+        ["default-model", "account-sub2api-token-groups:token:31", "default"],
+      ])
+    })
+
+    expect(result.current.availableAccountGroupsByAccountId).toEqual({
+      "account-sub2api-token-groups": ["default", "vip"],
+    })
+    expect(result.current.availableAccountGroupOptionsByAccountId).toEqual({
+      "account-sub2api-token-groups": [
+        { name: "default", ratio: 1 },
+        { name: "vip", ratio: 0.5 },
+      ],
     })
   })
 

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -10,6 +10,7 @@ import {
   createAccountSource,
   createAllAccountsSource,
   createProfileSource,
+  type ModelManagementSource,
 } from "~/features/ModelList/modelManagementSources"
 import { InvalidTokenPayloadError } from "~/services/accounts/utils/apiServiceRequest"
 import {
@@ -443,7 +444,7 @@ describe("useModelData all-accounts loading", () => {
     await waitFor(
       () => {
         expect(result.current.loadErrorMessage).toBe(
-          "modelList:status.loadFailed",
+          "modelList:status.loadFailedWithReason",
         )
       },
       { timeout: 3000 },
@@ -454,7 +455,7 @@ describe("useModelData all-accounts loading", () => {
     expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(accounts[1])
   })
 
-  it("loads Sub2API fallback pricing in all-accounts mode so it can be compared", async () => {
+  it("loads every Sub2API fallback key in all-accounts mode so each key can be compared", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
@@ -474,20 +475,35 @@ describe("useModelData all-accounts loading", () => {
       siteType: SITE_TYPES.SUB2API,
       userId: "sub2api-all-user",
     })
-    const fallbackToken = {
-      id: 21,
-      user_id: 21,
-      key: "sk-sub2api-all-masked",
-      status: 1,
-      name: "Only runtime key",
-      created_time: 0,
-      accessed_time: 0,
-      expired_time: -1,
-      remain_quota: 0,
-      unlimited_quota: true,
-      used_quota: 0,
-    }
-    const fallbackPricing = {
+    const fallbackTokens = [
+      {
+        id: 21,
+        user_id: 21,
+        key: "sk-sub2api-all-masked-a",
+        status: 1,
+        name: "Default runtime key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+      {
+        id: 22,
+        user_id: 21,
+        key: "sk-sub2api-all-masked-b",
+        status: 1,
+        name: "VIP runtime key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ]
+    const defaultPricing = {
       data: [
         {
           model_name: "example-runtime-priced-model",
@@ -513,11 +529,23 @@ describe("useModelData all-accounts loading", () => {
         supportsPricing: true,
       },
     }
+    const vipPricing = {
+      ...defaultPricing,
+      data: [
+        {
+          ...defaultPricing.data[0],
+          model_name: "example-runtime-vip-model",
+          enable_groups: ["vip"],
+        },
+      ],
+      group_ratio: { vip: 0.5 },
+      usable_group: { vip: "vip" },
+    }
 
-    mockFetchDisplayAccountTokens.mockResolvedValueOnce([fallbackToken])
-    mockLoadAccountTokenFallbackPricingResponse.mockResolvedValueOnce(
-      fallbackPricing,
-    )
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce(fallbackTokens)
+    mockLoadAccountTokenFallbackPricingResponse
+      .mockResolvedValueOnce(defaultPricing)
+      .mockResolvedValueOnce(vipPricing)
 
     const { result } = renderHook(
       () =>
@@ -532,10 +560,7 @@ describe("useModelData all-accounts loading", () => {
       () => {
         expect(
           mockLoadAccountTokenFallbackPricingResponse,
-        ).toHaveBeenCalledWith({
-          account,
-          token: fallbackToken,
-        })
+        ).toHaveBeenCalledTimes(2)
       },
       { timeout: 3000 },
     )
@@ -545,9 +570,413 @@ describe("useModelData all-accounts loading", () => {
     expect(result.current.pricingContexts).toEqual([
       {
         account,
-        pricing: fallbackPricing,
+        pricing: defaultPricing,
+        sourceIdentity: {
+          kind: "account-token",
+          id: "sub2api-all-accounts:token:21",
+          tokenId: 21,
+          tokenName: "Default runtime key",
+        },
+      },
+      {
+        account,
+        pricing: vipPricing,
+        sourceIdentity: {
+          kind: "account-token",
+          id: "sub2api-all-accounts:token:22",
+          tokenId: 22,
+          tokenName: "VIP runtime key",
+        },
       },
     ])
+  })
+
+  it("keeps successful Sub2API token contexts as partial instead of load failed when another token fails", async () => {
+    mockTrackProductAnalyticsActionCompleted.mockReset()
+    const fetchModelPricing = vi.fn()
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-partial",
+      name: "Sub2API Partial",
+      baseUrl: "https://sub2api-partial.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+    const tokens = [
+      {
+        id: 31,
+        user_id: 31,
+        key: "sk-success",
+        status: 1,
+        name: "Success key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+      {
+        id: 32,
+        user_id: 31,
+        key: "sk-failure",
+        status: 1,
+        name: "Failure key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ]
+    const pricing = {
+      data: [
+        {
+          model_name: "surviving-model",
+          quota_type: 0,
+          model_ratio: 1,
+          model_price: 0,
+          completion_ratio: 1,
+          enable_groups: ["default"],
+          supported_endpoint_types: [],
+        },
+      ],
+      group_ratio: { default: 1 },
+      success: true,
+      usable_group: { default: "default" },
+    }
+
+    mockFetchDisplayAccountTokens.mockResolvedValue(tokens)
+    mockLoadAccountTokenFallbackPricingResponse
+      .mockResolvedValueOnce(pricing)
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.pricingContexts).toHaveLength(1)
+      },
+      { timeout: 3000 },
+    )
+
+    expect(result.current.loadErrorMessage).toBeNull()
+    expect(result.current.accountQueryStates).toEqual([
+      expect.objectContaining({
+        account,
+        isLoading: false,
+        hasData: true,
+        hasError: true,
+        errorType: "partial-load-failed",
+        errorMessage: "modelList:accountSummary.partialLoadFailedReason",
+      }),
+    ])
+    expectLastModelDataAnalyticsCompletion({
+      result: PRODUCT_ANALYTICS_RESULTS.Failure,
+      sourceKind: PRODUCT_ANALYTICS_SOURCE_KINDS.ModelAllAccounts,
+      modelCount: 1,
+      successCount: 1,
+      failureCount: 1,
+      errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Network,
+      failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
+      failureReason: PRODUCT_ANALYTICS_FAILURE_REASONS.NetworkUnreachable,
+    })
+  })
+
+  it("marks a Sub2API account failed when every fallback key fails", async () => {
+    const fetchModelPricing = vi.fn()
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-all-failed",
+      name: "Sub2API Failed",
+      baseUrl: "https://sub2api-failed.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+    const tokens = [
+      {
+        id: 41,
+        user_id: 41,
+        key: "sk-failed",
+        status: 1,
+        name: "Failed key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ]
+
+    mockFetchDisplayAccountTokens.mockResolvedValue(tokens)
+    mockLoadAccountTokenFallbackPricingResponse.mockRejectedValue(
+      new Error("token failed"),
+    )
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.loadErrorMessage).toBe(
+          "modelList:status.loadFailedWithReason",
+        )
+      },
+      { timeout: 3000 },
+    )
+
+    expect(result.current.pricingContexts).toEqual([])
+    expect(result.current.accountQueryStates).toEqual([
+      expect.objectContaining({
+        account,
+        isLoading: false,
+        hasData: false,
+        hasError: true,
+        errorType: "load-failed",
+        errorMessage: "token failed",
+      }),
+    ])
+  })
+
+  it("marks mixed Sub2API all-token failures as load failed instead of invalid format", async () => {
+    const fetchModelPricing = vi.fn()
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-mixed-failed",
+      name: "Sub2API Mixed Failed",
+      baseUrl: "https://sub2api-mixed-failed.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+    const tokens = [
+      {
+        id: 51,
+        user_id: 51,
+        key: "sk-invalid",
+        status: 1,
+        name: "Invalid key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+      {
+        id: 52,
+        user_id: 51,
+        key: "sk-generic",
+        status: 1,
+        name: "Generic failure key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ]
+
+    mockFetchDisplayAccountTokens.mockResolvedValue(tokens)
+    mockLoadAccountTokenFallbackPricingResponse
+      .mockResolvedValueOnce({
+        data: null,
+        group_ratio: {},
+        success: true,
+        usable_group: {},
+      })
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce({
+        data: null,
+        group_ratio: {},
+        success: true,
+        usable_group: {},
+      })
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.loadErrorMessage).toBe(
+          "modelList:status.loadFailedWithReason",
+        )
+      },
+      { timeout: 3000 },
+    )
+
+    expect(result.current.dataFormatError).toBe(false)
+    expect(result.current.accountQueryStates).toEqual([
+      expect.objectContaining({
+        account,
+        isLoading: false,
+        hasData: false,
+        hasError: true,
+        errorType: "load-failed",
+        errorMessage: "Failed to fetch",
+      }),
+    ])
+    expectLastModelDataAnalyticsCompletion({
+      result: PRODUCT_ANALYTICS_RESULTS.Failure,
+      sourceKind: PRODUCT_ANALYTICS_SOURCE_KINDS.ModelAllAccounts,
+      modelCount: 0,
+      successCount: 0,
+      failureCount: 1,
+      errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Network,
+      failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
+      failureReason: PRODUCT_ANALYTICS_FAILURE_REASONS.NetworkUnreachable,
+    })
+  })
+
+  it("refetches all-accounts pricing after single-account query cache was populated", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    const fetchModelPricing = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [
+          {
+            model_name: "single-account-cached-model",
+            quota_type: 0,
+            model_ratio: 1,
+            model_price: 1,
+            completion_ratio: 1,
+            enable_groups: ["default"],
+            supported_endpoint_types: [],
+          },
+        ],
+        group_ratio: { default: 1 },
+        success: true,
+        usable_group: { default: true },
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            model_name: "all-accounts-refetched-model",
+            quota_type: 0,
+            model_ratio: 1,
+            model_price: 1,
+            completion_ratio: 1,
+            enable_groups: ["default"],
+            supported_endpoint_types: [],
+          },
+        ],
+        group_ratio: { default: 1 },
+        success: true,
+        usable_group: { default: true },
+      })
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing),
+    )
+
+    const account = createDisplayAccount({
+      id: "query-key-scope-account",
+      name: "Query Key Scope Account",
+      baseUrl: "https://query-key-scope.example.invalid",
+      userId: "query-key-user",
+    })
+    const cacheKey = [
+      account.id,
+      account.baseUrl,
+      account.userId,
+      account.siteType,
+      account.authType,
+    ].join("|")
+    type HookProps = {
+      selectedSource: ModelManagementSource
+      accounts: DisplaySiteData[]
+    }
+    const initialProps: HookProps = {
+      selectedSource: createAccountSource(account),
+      accounts: [account],
+    }
+
+    const { result, rerender } = renderHook(
+      ({ selectedSource, accounts }: HookProps) =>
+        useModelData({
+          selectedSource,
+          accounts,
+        }),
+      {
+        initialProps,
+        wrapper: createWrapper(),
+      },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.pricingData?.data[0]?.model_name).toBe(
+          "single-account-cached-model",
+        )
+      },
+      { timeout: 3000 },
+    )
+    await modelPricingCache.invalidate(cacheKey)
+
+    rerender({
+      selectedSource: createAllAccountsSource(),
+      accounts: [account],
+    })
+
+    await waitFor(
+      () => {
+        expect(result.current.pricingContexts).toEqual([
+          {
+            account,
+            pricing: expect.objectContaining({
+              data: [
+                expect.objectContaining({
+                  model_name: "all-accounts-refetched-model",
+                }),
+              ],
+            }),
+            sourceIdentity: {
+              kind: "account",
+              id: "query-key-scope-account",
+            },
+          },
+        ])
+      },
+      { timeout: 3000 },
+    )
+
+    expect(fetchModelPricing).toHaveBeenCalledTimes(2)
+    expect(result.current.loadErrorMessage).toBeNull()
   })
 
   it("tracks single-account pricing load success with model-count insight once", async () => {
@@ -1509,6 +1938,24 @@ describe("useModelData all-accounts loading", () => {
         ],
       }),
     )
+    expect(result.current.pricingContexts).toEqual([
+      {
+        account,
+        pricing: expect.objectContaining({
+          data: [
+            expect.objectContaining({
+              model_name: "example-runtime-model",
+            }),
+          ],
+        }),
+        sourceIdentity: {
+          kind: "account-token",
+          id: "sub2api-runtime-fallback-account:token:18",
+          tokenId: 18,
+          tokenName: "Runtime key",
+        },
+      },
+    ])
   })
 
   it("auto-loads Sub2API runtime models when a single fallback key is available", async () => {
@@ -2489,7 +2936,7 @@ describe("useModelData all-accounts loading", () => {
       () => {
         expect(result.current.dataFormatError).toBe(true)
         expect(result.current.loadErrorMessage).toBe(
-          "modelList:status.loadFailed",
+          "modelList:status.loadFailedWithReason",
         )
         expect(result.current.accountQueryStates).toEqual([
           expect.objectContaining({

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -403,7 +403,7 @@ describe("useModelData all-accounts loading", () => {
     expect(fetchModelPricing).not.toHaveBeenCalled()
   })
 
-  it("does not invoke all-account pricing when capability is disabled", async () => {
+  it("does not invoke all-account pricing when Sub2API has no fallback key", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
     const fetchModelPricing = vi
@@ -414,6 +414,7 @@ describe("useModelData all-accounts loading", () => {
         capabilities: { modelPricing: false },
       }),
     )
+    mockFetchDisplayAccountTokens.mockResolvedValue([])
 
     const accounts = [
       createDisplayAccount({
@@ -448,6 +449,105 @@ describe("useModelData all-accounts loading", () => {
       { timeout: 3000 },
     )
     expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(mockFetchDisplayAccountTokens).toHaveBeenCalledTimes(2)
+    expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(accounts[0])
+    expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(accounts[1])
+  })
+
+  it("loads Sub2API fallback pricing in all-accounts mode so it can be compared", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    const fetchModelPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("common pricing should not be called"))
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-all-accounts",
+      name: "Sub2API Account",
+      baseUrl: "https://sub2api-all.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+      userId: "sub2api-all-user",
+    })
+    const fallbackToken = {
+      id: 21,
+      user_id: 21,
+      key: "sk-sub2api-all-masked",
+      status: 1,
+      name: "Only runtime key",
+      created_time: 0,
+      accessed_time: 0,
+      expired_time: -1,
+      remain_quota: 0,
+      unlimited_quota: true,
+      used_quota: 0,
+    }
+    const fallbackPricing = {
+      data: [
+        {
+          model_name: "example-runtime-priced-model",
+          quota_type: 0,
+          model_ratio: 2,
+          model_price: 0,
+          completion_ratio: 1,
+          enable_groups: ["default"],
+          supported_endpoint_types: [],
+          price_metadata: {
+            source: MODEL_PRICE_SOURCE_KINDS.OFFICIAL_RATE_ESTIMATE,
+            precision: MODEL_PRICE_PRECISION_KINDS.ESTIMATED,
+          },
+        },
+      ],
+      group_ratio: { default: 1 },
+      success: true,
+      usable_group: { default: "default" },
+      model_list_source: {
+        kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
+        provider: SITE_TYPES.SUB2API,
+        supportsRuntimeModelList: true,
+        supportsPricing: true,
+      },
+    }
+
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce([fallbackToken])
+    mockLoadAccountTokenFallbackPricingResponse.mockResolvedValueOnce(
+      fallbackPricing,
+    )
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(
+          mockLoadAccountTokenFallbackPricingResponse,
+        ).toHaveBeenCalledWith({
+          account,
+          token: fallbackToken,
+        })
+      },
+      { timeout: 3000 },
+    )
+
+    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(result.current.loadErrorMessage).toBeNull()
+    expect(result.current.pricingContexts).toEqual([
+      {
+        account,
+        pricing: fallbackPricing,
+      },
+    ])
   })
 
   it("tracks single-account pricing load success with model-count insight once", async () => {
@@ -1312,7 +1412,7 @@ describe("useModelData all-accounts loading", () => {
       },
     ]
 
-    mockFetchDisplayAccountTokens.mockResolvedValueOnce(fallbackTokens)
+    mockFetchDisplayAccountTokens.mockResolvedValue(fallbackTokens)
     mockLoadAccountTokenFallbackPricingResponse.mockResolvedValueOnce({
       data: [
         {
@@ -1364,12 +1464,17 @@ describe("useModelData all-accounts loading", () => {
     expect(fetchModelPricing).not.toHaveBeenCalled()
     await waitFor(() => {
       expect(result.current.accountFallback?.selectedTokenId).toBeNull()
+      expect(result.current.accountFallback?.tokens).toEqual(fallbackTokens)
     })
 
     expect(mockLoadAccountTokenFallbackPricingResponse).not.toHaveBeenCalled()
 
     act(() => {
       result.current.accountFallback?.setSelectedTokenId(18)
+    })
+
+    await waitFor(() => {
+      expect(result.current.accountFallback?.selectedTokenId).toBe(18)
     })
 
     await act(async () => {
@@ -1466,7 +1571,7 @@ describe("useModelData all-accounts loading", () => {
       },
     }
 
-    mockFetchDisplayAccountTokens.mockResolvedValueOnce([fallbackToken])
+    mockFetchDisplayAccountTokens.mockResolvedValue([fallbackToken])
     mockLoadAccountTokenFallbackPricingResponse.mockResolvedValueOnce(
       fallbackPricing,
     )
@@ -1562,7 +1667,7 @@ describe("useModelData all-accounts loading", () => {
       },
     })
 
-    mockFetchDisplayAccountTokens.mockResolvedValueOnce([fallbackToken])
+    mockFetchDisplayAccountTokens.mockResolvedValue([fallbackToken])
     mockLoadAccountTokenFallbackPricingResponse
       .mockResolvedValueOnce(createFallbackPricing("stale-runtime-model"))
       .mockResolvedValueOnce(createFallbackPricing("fresh-runtime-model"))

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -591,6 +591,106 @@ describe("useModelData all-accounts loading", () => {
     ])
   })
 
+  it("loads only active Sub2API fallback keys in all-accounts mode", async () => {
+    const fetchModelPricing = vi.fn()
+    vi.mocked(getApiService).mockReturnValue(
+      createMockApiService(fetchModelPricing, {
+        capabilities: { modelPricing: false },
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "sub2api-active-only",
+      name: "Sub2API Active Only",
+      baseUrl: "https://sub2api-active-only.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    })
+    const tokens = [
+      {
+        id: 21,
+        user_id: 21,
+        key: "sk-active",
+        status: 1,
+        name: "Active runtime key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+      {
+        id: 22,
+        user_id: 21,
+        key: "sk-disabled",
+        status: 0,
+        name: "Disabled runtime key",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: -1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ]
+    const pricing = {
+      data: [
+        {
+          model_name: "active-model",
+          quota_type: 0,
+          model_ratio: 1,
+          model_price: 0,
+          completion_ratio: 1,
+          enable_groups: ["default"],
+          supported_endpoint_types: [],
+        },
+      ],
+      group_ratio: { default: 1 },
+      success: true,
+      usable_group: { default: true },
+    }
+
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce(tokens)
+    mockLoadAccountTokenFallbackPricingResponse.mockResolvedValueOnce(pricing)
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAllAccountsSource(),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(
+          mockLoadAccountTokenFallbackPricingResponse,
+        ).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 3000 },
+    )
+
+    expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith({
+      account,
+      token: tokens[0],
+    })
+    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(result.current.loadErrorMessage).toBeNull()
+    expect(result.current.pricingContexts).toEqual([
+      {
+        account,
+        pricing,
+        sourceIdentity: {
+          kind: "account-token",
+          id: "sub2api-active-only:token:21",
+          tokenId: 21,
+          tokenName: "Active runtime key",
+        },
+      },
+    ])
+  })
+
   it("keeps successful Sub2API token contexts as partial instead of load failed when another token fails", async () => {
     mockTrackProductAnalyticsActionCompleted.mockReset()
     const fetchModelPricing = vi.fn()

--- a/tests/features/ModelList/batchVerification.test.ts
+++ b/tests/features/ModelList/batchVerification.test.ts
@@ -6,7 +6,10 @@ import {
   pickBatchVerifyCompatibleToken,
   resolveBatchVerifyApiType,
 } from "~/features/ModelList/batchVerification"
-import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
+import {
+  MODEL_LIST_SOURCE_IDENTITY_KINDS,
+  MODEL_MANAGEMENT_SOURCE_KINDS,
+} from "~/features/ModelList/modelManagementSources"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 
@@ -69,6 +72,142 @@ describe("model list batch verification helpers", () => {
       "account:acc-1:gpt-4o",
       "account:acc-2:gpt-4o",
     ])
+  })
+
+  it("keeps same-account token rows separate for batch verification", () => {
+    const source = {
+      kind: MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT,
+      account: { id: "batch-sub2api-account" },
+      capabilities: { supportsBatchCredentialVerification: true },
+    } as any
+    const model = { model_name: "shared-model", enable_groups: ["default"] }
+
+    const result = createBatchVerifyModelItems([
+      {
+        model,
+        source,
+        sourceIdentity: {
+          kind: "account-token",
+          id: "batch-sub2api-account:token:51",
+          tokenId: 51,
+          tokenName: "Default key",
+        },
+        groupRatios: { default: 1 },
+        effectiveGroup: "default",
+      },
+      {
+        model,
+        source,
+        sourceIdentity: {
+          kind: "account-token",
+          id: "batch-sub2api-account:token:52",
+          tokenId: 52,
+          tokenName: "Second key",
+        },
+        groupRatios: { default: 1 },
+        effectiveGroup: "default",
+      },
+    ] as any)
+
+    expect(result.map((item) => item.key)).toEqual([
+      "account:batch-sub2api-account:token:51:shared-model",
+      "account:batch-sub2api-account:token:52:shared-model",
+    ])
+    expect(result.map((item) => item.sourceIdentity)).toEqual([
+      {
+        kind: "account-token",
+        id: "batch-sub2api-account:token:51",
+        tokenId: 51,
+        tokenName: "Default key",
+      },
+      {
+        kind: "account-token",
+        id: "batch-sub2api-account:token:52",
+        tokenId: 52,
+        tokenName: "Second key",
+      },
+    ])
+  })
+
+  it("selects the matching token for token-scoped rows", () => {
+    const tokens = [
+      {
+        id: 51,
+        status: 1,
+        group: DEFAULT_MODEL_GROUP,
+        model_limits_enabled: false,
+        model_limits: "",
+        models: "",
+      },
+      {
+        id: 52,
+        status: 1,
+        group: DEFAULT_MODEL_GROUP,
+        model_limits_enabled: false,
+        model_limits: "",
+        models: "",
+      },
+    ] as any
+
+    expect(
+      pickBatchVerifyCompatibleToken(tokens, {
+        modelId: "shared-model",
+        enableGroups: [DEFAULT_MODEL_GROUP],
+        sourceIdentity: {
+          kind: MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN,
+          id: "batch-sub2api-account:token:52",
+          tokenId: 52,
+          tokenName: "Second key",
+        },
+      })?.id,
+    ).toBe(52)
+  })
+
+  it("does not fall back to another compatible token for token-scoped rows", () => {
+    const tokens = [
+      {
+        id: 51,
+        status: 1,
+        group: DEFAULT_MODEL_GROUP,
+        model_limits_enabled: false,
+        model_limits: "",
+        models: "",
+      },
+      {
+        id: 52,
+        status: 1,
+        group: "vip",
+        model_limits_enabled: false,
+        model_limits: "",
+        models: "",
+      },
+    ] as any
+
+    expect(
+      pickBatchVerifyCompatibleToken(tokens, {
+        modelId: "shared-model",
+        enableGroups: [DEFAULT_MODEL_GROUP],
+        sourceIdentity: {
+          kind: MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN,
+          id: "batch-sub2api-account:token:53",
+          tokenId: 53,
+          tokenName: "Missing key",
+        },
+      }),
+    ).toBeNull()
+
+    expect(
+      pickBatchVerifyCompatibleToken(tokens, {
+        modelId: "shared-model",
+        enableGroups: [DEFAULT_MODEL_GROUP],
+        sourceIdentity: {
+          kind: MODEL_LIST_SOURCE_IDENTITY_KINDS.ACCOUNT_TOKEN,
+          id: "batch-sub2api-account:token:52",
+          tokenId: 52,
+          tokenName: "VIP key",
+        },
+      }),
+    ).toBeNull()
   })
 
   it("keeps missing model group metadata unrestricted", () => {

--- a/tests/features/ModelList/components/AccountSummaryBar.test.tsx
+++ b/tests/features/ModelList/components/AccountSummaryBar.test.tsx
@@ -111,4 +111,36 @@ describe("AccountSummaryBar", () => {
     )
     expect(screen.queryByText("accountSummary.models")).toBeNull()
   })
+
+  it("shows a warning summary with the failure reason when an account partially loads", () => {
+    render(
+      <AccountSummaryBar
+        items={[
+          {
+            accountId: "account-partial",
+            name: "Partial Account",
+            count: 2,
+            errorType: "partial-load-failed",
+            errorMessage: "Some keys failed to load. First failure: denied",
+          },
+        ]}
+      />,
+    )
+
+    const partialBadge = screen
+      .getByText("Partial Account")
+      .closest("[data-slot='badge']")
+
+    expect(partialBadge).toHaveAttribute(
+      "title",
+      "Some keys failed to load. First failure: denied",
+    )
+    expect(partialBadge).toHaveAccessibleName(
+      "Partial Account accountSummary.partialLoadFailed Some keys failed to load. First failure: denied",
+    )
+    expect(screen.getByText("accountSummary.partialLoadFailed")).toHaveClass(
+      "text-amber-600",
+      "dark:text-amber-300",
+    )
+  })
 })

--- a/tests/features/ModelList/components/ModelItem.test.tsx
+++ b/tests/features/ModelList/components/ModelItem.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import ModelItem from "~/features/ModelList/components/ModelItem"
 import { MODEL_LIST_GROUP_SELECTION_SCOPES } from "~/features/ModelList/groupSelectionScopes"
+import { createAccountTokenModelListSourceIdentity } from "~/features/ModelList/modelManagementSources"
 import type { ModelPricing } from "~/services/apiService/common/type"
 import type { CalculatedPrice } from "~/services/models/utils/modelPricing"
 import {
@@ -213,6 +214,7 @@ function createDefaultProps() {
       account: {
         id: "account-1",
         name: "Account One",
+        baseUrl: "https://account.example.invalid",
       },
       capabilities: {
         supportsPricing: true,
@@ -258,6 +260,25 @@ describe("ModelItem", () => {
     expect(
       screen.queryByText("availableGroups: vip (1x)"),
     ).not.toBeInTheDocument()
+  })
+
+  it("renders token-scoped account labels from source identity", () => {
+    render(
+      <ModelItem
+        {...createDefaultProps()}
+        sourceIdentity={createAccountTokenModelListSourceIdentity({
+          accountId: "account-1",
+          tokenId: 41,
+          tokenName: "VIP runtime key",
+        })}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        "Account One / VIP runtime key · account.example.invalid",
+      ),
+    ).toBeInTheDocument()
   })
 
   it("summarizes model groups in the row header without showing availability status", () => {


### PR DESCRIPTION
## Summary
- Add Sub2API all-key runtime model comparison planning/spec docs
- Distinguish token-scoped model-list sources in the Model List UI
- Load all Sub2API runtime keys for comparison and surface partial-load state clearly
- Preserve token identity during batch verification

## Test Plan
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-key Sub2API comparison in Model List, treating each token as a distinct comparison source and preventing row identity collisions.
  * Improved source labeling to show token names (when available) alongside the account name.
* **Bug Fixes**
  * Account summary status now surfaces user-friendly error details (including partial-load reasons) via badge titles and accessible labels.
  * Batch verification token selection is now token-source aware for more accurate compatibility matching.
* **Documentation**
  * Added/updated specs and an implementation plan for multi-key Sub2API “all-accounts”/“all-keys” comparison behavior and validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->