### PR TITLE
fix(webdav): probe collection connections with propfind

### DIFF
--- a/src/services/webdav/webdavService.ts
+++ b/src/services/webdav/webdavService.ts
@@ -132,6 +132,18 @@ function resolveConnectionTestUrl(url: string) {
 }
 
 /**
+ * Detects explicit backup file URLs so connection checks can keep the legacy
+ * GET probe for file paths while using a WebDAV-native probe for collections.
+ */
+function isExplicitWebdavJsonFileUrl(url: string) {
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith(".json")
+  } catch {
+    return /\.json($|[?#])/i.test(url)
+  }
+}
+
+/**
  * Derives the backup directory URL from a fully-qualified backup target URL.
  *
  * Used so we can create the collection via `MKCOL` before uploading.
@@ -638,19 +650,25 @@ async function getWebdavEncryptionConfig() {
  * Test connectivity and authentication against the configured WebDAV
  * endpoint.
  *
+ * Explicit JSON file URLs keep the legacy GET probe so missing backup files
+ * can still be treated as reachable. Collection-like URLs use PROPFIND with
+ * Depth: 0 because some WebDAV providers reject collection GET while accepting
+ * standard collection metadata probes.
+ *
  * Any non-auth HTTP status in the 2xx–4xx range is treated as a successful
- * connectivity check (the exact backup file does not need to exist yet).
- * 401/403 are treated as authentication failures and 5xx as connection
- * errors.
+ * connectivity check. 401/403 are treated as authentication failures and 5xx
+ * as connection errors.
  */
 export async function testWebdavConnection(custom?: Partial<WebDAVConfig>) {
   const { cfg } = await resolveWebdavBackupRequestContext(custom)
   const targetUrl = resolveConnectionTestUrl(cfg.url)
+  const usesFileProbe = isExplicitWebdavJsonFileUrl(targetUrl)
 
   const res = await fetch(targetUrl, {
-    method: "GET",
+    method: usesFileProbe ? "GET" : "PROPFIND",
     headers: {
       Authorization: buildAuthHeader(cfg.username, cfg.password),
+      ...(usesFileProbe ? {} : { Depth: "0" }),
     },
   })
   // 401/403 明确表示鉴权失败

--- a/tests/services/webdavService.test.ts
+++ b/tests/services/webdavService.test.ts
@@ -132,9 +132,9 @@ describe("webdavService", () => {
       expect(globalAny.fetch).not.toHaveBeenCalled()
     })
 
-    it("returns true when status is 200", async () => {
+    it("returns true when a collection probe returns WebDAV multistatus", async () => {
       mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
-      globalAny.fetch.mockResolvedValue({ status: 200 })
+      globalAny.fetch.mockResolvedValue({ status: 207 })
 
       const ok = await testWebdavConnection()
 
@@ -142,7 +142,13 @@ describe("webdavService", () => {
       expect(globalAny.fetch).toHaveBeenCalledTimes(1)
       const [url, init] = globalAny.fetch.mock.calls[0]
       expect(typeof url).toBe("string")
-      expect((init as RequestInit).method).toBe("GET")
+      expect((init as RequestInit).method).toBe("PROPFIND")
+      expect((init as RequestInit).headers).toEqual(
+        expect.objectContaining({
+          Authorization: "Basic dXNlcjpwYXNz",
+          Depth: "0",
+        }),
+      )
     })
 
     it("tests directory-like WebDAV URLs without expanding them to backup files", async () => {
@@ -160,21 +166,57 @@ describe("webdavService", () => {
       expect(globalAny.fetch).toHaveBeenCalledWith(
         "http://127.0.0.1:1900/configSync/ALL-API-HUB",
         expect.objectContaining({
+          method: "PROPFIND",
+          headers: expect.objectContaining({
+            Depth: "0",
+          }),
+        }),
+      )
+    })
+
+    it("keeps using GET for explicit JSON file URLs", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue({
+        webdav: {
+          ...basePrefs.webdav,
+          url: "https://webdav.example.invalid/backups/export.json",
+        },
+      })
+      globalAny.fetch.mockResolvedValue({ status: 200 })
+
+      const ok = await testWebdavConnection()
+
+      expect(ok).toBe(true)
+      expect(globalAny.fetch).toHaveBeenCalledWith(
+        "https://webdav.example.invalid/backups/export.json",
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            Depth: expect.any(String),
+          }),
           method: "GET",
         }),
       )
     })
 
-    it("returns true when status is 404 (file missing but auth ok)", async () => {
-      mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
+    it("returns true when explicit JSON file status is 404 (file missing but auth ok)", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue({
+        webdav: {
+          ...basePrefs.webdav,
+          url: "https://webdav.example.invalid/backups/export.json",
+        },
+      })
       globalAny.fetch.mockResolvedValue({ status: 404 })
 
       const ok = await testWebdavConnection()
       expect(ok).toBe(true)
     })
 
-    it("treats other non-auth 4xx (e.g. 405/409) as connectivity success", async () => {
-      mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
+    it("treats other explicit JSON file non-auth 4xx as connectivity success", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue({
+        webdav: {
+          ...basePrefs.webdav,
+          url: "https://webdav.example.invalid/backups/export.json",
+        },
+      })
       globalAny.fetch.mockResolvedValue({ status: 405 })
 
       const ok = await testWebdavConnection()

--- a/tests/services/webdavService.test.ts
+++ b/tests/services/webdavService.test.ts
@@ -197,6 +197,26 @@ describe("webdavService", () => {
       )
     })
 
+    it("keeps using GET for explicit JSON file paths that are not absolute URLs", async () => {
+      mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
+      globalAny.fetch.mockResolvedValue({ status: 200 })
+
+      const ok = await testWebdavConnection({
+        url: "backups/export.json",
+      })
+
+      expect(ok).toBe(true)
+      expect(globalAny.fetch).toHaveBeenCalledWith(
+        "backups/export.json",
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            Depth: expect.any(String),
+          }),
+          method: "GET",
+        }),
+      )
+    })
+
     it("returns true when explicit JSON file status is 404 (file missing but auth ok)", async () => {
       mockedUserPreferences.getPreferences.mockResolvedValue({
         webdav: {


### PR DESCRIPTION
Fixes #981

## Summary
- Use PROPFIND with Depth: 0 when testing collection-like WebDAV configuration URLs.
- Keep GET probes for explicit .json backup file URLs to preserve existing file-path behavior.
- Add regression coverage for collection probes, explicit file probes, and status handling.

## Test Plan
- pnpm vitest run tests/services/webdavService.test.ts
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebDAV connectivity detection to correctly distinguish between explicit JSON backup file targets and directory-style WebDAV endpoints, using the most appropriate probe method for each.
  * Ensures consistent handling of authentication errors, successful reachability responses, and server-side failures.

* **Tests**
  * Updated and expanded WebDAV connection tests to cover JSON file URLs versus directory endpoints, including verification of request behavior and expected outcomes across common HTTP status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->