### PR TITLE
fix(account): defer post-save data refresh

### DIFF
--- a/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
+++ b/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
@@ -7,6 +7,7 @@ import { OPTIONAL_PERMISSION_IDS } from "~/services/permissions/permissionManage
 import { AuthTypeEnum } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
+  readStoredAccounts,
   refreshAccountRowsAndReadStorage,
   saveManualAccountFromApp,
 } from "~~/e2e/scenarios/accountManualAdd"
@@ -54,6 +55,7 @@ test.beforeEach(async ({ context, page }) => {
 })
 
 test("grants the Chromium cookie/DNR optional permissions needed for cookie auth", async ({
+  context,
   extensionId,
   page,
 }) => {
@@ -65,6 +67,7 @@ test("grants the Chromium cookie/DNR optional permissions needed for cookie auth
     await expectPermissionOnboardingHidden(page)
     await grantCookieDnrPermissions(page, localSite.origin)
   } finally {
+    await closeOtherPages(context, page)
     await localSite.close()
   }
 })
@@ -123,6 +126,15 @@ test("isolates same-site cookie and access-token accounts through account refres
             cookieAuthSessionCookie: ACCOUNT_A_SESSION_COOKIE,
           },
         })
+        await localSite.waitForAuthenticatedSessionRequest(
+          ACCOUNT_A_SESSION_COOKIE,
+        )
+        await waitForStoredAccountQuota(
+          serviceWorker,
+          cookieAccountA.id,
+          33_000,
+        )
+
         const cookieAccountB = await saveManualAccountFromApp({
           page,
           extensionId,
@@ -137,6 +149,15 @@ test("isolates same-site cookie and access-token accounts through account refres
             cookieAuthSessionCookie: ACCOUNT_B_SESSION_COOKIE,
           },
         })
+        await localSite.waitForAuthenticatedSessionRequest(
+          ACCOUNT_B_SESSION_COOKIE,
+        )
+        await waitForStoredAccountQuota(
+          serviceWorker,
+          cookieAccountB.id,
+          44_000,
+        )
+
         const tokenAccountA = await saveManualAccountFromApp({
           page,
           extensionId,
@@ -151,6 +172,9 @@ test("isolates same-site cookie and access-token accounts through account refres
             accessToken: ACCESS_TOKEN_A,
           },
         })
+        await localSite.waitForAuthenticatedAccessTokenRequest(ACCESS_TOKEN_A)
+        await waitForStoredAccountQuota(serviceWorker, tokenAccountA.id, 55_000)
+
         const tokenAccountB = await saveManualAccountFromApp({
           page,
           extensionId,
@@ -165,6 +189,8 @@ test("isolates same-site cookie and access-token accounts through account refres
             accessToken: ACCESS_TOKEN_B,
           },
         })
+        await localSite.waitForAuthenticatedAccessTokenRequest(ACCESS_TOKEN_B)
+        await waitForStoredAccountQuota(serviceWorker, tokenAccountB.id, 66_000)
 
         return [cookieAccountA, cookieAccountB, tokenAccountA, tokenAccountB]
       })
@@ -307,6 +333,20 @@ async function grantCookieDnrPermissions(page: Page, origin: string) {
   expect(hasOriginPermission, `${originPattern} host access`).toBe(true)
 }
 
