### PR TITLE
refactor(api-adapters): add model catalog capability

### DIFF
--- a/docs/superpowers/plans/2026-06-17-api-adapter-model-catalog.md
+++ b/docs/superpowers/plans/2026-06-17-api-adapter-model-catalog.md
@@ -1,0 +1,681 @@
+# API Adapter Model Catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-api-adapter-model-catalog-design.md`
+
+**Goal:** Move Sub2API runtime model catalog discovery behind `getSiteAdapter(...)` while preserving existing Model List behavior.
+
+**Architecture:** Add a narrow `modelCatalog` capability to `apiAdapters`. The Sub2API Adapter delegates to the existing `fetchSub2ApiRuntimeModels(...)` implementation, while `apiCredentialProfiles/modelCatalog.ts` remains the product-level owner of `PricingResponse` construction and estimated-pricing fallback.
+
+**Tech Stack:** TypeScript, Vitest, existing `apiAdapters`, existing Sub2API API helpers, `pnpm run validate:staged`.
+
+---
+
+## File Structure
+
+- Create `src/services/apiAdapters/contracts/modelCatalog.ts`
+  - Defines the runtime API-key model catalog capability.
+- Modify `src/services/apiAdapters/contracts/siteAdapter.ts`
+  - Adds optional `modelCatalog`.
+- Create `src/services/apiAdapters/sub2api/modelCatalog.ts`
+  - Wraps existing `fetchSub2ApiRuntimeModels`.
+- Modify `src/services/apiAdapters/sub2api/index.ts`
+  - Exposes `modelCatalog` on `sub2ApiAdapter`.
+- Validate `src/services/apiAdapters/registry.ts`
+  - No source change is expected; registry tests should confirm the expanded Sub2API Adapter shape.
+- Create `tests/services/apiAdapters/sub2api/modelCatalog.test.ts`
+  - Verifies delegation to `fetchSub2ApiRuntimeModels`.
+- Modify `tests/services/apiAdapters/registry.test.ts`
+  - Verifies Sub2API has `modelCatalog`, while other sites do not.
+- Modify `src/services/apiCredentialProfiles/modelCatalog.ts`
+  - Replaces direct runtime model import/call with `getSiteAdapter(...).modelCatalog`.
+- Modify `tests/services/apiCredentialProfiles/modelCatalog.test.ts`
+  - Mocks `~/services/apiAdapters/registry` for the Sub2API runtime model path.
+
+---
+
+## Task 1: Add The Sub2API Model Catalog Adapter
+
+**Files:**
+- Create: `src/services/apiAdapters/contracts/modelCatalog.ts`
+- Modify: `src/services/apiAdapters/contracts/siteAdapter.ts`
+- Create: `src/services/apiAdapters/sub2api/modelCatalog.ts`
+- Modify: `src/services/apiAdapters/sub2api/index.ts`
+- Create: `tests/services/apiAdapters/sub2api/modelCatalog.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write the failing Sub2API model catalog Adapter test**
+
+Create `tests/services/apiAdapters/sub2api/modelCatalog.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+
+import { sub2ApiModelCatalog } from "~/services/apiAdapters/sub2api/modelCatalog"
+import { AuthTypeEnum } from "~/types"
+
+const { fetchSub2ApiRuntimeModelsMock } = vi.hoisted(() => ({
+  fetchSub2ApiRuntimeModelsMock: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchSub2ApiRuntimeModels: fetchSub2ApiRuntimeModelsMock,
+}))
+
+describe("sub2ApiModelCatalog", () => {
+  it("delegates runtime model discovery to the existing Sub2API helper", async () => {
+    fetchSub2ApiRuntimeModelsMock.mockResolvedValueOnce([
+      "example-model-a",
+      "example-model-b",
+    ])
+
+    const request = {
+      baseUrl: "https://sub2.example.com",
+      accountId: "account-1",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        apiKey: "runtime-key",
+      },
+    }
+
+    await expect(sub2ApiModelCatalog.fetchModels(request)).resolves.toEqual([
+      "example-model-a",
+      "example-model-b",
+    ])
+    expect(fetchSub2ApiRuntimeModelsMock).toHaveBeenCalledWith(request)
+  })
+})
+```
+
+- [ ] **Step 2: Update the registry test expectations before implementation**
+
+In `tests/services/apiAdapters/registry.test.ts`, update the Sub2API test to include `modelCatalog`:
+
+```ts
+expect(adapter.modelCatalog).toEqual({
+  fetchModels: expect.any(Function),
+})
+```
+
+In each New API-family and AIHubMix registry assertion, add:
+
+```ts
+expect(adapter.modelCatalog).toBeUndefined()
+```
+
+- [ ] **Step 3: Run the failing Adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/sub2api/modelCatalog.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because `sub2api/modelCatalog.ts` and the `modelCatalog` contract do not exist yet.
+
+- [ ] **Step 4: Add the model catalog contract**
+
+Create `src/services/apiAdapters/contracts/modelCatalog.ts`:
+
+```ts
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+
+export type ModelCatalogRequest = ApiServiceRequest & {
+  auth: ApiServiceRequest["auth"] & {
+    apiKey: string
+  }
+}
+
+export type ModelCatalogCapability = {
+  fetchModels(request: ModelCatalogRequest): Promise<string[]>
+}
+```
+
+- [ ] **Step 5: Extend the SiteAdapter contract**
+
+In `src/services/apiAdapters/contracts/siteAdapter.ts`, add this import:
+
+```ts
+import type { ModelCatalogCapability } from "./modelCatalog"
+```
+
+Then add this property to `SiteAdapter`:
+
+```ts
+  modelCatalog?: ModelCatalogCapability
+```
+
+The final shape should include `modelCatalog` alongside `siteNotice` and `siteAnnouncements`.
+
+- [ ] **Step 6: Add the Sub2API model catalog Adapter**
+
+Create `src/services/apiAdapters/sub2api/modelCatalog.ts`:
+
+```ts
+import { fetchSub2ApiRuntimeModels } from "~/services/apiService/sub2api"
+
+import type { ModelCatalogCapability } from "../contracts/modelCatalog"
+
+export const sub2ApiModelCatalog: ModelCatalogCapability = {
+  fetchModels: fetchSub2ApiRuntimeModels,
+}
+```
+
+- [ ] **Step 7: Expose the capability from the Sub2API Adapter**
+
+In `src/services/apiAdapters/sub2api/index.ts`, add:
+
+```ts
+import { sub2ApiModelCatalog } from "./modelCatalog"
+```
+
+Then update `sub2ApiAdapter`:
+
+```ts
+export const sub2ApiAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.SUB2API,
+  family: "sub2api",
+  siteAnnouncements: sub2ApiSiteAnnouncements,
+  modelCatalog: sub2ApiModelCatalog,
+}
+```
+
+- [ ] **Step 8: Run the Adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/sub2api/modelCatalog.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 1**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiAdapters/contracts/modelCatalog.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/sub2api/modelCatalog.ts src/services/apiAdapters/sub2api/index.ts tests/services/apiAdapters/sub2api/modelCatalog.test.ts tests/services/apiAdapters/registry.test.ts
+pnpm run validate:staged
+git commit -m "refactor(api-adapters): add sub2api model catalog capability"
+```
+
+Expected: `validate:staged` exits 0, then one focused commit is created containing only the Adapter capability and tests.
+
+---
+
+## Task 2: Route Sub2API Runtime Model Discovery Through The Adapter
+
+**Files:**
+- Modify: `src/services/apiCredentialProfiles/modelCatalog.ts`
+- Modify: `tests/services/apiCredentialProfiles/modelCatalog.test.ts`
+
+- [ ] **Step 1: Update the model catalog test mock setup**
+
+In `tests/services/apiCredentialProfiles/modelCatalog.test.ts`, add
+`getSiteAdapterMock` to the existing hoisted mock block. Do not add a second
+top-level `vi.hoisted(...)` block, because `fetchSub2ApiRuntimeModelsMock`
+already exists in the current hoisted block.
+
+Update the existing destructuring list from:
+
+```ts
+const {
+  fetchAnthropicModelIdsMock,
+  fetchGoogleModelIdsMock,
+  fetchOpenAICompatibleModelIdsMock,
+  fetchAccountTokensMock,
+  fetchSub2ApiAvailableGroupsMock,
+  fetchSub2ApiGroupRatesMock,
+  fetchSub2ApiRuntimeModelsMock,
+  getApiServiceMock,
+  loadModelPriceTableMock,
+  resolveDisplayAccountTokenForSecretMock,
+} = vi.hoisted(() => ({
+```
+
+to:
+
+```ts
+const {
+  fetchAnthropicModelIdsMock,
+  fetchGoogleModelIdsMock,
+  fetchOpenAICompatibleModelIdsMock,
+  fetchAccountTokensMock,
+  fetchSub2ApiAvailableGroupsMock,
+  fetchSub2ApiGroupRatesMock,
+  fetchSub2ApiRuntimeModelsMock,
+  getApiServiceMock,
+  getSiteAdapterMock,
+  loadModelPriceTableMock,
+  resolveDisplayAccountTokenForSecretMock,
+} = vi.hoisted(() => ({
+```
+
+Then add `getSiteAdapterMock` to the object returned by the same hoisted block:
+
+```ts
+  getSiteAdapterMock: vi.fn(),
+```
+
+Keep the existing direct Sub2API module mock for estimated-pricing helpers, but
+remove only the runtime-model export from that module mock. Change:
+
+```ts
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchAccountTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+  fetchSub2ApiAvailableGroups: (...args: unknown[]) =>
+    fetchSub2ApiAvailableGroupsMock(...args),
+  fetchSub2ApiGroupRates: (...args: unknown[]) =>
+    fetchSub2ApiGroupRatesMock(...args),
+  fetchSub2ApiRuntimeModels: (...args: unknown[]) =>
+    fetchSub2ApiRuntimeModelsMock(...args),
+}))
+```
+
+to:
+
+```ts
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchAccountTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+  fetchSub2ApiAvailableGroups: (...args: unknown[]) =>
+    fetchSub2ApiAvailableGroupsMock(...args),
+  fetchSub2ApiGroupRates: (...args: unknown[]) =>
+    fetchSub2ApiGroupRatesMock(...args),
+}))
+```
+
+Add the Adapter registry mock:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: getSiteAdapterMock,
+}))
+```
+
+Keep the existing `fetchSub2ApiRuntimeModelsMock` spy, but route it through the
+Adapter helper below instead of through the old direct module mock.
+
+- [ ] **Step 2: Add Sub2API Adapter test helpers**
+
+In `tests/services/apiCredentialProfiles/modelCatalog.test.ts`, add these helpers near the existing test fixtures:
+
+```ts
+const createSub2ApiModelCatalogAdapter = (
+  fetchModels = fetchSub2ApiRuntimeModelsMock,
+) => ({
+  siteType: SITE_TYPES.SUB2API,
+  family: "sub2api" as const,
+  modelCatalog: {
+    fetchModels,
+  },
+})
+
+const mockSub2ApiModelCatalogAdapter = (
+  fetchModels = fetchSub2ApiRuntimeModelsMock,
+) => {
+  getSiteAdapterMock.mockReturnValue(createSub2ApiModelCatalogAdapter(fetchModels))
+}
+```
+
+In the test `beforeEach`, reset the new mock and default the Adapter:
+
+```ts
+getSiteAdapterMock.mockReset()
+fetchSub2ApiRuntimeModelsMock.mockReset()
+mockSub2ApiModelCatalogAdapter()
+```
+
+At the end of the non-Sub2API tests for OpenAI-compatible fallback and AIHubMix
+fallback, add:
+
+```ts
+expect(getSiteAdapterMock).not.toHaveBeenCalled()
+```
+
+This proves the new Adapter Seam is used only for the Sub2API runtime catalog
+path in this slice.
+
+- [ ] **Step 3: Update existing runtime-model test assertions**
+
+In the existing test named like `"loads Sub2API selected-key runtime models as model-list-only rows"`, keep the existing setup:
+
+```ts
+fetchSub2ApiRuntimeModelsMock.mockResolvedValueOnce([
+  "example-model-a",
+  "example-model-b",
+])
+```
+
+Update the assertion to verify the Adapter path:
+
+```ts
+expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.SUB2API)
+expect(fetchSub2ApiRuntimeModelsMock).toHaveBeenCalledWith({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    apiKey: "resolved-runtime-key",
+  },
+})
+```
+
+Use the exact resolved key already expected by the existing test fixture. Do not assert a raw secret if the test currently uses a different placeholder key.
+
+- [ ] **Step 4: Add a missing-capability test**
+
+Add this test in the `loadAccountTokenFallbackPricingResponse` describe block:
+
+```ts
+it("sanitizes a missing Sub2API model catalog capability failure", async () => {
+  getSiteAdapterMock.mockReturnValueOnce({
+    siteType: SITE_TYPES.SUB2API,
+    family: "sub2api",
+  })
+
+  await expect(
+    loadAccountTokenFallbackPricingResponse({
+      account: sub2ApiAccount,
+      token: sub2ApiToken,
+    }),
+  ).rejects.toThrow("modelCatalog is not implemented for sub2api")
+
+  expect(fetchSub2ApiRuntimeModelsMock).not.toHaveBeenCalled()
+})
+```
+
+If the existing test fixtures use different names than `sub2ApiAccount` and `sub2ApiToken`, use the local Sub2API account and token fixtures already present in the file. Keep all hosts and keys as `example.*` or existing placeholder values.
+
+- [ ] **Step 5: Run the focused product tests to verify failure before implementation**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiCredentialProfiles/modelCatalog.test.ts
+```
+
+Expected: FAIL because `modelCatalog.ts` still directly imports `fetchSub2ApiRuntimeModels` and does not call `getSiteAdapter`.
+
+- [ ] **Step 6: Replace the direct Sub2API runtime model import**
+
+In `src/services/apiCredentialProfiles/modelCatalog.ts`, add:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+Remove `fetchSub2ApiRuntimeModels` from this import:
+
+```ts
+import {
+  fetchAccountTokens,
+  fetchSub2ApiAvailableGroups,
+  fetchSub2ApiGroupRates,
+  fetchSub2ApiRuntimeModels,
+} from "~/services/apiService/sub2api"
+```
+
+The resulting import should be:
+
+```ts
+import {
+  fetchAccountTokens,
+  fetchSub2ApiAvailableGroups,
+  fetchSub2ApiGroupRates,
+} from "~/services/apiService/sub2api"
+```
+
+- [ ] **Step 7: Add a local missing-capability helper**
+
+In `src/services/apiCredentialProfiles/modelCatalog.ts`, near `ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED`, add:
+
+```ts
+const createMissingModelCatalogCapabilityError = () =>
+  new Error("modelCatalog is not implemented for sub2api")
+```
+
+- [ ] **Step 8: Route Sub2API runtime model discovery through the Adapter**
+
+Replace this block:
+
+```ts
+const runtimeModelIds = await fetchSub2ApiRuntimeModels({
+  baseUrl: params.account.baseUrl,
+  accountId: params.account.id,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    apiKey: resolvedToken.key,
+  },
+} as ApiServiceRequest & {
+  auth: ApiServiceRequest["auth"] & { apiKey: string }
+})
+```
+
+with:
+
+```ts
+const adapter = getSiteAdapter(SITE_TYPES.SUB2API)
+if (!adapter.modelCatalog) {
+  throw createMissingModelCatalogCapabilityError()
+}
+
+const runtimeModelIds = await adapter.modelCatalog.fetchModels({
+  baseUrl: params.account.baseUrl,
+  accountId: params.account.id,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    apiKey: resolvedToken.key,
+  },
+})
+```
+
+This should remove the need for the type assertion because the Adapter contract requires `auth.apiKey`.
+
+- [ ] **Step 9: Run the product tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiCredentialProfiles/modelCatalog.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Confirm the direct runtime helper import is gone from the product Module**
+
+Run:
+
+```powershell
+rg -n "fetchSub2ApiRuntimeModels" src/services/apiCredentialProfiles src/services/apiAdapters tests/services/apiCredentialProfiles tests/services/apiAdapters
+```
+
+Expected matches:
+
+```text
+src/services/apiAdapters/sub2api/modelCatalog.ts
+tests/services/apiAdapters/sub2api/modelCatalog.test.ts
+tests/services/apiCredentialProfiles/modelCatalog.test.ts
+```
+
+There should be no match in `src/services/apiCredentialProfiles/modelCatalog.ts`.
+
+- [ ] **Step 11: Commit Task 2**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiCredentialProfiles/modelCatalog.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts
+pnpm run validate:staged
+git commit -m "refactor(model-list): use adapter model catalog"
+```
+
+Expected: `validate:staged` exits 0, then one focused commit is created containing only product routing and tests.
+
+---
+
+## Task 3: Final Validation And Scope Audit
+
+**Files:**
+- Validate: `src/services/apiAdapters/**`
+- Validate: `src/services/apiCredentialProfiles/modelCatalog.ts`
+- Validate: `tests/services/apiAdapters/**`
+- Validate: `tests/services/apiCredentialProfiles/modelCatalog.test.ts`
+
+- [ ] **Step 1: Run focused validation**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/sub2api/modelCatalog.test.ts tests/services/apiAdapters/registry.test.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run related validation**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/sub2api/modelCatalog.ts src/services/apiAdapters/registry.ts src/services/apiCredentialProfiles/modelCatalog.ts
+```
+
+Expected: PASS. If `vitest related` cannot resolve the new adapter file before staging, classify that as tooling and keep the focused suite as the primary evidence.
+
+- [ ] **Step 3: Run TypeScript validation**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS. This slice adds a shared Adapter contract and extends
+`SiteAdapter`, so compile is required even if focused Vitest passes.
+
+- [ ] **Step 4: Run the commit gate**
+
+If Tasks 1 and 2 were committed individually, skip staging and only inspect status. If the implementation was done as one batch, stage only task-scoped files:
+
+```powershell
+git add src/services/apiAdapters/contracts/modelCatalog.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/sub2api/modelCatalog.ts src/services/apiAdapters/sub2api/index.ts tests/services/apiAdapters/sub2api/modelCatalog.test.ts tests/services/apiAdapters/registry.test.ts
+git add src/services/apiCredentialProfiles/modelCatalog.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the pre-push / PR gate before publishing**
+
+Before pushing, opening a PR, or updating a PR branch, run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. This is required for the implementation because it changes
+shared TypeScript service contracts and dependency graph wiring.
+
+- [ ] **Step 6: Inspect the final diff or recent commits**
+
+If changes are staged, run:
+
+```powershell
+git diff --cached --stat
+git diff --cached --name-status
+```
+
+Expected staged files:
+
+```text
+A src/services/apiAdapters/contracts/modelCatalog.ts
+M src/services/apiAdapters/contracts/siteAdapter.ts
+A src/services/apiAdapters/sub2api/modelCatalog.ts
+M src/services/apiAdapters/sub2api/index.ts
+M tests/services/apiAdapters/registry.test.ts
+A tests/services/apiAdapters/sub2api/modelCatalog.test.ts
+M src/services/apiCredentialProfiles/modelCatalog.ts
+M tests/services/apiCredentialProfiles/modelCatalog.test.ts
+```
+
+If Tasks 1 and 2 were committed individually, run:
+
+```powershell
+git log --oneline -5
+git show --stat --oneline HEAD~2..HEAD
+```
+
+Expected recent commits include:
+
+```text
+refactor(api-adapters): add sub2api model catalog capability
+refactor(model-list): use adapter model catalog
+```
+
+- [ ] **Step 7: Confirm no out-of-scope migration leaked in**
+
+Run:
+
+```powershell
+git diff --name-only HEAD~2..HEAD
+```
+
+Expected: no files under these areas unless the implementation was intentionally batched differently and the diff is still task-scoped:
+
+```text
+src/services/redemption/
+src/services/accounts/
+src/services/managedSites/
+src/entrypoints/
+src/locales/
+e2e/
+```
+
+Also confirm:
+
+- no estimated-pricing group/rate fetch was moved to `apiAdapters`
+- no AIHubMix model pricing behavior changed
+- no `getApiService(...).capabilities.modelPricing` value changed
+- no user-facing copy or locale key was added
+- no Playwright E2E test was added
+
+- [ ] **Step 8: Final commit if needed**
+
+If Tasks 1 and 2 were not committed individually, commit the final staged task-scoped diff:
+
+```powershell
+git commit -m "refactor(api-adapters): migrate sub2api model catalog"
+```
+
+If Tasks 1 and 2 were committed individually, skip this step and report the commit hashes.
+
+- [ ] **Step 9: Record final status**
+
+Run:
+
+```powershell
+git status --porcelain
+```
+
+Expected: only unrelated pre-existing files remain untracked or modified.
+
+---
+
+## Out Of Scope
+
+- Do not migrate Sub2API estimated pricing inputs in this slice.
+- Do not move `fetchAccountTokens`, `fetchSub2ApiAvailableGroups`, or `fetchSub2ApiGroupRates`.
+- Do not change AIHubMix model pricing.
+- Do not change all-key comparison, source identity, source labels, filtering, sorting, or cache identity.
+- Do not change `getApiService` capability booleans.
+- Do not add `modelPricing`, `redemption`, `account`, or `keyManagement` Adapter capability fields.
+- Do not add locale files, telemetry, settings search entries, or Playwright E2E tests.
+
+## Self-Review Notes
+
+- Spec coverage: Task 1 adds the new `modelCatalog` Adapter capability and tests. Task 2 migrates the product-level Sub2API runtime model-list caller while preserving response construction and estimated-pricing behavior. Task 3 validates the focused route with focused Vitest, `compile`, `validate:staged`, `validate:push`, and scope audit.
+- Placeholder scan: All steps include exact paths, code snippets, commands, and expected outcomes. The fixture-name caveat is explicitly constrained to use existing local placeholders if the current test file names differ, and the mock rewrite is explicit about updating the existing hoisted block instead of redeclaring `fetchSub2ApiRuntimeModelsMock`.
+- Type consistency: The plan consistently uses `ModelCatalogCapability.fetchModels(request)`, `ModelCatalogRequest` with `auth.apiKey`, and `SiteAdapter.modelCatalog`.

--- a/docs/superpowers/specs/2026-06-17-api-adapter-model-catalog-design.md
+++ b/docs/superpowers/specs/2026-06-17-api-adapter-model-catalog-design.md
@@ -1,0 +1,321 @@
+# API Adapter Model Catalog Design
+
+Date: 2026-06-17
+
+## Purpose
+
+Move the Sub2API runtime model-list call behind the new `apiAdapters` Seam
+without changing Model List pricing, all-key comparison, or UI behavior.
+
+The previous site-announcements slice established `getSiteAdapter(siteType)` as
+the first real Adapter registry. This slice should use that same Seam for the
+next concrete backend capability: runtime model catalog discovery.
+
+## Current Context
+
+The repository now has a narrow Adapter Module:
+
+```text
+src/services/apiAdapters/
+  contracts/
+  newApi/
+  sub2api/
+  registry.ts
+```
+
+It currently exposes `siteNotice` for New API-family sites and
+`siteAnnouncements` for Sub2API.
+
+Sub2API model-list support already exists, but the backend dependency is still
+owned by `src/services/apiCredentialProfiles/modelCatalog.ts`:
+
+- `loadAccountTokenFallbackPricingResponse(...)` detects Sub2API accounts.
+- It resolves a saved runtime key.
+- It directly imports and calls `fetchSub2ApiRuntimeModels(...)` from
+  `src/services/apiService/sub2api`.
+- It then builds a Model List `PricingResponse` with
+  `MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY`.
+- If dashboard JWT data is available, the same Module separately loads group
+  metadata, account tokens, and a model price table to estimate prices.
+
+The product behavior is already correct enough for this slice: runtime model
+visibility comes from `/v1/models` with API-key auth, while estimated pricing is
+optional and explicitly marked as estimated or unavailable.
+
+## Problem
+
+`apiCredentialProfiles/modelCatalog.ts` is a product-level Model List source
+Module, but it currently knows a Sub2API backend helper directly. That weakens
+the Adapter Seam established by the site-announcements slice:
+
+1. Backend protocol calls remain scattered outside `apiAdapters`.
+2. Sub2API runtime catalog support is not visible on `getSiteAdapter(...)`.
+3. Later Model List slices cannot ask a site Adapter whether key-scoped runtime
+   model discovery is supported.
+4. The direct import makes `modelCatalog.ts` carry both product-level fallback
+   orchestration and backend-specific capability routing.
+
+Deletion test: if the direct Sub2API import were deleted from
+`modelCatalog.ts`, the complexity should not reappear as another direct
+provider import. It should live behind a `modelCatalog` capability on the
+Sub2API Adapter.
+
+## Goals
+
+- Add a narrow `modelCatalog` Adapter capability.
+- In the first implementation, expose only Sub2API runtime API-key model
+  discovery through that capability.
+- Keep Sub2API `/v1/models` behavior in
+  `src/services/apiService/sub2api/index.ts`; the Adapter should delegate to
+  the existing implementation.
+- Update `src/services/apiCredentialProfiles/modelCatalog.ts` to call
+  `getSiteAdapter(SITE_TYPES.SUB2API).modelCatalog`.
+- Preserve all existing `PricingResponse` output shapes and Model List UI
+  behavior.
+- Keep estimated pricing inputs and logic out of this slice.
+- Add focused tests for the new capability and the product Module routing.
+
+## Non-Goals
+
+- Do not migrate estimated pricing, group-rate resolution, account-token
+  lookup, model price table loading, or channel pricing in this slice.
+- Do not change `capabilities.modelPricing` on `getApiService(...)`.
+- Do not reclassify Sub2API as supporting full account-level model pricing.
+- Do not move AIHubMix model pricing into `apiAdapters`.
+- Do not change all-key comparison, source identity, cache identity, filtering,
+  sorting, or source labels.
+- Do not change Sub2API `/v1/models` endpoint behavior, auth type, validation,
+  sanitization, or error messages.
+- Do not add locale keys, telemetry, settings search entries, or Playwright
+  E2E coverage.
+
+## Design
+
+### 1. Add `ModelCatalogCapability`
+
+Create:
+
+```text
+src/services/apiAdapters/contracts/modelCatalog.ts
+```
+
+Contract:
+
+```ts
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+
+export type ModelCatalogRequest = ApiServiceRequest & {
+  auth: ApiServiceRequest["auth"] & {
+    apiKey: string
+  }
+}
+
+export type ModelCatalogCapability = {
+  fetchModels(request: ModelCatalogRequest): Promise<string[]>
+}
+```
+
+The request requires `apiKey` because this first capability is runtime
+API-key-scoped. It should not imply dashboard JWT support or account-level
+pricing support.
+
+### 2. Extend `SiteAdapter`
+
+Add:
+
+```ts
+modelCatalog?: ModelCatalogCapability
+```
+
+Capability presence remains the support signal. A missing `modelCatalog`
+means the site Adapter does not expose runtime model catalog discovery in this
+slice.
+
+### 3. Add Sub2API Adapter Implementation
+
+Create:
+
+```text
+src/services/apiAdapters/sub2api/modelCatalog.ts
+```
+
+Implementation:
+
+```ts
+import { fetchSub2ApiRuntimeModels } from "~/services/apiService/sub2api"
+
+import type { ModelCatalogCapability } from "../contracts/modelCatalog"
+
+export const sub2ApiModelCatalog: ModelCatalogCapability = {
+  fetchModels: fetchSub2ApiRuntimeModels,
+}
+```
+
+Then expose it from `src/services/apiAdapters/sub2api/index.ts`:
+
+```ts
+modelCatalog: sub2ApiModelCatalog
+```
+
+Do not add a New API-family `modelCatalog` implementation yet. OpenAI-compatible
+profile fallback model discovery currently goes through
+`src/services/aiApi/openaiCompatible`, not account-site backend Adapters. That
+can be revisited only if a future caller needs it.
+
+### 4. Update Product-Level Model Catalog Routing
+
+In `src/services/apiCredentialProfiles/modelCatalog.ts`, replace the direct
+Sub2API import and call:
+
+```ts
+fetchSub2ApiRuntimeModels(...)
+```
+
+with:
+
+```ts
+const adapter = getSiteAdapter(SITE_TYPES.SUB2API)
+if (!adapter.modelCatalog) {
+  throw new Error("modelCatalog is not implemented for sub2api")
+}
+
+const runtimeModelIds = await adapter.modelCatalog.fetchModels(...)
+```
+
+Keep the request payload unchanged:
+
+```ts
+{
+  baseUrl: params.account.baseUrl,
+  accountId: params.account.id,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    apiKey: resolvedToken.key,
+  },
+}
+```
+
+The product Module still owns:
+
+- resolving saved token secrets
+- building `PricingResponse`
+- marking prices unavailable
+- invoking estimated-pricing fallback
+- sanitizing errors before returning
+
+### 5. Keep Estimated Pricing Direct For Now
+
+The current estimated pricing path still directly imports:
+
+- `fetchAccountTokens`
+- `fetchSub2ApiAvailableGroups`
+- `fetchSub2ApiGroupRates`
+
+Leave those unchanged. They are dashboard-JWT pricing-estimation inputs, not the
+runtime model catalog capability being migrated here.
+
+This is intentional scope control. A later slice can introduce a separate
+capability for Sub2API price-estimation inputs if that improves Locality.
+
+## Error Handling
+
+Adapter capabilities should delegate backend errors unchanged. The product
+Module should keep the existing sanitization behavior in
+`loadAccountTokenFallbackPricingResponse(...)`:
+
+- include `params.account.baseUrl`, `params.token.key`, and the resolved token
+  key in the redaction list
+- throw `ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED` when the sanitized message is empty
+- preserve the original error as `cause`
+
+If `modelCatalog` is missing for Sub2API, treat that as an implementation error
+inside the existing catch path. The final surfaced message should be sanitized
+by the existing wrapper.
+
+## Telemetry Decision
+
+Telemetry decision: none.
+
+This is an internal architecture migration. It does not add a new user action,
+setting, background flow, or observable product state. Existing Model List load
+behavior and any existing analytics remain unchanged.
+
+## Testing Strategy
+
+Add focused Adapter tests:
+
+- Sub2API `modelCatalog.fetchModels` delegates to
+  `fetchSub2ApiRuntimeModels`.
+- The request object is passed through unchanged, including `auth.apiKey`.
+- The registry returns a Sub2API Adapter with `modelCatalog`.
+- The registry does not expose `modelCatalog` for New API-family or AIHubMix
+  sites in this slice.
+
+Update focused product tests:
+
+- `loadAccountTokenFallbackPricingResponse(...)` uses
+  `getSiteAdapter(SITE_TYPES.SUB2API).modelCatalog.fetchModels` for Sub2API
+  runtime models.
+- The existing runtime model-list-only response shape remains unchanged.
+- A missing Sub2API `modelCatalog` capability is sanitized through the existing
+  fallback error path.
+- Existing estimated-pricing tests keep passing without moving group/rate calls.
+
+No Playwright E2E is required. The risk is routing and service delegation, which
+is covered by Vitest.
+
+## Validation Plan
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/sub2api/modelCatalog.test.ts tests/services/apiAdapters/registry.test.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts
+```
+
+Related validation:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/sub2api/modelCatalog.ts src/services/apiAdapters/registry.ts src/services/apiCredentialProfiles/modelCatalog.ts
+```
+
+Commit gate:
+
+```powershell
+pnpm compile
+pnpm run validate:staged
+```
+
+Pre-push / PR gate:
+
+```powershell
+pnpm run validate:push
+```
+
+This slice adds a shared Adapter contract and registry-visible capability, so
+`compile` and the repo's push-equivalent validation are required before pushing
+or opening a PR.
+
+## Rollout
+
+1. Add the `modelCatalog` contract and Sub2API Adapter delegation test.
+2. Extend the Sub2API Adapter and registry tests.
+3. Update `apiCredentialProfiles/modelCatalog.ts` to consume
+   `getSiteAdapter(...).modelCatalog`.
+4. Keep estimated pricing imports and behavior unchanged.
+5. Run focused tests, related tests, `pnpm compile`, and `validate:staged`.
+6. Commit the narrow architecture slice.
+7. Run `validate:push` before pushing or opening a PR.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may migrate:
+
+- Sub2API price-estimation inputs: available groups, group rates, and account
+  token lookup.
+- AIHubMix model pricing into a truthful Adapter capability.
+- New API-family account-level pricing, only if callers benefit from the new
+  Seam.
+- Redemption, as a separate capability after Model List routing is cleaner.
+
+Each later slice should prove the Seam with a concrete caller benefit. Do not
+grow `apiAdapters` into a second flat `apiService` Interface.

--- a/src/services/apiAdapters/contracts/modelCatalog.ts
+++ b/src/services/apiAdapters/contracts/modelCatalog.ts
@@ -1,0 +1,11 @@
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+
+export type ModelCatalogRequest = ApiServiceRequest & {
+  auth: ApiServiceRequest["auth"] & {
+    apiKey: string
+  }
+}
+
+export type ModelCatalogCapability = {
+  fetchModels(request: ModelCatalogRequest): Promise<string[]>
+}

--- a/src/services/apiAdapters/contracts/siteAdapter.ts
+++ b/src/services/apiAdapters/contracts/siteAdapter.ts
@@ -1,5 +1,6 @@
 import type { AccountSiteType } from "~/constants/siteType"
 
+import type { ModelCatalogCapability } from "./modelCatalog"
 import type { SiteAnnouncementsCapability } from "./siteAnnouncements"
 import type { SiteNoticeCapability } from "./siteNotice"
 
@@ -10,4 +11,5 @@ export type SiteAdapter = {
   family?: SiteBackendFamily
   siteNotice?: SiteNoticeCapability
   siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
 }

--- a/src/services/apiAdapters/sub2api/index.ts
+++ b/src/services/apiAdapters/sub2api/index.ts
@@ -1,10 +1,12 @@
 import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
+import { sub2ApiModelCatalog } from "./modelCatalog"
 import { sub2ApiSiteAnnouncements } from "./siteAnnouncements"
 
 export const sub2ApiAdapter: SiteAdapter = {
   siteType: SITE_TYPES.SUB2API,
   family: "sub2api",
   siteAnnouncements: sub2ApiSiteAnnouncements,
+  modelCatalog: sub2ApiModelCatalog,
 }

--- a/src/services/apiAdapters/sub2api/modelCatalog.ts
+++ b/src/services/apiAdapters/sub2api/modelCatalog.ts
@@ -1,0 +1,7 @@
+import { fetchSub2ApiRuntimeModels } from "~/services/apiService/sub2api"
+
+import type { ModelCatalogCapability } from "../contracts/modelCatalog"
+
+export const sub2ApiModelCatalog: ModelCatalogCapability = {
+  fetchModels: fetchSub2ApiRuntimeModels,
+}

--- a/src/services/apiCredentialProfiles/modelCatalog.ts
+++ b/src/services/apiCredentialProfiles/modelCatalog.ts
@@ -3,6 +3,7 @@ import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/a
 import { fetchAnthropicModelIds } from "~/services/aiApi/anthropic"
 import { fetchGoogleModelIds } from "~/services/aiApi/google"
 import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { loadModelPriceTable } from "~/services/apiCredentialProfiles/modelPriceTable"
 import {
   applySub2ApiPriceEstimates,
@@ -21,7 +22,6 @@ import {
   fetchAccountTokens,
   fetchSub2ApiAvailableGroups,
   fetchSub2ApiGroupRates,
-  fetchSub2ApiRuntimeModels,
 } from "~/services/apiService/sub2api"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import {
@@ -54,6 +54,9 @@ type LoadAccountTokenFallbackPricingParams = {
 
 export const ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED =
   "ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED"
+
+const createMissingModelCatalogCapabilityError = () =>
+  new Error("modelCatalog is not implemented for sub2api")
 
 /**
  * Fetch raw model ids using a stored API credential profile.
@@ -120,15 +123,18 @@ export async function loadAccountTokenFallbackPricingResponse(
     resolvedTokenKey = resolvedToken.key
 
     if (params.account.siteType === SITE_TYPES.SUB2API) {
-      const runtimeModelIds = await fetchSub2ApiRuntimeModels({
+      const adapter = getSiteAdapter(SITE_TYPES.SUB2API)
+      if (!adapter.modelCatalog) {
+        throw createMissingModelCatalogCapabilityError()
+      }
+
+      const runtimeModelIds = await adapter.modelCatalog.fetchModels({
         baseUrl: params.account.baseUrl,
         accountId: params.account.id,
         auth: {
           authType: AuthTypeEnum.AccessToken,
           apiKey: resolvedToken.key,
         },
-      } as ApiServiceRequest & {
-        auth: ApiServiceRequest["auth"] & { apiKey: string }
       })
 
       const modelOnlyResponse =

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -15,6 +15,9 @@ describe("apiAdapters registry", () => {
       fetch: expect.any(Function),
       markRead: expect.any(Function),
     })
+    expect(adapter.modelCatalog).toEqual({
+      fetchModels: expect.any(Function),
+    })
     expect(adapter.siteNotice).toBeUndefined()
   })
 
@@ -44,6 +47,7 @@ describe("apiAdapters registry", () => {
         fetch: expect.any(Function),
       })
       expect(adapter.siteAnnouncements).toBeUndefined()
+      expect(adapter.modelCatalog).toBeUndefined()
     }
   })
 
@@ -55,5 +59,6 @@ describe("apiAdapters registry", () => {
     })
     expect(adapter.siteNotice).toBeUndefined()
     expect(adapter.siteAnnouncements).toBeUndefined()
+    expect(adapter.modelCatalog).toBeUndefined()
   })
 })

--- a/tests/services/apiAdapters/sub2api/modelCatalog.test.ts
+++ b/tests/services/apiAdapters/sub2api/modelCatalog.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { sub2ApiModelCatalog } from "~/services/apiAdapters/sub2api/modelCatalog"
+import { AuthTypeEnum } from "~/types"
+
+const { fetchSub2ApiRuntimeModelsMock } = vi.hoisted(() => ({
+  fetchSub2ApiRuntimeModelsMock: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchSub2ApiRuntimeModels: fetchSub2ApiRuntimeModelsMock,
+}))
+
+describe("sub2ApiModelCatalog", () => {
+  it("delegates runtime model discovery to the existing Sub2API helper", async () => {
+    fetchSub2ApiRuntimeModelsMock.mockResolvedValueOnce([
+      "example-model-a",
+      "example-model-b",
+    ])
+
+    const request = {
+      baseUrl: "https://sub2.example.com",
+      accountId: "account-1",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        apiKey: "runtime-key",
+      },
+    }
+
+    await expect(sub2ApiModelCatalog.fetchModels(request)).resolves.toEqual([
+      "example-model-a",
+      "example-model-b",
+    ])
+    expect(fetchSub2ApiRuntimeModelsMock).toHaveBeenCalledWith(request)
+  })
+})

--- a/tests/services/apiCredentialProfiles/modelCatalog.test.ts
+++ b/tests/services/apiCredentialProfiles/modelCatalog.test.ts
@@ -28,6 +28,7 @@ const {
   fetchSub2ApiGroupRatesMock,
   fetchSub2ApiRuntimeModelsMock,
   getApiServiceMock,
+  getSiteAdapterMock,
   loadModelPriceTableMock,
   resolveDisplayAccountTokenForSecretMock,
 } = vi.hoisted(() => ({
@@ -39,6 +40,7 @@ const {
   fetchSub2ApiGroupRatesMock: vi.fn(),
   fetchSub2ApiRuntimeModelsMock: vi.fn(),
   getApiServiceMock: vi.fn(),
+  getSiteAdapterMock: vi.fn(),
   loadModelPriceTableMock: vi.fn(),
   resolveDisplayAccountTokenForSecretMock: vi.fn(),
 }))
@@ -67,8 +69,10 @@ vi.mock("~/services/apiService/sub2api", () => ({
     fetchSub2ApiAvailableGroupsMock(...args),
   fetchSub2ApiGroupRates: (...args: unknown[]) =>
     fetchSub2ApiGroupRatesMock(...args),
-  fetchSub2ApiRuntimeModels: (...args: unknown[]) =>
-    fetchSub2ApiRuntimeModelsMock(...args),
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: getSiteAdapterMock,
 }))
 
 vi.mock("~/services/apiCredentialProfiles/modelPriceTable", () => ({
@@ -123,6 +127,24 @@ const TOKEN = {
   models: "",
 } as const
 
+const createSub2ApiModelCatalogAdapter = (
+  fetchModels = fetchSub2ApiRuntimeModelsMock,
+) => ({
+  siteType: SITE_TYPES.SUB2API,
+  family: "sub2api" as const,
+  modelCatalog: {
+    fetchModels,
+  },
+})
+
+const mockSub2ApiModelCatalogAdapter = (
+  fetchModels = fetchSub2ApiRuntimeModelsMock,
+) => {
+  getSiteAdapterMock.mockReturnValue(
+    createSub2ApiModelCatalogAdapter(fetchModels),
+  )
+}
+
 describe("loadAccountTokenFallbackPricingResponse", () => {
   beforeEach(() => {
     fetchAnthropicModelIdsMock.mockReset()
@@ -133,8 +155,10 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     fetchSub2ApiGroupRatesMock.mockReset()
     fetchSub2ApiRuntimeModelsMock.mockReset()
     getApiServiceMock.mockReset()
+    getSiteAdapterMock.mockReset()
     loadModelPriceTableMock.mockReset()
     resolveDisplayAccountTokenForSecretMock.mockReset()
+    mockSub2ApiModelCatalogAdapter()
     resolveDisplayAccountTokenForSecretMock.mockImplementation(
       async (_account, token) => token,
     )
@@ -219,6 +243,7 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
       baseUrl: "https://example.com",
       apiKey: "sk-real-secret",
     })
+    expect(getSiteAdapterMock).not.toHaveBeenCalled()
     expect(result.data.map((item) => item.model_name)).toEqual([
       "gpt-4o-mini",
       "claude-3-haiku",
@@ -291,6 +316,7 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
 
     expect(result).toBe(aihubmixPricing)
     expect(getApiServiceMock).toHaveBeenCalledWith(SITE_TYPES.AIHUBMIX)
+    expect(getSiteAdapterMock).not.toHaveBeenCalled()
     expect(fetchModelPricingMock).toHaveBeenCalledWith({
       baseUrl: "https://aihubmix.com",
       accountId: "account-1",
@@ -335,13 +361,14 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
         key: "sk-masked-sub2api",
       }),
     )
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.SUB2API)
     expect(fetchSub2ApiRuntimeModelsMock).toHaveBeenCalledWith({
       baseUrl: "https://sub2api.example.invalid",
       accountId: "account-1",
-      auth: expect.objectContaining({
+      auth: {
         authType: AuthTypeEnum.AccessToken,
         apiKey: "sk-real-sub2api-secret",
-      }),
+      },
     })
     expect(fetchOpenAICompatibleModelIdsMock).not.toHaveBeenCalled()
     expect(fetchSub2ApiAvailableGroupsMock).toHaveBeenCalledWith({
@@ -487,6 +514,29 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
         }),
       }),
     ])
+  })
+
+  it("sanitizes a missing Sub2API model catalog capability failure", async () => {
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.SUB2API,
+      family: "sub2api",
+    })
+
+    await expect(
+      loadAccountTokenFallbackPricingResponse({
+        account: {
+          ...ACCOUNT,
+          siteType: SITE_TYPES.SUB2API,
+          baseUrl: "https://sub2api.example.invalid",
+        },
+        token: {
+          ...TOKEN,
+          key: "sk-masked-sub2api",
+        },
+      }),
+    ).rejects.toThrow("modelCatalog is not implemented for sub2api")
+
+    expect(fetchSub2ApiRuntimeModelsMock).not.toHaveBeenCalled()
   })
 
   it("redacts the resolved key and base URL when fallback loading fails", async () => {


### PR DESCRIPTION
## Summary
- Add the model catalog adapter contract and wire Sub2API runtime catalog support through the adapter registry.
- Move model-list catalog loading to the adapter capability path while keeping fallback behavior covered.
- Include the planning/spec docs for the adapter model catalog slice.

## Test Plan
- pnpm run validate:push
- git push pre-push validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture specification and implementation plan for model catalog capability.

* **Refactor**
  * Restructured Sub2API runtime model discovery to route through the unified site adapter pattern, improving consistency with other adapter capabilities while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->