### PR TITLE
fix(api-profiles): clarify credential library guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,7 @@ Use validation as progressive gates:
 ### Locale Shape Consistency
 
 - Keep locale key shapes stable across languages; do not let one language drift into a pluralized or structurally different key family unless that family is intentionally introduced for every locale.
+- When changing an existing app locale string under `src/locales/**`, check the same key in every sibling locale before handoff. If the wording describes a renamed action, control, icon, or workflow, update all supported app locales in the same change unless a locale is intentionally generated or out of scope, and call that out explicitly.
 
 ## Security & Configuration Tips
 

--- a/src/components/icons/optionsPageIcons.ts
+++ b/src/components/icons/optionsPageIcons.ts
@@ -6,7 +6,6 @@ import {
   Cloud,
   Cpu,
   Info,
-  KeyRound,
   Layers,
   LayoutDashboard,
   LineChart,
@@ -15,10 +14,13 @@ import {
   RefreshCcw,
   Settings,
   UserRound,
-  UserRoundKey,
   type LucideIcon,
 } from "lucide-react"
 
+import {
+  AccountKeyIcon,
+  ApiCredentialLibraryIcon,
+} from "~/components/icons/productIcons"
 import { DEV_MENU_ITEM_IDS } from "~/constants/devOptionsMenuIds"
 import type { DevOptionsMenuItemId } from "~/constants/devOptionsMenuIds"
 import {
@@ -30,10 +32,10 @@ export const OPTIONS_MENU_ITEM_ICONS = {
   [MENU_ITEM_IDS.OVERVIEW]: LayoutDashboard,
   [MENU_ITEM_IDS.BASIC]: Settings,
   [MENU_ITEM_IDS.ACCOUNT]: UserRound,
-  [MENU_ITEM_IDS.API_CREDENTIAL_PROFILES]: KeyRound,
+  [MENU_ITEM_IDS.API_CREDENTIAL_PROFILES]: ApiCredentialLibraryIcon,
   [MENU_ITEM_IDS.BOOKMARK]: Bookmark,
   [MENU_ITEM_IDS.MODELS]: Cpu,
-  [MENU_ITEM_IDS.KEYS]: UserRoundKey,
+  [MENU_ITEM_IDS.KEYS]: AccountKeyIcon,
   [MENU_ITEM_IDS.AUTO_CHECKIN]: CalendarCheck2,
   [MENU_ITEM_IDS.SITE_ANNOUNCEMENTS]: Megaphone,
   [MENU_ITEM_IDS.BALANCE_HISTORY]: LineChart,

--- a/src/components/icons/productIcons.ts
+++ b/src/components/icons/productIcons.ts
@@ -1,0 +1,4 @@
+import { KeyRound, Library } from "lucide-react"
+
+export const AccountKeyIcon = KeyRound
+export const ApiCredentialLibraryIcon = Library

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -45,6 +45,7 @@ export interface IconButtonProps
     VariantProps<typeof iconButtonVariants> {
   loading?: boolean
   "aria-label": string
+  disableAutoTitle?: boolean
   analyticsAction?: ProductAnalyticsScopedActionConfig
 }
 
@@ -57,6 +58,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
       loading,
       children,
       disabled,
+      disableAutoTitle,
       analyticsAction,
       onClick,
       ...props
@@ -87,6 +89,9 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         disabled={isDisabled}
         onClick={handleClick}
         {...props}
+        title={
+          disableAutoTitle ? props.title : props.title ?? props["aria-label"]
+        }
       >
         {loading ? (
           <svg

--- a/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
+++ b/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
@@ -1,7 +1,8 @@
 import type { TFunction } from "i18next"
-import { Bookmark, ExternalLink, KeyRound, Plus } from "lucide-react"
+import { Bookmark, ExternalLink, Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
+import { ApiCredentialLibraryIcon } from "~/components/icons/productIcons"
 import { Badge, IconButton } from "~/components/ui"
 import {
   SPONSOR_RECOMMENDATION_ACTION_KINDS,
@@ -251,7 +252,10 @@ export function SponsorRecommendationCard({
                 ACCOUNT_MANAGEMENT_TEST_IDS.sponsorFallbackApiCredentialProfilesAction
               }
             >
-              <KeyRound aria-hidden="true" className="h-4 w-4" />
+              <ApiCredentialLibraryIcon
+                aria-hidden="true"
+                className="h-4 w-4"
+              />
             </IconButton>
           ) : null}
         </div>

--- a/src/features/ApiCredentialProfiles/ApiCredentialProfiles.tsx
+++ b/src/features/ApiCredentialProfiles/ApiCredentialProfiles.tsx
@@ -1,7 +1,7 @@
-import { KeyRound } from "lucide-react"
 import { useEffect, useMemo, useRef } from "react"
 import { useTranslation } from "react-i18next"
 
+import { ApiCredentialLibraryIcon } from "~/components/icons/productIcons"
 import { PageHeader } from "~/components/PageHeader"
 import { Button } from "~/components/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
@@ -77,7 +77,7 @@ export default function ApiCredentialProfiles({
     >
       <div className="space-y-6 p-6">
         <PageHeader
-          icon={KeyRound}
+          icon={ApiCredentialLibraryIcon}
           title={t("title")}
           description={t("description")}
           actions={

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
@@ -1,11 +1,12 @@
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
-import { KeyRound } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { ApiCredentialLibraryIcon } from "~/components/icons/productIcons"
 import {
   EmptyState,
   Input,
+  Notice,
   SearchableSelect,
   Spinner,
   TagFilter,
@@ -26,6 +27,7 @@ import {
   API_TYPES,
   type ApiVerificationApiType,
 } from "~/services/verification/aiApiVerification"
+import { openKeysPage } from "~/utils/navigation"
 
 import type { ApiCredentialProfilesController } from "../hooks/useApiCredentialProfilesController"
 import { ApiCredentialProfilesDialogs } from "./ApiCredentialProfilesDialogs"
@@ -285,6 +287,10 @@ export function ApiCredentialProfilesListView({
           entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
         }
 
+  const handleOpenKeyManagement = useCallback(() => {
+    void openKeysPage()
+  }, [])
+
   return (
     <div className={cn("space-y-4", className)}>
       <ApiCredentialProfilesDialogs controller={controller} />
@@ -362,28 +368,49 @@ export function ApiCredentialProfilesListView({
           </div>
         </div>
       ) : filteredProfiles.length === 0 ? (
-        <EmptyState
-          icon={<KeyRound className="h-8 w-8" />}
-          title={
-            controller.profiles.length === 0
-              ? t("apiCredentialProfiles:empty.title")
-              : t("apiCredentialProfiles:empty.filteredTitle")
-          }
-          description={
-            controller.profiles.length === 0
-              ? t("apiCredentialProfiles:empty.description")
-              : t("apiCredentialProfiles:empty.filteredDescription")
-          }
-          action={
-            controller.profiles.length === 0
-              ? {
-                  label: t("apiCredentialProfiles:actions.add"),
-                  onClick: controller.openAddDialog,
-                  analyticsAction: emptyStateAddAnalyticsAction,
-                }
-              : undefined
-          }
-        />
+        <div className="mx-auto flex max-w-md flex-col gap-4">
+          <EmptyState
+            icon={<ApiCredentialLibraryIcon className="h-8 w-8" />}
+            title={
+              controller.profiles.length === 0
+                ? t("apiCredentialProfiles:empty.title")
+                : t("apiCredentialProfiles:empty.filteredTitle")
+            }
+            description={
+              controller.profiles.length === 0
+                ? t("apiCredentialProfiles:empty.description")
+                : t("apiCredentialProfiles:empty.filteredDescription")
+            }
+            action={
+              controller.profiles.length === 0
+                ? {
+                    label: t("apiCredentialProfiles:actions.add"),
+                    onClick: controller.openAddDialog,
+                    analyticsAction: emptyStateAddAnalyticsAction,
+                  }
+                : undefined
+            }
+          />
+          {controller.profiles.length === 0 ? (
+            <Notice
+              tone="info"
+              icon={<ApiCredentialLibraryIcon className="h-3.5 w-3.5" />}
+              className="text-left"
+              description={
+                <span>
+                  {t("apiCredentialProfiles:empty.keyManagementImportHint")}{" "}
+                  <button
+                    type="button"
+                    className="font-medium text-blue-700 underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-blue-200"
+                    onClick={handleOpenKeyManagement}
+                  >
+                    {t("apiCredentialProfiles:empty.keyManagementLink")}
+                  </button>
+                </span>
+              }
+            />
+          ) : null}
+        </div>
       ) : (
         <ApiCredentialProfilesList
           profiles={filteredProfiles}

--- a/src/features/KeyManagement/components/Header.tsx
+++ b/src/features/KeyManagement/components/Header.tsx
@@ -1,7 +1,8 @@
-import { Cpu, KeyRound, Plus, RefreshCw, Wrench } from "lucide-react"
+import { Cpu, Plus, RefreshCw, Wrench } from "lucide-react"
 import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
+import { AccountKeyIcon } from "~/components/icons/productIcons"
 import { PageHeader } from "~/components/PageHeader"
 import Tooltip from "~/components/Tooltip"
 import { Button, IconButton } from "~/components/ui"
@@ -68,7 +69,7 @@ export function Header({
         surfaceId={PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementHeader}
       >
         <PageHeader
-          icon={KeyRound}
+          icon={AccountKeyIcon}
           title={t("title")}
           titleActionsTestId={KEY_MANAGEMENT_TEST_IDS.titleActions}
           titleActions={

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -1,7 +1,6 @@
 import {
   ArrowPathIcon,
   PencilIcon,
-  PlusIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
@@ -19,6 +18,7 @@ import { ClaudeCodeRouterIcon } from "~/components/icons/ClaudeCodeRouterIcon"
 import { CliProxyIcon } from "~/components/icons/CliProxyIcon"
 import { KiloCodeIcon } from "~/components/icons/KiloCodeIcon"
 import { ManagedSiteIcon } from "~/components/icons/ManagedSiteIcon"
+import { ApiCredentialLibraryIcon } from "~/components/icons/productIcons"
 import { KiloCodeExportDialog } from "~/components/KiloCodeExportDialog"
 import {
   getKeySignalLabel,
@@ -31,6 +31,7 @@ import {
   SignalBadge,
 } from "~/components/ManagedSiteChannelAssessmentSignalHelpers"
 import ManagedSiteChannelLinkButton from "~/components/ManagedSiteChannelLinkButton"
+import Tooltip from "~/components/Tooltip"
 import {
   Badge,
   Button,
@@ -476,15 +477,18 @@ function TokenActionButtons({
       >
         <Copy className="dark:text-dark-text-tertiary h-4 w-4 text-gray-500" />
       </IconButton>
-      <IconButton
-        aria-label={t("keyManagement:actions.saveToApiProfiles")}
-        data-testid={KEY_MANAGEMENT_TEST_IDS.saveToApiProfilesButton}
-        size="sm"
-        variant="ghost"
-        onClick={handleSaveToApiCredentialProfiles}
-      >
-        <PlusIcon className="dark:text-dark-text-tertiary h-4 w-4 text-gray-500" />
-      </IconButton>
+      <Tooltip content={t("keyManagement:actions.saveToApiProfilesHint")}>
+        <IconButton
+          aria-label={t("keyManagement:actions.saveToApiProfiles")}
+          title={t("keyManagement:actions.saveToApiProfilesHint")}
+          data-testid={KEY_MANAGEMENT_TEST_IDS.saveToApiProfilesButton}
+          size="sm"
+          variant="ghost"
+          onClick={handleSaveToApiCredentialProfiles}
+        >
+          <ApiCredentialLibraryIcon className="dark:text-dark-text-tertiary h-4 w-4 text-gray-500" />
+        </IconButton>
+      </Tooltip>
       <IconButton
         aria-label={t("actions.useInCherry")}
         size="sm"

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -92,7 +92,7 @@
     "description": "Save an API credential to use these API keys without adding a site account.",
     "filteredDescription": "Try adjusting your search or filters.",
     "filteredTitle": "No matching credentials",
-    "keyManagementImportHint": "Already have account keys? Use the archive button on a key row to save them here.",
+    "keyManagementImportHint": "Already have account keys? Use the save-to-library button on a key row to save them here.",
     "keyManagementLink": "Open Key Management",
     "title": "No API keys saved yet"
   },

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -92,6 +92,8 @@
     "description": "Save an API credential to use these API keys without adding a site account.",
     "filteredDescription": "Try adjusting your search or filters.",
     "filteredTitle": "No matching credentials",
+    "keyManagementImportHint": "Already have account keys? Use the archive button on a key row to save them here.",
+    "keyManagementLink": "Open Key Management",
     "title": "No API keys saved yet"
   },
   "filter": {

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -22,6 +22,7 @@
     "openSelectedAccountModels": "View account models",
     "retryFailed": "Retry failed",
     "saveToApiProfiles": "Save to API credential library",
+    "saveToApiProfilesHint": "Save this key to the API credential library for quick copying, verification, and export.",
     "showKey": "Show Key",
     "useInCherry": "Use in Cherry Studio"
   },

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -92,6 +92,8 @@
     "description": "API 認証情報を保存すると、サイトアカウントを追加せずにこれらの API キーを使用できます。",
     "filteredDescription": "検索条件またはフィルターを調整してください。",
     "filteredTitle": "一致する認証情報がありません",
+    "keyManagementImportHint": "既存のアカウントキーがある場合は、キー行の保存ボタンからここへ保存できます。",
+    "keyManagementLink": "キー管理を開く",
     "title": "保存済みの API キーはまだありません"
   },
   "filter": {

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -92,7 +92,7 @@
     "description": "API 認証情報を保存すると、サイトアカウントを追加せずにこれらの API キーを使用できます。",
     "filteredDescription": "検索条件またはフィルターを調整してください。",
     "filteredTitle": "一致する認証情報がありません",
-    "keyManagementImportHint": "既存のアカウントキーがある場合は、キー行の保存ボタンからここへ保存できます。",
+    "keyManagementImportHint": "既存のアカウントキーがある場合は、キー行の認証情報庫に保存ボタンからここへ保存できます。",
     "keyManagementLink": "キー管理を開く",
     "title": "保存済みの API キーはまだありません"
   },

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -21,6 +21,7 @@
     "openSelectedAccountModels": "アカウントモデルを見る",
     "retryFailed": "失敗を再試行",
     "saveToApiProfiles": "API 認証情報庫に保存",
+    "saveToApiProfilesHint": "このキーを API 認証情報庫に保存し、コピー、検証、エクスポートに再利用できます。",
     "showKey": "キーを表示",
     "useInCherry": "Cherry Studio で使う"
   },

--- a/src/locales/vi/apiCredentialProfiles.json
+++ b/src/locales/vi/apiCredentialProfiles.json
@@ -92,7 +92,7 @@
     "description": "Sau khi lưu thông tin xác thực API, bạn có thể sử dụng các API Key này mà không cần thêm tài khoản trang web.",
     "filteredDescription": "Hãy thử điều chỉnh từ khóa tìm kiếm hoặc điều kiện lọc.",
     "filteredTitle": "Không có thông tin xác thực nào khớp",
-    "keyManagementImportHint": "Nếu đã có khóa tài khoản, hãy dùng nút lưu trên từng dòng khóa để lưu vào đây.",
+    "keyManagementImportHint": "Nếu đã có khóa tài khoản, hãy dùng nút lưu vào thư viện thông tin xác thực trên từng dòng khóa để lưu vào đây.",
     "keyManagementLink": "Mở Quản lý khóa",
     "title": "Chưa lưu API Key nào"
   },

--- a/src/locales/vi/apiCredentialProfiles.json
+++ b/src/locales/vi/apiCredentialProfiles.json
@@ -92,6 +92,8 @@
     "description": "Sau khi lưu thông tin xác thực API, bạn có thể sử dụng các API Key này mà không cần thêm tài khoản trang web.",
     "filteredDescription": "Hãy thử điều chỉnh từ khóa tìm kiếm hoặc điều kiện lọc.",
     "filteredTitle": "Không có thông tin xác thực nào khớp",
+    "keyManagementImportHint": "Nếu đã có khóa tài khoản, hãy dùng nút lưu trên từng dòng khóa để lưu vào đây.",
+    "keyManagementLink": "Mở Quản lý khóa",
     "title": "Chưa lưu API Key nào"
   },
   "filter": {

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -21,6 +21,7 @@
     "openSelectedAccountModels": "Xem mô hình tài khoản",
     "retryFailed": "Thử lại tài khoản thất bại",
     "saveToApiProfiles": "Lưu vào Hồ sơ API",
+    "saveToApiProfilesHint": "Lưu khóa này vào thư viện thông tin xác thực API để sao chép, xác minh và xuất nhanh.",
     "showKey": "Hiển thị khóa",
     "useInCherry": "Sử dụng trong Cherry Studio"
   },

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -92,6 +92,8 @@
     "description": "保存一个 API 凭据后，可以在不添加站点账号的情况下使用这些 API Key。",
     "filteredDescription": "尝试调整搜索关键词或筛选条件。",
     "filteredTitle": "没有匹配的凭证",
+    "keyManagementImportHint": "如果已有账号密钥，可点击密钥行的存档按钮直接存入这里。",
+    "keyManagementLink": "打开密钥管理",
     "title": "还没有保存 API Key"
   },
   "filter": {

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -92,7 +92,7 @@
     "description": "保存一个 API 凭据后，可以在不添加站点账号的情况下使用这些 API Key。",
     "filteredDescription": "尝试调整搜索关键词或筛选条件。",
     "filteredTitle": "没有匹配的凭证",
-    "keyManagementImportHint": "如果已有账号密钥，可点击密钥行的存档按钮直接存入这里。",
+    "keyManagementImportHint": "如果已有账号密钥，可点击密钥行的保存到凭证库按钮直接存入这里。",
     "keyManagementLink": "打开密钥管理",
     "title": "还没有保存 API Key"
   },

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -21,6 +21,7 @@
     "openSelectedAccountModels": "查看账号模型",
     "retryFailed": "重试失败账号",
     "saveToApiProfiles": "保存到 API 凭据库",
+    "saveToApiProfilesHint": "将此密钥保存到 API 凭据库，用于快速复制、验证和导出。",
     "showKey": "显示密钥",
     "useInCherry": "在 Cherry Studio 中使用"
   },

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -92,7 +92,7 @@
     "description": "儲存一個 API 憑據後，可以在不新增站點帳號的情況下使用這些 API Key。",
     "filteredDescription": "嘗試調整搜尋關鍵詞或篩選條件。",
     "filteredTitle": "沒有匹配的憑證",
-    "keyManagementImportHint": "如果已有帳號金鑰，可點擊金鑰列的封存按鈕直接存入這裡。",
+    "keyManagementImportHint": "如果已有帳號金鑰，可點擊金鑰列的儲存到憑證庫按鈕直接存入這裡。",
     "keyManagementLink": "開啟金鑰管理",
     "title": "還沒有儲存 API Key"
   },

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -92,6 +92,8 @@
     "description": "儲存一個 API 憑據後，可以在不新增站點帳號的情況下使用這些 API Key。",
     "filteredDescription": "嘗試調整搜尋關鍵詞或篩選條件。",
     "filteredTitle": "沒有匹配的憑證",
+    "keyManagementImportHint": "如果已有帳號金鑰，可點擊金鑰列的封存按鈕直接存入這裡。",
+    "keyManagementLink": "開啟金鑰管理",
     "title": "還沒有儲存 API Key"
   },
   "filter": {

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -21,6 +21,7 @@
     "openSelectedAccountModels": "查看帳號模型",
     "retryFailed": "重試失敗帳號",
     "saveToApiProfiles": "儲存到 API 憑據庫",
+    "saveToApiProfilesHint": "將此金鑰儲存到 API 憑據庫，用於快速複製、驗證與匯出。",
     "showKey": "顯示金鑰",
     "useInCherry": "在 Cherry Studio 中使用"
   },

--- a/tests/components/IconButton.test.tsx
+++ b/tests/components/IconButton.test.tsx
@@ -50,6 +50,42 @@ describe("IconButton", () => {
     )
   })
 
+  it("uses aria-label as the fallback title for icon-only discovery", () => {
+    render(
+      <IconButton aria-label="Refresh profiles">
+        <span />
+      </IconButton>,
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Refresh profiles" }),
+    ).toHaveAttribute("title", "Refresh profiles")
+  })
+
+  it("keeps an explicit title when it differs from the accessible name", () => {
+    render(
+      <IconButton aria-label="Refresh profiles" title="Refresh the list">
+        <span />
+      </IconButton>,
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Refresh profiles" }),
+    ).toHaveAttribute("title", "Refresh the list")
+  })
+
+  it("can disable automatic title fallback for tooltip-managed buttons", () => {
+    render(
+      <IconButton aria-label="Refresh profiles" disableAutoTitle>
+        <span />
+      </IconButton>,
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Refresh profiles" }),
+    ).not.toHaveAttribute("title")
+  })
+
   it("tracks controlled analytics action without reading button content", () => {
     const onClick = vi.fn()
 

--- a/tests/entrypoints/options/pages/KeyManagement/TokenHeader.saveToApiProfiles.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/TokenHeader.saveToApiProfiles.test.tsx
@@ -200,6 +200,42 @@ describe("TokenHeader save to API profiles", () => {
     })
   })
 
+  it("explains the API credential library save action on the row button", () => {
+    const account = createAccountStub()
+
+    const token = {
+      id: 1,
+      user_id: 1,
+      key: "sk-test",
+      status: 1,
+      name: "Token",
+      created_time: 0,
+      accessed_time: 0,
+      expired_time: 0,
+      remain_quota: 0,
+      unlimited_quota: false,
+      used_quota: 0,
+      accountId: account.id,
+      accountName: account.name,
+    }
+
+    render(
+      <TokenHeader
+        token={token as any}
+        copyKey={vi.fn()}
+        handleEditToken={vi.fn()}
+        handleDeleteToken={vi.fn()}
+        account={account}
+      />,
+    )
+
+    expect(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.saveToApiProfiles",
+      }),
+    ).toHaveAttribute("title", "keyManagement:actions.saveToApiProfilesHint")
+  })
+
   it("creates an openai-compatible profile from token + account baseUrl", async () => {
     const user = userEvent.setup()
     const account = createAccountStub()

--- a/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
+++ b/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ApiCredentialProfilesListView } from "~/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView"
@@ -11,8 +12,14 @@ import {
 } from "~/services/productAnalytics/events"
 import { act, fireEvent, render, screen } from "~~/tests/test-utils/render"
 
-const { trackProductAnalyticsActionCompletedMock } = vi.hoisted(() => ({
-  trackProductAnalyticsActionCompletedMock: vi.fn(),
+const { openKeysPageMock, trackProductAnalyticsActionCompletedMock } =
+  vi.hoisted(() => ({
+    openKeysPageMock: vi.fn(),
+    trackProductAnalyticsActionCompletedMock: vi.fn(),
+  }))
+
+vi.mock("~/utils/navigation", () => ({
+  openKeysPage: (...args: unknown[]) => openKeysPageMock(...args),
 }))
 
 vi.mock("~/services/productAnalytics/actions", () => ({
@@ -80,6 +87,12 @@ vi.mock("~/components/ui", () => ({
       ) : null}
     </div>
   ),
+  Notice: ({ description, icon, tone }: any) => (
+    <div role="status" data-tone={tone}>
+      {icon ? <span data-testid="notice-icon">{icon}</span> : null}
+      <div>{description}</div>
+    </div>
+  ),
   Spinner: () => <div data-testid="spinner" />,
 }))
 
@@ -109,6 +122,7 @@ describe("ApiCredentialProfilesListView", () => {
   })
 
   beforeEach(() => {
+    openKeysPageMock.mockReset()
     trackProductAnalyticsActionCompletedMock.mockReset()
   })
 
@@ -136,6 +150,37 @@ describe("ApiCredentialProfilesListView", () => {
         PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
       ].join(":"),
     )
+    const importHint = screen.getByRole("status")
+    expect(importHint).toHaveAttribute("data-tone", "info")
+    expect(importHint).toHaveTextContent(
+      "apiCredentialProfiles:empty.keyManagementImportHint",
+    )
+    expect(
+      screen.getByRole("button", {
+        name: "apiCredentialProfiles:empty.keyManagementLink",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("opens Key Management from the empty-state import hint", async () => {
+    const user = userEvent.setup()
+    const controller = {
+      profiles: [],
+      isLoading: false,
+      tags: [],
+      tagNameById: new Map<string, string>(),
+      openAddDialog: vi.fn(),
+    } as any
+
+    render(<ApiCredentialProfilesListView controller={controller} />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "apiCredentialProfiles:empty.keyManagementLink",
+      }),
+    )
+
+    expect(openKeysPageMock).toHaveBeenCalledTimes(1)
   })
 
   it("declares popup empty-state add action analytics metadata", async () => {


### PR DESCRIPTION
## Summary
- clarify the Key Management save-to-API-credential-library action with tooltip/title copy and library-oriented icons
- add an API credential empty-state guidance notice with a Key Management shortcut
- centralize product icon aliases and infer IconButton titles from aria-labels

Fixes #985

## Validation
- pnpm vitest --run tests/entrypoints/options/Sidebar.test.tsx
- pnpm vitest --run tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
- pnpm vitest --run tests/entrypoints/options/pages/KeyManagement/TokenHeader.saveToApiProfiles.test.tsx
- pnpm vitest --run tests/features/AccountManagement/components/NewcomerSupportCard.test.tsx
- pnpm vitest --run tests/features/AccountManagement/components/AccountDialog.test.tsx -t "sponsor"
- pnpm vitest --run tests/components/IconButton.test.tsx
- pnpm compile
- pnpm run validate:staged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an informative empty-state for API credential profiles with a hint and a direct “Open Key Management” link.
* **UI Improvements**
  * Updated key-related icons throughout key management and credential profile screens for more consistent visuals.
  * Improved icon button tooltip/title behavior, including an option to disable automatic title fallback.
* **Localization**
  * Added new key-management guidance text across English, Japanese, Vietnamese, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->