+async function waitForStoredAccountQuota(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+  accountId: string,
+  expectedQuota: number,
+) {
+  await expect
+    .poll(async () => {
+      const accounts = await readStoredAccounts(serviceWorker)
+      const account = accounts.find((candidate) => candidate.id === accountId)
+      return account?.account_info.quota ?? null
+    })
+    .toBe(expectedQuota)
+}
+
 type CapturedSelfRequest = {
   cookieHeader: string
   matchedSessionCookie: string | null
@@ -318,8 +358,11 @@ type DnrCaptureNewApiServer = {
   origin: string
   selfRequests: CapturedSelfRequest[]
   clearSelfRequests: () => void
-  waitForAuthenticatedSelfRequest: (
+  waitForAuthenticatedSessionRequest: (
     sessionCookie: string,
+  ) => Promise<CapturedSelfRequest>
+  waitForAuthenticatedAccessTokenRequest: (
+    accessToken: string,
   ) => Promise<CapturedSelfRequest>
   close: () => Promise<void>
 }
@@ -328,7 +371,7 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
   const selfRequests: CapturedSelfRequest[] = []
   const sockets = new Set<Socket>()
   const waiters: Array<{
-    sessionCookie: string
+    matches: (request: CapturedSelfRequest) => boolean
     resolve: (request: CapturedSelfRequest) => void
     reject: (error: Error) => void
     timeout: ReturnType<typeof setTimeout>
@@ -336,7 +379,7 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
 
   const resolveMatchingWaiters = (captured: CapturedSelfRequest) => {
     for (const waiter of [...waiters]) {
-      if (captured.matchedSessionCookie !== waiter.sessionCookie) {
+      if (!waiter.matches(captured)) {
         continue
       }
       clearTimeout(waiter.timeout)
@@ -473,26 +516,31 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
     })
   })
 
-  const waitForAuthenticatedSelfRequest = async (sessionCookie: string) => {
-    const existing = selfRequests.find(
-      (request) => request.matchedSessionCookie === sessionCookie,
-    )
+  const waitForAuthenticatedRequest = async (
+    label: string,
+    matches: (request: CapturedSelfRequest) => boolean,
+  ) => {
+    const existing = selfRequests.find(matches)
     if (existing) return existing
 
     return await new Promise<CapturedSelfRequest>((resolve, reject) => {
       const timeout = setTimeout(() => {
         const seen = selfRequests
-          .map((request) => request.cookieHeader || "<empty>")
+          .map((request) =>
+            [
+              `cookie=${request.cookieHeader || "<empty>"}`,
+              `token=${request.matchedAccessToken ?? "<none>"}`,
+              `status=${request.responseStatus}`,
+            ].join(" "),
+          )
           .join(", ")
         reject(
-          new Error(
-            `Timed out waiting for ${sessionCookie}; seen Cookie headers: ${seen}`,
-          ),
+          new Error(`Timed out waiting for ${label}; seen requests: ${seen}`),
         )
       }, 15_000)
 
       waiters.push({
-        sessionCookie,
+        matches,
         resolve,
         reject,
         timeout,
@@ -522,7 +570,16 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
     clearSelfRequests: () => {
       selfRequests.splice(0)
     },
-    waitForAuthenticatedSelfRequest,
+    waitForAuthenticatedSessionRequest: (sessionCookie) =>
+      waitForAuthenticatedRequest(
+        sessionCookie,
+        (request) => request.matchedSessionCookie === sessionCookie,
+      ),
+    waitForAuthenticatedAccessTokenRequest: (accessToken) =>
+      waitForAuthenticatedRequest(
+        accessToken,
+        (request) => request.matchedAccessToken === accessToken,
+      ),
     close,
   }
 }

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -150,6 +150,18 @@ function createCurrentTabCookieImportContext(
  */
 const logger = createLogger("AccountDialogHook")
 
+/**
+ * Refreshes saved account data without keeping the account dialog save flow open.
+ */
+function schedulePostSaveAccountRefresh(accountId: string) {
+  void accountStorage.refreshAccount(accountId, true).catch((error) => {
+    logger.warn("Post-save deferred account refresh failed", {
+      accountId,
+      error: getErrorMessage(error),
+    })
+  })
+}
+
 interface CookieAuthPermissionState {
   granted: boolean | null
   pending: boolean
@@ -1799,6 +1811,7 @@ export function useAccountDialog({
               excludeFromTodayIncome,
               sub2apiAuth,
               {
+                deferDataRefresh: true,
                 skipAutoProvisionKeyOnAccountAdd:
                   options?.skipAutoProvisionKeyOnAccountAdd === true ||
                   isAihubmixNormalSaveForegroundKeyFlow(options),
@@ -1822,6 +1835,7 @@ export function useAccountDialog({
               excludeFromTotalBalance,
               excludeFromTodayIncome,
               sub2apiAuth,
+              { deferDataRefresh: true },
             )
 
       if (!result.success) {
@@ -1834,6 +1848,13 @@ export function useAccountDialog({
 
       analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Success)
       isAnalyticsActionCompleted = true
+
+      if (
+        typeof result.accountId === "string" &&
+        result.accountId.trim().length > 0
+      ) {
+        schedulePostSaveAccountRefresh(result.accountId.trim())
+      }
 
       const feedbackMessage =
         typeof result.message === "string" && result.message.trim().length > 0

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -594,6 +594,11 @@ type TagIdsInput = string[] | undefined
 
 export interface ValidateAndSaveAccountOptions {
   skipAutoProvisionKeyOnAccountAdd?: boolean
+  deferDataRefresh?: boolean
+}
+
+export interface ValidateAndUpdateAccountOptions {
+  deferDataRefresh?: boolean
 }
 
 /**
@@ -820,6 +825,77 @@ export async function validateAndSaveAccount(
     siteType: normalizedSiteType,
     url,
   })
+  const normalizedTagIds = normalizeTagIdsInput(tagIds)
+
+  if (options.deferDataRefresh === true) {
+    const accountData: Omit<
+      SiteAccount,
+      "id" | "created_at" | "updated_at" | "user_updated_at"
+    > = {
+      site_name: siteName.trim(),
+      site_url: storageSiteUrl,
+      site_type: normalizedSiteType,
+      authType: authType,
+      disabled: false,
+      excludeFromTotalBalance: excludeFromTotalBalance === true,
+      excludeFromTodayIncome: excludeFromTodayIncome === true,
+      cookieAuth:
+        authType === AuthTypeEnum.Cookie
+          ? { sessionCookie: sessionCookieHeader.trim() }
+          : undefined,
+      sub2apiAuth: normalizedSub2ApiAuth,
+      exchange_rate: resolveExchangeRate(exchangeRate),
+      notes,
+      manualBalanceUsd: normalizedManualBalanceUsd,
+      tagIds: normalizedTagIds,
+      checkIn: checkInConfig,
+      health: { status: SiteHealthStatus.Unknown },
+      account_info: {
+        id: accountIdentity,
+        access_token: accessToken.trim(),
+        username: username.trim(),
+        quota: manualQuota ?? 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+      last_sync_time: Date.now(),
+    }
+
+    try {
+      const accountId = await accountStorage.addAccount(accountData)
+      logger.info("Account saved before deferred data refresh", {
+        accountId,
+        siteName: siteName.trim(),
+        siteType: normalizedSiteType,
+      })
+
+      if (!options.skipAutoProvisionKeyOnAccountAdd) {
+        void autoProvisionKeyOnAccountAdd(
+          accountId,
+          shouldAutoProvisionKeyOnAccountAdd,
+        )
+      }
+
+      return {
+        success: true,
+        message: t("messages:toast.success.accountSaveSuccess"),
+        accountId,
+        feedbackLevel: "success",
+      }
+    } catch (saveError) {
+      logger.error("Failed to save account", saveError)
+      const errorMessage = getErrorMessage(saveError)
+      return {
+        success: false,
+        message: t("messages:errors.operation.saveFailed", {
+          error: errorMessage,
+        }),
+      }
+    }
+  }
 
   try {
     // 获取账号余额和今日使用情况
@@ -851,9 +927,6 @@ export async function validateAndSaveAccount(
           MANUAL_ADD_ACCOUNT_DATA_FETCH_TIMEOUT_MS,
         ),
     )
-
-    const normalizedTagIds = normalizeTagIdsInput(tagIds)
-
     const accountData: Omit<
       SiteAccount,
       "id" | "created_at" | "updated_at" | "user_updated_at"
@@ -913,9 +986,6 @@ export async function validateAndSaveAccount(
   } catch (error) {
     // FALLBACK: 即使获取数据失败也要保存配置
     logger.warn("Data fetch failed; saving configuration only", error)
-
-    // Build partial account data without quota/usage data
-    const normalizedTagIds = normalizeTagIdsInput(tagIds)
 
     const partialAccountData: Omit<
       SiteAccount,
@@ -1030,6 +1100,7 @@ export async function validateAndUpdateAccount(
   excludeFromTotalBalance = false,
   excludeFromTodayIncome = false,
   sub2apiAuth?: Sub2ApiAuthConfig,
+  options: ValidateAndUpdateAccountOptions = {},
 ): Promise<AccountSaveResponse> {
   const sessionCookieHeader =
     authType === AuthTypeEnum.Cookie
@@ -1072,6 +1143,60 @@ export async function validateAndUpdateAccount(
     siteType: normalizedSiteType,
     url,
   })
+  const normalizedTagIds = normalizeTagIdsInput(tagIds)
+
+  if (options.deferDataRefresh === true) {
+    const updateData = {
+      site_name: siteName.trim(),
+      site_url: storageSiteUrl,
+      site_type: normalizedSiteType,
+      authType: authType,
+      excludeFromTotalBalance: excludeFromTotalBalance === true,
+      excludeFromTodayIncome: excludeFromTodayIncome === true,
+      cookieAuth:
+        authType === AuthTypeEnum.Cookie
+          ? { sessionCookie: sessionCookieHeader.trim() }
+          : undefined,
+      sub2apiAuth: normalizedSub2ApiAuth,
+      exchange_rate: resolveExchangeRate(exchangeRate),
+      notes: notes,
+      manualBalanceUsd: normalizedManualBalanceUsd,
+      tagIds: normalizedTagIds,
+      checkIn: checkInConfig,
+      account_info: {
+        id: accountIdentity,
+        access_token: accessToken.trim(),
+        username: username.trim(),
+        ...(manualQuota === undefined ? {} : { quota: manualQuota }),
+      },
+    }
+
+    const success = await accountStorage.updateAccount(accountId, updateData, {
+      userTimestampMode: AccountUpdateUserTimestampMode.Touch,
+    })
+
+    if (!success) {
+      return {
+        success: false,
+        message: t("messages:errors.validation.updateAccountFailed", {
+          error: "",
+        }),
+      }
+    }
+
+    logger.info("Account updated before deferred data refresh", {
+      accountId,
+      siteName: siteName.trim(),
+      siteType: normalizedSiteType,
+    })
+
+    return {
+      success: true,
+      message: t("messages:toast.success.accountUpdateSuccess"),
+      accountId,
+      feedbackLevel: "success",
+    }
+  }
 
   try {
     // 获取账号余额和今日使用情况
@@ -1101,9 +1226,6 @@ export async function validateAndUpdateAccount(
             : undefined,
       },
     })
-
-    const normalizedTagIds = normalizeTagIdsInput(tagIds)
-
     const updateData: Partial<
       Omit<SiteAccount, "id" | "created_at" | "updated_at" | "user_updated_at">
     > = {
@@ -1165,9 +1287,6 @@ export async function validateAndUpdateAccount(
   } catch (error) {
     // FALLBACK: 即使获取数据失败也要保存配置
     logger.warn("Data fetch failed; saving configuration only", error)
-
-    // Build partial update preserving quota/usage data
-    const normalizedTagIds = normalizeTagIdsInput(tagIds)
 
     const partialUpdateData = {
       site_name: siteName.trim(),

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -451,7 +451,9 @@ describe("useAccountDialog save and auto-config flows", () => {
         skipAutoProvisionKeyOnAccountAdd: false,
       },
     )
-    expect(refreshSpy).toHaveBeenCalledWith("saved-account-id", true)
+    await waitFor(() => {
+      expect(refreshSpy).toHaveBeenCalledWith("saved-account-id", true)
+    })
   })
 
   it("does not persist Sub2API refresh-token auth until the mode is explicitly enabled", async () => {

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -183,6 +183,10 @@ describe("useAccountDialog save and auto-config flows", () => {
       created: false,
     })
     mockOpenWithAccount.mockResolvedValue({ opened: true })
+    vi.spyOn(accountStorage, "refreshAccount").mockResolvedValue({
+      account: buildSiteAccount({ id: "saved-account-id" }),
+      refreshed: true,
+    })
     mockAutoProvisionKeyOnAccountAdd(false)
     mockStartProductAnalyticsAction.mockReturnValue({
       complete: mockCompleteProductAnalyticsAction,
@@ -394,12 +398,60 @@ describe("useAccountDialog save and auto-config flows", () => {
         refreshToken: "refresh-token",
         tokenExpiresAt: 123456789,
       },
-      { skipAutoProvisionKeyOnAccountAdd: false },
+      {
+        deferDataRefresh: true,
+        skipAutoProvisionKeyOnAccountAdd: false,
+      },
     )
     expect(mockOpenSub2ApiTokenCreationDialog).toHaveBeenCalledWith(
       savedDisplayData,
     )
     expect(toast.success).toHaveBeenCalledWith("Saved successfully")
+  })
+
+  it("defers account data refresh after a successful manual save", async () => {
+    const refreshSpy = vi
+      .spyOn(accountStorage, "refreshAccount")
+      .mockResolvedValue({
+        account: buildSiteAccount({ id: "saved-account-id" }),
+        refreshed: true,
+      })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await fillStandardAddAccountDraft(result)
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    expect(mockValidateAndSaveAccount).toHaveBeenCalledWith(
+      "https://api.example.com/private",
+      "Sensitive Site",
+      "private-user",
+      "sk-private-token",
+      "12345",
+      "7",
+      "private notes",
+      ["secret-tag-id"],
+      expect.any(Object),
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+      "",
+      false,
+      false,
+      undefined,
+      {
+        deferDataRefresh: true,
+        skipAutoProvisionKeyOnAccountAdd: false,
+      },
+    )
+    expect(refreshSpy).toHaveBeenCalledWith("saved-account-id", true)
   })
 
   it("does not persist Sub2API refresh-token auth until the mode is explicitly enabled", async () => {
@@ -442,7 +494,10 @@ describe("useAccountDialog save and auto-config flows", () => {
       false,
       false,
       undefined,
-      { skipAutoProvisionKeyOnAccountAdd: false },
+      {
+        deferDataRefresh: true,
+        skipAutoProvisionKeyOnAccountAdd: false,
+      },
     )
   })
 
@@ -492,6 +547,7 @@ describe("useAccountDialog save and auto-config flows", () => {
       true,
       false,
       undefined,
+      { deferDataRefresh: true },
     )
     expect(toast.success).toHaveBeenCalledWith(
       "accountDialog:messages.updateSuccess",
@@ -933,7 +989,10 @@ describe("useAccountDialog save and auto-config flows", () => {
       false,
       false,
       undefined,
-      { skipAutoProvisionKeyOnAccountAdd: true },
+      {
+        deferDataRefresh: true,
+        skipAutoProvisionKeyOnAccountAdd: true,
+      },
     )
     expect(result.current.state.aihubmixPostSaveKeyPrompt.isOpen).toBe(true)
     expect(mockEnsureAccountTokenForPostSaveWorkflow).not.toHaveBeenCalled()
@@ -1158,7 +1217,10 @@ describe("useAccountDialog save and auto-config flows", () => {
       expect.any(Boolean),
       expect.any(Boolean),
       undefined,
-      { skipAutoProvisionKeyOnAccountAdd: false },
+      {
+        deferDataRefresh: true,
+        skipAutoProvisionKeyOnAccountAdd: false,
+      },
     )
     expect(result.current.state.aihubmixPostSaveKeyPrompt.isOpen).toBe(false)
     expect(
@@ -1691,7 +1753,10 @@ describe("useAccountDialog save and auto-config flows", () => {
       false,
       false,
       undefined,
-      { skipAutoProvisionKeyOnAccountAdd: true },
+      {
+        deferDataRefresh: true,
+        skipAutoProvisionKeyOnAccountAdd: true,
+      },
     )
     expect(mockEnsureAccountTokenForPostSaveWorkflow).toHaveBeenCalledWith({
       account: savedSiteAccount,

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -295,7 +295,54 @@ describe("accountOperations validateAndSaveAccount", () => {
     })
   })
 
-  it("can save account configuration without blocking on remote data refresh", async () => {
+  it("can save cookie account configuration without blocking on remote data refresh", async () => {
+    const result = await validateAndSaveAccount(
+      "https://api.example.com",
+      "Example",
+      "user",
+      "",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.Cookie,
+      "Cookie: session=abc123; theme=dark",
+      undefined,
+      false,
+      false,
+      undefined,
+      { deferDataRefresh: true },
+    )
+
+    expect(result).toMatchObject({
+      success: true,
+      message: "messages:toast.success.accountSaveSuccess",
+      feedbackLevel: "success",
+    })
+    expect(fetchAccountDataMock).not.toHaveBeenCalled()
+
+    const saved = await accountStorage.getAccountById(result.accountId!)
+    expect(saved).toMatchObject({
+      site_name: "Example",
+      site_type: SITE_TYPES.NEW_API,
+      health: { status: SiteHealthStatus.Unknown },
+      cookieAuth: { sessionCookie: "session=abc123" },
+      account_info: {
+        id: "1",
+        username: "user",
+        access_token: "",
+        quota: 0,
+      },
+    })
+  })
+
+  it("returns a stable save failure when deferred account persistence fails", async () => {
+    vi.spyOn(accountStorage, "addAccount").mockRejectedValueOnce(
+      new Error("disk full"),
+    )
+
     const result = await validateAndSaveAccount(
       "https://api.example.com",
       "Example",
@@ -316,25 +363,118 @@ describe("accountOperations validateAndSaveAccount", () => {
       { deferDataRefresh: true },
     )
 
+    expect(result).toEqual({
+      success: false,
+      message: "messages:errors.operation.saveFailed",
+    })
+    expect(fetchAccountDataMock).not.toHaveBeenCalled()
+  })
+
+  it("can update cookie account configuration without blocking on remote data refresh", async () => {
+    const accountId = await accountStorage.addAccount({
+      site_name: "Old Example",
+      site_url: "https://old.example.com",
+      site_type: SITE_TYPES.NEW_API,
+      health: { status: SiteHealthStatus.Healthy },
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      excludeFromTotalBalance: false,
+      excludeFromTodayIncome: false,
+      exchange_rate: 7,
+      notes: "",
+      tagIds: [],
+      checkIn: CHECK_IN_DISABLED,
+      account_info: {
+        id: "previous-id",
+        access_token: "old-token",
+        username: "old-user",
+        quota: 42,
+        today_prompt_tokens: 1,
+        today_completion_tokens: 2,
+        today_quota_consumption: 3,
+        today_requests_count: 4,
+        today_income: 5,
+      },
+      last_sync_time: 123,
+    })
+
+    const result = await validateAndUpdateAccount(
+      accountId,
+      "https://api.example.com",
+      "Example",
+      "user",
+      "",
+      "1",
+      "7.0",
+      "notes",
+      [" alpha ", "alpha", "beta"],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.Cookie,
+      "Cookie: session=abc123; theme=dark",
+      "2.5",
+      true,
+      false,
+      undefined,
+      { deferDataRefresh: true },
+    )
+
     expect(result).toMatchObject({
       success: true,
-      message: "messages:toast.success.accountSaveSuccess",
+      message: "messages:toast.success.accountUpdateSuccess",
+      accountId,
       feedbackLevel: "success",
     })
     expect(fetchAccountDataMock).not.toHaveBeenCalled()
 
-    const saved = await accountStorage.getAccountById(result.accountId!)
-    expect(saved).toMatchObject({
+    const updated = await accountStorage.getAccountById(accountId)
+    expect(updated).toMatchObject({
       site_name: "Example",
       site_type: SITE_TYPES.NEW_API,
-      health: { status: SiteHealthStatus.Unknown },
+      excludeFromTotalBalance: true,
+      tagIds: ["alpha", "beta"],
+      cookieAuth: { sessionCookie: "session=abc123" },
       account_info: {
         id: "1",
         username: "user",
-        access_token: "token",
-        quota: 0,
+        access_token: "",
+        quota: 1250000,
       },
     })
+  })
+
+  it("returns a stable update failure when deferred account persistence fails", async () => {
+    const updateAccountSpy = vi
+      .spyOn(accountStorage, "updateAccount")
+      .mockResolvedValueOnce(false)
+
+    const result = await validateAndUpdateAccount(
+      "existing-account-id",
+      "https://api.example.com",
+      "Example",
+      "user",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+      undefined,
+      false,
+      false,
+      undefined,
+      { deferDataRefresh: true },
+    )
+
+    expect(result).toEqual({
+      success: false,
+      message: "messages:errors.validation.updateAccountFailed",
+    })
+    expect(updateAccountSpy).toHaveBeenCalled()
+    expect(fetchAccountDataMock).not.toHaveBeenCalled()
   })
 
   it("normalizes unsupported site types before saving", async () => {

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -295,6 +295,48 @@ describe("accountOperations validateAndSaveAccount", () => {
     })
   })
 
+  it("can save account configuration without blocking on remote data refresh", async () => {
+    const result = await validateAndSaveAccount(
+      "https://api.example.com",
+      "Example",
+      "user",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+      undefined,
+      false,
+      false,
+      undefined,
+      { deferDataRefresh: true },
+    )
+
+    expect(result).toMatchObject({
+      success: true,
+      message: "messages:toast.success.accountSaveSuccess",
+      feedbackLevel: "success",
+    })
+    expect(fetchAccountDataMock).not.toHaveBeenCalled()
+
+    const saved = await accountStorage.getAccountById(result.accountId!)
+    expect(saved).toMatchObject({
+      site_name: "Example",
+      site_type: SITE_TYPES.NEW_API,
+      health: { status: SiteHealthStatus.Unknown },
+      account_info: {
+        id: "1",
+        username: "user",
+        access_token: "token",
+        quota: 0,
+      },
+    })
+  })
+
   it("normalizes unsupported site types before saving", async () => {
     const { getApiService } = await import("~/services/apiService")
     fetchAccountDataMock.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- Save account configuration before fetching remote account metrics in the account dialog flow.
- Trigger account data refresh asynchronously after save so slow/failed refreshes do not block the dialog.
- Cover deferred add/update behavior with focused service and hook tests.

## Test Plan
- pnpm vitest run tests/services/accountOperations.validateAndSaveAccount.test.ts
- pnpm vitest run tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
- pnpm vitest run tests/services/accountOperations.test.ts tests/services/accountOperations.manualQuota.test.ts tests/features/AccountManagement/hooks/useAccountDialog.manualBalanceUsd.test.tsx
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account save operations can now defer remote account metrics refresh, improving perceived speed for account creation and updates.

* **Tests**
  * Added unit coverage for deferred refresh success and stable failure handling.
  * Updated dialog and service tests to reflect the new save/update options.
  * Enhanced the DNR-required cookie/auth e2e spec to synchronize on backend processing and validate quota changes more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->