### PR TITLE
refactor(api-adapters): add key management adapter layer

### DIFF
--- a/docs/superpowers/plans/2026-06-18-api-adapter-key-management.md
+++ b/docs/superpowers/plans/2026-06-18-api-adapter-key-management.md
@@ -1,0 +1,1274 @@
+# API Adapter Key Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a narrow `keyManagement` capability to site adapters and route account token list/create/secret flows through it.
+
+**Architecture:** Keep HTTP/protocol behavior in existing `apiService/*` modules and add adapter wrappers that expose only token inventory, token creation, and token-secret resolution. Preserve `getApiService(...)` as a compatibility facade for non-migrated Key Management CRUD and group/model helpers, while moving the high-leverage account save/copy paths to `getSiteAdapter(siteType).keyManagement`.
+
+**Tech Stack:** TypeScript, WXT extension service modules, React account-management UI, Vitest with existing test utilities.
+
+---
+
+## File Structure
+
+- Create `src/services/apiAdapters/contracts/keyManagement.ts`
+  - Defines the adapter-level key management interface.
+- Modify `src/services/apiAdapters/contracts/siteAdapter.ts`
+  - Adds optional `keyManagement?: KeyManagementCapability`.
+- Create `src/services/apiAdapters/newApi/keyManagement.ts`
+  - Binds New API-family key operations to the current `siteType` via `getApiService(siteType)`.
+- Modify `src/services/apiAdapters/newApi/index.ts`
+  - Exports `createNewApiAdapter(siteType)` so registry-created OneHub/DoneHub/etc adapters keep their site-specific backend overrides.
+- Create `src/services/apiAdapters/sub2api/keyManagement.ts`
+  - Delegates to Sub2API token helpers.
+- Modify `src/services/apiAdapters/sub2api/index.ts`
+  - Attaches `sub2ApiKeyManagement`.
+- Create `src/services/apiAdapters/aihubmix/keyManagement.ts`
+  - Delegates to AIHubMix token helpers and preserves one-time-secret behavior from the backend helper.
+- Modify `src/services/apiAdapters/aihubmix/index.ts`
+  - Attaches `aihubmixKeyManagement`.
+- Modify `src/services/apiAdapters/registry.ts`
+  - Uses `createNewApiAdapter(siteType)` instead of spreading a static adapter.
+- Create `tests/services/apiAdapters/keyManagement.test.ts`
+  - Verifies adapter delegation for New API-family, Sub2API, and AIHubMix.
+- Modify `tests/services/apiAdapters/registry.test.ts`
+  - Verifies registry exposes `keyManagement` for supported adapters.
+- Modify `src/services/accounts/utils/apiServiceRequest.ts`
+  - Adds adapter/key-management context and routes display-account list/secret helpers through it.
+- Modify `tests/services/accounts/apiServiceRequest.test.ts`
+  - Updates mocks and expectations for adapter-backed token helpers.
+- Modify `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+  - Routes post-save inventory/create through adapter key management.
+- Modify `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+  - Routes background-safe default token provisioning through adapter key management.
+- Modify `src/services/accounts/accountOperations.ts`
+  - Routes legacy `ensureAccountApiToken(...)` key list/create through adapter key management while keeping `fetchUserGroups(...)` on `getApiService(...)`.
+- Modify `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+  - Updates key-operation mocks to use `getSiteAdapter(...)`.
+- Modify `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+  - Updates key-operation mocks to use `getSiteAdapter(...)` and keeps `fetchUserGroups(...)` on `getApiService(...)`.
+- Modify `src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts`
+  - Uses display-account token helper for list/refresh and adapter key management for create.
+- Modify `tests/features/AccountManagement/components/CopyKeyDialog.test.tsx`
+  - Updates key-operation mocks to use adapter key management.
+- Modify `tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx`
+  - Updates Sub2API dialog mocks with the same adapter-backed shape.
+- Modify `src/features/AccountManagement/components/AccountActionButtons/index.tsx`
+  - Uses `fetchDisplayAccountTokens(...)` for smart-copy and managed-channel locate inventory reads.
+- Modify `tests/features/AccountManagement/components/AccountActionButtons.test.tsx`
+  - Mocks `fetchDisplayAccountTokens(...)` and preserves behavior assertions.
+
+---
+
+### Task 1: Add Adapter Key Management Capability
+
+**Files:**
+- Create: `src/services/apiAdapters/contracts/keyManagement.ts`
+- Create: `src/services/apiAdapters/newApi/keyManagement.ts`
+- Create: `src/services/apiAdapters/sub2api/keyManagement.ts`
+- Create: `src/services/apiAdapters/aihubmix/keyManagement.ts`
+- Modify: `src/services/apiAdapters/contracts/siteAdapter.ts`
+- Modify: `src/services/apiAdapters/newApi/index.ts`
+- Modify: `src/services/apiAdapters/sub2api/index.ts`
+- Modify: `src/services/apiAdapters/aihubmix/index.ts`
+- Modify: `src/services/apiAdapters/registry.ts`
+- Create: `tests/services/apiAdapters/keyManagement.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write failing adapter delegation tests**
+
+Create `tests/services/apiAdapters/keyManagement.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { aihubmixKeyManagement } from "~/services/apiAdapters/aihubmix/keyManagement"
+import { createNewApiKeyManagement } from "~/services/apiAdapters/newApi/keyManagement"
+import { sub2ApiKeyManagement } from "~/services/apiAdapters/sub2api/keyManagement"
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import { AuthTypeEnum, type ApiToken } from "~/types"
+
+const {
+  getApiServiceMock,
+  newApiFetchTokensMock,
+  newApiCreateTokenMock,
+  newApiResolveTokenKeyMock,
+  sub2ApiFetchTokensMock,
+  sub2ApiCreateTokenMock,
+  sub2ApiResolveTokenKeyMock,
+  aihubmixFetchTokensMock,
+  aihubmixCreateTokenMock,
+  aihubmixResolveTokenKeyMock,
+} = vi.hoisted(() => ({
+  getApiServiceMock: vi.fn(),
+  newApiFetchTokensMock: vi.fn(),
+  newApiCreateTokenMock: vi.fn(),
+  newApiResolveTokenKeyMock: vi.fn(),
+  sub2ApiFetchTokensMock: vi.fn(),
+  sub2ApiCreateTokenMock: vi.fn(),
+  sub2ApiResolveTokenKeyMock: vi.fn(),
+  aihubmixFetchTokensMock: vi.fn(),
+  aihubmixCreateTokenMock: vi.fn(),
+  aihubmixResolveTokenKeyMock: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: (...args: unknown[]) => getApiServiceMock(...args),
+  }
+})
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchAccountTokens: (...args: unknown[]) => sub2ApiFetchTokensMock(...args),
+  createApiToken: (...args: unknown[]) => sub2ApiCreateTokenMock(...args),
+  resolveApiTokenKey: (...args: unknown[]) => sub2ApiResolveTokenKeyMock(...args),
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  fetchAccountTokens: (...args: unknown[]) => aihubmixFetchTokensMock(...args),
+  createApiToken: (...args: unknown[]) => aihubmixCreateTokenMock(...args),
+  resolveApiTokenKey: (...args: unknown[]) =>
+    aihubmixResolveTokenKeyMock(...args),
+}))
+
+const request: ApiServiceRequest = {
+  baseUrl: "https://api.example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "7",
+    accessToken: "access-token",
+  },
+}
+
+const token = {
+  id: 11,
+  user_id: 7,
+  key: "sk-token",
+  status: 1,
+  name: "default",
+  created_time: 1,
+  accessed_time: 1,
+  expired_time: -1,
+  remain_quota: 0,
+  unlimited_quota: true,
+  used_quota: 0,
+} as ApiToken
+
+const tokenRequest = {
+  name: "default",
+  remain_quota: 0,
+  expired_time: -1,
+  unlimited_quota: true,
+  model_limits_enabled: false,
+  model_limits: "",
+  allow_ips: "",
+  group: "",
+}
+
+describe("keyManagement adapters", () => {
+  beforeEach(() => {
+    getApiServiceMock.mockReset()
+    newApiFetchTokensMock.mockReset()
+    newApiCreateTokenMock.mockReset()
+    newApiResolveTokenKeyMock.mockReset()
+    sub2ApiFetchTokensMock.mockReset()
+    sub2ApiCreateTokenMock.mockReset()
+    sub2ApiResolveTokenKeyMock.mockReset()
+    aihubmixFetchTokensMock.mockReset()
+    aihubmixCreateTokenMock.mockReset()
+    aihubmixResolveTokenKeyMock.mockReset()
+  })
+
+  it("delegates New API-family key operations through the bound site type", async () => {
+    const service = {
+      fetchAccountTokens: newApiFetchTokensMock.mockResolvedValue([token]),
+      createApiToken: newApiCreateTokenMock.mockResolvedValue(token),
+      resolveApiTokenKey: newApiResolveTokenKeyMock.mockResolvedValue("sk-real"),
+    }
+    getApiServiceMock.mockReturnValue(service)
+
+    const keyManagement = createNewApiKeyManagement(SITE_TYPES.ONE_HUB)
+
+    await expect(
+      keyManagement.fetchTokens(request, { page: 2, size: 25 }),
+    ).resolves.toEqual([token])
+    await expect(keyManagement.createToken(request, tokenRequest)).resolves.toBe(
+      token,
+    )
+    await expect(
+      keyManagement.resolveTokenKey({ request, token }),
+    ).resolves.toBe("sk-real")
+
+    expect(getApiServiceMock).toHaveBeenCalledWith(SITE_TYPES.ONE_HUB)
+    expect(newApiFetchTokensMock).toHaveBeenCalledWith(request, 2, 25)
+    expect(newApiCreateTokenMock).toHaveBeenCalledWith(request, tokenRequest)
+    expect(newApiResolveTokenKeyMock).toHaveBeenCalledWith(request, token)
+  })
+
+  it("delegates Sub2API key operations to the Sub2API helpers", async () => {
+    sub2ApiFetchTokensMock.mockResolvedValue([token])
+    sub2ApiCreateTokenMock.mockResolvedValue(token)
+    sub2ApiResolveTokenKeyMock.mockResolvedValue("sub2-real")
+
+    await expect(
+      sub2ApiKeyManagement.fetchTokens(request, { page: 3, size: 10 }),
+    ).resolves.toEqual([token])
+    await expect(
+      sub2ApiKeyManagement.createToken(request, tokenRequest),
+    ).resolves.toBe(token)
+    await expect(
+      sub2ApiKeyManagement.resolveTokenKey({ request, token }),
+    ).resolves.toBe("sub2-real")
+
+    expect(sub2ApiFetchTokensMock).toHaveBeenCalledWith(request, 3, 10)
+    expect(sub2ApiCreateTokenMock).toHaveBeenCalledWith(request, tokenRequest)
+    expect(sub2ApiResolveTokenKeyMock).toHaveBeenCalledWith(request, token)
+  })
+
+  it("delegates AIHubMix key operations to the AIHubMix helpers", async () => {
+    aihubmixFetchTokensMock.mockResolvedValue([token])
+    aihubmixCreateTokenMock.mockResolvedValue(token)
+    aihubmixResolveTokenKeyMock.mockResolvedValue("aihubmix-real")
+
+    await expect(aihubmixKeyManagement.fetchTokens(request)).resolves.toEqual([
+      token,
+    ])
+    await expect(
+      aihubmixKeyManagement.createToken(request, tokenRequest),
+    ).resolves.toBe(token)
+    await expect(
+      aihubmixKeyManagement.resolveTokenKey({ request, token }),
+    ).resolves.toBe("aihubmix-real")
+
+    expect(aihubmixFetchTokensMock).toHaveBeenCalledWith(request)
+    expect(aihubmixCreateTokenMock).toHaveBeenCalledWith(request, tokenRequest)
+    expect(aihubmixResolveTokenKeyMock).toHaveBeenCalledWith(request, token)
+  })
+})
+```
+
+Update `tests/services/apiAdapters/registry.test.ts` expectations:
+
+```ts
+expect(adapter.keyManagement).toEqual({
+  fetchTokens: expect.any(Function),
+  createToken: expect.any(Function),
+  resolveTokenKey: expect.any(Function),
+})
+```
+
+Add the expectation inside the Sub2API test, the New API-family loop, and the AIHubMix test.
+
+- [ ] **Step 2: Run tests to verify the capability is missing**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because `keyManagement.ts` files and `adapter.keyManagement` do not exist yet.
+
+- [ ] **Step 3: Add the adapter contract**
+
+Create `src/services/apiAdapters/contracts/keyManagement.ts`:
+
+```ts
+import type {
+  ApiServiceRequest,
+  CreateTokenRequest,
+  CreateTokenResult,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+
+export type FetchAccountTokensOptions = {
+  page?: number
+  size?: number
+}
+
+export type ResolveTokenSecretRequest<
+  TToken extends Pick<ApiToken, "id" | "key"> = Pick<ApiToken, "id" | "key">,
+> = {
+  request: ApiServiceRequest
+  token: TToken
+}
+
+export type KeyManagementCapability = {
+  fetchTokens(
+    request: ApiServiceRequest,
+    options?: FetchAccountTokensOptions,
+  ): Promise<ApiToken[]>
+  createToken(
+    request: ApiServiceRequest,
+    tokenData: CreateTokenRequest,
+  ): Promise<CreateTokenResult>
+  resolveTokenKey<TToken extends Pick<ApiToken, "id" | "key">>(
+    params: ResolveTokenSecretRequest<TToken>,
+  ): Promise<string>
+}
+```
+
+Modify `src/services/apiAdapters/contracts/siteAdapter.ts`:
+
+```ts
+import type { KeyManagementCapability } from "./keyManagement"
+```
+
+Add the property to `SiteAdapter`:
+
+```ts
+  keyManagement?: KeyManagementCapability
+```
+
+- [ ] **Step 4: Implement New API-family key management with a bound site type**
+
+Create `src/services/apiAdapters/newApi/keyManagement.ts`:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import { getApiService } from "~/services/apiService"
+
+import type { KeyManagementCapability } from "../contracts/keyManagement"
+
+export const createNewApiKeyManagement = (
+  siteType: AccountSiteType,
+): KeyManagementCapability => ({
+  fetchTokens(request, options) {
+    return getApiService(siteType).fetchAccountTokens(
+      request,
+      options?.page,
+      options?.size,
+    )
+  },
+  createToken(request, tokenData) {
+    return getApiService(siteType).createApiToken(request, tokenData)
+  },
+  resolveTokenKey({ request, token }) {
+    return getApiService(siteType).resolveApiTokenKey(request, token)
+  },
+})
+```
+
+Replace `src/services/apiAdapters/newApi/index.ts` with:
+
+```ts
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+
+import type { SiteAdapter } from "../contracts/siteAdapter"
+import { newApiAccountCompletion } from "./accountCompletion"
+import { createNewApiKeyManagement } from "./keyManagement"
+import { newApiSiteNotice } from "./siteNotice"
+
+export const createNewApiAdapter = (
+  siteType: AccountSiteType = SITE_TYPES.NEW_API,
+): SiteAdapter => ({
+  siteType,
+  family: "newApiFamily",
+  siteNotice: newApiSiteNotice,
+  accountCompletion: newApiAccountCompletion,
+  keyManagement: createNewApiKeyManagement(siteType),
+})
+
+export const newApiAdapter = createNewApiAdapter(SITE_TYPES.NEW_API)
+```
+
+- [ ] **Step 5: Implement Sub2API and AIHubMix key management**
+
+Create `src/services/apiAdapters/sub2api/keyManagement.ts`:
+
+```ts
+import {
+  createApiToken,
+  fetchAccountTokens,
+  resolveApiTokenKey,
+} from "~/services/apiService/sub2api"
+
+import type { KeyManagementCapability } from "../contracts/keyManagement"
+
+export const sub2ApiKeyManagement: KeyManagementCapability = {
+  fetchTokens(request, options) {
+    return fetchAccountTokens(request, options?.page, options?.size)
+  },
+  createToken(request, tokenData) {
+    return createApiToken(request, tokenData)
+  },
+  resolveTokenKey({ request, token }) {
+    return resolveApiTokenKey(request, token)
+  },
+}
+```
+
+Modify `src/services/apiAdapters/sub2api/index.ts`:
+
+```ts
+import { sub2ApiKeyManagement } from "./keyManagement"
+```
+
+Add the property:
+
+```ts
+  keyManagement: sub2ApiKeyManagement,
+```
+
+Create `src/services/apiAdapters/aihubmix/keyManagement.ts`:
+
+```ts
+import {
+  createApiToken,
+  fetchAccountTokens,
+  resolveApiTokenKey,
+} from "~/services/apiService/aihubmix"
+
+import type { KeyManagementCapability } from "../contracts/keyManagement"
+
+export const aihubmixKeyManagement: KeyManagementCapability = {
+  fetchTokens(request) {
+    return fetchAccountTokens(request)
+  },
+  createToken(request, tokenData) {
+    return createApiToken(request, tokenData)
+  },
+  resolveTokenKey({ request, token }) {
+    return resolveApiTokenKey(request, token)
+  },
+}
+```
+
+Modify `src/services/apiAdapters/aihubmix/index.ts`:
+
+```ts
+import { aihubmixKeyManagement } from "./keyManagement"
+```
+
+Add the property:
+
+```ts
+  keyManagement: aihubmixKeyManagement,
+```
+
+- [ ] **Step 6: Update registry to use the New API adapter factory**
+
+Modify `src/services/apiAdapters/registry.ts`:
+
+```ts
+import { createNewApiAdapter } from "./newApi"
+```
+
+Replace `createNewApiFamilyAdapter` with:
+
+```ts
+const createNewApiFamilyAdapter = (siteType: AccountSiteType): SiteAdapter =>
+  createNewApiAdapter(siteType)
+```
+
+This preserves OneHub/DoneHub/Veloera key overrides because `keyManagement` now calls `getApiService(siteType)` with the registry site type.
+
+- [ ] **Step 7: Run adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit adapter capability**
+
+Run:
+
+```powershell
+git add src/services/apiAdapters/contracts/keyManagement.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/keyManagement.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/sub2api/keyManagement.ts src/services/apiAdapters/sub2api/index.ts src/services/apiAdapters/aihubmix/keyManagement.ts src/services/apiAdapters/aihubmix/index.ts src/services/apiAdapters/registry.ts tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts
+git commit -m "feat(api-adapters): add key management capability"
+```
+
+Expected: commit succeeds after the repo hook runs.
+
+---
+
+### Task 2: Route Display-Account Token Helpers Through Adapter
+
+**Files:**
+- Modify: `src/services/accounts/utils/apiServiceRequest.ts`
+- Modify: `tests/services/accounts/apiServiceRequest.test.ts`
+
+- [ ] **Step 1: Update failing helper tests**
+
+Modify `tests/services/accounts/apiServiceRequest.test.ts` imports:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import { getApiService } from "~/services/apiService"
+```
+
+Add the registry mock:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(),
+}))
+```
+
+Keep the `getApiService` mock because `createDisplayAccountApiContext(...)` remains a transitional context for non-migrated CRUD/group callers:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: vi.fn(),
+}))
+```
+
+Use this setup in `beforeEach`:
+
+```ts
+let fetchTokens: ReturnType<typeof vi.fn>
+let createToken: ReturnType<typeof vi.fn>
+let resolveTokenKey: ReturnType<typeof vi.fn>
+let keyManagement: {
+  fetchTokens: typeof fetchTokens
+  createToken: typeof createToken
+  resolveTokenKey: typeof resolveTokenKey
+}
+let adapter: { siteType: string; keyManagement?: typeof keyManagement }
+let service: { fetchUserGroups: ReturnType<typeof vi.fn> }
+
+beforeEach(() => {
+  fetchTokens = vi.fn()
+  createToken = vi.fn()
+  resolveTokenKey = vi.fn()
+  keyManagement = { fetchTokens, createToken, resolveTokenKey }
+  adapter = { siteType: "new-api", keyManagement }
+  service = { fetchUserGroups: vi.fn() }
+  vi.mocked(getSiteAdapter).mockReset()
+  vi.mocked(getSiteAdapter).mockReturnValue(adapter as any)
+  vi.mocked(getApiService).mockReset()
+  vi.mocked(getApiService).mockReturnValue(service as any)
+})
+```
+
+Change the valid payload test to expect adapter-backed calls:
+
+```ts
+fetchTokens.mockResolvedValue([{ id: 1, key: "sk-test", status: 1 }])
+
+const result = await fetchDisplayAccountTokens(ACCOUNT as any)
+
+expect(result).toEqual([{ id: 1, key: "sk-test", status: 1 }])
+expect(fetchTokens).toHaveBeenCalledWith({
+  baseUrl: "https://example.com",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "1",
+    accessToken: "token",
+    cookie: "",
+  },
+})
+expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual({
+  service,
+  adapter,
+  keyManagement,
+  request: {
+    baseUrl: "https://example.com",
+    accountId: "account-1",
+    auth: {
+      authType: AuthTypeEnum.AccessToken,
+      userId: "1",
+      accessToken: "token",
+      cookie: "",
+    },
+  },
+})
+```
+
+Change secret-resolution tests to use `resolveTokenKey`:
+
+```ts
+resolveTokenKey.mockResolvedValue("sk-real")
+```
+
+Add a missing-capability test:
+
+```ts
+it("fails clearly when the site adapter does not expose key management", async () => {
+  vi.mocked(getSiteAdapter).mockReturnValue({
+    siteType: "unsupported",
+  } as any)
+
+  await expect(
+    fetchDisplayAccountTokens({ ...ACCOUNT, siteType: "unsupported" } as any),
+  ).rejects.toThrow("keyManagement is not implemented for unsupported")
+})
+```
+
+- [ ] **Step 2: Run tests to verify old helper routing fails**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: FAIL because `fetchDisplayAccountTokens(...)` still calls `service.fetchAccountTokens(...)`.
+
+- [ ] **Step 3: Implement adapter-backed display-account context**
+
+Modify `src/services/accounts/utils/apiServiceRequest.ts` imports:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+```
+
+Add this helper after the logger:
+
+```ts
+export const createMissingKeyManagementCapabilityError = (
+  siteType: string,
+): Error => new Error(`keyManagement is not implemented for ${siteType}`)
+
+export const requireDisplayAccountKeyManagement = (
+  account: Pick<DisplaySiteData, "siteType">,
+  keyManagement: KeyManagementCapability | undefined,
+): KeyManagementCapability => {
+  if (!keyManagement) {
+    throw createMissingKeyManagementCapabilityError(account.siteType)
+  }
+
+  return keyManagement
+}
+```
+
+Change `createDisplayAccountApiContext(...)`:
+
+```ts
+export const createDisplayAccountApiContext = (
+  account: Pick<
+    DisplaySiteData,
+    | "siteType"
+    | "baseUrl"
+    | "id"
+    | "authType"
+    | "userId"
+    | "token"
+    | "cookieAuthSessionCookie"
+  >,
+) => {
+  const adapter = getSiteAdapter(account.siteType)
+
+  return {
+    service: getApiService(account.siteType),
+    adapter,
+    keyManagement: adapter.keyManagement,
+    request: buildApiRequestFromDisplayAccount(account),
+  }
+}
+```
+
+Change `fetchDisplayAccountTokens(...)`:
+
+```ts
+  const { keyManagement, request } = createDisplayAccountApiContext(account)
+  const tokensResponse = await requireDisplayAccountKeyManagement(
+    account,
+    keyManagement,
+  ).fetchTokens(request)
+```
+
+Change `resolveDisplayAccountTokenForSecret(...)`:
+
+```ts
+  const { keyManagement, request } = createDisplayAccountApiContext(account)
+  const resolvedKey = await requireDisplayAccountKeyManagement(
+    account,
+    keyManagement,
+  ).resolveTokenKey({ request, token })
+```
+
+- [ ] **Step 4: Run display-account helper tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit display-account helper migration**
+
+Run:
+
+```powershell
+git add src/services/accounts/utils/apiServiceRequest.ts tests/services/accounts/apiServiceRequest.test.ts
+git commit -m "refactor(accounts): route display token helpers through adapters"
+```
+
+Expected: commit succeeds after the repo hook runs.
+
+---
+
+### Task 3: Route Account Token Provisioning Through Adapter
+
+**Files:**
+- Modify: `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+- Modify: `src/services/accounts/accountOperations.ts`
+- Modify: `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+- Modify: `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+
+- [ ] **Step 1: Update provisioning tests to mock adapter key operations**
+
+In `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`, add the registry mock:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(() => ({
+    keyManagement: {
+      fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+      createToken: (...args: unknown[]) => createApiTokenMock(...args),
+      resolveTokenKey: vi.fn(),
+    },
+  })),
+}))
+```
+
+Keep `~/services/apiService` mocked only for `fetchUserGroups(...)`:
+
+```ts
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => ({
+      fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
+    })),
+  }
+})
+```
+
+In `tests/services/accountOperations.ensureAccountApiToken.test.ts`, use the same adapter mock:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(() => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
+      createToken: (...args: any[]) => createApiTokenMock(...args),
+      resolveTokenKey: vi.fn(),
+    },
+  })),
+}))
+```
+
+Keep this `getApiService` shape for Sub2API groups:
+
+```ts
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => ({
+      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+    })),
+  }
+})
+```
+
+- [ ] **Step 2: Run provisioning tests to verify old routing fails**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Expected: FAIL because implementation still expects `getApiService(...).fetchAccountTokens` and `getApiService(...).createApiToken`.
+
+- [ ] **Step 3: Update post-save token workflow**
+
+Modify `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts` imports:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Replace inventory loading in `inspectAccountTokenInventory(...)`:
+
+```ts
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
+  const tokens = await keyManagement.fetchTokens(
+    buildDisplayAccountRequest(displaySiteData),
+  )
+```
+
+Replace service usage in `createDefaultToken(...)`:
+
+```ts
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
+  const tokenData = generateDefaultTokenRequest()
+  if (typeof group === "string") {
+    tokenData.group = group
+  }
+
+  const created = await keyManagement.createToken(
+    buildCreateRequest(account),
+    tokenData,
+  )
+```
+
+Replace the follow-up inventory fetch:
+
+```ts
+  const updatedTokens = await keyManagement.fetchTokens(
+    buildDisplayAccountRequest(displaySiteData),
+  )
+```
+
+Remove the now-unused `getApiService` import.
+
+- [ ] **Step 4: Update default-token auto-provisioning**
+
+Modify `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts` imports:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+At the start of `ensureDefaultApiTokenForAccount(...)`, replace `service` with reusable requests and key management:
+
+```ts
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
+  const displayAccountRequest = {
+    baseUrl: displaySiteData.baseUrl,
+    accountId: displaySiteData.id,
+    auth: {
+      authType: displaySiteData.authType,
+      userId: displaySiteData.userId,
+      accessToken: displaySiteData.token,
+      cookie: displaySiteData.cookieAuthSessionCookie,
+    },
+  }
+  const createAccountRequest = {
+    baseUrl: account.site_url,
+    accountId: account.id,
+    auth: {
+      authType: account.authType,
+      userId: account.account_info.id,
+      accessToken: account.account_info.access_token,
+      cookie: account.cookieAuth?.sessionCookie,
+    },
+  }
+```
+
+Replace all key calls:
+
+```ts
+  const tokens = await keyManagement.fetchTokens(displayAccountRequest)
+```
+
+```ts
+  const createApiTokenResult = await keyManagement.createToken(
+    createAccountRequest,
+    newTokenData,
+  )
+```
+
+```ts
+  const updatedTokens = await keyManagement.fetchTokens(displayAccountRequest)
+```
+
+Remove the now-unused `getApiService` import.
+
+- [ ] **Step 5: Update legacy `ensureAccountApiToken(...)`**
+
+Modify `src/services/accounts/accountOperations.ts` imports:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+At the start of `ensureAccountApiToken(...)`, after `options`, define:
+
+```ts
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
+  const displayAccountRequest = {
+    baseUrl: displaySiteData.baseUrl,
+    accountId: displaySiteData.id,
+    auth: {
+      authType: displaySiteData.authType,
+      userId: displaySiteData.userId,
+      accessToken: displaySiteData.token,
+      cookie: displaySiteData.cookieAuthSessionCookie,
+    },
+  }
+  const createAccountRequest = {
+    baseUrl: account.site_url,
+    accountId: account.id,
+    auth: {
+      authType: account.authType,
+      userId: account.account_info.id,
+      accessToken: account.account_info.access_token,
+      cookie: account.cookieAuth?.sessionCookie,
+    },
+  }
+```
+
+Replace key calls:
+
+```ts
+  const tokens = await keyManagement.fetchTokens(displayAccountRequest)
+```
+
+```ts
+    const createApiTokenResult = await keyManagement.createToken(
+      createAccountRequest,
+      newTokenData,
+    )
+```
+
+```ts
+      const updatedTokens = await keyManagement.fetchTokens(
+        displayAccountRequest,
+      )
+```
+
+Keep `getApiService(...)` imported in this file because `fetchAccountData(...)`, `getOrCreateAccessToken(...)`, and `resolveSub2ApiQuickCreateResolution(...)` still use it.
+
+- [ ] **Step 6: Run provisioning tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit provisioning migration**
+
+Run:
+
+```powershell
+git add src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountOperations.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts
+git commit -m "refactor(accounts): use key management adapters for token provisioning"
+```
+
+Expected: commit succeeds after the repo hook runs.
+
+---
+
+### Task 4: Route Account Row And Copy Dialog Token Reads Through Adapter
+
+**Files:**
+- Modify: `src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts`
+- Modify: `src/features/AccountManagement/components/AccountActionButtons/index.tsx`
+- Modify: `tests/features/AccountManagement/components/CopyKeyDialog.test.tsx`
+- Modify: `tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx`
+- Modify: `tests/features/AccountManagement/components/AccountActionButtons.test.tsx`
+
+- [ ] **Step 1: Update UI tests for adapter-backed token calls**
+
+In `tests/features/AccountManagement/components/CopyKeyDialog.test.tsx`, add `getSiteAdapter` mocking:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
+      createToken: (...args: any[]) => createApiTokenMock(...args),
+      resolveTokenKey: (...args: any[]) => resolveApiTokenKeyMock(...args),
+    },
+  }),
+}))
+```
+
+Keep `getApiService` for model and group helpers:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: () => ({
+    fetchAccountAvailableModels: (...args: any[]) =>
+      fetchAccountAvailableModelsMock(...args),
+    fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+  }),
+}))
+```
+
+Apply the same mock split in `tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx`.
+
+In `tests/features/AccountManagement/components/AccountActionButtons.test.tsx`, replace the `~/services/apiService` token-list mock with a partial mock for display-account helpers:
+
+```ts
+vi.mock(
+  "~/services/accounts/utils/apiServiceRequest",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/accounts/utils/apiServiceRequest")
+      >()
+    return {
+      ...actual,
+      fetchDisplayAccountTokens: (...args: unknown[]) =>
+        fetchAccountTokensMock(...args),
+      resolveDisplayAccountTokenForSecret: async (
+        _account: unknown,
+        token: { key: string },
+      ) => token,
+    }
+  },
+)
+```
+
+Remove `fetchAccountTokensMock` from the `~/services/apiService` mock in this test file if no other assertion needs it.
+
+- [ ] **Step 2: Run UI tests to verify old direct service calls fail**
+
+Run:
+
+```powershell
+pnpm vitest run tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+```
+
+Expected: FAIL until UI implementation uses adapter-backed helpers.
+
+- [ ] **Step 3: Update Copy Key dialog hook**
+
+Modify `src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts` imports:
+
+```ts
+import {
+  canManageDisplayAccountTokens,
+  createDisplayAccountApiContext,
+  fetchDisplayAccountTokens,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Change `fetchTokens`:
+
+```ts
+      const tokensResponse = await fetchDisplayAccountTokens(account)
+      setTokens(tokensResponse)
+```
+
+Keep the existing catch block so load failures still set localized `loadFailed` copy.
+
+Change `refreshTokensAfterCreate(...)`:
+
+```ts
+        const refreshedTokens = await fetchDisplayAccountTokens(account)
+        setTokens(refreshedTokens)
+```
+
+Change `createDefaultKey(...)` before calling create:
+
+```ts
+      const { keyManagement, request } = createDisplayAccountApiContext(account)
+      const created = await requireDisplayAccountKeyManagement(
+        account,
+        keyManagement,
+      ).createToken(request, tokenRequest)
+```
+
+Keep the Sub2API quick-create resolution block before `createToken(...)`, and keep one-time-key handling in `refreshTokensAfterCreate(...)`.
+
+- [ ] **Step 4: Update account row action token list calls**
+
+Modify `src/features/AccountManagement/components/AccountActionButtons/index.tsx` imports:
+
+```ts
+import {
+  fetchDisplayAccountTokens,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Remove:
+
+```ts
+import { getApiService } from "~/services/apiService"
+```
+
+Replace the smart-copy inventory block with:
+
+```ts
+      const tokensResponse = await fetchDisplayAccountTokens(site)
+
+      if (tokensResponse.length === 1) {
+        const token = tokensResponse[0]
+        const resolvedToken = await resolveDisplayAccountTokenForSecret(
+          site,
+          token,
+        )
+        await navigator.clipboard.writeText(resolvedToken.key)
+        toast.success(t("actions.keyCopied"))
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
+          insights: {
+            itemCount: tokensResponse.length,
+          },
+        })
+      } else {
+        onCopyKey(site)
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped, {
+          insights: {
+            itemCount: tokensResponse.length,
+          },
+        })
+      }
+```
+
+Replace managed-channel locate inventory loading with:
+
+```ts
+      const tokensResponse = await fetchDisplayAccountTokens({
+        ...site,
+        baseUrl: accountBaseUrl,
+      })
+```
+
+Remove the old non-array branch in managed-channel locate because `fetchDisplayAccountTokens(...)` now owns invalid payload detection and throws `InvalidTokenPayloadError`.
+
+- [ ] **Step 5: Run UI tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit UI token-flow migration**
+
+Run:
+
+```powershell
+git add src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts src/features/AccountManagement/components/AccountActionButtons/index.tsx tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+git commit -m "refactor(account-ui): use key management adapters for token flows"
+```
+
+Expected: commit succeeds after the repo hook runs.
+
+---
+
+### Task 5: Final Validation And Scope Audit
+
+**Files:**
+- Inspect all task-scoped files changed in Tasks 1-4.
+
+- [ ] **Step 1: Run focused adapter and account tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accounts/apiServiceRequest.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused UI tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run related tests for changed source files**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/contracts/keyManagement.ts src/services/apiAdapters/registry.ts src/services/accounts/utils/apiServiceRequest.ts src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountOperations.ts src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts src/features/AccountManagement/components/AccountActionButtons/index.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run TypeScript compile**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run commit gate**
+
+Run:
+
+```powershell
+git status --porcelain=v1
+pnpm run validate:staged
+```
+
+Expected: `validate:staged` passes for task-scoped staged files. Unrelated pre-existing untracked files may remain untracked and must not be staged.
+
+- [ ] **Step 6: Run push gate before publishing**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. This gate is required before pushing or opening a PR because the slice changes shared TypeScript contracts and account workflow routing.
+
+- [ ] **Step 7: Inspect final diff for scope**
+
+Run:
+
+```powershell
+git diff --stat HEAD
+git diff -- src/services/apiAdapters src/services/accounts src/features/AccountManagement/components tests/services tests/features/AccountManagement
+```
+
+Expected: diff contains only key-management adapter contract/wrappers, account token-flow routing, and focused tests. No locale files, telemetry schema, settings search files, Playwright tests, managed-site provider logic, redemption logic, or new site types are changed.
+
+---
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+No new user action, setting, route, or analytics field is introduced. Existing copy-key, create-key, post-save, and managed-channel locate events remain emitted by their current owners.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E for this slice.
+
+The behavior risk is adapter routing and response-shape preservation. Vitest coverage at adapter, service workflow, hook, and component levels directly covers that risk. Browser-level extension behavior is not the primary risk in this refactor.
+
+## Self-Review
+
+- Spec coverage: Task 1 adds the capability for New API-family, Sub2API, and AIHubMix. Task 2 routes display-account list/secret helpers. Task 3 routes post-save/default-token workflows. Task 4 routes Copy Key dialog and account row flows. Task 5 covers validation, telemetry, and E2E decisions.
+- Scope control: The plan does not migrate full Key Management CRUD, `fetchUserGroups(...)`, redemption, model pricing, managed-site providers, site detection, locale files, telemetry schema, settings search, Playwright tests, or new site types.
+- Type consistency: The plan consistently uses `keyManagement.fetchTokens(request, options)`, `keyManagement.createToken(request, tokenData)`, and `keyManagement.resolveTokenKey({ request, token })`.
+- Compatibility: `createDisplayAccountApiContext(...)` keeps `service` while adding `adapter` and `keyManagement`, so existing non-migrated Key Management page callers keep working during this slice.

--- a/docs/superpowers/plans/2026-06-18-api-adapter-key-management.md
+++ b/docs/superpowers/plans/2026-06-18-api-adapter-key-management.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** TypeScript, WXT extension service modules, React account-management UI, Vitest with existing test utilities.
 
+**Implementation status:** Shipped in this branch. The task sections below are retained as the execution record for the completed slice, not as remaining work.
+
 ---
 
 ## File Structure
@@ -61,7 +63,7 @@
 
 ---
 
-### Task 1: Add Adapter Key Management Capability
+### Task 1: Add Adapter Key Management Capability (shipped)
 
 **Files:**
 - Create: `src/services/apiAdapters/contracts/keyManagement.ts`
@@ -1141,13 +1143,19 @@ Replace the smart-copy inventory block with:
       }
 ```
 
