### PR TITLE
feat(model-list): add price comparison shortcut

### DIFF
--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -21,7 +21,7 @@ const alertVariants = cva("relative w-full rounded-lg border p-4", {
     compact: {
       false:
         "[&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4",
-      true: "flex items-start gap-2 p-3 sm:items-center",
+      true: "grid grid-cols-[auto_minmax(0,1fr)] items-start gap-3 p-3",
     },
   },
   defaultVariants: {
@@ -55,7 +55,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
     const getIcon = () => {
       if (!showIcon) return null
 
-      const iconClassName = cn("h-4 w-4", compact && "mt-0.5 shrink-0 sm:mt-0")
+      const iconClassName = cn("h-4 w-4", compact && "mt-0.5 shrink-0")
 
       switch (variant) {
         case "destructive":
@@ -81,7 +81,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
         {...props}
       >
         {icon}
-        <div className={cn("ml-0 space-y-1.5", compact && "min-w-0 flex-1")}>
+        <div className={cn("ml-0 space-y-1.5", compact && "min-w-0")}>
           {title && (
             <Heading5 className="leading-none tracking-tight">{title}</Heading5>
           )}

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -578,6 +578,8 @@ export default function ModelList(props: {
           <ControlPanel
             selectedSource={selectedSource}
             sourceCapabilities={sourceCapabilities}
+            selectedSourceValue={selectedSourceValue}
+            setSelectedSourceValue={setSelectedSourceValue}
             searchTerm={searchTerm}
             setSearchTerm={setSearchTerm}
             sortMode={sortMode}

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -90,6 +90,8 @@ interface ControlPanelProps {
  * @param props Component props bundle.
  * @param props.selectedSource Active model-management source.
  * @param props.sourceCapabilities Capability flags for the active source.
+ * @param props.selectedSourceValue Active model-management source value.
+ * @param props.setSelectedSourceValue Setter for source selection value.
  * @param props.searchTerm Current search keyword.
  * @param props.setSearchTerm Setter to update search keyword.
  * @param props.sortMode Active sort mode.
@@ -285,6 +287,7 @@ export function ControlPanel({
     setSelectedBillingMode(MODEL_LIST_BILLING_MODES.ALL)
     setSelectedGroups([])
     setShowRealPrice(true)
+    const filterCount = 1 + (searchTerm.trim() ? 1 : 0)
 
     void trackProductAnalyticsActionCompleted({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ModelList,
@@ -295,7 +298,7 @@ export function ControlPanel({
       insights: {
         targetKind: PRODUCT_ANALYTICS_TARGET_KINDS.ModelFilter,
         mode: PRODUCT_ANALYTICS_MODE_IDS.All,
-        filterCount: 2,
+        filterCount,
       },
     })
   }

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -4,10 +4,11 @@ import {
   CpuChipIcon,
   MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline"
-import { Copy } from "lucide-react"
+import { Copy, TrendingDown } from "lucide-react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import Tooltip from "~/components/Tooltip"
 import {
   Alert,
   Button,
@@ -30,6 +31,7 @@ import {
   resolveGroupRatio,
 } from "~/features/ModelList/groupLabels"
 import {
+  ALL_ACCOUNTS_SOURCE_VALUE,
   MODEL_MANAGEMENT_SOURCE_KINDS,
   type ModelManagementSource,
   type ModelManagementSourceCapabilities,
@@ -54,6 +56,8 @@ import {
 interface ControlPanelProps {
   selectedSource: ModelManagementSource | null
   sourceCapabilities: ModelManagementSourceCapabilities
+  selectedSourceValue?: string
+  setSelectedSourceValue?: (sourceValue: string) => void
   searchTerm: string
   setSearchTerm: (term: string) => void
   sortMode: ModelListSortMode
@@ -111,6 +115,8 @@ interface ControlPanelProps {
 export function ControlPanel({
   selectedSource,
   sourceCapabilities,
+  selectedSourceValue = selectedSource?.value ?? "",
+  setSelectedSourceValue,
   searchTerm,
   setSearchTerm,
   sortMode,
@@ -136,8 +142,19 @@ export function ControlPanel({
   const isProfileSource =
     selectedSource?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE
   const isAllAccountsSource =
+    selectedSourceValue === ALL_ACCOUNTS_SOURCE_VALUE ||
     selectedSource?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS
   const supportsPriceSorting = sourceCapabilities.supportsPricing
+  const isPriceComparisonActive =
+    isAllAccountsSource &&
+    sortMode === MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST &&
+    selectedBillingMode === MODEL_LIST_BILLING_MODES.ALL &&
+    selectedGroups.length === 0 &&
+    showRealPrice
+  const shouldShowPriceComparisonPrompt =
+    sourceCapabilities.supportsPricing &&
+    !isProfileSource &&
+    !isPriceComparisonActive
   const groupOptions = availableGroups.map((group) => ({
     value: group,
     label: formatGroupLabel(
@@ -258,6 +275,28 @@ export function ControlPanel({
     setSelectedGroups(groups)
     trackFilterChange(PRODUCT_ANALYTICS_MODE_IDS.GroupFilter, {
       selectedGroups: groups,
+    })
+  }
+  const handleEnablePriceComparison = () => {
+    if (!isAllAccountsSource && setSelectedSourceValue) {
+      setSelectedSourceValue(ALL_ACCOUNTS_SOURCE_VALUE)
+    }
+    setSortMode(MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST)
+    setSelectedBillingMode(MODEL_LIST_BILLING_MODES.ALL)
+    setSelectedGroups([])
+    setShowRealPrice(true)
+
+    void trackProductAnalyticsActionCompleted({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ModelList,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.EnableModelPriceComparison,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsModelListControlPanel,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      result: PRODUCT_ANALYTICS_RESULTS.Success,
+      insights: {
+        targetKind: PRODUCT_ANALYTICS_TARGET_KINDS.ModelFilter,
+        mode: PRODUCT_ANALYTICS_MODE_IDS.All,
+        filterCount: 2,
+      },
     })
   }
 
@@ -397,6 +436,24 @@ export function ControlPanel({
                   {t("batchVerify.actions.open")}
                 </Button>
               ) : null}
+
+              {shouldShowPriceComparisonPrompt && (
+                <Tooltip
+                  content={t("comparison.tooltip")}
+                  wrapperClassName="contents"
+                >
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="sm"
+                    title={t("comparison.tooltip")}
+                    leftIcon={<TrendingDown className="h-4 w-4" />}
+                    onClick={handleEnablePriceComparison}
+                  >
+                    {t("comparison.cta")}
+                  </Button>
+                </Tooltip>
+              )}
             </div>
 
             <div className="flex items-center space-x-4 text-sm">

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -102,6 +102,10 @@
   "billingMode": "Billing Mode",
   "clickSwitchGroup": "Click to switch to {{group}} group",
   "collapseDetails": "Collapse details",
+  "comparison": {
+    "cta": "Compare Prices",
+    "tooltip": "Clear current filters, switch to all accounts, and sort each model by the lowest price."
+  },
   "copyAllNames": "Copy All Model Names",
   "description": "View and manage available AI models",
   "detailedPricing": "Detailed Pricing",

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -96,6 +96,10 @@
   "billingMode": "課金方式",
   "clickSwitchGroup": "{{group}} グループへ切り替える",
   "collapseDetails": "詳細を折りたたむ",
+  "comparison": {
+    "cta": "価格を比較",
+    "tooltip": "現在の絞り込みをクリアし、すべてのアカウントに切り替えて、同一モデルの最安値を優先して並べます。"
+  },
   "copyAllNames": "すべてのモデル名をコピー",
   "description": "利用可能な AI モデルを確認・管理します",
   "detailedPricing": "詳細料金",

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -96,6 +96,10 @@
   "billingMode": "Phương thức tính phí",
   "clickSwitchGroup": "Nhấp để chuyển sang nhóm {{group}}",
   "collapseDetails": "Thu gọn chi tiết",
+  "comparison": {
+    "cta": "So sánh giá",
+    "tooltip": "Xóa bộ lọc hiện tại, chuyển sang tất cả tài khoản và ưu tiên giá thấp nhất cho cùng mô hình."
+  },
   "copyAllNames": "Sao chép tất cả tên mô hình",
   "description": "Xem và quản lý các mô hình AI khả dụng",
   "detailedPricing": "Định giá chi tiết",

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -96,6 +96,10 @@
   "billingMode": "计费方式",
   "clickSwitchGroup": "点击切换到 {{group}} 分组",
   "collapseDetails": "收起详细信息",
+  "comparison": {
+    "cta": "一键比价",
+    "tooltip": "清空当前筛选，切换到所有账号，并按同模型最低价优先排序。"
+  },
   "copyAllNames": "复制所有模型名称",
   "description": "查看和管理可用的AI模型",
   "detailedPricing": "详细定价",

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -96,6 +96,10 @@
   "billingMode": "計費方式",
   "clickSwitchGroup": "點擊切換到 {{group}} 分組",
   "collapseDetails": "收起詳細資訊",
+  "comparison": {
+    "cta": "一鍵比價",
+    "tooltip": "清空目前篩選，切換到所有帳號，並按同模型最低價優先排序。"
+  },
   "copyAllNames": "複製所有模型名稱",
   "description": "檢視和管理可用的AI模型",
   "detailedPricing": "詳細定價",

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -355,6 +355,7 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
   DeleteManagedSiteChannel: "delete_managed_site_channel",
   DeleteSelectedManagedSiteChannels: "delete_selected_managed_site_channels",
   DisableSelectedAccounts: "disable_selected_accounts",
+  EnableModelPriceComparison: "enable_model_price_comparison",
   EnableProductAnalytics: "enable_product_analytics",
   EnterAccountBulkMode: "enter_account_bulk_mode",
   ExportAccountData: "export_account_data",
@@ -509,7 +510,6 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
     "select_all_managed_site_model_sync_channels",
   SelectManagedSiteModelSyncTab: "select_managed_site_model_sync_tab",
   SelectModelSource: "select_model_source",
-  EnableModelPriceComparison: "enable_model_price_comparison",
   FilterModelList: "filter_model_list",
   SelectApiCredentialProfileExportDestination:
     "select_api_credential_profile_export_destination",

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -509,6 +509,7 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
     "select_all_managed_site_model_sync_channels",
   SelectManagedSiteModelSyncTab: "select_managed_site_model_sync_tab",
   SelectModelSource: "select_model_source",
+  EnableModelPriceComparison: "enable_model_price_comparison",
   FilterModelList: "filter_model_list",
   SelectApiCredentialProfileExportDestination:
     "select_api_credential_profile_export_destination",

--- a/tests/components/ui/Alert.test.tsx
+++ b/tests/components/ui/Alert.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest"
 import { Alert } from "~/components/ui/Alert"
 
 describe("Alert", () => {
-  it("renders compact alerts with inline icon and text", () => {
+  it("renders compact alerts with a stable icon and content grid", () => {
     render(
       <Alert
         compact
@@ -16,13 +16,12 @@ describe("Alert", () => {
     const alert = screen.getByRole("alert")
     const icon = alert.querySelector("svg")
 
-    expect(alert).toHaveClass("flex")
+    expect(alert).toHaveClass("grid")
+    expect(alert).toHaveClass("grid-cols-[auto_minmax(0,1fr)]")
     expect(alert).toHaveClass("items-start")
-    expect(alert).toHaveClass("sm:items-center")
-    expect(alert).toHaveClass("gap-2")
+    expect(alert).toHaveClass("gap-3")
     expect(icon).toHaveClass("shrink-0")
     expect(icon).toHaveClass("mt-0.5")
-    expect(icon).toHaveClass("sm:mt-0")
     expect(alert).toHaveTextContent(
       "Save the draft before testing the connection.",
     )

--- a/tests/features/ModelList/components/ControlPanel.test.tsx
+++ b/tests/features/ModelList/components/ControlPanel.test.tsx
@@ -1,0 +1,287 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { MODEL_LIST_BILLING_MODES } from "~/features/ModelList/billingModes"
+import { ControlPanel } from "~/features/ModelList/components/ControlPanel"
+import {
+  ALL_ACCOUNTS_SOURCE_VALUE,
+  MODEL_MANAGEMENT_SOURCE_KINDS,
+  type ModelManagementSourceCapabilities,
+} from "~/features/ModelList/modelManagementSources"
+import { MODEL_LIST_SORT_MODES } from "~/features/ModelList/sortModes"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_RESULTS,
+} from "~/services/productAnalytics/events"
+
+const { trackProductAnalyticsActionCompletedMock } = vi.hoisted(() => ({
+  trackProductAnalyticsActionCompletedMock: vi.fn(),
+}))
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock("~/services/productAnalytics/actions", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/productAnalytics/actions")>()
+
+  return {
+    ...actual,
+    trackProductAnalyticsActionCompleted:
+      trackProductAnalyticsActionCompletedMock,
+  }
+})
+
+vi.mock("~/components/ui", () => ({
+  Alert: ({
+    title,
+    description,
+    children,
+    variant: _variant,
+    compact: _compact,
+    ...props
+  }: React.PropsWithChildren<{
+    title?: string
+    description?: string
+    variant?: string
+    compact?: boolean
+  }>) => (
+    <section role="alert" {...props}>
+      <div>{title}</div>
+      <div>{description}</div>
+      {children}
+    </section>
+  ),
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    leftIcon: _leftIcon,
+    analyticsAction: _analyticsAction,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: React.PropsWithChildren<
+    React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      leftIcon?: React.ReactNode
+      analyticsAction?: unknown
+      variant?: string
+      size?: string
+    }
+  >) => (
+    <button type="button" onClick={onClick} disabled={disabled} {...props}>
+      {children}
+    </button>
+  ),
+  Card: ({ children, ...props }: React.PropsWithChildren<object>) => (
+    <div {...props}>{children}</div>
+  ),
+  CardContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  CompactMultiSelect: () => <div data-testid="group-filter" />,
+  FormField: ({
+    label,
+    children,
+  }: React.PropsWithChildren<{ label: string }>) => (
+    <label>
+      {label}
+      {children}
+    </label>
+  ),
+  Input: ({
+    value,
+    onChange,
+    placeholder,
+  }: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input value={value} onChange={onChange} placeholder={placeholder} />
+  ),
+  Label: ({ children }: React.PropsWithChildren) => <span>{children}</span>,
+  SearchableSelect: ({
+    value,
+    onChange,
+    options,
+    placeholder,
+  }: {
+    value: string
+    onChange: (value: string) => void
+    options: Array<{ value: string; label: string }>
+    placeholder?: string
+  }) => (
+    <select
+      aria-label={placeholder}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+  Switch: ({
+    checked,
+    onChange,
+  }: {
+    checked: boolean
+    onChange: (checked: boolean) => void
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(event) => onChange(event.target.checked)}
+    />
+  ),
+}))
+
+const CAPABILITIES: ModelManagementSourceCapabilities = {
+  supportsPricing: true,
+  supportsRatioDisplay: true,
+  supportsGroupFiltering: true,
+  supportsAccountSummary: false,
+  supportsTokenCompatibility: true,
+  supportsCredentialVerification: true,
+  supportsBatchCredentialVerification: true,
+  supportsCliVerification: true,
+}
+
+const ACCOUNT_SOURCE = {
+  kind: MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT,
+  value: "account:account-1",
+  account: { id: "account-1", name: "Account One" },
+  capabilities: CAPABILITIES,
+} as any
+
+const ALL_ACCOUNTS_SOURCE = {
+  kind: MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS,
+  value: ALL_ACCOUNTS_SOURCE_VALUE,
+  capabilities: {
+    ...CAPABILITIES,
+    supportsAccountSummary: true,
+    supportsCredentialVerification: false,
+  },
+} as any
+
+function renderControlPanel(
+  overrides: Partial<React.ComponentProps<typeof ControlPanel>> = {},
+) {
+  const props: React.ComponentProps<typeof ControlPanel> = {
+    selectedSource: ACCOUNT_SOURCE,
+    sourceCapabilities: CAPABILITIES,
+    selectedSourceValue: "account:account-1",
+    setSelectedSourceValue: vi.fn(),
+    searchTerm: "",
+    setSearchTerm: vi.fn(),
+    sortMode: MODEL_LIST_SORT_MODES.DEFAULT,
+    setSortMode: vi.fn(),
+    selectedBillingMode: MODEL_LIST_BILLING_MODES.TOKEN_BASED,
+    setSelectedBillingMode: vi.fn(),
+    selectedGroups: ["vip"],
+    setSelectedGroups: vi.fn(),
+    availableGroups: ["vip"],
+    pricingData: { group_ratio: { vip: 1 } },
+    showRealPrice: false,
+    setShowRealPrice: vi.fn(),
+    showRatioColumn: false,
+    setShowRatioColumn: vi.fn(),
+    showEndpointTypes: false,
+    setShowEndpointTypes: vi.fn(),
+    totalModels: 2,
+    filteredModels: [{ model: { model_name: "gpt-test" } }],
+    getFilteredResultCount: vi.fn(() => 7),
+    ...overrides,
+  }
+
+  render(<ControlPanel {...props} />)
+
+  return props
+}
+
+describe("ControlPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("enables price comparison with one prominent action", async () => {
+    const user = userEvent.setup()
+    const props = renderControlPanel({
+      onBatchVerifyModels: vi.fn(),
+    })
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+
+    const copyButton = screen.getByRole("button", { name: "copyAllNames" })
+    const comparisonButton = screen.getByRole("button", {
+      name: "comparison.cta",
+    })
+    const batchVerifyButton = screen.getByRole("button", {
+      name: "batchVerify.actions.open",
+    })
+
+    expect(
+      copyButton.compareDocumentPosition(batchVerifyButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(
+      batchVerifyButton.compareDocumentPosition(comparisonButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+
+    await user.click(comparisonButton)
+
+    expect(props.setSelectedSourceValue).toHaveBeenCalledWith(
+      ALL_ACCOUNTS_SOURCE_VALUE,
+    )
+    expect(props.setSortMode).toHaveBeenCalledWith(
+      MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST,
+    )
+    expect(props.setSelectedBillingMode).toHaveBeenCalledWith(
+      MODEL_LIST_BILLING_MODES.ALL,
+    )
+    expect(props.setSelectedGroups).toHaveBeenCalledWith([])
+    expect(props.setShowRealPrice).toHaveBeenCalledWith(true)
+    expect(trackProductAnalyticsActionCompletedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: PRODUCT_ANALYTICS_ACTION_IDS.EnableModelPriceComparison,
+        result: PRODUCT_ANALYTICS_RESULTS.Success,
+      }),
+    )
+  })
+
+  it("hides the prompt when price comparison is already active", () => {
+    renderControlPanel({
+      selectedSource: ALL_ACCOUNTS_SOURCE,
+      selectedSourceValue: ALL_ACCOUNTS_SOURCE_VALUE,
+      sortMode: MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST,
+      selectedBillingMode: MODEL_LIST_BILLING_MODES.ALL,
+      selectedGroups: [],
+      showRealPrice: true,
+    })
+
+    expect(
+      screen.queryByRole("button", { name: "comparison.cta" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("does not show the prompt when pricing is unavailable", () => {
+    renderControlPanel({
+      sourceCapabilities: {
+        ...CAPABILITIES,
+        supportsPricing: false,
+      },
+    })
+
+    expect(
+      screen.queryByRole("button", { name: "comparison.cta" }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/tests/features/ModelList/components/ControlPanel.test.tsx
+++ b/tests/features/ModelList/components/ControlPanel.test.tsx
@@ -217,8 +217,6 @@ describe("ControlPanel", () => {
       onBatchVerifyModels: vi.fn(),
     })
 
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
-
     const copyButton = screen.getByRole("button", { name: "copyAllNames" })
     const comparisonButton = screen.getByRole("button", {
       name: "comparison.cta",
@@ -253,6 +251,28 @@ describe("ControlPanel", () => {
       expect.objectContaining({
         actionId: PRODUCT_ANALYTICS_ACTION_IDS.EnableModelPriceComparison,
         result: PRODUCT_ANALYTICS_RESULTS.Success,
+        insights: expect.objectContaining({
+          filterCount: 1,
+        }),
+      }),
+    )
+  })
+
+  it("counts the existing search term when enabling price comparison", async () => {
+    const user = userEvent.setup()
+    renderControlPanel({
+      searchTerm: "gpt",
+    })
+
+    await user.click(screen.getByRole("button", { name: "comparison.cta" }))
+
+    expect(trackProductAnalyticsActionCompletedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: PRODUCT_ANALYTICS_ACTION_IDS.EnableModelPriceComparison,
+        result: PRODUCT_ANALYTICS_RESULTS.Success,
+        insights: expect.objectContaining({
+          filterCount: 2,
+        }),
       }),
     )
   })


### PR DESCRIPTION
## Summary
- Add a less intrusive one-click price comparison shortcut to the Model List controls.
- Improve compact alert icon/content alignment.
- Add localized CTA/help copy and focused component coverage.

## Test Plan
- pnpm test tests/components/ui/Alert.test.tsx tests/features/ModelList/components/ControlPanel.test.tsx tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
- pnpm compile
- pnpm run i18n:extract:ci
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Compare Prices” control that, when enabled, switches to all accounts, clears current filters/groups, sorts models by the lowest price, and turns on real-price comparison.
  * Added localized text/tooltips for the new comparison feature across supported languages.

* **UI / Style**
  * Updated the compact alert layout and spacing for a cleaner alignment.

* **Tests**
  * Expanded test coverage for the comparison control behavior and updated alert compact layout expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->