### PR TITLE
refactor(account): route refresh through site adapters

### DIFF
--- a/docs/superpowers/plans/2026-06-18-api-adapter-account-refresh.md
+++ b/docs/superpowers/plans/2026-06-18-api-adapter-account-refresh.md
@@ -500,8 +500,8 @@ import {
 } from "~/services/apiService/sub2api"
 
 export const sub2ApiAccountRefresh: AccountRefreshCapability = {
-  fetchCheckInSupport,
-  refreshAccount: refreshAccountData,
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  refreshAccount: (request) => refreshAccountData(request),
 }
 ```
 
@@ -547,8 +547,8 @@ import {
 } from "~/services/apiService/aihubmix"
 
 export const aihubmixAccountRefresh: AccountRefreshCapability = {
-  fetchCheckInSupport,
-  refreshAccount: refreshAccountData,
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  refreshAccount: (request) => refreshAccountData(request),
 }
 ```
 

--- a/docs/superpowers/plans/2026-06-18-api-adapter-account-refresh.md
+++ b/docs/superpowers/plans/2026-06-18-api-adapter-account-refresh.md
@@ -1,0 +1,1053 @@
+# API Adapter Account Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move saved-account refresh through `SiteAdapter.accountRefresh` while preserving existing account refresh behavior.
+
+**Architecture:** Add a narrow `accountRefresh` capability to the existing `apiAdapters` Interface. Backend adapters delegate to the existing legacy refresh helpers, while `accountStorage.refreshAccount(...)` keeps product-owned persistence, manual balance overrides, custom check-in merging, balance-history capture, and Sub2API auth-update persistence.
+
+**Tech Stack:** TypeScript, WXT extension services, Vitest, existing `apiService` compatibility facade, existing `apiAdapters` registry.
+
+---
+
+## File Structure
+
+- Create `src/services/apiAdapters/contracts/accountRefresh.ts`
+  - Owns the `AccountRefreshCapability` Interface.
+  - Reuses `ApiServiceAccountRequest`, `ApiServiceRequest`, and `RefreshAccountResult`.
+- Modify `src/services/apiAdapters/contracts/siteAdapter.ts`
+  - Adds optional `accountRefresh?: AccountRefreshCapability`.
+- Create `src/services/apiAdapters/newApi/accountRefresh.ts`
+  - Creates a site-scoped New API-family refresh Adapter.
+- Modify `src/services/apiAdapters/newApi/index.ts`
+  - Registers `accountRefresh` for every New API-family site type.
+- Create `src/services/apiAdapters/sub2api/accountRefresh.ts`
+  - Delegates Sub2API refresh and check-in support probing to existing Sub2API helpers.
+- Modify `src/services/apiAdapters/sub2api/index.ts`
+  - Registers Sub2API `accountRefresh`.
+- Create `src/services/apiAdapters/aihubmix/accountRefresh.ts`
+  - Delegates AIHubMix refresh and check-in support probing to existing AIHubMix helpers.
+- Modify `src/services/apiAdapters/aihubmix/index.ts`
+  - Registers AIHubMix `accountRefresh`.
+- Modify `src/services/accounts/accountStorage.ts`
+  - Replaces direct refresh-path `getApiService(...)` calls with `getSiteAdapter(...).accountRefresh`.
+  - Keeps account persistence and product merge rules in account storage.
+- Create `tests/services/apiAdapters/newApi/accountRefresh.test.ts`
+  - Covers New API-family Adapter delegation.
+- Create `tests/services/apiAdapters/sub2api/accountRefresh.test.ts`
+  - Covers Sub2API Adapter delegation and `authUpdate` preservation.
+- Create `tests/services/apiAdapters/aihubmix/accountRefresh.test.ts`
+  - Covers AIHubMix Adapter delegation and unchanged disabled-check-in/zeroed-stat result.
+- Modify `tests/services/apiAdapters/registry.test.ts`
+  - Expects `accountRefresh` on New API-family, Sub2API, and AIHubMix Adapters.
+- Modify `tests/services/accountStorage.test.ts`
+  - Mocks `getSiteAdapter(...)`.
+  - Verifies refresh uses `accountRefresh`.
+  - Verifies missing capability produces persisted unhealthy status without throwing out of the refresh workflow.
+  - Keeps existing manual balance, support-probe failure, Sub2API auth-update, and snapshot assertions passing.
+
+## Task 1: Add Failing Adapter Capability Tests
+
+**Files:**
+- Create: `tests/services/apiAdapters/newApi/accountRefresh.test.ts`
+- Create: `tests/services/apiAdapters/sub2api/accountRefresh.test.ts`
+- Create: `tests/services/apiAdapters/aihubmix/accountRefresh.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write the New API-family Adapter test**
+
+Create `tests/services/apiAdapters/newApi/accountRefresh.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { createNewApiAccountRefresh } from "~/services/apiAdapters/newApi/accountRefresh"
+import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+
+const {
+  mockFetchSupportCheckIn,
+  mockGetApiService,
+  mockRefreshAccountData,
+} = vi.hoisted(() => ({
+  mockFetchSupportCheckIn: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockRefreshAccountData: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+const supportRequest = {
+  baseUrl: "https://one.example.invalid",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "account-token",
+  },
+}
+
+const refreshRequest = {
+  ...supportRequest,
+  accountId: "account-1",
+  checkIn: {
+    enableDetection: true,
+    autoCheckInEnabled: true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+  },
+  includeTodayCashflow: false,
+}
+
+describe("createNewApiAccountRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      fetchSupportCheckIn: mockFetchSupportCheckIn,
+      refreshAccountData: mockRefreshAccountData,
+    })
+  })
+
+  it("delegates refresh operations through the site-specific apiService", async () => {
+    const refreshResult = {
+      success: true,
+      data: {
+        quota: 123,
+        today_prompt_tokens: 1,
+        today_completion_tokens: 2,
+        today_quota_consumption: 3,
+        today_requests_count: 4,
+        today_income: 5,
+        checkIn: refreshRequest.checkIn,
+      },
+      healthStatus: {
+        status: SiteHealthStatus.Healthy,
+        message: "ok",
+      },
+    }
+    mockFetchSupportCheckIn.mockResolvedValueOnce(true)
+    mockRefreshAccountData.mockResolvedValueOnce(refreshResult)
+
+    const accountRefresh = createNewApiAccountRefresh(SITE_TYPES.ONE_HUB)
+
+    await expect(
+      accountRefresh.fetchCheckInSupport?.(supportRequest),
+    ).resolves.toBe(true)
+    await expect(accountRefresh.refreshAccount(refreshRequest)).resolves.toBe(
+      refreshResult,
+    )
+
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.ONE_HUB)
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(supportRequest)
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(refreshRequest)
+  })
+})
+```
+
+- [ ] **Step 2: Write the Sub2API Adapter test**
+
+Create `tests/services/apiAdapters/sub2api/accountRefresh.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { sub2ApiAccountRefresh } from "~/services/apiAdapters/sub2api/accountRefresh"
+import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+
+const { mockFetchSupportCheckIn, mockRefreshAccountData } = vi.hoisted(() => ({
+  mockFetchSupportCheckIn: vi.fn(),
+  mockRefreshAccountData: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchSupportCheckIn: mockFetchSupportCheckIn,
+  refreshAccountData: mockRefreshAccountData,
+}))
+
+const supportRequest = {
+  baseUrl: "https://sub2.example.invalid",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "dashboard-jwt",
+    refreshToken: "refresh-token",
+    tokenExpiresAt: 1999999999999,
+  },
+}
+
+const refreshRequest = {
+  ...supportRequest,
+  accountId: "sub2-account",
+  checkIn: {
+    enableDetection: true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+  },
+  includeTodayCashflow: true,
+}
+
+describe("sub2ApiAccountRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("delegates refresh operations and preserves authUpdate fields", async () => {
+    const refreshResult = {
+      success: true,
+      data: {
+        quota: 42,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+        checkIn: {
+          enableDetection: false,
+        },
+      },
+      healthStatus: {
+        status: SiteHealthStatus.Healthy,
+        message: "ok",
+      },
+      authUpdate: {
+        accessToken: "new-dashboard-jwt",
+        userId: "7",
+        username: "alice",
+        sub2apiAuth: {
+          refreshToken: "new-refresh-token",
+          tokenExpiresAt: 2000000000000,
+        },
+      },
+    }
+    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
+    mockRefreshAccountData.mockResolvedValueOnce(refreshResult)
+
+    await expect(
+      sub2ApiAccountRefresh.fetchCheckInSupport?.(supportRequest),
+    ).resolves.toBe(false)
+    await expect(
+      sub2ApiAccountRefresh.refreshAccount(refreshRequest),
+    ).resolves.toBe(refreshResult)
+
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(supportRequest)
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(refreshRequest)
+  })
+})
+```
+
+- [ ] **Step 3: Write the AIHubMix Adapter test**
+
+Create `tests/services/apiAdapters/aihubmix/accountRefresh.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { aihubmixAccountRefresh } from "~/services/apiAdapters/aihubmix/accountRefresh"
+import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+
+const { mockFetchSupportCheckIn, mockRefreshAccountData } = vi.hoisted(() => ({
+  mockFetchSupportCheckIn: vi.fn(),
+  mockRefreshAccountData: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  fetchSupportCheckIn: mockFetchSupportCheckIn,
+  refreshAccountData: mockRefreshAccountData,
+}))
+
+const supportRequest = {
+  baseUrl: "https://aihubmix.com",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "aihubmix-access-token",
+  },
+}
+
+const refreshRequest = {
+  ...supportRequest,
+  accountId: "aihubmix-account",
+  checkIn: {
+    enableDetection: true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+  },
+  includeTodayCashflow: true,
+}
+
+describe("aihubmixAccountRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("delegates refresh operations without reshaping disabled check-in or zeroed stats", async () => {
+    const refreshResult = {
+      success: true,
+      data: {
+        quota: 9800,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+        checkIn: {
+          enableDetection: false,
+          siteStatus: {
+            isCheckedInToday: undefined,
+          },
+        },
+      },
+      healthStatus: {
+        status: SiteHealthStatus.Healthy,
+        message: "ok",
+      },
+    }
+    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
+    mockRefreshAccountData.mockResolvedValueOnce(refreshResult)
+
+    await expect(
+      aihubmixAccountRefresh.fetchCheckInSupport?.(supportRequest),
+    ).resolves.toBe(false)
+    await expect(
+      aihubmixAccountRefresh.refreshAccount(refreshRequest),
+    ).resolves.toBe(refreshResult)
+
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(supportRequest)
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(refreshRequest)
+  })
+})
+```
+
+- [ ] **Step 4: Update registry expectations**
+
+In `tests/services/apiAdapters/registry.test.ts`, add `accountRefresh` expectations.
+
+In the Sub2API test, after the existing `keyManagement` expectation, add:
+
+```ts
+    expect(adapter.accountRefresh).toEqual({
+      fetchCheckInSupport: expect.any(Function),
+      refreshAccount: expect.any(Function),
+    })
+```
+
+In the New API-family loop, after the existing `keyManagement` expectation, add:
+
+```ts
+      expect(adapter.accountRefresh).toEqual({
+        fetchCheckInSupport: expect.any(Function),
+        refreshAccount: expect.any(Function),
+      })
+```
+
+In the AIHubMix test, after the existing `keyManagement` expectation, add:
+
+```ts
+    expect(adapter.accountRefresh).toEqual({
+      fetchCheckInSupport: expect.any(Function),
+      refreshAccount: expect.any(Function),
+    })
+```
+
+- [ ] **Step 5: Run tests and verify the expected failure**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/apiAdapters/newApi/accountRefresh.test.ts tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/aihubmix/accountRefresh.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because the new `accountRefresh` modules and `SiteAdapter.accountRefresh` contract do not exist yet.
+
+## Task 2: Implement Adapter Capability And Registry Wiring
+
+**Files:**
+- Create: `src/services/apiAdapters/contracts/accountRefresh.ts`
+- Modify: `src/services/apiAdapters/contracts/siteAdapter.ts`
+- Create: `src/services/apiAdapters/newApi/accountRefresh.ts`
+- Modify: `src/services/apiAdapters/newApi/index.ts`
+- Create: `src/services/apiAdapters/sub2api/accountRefresh.ts`
+- Modify: `src/services/apiAdapters/sub2api/index.ts`
+- Create: `src/services/apiAdapters/aihubmix/accountRefresh.ts`
+- Modify: `src/services/apiAdapters/aihubmix/index.ts`
+- Test: `tests/services/apiAdapters/newApi/accountRefresh.test.ts`
+- Test: `tests/services/apiAdapters/sub2api/accountRefresh.test.ts`
+- Test: `tests/services/apiAdapters/aihubmix/accountRefresh.test.ts`
+- Test: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Add the contract**
+
+Create `src/services/apiAdapters/contracts/accountRefresh.ts`:
+
+```ts
+import type {
+  ApiServiceAccountRequest,
+  ApiServiceRequest,
+  RefreshAccountResult,
+} from "~/services/apiService/common/type"
+
+export type AccountRefreshSupportRequest = {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+}
+
+export type AccountRefreshRequest = ApiServiceAccountRequest
+
+export type AccountRefreshCapability = {
+  fetchCheckInSupport?(
+    request: AccountRefreshSupportRequest,
+  ): Promise<boolean>
+  refreshAccount(request: AccountRefreshRequest): Promise<RefreshAccountResult>
+}
+```
+
+- [ ] **Step 2: Extend `SiteAdapter`**
+
+Modify `src/services/apiAdapters/contracts/siteAdapter.ts`.
+
+Add the import:
+
+```ts
+import type { AccountRefreshCapability } from "./accountRefresh"
+```
+
+Add the optional capability to `SiteAdapter`:
+
+```ts
+  accountRefresh?: AccountRefreshCapability
+```
+
+The final type should include:
+
+```ts
+export type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+}
+```
+
+- [ ] **Step 3: Add the New API-family Adapter**
+
+Create `src/services/apiAdapters/newApi/accountRefresh.ts`:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import type { AccountRefreshCapability } from "~/services/apiAdapters/contracts/accountRefresh"
+import { getApiService } from "~/services/apiService"
+
+/**
+ * Create account-refresh operations bound to the New API-family site type.
+ */
+export function createNewApiAccountRefresh(
+  siteType: AccountSiteType,
+): AccountRefreshCapability {
+  return {
+    fetchCheckInSupport: (request) =>
+      getApiService(siteType).fetchSupportCheckIn(request),
+    refreshAccount: (request) =>
+      getApiService(siteType).refreshAccountData(request),
+  }
+}
+```
+
+- [ ] **Step 4: Register the New API-family Adapter capability**
+
+Modify `src/services/apiAdapters/newApi/index.ts`.
+
+Add:
+
+```ts
+import { createNewApiAccountRefresh } from "./accountRefresh"
+```
+
+Add the property inside `createNewApiAdapter(...)`:
+
+```ts
+  accountRefresh: createNewApiAccountRefresh(siteType),
+```
+
+The returned object should include:
+
+```ts
+export const createNewApiAdapter = (
+  siteType: AccountSiteType = SITE_TYPES.NEW_API,
+): SiteAdapter => ({
+  siteType,
+  family: "newApiFamily",
+  siteNotice: newApiSiteNotice,
+  accountCompletion: newApiAccountCompletion,
+  keyManagement: createNewApiKeyManagement(siteType),
+  accountRefresh: createNewApiAccountRefresh(siteType),
+})
+```
+
+- [ ] **Step 5: Add the Sub2API Adapter**
+
+Create `src/services/apiAdapters/sub2api/accountRefresh.ts`:
+
+```ts
+import type { AccountRefreshCapability } from "~/services/apiAdapters/contracts/accountRefresh"
+import {
+  fetchSupportCheckIn,
+  refreshAccountData,
+} from "~/services/apiService/sub2api"
+
+export const sub2ApiAccountRefresh: AccountRefreshCapability = {
+  fetchCheckInSupport,
+  refreshAccount: refreshAccountData,
+}
+```
+
+- [ ] **Step 6: Register the Sub2API Adapter capability**
+
+Modify `src/services/apiAdapters/sub2api/index.ts`.
+
+Add:
+
+```ts
+import { sub2ApiAccountRefresh } from "./accountRefresh"
+```
+
+Add the property inside `sub2ApiAdapter`:
+
+```ts
+  accountRefresh: sub2ApiAccountRefresh,
+```
+
+The object should include:
+
+```ts
+export const sub2ApiAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.SUB2API,
+  family: "sub2api",
+  siteAnnouncements: sub2ApiSiteAnnouncements,
+  modelCatalog: sub2ApiModelCatalog,
+  accountCompletion: sub2ApiAccountCompletion,
+  keyManagement: sub2ApiKeyManagement,
+  accountRefresh: sub2ApiAccountRefresh,
+}
+```
+
+- [ ] **Step 7: Add the AIHubMix Adapter**
+
+Create `src/services/apiAdapters/aihubmix/accountRefresh.ts`:
+
+```ts
+import type { AccountRefreshCapability } from "~/services/apiAdapters/contracts/accountRefresh"
+import {
+  fetchSupportCheckIn,
+  refreshAccountData,
+} from "~/services/apiService/aihubmix"
+
+export const aihubmixAccountRefresh: AccountRefreshCapability = {
+  fetchCheckInSupport,
+  refreshAccount: refreshAccountData,
+}
+```
+
+- [ ] **Step 8: Register the AIHubMix Adapter capability**
+
+Modify `src/services/apiAdapters/aihubmix/index.ts`.
+
+Add:
+
+```ts
+import { aihubmixAccountRefresh } from "./accountRefresh"
+```
+
+Add the property inside `aihubmixAdapter`:
+
+```ts
+  accountRefresh: aihubmixAccountRefresh,
+```
+
+The object should include:
+
+```ts
+export const aihubmixAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.AIHUBMIX,
+  accountCompletion: aihubmixAccountCompletion,
+  keyManagement: aihubmixKeyManagement,
+  accountRefresh: aihubmixAccountRefresh,
+}
+```
+
+- [ ] **Step 9: Run focused Adapter tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/apiAdapters/newApi/accountRefresh.test.ts tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/aihubmix/accountRefresh.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit Adapter capability**
+
+Run:
+
+```bash
+git add src/services/apiAdapters/contracts/accountRefresh.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/accountRefresh.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/sub2api/accountRefresh.ts src/services/apiAdapters/sub2api/index.ts src/services/apiAdapters/aihubmix/accountRefresh.ts src/services/apiAdapters/aihubmix/index.ts tests/services/apiAdapters/newApi/accountRefresh.test.ts tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/aihubmix/accountRefresh.test.ts tests/services/apiAdapters/registry.test.ts
+git commit -m "refactor(api-adapters): add account refresh capability"
+```
+
+Expected: commit succeeds after the pre-commit hook runs `validate:staged`.
+
+## Task 3: Add Failing Account Storage Migration Tests
+
+**Files:**
+- Modify: `tests/services/accountStorage.test.ts`
+
+- [ ] **Step 1: Replace legacy API service mocks with `getSiteAdapter` mocks**
+
+In `tests/services/accountStorage.test.ts`, update the hoisted mock block.
+
+Remove these entries:
+
+```ts
+  mockValidateAccountConnection,
+  mockFetchTodayIncome,
+```
+
+Add this entry:
+
+```ts
+  mockGetSiteAdapter,
+```
+
+Add `mockGetSiteAdapter: vi.fn(),` in the returned object:
+
+```ts
+  mockGetSiteAdapter: vi.fn(),
+```
+
+The hoisted block should contain these refresh-related mocks:
+
+```ts
+  mockFetchSupportCheckIn,
+  mockGetAccountSiteType,
+  mockGetSiteAdapter,
+  mockRefreshAccountData,
+```
+
+- [ ] **Step 2: Replace the `apiService` module mock with an adapter-registry mock**
+
+Remove this mock:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: vi.fn(() => ({
+    fetchTodayIncome: mockFetchTodayIncome,
+    refreshAccountData: mockRefreshAccountData,
+    validateAccountConnection: mockValidateAccountConnection,
+    fetchSupportCheckIn: mockFetchSupportCheckIn,
+  })),
+}))
+```
+
+Add this mock in the same area:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: mockGetSiteAdapter,
+}))
+```
+
+After the replacement, `accountStorage.test.ts` should not mock `~/services/apiService` directly.
+
+- [ ] **Step 3: Update `beforeEach` default adapter behavior**
+
+In the `beforeEach`, remove:
+
+```ts
+    mockValidateAccountConnection.mockReset()
+    mockFetchTodayIncome.mockReset()
+```
+
+Add:
+
+```ts
+    mockGetSiteAdapter.mockReset()
+```
+
+After the existing `mockRefreshAccountData.mockImplementation(...)`, add:
+
+```ts
+    mockGetSiteAdapter.mockReturnValue({
+      accountRefresh: {
+        fetchCheckInSupport: mockFetchSupportCheckIn,
+        refreshAccount: mockRefreshAccountData,
+      },
+    })
+```
+
+- [ ] **Step 4: Remove obsolete legacy mock defaults and assertions**
+
+Remove this default:
+
+```ts
+    mockFetchTodayIncome.mockResolvedValue({ today_income: 0 })
+```
+
+Remove these assertions from refresh tests:
+
+```ts
+    expect(mockFetchTodayIncome).not.toHaveBeenCalled()
+```
+
+There should be no `mockValidateAccountConnection` or `mockFetchTodayIncome` references left after this step.
+
+Verify with:
+
+```bash
+rg -n "mockValidateAccountConnection|mockFetchTodayIncome" tests/services/accountStorage.test.ts
+```
+
+Expected: no matches.
+
+- [ ] **Step 5: Add an assertion that re-detected site type drives adapter selection**
+
+In the test named `"refreshAccount should re-detect unknown site type and check-in support"`, after the `mockGetAccountSiteType` assertion, add:
+
+```ts
+    expect(mockGetSiteAdapter).toHaveBeenCalledWith("one-api")
+```
+
+- [ ] **Step 6: Add an assertion that known site type drives adapter selection**
+
+In the test named `"refreshAccount should skip re-detection when site metadata is complete"`, after `expect(mockGetAccountSiteType).not.toHaveBeenCalled()`, add:
+
+```ts
+    expect(mockGetSiteAdapter).toHaveBeenCalledWith("one-api")
+```
+
+- [ ] **Step 7: Add a missing-capability regression test**
+
+Add this test near the existing refresh-account tests, after `"refreshAccount should continue when check-in support detection throws"`:
+
+```ts
+  it("refreshAccount should persist an unhealthy state when account refresh is unsupported", async () => {
+    const account = createAccount({
+      id: "unsupported-refresh",
+      site_url: "https://unsupported.example.com",
+      site_type: "unsupported-site",
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+      },
+    })
+    seedStorage([account])
+
+    mockGetSiteAdapter.mockReturnValueOnce({
+      siteType: "unsupported-site",
+    })
+
+    const result = await accountStorage.refreshAccount(
+      "unsupported-refresh",
+      true,
+    )
+    const updatedAccount = await accountStorage.getAccountById(
+      "unsupported-refresh",
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        refreshed: true,
+      }),
+    )
+    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+    expect(mockRefreshAccountData).not.toHaveBeenCalled()
+    expect(updatedAccount?.health).toEqual({
+      status: SiteHealthStatus.Unknown,
+      reason: "accountRefresh is not implemented for unsupported-site",
+      code: undefined,
+    })
+  })
+```
+
+- [ ] **Step 8: Run account storage test and verify the expected failure**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/accountStorage.test.ts
+```
+
+Expected: FAIL because `accountStorage.refreshAccount(...)` still imports `getApiService(...)` and does not call `getSiteAdapter(...).accountRefresh`.
+
+## Task 4: Migrate `accountStorage.refreshAccount(...)`
+
+**Files:**
+- Modify: `src/services/accounts/accountStorage.ts`
+- Test: `tests/services/accountStorage.test.ts`
+
+- [ ] **Step 1: Replace the refresh-path import**
+
+In `src/services/accounts/accountStorage.ts`, remove:
+
+```ts
+import { getApiService } from "~/services/apiService"
+```
+
+Add:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import type { RefreshAccountResult } from "~/services/apiService/common/type"
+```
+
+- [ ] **Step 2: Add the missing-capability result helper**
+
+After:
+
+```ts
+const logger = createLogger("AccountStorage")
+```
+
+add:
+
+```ts
+const createMissingAccountRefreshResult = (
+  siteType: string,
+): RefreshAccountResult => ({
+  success: false,
+  healthStatus: {
+    status: SiteHealthStatus.Unknown,
+    message: `accountRefresh is not implemented for ${siteType}`,
+    code: undefined,
+  },
+})
+```
+
+- [ ] **Step 3: Resolve `accountRefresh` after auth is built**
+
+Inside `refreshAccount(...)`, after the `auth` object is created, add:
+
+```ts
+      const accountRefresh = getSiteAdapter(account.site_type).accountRefresh
+```
+
+This should be placed before the `currentCheckIn` declaration.
+
+- [ ] **Step 4: Replace check-in support probing**
+
+Replace this block:
+
+```ts
+      try {
+        const support = await getApiService(
+          account.site_type,
+        ).fetchSupportCheckIn({
+          baseUrl,
+          auth,
+        })
+
+        if (typeof support === "boolean") {
+          checkInForRefresh = {
+            ...checkInForRefresh,
+            enableDetection: support,
+          }
+        }
+      } catch (error) {
+        logger.warn("Failed to determine check-in support", { baseUrl, error })
+      }
+```
+
+with:
+
+```ts
+      if (accountRefresh?.fetchCheckInSupport) {
+        try {
+          const support = await accountRefresh.fetchCheckInSupport({
+            baseUrl,
+            auth,
+          })
+
+          if (typeof support === "boolean") {
+            checkInForRefresh = {
+              ...checkInForRefresh,
+              enableDetection: support,
+            }
+          }
+        } catch (error) {
+          logger.warn("Failed to determine check-in support", {
+            baseUrl,
+            error,
+          })
+        }
+      }
+```
+
+- [ ] **Step 5: Replace account data refresh**
+
+Replace:
+
+```ts
+      // 刷新账号数据
+      const result = await getApiService(account.site_type).refreshAccountData({
+        baseUrl: account.site_url,
+        accountId: account.id,
+        checkIn: checkInForRefresh,
+        auth,
+        includeTodayCashflow,
+      })
+```
+
+with:
+
+```ts
+      // 刷新账号数据
+      const result = accountRefresh
+        ? await accountRefresh.refreshAccount({
+            baseUrl: account.site_url,
+            accountId: account.id,
+            checkIn: checkInForRefresh,
+            auth,
+            includeTodayCashflow,
+          })
+        : createMissingAccountRefreshResult(account.site_type)
+```
+
+- [ ] **Step 6: Run account storage test**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/accountStorage.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Confirm `accountStorage.ts` no longer imports `apiService`**
+
+Run:
+
+```bash
+rg -n "getApiService|~/services/apiService" src/services/accounts/accountStorage.ts
+```
+
+Expected: no matches.
+
+- [ ] **Step 8: Commit account storage migration**
+
+Run:
+
+```bash
+git add src/services/accounts/accountStorage.ts tests/services/accountStorage.test.ts
+git commit -m "refactor(account): route refresh through site adapters"
+```
+
+Expected: commit succeeds after the pre-commit hook runs `validate:staged`.
+
+## Task 5: Final Validation And Diff Review
+
+**Files:**
+- Review all task-scoped files from Tasks 1-4.
+
+- [ ] **Step 1: Run focused Adapter and account refresh tests**
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/apiAdapters/newApi/accountRefresh.test.ts tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/aihubmix/accountRefresh.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountStorage.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run TypeScript compile**
+
+Run:
+
+```bash
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run staged validation**
+
+If there are staged files, run:
+
+```bash
+pnpm run validate:staged
+```
+
+Expected: PASS. If the command reformats files, inspect `git diff` and restage only task-scoped files.
+
+- [ ] **Step 4: Run push gate**
+
+Because this slice adds a shared exported Adapter contract and registry wiring, run:
+
+```bash
+pnpm run validate:push
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect the final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD~2..HEAD
+git diff --name-status HEAD~2..HEAD
+```
+
+Expected: the diff is limited to:
+
+```text
+src/services/apiAdapters/contracts/accountRefresh.ts
+src/services/apiAdapters/contracts/siteAdapter.ts
+src/services/apiAdapters/newApi/accountRefresh.ts
+src/services/apiAdapters/newApi/index.ts
+src/services/apiAdapters/sub2api/accountRefresh.ts
+src/services/apiAdapters/sub2api/index.ts
+src/services/apiAdapters/aihubmix/accountRefresh.ts
+src/services/apiAdapters/aihubmix/index.ts
+src/services/accounts/accountStorage.ts
+tests/services/apiAdapters/newApi/accountRefresh.test.ts
+tests/services/apiAdapters/sub2api/accountRefresh.test.ts
+tests/services/apiAdapters/aihubmix/accountRefresh.test.ts
+tests/services/apiAdapters/registry.test.ts
+tests/services/accountStorage.test.ts
+```
+
+- [ ] **Step 6: Check remaining direct account refresh facade usage**
+
+Run:
+
+```bash
+rg -n "refreshAccountData\\(|fetchSupportCheckIn\\(" src/services/accounts src/features src/components
+```
+
+Expected: no `refreshAccountData(...)` or `fetchSupportCheckIn(...)` direct calls remain in `src/services/accounts/accountStorage.ts`. Other domains may still use the legacy facade and are outside this slice.
+
+- [ ] **Step 7: Record execution notes**
+
+Before handing off, report:
+
+```text
+Focused tests:
+- pnpm vitest --run tests/services/apiAdapters/newApi/accountRefresh.test.ts tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/aihubmix/accountRefresh.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountStorage.test.ts
+
+Validation:
+- pnpm compile
+- pnpm run validate:staged
+- pnpm run validate:push
+
+E2E decision:
+- No Playwright E2E added. This slice changes service-layer routing and account-storage merge behavior covered by Vitest; browser runtime behavior is unchanged.
+
+Telemetry decision:
+- None. No new user-visible action, setting, async job, or analytics-worthy outcome is introduced; existing refresh behavior is rerouted behind an Adapter.
+```

--- a/docs/superpowers/specs/2026-06-18-api-adapter-account-refresh-design.md
+++ b/docs/superpowers/specs/2026-06-18-api-adapter-account-refresh-design.md
@@ -1,0 +1,422 @@
+# API Adapter Account Refresh Design
+
+Date: 2026-06-18
+
+## Purpose
+
+Move account refresh behavior behind the `apiAdapters` Seam so a newly added
+account site type can define its quota, usage, income, check-in, health, and
+credential re-sync behavior in one Adapter Module.
+
+The recent adapter slices moved site announcements, runtime model catalog
+loading, account auto-detect completion, and key management behind
+`getSiteAdapter(siteType)`. Those slices make it easier to detect an account,
+create or resolve keys, and load key-scoped models. The remaining core account
+path is refresh: after an account is saved, All API Hub must be able to refresh
+balance and health data for the account to be useful in the account list,
+background jobs, balance history, and diagnostics.
+
+## Current Context
+
+The shipped `SiteAdapter` Interface currently exposes:
+
+```ts
+type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+}
+```
+
+`src/services/apiService/index.ts` remains the legacy compatibility facade. It
+selects the `common` implementation plus optional site overrides and exposes
+capability booleans such as `modelPricing` and `redeemCode`.
+
+The main account refresh workflow is still in
+`src/services/accounts/accountStorage.ts`:
+
+1. Load the stored account and skip disabled or interval-limited accounts.
+2. Normalize the base URL and build the account request auth object.
+3. Call `getApiService(account.site_type).fetchSupportCheckIn(...)`.
+4. Call `getApiService(account.site_type).refreshAccountData(...)`.
+5. Merge the returned account snapshot into persisted account data.
+6. Preserve local product rules:
+   - manual balance override
+   - custom check-in state reset
+   - account re-enable on successful manual refresh
+   - `authUpdate` persistence for refreshed credentials
+   - daily balance-history snapshot capture
+
+The backend implementations already differ:
+
+- New API-family sites aggregate quota, today usage, today income, and optional
+  check-in state from compatible One API/New API endpoints.
+- AnyRouter, WONG, Veloera, DoneHub, and OneHub keep site-specific refresh or
+  data parsing overrides under `src/services/apiService/*`.
+- Sub2API disables check-in, loads current-user quota, and may refresh or
+  re-sync dashboard JWT credentials through `authUpdate`.
+- AIHubMix disables check-in, loads account quota from its own account endpoint,
+  and returns zeroed daily stats until stable daily-stat endpoints exist.
+
+## Problem
+
+Account refresh is now the highest-value remaining legacy facade call for new
+account site types.
+
+Current friction:
+
+1. A new non-compatible account site must still be wired into
+   `src/services/apiService/index.ts` before account refresh can work.
+2. `accountStorage.refreshAccount(...)` calls the legacy facade directly for
+   both check-in support probing and data refresh, so product code still knows
+   that refresh consists of those facade calls.
+3. The old facade makes `refreshAccountData(...)` look uniform even though the
+   real backend contract varies by site: some sites support check-in probing,
+   some always disable it, and some refresh credentials as part of health
+   recovery.
+4. Tests for account refresh must mock the wide `apiService` facade instead of
+   exercising a narrow Interface.
+
+Deletion test: if the direct `getApiService(...).fetchSupportCheckIn(...)` and
+`getApiService(...).refreshAccountData(...)` calls were deleted from
+`accountStorage`, the complexity should not move to new `siteType` branches in
+the same file. It should move behind an `accountRefresh` capability that each
+Adapter can implement or omit.
+
+## Goals
+
+- Add a narrow `accountRefresh` Adapter capability.
+- Route `accountStorage.refreshAccount(...)` through
+  `getSiteAdapter(account.site_type).accountRefresh`.
+- Preserve the public `accountStorage.refreshAccount(...)` behavior and return
+  shape.
+- Preserve current `RefreshAccountResult` and `AccountData` semantics:
+  - quota
+  - today prompt/completion tokens
+  - today quota consumption
+  - today request count
+  - today income
+  - check-in state
+  - health status
+  - optional `authUpdate`
+- Keep product-owned persistence and local merge rules in `accountStorage`.
+- Provide Adapter implementations for:
+  - New API-family compatible account sites
+  - Sub2API
+  - AIHubMix
+- Preserve Sub2API credential refresh and JWT re-sync behavior.
+- Preserve AIHubMix zeroed daily-stat semantics and disabled check-in behavior.
+- Add focused Adapter tests plus account-refresh regression tests.
+
+## Non-Goals
+
+- Do not rewrite account storage, account migration, account ordering, pinning,
+  deletion, or disabled-account behavior.
+- Do not move manual balance override or balance-history snapshot capture behind
+  the Adapter.
+- Do not change check-in scheduler behavior, custom check-in URLs, or site
+  announcement refresh.
+- Do not migrate Model List pricing, runtime model catalog, redemption,
+  managed-site channel operations, managed-site model sync, or export dialogs in
+  this slice.
+- Do not add a new site type in this slice.
+- Do not remove `getApiService(...)` globally.
+- Do not change user-facing copy, locale keys, telemetry events, settings
+  search entries, or Playwright E2E tests.
+
+## Design
+
+### 1. Add `AccountRefreshCapability`
+
+Create:
+
+```text
+src/services/apiAdapters/contracts/accountRefresh.ts
+```
+
+The contract should reuse existing account refresh types rather than inventing
+another snapshot model.
+
+Proposed types:
+
+```ts
+import type {
+  ApiServiceAccountRequest,
+  ApiServiceRequest,
+  RefreshAccountResult,
+} from "~/services/apiService/common/type"
+
+export type AccountRefreshSupportRequest = {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+}
+
+export type AccountRefreshRequest = ApiServiceAccountRequest
+
+export type AccountRefreshCapability = {
+  fetchCheckInSupport?(
+    request: AccountRefreshSupportRequest,
+  ): Promise<boolean>
+  refreshAccount(request: AccountRefreshRequest): Promise<RefreshAccountResult>
+}
+```
+
+Capability presence is the support signal. `fetchCheckInSupport` is optional
+because some backends either do not support check-in or already return the
+final disabled state as part of `refreshAccount(...)`.
+
+The Interface is intentionally close to the existing `apiService` request and
+result shapes. This keeps the first migration small while moving the external
+Seam from the flat facade to `SiteAdapter`.
+
+### 2. Extend `SiteAdapter`
+
+Add:
+
+```ts
+accountRefresh?: AccountRefreshCapability
+```
+
+to `src/services/apiAdapters/contracts/siteAdapter.ts`.
+
+Missing `accountRefresh` for a saved account site is an unsupported account
+runtime path. The account refresh workflow should fail with a normalized
+unhealthy result rather than throwing through the background refresh loop.
+
+### 3. Add New API-Family Account Refresh Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/newApi/accountRefresh.ts
+```
+
+The New API-family Adapter should delegate to the current site-scoped legacy
+implementation:
+
+```ts
+import { getApiService } from "~/services/apiService"
+
+import type { AccountRefreshCapability } from "../contracts/accountRefresh"
+
+export const createNewApiAccountRefresh = (
+  siteType: AccountSiteType,
+): AccountRefreshCapability => ({
+  fetchCheckInSupport(request) {
+    return getApiService(siteType).fetchSupportCheckIn(request)
+  },
+  refreshAccount(request) {
+    return getApiService(siteType).refreshAccountData(request)
+  },
+})
+```
+
+`createNewApiAdapter(siteType)` should attach:
+
+```ts
+accountRefresh: createNewApiAccountRefresh(siteType)
+```
+
+This preserves existing One API/New API-compatible override behavior for
+OneHub, DoneHub, Veloera, AnyRouter, WONG, V-API, VoAPI, Super-API, Rix-API,
+Neo-API, and unknown-compatible sites because the Adapter is created with the
+current `siteType`.
+
+### 4. Add Sub2API Account Refresh Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/sub2api/accountRefresh.ts
+```
+
+The Sub2API Adapter should delegate refresh to the current Sub2API
+implementation:
+
+```ts
+import { fetchSupportCheckIn, refreshAccountData } from "~/services/apiService/sub2api"
+
+import type { AccountRefreshCapability } from "../contracts/accountRefresh"
+
+export const sub2ApiAccountRefresh: AccountRefreshCapability = {
+  fetchCheckInSupport,
+  refreshAccount: refreshAccountData,
+}
+```
+
+Although Sub2API currently disables check-in, keeping
+`fetchCheckInSupport(...)` delegated preserves the existing call behavior while
+the product workflow is migrated. The important contract is that
+`refreshAccount(...)` continues to return disabled check-in state and preserves
+Sub2API `authUpdate` behavior for proactive refresh, refresh-token recovery,
+and browser-context JWT re-sync.
+
+### 5. Add AIHubMix Account Refresh Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/aihubmix/accountRefresh.ts
+```
+
+The AIHubMix Adapter should delegate to the current AIHubMix implementation:
+
+```ts
+import { fetchSupportCheckIn, refreshAccountData } from "~/services/apiService/aihubmix"
+
+import type { AccountRefreshCapability } from "../contracts/accountRefresh"
+
+export const aihubmixAccountRefresh: AccountRefreshCapability = {
+  fetchCheckInSupport,
+  refreshAccount: refreshAccountData,
+}
+```
+
+The Adapter must preserve the existing AIHubMix contract:
+
+- API origin normalization stays in the AIHubMix implementation.
+- Token-authenticated requests continue sending raw `Authorization:
+  <access_token>` without a `Bearer` prefix.
+- Check-in remains disabled.
+- Daily usage and income remain zeroed until a stable backend contract exists.
+
+### 6. Route `accountStorage.refreshAccount(...)` Through The Adapter
+
+Modify `src/services/accounts/accountStorage.ts` so it resolves the Adapter once
+after the effective account and request auth are known:
+
+```ts
+const accountRefresh = getSiteAdapter(account.site_type).accountRefresh
+```
+
+If the capability is missing, return a failed refresh result with a health
+status that marks the account unhealthy and records an unsupported-capability
+reason suitable for existing account health UI.
+
+Then replace:
+
+```ts
+getApiService(account.site_type).fetchSupportCheckIn(...)
+getApiService(account.site_type).refreshAccountData(...)
+```
+
+with:
+
+```ts
+accountRefresh.fetchCheckInSupport?.(...)
+accountRefresh.refreshAccount(...)
+```
+
+`accountStorage` should keep ownership of:
+
+- skip logic
+- normalized base URL selection
+- preference lookup
+- manual balance override
+- local custom check-in date reset
+- persistence of `authUpdate`
+- Sub2API `sub2apiAuth` storage shape
+- balance-history capture
+- final account update write
+
+This keeps backend protocol facts behind the Adapter while preserving product
+semantics in the account storage Module.
+
+### 7. Preserve Check-In Merge Semantics
+
+When `fetchCheckInSupport` is absent, `accountStorage.refreshAccount(...)`
+should keep the existing `account.checkIn` configuration and rely on
+`refreshAccount(...)` to return the backend's refreshed check-in state.
+
+When `fetchCheckInSupport` returns a boolean, `accountStorage` should keep the
+current behavior of updating `checkIn.enableDetection` before calling
+`refreshAccount(...)`.
+
+When `fetchCheckInSupport` rejects, `accountStorage` should keep the existing
+warn-and-continue behavior.
+
+### 8. Do Not Migrate Validation Or Account Add/Edit Data Fetch Yet
+
+`src/services/accounts/accountOperations.ts` still has direct account data
+validation calls. Those should stay out of this slice unless implementation
+reveals that the same helper must be shared to avoid duplicating request
+construction.
+
+The migration target for this design is the saved-account refresh path, not the
+account add/edit validation path.
+
+## Testing
+
+Add focused tests for the new Adapter capability:
+
+- `tests/services/apiAdapters/newApi/accountRefresh.test.ts`
+  - verifies the Adapter calls the site-scoped `fetchSupportCheckIn`
+  - verifies the Adapter calls the site-scoped `refreshAccountData`
+  - verifies the factory preserves the supplied `siteType`
+- `tests/services/apiAdapters/sub2api/accountRefresh.test.ts`
+  - verifies delegation to Sub2API refresh
+  - verifies the result preserves `authUpdate` fields
+- `tests/services/apiAdapters/aihubmix/accountRefresh.test.ts`
+  - verifies delegation to AIHubMix refresh
+  - verifies check-in disabled and zeroed daily stats are not reshaped by the
+    Adapter
+
+Update account refresh regression tests:
+
+- `tests/services/accountStorage.test.ts`
+  - refresh uses `getSiteAdapter(...).accountRefresh`
+  - missing capability produces a failed refresh result instead of throwing out
+    of the refresh workflow
+  - check-in support rejection still warns and continues
+  - manual balance override still wins over refreshed quota
+  - Sub2API `authUpdate.sub2apiAuth` still persists
+
+Run:
+
+```bash
+pnpm vitest --run tests/services/apiAdapters/newApi/accountRefresh.test.ts tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/aihubmix/accountRefresh.test.ts tests/services/accountStorage.test.ts
+pnpm compile
+pnpm run validate:staged
+```
+
+If the final diff touches shared exported types or adapter registry wiring,
+also run:
+
+```bash
+pnpm run validate:push
+```
+
+## Rollout Notes
+
+This slice is intentionally larger than the previous single-capability adapter
+slices because refresh is one account user journey: support probing, data
+refresh, health mapping, and optional credential update are used together by
+the saved-account runtime path.
+
+The slice is still bounded:
+
+- It does not touch Model List pricing.
+- It does not touch redemption.
+- It does not touch managed-site operations.
+- It does not remove the legacy `apiService` facade.
+
+After this lands, the next high-leverage slices are:
+
+1. `modelPricing` capability for Model List direct pricing calls.
+2. An import guard or lint rule that prevents new product code from importing
+   the legacy `apiService` facade outside approved migration adapters.
+
+## Open Questions
+
+No product behavior question blocks this design. The only implementation choice
+to settle during planning is the exact missing-capability health code:
+
+- Prefer reusing an existing unsupported-capability health code if one already
+  exists in `TempWindowHealthStatusCode`.
+- If no existing code fits, use a generic unhealthy status with a local message
+  in the account storage Module rather than adding user-facing copy in this
+  slice.

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -7,7 +7,8 @@ import {
   collectDuplicateAccountNameKeys,
   resolveAccountDisplayName,
 } from "~/services/accounts/utils/accountDisplayName"
-import { getApiService } from "~/services/apiService"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import type { RefreshAccountResult } from "~/services/apiService/common/type"
 import {
   ACCOUNT_STORAGE_KEYS,
   STORAGE_LOCKS,
@@ -60,6 +61,17 @@ import {
 export { ACCOUNT_STORAGE_KEYS }
 
 const logger = createLogger("AccountStorage")
+
+const createMissingAccountRefreshResult = (
+  siteType: string,
+): RefreshAccountResult => ({
+  success: false,
+  healthStatus: {
+    status: SiteHealthStatus.Unknown,
+    message: `accountRefresh is not implemented for ${siteType}`,
+    code: undefined,
+  },
+})
 
 type RefreshAccountOptions = {
   includeTodayCashflow?: boolean
@@ -1064,27 +1076,31 @@ class AccountStorageService {
         refreshToken: account.sub2apiAuth?.refreshToken,
         tokenExpiresAt: account.sub2apiAuth?.tokenExpiresAt,
       }
+      const accountRefresh = getSiteAdapter(account.site_type).accountRefresh
 
       // Refresh check-in support status together with account refresh.
       const currentCheckIn = account.checkIn
       let checkInForRefresh = { ...currentCheckIn }
 
-      try {
-        const support = await getApiService(
-          account.site_type,
-        ).fetchSupportCheckIn({
-          baseUrl,
-          auth,
-        })
+      if (accountRefresh?.fetchCheckInSupport) {
+        try {
+          const support = await accountRefresh.fetchCheckInSupport({
+            baseUrl,
+            auth,
+          })
 
-        if (typeof support === "boolean") {
-          checkInForRefresh = {
-            ...checkInForRefresh,
-            enableDetection: support,
+          if (typeof support === "boolean") {
+            checkInForRefresh = {
+              ...checkInForRefresh,
+              enableDetection: support,
+            }
           }
+        } catch (error) {
+          logger.warn("Failed to determine check-in support", {
+            baseUrl,
+            error,
+          })
         }
-      } catch (error) {
-        logger.warn("Failed to determine check-in support", { baseUrl, error })
       }
 
       const prefs = await userPreferences.getPreferences()
@@ -1092,13 +1108,15 @@ class AccountStorageService {
         options?.includeTodayCashflow ?? prefs.showTodayCashflow ?? true
 
       // 刷新账号数据
-      const result = await getApiService(account.site_type).refreshAccountData({
-        baseUrl: account.site_url,
-        accountId: account.id,
-        checkIn: checkInForRefresh,
-        auth,
-        includeTodayCashflow,
-      })
+      const result = accountRefresh
+        ? await accountRefresh.refreshAccount({
+            baseUrl: account.site_url,
+            accountId: account.id,
+            checkIn: checkInForRefresh,
+            auth,
+            includeTodayCashflow,
+          })
+        : createMissingAccountRefreshResult(account.site_type)
 
       // 构建更新数据
       const updateData: Partial<

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -7,7 +7,6 @@ import {
   collectDuplicateAccountNameKeys,
   resolveAccountDisplayName,
 } from "~/services/accounts/utils/accountDisplayName"
-import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import type { RefreshAccountResult } from "~/services/apiService/common/type"
 import {
   ACCOUNT_STORAGE_KEYS,
@@ -1076,6 +1075,7 @@ class AccountStorageService {
         refreshToken: account.sub2apiAuth?.refreshToken,
         tokenExpiresAt: account.sub2apiAuth?.tokenExpiresAt,
       }
+      const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
       const accountRefresh = getSiteAdapter(account.site_type).accountRefresh
 
       // Refresh check-in support status together with account refresh.
@@ -1110,7 +1110,7 @@ class AccountStorageService {
       // 刷新账号数据
       const result = accountRefresh
         ? await accountRefresh.refreshAccount({
-            baseUrl: account.site_url,
+            baseUrl,
             accountId: account.id,
             checkIn: checkInForRefresh,
             auth,

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -1,3 +1,4 @@
+import { accountStorage } from "~/services/accounts/accountStorage"
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { getApiService } from "~/services/apiService"
@@ -64,6 +65,7 @@ const buildApiRequestFromDisplayAccount = (
 ): ApiServiceRequest => ({
   baseUrl: account.baseUrl,
   accountId: account.id,
+  accountAuthStore: accountStorage,
   auth: {
     authType: account.authType,
     userId: account.userId,

--- a/src/services/apiAdapters/aihubmix/accountRefresh.ts
+++ b/src/services/apiAdapters/aihubmix/accountRefresh.ts
@@ -1,0 +1,10 @@
+import type { AccountRefreshCapability } from "~/services/apiAdapters/contracts/accountRefresh"
+import {
+  fetchSupportCheckIn,
+  refreshAccountData,
+} from "~/services/apiService/aihubmix"
+
+export const aihubmixAccountRefresh: AccountRefreshCapability = {
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  refreshAccount: (request) => refreshAccountData(request),
+}

--- a/src/services/apiAdapters/aihubmix/index.ts
+++ b/src/services/apiAdapters/aihubmix/index.ts
@@ -2,10 +2,12 @@ import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
 import { aihubmixAccountCompletion } from "./accountCompletion"
+import { aihubmixAccountRefresh } from "./accountRefresh"
 import { aihubmixKeyManagement } from "./keyManagement"
 
 export const aihubmixAdapter: SiteAdapter = {
   siteType: SITE_TYPES.AIHUBMIX,
   accountCompletion: aihubmixAccountCompletion,
   keyManagement: aihubmixKeyManagement,
+  accountRefresh: aihubmixAccountRefresh,
 }

--- a/src/services/apiAdapters/contracts/accountRefresh.ts
+++ b/src/services/apiAdapters/contracts/accountRefresh.ts
@@ -1,0 +1,19 @@
+import type {
+  ApiServiceAccountRequest,
+  ApiServiceRequest,
+  RefreshAccountResult,
+} from "~/services/apiService/common/type"
+
+export type AccountRefreshSupportRequest = {
+  baseUrl: string
+  auth: ApiServiceRequest["auth"]
+}
+
+export type AccountRefreshRequest = ApiServiceAccountRequest
+
+export type AccountRefreshCapability = {
+  fetchCheckInSupport?(
+    request: AccountRefreshSupportRequest,
+  ): Promise<boolean | undefined>
+  refreshAccount(request: AccountRefreshRequest): Promise<RefreshAccountResult>
+}

--- a/src/services/apiAdapters/contracts/siteAdapter.ts
+++ b/src/services/apiAdapters/contracts/siteAdapter.ts
@@ -1,6 +1,7 @@
 import type { AccountSiteType } from "~/constants/siteType"
 
 import type { AccountCompletionCapability } from "./accountCompletion"
+import type { AccountRefreshCapability } from "./accountRefresh"
 import type { KeyManagementCapability } from "./keyManagement"
 import type { ModelCatalogCapability } from "./modelCatalog"
 import type { SiteAnnouncementsCapability } from "./siteAnnouncements"
@@ -16,4 +17,5 @@ export type SiteAdapter = {
   modelCatalog?: ModelCatalogCapability
   accountCompletion?: AccountCompletionCapability
   keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
 }

--- a/src/services/apiAdapters/newApi/accountRefresh.ts
+++ b/src/services/apiAdapters/newApi/accountRefresh.ts
@@ -1,0 +1,17 @@
+import type { AccountSiteType } from "~/constants/siteType"
+import type { AccountRefreshCapability } from "~/services/apiAdapters/contracts/accountRefresh"
+import { getApiService } from "~/services/apiService"
+
+/**
+ * Create account-refresh operations bound to the New API-family site type.
+ */
+export function createNewApiAccountRefresh(
+  siteType: AccountSiteType,
+): AccountRefreshCapability {
+  return {
+    fetchCheckInSupport: (request) =>
+      getApiService(siteType).fetchSupportCheckIn(request),
+    refreshAccount: (request) =>
+      getApiService(siteType).refreshAccountData(request),
+  }
+}

