### PR TITLE
refactor(accounts): move auto-detect completion workflow

### DIFF
--- a/docs/superpowers/plans/2026-06-17-account-auto-detect-completion.md
+++ b/docs/superpowers/plans/2026-06-17-account-auto-detect-completion.md
@@ -401,6 +401,31 @@ describe("completeAutoDetectedAccount", () => {
     })
   })
 
+  it("throws UsernameMissing when non-Sub2API completion returns no username", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "",
+      access_token: "account-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Missing Username Portal",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://username.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "6",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+    })
+  })
+
   it("classifies site status failures", async () => {
     mockGetOrCreateAccessToken.mockResolvedValueOnce({
       username: "status-user",

--- a/docs/superpowers/plans/2026-06-17-account-auto-detect-completion.md
+++ b/docs/superpowers/plans/2026-06-17-account-auto-detect-completion.md
@@ -1,0 +1,1131 @@
+# Account Auto-Detect Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-account-auto-detect-completion-design.md`
+
+**Goal:** Extract post-detection account completion from `autoDetectAccount(...)` into a narrow account completion module while preserving the current public response shape.
+
+**Architecture:** Keep `autoDetectAccount(...)` as the product workflow owner for URL validation, detection, response shaping, and analytics failure metadata. Move token/user-info completion, site status, check-in defaults, exchange-rate extraction, and site-specific completion rules into `src/services/accounts/autoDetectCompletion/`. Move site-name resolution to a small helper so the new completion module does not import back from `accountOperations.ts`.
+
+**Tech Stack:** TypeScript, Vitest, existing `apiService` facade, existing account auto-detect tests, `pnpm run validate:staged`.
+
+---
+
+## File Structure
+
+- Create `src/services/accounts/siteName.ts`
+  - Owns `extractDomainPrefix(...)` and `getSiteName(...)`.
+  - Keeps the existing site-name behavior intact.
+- Modify `src/services/accounts/accountOperations.ts`
+  - Imports `getSiteName(...)` from `siteName.ts` for the temporary success path.
+  - Re-exports `extractDomainPrefix(...)` and `getSiteName(...)` so existing callers and tests do not change imports.
+  - Later calls `completeAutoDetectedAccount(...)` after successful `autoDetectSmart(...)`.
+- Create `src/services/accounts/autoDetectCompletion/types.ts`
+  - Defines the completion boundary types and typed completion error.
+- Create `src/services/accounts/autoDetectCompletion/completion.ts`
+  - Owns the extracted completion orchestration.
+  - Keeps `getApiService(...)` inside the new module for this migration slice.
+- Create `tests/services/accounts/autoDetectCompletion/completion.test.ts`
+  - Adds focused coverage for the new module.
+- Keep `tests/services/accountOperations.autoDetectAccount.test.ts`
+  - Existing tests remain the broad migration contract.
+- Keep `tests/services/accountOperations.test.ts`
+  - Existing `getSiteName(...)` and `extractDomainPrefix(...)` tests remain the compatibility contract.
+
+---
+
+## Task 1: Extract Site Name Helper Without Behavior Changes
+
+**Files:**
+- Create: `src/services/accounts/siteName.ts`
+- Modify: `src/services/accounts/accountOperations.ts`
+- Test: `tests/services/accountOperations.test.ts`
+
+- [ ] **Step 1: Run the existing site-name contract before editing**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.test.ts -t "extractDomainPrefix|getSiteName"
+```
+
+Expected: PASS. These tests prove the helper extraction is behavior-neutral.
+
+- [ ] **Step 2: Create the dedicated site-name helper**
+
+Create `src/services/accounts/siteName.ts`:
+
+```ts
+import {
+  ACCOUNT_SITE_TITLE_RULES,
+  SITE_TYPES,
+} from "~/constants/siteType"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
+
+/**
+ * 提取域名关键部分（排除 www 与常见双后缀）供 UI 显示默认站点名使用。
+ * @param hostname 待分析的主机名
+ * @returns 规范化后的前缀并首字母大写
+ */
+export function extractDomainPrefix(hostname: string): string {
+  if (!hostname) return ""
+
+  const withoutWww = hostname.replace(/^www\./, "")
+  const parts = withoutWww.split(".")
+
+  if (parts.length >= 2) {
+    const lastPart = parts[parts.length - 1]
+    const secondLastPart = parts[parts.length - 2]
+    const doubleSuffixes = ["com", "net", "org", "gov", "edu", "co"]
+
+    if (
+      parts.length >= 3 &&
+      doubleSuffixes.includes(secondLastPart) &&
+      lastPart.length === 2
+    ) {
+      return (
+        parts[parts.length - 3].charAt(0).toUpperCase() +
+        parts[parts.length - 3].slice(1)
+      )
+    }
+
+    return secondLastPart.charAt(0).toUpperCase() + secondLastPart.slice(1)
+  }
+
+  return withoutWww.charAt(0).toUpperCase() + withoutWww.slice(1)
+}
+```
+
+Continue the same file with the existing site-name logic:
+
+```ts
+/**
+ * 判断站点名称是否仍是默认标题（如“未知站点”），用于决定是否替换。
+ * @param siteName 待检测的站点名称
+ * @returns true 表示不是默认名称
+ */
+function isNotDefaultSiteName(siteName: string): boolean {
+  return !ACCOUNT_SITE_TITLE_RULES.some(
+    (rule) => rule.name !== SITE_TYPES.UNKNOWN && rule.regex.test(siteName),
+  )
+}
+
+/**
+ * 根据 Tab、URL 或站点状态信息推断最终展示的站点名称。
+ * @param input 可能为浏览器 Tab 对象或字符串 URL
+ * @param siteTypeHint Optional site-type hint so site-specific API overrides can
+ * be used when resolving the display name.
+ * @param siteStatusInfo Optional pre-fetched site status info to avoid redundant API calls when resolving the display name.
+ * @returns 计算后的站点名称
+ */
+export async function getSiteName(
+  input: browser.tabs.Tab | string,
+  siteTypeHint?: string,
+  siteStatusInfo?: { system_name?: string | null } | null,
+): Promise<string> {
+  const urlString = typeof input === "string" ? input : input.url ?? ""
+  const tabTitle = typeof input === "string" ? null : input.title
+
+  if (tabTitle && isNotDefaultSiteName(tabTitle)) {
+    return tabTitle
+  }
+
+  const urlObj = new URL(urlString)
+  const hostWithProtocol = `${urlObj.protocol}//${urlObj.host}`
+
+  if (siteTypeHint) {
+    const resolvedSiteStatus =
+      siteStatusInfo ??
+      (await getApiService(siteTypeHint).fetchSiteStatus({
+        baseUrl: hostWithProtocol,
+        auth: {
+          authType: AuthTypeEnum.None,
+        },
+      }))
+
+    if (
+      resolvedSiteStatus?.system_name &&
+      isNotDefaultSiteName(resolvedSiteStatus.system_name)
+    ) {
+      return resolvedSiteStatus.system_name
+    }
+  }
+
+  return extractDomainPrefix(urlObj.hostname)
+}
+```
+
+- [ ] **Step 3: Re-export the helper from account operations**
+
+In `src/services/accounts/accountOperations.ts`, add this import near the account helper imports:
+
+```ts
+import { getSiteName } from "~/services/accounts/siteName"
+```
+
+Add this re-export after the constants:
+
+```ts
+export {
+  extractDomainPrefix,
+  getSiteName,
+} from "~/services/accounts/siteName"
+```
+
+Remove these imports from `accountOperations.ts` because the moved helper now owns them:
+
+```ts
+  ACCOUNT_SITE_TITLE_RULES,
+```
+
+- [ ] **Step 4: Delete the old helper bodies from account operations**
+
+Remove the full `extractDomainPrefix(...)`, `IsNotDefaultSiteName(...)`, and `getSiteName(...)` implementations from `src/services/accounts/accountOperations.ts`. Do not remove any surrounding account save/update functions.
+
+- [ ] **Step 5: Verify the helper extraction**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.test.ts -t "extractDomainPrefix|getSiteName"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the neutral helper extraction**
+
+Run:
+
+```powershell
+git add src/services/accounts/siteName.ts src/services/accounts/accountOperations.ts
+git commit -m "refactor(accounts): extract site name helper"
+```
+
+Expected: commit succeeds. If the repository policy prefers one final commit for the whole slice, skip this commit and keep the same files unstaged until Task 4.
+
+---
+
+## Task 2: Add Completion Module Contracts And Focused Tests
+
+**Files:**
+- Create: `src/services/accounts/autoDetectCompletion/types.ts`
+- Create: `src/services/accounts/autoDetectCompletion/completion.ts`
+- Create: `tests/services/accounts/autoDetectCompletion/completion.test.ts`
+
+- [ ] **Step 1: Write the focused completion-module tests**
+
+Create `tests/services/accounts/autoDetectCompletion/completion.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AUTO_DETECT_FAILURE_REASONS,
+  AUTO_DETECT_STRATEGIES,
+} from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { completeAutoDetectedAccount } from "~/services/accounts/autoDetectCompletion/completion"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockFetchSiteStatus,
+  mockFetchSupportCheckIn,
+  mockExtractDefaultExchangeRate,
+  mockFetchUserInfo,
+  mockGetOrCreateAccessToken,
+} = vi.hoisted(() => ({
+  mockFetchSiteStatus: vi.fn(),
+  mockFetchSupportCheckIn: vi.fn(),
+  mockExtractDefaultExchangeRate: vi.fn(),
+  mockFetchUserInfo: vi.fn(),
+  mockGetOrCreateAccessToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => ({
+      fetchSiteStatus: mockFetchSiteStatus,
+      fetchSupportCheckIn: mockFetchSupportCheckIn,
+      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+      fetchUserInfo: mockFetchUserInfo,
+      getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    })),
+  }
+})
+
+const currentTabFetchContext = (origin: string) => ({
+  kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+  tabId: 123,
+  origin,
+})
+
+describe("completeAutoDetectedAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("completes compatible access-token accounts through the service layer", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "billing-user",
+      access_token: "account-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Billing Portal",
+      checkin_enabled: true,
+      price: 7.5,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(7.5)
+
+    const fetchContext = currentTabFetchContext("https://new.example.com")
+    const autoDetectContext = {
+      strategy: AUTO_DETECT_STRATEGIES.CurrentTab,
+      siteType: SITE_TYPES.NEW_API,
+    }
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://new.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      detected: {
+        userId: "7",
+        user: { id: 7, username: "billing-user" },
+        siteType: SITE_TYPES.NEW_API,
+        fetchContext,
+      },
+      autoDetectContext,
+    })
+
+    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
+      baseUrl: "https://new.example.com",
+      fetchContext,
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "7",
+      },
+    })
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://new.example.com",
+      fetchContext,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+      },
+    })
+    expect(result).toMatchObject({
+      username: "billing-user",
+      siteName: "Billing Portal",
+      accessToken: "account-token",
+      userId: "7",
+      exchangeRate: 7.5,
+      authType: AuthTypeEnum.AccessToken,
+      siteType: SITE_TYPES.NEW_API,
+      fetchContext,
+      autoDetectContext,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+      },
+    })
+  })
+
+  it("uses detected Sub2API access-token data and disables check-in output", async () => {
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Sub2 Portal",
+      checkin_enabled: true,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const sub2apiAuth = {
+      refreshToken: "refresh-token",
+      tokenExpiresAt: 123,
+    }
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://sub2.example.com",
+      requestedAuthType: AuthTypeEnum.Cookie,
+      detected: {
+        userId: "12",
+        user: { id: 12, username: "" },
+        siteType: SITE_TYPES.SUB2API,
+        accessToken: "jwt-token",
+        sub2apiAuth,
+      },
+    })
+
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      username: "",
+      accessToken: "jwt-token",
+      userId: "12",
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      siteType: SITE_TYPES.SUB2API,
+      sub2apiAuth,
+      checkIn: {
+        enableDetection: false,
+        autoCheckInEnabled: false,
+      },
+    })
+  })
+
+  it("throws AccessTokenMissing when access-token completion returns no token", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "missing-token-user",
+      access_token: "",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Missing Token Portal",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://token.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "5",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+  })
+
+  it("classifies site status failures", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "status-user",
+      access_token: "status-token",
+    })
+    mockFetchSiteStatus.mockRejectedValueOnce(
+      new Error("private status backend text"),
+    )
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://status.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "9",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "AutoDetectCompletionError",
+      reason: AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the new test and verify it fails for the missing module**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/autoDetectCompletion/completion.test.ts
+```
+
+Expected: FAIL with an import error for `~/services/accounts/autoDetectCompletion/completion` or `~/services/accounts/autoDetectCompletion/types`.
+
+- [ ] **Step 3: Add the completion boundary types**
+
+Create `src/services/accounts/autoDetectCompletion/types.ts`:
+
+```ts
+import type {
+  AutoDetectAnalyticsContext,
+  AutoDetectFailureReason,
+} from "~/constants/autoDetect"
+import type { AccountSiteType } from "~/constants/siteType"
+import type { ApiServiceFetchContext } from "~/services/apiService/common/type"
+import type {
+  AuthTypeEnum,
+  CheckInConfig,
+  Sub2ApiAuthConfig,
+} from "~/types"
+import { getErrorMessage } from "~/utils/core/error"
+
+export type DetectedAccountIdentity = {
+  userId: string
+  user?: { username?: unknown } | Record<string, unknown> | null
+  siteType: AccountSiteType
+  accessToken?: string
+  sub2apiAuth?: Sub2ApiAuthConfig
+  fetchContext?: ApiServiceFetchContext
+}
+
+export type AutoDetectCompletionRequest = {
+  url: string
+  requestedAuthType: AuthTypeEnum
+  detected: DetectedAccountIdentity
+  autoDetectContext?: AutoDetectAnalyticsContext
+}
+
+export type AutoDetectCompletionData = {
+  username: string
+  siteName: string
+  accessToken: string
+  userId: string
+  exchangeRate: number
+  authType: AuthTypeEnum
+  checkIn: CheckInConfig
+  siteType: AccountSiteType
+  sub2apiAuth?: Sub2ApiAuthConfig
+  fetchContext?: ApiServiceFetchContext
+  autoDetectContext?: AutoDetectAnalyticsContext
+}
+
+/**
+ * Preserves the failing completion step while keeping the original error
+ * available for UI classification.
+ */
+export class AutoDetectCompletionError extends Error {
+  constructor(
+    readonly reason: AutoDetectFailureReason,
+    cause: unknown,
+  ) {
+    super(getErrorMessage(cause))
+    this.name = "AutoDetectCompletionError"
+    this.cause = cause
+  }
+}
+```
+
+- [ ] **Step 4: Add the completion implementation**
+
+Create `src/services/accounts/autoDetectCompletion/completion.ts`:
+
+```ts
+import {
+  AUTO_DETECT_FAILURE_REASONS,
+  type AutoDetectFailureReason,
+} from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { getSiteName } from "~/services/accounts/siteName"
+import { getApiService } from "~/services/apiService"
+import {
+  API_SERVICE_FETCH_CONTEXT_KINDS,
+  type ApiServiceFetchContext,
+  type ApiServiceRequest,
+  type SiteStatusInfo,
+} from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+import { getErrorMessage } from "~/utils/core/error"
+import { createLogger } from "~/utils/core/logger"
+import { t } from "~/utils/i18n/core"
+
+import {
+  AutoDetectCompletionError,
+  type AutoDetectCompletionData,
+  type AutoDetectCompletionRequest,
+} from "./types"
+
+const logger = createLogger("AccountAutoDetectCompletion")
+
+type AutoDetectTokenInfo = {
+  username?: string | null
+  access_token?: string | null
+}
+
+/**
+ * Resolves the most specific auto-detect completion reason available for analytics.
+ */
+export function getAutoDetectCompletionFailureReason(
+  error: unknown,
+): AutoDetectFailureReason {
+  return error instanceof AutoDetectCompletionError
+    ? error.reason
+    : AUTO_DETECT_FAILURE_REASONS.UnexpectedException
+}
+
+/**
+ * Extracts the matched current-tab context from successful auto-detect data.
+ */
+function getAutoDetectFetchContext(
+  detected: AutoDetectCompletionRequest["detected"],
+): ApiServiceFetchContext | undefined {
+  const fetchContext = detected.fetchContext
+
+  if (fetchContext?.kind === API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT) {
+    return fetchContext
+  }
+
+  if (fetchContext?.kind === API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB) {
+    if (
+      typeof fetchContext.tabId === "number" &&
+      typeof fetchContext.origin === "string" &&
+      fetchContext.origin.trim()
+    ) {
+      return fetchContext
+    }
+  }
+
+  if (fetchContext?.incognito === true || fetchContext?.cookieStoreId) {
+    return fetchContext
+  }
+
+  return undefined
+}
+
+/**
+ * Builds the service-layer request used by auto-detect completion.
+ */
+function createAutoDetectApiRequest(params: {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+  fetchContext?: ApiServiceFetchContext
+}): ApiServiceRequest {
+  return {
+    baseUrl: params.baseUrl,
+    auth: params.auth,
+    ...(params.fetchContext ? { fetchContext: params.fetchContext } : {}),
+  }
+}
+
+function getDetectedUsername(
+  user: AutoDetectCompletionRequest["detected"]["user"],
+): string {
+  if (!user || typeof user !== "object") {
+    return ""
+  }
+
+  const username = (user as { username?: unknown }).username
+  return typeof username === "string" ? username.trim() : ""
+}
+
+function getDetectedAccessToken(
+  detected: AutoDetectCompletionRequest["detected"],
+): string {
+  return typeof detected.accessToken === "string"
+    ? detected.accessToken.trim()
+    : ""
+}
+
+function createCompletionValidationError(
+  reason: AutoDetectFailureReason,
+): AutoDetectCompletionError {
+  const message =
+    reason === AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing
+      ? t("messages:operations.detection.getAccessTokenFailedDetailed")
+      : t("messages:operations.detection.getUsernameFailedDetailed")
+
+  return new AutoDetectCompletionError(reason, new Error(message))
+}
+
+export async function completeAutoDetectedAccount(
+  request: AutoDetectCompletionRequest,
+): Promise<AutoDetectCompletionData> {
+  const { url, requestedAuthType, detected, autoDetectContext } = request
+  const { userId, siteType, sub2apiAuth } = detected
+  const autoDetectFetchContext = getAutoDetectFetchContext(detected)
+  const isSub2Api = siteType === SITE_TYPES.SUB2API
+  const isAIHubMix = siteType === SITE_TYPES.AIHUBMIX
+  const effectiveAuthType =
+    isSub2Api || isAIHubMix ? AuthTypeEnum.AccessToken : requestedAuthType
+  const detectionAuthType = isAIHubMix
+    ? AuthTypeEnum.Cookie
+    : effectiveAuthType
+  const apiService = getApiService(siteType)
+
+  let tokenPromise: Promise<AutoDetectTokenInfo | null>
+
+  if (isSub2Api) {
+    tokenPromise = Promise.resolve({
+      username: getDetectedUsername(detected.user),
+      access_token: getDetectedAccessToken(detected),
+    })
+  } else if (isAIHubMix && typeof detected.accessToken === "string") {
+    tokenPromise = Promise.resolve({
+      username: getDetectedUsername(detected.user),
+      access_token: getDetectedAccessToken(detected),
+    })
+  } else if (effectiveAuthType === AuthTypeEnum.Cookie) {
+    tokenPromise = apiService.fetchUserInfo(
+      createAutoDetectApiRequest({
+        baseUrl: url,
+        fetchContext: autoDetectFetchContext,
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId,
+        },
+      }),
+    )
+  } else if (effectiveAuthType === AuthTypeEnum.AccessToken) {
+    tokenPromise = apiService.getOrCreateAccessToken(
+      createAutoDetectApiRequest({
+        baseUrl: url,
+        fetchContext: autoDetectFetchContext,
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId,
+        },
+      }),
+    )
+  } else {
+    tokenPromise = Promise.resolve(null)
+  }
+
+  const siteStatusPromise: Promise<SiteStatusInfo | null> =
+    apiService
+      .fetchSiteStatus(
+        createAutoDetectApiRequest({
+          baseUrl: url,
+          fetchContext: autoDetectFetchContext,
+          auth: {
+            authType: detectionAuthType || AuthTypeEnum.None,
+          },
+        }),
+      )
+      .catch((error) => {
+        throw new AutoDetectCompletionError(
+          AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+          error,
+        )
+      })
+
+  const checkSupportPromise: Promise<boolean | undefined> =
+    siteStatusPromise.then((siteStatus) =>
+      typeof siteStatus?.checkin_enabled === "boolean"
+        ? siteStatus.checkin_enabled
+        : apiService
+            .fetchSupportCheckIn(
+              createAutoDetectApiRequest({
+                baseUrl: url,
+                fetchContext: autoDetectFetchContext,
+                auth: {
+                  authType: AuthTypeEnum.None,
+                },
+              }),
+            )
+            .catch((error) => {
+              logger.warn("Auto-detect check-in support probe failed", {
+                siteType,
+                error: getErrorMessage(error),
+              })
+              return false
+            }),
+    )
+
+  const [tokenInfo, siteStatus, checkSupport, siteName] = await Promise.all([
+    tokenPromise.catch((error) => {
+      throw new AutoDetectCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+        error,
+      )
+    }),
+    siteStatusPromise,
+    checkSupportPromise,
+    siteStatusPromise.then((resolvedSiteStatus) =>
+      getSiteName(url, siteType, resolvedSiteStatus),
+    ),
+  ])
+
+  const detectedUsername =
+    typeof tokenInfo?.username === "string" ? tokenInfo.username : ""
+  const accessToken =
+    typeof tokenInfo?.access_token === "string" ? tokenInfo.access_token : ""
+  const isUsernameMissing = !isSub2Api && !detectedUsername
+  const isAccessTokenMissing =
+    (effectiveAuthType === AuthTypeEnum.AccessToken || isAIHubMix) &&
+    !accessToken
+
+  if (isUsernameMissing || isAccessTokenMissing) {
+    throw createCompletionValidationError(
+      isAccessTokenMissing
+        ? AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing
+        : AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+    )
+  }
+
+  const defaultExchangeRate =
+    apiService.extractDefaultExchangeRate(siteStatus) ??
+    UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
+
+  return {
+    username: detectedUsername,
+    siteName,
+    accessToken,
+    userId: userId.toString(),
+    exchangeRate: defaultExchangeRate,
+    authType: effectiveAuthType,
+    checkIn: {
+      enableDetection: isSub2Api ? false : checkSupport ?? false,
+      autoCheckInEnabled: isSub2Api ? false : true,
+      siteStatus: {
+        isCheckedInToday: false,
+      },
+      customCheckIn: {
+        url: "",
+        redeemUrl: "",
+        openRedeemWithCheckIn: true,
+        isCheckedInToday: false,
+      },
+    },
+    siteType,
+    ...(isSub2Api && sub2apiAuth ? { sub2apiAuth } : {}),
+    ...(autoDetectFetchContext ? { fetchContext: autoDetectFetchContext } : {}),
+    autoDetectContext,
+  }
+}
+```
+
+- [ ] **Step 5: Run the new completion tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/autoDetectCompletion/completion.test.ts
+```
+
+Expected: PASS.
+
+---
+
+## Task 3: Route `autoDetectAccount(...)` Through The Completion Module
+
+**Files:**
+- Modify: `src/services/accounts/accountOperations.ts`
+- Test: `tests/services/accountOperations.autoDetectAccount.test.ts`
+- Test: `tests/services/accounts/autoDetectCompletion/completion.test.ts`
+
+- [ ] **Step 1: Import the completion module**
+
+In `src/services/accounts/accountOperations.ts`, add:
+
+```ts
+import {
+  completeAutoDetectedAccount,
+  getAutoDetectCompletionFailureReason,
+} from "~/services/accounts/autoDetectCompletion/completion"
+```
+
+Remove these imports after the completion logic is deleted:
+
+```ts
+import {
+  API_SERVICE_FETCH_CONTEXT_KINDS,
+  type ApiServiceFetchContext,
+  type ApiServiceRequest,
+  type SiteStatusInfo,
+} from "~/services/apiService/common/type"
+```
+
+Keep `getApiService` in `accountOperations.ts`; it is still used by non-auto-detect account operations and token provisioning.
+
+- [ ] **Step 2: Remove the local completion error and request helpers**
+
+Delete these private helpers from `src/services/accounts/accountOperations.ts`:
+
+```ts
+class AutoDetectCompletionError extends Error {
+  constructor(
+    readonly reason: AutoDetectFailureReason,
+    cause: unknown,
+  ) {
+    super(getErrorMessage(cause))
+    this.name = "AutoDetectCompletionError"
+    this.cause = cause
+  }
+}
+
+function getAutoDetectCompletionFailureReason(
+  error: unknown,
+): AutoDetectFailureReason {
+  return error instanceof AutoDetectCompletionError
+    ? error.reason
+    : AUTO_DETECT_FAILURE_REASONS.UnexpectedException
+}
+
+function getAutoDetectFetchContext(...) {
+  ...
+}
+
+function createAutoDetectApiRequest(...) {
+  ...
+}
+```
+
+Do not delete `withFinalAutoDetectSiteType(...)`, `getAutoDetectFailureReasonByErrorCode(...)`, or `getAutoDetectCompletionFailureMessage(...)`.
+
+- [ ] **Step 3: Preserve validation-error response shaping**
+
+Update `getAutoDetectCompletionFailureMessage(...)` in `src/services/accounts/accountOperations.ts` so validation failures keep the previous user-facing messages:
+
+```ts
+function getAutoDetectCompletionFailureMessage(
+  reason: AutoDetectFailureReason,
+  fallbackErrorMessage: string,
+) {
+  switch (reason) {
+    case AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed:
+    case AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing:
+      return t("messages:operations.detection.getAccessTokenFailedDetailed")
+    case AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed:
+      return t("messages:operations.detection.getSiteStatusFailedDetailed")
+    case AUTO_DETECT_FAILURE_REASONS.UsernameMissing:
+      return t("messages:operations.detection.getUsernameFailedDetailed")
+    default:
+      return t("accountDialog:messages.autoDetectFailed", {
+        error: fallbackErrorMessage,
+      })
+  }
+}
+```
+
+Add this helper below it so `UsernameMissing` and `AccessTokenMissing` still return `AutoDetectErrorType.INVALID_RESPONSE`:
+
+```ts
+function getAutoDetectCompletionDetailedError(
+  error: unknown,
+  reason: AutoDetectFailureReason,
+  message: string,
+) {
+  switch (reason) {
+    case AUTO_DETECT_FAILURE_REASONS.UsernameMissing:
+    case AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing:
+      return {
+        type: AutoDetectErrorType.INVALID_RESPONSE,
+        message,
+      }
+    default:
+      return analyzeAutoDetectError(error)
+  }
+}
+```
+
+- [ ] **Step 4: Replace the success-branch completion block**
+
+In `autoDetectAccount(...)`, keep everything through this user-id guard:
+
+```ts
+const { userId, siteType } = detectResult.data
+autoDetectContext = withFinalAutoDetectSiteType(
+  detectResult.autoDetectContext,
+  siteType,
+)
+
+if (!userId) {
+  return {
+    success: false,
+    message: t("messages:operations.detection.getUserIdFailedDetailed"),
+    detailedError: {
+      type: AutoDetectErrorType.INVALID_RESPONSE,
+      message: t("messages:operations.detection.getUserIdFailedDetailed"),
+    },
+    autoDetectContext,
+    autoDetectFailureReason: AUTO_DETECT_FAILURE_REASONS.UserIdMissing,
+  }
+}
+```
+
+Replace the old token, site status, check-in, exchange-rate, and success-data construction block with:
+
+```ts
+const completed = await completeAutoDetectedAccount({
+  url,
+  requestedAuthType: authType,
+  detected: detectResult.data,
+  autoDetectContext,
+})
+
+return {
+  success: true,
+  message: t("accountDialog:messages.autoDetectSuccess"),
+  data: completed,
+}
+```
+
+- [ ] **Step 5: Update the catch block to use the preserved detailed error**
+
+Replace the final `detailedError` assignment in `autoDetectAccount(...)` with:
+
+```ts
+const detailedError = getAutoDetectCompletionDetailedError(
+  error,
+  autoDetectFailureReason,
+  message,
+)
+```
+
+The full catch block should end as:
+
+```ts
+  } catch (error) {
+    const errorMessage = getErrorMessage(error)
+    const autoDetectFailureReason = getAutoDetectCompletionFailureReason(error)
+    const message = getAutoDetectCompletionFailureMessage(
+      autoDetectFailureReason,
+      errorMessage,
+    )
+    logger.error(
+      t("messages:autodetect.failed", { error: errorMessage }),
+      error,
+    )
+    const detailedError = getAutoDetectCompletionDetailedError(
+      error,
+      autoDetectFailureReason,
+      message,
+    )
+    return {
+      success: false,
+      message,
+      detailedError,
+      autoDetectContext,
+      autoDetectFailureReason,
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Run the existing auto-detect regression suite**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.autoDetectAccount.test.ts
+```
+
+Expected: PASS. This confirms `AccountValidationResponse`, analytics context, fetch-context forwarding, AIHubMix, Sub2API, check-in fallback, and failure classifications did not regress.
+
+- [ ] **Step 7: Run the new module tests again**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/autoDetectCompletion/completion.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the completion extraction**
+
+Run:
+
+```powershell
+git add src/services/accounts/accountOperations.ts src/services/accounts/autoDetectCompletion src/services/accounts/siteName.ts tests/services/accounts/autoDetectCompletion/completion.test.ts
+git commit -m "refactor(accounts): extract auto-detect completion"
+```
+
+Expected: commit succeeds. If Task 1 was not committed separately, this commit includes the helper extraction and completion module together.
+
+---
+
+## Task 4: Final Validation And Diff Review
+
+**Files:**
+- Validate all files touched in Tasks 1 to 3.
+
+- [ ] **Step 1: Run related unit coverage**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/accounts/accountOperations.ts src/services/accounts/siteName.ts src/services/accounts/autoDetectCompletion/completion.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run targeted lint**
+
+Run:
+
+```powershell
+pnpm exec eslint src/services/accounts src/features/AccountManagement/components/AccountDialog
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect the diff for scope drift**
+
+Run:
+
+```powershell
+git diff --stat
+git diff -- src/services/accounts/accountOperations.ts src/services/accounts/siteName.ts src/services/accounts/autoDetectCompletion tests/services/accounts/autoDetectCompletion
+```
+
+Expected:
+- No changes to `src/services/siteDetection/autoDetectService.ts`.
+- No changes to Account Dialog UI state, cookie import, duplicate confirmation, save/update behavior, or post-save token prompts.
+- No locale, telemetry, settings search, or Playwright E2E changes.
+- `accountOperations.ts` still exports `getSiteName` and `extractDomainPrefix`.
+
+- [ ] **Step 4: Run the commit gate**
+
+Stage only the task-scoped files, then run:
+
+```powershell
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit any remaining task-scoped changes**
+
+If Task 1 and Task 3 were already committed and there are no remaining task-scoped changes, skip this step. Otherwise run:
+
+```powershell
+git add src/services/accounts/accountOperations.ts src/services/accounts/siteName.ts src/services/accounts/autoDetectCompletion tests/services/accounts/autoDetectCompletion/completion.test.ts
+git commit -m "refactor(accounts): extract auto-detect completion"
+```
+
+Expected: commit succeeds.
+
+- [ ] **Step 6: Decide whether to run the pre-push gate**
+
+Run this before pushing or opening/updating a PR because the slice moves shared TypeScript account workflow logic:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. If it fails, classify the failure as code, tooling, environment, auth, network, or permission before changing code.
+
+---
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This refactor does not add a new user action, setting, async workflow, or visible result. The existing `autoDetectContext` and `autoDetectFailureReason` fields continue to flow through `AccountValidationResponse`.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no Playwright E2E.
+
+The risk is service-layer routing and response-shape preservation. Existing Vitest coverage exercises the Account Dialog consumer contract and browser-context metadata; the new module receives focused unit coverage.
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Completion module introduced under `src/services/accounts/autoDetectCompletion/`.
+  - `autoDetectSmart(...)`, detection strategies, Account Dialog, save flow, cookie import, and post-save token initialization remain unchanged.
+  - Sub2API, AIHubMix, compatible cookie auth, compatible access-token auth, site status, check-in support, exchange-rate extraction, and failure classification are covered.
+- Placeholder scan:
+  - No task uses placeholder markers or incomplete test instructions.
+  - Code steps include concrete snippets and commands.
+- Type consistency:
+  - `completeAutoDetectedAccount(...)` accepts `AutoDetectCompletionRequest` and returns `AutoDetectCompletionData`.
+  - `accountOperations.ts` passes `requestedAuthType`, not `authType`, into the new module.
+  - `AutoDetectCompletionError.reason` uses `AutoDetectFailureReason`.
+- Scope guard:
+  - Do not add a new site type in this slice.
+  - Do not move full key management, model list, redemption, or managed-site behavior.
+  - Keep `getApiService(...)` in the new completion module until a later adapter-capability slice.

