### PR TITLE
refactor(sub2api): add auth session seam

### DIFF
--- a/docs/superpowers/plans/2026-06-18-sub2api-auth-session.md
+++ b/docs/superpowers/plans/2026-06-18-sub2api-auth-session.md
@@ -1,0 +1,1181 @@
+# Sub2API Auth Session Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-06-18-sub2api-auth-session-design.md`
+
+**Goal:** Move Sub2API stored-auth hydration and rotated-auth persistence from generic `ApiServiceRequest.accountAuthStore` to a Sub2API-specific auth session port.
+
+**Architecture:** Add a Sub2API-owned auth session contract and an account-layer storage adapter. Sub2API protocol code keeps token refresh, browser-session re-sync, retry, and error normalization; account/application code supplies the session only for Sub2API account-scoped requests. Generic `ApiTransportRequest` returns to a transport-only DTO.
+
+**Tech Stack:** TypeScript, WXT extension services, existing `apiService/sub2api` helpers, existing `apiAdapters`, Vitest, `pnpm run validate:staged`.
+
+---
+
+## File Structure
+
+- Create `src/services/apiService/sub2api/authSession.ts`
+  - Owns `Sub2ApiAuthSession`, auth snapshot/update types, and the session-aware request extension type.
+  - Does not import `accountStorage`.
+- Create `src/services/accounts/sub2apiAuthSession.ts`
+  - Account-layer Adapter from `accountStorage` to `Sub2ApiAuthSession`.
+  - Preserves `AccountUpdateUserTimestampMode.Preserve` for auth-only writes.
+- Modify `src/services/apiService/sub2api/index.ts`
+  - Replaces `request.accountAuthStore` with `request.sub2apiAuthSession`.
+  - Keeps protocol behavior and public operation signatures otherwise stable.
+- Modify `src/services/accounts/utils/apiServiceRequest.ts`
+  - Removes direct `accountStorage` injection from generic requests.
+  - Attaches `accountSub2ApiAuthSession` only to Sub2API display-account contexts.
+- Modify `src/services/apiTransport/type.ts`
+  - Removes `accountAuthStore` from `ApiTransportRequest`.
+- Create `tests/services/accounts/sub2apiAuthSession.test.ts`
+  - Covers stored auth snapshot reads and timestamp-preserving auth writes.
+- Modify `tests/services/accounts/apiServiceRequest.test.ts`
+  - Verifies non-Sub2API requests stay plain.
+  - Verifies Sub2API display-account contexts carry the auth session.
+- Modify `tests/services/apiService/sub2api/index.test.ts`
+  - Migrates stored-auth hydration and rotated-auth persistence tests to the session port.
+- Modify `tests/services/apiService/sub2api/keyManagement.test.ts`
+  - Migrates key-management recovery tests to the session port.
+
+---
+
+## Task 1: Add The Auth Session Contract And Account Adapter
+
+**Files:**
+- Create: `src/services/apiService/sub2api/authSession.ts`
+- Create: `src/services/accounts/sub2apiAuthSession.ts`
+- Create: `tests/services/accounts/sub2apiAuthSession.test.ts`
+
+- [ ] **Step 1: Write the failing account-layer session test**
+
+Create `tests/services/accounts/sub2apiAuthSession.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
+import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
+
+const { getAccountByIdMock, updateAccountMock } = vi.hoisted(() => ({
+  getAccountByIdMock: vi.fn(),
+  updateAccountMock: vi.fn(),
+}))
+
+vi.mock("~/services/accounts/accountStorage", () => ({
+  accountStorage: {
+    getAccountById: (...args: unknown[]) => getAccountByIdMock(...args),
+    updateAccount: (...args: unknown[]) => updateAccountMock(...args),
+  },
+}))
+
+describe("accountSub2ApiAuthSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getAccountByIdMock.mockResolvedValue(null)
+    updateAccountMock.mockResolvedValue(true)
+  })
+
+  it("returns a narrow stored auth snapshot for an existing Sub2API account", async () => {
+    getAccountByIdMock.mockResolvedValueOnce({
+      account_info: {
+        id: "9",
+        access_token: " stored-jwt ",
+      },
+      sub2apiAuth: {
+        refreshToken: " stored-refresh ",
+        tokenExpiresAt: 1_700_000_000_000,
+      },
+    })
+
+    await expect(
+      accountSub2ApiAuthSession.getLatestAuth("account-1"),
+    ).resolves.toEqual({
+      accessToken: "stored-jwt",
+      userId: "9",
+      sub2apiAuth: {
+        refreshToken: "stored-refresh",
+        tokenExpiresAt: 1_700_000_000_000,
+      },
+    })
+
+    expect(getAccountByIdMock).toHaveBeenCalledWith("account-1")
+  })
+
+  it("returns null when the account no longer exists", async () => {
+    getAccountByIdMock.mockResolvedValueOnce(null)
+
+    await expect(
+      accountSub2ApiAuthSession.getLatestAuth("missing-account"),
+    ).resolves.toBeNull()
+  })
+
+  it("persists access-token-only re-sync updates while preserving the user timestamp", async () => {
+    await expect(
+      accountSub2ApiAuthSession.persistAuthUpdate("account-1", {
+        accessToken: "resynced-jwt",
+      }),
+    ).resolves.toBe(true)
+
+    expect(updateAccountMock).toHaveBeenCalledWith(
+      "account-1",
+      {
+        account_info: {
+          access_token: "resynced-jwt",
+        },
+      },
+      { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+    )
+  })
+
+  it("persists rotated refresh-token metadata while preserving the user timestamp", async () => {
+    await expect(
+      accountSub2ApiAuthSession.persistAuthUpdate("account-1", {
+        accessToken: "new-jwt",
+        refreshToken: "new-refresh",
+        tokenExpiresAt: 1_700_000_060_000,
+      }),
+    ).resolves.toBe(true)
+
+    expect(updateAccountMock).toHaveBeenCalledWith(
+      "account-1",
+      {
+        account_info: {
+          access_token: "new-jwt",
+        },
+        sub2apiAuth: {
+          refreshToken: "new-refresh",
+          tokenExpiresAt: 1_700_000_060_000,
+        },
+      },
+      { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/sub2apiAuthSession.test.ts
+```
+
+Expected: FAIL because `src/services/accounts/sub2apiAuthSession.ts` and `src/services/apiService/sub2api/authSession.ts` do not exist yet.
+
+- [ ] **Step 3: Add the Sub2API auth session contract**
+
+Create `src/services/apiService/sub2api/authSession.ts`:
+
+```ts
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type { AccountIdentity, Sub2ApiAuthConfig } from "~/types"
+
+export type Sub2ApiStoredAuthSnapshot = {
+  accessToken?: string
+  userId?: AccountIdentity
+  sub2apiAuth?: Sub2ApiAuthConfig
+}
+
+export type Sub2ApiPersistAuthUpdate = {
+  accessToken: string
+  refreshToken?: string
+  tokenExpiresAt?: number
+}
+
+export type Sub2ApiAuthSession = {
+  getLatestAuth(accountId: string): Promise<Sub2ApiStoredAuthSnapshot | null>
+  persistAuthUpdate(
+    accountId: string,
+    update: Sub2ApiPersistAuthUpdate,
+  ): Promise<boolean>
+}
+
+export type Sub2ApiAuthSessionRequest<
+  TRequest extends ApiServiceRequest = ApiServiceRequest,
+> = TRequest & {
+  sub2apiAuthSession?: Sub2ApiAuthSession
+}
+
+export function getSub2ApiAuthSession(
+  request: ApiServiceRequest,
+): Sub2ApiAuthSession | undefined {
+  return (request as Sub2ApiAuthSessionRequest).sub2apiAuthSession
+}
+```
+
+- [ ] **Step 4: Add the account-layer storage adapter**
+
+Create `src/services/accounts/sub2apiAuthSession.ts`:
+
+```ts
+import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
+import { accountStorage } from "~/services/accounts/accountStorage"
+import type {
+  Sub2ApiAuthSession,
+  Sub2ApiPersistAuthUpdate,
+  Sub2ApiStoredAuthSnapshot,
+} from "~/services/apiService/sub2api/authSession"
+
+const normalizeString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+const normalizeTokenExpiresAt = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined
+
+const buildStoredAuthSnapshot = (account: any): Sub2ApiStoredAuthSnapshot => {
+  const accessToken = normalizeString(account.account_info?.access_token)
+  const refreshToken = normalizeString(account.sub2apiAuth?.refreshToken)
+  const tokenExpiresAt = normalizeTokenExpiresAt(
+    account.sub2apiAuth?.tokenExpiresAt,
+  )
+
+  return {
+    ...(accessToken ? { accessToken } : {}),
+    ...(account.account_info?.id !== undefined
+      ? { userId: account.account_info.id }
+      : {}),
+    ...(refreshToken
+      ? {
+          sub2apiAuth: {
+            refreshToken,
+            ...(typeof tokenExpiresAt === "number" ? { tokenExpiresAt } : {}),
+          },
+        }
+      : {}),
+  }
+}
+
+const buildPersistedAuthUpdate = (
+  update: Sub2ApiPersistAuthUpdate,
+): Record<string, any> => {
+  const persisted: Record<string, any> = {
+    account_info: {
+      access_token: update.accessToken,
+    },
+  }
+
+  if (update.refreshToken) {
+    persisted.sub2apiAuth = {
+      refreshToken: update.refreshToken,
+      ...(typeof update.tokenExpiresAt === "number" &&
+      Number.isFinite(update.tokenExpiresAt)
+        ? { tokenExpiresAt: update.tokenExpiresAt }
+        : {}),
+    }
+  }
+
+  return persisted
+}
+
+export const accountSub2ApiAuthSession: Sub2ApiAuthSession = {
+  async getLatestAuth(accountId) {
+    const account = await accountStorage.getAccountById(accountId)
+    return account ? buildStoredAuthSnapshot(account) : null
+  },
+  async persistAuthUpdate(accountId, update) {
+    return accountStorage.updateAccount(accountId, buildPersistedAuthUpdate(update), {
+      userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
+    })
+  },
+}
+```
+
+- [ ] **Step 5: Run the account-layer session test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/sub2apiAuthSession.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the auth session contract and account adapter**
+
+Run:
+
+```powershell
+git add src/services/apiService/sub2api/authSession.ts src/services/accounts/sub2apiAuthSession.ts tests/services/accounts/sub2apiAuthSession.test.ts
+git commit -m "refactor(sub2api): add auth session port"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+## Task 2: Refactor Sub2API Protocol Code To Use The Session Port
+
+**Files:**
+- Modify: `src/services/apiService/sub2api/index.ts`
+- Modify: `tests/services/apiService/sub2api/index.test.ts`
+- Modify: `tests/services/apiService/sub2api/keyManagement.test.ts`
+
+- [ ] **Step 1: Update the key-management test request helper**
+
+In `tests/services/apiService/sub2api/keyManagement.test.ts`, change the hoisted mocks from account storage naming to session naming.
+
+Replace:
+
+```ts
+  getAccountByIdMock,
+  updateAccountMock,
+```
+
+with:
+
+```ts
+  getLatestAuthMock,
+  persistAuthUpdateMock,
+```
+
+Replace the corresponding `vi.fn()` definitions:
+
+```ts
+  getLatestAuthMock: vi.fn(),
+  persistAuthUpdateMock: vi.fn(),
+```
+
+Change `createRequest(...)` from:
+
+```ts
+const createRequest = (
+  overrides: Partial<ApiServiceRequest> = {},
+): ApiServiceRequest => ({
+  baseUrl: "https://sub2.example.com",
+  accountId: "acc-1",
+  accountAuthStore: {
+    getAccountById: (...args: any[]) => getAccountByIdMock(...args),
+    updateAccount: (...args: any[]) => updateAccountMock(...args),
+  },
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "1",
+    accessToken: "old-jwt",
+  },
+  ...overrides,
+})
+```
+
+to:
+
+```ts
+const createRequest = (
+  overrides: Partial<ApiServiceRequest> = {},
+): ApiServiceRequest => ({
+  baseUrl: "https://sub2.example.com",
+  accountId: "acc-1",
+  sub2apiAuthSession: {
+    getLatestAuth: (...args: any[]) => getLatestAuthMock(...args),
+    persistAuthUpdate: (...args: any[]) => persistAuthUpdateMock(...args),
+  },
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "1",
+    accessToken: "old-jwt",
+  },
+  ...overrides,
+} as ApiServiceRequest)
+```
+
+In the `beforeEach`, replace:
+
+```ts
+getAccountByIdMock.mockReset()
+updateAccountMock.mockReset()
+getAccountByIdMock.mockResolvedValue(null)
+updateAccountMock.mockResolvedValue(true)
+```
+
+with:
+
+```ts
+getLatestAuthMock.mockReset()
+persistAuthUpdateMock.mockReset()
+getLatestAuthMock.mockResolvedValue(null)
+persistAuthUpdateMock.mockResolvedValue(true)
+```
+
+Update stored-auth test data from full account objects to snapshots:
+
+```ts
+getLatestAuthMock.mockResolvedValueOnce({
+  accessToken: "stored-jwt",
+  userId: "9",
+  sub2apiAuth: {
+    refreshToken: "stored-refresh",
+    tokenExpiresAt: now + 60_000,
+  },
+})
+```
+
+Update persistence assertions from `updateAccountMock` to:
+
+```ts
+expect(persistAuthUpdateMock).toHaveBeenCalledWith("acc-1", {
+  accessToken: "new-jwt",
+  refreshToken: "new-refresh",
+  tokenExpiresAt: now + 3600 * 1000,
+})
+```
+
+- [ ] **Step 2: Update the Sub2API account refresh tests**
+
+In `tests/services/apiService/sub2api/index.test.ts`, replace the storage mocks:
+
+```ts
+mockGetAccountById
+mockUpdateAccount
+```
+
+with session mocks:
+
+```ts
+mockGetLatestAuth
+mockPersistAuthUpdate
+```
+
+For the test `"hydrates auth from stored account state and persists refreshed credentials"`, replace the stored account setup with:
+
+```ts
+mockGetLatestAuth.mockResolvedValueOnce({
+  accessToken: "stored-jwt",
+  userId: "9",
+  sub2apiAuth: {
+    refreshToken: "stored-refresh",
+    tokenExpiresAt: now + 60_000,
+  },
+})
+```
+
+Replace the request override:
+
+```ts
+accountAuthStore: {
+  getAccountById: (...args: any[]) => mockGetAccountById(...args),
+  updateAccount: (...args: any[]) => mockUpdateAccount(...args),
+},
+```
+
+with:
+
+```ts
+sub2apiAuthSession: {
+  getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+  persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+},
+```
+
+Replace:
+
+```ts
+expect(mockGetAccountById).toHaveBeenCalledWith("account-1")
+expect(mockUpdateAccount).toHaveBeenCalledWith(
+  "account-1",
+  {
+    account_info: {
+      access_token: "new-jwt",
+    },
+    sub2apiAuth: {
+      refreshToken: "new-refresh",
+      tokenExpiresAt: now + 3600 * 1000,
+    },
+  },
+  { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+)
+```
+
+with:
+
+```ts
+expect(mockGetLatestAuth).toHaveBeenCalledWith("account-1")
+expect(mockPersistAuthUpdate).toHaveBeenCalledWith("account-1", {
+  accessToken: "new-jwt",
+  refreshToken: "new-refresh",
+  tokenExpiresAt: now + 3600 * 1000,
+})
+```
+
+For the test `"reuses newer stored auth instead of refreshing again when account storage already rotated the JWT"`, replace sequential account responses with sequential snapshots:
+
+```ts
+mockGetLatestAuth
+  .mockResolvedValueOnce({
+    accessToken: "old-jwt",
+    userId: "7",
+    sub2apiAuth: {
+      refreshToken: "old-refresh",
+      tokenExpiresAt: now + 3600 * 1000,
+    },
+  })
+  .mockResolvedValueOnce({
+    accessToken: "external-jwt",
+    userId: "7",
+    sub2apiAuth: {
+      refreshToken: "external-refresh",
+      tokenExpiresAt: now + 3600 * 1000,
+    },
+  })
+```
+
+Replace inline `accountAuthStore` with inline `sub2apiAuthSession` using the same mock functions.
+
+- [ ] **Step 3: Run Sub2API tests and verify expected failures**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts
+```
+
+Expected: FAIL because `apiService/sub2api/index.ts` still reads `request.accountAuthStore` and does not read `request.sub2apiAuthSession`.
+
+- [ ] **Step 4: Replace storage types and imports in `apiService/sub2api/index.ts`**
+
+In `src/services/apiService/sub2api/index.ts`, remove:
+
+```ts
+import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
+```
+
+Add:
+
+```ts
+import {
+  getSub2ApiAuthSession,
+  type Sub2ApiAuthSession,
+} from "./authSession"
+```
+
+Replace:
+
+```ts
+type Sub2ApiAccountAuthStore = NonNullable<
+  ApiServiceRequest["accountAuthStore"]
+>
+```
+
+with no replacement type. Use `Sub2ApiAuthSession` directly.
+
+Replace `HydratedSub2ApiAuth`:
+
+```ts
+type HydratedSub2ApiAuth<
+  TRequest extends ApiServiceRequest = ApiServiceRequest,
+> = {
+  request: TRequest
+  authSession?: Sub2ApiAuthSession
+}
+```
+
+- [ ] **Step 5: Refactor `hydrateSub2ApiAuthRequest(...)`**
+
+In `hydrateSub2ApiAuthRequest(...)`, replace:
+
+```ts
+  const accountAuthStore = request.accountAuthStore
+
+  if (request.accountId && accountAuthStore) {
+    const account = await accountAuthStore.getAccountById(request.accountId)
+    if (account) {
+      const storedAccessToken =
+        typeof account.account_info?.access_token === "string"
+          ? account.account_info.access_token.trim()
+          : ""
+      const storedRefreshToken = normalizeRefreshToken(
+        account.sub2apiAuth?.refreshToken,
+      )
+      const storedTokenExpiresAt = normalizeTokenExpiresAt(
+        account.sub2apiAuth?.tokenExpiresAt,
+      )
+```
+
+with:
+
+```ts
+  const authSession = getSub2ApiAuthSession(request)
+
+  if (request.accountId && authSession) {
+    const storedAuth = await authSession.getLatestAuth(request.accountId)
+    if (storedAuth) {
+      const storedAccessToken = normalizeAccessToken(storedAuth.accessToken)
+      const storedRefreshToken = normalizeRefreshToken(
+        storedAuth.sub2apiAuth?.refreshToken,
+      )
+      const storedTokenExpiresAt = normalizeTokenExpiresAt(
+        storedAuth.sub2apiAuth?.tokenExpiresAt,
+      )
+```
+
+Inside that block, replace:
+
+```ts
+      if (userId === undefined) {
+        userId = account.account_info?.id
+      }
+```
+
+with:
+
+```ts
+      if (userId === undefined) {
+        userId = storedAuth.userId
+      }
+```
+
+At the return, replace:
+
+```ts
+    accountAuthStore,
+```
+
+with:
+
+```ts
+    authSession,
+```
+
+- [ ] **Step 6: Refactor persistence and auth-recovery parameter names**
+
+Replace `persistSub2ApiAuthUpdate(...)` with:
+
+```ts
+const persistSub2ApiAuthUpdate = async (
+  request: ApiServiceRequest,
+  authUpdate: PersistableSub2ApiAuthUpdate,
+  authSession: Sub2ApiAuthSession | undefined,
+) => {
+  if (!request.accountId) {
+    return
+  }
+
+  if (!authSession) {
+    return
+  }
+
+  try {
+    const updated = await authSession.persistAuthUpdate(
+      request.accountId,
+      authUpdate,
+    )
+    if (!updated) {
+      logger.warn("Failed to persist Sub2API auth update after key request", {
+        accountId: request.accountId,
+      })
+    }
+  } catch (error) {
+    logger.warn("Failed to persist Sub2API auth update", {
+      accountId: request.accountId,
+      error: getSafeErrorMessage(error),
+    })
+  }
+}
+```
+
+Then rename internal parameter fields from `accountAuthStore` to `authSession` in:
+
+```text
+refreshSub2ApiRequestAuth
+resyncSub2ApiRequestAuth
+retrySub2ApiRunnerWithResyncedAuth
+executeAuthenticatedSub2ApiRequest
+refreshSub2ApiAccountViaResync
+fetchSub2ApiAccessTokenInfoWithResyncedAuth
+fetchSub2ApiAccessTokenInfoWithAuthRecovery
+getOrCreateAccessToken
+refreshAccountData
+```
+
+For example, in `refreshSub2ApiRequestAuth(...)`, use:
+
+```ts
+const latestAuthSession =
+  latestHydrated.authSession ?? params.authSession
+```
+
+and pass it to persistence:
+
+```ts
+await persistSub2ApiAuthUpdate(
+  refreshedRequest,
+  refreshed,
+  latestAuthSession,
+)
+```
+
+- [ ] **Step 7: Run Sub2API tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Confirm protocol code no longer references `accountAuthStore`**
+
+Run:
+
+```powershell
+rg -n "accountAuthStore|Sub2ApiAccountAuthStore" src/services/apiService/sub2api tests/services/apiService/sub2api
+```
+
+Expected: no source matches. Test matches are allowed only if they are negative assertions; prefer no matches in these Sub2API test files.
+
+- [ ] **Step 9: Commit the Sub2API protocol migration**
+
+Run:
+
+```powershell
+git add src/services/apiService/sub2api/index.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts
+git commit -m "refactor(sub2api): use auth session for token recovery"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+## Task 3: Route Account Display Contexts Through The Session And Remove Generic Storage
+
+**Files:**
+- Modify: `src/services/accounts/utils/apiServiceRequest.ts`
+- Modify: `src/services/apiTransport/type.ts`
+- Modify: `tests/services/accounts/apiServiceRequest.test.ts`
+
+- [ ] **Step 1: Update account helper tests for Sub2API-only session decoration**
+
+In `tests/services/accounts/apiServiceRequest.test.ts`, add:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
+```
+
+Mock the session module:
+
+```ts
+vi.mock("~/services/accounts/sub2apiAuthSession", () => ({
+  accountSub2ApiAuthSession: {
+    getLatestAuth: vi.fn(),
+    persistAuthUpdate: vi.fn(),
+  },
+}))
+```
+
+Replace the test named `"injects a narrow Sub2API auth store into account-scoped requests"` with:
+
+```ts
+  it("keeps non-Sub2API account-scoped requests transport-only", async () => {
+    fetchTokens.mockResolvedValue([])
+
+    await fetchDisplayAccountTokens(ACCOUNT as any)
+
+    const request = fetchTokens.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(request).toEqual(expect.objectContaining(REQUEST))
+    expect(request).not.toHaveProperty("accountAuthStore")
+    expect(request).not.toHaveProperty("sub2apiAuthSession")
+  })
+```
+
+Add a new Sub2API context test:
+
+```ts
+  it("adds a Sub2API auth session only for Sub2API display-account contexts", async () => {
+    const sub2apiAccount = {
+      ...ACCOUNT,
+      siteType: SITE_TYPES.SUB2API,
+    }
+    fetchTokens.mockResolvedValue([])
+
+    await fetchDisplayAccountTokens(sub2apiAccount as any)
+
+    const request = fetchTokens.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(request).toEqual(expect.objectContaining(REQUEST))
+    expect(request).not.toHaveProperty("accountAuthStore")
+    expect(request.sub2apiAuthSession).toBe(accountSub2ApiAuthSession)
+    expect(createDisplayAccountApiContext(sub2apiAccount as any).request).toEqual(
+      expect.objectContaining({
+        ...REQUEST,
+        sub2apiAuthSession: accountSub2ApiAuthSession,
+      }),
+    )
+  })
+```
+
+In the valid payload test, keep the existing context expectation but add:
+
+```ts
+      request: expect.not.objectContaining({
+        accountAuthStore: expect.anything(),
+      }),
+```
+
+Do not assert that all contexts are plain; Sub2API contexts intentionally carry the Sub2API-only session property so direct `createDisplayAccountApiContext(...)` key-management callers keep auth recovery.
+
+- [ ] **Step 2: Run account helper tests and verify expected failures**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: FAIL because `apiServiceRequest.ts` still imports `accountStorage` and injects `accountAuthStore`.
+
+- [ ] **Step 3: Update `apiServiceRequest.ts` imports**
+
+In `src/services/accounts/utils/apiServiceRequest.ts`, remove:
+
+```ts
+import { accountStorage } from "~/services/accounts/accountStorage"
+```
+
+Add:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
+import type { Sub2ApiAuthSessionRequest } from "~/services/apiService/sub2api/authSession"
+```
+
+- [ ] **Step 4: Add a display-account request decorator**
+
+After `buildApiRequestFromDisplayAccount(...)`, add:
+
+```ts
+const withDisplayAccountAuthSession = (
+  account: Pick<DisplaySiteData, "siteType">,
+  request: ApiServiceRequest,
+): ApiServiceRequest | Sub2ApiAuthSessionRequest => {
+  if (account.siteType !== SITE_TYPES.SUB2API) {
+    return request
+  }
+
+  return {
+    ...request,
+    sub2apiAuthSession: accountSub2ApiAuthSession,
+  } satisfies Sub2ApiAuthSessionRequest
+}
+```
+
+- [ ] **Step 5: Remove generic storage from request construction**
+
+Change `buildApiRequestFromDisplayAccount(...)` from:
+
+```ts
+): ApiServiceRequest => ({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  accountAuthStore: accountStorage,
+  auth: {
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+```
+
+to:
+
+```ts
+): ApiServiceRequest => ({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+```
+
+- [ ] **Step 6: Decorate the request returned by `createDisplayAccountApiContext(...)`**
+
+Replace:
+
+```ts
+    request: buildApiRequestFromDisplayAccount(account),
+```
+
+with:
+
+```ts
+    request: withDisplayAccountAuthSession(
+      account,
+      buildApiRequestFromDisplayAccount(account),
+    ),
+```
+
+This preserves Sub2API auth recovery for direct context callers such as Add Token, Copy Key, post-save token lookup, and legacy Key Management update/delete paths.
+
+- [ ] **Step 7: Remove `accountAuthStore` from the generic transport type**
+
+In `src/services/apiTransport/type.ts`, remove:
+
+```ts
+  accountAuthStore?: {
+    getAccountById: (id: string) => Promise<any>
+    updateAccount: (
+      id: string,
+      updates: Record<string, any>,
+      options: { userTimestampMode: "preserve" | "touch" },
+    ) => Promise<boolean>
+  }
+```
+
+Do not add another generic storage property.
+
+- [ ] **Step 8: Run account helper tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run TypeScript compile to catch request type leaks**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS. If compile finds remaining `accountAuthStore` references, migrate them to `sub2apiAuthSession` or remove them if they are transport-only.
+
+- [ ] **Step 10: Search for remaining generic storage references**
+
+Run:
+
+```powershell
+rg -n "accountAuthStore|ApiServiceRequest\\[\"accountAuthStore\"\\]|Sub2ApiAccountAuthStore" src tests
+```
+
+Expected: no source matches. Test matches should be limited to negative assertions that prove generic requests do not expose `accountAuthStore`; remove stale fake storage setup.
+
+- [ ] **Step 11: Commit account helper and transport cleanup**
+
+Run:
+
+```powershell
+git add src/services/accounts/utils/apiServiceRequest.ts src/services/apiTransport/type.ts tests/services/accounts/apiServiceRequest.test.ts
+git commit -m "refactor(accounts): scope sub2api auth session to account contexts"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+## Task 4: Verify Direct Account Context Callers And Runtime Bundle Scope
+
+**Files:**
+- Inspect: `src/features/KeyManagement/hooks/useKeyManagement.ts`
+- Inspect: `src/features/KeyManagement/components/AddTokenDialog/index.tsx`
+- Inspect: `src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts`
+- Inspect: `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+- Inspect: `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`
+- Inspect: `src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts`
+- Test: `tests/features/AccountManagement/components/CopyKeyDialog.test.tsx`
+- Test: `tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx`
+- Test: `tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx`
+- Test: `tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx`
+- Test: `tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx`
+- Test: `tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx`
+- Test: `tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx`
+- Validate: Sub2API auth/session source files
+
+- [ ] **Step 1: List direct context callers**
+
+Run:
+
+```powershell
+rg -n "createDisplayAccountApiContext\\(" src tests
+```
+
+Expected: every direct caller receives the decorated `request` returned by `createDisplayAccountApiContext(...)`. No caller should build a replacement Sub2API key-management request manually.
+
+- [ ] **Step 2: Confirm no protocol Module imports account storage**
+
+Run:
+
+```powershell
+rg -n "accountStorage|sub2apiAuthSession" src/services/apiService/sub2api
+```
+
+Expected:
+
+```text
+src/services/apiService/sub2api/authSession.ts
+src/services/apiService/sub2api/index.ts
+```
+
+There must be no import of `~/services/accounts/accountStorage` or `~/services/accounts/sub2apiAuthSession` from `src/services/apiService/sub2api/**`.
+
+- [ ] **Step 3: Run focused tests that cover direct context consumers**
+
+Run:
+
+```powershell
+pnpm vitest run tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the DNR bundle smoke checks if import scope changed**
+
+Run this if Step 2 shows any unexpected Sub2API protocol import path or if compile output indicates bundling-sensitive module movement:
+
+```powershell
+$env:AAH_E2E_BUILD_VARIANT = "dnr-required"; pnpm run build:e2e
+pnpm run e2e:dnr-required -- --grep "grants the Chromium cookie/DNR optional permissions needed for cookie auth"
+```
+
+Expected: PASS. If these checks are skipped because Step 2 is clean and no bundle-sensitive import changed, report that decision explicitly.
+
+---
+
+## Task 5: Final Validation And Scope Audit
+
+**Files:**
+- Validate all task-scoped files from Tasks 1-4.
+
+- [ ] **Step 1: Run focused service tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/sub2apiAuthSession.test.ts tests/services/accounts/apiServiceRequest.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run adapter/account regression tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/sub2api/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountStorage.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run related validation for changed source files**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/apiService/sub2api/authSession.ts src/services/accounts/sub2apiAuthSession.ts src/services/apiService/sub2api/index.ts src/services/accounts/utils/apiServiceRequest.ts src/services/apiTransport/type.ts
+```
+
+Expected: PASS. If `vitest related` cannot resolve a new file before staging, classify that as tooling and keep the focused suites plus `pnpm compile` as the primary evidence.
+
+- [ ] **Step 4: Run TypeScript compile**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run commit gate**
+
+Run:
+
+```powershell
+git status --porcelain
+pnpm run validate:staged
+```
+
+Expected: PASS for task-scoped staged files. Existing unrelated untracked files may remain untracked and must not be staged.
+
+- [ ] **Step 6: Run push gate before publishing**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. This is required before pushing or opening a PR because the slice changes shared TypeScript request types and cross-module auth-session wiring.
+
+- [ ] **Step 7: Inspect final diff for scope**
+
+If changes are staged, run:
+
+```powershell
+git diff --cached --stat
+git diff --cached --name-status
+```
+
+If tasks were committed individually, run:
+
+```powershell
+git show --stat --oneline HEAD~3..HEAD
+git diff --name-status HEAD~3..HEAD
+```
+
+Expected files are limited to:
+
+```text
+src/services/apiService/sub2api/authSession.ts
+src/services/accounts/sub2apiAuthSession.ts
+src/services/apiService/sub2api/index.ts
+src/services/accounts/utils/apiServiceRequest.ts
+src/services/apiTransport/type.ts
+tests/services/accounts/sub2apiAuthSession.test.ts
+tests/services/accounts/apiServiceRequest.test.ts
+tests/services/apiService/sub2api/index.test.ts
+tests/services/apiService/sub2api/keyManagement.test.ts
+```
+
+No locale files, telemetry schema, settings search files, Playwright tests, managed-site providers, model pricing, account completion, site announcements, or new site types should be changed.
+
+- [ ] **Step 8: Record execution notes**
+
+Before handing off, report:
+
+```text
+Focused tests:
+- pnpm vitest run tests/services/accounts/sub2apiAuthSession.test.ts tests/services/accounts/apiServiceRequest.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts
+- pnpm vitest run tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/sub2api/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountStorage.test.ts
+
+Validation:
+- pnpm compile
+- pnpm run validate:staged
+- pnpm run validate:push
+
+E2E decision:
+- No new Playwright E2E added. Run the DNR build/smoke only if Sub2API protocol import scope changes or implementation evidence suggests a bundle-sensitive path.
+
+Telemetry decision:
+- None. No new user-visible action, setting, async result, or analytics-worthy outcome is introduced.
+```
+
+---
+
+## Out Of Scope
+
+- Do not rewrite Sub2API token refresh, dashboard re-sync, key parsing, or runtime `/v1/models` behavior.
+- Do not move `accountStorage.refreshAccount(...)` persistence into the session port.
+- Do not migrate full Key Management CRUD to a new adapter capability in this slice.
+- Do not change Sub2API group selection UX, model pricing, site announcements, account completion, or account auto-detect.
+- Do not add user-facing copy, locale keys, telemetry fields, settings search entries, Playwright E2E tests, or new site types.
+- Do not import `accountStorage` or `accountSub2ApiAuthSession` from `src/services/apiService/sub2api/**`.
+
+## Self-Review
+
+- Spec coverage: Task 1 adds the auth session Interface and account-layer Adapter. Task 2 moves Sub2API hydration, refresh-token recovery, browser-session re-sync persistence, and rotated-auth writes to that Interface. Task 3 removes the generic transport property and supplies the session only for Sub2API account contexts. Task 4 verifies direct context callers and bundle-sensitive import scope. Task 5 covers validation and scope audit.
+- Scope control: The plan keeps saved-account refresh persistence in `accountStorage.refreshAccount(...)` and does not touch unrelated adapter capabilities, UI copy, telemetry, settings search, or Playwright tests.
+- Type consistency: The plan consistently uses `Sub2ApiAuthSession`, `Sub2ApiStoredAuthSnapshot`, `Sub2ApiPersistAuthUpdate`, and `Sub2ApiAuthSessionRequest`. It removes `ApiServiceRequest["accountAuthStore"]` and does not add another generic storage property.
+- Compatibility: `createDisplayAccountApiContext(...)` keeps returning `service`, `adapter`, `keyManagement`, and `request`; the `request` is decorated only for Sub2API so existing direct key-management callers keep auth recovery without each caller learning the session Interface.

--- a/docs/superpowers/specs/2026-06-18-sub2api-auth-session-design.md
+++ b/docs/superpowers/specs/2026-06-18-sub2api-auth-session-design.md
@@ -1,0 +1,483 @@
+# Sub2API Auth Session Design
+
+Date: 2026-06-18
+
+## Purpose
+
+Move Sub2API dashboard JWT hydration, refresh, re-sync, and rotated-auth
+persistence behind a Sub2API-specific auth session Interface instead of
+carrying storage-capable callbacks on the generic `ApiServiceRequest` transport
+shape.
+
+The previous account-refresh adapter slice moved saved-account refresh toward
+`SiteAdapter.accountRefresh`. During PR feedback resolution, the implementation
+briefly used a global Sub2API account-storage bridge, then replaced it with an
+explicit `ApiServiceRequest.accountAuthStore` callback pair. That avoided a
+hidden singleton and fixed the immediate DNR bundle risk, but it is still a
+transitional Seam: every account-scoped request can now carry a persistence
+adapter even though only Sub2API auth recovery needs it.
+
+## Current Context
+
+`ApiTransportRequest` currently includes:
+
+```ts
+accountAuthStore?: {
+  getAccountById: (id: string) => Promise<any>
+  updateAccount: (
+    id: string,
+    updates: Record<string, any>,
+    options: { userTimestampMode: "preserve" | "touch" },
+  ) => Promise<boolean>
+}
+```
+
+`ApiServiceRequest` is an alias of `ApiTransportRequest`, so that property is
+visible to common API transport, New API-family code, AIHubMix, Sub2API, and
+product Modules that only need a request DTO.
+
+The remaining storage-dependent path is Sub2API key-management and auth
+recovery:
+
+- `src/services/apiService/sub2api/index.ts`
+  - hydrates latest stored dashboard JWT and refresh-token metadata
+  - serializes refresh/re-sync mutations
+  - persists rotated access tokens and refresh tokens after key requests
+  - retries key-management requests after refresh-token recovery or
+    browser-session re-sync
+- `src/services/accounts/utils/apiServiceRequest.ts`
+  - builds display-account requests
+  - currently injects `accountStorage` into every account-scoped request
+- `src/services/apiAdapters/sub2api/keyManagement.ts`
+  - delegates `fetchTokens`, `createToken`, and `resolveTokenKey` into
+    `apiService/sub2api`
+
+Saved-account refresh already has the better persistence shape:
+
+- `accountStorage.refreshAccount(...)` builds an account refresh request.
+- `SiteAdapter.accountRefresh.refreshAccount(...)` returns `authUpdate`.
+- `accountStorage.refreshAccount(...)` persists `authUpdate` together with
+  account data, preserving product merge rules and user timestamp semantics.
+
+That refresh path should stay as-is for this slice.
+
+## Problem
+
+`accountAuthStore` makes the generic request Interface too wide and too
+backend-aware.
+
+Current friction:
+
+1. Generic transport types now know about account storage, even though HTTP
+   request execution does not need storage.
+2. New API-family and AIHubMix account-scoped requests receive a persistence
+   adapter they should never use.
+3. Sub2API auth recovery owns a real protocol concern, but its persistence
+   dependency is hidden inside the request DTO rather than declared as a
+   Sub2API auth session dependency.
+4. Tests must assert storage wiring on a generic request shape instead of
+   exercising a smaller Sub2API-specific Interface.
+
+Deletion test: if `ApiServiceRequest.accountAuthStore` is deleted, Sub2API
+should still be able to hydrate latest stored auth and persist rotated auth, but
+that complexity should not reappear as another generic request property or a
+global account-storage import in `apiService/sub2api`. It should sit behind a
+Sub2API auth session port supplied only by account/application callers that need
+stored-session behavior.
+
+## Goals
+
+- Define a narrow Sub2API auth session Interface outside the generic transport
+  request type.
+- Move the current `accountAuthStore` responsibilities behind that Interface:
+  - read latest stored access token, refresh token, token expiry, and user id
+  - persist refreshed access token
+  - persist rotated refresh token and expiry when returned by the backend
+  - preserve user timestamp semantics on auth-only background writes
+- Route Sub2API account-scoped key-management calls through an account-layer
+  helper that supplies the session.
+- Preserve current Sub2API behavior:
+  - proactive refresh near expiry
+  - refresh-token recovery after 401
+  - browser-session JWT re-sync fallback
+  - serialized mutation lock behavior
+  - persisted rotated auth for key-management requests
+  - `authUpdate` return behavior for saved-account refresh
+- Remove `accountAuthStore` from `ApiTransportRequest` and
+  `ApiServiceRequest`.
+- Keep the DNR/E2E bundle fix: no global `accountStorage` import or
+  registration inside `src/services/apiService/sub2api`.
+
+## Non-Goals
+
+- Do not rewrite Sub2API token refresh or dashboard re-sync protocol logic.
+- Do not move `accountStorage.refreshAccount(...)` persistence behind this
+  session port; saved-account refresh should continue to persist returned
+  `authUpdate`.
+- Do not migrate full Key Management CRUD, group selection UX, model pricing,
+  site announcements, runtime model catalog, or account completion.
+- Do not add user-facing copy, locale keys, telemetry fields, settings search
+  entries, or Playwright E2E tests.
+- Do not reintroduce `accountStorage` imports in `apiService/sub2api`.
+- Do not add a generic storage port to `apiTransport`.
+- Do not change Sub2API external backend behavior or saved account data shape.
+
+## Approaches Considered
+
+### Approach A: Keep `accountAuthStore` On `ApiServiceRequest`
+
+This is the current transitional state. It is explicit and avoids a global
+bridge, but the Interface is shallow: generic request callers must know about a
+storage dependency that only one backend uses.
+
+This should not be the final shape.
+
+### Approach B: Product Orchestrator Owns All Sub2API Auth Recovery
+
+Account/application code could perform hydration, token refresh, re-sync, and
+persistence before calling Sub2API key-management helpers.
+
+This would keep storage out of transport, but it would scatter Sub2API protocol
+rules across product Modules. The Sub2API service Module already has the right
+Locality for refresh/retry/error normalization, so moving the protocol up would
+reduce Leverage.
+
+### Approach C: Sub2API Auth Session Port Supplied By Account Callers
+
+Define a Sub2API-specific session Interface, keep protocol behavior in
+`apiService/sub2api`, and let account/application Modules provide an Adapter
+that reads/writes `accountStorage`.
+
+This is the recommended path. It gives Sub2API protocol code the dependency it
+needs without widening generic transport types. It also keeps account storage
+ownership in the account layer and avoids hidden singleton wiring.
+
+## Design
+
+### 1. Add A Sub2API Auth Session Contract
+
+Create a Sub2API-owned contract near the Sub2API implementation, for example:
+
+```text
+src/services/apiService/sub2api/authSession.ts
+```
+
+Proposed Interface:
+
+```ts
+import type { AccountIdentity, Sub2ApiAuthConfig } from "~/types"
+
+export type Sub2ApiStoredAuthSnapshot = {
+  accessToken?: string
+  userId?: AccountIdentity
+  sub2apiAuth?: Sub2ApiAuthConfig
+}
+
+export type Sub2ApiPersistAuthUpdate = {
+  accessToken: string
+  refreshToken?: string
+  tokenExpiresAt?: number
+}
+
+export type Sub2ApiAuthSession = {
+  getLatestAuth(accountId: string): Promise<Sub2ApiStoredAuthSnapshot | null>
+  persistAuthUpdate(
+    accountId: string,
+    update: Sub2ApiPersistAuthUpdate,
+  ): Promise<boolean>
+}
+```
+
+The Interface should not expose `SiteAccount`, `DisplaySiteData`, or
+`accountStorage.updateAccount(...)` directly. Sub2API protocol code needs a
+small auth snapshot and an auth-update write method, not the full account
+storage implementation.
+
+### 2. Define A Sub2API Session Request Shape
+
+Keep `ApiServiceRequest` transport-only, and add a local extension type used by
+Sub2API auth-aware helpers:
+
+```ts
+export type Sub2ApiAuthSessionRequest<TRequest extends ApiServiceRequest> =
+  TRequest & {
+    sub2apiAuthSession?: Sub2ApiAuthSession
+  }
+```
+
+Only Sub2API auth-aware entry points should accept this extension. Generic
+transport, common API service code, New API-family adapters, and AIHubMix should
+continue accepting plain `ApiServiceRequest`.
+
+### 3. Move Hydration To The Session Port
+
+Replace the current `hydrateSub2ApiAuthRequest(...)` dependency on
+`request.accountAuthStore` with `request.sub2apiAuthSession`.
+
+Hydration rules should stay unchanged:
+
+- start from request auth values
+- if `accountId` and session are present, load latest stored auth
+- prefer non-empty stored access token
+- prefer stored refresh token and expiry when present
+- fill missing user id from stored account identity
+- return a hydrated request plus the session reference used for later
+  persistence
+
+Requests without a session remain valid. They can still use request-provided
+access token and refresh token, but they cannot hydrate newer stored values or
+persist rotated auth.
+
+### 4. Move Persistence To The Session Port
+
+Replace `persistSub2ApiAuthUpdate(..., accountAuthStore)` with session-based
+persistence:
+
+```ts
+await session.persistAuthUpdate(request.accountId, authUpdate)
+```
+
+Persistence should remain best-effort for key-management requests:
+
+- no `accountId`: skip
+- no session: skip
+- persistence returns `false`: warn
+- persistence throws: warn with safe error details
+
+The persisted update must preserve current semantics:
+
+- always persist `account_info.access_token` equivalent when an access token is
+  refreshed or re-synced
+- persist `sub2apiAuth.refreshToken` and `tokenExpiresAt` only when a refresh
+  token is present in the update
+- preserve user timestamp mode in the account-layer Adapter
+
+### 5. Add An Account-Layer Session Adapter
+
+Create the storage-backed Adapter outside `apiService/sub2api`, for example:
+
+```text
+src/services/accounts/sub2apiAuthSession.ts
+```
+
+Responsibilities:
+
+- import `accountStorage`
+- implement `Sub2ApiAuthSession`
+- read the latest stored account by id
+- return only the auth snapshot needed by Sub2API
+- update only auth-related fields
+- call `accountStorage.updateAccount(..., { userTimestampMode: "preserve" })`
+
+This keeps account persistence in the account layer and prevents DNR bundle
+regressions caused by Sub2API protocol code importing account storage.
+
+### 6. Supply The Session Only For Sub2API Account-Key Flows
+
+Modify `src/services/accounts/utils/apiServiceRequest.ts` so
+`buildApiRequestFromDisplayAccount(...)` no longer adds storage to the generic
+request.
+
+For account-scoped key-management helpers:
+
+- build the plain request as before
+- if `account.siteType === SITE_TYPES.SUB2API`, attach
+  `sub2apiAuthSession: accountSub2ApiAuthSession` only for the call path that
+  enters Sub2API key management
+- do not attach a session for New API-family or AIHubMix requests
+
+This helper remains the product-level entry point for:
+
+- `fetchDisplayAccountTokens(...)`
+- `resolveDisplayAccountTokenForSecret(...)`
+- `createDisplayAccountApiContext(...)`
+
+The exact implementation can be either:
+
+1. return `request` plus an optional Sub2API session-aware request from
+   `createDisplayAccountApiContext(...)`, or
+2. keep `request` plain and use a small helper that decorates only Sub2API
+   requests immediately before calling `adapter.keyManagement`.
+
+Prefer the second option if it keeps the public helper Interface smaller.
+
+### 7. Keep Account Refresh Persistence Separate
+
+Do not force `accountStorage.refreshAccount(...)` through the session port.
+
+Saved-account refresh should continue to:
+
+- pass auth data in the account refresh request
+- call `accountRefresh.refreshAccount(...)`
+- receive `RefreshAccountResult.authUpdate`
+- merge and persist auth updates in `accountStorage.refreshAccount(...)`
+
+This distinction is important:
+
+- key-management requests need best-effort auth persistence during protocol
+  recovery
+- saved-account refresh already has a product-owned persistence transaction
+  with account data, health, balance history, and timestamp rules
+
+### 8. Remove The Generic Transport Property
+
+After all Sub2API auth recovery call sites use `sub2apiAuthSession`, remove
+`accountAuthStore` from:
+
+```text
+src/services/apiTransport/type.ts
+```
+
+Then update tests and any type-only references that still mention
+`ApiServiceRequest["accountAuthStore"]`.
+
+## Error Handling
+
+The refactor should preserve existing Sub2API error behavior.
+
+- Missing access token with no recoverable session still maps to
+  `messages:sub2api.loginRequired`.
+- Invalid refresh-token contract still maps to
+  `messages:sub2api.refreshTokenInvalid`.
+- Browser-session re-sync absence still maps to login-required behavior.
+- Business errors returned by Sub2API key/runtime endpoints remain business
+  errors, not auth-session failures.
+- Session read/write failures are non-fatal for key-management requests and
+  should be logged with redacted messages.
+
+Do not surface new user-facing copy for session persistence failures in this
+slice.
+
+## Telemetry Decision
+
+Telemetry decision: none.
+
+This is an internal architecture migration. It does not add a user action,
+setting, result category, or visible product state. Existing key-management and
+account-refresh telemetry should continue from their current owners.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E in this slice.
+
+The behavioral risk is service-layer auth recovery and type/interface routing.
+Focused Vitest coverage is the right validation layer. Existing DNR/cookie-auth
+E2E coverage should remain the browser-level guard against bundle/runtime
+regressions.
+
+## Testing Strategy
+
+Use TDD for the migration.
+
+Update account request helper tests:
+
+- non-Sub2API display-account requests do not expose `accountAuthStore`
+- generic `createDisplayAccountApiContext(...)` returns a plain request
+- Sub2API token inventory and secret-resolution calls receive a
+  Sub2API-specific auth session
+- New API-family and AIHubMix calls do not receive that session
+
+Update Sub2API service tests:
+
+- stored auth hydration uses `sub2apiAuthSession.getLatestAuth(...)`
+- refresh-token recovery persists rotated access token, refresh token, and
+  expiry via `sub2apiAuthSession.persistAuthUpdate(...)`
+- browser-session re-sync persists the re-synced access token via the session
+- requests without a session still work with request-provided auth and skip
+  persistence
+- mutation-lock behavior still avoids duplicate refreshes when concurrent
+  callers share account id or auth identity
+
+Update key-management tests:
+
+- `fetchAccountTokens(...)`, `createApiToken(...)`, and
+  `resolveApiTokenKey(...)` preserve current request retry/recovery behavior
+  when passed a session-aware request
+- tests no longer build fake `accountAuthStore` values on `ApiServiceRequest`
+
+Update type/registry-related tests as needed:
+
+- `ApiTransportRequest` has no storage-capable property
+- Sub2API adapter delegation still passes request objects through unchanged
+  except for account-layer session decoration before the adapter call
+
+## Validation Plan
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts
+```
+
+Adapter/account regression validation:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/sub2api/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountStorage.test.ts
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+If the implementation changes shared exported types, adapter contracts, or
+cross-module request construction, run before pushing:
+
+```powershell
+pnpm run validate:push
+```
+
+If DNR bundle-risk code paths change or any Sub2API module starts importing
+account-layer modules, run the DNR build/smoke checks from the handoff:
+
+```powershell
+$env:AAH_E2E_BUILD_VARIANT = "dnr-required"; pnpm run build:e2e
+pnpm run e2e:dnr-required -- --grep "grants the Chromium cookie/DNR optional permissions needed for cookie auth"
+```
+
+## Rollout
+
+1. Add the Sub2API auth session contract and failing tests for account-helper
+   routing.
+2. Add the account-layer storage-backed session Adapter.
+3. Migrate Sub2API hydration and persistence internals from `accountAuthStore`
+   to the session Interface.
+4. Route display-account Sub2API key-management calls through the session
+   Adapter while keeping non-Sub2API requests plain.
+5. Update Sub2API service and key-management tests from fake
+   `accountAuthStore` to fake `sub2apiAuthSession`.
+6. Remove `accountAuthStore` from `ApiTransportRequest`.
+7. Run focused tests and `pnpm compile`.
+8. Run `pnpm run validate:staged`, inspect the final diff, and commit the
+   implementation slice.
+9. Run `pnpm run validate:push` before pushing or updating the PR branch.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may consider:
+
+- a richer account-session helper if another backend needs stored auth
+  recovery
+- migrating additional Sub2API account workflows through smaller product
+  helpers
+- a lint/import guard that prevents protocol Modules from importing
+  account-storage Modules directly
+- a dedicated auth-session test fixture shared by Sub2API service tests
+
+Do not generalize this into a cross-backend storage abstraction until a second
+backend proves the same Seam. One Adapter is a hypothetical Seam; this slice is
+valuable because it removes a known generic Interface leak while keeping the
+Sub2API-specific behavior local.

--- a/src/services/accounts/sub2apiAuthSession.ts
+++ b/src/services/accounts/sub2apiAuthSession.ts
@@ -1,0 +1,81 @@
+import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
+import { accountStorage } from "~/services/accounts/accountStorage"
+import type {
+  Sub2ApiAuthSession,
+  Sub2ApiPersistAuthUpdate,
+  Sub2ApiStoredAuthSnapshot,
+} from "~/services/apiService/sub2api/authSession"
+import type { SiteAccount } from "~/types"
+import type { DeepPartial } from "~/types/utils"
+
+const normalizeString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+const normalizeTokenExpiresAt = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined
+
+const buildStoredAuthSnapshot = (
+  account: Pick<SiteAccount, "account_info" | "sub2apiAuth">,
+): Sub2ApiStoredAuthSnapshot => {
+  const accessToken = normalizeString(account.account_info?.access_token)
+  const userId = normalizeString(account.account_info?.id)
+  const refreshToken = normalizeString(account.sub2apiAuth?.refreshToken)
+  const tokenExpiresAt = normalizeTokenExpiresAt(
+    account.sub2apiAuth?.tokenExpiresAt,
+  )
+
+  return {
+    ...(accessToken ? { accessToken } : {}),
+    ...(userId ? { userId } : {}),
+    ...(refreshToken
+      ? {
+          sub2apiAuth: {
+            refreshToken,
+            ...(typeof tokenExpiresAt === "number" ? { tokenExpiresAt } : {}),
+          },
+        }
+      : {}),
+  }
+}
+
+const buildPersistedAuthUpdate = (
+  update: Sub2ApiPersistAuthUpdate,
+): DeepPartial<SiteAccount> => {
+  const refreshToken = normalizeString(update.refreshToken)
+  const persisted: DeepPartial<SiteAccount> = {
+    account_info: {
+      access_token: update.accessToken,
+    },
+  }
+
+  if (refreshToken) {
+    persisted.sub2apiAuth = {
+      refreshToken,
+      ...(typeof update.tokenExpiresAt === "number" &&
+      Number.isFinite(update.tokenExpiresAt)
+        ? { tokenExpiresAt: update.tokenExpiresAt }
+        : {}),
+    }
+  }
+
+  return persisted
+}
+
+export const accountSub2ApiAuthSession: Sub2ApiAuthSession = {
+  async getLatestAuth(accountId) {
+    const account = await accountStorage.getAccountById(accountId)
+    return account ? buildStoredAuthSnapshot(account) : null
+  },
+  async persistAuthUpdate(accountId, update) {
+    return accountStorage.updateAccount(
+      accountId,
+      buildPersistedAuthUpdate(update),
+      {
+        userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
+      },
+    )
+  },
+}

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -1,9 +1,11 @@
-import { accountStorage } from "~/services/accounts/accountStorage"
+import { SITE_TYPES } from "~/constants/siteType"
+import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { getApiService } from "~/services/apiService"
 import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import type { Sub2ApiAuthSessionRequest } from "~/services/apiService/sub2api/authSession"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { createLogger } from "~/utils/core/logger"
 
@@ -65,7 +67,6 @@ const buildApiRequestFromDisplayAccount = (
 ): ApiServiceRequest => ({
   baseUrl: account.baseUrl,
   accountId: account.id,
-  accountAuthStore: accountStorage,
   auth: {
     authType: account.authType,
     userId: account.userId,
@@ -73,6 +74,20 @@ const buildApiRequestFromDisplayAccount = (
     cookie: account.cookieAuthSessionCookie,
   },
 })
+
+const withDisplayAccountAuthSession = (
+  account: Pick<DisplaySiteData, "siteType">,
+  request: ApiServiceRequest,
+): ApiServiceRequest | Sub2ApiAuthSessionRequest => {
+  if (account.siteType !== SITE_TYPES.SUB2API) {
+    return request
+  }
+
+  return {
+    ...request,
+    sub2apiAuthSession: accountSub2ApiAuthSession,
+  } satisfies Sub2ApiAuthSessionRequest
+}
 
 /**
  * Resolve both the site-specific service and its request DTO for a display account.
@@ -95,7 +110,10 @@ export const createDisplayAccountApiContext = (
     service: getApiService(account.siteType),
     adapter,
     keyManagement: adapter.keyManagement,
-    request: buildApiRequestFromDisplayAccount(account),
+    request: withDisplayAccountAuthSession(
+      account,
+      buildApiRequestFromDisplayAccount(account),
+    ),
   }
 }
 

--- a/src/services/apiService/sub2api/authSession.ts
+++ b/src/services/apiService/sub2api/authSession.ts
@@ -1,0 +1,37 @@
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type { AccountIdentity, Sub2ApiAuthConfig } from "~/types"
+
+export type Sub2ApiStoredAuthSnapshot = {
+  accessToken?: string
+  userId?: AccountIdentity
+  sub2apiAuth?: Sub2ApiAuthConfig
+}
+
+export type Sub2ApiPersistAuthUpdate = {
+  accessToken: string
+  refreshToken?: string
+  tokenExpiresAt?: number
+}
+
+export type Sub2ApiAuthSession = {
+  getLatestAuth(accountId: string): Promise<Sub2ApiStoredAuthSnapshot | null>
+  persistAuthUpdate(
+    accountId: string,
+    update: Sub2ApiPersistAuthUpdate,
+  ): Promise<boolean>
+}
+
+export type Sub2ApiAuthSessionRequest<
+  TRequest extends ApiServiceRequest = ApiServiceRequest,
+> = TRequest & {
+  sub2apiAuthSession?: Sub2ApiAuthSession
+}
+
+/**
+ * Gets the Sub2API auth-session port attached to an API service request.
+ */
+export function getSub2ApiAuthSession(
+  request: ApiServiceRequest,
+): Sub2ApiAuthSession | undefined {
+  return (request as Sub2ApiAuthSessionRequest).sub2apiAuthSession
+}

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -4,7 +4,6 @@
  * Sub2API differs from One-API/New-API backends in that authenticated endpoints
  * live under `/api/v1/*` and require a dashboard JWT.
  */
-import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
 import {
   determineHealthStatus,
   extractDefaultExchangeRate as extractCommonDefaultExchangeRate,
@@ -36,6 +35,7 @@ import {
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
 
+import { getSub2ApiAuthSession, type Sub2ApiAuthSession } from "./authSession"
 import {
   buildSub2ApiUserGroups,
   extractSub2ApiKeyItems,
@@ -155,15 +155,11 @@ type RefreshedSub2ApiRequest<
   tokenExpiresAt: number
 }
 
-type Sub2ApiAccountAuthStore = NonNullable<
-  ApiServiceRequest["accountAuthStore"]
->
-
 type HydratedSub2ApiAuth<
   TRequest extends ApiServiceRequest = ApiServiceRequest,
 > = {
   request: TRequest
-  accountAuthStore?: Sub2ApiAccountAuthStore
+  authSession?: Sub2ApiAuthSession
 }
 
 const hydrateSub2ApiAuthRequest = async <TRequest extends ApiServiceRequest>(
@@ -173,20 +169,17 @@ const hydrateSub2ApiAuthRequest = async <TRequest extends ApiServiceRequest>(
   let refreshToken = normalizeRefreshToken(request.auth?.refreshToken)
   let tokenExpiresAt = normalizeTokenExpiresAt(request.auth?.tokenExpiresAt)
   let userId = request.auth?.userId
-  const accountAuthStore = request.accountAuthStore
+  const authSession = getSub2ApiAuthSession(request)
 
-  if (request.accountId && accountAuthStore) {
-    const account = await accountAuthStore.getAccountById(request.accountId)
-    if (account) {
-      const storedAccessToken =
-        typeof account.account_info?.access_token === "string"
-          ? account.account_info.access_token.trim()
-          : ""
+  if (request.accountId && authSession) {
+    const storedAuth = await authSession.getLatestAuth(request.accountId)
+    if (storedAuth) {
+      const storedAccessToken = normalizeAccessToken(storedAuth.accessToken)
       const storedRefreshToken = normalizeRefreshToken(
-        account.sub2apiAuth?.refreshToken,
+        storedAuth.sub2apiAuth?.refreshToken,
       )
       const storedTokenExpiresAt = normalizeTokenExpiresAt(
-        account.sub2apiAuth?.tokenExpiresAt,
+        storedAuth.sub2apiAuth?.tokenExpiresAt,
       )
 
       const shouldPreferStoredAccess = Boolean(storedAccessToken)
@@ -201,7 +194,7 @@ const hydrateSub2ApiAuthRequest = async <TRequest extends ApiServiceRequest>(
         tokenExpiresAt = storedTokenExpiresAt
       }
       if (userId === undefined) {
-        userId = account.account_info?.id
+        userId = storedAuth.userId
       }
     }
   }
@@ -220,45 +213,27 @@ const hydrateSub2ApiAuthRequest = async <TRequest extends ApiServiceRequest>(
 
   return {
     request: hydratedRequest,
-    accountAuthStore,
+    authSession,
   }
 }
 
 const persistSub2ApiAuthUpdate = async (
   request: ApiServiceRequest,
   authUpdate: PersistableSub2ApiAuthUpdate,
-  accountAuthStore: Sub2ApiAccountAuthStore | undefined,
+  authSession: Sub2ApiAuthSession | undefined,
 ) => {
   if (!request.accountId) {
     return
   }
 
-  if (!accountAuthStore) {
+  if (!authSession) {
     return
   }
 
   try {
-    const updates: Record<string, any> = {
-      account_info: {
-        access_token: authUpdate.accessToken,
-      },
-    }
-
-    if (authUpdate.refreshToken) {
-      updates.sub2apiAuth = {
-        refreshToken: authUpdate.refreshToken,
-        ...(typeof authUpdate.tokenExpiresAt === "number"
-          ? { tokenExpiresAt: authUpdate.tokenExpiresAt }
-          : {}),
-      }
-    }
-
-    const updated = await accountAuthStore.updateAccount(
+    const updated = await authSession.persistAuthUpdate(
       request.accountId,
-      updates,
-      {
-        userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
-      },
+      authUpdate,
     )
     if (!updated) {
       logger.warn("Failed to persist Sub2API auth update after key request", {
@@ -351,13 +326,12 @@ const refreshSub2ApiRequestAuth = async <
 >(params: {
   request: TRequest
   refreshToken: string
-  accountAuthStore?: Sub2ApiAccountAuthStore
+  authSession?: Sub2ApiAuthSession
 }): Promise<RefreshedSub2ApiRequest<TRequest>> => {
   return withSub2ApiAuthMutationLock(params.request, async () => {
     const latestHydrated = await hydrateSub2ApiAuthRequest(params.request)
     const latestRequest = latestHydrated.request
-    const latestAccountAuthStore =
-      latestHydrated.accountAuthStore ?? params.accountAuthStore
+    const latestAuthSession = latestHydrated.authSession ?? params.authSession
     const latestRefreshToken =
       normalizeRefreshToken(latestRequest.auth?.refreshToken) ||
       normalizeRefreshToken(params.refreshToken)
@@ -387,7 +361,7 @@ const refreshSub2ApiRequestAuth = async <
     await persistSub2ApiAuthUpdate(
       refreshedRequest,
       refreshed,
-      latestAccountAuthStore,
+      latestAuthSession,
     )
 
     return {
@@ -403,13 +377,12 @@ const resyncSub2ApiRequestAuth = async <
 >(params: {
   request: TRequest
   endpoint: string
-  accountAuthStore?: Sub2ApiAccountAuthStore
+  authSession?: Sub2ApiAuthSession
 }): Promise<TRequest> => {
   return withSub2ApiAuthMutationLock(params.request, async () => {
     const latestHydrated = await hydrateSub2ApiAuthRequest(params.request)
     const latestRequest = latestHydrated.request
-    const latestAccountAuthStore =
-      latestHydrated.accountAuthStore ?? params.accountAuthStore
+    const latestAuthSession = latestHydrated.authSession ?? params.authSession
 
     if (didSub2ApiAuthChange(params.request, latestRequest)) {
       return latestRequest
@@ -432,7 +405,7 @@ const resyncSub2ApiRequestAuth = async <
     await persistSub2ApiAuthUpdate(
       resyncedRequest,
       { accessToken: resynced.accessToken },
-      latestAccountAuthStore,
+      latestAuthSession,
     )
 
     return resyncedRequest
@@ -444,13 +417,13 @@ type AuthenticatedSub2ApiRunner<T> = (request: ApiServiceRequest) => Promise<T>
 const retrySub2ApiRunnerWithResyncedAuth = async <T>(params: {
   request: ApiServiceRequest
   endpoint: string
-  accountAuthStore?: Sub2ApiAccountAuthStore
+  authSession?: Sub2ApiAuthSession
   runner: AuthenticatedSub2ApiRunner<T>
 }): Promise<T> => {
   const updatedRequest = await resyncSub2ApiRequestAuth({
     request: params.request,
     endpoint: params.endpoint,
-    accountAuthStore: params.accountAuthStore,
+    authSession: params.authSession,
   })
 
   try {
@@ -491,7 +464,7 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
       const refreshed = await refreshSub2ApiRequestAuth({
         request: effectiveRequest,
         refreshToken,
-        accountAuthStore: hydrated.accountAuthStore,
+        authSession: hydrated.authSession,
       })
 
       effectiveRequest = refreshed.request
@@ -516,7 +489,7 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
         const refreshed = await refreshSub2ApiRequestAuth({
           request: effectiveRequest,
           refreshToken,
-          accountAuthStore: hydrated.accountAuthStore,
+          authSession: hydrated.authSession,
         })
 
         effectiveRequest = refreshed.request
@@ -536,7 +509,7 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
           updatedRequest = await resyncSub2ApiRequestAuth({
             request: effectiveRequest,
             endpoint,
-            accountAuthStore: hydrated.accountAuthStore,
+            authSession: hydrated.authSession,
           })
         } catch {
           throw refreshError
@@ -557,7 +530,7 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
     return await retrySub2ApiRunnerWithResyncedAuth({
       request: effectiveRequest,
       endpoint,
-      accountAuthStore: hydrated.accountAuthStore,
+      authSession: hydrated.authSession,
       runner,
     })
   }
@@ -833,13 +806,13 @@ const createRefreshSuccessResult = (
 
 const refreshSub2ApiAccountViaResync = async (params: {
   request: ApiServiceRequest
-  accountAuthStore?: Sub2ApiAccountAuthStore
+  authSession?: Sub2ApiAuthSession
   checkIn: CheckInConfig
 }): Promise<RefreshAccountResult> => {
   const retryRequest = await resyncSub2ApiRequestAuth({
     request: params.request,
     endpoint: SUB2API_AUTH_ME_ENDPOINT,
-    accountAuthStore: params.accountAuthStore,
+    authSession: params.authSession,
   })
 
   const currentUser = await fetchCurrentUser(retryRequest)
@@ -943,12 +916,12 @@ const fetchSub2ApiAccessTokenInfo = async (
 
 const fetchSub2ApiAccessTokenInfoWithResyncedAuth = async (params: {
   request: ApiServiceRequest
-  accountAuthStore?: Sub2ApiAccountAuthStore
+  authSession?: Sub2ApiAuthSession
 }): Promise<AccessTokenInfo> => {
   const resyncedRequest = await resyncSub2ApiRequestAuth({
     request: params.request,
     endpoint: SUB2API_AUTH_ME_ENDPOINT,
-    accountAuthStore: params.accountAuthStore,
+    authSession: params.authSession,
   })
 
   try {
@@ -965,7 +938,7 @@ const fetchSub2ApiAccessTokenInfoWithResyncedAuth = async (params: {
 const fetchSub2ApiAccessTokenInfoWithAuthRecovery = async (params: {
   request: ApiServiceRequest
   refreshToken: string
-  accountAuthStore?: Sub2ApiAccountAuthStore
+  authSession?: Sub2ApiAuthSession
 }): Promise<AccessTokenInfo> => {
   try {
     return await fetchSub2ApiAccessTokenInfo(params.request)
@@ -979,7 +952,7 @@ const fetchSub2ApiAccessTokenInfoWithAuthRecovery = async (params: {
         const refreshed = await refreshSub2ApiRequestAuth({
           request: params.request,
           refreshToken: params.refreshToken,
-          accountAuthStore: params.accountAuthStore,
+          authSession: params.authSession,
         })
 
         return await fetchSub2ApiAccessTokenInfo(refreshed.request)
@@ -993,7 +966,7 @@ const fetchSub2ApiAccessTokenInfoWithAuthRecovery = async (params: {
 
     return await fetchSub2ApiAccessTokenInfoWithResyncedAuth({
       request: params.request,
-      accountAuthStore: params.accountAuthStore,
+      authSession: params.authSession,
     })
   }
 }
@@ -1018,7 +991,7 @@ export async function getOrCreateAccessToken(
     return await fetchSub2ApiAccessTokenInfoWithAuthRecovery({
       request: effectiveRequest,
       refreshToken,
-      accountAuthStore: hydrated.accountAuthStore,
+      authSession: hydrated.authSession,
     })
   }
 
@@ -1027,7 +1000,7 @@ export async function getOrCreateAccessToken(
       const refreshed = await refreshSub2ApiRequestAuth({
         request: effectiveRequest,
         refreshToken,
-        accountAuthStore: hydrated.accountAuthStore,
+        authSession: hydrated.authSession,
       })
       effectiveRequest = refreshed.request
       accessToken = normalizeAccessToken(effectiveRequest.auth?.accessToken)
@@ -1047,7 +1020,7 @@ export async function getOrCreateAccessToken(
 
   return await fetchSub2ApiAccessTokenInfoWithResyncedAuth({
     request: effectiveRequest,
-    accountAuthStore: hydrated.accountAuthStore,
+    authSession: hydrated.authSession,
   })
 }
 
@@ -1158,7 +1131,7 @@ export async function refreshAccountData(
           const refreshed = await refreshSub2ApiRequestAuth({
             request: effectiveRequest,
             refreshToken,
-            accountAuthStore: hydratedRequest.accountAuthStore,
+            authSession: hydratedRequest.authSession,
           })
 
           effectiveRequest = refreshed.request
@@ -1200,7 +1173,7 @@ export async function refreshAccountData(
           const refreshed = await refreshSub2ApiRequestAuth({
             request: effectiveRequest,
             refreshToken,
-            accountAuthStore: hydratedRequest.accountAuthStore,
+            authSession: hydratedRequest.authSession,
           })
 
           const retryRequest = refreshed.request
@@ -1222,7 +1195,7 @@ export async function refreshAccountData(
           try {
             return await refreshSub2ApiAccountViaResync({
               request: effectiveRequest,
-              accountAuthStore: hydratedRequest.accountAuthStore,
+              authSession: hydratedRequest.authSession,
               checkIn,
             })
           } catch {
@@ -1237,7 +1210,7 @@ export async function refreshAccountData(
       try {
         return await refreshSub2ApiAccountViaResync({
           request: hydratedRequest.request,
-          accountAuthStore: hydratedRequest.accountAuthStore,
+          authSession: hydratedRequest.authSession,
           checkIn,
         })
       } catch (retryError) {

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -84,14 +84,6 @@ export interface ApiTransportRequest {
   baseUrl: string
   data?: Record<string, any>
   accountId?: string
-  accountAuthStore?: {
-    getAccountById: (id: string) => Promise<any>
-    updateAccount: (
-      id: string,
-      updates: Record<string, any>,
-      options: { userTimestampMode: "preserve" | "touch" },
-    ) => Promise<boolean>
-  }
   cookieAuthSessionCookie?: string
   fetchContext?: ApiTransportFetchContext
 }

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
+import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
 import {
   canManageDisplayAccountTokens,
   createDisplayAccountApiContext,
@@ -17,6 +19,13 @@ vi.mock("~/services/apiAdapters/registry", () => ({
 
 vi.mock("~/services/apiService", () => ({
   getApiService: vi.fn(),
+}))
+
+vi.mock("~/services/accounts/sub2apiAuthSession", () => ({
+  accountSub2ApiAuthSession: {
+    getLatestAuth: vi.fn(),
+    persistAuthUpdate: vi.fn(),
+  },
 }))
 
 const ACCOUNT = {
@@ -84,19 +93,46 @@ describe("fetchDisplayAccountTokens", () => {
       keyManagement,
       request: expect.objectContaining(REQUEST),
     })
+    expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual(
+      expect.objectContaining({
+        request: expect.not.objectContaining({
+          accountAuthStore: expect.anything(),
+        }),
+      }),
+    )
   })
 
-  it("injects a narrow Sub2API auth store into account-scoped requests", async () => {
+  it("keeps non-Sub2API account-scoped requests transport-only", async () => {
     fetchTokens.mockResolvedValue([])
 
     await fetchDisplayAccountTokens(ACCOUNT as any)
 
-    const request = fetchTokens.mock.calls[0]?.[0]
-    expect(request?.accountAuthStore?.getAccountById).toEqual(
-      expect.any(Function),
-    )
-    expect(request?.accountAuthStore?.updateAccount).toEqual(
-      expect.any(Function),
+    const request = fetchTokens.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(request).toEqual(expect.objectContaining(REQUEST))
+    expect(request).not.toHaveProperty("accountAuthStore")
+    expect(request).not.toHaveProperty("sub2apiAuthSession")
+  })
+
+  it("adds a Sub2API auth session only for Sub2API display-account contexts", async () => {
+    const sub2apiAccount = {
+      ...ACCOUNT,
+      siteType: SITE_TYPES.SUB2API,
+    }
+    fetchTokens.mockResolvedValue([])
+
+    await fetchDisplayAccountTokens(sub2apiAccount as any)
+
+    const request = fetchTokens.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(request).toEqual(expect.objectContaining(REQUEST))
+    expect(request).not.toHaveProperty("accountAuthStore")
+    expect(request.sub2apiAuthSession).toBe(accountSub2ApiAuthSession)
+    expect(
+      createDisplayAccountApiContext(sub2apiAccount as any).request,
+    ).toEqual(
+      expect.objectContaining({
+        ...REQUEST,
+        sub2apiAuthSession: accountSub2ApiAuthSession,
+      }),
     )
   })
 

--- a/tests/services/accounts/sub2apiAuthSession.test.ts
+++ b/tests/services/accounts/sub2apiAuthSession.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
+import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
+
+const { getAccountByIdMock, updateAccountMock } = vi.hoisted(() => ({
+  getAccountByIdMock: vi.fn(),
+  updateAccountMock: vi.fn(),
+}))
+
+vi.mock("~/services/accounts/accountStorage", () => ({
+  accountStorage: {
+    getAccountById: (...args: unknown[]) => getAccountByIdMock(...args),
+    updateAccount: (...args: unknown[]) => updateAccountMock(...args),
+  },
+}))
+
+describe("accountSub2ApiAuthSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getAccountByIdMock.mockResolvedValue(null)
+    updateAccountMock.mockResolvedValue(true)
+  })
+
+  it("returns a narrow stored auth snapshot for an existing Sub2API account", async () => {
+    getAccountByIdMock.mockResolvedValueOnce({
+      account_info: {
+        id: "9",
+        access_token: " stored-jwt ",
+      },
+      sub2apiAuth: {
+        refreshToken: " stored-refresh ",
+        tokenExpiresAt: 1_700_000_000_000,
+      },
+    })
+
+    await expect(
+      accountSub2ApiAuthSession.getLatestAuth("account-1"),
+    ).resolves.toEqual({
+      accessToken: "stored-jwt",
+      userId: "9",
+      sub2apiAuth: {
+        refreshToken: "stored-refresh",
+        tokenExpiresAt: 1_700_000_000_000,
+      },
+    })
+
+    expect(getAccountByIdMock).toHaveBeenCalledWith("account-1")
+  })
+
+  it("omits invalid stored auth fields while preserving valid partial snapshot data", async () => {
+    getAccountByIdMock.mockResolvedValueOnce({
+      account_info: {
+        id: "   ",
+        access_token: "   ",
+      },
+      sub2apiAuth: {
+        refreshToken: "   ",
+        tokenExpiresAt: Infinity,
+      },
+    })
+
+    await expect(
+      accountSub2ApiAuthSession.getLatestAuth("account-1"),
+    ).resolves.toEqual({})
+
+    getAccountByIdMock.mockResolvedValueOnce({
+      account_info: {
+        id: "",
+        access_token: "valid-jwt",
+      },
+    })
+
+    await expect(
+      accountSub2ApiAuthSession.getLatestAuth("account-1"),
+    ).resolves.toEqual({
+      accessToken: "valid-jwt",
+    })
+
+    getAccountByIdMock.mockResolvedValueOnce({
+      account_info: {
+        id: "10",
+        access_token: "valid-jwt",
+      },
+      sub2apiAuth: {
+        refreshToken: "valid-refresh",
+        tokenExpiresAt: NaN,
+      },
+    })
+
+    await expect(
+      accountSub2ApiAuthSession.getLatestAuth("account-1"),
+    ).resolves.toEqual({
+      accessToken: "valid-jwt",
+      userId: "10",
+      sub2apiAuth: {
+        refreshToken: "valid-refresh",
+      },
+    })
+  })
+
+  it("returns null when the account no longer exists", async () => {
+    getAccountByIdMock.mockResolvedValueOnce(null)
+
+    await expect(
+      accountSub2ApiAuthSession.getLatestAuth("missing-account"),
+    ).resolves.toBeNull()
+  })
+
+  it("persists access-token-only re-sync updates while preserving the user timestamp", async () => {
+    await expect(
+      accountSub2ApiAuthSession.persistAuthUpdate("account-1", {
+        accessToken: "resynced-jwt",
+      }),
+    ).resolves.toBe(true)
+
+    expect(updateAccountMock).toHaveBeenCalledWith(
+      "account-1",
+      {
+        account_info: {
+          access_token: "resynced-jwt",
+        },
+      },
+      { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+    )
+  })
+
+  it("normalizes refresh-token updates before persisting", async () => {
+    await expect(
+      accountSub2ApiAuthSession.persistAuthUpdate("account-1", {
+        accessToken: "new-jwt",
+        refreshToken: "  trimmed-refresh  ",
+        tokenExpiresAt: 1_700_000_060_000,
+      }),
+    ).resolves.toBe(true)
+
+    expect(updateAccountMock).toHaveBeenCalledWith(
+      "account-1",
+      {
+        account_info: {
+          access_token: "new-jwt",
+        },
+        sub2apiAuth: {
+          refreshToken: "trimmed-refresh",
+          tokenExpiresAt: 1_700_000_060_000,
+        },
+      },
+      { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+    )
+
+    updateAccountMock.mockClear()
+
+    await expect(
+      accountSub2ApiAuthSession.persistAuthUpdate("account-1", {
+        accessToken: "new-jwt",
+        refreshToken: "   ",
+        tokenExpiresAt: 1_700_000_060_000,
+      }),
+    ).resolves.toBe(true)
+
+    expect(updateAccountMock).toHaveBeenCalledWith(
+      "account-1",
+      {
+        account_info: {
+          access_token: "new-jwt",
+        },
+      },
+      { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+    )
+  })
+
+  it("persists rotated refresh-token metadata while preserving the user timestamp", async () => {
+    await expect(
+      accountSub2ApiAuthSession.persistAuthUpdate("account-1", {
+        accessToken: "new-jwt",
+        refreshToken: "new-refresh",
+        tokenExpiresAt: 1_700_000_060_000,
+      }),
+    ).resolves.toBe(true)
+
+    expect(updateAccountMock).toHaveBeenCalledWith(
+      "account-1",
+      {
+        account_info: {
+          access_token: "new-jwt",
+        },
+        sub2apiAuth: {
+          refreshToken: "new-refresh",
+          tokenExpiresAt: 1_700_000_060_000,
+        },
+      },
+      { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+    )
+  })
+})

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -29,6 +29,7 @@ import {
   refreshAccountData,
   updateApiToken,
 } from "~/services/apiService/sub2api"
+import type { Sub2ApiAuthSessionRequest } from "~/services/apiService/sub2api/authSession"
 import {
   buildSub2ApiUserGroups,
   convertExpirySecondsToSub2ApiDays,
@@ -508,8 +509,10 @@ describe("apiService sub2api refreshAccountData", () => {
   })
 
   const createRequest = (
-    overrides: Partial<ApiServiceAccountRequest> = {},
-  ): ApiServiceAccountRequest =>
+    overrides: Partial<
+      Sub2ApiAuthSessionRequest<ApiServiceAccountRequest>
+    > = {},
+  ): Sub2ApiAuthSessionRequest<ApiServiceAccountRequest> =>
     ({
       baseUrl: "https://sub2.example.com",
       auth: {
@@ -524,7 +527,7 @@ describe("apiService sub2api refreshAccountData", () => {
         customCheckIn: { url: "", redeemUrl: "", openRedeemWithCheckIn: true },
       },
       ...overrides,
-    }) as ApiServiceAccountRequest
+    }) as Sub2ApiAuthSessionRequest<ApiServiceAccountRequest>
 
   const createTokenRequest = (
     overrides: Partial<CreateTokenRequest> = {},

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import type {
   ApiServiceAccountRequest,
@@ -49,9 +48,9 @@ import type {
 } from "~/services/apiService/sub2api/type"
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
 
-const { mockGetAccountById, mockUpdateAccount } = vi.hoisted(() => ({
-  mockGetAccountById: vi.fn(),
-  mockUpdateAccount: vi.fn(),
+const { mockGetLatestAuth, mockPersistAuthUpdate } = vi.hoisted(() => ({
+  mockGetLatestAuth: vi.fn(),
+  mockPersistAuthUpdate: vi.fn(),
 }))
 
 vi.mock("~/services/apiService/common", () => ({
@@ -502,10 +501,10 @@ describe("apiService sub2api refreshAccountData", () => {
     vi.clearAllMocks()
     vi.mocked(fetchApi).mockReset()
     vi.mocked(resyncSub2ApiAuthToken).mockReset()
-    mockGetAccountById.mockReset()
-    mockUpdateAccount.mockReset()
-    mockGetAccountById.mockResolvedValue(null)
-    mockUpdateAccount.mockResolvedValue(true)
+    mockGetLatestAuth.mockReset()
+    mockPersistAuthUpdate.mockReset()
+    mockGetLatestAuth.mockResolvedValue(null)
+    mockPersistAuthUpdate.mockResolvedValue(true)
   })
 
   const createRequest = (
@@ -721,7 +720,7 @@ describe("apiService sub2api refreshAccountData", () => {
 
     expect(result.success).toBe(true)
     expect(result.authUpdate?.accessToken).toBe("new-jwt")
-    expect(mockUpdateAccount).not.toHaveBeenCalled()
+    expect(mockPersistAuthUpdate).not.toHaveBeenCalled()
 
     nowSpy.mockRestore()
   })
@@ -1066,11 +1065,9 @@ describe("apiService sub2api refreshAccountData", () => {
     const now = 1_700_000_000_000
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
 
-    mockGetAccountById.mockResolvedValueOnce({
-      account_info: {
-        id: "9",
-        access_token: "stored-jwt",
-      },
+    mockGetLatestAuth.mockResolvedValueOnce({
+      accessToken: "stored-jwt",
+      userId: "9",
       sub2apiAuth: {
         refreshToken: "stored-refresh",
         tokenExpiresAt: now + 60_000,
@@ -1102,9 +1099,9 @@ describe("apiService sub2api refreshAccountData", () => {
     const result = await refreshAccountData(
       createRequest({
         accountId: "account-1",
-        accountAuthStore: {
-          getAccountById: (...args: any[]) => mockGetAccountById(...args),
-          updateAccount: (...args: any[]) => mockUpdateAccount(...args),
+        sub2apiAuthSession: {
+          getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+          persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
         },
         auth: {
           authType: AuthTypeEnum.AccessToken,
@@ -1113,7 +1110,7 @@ describe("apiService sub2api refreshAccountData", () => {
       }),
     )
 
-    expect(mockGetAccountById).toHaveBeenCalledWith("account-1")
+    expect(mockGetLatestAuth).toHaveBeenCalledWith("account-1")
     expect((vi.mocked(fetchApi).mock.calls[0]?.[0] as any)?.auth).toMatchObject(
       {
         accessToken: "new-jwt",
@@ -1122,19 +1119,11 @@ describe("apiService sub2api refreshAccountData", () => {
         userId: "9",
       },
     )
-    expect(mockUpdateAccount).toHaveBeenCalledWith(
-      "account-1",
-      {
-        account_info: {
-          access_token: "new-jwt",
-        },
-        sub2apiAuth: {
-          refreshToken: "new-refresh",
-          tokenExpiresAt: now + 3600 * 1000,
-        },
-      },
-      { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
-    )
+    expect(mockPersistAuthUpdate).toHaveBeenCalledWith("account-1", {
+      accessToken: "new-jwt",
+      refreshToken: "new-refresh",
+      tokenExpiresAt: now + 3600 * 1000,
+    })
     expect(result.success).toBe(true)
     expect(result.authUpdate?.userId).toBe("9")
     expect(result.authUpdate?.username).toBe("stored-user")
@@ -1150,10 +1139,10 @@ describe("apiService sub2api exported operations", () => {
     vi.clearAllMocks()
     vi.mocked(fetchApi).mockReset()
     vi.mocked(resyncSub2ApiAuthToken).mockReset()
-    mockGetAccountById.mockReset()
-    mockUpdateAccount.mockReset()
-    mockGetAccountById.mockResolvedValue(null)
-    mockUpdateAccount.mockResolvedValue(true)
+    mockGetLatestAuth.mockReset()
+    mockPersistAuthUpdate.mockReset()
+    mockGetLatestAuth.mockResolvedValue(null)
+    mockPersistAuthUpdate.mockResolvedValue(true)
   })
 
   const baseRequest = {
@@ -2020,22 +2009,18 @@ describe("apiService sub2api exported operations", () => {
     const now = 1_700_000_000_000
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
 
-    mockGetAccountById
+    mockGetLatestAuth
       .mockResolvedValueOnce({
-        account_info: {
-          id: "7",
-          access_token: "old-jwt",
-        },
+        accessToken: "old-jwt",
+        userId: "7",
         sub2apiAuth: {
           refreshToken: "old-refresh",
           tokenExpiresAt: now + 3600 * 1000,
         },
       })
       .mockResolvedValueOnce({
-        account_info: {
-          id: "7",
-          access_token: "external-jwt",
-        },
+        accessToken: "external-jwt",
+        userId: "7",
         sub2apiAuth: {
           refreshToken: "external-refresh",
           tokenExpiresAt: now + 3600 * 1000,
@@ -2057,9 +2042,9 @@ describe("apiService sub2api exported operations", () => {
       fetchAccountTokens({
         ...baseRequest,
         accountId: "account-1",
-        accountAuthStore: {
-          getAccountById: (...args: any[]) => mockGetAccountById(...args),
-          updateAccount: (...args: any[]) => mockUpdateAccount(...args),
+        sub2apiAuthSession: {
+          getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+          persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
         },
         auth: {
           authType: AuthTypeEnum.AccessToken,

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -15,6 +15,7 @@ import {
   resolveApiTokenKey,
   updateApiToken,
 } from "~/services/apiService/sub2api"
+import type { Sub2ApiAuthSessionRequest } from "~/services/apiService/sub2api/authSession"
 import {
   convertExpirySecondsToSub2ApiDays,
   parseSub2ApiKey,
@@ -45,8 +46,8 @@ vi.mock("~/services/apiService/sub2api/tokenResync", () => ({
 }))
 
 const createRequest = (
-  overrides: Partial<ApiServiceRequest> = {},
-): ApiServiceRequest => ({
+  overrides: Partial<Sub2ApiAuthSessionRequest<ApiServiceRequest>> = {},
+): Sub2ApiAuthSessionRequest<ApiServiceRequest> => ({
   baseUrl: "https://sub2.example.com",
   accountId: "acc-1",
   sub2apiAuthSession: {

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
 import { ApiError } from "~/services/apiService/common/errors"
 import type {
   ApiServiceRequest,
@@ -27,13 +26,13 @@ import { AuthTypeEnum } from "~/types"
 const {
   fetchApiMock,
   resyncSub2ApiAuthTokenMock,
-  getAccountByIdMock,
-  updateAccountMock,
+  getLatestAuthMock,
+  persistAuthUpdateMock,
 } = vi.hoisted(() => ({
   fetchApiMock: vi.fn(),
   resyncSub2ApiAuthTokenMock: vi.fn(),
-  getAccountByIdMock: vi.fn(),
-  updateAccountMock: vi.fn(),
+  getLatestAuthMock: vi.fn(),
+  persistAuthUpdateMock: vi.fn(),
 }))
 
 vi.mock("~/services/apiService/common/utils", () => ({
@@ -50,9 +49,9 @@ const createRequest = (
 ): ApiServiceRequest => ({
   baseUrl: "https://sub2.example.com",
   accountId: "acc-1",
-  accountAuthStore: {
-    getAccountById: (...args: any[]) => getAccountByIdMock(...args),
-    updateAccount: (...args: any[]) => updateAccountMock(...args),
+  sub2apiAuthSession: {
+    getLatestAuth: (...args: any[]) => getLatestAuthMock(...args),
+    persistAuthUpdate: (...args: any[]) => persistAuthUpdateMock(...args),
   },
   auth: {
     authType: AuthTypeEnum.AccessToken,
@@ -197,10 +196,10 @@ describe("apiService sub2api key management service", () => {
     vi.unstubAllGlobals()
     fetchApiMock.mockReset()
     resyncSub2ApiAuthTokenMock.mockReset()
-    getAccountByIdMock.mockReset()
-    updateAccountMock.mockReset()
-    getAccountByIdMock.mockResolvedValue(null)
-    updateAccountMock.mockResolvedValue(true)
+    getLatestAuthMock.mockReset()
+    persistAuthUpdateMock.mockReset()
+    getLatestAuthMock.mockResolvedValue(null)
+    persistAuthUpdateMock.mockResolvedValue(true)
   })
 
   it("combines available groups with rate data for shared forms", async () => {
@@ -388,11 +387,9 @@ describe("apiService sub2api key management service", () => {
   })
 
   it("uses hydrated auth user id when create returns a key DTO without user_id", async () => {
-    getAccountByIdMock.mockResolvedValue({
-      account_info: {
-        id: "42",
-        access_token: "stored-jwt",
-      },
+    getLatestAuthMock.mockResolvedValue({
+      accessToken: "stored-jwt",
+      userId: "42",
     })
     fetchApiMock
       .mockResolvedValueOnce({
@@ -510,9 +507,9 @@ describe("apiService sub2api key management service", () => {
   })
 
   it("uses hydrated auth userId when listing keys without upstream user_id", async () => {
-    getAccountByIdMock.mockResolvedValue({
-      id: "acc-1",
-      account_info: { id: "42", access_token: "stored-jwt" },
+    getLatestAuthMock.mockResolvedValue({
+      accessToken: "stored-jwt",
+      userId: "42",
     })
 
     fetchApiMock.mockResolvedValueOnce({
@@ -554,9 +551,9 @@ describe("apiService sub2api key management service", () => {
   })
 
   it("uses hydrated auth userId when fetching key detail without upstream user_id", async () => {
-    getAccountByIdMock.mockResolvedValue({
-      id: "acc-1",
-      account_info: { id: "42", access_token: "stored-jwt" },
+    getLatestAuthMock.mockResolvedValue({
+      accessToken: "stored-jwt",
+      userId: "42",
     })
 
     fetchApiMock.mockResolvedValueOnce({
@@ -595,29 +592,28 @@ describe("apiService sub2api key management service", () => {
     vi.spyOn(Date, "now").mockReturnValue(now)
 
     let currentAccount = {
-      id: "acc-1",
-      account_info: { id: "1", access_token: "stored-jwt" },
+      accessToken: "stored-jwt",
+      userId: "1",
       sub2apiAuth: {
         refreshToken: "stored-refresh",
         tokenExpiresAt: now + 30_000,
       },
     }
 
-    getAccountByIdMock.mockImplementation(async () =>
+    getLatestAuthMock.mockImplementation(async () =>
       structuredClone(currentAccount),
     )
-    updateAccountMock.mockImplementation(async (_id, updates) => {
+    persistAuthUpdateMock.mockImplementation(async (_id, updates) => {
       currentAccount = {
         ...currentAccount,
-        ...updates,
-        account_info: {
-          ...currentAccount.account_info,
-          ...(updates.account_info ?? {}),
-        },
-        sub2apiAuth: updates.sub2apiAuth
+        accessToken: updates.accessToken,
+        sub2apiAuth: updates.refreshToken
           ? {
               ...(currentAccount.sub2apiAuth ?? {}),
-              ...updates.sub2apiAuth,
+              refreshToken: updates.refreshToken,
+              ...(typeof updates.tokenExpiresAt === "number"
+                ? { tokenExpiresAt: updates.tokenExpiresAt }
+                : {}),
             }
           : currentAccount.sub2apiAuth,
       }
@@ -671,16 +667,16 @@ describe("apiService sub2api key management service", () => {
       default: { desc: "Default plan", ratio: 1 },
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(persistAuthUpdateMock).toHaveBeenCalledTimes(1)
   })
 
   it("retries key requests with refresh-token recovery and persists rotated auth", async () => {
     const now = 1_772_713_600_000
     vi.spyOn(Date, "now").mockReturnValue(now)
 
-    getAccountByIdMock.mockResolvedValue({
-      id: "acc-1",
-      account_info: { id: "1", access_token: "stored-jwt" },
+    getLatestAuthMock.mockResolvedValue({
+      accessToken: "stored-jwt",
+      userId: "1",
       sub2apiAuth: { refreshToken: "stored-refresh" },
     })
 
@@ -734,21 +730,15 @@ describe("apiService sub2api key management service", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(tokens).toHaveLength(1)
     expect(tokens[0].key).toBe("retried-key")
-    expect(updateAccountMock).toHaveBeenCalledWith(
-      "acc-1",
-      expect.objectContaining({
-        account_info: { access_token: "new-jwt" },
-        sub2apiAuth: {
-          refreshToken: "rotated-refresh",
-          tokenExpiresAt: now + 3600 * 1000,
-        },
-      }),
-      { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
-    )
+    expect(persistAuthUpdateMock).toHaveBeenCalledWith("acc-1", {
+      accessToken: "new-jwt",
+      refreshToken: "rotated-refresh",
+      tokenExpiresAt: now + 3600 * 1000,
+    })
   })
 
   it("retries key requests with dashboard-session re-sync when no refresh token exists", async () => {
-    getAccountByIdMock.mockResolvedValue(null)
+    getLatestAuthMock.mockResolvedValue(null)
     resyncSub2ApiAuthTokenMock.mockResolvedValue({
       accessToken: "resynced-jwt",
       source: "existing_tab",
@@ -789,19 +779,15 @@ describe("apiService sub2api key management service", () => {
     expect(resyncSub2ApiAuthTokenMock).toHaveBeenCalledWith(
       "https://sub2.example.com",
     )
-    expect(updateAccountMock).toHaveBeenCalledWith(
-      "acc-1",
-      expect.objectContaining({
-        account_info: { access_token: "resynced-jwt" },
-      }),
-      { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
-    )
+    expect(persistAuthUpdateMock).toHaveBeenCalledWith("acc-1", {
+      accessToken: "resynced-jwt",
+    })
   })
 
   it("surfaces login-required when auth recovery is unavailable", async () => {
-    getAccountByIdMock.mockResolvedValue({
-      id: "acc-1",
-      account_info: { id: "1", access_token: "stored-jwt" },
+    getLatestAuthMock.mockResolvedValue({
+      accessToken: "stored-jwt",
+      userId: "1",
     })
     resyncSub2ApiAuthTokenMock.mockResolvedValue(null)
 


### PR DESCRIPTION
## Summary
- Add a Sub2API auth session port and account-backed implementation for token recovery.
- Route Sub2API token refresh through the narrow session contract instead of the broad account auth store.
- Scope session injection to Sub2API display-account contexts and document the seam.

## Test Plan
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured authentication session handling for Sub2API accounts to use a dedicated session mechanism instead of generic account storage.
  * Updated API request construction to attach session data for Sub2API contexts.

* **Documentation**
  * Added implementation plan and design specification for Sub2API auth session refactoring.

* **Tests**
  * Added comprehensive test coverage for new auth session functionality.
  * Updated existing test suites to reflect refactored authentication session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->