### PR TITLE
refactor(api-adapters): add model pricing capability

### DIFF
--- a/docs/superpowers/plans/2026-06-19-api-adapter-model-pricing.md
+++ b/docs/superpowers/plans/2026-06-19-api-adapter-model-pricing.md
@@ -1,0 +1,1021 @@
+# API Adapter Model Pricing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move normal account model-pricing loads from the legacy `getApiService(...)` facade to `SiteAdapter.modelPricing`.
+
+**Architecture:** Add a narrow `modelPricing` Adapter capability for the normal account-pricing contract. New API-family and AIHubMix adapters delegate to existing backend helpers, while Sub2API intentionally keeps only `modelCatalog` and product-owned runtime-key fallback logic.
+
+**Tech Stack:** TypeScript, React Query, WXT extension services, existing `apiAdapters`, Vitest, `pnpm run validate:staged`.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-api-adapter-model-pricing-design.md`
+
+---
+
+## File Structure
+
+- Create `src/services/apiAdapters/contracts/modelPricing.ts`
+  - Defines `ModelPricingCapability` and `ModelPricingRequest`.
+- Modify `src/services/apiAdapters/contracts/siteAdapter.ts`
+  - Adds optional `modelPricing?: ModelPricingCapability`.
+- Create `src/services/apiAdapters/newApi/modelPricing.ts`
+  - Binds New API-family pricing to `getApiService(siteType).fetchModelPricing(...)`.
+- Modify `src/services/apiAdapters/newApi/index.ts`
+  - Registers `modelPricing` for every New API-family adapter instance.
+- Create `src/services/apiAdapters/aihubmix/modelPricing.ts`
+  - Delegates AIHubMix pricing to `fetchModelPricing(...)`.
+- Modify `src/services/apiAdapters/aihubmix/index.ts`
+  - Registers `modelPricing`.
+- Do not modify `src/services/apiAdapters/sub2api/index.ts`
+  - Sub2API intentionally does not expose normal account `modelPricing`.
+- Create `tests/services/apiAdapters/modelPricing.test.ts`
+  - Covers adapter delegation for New API-family and AIHubMix.
+- Modify `tests/services/apiAdapters/registry.test.ts`
+  - Asserts New API-family and AIHubMix expose `modelPricing`, and Sub2API does not.
+- Modify `src/services/apiCredentialProfiles/modelCatalog.ts`
+  - Routes AIHubMix selected-token fallback through `getSiteAdapter(...).modelPricing`.
+- Modify `tests/services/apiCredentialProfiles/modelCatalog.test.ts`
+  - Updates AIHubMix fallback tests from `getApiService` to Adapter-backed pricing.
+- Modify `src/features/ModelList/hooks/useModelData.ts`
+  - Routes single-account and all-accounts normal pricing through `getSiteAdapter(...).modelPricing`.
+  - Preserves Sub2API runtime-key fallback paths.
+- Modify `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
+  - Updates normal pricing mocks to Adapter-backed pricing.
+  - Preserves Sub2API fallback and cache guard coverage.
+
+---
+
+### Task 1: Add Adapter Model Pricing Capability
+
+**Files:**
+- Create: `src/services/apiAdapters/contracts/modelPricing.ts`
+- Create: `src/services/apiAdapters/newApi/modelPricing.ts`
+- Create: `src/services/apiAdapters/aihubmix/modelPricing.ts`
+- Modify: `src/services/apiAdapters/contracts/siteAdapter.ts`
+- Modify: `src/services/apiAdapters/newApi/index.ts`
+- Modify: `src/services/apiAdapters/aihubmix/index.ts`
+- Create: `tests/services/apiAdapters/modelPricing.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write the failing adapter delegation test**
+
+Create `tests/services/apiAdapters/modelPricing.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { aihubmixModelPricing } from "~/services/apiAdapters/aihubmix/modelPricing"
+import { createNewApiModelPricing } from "~/services/apiAdapters/newApi/modelPricing"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockAihubmixFetchModelPricing,
+  mockFetchModelPricing,
+  mockGetApiService,
+} = vi.hoisted(() => ({
+  mockAihubmixFetchModelPricing: vi.fn(),
+  mockFetchModelPricing: vi.fn(),
+  mockGetApiService: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  fetchModelPricing: mockAihubmixFetchModelPricing,
+}))
+
+const request = {
+  baseUrl: "https://api.example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "7",
+    accessToken: "account-token",
+  },
+}
+
+const pricingResponse = {
+  success: true,
+  data: [
+    {
+      model_name: "example-model",
+      quota_type: 0,
+      model_ratio: 1,
+      model_price: 0,
+      completion_ratio: 1,
+      enable_groups: [],
+      supported_endpoint_types: [],
+    },
+  ],
+  group_ratio: {},
+  usable_group: {},
+}
+
+describe("apiAdapter modelPricing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      fetchModelPricing: mockFetchModelPricing,
+    })
+  })
+
+  it("delegates New API-family model pricing through the site-specific apiService", async () => {
+    mockFetchModelPricing.mockResolvedValueOnce(pricingResponse)
+
+    const modelPricing = createNewApiModelPricing(SITE_TYPES.ONE_HUB)
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+
+    await expect(modelPricing.fetchPricing(request)).resolves.toBe(
+      pricingResponse,
+    )
+
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.ONE_HUB)
+    expect(mockFetchModelPricing).toHaveBeenCalledWith(request)
+  })
+
+  it("delegates AIHubMix model pricing to the AIHubMix helper", async () => {
+    mockAihubmixFetchModelPricing.mockResolvedValueOnce(pricingResponse)
+
+    await expect(aihubmixModelPricing.fetchPricing(request)).resolves.toBe(
+      pricingResponse,
+    )
+
+    expect(mockAihubmixFetchModelPricing).toHaveBeenCalledWith(request)
+    expect(mockGetApiService).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Update registry expectations to require the new capability**
+
+Modify `tests/services/apiAdapters/registry.test.ts`.
+
+In the Sub2API test, after the `accountRefresh` expectation, add:
+
+```ts
+    expect(adapter.modelPricing).toBeUndefined()
+```
+
+In the New API-family loop, after the `accountRefresh` expectation, add:
+
+```ts
+      expect(adapter.modelPricing).toEqual({
+        fetchPricing: expect.any(Function),
+      })
+```
+
+In the AIHubMix test, after the `accountRefresh` expectation, add:
+
+```ts
+    expect(adapter.modelPricing).toEqual({
+      fetchPricing: expect.any(Function),
+    })
+```
+
+- [ ] **Step 3: Run adapter tests and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/modelPricing.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because `modelPricing` contract and adapter modules do not exist yet.
+
+- [ ] **Step 4: Add the model pricing contract**
+
+Create `src/services/apiAdapters/contracts/modelPricing.ts`:
+
+```ts
+import type {
+  ApiServiceRequest,
+  PricingResponse,
+} from "~/services/apiService/common/type"
+
+export type ModelPricingRequest = ApiServiceRequest
+
+export type ModelPricingCapability = {
+  fetchPricing(request: ModelPricingRequest): Promise<PricingResponse>
+}
+```
+
+- [ ] **Step 5: Extend `SiteAdapter`**
+
+Modify `src/services/apiAdapters/contracts/siteAdapter.ts`.
+
+Add the import:
+
+```ts
+import type { ModelPricingCapability } from "./modelPricing"
+```
+
+Add the optional property to `SiteAdapter`:
+
+```ts
+  modelPricing?: ModelPricingCapability
+```
+
+The final type should include:
+
+```ts
+export type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+  modelPricing?: ModelPricingCapability
+}
+```
+
+- [ ] **Step 6: Add New API-family model pricing**
+
+Create `src/services/apiAdapters/newApi/modelPricing.ts`:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import type { ModelPricingCapability } from "~/services/apiAdapters/contracts/modelPricing"
+import { getApiService } from "~/services/apiService"
+
+/**
+ * Create account model-pricing operations bound to the New API-family site type.
+ */
+export function createNewApiModelPricing(
+  siteType: AccountSiteType,
+): ModelPricingCapability {
+  return {
+    fetchPricing: (request) =>
+      getApiService(siteType).fetchModelPricing(request),
+  }
+}
+```
+
+Modify `src/services/apiAdapters/newApi/index.ts`.
+
+Add:
+
+```ts
+import { createNewApiModelPricing } from "./modelPricing"
+```
+
+Add the property inside `createNewApiAdapter(...)`:
+
+```ts
+  modelPricing: createNewApiModelPricing(siteType),
+```
+
+The returned object should include:
+
+```ts
+export const createNewApiAdapter = (
+  siteType: AccountSiteType = SITE_TYPES.NEW_API,
+): SiteAdapter => ({
+  siteType,
+  family: "newApiFamily",
+  siteNotice: newApiSiteNotice,
+  accountCompletion: newApiAccountCompletion,
+  keyManagement: createNewApiKeyManagement(siteType),
+  accountRefresh: createNewApiAccountRefresh(siteType),
+  modelPricing: createNewApiModelPricing(siteType),
+})
+```
+
+- [ ] **Step 7: Add AIHubMix model pricing**
+
+Create `src/services/apiAdapters/aihubmix/modelPricing.ts`:
+
+```ts
+import type { ModelPricingCapability } from "~/services/apiAdapters/contracts/modelPricing"
+import { fetchModelPricing } from "~/services/apiService/aihubmix"
+
+export const aihubmixModelPricing: ModelPricingCapability = {
+  fetchPricing: (request) => fetchModelPricing(request),
+}
+```
+
+Modify `src/services/apiAdapters/aihubmix/index.ts`.
+
+Add:
+
+```ts
+import { aihubmixModelPricing } from "./modelPricing"
+```
+
+Add the property inside `aihubmixAdapter`:
+
+```ts
+  modelPricing: aihubmixModelPricing,
+```
+
+The object should include:
+
+```ts
+export const aihubmixAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.AIHUBMIX,
+  accountCompletion: aihubmixAccountCompletion,
+  keyManagement: aihubmixKeyManagement,
+  accountRefresh: aihubmixAccountRefresh,
+  modelPricing: aihubmixModelPricing,
+}
+```
+
+Do not add `modelPricing` to `src/services/apiAdapters/sub2api/index.ts`.
+
+- [ ] **Step 8: Run adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/modelPricing.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit adapter capability**
+
+Run:
+
+```powershell
+git add src/services/apiAdapters/contracts/modelPricing.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/modelPricing.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/aihubmix/modelPricing.ts src/services/apiAdapters/aihubmix/index.ts tests/services/apiAdapters/modelPricing.test.ts tests/services/apiAdapters/registry.test.ts
+git commit -m "refactor(api-adapters): add model pricing capability"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 2: Route AIHubMix Fallback Pricing Through The Adapter
+
+**Files:**
+- Modify: `src/services/apiCredentialProfiles/modelCatalog.ts`
+- Modify: `tests/services/apiCredentialProfiles/modelCatalog.test.ts`
+
+- [ ] **Step 1: Update the AIHubMix fallback test to use `getSiteAdapter(...)`**
+
+In `tests/services/apiCredentialProfiles/modelCatalog.test.ts`, update the hoisted block.
+
+Remove `getApiServiceMock` from the destructuring:
+
+```ts
+const {
+  fetchAnthropicModelIdsMock,
+  fetchGoogleModelIdsMock,
+  fetchOpenAICompatibleModelIdsMock,
+  fetchAccountTokensMock,
+  fetchSub2ApiAvailableGroupsMock,
+  fetchSub2ApiGroupRatesMock,
+  fetchSub2ApiRuntimeModelsMock,
+  getSiteAdapterMock,
+  loadModelPriceTableMock,
+  resolveDisplayAccountTokenForSecretMock,
+} = vi.hoisted(() => ({
+```
+
+Remove `getApiServiceMock: vi.fn(),` from the returned object.
+
+Delete this module mock:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: (...args: unknown[]) => getApiServiceMock(...args),
+}))
+```
+
+In `beforeEach`, remove:
+
+```ts
+    getApiServiceMock.mockReset()
+```
+
+Then replace the AIHubMix test body setup with this adapter-backed setup:
+
+```ts
+    const fetchPricingMock = vi.fn().mockResolvedValueOnce(aihubmixPricing)
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.AIHUBMIX,
+      modelPricing: {
+        fetchPricing: fetchPricingMock,
+      },
+    })
+    resolveDisplayAccountTokenForSecretMock.mockRejectedValueOnce(
+      new Error("AIHubMix cannot reveal masked keys"),
+    )
+```
+
+Replace the assertions in that test with:
+
+```ts
+    expect(result).toBe(aihubmixPricing)
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.AIHUBMIX)
+    expect(fetchPricingMock).toHaveBeenCalledWith({
+      baseUrl: "https://aihubmix.com",
+      accountId: "account-1",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        userId: "1",
+        accessToken: "account-token",
+        cookie: undefined,
+      },
+    })
+    expect(resolveDisplayAccountTokenForSecretMock).not.toHaveBeenCalled()
+    expect(fetchOpenAICompatibleModelIdsMock).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 2: Add a missing AIHubMix model-pricing capability regression test**
+
+Add this test after the AIHubMix fallback test:
+
+```ts
+  it("sanitizes a missing AIHubMix model pricing capability failure", async () => {
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.AIHUBMIX,
+    })
+
+    await expect(
+      loadAccountTokenFallbackPricingResponse({
+        account: {
+          ...ACCOUNT,
+          siteType: SITE_TYPES.AIHUBMIX,
+          baseUrl: "https://aihubmix.com",
+        },
+        token: {
+          ...TOKEN,
+          key: "sk-****masked",
+          models: "",
+        },
+      }),
+    ).rejects.toThrow("modelPricing is not implemented for AIHubMix")
+
+    expect(resolveDisplayAccountTokenForSecretMock).not.toHaveBeenCalled()
+    expect(fetchOpenAICompatibleModelIdsMock).not.toHaveBeenCalled()
+  })
+```
+
+- [ ] **Step 3: Run the profile catalog test and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiCredentialProfiles/modelCatalog.test.ts
+```
+
+Expected: FAIL because `modelCatalog.ts` still imports `getApiService(...)` for the AIHubMix fallback branch.
+
+- [ ] **Step 4: Replace the AIHubMix direct service call**
+
+Modify `src/services/apiCredentialProfiles/modelCatalog.ts`.
+
+Remove this import:
+
+```ts
+import { getApiService } from "~/services/apiService"
+```
+
+Add this helper near `createMissingModelCatalogCapabilityError`:
+
+```ts
+const createMissingModelPricingCapabilityError = (siteType: string) =>
+  new Error(`modelPricing is not implemented for ${siteType}`)
+```
+
+Add this helper near `createSub2ApiDashboardRequest(...)`:
+
+```ts
+const createAccountModelPricingRequest = (
+  account: LoadAccountTokenFallbackPricingParams["account"],
+): ApiServiceRequest => ({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+```
+
+Move the AIHubMix branch inside the existing `try` block in
+`loadAccountTokenFallbackPricingResponse(...)`.
+
+The start of the function should become:
+
+```ts
+export async function loadAccountTokenFallbackPricingResponse(
+  params: LoadAccountTokenFallbackPricingParams,
+): Promise<PricingResponse> {
+  const declaredModelIds = parseDelimitedList(params.token.models)
+  let resolvedTokenKey = ""
+
+  try {
+    if (params.account.siteType === SITE_TYPES.AIHUBMIX) {
+      const adapter = getSiteAdapter(params.account.siteType)
+      if (!adapter.modelPricing) {
+        throw createMissingModelPricingCapabilityError(params.account.siteType)
+      }
+
+      return await adapter.modelPricing.fetchPricing(
+        createAccountModelPricingRequest(params.account),
+      )
+    }
+
+    const resolvedToken = await resolveDisplayAccountTokenForSecret(
+      params.account,
+      params.token,
+    )
+    resolvedTokenKey = resolvedToken.key
+```
+
+Keep the existing Sub2API and OpenAI-compatible fallback branches after this block.
+
+- [ ] **Step 5: Run the profile catalog test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiCredentialProfiles/modelCatalog.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Confirm direct pricing service usage is gone from `modelCatalog.ts`**
+
+Run:
+
+```powershell
+rg -n "getApiService|fetchModelPricing" src/services/apiCredentialProfiles/modelCatalog.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts
+```
+
+Expected: no matches.
+
+- [ ] **Step 7: Commit profile catalog migration**
+
+Run:
+
+```powershell
+git add src/services/apiCredentialProfiles/modelCatalog.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts
+git commit -m "refactor(api-profiles): use model pricing adapters for aihubmix"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 3: Route Model List Direct Pricing Through The Adapter
+
+**Files:**
+- Modify: `src/features/ModelList/hooks/useModelData.ts`
+- Modify: `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`
+
+- [ ] **Step 1: Update Model List test imports and module mocks**
+
+In `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`, replace:
+
+```ts
+import {
+  getApiService,
+  type ApiServiceCapabilities,
+} from "~/services/apiService"
+```
+
+with:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+Replace:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: vi.fn(),
+}))
+```
+
+with:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(),
+}))
+```
+
+Replace the helper `createMockApiService(...)` with:
+
+```ts
+const createMockSiteAdapter = (
+  fetchPricing: ReturnType<typeof vi.fn>,
+  overrides: {
+    siteType?: DisplaySiteData["siteType"]
+    modelPricing?: false
+  } = {},
+) =>
+  ({
+    siteType: overrides.siteType ?? SITE_TYPES.NEW_API,
+    ...(overrides.modelPricing === false
+      ? {}
+      : {
+          modelPricing: {
+            fetchPricing,
+          },
+        }),
+  }) as any
+```
+
+- [ ] **Step 2: Update normal-pricing mock setup in Model List tests**
+
+In `tests/entrypoints/options/pages/ModelList/useModelData.test.tsx`, replace normal supported-site setup like:
+
+```ts
+vi.mocked(getApiService).mockReturnValue(createMockApiService(fetchModelPricing))
+```
+
+with:
+
+```ts
+vi.mocked(getSiteAdapter).mockReturnValue(createMockSiteAdapter(fetchPricing))
+```
+
+When a test currently creates `const fetchModelPricing = vi.fn(...)`, rename that local variable to `fetchPricing` in the same test and update assertions from:
+
+```ts
+expect(fetchModelPricing).toHaveBeenCalledWith(...)
+```
+
+to:
+
+```ts
+expect(fetchPricing).toHaveBeenCalledWith(...)
+```
+
+Update unsupported-site setup from:
+
+```ts
+vi.mocked(getApiService).mockReturnValue(
+  createMockApiService(fetchModelPricing, {
+    capabilities: { modelPricing: false },
+  }),
+)
+```
+
+to:
+
+```ts
+vi.mocked(getSiteAdapter).mockReturnValue(
+  createMockSiteAdapter(fetchPricing, {
+    siteType: SITE_TYPES.SUB2API,
+    modelPricing: false,
+  }),
+)
+```
+
+For non-Sub2API unsupported tests, use:
+
+```ts
+vi.mocked(getSiteAdapter).mockReturnValue(
+  createMockSiteAdapter(fetchPricing, {
+    siteType: SITE_TYPES.UNKNOWN,
+    modelPricing: false,
+  }),
+)
+```
+
+- [ ] **Step 3: Update the unsupported cached-pricing regression test**
+
+In the test named `"does not return cached pricing for unsupported Sub2API accounts"`, replace its unsupported-site setup with:
+
+```ts
+    const fetchPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("fetch should not be called"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
+      }),
+    )
+```
+
+Keep the assertion:
+
+```ts
+    expect(fetchPricing).not.toHaveBeenCalled()
+```
+
+This preserves the existing rule that the unsupported-site guard must run before `modelPricingCache.get(...)`.
+
+- [ ] **Step 4: Run the Model List hook test and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+```
+
+Expected: FAIL because `useModelData.ts` still imports `getApiService(...)` and does not call `getSiteAdapter(...).modelPricing`.
+
+- [ ] **Step 5: Update Model List hook imports and request helper**
+
+Modify `src/features/ModelList/hooks/useModelData.ts`.
+
+Remove:
+
+```ts
+import { getApiService } from "~/services/apiService"
+```
+
+Add:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import type { ModelPricingRequest } from "~/services/apiAdapters/contracts/modelPricing"
+```
+
+Add this helper near `createModelPricingCacheKey(...)`:
+
+```ts
+function createDisplayAccountModelPricingRequest(
+  account: DisplaySiteData,
+): ModelPricingRequest {
+  return {
+    baseUrl: account.baseUrl,
+    accountId: account.id,
+    auth: {
+      authType: account.authType,
+      userId: account.userId,
+      accessToken: account.token,
+      cookie: account.cookieAuthSessionCookie,
+    },
+  }
+}
+```
+
+- [ ] **Step 6: Migrate single-account direct pricing**
+
+In the `useSingleAccountModelData(...)` query function, replace:
+
+```ts
+      const service = getApiService(currentAccount.siteType)
+      if (!service.capabilities.modelPricing) {
+        throw createUnsupportedModelPricingError()
+      }
+```
+
+with:
+
+```ts
+      const modelPricing =
+        getSiteAdapter(currentAccount.siteType).modelPricing
+      if (!modelPricing) {
+        throw createUnsupportedModelPricingError()
+      }
+```
+
+Then replace:
+
+```ts
+      const data = await service.fetchModelPricing({
+        baseUrl: currentAccount.baseUrl,
+        accountId: currentAccount.id,
+        auth: {
+          authType: currentAccount.authType,
+          userId: currentAccount.userId,
+          accessToken: currentAccount.token,
+          cookie: currentAccount.cookieAuthSessionCookie,
+        },
+      })
+```
+
+with:
+
+```ts
+      const data = await modelPricing.fetchPricing(
+        createDisplayAccountModelPricingRequest(currentAccount),
+      )
+```
+
+Keep the capability guard before `modelPricingCache.get(...)`.
+
+- [ ] **Step 7: Migrate all-accounts direct pricing**
+
+In the `useAllAccountsModelData(...)` query function, replace:
+
+```ts
+        const service = getApiService(account.siteType)
+        if (!service.capabilities.modelPricing) {
+          if (account.siteType === SITE_TYPES.SUB2API) {
+            return fetchSub2ApiAllAccountsFallbackPricingContexts(account)
+          }
+
+          throw createUnsupportedModelPricingError()
+        }
+```
+
+with:
+
+```ts
+        const modelPricing = getSiteAdapter(account.siteType).modelPricing
+        if (!modelPricing) {
+          if (account.siteType === SITE_TYPES.SUB2API) {
+            return fetchSub2ApiAllAccountsFallbackPricingContexts(account)
+          }
+
+          throw createUnsupportedModelPricingError()
+        }
+```
+
+Then replace:
+
+```ts
+        const data = await service.fetchModelPricing({
+          baseUrl: account.baseUrl,
+          accountId: account.id,
+          auth: {
+            authType: account.authType,
+            userId: account.userId,
+            accessToken: account.token,
+            cookie: account.cookieAuthSessionCookie,
+          },
+        })
+```
+
+with:
+
+```ts
+        const data = await modelPricing.fetchPricing(
+          createDisplayAccountModelPricingRequest(account),
+        )
+```
+
+Keep the capability guard before `modelPricingCache.get(...)`.
+
+- [ ] **Step 8: Run the Model List hook test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Confirm Model List no longer imports the legacy facade**
+
+Run:
+
+```powershell
+rg -n "getApiService|capabilities\\.modelPricing|fetchModelPricing" src/features/ModelList/hooks/useModelData.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+```
+
+Expected: no matches.
+
+- [ ] **Step 10: Commit Model List migration**
+
+Run:
+
+```powershell
+git add src/features/ModelList/hooks/useModelData.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+git commit -m "refactor(model-list): load pricing through site adapters"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 4: Final Validation And Scope Audit
+
+**Files:**
+- Review all task-scoped files from Tasks 1-3.
+
+- [ ] **Step 1: Run focused adapter and pricing tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/modelPricing.test.ts tests/services/apiAdapters/registry.test.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run related tests for changed source files**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/contracts/modelPricing.ts src/services/apiAdapters/newApi/modelPricing.ts src/services/apiAdapters/aihubmix/modelPricing.ts src/services/apiCredentialProfiles/modelCatalog.ts src/features/ModelList/hooks/useModelData.ts
+```
+
+Expected: PASS. If `vitest related` expands into unrelated long-running UI suites, classify the failure or timeout separately and rely on the focused tests plus `pnpm compile` for this slice.
+
+- [ ] **Step 3: Run TypeScript compile**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the commit gate**
+
+Run:
+
+```powershell
+git status --porcelain=v1
+pnpm run validate:staged
+```
+
+Expected: PASS for task-scoped staged files. Existing unrelated untracked files may remain untracked and must not be staged.
+
+- [ ] **Step 5: Run the push gate before publishing**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. This gate is required before pushing or opening a PR because the slice changes shared Adapter contracts and Model List account-loading wiring.
+
+- [ ] **Step 6: Inspect final diff scope**
+
+If tasks were committed individually, run:
+
+```powershell
+git show --stat --oneline HEAD~3..HEAD
+git diff --name-status HEAD~3..HEAD
+```
+
+Expected changed files are limited to:
+
+```text
+src/services/apiAdapters/contracts/modelPricing.ts
+src/services/apiAdapters/contracts/siteAdapter.ts
+src/services/apiAdapters/newApi/modelPricing.ts
+src/services/apiAdapters/newApi/index.ts
+src/services/apiAdapters/aihubmix/modelPricing.ts
+src/services/apiAdapters/aihubmix/index.ts
+src/services/apiCredentialProfiles/modelCatalog.ts
+src/features/ModelList/hooks/useModelData.ts
+tests/services/apiAdapters/modelPricing.test.ts
+tests/services/apiAdapters/registry.test.ts
+tests/services/apiCredentialProfiles/modelCatalog.test.ts
+tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+```
+
+There should be no changes to locale files, telemetry schema, settings search files, Playwright tests, redemption, managed-site providers, account validation, user-group helpers, full Key Management CRUD, or new site types.
+
+- [ ] **Step 7: Check remaining direct model-pricing facade usage**
+
+Run:
+
+```powershell
+rg -n "fetchModelPricing|capabilities\\.modelPricing" src tests
+```
+
+Expected: remaining matches are limited to backend implementations, adapter delegation tests, legacy `apiService` capability tests, and non-migrated historical docs. Product callers in `src/features/ModelList/**` and `src/services/apiCredentialProfiles/modelCatalog.ts` should not match.
+
+- [ ] **Step 8: Record execution notes**
+
+Before handing off, report:
+
+```text
+Focused tests:
+- pnpm vitest run tests/services/apiAdapters/modelPricing.test.ts tests/services/apiAdapters/registry.test.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+
+Validation:
+- pnpm compile
+- pnpm run validate:staged
+- pnpm run validate:push
+
+E2E decision:
+- No Playwright E2E added. This slice changes service-layer routing and hook-level loading behavior covered by Vitest; browser runtime behavior is unchanged.
+
+Telemetry decision:
+- Reuse existing. Model List load-completion events keep their current owners and payload shape.
+```
+
+---
+
+## Out Of Scope
+
+- Do not add a new site type.
+- Do not attach `modelPricing` to `sub2ApiAdapter`.
+- Do not move Sub2API runtime-key model catalog, group-rate lookup, or price-table estimation into the `modelPricing` capability.
+- Do not migrate `fetchAccountAvailableModels(...)`, `fetchUserGroups(...)`, account validation, account data fetch, redemption, managed-site operations, full Key Management CRUD, locale files, telemetry schema, settings search, or Playwright E2E tests.
+- Do not remove `ApiServiceCapabilities.modelPricing` globally in this slice.
+
+## Self-Review
+
+- Spec coverage: Task 1 adds the `modelPricing` Interface and adapter wiring. Task 2 routes AIHubMix selected-token fallback through the Adapter. Task 3 migrates Model List single-account and all-accounts normal pricing loads while preserving Sub2API fallback. Task 4 covers validation, scope audit, telemetry, and E2E decisions.
+- Scope control: The plan keeps Sub2API normal model pricing unsupported and does not touch user groups, redemption, managed-site operations, account validation, locale files, or telemetry schema.
+- Type consistency: The plan consistently uses `ModelPricingCapability.fetchPricing(request)`, `ModelPricingRequest`, and `SiteAdapter.modelPricing`.
+- Cache guard: The plan preserves the requirement that unsupported-site checks happen before `modelPricingCache.get(...)`, preventing stale cached pricing from leaking into unsupported sites.

--- a/docs/superpowers/specs/2026-06-19-api-adapter-model-pricing-design.md
+++ b/docs/superpowers/specs/2026-06-19-api-adapter-model-pricing-design.md
@@ -1,0 +1,507 @@
+# API Adapter Model Pricing Design
+
+Date: 2026-06-19
+
+## Purpose
+
+Move account model-pricing loading behind the `apiAdapters` Seam so a newly
+added account site type can expose Model List support from its Adapter Module
+instead of requiring product Modules to call the legacy `getApiService(...)`
+facade directly.
+
+Recent adapter slices moved account completion, key management, account
+refresh, site announcements, Sub2API runtime model catalog loading, and
+Sub2API stored-auth recovery behind narrower Interfaces. Those slices make a
+new account site type detectable, refreshable, and usable enough to create or
+resolve API keys. The next high-leverage account usability path is Model List:
+users expect a saved account to load model pricing or clearly fall back to a
+model-only catalog when pricing is not available.
+
+## Current Context
+
+The current `SiteAdapter` Interface exposes:
+
+```ts
+type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+}
+```
+
+The remaining account Model List pricing paths still use
+`getApiService(siteType)` directly:
+
+- `src/features/ModelList/hooks/useModelData.ts`
+  - single-account direct pricing load
+  - all-accounts direct pricing load
+  - capability check through `service.capabilities.modelPricing`
+- `src/services/apiCredentialProfiles/modelCatalog.ts`
+  - AIHubMix selected-token fallback currently calls
+    `getApiService(account.siteType).fetchModelPricing(...)`
+
+The existing Sub2API path is deliberately not the same as normal account
+pricing:
+
+- Direct Sub2API account pricing is disabled through
+  `getApiService(SITE_TYPES.SUB2API).capabilities.modelPricing === false`.
+- Selected-key fallback resolves an API key, calls
+  `getSiteAdapter(SITE_TYPES.SUB2API).modelCatalog.fetchModels(...)`, and
+  returns a runtime-key model catalog.
+- When dashboard auth and group/rate data are available, the fallback applies
+  best-effort Sub2API price estimates.
+- When pricing data cannot be estimated, the fallback still returns model rows
+  with unavailable-pricing metadata.
+
+That split is product-significant: Sub2API can provide model visibility for a
+selected runtime key even though it does not expose the normal compatible
+`/api/pricing` account-pricing contract.
+
+## Problem
+
+Model pricing is now the highest-value remaining legacy facade path for new
+account site types.
+
+Current friction:
+
+1. Product code still asks the legacy `apiService` facade whether model pricing
+   is supported, then calls `fetchModelPricing(...)` directly.
+2. A new non-compatible site type must still be wired into
+   `src/services/apiService/index.ts` capability overrides before Model List
+   can make a truthful support decision.
+3. Model List tests mock the wide `apiService` facade instead of the narrower
+   account-pricing Interface that the UI actually needs.
+4. AIHubMix selected-token fallback is a direct special case in the profile
+   catalog helper, even though AIHubMix can expose normal account model
+   pricing as an Adapter capability.
+5. Sub2API's runtime-key model catalog path is already adapter-backed, but the
+   caller still reasons about normal pricing support through the legacy facade.
+
+Deletion test: if direct `getApiService(...).fetchModelPricing(...)` and
+`service.capabilities.modelPricing` calls were deleted from Model List product
+Modules, the complexity should not move to new `siteType` branches in the same
+Modules. Normal account-pricing support should live behind a
+`modelPricing` capability. Sub2API's runtime-key fallback should remain a
+separate product path because it is not the same Interface.
+
+## Goals
+
+- Add a narrow `modelPricing` Adapter capability.
+- Route Model List single-account and all-accounts normal pricing loads through
+  `getSiteAdapter(siteType).modelPricing`.
+- Route AIHubMix selected-token fallback pricing through the Adapter instead of
+  direct `getApiService(...)`.
+- Preserve current caching, query keys, invalid response handling, toasts, and
+  analytics diagnostics.
+- Preserve Sub2API behavior:
+  - normal account pricing remains unsupported
+  - selected-token runtime model catalog remains available
+  - all-key comparison keeps partial-success semantics
+  - best-effort group/rate price estimation remains in the profile/model-list
+    fallback path
+- Provide Adapter implementations for:
+  - New API-family compatible account sites
+  - AIHubMix
+- Keep the legacy `getApiService(...)` facade available for non-migrated
+  capabilities.
+- Add focused Adapter tests and Model List regression tests.
+
+## Non-Goals
+
+- Do not add a new site type in this slice.
+- Do not enable direct Sub2API `modelPricing`.
+- Do not move Sub2API runtime model catalog, group-rate lookup, or price-table
+  estimation into `modelPricing`.
+- Do not migrate full Key Management CRUD, user groups, account validation,
+  account data fetch, redemption, managed-site channel operations, or managed
+  site model sync.
+- Do not remove `ApiServiceCapabilities.modelPricing` globally in this slice.
+- Do not change user-facing copy, locale keys, telemetry schema, settings
+  search entries, or Playwright E2E tests.
+- Do not change Model List cache key semantics or persisted cache storage.
+
+## Approaches Considered
+
+### Approach A: Keep Capability Booleans On `apiService`
+
+This is the current state. It is functional, but it keeps product Modules
+coupled to the wide legacy facade. New site type support still requires
+checking both Adapter wiring and legacy capability overrides.
+
+This should not be the next step.
+
+### Approach B: Add A Generic `modelData` Product Module Only
+
+Model List could wrap pricing loads in a product helper without adding an
+Adapter capability.
+
+This would reduce duplication inside the hook, but it would not give new site
+types a truthful Adapter-owned support signal. The backend-specific support
+decision would still live outside the Adapter registry.
+
+### Approach C: Adapter Capability For Normal Pricing, Keep Fallbacks Product-Owned
+
+Add `SiteAdapter.modelPricing` for the normal account-pricing contract, migrate
+the direct callers, and keep Sub2API runtime-key fallback as product-owned
+fallback logic that uses `modelCatalog` and existing Sub2API pricing helpers.
+
+This is the recommended path. It is narrow enough to preserve existing Model
+List behavior while moving the real backend variation point behind the Adapter
+Seam.
+
+## Design
+
+### 1. Add `ModelPricingCapability`
+
+Create:
+
+```text
+src/services/apiAdapters/contracts/modelPricing.ts
+```
+
+Proposed Interface:
+
+```ts
+import type {
+  ApiServiceRequest,
+  PricingResponse,
+} from "~/services/apiService/common/type"
+
+export type ModelPricingRequest = ApiServiceRequest
+
+export type ModelPricingCapability = {
+  fetchPricing(request: ModelPricingRequest): Promise<PricingResponse>
+}
+```
+
+Capability presence is the support signal. A missing `modelPricing` capability
+means the account site does not support the normal account-pricing contract.
+
+The Interface intentionally reuses `ApiServiceRequest` and `PricingResponse`.
+This slice changes the Seam, not the pricing response model.
+
+### 2. Extend `SiteAdapter`
+
+Add:
+
+```ts
+modelPricing?: ModelPricingCapability
+```
+
+to `src/services/apiAdapters/contracts/siteAdapter.ts`.
+
+Expected support after this slice:
+
+- New API-family Adapters expose `modelPricing`.
+- AIHubMix exposes `modelPricing`.
+- Sub2API does not expose `modelPricing`.
+- Unsupported Adapters omit `modelPricing`.
+
+This keeps Sub2API honest: it has `modelCatalog` for runtime-key model
+visibility, not normal account pricing.
+
+### 3. Add New API-Family Model Pricing Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/newApi/modelPricing.ts
+```
+
+The Adapter should delegate through the site-scoped legacy facade:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import type { ModelPricingCapability } from "~/services/apiAdapters/contracts/modelPricing"
+import { getApiService } from "~/services/apiService"
+
+export const createNewApiModelPricing = (
+  siteType: AccountSiteType,
+): ModelPricingCapability => ({
+  fetchPricing(request) {
+    return getApiService(siteType).fetchModelPricing(request)
+  },
+})
+```
+
+`createNewApiAdapter(siteType)` should attach:
+
+```ts
+modelPricing: createNewApiModelPricing(siteType)
+```
+
+Delegating through `getApiService(siteType)` preserves OneHub, DoneHub,
+Veloera, AnyRouter, WONG, V-API, VoAPI, Super-API, Rix-API, Neo-API, and
+unknown-compatible behavior while the lower-level backend Modules remain in
+place.
+
+### 4. Add AIHubMix Model Pricing Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/aihubmix/modelPricing.ts
+```
+
+The Adapter should delegate to the existing AIHubMix implementation:
+
+```ts
+import type { ModelPricingCapability } from "~/services/apiAdapters/contracts/modelPricing"
+import { fetchModelPricing } from "~/services/apiService/aihubmix"
+
+export const aihubmixModelPricing: ModelPricingCapability = {
+  fetchPricing: (request) => fetchModelPricing(request),
+}
+```
+
+The Adapter must preserve AIHubMix behavior:
+
+- API origin normalization stays in the AIHubMix implementation.
+- Token-authenticated requests continue sending raw
+  `Authorization: <access_token>` without a `Bearer` prefix.
+- User-scoped available-model fallback behavior remains in the AIHubMix
+  service implementation.
+- Pricing response source metadata remains unchanged.
+
+### 5. Keep Sub2API Without Normal Model Pricing
+
+Do not attach `modelPricing` to `sub2ApiAdapter`.
+
+Sub2API support should continue through the existing paths:
+
+- `sub2ApiAdapter.modelCatalog.fetchModels(...)` for runtime-key model ids.
+- `loadSub2ApiEstimatedPricingResponse(...)` for dashboard-auth best-effort
+  price estimates.
+- `MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY` and unavailable-price metadata
+  when exact pricing cannot be estimated.
+
+This means Model List should switch from:
+
+```ts
+const service = getApiService(account.siteType)
+if (!service.capabilities.modelPricing) {
+  if (account.siteType === SITE_TYPES.SUB2API) {
+    return fetchSub2ApiAllAccountsFallbackPricingContexts(account)
+  }
+  throw createUnsupportedModelPricingError()
+}
+```
+
+to:
+
+```ts
+const modelPricing = getSiteAdapter(account.siteType).modelPricing
+if (!modelPricing) {
+  if (account.siteType === SITE_TYPES.SUB2API) {
+    return fetchSub2ApiAllAccountsFallbackPricingContexts(account)
+  }
+  throw createUnsupportedModelPricingError()
+}
+```
+
+Sub2API remains the only product-special fallback in this slice because it is
+not a normal account-pricing backend.
+
+### 6. Add A Small Product Helper For Normal Pricing Loads
+
+To keep Model List from duplicating request construction, add a small helper in
+the Model List hook file or a local service helper:
+
+```ts
+const createDisplayAccountModelPricingRequest = (
+  account: DisplaySiteData,
+): ModelPricingRequest => ({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+```
+
+Then normal pricing loaders should:
+
+1. Resolve `getSiteAdapter(account.siteType).modelPricing`.
+2. Throw `createUnsupportedModelPricingError()` when the capability is missing.
+3. Use the existing cache lookup.
+4. Call `modelPricing.fetchPricing(createDisplayAccountModelPricingRequest(account))`.
+5. Validate `Array.isArray(data.data)`.
+6. Store the existing cache payload unchanged.
+
+This helper is product-level request construction. It should not be part of the
+Adapter Interface.
+
+### 7. Route AIHubMix Selected-Token Fallback Through The Adapter
+
+Modify `loadAccountTokenFallbackPricingResponse(...)` so the AIHubMix branch
+uses:
+
+```ts
+const modelPricing = getSiteAdapter(params.account.siteType).modelPricing
+```
+
+Then call `modelPricing.fetchPricing(...)` with the same account request shape.
+
+If the capability is missing, throw the existing sanitized fallback-load error
+path rather than adding user-facing copy in this slice.
+
+This removes the remaining direct pricing call from the profile catalog helper
+without changing AIHubMix selected-token behavior.
+
+### 8. Preserve Cache, Error, And Analytics Semantics
+
+Model List should keep:
+
+- `createModelPricingQueryKey(...)`
+- `createAllAccountsModelPricingQueryKey(...)`
+- `createModelPricingCacheKey(...)`
+- `MODEL_PRICING_CACHE_TTL_MS`
+- `modelPricingCache.get(...)`, `.set(...)`, and `.invalidate(...)`
+- `createInvalidFormatError()`
+- `MODEL_PRICING_UNSUPPORTED_ERROR`
+- existing direct-load and aggregate analytics diagnostics
+- existing Sub2API fallback telemetry fields:
+  `fallbackAvailable`, `fallbackUsed`, `successCount`, and `failureCount`
+
+Only the backend capability lookup and normal pricing invocation should move.
+
+## Error Handling
+
+Adapter methods should delegate backend errors unchanged.
+
+Product Modules should keep their current error mapping:
+
+- Invalid pricing payloads still throw `MODEL_LIST_DATA_ERROR_CODES.INVALID_FORMAT`.
+- Unsupported normal account pricing still throws
+  `MODEL_PRICING_UNSUPPORTED_ERROR`.
+- Sub2API single-account direct-load unsupported errors still allow selected-key
+  fallback controls when tokens are manageable.
+- Sub2API all-accounts mode still reports partial failure when some key
+  catalogs fail and at least one succeeds.
+- AIHubMix fallback errors remain sanitized by
+  `toSanitizedErrorSummary(...)`.
+
+Do not add user-facing copy for missing `modelPricing` in this slice.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This is an internal architecture migration. It does not add a new user action,
+setting, source type, or analytics field. Existing Model List load-completion
+events should continue to emit with the same result categories and diagnostics.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E in this slice.
+
+The risk is service-layer routing and response-shape preservation. Focused
+Vitest coverage at Adapter, helper, and Model List hook levels directly covers
+that risk. Browser runtime behavior is unchanged.
+
+## Testing Strategy
+
+Add Adapter tests:
+
+- `tests/services/apiAdapters/modelPricing.test.ts`
+  - New API-family `modelPricing` delegates to `getApiService(siteType)`.
+  - AIHubMix `modelPricing` delegates to AIHubMix `fetchModelPricing(...)`.
+  - Delegated results are returned without reshaping.
+
+Update registry tests:
+
+- New API-family Adapters expose `modelPricing`.
+- AIHubMix exposes `modelPricing`.
+- Sub2API does not expose `modelPricing`.
+
+Update profile catalog tests:
+
+- AIHubMix selected-token fallback uses
+  `getSiteAdapter(...).modelPricing.fetchPricing(...)`.
+- The request shape matches the current direct `fetchModelPricing(...)` request.
+- Missing AIHubMix `modelPricing` capability is mapped through the existing
+  sanitized fallback error path.
+- Sub2API selected-token runtime catalog behavior remains unchanged.
+
+Update Model List hook tests:
+
+- Single-account normal pricing uses `getSiteAdapter(...).modelPricing`.
+- Single-account missing capability still produces unsupported behavior.
+- Sub2API single-account direct pricing does not call normal `fetchPricing(...)`
+  and keeps fallback controls.
+- All-accounts normal pricing uses Adapter `modelPricing`.
+- All-accounts Sub2API still uses `fetchSub2ApiAllAccountsFallbackPricingContexts(...)`.
+- Cache hit, cache invalidation, invalid payload, partial failure, and analytics
+  assertions remain intact.
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/modelPricing.test.ts tests/services/apiAdapters/registry.test.ts tests/services/apiCredentialProfiles/modelCatalog.test.ts tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Push gate before publishing:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before opening or updating a PR because the slice changes
+shared Adapter contracts and Model List account-loading wiring.
+
+## Rollout
+
+1. Add the `modelPricing` contract and Adapter delegation tests.
+2. Extend `SiteAdapter`, New API-family, AIHubMix, and registry expectations.
+3. Migrate AIHubMix fallback in `modelCatalog.ts` to the Adapter capability.
+4. Migrate Model List single-account normal pricing loads to the Adapter
+   capability.
+5. Migrate Model List all-accounts normal pricing loads to the Adapter
+   capability.
+6. Re-run focused tests after each migration group.
+7. Run `pnpm compile` and `pnpm run validate:staged`.
+8. Inspect the diff for scope drift.
+9. Run `pnpm run validate:push` before pushing or opening a PR.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may migrate:
+
+- `fetchAccountAvailableModels(...)`
+- `fetchUserGroups(...)` and group coverage helpers
+- full Key Management page CRUD
+- account validation and account data fetch for add/edit flows
+- redemption
+- managed-site channel and model-sync operations
+- an import guard that prevents new product Modules from importing the legacy
+  `apiService` facade outside approved adapter/compatibility layers
+
+Do not turn `SiteAdapter` into a second flat `apiService` facade. Add each
+capability only when it hides backend-specific behavior behind a smaller
+Interface and gives real caller Leverage.

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -17,13 +17,14 @@ import {
   fetchDisplayAccountTokens,
   InvalidTokenPayloadError,
 } from "~/services/accounts/utils/apiServiceRequest"
+import type { ModelPricingRequest } from "~/services/apiAdapters/contracts/modelPricing"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import {
   ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED,
   buildApiCredentialProfilePricingResponse,
   fetchApiCredentialModelIds,
   loadAccountTokenFallbackPricingResponse,
 } from "~/services/apiCredentialProfiles/modelCatalog"
-import { getApiService } from "~/services/apiService"
 import type { PricingResponse } from "~/services/apiService/common/type"
 import {
   MODEL_PRICING_CACHE_TTL_MS,
@@ -393,6 +394,22 @@ function createModelPricingCacheKey(
   ].join("|")
 }
 
+/** Builds the adapter pricing request from a display account. */
+function createDisplayAccountModelPricingRequest(
+  account: DisplaySiteData,
+): ModelPricingRequest {
+  return {
+    baseUrl: account.baseUrl,
+    accountId: account.id,
+    auth: {
+      authType: account.authType,
+      userId: account.userId,
+      accessToken: account.token,
+      cookie: account.cookieAuthSessionCookie,
+    },
+  }
+}
+
 const SUB2API_ALL_ACCOUNTS_TOKEN_CONCURRENCY = 4
 
 /** Checks that a pricing response exposes the expected model row array. */
@@ -691,8 +708,8 @@ function useSingleAccountModelData(params: {
         throw new Error("No account selected")
       }
 
-      const service = getApiService(currentAccount.siteType)
-      if (!service.capabilities.modelPricing) {
+      const modelPricing = getSiteAdapter(currentAccount.siteType).modelPricing
+      if (!modelPricing) {
         throw createUnsupportedModelPricingError()
       }
 
@@ -705,16 +722,9 @@ function useSingleAccountModelData(params: {
       }
       directLoadCacheHitRef.current = false
 
-      const data = await service.fetchModelPricing({
-        baseUrl: currentAccount.baseUrl,
-        accountId: currentAccount.id,
-        auth: {
-          authType: currentAccount.authType,
-          userId: currentAccount.userId,
-          accessToken: currentAccount.token,
-          cookie: currentAccount.cookieAuthSessionCookie,
-        },
-      })
+      const data = await modelPricing.fetchPricing(
+        createDisplayAccountModelPricingRequest(currentAccount),
+      )
 
       if (!Array.isArray(data.data)) {
         throw createInvalidFormatError()
@@ -1171,8 +1181,8 @@ function useAllAccountsModelData(
       refetchOnWindowFocus: false,
       retry: shouldRetryModelPricingQuery,
       queryFn: async () => {
-        const service = getApiService(account.siteType)
-        if (!service.capabilities.modelPricing) {
+        const modelPricing = getSiteAdapter(account.siteType).modelPricing
+        if (!modelPricing) {
           if (account.siteType === SITE_TYPES.SUB2API) {
             return fetchSub2ApiAllAccountsFallbackPricingContexts(account)
           }
@@ -1196,16 +1206,9 @@ function useAllAccountsModelData(
           }
         }
 
-        const data = await service.fetchModelPricing({
-          baseUrl: account.baseUrl,
-          accountId: account.id,
-          auth: {
-            authType: account.authType,
-            userId: account.userId,
-            accessToken: account.token,
-            cookie: account.cookieAuthSessionCookie,
-          },
-        })
+        const data = await modelPricing.fetchPricing(
+          createDisplayAccountModelPricingRequest(account),
+        )
 
         if (!Array.isArray(data.data)) {
           throw createInvalidFormatError()

--- a/src/services/apiAdapters/aihubmix/index.ts
+++ b/src/services/apiAdapters/aihubmix/index.ts
@@ -4,10 +4,12 @@ import type { SiteAdapter } from "../contracts/siteAdapter"
 import { aihubmixAccountCompletion } from "./accountCompletion"
 import { aihubmixAccountRefresh } from "./accountRefresh"
 import { aihubmixKeyManagement } from "./keyManagement"
+import { aihubmixModelPricing } from "./modelPricing"
 
 export const aihubmixAdapter: SiteAdapter = {
   siteType: SITE_TYPES.AIHUBMIX,
   accountCompletion: aihubmixAccountCompletion,
   keyManagement: aihubmixKeyManagement,
   accountRefresh: aihubmixAccountRefresh,
+  modelPricing: aihubmixModelPricing,
 }

--- a/src/services/apiAdapters/aihubmix/modelPricing.ts
+++ b/src/services/apiAdapters/aihubmix/modelPricing.ts
@@ -1,0 +1,6 @@
+import type { ModelPricingCapability } from "~/services/apiAdapters/contracts/modelPricing"
+import { fetchModelPricing } from "~/services/apiService/aihubmix"
+
+export const aihubmixModelPricing: ModelPricingCapability = {
+  fetchPricing: (request) => fetchModelPricing(request),
+}

--- a/src/services/apiAdapters/contracts/modelPricing.ts
+++ b/src/services/apiAdapters/contracts/modelPricing.ts
@@ -1,0 +1,10 @@
+import type {
+  ApiServiceRequest,
+  PricingResponse,
+} from "~/services/apiService/common/type"
+
+export type ModelPricingRequest = ApiServiceRequest
+
+export type ModelPricingCapability = {
+  fetchPricing(request: ModelPricingRequest): Promise<PricingResponse>
+}

--- a/src/services/apiAdapters/contracts/siteAdapter.ts
+++ b/src/services/apiAdapters/contracts/siteAdapter.ts
@@ -4,6 +4,7 @@ import type { AccountCompletionCapability } from "./accountCompletion"
 import type { AccountRefreshCapability } from "./accountRefresh"
 import type { KeyManagementCapability } from "./keyManagement"
 import type { ModelCatalogCapability } from "./modelCatalog"
+import type { ModelPricingCapability } from "./modelPricing"
 import type { SiteAnnouncementsCapability } from "./siteAnnouncements"
 import type { SiteNoticeCapability } from "./siteNotice"
 
@@ -15,6 +16,7 @@ export type SiteAdapter = {
   siteNotice?: SiteNoticeCapability
   siteAnnouncements?: SiteAnnouncementsCapability
   modelCatalog?: ModelCatalogCapability
+  modelPricing?: ModelPricingCapability
   accountCompletion?: AccountCompletionCapability
   keyManagement?: KeyManagementCapability
   accountRefresh?: AccountRefreshCapability

--- a/src/services/apiAdapters/newApi/index.ts
+++ b/src/services/apiAdapters/newApi/index.ts
@@ -4,6 +4,7 @@ import type { SiteAdapter } from "../contracts/siteAdapter"
 import { newApiAccountCompletion } from "./accountCompletion"
 import { createNewApiAccountRefresh } from "./accountRefresh"
 import { createNewApiKeyManagement } from "./keyManagement"
+import { createNewApiModelPricing } from "./modelPricing"
 import { newApiSiteNotice } from "./siteNotice"
 
 export const createNewApiAdapter = (
@@ -15,4 +16,5 @@ export const createNewApiAdapter = (
   accountCompletion: newApiAccountCompletion,
   keyManagement: createNewApiKeyManagement(siteType),
   accountRefresh: createNewApiAccountRefresh(siteType),
+  modelPricing: createNewApiModelPricing(siteType),
 })

--- a/src/services/apiAdapters/newApi/modelPricing.ts
+++ b/src/services/apiAdapters/newApi/modelPricing.ts
@@ -1,0 +1,15 @@
+import type { AccountSiteType } from "~/constants/siteType"
+import type { ModelPricingCapability } from "~/services/apiAdapters/contracts/modelPricing"
+import { getApiService } from "~/services/apiService"
+
+/**
+ * Create account model-pricing operations bound to the New API-family site type.
+ */
+export function createNewApiModelPricing(
+  siteType: AccountSiteType,
+): ModelPricingCapability {
+  return {
+    fetchPricing: (request) =>
+      getApiService(siteType).fetchModelPricing(request),
+  }
+}

--- a/src/services/apiCredentialProfiles/modelCatalog.ts
+++ b/src/services/apiCredentialProfiles/modelCatalog.ts
@@ -9,7 +9,6 @@ import {
   applySub2ApiPriceEstimates,
   resolveSub2ApiKeyGroupForPriceEstimation,
 } from "~/services/apiCredentialProfiles/sub2apiPriceEstimation"
-import { getApiService } from "~/services/apiService"
 import {
   MODEL_LIST_SOURCE_KINDS,
   MODEL_PRICE_PRECISION_KINDS,
@@ -58,6 +57,9 @@ export const ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED =
 const createMissingModelCatalogCapabilityError = () =>
   new Error("modelCatalog is not implemented for sub2api")
 
+const createMissingModelPricingCapabilityError = (siteType: string) =>
+  new Error(`modelPricing is not implemented for ${siteType}`)
+
 /**
  * Fetch raw model ids using a stored API credential profile.
  */
@@ -99,23 +101,20 @@ export async function loadAccountTokenFallbackPricingResponse(
   params: LoadAccountTokenFallbackPricingParams,
 ): Promise<PricingResponse> {
   const declaredModelIds = parseDelimitedList(params.token.models)
-
-  if (params.account.siteType === SITE_TYPES.AIHUBMIX) {
-    return getApiService(params.account.siteType).fetchModelPricing({
-      baseUrl: params.account.baseUrl,
-      accountId: params.account.id,
-      auth: {
-        authType: params.account.authType,
-        userId: params.account.userId,
-        accessToken: params.account.token,
-        cookie: params.account.cookieAuthSessionCookie,
-      },
-    })
-  }
-
   let resolvedTokenKey = ""
 
   try {
+    if (params.account.siteType === SITE_TYPES.AIHUBMIX) {
+      const adapter = getSiteAdapter(params.account.siteType)
+      if (!adapter.modelPricing) {
+        throw createMissingModelPricingCapabilityError(params.account.siteType)
+      }
+
+      return await adapter.modelPricing.fetchPricing(
+        createAccountModelPricingRequest(params.account),
+      )
+    }
+
     const resolvedToken = await resolveDisplayAccountTokenForSecret(
       params.account,
       params.token,
@@ -278,6 +277,19 @@ const createSub2ApiDashboardRequest = (
   accountId: account.id,
   auth: {
     authType: AuthTypeEnum.AccessToken,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+
+const createAccountModelPricingRequest = (
+  account: LoadAccountTokenFallbackPricingParams["account"],
+): ApiServiceRequest => ({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
     userId: account.userId,
     accessToken: account.token,
     cookie: account.cookieAuthSessionCookie,

--- a/src/services/apiService/index.ts
+++ b/src/services/apiService/index.ts
@@ -38,7 +38,7 @@ const strictOverrideSites = new Set<ApiOverrideSite>([
   SITE_TYPES.SUB2API,
 ])
 
-export type ApiServiceCapabilities = {
+type ApiServiceCapabilities = {
   keyManagement: boolean
   modelPricing: boolean
   redeemCode: boolean

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -13,10 +13,7 @@ import {
   type ModelManagementSource,
 } from "~/features/ModelList/modelManagementSources"
 import { InvalidTokenPayloadError } from "~/services/accounts/utils/apiServiceRequest"
-import {
-  getApiService,
-  type ApiServiceCapabilities,
-} from "~/services/apiService"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import {
   MODEL_LIST_SOURCE_KINDS,
@@ -66,8 +63,8 @@ vi.mock("react-hot-toast", () => ({
   },
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: vi.fn(),
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(),
 }))
 
 vi.mock("~/services/productAnalytics/actions", async (importOriginal) => {
@@ -148,18 +145,22 @@ const createDeferred = <T,>() => {
   return { promise, resolve, reject }
 }
 
-const createMockApiService = (
-  fetchModelPricing: ReturnType<typeof vi.fn>,
+const createMockSiteAdapter = (
+  fetchPricing: ReturnType<typeof vi.fn>,
   overrides: {
-    capabilities?: Partial<Pick<ApiServiceCapabilities, "modelPricing">>
+    siteType?: DisplaySiteData["siteType"]
+    modelPricing?: false
   } = {},
 ) =>
   ({
-    fetchModelPricing,
-    capabilities: {
-      modelPricing: true,
-      ...overrides.capabilities,
-    },
+    siteType: overrides.siteType ?? SITE_TYPES.NEW_API,
+    ...(overrides.modelPricing === false
+      ? {}
+      : {
+          modelPricing: {
+            fetchPricing,
+          },
+        }),
   }) as any
 
 const createWrapper = () => {
@@ -282,20 +283,20 @@ describe("useModelData all-accounts loading", () => {
     mockFetchDisplayAccountTokens.mockReset()
     mockLoadAccountTokenFallbackPricingResponse.mockReset()
     mockTrackProductAnalyticsActionCompleted.mockReset()
-    vi.mocked(getApiService).mockReset()
+    vi.mocked(getSiteAdapter).mockReset()
   })
 
   it("does not fetch all-account pricing until selectedAccount is 'all'", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
-    const fetchModelPricing = vi.fn().mockResolvedValue({
+    const fetchPricing = vi.fn().mockResolvedValue({
       data: [],
       group_ratio: {},
       success: true,
       usable_group: {},
     })
-    const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue(createMockApiService(fetchModelPricing))
+    const mockedGetSiteAdapter = vi.mocked(getSiteAdapter)
+    mockedGetSiteAdapter.mockReturnValue(createMockSiteAdapter(fetchPricing))
 
     const accounts = [
       createDisplayAccount({
@@ -321,20 +322,20 @@ describe("useModelData all-accounts loading", () => {
 
     // Yield at least one tick; with the pre-fix behaviour this would start queries immediately.
     await new Promise((resolve) => setTimeout(resolve, 0))
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
   })
 
   it("fetches all-account pricing when selectedAccount is 'all'", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
-    const fetchModelPricing = vi.fn().mockResolvedValue({
+    const fetchPricing = vi.fn().mockResolvedValue({
       data: [],
       group_ratio: {},
       success: true,
       usable_group: {},
     })
-    const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue(createMockApiService(fetchModelPricing))
+    const mockedGetSiteAdapter = vi.mocked(getSiteAdapter)
+    mockedGetSiteAdapter.mockReturnValue(createMockSiteAdapter(fetchPricing))
 
     const accounts = [
       createDisplayAccount({
@@ -358,8 +359,8 @@ describe("useModelData all-accounts loading", () => {
       { wrapper: createWrapper() },
     )
 
-    await waitFor(() => expect(fetchModelPricing).toHaveBeenCalledTimes(2))
-    const calledAccountIds = fetchModelPricing.mock.calls.map(
+    await waitFor(() => expect(fetchPricing).toHaveBeenCalledTimes(2))
+    const calledAccountIds = fetchPricing.mock.calls.map(
       (call) => call[0]?.accountId,
     )
     expect(calledAccountIds).toEqual(expect.arrayContaining(["a", "b"]))
@@ -368,12 +369,13 @@ describe("useModelData all-accounts loading", () => {
   it("does not invoke model pricing for unsupported Sub2API accounts", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockRejectedValue(new Error("fetch should not be called"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
 
@@ -401,18 +403,60 @@ describe("useModelData all-accounts loading", () => {
       { timeout: 3000 },
     )
     expect(result.current.loadErrorMessage).toBeNull()
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
+  })
+
+  it("reports unsupported non-Sub2API accounts as direct pricing failures", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+    const fetchPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("fetch should not be called"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.UNKNOWN,
+        modelPricing: false,
+      }),
+    )
+
+    const account = createDisplayAccount({
+      id: "unsupported-unknown",
+      baseUrl: "https://unsupported-unknown.example.invalid",
+      siteType: SITE_TYPES.UNKNOWN,
+      userId: "unsupported-unknown-user",
+    })
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAccountSource(account),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.loadErrorMessage).toBe(
+          "modelList:status.loadFailed",
+        )
+      },
+      { timeout: 3000 },
+    )
+    expect(fetchPricing).not.toHaveBeenCalled()
+    expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(account)
   })
 
   it("does not invoke all-account pricing when Sub2API has no fallback key", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockRejectedValue(new Error("fetch should not be called"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
     mockFetchDisplayAccountTokens.mockResolvedValue([])
@@ -449,7 +493,7 @@ describe("useModelData all-accounts loading", () => {
       },
       { timeout: 3000 },
     )
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
     expect(mockFetchDisplayAccountTokens).toHaveBeenCalledTimes(2)
     expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(accounts[0])
     expect(mockFetchDisplayAccountTokens).toHaveBeenCalledWith(accounts[1])
@@ -459,12 +503,13 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockRejectedValue(new Error("common pricing should not be called"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
 
@@ -565,7 +610,7 @@ describe("useModelData all-accounts loading", () => {
       { timeout: 3000 },
     )
 
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
     expect(result.current.loadErrorMessage).toBeNull()
     expect(result.current.pricingContexts).toEqual([
       {
@@ -592,10 +637,11 @@ describe("useModelData all-accounts loading", () => {
   })
 
   it("loads only active Sub2API fallback keys in all-accounts mode", async () => {
-    const fetchModelPricing = vi.fn()
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    const fetchPricing = vi.fn()
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
 
@@ -675,7 +721,7 @@ describe("useModelData all-accounts loading", () => {
       account,
       token: tokens[0],
     })
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
     expect(result.current.loadErrorMessage).toBeNull()
     expect(result.current.pricingContexts).toEqual([
       {
@@ -693,10 +739,13 @@ describe("useModelData all-accounts loading", () => {
 
   it("keeps successful Sub2API token contexts as partial instead of load failed when another token fails", async () => {
     mockTrackProductAnalyticsActionCompleted.mockReset()
-    const fetchModelPricing = vi.fn()
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    const fetchPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("fetch should not be called"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
 
@@ -796,10 +845,11 @@ describe("useModelData all-accounts loading", () => {
   })
 
   it("marks a Sub2API account failed when every fallback key fails", async () => {
-    const fetchModelPricing = vi.fn()
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    const fetchPricing = vi.fn()
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
 
@@ -862,10 +912,11 @@ describe("useModelData all-accounts loading", () => {
   })
 
   it("marks mixed Sub2API all-token failures as load failed instead of invalid format", async () => {
-    const fetchModelPricing = vi.fn()
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    const fetchPricing = vi.fn()
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
 
@@ -966,7 +1017,7 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockResolvedValueOnce({
         data: [
@@ -1000,8 +1051,8 @@ describe("useModelData all-accounts loading", () => {
         success: true,
         usable_group: { default: true },
       })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const account = createDisplayAccount({
@@ -1075,7 +1126,7 @@ describe("useModelData all-accounts loading", () => {
       { timeout: 3000 },
     )
 
-    expect(fetchModelPricing).toHaveBeenCalledTimes(2)
+    expect(fetchPricing).toHaveBeenCalledTimes(2)
     expect(result.current.loadErrorMessage).toBeNull()
   })
 
@@ -1083,7 +1134,7 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockResolvedValue({
+    const fetchPricing = vi.fn().mockResolvedValue({
       data: [
         {
           model_name: "gpt-4o-mini",
@@ -1108,8 +1159,8 @@ describe("useModelData all-accounts loading", () => {
       success: true,
       usable_group: { default: true },
     })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const account = createDisplayAccount({
@@ -1155,14 +1206,14 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockResolvedValue({
+    const fetchPricing = vi.fn().mockResolvedValue({
       data: null,
       group_ratio: {},
       success: true,
       usable_group: {},
     })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const account = createDisplayAccount({
@@ -1203,7 +1254,7 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockImplementation(({ accountId }) => {
+    const fetchPricing = vi.fn().mockImplementation(({ accountId }) => {
       if (accountId === "analytics-all-success") {
         return Promise.resolve({
           data: [
@@ -1225,8 +1276,8 @@ describe("useModelData all-accounts loading", () => {
 
       return Promise.reject(new Error("private backend failure"))
     })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const accounts = [
@@ -1275,7 +1326,7 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockImplementation(({ accountId }) => {
+    const fetchPricing = vi.fn().mockImplementation(({ accountId }) => {
       if (accountId === "analytics-all-success") {
         return Promise.resolve({
           data: [
@@ -1297,8 +1348,8 @@ describe("useModelData all-accounts loading", () => {
 
       return Promise.reject(new TypeError("Failed to fetch"))
     })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const accounts = [
@@ -1347,7 +1398,7 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockImplementation(({ accountId }) => {
+    const fetchPricing = vi.fn().mockImplementation(({ accountId }) => {
       if (accountId === "analytics-all-valid") {
         return Promise.resolve({
           data: [
@@ -1374,8 +1425,8 @@ describe("useModelData all-accounts loading", () => {
         usable_group: {},
       })
     })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const accounts = [
@@ -1424,7 +1475,7 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockImplementation(({ accountId }) => {
+    const fetchPricing = vi.fn().mockImplementation(({ accountId }) => {
       if (accountId === "analytics-all-auth-failure") {
         return Promise.reject(
           new ApiError(
@@ -1443,8 +1494,8 @@ describe("useModelData all-accounts loading", () => {
         usable_group: {},
       })
     })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const accounts = [
@@ -1559,9 +1610,9 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    const fetchPricing = vi.fn().mockRejectedValue(new Error("boom"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const fallbackToken = {
@@ -1653,7 +1704,7 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockResolvedValueOnce({
         data: [
@@ -1687,8 +1738,8 @@ describe("useModelData all-accounts loading", () => {
         success: true,
         usable_group: { default: true },
       })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const firstAccount = createDisplayAccount({
@@ -1728,7 +1779,7 @@ describe("useModelData all-accounts loading", () => {
     )
 
     await waitFor(() => {
-      expect(fetchModelPricing).toHaveBeenCalledTimes(1)
+      expect(fetchPricing).toHaveBeenCalledTimes(1)
       expect(result.current.pricingData?.data[0]?.model_name).toBe(
         "access-token-model",
       )
@@ -1740,8 +1791,8 @@ describe("useModelData all-accounts loading", () => {
     })
 
     await waitFor(() => {
-      expect(fetchModelPricing).toHaveBeenCalledTimes(2)
-      expect(fetchModelPricing).toHaveBeenLastCalledWith(
+      expect(fetchPricing).toHaveBeenCalledTimes(2)
+      expect(fetchPricing).toHaveBeenLastCalledWith(
         expect.objectContaining({
           accountId: "credential-change-account",
           auth: expect.objectContaining({
@@ -1760,9 +1811,9 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn()
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    const fetchPricing = vi.fn()
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const account = createDisplayAccount({
@@ -1814,7 +1865,7 @@ describe("useModelData all-accounts loading", () => {
         "cached-model",
       )
     })
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
     expectLastModelDataAnalyticsCompletion({
       result: PRODUCT_ANALYTICS_RESULTS.Success,
       sourceKind: PRODUCT_ANALYTICS_SOURCE_KINDS.ModelAccount,
@@ -1831,10 +1882,13 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn()
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    const fetchPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("fetch should not be called"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
 
@@ -1887,7 +1941,7 @@ describe("useModelData all-accounts loading", () => {
         { timeout: 3000 },
       )
       expect(result.current.loadErrorMessage).toBeNull()
-      expect(fetchModelPricing).not.toHaveBeenCalled()
+      expect(fetchPricing).not.toHaveBeenCalled()
       expect(result.current.pricingData).toBeNull()
     } finally {
       await modelPricingCache.invalidate(cacheKey)
@@ -1898,13 +1952,14 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockRejectedValue(new Error("common pricing should not be called"))
-    const sub2apiService = createMockApiService(fetchModelPricing, {
-      capabilities: { modelPricing: false },
+    const sub2apiAdapter = createMockSiteAdapter(fetchPricing, {
+      siteType: SITE_TYPES.SUB2API,
+      modelPricing: false,
     })
-    vi.mocked(getApiService).mockReturnValue(sub2apiService)
+    vi.mocked(getSiteAdapter).mockReturnValue(sub2apiAdapter)
 
     const account = createDisplayAccount({
       id: "sub2api-runtime-fallback-account",
@@ -1971,7 +2026,7 @@ describe("useModelData all-accounts loading", () => {
     })
 
     const selectedSource = createAccountSource(account)
-    expect(sub2apiService.capabilities.modelPricing).toBe(false)
+    expect(sub2apiAdapter.modelPricing).toBeUndefined()
     expect(selectedSource.capabilities.supportsPricing).toBe(true)
 
     const { result } = renderHook(
@@ -1990,7 +2045,7 @@ describe("useModelData all-accounts loading", () => {
       { timeout: 3000 },
     )
     expect(result.current.loadErrorMessage).toBeNull()
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
     await waitFor(() => {
       expect(result.current.accountFallback?.selectedTokenId).toBeNull()
       expect(result.current.accountFallback?.tokens).toEqual(fallbackTokens)
@@ -2062,12 +2117,13 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockRejectedValue(new Error("common pricing should not be called"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
 
@@ -2155,7 +2211,7 @@ describe("useModelData all-accounts loading", () => {
       expect(result.current.accountFallback?.isActive).toBe(true)
       expect(result.current.pricingData).toEqual(fallbackPricing)
     })
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
     expect(result.current.loadErrorMessage).toBeNull()
   })
 
@@ -2163,12 +2219,13 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockRejectedValue(new Error("common pricing should not be called"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing, {
-        capabilities: { modelPricing: false },
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing, {
+        siteType: SITE_TYPES.SUB2API,
+        modelPricing: false,
       }),
     )
 
@@ -2258,7 +2315,7 @@ describe("useModelData all-accounts loading", () => {
       account,
       token: fallbackToken,
     })
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
   })
 
   it("marks all-account queries as loading before each account returns data", async () => {
@@ -2277,11 +2334,11 @@ describe("useModelData all-accounts loading", () => {
       success: true
       usable_group: Record<string, never>
     }>()
-    const fetchModelPricing = vi.fn().mockImplementation(({ accountId }) => {
+    const fetchPricing = vi.fn().mockImplementation(({ accountId }) => {
       return accountId === "a" ? firstDeferred.promise : secondDeferred.promise
     })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const accounts = [
@@ -2364,9 +2421,9 @@ describe("useModelData all-accounts loading", () => {
   it("loads a profile-backed model catalog without a SiteAccount", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
-    const fetchModelPricing = vi.fn()
-    const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue(createMockApiService(fetchModelPricing))
+    const fetchPricing = vi.fn()
+    const mockedGetSiteAdapter = vi.mocked(getSiteAdapter)
+    mockedGetSiteAdapter.mockReturnValue(createMockSiteAdapter(fetchPricing))
     mockFetchApiCredentialModelIds.mockResolvedValueOnce([
       "gpt-4o-mini",
       "claude-3-5-sonnet",
@@ -2408,16 +2465,16 @@ describe("useModelData all-accounts loading", () => {
     expect(
       result.current.pricingData?.data.map((item) => item.model_name),
     ).toEqual(["gpt-4o-mini", "claude-3-5-sonnet"])
-    expect(fetchModelPricing).not.toHaveBeenCalled()
+    expect(fetchPricing).not.toHaveBeenCalled()
   })
 
   it("clears single-account errors when the query becomes idle", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    const fetchPricing = vi.fn().mockRejectedValue(new Error("boom"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const account = createDisplayAccount({
@@ -2463,9 +2520,9 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    const fetchPricing = vi.fn().mockRejectedValue(new Error("boom"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const account = createDisplayAccount({
@@ -2531,7 +2588,7 @@ describe("useModelData all-accounts loading", () => {
     )
 
     await waitFor(() => {
-      expect(fetchModelPricing).toHaveBeenCalledTimes(1)
+      expect(fetchPricing).toHaveBeenCalledTimes(1)
     })
     await waitFor(
       () => {
@@ -2580,12 +2637,12 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockRejectedValueOnce(new Error("boom"))
       .mockRejectedValueOnce(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const account = createDisplayAccount({
@@ -2639,7 +2696,7 @@ describe("useModelData all-accounts loading", () => {
     )
 
     await waitFor(() => {
-      expect(fetchModelPricing).toHaveBeenCalledTimes(1)
+      expect(fetchPricing).toHaveBeenCalledTimes(1)
     })
     await waitFor(
       () => {
@@ -2668,7 +2725,7 @@ describe("useModelData all-accounts loading", () => {
     expect(result.current.pricingData?.data[0]?.model_name).toBe(
       "stale-fallback-model",
     )
-    const pricingCallCountBeforeRefresh = fetchModelPricing.mock.calls.length
+    const pricingCallCountBeforeRefresh = fetchPricing.mock.calls.length
 
     await act(async () => {
       await result.current.loadPricingData()
@@ -2685,9 +2742,7 @@ describe("useModelData all-accounts loading", () => {
     expect(
       result.current.pricingData?.data.map((item) => item.model_name),
     ).toEqual(["fresh-fallback-model"])
-    expect(fetchModelPricing).toHaveBeenCalledTimes(
-      pricingCallCountBeforeRefresh,
-    )
+    expect(fetchPricing).toHaveBeenCalledTimes(pricingCallCountBeforeRefresh)
   })
 
   it("discards stale fallback token results after switching accounts", async () => {
@@ -2695,7 +2750,7 @@ describe("useModelData all-accounts loading", () => {
     toastErrorMock.mockReset()
 
     const deferredTokens = createDeferred<any[]>()
-    const fetchModelPricing = vi
+    const fetchPricing = vi
       .fn()
       .mockRejectedValueOnce(new Error("boom"))
       .mockRejectedValueOnce(new Error("boom"))
@@ -2705,8 +2760,8 @@ describe("useModelData all-accounts loading", () => {
         success: true,
         usable_group: {},
       })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
     mockFetchDisplayAccountTokens.mockReturnValueOnce(deferredTokens.promise)
 
@@ -2788,9 +2843,9 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    const fetchPricing = vi.fn().mockRejectedValue(new Error("boom"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
     mockFetchDisplayAccountTokens.mockRejectedValueOnce(
       new InvalidTokenPayloadError({
@@ -2837,9 +2892,9 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    const fetchPricing = vi.fn().mockRejectedValue(new Error("boom"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const fallbackToken = {
@@ -2910,9 +2965,9 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockRejectedValue(new Error("boom"))
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    const fetchPricing = vi.fn().mockRejectedValue(new Error("boom"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const fallbackToken = {
@@ -2994,7 +3049,7 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockImplementation(({ accountId }) => {
+    const fetchPricing = vi.fn().mockImplementation(({ accountId }) => {
       if (accountId === "bad-format") {
         return Promise.resolve({
           data: null,
@@ -3006,8 +3061,8 @@ describe("useModelData all-accounts loading", () => {
 
       return Promise.reject(new Error("boom"))
     })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const accounts = [
@@ -3063,14 +3118,14 @@ describe("useModelData all-accounts loading", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
-    const fetchModelPricing = vi.fn().mockResolvedValue({
+    const fetchPricing = vi.fn().mockResolvedValue({
       data: null,
       group_ratio: {},
       success: true,
       usable_group: {},
     })
-    vi.mocked(getApiService).mockReturnValue(
-      createMockApiService(fetchModelPricing),
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
     )
 
     const account = createDisplayAccount({

--- a/tests/services/apiAdapters/modelPricing.test.ts
+++ b/tests/services/apiAdapters/modelPricing.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { aihubmixModelPricing } from "~/services/apiAdapters/aihubmix/modelPricing"
+import { createNewApiModelPricing } from "~/services/apiAdapters/newApi/modelPricing"
+import type { PricingResponse } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockAihubmixFetchModelPricing,
+  mockFetchModelPricing,
+  mockGetApiService,
+} = vi.hoisted(() => ({
+  mockAihubmixFetchModelPricing: vi.fn(),
+  mockFetchModelPricing: vi.fn(),
+  mockGetApiService: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  fetchModelPricing: mockAihubmixFetchModelPricing,
+}))
+
+const request = {
+  baseUrl: "https://api.example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: 7,
+    accessToken: "account-token",
+  },
+}
+
+const pricingResponse: PricingResponse = {
+  data: [
+    {
+      model_name: "example-model",
+      quota_type: 0,
+      model_ratio: 1,
+      model_price: 0,
+      completion_ratio: 1,
+      enable_groups: [],
+      supported_endpoint_types: [],
+    },
+  ],
+  group_ratio: {},
+  success: true,
+  usable_group: {},
+}
+
+describe("apiAdapter modelPricing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      fetchModelPricing: mockFetchModelPricing,
+    })
+  })
+
+  it("delegates New API-family model pricing through the site-specific apiService", async () => {
+    mockFetchModelPricing.mockResolvedValueOnce(pricingResponse)
+
+    const modelPricing = createNewApiModelPricing(SITE_TYPES.ONE_HUB)
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+
+    await expect(modelPricing.fetchPricing(request)).resolves.toBe(
+      pricingResponse,
+    )
+
+    expect(mockGetApiService).toHaveBeenCalledOnce()
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.ONE_HUB)
+    expect(mockFetchModelPricing).toHaveBeenCalledOnce()
+    expect(mockFetchModelPricing).toHaveBeenCalledWith(request)
+  })
+
+  it("delegates AIHubMix model pricing to the AIHubMix helper", async () => {
+    mockAihubmixFetchModelPricing.mockResolvedValueOnce(pricingResponse)
+
+    await expect(aihubmixModelPricing.fetchPricing(request)).resolves.toBe(
+      pricingResponse,
+    )
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+    expect(mockAihubmixFetchModelPricing).toHaveBeenCalledOnce()
+    expect(mockAihubmixFetchModelPricing).toHaveBeenCalledWith(request)
+  })
+})

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -30,6 +30,7 @@ describe("apiAdapters registry", () => {
       fetchCheckInSupport: expect.any(Function),
       refreshAccount: expect.any(Function),
     })
+    expect(adapter.modelPricing).toBeUndefined()
     expect(adapter.siteNotice).toBeUndefined()
   })
 
@@ -70,6 +71,9 @@ describe("apiAdapters registry", () => {
         fetchCheckInSupport: expect.any(Function),
         refreshAccount: expect.any(Function),
       })
+      expect(adapter.modelPricing).toEqual({
+        fetchPricing: expect.any(Function),
+      })
       expect(adapter.siteAnnouncements).toBeUndefined()
       expect(adapter.modelCatalog).toBeUndefined()
     }
@@ -92,6 +96,9 @@ describe("apiAdapters registry", () => {
     expect(adapter.accountRefresh).toEqual({
       fetchCheckInSupport: expect.any(Function),
       refreshAccount: expect.any(Function),
+    })
+    expect(adapter.modelPricing).toEqual({
+      fetchPricing: expect.any(Function),
     })
     expect(adapter.siteNotice).toBeUndefined()
     expect(adapter.siteAnnouncements).toBeUndefined()

--- a/tests/services/apiCredentialProfiles/modelCatalog.test.ts
+++ b/tests/services/apiCredentialProfiles/modelCatalog.test.ts
@@ -27,7 +27,6 @@ const {
   fetchSub2ApiAvailableGroupsMock,
   fetchSub2ApiGroupRatesMock,
   fetchSub2ApiRuntimeModelsMock,
-  getApiServiceMock,
   getSiteAdapterMock,
   loadModelPriceTableMock,
   resolveDisplayAccountTokenForSecretMock,
@@ -39,14 +38,9 @@ const {
   fetchSub2ApiAvailableGroupsMock: vi.fn(),
   fetchSub2ApiGroupRatesMock: vi.fn(),
   fetchSub2ApiRuntimeModelsMock: vi.fn(),
-  getApiServiceMock: vi.fn(),
   getSiteAdapterMock: vi.fn(),
   loadModelPriceTableMock: vi.fn(),
   resolveDisplayAccountTokenForSecretMock: vi.fn(),
-}))
-
-vi.mock("~/services/apiService", () => ({
-  getApiService: (...args: unknown[]) => getApiServiceMock(...args),
 }))
 
 vi.mock("~/services/aiApi/anthropic", () => ({
@@ -154,7 +148,6 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     fetchSub2ApiAvailableGroupsMock.mockReset()
     fetchSub2ApiGroupRatesMock.mockReset()
     fetchSub2ApiRuntimeModelsMock.mockReset()
-    getApiServiceMock.mockReset()
     getSiteAdapterMock.mockReset()
     loadModelPriceTableMock.mockReset()
     resolveDisplayAccountTokenForSecretMock.mockReset()
@@ -293,9 +286,12 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
         },
       ],
     }
-    const fetchModelPricingMock = vi.fn().mockResolvedValueOnce(aihubmixPricing)
-    getApiServiceMock.mockReturnValueOnce({
-      fetchModelPricing: fetchModelPricingMock,
+    const fetchPricingMock = vi.fn().mockResolvedValueOnce(aihubmixPricing)
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.AIHUBMIX,
+      modelPricing: {
+        fetchPricing: fetchPricingMock,
+      },
     })
     resolveDisplayAccountTokenForSecretMock.mockRejectedValueOnce(
       new Error("AIHubMix cannot reveal masked keys"),
@@ -315,9 +311,8 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     })
 
     expect(result).toBe(aihubmixPricing)
-    expect(getApiServiceMock).toHaveBeenCalledWith(SITE_TYPES.AIHUBMIX)
-    expect(getSiteAdapterMock).not.toHaveBeenCalled()
-    expect(fetchModelPricingMock).toHaveBeenCalledWith({
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.AIHUBMIX)
+    expect(fetchPricingMock).toHaveBeenCalledWith({
       baseUrl: "https://aihubmix.com",
       accountId: "account-1",
       auth: {
@@ -327,6 +322,30 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
         cookie: undefined,
       },
     })
+    expect(resolveDisplayAccountTokenForSecretMock).not.toHaveBeenCalled()
+    expect(fetchOpenAICompatibleModelIdsMock).not.toHaveBeenCalled()
+  })
+
+  it("sanitizes a missing AIHubMix model pricing capability failure", async () => {
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.AIHUBMIX,
+    })
+
+    await expect(
+      loadAccountTokenFallbackPricingResponse({
+        account: {
+          ...ACCOUNT,
+          siteType: SITE_TYPES.AIHUBMIX,
+          baseUrl: "https://aihubmix.com",
+        },
+        token: {
+          ...TOKEN,
+          key: "sk-****masked",
+          models: "",
+        },
+      }),
+    ).rejects.toThrow("modelPricing is not implemented for AIHubMix")
+
     expect(resolveDisplayAccountTokenForSecretMock).not.toHaveBeenCalled()
     expect(fetchOpenAICompatibleModelIdsMock).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
- Add a `modelPricing` site-adapter capability for New API-family sites and AIHubMix.
- Route AIHubMix profile fallback and Model List pricing loads through site adapters.
- Add focused adapter, profile, and Model List regression coverage.

## Test Plan
- [x] `pnpm run validate:push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored model pricing loading system to use an improved site adapter pattern, enhancing code organization and maintainability across pricing-related operations.

* **Tests**
  * Extended test coverage for new adapter-based pricing implementations and updated existing test suites to reflect architectural changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->