--- a/docs/superpowers/specs/2026-06-17-account-auto-detect-completion-design.md
+++ b/docs/superpowers/specs/2026-06-17-account-auto-detect-completion-design.md
@@ -1,0 +1,407 @@
+# Account Auto-Detect Completion Adapter Design
+
+Date: 2026-06-17
+
+## Purpose
+
+Make new account-site support easier by moving the post-detection account
+completion logic out of the large `autoDetectAccount(...)` workflow and behind
+a narrow Adapter Seam.
+
+The previous `apiAdapters` slices stopped direct backend calls from leaking into
+site announcements and runtime model catalog loading. The new lint guard now
+prevents ordinary product code from importing backend-specific `apiService`
+Implementations directly. The next useful slice is the part that matters most
+for new site types: once the site type and user id are detected, the app must
+complete the account form with a username, access token, site status, exchange
+rate, and check-in defaults.
+
+## Current Context
+
+The current flow is split across three areas:
+
+- `src/services/siteDetection/autoDetectService.ts` chooses a detection
+  strategy and returns detected identity data:
+  - current tab content script
+  - background temporary browser context
+  - direct cookie-auth API fallback
+- `src/services/accounts/accountOperations.ts` owns
+  `autoDetectAccount(url, authType)` and performs completion after detection:
+  - tracks the cookie interceptor URL
+  - calls `autoDetectSmart(...)`
+  - decides effective auth type for Sub2API and AIHubMix
+  - gets token/user info with `fetchUserInfo(...)`,
+    `getOrCreateAccessToken(...)`, or detected access-token data
+  - fetches site status
+  - derives check-in support and default exchange rate
+  - maps missing username/token and backend failures into stable UI responses
+- `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+  consumes the final `AccountValidationResponse`, fills the form, imports
+  cookies when needed, saves the account, and runs post-save token prompts.
+
+The completion part is the highest-friction path for adding new account-site
+types because it currently mixes generic workflow orchestration with
+site-specific auth and backend capability differences.
+
+## Problem
+
+`autoDetectAccount(...)` is too wide. It knows facts that should live at a
+site Adapter Seam:
+
+1. Sub2API and AIHubMix force `AccessToken` saved auth even when the UI selected
+   cookie auth.
+2. Sub2API and AIHubMix can use access-token data already returned by detection,
+   while compatible sites call account-site API helpers.
+3. Site status and check-in support are common-looking operations, but their
+   request auth mode and fallback behavior vary by backend.
+4. The same function owns error classification, response shaping, exchange-rate
+   extraction, and check-in defaults, making it hard to add a new site type
+   without editing the central workflow.
+
+Deletion test: if the site-specific completion branches were deleted from
+`autoDetectAccount(...)`, the complexity would reappear as new `siteType`
+conditionals in the same function or in the Account Dialog. It should instead
+move behind a small completion capability with product-level response shaping
+remaining in the account workflow.
+
+## Goals
+
+- Introduce a narrow account auto-detect completion Module under
+  `src/services/accounts/autoDetectCompletion/`.
+- Move completion orchestration into that Module while preserving the
+  `autoDetectAccount(...)` public Interface and returned
+  `AccountValidationResponse` shape.
+- Keep `autoDetectSmart(...)` and detection strategy selection unchanged.
+- Keep account save, cookie import, and post-save token initialization
+  unchanged.
+- Make site-specific completion facts explicit:
+  - effective saved auth type
+  - detection request auth type
+  - token/user-info completion path
+  - site status request auth mode
+  - whether check-in automation should be disabled
+- Keep `getApiService(...)` usage inside the new completion Module for this
+  migration slice. The new Module becomes the owner to migrate later into
+  `apiAdapters` capabilities when the Interface is stable.
+- Preserve existing analytics-safe failure reasons:
+  - `TokenFetchFailed`
+  - `SiteStatusFetchFailed`
+  - `UsernameMissing`
+  - `AccessTokenMissing`
+  - `UserIdMissing`
+
+## Non-Goals
+
+- Do not change `detectSiteType`, `autoDetectSmart`, current-tab detection,
+  background temp-context detection, or direct API detection.
+- Do not move content-script localStorage parsing, Sub2API token refresh, or
+  browser-context fallback logic in this slice.
+- Do not change Account Dialog state, cookie import, duplicate confirmation,
+  save/update behavior, post-save refresh, Sub2API token dialog, or AIHubMix
+  one-time key prompt behavior.
+- Do not add a new site type in this slice.
+- Do not migrate full key management, post-save token provisioning,
+  Model List pricing, redemption, or managed-site behavior.
+- Do not add user-facing copy, locale keys, telemetry events, settings search
+  entries, or Playwright E2E tests.
+- Do not move `getApiService(...)` out of all account code at once.
+
+## Design
+
+### 1. Add A Completion Module
+
+Create:
+
+```text
+src/services/accounts/autoDetectCompletion/
+  completion.ts
+  types.ts
+```
+
+`types.ts` owns the Interface for this slice. It should reuse existing account
+and auto-detect types where possible instead of inventing a second response
+model.
+
+Proposed public types:
+
+```ts
+import type { AutoDetectAnalyticsContext } from "~/constants/autoDetect"
+import type { AccountSiteType } from "~/constants/siteType"
+import type {
+  ApiServiceFetchContext,
+  SiteStatusInfo,
+} from "~/services/apiService/common/type"
+import type { AuthTypeEnum, CheckInConfig, Sub2ApiAuthConfig } from "~/types"
+
+export type DetectedAccountIdentity = {
+  userId: string
+  user?: any
+  siteType: AccountSiteType
+  accessToken?: string
+  sub2apiAuth?: Sub2ApiAuthConfig
+  fetchContext?: ApiServiceFetchContext
+}
+
+export type AutoDetectCompletionRequest = {
+  url: string
+  requestedAuthType: AuthTypeEnum
+  detected: DetectedAccountIdentity
+  autoDetectContext?: AutoDetectAnalyticsContext
+}
+
+export type AutoDetectCompletionData = {
+  username: string
+  siteName: string
+  accessToken: string
+  userId: string
+  exchangeRate: number
+  authType: AuthTypeEnum
+  checkIn: CheckInConfig
+  siteType: AccountSiteType
+  sub2apiAuth?: Sub2ApiAuthConfig
+  fetchContext?: ApiServiceFetchContext
+  autoDetectContext?: AutoDetectAnalyticsContext
+}
+```
+
+`completion.ts` exports:
+
+```ts
+export async function completeAutoDetectedAccount(
+  request: AutoDetectCompletionRequest,
+): Promise<AutoDetectCompletionData>
+```
+
+This function should own the current completion behavior that happens after
+`autoDetectSmart(...)` succeeds and before `autoDetectAccount(...)` returns
+success.
+
+### 2. Keep Product Response Shaping In `accountOperations`
+
+`autoDetectAccount(...)` should still own:
+
+- blank URL validation
+- cookie interceptor tracking
+- calling `autoDetectSmart(...)`
+- mapping failed detection result to `AccountValidationResponse`
+- `UserIdMissing` response before completion
+- catching completion errors and converting them to stable UI responses
+
+The success branch should become:
+
+```ts
+const completed = await completeAutoDetectedAccount({
+  url,
+  requestedAuthType: authType,
+  detected: detectResult.data,
+  autoDetectContext,
+})
+
+return {
+  success: true,
+  message: t("accountDialog:messages.autoDetectSuccess"),
+  data: completed,
+}
+```
+
+The new Module returns successful completion data or throws a typed completion
+error. It should not return `AccountValidationResponse`; keeping response
+shaping in `accountOperations` preserves the existing public workflow Interface.
+
+### 3. Move Completion Error Typing Into The New Module
+
+Move `AutoDetectCompletionError` and completion failure helpers into the new
+Module or export them from `types.ts`:
+
+```ts
+export class AutoDetectCompletionError extends Error {
+  constructor(
+    readonly reason: AutoDetectFailureReason,
+    cause: unknown,
+  )
+}
+```
+
+`accountOperations.ts` should use exported helpers to preserve the current
+failure behavior:
+
+- `getAutoDetectCompletionFailureReason(error)`
+- `getAutoDetectCompletionFailureMessage(reason, message)`
+
+If moving all helpers would create noisy churn, move only the class and keep the
+message mapping in `accountOperations` for the first slice. The implementation
+plan should choose the smaller diff after checking current tests.
+
+### 4. Site-Specific Completion Rules
+
+The first implementation should preserve the current rule table exactly.
+
+Sub2API:
+
+- saved auth type is `AccessToken`
+- username may be empty
+- access token comes from `detected.accessToken`
+- no `getOrCreateAccessToken(...)` call
+- check-in detection and auto-check-in are disabled
+- Sub2API refresh-token auth is passed through when present
+
+AIHubMix:
+
+- saved auth type is `AccessToken`
+- completion uses access-token data returned by detection when available
+- completion can fall back to `getOrCreateAccessToken(...)` only when no
+  detected access token exists, matching current behavior
+- site status request uses cookie auth during import
+- missing username fails as `UsernameMissing`
+- missing access token fails as `AccessTokenMissing`
+
+Compatible sites:
+
+- saved auth type follows the requested auth type
+- cookie auth calls `fetchUserInfo(...)`
+- access-token auth calls `getOrCreateAccessToken(...)`
+- site status request uses the effective requested auth mode
+- check-in support uses `siteStatus.checkin_enabled` when present, otherwise
+  falls back to `fetchSupportCheckIn(...)`
+
+All site types:
+
+- `fetchContext` is forwarded to service requests when present
+- site name uses the existing `getSiteName(...)` behavior
+- exchange rate uses `extractDefaultExchangeRate(siteStatus)` with the existing
+  default fallback
+- check-in support probe failure logs and falls back to disabled detection
+
+### 5. Existing Tests Become The Contract
+
+`tests/services/accountOperations.autoDetectAccount.test.ts` already covers the
+risky behavior:
+
+- Sub2API access-token semantics
+- AIHubMix detected token path and missing-token/username failures
+- cookie auth and access-token auth completion for compatible sites
+- current-tab and browser-context forwarding
+- site status and check-in fallback behavior
+- token fetch failure classification
+
+The migration should add focused tests for `completeAutoDetectedAccount(...)`
+and keep the existing `autoDetectAccount(...)` tests green. The new tests should
+not duplicate the full matrix. They should prove the new Module's Interface:
+
+- compatible access-token completion calls `getOrCreateAccessToken`,
+  `fetchSiteStatus`, and derives exchange rate/check-in output
+- Sub2API completion uses detected access-token data and disables check-in
+- missing token/user info throws `AutoDetectCompletionError` with the right
+  reason
+- site status failure throws `AutoDetectCompletionError` with
+  `SiteStatusFetchFailed`
+
+No Playwright E2E is required. This is a service-layer refactor with existing
+Vitest coverage for the Account Dialog consumer path.
+
+## Error Handling
+
+The new completion Module should throw typed completion errors for failing
+backend calls:
+
+- token/user-info call failure -> `TokenFetchFailed`
+- site status call failure -> `SiteStatusFetchFailed`
+
+It should return normal completion data for best-effort check-in support probe
+failures, with check-in detection disabled, matching current behavior.
+
+It should throw validation-style completion errors for:
+
+- username missing when required
+- access token missing when required
+
+`autoDetectAccount(...)` remains responsible for converting those errors into
+the current localized messages and `AutoDetectErrorType.INVALID_RESPONSE` where
+applicable.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This slice preserves the existing Account Management auto-detect action and
+does not add a new user action, setting, funnel step, or visible behavior.
+Existing `autoDetectFailureReason`, strategy, fetch-context, and result
+analytics should continue to flow through the same `AccountValidationResponse`
+data.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, anchors, routes, or search definitions change.
+
+## E2E Decision
+
+E2E decision: no Playwright E2E.
+
+The main risk is service-layer routing and response shape preservation. The
+existing Vitest suite already covers browser-context metadata and Account Dialog
+consumer behavior; the implementation should extend Vitest rather than adding a
+browser scenario.
+
+## Validation Plan
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.autoDetectAccount.test.ts
+```
+
+Related validation:
+
+```powershell
+pnpm vitest related --run src/services/accounts/accountOperations.ts src/services/accounts/autoDetectCompletion/completion.ts
+```
+
+Lint/config validation:
+
+```powershell
+pnpm exec eslint src/services/accounts src/features/AccountManagement/components/AccountDialog
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Pre-push / PR gate:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before publishing because this slice moves shared account
+workflow logic and touches TypeScript module structure.
+
+## Rollout
+
+1. Add the completion Module and focused tests with `autoDetectAccount(...)`
+   still unchanged.
+2. Move the current completion behavior into `completeAutoDetectedAccount(...)`.
+3. Update `autoDetectAccount(...)` to call the new Module after successful
+   `autoDetectSmart(...)`.
+4. Keep all existing Account Dialog behavior unchanged.
+5. Run focused tests and related tests.
+6. Inspect the diff to confirm no detection strategy, save workflow, post-save
+   token initialization, locale, or UI changes leaked in.
+7. Commit the narrow refactor.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices can build on this Module:
+
+- introduce a declarative site completion Adapter registry after the extracted
+  Interface proves stable
+- move post-save token initialization into a separate onboarding capability
+- document the minimal new-site onboarding checklist
+- migrate `getApiService(...)` calls inside completion to `apiAdapters`
+  capability objects
+- decide whether Sub2API and AIHubMix completion rules should become separate
+  concrete Adapters
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,17 @@ const globalsConfig = {
 
 const jsFamilyFilePattern = "**/*.{js,cjs,mjs,jsx,ts,tsx}"
 const srcJsFamilyFilePattern = "src/**/*.{js,cjs,mjs,jsx,ts,tsx}"
+const optionsPageImportRestrictionPattern = {
+  group: ["~/entrypoints/options/pages/**"],
+  message:
+    "Do not import from `~/entrypoints/options/pages/**` outside the options entrypoint. Extract shared code into `~/features/`, `~/services/`, `~/utils/`, or `~/types/` instead.",
+}
+const apiServiceBackendImplementationImportPattern = {
+  regex:
+    "^(?:~/services/apiService|(?:\\.\\./){1,4}apiService)/(?:aihubmix|anyrouter|axonHub|claudeCodeHub|doneHub|octopus|oneHub|sub2api|veloera|wong)$",
+  message:
+    "Do not import backend-specific apiService implementations from product code. Add or use an adapter/workflow module instead.",
+}
 
 export default defineConfig([
   {
@@ -231,13 +242,7 @@ export default defineConfig([
       "no-restricted-imports": [
         "error",
         {
-          patterns: [
-            {
-              group: ["~/entrypoints/options/pages/**"],
-              message:
-                "Do not import from `~/entrypoints/options/pages/**` outside the options entrypoint. Extract shared code into `~/features/`, `~/services/`, `~/utils/`, or `~/types/` instead.",
-            },
-          ],
+          patterns: [optionsPageImportRestrictionPattern],
         },
       ],
     },
@@ -249,6 +254,28 @@ export default defineConfig([
       "no-restricted-imports": "off",
     },
   },
+  // Guardrails: keep direct backend-specific apiService imports behind adapters
+  // or workflow owner modules while the account-site adapter migration proceeds.
+  {
+    files: [srcJsFamilyFilePattern],
+    ignores: [
+      "src/services/apiService/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/services/apiAdapters/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/services/apiCredentialProfiles/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/services/checkin/autoCheckin/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/services/managedSites/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/services/models/modelSync/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/features/BasicSettings/components/tabs/ManagedSite/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [apiServiceBackendImplementationImportPattern],
+        },
+      ],
+    },
+  },
   // Guardrails: AI API protocol modules must not depend on account-site apiService internals.
   {
     files: ["src/services/aiApi/**/*.{js,cjs,mjs,jsx,ts,tsx}"],