-Replace managed-channel locate inventory loading with:
+Replace managed-channel locate inventory and secret-resolution account loading with:
 
 ```ts
-      const tokensResponse = await fetchDisplayAccountTokens({
+      const tokenLookupAccount = {
         ...site,
         baseUrl: accountBaseUrl,
-      })
+      }
+      const tokensResponse = await fetchDisplayAccountTokens(tokenLookupAccount)
+      // ...
+      const resolvedToken = await resolveDisplayAccountTokenForSecret(
+        tokenLookupAccount,
+        apiToken,
+      )
 ```
 
 Remove the old non-array branch in managed-channel locate because `fetchDisplayAccountTokens(...)` now owns invalid payload detection and throws `InvalidTokenPayloadError`.

--- a/docs/superpowers/specs/2026-06-18-api-adapter-key-management-design.md
+++ b/docs/superpowers/specs/2026-06-18-api-adapter-key-management-design.md
@@ -1,0 +1,558 @@
+# API Adapter Key Management Design
+
+Date: 2026-06-18
+
+## Purpose
+
+Move account token inventory, default token creation, and token-secret
+resolution behind the `apiAdapters` Seam so new account site types can become
+usable after account detection without scattering backend-specific key behavior
+across account workflows and UI entry points.
+
+The recent adapter slices established `getSiteAdapter(siteType)` for site
+announcements, runtime model catalog discovery, and account auto-detect
+completion. The next highest-leverage slice is key management because a newly
+adapted site is not practically usable unless the product can list API keys,
+create a default key when appropriate, and resolve a displayed key into a
+usable secret for copy/export/model-list flows.
+
+## Current Context
+
+The current `SiteAdapter` Interface exposes:
+
+```ts
+type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  accountCompletion?: AccountCompletionCapability
+}
+```
+
+`src/services/apiService/index.ts` still provides the legacy compatibility
+facade. It merges `common` helpers with site overrides and still exposes
+`capabilities.keyManagement`, but product Modules use concrete helper names
+directly:
+
+- `fetchAccountTokens(...)`
+- `createApiToken(...)`
+- `resolveApiTokenKey(...)`
+- in some flows, `deleteApiToken(...)`, `updateApiToken(...)`, and
+  `fetchUserGroups(...)`
+
+Important current callers:
+
+- `src/services/accounts/utils/apiServiceRequest.ts`
+  - builds display-account requests
+  - fetches token inventory
+  - resolves masked/displayed token keys into usable secrets
+- `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+  - inspects token inventory after save
+  - creates a default token
+  - preserves AIHubMix one-time-secret handling
+  - preserves Sub2API group-selection handling
+- `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+  - background-safe default token provisioning
+- `src/services/accounts/accountOperations.ts`
+  - older `ensureAccountApiToken(...)` compatibility helper
+- `src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts`
+  - loads keys
+  - copies resolved secrets
+  - creates a default key from the account row dialog
+- `src/features/AccountManagement/components/AccountActionButtons/index.tsx`
+  - smart-copy key shortcut
+  - managed-site channel locate flow that needs the account token secret
+
+Backend behavior already differs:
+
+- New API-family sites use common token routes and optional `sk-` display/auth
+  semantics.
+- OneHub and DoneHub override token inventory response parsing.
+- Sub2API key routes live under `/api/v1/keys`; key detail is the defensive
+  secret-resolution fallback and must not fall through to One/New API
+  `/api/token/{id}/key`.
+- AIHubMix can expose the full key only at creation time; saved/listed/detail
+  keys may be masked and not revealable later.
+
+## Problem
+
+The old flat `getApiService(...)` Interface keeps key-management behavior
+working, but it is a shallow Interface for new site adaptation:
+
+1. Product Modules must know which site types need special creation handling
+   (`Sub2API` group selection, `AIHubMix` one-time secret behavior).
+2. Token inventory and secret resolution are scattered across account
+   workflows, row actions, copy dialogs, Model List, managed-site helpers, and
+   repair flows.
+3. New site support requires editing both the low-level backend implementation
+   and multiple product callers to avoid wrong fallback behavior.
+4. The existing `capabilities.keyManagement` boolean is too coarse. It cannot
+   express "can list", "can create but the secret is one-time", "can resolve
+   masked keys", or "create needs a selected group".
+
+Deletion test: if direct `getApiService(...).fetchAccountTokens` and
+`resolveApiTokenKey` calls were removed from account product Modules, the
+complexity should not reappear as direct imports from `apiService/sub2api` or
+`apiService/aihubmix`. It should sit behind a `keyManagement` capability on the
+site Adapter, with product Modules handling product-level UX and result
+mapping.
+
+## Goals
+
+- Add a `keyManagement` Adapter capability.
+- Keep the first Interface narrow enough to accelerate new site support:
+  - list account tokens
+  - create account tokens
+  - resolve token secrets
+- Implement the capability for:
+  - New API-family compatible sites
+  - Sub2API
+  - AIHubMix
+- Route display-account token helpers through
+  `getSiteAdapter(siteType).keyManagement`.
+- Route post-save/default-token account workflows through the capability.
+- Route the account-row copy-key and managed-channel locate flows through the
+  existing display-account helper instead of direct `getApiService(...)` calls.
+- Preserve current behavior for:
+  - optional `sk-` formatting
+  - masked-key handling
+  - AIHubMix one-time-secret UX
+  - Sub2API group-required and single-group quick-create behavior
+  - token list invalid-payload errors
+  - product analytics and user-facing copy
+- Keep backend protocol logic in the existing `apiService/*` Modules for this
+  slice. The Adapter should delegate rather than reimplement HTTP behavior.
+
+## Non-Goals
+
+- Do not migrate full Key Management page CRUD in the first implementation
+  slice.
+- Do not migrate `updateApiToken(...)`, `deleteApiToken(...)`,
+  `fetchTokenById(...)`, `searchApiTokens(...)`, or group-repair deletion unless
+  the implementation plan adds a clearly separated follow-up task.
+- Do not migrate `fetchUserGroups(...)` in this first Interface.
+- Do not move Sub2API available-groups or group-rate pricing inputs.
+- Do not migrate redemption, model pricing, managed-site provider behavior, or
+  site detection.
+- Do not remove or rewrite the `getApiService(...)` compatibility facade.
+- Do not change locale keys, telemetry schema, settings search, or Playwright
+  E2E coverage.
+- Do not add a new site type in this slice.
+
+## Approaches Considered
+
+### Approach A: Thin Adapter Wrapper Only
+
+Add `keyManagement` with direct wrappers around `fetchAccountTokens`,
+`createApiToken`, and `resolveApiTokenKey`, then migrate only
+`src/services/accounts/utils/apiServiceRequest.ts`.
+
+This is low risk, but the caller benefit is too small. Post-save token
+provisioning and row actions would still know site-specific details, so new
+site adaptation would still require edits in several places.
+
+### Approach B: Product-Level Key Workflow Module Only
+
+Create a product Module that hides token list/create/secret resolution without
+adding an Adapter capability.
+
+This improves some callers, but it keeps backend capability ownership outside
+the Adapter Seam. A new site still cannot expose truthful capability support
+from `getSiteAdapter(siteType)`.
+
+### Approach C: Adapter Capability Plus Product Caller Migration
+
+Add `keyManagement` to `SiteAdapter`, implement it by delegating to current
+backend helpers, and migrate the display-account helper plus post-save/default
+token workflows first.
+
+This is the recommended path. It is larger than the previous one-function
+slices, but still cohesive: one capability family, one Interface, and a small
+set of high-leverage product callers. It improves Locality for backend-specific
+key rules while preserving current product UX.
+
+## Design
+
+### 1. Add `KeyManagementCapability`
+
+Create:
+
+```text
+src/services/apiAdapters/contracts/keyManagement.ts
+```
+
+Initial Interface:
+
+```ts
+import type {
+  ApiServiceRequest,
+  CreateTokenRequest,
+  CreateTokenResult,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+
+export type FetchAccountTokensOptions = {
+  page?: number
+  size?: number
+}
+
+export type ResolveTokenSecretRequest<TToken extends Pick<ApiToken, "id" | "key">> = {
+  request: ApiServiceRequest
+  token: TToken
+}
+
+export type KeyManagementCapability = {
+  fetchTokens(
+    request: ApiServiceRequest,
+    options?: FetchAccountTokensOptions,
+  ): Promise<ApiToken[]>
+  createToken(
+    request: ApiServiceRequest,
+    tokenData: CreateTokenRequest,
+  ): Promise<CreateTokenResult>
+  resolveTokenKey<TToken extends Pick<ApiToken, "id" | "key">>(
+    params: ResolveTokenSecretRequest<TToken>,
+  ): Promise<string>
+}
+```
+
+Notes:
+
+- The Interface intentionally starts with the product paths needed for account
+  save/copy/export readiness.
+- Pagination stays optional because most current display-account callers use
+  default inventory loading.
+- `resolveTokenKey(...)` returns the raw usable secret. Existing product helpers
+  still format optional `sk-` display/auth keys after resolution.
+- Capability presence is the support signal. Missing `keyManagement` means the
+  Adapter cannot participate in token inventory/create/copy flows.
+
+### 2. Extend `SiteAdapter`
+
+Add:
+
+```ts
+keyManagement?: KeyManagementCapability
+```
+
+Registry expectations:
+
+- New API-family site Adapters expose `keyManagement`.
+- Sub2API exposes `keyManagement`.
+- AIHubMix exposes `keyManagement`.
+- Existing capability expectations for `siteNotice`, `siteAnnouncements`,
+  `modelCatalog`, and `accountCompletion` remain unchanged.
+
+### 3. Add New API-Family Key Management Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/newApi/keyManagement.ts
+```
+
+Implementation should delegate by site type through the compatibility facade:
+
+- `getApiService(siteType).fetchAccountTokens(...)`
+- `getApiService(siteType).createApiToken(...)`
+- `getApiService(siteType).resolveApiTokenKey(...)`
+
+This is important for OneHub/DoneHub/Veloera-style variants that still rely on
+current `getApiService(siteType)` override resolution. The New API-family
+Adapter must not call `common` directly.
+
+### 4. Add Sub2API Key Management Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/sub2api/keyManagement.ts
+```
+
+Implementation should delegate to the existing Sub2API helpers:
+
+- `fetchAccountTokens(...)`
+- `createApiToken(...)`
+- `resolveApiTokenKey(...)`
+
+The Adapter should preserve the Sub2API contract that secret resolution may use
+key detail as a defensive fallback and must never fall through to compatible
+`/api/token/{id}/key` behavior.
+
+Do not move Sub2API group-selection UX into the Adapter in this slice.
+Product-level workflows still decide when a group is required or can be
+auto-selected, then call `createToken(...)` with the chosen group.
+
+### 5. Add AIHubMix Key Management Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/aihubmix/keyManagement.ts
+```
+
+Implementation should delegate to the existing AIHubMix helpers:
+
+- `fetchAccountTokens(...)`
+- `createApiToken(...)`
+- `resolveApiTokenKey(...)`
+
+The Adapter must preserve AIHubMix one-time-secret behavior:
+
+- `createToken(...)` may return the only full secret value.
+- `fetchTokens(...)` and detail reads may return masked keys.
+- `resolveTokenKey(...)` must reject masked keys with the existing
+  token-secret-unavailable behavior, not fall back to compatible reveal routes.
+
+### 6. Update Display-Account Token Helpers
+
+Modify:
+
+```text
+src/services/accounts/utils/apiServiceRequest.ts
+```
+
+Current helper responsibilities should stay:
+
+- build the display-account `ApiServiceRequest`
+- validate token inventory payload shape
+- log invalid payloads safely
+- format optional `sk-` keys for compatible site types
+- keep `canManageDisplayAccountTokens(...)`
+
+Changes:
+
+- `createDisplayAccountApiContext(...)` should include
+  `adapter: getSiteAdapter(account.siteType)`.
+- `fetchDisplayAccountTokens(...)` should call
+  `adapter.keyManagement.fetchTokens(request)`.
+- `resolveDisplayAccountTokenForSecret(...)` should call
+  `adapter.keyManagement.resolveTokenKey({ request, token })`.
+- Missing `keyManagement` should throw an implementation-oriented error such as
+  `keyManagement is not implemented for <siteType>`.
+
+This makes row actions, copy dialogs, Model List, and managed-site token helper
+callers converge on one product helper instead of each resolving the backend
+service independently.
+
+### 7. Update Post-Save And Default Token Workflows
+
+Modify:
+
+```text
+src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+src/services/accounts/accountOperations.ts
+```
+
+Use `getSiteAdapter(displaySiteData.siteType).keyManagement` for:
+
+- inventory inspection
+- default token creation
+- follow-up inventory reload when create returns only `true`
+
+Keep the product-level rules in these Modules:
+
+- Sub2API group selection and blocked/selection-required result mapping
+- AIHubMix one-time-secret blocked messages
+- created-token vs follow-up-inventory selection
+- existing token selection by id diff
+- toast/user-facing message behavior in `ensureAccountApiToken(...)`
+
+This is deliberately not a `tokenProvisioning` Adapter yet. The Adapter owns
+backend token operations; the account workflow Modules own product UX and
+workflow decisions.
+
+### 8. Update Account Row Copy/Locate Flows
+
+Modify:
+
+```text
+src/features/AccountManagement/components/AccountActionButtons/index.tsx
+```
+
+Replace direct `getApiService(site.siteType).fetchAccountTokens(...)` calls
+with `fetchDisplayAccountTokens(site)`.
+
+Keep:
+
+- smart-copy branching for zero/one/many tokens
+- fallback to opening the Copy Key dialog on load failure
+- managed-site channel locate fallback behavior
+- safe secret redaction before logging
+- existing product analytics result categories
+
+The flow should still use `resolveDisplayAccountTokenForSecret(...)` for
+secret resolution.
+
+### 9. Keep Copy Key Dialog Creation Focused
+
+Modify:
+
+```text
+src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+```
+
+Use `fetchDisplayAccountTokens(account)` for list and refresh paths.
+
+For create:
+
+- continue to use the Sub2API quick-create resolution helper before calling
+  create
+- obtain `keyManagement` through `createDisplayAccountApiContext(account)`
+- call `adapter.keyManagement.createToken(request, tokenRequest)`
+- preserve one-time key dialog behavior and auto-copy behavior
+
+This keeps UI state unchanged while removing direct service calls from the
+dialog.
+
+## Error Handling
+
+Adapter methods should delegate backend errors unchanged. Product Modules
+should keep their current error mapping:
+
+- Copy Key dialog uses localized load/create/copy failures.
+- Account row smart-copy falls back to opening the dialog when token list load
+  fails.
+- Post-save workflow maps blocked states to existing
+  `ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES`.
+- `InvalidTokenPayloadError` remains owned by
+  `src/services/accounts/utils/apiServiceRequest.ts`.
+- AIHubMix masked-key secret resolution keeps returning the existing
+  token-secret-unavailable error.
+
+Missing `keyManagement` should be treated as an implementation error for
+account sites that reach these workflows.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This is an internal architecture migration. It does not add a new user action
+or analytics field. Existing copy-key, create-key, delete-key, managed-channel
+locate, and post-save events should continue to emit from their current owners.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E in this slice.
+
+The risk is service-layer routing and response-shape preservation. Focused
+Vitest coverage is the right first validation layer. Existing mocked account
+flows and key-management E2E coverage already exercise the browser-level
+surfaces.
+
+## Testing Strategy
+
+Add Adapter tests:
+
+- New API-family `keyManagement` delegates to `getApiService(siteType)` and
+  preserves pagination options.
+- Sub2API `keyManagement` delegates to Sub2API token helpers.
+- AIHubMix `keyManagement` delegates to AIHubMix token helpers.
+- Registry exposes `keyManagement` for New API-family, Sub2API, and AIHubMix
+  Adapters.
+
+Update product helper tests:
+
+- `fetchDisplayAccountTokens(...)` calls
+  `getSiteAdapter(siteType).keyManagement.fetchTokens(...)`.
+- invalid token inventory payload still throws `InvalidTokenPayloadError`.
+- `resolveDisplayAccountTokenForSecret(...)` calls
+  `keyManagement.resolveTokenKey(...)` and keeps optional `sk-` formatting.
+- missing `keyManagement` fails clearly.
+
+Update workflow tests:
+
+- `ensureAccountTokenForPostSaveWorkflow(...)` uses Adapter key operations
+  while preserving AIHubMix one-time-secret and Sub2API group-selection rules.
+- `ensureDefaultApiTokenForAccount(...)` uses Adapter key operations and keeps
+  existing unsupported-site messages.
+- `ensureAccountApiToken(...)` uses Adapter key operations and keeps current
+  Sub2API group and AIHubMix blocked behavior.
+
+Update UI/hook tests where existing tests mock `getApiService(...)` for token
+list/create:
+
+- Copy Key dialog hook/component tests mock the display-account helper or
+  Adapter-backed context.
+- Account row action tests assert smart-copy behavior, not direct service
+  implementation details.
+
+## Validation Plan
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/registry.test.ts tests/services/accounts/apiServiceRequest.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Additional focused validation if the implementation touches the dialog and row
+actions:
+
+```powershell
+pnpm vitest run tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+```
+
+Related validation:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/contracts/keyManagement.ts src/services/accounts/utils/apiServiceRequest.ts src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/features/AccountManagement/components/AccountActionButtons/index.tsx
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Pre-push / PR gate:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before publishing because the slice changes shared
+TypeScript contracts, account workflow routing, and UI token-flow imports.
+
+## Rollout
+
+1. Add the `keyManagement` contract and Adapter delegation tests.
+2. Extend `SiteAdapter`, New API-family, Sub2API, AIHubMix, and registry tests.
+3. Migrate `src/services/accounts/utils/apiServiceRequest.ts`.
+4. Migrate post-save/default-token product workflows.
+5. Migrate Copy Key dialog list/create paths and account row direct inventory
+   calls.
+6. Run focused tests after each task group.
+7. Run related tests, `pnpm compile`, and `validate:staged`.
+8. Inspect the diff for scope drift.
+9. Run `validate:push` before pushing or opening a PR.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may migrate:
+
+- full Key Management page create/update/delete flows
+- key repair deletion and group coverage
+- `fetchUserGroups(...)` / site group capability
+- Sub2API price-estimation inputs
+- redemption capability
+- a richer support descriptor when product UI needs to distinguish list,
+  create, update, delete, and secret-resolution support separately
+
+Do not grow `SiteAdapter` into a second flat `apiService` Interface. Add each
+capability only when it hides backend-specific behavior behind a smaller
+Interface and gives real caller Leverage.

--- a/docs/superpowers/specs/2026-06-18-api-adapter-key-management-design.md
+++ b/docs/superpowers/specs/2026-06-18-api-adapter-key-management-design.md
@@ -18,7 +18,7 @@ usable secret for copy/export/model-list flows.
 
 ## Current Context
 
-The current `SiteAdapter` Interface exposes:
+The shipped `SiteAdapter` Interface exposes:
 
 ```ts
 type SiteAdapter = {
@@ -28,13 +28,14 @@ type SiteAdapter = {
   siteAnnouncements?: SiteAnnouncementsCapability
   modelCatalog?: ModelCatalogCapability
   accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
 }
 ```
 
 `src/services/apiService/index.ts` still provides the legacy compatibility
 facade. It merges `common` helpers with site overrides and still exposes
-`capabilities.keyManagement`, but product Modules use concrete helper names
-directly:
+`capabilities.keyManagement`, while the migrated account save/copy paths now
+enter backend key operations through `getSiteAdapter(siteType).keyManagement`:
 
 - `fetchAccountTokens(...)`
 - `createApiToken(...)`

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -30,8 +30,11 @@ import { useDialogStateContext } from "~/features/AccountManagement/hooks/Dialog
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import { translateAutoCheckinMessageKey } from "~/features/AutoCheckin/utils/autoCheckin"
 import { exportShareSnapshotWithToast } from "~/features/ShareSnapshots/utils/exportShareSnapshotWithToast"
-import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
-import { getApiService } from "~/services/apiService"
+import {
+  fetchDisplayAccountTokens,
+  InvalidTokenPayloadError,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
 import { sendAutoCheckinMessage } from "~/services/checkin/autoCheckin/messaging"
 import {
   getManagedSiteChannelExactMatch,
@@ -343,61 +346,37 @@ export default function AccountActionButtons({
 
     try {
       // Fetch tokens to check count before deciding action
-      const tokensResponse = await getApiService(
-        site.siteType,
-      ).fetchAccountTokens({
-        baseUrl: site.baseUrl,
-        accountId: site.id,
-        auth: {
-          authType: site.authType,
-          userId: site.userId,
-          accessToken: site.token,
-          cookie: site.cookieAuthSessionCookie,
-        },
-      })
+      const tokensResponse = await fetchDisplayAccountTokens(site)
 
-      if (Array.isArray(tokensResponse)) {
-        if (tokensResponse.length === 1) {
-          // Single token - copy directly
-          const token = tokensResponse[0]
-          const resolvedToken = await resolveDisplayAccountTokenForSecret(
-            site,
-            token,
-          )
-          await navigator.clipboard.writeText(resolvedToken.key)
-          toast.success(t("actions.keyCopied"))
-          tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
-            insights: {
-              itemCount: tokensResponse.length,
-            },
-          })
-        } else if (tokensResponse.length > 1) {
-          // Multiple tokens - open dialog
-          onCopyKey(site)
-          tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped, {
-            insights: {
-              itemCount: tokensResponse.length,
-            },
-          })
-        } else {
-          // No tokens found - open dialog for actionable empty state
-          onCopyKey(site)
-          tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped, {
-            insights: {
-              itemCount: tokensResponse.length,
-            },
-          })
-        }
-      } else {
-        logger.warn("Token response is not an array", {
-          siteId: site.id,
-          baseUrl: site.baseUrl,
-          responseType: typeof tokensResponse,
-          siteType: site.siteType,
+      if (tokensResponse.length === 1) {
+        // Single token - copy directly
+        const token = tokensResponse[0]
+        const resolvedToken = await resolveDisplayAccountTokenForSecret(
+          site,
+          token,
+        )
+        await navigator.clipboard.writeText(resolvedToken.key)
+        toast.success(t("actions.keyCopied"))
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
+          insights: {
+            itemCount: tokensResponse.length,
+          },
         })
-        toast.error(t("actions.fetchKeyInfoFailed"))
-        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      } else if (tokensResponse.length > 1) {
+        // Multiple tokens - open dialog
+        onCopyKey(site)
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped, {
+          insights: {
+            itemCount: tokensResponse.length,
+          },
+        })
+      } else {
+        // No tokens found - open dialog for actionable empty state
+        onCopyKey(site)
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped, {
+          insights: {
+            itemCount: tokensResponse.length,
+          },
         })
       }
     } catch (error) {
@@ -407,6 +386,14 @@ export default function AccountActionButtons({
         baseUrl: site.baseUrl,
         siteType: site.siteType,
       })
+      if (error instanceof InvalidTokenPayloadError) {
+        toast.error(t("actions.fetchKeyInfoFailed"))
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
+          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        })
+        return
+      }
+
       const errorMessage = getErrorMessage(error)
       toast.error(t("actions.fetchKeyListFailed", { errorMessage }))
       // Fallback to opening dialog
@@ -477,24 +464,10 @@ export default function AccountActionButtons({
         }
       })
 
-      const tokensResponse = await getApiService(
-        site.siteType,
-      ).fetchAccountTokens({
+      const tokensResponse = await fetchDisplayAccountTokens({
+        ...site,
         baseUrl: accountBaseUrl,
-        accountId: site.id,
-        auth: {
-          authType: site.authType,
-          userId: site.userId,
-          accessToken: site.token,
-          cookie: site.cookieAuthSessionCookie,
-        },
       })
-
-      if (!Array.isArray(tokensResponse)) {
-        toast.error(t("actions.channelLocateFailed"))
-        openManagedSiteChannelsPage({ search: normalizedAccountBaseUrl })
-        return
-      }
 
       if (tokensResponse.length === 0) {
         return handleChannelLocateFallback(

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -464,10 +464,11 @@ export default function AccountActionButtons({
         }
       })
 
-      const tokensResponse = await fetchDisplayAccountTokens({
+      const tokenLookupAccount = {
         ...site,
         baseUrl: accountBaseUrl,
-      })
+      }
+      const tokensResponse = await fetchDisplayAccountTokens(tokenLookupAccount)
 
       if (tokensResponse.length === 0) {
         return handleChannelLocateFallback(
@@ -486,7 +487,7 @@ export default function AccountActionButtons({
         secretsToRedact.add(apiToken.key)
       }
       const resolvedToken = await resolveDisplayAccountTokenForSecret(
-        site,
+        tokenLookupAccount,
         apiToken,
       )
       if (resolvedToken.key) {

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -36,7 +36,10 @@ import {
   type AccountPostSaveWorkflowStep,
 } from "~/services/accounts/accountPostSaveWorkflow"
 import { accountStorage } from "~/services/accounts/accountStorage"
-import { createDisplayAccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+} from "~/services/accounts/utils/apiServiceRequest"
 import {
   analyzeAutoDetectError,
   AutoDetectError,
@@ -2207,10 +2210,13 @@ export function useAccountDialog({
       }
 
       try {
-        const { service, request } = createDisplayAccountApiContext(
+        const { keyManagement, request } = createDisplayAccountApiContext(
           pending.displaySiteData,
         )
-        const fetchedTokens = await service.fetchAccountTokens(request)
+        const fetchedTokens = await requireDisplayAccountKeyManagement(
+          pending.displaySiteData,
+          keyManagement,
+        ).fetchTokens(request)
         if (postSaveAutoConfigRunRef.current !== runId) {
           return
         }

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -8,6 +8,9 @@ import { resolveSub2ApiQuickCreateResolution } from "~/services/accounts/account
 import {
   canManageDisplayAccountTokens,
   createDisplayAccountApiContext,
+  fetchDisplayAccountTokens,
+  InvalidTokenPayloadError,
+  requireDisplayAccountKeyManagement,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
@@ -40,6 +43,9 @@ const isCreatedApiToken = (value: unknown): value is ApiToken =>
   typeof value === "object" &&
   typeof (value as Partial<ApiToken>).id === "number" &&
   typeof (value as Partial<ApiToken>).key === "string"
+
+const getTokenInventoryErrorMessage = (error: unknown, fallback: string) =>
+  error instanceof InvalidTokenPayloadError ? fallback : getErrorMessage(error)
 
 /**
  * CopyKeyDialog 核心逻辑 hook，负责加载 token、处理复制与展开状态。
@@ -92,19 +98,8 @@ export function useCopyKeyDialog(
     clearSub2ApiCreateAllowedGroups()
 
     try {
-      const { service, request } = createDisplayAccountApiContext(account)
-      const tokensResponse = await service.fetchAccountTokens(request)
-      if (Array.isArray(tokensResponse)) {
-        setTokens(tokensResponse)
-      } else {
-        logger.warn("Token response is not an array", {
-          accountId: account.id,
-          baseUrl: account.baseUrl,
-          responseType: typeof tokensResponse,
-          siteType: account.siteType,
-        })
-        setTokens([])
-      }
+      const tokensResponse = await fetchDisplayAccountTokens(account)
+      setTokens(tokensResponse)
     } catch (error) {
       logger.error("Failed to load key list", {
         error,
@@ -112,7 +107,10 @@ export function useCopyKeyDialog(
         baseUrl: account.baseUrl,
         siteType: account.siteType,
       })
-      const errorMessage = getErrorMessage(error)
+      const errorMessage = getTokenInventoryErrorMessage(
+        error,
+        t("ui:dialog.copyKey.getFailed"),
+      )
       setError(t("ui:dialog.copyKey.loadFailed", { error: errorMessage }))
     } finally {
       setIsLoading(false)
@@ -222,12 +220,7 @@ export function useCopyKeyDialog(
           return
         }
 
-        const { service, request } = createDisplayAccountApiContext(account)
-        const refreshedTokens = await service.fetchAccountTokens(request)
-        if (!Array.isArray(refreshedTokens)) {
-          throw new Error("token_refresh_failed")
-        }
-
+        const refreshedTokens = await fetchDisplayAccountTokens(account)
         setTokens(refreshedTokens)
 
         if (refreshedTokens.length === 0) {
@@ -248,7 +241,10 @@ export function useCopyKeyDialog(
           baseUrl: account.baseUrl,
           siteType: account.siteType,
         })
-        const errorMessage = getErrorMessage(error)
+        const errorMessage = getTokenInventoryErrorMessage(
+          error,
+          t("ui:dialog.copyKey.getFailed"),
+        )
         setCreateError(
           t("ui:dialog.copyKey.createFailed", { error: errorMessage }),
         )
@@ -272,7 +268,7 @@ export function useCopyKeyDialog(
     clearSub2ApiCreateAllowedGroups()
 
     try {
-      const { service, request } = createDisplayAccountApiContext(account)
+      const { keyManagement, request } = createDisplayAccountApiContext(account)
       const tokenRequest = generateDefaultTokenRequest()
       if (account.siteType === "sub2api") {
         // Sub2API quick-create may skip the chooser only when the current
@@ -291,7 +287,10 @@ export function useCopyKeyDialog(
         tokenRequest.group = resolution.group
       }
 
-      const created = await service.createApiToken(request, tokenRequest)
+      const created = await requireDisplayAccountKeyManagement(
+        account,
+        keyManagement,
+      ).createToken(request, tokenRequest)
       if (!created) {
         throw new Error("create_token_failed")
       }

--- a/src/features/KeyManagement/components/AddTokenDialog/index.tsx
+++ b/src/features/KeyManagement/components/AddTokenDialog/index.tsx
@@ -5,7 +5,10 @@ import { useTranslation } from "react-i18next"
 import { Alert } from "~/components/ui"
 import { Modal } from "~/components/ui/Dialog/Modal"
 import { UI_CONSTANTS } from "~/constants/ui"
-import { createDisplayAccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+} from "~/services/accounts/utils/apiServiceRequest"
 import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
@@ -179,14 +182,17 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
         allow_ips: formData.allowIps.trim() || "",
         group: formData.group,
       }
-      const { service, request } =
+      const { keyManagement, request, service } =
         createDisplayAccountApiContext(currentAccount)
 
       if (isEditMode && editingToken) {
         await service.updateApiToken(request, editingToken.id, tokenData)
         toast.success(t("dialog.updateSuccess"))
       } else {
-        const created = await service.createApiToken(request, tokenData)
+        const created = await requireDisplayAccountKeyManagement(
+          currentAccount,
+          keyManagement,
+        ).createToken(request, tokenData)
         const createdToken = isCreatedApiToken(created) ? created : undefined
         const displayCreatedToken = createdToken
           ? formatOptionalSkPrefixSiteToken(

--- a/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
@@ -1,5 +1,6 @@
 import { SITE_TYPES } from "~/constants/siteType"
-import { getApiService } from "~/services/apiService"
+import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
 import { t } from "~/utils/i18n/core"
@@ -42,9 +43,11 @@ export async function ensureDefaultApiTokenForAccount(params: {
   displaySiteData: DisplaySiteData
 }): Promise<{ token: ApiToken; created: boolean }> {
   const { account, displaySiteData } = params
-  const service = getApiService(displaySiteData.siteType)
-
-  const tokens = await service.fetchAccountTokens({
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
+  const displayAccountRequest = {
     baseUrl: displaySiteData.baseUrl,
     accountId: displaySiteData.id,
     auth: {
@@ -53,7 +56,19 @@ export async function ensureDefaultApiTokenForAccount(params: {
       accessToken: displaySiteData.token,
       cookie: displaySiteData.cookieAuthSessionCookie,
     },
-  })
+  }
+  const createAccountRequest = {
+    baseUrl: account.site_url,
+    accountId: account.id,
+    auth: {
+      authType: account.authType,
+      userId: account.account_info.id,
+      accessToken: account.account_info.access_token,
+      cookie: account.cookieAuth?.sessionCookie,
+    },
+  }
+
+  const tokens = await keyManagement.fetchTokens(displayAccountRequest)
 
   let apiToken: ApiToken | undefined = tokens.at(-1)
   if (apiToken) {
@@ -69,17 +84,8 @@ export async function ensureDefaultApiTokenForAccount(params: {
   }
 
   const newTokenData = generateDefaultTokenRequest()
-  const createApiTokenResult = await service.createApiToken(
-    {
-      baseUrl: account.site_url,
-      accountId: account.id,
-      auth: {
-        authType: account.authType,
-        userId: account.account_info.id,
-        accessToken: account.account_info.access_token,
-        cookie: account.cookieAuth?.sessionCookie,
-      },
-    },
+  const createApiTokenResult = await keyManagement.createToken(
+    createAccountRequest,
     newTokenData,
   )
 
@@ -94,16 +100,7 @@ export async function ensureDefaultApiTokenForAccount(params: {
   // Backends such as AIHubMix may only expose the full API key in the create
   // response; a follow-up inventory fetch can return a masked key that cannot
   // be revealed later. This helper currently returns inventory data only.
-  const updatedTokens = await service.fetchAccountTokens({
-    baseUrl: displaySiteData.baseUrl,
-    accountId: displaySiteData.id,
-    auth: {
-      authType: displaySiteData.authType,
-      userId: displaySiteData.userId,
-      accessToken: displaySiteData.token,
-      cookie: displaySiteData.cookieAuthSessionCookie,
-    },
-  })
+  const updatedTokens = await keyManagement.fetchTokens(displayAccountRequest)
   apiToken = updatedTokens.at(-1)
 
   if (!apiToken) {

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -24,7 +24,10 @@ import {
   completeAutoDetectedAccount,
   getAutoDetectCompletionFailureReason,
 } from "~/services/accounts/autoDetectCompletion/completion"
-import { createDisplayAccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+} from "~/services/accounts/utils/apiServiceRequest"
 import {
   analyzeAutoDetectError,
   AUTO_DETECT_FAILURE_REASONS,
@@ -34,6 +37,7 @@ import {
   type AutoDetectFailureReason,
 } from "~/services/accounts/utils/autoDetectUtils"
 import { normalizeAccountSiteUrlForStorage } from "~/services/accounts/utils/siteUrlNormalization"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { getApiService } from "~/services/apiService"
 import {
   DEFAULT_PREFERENCES,
@@ -1152,9 +1156,11 @@ export async function ensureAccountApiToken(
     id: options.toastId,
   })
 
-  const tokens = await getApiService(
-    displaySiteData.siteType,
-  ).fetchAccountTokens({
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
+  const displayAccountRequest = {
     baseUrl: displaySiteData.baseUrl,
     accountId: displaySiteData.id,
     auth: {
@@ -1163,7 +1169,19 @@ export async function ensureAccountApiToken(
       accessToken: displaySiteData.token,
       cookie: displaySiteData.cookieAuthSessionCookie,
     },
-  })
+  }
+  const createAccountRequest = {
+    baseUrl: account.site_url,
+    accountId: account.id,
+    auth: {
+      authType: account.authType,
+      userId: account.account_info.id,
+      accessToken: account.account_info.access_token,
+      cookie: account.cookieAuth?.sessionCookie,
+    },
+  }
+
+  const tokens = await keyManagement.fetchTokens(displayAccountRequest)
   let apiToken: ApiToken | undefined = tokens.at(-1)
 
   if (!apiToken) {
@@ -1188,19 +1206,8 @@ export async function ensureAccountApiToken(
       throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
     }
 
-    const createApiTokenResult = await getApiService(
-      displaySiteData.siteType,
-    ).createApiToken(
-      {
-        baseUrl: account.site_url,
-        accountId: account.id,
-        auth: {
-          authType: account.authType,
-          userId: account.account_info.id,
-          accessToken: account.account_info.access_token,
-          cookie: account.cookieAuth?.sessionCookie,
-        },
-      },
+    const createApiTokenResult = await keyManagement.createToken(
+      createAccountRequest,
       newTokenData,
     )
 
@@ -1213,18 +1220,9 @@ export async function ensureAccountApiToken(
     } else {
       // Do not assume a created key can be read back in full. AIHubMix returns
       // complete API keys only at creation time and may list masked keys here.
-      const updatedTokens = await getApiService(
-        displaySiteData.siteType,
-      ).fetchAccountTokens({
-        baseUrl: displaySiteData.baseUrl,
-        accountId: displaySiteData.id,
-        auth: {
-          authType: displaySiteData.authType,
-          userId: displaySiteData.userId,
-          accessToken: displaySiteData.token,
-          cookie: displaySiteData.cookieAuthSessionCookie,
-        },
-      })
+      const updatedTokens = await keyManagement.fetchTokens(
+        displayAccountRequest,
+      )
       apiToken = updatedTokens.at(-1)
     }
   }

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -1,7 +1,8 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import { resolveSub2ApiQuickCreateResolution } from "~/services/accounts/accountOperations"
-import { getApiService } from "~/services/apiService"
+import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import {
   hasUsableApiTokenKey,
   isMaskedApiTokenKey,
@@ -85,8 +86,11 @@ export async function inspectAccountTokenInventory(params: {
   displaySiteData: DisplaySiteData
 }): Promise<AccountTokenInventoryState> {
   const { displaySiteData } = params
-  const service = getApiService(displaySiteData.siteType)
-  const tokens = await service.fetchAccountTokens(
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
+  const tokens = await keyManagement.fetchTokens(
     buildDisplayAccountRequest(displaySiteData),
   )
   const existingTokens = sanitizeApiTokens(tokens)
@@ -120,13 +124,16 @@ async function createDefaultToken(params: {
   existingTokenIds: number[]
 }): Promise<ApiToken | null> {
   const { account, displaySiteData, group, existingTokenIds } = params
-  const service = getApiService(displaySiteData.siteType)
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
   const tokenData = generateDefaultTokenRequest()
   if (typeof group === "string") {
     tokenData.group = group
   }
 
-  const created = await service.createApiToken(
+  const created = await keyManagement.createToken(
     buildCreateRequest(account),
     tokenData,
   )
@@ -143,7 +150,7 @@ async function createDefaultToken(params: {
     return null
   }
 
-  const updatedTokens = await service.fetchAccountTokens(
+  const updatedTokens = await keyManagement.fetchTokens(
     buildDisplayAccountRequest(displaySiteData),
   )
 

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -1,3 +1,5 @@
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { getApiService } from "~/services/apiService"
 import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import type { ApiServiceRequest } from "~/services/apiService/common/type"
@@ -8,6 +10,21 @@ const hasNonEmptyString = (value: unknown): value is string =>
   typeof value === "string" && value.trim().length > 0
 
 const logger = createLogger("DisplayAccountApiContext")
+
+export const createMissingKeyManagementCapabilityError = (
+  siteType: string,
+): Error => new Error(`keyManagement is not implemented for ${siteType}`)
+
+export const requireDisplayAccountKeyManagement = (
+  account: Pick<DisplaySiteData, "siteType">,
+  keyManagement: KeyManagementCapability | undefined,
+): KeyManagementCapability => {
+  if (!keyManagement) {
+    throw createMissingKeyManagementCapabilityError(account.siteType)
+  }
+
+  return keyManagement
+}
 
 export class InvalidTokenPayloadError extends Error {
   readonly code = "INVALID_TOKEN_PAYLOAD"
@@ -69,10 +86,16 @@ export const createDisplayAccountApiContext = (
     | "token"
     | "cookieAuthSessionCookie"
   >,
-) => ({
-  service: getApiService(account.siteType),
-  request: buildApiRequestFromDisplayAccount(account),
-})
+) => {
+  const adapter = getSiteAdapter(account.siteType)
+
+  return {
+    service: getApiService(account.siteType),
+    adapter,
+    keyManagement: adapter.keyManagement,
+    request: buildApiRequestFromDisplayAccount(account),
+  }
+}
 
 /**
  * Fetches the current token inventory for a display account.
@@ -89,8 +112,11 @@ export async function fetchDisplayAccountTokens(
     | "cookieAuthSessionCookie"
   >,
 ): Promise<ApiToken[]> {
-  const { service, request } = createDisplayAccountApiContext(account)
-  const tokensResponse = await service.fetchAccountTokens(request)
+  const { keyManagement, request } = createDisplayAccountApiContext(account)
+  const tokensResponse = await requireDisplayAccountKeyManagement(
+    account,
+    keyManagement,
+  ).fetchTokens(request)
 
   if (Array.isArray(tokensResponse)) {
     return tokensResponse
@@ -130,8 +156,11 @@ export async function resolveDisplayAccountTokenForSecret<
   >,
   token: TToken,
 ): Promise<TToken> {
-  const { service, request } = createDisplayAccountApiContext(account)
-  const resolvedKey = await service.resolveApiTokenKey(request, token)
+  const { keyManagement, request } = createDisplayAccountApiContext(account)
+  const resolvedKey = await requireDisplayAccountKeyManagement(
+    account,
+    keyManagement,
+  ).resolveTokenKey({ request, token })
   return formatOptionalSkPrefixSiteToken(
     resolvedKey === token.key ? token : { ...token, key: resolvedKey },
     account.siteType,

--- a/src/services/apiAdapters/aihubmix/index.ts
+++ b/src/services/apiAdapters/aihubmix/index.ts
@@ -2,8 +2,10 @@ import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
 import { aihubmixAccountCompletion } from "./accountCompletion"
+import { aihubmixKeyManagement } from "./keyManagement"
 
 export const aihubmixAdapter: SiteAdapter = {
   siteType: SITE_TYPES.AIHUBMIX,
   accountCompletion: aihubmixAccountCompletion,
+  keyManagement: aihubmixKeyManagement,
 }

--- a/src/services/apiAdapters/aihubmix/keyManagement.ts
+++ b/src/services/apiAdapters/aihubmix/keyManagement.ts
@@ -1,0 +1,12 @@
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import {
+  createApiToken,
+  fetchAccountTokens,
+  resolveApiTokenKey,
+} from "~/services/apiService/aihubmix"
+
+export const aihubmixKeyManagement: KeyManagementCapability = {
+  fetchTokens: (request) => fetchAccountTokens(request),
+  createToken: (request, tokenData) => createApiToken(request, tokenData),
+  resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
+}

--- a/src/services/apiAdapters/contracts/keyManagement.ts
+++ b/src/services/apiAdapters/contracts/keyManagement.ts
@@ -1,0 +1,32 @@
+import type {
+  ApiServiceRequest,
+  CreateTokenRequest,
+  CreateTokenResult,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+
+export type FetchAccountTokensOptions = {
+  page?: number
+  size?: number
+}
+
+export type ResolveTokenSecretRequest<
+  TToken extends Pick<ApiToken, "id" | "key"> = Pick<ApiToken, "id" | "key">,
+> = {
+  request: ApiServiceRequest
+  token: TToken
+}
+
+export type KeyManagementCapability = {
+  fetchTokens(
+    request: ApiServiceRequest,
+    options?: FetchAccountTokensOptions,
+  ): Promise<ApiToken[]>
+  createToken(
+    request: ApiServiceRequest,
+    tokenData: CreateTokenRequest,
+  ): Promise<CreateTokenResult>
+  resolveTokenKey<TToken extends Pick<ApiToken, "id" | "key">>(
+    request: ResolveTokenSecretRequest<TToken>,
+  ): Promise<string>
+}

--- a/src/services/apiAdapters/contracts/siteAdapter.ts
+++ b/src/services/apiAdapters/contracts/siteAdapter.ts
@@ -1,6 +1,7 @@
 import type { AccountSiteType } from "~/constants/siteType"
 
 import type { AccountCompletionCapability } from "./accountCompletion"
+import type { KeyManagementCapability } from "./keyManagement"
 import type { ModelCatalogCapability } from "./modelCatalog"
 import type { SiteAnnouncementsCapability } from "./siteAnnouncements"
 import type { SiteNoticeCapability } from "./siteNotice"
@@ -14,4 +15,5 @@ export type SiteAdapter = {
   siteAnnouncements?: SiteAnnouncementsCapability
   modelCatalog?: ModelCatalogCapability
   accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
 }

--- a/src/services/apiAdapters/newApi/index.ts
+++ b/src/services/apiAdapters/newApi/index.ts
@@ -1,12 +1,16 @@
-import { SITE_TYPES } from "~/constants/siteType"
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
 import { newApiAccountCompletion } from "./accountCompletion"
+import { createNewApiKeyManagement } from "./keyManagement"
 import { newApiSiteNotice } from "./siteNotice"
 
-export const newApiAdapter: SiteAdapter = {
-  siteType: SITE_TYPES.NEW_API,
+export const createNewApiAdapter = (
+  siteType: AccountSiteType = SITE_TYPES.NEW_API,
+): SiteAdapter => ({
+  siteType,
   family: "newApiFamily",
   siteNotice: newApiSiteNotice,
   accountCompletion: newApiAccountCompletion,
-}
+  keyManagement: createNewApiKeyManagement(siteType),
+})

--- a/src/services/apiAdapters/newApi/keyManagement.ts
+++ b/src/services/apiAdapters/newApi/keyManagement.ts
@@ -1,0 +1,23 @@
+import type { AccountSiteType } from "~/constants/siteType"
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import { getApiService } from "~/services/apiService"
+
+/**
+ * Create key-management operations bound to the New API-family site type.
+ */
+export function createNewApiKeyManagement(
+  siteType: AccountSiteType,
+): KeyManagementCapability {
+  return {
+    fetchTokens: (request, options) =>
+      getApiService(siteType).fetchAccountTokens(
+        request,
+        options?.page,
+        options?.size,
+      ),
+    createToken: (request, tokenData) =>
+      getApiService(siteType).createApiToken(request, tokenData),
+    resolveTokenKey: ({ request, token }) =>
+      getApiService(siteType).resolveApiTokenKey(request, token),
+  }
+}

--- a/src/services/apiAdapters/registry.ts
+++ b/src/services/apiAdapters/registry.ts
@@ -2,7 +2,7 @@ import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 
 import { aihubmixAdapter } from "./aihubmix"
 import type { SiteAdapter } from "./contracts/siteAdapter"
-import { newApiAdapter } from "./newApi"
+import { createNewApiAdapter } from "./newApi"
 import { sub2ApiAdapter } from "./sub2api"
 
 const newApiFamilySiteTypes = new Set<AccountSiteType>([
@@ -21,10 +21,8 @@ const newApiFamilySiteTypes = new Set<AccountSiteType>([
   SITE_TYPES.UNKNOWN,
 ])
 
-const createNewApiFamilyAdapter = (siteType: AccountSiteType): SiteAdapter => ({
-  ...newApiAdapter,
-  siteType,
-})
+const createNewApiFamilyAdapter = (siteType: AccountSiteType): SiteAdapter =>
+  createNewApiAdapter(siteType)
 
 const createUnsupportedAdapter = (siteType: AccountSiteType): SiteAdapter => ({
   siteType,

--- a/src/services/apiAdapters/sub2api/index.ts
+++ b/src/services/apiAdapters/sub2api/index.ts
@@ -2,6 +2,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
 import { sub2ApiAccountCompletion } from "./accountCompletion"
+import { sub2ApiKeyManagement } from "./keyManagement"
 import { sub2ApiModelCatalog } from "./modelCatalog"
 import { sub2ApiSiteAnnouncements } from "./siteAnnouncements"
 
@@ -11,4 +12,5 @@ export const sub2ApiAdapter: SiteAdapter = {
   siteAnnouncements: sub2ApiSiteAnnouncements,
   modelCatalog: sub2ApiModelCatalog,
   accountCompletion: sub2ApiAccountCompletion,
+  keyManagement: sub2ApiKeyManagement,
 }

--- a/src/services/apiAdapters/sub2api/keyManagement.ts
+++ b/src/services/apiAdapters/sub2api/keyManagement.ts
@@ -1,0 +1,13 @@
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import {
+  createApiToken,
+  fetchAccountTokens,
+  resolveApiTokenKey,
+} from "~/services/apiService/sub2api"
+
+export const sub2ApiKeyManagement: KeyManagementCapability = {
+  fetchTokens: (request, options) =>
+    fetchAccountTokens(request, options?.page, options?.size),
+  createToken: (request, tokenData) => createApiToken(request, tokenData),
+  resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
+}

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -55,11 +55,21 @@ vi.mock("react-hot-toast", () => ({
 
 vi.mock("~/services/apiService", () => ({
   getApiService: () => ({
-    createApiToken: (...args: any[]) => createApiTokenMock(...args),
     updateApiToken: (...args: any[]) => updateApiTokenMock(...args),
     fetchAccountAvailableModels: (...args: any[]) =>
       fetchAccountAvailableModelsMock(...args),
     fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+  }),
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: vi.fn(async () => []),
+      createToken: (...args: any[]) => createApiTokenMock(...args),
+      resolveTokenKey: async ({ token }: { token: { key: string } }) =>
+        token.key,
+    },
   }),
 }))
 

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
@@ -29,11 +29,21 @@ vi.mock("react-hot-toast", () => ({
 
 vi.mock("~/services/apiService", () => ({
   getApiService: () => ({
-    fetchAccountTokens: (...args: any[]) => fetchAccountTokensMock(...args),
     createApiToken: (...args: any[]) => createApiTokenMock(...args),
     fetchAccountAvailableModels: vi.fn(async () => []),
     fetchUserGroups: vi.fn(async () => ({})),
     updateApiToken: vi.fn(async () => true),
+  }),
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
+      createToken: (...args: any[]) => createApiTokenMock(...args),
+      resolveTokenKey: async ({ token }: { token: { key: string } }) =>
+        token.key,
+    },
   }),
 }))
 

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -64,11 +64,21 @@ vi.mock(
 
 vi.mock("~/services/apiService", () => ({
   getApiService: () => ({
-    fetchAccountTokens: (...args: any[]) => fetchAccountTokensMock(...args),
     createApiToken: (...args: any[]) => createApiTokenMock(...args),
     fetchAccountAvailableModels: vi.fn(async () => []),
     fetchUserGroups: vi.fn(async () => ({})),
     updateApiToken: vi.fn(async () => true),
+  }),
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
+      createToken: (...args: any[]) => createApiTokenMock(...args),
+      resolveTokenKey: async ({ token }: { token: { key: string } }) =>
+        token.key,
+    },
   }),
 }))
 

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -94,14 +94,6 @@ vi.mock("react-hot-toast", () => ({
   },
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: () => ({
-    fetchAccountTokens: fetchAccountTokensMock,
-    resolveApiTokenKey: async (_request: unknown, token: { key: string }) =>
-      token.key,
-  }),
-}))
-
 vi.mock("~/services/managedSites/managedSiteService", () => ({
   getManagedSiteService: getManagedSiteServiceMock,
   hasValidManagedSiteConfig: hasValidManagedSiteConfigMock,
@@ -179,11 +171,36 @@ vi.mock("~/services/productAnalytics/actions", async (importOriginal) => {
   }
 })
 
-vi.mock("~/services/accounts/utils/apiServiceRequest", () => ({
-  resolveDisplayAccountTokenForSecret: vi.fn(
-    async (_site: unknown, token: { key: string }) => token,
-  ),
-}))
+vi.mock(
+  "~/services/accounts/utils/apiServiceRequest",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/accounts/utils/apiServiceRequest")
+      >()
+
+    return {
+      ...actual,
+      fetchDisplayAccountTokens: async (...args: unknown[]) => {
+        const result = await fetchAccountTokensMock(...args)
+        if (Array.isArray(result)) {
+          return result
+        }
+
+        throw new actual.InvalidTokenPayloadError({
+          accountId: "test-account",
+          baseUrl: "https://example.com",
+          siteType: "test-site",
+          responseType: typeof result,
+        })
+      },
+      resolveDisplayAccountTokenForSecret: async (
+        _account: unknown,
+        token: { key: string },
+      ) => token,
+    }
+  },
+)
 
 describe("AccountActionButtons", () => {
   beforeEach(() => {
@@ -648,7 +665,7 @@ describe("AccountActionButtons", () => {
     await waitFor(() => {
       expect(fetchAccountTokensMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          accountId: "acc-single-key",
+          id: "acc-single-key",
         }),
       )
       expect(toastSuccessMock).toHaveBeenCalledWith("account:actions.keyCopied")

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -43,6 +43,7 @@ const {
   startProductAnalyticsActionMock,
   completeProductAnalyticsActionMock,
   resolveProductAnalyticsErrorCategoryFromErrorMock,
+  resolveDisplayAccountTokenForSecretMock,
 } = vi.hoisted(() => ({
   mockHandleSetAccountDisabled: vi.fn(),
   mockTogglePinAccount: vi.fn(),
@@ -82,6 +83,7 @@ const {
   startProductAnalyticsActionMock: vi.fn(),
   completeProductAnalyticsActionMock: vi.fn(),
   resolveProductAnalyticsErrorCategoryFromErrorMock: vi.fn(),
+  resolveDisplayAccountTokenForSecretMock: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -195,9 +197,9 @@ vi.mock(
         })
       },
       resolveDisplayAccountTokenForSecret: async (
-        _account: unknown,
+        account: unknown,
         token: { key: string },
-      ) => token,
+      ) => resolveDisplayAccountTokenForSecretMock(account, token),
     }
   },
 )
@@ -225,6 +227,9 @@ describe("AccountActionButtons", () => {
       PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
     )
     completeProductAnalyticsActionMock.mockResolvedValue(undefined)
+    resolveDisplayAccountTokenForSecretMock.mockImplementation(
+      async (_account: unknown, token: { key: string }) => token,
+    )
     exportShareSnapshotWithToastMock.mockResolvedValue(undefined)
   })
 
@@ -712,6 +717,47 @@ describe("AccountActionButtons", () => {
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
         errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      },
+    )
+  })
+
+  it("opens the copy dialog when smart copy finds multiple tokens", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([
+      { key: "sk-one" },
+      { key: "sk-two" },
+    ])
+
+    const user = userEvent.setup()
+    const onCopyKey = vi.fn()
+
+    render(
+      <AccountActionButtons
+        site={buildDisplaySiteData({
+          id: "acc-multiple-keys",
+          disabled: false,
+          name: "Site",
+        })}
+        onCopyKey={onCopyKey}
+        onDeleteAccount={vi.fn()}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "account:actions.copyKey" }),
+    )
+
+    await waitFor(() => {
+      expect(onCopyKey).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "acc-multiple-keys" }),
+      )
+    })
+    expect(clipboardWriteTextMock).not.toHaveBeenCalled()
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Skipped,
+      {
+        insights: {
+          itemCount: 2,
+        },
       },
     )
   })
@@ -1713,7 +1759,7 @@ describe("AccountActionButtons", () => {
           id: "acc-6b",
           disabled: false,
           name: "Site",
-          baseUrl: "https://api.example.com/v1/openai",
+          baseUrl: "  https://api.example.com/v1/openai  ",
         })}
         onCopyKey={vi.fn()}
         onDeleteAccount={vi.fn()}
@@ -1746,6 +1792,12 @@ describe("AccountActionButtons", () => {
       expect.objectContaining({
         baseUrl: "https://api.example.com/v1/openai",
       }),
+    )
+    expect(resolveDisplayAccountTokenForSecretMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://api.example.com/v1/openai",
+      }),
+      expect.objectContaining({ key: "" }),
     )
     expect(openManagedSiteChannelsForChannelMock).not.toHaveBeenCalled()
   })

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -33,12 +33,23 @@ vi.mock("react-hot-toast", () => ({
 
 vi.mock("~/services/apiService", () => ({
   getApiService: () => ({
-    fetchAccountTokens: (...args: any[]) => fetchAccountTokensMock(...args),
-    createApiToken: (...args: any[]) => createApiTokenMock(...args),
     fetchAccountAvailableModels: (...args: any[]) =>
       fetchAccountAvailableModelsMock(...args),
     fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
     updateApiToken: vi.fn(async () => true),
+  }),
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
+      createToken: (...args: any[]) => createApiTokenMock(...args),
+      resolveTokenKey: async (_params: {
+        request: unknown
+        token: { key: string }
+      }) => _params.token.key,
+    },
   }),
 }))
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -55,12 +55,19 @@ vi.mock("react-hot-toast", () => ({
 
 vi.mock("~/services/apiService", () => ({
   getApiService: () => ({
-    fetchAccountTokens: (...args: any[]) => fetchAccountTokensMock(...args),
-    createApiToken: (...args: any[]) => createApiTokenMock(...args),
     fetchAccountAvailableModels: (...args: any[]) =>
       fetchAccountAvailableModelsMock(...args),
     fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
-    resolveApiTokenKey: (...args: any[]) => resolveApiTokenKeyMock(...args),
+  }),
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
+      createToken: (...args: any[]) => createApiTokenMock(...args),
+      resolveTokenKey: (...args: any[]) => resolveApiTokenKeyMock(...args),
+    },
   }),
 }))
 
@@ -150,7 +157,7 @@ describe("CopyKeyDialog", () => {
     })
     completeProductAnalyticsActionMock.mockResolvedValue(undefined)
     resolveApiTokenKeyMock.mockImplementation(
-      async (_request, token: { key: string }) => token.key,
+      async ({ token }: { token: { key: string } }) => token.key,
     )
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
@@ -356,6 +363,7 @@ describe("CopyKeyDialog", () => {
     expect(
       await screen.findByText("ui:dialog.copyKey.createFailed"),
     ).toBeInTheDocument()
+    expect(screen.queryByText("invalid_token_payload")).not.toBeInTheDocument()
   })
 
   it("shows a load error when the initial token inventory request fails", async () => {
@@ -368,16 +376,15 @@ describe("CopyKeyDialog", () => {
     ).toBeInTheDocument()
   })
 
-  it("handles a malformed initial token inventory as an empty list", async () => {
+  it("shows a load error when the initial token inventory is malformed", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce(null)
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
     expect(
-      await screen.findByRole("button", {
-        name: "ui:dialog.copyKey.createKey",
-      }),
+      await screen.findByText("ui:dialog.copyKey.loadFailed"),
     ).toBeInTheDocument()
+    expect(screen.queryByText("invalid_token_payload")).not.toBeInTheDocument()
     expect(screen.queryByText("default")).not.toBeInTheDocument()
   })
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -2280,6 +2280,19 @@ describe("useAccountDialog save and auto-config flows", () => {
       apiServiceRequest,
       "createDisplayAccountApiContext",
     ).mockReturnValue({
+      adapter: {
+        siteType: SITE_TYPES.SUB2API,
+        keyManagement: {
+          fetchTokens: fetchAccountTokens,
+          createToken: vi.fn(),
+          resolveTokenKey: vi.fn(),
+        },
+      } as any,
+      keyManagement: {
+        fetchTokens: fetchAccountTokens,
+        createToken: vi.fn(),
+        resolveTokenKey: vi.fn(),
+      } as any,
       service: {
         fetchAccountTokens,
       } as any,
@@ -2378,6 +2391,19 @@ describe("useAccountDialog save and auto-config flows", () => {
       apiServiceRequest,
       "createDisplayAccountApiContext",
     ).mockReturnValue({
+      adapter: {
+        siteType: SITE_TYPES.SUB2API,
+        keyManagement: {
+          fetchTokens: fetchAccountTokens,
+          createToken: vi.fn(),
+          resolveTokenKey: vi.fn(),
+        },
+      } as any,
+      keyManagement: {
+        fetchTokens: fetchAccountTokens,
+        createToken: vi.fn(),
+        resolveTokenKey: vi.fn(),
+      } as any,
       service: {
         fetchAccountTokens,
       } as any,
@@ -2469,6 +2495,19 @@ describe("useAccountDialog save and auto-config flows", () => {
       apiServiceRequest,
       "createDisplayAccountApiContext",
     ).mockReturnValue({
+      adapter: {
+        siteType: SITE_TYPES.SUB2API,
+        keyManagement: {
+          fetchTokens: fetchAccountTokens,
+          createToken: vi.fn(),
+          resolveTokenKey: vi.fn(),
+        },
+      } as any,
+      keyManagement: {
+        fetchTokens: fetchAccountTokens,
+        createToken: vi.fn(),
+        resolveTokenKey: vi.fn(),
+      } as any,
       service: {
         fetchAccountTokens,
       } as any,

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -2269,6 +2269,9 @@ describe("useAccountDialog save and auto-config flows", () => {
     const fetchAccountTokens = vi
       .fn()
       .mockResolvedValue([createdToken, existingToken])
+    const serviceFetchAccountTokens = vi.fn(() => {
+      throw new Error("service token fetch should not be used")
+    })
 
     vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
       savedSiteAccount,
@@ -2294,7 +2297,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         resolveTokenKey: vi.fn(),
       } as any,
       service: {
-        fetchAccountTokens,
+        fetchAccountTokens: serviceFetchAccountTokens,
       } as any,
       request: { accountId: savedDisplayData.id } as any,
     })
@@ -2335,6 +2338,7 @@ describe("useAccountDialog save and auto-config flows", () => {
     expect(fetchAccountTokens).toHaveBeenCalledWith({
       accountId: savedDisplayData.id,
     })
+    expect(serviceFetchAccountTokens).not.toHaveBeenCalled()
     expect(mockOpenWithAccount).toHaveBeenCalledWith(
       savedDisplayData,
       createdToken,
@@ -2380,6 +2384,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       .fn()
       .mockResolvedValueOnce([existingToken])
       .mockResolvedValueOnce([existingToken])
+    const serviceFetchAccountTokens = vi.fn(() => {
+      throw new Error("service token fetch should not be used")
+    })
 
     vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
       savedSiteAccount,
@@ -2405,7 +2412,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         resolveTokenKey: vi.fn(),
       } as any,
       service: {
-        fetchAccountTokens,
+        fetchAccountTokens: serviceFetchAccountTokens,
       } as any,
       request: { accountId: savedDisplayData.id } as any,
     })
@@ -2440,6 +2447,7 @@ describe("useAccountDialog save and auto-config flows", () => {
     })
 
     expect(mockOpenWithAccount).not.toHaveBeenCalled()
+    expect(serviceFetchAccountTokens).not.toHaveBeenCalled()
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
     )
@@ -2484,6 +2492,9 @@ describe("useAccountDialog save and auto-config flows", () => {
           resolveFetchAccountTokens = resolve
         }),
     )
+    const serviceFetchAccountTokens = vi.fn(() => {
+      throw new Error("service token fetch should not be used")
+    })
 
     vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
       savedSiteAccount,
@@ -2509,7 +2520,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         resolveTokenKey: vi.fn(),
       } as any,
       service: {
-        fetchAccountTokens,
+        fetchAccountTokens: serviceFetchAccountTokens,
       } as any,
       request: { accountId: savedDisplayData.id } as any,
     })
@@ -2566,6 +2577,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         accountId: savedDisplayData.id,
       })
     })
+    expect(serviceFetchAccountTokens).not.toHaveBeenCalled()
 
     await act(async () => {
       result.current.handlers.handleClose()

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -21,13 +21,27 @@ const {
   fetchAccountTokensMock,
   createApiTokenMock,
   fetchUserGroupsMock,
+  getSiteAdapterMock,
   toastLoadingMock,
-} = vi.hoisted(() => ({
-  fetchAccountTokensMock: vi.fn(),
-  createApiTokenMock: vi.fn(),
-  fetchUserGroupsMock: vi.fn(),
-  toastLoadingMock: vi.fn(),
-}))
+} = vi.hoisted(() => {
+  const fetchAccountTokensMock = vi.fn()
+  const createApiTokenMock = vi.fn()
+  const fetchUserGroupsMock = vi.fn()
+
+  return {
+    fetchAccountTokensMock,
+    createApiTokenMock,
+    fetchUserGroupsMock,
+    getSiteAdapterMock: vi.fn(() => ({
+      keyManagement: {
+        fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+        createToken: (...args: unknown[]) => createApiTokenMock(...args),
+        resolveTokenKey: vi.fn(),
+      },
+    })),
+    toastLoadingMock: vi.fn(),
+  }
+})
 
 vi.mock("react-hot-toast", () => ({
   default: {
@@ -42,12 +56,14 @@ vi.mock("~/services/apiService", async (importOriginal) => {
   return {
     ...actual,
     getApiService: vi.fn(() => ({
-      fetchAccountTokens: (...args: any[]) => fetchAccountTokensMock(...args),
-      createApiToken: (...args: any[]) => createApiTokenMock(...args),
-      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+      fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
     })),
   }
 })
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: getSiteAdapterMock,
+}))
 
 const createTestAccounts = () => {
   const displayAccount = buildSub2ApiAccount()
@@ -150,6 +166,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     fetchAccountTokensMock.mockReset()
     createApiTokenMock.mockReset()
     fetchUserGroupsMock.mockReset()
+    getSiteAdapterMock.mockClear()
     toastLoadingMock.mockReset()
 
     const testAccounts = createTestAccounts()
@@ -271,6 +288,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     fetchAccountTokensMock.mockReset()
     createApiTokenMock.mockReset()
     fetchUserGroupsMock.mockReset()
+    getSiteAdapterMock.mockClear()
     toastLoadingMock.mockReset()
   })
 
@@ -308,6 +326,86 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
         baseUrl: displayAccount.baseUrl,
         accountId: displayAccount.id,
       }),
+      expect.objectContaining({
+        name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: "",
+      }),
+    )
+  })
+
+  it("uses display account fields for inventory reads and stored account fields for token creation", async () => {
+    const displayAccount = {
+      id: "display-account-id",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://display.example.invalid",
+      authType: AuthTypeEnum.Cookie,
+      userId: "display-user-id",
+      token: "display-access-token",
+      cookieAuthSessionCookie: "display-session-cookie",
+    }
+    const siteAccount = buildSiteAccount({
+      id: "stored-account-id",
+      site_type: SITE_TYPES.NEW_API,
+      site_url: "https://stored.example.invalid",
+      authType: AuthTypeEnum.Cookie,
+      cookieAuth: { sessionCookie: "stored-session-cookie" },
+      account_info: {
+        id: "stored-user-id",
+        access_token: "stored-access-token",
+        username: "stored-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const createdToken = { id: 25, key: "sk-created-secret" }
+
+    fetchAccountTokensMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([createdToken])
+    createApiTokenMock.mockResolvedValueOnce(true)
+
+    await expect(
+      ensureDefaultApiTokenForAccount({
+        account: siteAccount,
+        displaySiteData: displayAccount as any,
+      }),
+    ).resolves.toEqual({ token: createdToken, created: true })
+
+    const expectedDisplayRequest = {
+      baseUrl: "https://display.example.invalid",
+      accountId: "display-account-id",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "display-user-id",
+        accessToken: "display-access-token",
+        cookie: "display-session-cookie",
+      },
+    }
+
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
+      1,
+      expectedDisplayRequest,
+    )
+    expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
+      2,
+      expectedDisplayRequest,
+    )
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://stored.example.invalid",
+        accountId: "stored-account-id",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: "stored-user-id",
+          accessToken: "stored-access-token",
+          cookie: "stored-session-cookie",
+        },
+      },
       expect.objectContaining({
         name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
         group: "",
@@ -383,6 +481,84 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     ).resolves.toEqual(createdToken)
 
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("uses display account fields for shared inventory reads and stored account fields for shared token creation", async () => {
+    const displayAccount = {
+      id: "shared-display-account-id",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://shared-display.example.invalid",
+      authType: AuthTypeEnum.Cookie,
+      userId: "shared-display-user-id",
+      token: "shared-display-access-token",
+      cookieAuthSessionCookie: "shared-display-session-cookie",
+    }
+    const siteAccount = buildSiteAccount({
+      id: "shared-stored-account-id",
+      site_type: SITE_TYPES.NEW_API,
+      site_url: "https://shared-stored.example.invalid",
+      authType: AuthTypeEnum.Cookie,
+      cookieAuth: { sessionCookie: "shared-stored-session-cookie" },
+      account_info: {
+        id: "shared-stored-user-id",
+        access_token: "shared-stored-access-token",
+        username: "shared-stored-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const createdToken = {
+      id: 26,
+      user_id: "shared-display-user-id",
+      key: "sk-shared-created-secret",
+      status: 1,
+      name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+      created_time: 1,
+      accessed_time: 1,
+      expired_time: -1,
+      remain_quota: -1,
+      unlimited_quota: true,
+      used_quota: 0,
+    }
+
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+
+    await expect(
+      ensureAccountApiToken(siteAccount, displayAccount as any),
+    ).resolves.toEqual(createdToken)
+
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(fetchAccountTokensMock).toHaveBeenCalledWith({
+      baseUrl: "https://shared-display.example.invalid",
+      accountId: "shared-display-account-id",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "shared-display-user-id",
+        accessToken: "shared-display-access-token",
+        cookie: "shared-display-session-cookie",
+      },
+    })
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://shared-stored.example.invalid",
+        accountId: "shared-stored-account-id",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: "shared-stored-user-id",
+          accessToken: "shared-stored-access-token",
+          cookie: "shared-stored-session-cookie",
+        },
+      },
+      expect.objectContaining({
+        name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: "",
+      }),
+    )
   })
 
   it("blocks shared AIHubMix token ensure when no token exists because no one-time dialog is available", async () => {

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -13,25 +13,43 @@ import {
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
 
-const { fetchAccountTokensMock, createApiTokenMock, fetchUserGroupsMock } =
-  vi.hoisted(() => ({
-    fetchAccountTokensMock: vi.fn(),
-    createApiTokenMock: vi.fn(),
-    fetchUserGroupsMock: vi.fn(),
-  }))
+const {
+  fetchAccountTokensMock,
+  createApiTokenMock,
+  fetchUserGroupsMock,
+  getSiteAdapterMock,
+} = vi.hoisted(() => {
+  const fetchAccountTokensMock = vi.fn()
+  const createApiTokenMock = vi.fn()
+  const fetchUserGroupsMock = vi.fn()
+
+  return {
+    fetchAccountTokensMock,
+    createApiTokenMock,
+    fetchUserGroupsMock,
+    getSiteAdapterMock: vi.fn(() => ({
+      keyManagement: {
+        fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+        createToken: (...args: unknown[]) => createApiTokenMock(...args),
+        resolveTokenKey: vi.fn(),
+      },
+    })),
+  }
+})
 
 vi.mock("~/services/apiService", async (importOriginal) => {
   const actual = await importOriginal<typeof import("~/services/apiService")>()
   return {
     ...actual,
     getApiService: vi.fn(() => ({
-      fetchAccountTokens: (...args: unknown[]) =>
-        fetchAccountTokensMock(...args),
-      createApiToken: (...args: unknown[]) => createApiTokenMock(...args),
       fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
     })),
   }
 })
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: getSiteAdapterMock,
+}))
 
 const buildToken = (overrides: Partial<ApiToken> = {}): ApiToken => ({
   id: 1,
@@ -97,6 +115,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     fetchAccountTokensMock.mockReset()
     createApiTokenMock.mockReset()
     fetchUserGroupsMock.mockReset()
+    getSiteAdapterMock.mockClear()
   })
 
   it("selects the single newly created token by id diff even when it is not the last refetched token", () => {
@@ -221,6 +240,91 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       }),
     )
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("uses display account fields for inventory reads and stored account fields for token creation", async () => {
+    const displayAccount = buildDisplayAccount({
+      id: "display-account-id",
+      baseUrl: "https://display.example.invalid",
+      authType: AuthTypeEnum.Cookie,
+      userId: "display-user-id",
+      token: "display-access-token",
+      cookieAuthSessionCookie: "display-session-cookie",
+    })
+    const account = buildSiteAccount({
+      id: "stored-account-id",
+      site_name: "Stored Account",
+      site_url: "https://stored.example.invalid",
+      site_type: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.Cookie,
+      cookieAuth: { sessionCookie: "stored-session-cookie" },
+      account_info: {
+        id: "stored-user-id",
+        access_token: "stored-access-token",
+        username: "stored-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const createdToken = buildToken({ id: 16, key: "sk-created" })
+
+    fetchAccountTokensMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([createdToken])
+    createApiTokenMock.mockResolvedValueOnce(true)
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: false,
+    })
+
+    const expectedDisplayRequest = {
+      baseUrl: "https://display.example.invalid",
+      accountId: "display-account-id",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "display-user-id",
+        accessToken: "display-access-token",
+        cookie: "display-session-cookie",
+      },
+    }
+
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
+      1,
+      expectedDisplayRequest,
+    )
+    expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
+      2,
+      expectedDisplayRequest,
+    )
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      {
+        baseUrl: "https://stored.example.invalid",
+        accountId: "stored-account-id",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: "stored-user-id",
+          accessToken: "stored-access-token",
+          cookie: "stored-session-cookie",
+        },
+      },
+      expect.objectContaining({
+        name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: "",
+      }),
+    )
   })
 
   it("blocks ordinary token creation when create succeeds but refetch cannot identify the new token", async () => {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -7,8 +7,13 @@ import {
   InvalidTokenPayloadError,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { getApiService } from "~/services/apiService"
 import { AuthTypeEnum } from "~/types"
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(),
+}))
 
 vi.mock("~/services/apiService", () => ({
   getApiService: vi.fn(),
@@ -24,39 +29,65 @@ const ACCOUNT = {
   cookieAuthSessionCookie: "",
 } as const
 
+const REQUEST = {
+  baseUrl: "https://example.com",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "1",
+    accessToken: "token",
+    cookie: "",
+  },
+}
+
 describe("fetchDisplayAccountTokens", () => {
+  let fetchTokens: ReturnType<typeof vi.fn>
+  let createToken: ReturnType<typeof vi.fn>
+  let resolveTokenKey: ReturnType<typeof vi.fn>
+  let keyManagement: {
+    fetchTokens: typeof fetchTokens
+    createToken: typeof createToken
+    resolveTokenKey: typeof resolveTokenKey
+  }
+  let adapter: {
+    siteType: string
+    keyManagement?: typeof keyManagement
+  }
+  let service: {
+    fetchUserGroups: ReturnType<typeof vi.fn>
+  }
+
   beforeEach(() => {
+    fetchTokens = vi.fn()
+    createToken = vi.fn()
+    resolveTokenKey = vi.fn()
+    keyManagement = { fetchTokens, createToken, resolveTokenKey }
+    adapter = { siteType: "new-api", keyManagement }
+    service = { fetchUserGroups: vi.fn() }
+
+    vi.mocked(getSiteAdapter).mockReset()
     vi.mocked(getApiService).mockReset()
+    vi.mocked(getSiteAdapter).mockReturnValue(adapter as any)
+    vi.mocked(getApiService).mockReturnValue(service as any)
   })
 
   it("returns the token array when the API payload is valid", async () => {
-    const fetchAccountTokens = vi
-      .fn()
-      .mockResolvedValue([{ id: 1, key: "sk-test", status: 1 }])
-    const service = { fetchAccountTokens }
-    vi.mocked(getApiService).mockReturnValue(service as any)
+    fetchTokens.mockResolvedValue([{ id: 1, key: "sk-test", status: 1 }])
 
     const result = await fetchDisplayAccountTokens(ACCOUNT as any)
 
     expect(result).toEqual([{ id: 1, key: "sk-test", status: 1 }])
+    expect(fetchTokens).toHaveBeenCalledWith(REQUEST)
     expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual({
       service,
-      request: {
-        baseUrl: "https://example.com",
-        accountId: "account-1",
-        auth: {
-          authType: AuthTypeEnum.AccessToken,
-          userId: "1",
-          accessToken: "token",
-          cookie: "",
-        },
-      },
+      adapter,
+      keyManagement,
+      request: REQUEST,
     })
   })
 
   it("throws InvalidTokenPayloadError when the API payload is not an array", async () => {
-    const fetchAccountTokens = vi.fn().mockResolvedValue({ items: [] })
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    fetchTokens.mockResolvedValue({ items: [] })
 
     await expect(
       fetchDisplayAccountTokens(ACCOUNT as any),
@@ -79,8 +110,7 @@ describe("fetchDisplayAccountTokens", () => {
 
   it("returns the original token object when the resolved secret key is unchanged", async () => {
     const token = { id: 1, key: "sk-test", status: 1 }
-    const resolveApiTokenKey = vi.fn().mockResolvedValue("sk-test")
-    vi.mocked(getApiService).mockReturnValue({ resolveApiTokenKey } as any)
+    resolveTokenKey.mockResolvedValue("sk-test")
 
     const result = await resolveDisplayAccountTokenForSecret(
       ACCOUNT as any,
@@ -88,12 +118,12 @@ describe("fetchDisplayAccountTokens", () => {
     )
 
     expect(result).toBe(token)
+    expect(resolveTokenKey).toHaveBeenCalledWith({ request: REQUEST, token })
   })
 
   it("clones the token when the resolved secret key differs from the masked key", async () => {
     const token = { id: 1, key: "sk-masked", status: 1, name: "Masked" }
-    const resolveApiTokenKey = vi.fn().mockResolvedValue("sk-real")
-    vi.mocked(getApiService).mockReturnValue({ resolveApiTokenKey } as any)
+    resolveTokenKey.mockResolvedValue("sk-real")
 
     const result = await resolveDisplayAccountTokenForSecret(
       ACCOUNT as any,
@@ -107,12 +137,12 @@ describe("fetchDisplayAccountTokens", () => {
       name: "Masked",
     })
     expect(result).not.toBe(token)
+    expect(resolveTokenKey).toHaveBeenCalledWith({ request: REQUEST, token })
   })
 
   it("returns a transient sk-prefixed secret for optional-prefix compatible account types", async () => {
     const token = { id: 1, key: "plain-secret", status: 1, name: "Plain" }
-    const resolveApiTokenKey = vi.fn().mockResolvedValue("plain-secret")
-    vi.mocked(getApiService).mockReturnValue({ resolveApiTokenKey } as any)
+    resolveTokenKey.mockResolvedValue("plain-secret")
 
     const result = await resolveDisplayAccountTokenForSecret(
       { ...ACCOUNT, siteType: "Veloera" } as any,
@@ -131,8 +161,7 @@ describe("fetchDisplayAccountTokens", () => {
 
   it("does not synthesize sk-prefixes for non-compatible account types", async () => {
     const token = { id: 1, key: "plain-secret", status: 1, name: "Plain" }
-    const resolveApiTokenKey = vi.fn().mockResolvedValue("plain-secret")
-    vi.mocked(getApiService).mockReturnValue({ resolveApiTokenKey } as any)
+    resolveTokenKey.mockResolvedValue("plain-secret")
 
     const result = await resolveDisplayAccountTokenForSecret(
       { ...ACCOUNT, siteType: "sub2api" } as any,
@@ -140,6 +169,19 @@ describe("fetchDisplayAccountTokens", () => {
     )
 
     expect(result).toBe(token)
+  })
+
+  it("throws when adapter key management is not implemented", async () => {
+    vi.mocked(getSiteAdapter).mockReturnValue({
+      siteType: "unsupported",
+    } as any)
+
+    await expect(
+      fetchDisplayAccountTokens({
+        ...ACCOUNT,
+        siteType: "unsupported",
+      } as any),
+    ).rejects.toThrow("keyManagement is not implemented for unsupported")
   })
 
   it("only allows token management for enabled accounts with complete auth context", () => {

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { aihubmixKeyManagement } from "~/services/apiAdapters/aihubmix/keyManagement"
+import { createNewApiKeyManagement } from "~/services/apiAdapters/newApi/keyManagement"
+import { sub2ApiKeyManagement } from "~/services/apiAdapters/sub2api/keyManagement"
+import { AuthTypeEnum, type ApiToken } from "~/types"
+
+const {
+  mockAihubmixCreateApiToken,
+  mockAihubmixFetchAccountTokens,
+  mockAihubmixResolveApiTokenKey,
+  mockCreateApiToken,
+  mockFetchAccountTokens,
+  mockGetApiService,
+  mockResolveApiTokenKey,
+  mockSub2ApiCreateApiToken,
+  mockSub2ApiFetchAccountTokens,
+  mockSub2ApiResolveApiTokenKey,
+} = vi.hoisted(() => ({
+  mockAihubmixCreateApiToken: vi.fn(),
+  mockAihubmixFetchAccountTokens: vi.fn(),
+  mockAihubmixResolveApiTokenKey: vi.fn(),
+  mockCreateApiToken: vi.fn(),
+  mockFetchAccountTokens: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockResolveApiTokenKey: vi.fn(),
+  mockSub2ApiCreateApiToken: vi.fn(),
+  mockSub2ApiFetchAccountTokens: vi.fn(),
+  mockSub2ApiResolveApiTokenKey: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  createApiToken: mockSub2ApiCreateApiToken,
+  fetchAccountTokens: mockSub2ApiFetchAccountTokens,
+  resolveApiTokenKey: mockSub2ApiResolveApiTokenKey,
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  createApiToken: mockAihubmixCreateApiToken,
+  fetchAccountTokens: mockAihubmixFetchAccountTokens,
+  resolveApiTokenKey: mockAihubmixResolveApiTokenKey,
+}))
+
+const request = {
+  baseUrl: "https://api.example.invalid",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    token: "access-token",
+  },
+}
+
+const token = {
+  id: 123,
+  key: "sk-...",
+  name: "Example token",
+} as ApiToken
+
+const tokenData = {
+  name: "Example token",
+  remain_quota: 500000,
+  expired_time: -1,
+  unlimited_quota: false,
+  model_limits_enabled: false,
+  model_limits: "",
+  allow_ips: "",
+  group: "",
+}
+
+describe("apiAdapter keyManagement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      createApiToken: mockCreateApiToken,
+      fetchAccountTokens: mockFetchAccountTokens,
+      resolveApiTokenKey: mockResolveApiTokenKey,
+    })
+  })
+
+  it("delegates New API-family key operations through the site-specific apiService", async () => {
+    const expectedTokens = [token]
+    mockFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
+    mockCreateApiToken.mockResolvedValueOnce(true)
+    mockResolveApiTokenKey.mockResolvedValueOnce("sk-real")
+
+    const keyManagement = createNewApiKeyManagement(SITE_TYPES.ONE_HUB)
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+
+    await expect(
+      keyManagement.fetchTokens(request, { page: 2, size: 25 }),
+    ).resolves.toBe(expectedTokens)
+    await expect(keyManagement.createToken(request, tokenData)).resolves.toBe(
+      true,
+    )
+    await expect(
+      keyManagement.resolveTokenKey({ request, token }),
+    ).resolves.toBe("sk-real")
+
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.ONE_HUB)
+    expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, 2, 25)
+    expect(mockCreateApiToken).toHaveBeenCalledWith(request, tokenData)
+    expect(mockResolveApiTokenKey).toHaveBeenCalledWith(request, token)
+  })
+
+  it("delegates Sub2API key operations to backend key helpers", async () => {
+    const expectedTokens = [token]
+    mockSub2ApiFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
+    mockSub2ApiCreateApiToken.mockResolvedValueOnce(token)
+    mockSub2ApiResolveApiTokenKey.mockResolvedValueOnce("sk-sub2api")
+
+    await expect(
+      sub2ApiKeyManagement.fetchTokens(request, { page: 3, size: 50 }),
+    ).resolves.toBe(expectedTokens)
+    await expect(
+      sub2ApiKeyManagement.createToken(request, tokenData),
+    ).resolves.toBe(token)
+    await expect(
+      sub2ApiKeyManagement.resolveTokenKey({ request, token }),
+    ).resolves.toBe("sk-sub2api")
+
+    expect(mockSub2ApiFetchAccountTokens).toHaveBeenCalledWith(request, 3, 50)
+    expect(mockSub2ApiCreateApiToken).toHaveBeenCalledWith(request, tokenData)
+    expect(mockSub2ApiResolveApiTokenKey).toHaveBeenCalledWith(request, token)
+  })
+
+  it("delegates AIHubMix key operations while preserving fetch option behavior", async () => {
+    const expectedTokens = [token]
+    mockAihubmixFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
+    mockAihubmixCreateApiToken.mockResolvedValueOnce(token)
+    mockAihubmixResolveApiTokenKey.mockResolvedValueOnce("aihubmix-secret")
+
+    await expect(
+      aihubmixKeyManagement.fetchTokens(request, { page: 4, size: 10 }),
+    ).resolves.toBe(expectedTokens)
+    await expect(
+      aihubmixKeyManagement.createToken(request, tokenData),
+    ).resolves.toBe(token)
+    await expect(
+      aihubmixKeyManagement.resolveTokenKey({ request, token }),
+    ).resolves.toBe("aihubmix-secret")
+
+    expect(mockAihubmixFetchAccountTokens).toHaveBeenCalledWith(request)
+    expect(mockAihubmixCreateApiToken).toHaveBeenCalledWith(request, tokenData)
+    expect(mockAihubmixResolveApiTokenKey).toHaveBeenCalledWith(request, token)
+  })
+})

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -21,6 +21,11 @@ describe("apiAdapters registry", () => {
     expect(adapter.accountCompletion).toEqual({
       complete: expect.any(Function),
     })
+    expect(adapter.keyManagement).toEqual({
+      fetchTokens: expect.any(Function),
+      createToken: expect.any(Function),
+      resolveTokenKey: expect.any(Function),
+    })
     expect(adapter.siteNotice).toBeUndefined()
   })
 
@@ -52,12 +57,17 @@ describe("apiAdapters registry", () => {
       expect(adapter.accountCompletion).toEqual({
         complete: expect.any(Function),
       })
+      expect(adapter.keyManagement).toEqual({
+        fetchTokens: expect.any(Function),
+        createToken: expect.any(Function),
+        resolveTokenKey: expect.any(Function),
+      })
       expect(adapter.siteAnnouncements).toBeUndefined()
       expect(adapter.modelCatalog).toBeUndefined()
     }
   })
 
-  it("returns an AIHubMix Adapter with account completion only", () => {
+  it("returns an AIHubMix Adapter with account completion and key management", () => {
     const adapter = getSiteAdapter(SITE_TYPES.AIHUBMIX)
 
     expect(adapter).toMatchObject({
@@ -65,6 +75,11 @@ describe("apiAdapters registry", () => {
     })
     expect(adapter.accountCompletion).toEqual({
       complete: expect.any(Function),
+    })
+    expect(adapter.keyManagement).toEqual({
+      fetchTokens: expect.any(Function),
+      createToken: expect.any(Function),
+      resolveTokenKey: expect.any(Function),
     })
     expect(adapter.siteNotice).toBeUndefined()
     expect(adapter.siteAnnouncements).toBeUndefined()


### PR DESCRIPTION
## Summary
- Add a key-management capability to the API adapter registry for New API-family, Sub2API, and AIHubMix account flows.
- Route account token lookup, provisioning, and UI token dialogs through the adapter layer.
- Keep the implementation documented with the key-management migration plan/spec.

## Test Plan
- pnpm run validate:push
- per-commit validate:staged hooks during branch rewrite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced adapter-scoped key management that standardizes token inventory, creation, and secret resolution across API integrations.

* **Refactor**
  * Updated account token provisioning and post-save provisioning to route token operations through adapter key management.
  * Updated account copy-key and managed-site channel flows to use shared token helpers and improved invalid-token handling.

* **Tests**
  * Expanded Vitest coverage for adapter delegation and updated UI/account-management mocks and assertions.

* **Documentation**
  * Added architecture and migration plan specs for the adapter key-management rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->