### PR TITLE
refactor(account): route account data through adapters

### DIFF
--- a/docs/superpowers/plans/2026-06-19-api-adapter-account-data.md
+++ b/docs/superpowers/plans/2026-06-19-api-adapter-account-data.md
@@ -1,0 +1,1128 @@
+# API Adapter Account Data Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route manual account add/edit live account-data loading through `SiteAdapter.accountData` instead of the legacy `getApiService(...).fetchAccountData(...)` facade.
+
+**Architecture:** Add a narrow `accountData` Adapter capability for raw `AccountData` snapshots. Provider Adapters delegate to existing backend implementations, while `accountOperations` keeps product persistence, fallback, timeout, and health semantics.
+
+**Tech Stack:** TypeScript, WXT, Vitest, pnpm, existing `src/services/apiAdapters/**` patterns.
+
+---
+
+## File Structure
+
+Create:
+
+- `src/services/apiAdapters/contracts/accountData.ts`
+  - Defines the `AccountDataCapability` Interface.
+- `src/services/apiAdapters/newApi/accountData.ts`
+  - New API-family Adapter implementation, delegating to `getApiService(siteType).fetchAccountData(...)`.
+- `src/services/apiAdapters/sub2api/accountData.ts`
+  - Sub2API Adapter implementation, delegating to `~/services/apiService/sub2api.fetchAccountData`.
+- `src/services/apiAdapters/aihubmix/accountData.ts`
+  - AIHubMix Adapter implementation, delegating to `~/services/apiService/aihubmix.fetchAccountData`.
+- `tests/services/apiAdapters/accountData.test.ts`
+  - Adapter delegation tests for New API-family, Sub2API, and AIHubMix.
+
+Modify:
+
+- `src/services/apiAdapters/contracts/siteAdapter.ts`
+  - Adds optional `accountData?: AccountDataCapability`.
+- `src/services/apiAdapters/newApi/index.ts`
+  - Attaches `createNewApiAccountData(siteType)`.
+- `src/services/apiAdapters/sub2api/index.ts`
+  - Attaches `sub2ApiAccountData`.
+- `src/services/apiAdapters/aihubmix/index.ts`
+  - Attaches `aihubmixAccountData`.
+- `tests/services/apiAdapters/registry.test.ts`
+  - Verifies Adapter registry exposes `accountData` for supported site types.
+- `tests/services/accountOperations.validateAndSaveAccount.test.ts`
+  - Migrates mocks from `getApiService(...).fetchAccountData` to `getSiteAdapter(...).accountData.fetchData`.
+  - Keeps manual save/update behavior assertions.
+- `tests/services/accountOperations.test.ts`
+  - Migrates validate-update tests to Adapter-based account-data mocks.
+- `src/services/accounts/accountOperations.ts`
+  - Imports `getSiteAdapter` and `AccountDataCapability`.
+  - Adds `requireAccountDataCapability(...)`.
+  - Routes `validateAndSaveAccount(...)` and `validateAndUpdateAccount(...)` through the Adapter capability.
+
+Do not modify:
+
+- `src/services/accounts/accountStorage.ts`
+  - Saved-account refresh already uses `accountRefresh`; do not route it through `accountData`.
+- `src/services/apiService/**`
+  - Existing backend implementations remain the delegated implementation.
+- `src/services/apiAdapters/contracts/accountRefresh.ts`
+  - Keep saved refresh separate from manual add/edit live data loading.
+- locale files, telemetry files, settings search files, Playwright tests.
+
+---
+
+### Task 1: Add Account Data Adapter Capability
+
+**Files:**
+
+- Create: `tests/services/apiAdapters/accountData.test.ts`
+- Create: `src/services/apiAdapters/contracts/accountData.ts`
+- Create: `src/services/apiAdapters/newApi/accountData.ts`
+- Create: `src/services/apiAdapters/sub2api/accountData.ts`
+- Create: `src/services/apiAdapters/aihubmix/accountData.ts`
+
+- [ ] **Step 1: Write the failing Adapter delegation tests**
+
+Create `tests/services/apiAdapters/accountData.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { aihubmixAccountData } from "~/services/apiAdapters/aihubmix/accountData"
+import { createNewApiAccountData } from "~/services/apiAdapters/newApi/accountData"
+import { sub2ApiAccountData } from "~/services/apiAdapters/sub2api/accountData"
+import type { AccountData } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockAihubmixFetchAccountData,
+  mockFetchAccountData,
+  mockGetApiService,
+  mockSub2ApiFetchAccountData,
+} = vi.hoisted(() => ({
+  mockAihubmixFetchAccountData: vi.fn(),
+  mockFetchAccountData: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockSub2ApiFetchAccountData: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchAccountData: mockSub2ApiFetchAccountData,
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  fetchAccountData: mockAihubmixFetchAccountData,
+}))
+
+const request = {
+  baseUrl: "https://api.example.invalid",
+  accountId: "account-1",
+  checkIn: {
+    enableDetection: true,
+    autoCheckInEnabled: true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+  },
+  includeTodayCashflow: false,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "user-1",
+    accessToken: "account-token",
+  },
+}
+
+const accountData: AccountData = {
+  quota: 123,
+  today_prompt_tokens: 1,
+  today_completion_tokens: 2,
+  today_quota_consumption: 3,
+  today_requests_count: 4,
+  today_income: 5,
+  checkIn: request.checkIn,
+}
+
+const disabledCheckInAccountData: AccountData = {
+  quota: 9800,
+  today_prompt_tokens: 0,
+  today_completion_tokens: 0,
+  today_quota_consumption: 0,
+  today_requests_count: 0,
+  today_income: 0,
+  checkIn: {
+    enableDetection: false,
+    siteStatus: {
+      isCheckedInToday: undefined,
+    },
+  },
+}
+
+describe("apiAdapter accountData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      fetchAccountData: mockFetchAccountData,
+    })
+  })
+
+  it("delegates New API-family account data through the site-specific apiService", async () => {
+    mockFetchAccountData.mockResolvedValueOnce(accountData)
+
+    const accountDataCapability = createNewApiAccountData(SITE_TYPES.ONE_HUB)
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+
+    await expect(accountDataCapability.fetchData(request)).resolves.toBe(
+      accountData,
+    )
+
+    expect(mockGetApiService).toHaveBeenCalledOnce()
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.ONE_HUB)
+    expect(mockFetchAccountData).toHaveBeenCalledOnce()
+    expect(mockFetchAccountData).toHaveBeenCalledWith(request)
+  })
+
+  it("delegates Sub2API account data without reshaping disabled check-in or zeroed stats", async () => {
+    mockSub2ApiFetchAccountData.mockResolvedValueOnce(disabledCheckInAccountData)
+
+    await expect(sub2ApiAccountData.fetchData(request)).resolves.toBe(
+      disabledCheckInAccountData,
+    )
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+    expect(mockSub2ApiFetchAccountData).toHaveBeenCalledOnce()
+    expect(mockSub2ApiFetchAccountData).toHaveBeenCalledWith(request)
+  })
+
+  it("delegates AIHubMix account data without reshaping disabled check-in or zeroed fields", async () => {
+    mockAihubmixFetchAccountData.mockResolvedValueOnce(disabledCheckInAccountData)
+
+    await expect(aihubmixAccountData.fetchData(request)).resolves.toBe(
+      disabledCheckInAccountData,
+    )
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+    expect(mockAihubmixFetchAccountData).toHaveBeenCalledOnce()
+    expect(mockAihubmixFetchAccountData).toHaveBeenCalledWith(request)
+  })
+})
+```
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountData.test.ts
+```
+
+Expected: FAIL with missing module errors for one or more of:
+
+- `~/services/apiAdapters/aihubmix/accountData`
+- `~/services/apiAdapters/newApi/accountData`
+- `~/services/apiAdapters/sub2api/accountData`
+
+- [ ] **Step 3: Add the accountData contract**
+
+Create `src/services/apiAdapters/contracts/accountData.ts`:
+
+```ts
+import type {
+  AccountData,
+  ApiServiceAccountRequest,
+} from "~/services/apiService/common/type"
+
+export type AccountDataRequest = ApiServiceAccountRequest
+
+export type AccountDataCapability = {
+  fetchData(request: AccountDataRequest): Promise<AccountData>
+}
+```
+
+- [ ] **Step 4: Add the New API-family Adapter**
+
+Create `src/services/apiAdapters/newApi/accountData.ts`:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { getApiService } from "~/services/apiService"
+
+/**
+ * Create account-data loading bound to the New API-family site type.
+ */
+export function createNewApiAccountData(
+  siteType: AccountSiteType,
+): AccountDataCapability {
+  return {
+    fetchData: (request) => getApiService(siteType).fetchAccountData(request),
+  }
+}
+```
+
+- [ ] **Step 5: Add the Sub2API Adapter**
+
+Create `src/services/apiAdapters/sub2api/accountData.ts`:
+
+```ts
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { fetchAccountData } from "~/services/apiService/sub2api"
+
+export const sub2ApiAccountData: AccountDataCapability = {
+  fetchData: (request) => fetchAccountData(request),
+}
+```
+
+- [ ] **Step 6: Add the AIHubMix Adapter**
+
+Create `src/services/apiAdapters/aihubmix/accountData.ts`:
+
+```ts
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { fetchAccountData } from "~/services/apiService/aihubmix"
+
+export const aihubmixAccountData: AccountDataCapability = {
+  fetchData: (request) => fetchAccountData(request),
+}
+```
+
+- [ ] **Step 7: Run the Adapter delegation test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountData.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 1**
+
+Run:
+
+```powershell
+git status --short
+git add src/services/apiAdapters/contracts/accountData.ts src/services/apiAdapters/newApi/accountData.ts src/services/apiAdapters/sub2api/accountData.ts src/services/apiAdapters/aihubmix/accountData.ts tests/services/apiAdapters/accountData.test.ts
+git commit -m "refactor(api-adapters): add account data capability"
+```
+
+Expected: commit succeeds after staged validation.
+
+---
+
+### Task 2: Register Account Data On Site Adapters
+
+**Files:**
+
+- Modify: `src/services/apiAdapters/contracts/siteAdapter.ts`
+- Modify: `src/services/apiAdapters/newApi/index.ts`
+- Modify: `src/services/apiAdapters/sub2api/index.ts`
+- Modify: `src/services/apiAdapters/aihubmix/index.ts`
+- Test: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write failing registry expectations**
+
+Modify `tests/services/apiAdapters/registry.test.ts`.
+
+In the Sub2API test, after the `accountRefresh` expectation, add:
+
+```ts
+expect(adapter.accountData).toEqual({
+  fetchData: expect.any(Function),
+})
+```
+
+In the New API-family loop, after the `accountRefresh` expectation, add:
+
+```ts
+expect(adapter.accountData).toEqual({
+  fetchData: expect.any(Function),
+})
+```
+
+In the AIHubMix test, after the `accountRefresh` expectation, add:
+
+```ts
+expect(adapter.accountData).toEqual({
+  fetchData: expect.any(Function),
+})
+```
+
+- [ ] **Step 2: Run registry tests to verify they fail**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because `adapter.accountData` is `undefined`.
+
+- [ ] **Step 3: Extend the SiteAdapter Interface**
+
+Modify `src/services/apiAdapters/contracts/siteAdapter.ts`.
+
+Add the import:
+
+```ts
+import type { AccountDataCapability } from "./accountData"
+```
+
+Add the optional property before `accountCompletion`:
+
+```ts
+  accountData?: AccountDataCapability
+```
+
+The final type should include this group:
+
+```ts
+  modelPricing?: ModelPricingCapability
+  accountData?: AccountDataCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+```
+
+- [ ] **Step 4: Attach accountData to the New API-family Adapter**
+
+Modify `src/services/apiAdapters/newApi/index.ts`.
+
+Add the import:
+
+```ts
+import { createNewApiAccountData } from "./accountData"
+```
+
+Add the property in `createNewApiAdapter(...)`:
+
+```ts
+  accountData: createNewApiAccountData(siteType),
+```
+
+Place it near the other account capabilities:
+
+```ts
+  siteNotice: newApiSiteNotice,
+  accountData: createNewApiAccountData(siteType),
+  accountCompletion: newApiAccountCompletion,
+  keyManagement: createNewApiKeyManagement(siteType),
+```
+
+- [ ] **Step 5: Attach accountData to the Sub2API Adapter**
+
+Modify `src/services/apiAdapters/sub2api/index.ts`.
+
+Add the import:
+
+```ts
+import { sub2ApiAccountData } from "./accountData"
+```
+
+Add the property:
+
+```ts
+  accountData: sub2ApiAccountData,
+```
+
+Place it before `accountCompletion`:
+
+```ts
+  siteAnnouncements: sub2ApiSiteAnnouncements,
+  modelCatalog: sub2ApiModelCatalog,
+  accountData: sub2ApiAccountData,
+  accountCompletion: sub2ApiAccountCompletion,
+```
+
+- [ ] **Step 6: Attach accountData to the AIHubMix Adapter**
+
+Modify `src/services/apiAdapters/aihubmix/index.ts`.
+
+Add the import:
+
+```ts
+import { aihubmixAccountData } from "./accountData"
+```
+
+Add the property:
+
+```ts
+  accountData: aihubmixAccountData,
+```
+
+Place it before `accountCompletion`:
+
+```ts
+export const aihubmixAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.AIHUBMIX,
+  accountData: aihubmixAccountData,
+  accountCompletion: aihubmixAccountCompletion,
+  keyManagement: aihubmixKeyManagement,
+  accountRefresh: aihubmixAccountRefresh,
+  modelPricing: aihubmixModelPricing,
+}
+```
+
+- [ ] **Step 7: Run Adapter and registry tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountData.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```powershell
+git status --short
+git add src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/sub2api/index.ts src/services/apiAdapters/aihubmix/index.ts tests/services/apiAdapters/registry.test.ts
+git commit -m "refactor(api-adapters): register account data adapters"
+```
+
+Expected: commit succeeds after staged validation.
+
+---
+
+### Task 3: Route validateAndSaveAccount Through accountData
+
+**Files:**
+
+- Modify: `tests/services/accountOperations.validateAndSaveAccount.test.ts`
+- Modify: `src/services/accounts/accountOperations.ts`
+
+- [ ] **Step 1: Add getSiteAdapter test mock alongside the legacy apiService mock**
+
+Modify the top of `tests/services/accountOperations.validateAndSaveAccount.test.ts`.
+
+Replace:
+
+```ts
+const { fetchAccountDataMock, ensureDefaultApiTokenForAccountMock } =
+  vi.hoisted(() => ({
+    fetchAccountDataMock: vi.fn(),
+    ensureDefaultApiTokenForAccountMock: vi.fn(),
+  }))
+```
+
+with:
+
+```ts
+const {
+  fetchAccountDataMock,
+  getApiServiceMock,
+  getSiteAdapterMock,
+  ensureDefaultApiTokenForAccountMock,
+} =
+  vi.hoisted(() => ({
+    fetchAccountDataMock: vi.fn(),
+    getApiServiceMock: vi.fn(),
+    getSiteAdapterMock: vi.fn(),
+    ensureDefaultApiTokenForAccountMock: vi.fn(),
+  }))
+```
+
+Then change the `~/services/apiService` mock from:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: vi.fn(() => ({
+    fetchAccountData: fetchAccountDataMock,
+  })),
+}))
+```
+
+to:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: getApiServiceMock,
+}))
+```
+
+Then add a separate Adapter registry mock:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: getSiteAdapterMock,
+}))
+```
+
+In the `beforeEach`, after the preferences spy, add:
+
+```ts
+    getApiServiceMock.mockReturnValue({
+      fetchAccountData: fetchAccountDataMock,
+    })
+    getSiteAdapterMock.mockReturnValue({
+      accountData: {
+        fetchData: fetchAccountDataMock,
+      },
+    })
+```
+
+Keep the legacy `getApiServiceMock` in this file during Task 3 because this
+same file still contains update-path tests. Those update-path tests should keep
+passing until Task 4 migrates `validateAndUpdateAccount(...)`.
+
+- [ ] **Step 2: Update direct mock assertions in the save/update test file**
+
+In `tests/services/accountOperations.validateAndSaveAccount.test.ts`, update assertions that currently inspect `getApiService`.
+
+In `"normalizes unsupported site types before saving"`, replace:
+
+```ts
+const { getApiService } = await import("~/services/apiService")
+```
+
+with:
+
+```ts
+const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
+```
+
+And replace:
+
+```ts
+expect(getApiService).toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
+```
+
+with:
+
+```ts
+expect(getSiteAdapter).toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
+```
+
+Keep all `fetchAccountDataMock` request-shape assertions unchanged in this task. They should still fail until production code calls `accountData.fetchData(...)`.
+
+- [ ] **Step 3: Add a missing-capability fallback save test**
+
+In `tests/services/accountOperations.validateAndSaveAccount.test.ts`, add this test inside `describe("accountOperations validateAndSaveAccount", () => { ... })` after `"saves a warning-only Sub2API account when remote data refresh fails"`:
+
+```ts
+  it("saves warning-only account data when accountData capability is missing", async () => {
+    getSiteAdapterMock.mockReturnValueOnce({})
+
+    const result = await validateAndSaveAccount(
+      "https://unsupported.example.com",
+      "Unsupported Portal",
+      "tester",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result).toMatchObject({
+      success: true,
+      message: "messages:warnings.accountSavedWithoutDataRefresh",
+      feedbackLevel: "warning",
+    })
+    expect(fetchAccountDataMock).not.toHaveBeenCalled()
+
+    const saved = await accountStorage.getAccountById(result.accountId!)
+    expect(saved).toMatchObject({
+      site_name: "Unsupported Portal",
+      health: {
+        status: SiteHealthStatus.Warning,
+        reason: "accountData is not implemented for new-api",
+      },
+      account_info: {
+        id: "1",
+        username: "tester",
+        access_token: "token",
+        quota: 0,
+      },
+    })
+  })
+```
+
+- [ ] **Step 4: Run save/update tests to verify they fail**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.validateAndSaveAccount.test.ts
+```
+
+Expected: FAIL because `accountOperations` still imports `getApiService(...)` and does not use `getSiteAdapter(...)`.
+
+- [ ] **Step 5: Import Adapter registry and capability type**
+
+Modify `src/services/accounts/accountOperations.ts`.
+
+Add imports near the existing account/service imports:
+
+```ts
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+Keep the existing `getApiService` import because other functions in the file still use it for unmigrated capabilities such as `fetchUserGroups(...)`, `fetchSiteStatus(...)`, and account completion helpers.
+
+- [ ] **Step 6: Add the local capability guard**
+
+In `src/services/accounts/accountOperations.ts`, add this helper near other small local helpers, before `validateAndSaveAccount(...)`:
+
+```ts
+const createMissingAccountDataCapabilityError = (siteType: string): Error =>
+  new Error(`accountData is not implemented for ${siteType}`)
+
+const requireAccountDataCapability = (
+  siteType: string,
+  accountData: AccountDataCapability | undefined,
+): AccountDataCapability => {
+  if (!accountData) {
+    throw createMissingAccountDataCapabilityError(siteType)
+  }
+
+  return accountData
+}
+```
+
+- [ ] **Step 7: Route validateAndSaveAccount live data loading through the Adapter**
+
+In `validateAndSaveAccount(...)`, inside the non-deferred `try` block, replace:
+
+```ts
+    const freshAccountData = await withTimeout(
+      getApiService(normalizedSiteType).fetchAccountData({
+        baseUrl: requestBaseUrl,
+        checkIn: checkInConfig,
+        accountId: undefined, // New account, no ID yet
+        includeTodayCashflow,
+        auth: {
+          authType,
+          userId: accountIdentity,
+          accessToken: accessToken.trim(),
+          cookie:
+            authType === AuthTypeEnum.Cookie
+              ? sessionCookieHeader.trim()
+              : undefined,
+        },
+      }),
+      MANUAL_ADD_ACCOUNT_DATA_FETCH_TIMEOUT_MS,
+      () =>
+        createAccountDataFetchTimeoutError(
+          MANUAL_ADD_ACCOUNT_DATA_FETCH_TIMEOUT_MS,
+        ),
+    )
+```
+
+with:
+
+```ts
+    const accountData = requireAccountDataCapability(
+      normalizedSiteType,
+      getSiteAdapter(normalizedSiteType).accountData,
+    )
+    const freshAccountData = await withTimeout(
+      accountData.fetchData({
+        baseUrl: requestBaseUrl,
+        checkIn: checkInConfig,
+        accountId: undefined, // New account, no ID yet
+        includeTodayCashflow,
+        auth: {
+          authType,
+          userId: accountIdentity,
+          accessToken: accessToken.trim(),
+          cookie:
+            authType === AuthTypeEnum.Cookie
+              ? sessionCookieHeader.trim()
+              : undefined,
+        },
+      }),
+      MANUAL_ADD_ACCOUNT_DATA_FETCH_TIMEOUT_MS,
+      () =>
+        createAccountDataFetchTimeoutError(
+          MANUAL_ADD_ACCOUNT_DATA_FETCH_TIMEOUT_MS,
+        ),
+    )
+```
+
+- [ ] **Step 8: Run save/update tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.validateAndSaveAccount.test.ts
+```
+
+Expected: PASS. The update-path tests in this file should still pass because
+the legacy `getApiServiceMock` remains available until Task 4 migrates
+`validateAndUpdateAccount(...)`.
+
+- [ ] **Step 9: Commit Task 3**
+
+Run:
+
+```powershell
+git status --short
+git add src/services/accounts/accountOperations.ts tests/services/accountOperations.validateAndSaveAccount.test.ts
+git commit -m "refactor(account): use adapter account data on save"
+```
+
+Expected: commit succeeds after staged validation if only save-path changes are staged. If update-path test edits were required in the same file and cannot be split safely, include them in Task 4's commit instead of this one.
+
+---
+
+### Task 4: Route validateAndUpdateAccount Through accountData
+
+**Files:**
+
+- Modify: `tests/services/accountOperations.validateAndSaveAccount.test.ts`
+- Modify: `tests/services/accountOperations.test.ts`
+- Modify: `src/services/accounts/accountOperations.ts`
+
+- [ ] **Step 1: Add a missing-capability fallback update test**
+
+In `tests/services/accountOperations.validateAndSaveAccount.test.ts`, add this test near the existing update/deferred update tests:
+
+```ts
+  it("updates warning-only account data when accountData capability is missing", async () => {
+    const accountId = await accountStorage.addAccount({
+      site_name: "Old Example",
+      site_url: "https://old.example.com",
+      site_type: SITE_TYPES.NEW_API,
+      health: { status: SiteHealthStatus.Healthy },
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      excludeFromTotalBalance: false,
+      excludeFromTodayIncome: false,
+      exchange_rate: 7,
+      notes: "",
+      tagIds: [],
+      checkIn: CHECK_IN_DISABLED,
+      account_info: {
+        id: "previous-id",
+        access_token: "old-token",
+        username: "old-user",
+        quota: 42,
+        today_prompt_tokens: 1,
+        today_completion_tokens: 2,
+        today_quota_consumption: 3,
+        today_requests_count: 4,
+        today_income: 5,
+      },
+      last_sync_time: 123,
+    })
+    getSiteAdapterMock.mockReturnValueOnce({})
+
+    const result = await validateAndUpdateAccount(
+      accountId,
+      "https://unsupported.example.com",
+      "Unsupported Portal",
+      "tester",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result).toMatchObject({
+      success: true,
+      message: "messages:warnings.accountUpdatedWithoutDataRefresh",
+      feedbackLevel: "warning",
+    })
+    expect(fetchAccountDataMock).not.toHaveBeenCalled()
+
+    const updated = await accountStorage.getAccountById(accountId)
+    expect(updated).toMatchObject({
+      site_name: "Unsupported Portal",
+      health: {
+        status: SiteHealthStatus.Warning,
+        reason: "accountData is not implemented for new-api",
+      },
+      account_info: {
+        id: "1",
+        username: "tester",
+        access_token: "token",
+        quota: 0,
+      },
+    })
+  })
+```
+
+- [ ] **Step 2: Migrate accountOperations.test.ts mocks to getSiteAdapter**
+
+Modify the top of `tests/services/accountOperations.test.ts`.
+
+Replace:
+
+```ts
+const { mockFetchAccountData, mockFetchSiteStatus, mockUpdateAccount } =
+  vi.hoisted(() => ({
+    mockFetchAccountData: vi.fn(),
+    mockFetchSiteStatus: vi.fn(),
+    mockUpdateAccount: vi.fn(),
+  }))
+```
+
+with:
+
+```ts
+const {
+  mockFetchAccountData,
+  mockFetchSiteStatus,
+  mockGetApiService,
+  mockGetSiteAdapter,
+  mockUpdateAccount,
+} = vi.hoisted(() => ({
+  mockFetchAccountData: vi.fn(),
+  mockFetchSiteStatus: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockGetSiteAdapter: vi.fn(),
+  mockUpdateAccount: vi.fn(),
+}))
+```
+
+Replace the `~/services/apiService` mock with:
+
+```ts
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: mockGetApiService,
+  }
+})
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: mockGetSiteAdapter,
+}))
+```
+
+In `beforeEach`, replace the existing resets with:
+
+```ts
+    mockFetchAccountData.mockReset()
+    mockFetchSiteStatus.mockReset()
+    mockGetApiService.mockReset()
+    mockGetSiteAdapter.mockReset()
+    mockUpdateAccount.mockReset()
+    mockGetApiService.mockReturnValue({
+      fetchSiteStatus: mockFetchSiteStatus,
+    })
+    mockGetSiteAdapter.mockReturnValue({
+      accountData: {
+        fetchData: mockFetchAccountData,
+      },
+    })
+```
+
+- [ ] **Step 3: Update accountOperations.test.ts site-type assertions**
+
+In `"normalizes unsupported site types before updating"`, replace:
+
+```ts
+expect(vi.mocked(getApiService)).toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
+```
+
+with:
+
+```ts
+const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
+expect(vi.mocked(getSiteAdapter)).toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
+```
+
+Keep `getSiteName(...)` tests using `getApiService` unchanged. Those tests still verify site-status lookup and are not part of `accountData`.
+
+- [ ] **Step 4: Run update tests to verify they fail**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.validateAndSaveAccount.test.ts tests/services/accountOperations.test.ts
+```
+
+Expected: FAIL because `validateAndUpdateAccount(...)` still calls `getApiService(...).fetchAccountData(...)`.
+
+- [ ] **Step 5: Route validateAndUpdateAccount live data loading through the Adapter**
+
+In `src/services/accounts/accountOperations.ts`, inside the non-deferred `validateAndUpdateAccount(...)` `try` block, replace:
+
+```ts
+    const freshAccountData = await getApiService(
+      normalizedSiteType,
+    ).fetchAccountData({
+      baseUrl: requestBaseUrl,
+      checkIn: checkInConfig,
+      accountId,
+      includeTodayCashflow,
+      auth: {
+        authType,
+        userId: accountIdentity,
+        accessToken: accessToken.trim(),
+        cookie:
+          authType === AuthTypeEnum.Cookie
+            ? sessionCookieHeader.trim()
+            : undefined,
+      },
+    })
+```
+
+with:
+
+```ts
+    const accountData = requireAccountDataCapability(
+      normalizedSiteType,
+      getSiteAdapter(normalizedSiteType).accountData,
+    )
+    const freshAccountData = await accountData.fetchData({
+      baseUrl: requestBaseUrl,
+      checkIn: checkInConfig,
+      accountId,
+      includeTodayCashflow,
+      auth: {
+        authType,
+        userId: accountIdentity,
+        accessToken: accessToken.trim(),
+        cookie:
+          authType === AuthTypeEnum.Cookie
+            ? sessionCookieHeader.trim()
+            : undefined,
+      },
+    })
+```
+
+- [ ] **Step 6: Run update tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.validateAndSaveAccount.test.ts tests/services/accountOperations.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run focused Adapter plus account operation tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountData.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountOperations.validateAndSaveAccount.test.ts tests/services/accountOperations.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 4**
+
+Run:
+
+```powershell
+git status --short
+git add src/services/accounts/accountOperations.ts tests/services/accountOperations.validateAndSaveAccount.test.ts tests/services/accountOperations.test.ts
+git commit -m "refactor(account): use adapter account data on update"
+```
+
+Expected: commit succeeds after staged validation.
+
+---
+
+### Task 5: Final Validation And Diff Review
+
+**Files:**
+
+- Review all changed task files.
+- No new implementation files should be added outside the paths listed in this plan.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountData.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountOperations.validateAndSaveAccount.test.ts tests/services/accountOperations.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type validation**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run staged validation**
+
+If there are any uncommitted task-scoped changes, stage only those files:
+
+```powershell
+git status --short
+git add src/services/apiAdapters/contracts/accountData.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/accountData.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/sub2api/accountData.ts src/services/apiAdapters/sub2api/index.ts src/services/apiAdapters/aihubmix/accountData.ts src/services/apiAdapters/aihubmix/index.ts src/services/accounts/accountOperations.ts tests/services/apiAdapters/accountData.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountOperations.validateAndSaveAccount.test.ts tests/services/accountOperations.test.ts
+pnpm run validate:staged
+```
+
+Expected: PASS. If all prior task commits succeeded and there is nothing staged, run `pnpm run validate:staged` only after staging the remaining task-scoped files.
+
+- [ ] **Step 4: Run push gate**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```powershell
+git status --short --branch
+git diff --stat origin/main...HEAD
+git diff --name-only origin/main...HEAD
+```
+
+Expected changed files are limited to:
+
+```text
+src/services/apiAdapters/contracts/accountData.ts
+src/services/apiAdapters/contracts/siteAdapter.ts
+src/services/apiAdapters/newApi/accountData.ts
+src/services/apiAdapters/newApi/index.ts
+src/services/apiAdapters/sub2api/accountData.ts
+src/services/apiAdapters/sub2api/index.ts
+src/services/apiAdapters/aihubmix/accountData.ts
+src/services/apiAdapters/aihubmix/index.ts
+src/services/accounts/accountOperations.ts
+tests/services/apiAdapters/accountData.test.ts
+tests/services/apiAdapters/registry.test.ts
+tests/services/accountOperations.validateAndSaveAccount.test.ts
+tests/services/accountOperations.test.ts
+```
+
+Existing unrelated untracked local files may still appear in `git status`; do not stage or delete them.
+
+- [ ] **Step 6: If final task-scoped changes remain uncommitted, commit them**
+
+Run:
+
+```powershell
+git status --short
+git add src/services/apiAdapters/contracts/accountData.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/accountData.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/sub2api/accountData.ts src/services/apiAdapters/sub2api/index.ts src/services/apiAdapters/aihubmix/accountData.ts src/services/apiAdapters/aihubmix/index.ts src/services/accounts/accountOperations.ts tests/services/apiAdapters/accountData.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountOperations.validateAndSaveAccount.test.ts tests/services/accountOperations.test.ts
+git commit -m "refactor(account): route account data through adapters"
+```
+
+Expected: commit succeeds. Skip this step if Tasks 1-4 already committed all task-scoped changes.
+
+---
+
+## Implementation Notes
+
+- Keep `getApiService` imported in `accountOperations.ts`; this slice only migrates manual add/edit `fetchAccountData(...)`.
+- Missing `accountData` capability must be thrown inside the existing live-load `try` blocks so the existing fallback save/update behavior handles it.
+- Do not add user-facing copy for missing `accountData`.
+- Do not modify `accountStorage.refreshAccount(...)`; that path intentionally uses `accountRefresh`.
+- Use placeholder domains such as `example.invalid` in new tests.
+- If `validate:staged` or commit hooks format files, inspect `git diff --cached` before retrying or committing.

--- a/docs/superpowers/specs/2026-06-19-api-adapter-account-data-design.md
+++ b/docs/superpowers/specs/2026-06-19-api-adapter-account-data-design.md
@@ -1,0 +1,562 @@
+# API Adapter Account Data Design
+
+Date: 2026-06-19
+
+## Purpose
+
+Move manual account add/edit live account-data loading behind the
+`apiAdapters` Seam so a newly added account site type can define its initial
+quota, usage, income, and check-in data loading in its Adapter Module.
+
+Recent adapter slices moved site announcements, runtime model catalog loading,
+account completion, key management, account refresh, Sub2API stored auth
+recovery, and model pricing behind `getSiteAdapter(siteType)`. Those slices
+make a saved account mostly usable after it exists. The remaining gap in the
+new-site-type onboarding path is manual save/update validation: before an
+account is saved or updated, `accountOperations` still calls the legacy
+`getApiService(...).fetchAccountData(...)` facade directly.
+
+## Current Context
+
+The current `SiteAdapter` Interface exposes:
+
+```ts
+type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  modelPricing?: ModelPricingCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+}
+```
+
+Saved-account refresh already uses:
+
+```ts
+getSiteAdapter(account.site_type).accountRefresh
+```
+
+Manual add/edit live account-data loading still uses the legacy facade:
+
+- `src/services/accounts/accountOperations.ts`
+  - `validateAndSaveAccount(...)` calls
+    `getApiService(normalizedSiteType).fetchAccountData(...)`.
+  - `validateAndUpdateAccount(...)` calls
+    `getApiService(normalizedSiteType).fetchAccountData(...)`.
+
+Those calls build the first `AccountData` snapshot used to persist:
+
+- quota
+- today prompt/completion tokens
+- today quota consumption
+- today request count
+- today income
+- check-in state
+- healthy or warning status after save/update
+
+The backend implementations already vary:
+
+- New API-family compatible sites aggregate quota, usage logs, income logs, and
+  optional check-in state through the existing compatible implementation plus
+  site-specific overrides.
+- Sub2API loads current-user quota, disables check-in, and returns zeroed
+  today stats.
+- AIHubMix loads quota and used quota from its account endpoint, disables
+  check-in, and returns zeroed token/request/income stats until stable endpoints
+  exist.
+
+## Problem
+
+Account data is now the highest-value remaining legacy facade path in the
+manual account add/edit flow.
+
+Current friction:
+
+1. A new non-compatible account site type still needs legacy `apiService`
+   wiring before manual save/update can perform live data loading.
+2. `accountOperations` must know that the backend operation is
+   `fetchAccountData(...)` on the wide facade instead of asking the account
+   site's Adapter for the account-data capability.
+3. Tests for manual add/edit account data mock `getApiService(...)`, even
+   though the product behavior only needs a narrow account-data Interface.
+4. Saved-account refresh and manual add/edit live data loading now use different
+   Seams despite loading the same `AccountData` shape.
+
+Deletion test: if direct `getApiService(...).fetchAccountData(...)` calls are
+deleted from `accountOperations`, the complexity should not reappear as raw
+`siteType` branches in the same Module. It should sit behind an `accountData`
+capability that each Adapter can implement or omit.
+
+## Goals
+
+- Add a narrow `accountData` Adapter capability.
+- Route manual add-account live data loading through
+  `getSiteAdapter(siteType).accountData`.
+- Route manual edit-account live data loading through
+  `getSiteAdapter(siteType).accountData`.
+- Preserve all existing `validateAndSaveAccount(...)` and
+  `validateAndUpdateAccount(...)` behavior:
+  - validation rules
+  - request base URL selection
+  - storage URL normalization
+  - manual balance override
+  - deferred data refresh option
+  - fallback-to-config-only save/update when live data loading fails
+  - health status mapping
+  - tag, note, exclusion, cookie, and Sub2API auth persistence
+  - auto-provision-on-add behavior
+- Provide Adapter implementations for:
+  - New API-family compatible account sites
+  - Sub2API
+  - AIHubMix
+- Keep `accountRefresh` as the saved-account refresh capability.
+- Keep the legacy `getApiService(...)` facade available for non-migrated
+  capabilities.
+- Add focused Adapter tests and account operation regression tests.
+
+## Non-Goals
+
+- Do not add a new site type in this slice.
+- Do not merge `accountData` and `accountRefresh` into one capability.
+- Do not move account persistence, manual balance override, save/update
+  fallback behavior, or auto-provisioning behind the Adapter.
+- Do not migrate `fetchUserInfo(...)`, `getOrCreateAccessToken(...)`,
+  `fetchSiteStatus(...)`, `fetchSupportCheckIn(...)`, or
+  `extractDefaultExchangeRate(...)` in account completion.
+- Do not migrate `fetchUserGroups(...)`, `deleteApiToken(...)`, redemption,
+  managed-site channel operations, managed-site model sync, or site detection.
+- Do not add an import guard in this slice.
+- Do not change user-facing copy, locale keys, telemetry events, settings
+  search entries, or Playwright E2E tests.
+
+## Approaches Considered
+
+### Approach A: Reuse `accountRefresh` For Add/Edit Data Loading
+
+`accountRefresh.refreshAccount(...)` already returns a health-wrapped result
+containing `AccountData`, so manual add/edit could call that capability.
+
+This is not the right Interface. Manual save/update already owns fallback,
+storage, and health behavior. It needs raw `AccountData` or an exception so it
+can preserve current "save config anyway" semantics. `accountRefresh` also
+allows auth updates and refresh-loop health mapping that are specific to saved
+accounts.
+
+### Approach B: Keep `fetchAccountData(...)` On The Legacy Facade
+
+This keeps the current behavior and avoids a small Adapter contract.
+
+It leaves the manual account flow coupled to `getApiService(...)`, which is
+exactly the remaining friction for adding new non-compatible account site
+types.
+
+### Approach C: Add `accountData` Capability For Live Account Snapshots
+
+Add `SiteAdapter.accountData.fetchData(...)` for the raw live account snapshot
+used by manual add/edit flows. Keep persistence and fallback semantics in
+`accountOperations`.
+
+This is the recommended path. It creates a truthful Interface for one account
+site capability without widening `accountRefresh` or turning `SiteAdapter` into
+a second flat `apiService` facade.
+
+## Design
+
+### 1. Add `AccountDataCapability`
+
+Create:
+
+```text
+src/services/apiAdapters/contracts/accountData.ts
+```
+
+Proposed Interface:
+
+```ts
+import type {
+  AccountData,
+  ApiServiceAccountRequest,
+} from "~/services/apiService/common/type"
+
+export type AccountDataRequest = ApiServiceAccountRequest
+
+export type AccountDataCapability = {
+  fetchData(request: AccountDataRequest): Promise<AccountData>
+}
+```
+
+The Interface intentionally reuses `ApiServiceAccountRequest` and
+`AccountData`. This slice changes the Seam, not the account snapshot model.
+
+Capability presence is the support signal. A missing `accountData` capability
+means the site type cannot perform live account-data loading in manual add/edit
+flows.
+
+### 2. Extend `SiteAdapter`
+
+Add:
+
+```ts
+accountData?: AccountDataCapability
+```
+
+to `src/services/apiAdapters/contracts/siteAdapter.ts`.
+
+Expected support after this slice:
+
+- New API-family Adapters expose `accountData`.
+- Sub2API exposes `accountData`.
+- AIHubMix exposes `accountData`.
+- Unsupported Adapters omit `accountData`.
+
+### 3. Add New API-Family Account Data Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/newApi/accountData.ts
+```
+
+The Adapter should delegate through the site-scoped legacy facade:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { getApiService } from "~/services/apiService"
+
+export const createNewApiAccountData = (
+  siteType: AccountSiteType,
+): AccountDataCapability => ({
+  fetchData(request) {
+    return getApiService(siteType).fetchAccountData(request)
+  },
+})
+```
+
+`createNewApiAdapter(siteType)` should attach:
+
+```ts
+accountData: createNewApiAccountData(siteType)
+```
+
+Delegating through `getApiService(siteType)` preserves existing One API/New
+API-compatible override behavior for AnyRouter, Veloera, OneHub, DoneHub,
+V-API, VoAPI, Super-API, Rix-API, Neo-API, WONG, and unknown-compatible sites
+while lower-level backend Modules remain in place.
+
+### 4. Add Sub2API Account Data Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/sub2api/accountData.ts
+```
+
+The Adapter should delegate to the existing Sub2API implementation:
+
+```ts
+import { fetchAccountData } from "~/services/apiService/sub2api"
+
+import type { AccountDataCapability } from "../contracts/accountData"
+
+export const sub2ApiAccountData: AccountDataCapability = {
+  fetchData: fetchAccountData,
+}
+```
+
+The Adapter must preserve Sub2API behavior:
+
+- load quota from the current-user endpoint
+- disable check-in
+- return zeroed today stats
+- keep any auth recovery behavior already owned by the Sub2API implementation
+
+### 5. Add AIHubMix Account Data Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/aihubmix/accountData.ts
+```
+
+The Adapter should delegate to the existing AIHubMix implementation:
+
+```ts
+import { fetchAccountData } from "~/services/apiService/aihubmix"
+
+import type { AccountDataCapability } from "../contracts/accountData"
+
+export const aihubmixAccountData: AccountDataCapability = {
+  fetchData: fetchAccountData,
+}
+```
+
+The Adapter must preserve AIHubMix behavior:
+
+- API origin normalization stays in the AIHubMix implementation.
+- Token-authenticated requests continue sending raw
+  `Authorization: <access_token>` without a `Bearer` prefix.
+- Check-in remains disabled.
+- Daily request/token/income stats remain zeroed until stable backend endpoints
+  exist.
+
+### 6. Route Manual Save Through The Adapter
+
+Modify `validateAndSaveAccount(...)` in:
+
+```text
+src/services/accounts/accountOperations.ts
+```
+
+After `normalizedSiteType`, request base URL, auth, check-in config, and
+`includeTodayCashflow` are known, resolve:
+
+```ts
+const accountData = getSiteAdapter(normalizedSiteType).accountData
+```
+
+Then replace the direct call:
+
+```ts
+getApiService(normalizedSiteType).fetchAccountData(...)
+```
+
+with:
+
+```ts
+requireAccountDataCapability(normalizedSiteType, accountData).fetchData(...)
+```
+
+The request shape must remain unchanged:
+
+```ts
+{
+  baseUrl: requestBaseUrl,
+  checkIn: checkInConfig,
+  accountId: undefined,
+  includeTodayCashflow,
+  auth: {
+    authType,
+    userId: accountIdentity,
+    accessToken: accessToken.trim(),
+    cookie:
+      authType === AuthTypeEnum.Cookie
+        ? sessionCookieHeader.trim()
+        : undefined,
+  },
+}
+```
+
+If the capability is missing, throw a local unsupported-capability error inside
+the existing `try` block. The existing catch path should then save a
+configuration-only account with warning status, matching current behavior for
+failed live data loading.
+
+### 7. Route Manual Update Through The Adapter
+
+Modify `validateAndUpdateAccount(...)` in the same file.
+
+Replace:
+
+```ts
+getApiService(normalizedSiteType).fetchAccountData(...)
+```
+
+with:
+
+```ts
+requireAccountDataCapability(normalizedSiteType, accountData).fetchData(...)
+```
+
+The request shape must remain unchanged:
+
+```ts
+{
+  baseUrl: requestBaseUrl,
+  checkIn: checkInConfig,
+  accountId,
+  includeTodayCashflow,
+  auth: {
+    authType,
+    userId: accountIdentity,
+    accessToken: accessToken.trim(),
+    cookie:
+      authType === AuthTypeEnum.Cookie
+        ? sessionCookieHeader.trim()
+        : undefined,
+  },
+}
+```
+
+If the capability is missing or live loading fails, preserve the current
+fallback-to-config-only update behavior and warning feedback.
+
+### 8. Keep Product Persistence In `accountOperations`
+
+`accountOperations` should keep ownership of:
+
+- form validation
+- manual quota conversion
+- URL normalization for storage
+- request base URL selection
+- saved account data shape
+- fallback-to-config-only save/update
+- health status assignment after save/update
+- auto-provision key scheduling after save
+- user timestamp mode for updates
+
+The Adapter only owns the backend live account snapshot. That keeps backend
+protocol facts behind the Adapter while preserving product semantics in the
+account Module.
+
+### 9. Keep Saved-Account Refresh Separate
+
+Do not route `accountStorage.refreshAccount(...)` through `accountData`.
+
+The saved refresh path should continue using `accountRefresh.refreshAccount(...)`
+because it needs a health-wrapped result and may persist auth updates for saved
+accounts.
+
+Manual add/edit live data loading should use `accountData.fetchData(...)`
+because the product Module already owns success/failure mapping.
+
+## Error Handling
+
+Adapter methods should delegate backend errors unchanged.
+
+Product behavior should stay as it is today:
+
+- Successful live data loading saves/updates the account with healthy status.
+- Live data loading failure still saves/updates configuration-only data when
+  persistence succeeds.
+- The fallback warning reason should continue using `getErrorMessage(error)`.
+- Timeout behavior in `validateAndSaveAccount(...)` remains wrapped around the
+  Adapter call.
+- Missing `accountData` capability is treated like a live data loading failure
+  in manual add/edit flows, not as a hard save/update blocker.
+
+Do not add user-facing copy for missing `accountData` in this slice.
+
+## Telemetry Decision
+
+Telemetry decision: none.
+
+This is an internal architecture migration. It does not add a new user action,
+setting, result category, or visible state. Existing account save/update
+behavior and feedback levels should remain unchanged.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E in this slice.
+
+The risk is service-layer routing and request/response preservation. Focused
+Vitest coverage at Adapter and account operation levels directly covers that
+risk. Browser runtime behavior is unchanged.
+
+## Testing Strategy
+
+Add Adapter tests:
+
+- `tests/services/apiAdapters/accountData.test.ts`
+  - New API-family `accountData` delegates to
+    `getApiService(siteType).fetchAccountData(...)`.
+  - Delegated `AccountData` is returned without reshaping.
+- `tests/services/apiAdapters/sub2api/accountData.test.ts`
+  - Sub2API `accountData` delegates to Sub2API `fetchAccountData(...)`.
+  - Check-in disabled and zeroed today stats are not reshaped by the Adapter.
+- `tests/services/apiAdapters/aihubmix/accountData.test.ts`
+  - AIHubMix `accountData` delegates to AIHubMix `fetchAccountData(...)`.
+  - Check-in disabled and zeroed daily fields remain implementation-owned.
+
+Update registry tests:
+
+- New API-family Adapters expose `accountData`.
+- Sub2API exposes `accountData`.
+- AIHubMix exposes `accountData`.
+- Unsupported Adapters omit `accountData`.
+
+Update account operation tests:
+
+- `validateAndSaveAccount(...)` calls
+  `getSiteAdapter(...).accountData.fetchData(...)` with the unchanged request
+  shape.
+- `validateAndSaveAccount(...)` preserves timeout wrapping.
+- `validateAndSaveAccount(...)` saves configuration-only data when
+  `accountData.fetchData(...)` rejects.
+- `validateAndUpdateAccount(...)` calls
+  `getSiteAdapter(...).accountData.fetchData(...)` with the unchanged request
+  shape.
+- `validateAndUpdateAccount(...)` updates configuration-only data when
+  `accountData.fetchData(...)` rejects.
+- Deferred data refresh paths still do not call `accountData`.
+- Manual balance override still wins over refreshed quota.
+- AIHubMix storage URL normalization remains unchanged.
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountData.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountOperations.validateAndSaveAccount.test.ts tests/services/accountOperations.test.ts
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Push gate before publishing:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before opening or updating a PR because this slice changes
+shared Adapter contracts and account save/update wiring.
+
+## Rollout
+
+1. Add the `accountData` contract and Adapter delegation tests.
+2. Extend `SiteAdapter`, New API-family, Sub2API, AIHubMix, and registry
+   expectations.
+3. Migrate `validateAndSaveAccount(...)` live data loading to
+   `getSiteAdapter(...).accountData`.
+4. Migrate `validateAndUpdateAccount(...)` live data loading to
+   `getSiteAdapter(...).accountData`.
+5. Re-run focused tests after each migration group.
+6. Run `pnpm compile` and `pnpm run validate:staged`.
+7. Inspect the diff for scope drift.
+8. Run `pnpm run validate:push` before pushing or opening a PR.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may migrate:
+
+- `fetchUserGroups(...)` and group coverage helpers
+- `deleteApiToken(...)` in key-management deletion flows
+- redemption through a `redemption` capability
+- a narrow import guard preventing new product Modules from importing the
+  legacy `apiService` facade
+- account-completion internals that still call `fetchSiteStatus(...)`,
+  `fetchSupportCheckIn(...)`, and `getOrCreateAccessToken(...)`
+- managed-site channel operations and model sync
+- site detection and route/status probing
+
+Do not turn `SiteAdapter` into a second flat `apiService` facade. Add each
+capability only when it hides backend-specific behavior behind a smaller
+Interface and gives real caller Leverage.

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -37,8 +37,8 @@ import {
   type AutoDetectFailureReason,
 } from "~/services/accounts/utils/autoDetectUtils"
 import { normalizeAccountSiteUrlForStorage } from "~/services/accounts/utils/siteUrlNormalization"
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
-import { getApiService } from "~/services/apiService"
 import {
   DEFAULT_PREFERENCES,
   userPreferences,
@@ -186,6 +186,20 @@ async function withTimeout<T>(
       clearTimeout(timeoutId)
     }
   }
+}
+
+const createMissingAccountDataCapabilityError = (siteType: string): Error =>
+  new Error(`accountData is not implemented for ${siteType}`)
+
+const requireAccountDataCapability = (
+  siteType: string,
+  accountData: AccountDataCapability | undefined,
+): AccountDataCapability => {
+  if (!accountData) {
+    throw createMissingAccountDataCapabilityError(siteType)
+  }
+
+  return accountData
 }
 
 /**
@@ -684,8 +698,12 @@ export async function validateAndSaveAccount(
       authType,
       userId: accountIdentity,
     })
+    const accountDataCapability = requireAccountDataCapability(
+      normalizedSiteType,
+      getSiteAdapter(normalizedSiteType).accountData,
+    )
     const freshAccountData = await withTimeout(
-      getApiService(normalizedSiteType).fetchAccountData({
+      accountDataCapability.fetchData({
         baseUrl: requestBaseUrl,
         checkIn: checkInConfig,
         accountId: undefined, // New account, no ID yet
@@ -988,9 +1006,11 @@ export async function validateAndUpdateAccount(
     })
     const includeTodayCashflow =
       (await userPreferences.getPreferences()).showTodayCashflow ?? true
-    const freshAccountData = await getApiService(
+    const accountData = requireAccountDataCapability(
       normalizedSiteType,
-    ).fetchAccountData({
+      getSiteAdapter(normalizedSiteType).accountData,
+    )
+    const freshAccountData = await accountData.fetchData({
       baseUrl: requestBaseUrl,
       checkIn: checkInConfig,
       accountId,

--- a/src/services/apiAdapters/aihubmix/accountData.ts
+++ b/src/services/apiAdapters/aihubmix/accountData.ts
@@ -1,0 +1,6 @@
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { fetchAccountData } from "~/services/apiService/aihubmix"
+
+export const aihubmixAccountData: AccountDataCapability = {
+  fetchData: (request) => fetchAccountData(request),
+}

--- a/src/services/apiAdapters/aihubmix/index.ts
+++ b/src/services/apiAdapters/aihubmix/index.ts
@@ -2,12 +2,14 @@ import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
 import { aihubmixAccountCompletion } from "./accountCompletion"
+import { aihubmixAccountData } from "./accountData"
 import { aihubmixAccountRefresh } from "./accountRefresh"
 import { aihubmixKeyManagement } from "./keyManagement"
 import { aihubmixModelPricing } from "./modelPricing"
 
 export const aihubmixAdapter: SiteAdapter = {
   siteType: SITE_TYPES.AIHUBMIX,
+  accountData: aihubmixAccountData,
   accountCompletion: aihubmixAccountCompletion,
   keyManagement: aihubmixKeyManagement,
   accountRefresh: aihubmixAccountRefresh,

--- a/src/services/apiAdapters/contracts/accountData.ts
+++ b/src/services/apiAdapters/contracts/accountData.ts
@@ -1,0 +1,10 @@
+import type {
+  AccountData,
+  ApiServiceAccountRequest,
+} from "~/services/apiService/common/type"
+
+export type AccountDataRequest = ApiServiceAccountRequest
+
+export type AccountDataCapability = {
+  fetchData(request: AccountDataRequest): Promise<AccountData>
+}

--- a/src/services/apiAdapters/contracts/siteAdapter.ts
+++ b/src/services/apiAdapters/contracts/siteAdapter.ts
@@ -1,6 +1,7 @@
 import type { AccountSiteType } from "~/constants/siteType"
 
 import type { AccountCompletionCapability } from "./accountCompletion"
+import type { AccountDataCapability } from "./accountData"
 import type { AccountRefreshCapability } from "./accountRefresh"
 import type { KeyManagementCapability } from "./keyManagement"
 import type { ModelCatalogCapability } from "./modelCatalog"
@@ -17,6 +18,7 @@ export type SiteAdapter = {
   siteAnnouncements?: SiteAnnouncementsCapability
   modelCatalog?: ModelCatalogCapability
   modelPricing?: ModelPricingCapability
+  accountData?: AccountDataCapability
   accountCompletion?: AccountCompletionCapability
   keyManagement?: KeyManagementCapability
   accountRefresh?: AccountRefreshCapability

--- a/src/services/apiAdapters/newApi/accountData.ts
+++ b/src/services/apiAdapters/newApi/accountData.ts
@@ -1,0 +1,14 @@
+import type { AccountSiteType } from "~/constants/siteType"
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { getApiService } from "~/services/apiService"
+
+/**
+ * Create account-data loading bound to the New API-family site type.
+ */
+export function createNewApiAccountData(
+  siteType: AccountSiteType,
+): AccountDataCapability {
+  return {
+    fetchData: (request) => getApiService(siteType).fetchAccountData(request),
+  }
+}

--- a/src/services/apiAdapters/newApi/index.ts
+++ b/src/services/apiAdapters/newApi/index.ts
@@ -2,6 +2,7 @@ import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
 import { newApiAccountCompletion } from "./accountCompletion"
+import { createNewApiAccountData } from "./accountData"
 import { createNewApiAccountRefresh } from "./accountRefresh"
 import { createNewApiKeyManagement } from "./keyManagement"
 import { createNewApiModelPricing } from "./modelPricing"
@@ -13,6 +14,7 @@ export const createNewApiAdapter = (
   siteType,
   family: "newApiFamily",
   siteNotice: newApiSiteNotice,
+  accountData: createNewApiAccountData(siteType),
   accountCompletion: newApiAccountCompletion,
   keyManagement: createNewApiKeyManagement(siteType),
   accountRefresh: createNewApiAccountRefresh(siteType),

--- a/src/services/apiAdapters/sub2api/accountData.ts
+++ b/src/services/apiAdapters/sub2api/accountData.ts
@@ -1,0 +1,6 @@
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { fetchAccountData } from "~/services/apiService/sub2api"
+
+export const sub2ApiAccountData: AccountDataCapability = {
+  fetchData: (request) => fetchAccountData(request),
+}

--- a/src/services/apiAdapters/sub2api/index.ts
+++ b/src/services/apiAdapters/sub2api/index.ts
@@ -2,6 +2,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
 import { sub2ApiAccountCompletion } from "./accountCompletion"
+import { sub2ApiAccountData } from "./accountData"
 import { sub2ApiAccountRefresh } from "./accountRefresh"
 import { sub2ApiKeyManagement } from "./keyManagement"
 import { sub2ApiModelCatalog } from "./modelCatalog"
@@ -12,6 +13,7 @@ export const sub2ApiAdapter: SiteAdapter = {
   family: "sub2api",
   siteAnnouncements: sub2ApiSiteAnnouncements,
   modelCatalog: sub2ApiModelCatalog,
+  accountData: sub2ApiAccountData,
   accountCompletion: sub2ApiAccountCompletion,
   keyManagement: sub2ApiKeyManagement,
   accountRefresh: sub2ApiAccountRefresh,

--- a/tests/services/accountOperations.test.ts
+++ b/tests/services/accountOperations.test.ts
@@ -14,23 +14,31 @@ import {
 import { getApiService } from "~/services/apiService"
 import { AuthTypeEnum } from "~/types"
 
-const { mockFetchAccountData, mockFetchSiteStatus, mockUpdateAccount } =
-  vi.hoisted(() => ({
-    mockFetchAccountData: vi.fn(),
-    mockFetchSiteStatus: vi.fn(),
-    mockUpdateAccount: vi.fn(),
-  }))
+const {
+  mockFetchAccountData,
+  mockFetchSiteStatus,
+  mockGetApiService,
+  mockGetSiteAdapter,
+  mockUpdateAccount,
+} = vi.hoisted(() => ({
+  mockFetchAccountData: vi.fn(),
+  mockFetchSiteStatus: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockGetSiteAdapter: vi.fn(),
+  mockUpdateAccount: vi.fn(),
+}))
 
 vi.mock("~/services/apiService", async (importOriginal) => {
   const actual = await importOriginal<typeof import("~/services/apiService")>()
   return {
     ...actual,
-    getApiService: vi.fn(() => ({
-      fetchAccountData: mockFetchAccountData,
-      fetchSiteStatus: mockFetchSiteStatus,
-    })),
+    getApiService: mockGetApiService,
   }
 })
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: mockGetSiteAdapter,
+}))
 
 vi.mock("~/services/accounts/accountStorage", async (importOriginal) => {
   const actual =
@@ -49,7 +57,17 @@ describe("accountOperations", () => {
   beforeEach(() => {
     mockFetchAccountData.mockReset()
     mockFetchSiteStatus.mockReset()
+    mockGetApiService.mockReset()
+    mockGetSiteAdapter.mockReset()
     mockUpdateAccount.mockReset()
+    mockGetApiService.mockReturnValue({
+      fetchSiteStatus: mockFetchSiteStatus,
+    })
+    mockGetSiteAdapter.mockReturnValue({
+      accountData: {
+        fetchData: mockFetchAccountData,
+      },
+    })
   })
 
   describe("validateAndUpdateAccount", () => {
@@ -215,7 +233,8 @@ describe("accountOperations", () => {
       )
 
       expect(result.success).toBe(true)
-      expect(vi.mocked(getApiService)).toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
+      const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
+      expect(vi.mocked(getSiteAdapter)).toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
       expect(mockUpdateAccount).toHaveBeenCalledWith(
         "account-1",
         expect.objectContaining({

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -13,11 +13,17 @@ import {
 } from "~/services/preferences/userPreferences"
 import { AuthTypeEnum, SiteHealthStatus, type CheckInConfig } from "~/types"
 
-const { fetchAccountDataMock, ensureDefaultApiTokenForAccountMock } =
-  vi.hoisted(() => ({
-    fetchAccountDataMock: vi.fn(),
-    ensureDefaultApiTokenForAccountMock: vi.fn(),
-  }))
+const {
+  fetchAccountDataMock,
+  getApiServiceMock,
+  getSiteAdapterMock,
+  ensureDefaultApiTokenForAccountMock,
+} = vi.hoisted(() => ({
+  fetchAccountDataMock: vi.fn(),
+  getApiServiceMock: vi.fn(),
+  getSiteAdapterMock: vi.fn(),
+  ensureDefaultApiTokenForAccountMock: vi.fn(),
+}))
 
 vi.mock("react-hot-toast", () => ({
   default: {
@@ -29,9 +35,11 @@ vi.mock("react-hot-toast", () => ({
 }))
 
 vi.mock("~/services/apiService", () => ({
-  getApiService: vi.fn(() => ({
-    fetchAccountData: fetchAccountDataMock,
-  })),
+  getApiService: getApiServiceMock,
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: getSiteAdapterMock,
 }))
 
 vi.mock(
@@ -78,6 +86,14 @@ describe("accountOperations validateAndSaveAccount", () => {
       ...DEFAULT_PREFERENCES,
       autoProvisionKeyOnAccountAdd: false,
       showTodayCashflow: false,
+    })
+    getApiServiceMock.mockReturnValue({
+      fetchAccountData: fetchAccountDataMock,
+    })
+    getSiteAdapterMock.mockReturnValue({
+      accountData: {
+        fetchData: fetchAccountDataMock,
+      },
     })
   })
 
@@ -215,6 +231,8 @@ describe("accountOperations validateAndSaveAccount", () => {
       today_income: 0,
       checkIn: CHECK_IN_DISABLED,
     })
+    getApiServiceMock.mockClear()
+    getSiteAdapterMock.mockClear()
 
     const result = await validateAndUpdateAccount(
       accountId,
@@ -233,6 +251,8 @@ describe("accountOperations validateAndSaveAccount", () => {
     )
 
     expect(result.success).toBe(true)
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.AIHUBMIX)
+    expect(getApiServiceMock).not.toHaveBeenCalled()
 
     const saved = await accountStorage.getAccountById(accountId)
     expect(saved?.site_url).toBe("https://console.aihubmix.com")
@@ -291,6 +311,115 @@ describe("accountOperations validateAndSaveAccount", () => {
         username: "",
         access_token: "access-123",
         quota: 0,
+      },
+    })
+  })
+
+  it("saves warning-only account data when accountData capability is missing", async () => {
+    getSiteAdapterMock.mockReturnValueOnce({})
+
+    const result = await validateAndSaveAccount(
+      "https://unsupported.example.invalid",
+      "Unsupported Portal",
+      "tester",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result).toMatchObject({
+      success: true,
+      message: "messages:warnings.accountSavedWithoutDataRefresh",
+      feedbackLevel: "warning",
+    })
+    expect(fetchAccountDataMock).not.toHaveBeenCalled()
+
+    const saved = await accountStorage.getAccountById(result.accountId!)
+    expect(saved).toMatchObject({
+      site_name: "Unsupported Portal",
+      health: {
+        status: SiteHealthStatus.Warning,
+        reason: "accountData is not implemented for new-api",
+      },
+      account_info: {
+        id: "1",
+        username: "tester",
+        access_token: "token",
+        quota: 0,
+      },
+    })
+  })
+
+  it("updates warning-only account data when accountData capability is missing", async () => {
+    const accountId = await accountStorage.addAccount({
+      site_name: "Old Example",
+      site_url: "https://old.example.com",
+      site_type: SITE_TYPES.NEW_API,
+      health: { status: SiteHealthStatus.Healthy },
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      excludeFromTotalBalance: false,
+      excludeFromTodayIncome: false,
+      exchange_rate: 7,
+      notes: "",
+      tagIds: [],
+      checkIn: CHECK_IN_DISABLED,
+      account_info: {
+        id: "previous-id",
+        access_token: "old-token",
+        username: "old-user",
+        quota: 42,
+        today_prompt_tokens: 1,
+        today_completion_tokens: 2,
+        today_quota_consumption: 3,
+        today_requests_count: 4,
+        today_income: 5,
+      },
+      last_sync_time: 123,
+    })
+    getSiteAdapterMock.mockReturnValue({})
+
+    const result = await validateAndUpdateAccount(
+      accountId,
+      "https://unsupported.example.invalid",
+      "Unsupported Portal",
+      "tester",
+      "token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      SITE_TYPES.NEW_API,
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result).toMatchObject({
+      success: true,
+      message: "messages:warnings.accountUpdatedWithoutDataRefresh",
+      feedbackLevel: "warning",
+    })
+    expect(fetchAccountDataMock).not.toHaveBeenCalled()
+
+    const updated = await accountStorage.getAccountById(accountId)
+    expect(updated).toMatchObject({
+      site_name: "Unsupported Portal",
+      health: {
+        status: SiteHealthStatus.Warning,
+        reason: "accountData is not implemented for new-api",
+      },
+      account_info: {
+        id: "1",
+        username: "tester",
+        access_token: "token",
+        quota: 42,
       },
     })
   })
@@ -478,7 +607,7 @@ describe("accountOperations validateAndSaveAccount", () => {
   })
 
   it("normalizes unsupported site types before saving", async () => {
-    const { getApiService } = await import("~/services/apiService")
+    const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
     fetchAccountDataMock.mockResolvedValueOnce({
       quota: 12,
       today_prompt_tokens: 0,
@@ -505,7 +634,7 @@ describe("accountOperations validateAndSaveAccount", () => {
     )
 
     expect(result.success).toBe(true)
-    expect(getApiService).toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
+    expect(getSiteAdapter).toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
 
     const saved = await accountStorage.getAccountById(result.accountId!)
     expect(saved?.site_type).toBe(SITE_TYPES.UNKNOWN)
@@ -673,6 +802,9 @@ describe("accountOperations validateAndSaveAccount", () => {
   })
 
   it("allows New API-family account sites to update non-canonical string user ids", async () => {
+    getApiServiceMock.mockClear()
+    getSiteAdapterMock.mockClear()
+
     for (const userId of ["1.5", "1e3", "-1", "0", "001"]) {
       const accountId = await accountStorage.addAccount({
         site_name: "Test Site",
@@ -740,6 +872,9 @@ describe("accountOperations validateAndSaveAccount", () => {
     }
 
     expect(fetchAccountDataMock).toHaveBeenCalledTimes(5)
+    expect(getSiteAdapterMock).toHaveBeenCalledTimes(5)
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(getApiServiceMock).not.toHaveBeenCalled()
   })
 
   it("allows AIHubMix to save a stable username identity", async () => {

--- a/tests/services/apiAdapters/accountData.test.ts
+++ b/tests/services/apiAdapters/accountData.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { aihubmixAccountData } from "~/services/apiAdapters/aihubmix/accountData"
+import { createNewApiAccountData } from "~/services/apiAdapters/newApi/accountData"
+import { sub2ApiAccountData } from "~/services/apiAdapters/sub2api/accountData"
+import type { AccountData } from "~/services/apiService/common/type"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockAihubmixFetchAccountData,
+  mockFetchAccountData,
+  mockGetApiService,
+  mockSub2ApiFetchAccountData,
+} = vi.hoisted(() => ({
+  mockAihubmixFetchAccountData: vi.fn(),
+  mockFetchAccountData: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockSub2ApiFetchAccountData: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  fetchAccountData: mockSub2ApiFetchAccountData,
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  fetchAccountData: mockAihubmixFetchAccountData,
+}))
+
+const request = {
+  baseUrl: "https://api.example.invalid",
+  accountId: "account-1",
+  checkIn: {
+    enableDetection: true,
+    autoCheckInEnabled: true,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+  },
+  includeTodayCashflow: false,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "user-1",
+    accessToken: "account-token",
+  },
+}
+
+const accountData: AccountData = {
+  quota: 123,
+  today_prompt_tokens: 1,
+  today_completion_tokens: 2,
+  today_quota_consumption: 3,
+  today_requests_count: 4,
+  today_income: 5,
+  checkIn: request.checkIn,
+}
+
+const disabledCheckInAccountData: AccountData = {
+  quota: 9800,
+  today_prompt_tokens: 0,
+  today_completion_tokens: 0,
+  today_quota_consumption: 0,
+  today_requests_count: 0,
+  today_income: 0,
+  checkIn: {
+    enableDetection: false,
+    siteStatus: {
+      isCheckedInToday: undefined,
+    },
+  },
+}
+
+describe("apiAdapter accountData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiService.mockReturnValue({
+      fetchAccountData: mockFetchAccountData,
+    })
+  })
+
+  it("delegates New API-family account data through the site-specific apiService", async () => {
+    mockFetchAccountData.mockResolvedValueOnce(accountData)
+
+    const accountDataCapability = createNewApiAccountData(SITE_TYPES.ONE_HUB)
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+
+    await expect(accountDataCapability.fetchData(request)).resolves.toBe(
+      accountData,
+    )
+
+    expect(mockGetApiService).toHaveBeenCalledOnce()
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.ONE_HUB)
+    expect(mockFetchAccountData).toHaveBeenCalledOnce()
+    expect(mockFetchAccountData).toHaveBeenCalledWith(request)
+  })
+
+  it("delegates Sub2API account data without reshaping disabled check-in or zeroed stats", async () => {
+    mockSub2ApiFetchAccountData.mockResolvedValueOnce(
+      disabledCheckInAccountData,
+    )
+
+    await expect(sub2ApiAccountData.fetchData(request)).resolves.toBe(
+      disabledCheckInAccountData,
+    )
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+    expect(mockSub2ApiFetchAccountData).toHaveBeenCalledOnce()
+    expect(mockSub2ApiFetchAccountData).toHaveBeenCalledWith(request)
+  })
+
+  it("delegates AIHubMix account data without reshaping disabled check-in or zeroed fields", async () => {
+    mockAihubmixFetchAccountData.mockResolvedValueOnce(
+      disabledCheckInAccountData,
+    )
+
+    await expect(aihubmixAccountData.fetchData(request)).resolves.toBe(
+      disabledCheckInAccountData,
+    )
+
+    expect(mockGetApiService).not.toHaveBeenCalled()
+    expect(mockAihubmixFetchAccountData).toHaveBeenCalledOnce()
+    expect(mockAihubmixFetchAccountData).toHaveBeenCalledWith(request)
+  })
+})

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -30,6 +30,9 @@ describe("apiAdapters registry", () => {
       fetchCheckInSupport: expect.any(Function),
       refreshAccount: expect.any(Function),
     })
+    expect(adapter.accountData).toEqual({
+      fetchData: expect.any(Function),
+    })
     expect(adapter.modelPricing).toBeUndefined()
     expect(adapter.siteNotice).toBeUndefined()
   })
@@ -71,6 +74,9 @@ describe("apiAdapters registry", () => {
         fetchCheckInSupport: expect.any(Function),
         refreshAccount: expect.any(Function),
       })
+      expect(adapter.accountData).toEqual({
+        fetchData: expect.any(Function),
+      })
       expect(adapter.modelPricing).toEqual({
         fetchPricing: expect.any(Function),
       })
@@ -96,6 +102,9 @@ describe("apiAdapters registry", () => {
     expect(adapter.accountRefresh).toEqual({
       fetchCheckInSupport: expect.any(Function),
       refreshAccount: expect.any(Function),
+    })
+    expect(adapter.accountData).toEqual({
+      fetchData: expect.any(Function),
     })
     expect(adapter.modelPricing).toEqual({
       fetchPricing: expect.any(Function),


### PR DESCRIPTION
## Summary
- Add a SiteAdapter accountData capability and provider adapters for New API-family, Sub2API, and AIHubMix.
- Route manual account save/update live data loading through accountData adapters while preserving warning fallback behavior.
- Add adapter and account operation regression coverage.

## Test Plan
- pnpm vitest run tests/services/apiAdapters/accountData.test.ts tests/services/apiAdapters/registry.test.ts
- pnpm vitest run tests/services/accountOperations.validateAndSaveAccount.test.ts tests/services/accountOperations.test.ts
- pnpm compile
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Account save and update operations now safely proceed with warning status when live data cannot be loaded, enabling fallback to configuration-only mode instead of potential failures.

* **Refactor**
  * Modernized account data retrieval architecture for improved consistency and maintainability across all site adapter implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->