--- a/src/services/apiAdapters/newApi/index.ts
+++ b/src/services/apiAdapters/newApi/index.ts
@@ -2,6 +2,7 @@ import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
 import { newApiAccountCompletion } from "./accountCompletion"
+import { createNewApiAccountRefresh } from "./accountRefresh"
 import { createNewApiKeyManagement } from "./keyManagement"
 import { newApiSiteNotice } from "./siteNotice"
 
@@ -13,4 +14,5 @@ export const createNewApiAdapter = (
   siteNotice: newApiSiteNotice,
   accountCompletion: newApiAccountCompletion,
   keyManagement: createNewApiKeyManagement(siteType),
+  accountRefresh: createNewApiAccountRefresh(siteType),
 })

--- a/src/services/apiAdapters/sub2api/accountRefresh.ts
+++ b/src/services/apiAdapters/sub2api/accountRefresh.ts
@@ -1,0 +1,10 @@
+import type { AccountRefreshCapability } from "~/services/apiAdapters/contracts/accountRefresh"
+import {
+  fetchSupportCheckIn,
+  refreshAccountData,
+} from "~/services/apiService/sub2api"
+
+export const sub2ApiAccountRefresh: AccountRefreshCapability = {
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  refreshAccount: (request) => refreshAccountData(request),
+}