@@ -257,11 +284,7 @@ export default defineConfig([
         "error",
         {
           patterns: [
-            {
-              group: ["~/entrypoints/options/pages/**"],
-              message:
-                "Do not import from `~/entrypoints/options/pages/**` outside the options entrypoint. Extract shared code into `~/features/`, `~/services/`, `~/utils/`, or `~/types/` instead.",
-            },
+            optionsPageImportRestrictionPattern,
             {
               group: [
                 "~/services/apiService/**",

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -8,7 +8,6 @@ import type { AutoDetectErrorCode } from "~/constants/autoDetect"
 import { AUTO_DETECT_ERROR_CODES } from "~/constants/autoDetect"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import {
-  ACCOUNT_SITE_TITLE_RULES,
   isAccountSiteType,
   SITE_TYPES,
   type AccountSiteType,
@@ -21,6 +20,7 @@ import {
   generateDefaultTokenRequest,
 } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { getSiteName } from "~/services/accounts/siteName"
 import { createDisplayAccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
 import {
   analyzeAutoDetectError,
@@ -66,6 +66,8 @@ import { t } from "~/utils/i18n/core"
 const logger = createLogger("AccountOperations")
 
 export const MANUAL_ADD_ACCOUNT_DATA_FETCH_TIMEOUT_MS = 20000
+
+export { extractDomainPrefix, getSiteName } from "~/services/accounts/siteName"
 
 const isCreatedApiToken = (value: unknown): value is ApiToken =>
   !!value &&
@@ -1341,103 +1343,6 @@ export async function validateAndUpdateAccount(
       feedbackLevel: "warning",
     }
   }
-}
-
-/**
- * 提取域名关键部分（排除 www 与常见双后缀）供 UI 显示默认站点名使用。
- * @param hostname 待分析的主机名
- * @returns 规范化后的前缀并首字母大写
- */
-export function extractDomainPrefix(hostname: string): string {
-  if (!hostname) return ""
-
-  // 移除 www. 前缀
-  const withoutWww = hostname.replace(/^www\./, "")
-
-  // 处理子域名情况，例如：xxx.xx.google.com -> google
-  const parts = withoutWww.split(".")
-  if (parts.length >= 2) {
-    // 如果是常见的二级域名（如 .com.cn, .co.uk 等），取倒数第三个部分
-    const lastPart = parts[parts.length - 1]
-    const secondLastPart = parts[parts.length - 2]
-
-    // 检查是否为双重后缀
-    const doubleSuffixes = ["com", "net", "org", "gov", "edu", "co"]
-    if (
-      parts.length >= 3 &&
-      doubleSuffixes.includes(secondLastPart) &&
-      lastPart.length === 2
-    ) {
-      // 首字母大写
-      return (
-        parts[parts.length - 3].charAt(0).toUpperCase() +
-        parts[parts.length - 3].slice(1)
-      )
-    }
-
-    // 否则返回倒数第二个部分
-    return secondLastPart.charAt(0).toUpperCase() + secondLastPart.slice(1)
-  }
-
-  return withoutWww.charAt(0).toUpperCase() + withoutWww.slice(1)
-}
-
-/**
- * 判断站点名称是否仍是默认标题（如“未知站点”），用于决定是否替换。
- * @param siteName 待检测的站点名称
- * @returns true 表示不是默认名称
- */
-function IsNotDefaultSiteName(siteName: string): boolean {
-  return !ACCOUNT_SITE_TITLE_RULES.some(
-    (rule) => rule.name !== SITE_TYPES.UNKNOWN && rule.regex.test(siteName),
-  )
-}
-/**
- * 根据 Tab、URL 或站点状态信息推断最终展示的站点名称。
- * @param input 可能为浏览器 Tab 对象或字符串 URL
- * @param siteTypeHint Optional site-type hint so site-specific API overrides can
- * be used when resolving the display name.
- * @param siteStatusInfo Optional pre-fetched site status info to avoid redundant API calls when resolving the display name.
- * @returns 计算后的站点名称
- */
-export async function getSiteName(
-  input: browser.tabs.Tab | string,
-  siteTypeHint?: string,
-  siteStatusInfo?: { system_name?: string | null } | null,
-): Promise<string> {
-  // 1. 统一提取信息
-  const urlString = typeof input === "string" ? input : input.url ?? ""
-  const tabTitle = typeof input === "string" ? null : input.title
-
-  // 2. 优先从 Tab 标题获取
-  if (tabTitle && IsNotDefaultSiteName(tabTitle)) {
-    return tabTitle
-  }
-
-  // 3. 解析 URL
-  const urlObj = new URL(urlString)
-  const hostWithProtocol = `${urlObj.protocol}//${urlObj.host}`
-
-  // 4. 仅在已知 siteType 时才请求站点状态，避免为未知站点增加额外探测请求。
-  if (siteTypeHint) {
-    const resolvedSiteStatus =
-      siteStatusInfo ??
-      (await getApiService(siteTypeHint).fetchSiteStatus({
-        baseUrl: hostWithProtocol,
-        auth: {
-          authType: AuthTypeEnum.None,
-        },
-      }))
-    if (
-      resolvedSiteStatus?.system_name &&
-      IsNotDefaultSiteName(resolvedSiteStatus.system_name)
-    ) {
-      return resolvedSiteStatus.system_name
-    }
-  }
-
-  // 5. 最后从域名获取
-  return extractDomainPrefix(urlObj.hostname)
 }
 
 /**

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -20,7 +20,10 @@ import {
   generateDefaultTokenRequest,
 } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import { accountStorage } from "~/services/accounts/accountStorage"
-import { getSiteName } from "~/services/accounts/siteName"
+import {
+  completeAutoDetectedAccount,
+  getAutoDetectCompletionFailureReason,
+} from "~/services/accounts/autoDetectCompletion/completion"
 import { createDisplayAccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
 import {
   analyzeAutoDetectError,
@@ -32,12 +35,6 @@ import {
 } from "~/services/accounts/utils/autoDetectUtils"
 import { normalizeAccountSiteUrlForStorage } from "~/services/accounts/utils/siteUrlNormalization"
 import { getApiService } from "~/services/apiService"
-import {
-  API_SERVICE_FETCH_CONTEXT_KINDS,
-  type ApiServiceFetchContext,
-  type ApiServiceRequest,
-  type SiteStatusInfo,
-} from "~/services/apiService/common/type"
 import {
   DEFAULT_PREFERENCES,
   userPreferences,
@@ -105,31 +102,6 @@ function getAutoDetectFailureReasonByErrorCode(
 }
 
 /**
- * Preserves the failing completion step while keeping the original error available for UI classification.
- */
-class AutoDetectCompletionError extends Error {
-  constructor(
-    readonly reason: AutoDetectFailureReason,
-    cause: unknown,
-  ) {
-    super(getErrorMessage(cause))
-    this.name = "AutoDetectCompletionError"
-    this.cause = cause
-  }
-}
-
-/**
- * Resolves the most specific auto-detect completion reason available for analytics.
- */
-function getAutoDetectCompletionFailureReason(
-  error: unknown,
-): AutoDetectFailureReason {
-  return error instanceof AutoDetectCompletionError
-    ? error.reason
-    : AUTO_DETECT_FAILURE_REASONS.UnexpectedException
-}
-
-/**
  * Returns local user-facing guidance for known completion failures.
  */
 function getAutoDetectCompletionFailureMessage(
@@ -138,13 +110,36 @@ function getAutoDetectCompletionFailureMessage(
 ) {
   switch (reason) {
     case AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed:
+    case AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing:
       return t("messages:operations.detection.getAccessTokenFailedDetailed")
     case AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed:
       return t("messages:operations.detection.getSiteStatusFailedDetailed")
+    case AUTO_DETECT_FAILURE_REASONS.UsernameMissing:
+      return t("messages:operations.detection.getUsernameFailedDetailed")
     default:
       return t("accountDialog:messages.autoDetectFailed", {
         error: fallbackErrorMessage,
       })
+  }
+}
+
+/**
+ * Preserves invalid-response details for completion validation failures.
+ */
+function getAutoDetectCompletionDetailedError(
+  error: unknown,
+  reason: AutoDetectFailureReason,
+  message: string,
+) {
+  switch (reason) {
+    case AUTO_DETECT_FAILURE_REASONS.UsernameMissing:
+    case AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing:
+      return {
+        type: AutoDetectErrorType.INVALID_RESPONSE,
+        message,
+      }
+    default:
+      return analyzeAutoDetectError(error)
   }
 }
 
@@ -186,51 +181,6 @@ async function withTimeout<T>(
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId)
     }
-  }
-}
-
-/**
- * Extracts the matched current-tab context from successful auto-detect data.
- */
-function getAutoDetectFetchContext(
-  detectResultData: NonNullable<
-    Awaited<ReturnType<typeof autoDetectSmart>>["data"]
-  >,
-): ApiServiceFetchContext | undefined {
-  const fetchContext = detectResultData.fetchContext
-  if (fetchContext?.kind === API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT) {
-    return fetchContext
-  }
-
-  if (fetchContext?.kind === API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB) {
-    if (
-      typeof fetchContext.tabId === "number" &&
-      typeof fetchContext.origin === "string" &&
-      fetchContext.origin.trim()
-    ) {
-      return fetchContext
-    }
-  }
-
-  if (fetchContext?.incognito === true || fetchContext?.cookieStoreId) {
-    return fetchContext
-  }
-
-  return undefined
-}
-
-/**
- * Builds the service-layer request used by auto-detect completion.
- */
-function createAutoDetectApiRequest(params: {
-  baseUrl: string
-  auth: ApiServiceRequest["auth"]
-  fetchContext?: ApiServiceFetchContext
-}): ApiServiceRequest {
-  return {
-    baseUrl: params.baseUrl,
-    auth: params.auth,
-    ...(params.fetchContext ? { fetchContext: params.fetchContext } : {}),
   }
 }
 
@@ -311,21 +261,11 @@ export async function autoDetectAccount(
       }
     }
 
-    const { userId, siteType, sub2apiAuth } = detectResult.data
+    const { userId, siteType } = detectResult.data
     autoDetectContext = withFinalAutoDetectSiteType(
       detectResult.autoDetectContext,
       siteType,
     )
-    const autoDetectFetchContext = getAutoDetectFetchContext(detectResult.data)
-    const isSub2Api = siteType === SITE_TYPES.SUB2API
-    const isAIHubMix = siteType === SITE_TYPES.AIHUBMIX
-    const effectiveAuthType =
-      isSub2Api || isAIHubMix ? AuthTypeEnum.AccessToken : authType
-    // AIHubMix imports through cookie-authenticated web endpoints, then stores
-    // the retrieved account access token for all normal account/key/model APIs.
-    const detectionAuthType = isAIHubMix
-      ? AuthTypeEnum.Cookie
-      : effectiveAuthType
 
     if (!userId) {
       return {
@@ -340,188 +280,17 @@ export async function autoDetectAccount(
       }
     }
 
-    let tokenPromise: Promise<any>
-
-    // 根据 authType 选择对应的 Promise
-    if (isSub2Api) {
-      const accessToken =
-        typeof detectResult.data.accessToken === "string"
-          ? detectResult.data.accessToken.trim()
-          : ""
-      const detectedUsername =
-        typeof detectResult.data.user?.username === "string"
-          ? detectResult.data.user.username.trim()
-          : ""
-
-      tokenPromise = Promise.resolve({
-        username: detectedUsername,
-        access_token: accessToken,
-      })
-    } else if (
-      isAIHubMix &&
-      typeof detectResult.data.accessToken === "string"
-    ) {
-      const detectedUsername =
-        typeof detectResult.data.user?.username === "string"
-          ? detectResult.data.user.username.trim()
-          : ""
-
-      tokenPromise = Promise.resolve({
-        username: detectedUsername,
-        access_token: detectResult.data.accessToken.trim(),
-      })
-    } else if (effectiveAuthType === AuthTypeEnum.Cookie) {
-      tokenPromise = getApiService(siteType).fetchUserInfo(
-        createAutoDetectApiRequest({
-          baseUrl: url,
-          fetchContext: autoDetectFetchContext,
-          auth: {
-            authType: AuthTypeEnum.Cookie,
-            userId,
-          },
-        }),
-      )
-    } else if (effectiveAuthType === AuthTypeEnum.AccessToken) {
-      tokenPromise = getApiService(siteType).getOrCreateAccessToken(
-        createAutoDetectApiRequest({
-          baseUrl: url,
-          fetchContext: autoDetectFetchContext,
-          auth: {
-            authType: AuthTypeEnum.Cookie,
-            userId,
-          },
-        }),
-      )
-    } else {
-      // none 或其他情况
-      tokenPromise = Promise.resolve(null)
-    }
-
-    const fetchSiteStatusFallback = () =>
-      getApiService(siteType).fetchSiteStatus(
-        createAutoDetectApiRequest({
-          baseUrl: url,
-          fetchContext: autoDetectFetchContext,
-          auth: {
-            authType: detectionAuthType || AuthTypeEnum.None,
-          },
-        }),
-      )
-
-    const siteStatusPromise: Promise<SiteStatusInfo | null> =
-      fetchSiteStatusFallback()
-    const classifiedSiteStatusPromise = siteStatusPromise.catch((error) => {
-      throw new AutoDetectCompletionError(
-        AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
-        error,
-      )
+    const completed = await completeAutoDetectedAccount({
+      url,
+      requestedAuthType: authType,
+      detected: detectResult.data,
+      autoDetectContext,
     })
-
-    const fetchSupportCheckInFallback = () =>
-      getApiService(siteType).fetchSupportCheckIn(
-        createAutoDetectApiRequest({
-          baseUrl: url,
-          fetchContext: autoDetectFetchContext,
-          auth: {
-            authType: AuthTypeEnum.None,
-          },
-        }),
-      )
-
-    const checkSupportPromise: Promise<boolean | undefined> =
-      classifiedSiteStatusPromise.then((siteStatus) =>
-        typeof siteStatus?.checkin_enabled === "boolean"
-          ? siteStatus.checkin_enabled
-          : fetchSupportCheckInFallback().catch((error) => {
-              logger.warn("Auto-detect check-in support probe failed", {
-                siteType,
-                error: getErrorMessage(error),
-              })
-              return false
-            }),
-      )
-
-    // 并行执行 token 获取和 site 状态获取（降低端到端等待）
-    const [tokenInfo, siteStatus, checkSupport, siteName] = await Promise.all([
-      tokenPromise.catch((error) => {
-        throw new AutoDetectCompletionError(
-          AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
-          error,
-        )
-      }),
-      classifiedSiteStatusPromise,
-      checkSupportPromise,
-      classifiedSiteStatusPromise.then((resolvedSiteStatus) =>
-        getSiteName(url, siteType, resolvedSiteStatus),
-      ),
-    ])
-
-    const { username: detectedUsername, access_token } = tokenInfo
-
-    // 验证获取到的用户信息是否完整
-    const isUsernameMissing = !isSub2Api && !detectedUsername
-    const isAccessTokenMissing =
-      (effectiveAuthType === AuthTypeEnum.AccessToken || isAIHubMix) &&
-      !access_token
-
-    if (
-      // Sub2API 默认可能返回空 username（""），此时不应阻止账号识别；但 AccessToken 仍然必须存在
-      isUsernameMissing ||
-      isAccessTokenMissing
-    ) {
-      const failureReason = isAccessTokenMissing
-        ? AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing
-        : AUTO_DETECT_FAILURE_REASONS.UsernameMissing
-      const message = isAccessTokenMissing
-        ? t("messages:operations.detection.getAccessTokenFailedDetailed")
-        : t("messages:operations.detection.getUsernameFailedDetailed")
-      return {
-        success: false,
-        message,
-        detailedError: {
-          type: AutoDetectErrorType.INVALID_RESPONSE,
-          message,
-        },
-        autoDetectContext,
-        autoDetectFailureReason: failureReason,
-      }
-    }
-
-    // 获取默认充值比例
-    const defaultExchangeRate =
-      getApiService(siteType).extractDefaultExchangeRate(siteStatus) ??
-      UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
 
     return {
       success: true,
       message: t("accountDialog:messages.autoDetectSuccess"),
-      data: {
-        username: detectedUsername,
-        siteName: siteName,
-        accessToken: access_token,
-        userId: userId.toString(),
-        exchangeRate: defaultExchangeRate,
-        authType: effectiveAuthType,
-        checkIn: {
-          enableDetection: isSub2Api ? false : checkSupport ?? false,
-          autoCheckInEnabled: isSub2Api ? false : true,
-          siteStatus: {
-            isCheckedInToday: false,
-          },
-          customCheckIn: {
-            url: "",
-            redeemUrl: "",
-            openRedeemWithCheckIn: true,
-            isCheckedInToday: false,
-          },
-        },
-        siteType: siteType,
-        ...(isSub2Api && sub2apiAuth ? { sub2apiAuth } : {}),
-        ...(autoDetectFetchContext
-          ? { fetchContext: autoDetectFetchContext }
-          : {}),
-        autoDetectContext,
-      },
+      data: completed,
     }
   } catch (error) {
     const errorMessage = getErrorMessage(error)
@@ -534,7 +303,11 @@ export async function autoDetectAccount(
       t("messages:autodetect.failed", { error: errorMessage }),
       error,
     )
-    const detailedError = analyzeAutoDetectError(error)
+    const detailedError = getAutoDetectCompletionDetailedError(
+      error,
+      autoDetectFailureReason,
+      message,
+    )
     return {
       success: false,
       message,

--- a/src/services/accounts/autoDetectCompletion/completion.ts
+++ b/src/services/accounts/autoDetectCompletion/completion.ts
@@ -1,10 +1,10 @@
-import { SITE_TYPES } from "~/constants/siteType"
-import { UI_CONSTANTS } from "~/constants/ui"
-import { getSiteName } from "~/services/accounts/siteName"
 import {
   AUTO_DETECT_FAILURE_REASONS,
   type AutoDetectFailureReason,
-} from "~/services/accounts/utils/autoDetectUtils"
+} from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { getSiteName } from "~/services/accounts/siteName"
 import { getApiService } from "~/services/apiService"
 import {
   API_SERVICE_FETCH_CONTEXT_KINDS,

--- a/src/services/accounts/autoDetectCompletion/completion.ts
+++ b/src/services/accounts/autoDetectCompletion/completion.ts
@@ -1,0 +1,268 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { getSiteName } from "~/services/accounts/siteName"
+import {
+  AUTO_DETECT_FAILURE_REASONS,
+  type AutoDetectFailureReason,
+} from "~/services/accounts/utils/autoDetectUtils"
+import { getApiService } from "~/services/apiService"
+import {
+  API_SERVICE_FETCH_CONTEXT_KINDS,
+  type ApiServiceFetchContext,
+  type ApiServiceRequest,
+  type SiteStatusInfo,
+} from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+import { getErrorMessage } from "~/utils/core/error"
+import { createLogger } from "~/utils/core/logger"
+import { t } from "~/utils/i18n/core"
+
+import {
+  AutoDetectCompletionError,
+  type AutoDetectCompletionData,
+  type AutoDetectCompletionRequest,
+  type DetectedAccountIdentity,
+} from "./types"
+
+export { AutoDetectCompletionError }
+
+const logger = createLogger("AccountAutoDetectCompletion")
+
+/**
+ * Resolves the most specific auto-detect completion reason available for analytics.
+ */
+export function getAutoDetectCompletionFailureReason(
+  error: unknown,
+): AutoDetectFailureReason {
+  return error instanceof AutoDetectCompletionError
+    ? error.reason
+    : AUTO_DETECT_FAILURE_REASONS.UnexpectedException
+}
+
+/**
+ * Keeps only auto-detect fetch contexts that are safe to reuse in service calls.
+ */
+function getAutoDetectFetchContext(
+  detected: DetectedAccountIdentity,
+): ApiServiceFetchContext | undefined {
+  const fetchContext = detected.fetchContext
+  if (fetchContext?.kind === API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT) {
+    return fetchContext
+  }
+
+  if (fetchContext?.kind === API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB) {
+    if (
+      typeof fetchContext.tabId === "number" &&
+      typeof fetchContext.origin === "string" &&
+      fetchContext.origin.trim()
+    ) {
+      return fetchContext
+    }
+  }
+
+  if (fetchContext?.incognito === true || fetchContext?.cookieStoreId) {
+    return fetchContext
+  }
+
+  return undefined
+}
+
+/**
+ * Builds the shared service request shape used by completion probes.
+ */
+function createAutoDetectApiRequest(params: {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+  fetchContext?: ApiServiceFetchContext
+}): ApiServiceRequest {
+  return {
+    baseUrl: params.baseUrl,
+    auth: params.auth,
+    ...(params.fetchContext ? { fetchContext: params.fetchContext } : {}),
+  }
+}
+
+/**
+ * Normalizes optional service and detected string fields.
+ */
+function trimString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+/**
+ * Creates the persisted check-in shape used by auto-detected accounts.
+ */
+function createInitialCheckInConfig(
+  isSub2Api: boolean,
+  checkSupport: boolean | undefined,
+) {
+  return {
+    enableDetection: isSub2Api ? false : checkSupport ?? false,
+    autoCheckInEnabled: isSub2Api ? false : true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  }
+}
+
+/**
+ * Completes a detected identity with service-backed token, status, and defaults.
+ */
+export async function completeAutoDetectedAccount(
+  request: AutoDetectCompletionRequest,
+): Promise<AutoDetectCompletionData> {
+  const { url, requestedAuthType, detected, autoDetectContext } = request
+  const { userId, siteType, sub2apiAuth } = detected
+  const autoDetectFetchContext = getAutoDetectFetchContext(detected)
+  const apiService = getApiService(siteType)
+  const isSub2Api = siteType === SITE_TYPES.SUB2API
+  const isAIHubMix = siteType === SITE_TYPES.AIHUBMIX
+  const effectiveAuthType =
+    isSub2Api || isAIHubMix ? AuthTypeEnum.AccessToken : requestedAuthType
+  // AIHubMix imports through cookie-authenticated web endpoints, then stores
+  // the retrieved account access token for all normal account/key/model APIs.
+  const detectionAuthType = isAIHubMix ? AuthTypeEnum.Cookie : effectiveAuthType
+
+  let tokenPromise: Promise<unknown>
+
+  if (isSub2Api) {
+    tokenPromise = Promise.resolve({
+      username: trimString(detected.user?.username),
+      access_token: trimString(detected.accessToken),
+    })
+  } else if (isAIHubMix && typeof detected.accessToken === "string") {
+    tokenPromise = Promise.resolve({
+      username: trimString(detected.user?.username),
+      access_token: trimString(detected.accessToken),
+    })
+  } else if (effectiveAuthType === AuthTypeEnum.Cookie) {
+    tokenPromise = apiService.fetchUserInfo(
+      createAutoDetectApiRequest({
+        baseUrl: url,
+        fetchContext: autoDetectFetchContext,
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId,
+        },
+      }),
+    )
+  } else if (effectiveAuthType === AuthTypeEnum.AccessToken) {
+    tokenPromise = apiService.getOrCreateAccessToken(
+      createAutoDetectApiRequest({
+        baseUrl: url,
+        fetchContext: autoDetectFetchContext,
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId,
+        },
+      }),
+    )
+  } else {
+    // Auto-detect does not normally route non-token completion with None auth;
+    // if it does, the shared identity validation below classifies missing data.
+    tokenPromise = Promise.resolve(null)
+  }
+
+  const fetchSiteStatusFallback = () =>
+    apiService.fetchSiteStatus(
+      createAutoDetectApiRequest({
+        baseUrl: url,
+        fetchContext: autoDetectFetchContext,
+        auth: {
+          authType: detectionAuthType || AuthTypeEnum.None,
+        },
+      }),
+    )
+
+  const siteStatusPromise: Promise<SiteStatusInfo | null> =
+    fetchSiteStatusFallback()
+  const classifiedSiteStatusPromise = siteStatusPromise.catch((error) => {
+    throw new AutoDetectCompletionError(
+      AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+      error,
+    )
+  })
+
+  const fetchSupportCheckInFallback = () =>
+    apiService.fetchSupportCheckIn(
+      createAutoDetectApiRequest({
+        baseUrl: url,
+        fetchContext: autoDetectFetchContext,
+        auth: {
+          authType: AuthTypeEnum.None,
+        },
+      }),
+    )
+
+  const checkSupportPromise: Promise<boolean | undefined> =
+    classifiedSiteStatusPromise.then((siteStatus) =>
+      typeof siteStatus?.checkin_enabled === "boolean"
+        ? siteStatus.checkin_enabled
+        : fetchSupportCheckInFallback().catch((error) => {
+            logger.warn("Auto-detect check-in support probe failed", {
+              siteType,
+              error: getErrorMessage(error),
+            })
+            return false
+          }),
+    )
+
+  const [tokenInfo, siteStatus, checkSupport, siteName] = await Promise.all([
+    tokenPromise.catch((error) => {
+      throw new AutoDetectCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+        error,
+      )
+    }),
+    classifiedSiteStatusPromise,
+    checkSupportPromise,
+    classifiedSiteStatusPromise.then((resolvedSiteStatus) =>
+      getSiteName(url, siteType, resolvedSiteStatus),
+    ),
+  ])
+
+  const tokenData =
+    tokenInfo && typeof tokenInfo === "object"
+      ? (tokenInfo as { username?: unknown; access_token?: unknown })
+      : {}
+  const detectedUsername = trimString(tokenData.username)
+  const accessToken = trimString(tokenData.access_token)
+  const isUsernameMissing = !isSub2Api && !detectedUsername
+  const isAccessTokenMissing =
+    (effectiveAuthType === AuthTypeEnum.AccessToken || isAIHubMix) &&
+    !accessToken
+
+  if (isUsernameMissing || isAccessTokenMissing) {
+    const failureReason = isAccessTokenMissing
+      ? AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing
+      : AUTO_DETECT_FAILURE_REASONS.UsernameMissing
+    const message = isAccessTokenMissing
+      ? t("messages:operations.detection.getAccessTokenFailedDetailed")
+      : t("messages:operations.detection.getUsernameFailedDetailed")
+    throw new AutoDetectCompletionError(failureReason, new Error(message))
+  }
+
+  const defaultExchangeRate =
+    apiService.extractDefaultExchangeRate(siteStatus) ??
+    UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
+
+  return {
+    username: detectedUsername,
+    siteName,
+    accessToken,
+    userId: userId.toString(),
+    exchangeRate: defaultExchangeRate,
+    authType: effectiveAuthType,
+    checkIn: createInitialCheckInConfig(isSub2Api, checkSupport),
+    siteType,
+    ...(isSub2Api && sub2apiAuth ? { sub2apiAuth } : {}),
+    ...(autoDetectFetchContext ? { fetchContext: autoDetectFetchContext } : {}),
+    autoDetectContext,
+  }
+}

--- a/src/services/accounts/autoDetectCompletion/types.ts
+++ b/src/services/accounts/autoDetectCompletion/types.ts
@@ -1,0 +1,54 @@
+import type {
+  AutoDetectAnalyticsContext,
+  AutoDetectFailureReason,
+} from "~/constants/autoDetect"
+import type { AccountSiteType } from "~/constants/siteType"
+import type { ApiServiceFetchContext } from "~/services/apiService/common/type"
+import type { AuthTypeEnum, CheckInConfig, Sub2ApiAuthConfig } from "~/types"
+import { getErrorMessage } from "~/utils/core/error"
+
+export interface DetectedAccountIdentity {
+  userId: string
+  user?: {
+    id?: string | number
+    username?: string
+  }
+  siteType: AccountSiteType
+  accessToken?: string
+  sub2apiAuth?: Sub2ApiAuthConfig
+  fetchContext?: ApiServiceFetchContext
+}
+
+export interface AutoDetectCompletionRequest {
+  url: string
+  requestedAuthType: AuthTypeEnum
+  detected: DetectedAccountIdentity
+  autoDetectContext?: AutoDetectAnalyticsContext
+}
+
+export interface AutoDetectCompletionData {
+  username: string
+  siteName: string
+  accessToken: string
+  userId: string
+  exchangeRate: number | null
+  authType: AuthTypeEnum
+  checkIn: CheckInConfig
+  siteType: AccountSiteType
+  sub2apiAuth?: Sub2ApiAuthConfig
+  fetchContext?: ApiServiceFetchContext
+  autoDetectContext?: AutoDetectAnalyticsContext
+}
+
+export class AutoDetectCompletionError extends Error {
+  readonly name = "AutoDetectCompletionError"
+  readonly cause: unknown
+
+  constructor(
+    readonly reason: AutoDetectFailureReason,
+    cause: unknown,
+  ) {
+    super(getErrorMessage(cause))
+    this.cause = cause
+  }
+}

--- a/src/services/accounts/siteName.ts
+++ b/src/services/accounts/siteName.ts
@@ -1,0 +1,101 @@
+import { ACCOUNT_SITE_TITLE_RULES, SITE_TYPES } from "~/constants/siteType"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
+
+/**
+ * 提取域名关键部分（排除 www 与常见双后缀）供 UI 显示默认站点名使用。
+ * @param hostname 待分析的主机名
+ * @returns 规范化后的前缀并首字母大写
+ */
+export function extractDomainPrefix(hostname: string): string {
+  if (!hostname) return ""
+
+  // 移除 www. 前缀
+  const withoutWww = hostname.replace(/^www\./, "")
+
+  // 处理子域名情况，例如：xxx.xx.google.com -> google
+  const parts = withoutWww.split(".")
+  if (parts.length >= 2) {
+    // 如果是常见的二级域名（如 .com.cn, .co.uk 等），取倒数第三个部分
+    const lastPart = parts[parts.length - 1]
+    const secondLastPart = parts[parts.length - 2]
+
+    // 检查是否为双重后缀
+    const doubleSuffixes = ["com", "net", "org", "gov", "edu", "co"]
+    if (
+      parts.length >= 3 &&
+      doubleSuffixes.includes(secondLastPart) &&
+      lastPart.length === 2
+    ) {
+      // 首字母大写
+      return (
+        parts[parts.length - 3].charAt(0).toUpperCase() +
+        parts[parts.length - 3].slice(1)
+      )
+    }
+
+    // 否则返回倒数第二个部分
+    return secondLastPart.charAt(0).toUpperCase() + secondLastPart.slice(1)
+  }
+
+  return withoutWww.charAt(0).toUpperCase() + withoutWww.slice(1)
+}
+
+/**
+ * 判断站点名称是否仍是默认标题（如“未知站点”），用于决定是否替换。
+ * @param siteName 待检测的站点名称
+ * @returns true 表示不是默认名称
+ */
+function isNotDefaultSiteName(siteName: string): boolean {
+  return !ACCOUNT_SITE_TITLE_RULES.some(
+    (rule) => rule.name !== SITE_TYPES.UNKNOWN && rule.regex.test(siteName),
+  )
+}
+
+/**
+ * 根据 Tab、URL 或站点状态信息推断最终展示的站点名称。
+ * @param input 可能为浏览器 Tab 对象或字符串 URL
+ * @param siteTypeHint Optional site-type hint so site-specific API overrides can
+ * be used when resolving the display name.
+ * @param siteStatusInfo Optional pre-fetched site status info to avoid redundant API calls when resolving the display name.
+ * @returns 计算后的站点名称
+ */
+export async function getSiteName(
+  input: browser.tabs.Tab | string,
+  siteTypeHint?: string,
+  siteStatusInfo?: { system_name?: string | null } | null,
+): Promise<string> {
+  // 1. 统一提取信息
+  const urlString = typeof input === "string" ? input : input.url ?? ""
+  const tabTitle = typeof input === "string" ? null : input.title
+
+  // 2. 优先从 Tab 标题获取
+  if (tabTitle && isNotDefaultSiteName(tabTitle)) {
+    return tabTitle
+  }
+
+  // 3. 解析 URL
+  const urlObj = new URL(urlString)
+  const hostWithProtocol = `${urlObj.protocol}//${urlObj.host}`
+
+  // 4. 仅在已知 siteType 时才请求站点状态，避免为未知站点增加额外探测请求。
+  if (siteTypeHint) {
+    const resolvedSiteStatus =
+      siteStatusInfo ??
+      (await getApiService(siteTypeHint).fetchSiteStatus({
+        baseUrl: hostWithProtocol,
+        auth: {
+          authType: AuthTypeEnum.None,
+        },
+      }))
+    if (
+      resolvedSiteStatus?.system_name &&
+      isNotDefaultSiteName(resolvedSiteStatus.system_name)
+    ) {
+      return resolvedSiteStatus.system_name
+    }
+  }
+
+  // 5. 最后从域名获取
+  return extractDomainPrefix(urlObj.hostname)
+}

--- a/src/services/accounts/siteName.ts
+++ b/src/services/accounts/siteName.ts
@@ -75,19 +75,29 @@ export async function getSiteName(
   }
 
   // 3. 解析 URL
-  const urlObj = new URL(urlString)
+  let urlObj: URL
+  try {
+    urlObj = new URL(urlString)
+  } catch {
+    return urlString.split("/")[0] || ""
+  }
   const hostWithProtocol = `${urlObj.protocol}//${urlObj.host}`
 
   // 4. 仅在已知 siteType 时才请求站点状态，避免为未知站点增加额外探测请求。
   if (siteTypeHint) {
-    const resolvedSiteStatus =
-      siteStatusInfo ??
-      (await getApiService(siteTypeHint).fetchSiteStatus({
-        baseUrl: hostWithProtocol,
-        auth: {
-          authType: AuthTypeEnum.None,
-        },
-      }))
+    let resolvedSiteStatus = siteStatusInfo
+    if (!resolvedSiteStatus) {
+      try {
+        resolvedSiteStatus = await getApiService(siteTypeHint).fetchSiteStatus({
+          baseUrl: hostWithProtocol,
+          auth: {
+            authType: AuthTypeEnum.None,
+          },
+        })
+      } catch {
+        resolvedSiteStatus = null
+      }
+    }
     if (
       resolvedSiteStatus?.system_name &&
       isNotDefaultSiteName(resolvedSiteStatus.system_name)

--- a/tests/services/accountOperations.test.ts
+++ b/tests/services/accountOperations.test.ts
@@ -403,6 +403,10 @@ describe("accountOperations", () => {
       expect(extractDomainPrefix("")).toBe("")
     })
 
+    it("handles single-segment hostnames", () => {
+      expect(extractDomainPrefix("localhost")).toBe("Localhost")
+    })
+
     it("capitalizes first letter", () => {
       expect(extractDomainPrefix("github.com")).toBe("Github")
     })
@@ -491,6 +495,24 @@ describe("accountOperations", () => {
 
       expect(result).toBe("Billing Center")
       expect(mockFetchSiteStatus).not.toHaveBeenCalled()
+    })
+
+    it("falls back to the raw input prefix when the URL cannot be parsed", async () => {
+      const result = await getSiteName("not a url/path", SITE_TYPES.NEW_API)
+
+      expect(result).toBe("not a url")
+      expect(mockFetchSiteStatus).not.toHaveBeenCalled()
+    })
+
+    it("falls back to the domain name when site status fetch fails", async () => {
+      mockFetchSiteStatus.mockRejectedValueOnce(new Error("status failed"))
+
+      const result = await getSiteName(
+        "https://api.example.com/dashboard",
+        SITE_TYPES.NEW_API,
+      )
+
+      expect(result).toBe("Example")
     })
   })
 })

--- a/tests/services/accounts/autoDetectCompletion/completion.test.ts
+++ b/tests/services/accounts/autoDetectCompletion/completion.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { AUTO_DETECT_STRATEGIES } from "~/constants/autoDetect"
+import {
+  AUTO_DETECT_FAILURE_REASONS,
+  AUTO_DETECT_STRATEGIES,
+} from "~/constants/autoDetect"
 import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
 import {
   AutoDetectCompletionError,
   completeAutoDetectedAccount,
 } from "~/services/accounts/autoDetectCompletion/completion"
-import { AUTO_DETECT_FAILURE_REASONS } from "~/services/accounts/utils/autoDetectUtils"
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
 import type { ApiServiceFetchContext } from "~/services/apiService/common/type"
 import { AuthTypeEnum } from "~/types"
@@ -337,6 +339,106 @@ describe("auto-detect completion", () => {
       }),
     ).rejects.toMatchObject({
       reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+  })
+
+  it("throws username missing when non-Sub2API completion returns no usable username", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "  ",
+      access_token: "username-missing-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Missing Username Portal",
+    })
+    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://username.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "6",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+    })
+  })
+
+  it("wraps token service failures as token-fetch completion errors", async () => {
+    const tokenError = new Error("token failed")
+    mockGetOrCreateAccessToken.mockRejectedValueOnce(tokenError)
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Token Failure Portal",
+      checkin_enabled: true,
+    })
+
+    const completionPromise = completeAutoDetectedAccount({
+      url: "https://token-failure.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      detected: {
+        userId: "10",
+        siteType: SITE_TYPES.NEW_API,
+      },
+    })
+
+    await expect(completionPromise).rejects.toMatchObject({
+      name: "AutoDetectCompletionError",
+      reason: AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+      cause: tokenError,
+    })
+  })
+
+  it("falls back to disabled check-in when support probing fails", async () => {
+    const supportError = new Error("support failed")
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "support-user",
+      access_token: "support-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Support Failure Portal",
+    })
+    mockFetchSupportCheckIn.mockRejectedValueOnce(supportError)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://support.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      detected: {
+        userId: "13",
+        siteType: SITE_TYPES.NEW_API,
+      },
+    })
+
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
+      baseUrl: "https://support.example.com",
+      auth: {
+        authType: AuthTypeEnum.None,
+      },
+    })
+    expect(result.checkIn.enableDetection).toBe(false)
+  })
+
+  it("classifies unsupported completion auth as username missing", async () => {
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Unsupported Auth Portal",
+      checkin_enabled: true,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://unsupported-auth.example.com",
+        requestedAuthType: AuthTypeEnum.None,
+        detected: {
+          userId: "14",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
     })
   })
 

