### PR TITLE
refactor(accounts): route completion through adapters

### DIFF
--- a/docs/superpowers/plans/2026-06-17-account-completion-adapter.md
+++ b/docs/superpowers/plans/2026-06-17-account-completion-adapter.md
@@ -1,0 +1,1979 @@
+# Account Completion Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-account-completion-adapter-design.md`
+
+**Goal:** Move account auto-detect completion rules behind `getSiteAdapter(siteType).accountCompletion` while preserving the current `autoDetectAccount(...)` response behavior.
+
+**Architecture:** Add a narrow `accountCompletion` capability to `src/services/apiAdapters`. New API-family, Sub2API, and AIHubMix Adapters own site-specific completion rules; `completeAutoDetectedAccount(...)` stays the product-level orchestrator for fetch-context validation, helper creation, and final response data assembly.
+
+**Tech Stack:** TypeScript, Vitest, existing `apiAdapters`, existing account auto-detect completion tests, `pnpm run validate:staged`.
+
+---
+
+## File Structure
+
+- Create `src/services/apiAdapters/contracts/accountCompletion.ts`
+  - Defines the Adapter Interface for account auto-detect completion.
+- Modify `src/services/apiAdapters/contracts/siteAdapter.ts`
+  - Adds optional `accountCompletion`.
+- Create `src/services/apiAdapters/newApi/accountCompletion.ts`
+  - Implements compatible New API-family account completion.
+- Modify `src/services/apiAdapters/newApi/index.ts`
+  - Exposes the New API-family completion capability.
+- Create `src/services/apiAdapters/sub2api/accountCompletion.ts`
+  - Implements Sub2API account completion.
+- Modify `src/services/apiAdapters/sub2api/index.ts`
+  - Exposes the Sub2API completion capability.
+- Create `src/services/apiAdapters/aihubmix/accountCompletion.ts`
+  - Implements AIHubMix account completion.
+- Create `src/services/apiAdapters/aihubmix/index.ts`
+  - Exposes the AIHubMix Adapter with only `accountCompletion`.
+- Modify `src/services/apiAdapters/registry.ts`
+  - Returns AIHubMix Adapter and verifies completion capability support.
+- Create `tests/services/apiAdapters/newApi/accountCompletion.test.ts`
+  - Covers compatible-site completion rules.
+- Create `tests/services/apiAdapters/sub2api/accountCompletion.test.ts`
+  - Covers Sub2API completion rules.
+- Create `tests/services/apiAdapters/aihubmix/accountCompletion.test.ts`
+  - Covers AIHubMix completion rules.
+- Modify `tests/services/apiAdapters/registry.test.ts`
+  - Covers registry-visible `accountCompletion`.
+- Modify `src/services/accounts/autoDetectCompletion/completion.ts`
+  - Routes completion through `getSiteAdapter(siteType).accountCompletion`.
+- Modify `tests/services/accounts/autoDetectCompletion/completion.test.ts`
+  - Covers the orchestrator and missing capability behavior.
+- Keep `tests/services/accountOperations.autoDetectAccount.test.ts`
+  - Existing broad workflow contract remains green.
+
+---
+
+## Task 1: Add Account Completion Contract And New API-Family Adapter
+
+**Files:**
+- Create: `src/services/apiAdapters/contracts/accountCompletion.ts`
+- Modify: `src/services/apiAdapters/contracts/siteAdapter.ts`
+- Create: `src/services/apiAdapters/newApi/accountCompletion.ts`
+- Modify: `src/services/apiAdapters/newApi/index.ts`
+- Create: `tests/services/apiAdapters/newApi/accountCompletion.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write the failing New API-family Adapter test**
+
+Create `tests/services/apiAdapters/newApi/accountCompletion.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  AUTO_DETECT_FAILURE_REASONS,
+  AUTO_DETECT_STRATEGIES,
+} from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { newApiAccountCompletion } from "~/services/apiAdapters/newApi/accountCompletion"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  getApiServiceMock,
+  fetchUserInfoMock,
+  getOrCreateAccessTokenMock,
+  fetchSiteStatusMock,
+  fetchSupportCheckInMock,
+  extractDefaultExchangeRateMock,
+} = vi.hoisted(() => ({
+  getApiServiceMock: vi.fn(),
+  fetchUserInfoMock: vi.fn(),
+  getOrCreateAccessTokenMock: vi.fn(),
+  fetchSiteStatusMock: vi.fn(),
+  fetchSupportCheckInMock: vi.fn(),
+  extractDefaultExchangeRateMock: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: getApiServiceMock,
+}))
+
+const createServiceRequest = (input: {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+  context: {
+    fetchContext?: ApiServiceRequest["fetchContext"]
+  }
+}): ApiServiceRequest => ({
+  baseUrl: input.baseUrl,
+  auth: input.auth,
+  ...(input.context.fetchContext
+    ? { fetchContext: input.context.fetchContext }
+    : {}),
+})
+
+const helpers = {
+  createServiceRequest,
+  fetchSiteName: vi.fn(async (siteStatus: { system_name?: string } | null) =>
+    siteStatus?.system_name ? siteStatus.system_name : "Example",
+  ),
+  createCompletionError: (reason: string, cause: unknown) =>
+    Object.assign(new Error(cause instanceof Error ? cause.message : reason), {
+      name: "AutoDetectCompletionError",
+      reason,
+      cause,
+    }),
+  trimString: (value: unknown) =>
+    typeof value === "string" ? value.trim() : "",
+  createInitialCheckInConfig: (input: {
+    enableDetection: boolean
+    autoCheckInEnabled: boolean
+  }) => ({
+    enableDetection: input.enableDetection,
+    autoCheckInEnabled: input.autoCheckInEnabled,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  }),
+  handleCheckInSupportFetchFailure: vi.fn(() => false),
+}
+
+const fetchContext = {
+  kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+  tabId: 1,
+  origin: "https://new.example.com",
+}
+
+const mockService = () => {
+  getApiServiceMock.mockReturnValue({
+    fetchUserInfo: fetchUserInfoMock,
+    getOrCreateAccessToken: getOrCreateAccessTokenMock,
+    fetchSiteStatus: fetchSiteStatusMock,
+    fetchSupportCheckIn: fetchSupportCheckInMock,
+    extractDefaultExchangeRate: extractDefaultExchangeRateMock,
+  })
+}
+
+describe("newApiAccountCompletion", () => {
+  it("completes access-token accounts through getOrCreateAccessToken", async () => {
+    mockService()
+    const siteStatus = {
+      system_name: "Status Portal",
+      checkin_enabled: true,
+    }
+    getOrCreateAccessTokenMock.mockResolvedValueOnce({
+      username: "  service-user  ",
+      access_token: "  service-token  ",
+    })
+    fetchSiteStatusMock.mockResolvedValueOnce(siteStatus)
+    extractDefaultExchangeRateMock.mockReturnValueOnce(6.8)
+
+    await expect(
+      newApiAccountCompletion.complete(
+        {
+          url: "https://new.example.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          context: { fetchContext },
+          autoDetectContext: {
+            strategy: AUTO_DETECT_STRATEGIES.CurrentTab,
+            siteType: SITE_TYPES.NEW_API,
+          },
+          detected: {
+            userId: "7",
+            siteType: SITE_TYPES.NEW_API,
+            fetchContext,
+          },
+        },
+        helpers,
+      ),
+    ).resolves.toMatchObject({
+      username: "service-user",
+      siteName: "Status Portal",
+      accessToken: "service-token",
+      userId: "7",
+      exchangeRate: 6.8,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+      },
+    })
+
+    expect(getApiServiceMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(getOrCreateAccessTokenMock).toHaveBeenCalledWith({
+      baseUrl: "https://new.example.com",
+      fetchContext,
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "7",
+      },
+    })
+    expect(fetchUserInfoMock).not.toHaveBeenCalled()
+    expect(fetchSiteStatusMock).toHaveBeenCalledWith({
+      baseUrl: "https://new.example.com",
+      fetchContext,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+      },
+    })
+    expect(fetchSupportCheckInMock).not.toHaveBeenCalled()
+    expect(extractDefaultExchangeRateMock).toHaveBeenCalledWith(siteStatus)
+  })
+
+  it("completes cookie accounts through fetchUserInfo and support probing", async () => {
+    mockService()
+    fetchUserInfoMock.mockResolvedValueOnce({
+      username: "cookie-user",
+      access_token: "",
+    })
+    fetchSiteStatusMock.mockResolvedValueOnce({
+      system_name: "Cookie Portal",
+    })
+    fetchSupportCheckInMock.mockResolvedValueOnce(true)
+    extractDefaultExchangeRateMock.mockReturnValueOnce(null)
+
+    const result = await newApiAccountCompletion.complete(
+      {
+        url: "https://cookie.example.com",
+        requestedAuthType: AuthTypeEnum.Cookie,
+        context: {},
+        detected: {
+          userId: "8",
+          siteType: SITE_TYPES.ONE_API,
+        },
+      },
+      helpers,
+    )
+
+    expect(result).toMatchObject({
+      username: "cookie-user",
+      accessToken: "",
+      authType: AuthTypeEnum.Cookie,
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+      },
+    })
+    expect(fetchUserInfoMock).toHaveBeenCalledWith({
+      baseUrl: "https://cookie.example.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "8",
+      },
+    })
+    expect(fetchSupportCheckInMock).toHaveBeenCalledWith({
+      baseUrl: "https://cookie.example.com",
+      auth: {
+        authType: AuthTypeEnum.None,
+      },
+    })
+  })
+
+  it("classifies missing username and access token", async () => {
+    mockService()
+    getOrCreateAccessTokenMock.mockResolvedValueOnce({
+      username: "  ",
+      access_token: "  ",
+    })
+    fetchSiteStatusMock.mockResolvedValueOnce({
+      system_name: "Broken Portal",
+      checkin_enabled: false,
+    })
+    extractDefaultExchangeRateMock.mockReturnValueOnce(null)
+
+    await expect(
+      newApiAccountCompletion.complete(
+        {
+          url: "https://broken.example.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          context: {},
+          detected: {
+            userId: "9",
+            siteType: SITE_TYPES.NEW_API,
+          },
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Update registry tests for New API-family capability**
+
+In `tests/services/apiAdapters/registry.test.ts`, inside the New API-family loop, add:
+
+```ts
+expect(adapter.accountCompletion).toEqual({
+  complete: expect.any(Function),
+})
+```
+
+Keep the AIHubMix and Sub2API assertions unchanged in this task.
+
+- [ ] **Step 3: Run the failing tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because `newApi/accountCompletion.ts` and the `accountCompletion` contract do not exist yet.
+
+- [ ] **Step 4: Add the account completion contract**
+
+Create `src/services/apiAdapters/contracts/accountCompletion.ts`:
+
+```ts
+import type { AutoDetectFailureReason } from "~/constants/autoDetect"
+import type {
+  AutoDetectCompletionData,
+  AutoDetectCompletionRequest,
+} from "~/services/accounts/autoDetectCompletion/types"
+import type {
+  ApiServiceFetchContext,
+  ApiServiceRequest,
+  SiteStatusInfo,
+} from "~/services/apiService/common/type"
+
+export type AccountCompletionRuntimeContext = {
+  fetchContext?: ApiServiceFetchContext
+}
+
+export type AccountCompletionServiceRequestInput = {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+  context: AccountCompletionRuntimeContext
+}
+
+export type AccountCompletionAdapterRequest = AutoDetectCompletionRequest & {
+  context: AccountCompletionRuntimeContext
+}
+
+export type AccountCompletionAdapterResult = Omit<
+  AutoDetectCompletionData,
+  "siteType" | "fetchContext" | "autoDetectContext"
+>
+
+export type AccountCompletionHelpers = {
+  createServiceRequest(
+    input: AccountCompletionServiceRequestInput,
+  ): ApiServiceRequest
+  fetchSiteName(siteStatus: SiteStatusInfo | null): Promise<string>
+  createCompletionError(reason: AutoDetectFailureReason, cause: unknown): Error
+  trimString(value: unknown): string
+  createInitialCheckInConfig(input: {
+    enableDetection: boolean
+    autoCheckInEnabled: boolean
+  }): AutoDetectCompletionData["checkIn"]
+  handleCheckInSupportFetchFailure(error: unknown): false
+}
+
+export type AccountCompletionCapability = {
+  complete(
+    request: AccountCompletionAdapterRequest,
+    helpers: AccountCompletionHelpers,
+  ): Promise<AccountCompletionAdapterResult>
+}
+```
+
+- [ ] **Step 5: Extend the SiteAdapter contract**
+
+In `src/services/apiAdapters/contracts/siteAdapter.ts`, add:
+
+```ts
+import type { AccountCompletionCapability } from "./accountCompletion"
+```
+
+Then add this property to `SiteAdapter`:
+
+```ts
+  accountCompletion?: AccountCompletionCapability
+```
+
+- [ ] **Step 6: Implement New API-family account completion**
+
+Create `src/services/apiAdapters/newApi/accountCompletion.ts`:
+
+```ts
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
+
+import type {
+  AccountCompletionAdapterRequest,
+  AccountCompletionCapability,
+  AccountCompletionHelpers,
+} from "../contracts/accountCompletion"
+
+const readTokenInfo = (value: unknown) =>
+  value && typeof value === "object"
+    ? (value as { username?: unknown; access_token?: unknown })
+    : {}
+
+const fetchTokenInfo = async (
+  request: AccountCompletionAdapterRequest,
+  helpers: AccountCompletionHelpers,
+) => {
+  const service = getApiService(request.detected.siteType)
+  const { url, requestedAuthType, detected, context } = request
+
+  if (requestedAuthType === AuthTypeEnum.Cookie) {
+    return await service.fetchUserInfo(
+      helpers.createServiceRequest({
+        baseUrl: url,
+        context,
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: detected.userId,
+        },
+      }),
+    )
+  }
+
+  if (requestedAuthType === AuthTypeEnum.AccessToken) {
+    return await service.getOrCreateAccessToken(
+      helpers.createServiceRequest({
+        baseUrl: url,
+        context,
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: detected.userId,
+        },
+      }),
+    )
+  }
+
+  return null
+}
+
+export const newApiAccountCompletion: AccountCompletionCapability = {
+  async complete(request, helpers) {
+    const service = getApiService(request.detected.siteType)
+    const { url, requestedAuthType, context } = request
+
+    let tokenInfo: unknown
+    try {
+      tokenInfo = await fetchTokenInfo(request, helpers)
+    } catch (error) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+        error,
+      )
+    }
+
+    let siteStatus = null
+    try {
+      siteStatus = await service.fetchSiteStatus(
+        helpers.createServiceRequest({
+          baseUrl: url,
+          context,
+          auth: {
+            authType: requestedAuthType || AuthTypeEnum.None,
+          },
+        }),
+      )
+    } catch (error) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+        error,
+      )
+    }
+
+    const checkSupport =
+      typeof siteStatus?.checkin_enabled === "boolean"
+        ? siteStatus.checkin_enabled
+        : await service
+            .fetchSupportCheckIn(
+              helpers.createServiceRequest({
+                baseUrl: url,
+                context,
+                auth: {
+                  authType: AuthTypeEnum.None,
+                },
+              }),
+            )
+            .catch(helpers.handleCheckInSupportFetchFailure)
+
+    const tokenData = readTokenInfo(tokenInfo)
+    const username = helpers.trimString(tokenData.username)
+    const accessToken = helpers.trimString(tokenData.access_token)
+    const isAccessTokenMissing =
+      requestedAuthType === AuthTypeEnum.AccessToken && !accessToken
+
+    if (!username || isAccessTokenMissing) {
+      throw helpers.createCompletionError(
+        isAccessTokenMissing
+          ? AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing
+          : AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+        new Error(
+          isAccessTokenMissing
+            ? "access token missing"
+            : "username missing",
+        ),
+      )
+    }
+
+    return {
+      username,
+      siteName: await helpers.fetchSiteName(siteStatus),
+      accessToken,
+      userId: request.detected.userId.toString(),
+      exchangeRate:
+        service.extractDefaultExchangeRate(siteStatus) ??
+        UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: requestedAuthType,
+      checkIn: helpers.createInitialCheckInConfig({
+        enableDetection: checkSupport ?? false,
+        autoCheckInEnabled: true,
+      }),
+    }
+  },
+}
+```
+
+- [ ] **Step 7: Expose New API-family account completion**
+
+In `src/services/apiAdapters/newApi/index.ts`, add:
+
+```ts
+import { newApiAccountCompletion } from "./accountCompletion"
+```
+
+Then update `newApiAdapter`:
+
+```ts
+export const newApiAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.NEW_API,
+  family: "newApiFamily",
+  siteNotice: newApiSiteNotice,
+  accountCompletion: newApiAccountCompletion,
+}
+```
+
+- [ ] **Step 8: Run the New API-family Adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 1**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiAdapters/contracts/accountCompletion.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/accountCompletion.ts src/services/apiAdapters/newApi/index.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts
+pnpm run validate:staged
+git commit -m "refactor(api-adapters): add new-api account completion"
+```
+
+Expected: `validate:staged` exits 0, then the commit contains only the account-completion contract, New API-family Adapter, and focused tests.
+
+---
+
+## Task 2: Add Sub2API Account Completion Adapter
+
+**Files:**
+- Create: `src/services/apiAdapters/sub2api/accountCompletion.ts`
+- Modify: `src/services/apiAdapters/sub2api/index.ts`
+- Create: `tests/services/apiAdapters/sub2api/accountCompletion.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write the failing Sub2API Adapter test**
+
+Create `tests/services/apiAdapters/sub2api/accountCompletion.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { sub2ApiAccountCompletion } from "~/services/apiAdapters/sub2api/accountCompletion"
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  getApiServiceMock,
+  fetchUserInfoMock,
+  getOrCreateAccessTokenMock,
+  fetchSiteStatusMock,
+  fetchSupportCheckInMock,
+  extractDefaultExchangeRateMock,
+} = vi.hoisted(() => ({
+  getApiServiceMock: vi.fn(),
+  fetchUserInfoMock: vi.fn(),
+  getOrCreateAccessTokenMock: vi.fn(),
+  fetchSiteStatusMock: vi.fn(),
+  fetchSupportCheckInMock: vi.fn(),
+  extractDefaultExchangeRateMock: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: getApiServiceMock,
+}))
+
+const helpers = {
+  createServiceRequest: (input: {
+    baseUrl: string
+    auth: ApiServiceRequest["auth"]
+    context: {
+      fetchContext?: ApiServiceRequest["fetchContext"]
+    }
+  }): ApiServiceRequest => ({
+    baseUrl: input.baseUrl,
+    auth: input.auth,
+    ...(input.context.fetchContext
+      ? { fetchContext: input.context.fetchContext }
+      : {}),
+  }),
+  fetchSiteName: vi.fn(async (siteStatus: { system_name?: string } | null) =>
+    siteStatus?.system_name ? siteStatus.system_name : "Sub2",
+  ),
+  createCompletionError: (reason: string, cause: unknown) =>
+    Object.assign(new Error(cause instanceof Error ? cause.message : reason), {
+      name: "AutoDetectCompletionError",
+      reason,
+      cause,
+    }),
+  trimString: (value: unknown) =>
+    typeof value === "string" ? value.trim() : "",
+  createInitialCheckInConfig: (input: {
+    enableDetection: boolean
+    autoCheckInEnabled: boolean
+  }) => ({
+    enableDetection: input.enableDetection,
+    autoCheckInEnabled: input.autoCheckInEnabled,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  }),
+  handleCheckInSupportFetchFailure: vi.fn(() => false),
+}
+
+describe("sub2ApiAccountCompletion", () => {
+  it("uses detected access-token data and disables check-in", async () => {
+    getApiServiceMock.mockReturnValue({
+      fetchUserInfo: fetchUserInfoMock,
+      getOrCreateAccessToken: getOrCreateAccessTokenMock,
+      fetchSiteStatus: fetchSiteStatusMock,
+      fetchSupportCheckIn: fetchSupportCheckInMock,
+      extractDefaultExchangeRate: extractDefaultExchangeRateMock,
+    })
+    const sub2apiAuth = {
+      refreshToken: "refresh-token",
+      tokenExpiresAt: 1999999999999,
+    }
+    const siteStatus = {
+      system_name: "Runtime Portal",
+    }
+    fetchSiteStatusMock.mockResolvedValueOnce(siteStatus)
+    extractDefaultExchangeRateMock.mockReturnValueOnce(null)
+
+    const result = await sub2ApiAccountCompletion.complete(
+      {
+        url: "https://sub2.example.com",
+        requestedAuthType: AuthTypeEnum.Cookie,
+        context: {},
+        detected: {
+          userId: "12",
+          user: { id: 12, username: "  " },
+          siteType: SITE_TYPES.SUB2API,
+          accessToken: "  jwt-token  ",
+          sub2apiAuth,
+        },
+      },
+      helpers,
+    )
+
+    expect(fetchUserInfoMock).not.toHaveBeenCalled()
+    expect(getOrCreateAccessTokenMock).not.toHaveBeenCalled()
+    expect(fetchSupportCheckInMock).not.toHaveBeenCalled()
+    expect(fetchSiteStatusMock).toHaveBeenCalledWith({
+      baseUrl: "https://sub2.example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+      },
+    })
+    expect(result).toMatchObject({
+      username: "",
+      siteName: "Runtime Portal",
+      accessToken: "jwt-token",
+      userId: "12",
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      sub2apiAuth,
+      checkIn: {
+        enableDetection: false,
+        autoCheckInEnabled: false,
+      },
+    })
+  })
+
+  it("classifies missing detected access token", async () => {
+    getApiServiceMock.mockReturnValue({
+      fetchSiteStatus: fetchSiteStatusMock,
+      extractDefaultExchangeRate: extractDefaultExchangeRateMock,
+    })
+    fetchSiteStatusMock.mockResolvedValueOnce({
+      system_name: "Runtime Portal",
+    })
+    extractDefaultExchangeRateMock.mockReturnValueOnce(null)
+
+    await expect(
+      sub2ApiAccountCompletion.complete(
+        {
+          url: "https://sub2.example.com",
+          requestedAuthType: AuthTypeEnum.Cookie,
+          context: {},
+          detected: {
+            userId: "12",
+            siteType: SITE_TYPES.SUB2API,
+            accessToken: "  ",
+          },
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Update registry tests for Sub2API account completion**
+
+In the Sub2API test in `tests/services/apiAdapters/registry.test.ts`, add:
+
+```ts
+expect(adapter.accountCompletion).toEqual({
+  complete: expect.any(Function),
+})
+```
+
+- [ ] **Step 3: Run the failing Sub2API tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because `sub2api/accountCompletion.ts` does not exist yet.
+
+- [ ] **Step 4: Implement the Sub2API account completion Adapter**
+
+Create `src/services/apiAdapters/sub2api/accountCompletion.ts`:
+
+```ts
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
+
+import type { AccountCompletionCapability } from "../contracts/accountCompletion"
+
+export const sub2ApiAccountCompletion: AccountCompletionCapability = {
+  async complete(request, helpers) {
+    const service = getApiService(SITE_TYPES.SUB2API)
+    const { url, detected, context } = request
+
+    let siteStatus = null
+    try {
+      siteStatus = await service.fetchSiteStatus(
+        helpers.createServiceRequest({
+          baseUrl: url,
+          context,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+          },
+        }),
+      )
+    } catch (error) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+        error,
+      )
+    }
+
+    const accessToken = helpers.trimString(detected.accessToken)
+    if (!accessToken) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+        new Error("access token missing"),
+      )
+    }
+
+    return {
+      username: helpers.trimString(detected.user?.username),
+      siteName: await helpers.fetchSiteName(siteStatus),
+      accessToken,
+      userId: detected.userId.toString(),
+      exchangeRate:
+        service.extractDefaultExchangeRate(siteStatus) ??
+        UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: helpers.createInitialCheckInConfig({
+        enableDetection: false,
+        autoCheckInEnabled: false,
+      }),
+      ...(detected.sub2apiAuth ? { sub2apiAuth: detected.sub2apiAuth } : {}),
+    }
+  },
+}
+```
+
+- [ ] **Step 5: Expose the Sub2API account completion capability**
+
+In `src/services/apiAdapters/sub2api/index.ts`, add:
+
+```ts
+import { sub2ApiAccountCompletion } from "./accountCompletion"
+```
+
+Then update `sub2ApiAdapter`:
+
+```ts
+export const sub2ApiAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.SUB2API,
+  family: "sub2api",
+  siteAnnouncements: sub2ApiSiteAnnouncements,
+  modelCatalog: sub2ApiModelCatalog,
+  accountCompletion: sub2ApiAccountCompletion,
+}
+```
+
+- [ ] **Step 6: Run the Sub2API Adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 2**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiAdapters/sub2api/accountCompletion.ts src/services/apiAdapters/sub2api/index.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts
+pnpm run validate:staged
+git commit -m "refactor(api-adapters): add sub2api account completion"
+```
+
+Expected: `validate:staged` exits 0, then the commit contains only the Sub2API Adapter and tests.
+
+---
+
+## Task 3: Add AIHubMix Account Completion Adapter
+
+**Files:**
+- Create: `src/services/apiAdapters/aihubmix/accountCompletion.ts`
+- Create: `src/services/apiAdapters/aihubmix/index.ts`
+- Modify: `src/services/apiAdapters/registry.ts`
+- Create: `tests/services/apiAdapters/aihubmix/accountCompletion.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write the failing AIHubMix Adapter test**
+
+Create `tests/services/apiAdapters/aihubmix/accountCompletion.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { aihubmixAccountCompletion } from "~/services/apiAdapters/aihubmix/accountCompletion"
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  getApiServiceMock,
+  getOrCreateAccessTokenMock,
+  fetchSiteStatusMock,
+  fetchSupportCheckInMock,
+  extractDefaultExchangeRateMock,
+} = vi.hoisted(() => ({
+  getApiServiceMock: vi.fn(),
+  getOrCreateAccessTokenMock: vi.fn(),
+  fetchSiteStatusMock: vi.fn(),
+  fetchSupportCheckInMock: vi.fn(),
+  extractDefaultExchangeRateMock: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: getApiServiceMock,
+}))
+
+const helpers = {
+  createServiceRequest: (input: {
+    baseUrl: string
+    auth: ApiServiceRequest["auth"]
+    context: {
+      fetchContext?: ApiServiceRequest["fetchContext"]
+    }
+  }): ApiServiceRequest => ({
+    baseUrl: input.baseUrl,
+    auth: input.auth,
+    ...(input.context.fetchContext
+      ? { fetchContext: input.context.fetchContext }
+      : {}),
+  }),
+  fetchSiteName: vi.fn(async (siteStatus: { system_name?: string } | null) =>
+    siteStatus?.system_name ? siteStatus.system_name : "AIHubMix",
+  ),
+  createCompletionError: (reason: string, cause: unknown) =>
+    Object.assign(new Error(cause instanceof Error ? cause.message : reason), {
+      name: "AutoDetectCompletionError",
+      reason,
+      cause,
+    }),
+  trimString: (value: unknown) =>
+    typeof value === "string" ? value.trim() : "",
+  createInitialCheckInConfig: (input: {
+    enableDetection: boolean
+    autoCheckInEnabled: boolean
+  }) => ({
+    enableDetection: input.enableDetection,
+    autoCheckInEnabled: input.autoCheckInEnabled,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  }),
+  handleCheckInSupportFetchFailure: vi.fn(() => false),
+}
+
+const mockService = () => {
+  getApiServiceMock.mockReturnValue({
+    getOrCreateAccessToken: getOrCreateAccessTokenMock,
+    fetchSiteStatus: fetchSiteStatusMock,
+    fetchSupportCheckIn: fetchSupportCheckInMock,
+    extractDefaultExchangeRate: extractDefaultExchangeRateMock,
+  })
+}
+
+describe("aihubmixAccountCompletion", () => {
+  it("uses detected access-token data and probes status with cookie auth", async () => {
+    mockService()
+    const siteStatus = {
+      system_name: "AIHubMix",
+      checkin_enabled: false,
+    }
+    fetchSiteStatusMock.mockResolvedValueOnce(siteStatus)
+    extractDefaultExchangeRateMock.mockReturnValueOnce(null)
+
+    const result = await aihubmixAccountCompletion.complete(
+      {
+        url: "https://aihubmix.com",
+        requestedAuthType: AuthTypeEnum.Cookie,
+        context: {},
+        detected: {
+          userId: "11",
+          user: { id: 11, username: "  aihubmix-user  " },
+          siteType: SITE_TYPES.AIHUBMIX,
+          accessToken: "  detected-console-token  ",
+        },
+      },
+      helpers,
+    )
+
+    expect(getOrCreateAccessTokenMock).not.toHaveBeenCalled()
+    expect(fetchSiteStatusMock).toHaveBeenCalledWith({
+      baseUrl: "https://aihubmix.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+      },
+    })
+    expect(result).toMatchObject({
+      username: "aihubmix-user",
+      accessToken: "detected-console-token",
+      authType: AuthTypeEnum.AccessToken,
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      checkIn: {
+        enableDetection: false,
+        autoCheckInEnabled: true,
+      },
+    })
+  })
+
+  it("falls back to getOrCreateAccessToken when detected token data is absent", async () => {
+    mockService()
+    getOrCreateAccessTokenMock.mockResolvedValueOnce({
+      username: "fallback-user",
+      access_token: "fallback-token",
+    })
+    fetchSiteStatusMock.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+    })
+    fetchSupportCheckInMock.mockResolvedValueOnce(true)
+    extractDefaultExchangeRateMock.mockReturnValueOnce(null)
+
+    const result = await aihubmixAccountCompletion.complete(
+      {
+        url: "https://aihubmix.com",
+        requestedAuthType: AuthTypeEnum.Cookie,
+        context: {},
+        detected: {
+          userId: "11",
+          user: { id: 11, username: "fallback-user" },
+          siteType: SITE_TYPES.AIHUBMIX,
+        },
+      },
+      helpers,
+    )
+
+    expect(getOrCreateAccessTokenMock).toHaveBeenCalledWith({
+      baseUrl: "https://aihubmix.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "11",
+      },
+    })
+    expect(result).toMatchObject({
+      username: "fallback-user",
+      accessToken: "fallback-token",
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+      },
+    })
+  })
+
+  it("classifies missing username and token", async () => {
+    mockService()
+    fetchSiteStatusMock.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+      checkin_enabled: false,
+    })
+    extractDefaultExchangeRateMock.mockReturnValueOnce(null)
+
+    await expect(
+      aihubmixAccountCompletion.complete(
+        {
+          url: "https://aihubmix.com",
+          requestedAuthType: AuthTypeEnum.Cookie,
+          context: {},
+          detected: {
+            userId: "11",
+            user: { id: 11, username: "  " },
+            siteType: SITE_TYPES.AIHUBMIX,
+            accessToken: "  ",
+          },
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Update registry tests for AIHubMix account completion**
+
+In the AIHubMix registry test, change the capability expectations to:
+
+```ts
+expect(adapter.accountCompletion).toEqual({
+  complete: expect.any(Function),
+})
+expect(adapter.siteNotice).toBeUndefined()
+expect(adapter.siteAnnouncements).toBeUndefined()
+expect(adapter.modelCatalog).toBeUndefined()
+```
+
+- [ ] **Step 3: Run the failing AIHubMix tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/aihubmix/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because `apiAdapters/aihubmix` does not exist yet.
+
+- [ ] **Step 4: Implement the AIHubMix account completion Adapter**
+
+Create `src/services/apiAdapters/aihubmix/accountCompletion.ts`:
+
+```ts
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
+
+import type { AccountCompletionCapability } from "../contracts/accountCompletion"
+
+const getDetectedTokenInfo = (
+  detected: Parameters<AccountCompletionCapability["complete"]>[0]["detected"],
+  trimString: (value: unknown) => string,
+) =>
+  typeof detected.accessToken === "string"
+    ? {
+        username: trimString(detected.user?.username),
+        access_token: trimString(detected.accessToken),
+      }
+    : null
+
+export const aihubmixAccountCompletion: AccountCompletionCapability = {
+  async complete(request, helpers) {
+    const service = getApiService(SITE_TYPES.AIHUBMIX)
+    const { url, detected, context } = request
+
+    let tokenInfo: unknown = getDetectedTokenInfo(
+      detected,
+      helpers.trimString,
+    )
+    if (!tokenInfo) {
+      try {
+        tokenInfo = await service.getOrCreateAccessToken(
+          helpers.createServiceRequest({
+            baseUrl: url,
+            context,
+            auth: {
+              authType: AuthTypeEnum.Cookie,
+              userId: detected.userId,
+            },
+          }),
+        )
+      } catch (error) {
+        throw helpers.createCompletionError(
+          AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+          error,
+        )
+      }
+    }
+
+    let siteStatus = null
+    try {
+      siteStatus = await service.fetchSiteStatus(
+        helpers.createServiceRequest({
+          baseUrl: url,
+          context,
+          auth: {
+            authType: AuthTypeEnum.Cookie,
+          },
+        }),
+      )
+    } catch (error) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+        error,
+      )
+    }
+
+    const checkSupport =
+      typeof siteStatus?.checkin_enabled === "boolean"
+        ? siteStatus.checkin_enabled
+        : await service
+            .fetchSupportCheckIn(
+              helpers.createServiceRequest({
+                baseUrl: url,
+                context,
+                auth: {
+                  authType: AuthTypeEnum.None,
+                },
+              }),
+            )
+            .catch(helpers.handleCheckInSupportFetchFailure)
+
+    const tokenData =
+      tokenInfo && typeof tokenInfo === "object"
+        ? (tokenInfo as { username?: unknown; access_token?: unknown })
+        : {}
+    const username = helpers.trimString(tokenData.username)
+    const accessToken = helpers.trimString(tokenData.access_token)
+
+    if (!username || !accessToken) {
+      throw helpers.createCompletionError(
+        !accessToken
+          ? AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing
+          : AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+        new Error(!accessToken ? "access token missing" : "username missing"),
+      )
+    }
+
+    return {
+      username,
+      siteName: await helpers.fetchSiteName(siteStatus),
+      accessToken,
+      userId: detected.userId.toString(),
+      exchangeRate:
+        service.extractDefaultExchangeRate(siteStatus) ??
+        UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: helpers.createInitialCheckInConfig({
+        enableDetection: checkSupport ?? false,
+        autoCheckInEnabled: true,
+      }),
+    }
+  },
+}
+```
+
+- [ ] **Step 5: Add the AIHubMix Adapter entrypoint**
+
+Create `src/services/apiAdapters/aihubmix/index.ts`:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+
+import type { SiteAdapter } from "../contracts/siteAdapter"
+import { aihubmixAccountCompletion } from "./accountCompletion"
+
+export const aihubmixAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.AIHUBMIX,
+  accountCompletion: aihubmixAccountCompletion,
+}
+```
+
+- [ ] **Step 6: Register AIHubMix in the Adapter registry**
+
+In `src/services/apiAdapters/registry.ts`, add:
+
+```ts
+import { aihubmixAdapter } from "./aihubmix"
+```
+
+Then update `getSiteAdapter(...)` before the New API-family fallback:
+
+```ts
+  if (siteType === SITE_TYPES.AIHUBMIX) {
+    return aihubmixAdapter
+  }
+```
+
+- [ ] **Step 7: Run the AIHubMix Adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/aihubmix/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 3**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiAdapters/aihubmix src/services/apiAdapters/registry.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts
+pnpm run validate:staged
+git commit -m "refactor(api-adapters): add aihubmix account completion"
+```
+
+Expected: `validate:staged` exits 0, then the commit contains only the AIHubMix Adapter, registry change, and tests.
+
+---
+
+## Task 4: Route Auto-Detect Completion Through The Adapter
+
+**Files:**
+- Modify: `src/services/accounts/autoDetectCompletion/completion.ts`
+- Modify: `tests/services/accounts/autoDetectCompletion/completion.test.ts`
+- Test: `tests/services/accountOperations.autoDetectAccount.test.ts`
+
+- [ ] **Step 1: Replace the completion test service mock with an Adapter mock**
+
+In `tests/services/accounts/autoDetectCompletion/completion.test.ts`, replace the existing `getApiService` mock setup with:
+
+```ts
+const { getSiteAdapterMock, accountCompletionMock } = vi.hoisted(() => ({
+  getSiteAdapterMock: vi.fn(),
+  accountCompletionMock: {
+    complete: vi.fn(),
+  },
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: getSiteAdapterMock,
+}))
+```
+
+Keep the current imports for `AutoDetectCompletionError`,
+`completeAutoDetectedAccount`, `API_SERVICE_FETCH_CONTEXT_KINDS`,
+`ApiServiceFetchContext`, and `AuthTypeEnum`.
+
+- [ ] **Step 2: Add focused orchestrator tests**
+
+Replace the existing service-layer matrix in `tests/services/accounts/autoDetectCompletion/completion.test.ts` with tests focused on orchestration:
+
+```ts
+describe("auto-detect completion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSiteAdapterMock.mockReturnValue({
+      siteType: SITE_TYPES.NEW_API,
+      accountCompletion: accountCompletionMock,
+    })
+  })
+
+  it("passes validated current-tab fetch context to the site Adapter", async () => {
+    const fetchContext = {
+      kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+      tabId: 123,
+      origin: "https://status.example.com",
+    }
+    const autoDetectContext = {
+      strategy: AUTO_DETECT_STRATEGIES.CurrentTab,
+      siteType: SITE_TYPES.NEW_API,
+    }
+    accountCompletionMock.complete.mockResolvedValueOnce({
+      username: "service-user",
+      siteName: "Status Portal",
+      accessToken: "service-token",
+      userId: "7",
+      exchangeRate: 6.8,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+        customCheckIn: {
+          url: "",
+          redeemUrl: "",
+          openRedeemWithCheckIn: true,
+          isCheckedInToday: false,
+        },
+      },
+    })
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://status.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      autoDetectContext,
+      detected: {
+        userId: "7",
+        siteType: SITE_TYPES.NEW_API,
+        fetchContext,
+      },
+    })
+
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(accountCompletionMock.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://status.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        context: { fetchContext },
+        detected: expect.objectContaining({
+          userId: "7",
+          siteType: SITE_TYPES.NEW_API,
+        }),
+      }),
+      expect.objectContaining({
+        createServiceRequest: expect.any(Function),
+        fetchSiteName: expect.any(Function),
+        createCompletionError: expect.any(Function),
+        trimString: expect.any(Function),
+        createInitialCheckInConfig: expect.any(Function),
+        handleCheckInSupportFetchFailure: expect.any(Function),
+      }),
+    )
+    expect(result).toMatchObject({
+      username: "service-user",
+      siteName: "Status Portal",
+      accessToken: "service-token",
+      siteType: SITE_TYPES.NEW_API,
+      fetchContext,
+      autoDetectContext,
+    })
+  })
+
+  it("drops malformed current-tab fetch context before calling the Adapter", async () => {
+    const malformedFetchContext = {
+      kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+      tabId: "not-a-number",
+      origin: "https://malformed.example.com",
+    } as unknown as ApiServiceFetchContext
+    accountCompletionMock.complete.mockResolvedValueOnce({
+      username: "malformed-context-user",
+      siteName: "Malformed Context Portal",
+      accessToken: "malformed-context-token",
+      userId: "8",
+      exchangeRate: null,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+        customCheckIn: {
+          url: "",
+          redeemUrl: "",
+          openRedeemWithCheckIn: true,
+          isCheckedInToday: false,
+        },
+      },
+    })
+
+    const result = await completeAutoDetectedAccount({
+      url: "https://malformed.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      detected: {
+        userId: "8",
+        siteType: SITE_TYPES.NEW_API,
+        fetchContext: malformedFetchContext,
+      },
+    })
+
+    expect(accountCompletionMock.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: {},
+      }),
+      expect.any(Object),
+    )
+    expect(result).not.toHaveProperty("fetchContext")
+  })
+
+  it("classifies missing accountCompletion as an unexpected completion error", async () => {
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.NEW_API,
+    })
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://missing.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "9",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toBeInstanceOf(AutoDetectCompletionError)
+  })
+
+  it("passes Adapter completion errors through unchanged", async () => {
+    const completionError = new AutoDetectCompletionError(
+      AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+      new Error("token failed"),
+    )
+    accountCompletionMock.complete.mockRejectedValueOnce(completionError)
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://token.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "10",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toBe(completionError)
+  })
+})
+```
+
+Add one browser-context retention test after the malformed-context test:
+
+```ts
+it("retains browser fetch context before calling the Adapter", async () => {
+  const fetchContext = {
+    kind: API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT,
+    cookieStoreId: "firefox-container-2",
+  }
+  accountCompletionMock.complete.mockResolvedValueOnce({
+    username: "browser-context-user",
+    siteName: "Browser Context Portal",
+    accessToken: "browser-context-token",
+    userId: "9",
+    exchangeRate: null,
+    authType: AuthTypeEnum.AccessToken,
+    checkIn: {
+      enableDetection: true,
+      autoCheckInEnabled: true,
+      siteStatus: {
+        isCheckedInToday: false,
+      },
+      customCheckIn: {
+        url: "",
+        redeemUrl: "",
+        openRedeemWithCheckIn: true,
+        isCheckedInToday: false,
+      },
+    },
+  })
+
+  const result = await completeAutoDetectedAccount({
+    url: "https://browser-context.example.com",
+    requestedAuthType: AuthTypeEnum.AccessToken,
+    detected: {
+      userId: "9",
+      siteType: SITE_TYPES.NEW_API,
+      fetchContext,
+    },
+  })
+
+  expect(accountCompletionMock.complete).toHaveBeenCalledWith(
+    expect.objectContaining({
+      context: { fetchContext },
+    }),
+    expect.any(Object),
+  )
+  expect(result.fetchContext).toEqual(fetchContext)
+})
+```
+
+- [ ] **Step 3: Run the focused completion test and verify failure before implementation**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/autoDetectCompletion/completion.test.ts
+```
+
+Expected: FAIL because `completeAutoDetectedAccount(...)` still calls `getApiService(...)` and does not use `getSiteAdapter(...)`.
+
+- [ ] **Step 4: Import the Adapter registry in completion**
+
+In `src/services/accounts/autoDetectCompletion/completion.ts`, add:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+Remove this import because the orchestrator no longer calls service methods directly:
+
+```ts
+import { getApiService } from "~/services/apiService"
+```
+
+Keep imports for `AUTO_DETECT_FAILURE_REASONS`, `getSiteName`,
+`ApiServiceFetchContext`, `ApiServiceRequest`, `SiteStatusInfo`, `AuthTypeEnum`,
+`getErrorMessage`, and `logger`. Remove the `t` import after deleting the old
+validation-message branch, because completion error messages remain owned by
+`accountOperations.ts`.
+
+- [ ] **Step 5: Keep shared helpers in completion**
+
+Keep these helper functions in `completion.ts`:
+
+```ts
+function getAutoDetectFetchContext(
+  detected: DetectedAccountIdentity,
+): ApiServiceFetchContext | undefined {
+  const fetchContext = detected.fetchContext
+  if (fetchContext?.kind === API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT) {
+    return fetchContext
+  }
+
+  if (fetchContext?.kind === API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB) {
+    if (
+      typeof fetchContext.tabId === "number" &&
+      typeof fetchContext.origin === "string" &&
+      fetchContext.origin.trim()
+    ) {
+      return fetchContext
+    }
+  }
+
+  if (fetchContext?.incognito === true || fetchContext?.cookieStoreId) {
+    return fetchContext
+  }
+
+  return undefined
+}
+
+function createAutoDetectApiRequest(params: {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+  fetchContext?: ApiServiceFetchContext
+}): ApiServiceRequest {
+  return {
+    baseUrl: params.baseUrl,
+    auth: params.auth,
+    ...(params.fetchContext ? { fetchContext: params.fetchContext } : {}),
+  }
+}
+
+function trimString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function createInitialCheckInConfig(input: {
+  enableDetection: boolean
+  autoCheckInEnabled: boolean
+}) {
+  return {
+    enableDetection: input.enableDetection,
+    autoCheckInEnabled: input.autoCheckInEnabled,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  }
+}
+```
+
+Delete local token-branch helpers that are no longer used after the Adapter call is introduced.
+
+- [ ] **Step 6: Add Adapter helper construction**
+
+In `src/services/accounts/autoDetectCompletion/completion.ts`, add:
+
+```ts
+const createMissingAccountCompletionCapabilityError = (siteType: string) =>
+  new Error(`accountCompletion is not implemented for ${siteType}`)
+
+const createCompletionError = (
+  reason: AutoDetectFailureReason,
+  cause: unknown,
+) => new AutoDetectCompletionError(reason, cause)
+
+const createAccountCompletionHelpers = (params: {
+  url: string
+  siteType: string
+  fetchContext?: ApiServiceFetchContext
+}) => ({
+  createServiceRequest(input: {
+    baseUrl: string
+    auth: ApiServiceRequest["auth"]
+    context: {
+      fetchContext?: ApiServiceFetchContext
+    }
+  }) {
+    return createAutoDetectApiRequest({
+      baseUrl: input.baseUrl,
+      auth: input.auth,
+      fetchContext: input.context.fetchContext,
+    })
+  },
+  fetchSiteName(siteStatus: SiteStatusInfo | null) {
+    return getSiteName(params.url, params.siteType, siteStatus)
+  },
+  createCompletionError,
+  trimString,
+  createInitialCheckInConfig,
+  handleCheckInSupportFetchFailure(error: unknown) {
+    logger.warn("Auto-detect check-in support probe failed", {
+      siteType: params.siteType,
+      error: getErrorMessage(error),
+    })
+    return false as const
+  },
+})
+```
+
+This helper intentionally accepts `siteType: string` because
+`getSiteName(url, siteType, siteStatus)` already accepts a string hint.
+
+- [ ] **Step 7: Replace the central completion branches with the Adapter call**
+
+Replace the body of `completeAutoDetectedAccount(...)` after `autoDetectFetchContext` is resolved with:
+
+```ts
+  const adapter = getSiteAdapter(siteType)
+  if (!adapter.accountCompletion) {
+    throw new AutoDetectCompletionError(
+      AUTO_DETECT_FAILURE_REASONS.UnexpectedException,
+      createMissingAccountCompletionCapabilityError(siteType),
+    )
+  }
+
+  const completed = await adapter.accountCompletion.complete(
+    {
+      url,
+      requestedAuthType,
+      detected,
+      autoDetectContext,
+      context: {
+        ...(autoDetectFetchContext
+          ? { fetchContext: autoDetectFetchContext }
+          : {}),
+      },
+    },
+    createAccountCompletionHelpers({
+      url,
+      siteType,
+      fetchContext: autoDetectFetchContext,
+    }),
+  )
+
+  return {
+    ...completed,
+    siteType,
+    ...(autoDetectFetchContext ? { fetchContext: autoDetectFetchContext } : {}),
+    autoDetectContext,
+  }
+```
+
+After this replacement, remove the old `isSub2Api`, `isAIHubMix`, token promise, site status promise, check-in promise, and exchange-rate code from `completion.ts`.
+
+- [ ] **Step 8: Run the completion orchestrator tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/autoDetectCompletion/completion.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run the public auto-detect workflow regression suite**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.autoDetectAccount.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit Task 4**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/autoDetectCompletion/completion.ts tests/services/accounts/autoDetectCompletion/completion.test.ts
+pnpm run validate:staged
+git commit -m "refactor(accounts): route completion through adapters"
+```
+
+Expected: `validate:staged` exits 0, then the commit contains only completion orchestrator changes and tests.
+
+---
+
+## Task 5: Final Validation And Scope Audit
+
+**Files:**
+- Validate: `src/services/apiAdapters/**`
+- Validate: `src/services/accounts/autoDetectCompletion/completion.ts`
+- Validate: `tests/services/apiAdapters/**`
+- Validate: `tests/services/accounts/autoDetectCompletion/completion.test.ts`
+- Validate: `tests/services/accountOperations.autoDetectAccount.test.ts`
+
+- [ ] **Step 1: Run focused validation**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/registry.test.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts tests/services/accounts/autoDetectCompletion/completion.test.ts tests/services/accountOperations.autoDetectAccount.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run related validation**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/contracts/accountCompletion.ts src/services/apiAdapters/registry.ts src/services/accounts/autoDetectCompletion/completion.ts
+```
+
+Expected: PASS. If `vitest related` cannot map a newly created file before staging, classify that as tooling and keep the focused test suite as the primary evidence.
+
+- [ ] **Step 3: Run TypeScript validation**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the commit gate for any remaining task-scoped changes**
+
+If Tasks 1 through 4 were committed individually and there are no remaining task-scoped changes, inspect status only. If implementation was batched, stage only task-scoped files and run:
+
+```powershell
+git add src/services/apiAdapters/contracts/accountCompletion.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/accountCompletion.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/sub2api/accountCompletion.ts src/services/apiAdapters/sub2api/index.ts src/services/apiAdapters/aihubmix src/services/apiAdapters/registry.ts src/services/accounts/autoDetectCompletion/completion.ts tests/services/apiAdapters/registry.test.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts tests/services/accounts/autoDetectCompletion/completion.test.ts
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect the final diff or recent commits**
+
+If changes are staged, run:
+
+```powershell
+git diff --cached --stat
+git diff --cached --name-status
+```
+
+Expected staged files are limited to:
+
+```text
+src/services/apiAdapters/contracts/accountCompletion.ts
+src/services/apiAdapters/contracts/siteAdapter.ts
+src/services/apiAdapters/newApi/accountCompletion.ts
+src/services/apiAdapters/newApi/index.ts
+src/services/apiAdapters/sub2api/accountCompletion.ts
+src/services/apiAdapters/sub2api/index.ts
+src/services/apiAdapters/aihubmix/accountCompletion.ts
+src/services/apiAdapters/aihubmix/index.ts
+src/services/apiAdapters/registry.ts
+src/services/accounts/autoDetectCompletion/completion.ts
+tests/services/apiAdapters/registry.test.ts
+tests/services/apiAdapters/newApi/accountCompletion.test.ts
+tests/services/apiAdapters/sub2api/accountCompletion.test.ts
+tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+tests/services/accounts/autoDetectCompletion/completion.test.ts
+```
+
+If Tasks 1 through 4 were committed individually, run:
+
+```powershell
+git log --oneline -6
+git show --stat --oneline HEAD~4..HEAD
+```
+
+Expected recent commits include:
+
+```text
+refactor(api-adapters): add new-api account completion
+refactor(api-adapters): add sub2api account completion
+refactor(api-adapters): add aihubmix account completion
+refactor(accounts): route completion through adapters
+```
+
+- [ ] **Step 6: Confirm no out-of-scope migration leaked in**
+
+Run:
+
+```powershell
+git diff --name-only HEAD~4..HEAD
+```
+
+Expected: no task changes under these paths unless implementation was intentionally batched and the diff is still task-scoped:
+
+```text
+src/services/accounts/accountPostSaveWorkflow/
+src/services/apiCredentialProfiles/
+src/services/redemption/
+src/services/managedSites/
+src/features/AccountManagement/components/AccountDialog/
+src/locales/
+e2e/
+```
+
+Also confirm:
+
+- no post-save token provisioning behavior moved
+- no Model List pricing behavior changed
+- no Account Dialog UI state changed
+- no locale key was added
+- no telemetry event was added
+- no Playwright E2E test was added
+
+- [ ] **Step 7: Run the pre-push / PR gate before publishing**
+
+Before pushing, opening a PR, or updating a PR branch, run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. If it fails, classify the failure as code, tooling, environment, auth, network, or permission before changing code.
+
+- [ ] **Step 8: Final commit if implementation was batched**
+
+If Tasks 1 through 4 were not committed individually, commit the final staged task-scoped diff:
+
+```powershell
+git commit -m "refactor(api-adapters): migrate account completion"
+```
+
+If Tasks 1 through 4 were committed individually, skip this step and report the commit hashes.
+
+- [ ] **Step 9: Record final status**
+
+Run:
+
+```powershell
+git status --porcelain
+```
+
+Expected: only unrelated pre-existing untracked files remain.
+
+---
+
+## Out Of Scope
+
+- Do not move post-save token provisioning in this implementation.
+- Do not move Sub2API price-estimation inputs.
+- Do not move AIHubMix Model List pricing.
+- Do not change Account Dialog UI behavior.
+- Do not change detection strategy selection or site-type detection.
+- Do not add locale keys, telemetry fields, settings search entries, or Playwright E2E tests.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This refactor does not add a new user action, setting, async workflow, or visible result. Existing `autoDetectContext` and `autoDetectFailureReason` data continue to flow through `AccountValidationResponse`.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no Playwright E2E.
+
+The risk is service-layer routing and response-shape preservation. Focused Vitest coverage plus the existing `accountOperations.autoDetectAccount` suite is the right validation layer.
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Task 1 adds the `accountCompletion` contract and New API-family Adapter.
+  - Task 2 adds Sub2API account completion behavior.
+  - Task 3 adds AIHubMix account completion behavior.
+  - Task 4 routes `completeAutoDetectedAccount(...)` through the Adapter and keeps `autoDetectAccount(...)` response shaping unchanged.
+  - Task 5 validates focused behavior, TypeScript contracts, commit gate, push gate, and scope.
+- Placeholder scan:
+  - Every task has exact files, code snippets, commands, expected results, and commit commands.
+  - No step asks a worker to invent missing error handling or unspecified tests.
+- Type consistency:
+  - The plan consistently uses `AccountCompletionCapability.complete(request, helpers)`.
+  - The plan consistently uses `AccountCompletionAdapterRequest.context.fetchContext`.
+  - Adapter results omit `siteType`, `fetchContext`, and `autoDetectContext`; the orchestrator attaches them.
+- Scope guard:
+  - Token provisioning, model pricing, Account Dialog UI state, locale files, telemetry, settings search, and E2E remain outside this slice.

--- a/docs/superpowers/specs/2026-06-17-account-completion-adapter-design.md
+++ b/docs/superpowers/specs/2026-06-17-account-completion-adapter-design.md
@@ -1,0 +1,464 @@
+# Account Completion Adapter Design
+
+Date: 2026-06-17
+
+## Purpose
+
+Move account auto-detect completion rules behind the `apiAdapters` Seam so a new
+account site type can define its saved auth mode, token completion path, site
+status probe, exchange-rate handling, and check-in defaults in one Adapter
+Module.
+
+The previous account auto-detect completion slice extracted the post-detection
+workflow from `autoDetectAccount(...)` into
+`src/services/accounts/autoDetectCompletion/`. That made the workflow easier to
+test, but the new Module still hardcodes Sub2API and AIHubMix rules. This slice
+should keep the public `autoDetectAccount(...)` response unchanged while moving
+site-specific completion behavior into `getSiteAdapter(siteType)`.
+
+## Current Context
+
+The current architecture has three relevant layers:
+
+- `src/services/siteDetection/autoDetectService.ts` detects an account identity
+  and returns a site type, user id, optional user data, optional detected access
+  token, optional Sub2API auth metadata, and optional fetch context.
+- `src/services/accounts/accountOperations.ts` owns the public
+  `autoDetectAccount(url, authType)` workflow and maps completion failures into
+  `AccountValidationResponse`.
+- `src/services/accounts/autoDetectCompletion/completion.ts` completes a
+  detected identity with user/token data, site status, site name, exchange rate,
+  check-in defaults, saved auth type, and analytics-safe failure reasons.
+
+`completion.ts` currently calls `getApiService(siteType)` directly and contains
+the site-specific decision table:
+
+- Sub2API saves as access-token auth, uses the detected runtime access token,
+  permits an empty username, forwards Sub2API auth metadata, and disables
+  check-in.
+- AIHubMix saves as access-token auth, can use detected web access-token data,
+  probes site status with cookie auth, and requires username plus access token.
+- Compatible sites follow the requested auth type, use `fetchUserInfo(...)` for
+  cookie completion, use `getOrCreateAccessToken(...)` for access-token
+  completion, and enable check-in based on site status or support probing.
+
+The current `apiAdapters` tree already exposes narrow capabilities for:
+
+- `siteNotice`
+- `siteAnnouncements`
+- `modelCatalog`
+
+Those slices proved the registry pattern without replacing the old
+`getApiService(...)` facade.
+
+## Problem
+
+`autoDetectCompletion` is now the highest-friction path for adding a new account
+site type. The Module is deeper than the old `accountOperations.ts` branch, but
+its Interface is still not the right Seam for site-specific behavior.
+
+Current friction:
+
+1. A new non-compatible account site still requires editing the central
+   completion implementation to choose saved auth mode and token completion
+   strategy.
+2. The central Module must know which sites can trust detected access-token
+   data, which sites require username, and which sites disable check-in.
+3. Site status and exchange-rate completion look common, but the auth mode and
+   fallback behavior are backend-specific.
+4. Tests verify the extracted workflow, but a new site would need new branch
+   coverage in the same central test file instead of focused Adapter tests.
+
+Deletion test: if the Sub2API and AIHubMix branches were deleted from
+`completion.ts`, the complexity would reappear either in the same Module, in
+`accountOperations.ts`, or in the Account Dialog. It should instead move behind
+an `accountCompletion` capability on each relevant site Adapter.
+
+## Goals
+
+- Add a narrow `accountCompletion` Adapter capability.
+- Keep `autoDetectAccount(...)` as the public workflow and response-shaping
+  owner.
+- Keep `completeAutoDetectedAccount(...)` as the product-level completion
+  orchestrator, but make it call the site Adapter for backend-specific
+  completion.
+- Provide concrete account-completion Adapters for:
+  - New API-family compatible account sites
+  - Sub2API
+  - AIHubMix
+- Preserve the existing `AutoDetectCompletionData` output shape.
+- Preserve existing failure reasons:
+  - `TokenFetchFailed`
+  - `SiteStatusFetchFailed`
+  - `UsernameMissing`
+  - `AccessTokenMissing`
+- Keep fetch-context validation and response shaping behavior unchanged.
+- Add focused Adapter tests plus existing completion workflow regression tests.
+
+## Non-Goals
+
+- Do not change detection strategy selection, content-script parsing, browser
+  temporary-context detection, direct cookie-auth detection, or site-type
+  detection.
+- Do not change Account Dialog UI state, save/update behavior, duplicate
+  confirmation, cookie import, or post-save token prompts.
+- Do not move post-save token provisioning in this slice.
+- Do not migrate Model List pricing, Sub2API price-estimation inputs, AIHubMix
+  pricing, redemption, managed-site behavior, or key-management UI actions.
+- Do not add a new site type in this slice.
+- Do not remove `getApiService(...)` from the whole account area.
+- Do not add user-facing copy, locale keys, telemetry events, settings search
+  entries, or Playwright E2E tests.
+
+## Design
+
+### 1. Add `AccountCompletionCapability`
+
+Create:
+
+```text
+src/services/apiAdapters/contracts/accountCompletion.ts
+```
+
+The contract should reuse the current account auto-detect completion types
+instead of inventing a parallel response model.
+
+Proposed types:
+
+```ts
+import type {
+  AutoDetectCompletionData,
+  AutoDetectCompletionRequest,
+} from "~/services/accounts/autoDetectCompletion/types"
+import type { AutoDetectFailureReason } from "~/constants/autoDetect"
+import type {
+  ApiServiceFetchContext,
+  ApiServiceRequest,
+  SiteStatusInfo,
+} from "~/services/apiService/common/type"
+import type { AuthTypeEnum } from "~/types"
+
+export type AccountCompletionRuntimeContext = {
+  fetchContext?: ApiServiceFetchContext
+}
+
+export type AccountCompletionServiceRequestInput = {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+  context: AccountCompletionRuntimeContext
+}
+
+export type AccountCompletionTokenInfo = {
+  username: string
+  accessToken: string
+}
+
+export type AccountCompletionCheckInDefaults = {
+  enableDetection: boolean
+  autoCheckInEnabled: boolean
+}
+
+export type AccountCompletionAdapterResult = Omit<
+  AutoDetectCompletionData,
+  "siteType" | "fetchContext" | "autoDetectContext"
+>
+
+export type AccountCompletionAdapterRequest = AutoDetectCompletionRequest & {
+  context: AccountCompletionRuntimeContext
+}
+
+export type AccountCompletionHelpers = {
+  createServiceRequest(
+    input: AccountCompletionServiceRequestInput,
+  ): ApiServiceRequest
+  fetchSiteName(siteStatus: SiteStatusInfo | null): Promise<string>
+  createCompletionError(reason: AutoDetectFailureReason, cause: unknown): Error
+  trimString(value: unknown): string
+}
+
+export type AccountCompletionCapability = {
+  complete(
+    request: AccountCompletionAdapterRequest,
+    helpers: AccountCompletionHelpers,
+  ): Promise<AccountCompletionAdapterResult>
+}
+```
+
+Implementation may tune names while preserving the Interface intent:
+
+- The Adapter owns site-specific completion behavior.
+- The product Module owns context validation, final `siteType` /
+  `fetchContext` / `autoDetectContext` attachment, and failure classification
+  integration.
+- Helpers keep shared mechanics out of each Adapter without forcing Adapters to
+  import `accountOperations.ts` or duplicate request-building code.
+
+### 2. Extend `SiteAdapter`
+
+Add:
+
+```ts
+accountCompletion?: AccountCompletionCapability
+```
+
+Capability presence is the support signal. Missing `accountCompletion` for an
+account site is an implementation error when auto-detect completion reaches that
+site.
+
+### 3. Add New API-Family Account Completion Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/newApi/accountCompletion.ts
+```
+
+Responsibilities:
+
+- Use `getApiService(siteType)` from the incoming detected site type so existing
+  New API-family overrides remain intact.
+- Preserve requested auth type:
+  - cookie completion calls `fetchUserInfo(...)`
+  - access-token completion calls `getOrCreateAccessToken(...)`
+- Fetch site status using the effective requested auth mode.
+- Use `siteStatus.checkin_enabled` when present.
+- Fall back to `fetchSupportCheckIn(...)` with `AuthTypeEnum.None`.
+- Use `extractDefaultExchangeRate(siteStatus)` with
+  `UI_CONSTANTS.EXCHANGE_RATE.DEFAULT` fallback.
+- Require username for successful completion.
+- Require access token only when the effective saved auth type is
+  `AuthTypeEnum.AccessToken`.
+
+The Adapter should continue to support all site types that currently map to the
+New API-family Adapter in `apiAdapters/registry.ts`.
+
+### 4. Add Sub2API Account Completion Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/sub2api/accountCompletion.ts
+```
+
+Responsibilities:
+
+- Save accounts as `AuthTypeEnum.AccessToken`.
+- Use `detected.accessToken` and `detected.user?.username`; do not call
+  `fetchUserInfo(...)` or `getOrCreateAccessToken(...)`.
+- Preserve `detected.sub2apiAuth` in the returned data when present.
+- Fetch site status through the existing Sub2API service implementation using
+  access-token auth.
+- Permit an empty username.
+- Require a non-empty access token.
+- Disable check-in detection and auto-check-in.
+- Use `extractDefaultExchangeRate(siteStatus)` with
+  `UI_CONSTANTS.EXCHANGE_RATE.DEFAULT` fallback.
+
+The Adapter should not change Sub2API refresh-token handling or token resync
+behavior.
+
+### 5. Add AIHubMix Account Completion Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/aihubmix/accountCompletion.ts
+src/services/apiAdapters/aihubmix/index.ts
+```
+
+and register AIHubMix as an Adapter with `accountCompletion` only.
+
+Responsibilities:
+
+- Save accounts as `AuthTypeEnum.AccessToken`.
+- Prefer detected access-token data from auto-detect.
+- Preserve the current fallback to `getOrCreateAccessToken(...)` when detected
+  access-token data is absent.
+- Fetch site status with cookie auth during import.
+- Require a non-empty username.
+- Require a non-empty access token.
+- Use `extractDefaultExchangeRate(siteStatus)` with
+  `UI_CONSTANTS.EXCHANGE_RATE.DEFAULT` fallback.
+- Preserve current check-in defaults:
+  - `enableDetection` follows the resolved support value
+  - `autoCheckInEnabled` remains true
+
+Do not add `siteNotice`, `siteAnnouncements`, or `modelCatalog` to AIHubMix in
+this slice.
+
+### 6. Update Completion Orchestrator
+
+`src/services/accounts/autoDetectCompletion/completion.ts` should:
+
+1. Keep `getAutoDetectFetchContext(...)`.
+2. Build an `AccountCompletionRuntimeContext` from the validated fetch context.
+3. Resolve `const adapter = getSiteAdapter(siteType)`.
+4. Throw an `AutoDetectCompletionError` with an implementation-oriented cause if
+   `adapter.accountCompletion` is missing.
+5. Call `adapter.accountCompletion.complete(...)`.
+6. Attach:
+   - `siteType`
+   - valid `fetchContext`
+   - `autoDetectContext`
+
+The central Module should no longer contain Sub2API or AIHubMix auth/token
+branches. It may keep shared helper functions for request building, string
+normalization, site-name resolution, check-in shape creation, and typed error
+creation if those helpers keep Adapter Implementations small.
+
+### 7. Keep Post-Save Token Provisioning For Later
+
+`src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts` still has
+Sub2API and AIHubMix rules. That is a good next slice, but not part of this
+one.
+
+This slice should make `completeAutoDetectedAccount(...)` Adapter-backed first.
+After that Interface proves stable, a later `tokenProvisioning` capability can
+move post-save token inventory, default token creation, Sub2API group
+selection, and AIHubMix one-time-secret behavior behind the same Adapter
+registry.
+
+## Error Handling
+
+Adapters should throw `AutoDetectCompletionError` through the helper when they
+can classify a failure:
+
+- token/user-info completion failure -> `TokenFetchFailed`
+- site status failure -> `SiteStatusFetchFailed`
+- missing username -> `UsernameMissing`
+- missing access token -> `AccessTokenMissing`
+
+Best-effort check-in support probe failures should not fail completion. They
+should log through the existing completion logger or a helper and fall back to
+disabled check-in detection, matching current behavior.
+
+Missing `accountCompletion` should be treated as an implementation error inside
+`completeAutoDetectedAccount(...)`. The public `autoDetectAccount(...)` catch
+path should continue to convert unexpected completion errors into the existing
+localized failure response.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This is an internal architecture migration. It does not add a new user action,
+setting, background flow, visible result, or analytics field. Existing
+`autoDetectContext` and `autoDetectFailureReason` values should remain
+unchanged.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, anchors, routes, or search definitions change.
+
+## E2E Decision
+
+E2E decision: no Playwright E2E.
+
+The risk is service-layer routing and response-shape preservation. Existing and
+updated Vitest coverage is the right layer. Browser entrypoints, UI behavior,
+storage, and cross-entrypoint interactions should not change.
+
+## Testing Strategy
+
+Add focused Adapter tests:
+
+- New API-family account completion:
+  - access-token completion calls `getOrCreateAccessToken(...)`
+  - cookie completion calls `fetchUserInfo(...)`
+  - site status uses the effective requested auth mode
+  - check-in uses `siteStatus.checkin_enabled` before support probing
+  - missing username and missing access token throw classified completion errors
+- Sub2API account completion:
+  - uses detected access-token data
+  - does not call user/token completion helpers
+  - saves as access-token auth
+  - permits empty username
+  - disables check-in
+  - preserves `sub2apiAuth`
+- AIHubMix account completion:
+  - uses detected access-token data when present
+  - falls back to `getOrCreateAccessToken(...)` when needed
+  - probes site status with cookie auth
+  - requires username and access token
+
+Update registry tests:
+
+- New API-family adapters expose `accountCompletion`.
+- Sub2API exposes `accountCompletion`.
+- AIHubMix exposes `accountCompletion` but not unrelated capabilities.
+
+Update completion workflow tests:
+
+- Mock `getSiteAdapter(...)` instead of `getApiService(...)` for the central
+  `completeAutoDetectedAccount(...)` tests.
+- Keep coverage for valid and malformed fetch contexts.
+- Keep coverage for missing capability classification.
+- Keep the existing `tests/services/accountOperations.autoDetectAccount.test.ts`
+  suite green as the public workflow regression contract.
+
+## Validation Plan
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/registry.test.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts tests/services/accounts/autoDetectCompletion/completion.test.ts tests/services/accountOperations.autoDetectAccount.test.ts
+```
+
+Related validation:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/contracts/accountCompletion.ts src/services/apiAdapters/registry.ts src/services/accounts/autoDetectCompletion/completion.ts
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Pre-push / PR gate:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before publishing because this slice changes shared
+TypeScript service contracts and account workflow routing.
+
+## Rollout
+
+1. Add the account-completion contract and registry shape tests.
+2. Add New API-family, Sub2API, and AIHubMix Adapter tests.
+3. Implement the three account-completion Adapters.
+4. Update `completeAutoDetectedAccount(...)` to call
+   `getSiteAdapter(siteType).accountCompletion`.
+5. Keep `autoDetectAccount(...)` unchanged except for any import fallout caused
+   by the orchestrator change.
+6. Run focused and related tests.
+7. Inspect the diff to confirm no post-save token, model pricing, Account
+   Dialog UI, locale, telemetry, settings search, or E2E changes leaked in.
+8. Commit the narrow architecture slice.
+
+## Follow-Up, Not In Scope For This Spec
+
+Recommended next slices after this one:
+
+- `tokenProvisioning` Adapter capability for post-save token inventory, default
+  token creation, Sub2API group selection, and AIHubMix one-time-secret
+  handling.
+- Model pricing inputs capability for Sub2API dashboard groups/rates/tokens and
+  AIHubMix account-backed pricing.
+- Site capability descriptor Module for backend family and support metadata,
+  after the Adapter capabilities have enough real callers to justify it.
+
+Do not grow `SiteAdapter` into a second flat `apiService` Interface. Each new
+capability should correspond to a concrete caller benefit and should hide
+backend-specific behavior behind a small Interface.

--- a/docs/superpowers/specs/2026-06-17-account-completion-adapter-design.md
+++ b/docs/superpowers/specs/2026-06-17-account-completion-adapter-design.md
@@ -128,6 +128,7 @@ Proposed types:
 ```ts
 import type {
   AutoDetectCompletionData,
+  AutoDetectCompletionError,
   AutoDetectCompletionRequest,
 } from "~/services/accounts/autoDetectCompletion/types"
 import type { AutoDetectFailureReason } from "~/constants/autoDetect"
@@ -172,8 +173,16 @@ export type AccountCompletionHelpers = {
     input: AccountCompletionServiceRequestInput,
   ): ApiServiceRequest
   fetchSiteName(siteStatus: SiteStatusInfo | null): Promise<string>
-  createCompletionError(reason: AutoDetectFailureReason, cause: unknown): Error
+  createCompletionError(
+    reason: AutoDetectFailureReason,
+    cause: unknown,
+  ): AutoDetectCompletionError
   trimString(value: unknown): string
+  createInitialCheckInConfig(input: {
+    enableDetection: boolean
+    autoCheckInEnabled: boolean
+  }): AutoDetectCompletionData["checkIn"]
+  handleCheckInSupportFetchFailure(error: unknown): false
 }
 
 export type AccountCompletionCapability = {

--- a/src/services/accounts/autoDetectCompletion/completion.ts
+++ b/src/services/accounts/autoDetectCompletion/completion.ts
@@ -2,20 +2,17 @@ import {
   AUTO_DETECT_FAILURE_REASONS,
   type AutoDetectFailureReason,
 } from "~/constants/autoDetect"
-import { SITE_TYPES } from "~/constants/siteType"
-import { UI_CONSTANTS } from "~/constants/ui"
 import { getSiteName } from "~/services/accounts/siteName"
-import { getApiService } from "~/services/apiService"
+import type { AccountCompletionHelpers } from "~/services/apiAdapters/contracts/accountCompletion"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import {
   API_SERVICE_FETCH_CONTEXT_KINDS,
   type ApiServiceFetchContext,
   type ApiServiceRequest,
   type SiteStatusInfo,
 } from "~/services/apiService/common/type"
-import { AuthTypeEnum } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
-import { t } from "~/utils/i18n/core"
 
 import {
   AutoDetectCompletionError,
@@ -92,13 +89,13 @@ function trimString(value: unknown): string {
 /**
  * Creates the persisted check-in shape used by auto-detected accounts.
  */
-function createInitialCheckInConfig(
-  isSub2Api: boolean,
-  checkSupport: boolean | undefined,
-) {
+function createInitialCheckInConfig(input: {
+  enableDetection: boolean
+  autoCheckInEnabled: boolean
+}) {
   return {
-    enableDetection: isSub2Api ? false : checkSupport ?? false,
-    autoCheckInEnabled: isSub2Api ? false : true,
+    enableDetection: input.enableDetection,
+    autoCheckInEnabled: input.autoCheckInEnabled,
     siteStatus: {
       isCheckedInToday: false,
     },
@@ -111,6 +108,46 @@ function createInitialCheckInConfig(
   }
 }
 
+const createMissingAccountCompletionCapabilityError = (siteType: string) =>
+  new Error(`accountCompletion is not implemented for ${siteType}`)
+
+const createCompletionError = (
+  reason: AutoDetectFailureReason,
+  cause: unknown,
+) => new AutoDetectCompletionError(reason, cause)
+
+const createAccountCompletionHelpers = (params: {
+  url: string
+  siteType: string
+}): AccountCompletionHelpers => ({
+  createServiceRequest(input: {
+    baseUrl: string
+    auth: ApiServiceRequest["auth"]
+    context: {
+      fetchContext?: ApiServiceFetchContext
+    }
+  }) {
+    return createAutoDetectApiRequest({
+      baseUrl: input.baseUrl,
+      auth: input.auth,
+      fetchContext: input.context.fetchContext,
+    })
+  },
+  fetchSiteName(siteStatus: SiteStatusInfo | null) {
+    return getSiteName(params.url, params.siteType, siteStatus)
+  },
+  createCompletionError,
+  trimString,
+  createInitialCheckInConfig,
+  handleCheckInSupportFetchFailure(error: unknown) {
+    logger.warn("Auto-detect check-in support probe failed", {
+      siteType: params.siteType,
+      error: getErrorMessage(error),
+    })
+    return false as const
+  },
+})
+
 /**
  * Completes a detected identity with service-backed token, status, and defaults.
  */
@@ -118,150 +155,37 @@ export async function completeAutoDetectedAccount(
   request: AutoDetectCompletionRequest,
 ): Promise<AutoDetectCompletionData> {
   const { url, requestedAuthType, detected, autoDetectContext } = request
-  const { userId, siteType, sub2apiAuth } = detected
+  const { siteType } = detected
   const autoDetectFetchContext = getAutoDetectFetchContext(detected)
-  const apiService = getApiService(siteType)
-  const isSub2Api = siteType === SITE_TYPES.SUB2API
-  const isAIHubMix = siteType === SITE_TYPES.AIHUBMIX
-  const effectiveAuthType =
-    isSub2Api || isAIHubMix ? AuthTypeEnum.AccessToken : requestedAuthType
-  // AIHubMix imports through cookie-authenticated web endpoints, then stores
-  // the retrieved account access token for all normal account/key/model APIs.
-  const detectionAuthType = isAIHubMix ? AuthTypeEnum.Cookie : effectiveAuthType
-
-  let tokenPromise: Promise<unknown>
-
-  if (isSub2Api) {
-    tokenPromise = Promise.resolve({
-      username: trimString(detected.user?.username),
-      access_token: trimString(detected.accessToken),
-    })
-  } else if (isAIHubMix && typeof detected.accessToken === "string") {
-    tokenPromise = Promise.resolve({
-      username: trimString(detected.user?.username),
-      access_token: trimString(detected.accessToken),
-    })
-  } else if (effectiveAuthType === AuthTypeEnum.Cookie) {
-    tokenPromise = apiService.fetchUserInfo(
-      createAutoDetectApiRequest({
-        baseUrl: url,
-        fetchContext: autoDetectFetchContext,
-        auth: {
-          authType: AuthTypeEnum.Cookie,
-          userId,
-        },
-      }),
-    )
-  } else if (effectiveAuthType === AuthTypeEnum.AccessToken) {
-    tokenPromise = apiService.getOrCreateAccessToken(
-      createAutoDetectApiRequest({
-        baseUrl: url,
-        fetchContext: autoDetectFetchContext,
-        auth: {
-          authType: AuthTypeEnum.Cookie,
-          userId,
-        },
-      }),
-    )
-  } else {
-    // Auto-detect does not normally route non-token completion with None auth;
-    // if it does, the shared identity validation below classifies missing data.
-    tokenPromise = Promise.resolve(null)
-  }
-
-  const fetchSiteStatusFallback = () =>
-    apiService.fetchSiteStatus(
-      createAutoDetectApiRequest({
-        baseUrl: url,
-        fetchContext: autoDetectFetchContext,
-        auth: {
-          authType: detectionAuthType || AuthTypeEnum.None,
-        },
-      }),
-    )
-
-  const siteStatusPromise: Promise<SiteStatusInfo | null> =
-    fetchSiteStatusFallback()
-  const classifiedSiteStatusPromise = siteStatusPromise.catch((error) => {
+  const adapter = getSiteAdapter(siteType)
+  if (!adapter.accountCompletion) {
     throw new AutoDetectCompletionError(
-      AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
-      error,
+      AUTO_DETECT_FAILURE_REASONS.UnexpectedException,
+      createMissingAccountCompletionCapabilityError(siteType),
     )
-  })
-
-  const fetchSupportCheckInFallback = () =>
-    apiService.fetchSupportCheckIn(
-      createAutoDetectApiRequest({
-        baseUrl: url,
-        fetchContext: autoDetectFetchContext,
-        auth: {
-          authType: AuthTypeEnum.None,
-        },
-      }),
-    )
-
-  const checkSupportPromise: Promise<boolean | undefined> =
-    classifiedSiteStatusPromise.then((siteStatus) =>
-      typeof siteStatus?.checkin_enabled === "boolean"
-        ? siteStatus.checkin_enabled
-        : fetchSupportCheckInFallback().catch((error) => {
-            logger.warn("Auto-detect check-in support probe failed", {
-              siteType,
-              error: getErrorMessage(error),
-            })
-            return false
-          }),
-    )
-
-  const [tokenInfo, siteStatus, checkSupport, siteName] = await Promise.all([
-    tokenPromise.catch((error) => {
-      throw new AutoDetectCompletionError(
-        AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
-        error,
-      )
-    }),
-    classifiedSiteStatusPromise,
-    checkSupportPromise,
-    classifiedSiteStatusPromise.then((resolvedSiteStatus) =>
-      getSiteName(url, siteType, resolvedSiteStatus),
-    ),
-  ])
-
-  const tokenData =
-    tokenInfo && typeof tokenInfo === "object"
-      ? (tokenInfo as { username?: unknown; access_token?: unknown })
-      : {}
-  const detectedUsername = trimString(tokenData.username)
-  const accessToken = trimString(tokenData.access_token)
-  const isUsernameMissing = !isSub2Api && !detectedUsername
-  const isAccessTokenMissing =
-    (effectiveAuthType === AuthTypeEnum.AccessToken || isAIHubMix) &&
-    !accessToken
-
-  if (isUsernameMissing || isAccessTokenMissing) {
-    const failureReason = isAccessTokenMissing
-      ? AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing
-      : AUTO_DETECT_FAILURE_REASONS.UsernameMissing
-    const message = isAccessTokenMissing
-      ? t("messages:operations.detection.getAccessTokenFailedDetailed")
-      : t("messages:operations.detection.getUsernameFailedDetailed")
-    throw new AutoDetectCompletionError(failureReason, new Error(message))
   }
 
-  const defaultExchangeRate =
-    apiService.extractDefaultExchangeRate(siteStatus) ??
-    UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
+  const completed = await adapter.accountCompletion.complete(
+    {
+      url,
+      requestedAuthType,
+      detected,
+      autoDetectContext,
+      context: {
+        ...(autoDetectFetchContext
+          ? { fetchContext: autoDetectFetchContext }
+          : {}),
+      },
+    },
+    createAccountCompletionHelpers({
+      url,
+      siteType,
+    }),
+  )
 
   return {
-    username: detectedUsername,
-    siteName,
-    accessToken,
-    userId: userId.toString(),
-    exchangeRate: defaultExchangeRate,
-    authType: effectiveAuthType,
-    checkIn: createInitialCheckInConfig(isSub2Api, checkSupport),
+    ...completed,
     siteType,
-    ...(isSub2Api && sub2apiAuth ? { sub2apiAuth } : {}),
     ...(autoDetectFetchContext ? { fetchContext: autoDetectFetchContext } : {}),
     autoDetectContext,
   }

--- a/src/services/apiAdapters/aihubmix/accountCompletion.ts
+++ b/src/services/apiAdapters/aihubmix/accountCompletion.ts
@@ -1,0 +1,110 @@
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
+
+import type { AccountCompletionCapability } from "../contracts/accountCompletion"
+
+const getDetectedTokenInfo = (
+  detected: Parameters<AccountCompletionCapability["complete"]>[0]["detected"],
+  trimString: (value: unknown) => string,
+) =>
+  typeof detected.accessToken === "string"
+    ? {
+        username: trimString(detected.user?.username),
+        access_token: trimString(detected.accessToken),
+      }
+    : null
+
+export const aihubmixAccountCompletion: AccountCompletionCapability = {
+  async complete(request, helpers) {
+    const service = getApiService(SITE_TYPES.AIHUBMIX)
+    const { url, detected, context } = request
+
+    let tokenInfo: unknown = getDetectedTokenInfo(detected, helpers.trimString)
+    if (!tokenInfo) {
+      try {
+        tokenInfo = await service.getOrCreateAccessToken(
+          helpers.createServiceRequest({
+            baseUrl: url,
+            context,
+            auth: {
+              authType: AuthTypeEnum.Cookie,
+              userId: detected.userId,
+            },
+          }),
+        )
+      } catch (error) {
+        throw helpers.createCompletionError(
+          AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+          error,
+        )
+      }
+    }
+
+    let siteStatus = null
+    try {
+      siteStatus = await service.fetchSiteStatus(
+        helpers.createServiceRequest({
+          baseUrl: url,
+          context,
+          auth: {
+            authType: AuthTypeEnum.Cookie,
+          },
+        }),
+      )
+    } catch (error) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+        error,
+      )
+    }
+
+    const checkSupport =
+      typeof siteStatus?.checkin_enabled === "boolean"
+        ? siteStatus.checkin_enabled
+        : await service
+            .fetchSupportCheckIn(
+              helpers.createServiceRequest({
+                baseUrl: url,
+                context,
+                auth: {
+                  authType: AuthTypeEnum.None,
+                },
+              }),
+            )
+            .catch(helpers.handleCheckInSupportFetchFailure)
+
+    const tokenData =
+      tokenInfo && typeof tokenInfo === "object"
+        ? (tokenInfo as { username?: unknown; access_token?: unknown })
+        : {}
+    const username = helpers.trimString(tokenData.username)
+    const accessToken = helpers.trimString(tokenData.access_token)
+
+    if (!username || !accessToken) {
+      throw helpers.createCompletionError(
+        !accessToken
+          ? AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing
+          : AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+        new Error(!accessToken ? "access token missing" : "username missing"),
+      )
+    }
+
+    return {
+      username,
+      siteName: await helpers.fetchSiteName(siteStatus),
+      accessToken,
+      userId: detected.userId.toString(),
+      exchangeRate:
+        service.extractDefaultExchangeRate(siteStatus) ??
+        UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: helpers.createInitialCheckInConfig({
+        enableDetection: checkSupport ?? false,
+        autoCheckInEnabled: true,
+      }),
+    }
+  },
+}

--- a/src/services/apiAdapters/aihubmix/index.ts
+++ b/src/services/apiAdapters/aihubmix/index.ts
@@ -1,0 +1,9 @@
+import { SITE_TYPES } from "~/constants/siteType"
+
+import type { SiteAdapter } from "../contracts/siteAdapter"
+import { aihubmixAccountCompletion } from "./accountCompletion"
+
+export const aihubmixAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.AIHUBMIX,
+  accountCompletion: aihubmixAccountCompletion,
+}

--- a/src/services/apiAdapters/contracts/accountCompletion.ts
+++ b/src/services/apiAdapters/contracts/accountCompletion.ts
@@ -1,0 +1,54 @@
+import type { AutoDetectFailureReason } from "~/constants/autoDetect"
+import type {
+  AutoDetectCompletionData,
+  AutoDetectCompletionError,
+  AutoDetectCompletionRequest,
+} from "~/services/accounts/autoDetectCompletion/types"
+import type {
+  ApiServiceFetchContext,
+  ApiServiceRequest,
+  SiteStatusInfo,
+} from "~/services/apiService/common/type"
+
+export type AccountCompletionRuntimeContext = {
+  fetchContext?: ApiServiceFetchContext
+}
+
+export type AccountCompletionServiceRequestInput = {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+  context: AccountCompletionRuntimeContext
+}
+
+export type AccountCompletionAdapterRequest = AutoDetectCompletionRequest & {
+  context: AccountCompletionRuntimeContext
+}
+
+export type AccountCompletionAdapterResult = Omit<
+  AutoDetectCompletionData,
+  "siteType" | "fetchContext" | "autoDetectContext"
+>
+
+export type AccountCompletionHelpers = {
+  createServiceRequest(
+    input: AccountCompletionServiceRequestInput,
+  ): ApiServiceRequest
+  fetchSiteName(siteStatus: SiteStatusInfo | null): Promise<string>
+  createCompletionError(
+    reason: AutoDetectFailureReason,
+    cause: unknown,
+  ): AutoDetectCompletionError
+  trimString(value: unknown): string
+  createInitialCheckInConfig(input: {
+    enableDetection: boolean
+    autoCheckInEnabled: boolean
+  }): AutoDetectCompletionData["checkIn"]
+  handleCheckInSupportFetchFailure(error: unknown): false
+}
+
+export type AccountCompletionCapability = {
+  complete(
+    request: AccountCompletionAdapterRequest,
+    helpers: AccountCompletionHelpers,
+  ): Promise<AccountCompletionAdapterResult>
+}

--- a/src/services/apiAdapters/contracts/siteAdapter.ts
+++ b/src/services/apiAdapters/contracts/siteAdapter.ts
@@ -1,5 +1,6 @@
 import type { AccountSiteType } from "~/constants/siteType"
 
+import type { AccountCompletionCapability } from "./accountCompletion"
 import type { ModelCatalogCapability } from "./modelCatalog"
 import type { SiteAnnouncementsCapability } from "./siteAnnouncements"
 import type { SiteNoticeCapability } from "./siteNotice"
@@ -12,4 +13,5 @@ export type SiteAdapter = {
   siteNotice?: SiteNoticeCapability
   siteAnnouncements?: SiteAnnouncementsCapability
   modelCatalog?: ModelCatalogCapability
+  accountCompletion?: AccountCompletionCapability
 }

--- a/src/services/apiAdapters/newApi/accountCompletion.ts
+++ b/src/services/apiAdapters/newApi/accountCompletion.ts
@@ -1,0 +1,119 @@
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
+
+import type { AccountCompletionCapability } from "../contracts/accountCompletion"
+
+export const newApiAccountCompletion: AccountCompletionCapability = {
+  async complete(request, helpers) {
+    const { url, requestedAuthType, detected, context } = request
+    const apiService = getApiService(detected.siteType)
+
+    const createRequest = (
+      auth: Parameters<typeof helpers.createServiceRequest>[0]["auth"],
+    ) =>
+      helpers.createServiceRequest({
+        baseUrl: url,
+        auth,
+        context,
+      })
+
+    const fetchTokenInfo = () => {
+      if (requestedAuthType === AuthTypeEnum.Cookie) {
+        return apiService.fetchUserInfo(
+          createRequest({
+            authType: AuthTypeEnum.Cookie,
+            userId: detected.userId,
+          }),
+        )
+      }
+
+      if (requestedAuthType === AuthTypeEnum.AccessToken) {
+        return apiService.getOrCreateAccessToken(
+          createRequest({
+            authType: AuthTypeEnum.Cookie,
+            userId: detected.userId,
+          }),
+        )
+      }
+
+      return Promise.resolve(null)
+    }
+
+    const tokenPromise = fetchTokenInfo()
+
+    const siteStatusPromise = apiService
+      .fetchSiteStatus(
+        createRequest({
+          authType: requestedAuthType || AuthTypeEnum.None,
+        }),
+      )
+      .catch((error) => {
+        throw helpers.createCompletionError(
+          AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+          error,
+        )
+      })
+
+    const checkSupportPromise = siteStatusPromise.then((siteStatus) =>
+      typeof siteStatus?.checkin_enabled === "boolean"
+        ? siteStatus.checkin_enabled
+        : apiService
+            .fetchSupportCheckIn(
+              createRequest({
+                authType: AuthTypeEnum.None,
+              }),
+            )
+            .catch(helpers.handleCheckInSupportFetchFailure),
+    )
+
+    const [tokenInfo, siteStatus, checkSupport, siteName] = await Promise.all([
+      tokenPromise.catch((error) => {
+        throw helpers.createCompletionError(
+          AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+          error,
+        )
+      }),
+      siteStatusPromise,
+      checkSupportPromise,
+      siteStatusPromise.then(helpers.fetchSiteName),
+    ])
+
+    const tokenData =
+      tokenInfo && typeof tokenInfo === "object"
+        ? (tokenInfo as { username?: unknown; access_token?: unknown })
+        : {}
+    const username = helpers.trimString(tokenData.username)
+    const accessToken = helpers.trimString(tokenData.access_token)
+
+    if (requestedAuthType === AuthTypeEnum.AccessToken && !accessToken) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+        new Error("Access token is missing"),
+      )
+    }
+
+    if (!username) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+        new Error("Username is missing"),
+      )
+    }
+
+    return {
+      username,
+      siteName,
+      accessToken,
+      userId: detected.userId.toString(),
+      exchangeRate:
+        apiService.extractDefaultExchangeRate(siteStatus) ??
+        UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: requestedAuthType,
+      checkIn: helpers.createInitialCheckInConfig({
+        enableDetection: checkSupport ?? false,
+        autoCheckInEnabled: true,
+      }),
+    }
+  },
+}

--- a/src/services/apiAdapters/newApi/index.ts
+++ b/src/services/apiAdapters/newApi/index.ts
@@ -1,10 +1,12 @@
 import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
+import { newApiAccountCompletion } from "./accountCompletion"
 import { newApiSiteNotice } from "./siteNotice"
 
 export const newApiAdapter: SiteAdapter = {
   siteType: SITE_TYPES.NEW_API,
   family: "newApiFamily",
   siteNotice: newApiSiteNotice,
+  accountCompletion: newApiAccountCompletion,
 }

--- a/src/services/apiAdapters/registry.ts
+++ b/src/services/apiAdapters/registry.ts
@@ -1,5 +1,6 @@
 import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 
+import { aihubmixAdapter } from "./aihubmix"
 import type { SiteAdapter } from "./contracts/siteAdapter"
 import { newApiAdapter } from "./newApi"
 import { sub2ApiAdapter } from "./sub2api"
@@ -35,6 +36,10 @@ const createUnsupportedAdapter = (siteType: AccountSiteType): SiteAdapter => ({
 export function getSiteAdapter(siteType: AccountSiteType): SiteAdapter {
   if (siteType === SITE_TYPES.SUB2API) {
     return sub2ApiAdapter
+  }
+
+  if (siteType === SITE_TYPES.AIHUBMIX) {
+    return aihubmixAdapter
   }
 
   if (newApiFamilySiteTypes.has(siteType)) {

--- a/src/services/apiAdapters/sub2api/accountCompletion.ts
+++ b/src/services/apiAdapters/sub2api/accountCompletion.ts
@@ -1,0 +1,56 @@
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
+
+import type { AccountCompletionCapability } from "../contracts/accountCompletion"
+
+export const sub2ApiAccountCompletion: AccountCompletionCapability = {
+  async complete(request, helpers) {
+    const service = getApiService(SITE_TYPES.SUB2API)
+    const { url, detected, context } = request
+
+    let siteStatus = null
+    try {
+      siteStatus = await service.fetchSiteStatus(
+        helpers.createServiceRequest({
+          baseUrl: url,
+          context,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+          },
+        }),
+      )
+    } catch (error) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+        error,
+      )
+    }
+
+    const accessToken = helpers.trimString(detected.accessToken)
+    if (!accessToken) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+        new Error("access token missing"),
+      )
+    }
+
+    return {
+      username: helpers.trimString(detected.user?.username),
+      siteName: await helpers.fetchSiteName(siteStatus),
+      accessToken,
+      userId: detected.userId.toString(),
+      exchangeRate:
+        service.extractDefaultExchangeRate(siteStatus) ??
+        UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: helpers.createInitialCheckInConfig({
+        enableDetection: false,
+        autoCheckInEnabled: false,
+      }),
+      ...(detected.sub2apiAuth ? { sub2apiAuth: detected.sub2apiAuth } : {}),
+    }
+  },
+}

--- a/src/services/apiAdapters/sub2api/accountCompletion.ts
+++ b/src/services/apiAdapters/sub2api/accountCompletion.ts
@@ -11,6 +11,14 @@ export const sub2ApiAccountCompletion: AccountCompletionCapability = {
     const service = getApiService(SITE_TYPES.SUB2API)
     const { url, detected, context } = request
 
+    const accessToken = helpers.trimString(detected.accessToken)
+    if (!accessToken) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+        new Error("access token missing"),
+      )
+    }
+
     let siteStatus = null
     try {
       siteStatus = await service.fetchSiteStatus(
@@ -26,14 +34,6 @@ export const sub2ApiAccountCompletion: AccountCompletionCapability = {
       throw helpers.createCompletionError(
         AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
         error,
-      )
-    }
-
-    const accessToken = helpers.trimString(detected.accessToken)
-    if (!accessToken) {
-      throw helpers.createCompletionError(
-        AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
-        new Error("access token missing"),
       )
     }
 

--- a/src/services/apiAdapters/sub2api/index.ts
+++ b/src/services/apiAdapters/sub2api/index.ts
@@ -1,6 +1,7 @@
 import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
+import { sub2ApiAccountCompletion } from "./accountCompletion"
 import { sub2ApiModelCatalog } from "./modelCatalog"
 import { sub2ApiSiteAnnouncements } from "./siteAnnouncements"
 
@@ -9,4 +10,5 @@ export const sub2ApiAdapter: SiteAdapter = {
   family: "sub2api",
   siteAnnouncements: sub2ApiSiteAnnouncements,
   modelCatalog: sub2ApiModelCatalog,
+  accountCompletion: sub2ApiAccountCompletion,
 }

--- a/tests/services/accountOperations.autoDetectAccount.test.ts
+++ b/tests/services/accountOperations.autoDetectAccount.test.ts
@@ -106,7 +106,6 @@ describe("accountOperations autoDetectAccount", () => {
     })
 
     mockFetchSiteStatus.mockResolvedValueOnce(null)
-    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
     mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
 
     const result = await autoDetectAccount(
@@ -134,7 +133,6 @@ describe("accountOperations autoDetectAccount", () => {
       },
     })
     mockFetchSiteStatus.mockResolvedValueOnce(null)
-    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
     mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
 
     const result = await autoDetectAccount(

--- a/tests/services/accounts/autoDetectCompletion/completion.test.ts
+++ b/tests/services/accounts/autoDetectCompletion/completion.test.ts
@@ -5,42 +5,26 @@ import {
   AUTO_DETECT_STRATEGIES,
 } from "~/constants/autoDetect"
 import { SITE_TYPES } from "~/constants/siteType"
-import { UI_CONSTANTS } from "~/constants/ui"
 import {
   AutoDetectCompletionError,
   completeAutoDetectedAccount,
 } from "~/services/accounts/autoDetectCompletion/completion"
-import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
-import type { ApiServiceFetchContext } from "~/services/apiService/common/type"
+import {
+  API_SERVICE_FETCH_CONTEXT_KINDS,
+  type ApiServiceFetchContext,
+} from "~/services/apiService/common/type"
 import { AuthTypeEnum } from "~/types"
 
-const {
-  mockFetchSiteStatus,
-  mockFetchSupportCheckIn,
-  mockExtractDefaultExchangeRate,
-  mockFetchUserInfo,
-  mockGetOrCreateAccessToken,
-} = vi.hoisted(() => ({
-  mockFetchSiteStatus: vi.fn(),
-  mockFetchSupportCheckIn: vi.fn(),
-  mockExtractDefaultExchangeRate: vi.fn(),
-  mockFetchUserInfo: vi.fn(),
-  mockGetOrCreateAccessToken: vi.fn(),
+const { getSiteAdapterMock, accountCompletionMock } = vi.hoisted(() => ({
+  getSiteAdapterMock: vi.fn(),
+  accountCompletionMock: {
+    complete: vi.fn(),
+  },
 }))
 
-vi.mock("~/services/apiService", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("~/services/apiService")>()
-  return {
-    ...actual,
-    getApiService: vi.fn(() => ({
-      fetchSiteStatus: mockFetchSiteStatus,
-      fetchSupportCheckIn: mockFetchSupportCheckIn,
-      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
-      fetchUserInfo: mockFetchUserInfo,
-      getOrCreateAccessToken: mockGetOrCreateAccessToken,
-    })),
-  }
-})
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: getSiteAdapterMock,
+}))
 
 const currentTabFetchContext = (origin: string) => ({
   kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
@@ -53,203 +37,133 @@ const browserFetchContext = () => ({
   cookieStoreId: "firefox-container-2",
 })
 
+const completedAccountData = {
+  username: "service-user",
+  siteName: "Status Portal",
+  accessToken: "service-token",
+  userId: "7",
+  exchangeRate: 6.8,
+  authType: AuthTypeEnum.AccessToken,
+  checkIn: {
+    enableDetection: true,
+    autoCheckInEnabled: true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  },
+}
+
 describe("auto-detect completion", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    getSiteAdapterMock.mockReturnValue({
+      siteType: SITE_TYPES.NEW_API,
+      accountCompletion: accountCompletionMock,
+    })
+    accountCompletionMock.complete.mockResolvedValue(completedAccountData)
   })
 
-  it("completes compatible access-token account data through the service layer", async () => {
+  it("routes completion through the adapter with valid current-tab context", async () => {
     const fetchContext = currentTabFetchContext("https://status.example.com")
     const autoDetectContext = {
       strategy: AUTO_DETECT_STRATEGIES.CurrentTab,
       siteType: SITE_TYPES.NEW_API,
     }
-    const siteStatus = {
-      system_name: "Status Portal",
-      checkin_enabled: true,
+    const detected = {
+      userId: "7",
+      siteType: SITE_TYPES.NEW_API,
+      fetchContext,
     }
-    mockGetOrCreateAccessToken.mockResolvedValueOnce({
-      username: "  service-user  ",
-      access_token: "  service-token  ",
-    })
-    mockFetchSiteStatus.mockResolvedValueOnce(siteStatus)
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(6.8)
 
     const result = await completeAutoDetectedAccount({
       url: "https://status.example.com",
       requestedAuthType: AuthTypeEnum.AccessToken,
       autoDetectContext,
-      detected: {
-        userId: "7",
-        siteType: SITE_TYPES.NEW_API,
-        fetchContext,
-      },
+      detected,
     })
 
-    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(accountCompletionMock.complete).toHaveBeenCalledTimes(1)
+
+    const [adapterRequest, helpers] =
+      accountCompletionMock.complete.mock.calls[0]
+    expect(adapterRequest).toEqual({
+      url: "https://status.example.com",
+      requestedAuthType: AuthTypeEnum.AccessToken,
+      detected,
+      autoDetectContext,
+      context: { fetchContext },
+    })
+    expect(Object.keys(helpers).sort()).toEqual(
+      [
+        "createServiceRequest",
+        "fetchSiteName",
+        "createCompletionError",
+        "trimString",
+        "createInitialCheckInConfig",
+        "handleCheckInSupportFetchFailure",
+      ].sort(),
+    )
+    expect(
+      helpers.createServiceRequest({
+        baseUrl: "https://status.example.com",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: "7",
+        },
+        context: { fetchContext },
+      }),
+    ).toEqual({
       baseUrl: "https://status.example.com",
-      fetchContext,
       auth: {
         authType: AuthTypeEnum.Cookie,
         userId: "7",
       },
-    })
-    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
-      baseUrl: "https://status.example.com",
       fetchContext,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-      },
     })
-    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
-    expect(mockExtractDefaultExchangeRate).toHaveBeenCalledWith(siteStatus)
-    expect(result).toEqual({
-      username: "service-user",
-      siteName: "Status Portal",
-      accessToken: "service-token",
-      userId: "7",
-      exchangeRate: 6.8,
-      authType: AuthTypeEnum.AccessToken,
-      checkIn: {
+    expect(helpers.trimString("  trimmed  ")).toBe("trimmed")
+    expect(
+      helpers.createInitialCheckInConfig({
         enableDetection: true,
         autoCheckInEnabled: true,
-        siteStatus: {
-          isCheckedInToday: false,
-        },
-        customCheckIn: {
-          url: "",
-          redeemUrl: "",
-          openRedeemWithCheckIn: true,
-          isCheckedInToday: false,
-        },
-      },
+      }),
+    ).toEqual(completedAccountData.checkIn)
+    expect(
+      helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+        new Error("token failed"),
+      ),
+    ).toBeInstanceOf(AutoDetectCompletionError)
+    expect(
+      helpers.handleCheckInSupportFetchFailure(new Error("probe failed")),
+    ).toBe(false)
+
+    await expect(
+      helpers.fetchSiteName({
+        system_name: "Status Portal",
+      }),
+    ).resolves.toBe("Status Portal")
+    expect(result).toEqual({
+      ...completedAccountData,
       siteType: SITE_TYPES.NEW_API,
       fetchContext,
       autoDetectContext,
     })
   })
 
-  it("uses detected Sub2API access-token data without user/token service completion", async () => {
-    const fetchContext = currentTabFetchContext("https://sub2.example.com")
-    const sub2apiAuth = {
-      refreshToken: "refresh-token",
-      tokenExpiresAt: 1999999999999,
-    }
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "Runtime Portal",
-    })
-    mockFetchSupportCheckIn.mockResolvedValueOnce(true)
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
-
-    const result = await completeAutoDetectedAccount({
-      url: "https://sub2.example.com",
-      requestedAuthType: AuthTypeEnum.Cookie,
-      detected: {
-        userId: "12",
-        user: { id: 12, username: "  " },
-        siteType: SITE_TYPES.SUB2API,
-        accessToken: "  jwt-token  ",
-        sub2apiAuth,
-        fetchContext,
-      },
-    })
-
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
-    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      username: "",
-      siteName: "Runtime Portal",
-      accessToken: "jwt-token",
-      userId: "12",
-      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
-      authType: AuthTypeEnum.AccessToken,
-      siteType: SITE_TYPES.SUB2API,
-      sub2apiAuth,
-      fetchContext,
-      checkIn: {
-        enableDetection: false,
-        autoCheckInEnabled: false,
-        siteStatus: {
-          isCheckedInToday: false,
-        },
-        customCheckIn: {
-          url: "",
-          redeemUrl: "",
-          openRedeemWithCheckIn: true,
-          isCheckedInToday: false,
-        },
-      },
-    })
-  })
-
-  it("uses detected AIHubMix access-token data and probes site status with Cookie auth", async () => {
-    const fetchContext = currentTabFetchContext("https://aihubmix.com")
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "AIHubMix",
-      checkin_enabled: false,
-    })
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
-
-    const result = await completeAutoDetectedAccount({
-      url: "https://aihubmix.com",
-      requestedAuthType: AuthTypeEnum.Cookie,
-      detected: {
-        userId: "11",
-        user: { id: 11, username: "  aihubmix-user  " },
-        siteType: SITE_TYPES.AIHUBMIX,
-        accessToken: "  detected-console-token  ",
-        fetchContext,
-      },
-    })
-
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
-    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
-    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
-      baseUrl: "https://aihubmix.com",
-      fetchContext,
-      auth: {
-        authType: AuthTypeEnum.Cookie,
-      },
-    })
-    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      username: "aihubmix-user",
-      accessToken: "detected-console-token",
-      authType: AuthTypeEnum.AccessToken,
-      siteType: SITE_TYPES.AIHUBMIX,
-      fetchContext,
-      checkIn: {
-        enableDetection: false,
-        autoCheckInEnabled: true,
-        siteStatus: {
-          isCheckedInToday: false,
-        },
-        customCheckIn: {
-          url: "",
-          redeemUrl: "",
-          openRedeemWithCheckIn: true,
-          isCheckedInToday: false,
-        },
-      },
-    })
-  })
-
-  it("drops malformed current-tab fetch context from service requests and result", async () => {
+  it("drops malformed current-tab context before adapter completion", async () => {
     const malformedFetchContext = {
       kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
       tabId: "not-a-number",
       origin: "https://malformed.example.com",
       cookieStoreId: "",
     } as unknown as ApiServiceFetchContext
-    mockGetOrCreateAccessToken.mockResolvedValueOnce({
-      username: "malformed-context-user",
-      access_token: "malformed-context-token",
-    })
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "Malformed Context Portal",
-      checkin_enabled: true,
-    })
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
 
     const result = await completeAutoDetectedAccount({
       url: "https://malformed.example.com",
@@ -261,33 +175,24 @@ describe("auto-detect completion", () => {
       },
     })
 
+    const [adapterRequest, helpers] =
+      accountCompletionMock.complete.mock.calls[0]
+    expect(adapterRequest.context).toEqual({})
+    expect(
+      helpers.createServiceRequest({
+        baseUrl: "https://malformed.example.com",
+        auth: { authType: AuthTypeEnum.Cookie, userId: "8" },
+        context: {},
+      }),
+    ).toEqual({
+      baseUrl: "https://malformed.example.com",
+      auth: { authType: AuthTypeEnum.Cookie, userId: "8" },
+    })
     expect(result).not.toHaveProperty("fetchContext")
-    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
-      baseUrl: "https://malformed.example.com",
-      auth: {
-        authType: AuthTypeEnum.Cookie,
-        userId: "8",
-      },
-    })
-    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
-      baseUrl: "https://malformed.example.com",
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-      },
-    })
   })
 
-  it("retains browser fetch context in service requests and result", async () => {
+  it("retains browser fetch context before adapter completion and result", async () => {
     const fetchContext = browserFetchContext()
-    mockGetOrCreateAccessToken.mockResolvedValueOnce({
-      username: "browser-context-user",
-      access_token: "browser-context-token",
-    })
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "Browser Context Portal",
-      checkin_enabled: true,
-    })
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
 
     const result = await completeAutoDetectedAccount({
       url: "https://browser-context.example.com",
@@ -299,174 +204,52 @@ describe("auto-detect completion", () => {
       },
     })
 
-    expect(result.fetchContext).toEqual(fetchContext)
-    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
-      baseUrl: "https://browser-context.example.com",
-      fetchContext,
-      auth: {
-        authType: AuthTypeEnum.Cookie,
-        userId: "9",
-      },
-    })
-    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
-      baseUrl: "https://browser-context.example.com",
-      fetchContext,
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-      },
-    })
-  })
-
-  it("throws access-token missing when token completion returns no usable token", async () => {
-    mockGetOrCreateAccessToken.mockResolvedValueOnce({
-      username: "missing-token-user",
-      access_token: "  ",
-    })
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "Missing Token Portal",
-    })
-    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
-
-    await expect(
-      completeAutoDetectedAccount({
-        url: "https://token.example.com",
-        requestedAuthType: AuthTypeEnum.AccessToken,
-        detected: {
-          userId: "5",
-          siteType: SITE_TYPES.NEW_API,
-        },
+    expect(accountCompletionMock.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: { fetchContext },
       }),
-    ).rejects.toMatchObject({
-      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
-    })
-  })
-
-  it("throws username missing when non-Sub2API completion returns no usable username", async () => {
-    mockGetOrCreateAccessToken.mockResolvedValueOnce({
-      username: "  ",
-      access_token: "username-missing-token",
-    })
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "Missing Username Portal",
-    })
-    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
-
-    await expect(
-      completeAutoDetectedAccount({
-        url: "https://username.example.com",
-        requestedAuthType: AuthTypeEnum.AccessToken,
-        detected: {
-          userId: "6",
-          siteType: SITE_TYPES.NEW_API,
-        },
-      }),
-    ).rejects.toMatchObject({
-      reason: AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
-    })
-  })
-
-  it("wraps token service failures as token-fetch completion errors", async () => {
-    const tokenError = new Error("token failed")
-    mockGetOrCreateAccessToken.mockRejectedValueOnce(tokenError)
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "Token Failure Portal",
-      checkin_enabled: true,
-    })
-
-    const completionPromise = completeAutoDetectedAccount({
-      url: "https://token-failure.example.com",
-      requestedAuthType: AuthTypeEnum.AccessToken,
-      detected: {
-        userId: "10",
-        siteType: SITE_TYPES.NEW_API,
-      },
-    })
-
-    await expect(completionPromise).rejects.toMatchObject({
-      name: "AutoDetectCompletionError",
-      reason: AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
-      cause: tokenError,
-    })
-  })
-
-  it("falls back to disabled check-in when support probing fails", async () => {
-    const supportError = new Error("support failed")
-    mockGetOrCreateAccessToken.mockResolvedValueOnce({
-      username: "support-user",
-      access_token: "support-token",
-    })
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "Support Failure Portal",
-    })
-    mockFetchSupportCheckIn.mockRejectedValueOnce(supportError)
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
-
-    const result = await completeAutoDetectedAccount({
-      url: "https://support.example.com",
-      requestedAuthType: AuthTypeEnum.AccessToken,
-      detected: {
-        userId: "13",
-        siteType: SITE_TYPES.NEW_API,
-      },
-    })
-
-    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
-      baseUrl: "https://support.example.com",
-      auth: {
-        authType: AuthTypeEnum.None,
-      },
-    })
-    expect(result.checkIn.enableDetection).toBe(false)
-  })
-
-  it("classifies unsupported completion auth as username missing", async () => {
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "Unsupported Auth Portal",
-      checkin_enabled: true,
-    })
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
-
-    await expect(
-      completeAutoDetectedAccount({
-        url: "https://unsupported-auth.example.com",
-        requestedAuthType: AuthTypeEnum.None,
-        detected: {
-          userId: "14",
-          siteType: SITE_TYPES.NEW_API,
-        },
-      }),
-    ).rejects.toMatchObject({
-      reason: AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
-    })
-  })
-
-  it("throws completion error when site status fetch fails", async () => {
-    const statusError = new Error("status failed")
-    mockGetOrCreateAccessToken.mockResolvedValueOnce({
-      username: "status-user",
-      access_token: "status-token",
-    })
-    mockFetchSiteStatus.mockRejectedValueOnce(statusError)
-
-    const completionPromise = completeAutoDetectedAccount({
-      url: "https://status.example.com",
-      requestedAuthType: AuthTypeEnum.AccessToken,
-      detected: {
-        userId: "8",
-        siteType: SITE_TYPES.NEW_API,
-      },
-    })
-
-    await expect(completionPromise).rejects.toMatchObject({
-      name: "AutoDetectCompletionError",
-      reason: AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
-      cause: statusError,
-    })
-
-    await expect(completionPromise).rejects.toBeInstanceOf(
-      AutoDetectCompletionError,
+      expect.any(Object),
     )
+    expect(result.fetchContext).toEqual(fetchContext)
+  })
+
+  it("rejects when the adapter does not implement account completion", async () => {
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.NEW_API,
+    })
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://unsupported.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "10",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "AutoDetectCompletionError",
+      reason: AUTO_DETECT_FAILURE_REASONS.UnexpectedException,
+    })
+    expect(accountCompletionMock.complete).not.toHaveBeenCalled()
+  })
+
+  it("passes adapter completion errors through unchanged", async () => {
+    const completionError = new AutoDetectCompletionError(
+      AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+      new Error("token failed"),
+    )
+    accountCompletionMock.complete.mockRejectedValueOnce(completionError)
+
+    await expect(
+      completeAutoDetectedAccount({
+        url: "https://token-failure.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "11",
+          siteType: SITE_TYPES.NEW_API,
+        },
+      }),
+    ).rejects.toBe(completionError)
   })
 })

--- a/tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AUTO_DETECT_FAILURE_REASONS,
+  type AutoDetectFailureReason,
+} from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { AutoDetectCompletionError } from "~/services/accounts/autoDetectCompletion/types"
+import { aihubmixAccountCompletion } from "~/services/apiAdapters/aihubmix/accountCompletion"
+import type { AccountCompletionHelpers } from "~/services/apiAdapters/contracts/accountCompletion"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockExtractDefaultExchangeRate,
+  mockFetchSiteStatus,
+  mockFetchSupportCheckIn,
+  mockGetApiService,
+  mockGetOrCreateAccessToken,
+} = vi.hoisted(() => ({
+  mockExtractDefaultExchangeRate: vi.fn(),
+  mockFetchSiteStatus: vi.fn(),
+  mockFetchSupportCheckIn: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockGetOrCreateAccessToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+const currentTabFetchContext = {
+  kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+  tabId: 123,
+  origin: "https://aihubmix.com",
+}
+
+const createServiceRequest = vi.fn(
+  ({
+    baseUrl,
+    auth,
+    context,
+  }: Parameters<AccountCompletionHelpers["createServiceRequest"]>[0]) => ({
+    baseUrl,
+    auth,
+    ...(context.fetchContext ? { fetchContext: context.fetchContext } : {}),
+  }),
+)
+
+const fetchSiteName = vi.fn(async (siteStatus) =>
+  typeof siteStatus?.system_name === "string" && siteStatus.system_name.trim()
+    ? siteStatus.system_name.trim()
+    : "Example API",
+)
+
+const createCompletionError = vi.fn(
+  (reason: AutoDetectFailureReason, cause: unknown) =>
+    new AutoDetectCompletionError(reason, cause),
+)
+
+const trimString = vi.fn((value: unknown) =>
+  typeof value === "string" ? value.trim() : "",
+)
+
+const createInitialCheckInConfig = vi.fn(
+  ({ enableDetection, autoCheckInEnabled }) => ({
+    enableDetection,
+    autoCheckInEnabled,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  }),
+)
+
+const handleCheckInSupportFetchFailure = vi.fn(() => false as const)
+
+const helpers = {
+  createServiceRequest,
+  fetchSiteName,
+  createCompletionError,
+  trimString,
+  createInitialCheckInConfig,
+  handleCheckInSupportFetchFailure,
+} satisfies AccountCompletionHelpers
+
+describe("aihubmixAccountCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+      fetchSiteStatus: mockFetchSiteStatus,
+      fetchSupportCheckIn: mockFetchSupportCheckIn,
+      getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    })
+  })
+
+  it("uses detected access-token data and probes status with Cookie auth", async () => {
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await aihubmixAccountCompletion.complete(
+      {
+        url: "https://aihubmix.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "11",
+          user: {
+            id: 11,
+            username: "  aihubmix-user  ",
+          },
+          siteType: SITE_TYPES.AIHUBMIX,
+          accessToken: "  detected-console-token  ",
+        },
+        context: {
+          fetchContext: currentTabFetchContext,
+        },
+      },
+      helpers,
+    )
+
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.AIHUBMIX)
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://aihubmix.com",
+      fetchContext: currentTabFetchContext,
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+      },
+    })
+    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+    expect(createInitialCheckInConfig).toHaveBeenCalledWith({
+      enableDetection: false,
+      autoCheckInEnabled: true,
+    })
+    expect(result).toEqual({
+      username: "aihubmix-user",
+      siteName: "AIHubMix",
+      accessToken: "detected-console-token",
+      userId: "11",
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: {
+        enableDetection: false,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+        customCheckIn: {
+          url: "",
+          redeemUrl: "",
+          openRedeemWithCheckIn: true,
+          isCheckedInToday: false,
+        },
+      },
+    })
+  })
+
+  it("falls back to getOrCreateAccessToken when detected token data is absent", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "  generated-aihubmix-user  ",
+      access_token: "  generated-aihubmix-token  ",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+    })
+    mockFetchSupportCheckIn.mockResolvedValueOnce(true)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await aihubmixAccountCompletion.complete(
+      {
+        url: "https://aihubmix.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "12",
+          siteType: SITE_TYPES.AIHUBMIX,
+        },
+        context: {},
+      },
+      helpers,
+    )
+
+    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
+      baseUrl: "https://aihubmix.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "12",
+      },
+    })
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://aihubmix.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+      },
+    })
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
+      baseUrl: "https://aihubmix.com",
+      auth: {
+        authType: AuthTypeEnum.None,
+      },
+    })
+    expect(result).toMatchObject({
+      username: "generated-aihubmix-user",
+      accessToken: "generated-aihubmix-token",
+      userId: "12",
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: expect.objectContaining({
+        enableDetection: true,
+        autoCheckInEnabled: true,
+      }),
+    })
+  })
+
+  it("classifies missing detected username and token as missing access token", async () => {
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      aihubmixAccountCompletion.complete(
+        {
+          url: "https://aihubmix.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "13",
+            user: {
+              id: 13,
+              username: "  ",
+            },
+            siteType: SITE_TYPES.AIHUBMIX,
+            accessToken: "  ",
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+      expect.any(Error),
+    )
+  })
+})

--- a/tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
@@ -255,4 +255,200 @@ describe("aihubmixAccountCompletion", () => {
       expect.any(Error),
     )
   })
+
+  it("classifies generated token fetch failures", async () => {
+    const tokenError = new Error("token unavailable")
+    mockGetOrCreateAccessToken.mockRejectedValueOnce(tokenError)
+
+    await expect(
+      aihubmixAccountCompletion.complete(
+        {
+          url: "https://aihubmix.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "14",
+            siteType: SITE_TYPES.AIHUBMIX,
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+      cause: tokenError,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+      tokenError,
+    )
+    expect(mockFetchSiteStatus).not.toHaveBeenCalled()
+  })
+
+  it("classifies site status fetch failures", async () => {
+    const siteStatusError = new Error("site status unavailable")
+    mockFetchSiteStatus.mockRejectedValueOnce(siteStatusError)
+
+    await expect(
+      aihubmixAccountCompletion.complete(
+        {
+          url: "https://aihubmix.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "15",
+            user: {
+              id: 15,
+              username: "aihubmix-user",
+            },
+            siteType: SITE_TYPES.AIHUBMIX,
+            accessToken: "detected-token",
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+      cause: siteStatusError,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+      siteStatusError,
+    )
+    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+  })
+
+  it("falls back to disabled check-in detection when support probing fails", async () => {
+    const supportError = new Error("support probe unavailable")
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+    })
+    mockFetchSupportCheckIn.mockRejectedValueOnce(supportError)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await aihubmixAccountCompletion.complete(
+      {
+        url: "https://aihubmix.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "16",
+          user: {
+            id: 16,
+            username: "aihubmix-user",
+          },
+          siteType: SITE_TYPES.AIHUBMIX,
+          accessToken: "detected-token",
+        },
+        context: {},
+      },
+      helpers,
+    )
+
+    expect(handleCheckInSupportFetchFailure).toHaveBeenCalledWith(supportError)
+    expect(createInitialCheckInConfig).toHaveBeenCalledWith({
+      enableDetection: false,
+      autoCheckInEnabled: true,
+    })
+    expect(result.checkIn.enableDetection).toBe(false)
+  })
+
+  it("classifies missing generated access token when username is present", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "aihubmix-user",
+      access_token: "  ",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      aihubmixAccountCompletion.complete(
+        {
+          url: "https://aihubmix.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "17",
+            siteType: SITE_TYPES.AIHUBMIX,
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+      expect.any(Error),
+    )
+  })
+
+  it("classifies invalid generated token payloads as missing access token", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce(null)
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      aihubmixAccountCompletion.complete(
+        {
+          url: "https://aihubmix.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "18",
+            siteType: SITE_TYPES.AIHUBMIX,
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+      expect.any(Error),
+    )
+  })
+
+  it("classifies missing generated username when access token is present", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "  ",
+      access_token: "generated-aihubmix-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "AIHubMix",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      aihubmixAccountCompletion.complete(
+        {
+          url: "https://aihubmix.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "19",
+            siteType: SITE_TYPES.AIHUBMIX,
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+      expect.any(Error),
+    )
+  })
 })

--- a/tests/services/apiAdapters/newApi/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/newApi/accountCompletion.test.ts
@@ -1,0 +1,339 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AUTO_DETECT_FAILURE_REASONS,
+  type AutoDetectFailureReason,
+} from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { AutoDetectCompletionError } from "~/services/accounts/autoDetectCompletion/types"
+import type { AccountCompletionHelpers } from "~/services/apiAdapters/contracts/accountCompletion"
+import { newApiAccountCompletion } from "~/services/apiAdapters/newApi/accountCompletion"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockExtractDefaultExchangeRate,
+  mockFetchSiteStatus,
+  mockFetchSupportCheckIn,
+  mockFetchUserInfo,
+  mockGetApiService,
+  mockGetOrCreateAccessToken,
+} = vi.hoisted(() => ({
+  mockExtractDefaultExchangeRate: vi.fn(),
+  mockFetchSiteStatus: vi.fn(),
+  mockFetchSupportCheckIn: vi.fn(),
+  mockFetchUserInfo: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockGetOrCreateAccessToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+const currentTabFetchContext = {
+  kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+  tabId: 123,
+  origin: "https://new.example.com",
+}
+
+const createServiceRequest = vi.fn(
+  ({
+    baseUrl,
+    auth,
+    context,
+  }: Parameters<AccountCompletionHelpers["createServiceRequest"]>[0]) => ({
+    baseUrl,
+    auth,
+    ...(context.fetchContext ? { fetchContext: context.fetchContext } : {}),
+  }),
+)
+
+const fetchSiteName = vi.fn(async (siteStatus) =>
+  typeof siteStatus?.system_name === "string" && siteStatus.system_name.trim()
+    ? siteStatus.system_name.trim()
+    : "Example API",
+)
+
+const createCompletionError = vi.fn(
+  (reason: AutoDetectFailureReason, cause: unknown) =>
+    new AutoDetectCompletionError(reason, cause),
+)
+
+const trimString = vi.fn((value: unknown) =>
+  typeof value === "string" ? value.trim() : "",
+)
+
+const createInitialCheckInConfig = vi.fn(
+  ({ enableDetection, autoCheckInEnabled }) => ({
+    enableDetection,
+    autoCheckInEnabled,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  }),
+)
+
+const handleCheckInSupportFetchFailure = vi.fn(() => false as const)
+
+const helpers = {
+  createServiceRequest,
+  fetchSiteName,
+  createCompletionError,
+  trimString,
+  createInitialCheckInConfig,
+  handleCheckInSupportFetchFailure,
+} satisfies AccountCompletionHelpers
+
+describe("newApiAccountCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+      fetchSiteStatus: mockFetchSiteStatus,
+      fetchSupportCheckIn: mockFetchSupportCheckIn,
+      fetchUserInfo: mockFetchUserInfo,
+      getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    })
+  })
+
+  it("completes access-token accounts with cookie token fetch and site status check-in config", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "  token-user  ",
+      access_token: "  generated-token  ",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "  Token Portal  ",
+      checkin_enabled: true,
+      price: 6.8,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(6.8)
+
+    const result = await newApiAccountCompletion.complete(
+      {
+        url: "https://new.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "7",
+          siteType: SITE_TYPES.NEW_API,
+        },
+        context: {
+          fetchContext: currentTabFetchContext,
+        },
+      },
+      helpers,
+    )
+
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
+      baseUrl: "https://new.example.com",
+      fetchContext: currentTabFetchContext,
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "7",
+      },
+    })
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://new.example.com",
+      fetchContext: currentTabFetchContext,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+      },
+    })
+    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+    expect(mockExtractDefaultExchangeRate).toHaveBeenCalledWith({
+      system_name: "  Token Portal  ",
+      checkin_enabled: true,
+      price: 6.8,
+    })
+    expect(createInitialCheckInConfig).toHaveBeenCalledWith({
+      enableDetection: true,
+      autoCheckInEnabled: true,
+    })
+    expect(result).toEqual({
+      username: "token-user",
+      siteName: "Token Portal",
+      accessToken: "generated-token",
+      userId: "7",
+      exchangeRate: 6.8,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+        customCheckIn: {
+          url: "",
+          redeemUrl: "",
+          openRedeemWithCheckIn: true,
+          isCheckedInToday: false,
+        },
+      },
+    })
+  })
+
+  it("completes cookie accounts with support probing and default exchange rate", async () => {
+    mockFetchUserInfo.mockResolvedValueOnce({
+      username: "  cookie-user  ",
+      access_token: "  cookie-visible-token  ",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Cookie Portal",
+    })
+    mockFetchSupportCheckIn.mockResolvedValueOnce(true)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await newApiAccountCompletion.complete(
+      {
+        url: "https://cookie.example.com",
+        requestedAuthType: AuthTypeEnum.Cookie,
+        detected: {
+          userId: "8",
+          siteType: SITE_TYPES.NEW_API,
+        },
+        context: {},
+      },
+      helpers,
+    )
+
+    expect(mockFetchUserInfo).toHaveBeenCalledWith({
+      baseUrl: "https://cookie.example.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "8",
+      },
+    })
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://cookie.example.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+      },
+    })
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
+      baseUrl: "https://cookie.example.com",
+      auth: {
+        authType: AuthTypeEnum.None,
+      },
+    })
+    expect(result).toMatchObject({
+      username: "cookie-user",
+      siteName: "Cookie Portal",
+      accessToken: "cookie-visible-token",
+      userId: "8",
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.Cookie,
+      checkIn: expect.objectContaining({
+        enableDetection: true,
+        autoCheckInEnabled: true,
+      }),
+    })
+  })
+
+  it("classifies missing access token for access-token completion", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "token-user",
+      access_token: "  ",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Broken Portal",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      newApiAccountCompletion.complete(
+        {
+          url: "https://broken.example.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "9",
+            siteType: SITE_TYPES.NEW_API,
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+      expect.any(Error),
+    )
+  })
+
+  it("does not fetch token info for unsupported auth and classifies missing username", async () => {
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "None Auth Portal",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      newApiAccountCompletion.complete(
+        {
+          url: "https://none.example.com",
+          requestedAuthType: AuthTypeEnum.None,
+          detected: {
+            userId: "10",
+            siteType: SITE_TYPES.NEW_API,
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+    })
+
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+      expect.any(Error),
+    )
+  })
+
+  it("classifies missing username for cookie completion", async () => {
+    mockFetchUserInfo.mockResolvedValueOnce({
+      username: "  ",
+      access_token: "cookie-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Missing Username Portal",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      newApiAccountCompletion.complete(
+        {
+          url: "https://missing-user.example.com",
+          requestedAuthType: AuthTypeEnum.Cookie,
+          detected: {
+            userId: "11",
+            siteType: SITE_TYPES.NEW_API,
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+      expect.any(Error),
+    )
+  })
+})

--- a/tests/services/apiAdapters/newApi/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/newApi/accountCompletion.test.ts
@@ -336,4 +336,70 @@ describe("newApiAccountCompletion", () => {
       expect.any(Error),
     )
   })
+
+  it("classifies site status fetch failures", async () => {
+    const siteStatusError = new Error("site status unavailable")
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "token-user",
+      access_token: "generated-token",
+    })
+    mockFetchSiteStatus.mockRejectedValueOnce(siteStatusError)
+
+    await expect(
+      newApiAccountCompletion.complete(
+        {
+          url: "https://status-failure.example.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "12",
+            siteType: SITE_TYPES.NEW_API,
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+      cause: siteStatusError,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+      siteStatusError,
+    )
+    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+  })
+
+  it("falls back to disabled check-in detection when support probing fails", async () => {
+    const supportError = new Error("support probe unavailable")
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "token-user",
+      access_token: "generated-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Token Portal",
+    })
+    mockFetchSupportCheckIn.mockRejectedValueOnce(supportError)
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await newApiAccountCompletion.complete(
+      {
+        url: "https://support-failure.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "13",
+          siteType: SITE_TYPES.NEW_API,
+        },
+        context: {},
+      },
+      helpers,
+    )
+
+    expect(handleCheckInSupportFetchFailure).toHaveBeenCalledWith(supportError)
+    expect(createInitialCheckInConfig).toHaveBeenCalledWith({
+      enableDetection: false,
+      autoCheckInEnabled: true,
+    })
+    expect(result.checkIn.enableDetection).toBe(false)
+  })
 })

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -18,6 +18,9 @@ describe("apiAdapters registry", () => {
     expect(adapter.modelCatalog).toEqual({
       fetchModels: expect.any(Function),
     })
+    expect(adapter.accountCompletion).toEqual({
+      complete: expect.any(Function),
+    })
     expect(adapter.siteNotice).toBeUndefined()
   })
 
@@ -46,16 +49,22 @@ describe("apiAdapters registry", () => {
       expect(adapter.siteNotice).toEqual({
         fetch: expect.any(Function),
       })
+      expect(adapter.accountCompletion).toEqual({
+        complete: expect.any(Function),
+      })
       expect(adapter.siteAnnouncements).toBeUndefined()
       expect(adapter.modelCatalog).toBeUndefined()
     }
   })
 
-  it("keeps AIHubMix unsupported for siteNotice in the first slice", () => {
+  it("returns an AIHubMix Adapter with account completion only", () => {
     const adapter = getSiteAdapter(SITE_TYPES.AIHUBMIX)
 
     expect(adapter).toMatchObject({
       siteType: SITE_TYPES.AIHUBMIX,
+    })
+    expect(adapter.accountCompletion).toEqual({
+      complete: expect.any(Function),
     })
     expect(adapter.siteNotice).toBeUndefined()
     expect(adapter.siteAnnouncements).toBeUndefined()

--- a/tests/services/apiAdapters/sub2api/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/sub2api/accountCompletion.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AUTO_DETECT_FAILURE_REASONS,
+  type AutoDetectFailureReason,
+} from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { AutoDetectCompletionError } from "~/services/accounts/autoDetectCompletion/types"
+import type { AccountCompletionHelpers } from "~/services/apiAdapters/contracts/accountCompletion"
+import { sub2ApiAccountCompletion } from "~/services/apiAdapters/sub2api/accountCompletion"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockExtractDefaultExchangeRate,
+  mockFetchSiteStatus,
+  mockFetchSupportCheckIn,
+  mockFetchUserInfo,
+  mockGetApiService,
+  mockGetOrCreateAccessToken,
+} = vi.hoisted(() => ({
+  mockExtractDefaultExchangeRate: vi.fn(),
+  mockFetchSiteStatus: vi.fn(),
+  mockFetchSupportCheckIn: vi.fn(),
+  mockFetchUserInfo: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockGetOrCreateAccessToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+const currentTabFetchContext = {
+  kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+  tabId: 123,
+  origin: "https://sub2.example.com",
+}
+
+const createServiceRequest = vi.fn(
+  ({
+    baseUrl,
+    auth,
+    context,
+  }: Parameters<AccountCompletionHelpers["createServiceRequest"]>[0]) => ({
+    baseUrl,
+    auth,
+    ...(context.fetchContext ? { fetchContext: context.fetchContext } : {}),
+  }),
+)
+
+const fetchSiteName = vi.fn(async (siteStatus) =>
+  typeof siteStatus?.system_name === "string" && siteStatus.system_name.trim()
+    ? siteStatus.system_name.trim()
+    : "Example API",
+)
+
+const createCompletionError = vi.fn(
+  (reason: AutoDetectFailureReason, cause: unknown) =>
+    new AutoDetectCompletionError(reason, cause),
+)
+
+const trimString = vi.fn((value: unknown) =>
+  typeof value === "string" ? value.trim() : "",
+)
+
+const createInitialCheckInConfig = vi.fn(
+  ({ enableDetection, autoCheckInEnabled }) => ({
+    enableDetection,
+    autoCheckInEnabled,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  }),
+)
+
+const handleCheckInSupportFetchFailure = vi.fn(() => false as const)
+
+const helpers = {
+  createServiceRequest,
+  fetchSiteName,
+  createCompletionError,
+  trimString,
+  createInitialCheckInConfig,
+  handleCheckInSupportFetchFailure,
+} satisfies AccountCompletionHelpers
+
+describe("sub2ApiAccountCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+      fetchSiteStatus: mockFetchSiteStatus,
+      fetchSupportCheckIn: mockFetchSupportCheckIn,
+      fetchUserInfo: mockFetchUserInfo,
+      getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    })
+  })
+
+  it("uses detected access-token data and disables check-in", async () => {
+    const sub2apiAuth = {
+      refreshToken: "refresh-token",
+      tokenExpiresAt: 1999999999999,
+    }
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "  Sub2 Portal  ",
+      price: 7.2,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(7.2)
+
+    const result = await sub2ApiAccountCompletion.complete(
+      {
+        url: "https://sub2.example.com",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "12",
+          user: {
+            id: 12,
+            username: "  ",
+          },
+          siteType: SITE_TYPES.SUB2API,
+          accessToken: "  jwt-token  ",
+          sub2apiAuth,
+        },
+        context: {
+          fetchContext: currentTabFetchContext,
+        },
+      },
+      helpers,
+    )
+
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.SUB2API)
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://sub2.example.com",
+      fetchContext: currentTabFetchContext,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+      },
+    })
+    expect(mockExtractDefaultExchangeRate).toHaveBeenCalledWith({
+      system_name: "  Sub2 Portal  ",
+      price: 7.2,
+    })
+    expect(createInitialCheckInConfig).toHaveBeenCalledWith({
+      enableDetection: false,
+      autoCheckInEnabled: false,
+    })
+    expect(result).toEqual({
+      username: "",
+      siteName: "Sub2 Portal",
+      accessToken: "jwt-token",
+      userId: "12",
+      exchangeRate: 7.2,
+      authType: AuthTypeEnum.AccessToken,
+      sub2apiAuth,
+      checkIn: {
+        enableDetection: false,
+        autoCheckInEnabled: false,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+        customCheckIn: {
+          url: "",
+          redeemUrl: "",
+          openRedeemWithCheckIn: true,
+          isCheckedInToday: false,
+        },
+      },
+    })
+  })
+
+  it("classifies missing detected access token", async () => {
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Sub2 Portal",
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    await expect(
+      sub2ApiAccountCompletion.complete(
+        {
+          url: "https://sub2.example.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "12",
+            siteType: SITE_TYPES.SUB2API,
+            accessToken: "  ",
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+      expect.any(Error),
+    )
+  })
+
+  it("classifies site status fetch failures", async () => {
+    const siteStatusError = new Error("site status unavailable")
+    mockFetchSiteStatus.mockRejectedValueOnce(siteStatusError)
+
+    await expect(
+      sub2ApiAccountCompletion.complete(
+        {
+          url: "https://sub2.example.com",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "12",
+            siteType: SITE_TYPES.SUB2API,
+            accessToken: "jwt-token",
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+      cause: siteStatusError,
+    })
+
+    expect(createCompletionError).toHaveBeenCalledWith(
+      AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
+      siteStatusError,
+    )
+    expect(mockExtractDefaultExchangeRate).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/apiAdapters/sub2api/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/sub2api/accountCompletion.test.ts
@@ -179,11 +179,6 @@ describe("sub2ApiAccountCompletion", () => {
   })
 
   it("classifies missing detected access token", async () => {
-    mockFetchSiteStatus.mockResolvedValueOnce({
-      system_name: "Sub2 Portal",
-    })
-    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
-
     await expect(
       sub2ApiAccountCompletion.complete(
         {
@@ -206,6 +201,7 @@ describe("sub2ApiAccountCompletion", () => {
       AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
       expect.any(Error),
     )
+    expect(mockFetchSiteStatus).not.toHaveBeenCalled()
   })
 
   it("classifies site status fetch failures", async () => {


### PR DESCRIPTION
## Summary
- Adds an account-completion capability to the API adapter layer for New API, Sub2API, and AIHubMix.
- Routes account auto-detect completion through site adapters instead of backend-specific branching in the account workflow.
- Documents the adapter slice with design and implementation plan artifacts.

## Test Plan
- pnpm exec vitest --run tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accounts/autoDetectCompletion/completion.test.ts tests/services/accountOperations.autoDetectAccount.test.ts
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added account auto-detect completion support for the AIHubMix site family via a dedicated adapter.

* **Refactor**
  * Refactored auto-detected account completion to delegate to site-specific adapter handlers, with consistent context handling and clearer error behavior when completion support is missing.
  * Standardized check-in initialization configuration.

* **Tests**
  * Expanded and updated adapter-focused test coverage, including success paths, context routing, and detailed failure classification.

* **Documentation**
  * Added architecture specs and an implementation plan for the account completion adapter system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->