--- a/src/services/apiAdapters/sub2api/index.ts
+++ b/src/services/apiAdapters/sub2api/index.ts
@@ -2,6 +2,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
 import { sub2ApiAccountCompletion } from "./accountCompletion"
+import { sub2ApiAccountRefresh } from "./accountRefresh"
 import { sub2ApiKeyManagement } from "./keyManagement"
 import { sub2ApiModelCatalog } from "./modelCatalog"
 import { sub2ApiSiteAnnouncements } from "./siteAnnouncements"
@@ -13,4 +14,5 @@ export const sub2ApiAdapter: SiteAdapter = {
   modelCatalog: sub2ApiModelCatalog,
   accountCompletion: sub2ApiAccountCompletion,
   keyManagement: sub2ApiKeyManagement,
+  accountRefresh: sub2ApiAccountRefresh,
 }

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -4,6 +4,7 @@
  * Sub2API differs from One-API/New-API backends in that authenticated endpoints
  * live under `/api/v1/*` and require a dashboard JWT.
  */
+import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
 import {
   determineHealthStatus,
   extractDefaultExchangeRate as extractCommonDefaultExchangeRate,
@@ -256,7 +257,7 @@ const persistSub2ApiAuthUpdate = async (
       request.accountId,
       updates,
       {
-        userTimestampMode: "preserve",
+        userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
       },
     )
     if (!updated) {

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -5,10 +5,6 @@
  * live under `/api/v1/*` and require a dashboard JWT.
  */
 import {
-  AccountUpdateUserTimestampMode,
-  type AccountUpdateUserTimestampMode as AccountUpdateUserTimestampModeValue,
-} from "~/services/accounts/accountDefaults"
-import {
   determineHealthStatus,
   extractDefaultExchangeRate as extractCommonDefaultExchangeRate,
 } from "~/services/apiService/common"
@@ -158,20 +154,15 @@ type RefreshedSub2ApiRequest<
   tokenExpiresAt: number
 }
 
-type Sub2ApiAccountStorageRef = {
-  getAccountById: (id: string) => Promise<any>
-  updateAccount: (
-    id: string,
-    updates: Record<string, any>,
-    options: { userTimestampMode: AccountUpdateUserTimestampModeValue },
-  ) => Promise<boolean>
-} | null
+type Sub2ApiAccountAuthStore = NonNullable<
+  ApiServiceRequest["accountAuthStore"]
+>
 
 type HydratedSub2ApiAuth<
   TRequest extends ApiServiceRequest = ApiServiceRequest,
 > = {
   request: TRequest
-  accountStorageRef: Sub2ApiAccountStorageRef
+  accountAuthStore?: Sub2ApiAccountAuthStore
 }
 
 const hydrateSub2ApiAuthRequest = async <TRequest extends ApiServiceRequest>(
@@ -181,15 +172,10 @@ const hydrateSub2ApiAuthRequest = async <TRequest extends ApiServiceRequest>(
   let refreshToken = normalizeRefreshToken(request.auth?.refreshToken)
   let tokenExpiresAt = normalizeTokenExpiresAt(request.auth?.tokenExpiresAt)
   let userId = request.auth?.userId
-  let accountStorageRef: Sub2ApiAccountStorageRef = null
+  const accountAuthStore = request.accountAuthStore
 
-  if (request.accountId) {
-    const { accountStorage } = await import(
-      "~/services/accounts/accountStorage"
-    )
-    accountStorageRef = accountStorage
-
-    const account = await accountStorage.getAccountById(request.accountId)
+  if (request.accountId && accountAuthStore) {
+    const account = await accountAuthStore.getAccountById(request.accountId)
     if (account) {
       const storedAccessToken =
         typeof account.account_info?.access_token === "string"
@@ -233,24 +219,24 @@ const hydrateSub2ApiAuthRequest = async <TRequest extends ApiServiceRequest>(
 
   return {
     request: hydratedRequest,
-    accountStorageRef,
+    accountAuthStore,
   }
 }
 
 const persistSub2ApiAuthUpdate = async (
   request: ApiServiceRequest,
   authUpdate: PersistableSub2ApiAuthUpdate,
-  accountStorageRef: Sub2ApiAccountStorageRef,
+  accountAuthStore: Sub2ApiAccountAuthStore | undefined,
 ) => {
   if (!request.accountId) {
     return
   }
 
-  try {
-    const storage =
-      accountStorageRef ??
-      (await import("~/services/accounts/accountStorage")).accountStorage
+  if (!accountAuthStore) {
+    return
+  }
 
+  try {
     const updates: Record<string, any> = {
       account_info: {
         access_token: authUpdate.accessToken,
@@ -266,9 +252,13 @@ const persistSub2ApiAuthUpdate = async (
       }
     }
 
-    const updated = await storage.updateAccount(request.accountId, updates, {
-      userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
-    })
+    const updated = await accountAuthStore.updateAccount(
+      request.accountId,
+      updates,
+      {
+        userTimestampMode: "preserve",
+      },
+    )
     if (!updated) {
       logger.warn("Failed to persist Sub2API auth update after key request", {
         accountId: request.accountId,
@@ -360,13 +350,13 @@ const refreshSub2ApiRequestAuth = async <
 >(params: {
   request: TRequest
   refreshToken: string
-  accountStorageRef: Sub2ApiAccountStorageRef
+  accountAuthStore?: Sub2ApiAccountAuthStore
 }): Promise<RefreshedSub2ApiRequest<TRequest>> => {
   return withSub2ApiAuthMutationLock(params.request, async () => {
     const latestHydrated = await hydrateSub2ApiAuthRequest(params.request)
     const latestRequest = latestHydrated.request
-    const latestStorageRef =
-      latestHydrated.accountStorageRef ?? params.accountStorageRef
+    const latestAccountAuthStore =
+      latestHydrated.accountAuthStore ?? params.accountAuthStore
     const latestRefreshToken =
       normalizeRefreshToken(latestRequest.auth?.refreshToken) ||
       normalizeRefreshToken(params.refreshToken)
@@ -396,7 +386,7 @@ const refreshSub2ApiRequestAuth = async <
     await persistSub2ApiAuthUpdate(
       refreshedRequest,
       refreshed,
-      latestStorageRef,
+      latestAccountAuthStore,
     )
 
     return {
@@ -412,13 +402,13 @@ const resyncSub2ApiRequestAuth = async <
 >(params: {
   request: TRequest
   endpoint: string
-  accountStorageRef: Sub2ApiAccountStorageRef
+  accountAuthStore?: Sub2ApiAccountAuthStore
 }): Promise<TRequest> => {
   return withSub2ApiAuthMutationLock(params.request, async () => {
     const latestHydrated = await hydrateSub2ApiAuthRequest(params.request)
     const latestRequest = latestHydrated.request
-    const latestStorageRef =
-      latestHydrated.accountStorageRef ?? params.accountStorageRef
+    const latestAccountAuthStore =
+      latestHydrated.accountAuthStore ?? params.accountAuthStore
 
     if (didSub2ApiAuthChange(params.request, latestRequest)) {
       return latestRequest
@@ -441,7 +431,7 @@ const resyncSub2ApiRequestAuth = async <
     await persistSub2ApiAuthUpdate(
       resyncedRequest,
       { accessToken: resynced.accessToken },
-      latestStorageRef,
+      latestAccountAuthStore,
     )
 
     return resyncedRequest
@@ -453,13 +443,13 @@ type AuthenticatedSub2ApiRunner<T> = (request: ApiServiceRequest) => Promise<T>
 const retrySub2ApiRunnerWithResyncedAuth = async <T>(params: {
   request: ApiServiceRequest
   endpoint: string
-  accountStorageRef: Sub2ApiAccountStorageRef
+  accountAuthStore?: Sub2ApiAccountAuthStore
   runner: AuthenticatedSub2ApiRunner<T>
 }): Promise<T> => {
   const updatedRequest = await resyncSub2ApiRequestAuth({
     request: params.request,
     endpoint: params.endpoint,
-    accountStorageRef: params.accountStorageRef,
+    accountAuthStore: params.accountAuthStore,
   })
 
   try {
@@ -500,7 +490,7 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
       const refreshed = await refreshSub2ApiRequestAuth({
         request: effectiveRequest,
         refreshToken,
-        accountStorageRef: hydrated.accountStorageRef,
+        accountAuthStore: hydrated.accountAuthStore,
       })
 
       effectiveRequest = refreshed.request
@@ -525,7 +515,7 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
         const refreshed = await refreshSub2ApiRequestAuth({
           request: effectiveRequest,
           refreshToken,
-          accountStorageRef: hydrated.accountStorageRef,
+          accountAuthStore: hydrated.accountAuthStore,
         })
 
         effectiveRequest = refreshed.request
@@ -545,7 +535,7 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
           updatedRequest = await resyncSub2ApiRequestAuth({
             request: effectiveRequest,
             endpoint,
-            accountStorageRef: hydrated.accountStorageRef,
+            accountAuthStore: hydrated.accountAuthStore,
           })
         } catch {
           throw refreshError
@@ -566,7 +556,7 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
     return await retrySub2ApiRunnerWithResyncedAuth({
       request: effectiveRequest,
       endpoint,
-      accountStorageRef: hydrated.accountStorageRef,
+      accountAuthStore: hydrated.accountAuthStore,
       runner,
     })
   }
@@ -842,13 +832,13 @@ const createRefreshSuccessResult = (
 
 const refreshSub2ApiAccountViaResync = async (params: {
   request: ApiServiceRequest
-  accountStorageRef: Sub2ApiAccountStorageRef
+  accountAuthStore?: Sub2ApiAccountAuthStore
   checkIn: CheckInConfig
 }): Promise<RefreshAccountResult> => {
   const retryRequest = await resyncSub2ApiRequestAuth({
     request: params.request,
     endpoint: SUB2API_AUTH_ME_ENDPOINT,
-    accountStorageRef: params.accountStorageRef,
+    accountAuthStore: params.accountAuthStore,
   })
 
   const currentUser = await fetchCurrentUser(retryRequest)
@@ -952,12 +942,12 @@ const fetchSub2ApiAccessTokenInfo = async (
 
 const fetchSub2ApiAccessTokenInfoWithResyncedAuth = async (params: {
   request: ApiServiceRequest
-  accountStorageRef: Sub2ApiAccountStorageRef
+  accountAuthStore?: Sub2ApiAccountAuthStore
 }): Promise<AccessTokenInfo> => {
   const resyncedRequest = await resyncSub2ApiRequestAuth({
     request: params.request,
     endpoint: SUB2API_AUTH_ME_ENDPOINT,
-    accountStorageRef: params.accountStorageRef,
+    accountAuthStore: params.accountAuthStore,
   })
 
   try {
@@ -974,7 +964,7 @@ const fetchSub2ApiAccessTokenInfoWithResyncedAuth = async (params: {
 const fetchSub2ApiAccessTokenInfoWithAuthRecovery = async (params: {
   request: ApiServiceRequest
   refreshToken: string
-  accountStorageRef: Sub2ApiAccountStorageRef
+  accountAuthStore?: Sub2ApiAccountAuthStore
 }): Promise<AccessTokenInfo> => {
   try {
     return await fetchSub2ApiAccessTokenInfo(params.request)
@@ -988,7 +978,7 @@ const fetchSub2ApiAccessTokenInfoWithAuthRecovery = async (params: {
         const refreshed = await refreshSub2ApiRequestAuth({
           request: params.request,
           refreshToken: params.refreshToken,
-          accountStorageRef: params.accountStorageRef,
+          accountAuthStore: params.accountAuthStore,
         })
 
         return await fetchSub2ApiAccessTokenInfo(refreshed.request)
@@ -1002,7 +992,7 @@ const fetchSub2ApiAccessTokenInfoWithAuthRecovery = async (params: {
 
     return await fetchSub2ApiAccessTokenInfoWithResyncedAuth({
       request: params.request,
-      accountStorageRef: params.accountStorageRef,
+      accountAuthStore: params.accountAuthStore,
     })
   }
 }
@@ -1027,7 +1017,7 @@ export async function getOrCreateAccessToken(
     return await fetchSub2ApiAccessTokenInfoWithAuthRecovery({
       request: effectiveRequest,
       refreshToken,
-      accountStorageRef: hydrated.accountStorageRef,
+      accountAuthStore: hydrated.accountAuthStore,
     })
   }
 
@@ -1036,7 +1026,7 @@ export async function getOrCreateAccessToken(
       const refreshed = await refreshSub2ApiRequestAuth({
         request: effectiveRequest,
         refreshToken,
-        accountStorageRef: hydrated.accountStorageRef,
+        accountAuthStore: hydrated.accountAuthStore,
       })
       effectiveRequest = refreshed.request
       accessToken = normalizeAccessToken(effectiveRequest.auth?.accessToken)
@@ -1056,7 +1046,7 @@ export async function getOrCreateAccessToken(
 
   return await fetchSub2ApiAccessTokenInfoWithResyncedAuth({
     request: effectiveRequest,
-    accountStorageRef: hydrated.accountStorageRef,
+    accountAuthStore: hydrated.accountAuthStore,
   })
 }
 
@@ -1167,7 +1157,7 @@ export async function refreshAccountData(
           const refreshed = await refreshSub2ApiRequestAuth({
             request: effectiveRequest,
             refreshToken,
-            accountStorageRef: hydratedRequest.accountStorageRef,
+            accountAuthStore: hydratedRequest.accountAuthStore,
           })
 
           effectiveRequest = refreshed.request
@@ -1209,7 +1199,7 @@ export async function refreshAccountData(
           const refreshed = await refreshSub2ApiRequestAuth({
             request: effectiveRequest,
             refreshToken,
-            accountStorageRef: hydratedRequest.accountStorageRef,
+            accountAuthStore: hydratedRequest.accountAuthStore,
           })
 
           const retryRequest = refreshed.request
@@ -1231,7 +1221,7 @@ export async function refreshAccountData(
           try {
             return await refreshSub2ApiAccountViaResync({
               request: effectiveRequest,
-              accountStorageRef: hydratedRequest.accountStorageRef,
+              accountAuthStore: hydratedRequest.accountAuthStore,
               checkIn,
             })
           } catch {
@@ -1246,7 +1236,7 @@ export async function refreshAccountData(
       try {
         return await refreshSub2ApiAccountViaResync({
           request: hydratedRequest.request,
-          accountStorageRef: hydratedRequest.accountStorageRef,
+          accountAuthStore: hydratedRequest.accountAuthStore,
           checkIn,
         })
       } catch (retryError) {

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -84,6 +84,14 @@ export interface ApiTransportRequest {
   baseUrl: string
   data?: Record<string, any>
   accountId?: string
+  accountAuthStore?: {
+    getAccountById: (id: string) => Promise<any>
+    updateAccount: (
+      id: string,
+      updates: Record<string, any>,
+      options: { userTimestampMode: "preserve" | "touch" },
+    ) => Promise<boolean>
+  }
   cookieAuthSessionCookie?: string
   fetchContext?: ApiTransportFetchContext
 }

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -1856,6 +1856,29 @@ describe("accountStorage core behaviors", () => {
     expect(updatedAccount?.health?.status).toBe(SiteHealthStatus.Healthy)
   })
 
+  it("refreshAccount should route adapter refreshes with normalized base URLs", async () => {
+    const account = createAccount({
+      id: "pathful-refresh-url",
+      site_url: "https://pathful.example.com/dashboard?tab=usage",
+      site_type: SITE_TYPES.NEW_API,
+      checkIn: { enableDetection: true },
+    })
+    seedStorage([account])
+
+    await accountStorage.refreshAccount("pathful-refresh-url", true)
+
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://pathful.example.com",
+      }),
+    )
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://pathful.example.com",
+      }),
+    )
+  })
+
   it("refreshAccount should persist an unhealthy state when account refresh is unsupported", async () => {
     const account = createAccount({
       id: "unsupported-refresh",

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -34,20 +34,18 @@ const storageHooks: {
   beforeRemove: async () => {},
 }
 const {
-  mockValidateAccountConnection,
   mockFetchSupportCheckIn,
   mockGetAccountSiteType,
+  mockGetSiteAdapter,
   mockRefreshAccountData,
-  mockFetchTodayIncome,
   markAccountDisabledInStatusMock,
   markAccountsDisabledInStatusMock,
   pruneStatusForAccountIdsMock,
 } = vi.hoisted(() => ({
-  mockValidateAccountConnection: vi.fn(),
   mockFetchSupportCheckIn: vi.fn(),
   mockGetAccountSiteType: vi.fn(),
+  mockGetSiteAdapter: vi.fn(),
   mockRefreshAccountData: vi.fn(),
-  mockFetchTodayIncome: vi.fn(),
   markAccountDisabledInStatusMock: vi.fn(),
   markAccountsDisabledInStatusMock: vi.fn(),
   pruneStatusForAccountIdsMock: vi.fn(),
@@ -76,13 +74,8 @@ vi.mock("@plasmohq/storage", () => {
   return { Storage }
 })
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: vi.fn(() => ({
-    fetchTodayIncome: mockFetchTodayIncome,
-    refreshAccountData: mockRefreshAccountData,
-    validateAccountConnection: mockValidateAccountConnection,
-    fetchSupportCheckIn: mockFetchSupportCheckIn,
-  })),
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: mockGetSiteAdapter,
 }))
 
 vi.mock("~/services/siteDetection/detectSiteType", () => ({
@@ -175,11 +168,10 @@ describe("accountStorage core behaviors", () => {
     storageHooks.beforeGet = async () => {}
     storageHooks.beforeSet = async () => {}
     storageHooks.beforeRemove = async () => {}
-    mockValidateAccountConnection.mockReset()
     mockFetchSupportCheckIn.mockReset()
     mockGetAccountSiteType.mockReset()
+    mockGetSiteAdapter.mockReset()
     mockRefreshAccountData.mockReset()
-    mockFetchTodayIncome.mockReset()
     markAccountDisabledInStatusMock.mockReset()
     markAccountsDisabledInStatusMock.mockReset()
     pruneStatusForAccountIdsMock.mockReset()
@@ -211,7 +203,12 @@ describe("accountStorage core behaviors", () => {
       },
     }))
 
-    mockFetchTodayIncome.mockResolvedValue({ today_income: 0 })
+    mockGetSiteAdapter.mockReturnValue({
+      accountRefresh: {
+        fetchCheckInSupport: mockFetchSupportCheckIn,
+        refreshAccount: mockRefreshAccountData,
+      },
+    })
   })
 
   it("migrates legacy string tags on reads (account.tags -> tagIds + global tag store)", async () => {
@@ -1642,6 +1639,8 @@ describe("accountStorage core behaviors", () => {
     expect(mockGetAccountSiteType).toHaveBeenCalledWith(
       "https://foo.example.com",
     )
+    expect(mockGetSiteAdapter).toHaveBeenCalledWith("one-api")
+    expect(mockGetSiteAdapter).not.toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
     expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
       baseUrl: "https://foo.example.com",
       auth: {
@@ -1673,9 +1672,9 @@ describe("accountStorage core behaviors", () => {
       }),
     )
     expect(mockGetAccountSiteType).not.toHaveBeenCalled()
+    expect(mockGetSiteAdapter).not.toHaveBeenCalled()
     expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
     expect(mockRefreshAccountData).not.toHaveBeenCalled()
-    expect(mockFetchTodayIncome).not.toHaveBeenCalled()
   })
 
   it("refreshAccount should probe disabled accounts when explicitly allowed and re-enable them on success", async () => {
@@ -1786,7 +1785,6 @@ describe("accountStorage core behaviors", () => {
         }),
       )
       expect(mockRefreshAccountData).not.toHaveBeenCalled()
-      expect(mockFetchTodayIncome).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }
@@ -1806,6 +1804,7 @@ describe("accountStorage core behaviors", () => {
     await accountStorage.refreshAccount("known-site", true)
 
     expect(mockGetAccountSiteType).not.toHaveBeenCalled()
+    expect(mockGetSiteAdapter).toHaveBeenCalledWith("one-api")
     expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
       baseUrl: "https://bar.example.com",
       auth: {
@@ -1814,7 +1813,6 @@ describe("accountStorage core behaviors", () => {
         accessToken: "token",
       },
     })
-    expect(mockFetchTodayIncome).not.toHaveBeenCalled()
     const updatedAccount = await accountStorage.getAccountById("known-site")
     expect(updatedAccount?.site_type).toBe("one-api")
     expect(updatedAccount?.checkIn?.enableDetection).toBe(false)
@@ -1858,6 +1856,47 @@ describe("accountStorage core behaviors", () => {
     expect(updatedAccount?.health?.status).toBe(SiteHealthStatus.Healthy)
   })
 
+  it("refreshAccount should persist an unhealthy state when account refresh is unsupported", async () => {
+    const account = createAccount({
+      id: "unsupported-refresh",
+      site_url: "https://unsupported.example.com",
+      site_type: SITE_TYPES.ONE_API,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+      },
+    })
+    seedStorage([account])
+
+    mockGetSiteAdapter.mockReturnValueOnce({
+      siteType: SITE_TYPES.ONE_API,
+    })
+
+    const result = await accountStorage.refreshAccount(
+      "unsupported-refresh",
+      true,
+    )
+    const updatedAccount = await accountStorage.getAccountById(
+      "unsupported-refresh",
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        refreshed: true,
+      }),
+    )
+    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+    expect(mockRefreshAccountData).not.toHaveBeenCalled()
+    expect(updatedAccount?.health).toEqual({
+      status: SiteHealthStatus.Unknown,
+      reason: "accountRefresh is not implemented for one-api",
+      code: undefined,
+    })
+  })
+
   it("refreshAccount should persist today_income from refreshAccountData", async () => {
     const account = createAccount({
       id: "income-sync",
@@ -1893,7 +1932,6 @@ describe("accountStorage core behaviors", () => {
 
     const updatedAccount = await accountStorage.getAccountById("income-sync")
     expect(updatedAccount?.account_info.today_income).toBe(123_456)
-    expect(mockFetchTodayIncome).not.toHaveBeenCalled()
   })
 
   it("refreshAccount should persist Sub2API refresh-token auth updates", async () => {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -77,13 +77,27 @@ describe("fetchDisplayAccountTokens", () => {
     const result = await fetchDisplayAccountTokens(ACCOUNT as any)
 
     expect(result).toEqual([{ id: 1, key: "sk-test", status: 1 }])
-    expect(fetchTokens).toHaveBeenCalledWith(REQUEST)
+    expect(fetchTokens).toHaveBeenCalledWith(expect.objectContaining(REQUEST))
     expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual({
       service,
       adapter,
       keyManagement,
-      request: REQUEST,
+      request: expect.objectContaining(REQUEST),
     })
+  })
+
+  it("injects a narrow Sub2API auth store into account-scoped requests", async () => {
+    fetchTokens.mockResolvedValue([])
+
+    await fetchDisplayAccountTokens(ACCOUNT as any)
+
+    const request = fetchTokens.mock.calls[0]?.[0]
+    expect(request?.accountAuthStore?.getAccountById).toEqual(
+      expect.any(Function),
+    )
+    expect(request?.accountAuthStore?.updateAccount).toEqual(
+      expect.any(Function),
+    )
   })
 
   it("throws InvalidTokenPayloadError when the API payload is not an array", async () => {
@@ -118,7 +132,10 @@ describe("fetchDisplayAccountTokens", () => {
     )
 
     expect(result).toBe(token)
-    expect(resolveTokenKey).toHaveBeenCalledWith({ request: REQUEST, token })
+    expect(resolveTokenKey).toHaveBeenCalledWith({
+      request: expect.objectContaining(REQUEST),
+      token,
+    })
   })
 
   it("clones the token when the resolved secret key differs from the masked key", async () => {
@@ -137,7 +154,10 @@ describe("fetchDisplayAccountTokens", () => {
       name: "Masked",
     })
     expect(result).not.toBe(token)
-    expect(resolveTokenKey).toHaveBeenCalledWith({ request: REQUEST, token })
+    expect(resolveTokenKey).toHaveBeenCalledWith({
+      request: expect.objectContaining(REQUEST),
+      token,
+    })
   })
 
   it("returns a transient sk-prefixed secret for optional-prefix compatible account types", async () => {

--- a/tests/services/apiAdapters/aihubmix/accountRefresh.test.ts
+++ b/tests/services/apiAdapters/aihubmix/accountRefresh.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { aihubmixAccountRefresh } from "~/services/apiAdapters/aihubmix/accountRefresh"
+import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+
+const { mockFetchSupportCheckIn, mockRefreshAccountData } = vi.hoisted(() => ({
+  mockFetchSupportCheckIn: vi.fn(),
+  mockRefreshAccountData: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  fetchSupportCheckIn: mockFetchSupportCheckIn,
+  refreshAccountData: mockRefreshAccountData,
+}))
+
+const supportRequest = {
+  baseUrl: "https://aihubmix.com",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "aihubmix-access-token",
+  },
+}
+
+const refreshRequest = {
+  ...supportRequest,
+  accountId: "aihubmix-account",
+  checkIn: {
+    enableDetection: true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+  },
+  includeTodayCashflow: true,
+}
+
+describe("aihubmixAccountRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("delegates refresh operations without reshaping disabled check-in or zeroed stats", async () => {
+    const refreshResult = {
+      success: true,
+      data: {
+        quota: 9800,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+        checkIn: {
+          enableDetection: false,
+          siteStatus: {
+            isCheckedInToday: undefined,
+          },
+        },
+      },
+      healthStatus: {
+        status: SiteHealthStatus.Healthy,
+        message: "ok",
+      },
+    }
+    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
+    mockRefreshAccountData.mockResolvedValueOnce(refreshResult)
+
+    await expect(
+      aihubmixAccountRefresh.fetchCheckInSupport?.(supportRequest),
+    ).resolves.toBe(false)
+    await expect(
+      aihubmixAccountRefresh.refreshAccount(refreshRequest),
+    ).resolves.toBe(refreshResult)
+
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(supportRequest)
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(refreshRequest)
+  })
+})

--- a/tests/services/apiAdapters/newApi/accountRefresh.test.ts
+++ b/tests/services/apiAdapters/newApi/accountRefresh.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { createNewApiAccountRefresh } from "~/services/apiAdapters/newApi/accountRefresh"
+import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+
+const { mockFetchSupportCheckIn, mockGetApiService, mockRefreshAccountData } =
+  vi.hoisted(() => ({
+    mockFetchSupportCheckIn: vi.fn(),
+    mockGetApiService: vi.fn(),
+    mockRefreshAccountData: vi.fn(),
+  }))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+const supportRequest = {
+  baseUrl: "https://one.example.invalid",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "account-token",
+  },
+}
+
+const refreshRequest = {
+  ...supportRequest,
+  accountId: "account-1",
+  checkIn: {
+    enableDetection: true,
+    autoCheckInEnabled: true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+  },
+  includeTodayCashflow: false,
+}
+
+describe("createNewApiAccountRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      fetchSupportCheckIn: mockFetchSupportCheckIn,
+      refreshAccountData: mockRefreshAccountData,
+    })
+  })
+
+  it("delegates refresh operations through the site-specific apiService", async () => {
+    const refreshResult = {
+      success: true,
+      data: {
+        quota: 123,
+        today_prompt_tokens: 1,
+        today_completion_tokens: 2,
+        today_quota_consumption: 3,
+        today_requests_count: 4,
+        today_income: 5,
+        checkIn: refreshRequest.checkIn,
+      },
+      healthStatus: {
+        status: SiteHealthStatus.Healthy,
+        message: "ok",
+      },
+    }
+    mockFetchSupportCheckIn.mockResolvedValueOnce(true)
+    mockRefreshAccountData.mockResolvedValueOnce(refreshResult)
+
+    const accountRefresh = createNewApiAccountRefresh(SITE_TYPES.ONE_HUB)
+
+    await expect(
+      accountRefresh.fetchCheckInSupport?.(supportRequest),
+    ).resolves.toBe(true)
+    await expect(accountRefresh.refreshAccount(refreshRequest)).resolves.toBe(
+      refreshResult,
+    )
+
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.ONE_HUB)
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(supportRequest)
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(refreshRequest)
+  })
+})

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -26,6 +26,10 @@ describe("apiAdapters registry", () => {
       createToken: expect.any(Function),
       resolveTokenKey: expect.any(Function),
     })
+    expect(adapter.accountRefresh).toEqual({
+      fetchCheckInSupport: expect.any(Function),
+      refreshAccount: expect.any(Function),
+    })
     expect(adapter.siteNotice).toBeUndefined()
   })
 
@@ -62,6 +66,10 @@ describe("apiAdapters registry", () => {
         createToken: expect.any(Function),
         resolveTokenKey: expect.any(Function),
       })
+      expect(adapter.accountRefresh).toEqual({
+        fetchCheckInSupport: expect.any(Function),
+        refreshAccount: expect.any(Function),
+      })
       expect(adapter.siteAnnouncements).toBeUndefined()
       expect(adapter.modelCatalog).toBeUndefined()
     }
@@ -80,6 +88,10 @@ describe("apiAdapters registry", () => {
       fetchTokens: expect.any(Function),
       createToken: expect.any(Function),
       resolveTokenKey: expect.any(Function),
+    })
+    expect(adapter.accountRefresh).toEqual({
+      fetchCheckInSupport: expect.any(Function),
+      refreshAccount: expect.any(Function),
     })
     expect(adapter.siteNotice).toBeUndefined()
     expect(adapter.siteAnnouncements).toBeUndefined()

--- a/tests/services/apiAdapters/sub2api/accountRefresh.test.ts
+++ b/tests/services/apiAdapters/sub2api/accountRefresh.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { sub2ApiAccountRefresh } from "~/services/apiAdapters/sub2api/accountRefresh"
+import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+
+const { mockFetchSupportCheckIn, mockRefreshAccountData } = vi.hoisted(() => ({
+  mockFetchSupportCheckIn: vi.fn(),
+  mockRefreshAccountData: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchSupportCheckIn: mockFetchSupportCheckIn,
+  refreshAccountData: mockRefreshAccountData,
+}))
+
+const supportRequest = {
+  baseUrl: "https://sub2.example.invalid",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "dashboard-jwt",
+    refreshToken: "refresh-token",
+    tokenExpiresAt: 1999999999999,
+  },
+}
+
+const refreshRequest = {
+  ...supportRequest,
+  accountId: "sub2-account",
+  checkIn: {
+    enableDetection: true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+  },
+  includeTodayCashflow: true,
+}
+
+describe("sub2ApiAccountRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("delegates refresh operations and preserves authUpdate fields", async () => {
+    const refreshResult = {
+      success: true,
+      data: {
+        quota: 42,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+        checkIn: {
+          enableDetection: false,
+        },
+      },
+      healthStatus: {
+        status: SiteHealthStatus.Healthy,
+        message: "ok",
+      },
+      authUpdate: {
+        accessToken: "new-dashboard-jwt",
+        userId: "7",
+        username: "alice",
+        sub2apiAuth: {
+          refreshToken: "new-refresh-token",
+          tokenExpiresAt: 2000000000000,
+        },
+      },
+    }
+    mockFetchSupportCheckIn.mockResolvedValueOnce(false)
+    mockRefreshAccountData.mockResolvedValueOnce(refreshResult)
+
+    await expect(
+      sub2ApiAccountRefresh.fetchCheckInSupport?.(supportRequest),
+    ).resolves.toBe(false)
+    await expect(
+      sub2ApiAccountRefresh.refreshAccount(refreshRequest),
+    ).resolves.toBe(refreshResult)
+
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(supportRequest)
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(refreshRequest)
+  })
+})

--- a/tests/services/apiService/index.test.ts
+++ b/tests/services/apiService/index.test.ts
@@ -9,24 +9,50 @@ const {
   commonFetchAccountTokens,
   commonResolveApiTokenKey,
   commonExtractDefaultExchangeRate,
+  commonFetchSiteNotice,
   aihubmixFetchAccountTokens,
   oneHubFetchModelPricing,
   oneHubFetchAccountTokens,
   wongResolveApiTokenKey,
   sub2apiFetchUserInfo,
   sub2apiExtractDefaultExchangeRate,
+  sub2apiFetchSub2ApiRuntimeModels,
+  sub2apiFetchSub2ApiAnnouncements,
+  sub2apiMarkSub2ApiAnnouncementRead,
+  sub2apiFetchAccountTokens,
+  sub2apiCreateApiToken,
+  sub2apiResolveApiTokenKey,
+  sub2apiFetchSupportCheckIn,
+  sub2apiRefreshAccountData,
+  aihubmixCreateApiToken,
+  aihubmixResolveApiTokenKey,
+  aihubmixFetchSupportCheckIn,
+  aihubmixRefreshAccountData,
 } = vi.hoisted(() => ({
   commonFetchUserInfo: vi.fn(),
   commonFetchModelPricing: vi.fn(),
   commonFetchAccountTokens: vi.fn(),
   commonResolveApiTokenKey: vi.fn(),
   commonExtractDefaultExchangeRate: vi.fn(),
+  commonFetchSiteNotice: vi.fn(),
   aihubmixFetchAccountTokens: vi.fn(),
   oneHubFetchModelPricing: vi.fn(),
   oneHubFetchAccountTokens: vi.fn(),
   wongResolveApiTokenKey: vi.fn(),
   sub2apiFetchUserInfo: vi.fn(),
   sub2apiExtractDefaultExchangeRate: vi.fn(),
+  sub2apiFetchSub2ApiRuntimeModels: vi.fn(),
+  sub2apiFetchSub2ApiAnnouncements: vi.fn(),
+  sub2apiMarkSub2ApiAnnouncementRead: vi.fn(),
+  sub2apiFetchAccountTokens: vi.fn(),
+  sub2apiCreateApiToken: vi.fn(),
+  sub2apiResolveApiTokenKey: vi.fn(),
+  sub2apiFetchSupportCheckIn: vi.fn(),
+  sub2apiRefreshAccountData: vi.fn(),
+  aihubmixCreateApiToken: vi.fn(),
+  aihubmixResolveApiTokenKey: vi.fn(),
+  aihubmixFetchSupportCheckIn: vi.fn(),
+  aihubmixRefreshAccountData: vi.fn(),
 }))
 
 vi.mock("~/services/apiService/common", () => ({
@@ -35,6 +61,7 @@ vi.mock("~/services/apiService/common", () => ({
   fetchAccountTokens: commonFetchAccountTokens,
   resolveApiTokenKey: commonResolveApiTokenKey,
   extractDefaultExchangeRate: commonExtractDefaultExchangeRate,
+  fetchSiteNotice: commonFetchSiteNotice,
 }))
 
 vi.mock("~/services/apiService/oneHub", () => ({
@@ -45,6 +72,10 @@ vi.mock("~/services/apiService/oneHub", () => ({
 
 vi.mock("~/services/apiService/aihubmix", () => ({
   fetchAccountTokens: aihubmixFetchAccountTokens,
+  createApiToken: aihubmixCreateApiToken,
+  resolveApiTokenKey: aihubmixResolveApiTokenKey,
+  fetchSupportCheckIn: aihubmixFetchSupportCheckIn,
+  refreshAccountData: aihubmixRefreshAccountData,
 }))
 
 vi.mock("~/services/apiService/wong", () => ({
@@ -54,6 +85,14 @@ vi.mock("~/services/apiService/wong", () => ({
 vi.mock("~/services/apiService/sub2api", () => ({
   fetchUserInfo: sub2apiFetchUserInfo,
   extractDefaultExchangeRate: sub2apiExtractDefaultExchangeRate,
+  fetchSub2ApiRuntimeModels: sub2apiFetchSub2ApiRuntimeModels,
+  fetchSub2ApiAnnouncements: sub2apiFetchSub2ApiAnnouncements,
+  markSub2ApiAnnouncementRead: sub2apiMarkSub2ApiAnnouncementRead,
+  fetchAccountTokens: sub2apiFetchAccountTokens,
+  createApiToken: sub2apiCreateApiToken,
+  resolveApiTokenKey: sub2apiResolveApiTokenKey,
+  fetchSupportCheckIn: sub2apiFetchSupportCheckIn,
+  refreshAccountData: sub2apiRefreshAccountData,
   // Intentionally omit fetchModelPricing so strict override behavior can be asserted.
 }))
 

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -72,13 +72,6 @@ vi.mock("~/services/apiService/sub2api/tokenResync", () => ({
   resyncSub2ApiAuthToken: vi.fn(),
 }))
 
-vi.mock("~/services/accounts/accountStorage", () => ({
-  accountStorage: {
-    getAccountById: (...args: any[]) => mockGetAccountById(...args),
-    updateAccount: (...args: any[]) => mockUpdateAccount(...args),
-  },
-}))
-
 describe("apiService sub2api parsing", () => {
   it("convertUsdBalanceToQuota rounds using conversion factor", () => {
     expect(convertUsdBalanceToQuota(0)).toBe(0)
@@ -1063,6 +1056,10 @@ describe("apiService sub2api refreshAccountData", () => {
     const result = await refreshAccountData(
       createRequest({
         accountId: "account-1",
+        accountAuthStore: {
+          getAccountById: (...args: any[]) => mockGetAccountById(...args),
+          updateAccount: (...args: any[]) => mockUpdateAccount(...args),
+        },
         auth: {
           authType: AuthTypeEnum.AccessToken,
           accessToken: "stale-request-jwt",
@@ -2014,6 +2011,10 @@ describe("apiService sub2api exported operations", () => {
       fetchAccountTokens({
         ...baseRequest,
         accountId: "account-1",
+        accountAuthStore: {
+          getAccountById: (...args: any[]) => mockGetAccountById(...args),
+          updateAccount: (...args: any[]) => mockUpdateAccount(...args),
+        },
         auth: {
           authType: AuthTypeEnum.AccessToken,
           accessToken: "request-jwt",

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -680,6 +680,52 @@ describe("apiService sub2api refreshAccountData", () => {
     nowSpy.mockRestore()
   })
 
+  it("skips persistence when refreshed credentials have no auth store", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          code: 0,
+          message: "ok",
+          data: {
+            access_token: "new-jwt",
+            refresh_token: "new-refresh",
+            expires_in: 3600,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    vi.stubGlobal("fetch", fetchMock as any)
+
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { id: 1, username: "alice", balance: 2 },
+    } as any)
+
+    const result = await refreshAccountData(
+      createRequest({
+        accountId: "account-without-store",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "old-jwt",
+          refreshToken: "old-refresh",
+          tokenExpiresAt: now + 60_000,
+        },
+      }),
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.authUpdate?.accessToken).toBe("new-jwt")
+    expect(mockUpdateAccount).not.toHaveBeenCalled()
+
+    nowSpy.mockRestore()
+  })
+
   it("uses rotated refresh token for 401 retry after proactive refresh", async () => {
     const now = 1_700_000_000_000
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -45,18 +45,15 @@ vi.mock("~/services/apiService/sub2api/tokenResync", () => ({
     resyncSub2ApiAuthTokenMock(...args),
 }))
 
-vi.mock("~/services/accounts/accountStorage", () => ({
-  accountStorage: {
-    getAccountById: (...args: any[]) => getAccountByIdMock(...args),
-    updateAccount: (...args: any[]) => updateAccountMock(...args),
-  },
-}))
-
 const createRequest = (
   overrides: Partial<ApiServiceRequest> = {},
 ): ApiServiceRequest => ({
   baseUrl: "https://sub2.example.com",
   accountId: "acc-1",
+  accountAuthStore: {
+    getAccountById: (...args: any[]) => getAccountByIdMock(...args),
+    updateAccount: (...args: any[]) => updateAccountMock(...args),
+  },
   auth: {
     authType: AuthTypeEnum.AccessToken,
     userId: "1",


### PR DESCRIPTION
## Summary
- Add a site-adapter `accountRefresh` capability for New API-family, Sub2API, and AIHubMix account refresh flows.
- Route saved-account refresh through `getSiteAdapter(...).accountRefresh` while keeping account persistence and merge rules in account storage.
- Add adapter and account-storage tests plus the account-refresh adapter spec/plan docs.

## Validation
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added design specs and implementation plans for the account refresh workflow.

* **New Features**
  * Introduced an optional `accountRefresh` capability on API adapters, enabling integration-specific account refresh and check-in support probing.

* **Refactor / Improvements**
  * Updated account refresh to use adapter routing; when unsupported, health is saved as “unknown” with a clear reason instead of failing.

* **Tests**
  * Added and updated Vitest coverage for adapter capabilities, registry wiring, routing/unsupported behavior, and refreshed request/auth store handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->