--- a/tests/services/accounts/autoDetectCompletion/completion.test.ts
+++ b/tests/services/accounts/autoDetectCompletion/completion.test.ts
@@ -1,0 +1,370 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AUTO_DETECT_STRATEGIES } from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import {
+  AutoDetectCompletionError,
+  completeAutoDetectedAccount,
+} from "~/services/accounts/autoDetectCompletion/completion"
+import { AUTO_DETECT_FAILURE_REASONS } from "~/services/accounts/utils/autoDetectUtils"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
+import type { ApiServiceFetchContext } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockFetchSiteStatus,
+  mockFetchSupportCheckIn,
+  mockExtractDefaultExchangeRate,
+  mockFetchUserInfo,
+  mockGetOrCreateAccessToken,
+} = vi.hoisted(() => ({
+  mockFetchSiteStatus: vi.fn(),
+  mockFetchSupportCheckIn: vi.fn(),
+  mockExtractDefaultExchangeRate: vi.fn(),
+  mockFetchUserInfo: vi.fn(),
+  mockGetOrCreateAccessToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => ({
+      fetchSiteStatus: mockFetchSiteStatus,
+      fetchSupportCheckIn: mockFetchSupportCheckIn,
+      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+      fetchUserInfo: mockFetchUserInfo,
+      getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    })),
+  }
+})
+
+const currentTabFetchContext = (origin: string) => ({
+  kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+  tabId: 123,
+  origin,
+})
+
+const browserFetchContext = () => ({
+  kind: API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT,
+  cookieStoreId: "firefox-container-2",
+})
+
+describe("auto-detect completion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("completes compatible access-token account data through the service layer", async () => {
+    const fetchContext = currentTabFetchContext("https://status.example.com")
+    const autoDetectContext = {
+      strategy: AUTO_DETECT_STRATEGIES.CurrentTab,
+      siteType: SITE_TYPES.NEW_API,
+    }
+    const siteStatus = {
+      system_name: "Status Portal",
+      checkin_enabled: true,
+    }
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "  service-user  ",
+      access_token: "  service-token  ",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce(siteStatus)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(6.8)
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://status.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      autoDetectContext,
+      detected: {
+        userId: "7",
+        siteType: SITE_TYPES.NEW_API,
+        fetchContext,
+      },
+    })
+
+    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
+      baseUrl: "https://status.example.com",
+      fetchContext,
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "7",
+      },
+    })
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://status.example.com",
+      fetchContext,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+      },
+    })
+    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+    expect(mockExtractDefaultExchangeRate).toHaveBeenCalledWith(siteStatus)
+    expect(result).toEqual({
+      username: "service-user",
+      siteName: "Status Portal",
+      accessToken: "service-token",
+      userId: "7",
+      exchangeRate: 6.8,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+        customCheckIn: {
+          url: "",
+          redeemUrl: "",
+          openRedeemWithCheckIn: true,
+          isCheckedInToday: false,
+        },
+      },
+      siteType: SITE_TYPES.NEW_API,
+      fetchContext,
+      autoDetectContext,
+    })
+  })
+
+  it("uses detected Sub2API access-token data without user/token service completion", async () => {
+    const fetchContext = currentTabFetchContext("https://sub2.example.com")
+    const sub2apiAuth = {
+      refreshToken: "refresh-token",
+      tokenExpiresAt: 1999999999999,
+    }
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Runtime Portal",
+    })
+    mockFetchSupportCheckIn.mockResolvedValueOnce(true)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://sub2.example.com",
+      requestedAuthType: AuthTypeEnum.Cookie,
+      detected: {
+        userId: "12",
+        user: { id: 12, username: "  " },
+        siteType: SITE_TYPES.SUB2API,
+        accessToken: "  jwt-token  ",
+        sub2apiAuth,
+        fetchContext,
+      },
+    })
+
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      username: "",
+      siteName: "Runtime Portal",
+      accessToken: "jwt-token",
+      userId: "12",
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      siteType: SITE_TYPES.SUB2API,
+      sub2apiAuth,
+      fetchContext,
+      checkIn: {
+        enableDetection: false,
+        autoCheckInEnabled: false,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+        customCheckIn: {
+          url: "",
+          redeemUrl: "",
+          openRedeemWithCheckIn: true,
+          isCheckedInToday: false,
+        },
+      },
+    })
+  })
+
+  it("uses detected AIHubMix access-token data and probes site status with Cookie auth", async () => {
+    const fetchContext = currentTabFetchContext("https://aihubmix.com")
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://aihubmix.com",
+      requestedAuthType: AuthTypeEnum.Cookie,
+      detected: {
+        userId: "11",
+        user: { id: 11, username: "  aihubmix-user  " },
+        siteType: SITE_TYPES.AIHUBMIX,
+        accessToken: "  detected-console-token  ",
+        fetchContext,
+      },
+    })
+
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://aihubmix.com",
+      fetchContext,
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+      },
+    })
+    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      username: "aihubmix-user",
+      accessToken: "detected-console-token",
+      authType: AuthTypeEnum.AccessToken,
+      siteType: SITE_TYPES.AIHUBMIX,
+      fetchContext,
+      checkIn: {
+        enableDetection: false,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+        customCheckIn: {
+          url: "",
+          redeemUrl: "",
+          openRedeemWithCheckIn: true,
+          isCheckedInToday: false,
+        },
+      },
+    })
+  })
+
+  it("drops malformed current-tab fetch context from service requests and result", async () => {
+    const malformedFetchContext = {
+      kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+      tabId: "not-a-number",
+      origin: "https://malformed.example.com",
+      cookieStoreId: "",
+    } as unknown as ApiServiceFetchContext
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "malformed-context-user",
+      access_token: "malformed-context-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Malformed Context Portal",
+      checkin_enabled: true,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://malformed.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      detected: {
+        userId: "8",
+        siteType: SITE_TYPES.NEW_API,
+        fetchContext: malformedFetchContext,
+      },
+    })
+
+    expect(result).not.toHaveProperty("fetchContext")
+    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
+      baseUrl: "https://malformed.example.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "8",
+      },
+    })
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://malformed.example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+      },
+    })
+  })
+
+  it("retains browser fetch context in service requests and result", async () => {
+    const fetchContext = browserFetchContext()
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "browser-context-user",
+      access_token: "browser-context-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Browser Context Portal",
+      checkin_enabled: true,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://browser-context.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      detected: {
+        userId: "9",
+        siteType: SITE_TYPES.NEW_API,
+        fetchContext,
+      },
+    })
+
+    expect(result.fetchContext).toEqual(fetchContext)
+    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
+      baseUrl: "https://browser-context.example.com",
+      fetchContext,
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "9",
+      },
+    })
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://browser-context.example.com",
+      fetchContext,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+      },
+    })
+  })
+
+  it("throws access-token missing when token completion returns no usable token", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "missing-token-user",
+      access_token: "  ",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Missing Token Portal",
+    })
+    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://token.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "5",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+  })
+
+  it("throws completion error when site status fetch fails", async () => {
+    const statusError = new Error("status failed")
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "status-user",
+      access_token: "status-token",
+    })
+    mockFetchSiteStatus.mockRejectedValueOnce(statusError)
+
+    const completionPromise = completeAutoDetectedAccount({
+      url: "https://status.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      detected: {
+        userId: "8",
+        siteType: SITE_TYPES.NEW_API,
+      },
+    })
+
+    await expect(completionPromise).rejects.toMatchObject({
+      name: "AutoDetectCompletionError",
+      reason: AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+      cause: statusError,
+    })
+
+    await expect(completionPromise).rejects.toBeInstanceOf(
+      AutoDetectCompletionError,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add an eslint guardrail for direct backend apiService imports
- document the account auto-detect completion refactor plan
- extract site-name helpers and move auto-detect completion into a dedicated service module with focused coverage

## Validation
- pnpm vitest --run tests/services/accounts/autoDetectCompletion/completion.test.ts
- pnpm compile
- pnpm run validate:push
- git push pre-push validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new planning and design specs for refactoring account auto-detect completion.

* **Refactor**
  * Streamlined account auto-detect completion workflow into dedicated modules for clearer validation and error handling.
  * Centralized site-name inference utilities used during account detection.
  * Updated ESLint import-guard rules to standardize restrictions.

* **Tests**
  * Added comprehensive automated coverage for auto-detect completion success, edge cases, and failure reason mapping.
  * Extended domain/site-name parsing tests (including localhost and error fallback scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->