### PR TITLE
refactor(api-adapters): route key management lifecycle through adapters

### DIFF
--- a/docs/superpowers/plans/2026-06-19-api-adapter-key-management-lifecycle.md
+++ b/docs/superpowers/plans/2026-06-19-api-adapter-key-management-lifecycle.md
@@ -1,0 +1,1747 @@
+# API Adapter Key Management Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deepen `SiteAdapter.keyManagement` so account token deletion, group lookup, available-model lookup, group coverage repair, and secondary token inventory reads no longer call the legacy `getApiService(...)` facade from product modules.
+
+**Architecture:** Extend the existing key-management adapter instead of adding a parallel capability. Backend protocol modules remain the delegated implementations; product code asks `createDisplayAccountApiContext(...)` and `requireDisplayAccountKeyManagement(...)` for the site-specific token lifecycle surface.
+
+**Tech Stack:** TypeScript, React hooks/components, WXT extension services, existing `apiAdapters`, Vitest, `pnpm run validate:staged`, `pnpm run validate:push`.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-api-adapter-key-management-lifecycle-design.md`
+
+---
+
+## File Structure
+
+- Modify `src/services/apiAdapters/contracts/keyManagement.ts`
+  - Adds `deleteToken(...)`, `fetchUserGroups(...)`, and `fetchAvailableModels(...)` to the existing `KeyManagementCapability`.
+- Modify `src/services/apiAdapters/newApi/keyManagement.ts`
+  - Delegates the new methods to the site-bound `getApiService(siteType)` implementation.
+- Modify `src/services/apiAdapters/sub2api/keyManagement.ts`
+  - Delegates the new methods to Sub2API backend helpers.
+- Modify `src/services/apiAdapters/aihubmix/keyManagement.ts`
+  - Delegates the new methods to AIHubMix backend helpers.
+- Modify `tests/services/apiAdapters/keyManagement.test.ts`
+  - Covers delegation for delete, groups, and available models.
+- Modify `tests/services/apiAdapters/registry.test.ts`
+  - Verifies registered key-management adapters expose the widened method set.
+- Modify `src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts`
+  - Loads model and group bootstrap data through `keyManagement`.
+- Modify `tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx`
+  - Mocks adapter-backed bootstrap data.
+- Modify `src/services/accounts/accountOperations.ts`
+  - Routes `resolveSub2ApiQuickCreateResolution(...)` group lookup through `keyManagement`.
+- Modify `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+  - Moves Sub2API quick-create group mocks from `getApiService(...)` to adapter `keyManagement.fetchUserGroups(...)`.
+- Modify `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+  - Keeps post-save behavior covered after quick-create group lookup moves to the adapter.
+- Modify `src/features/KeyManagement/hooks/useKeyManagement.ts`
+  - Loads and deletes Key Management page tokens through `keyManagement`.
+- Modify `tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx`
+  - Migrates token inventory and delete mocks to adapter key-management mocks.
+- Modify `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+  - Routes group coverage list/group/create/delete operations through `keyManagement`.
+- Modify `tests/services/accountKeyGroupCoverage.test.ts`
+  - Migrates group coverage mocks and delete assertions to the adapter method signatures.
+- Modify `src/components/KiloCodeExportDialog.tsx`
+  - Loads token inventory through `keyManagement`.
+- Modify `tests/components/KiloCodeExportDialog.test.tsx`
+  - Updates inventory mocks to `getSiteAdapter(...).keyManagement.fetchTokens(...)`.
+- Modify `src/components/dialogs/VerifyApiDialog/index.tsx`
+  - Loads account-source token inventory through `keyManagement`.
+- Modify `tests/components/VerifyApiDialog.test.tsx`
+  - Updates account-source token mocks to the adapter path.
+- Modify `src/components/dialogs/VerifyCliSupportDialog/index.tsx`
+  - Loads account-source token inventory through `keyManagement`.
+- Modify `tests/components/VerifyCliSupportDialog.test.tsx`
+  - Updates the `apiServiceRequest` partial mock for the new imports.
+- Modify `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`
+  - Loads and refetches account tokens through `keyManagement`.
+- Modify `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`
+  - Updates Channel dialog token inventory mocks to the adapter path.
+
+Do not modify:
+
+- `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+  - Token list/create already uses `keyManagement`; only its quick-create dependency changes through `accountOperations.ts`.
+- `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+  - Default-token list/create already uses `keyManagement`.
+- `src/services/apiService/**`
+  - Existing backend functions stay as delegated implementations.
+- locale files, telemetry schemas, settings search files, Playwright tests, redemption code, managed-site provider/channel CRUD, or new site-type definitions.
+
+---
+
+### Task 1: Extend Key Management Adapter Lifecycle Methods
+
+**Files:**
+- Modify: `src/services/apiAdapters/contracts/keyManagement.ts`
+- Modify: `src/services/apiAdapters/newApi/keyManagement.ts`
+- Modify: `src/services/apiAdapters/sub2api/keyManagement.ts`
+- Modify: `src/services/apiAdapters/aihubmix/keyManagement.ts`
+- Modify: `tests/services/apiAdapters/keyManagement.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Update adapter delegation tests for the widened interface**
+
+In `tests/services/apiAdapters/keyManagement.test.ts`, extend the hoisted mocks:
+
+```ts
+const {
+  mockAihubmixCreateApiToken,
+  mockAihubmixDeleteApiToken,
+  mockAihubmixFetchAccountAvailableModels,
+  mockAihubmixFetchAccountTokens,
+  mockAihubmixFetchUserGroups,
+  mockAihubmixResolveApiTokenKey,
+  mockCreateApiToken,
+  mockDeleteApiToken,
+  mockFetchAccountAvailableModels,
+  mockFetchAccountTokens,
+  mockFetchUserGroups,
+  mockGetApiService,
+  mockResolveApiTokenKey,
+  mockSub2ApiCreateApiToken,
+  mockSub2ApiDeleteApiToken,
+  mockSub2ApiFetchAccountAvailableModels,
+  mockSub2ApiFetchAccountTokens,
+  mockSub2ApiFetchUserGroups,
+  mockSub2ApiResolveApiTokenKey,
+} = vi.hoisted(() => ({
+  mockAihubmixCreateApiToken: vi.fn(),
+  mockAihubmixDeleteApiToken: vi.fn(),
+  mockAihubmixFetchAccountAvailableModels: vi.fn(),
+  mockAihubmixFetchAccountTokens: vi.fn(),
+  mockAihubmixFetchUserGroups: vi.fn(),
+  mockAihubmixResolveApiTokenKey: vi.fn(),
+  mockCreateApiToken: vi.fn(),
+  mockDeleteApiToken: vi.fn(),
+  mockFetchAccountAvailableModels: vi.fn(),
+  mockFetchAccountTokens: vi.fn(),
+  mockFetchUserGroups: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockResolveApiTokenKey: vi.fn(),
+  mockSub2ApiCreateApiToken: vi.fn(),
+  mockSub2ApiDeleteApiToken: vi.fn(),
+  mockSub2ApiFetchAccountAvailableModels: vi.fn(),
+  mockSub2ApiFetchAccountTokens: vi.fn(),
+  mockSub2ApiFetchUserGroups: vi.fn(),
+  mockSub2ApiResolveApiTokenKey: vi.fn(),
+}))
+```
+
+Update the Sub2API module mock:
+
+```ts
+vi.mock("~/services/apiService/sub2api", () => ({
+  createApiToken: mockSub2ApiCreateApiToken,
+  deleteApiToken: mockSub2ApiDeleteApiToken,
+  fetchAccountAvailableModels: mockSub2ApiFetchAccountAvailableModels,
+  fetchAccountTokens: mockSub2ApiFetchAccountTokens,
+  fetchUserGroups: mockSub2ApiFetchUserGroups,
+  resolveApiTokenKey: mockSub2ApiResolveApiTokenKey,
+}))
+```
+
+Update the AIHubMix module mock:
+
+```ts
+vi.mock("~/services/apiService/aihubmix", () => ({
+  createApiToken: mockAihubmixCreateApiToken,
+  deleteApiToken: mockAihubmixDeleteApiToken,
+  fetchAccountAvailableModels: mockAihubmixFetchAccountAvailableModels,
+  fetchAccountTokens: mockAihubmixFetchAccountTokens,
+  fetchUserGroups: mockAihubmixFetchUserGroups,
+  resolveApiTokenKey: mockAihubmixResolveApiTokenKey,
+}))
+```
+
+In `beforeEach`, return the widened site-specific service:
+
+```ts
+mockGetApiService.mockReturnValue({
+  createApiToken: mockCreateApiToken,
+  deleteApiToken: mockDeleteApiToken,
+  fetchAccountAvailableModels: mockFetchAccountAvailableModels,
+  fetchAccountTokens: mockFetchAccountTokens,
+  fetchUserGroups: mockFetchUserGroups,
+  resolveApiTokenKey: mockResolveApiTokenKey,
+})
+```
+
+Add shared test data after `tokenData`:
+
+```ts
+const userGroups = {
+  default: { desc: "Default", ratio: 1 },
+  vip: { desc: "VIP", ratio: 2 },
+}
+
+const availableModels = ["gpt-4o-mini", "claude-3-haiku"]
+```
+
+Extend the New API-family test:
+
+```ts
+mockDeleteApiToken.mockResolvedValueOnce(true)
+mockFetchUserGroups.mockResolvedValueOnce(userGroups)
+mockFetchAccountAvailableModels.mockResolvedValueOnce(availableModels)
+
+await expect(
+  keyManagement.deleteToken({ request, tokenId: token.id }),
+).resolves.toBe(true)
+await expect(keyManagement.fetchUserGroups(request)).resolves.toBe(userGroups)
+await expect(keyManagement.fetchAvailableModels(request)).resolves.toBe(
+  availableModels,
+)
+
+expect(mockDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+expect(mockFetchUserGroups).toHaveBeenCalledWith(request)
+expect(mockFetchAccountAvailableModels).toHaveBeenCalledWith(request)
+```
+
+Extend the Sub2API test:
+
+```ts
+mockSub2ApiDeleteApiToken.mockResolvedValueOnce(true)
+mockSub2ApiFetchUserGroups.mockResolvedValueOnce(userGroups)
+mockSub2ApiFetchAccountAvailableModels.mockResolvedValueOnce(availableModels)
+
+await expect(
+  sub2ApiKeyManagement.deleteToken({ request, tokenId: token.id }),
+).resolves.toBe(true)
+await expect(sub2ApiKeyManagement.fetchUserGroups(request)).resolves.toBe(
+  userGroups,
+)
+await expect(sub2ApiKeyManagement.fetchAvailableModels(request)).resolves.toBe(
+  availableModels,
+)
+
+expect(mockSub2ApiDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+expect(mockSub2ApiFetchUserGroups).toHaveBeenCalledWith(request)
+expect(mockSub2ApiFetchAccountAvailableModels).toHaveBeenCalledWith(request)
+```
+
+Extend the AIHubMix test:
+
+```ts
+mockAihubmixDeleteApiToken.mockResolvedValueOnce(true)
+mockAihubmixFetchUserGroups.mockResolvedValueOnce(userGroups)
+mockAihubmixFetchAccountAvailableModels.mockResolvedValueOnce(availableModels)
+
+await expect(
+  aihubmixKeyManagement.deleteToken({ request, tokenId: token.id }),
+).resolves.toBe(true)
+await expect(aihubmixKeyManagement.fetchUserGroups(request)).resolves.toBe(
+  userGroups,
+)
+await expect(aihubmixKeyManagement.fetchAvailableModels(request)).resolves.toBe(
+  availableModels,
+)
+
+expect(mockAihubmixDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+expect(mockAihubmixFetchUserGroups).toHaveBeenCalledWith(request)
+expect(mockAihubmixFetchAccountAvailableModels).toHaveBeenCalledWith(request)
+```
+
+- [ ] **Step 2: Update registry expectations**
+
+In `tests/services/apiAdapters/registry.test.ts`, replace each `adapter.keyManagement` expectation with:
+
+```ts
+expect(adapter.keyManagement).toEqual({
+  fetchTokens: expect.any(Function),
+  createToken: expect.any(Function),
+  resolveTokenKey: expect.any(Function),
+  deleteToken: expect.any(Function),
+  fetchUserGroups: expect.any(Function),
+  fetchAvailableModels: expect.any(Function),
+})
+```
+
+Apply this to the Sub2API test, the New API-family loop, and the AIHubMix test.
+
+- [ ] **Step 3: Run adapter tests and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because `KeyManagementCapability` does not yet include `deleteToken`, `fetchUserGroups`, or `fetchAvailableModels`.
+
+- [ ] **Step 4: Extend the key-management contract**
+
+Modify `src/services/apiAdapters/contracts/keyManagement.ts` to include `UserGroupInfo` and `DeleteTokenRequest`:
+
+```ts
+import type {
+  ApiServiceRequest,
+  CreateTokenRequest,
+  CreateTokenResult,
+  UserGroupInfo,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+
+export type FetchAccountTokensOptions = {
+  page?: number
+  size?: number
+}
+
+export type ResolveTokenSecretRequest<
+  TToken extends Pick<ApiToken, "id" | "key"> = Pick<ApiToken, "id" | "key">,
+> = {
+  request: ApiServiceRequest
+  token: TToken
+}
+
+export type DeleteTokenRequest = {
+  request: ApiServiceRequest
+  tokenId: number
+}
+
+export type KeyManagementCapability = {
+  fetchTokens(
+    request: ApiServiceRequest,
+    options?: FetchAccountTokensOptions,
+  ): Promise<ApiToken[]>
+  createToken(
+    request: ApiServiceRequest,
+    tokenData: CreateTokenRequest,
+  ): Promise<CreateTokenResult>
+  resolveTokenKey<TToken extends Pick<ApiToken, "id" | "key">>(
+    request: ResolveTokenSecretRequest<TToken>,
+  ): Promise<string>
+  deleteToken(request: DeleteTokenRequest): Promise<boolean | void>
+  fetchUserGroups(
+    request: ApiServiceRequest,
+  ): Promise<Record<string, UserGroupInfo>>
+  fetchAvailableModels(request: ApiServiceRequest): Promise<string[]>
+}
+```
+
+- [ ] **Step 5: Extend New API-family key management**
+
+Modify `src/services/apiAdapters/newApi/keyManagement.ts`:
+
+```ts
+export function createNewApiKeyManagement(
+  siteType: AccountSiteType,
+): KeyManagementCapability {
+  return {
+    fetchTokens: (request, options) =>
+      getApiService(siteType).fetchAccountTokens(
+        request,
+        options?.page,
+        options?.size,
+      ),
+    createToken: (request, tokenData) =>
+      getApiService(siteType).createApiToken(request, tokenData),
+    resolveTokenKey: ({ request, token }) =>
+      getApiService(siteType).resolveApiTokenKey(request, token),
+    deleteToken: ({ request, tokenId }) =>
+      getApiService(siteType).deleteApiToken(request, tokenId),
+    fetchUserGroups: (request) =>
+      getApiService(siteType).fetchUserGroups(request),
+    fetchAvailableModels: (request) =>
+      getApiService(siteType).fetchAccountAvailableModels(request),
+  }
+}
+```
+
+- [ ] **Step 6: Extend Sub2API key management**
+
+Modify `src/services/apiAdapters/sub2api/keyManagement.ts`:
+
+```ts
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import {
+  createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
+  fetchAccountTokens,
+  fetchUserGroups,
+  resolveApiTokenKey,
+} from "~/services/apiService/sub2api"
+
+export const sub2ApiKeyManagement: KeyManagementCapability = {
+  fetchTokens: (request, options) =>
+    fetchAccountTokens(request, options?.page, options?.size),
+  createToken: (request, tokenData) => createApiToken(request, tokenData),
+  resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
+  deleteToken: ({ request, tokenId }) => deleteApiToken(request, tokenId),
+  fetchUserGroups: (request) => fetchUserGroups(request),
+  fetchAvailableModels: (request) => fetchAccountAvailableModels(request),
+}
+```
+
+- [ ] **Step 7: Extend AIHubMix key management**
+
+Modify `src/services/apiAdapters/aihubmix/keyManagement.ts`:
+
+```ts
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import {
+  createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
+  fetchAccountTokens,
+  fetchUserGroups,
+  resolveApiTokenKey,
+} from "~/services/apiService/aihubmix"
+
+export const aihubmixKeyManagement: KeyManagementCapability = {
+  fetchTokens: (request) => fetchAccountTokens(request),
+  createToken: (request, tokenData) => createApiToken(request, tokenData),
+  resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
+  deleteToken: ({ request, tokenId }) => deleteApiToken(request, tokenId),
+  fetchUserGroups: (request) => fetchUserGroups(request),
+  fetchAvailableModels: (request) => fetchAccountAvailableModels(request),
+}
+```
+
+- [ ] **Step 8: Run adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit adapter lifecycle methods**
+
+Run:
+
+```powershell
+git add src/services/apiAdapters/contracts/keyManagement.ts src/services/apiAdapters/newApi/keyManagement.ts src/services/apiAdapters/sub2api/keyManagement.ts src/services/apiAdapters/aihubmix/keyManagement.ts tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts
+git commit -m "refactor(api-adapters): extend key management lifecycle"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 2: Route Add Token Bootstrap And Sub2API Quick-Create Groups
+
+**Files:**
+- Modify: `src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts`
+- Modify: `tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx`
+- Modify: `src/services/accounts/accountOperations.ts`
+- Modify: `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+- Modify: `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+
+- [ ] **Step 1: Update `useTokenData` tests to mock adapter key-management bootstrap methods**
+
+In `tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx`, update the `apiServiceRequest` mock:
+
+```ts
+vi.mock("~/services/accounts/utils/apiServiceRequest", () => ({
+  createDisplayAccountApiContext: (...args: any[]) =>
+    createDisplayAccountApiContextMock(...args),
+  requireDisplayAccountKeyManagement: (
+    _account: unknown,
+    keyManagement: unknown,
+  ) => keyManagement,
+}))
+```
+
+In `beforeEach`, return `keyManagement` instead of `service`:
+
+```ts
+createDisplayAccountApiContextMock.mockReturnValue({
+  keyManagement: {
+    fetchAvailableModels: fetchAccountAvailableModelsMock,
+    fetchUserGroups: fetchUserGroupsMock,
+  },
+  request: { accountId: ACCOUNT.id },
+})
+```
+
+Keep the existing assertions against `fetchAccountAvailableModelsMock` and `fetchUserGroupsMock`; those function names can remain as test-local legacy names even though the adapter method is `fetchAvailableModels(...)`.
+
+- [ ] **Step 2: Update Sub2API quick-create tests to source groups from the adapter**
+
+In `tests/services/accountOperations.ensureAccountApiToken.test.ts`, extend the `getSiteAdapterMock` key-management object:
+
+```ts
+getSiteAdapterMock: vi.fn(() => ({
+  keyManagement: {
+    fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+    createToken: (...args: unknown[]) => createApiTokenMock(...args),
+    resolveTokenKey: vi.fn(),
+    deleteToken: vi.fn(),
+    fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
+    fetchAvailableModels: vi.fn(),
+  },
+})),
+```
+
+Replace the `~/services/apiService` mock with an inert facade for this test file:
+
+```ts
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => ({})),
+  }
+})
+```
+
+In `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`, make the same `keyManagement.fetchUserGroups` addition:
+
+```ts
+getSiteAdapterMock: vi.fn(() => ({
+  keyManagement: {
+    fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+    createToken: (...args: unknown[]) => createApiTokenMock(...args),
+    resolveTokenKey: vi.fn(),
+    deleteToken: vi.fn(),
+    fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
+    fetchAvailableModels: vi.fn(),
+  },
+})),
+```
+
+Replace that file's `~/services/apiService` mock with:
+
+```ts
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => ({})),
+  }
+})
+```
+
+- [ ] **Step 3: Run affected tests and verify the expected failures**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+```
+
+Expected: FAIL because `useTokenData.ts` and `resolveSub2ApiQuickCreateResolution(...)` still call `service.fetchAccountAvailableModels(...)` and `service.fetchUserGroups(...)`.
+
+- [ ] **Step 4: Route Add Token bootstrap data through key management**
+
+Modify `src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts`.
+
+Replace the import:
+
+```ts
+import { createDisplayAccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+with:
+
+```ts
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Replace the context and bootstrap load block:
+
+```ts
+const { service, request } =
+  createDisplayAccountApiContext(currentAccount)
+
+const [models, groupsData] = await Promise.all([
+  service.fetchAccountAvailableModels(request),
+  service.fetchUserGroups(request).catch((error) => {
+    if (isFeatureUnsupportedError(error)) {
+      return EMPTY_USER_GROUPS
+    }
+
+    throw error
+  }),
+])
+```
+
+with:
+
+```ts
+const { keyManagement, request } =
+  createDisplayAccountApiContext(currentAccount)
+const capability = requireDisplayAccountKeyManagement(
+  currentAccount,
+  keyManagement,
+)
+
+const [models, groupsData] = await Promise.all([
+  capability.fetchAvailableModels(request),
+  capability.fetchUserGroups(request).catch((error) => {
+    if (isFeatureUnsupportedError(error)) {
+      return EMPTY_USER_GROUPS
+    }
+
+    throw error
+  }),
+])
+```
+
+Do not change the group defaulting block below this code.
+
+- [ ] **Step 5: Route Sub2API quick-create group lookup through key management**
+
+Modify `src/services/accounts/accountOperations.ts`.
+
+Replace the group lookup in `resolveSub2ApiQuickCreateResolution(...)`:
+
+```ts
+const { service, request } = createDisplayAccountApiContext(account)
+const groups = await service.fetchUserGroups(request)
+```
+
+with:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(account)
+const groups = await requireDisplayAccountKeyManagement(
+  account,
+  keyManagement,
+).fetchUserGroups(request)
+```
+
+Keep `getApiService(...)` imports and uses that support other account operations outside this function.
+
+- [ ] **Step 6: Run affected tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit bootstrap and quick-create migration**
+
+Run:
+
+```powershell
+git add src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx src/services/accounts/accountOperations.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+git commit -m "refactor(key-management): load groups and models through adapters"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 3: Route Key Management Page Inventory And Delete
+
+**Files:**
+- Modify: `src/features/KeyManagement/hooks/useKeyManagement.ts`
+- Modify: `tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx`
+
+- [ ] **Step 1: Add an adapter registry mock to the Key Management hook tests**
+
+In `tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx`, add this import:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+Add this module mock near the existing `~/services/apiService` mock:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(),
+}))
+```
+
+Add this helper after `createWrapper()`:
+
+```ts
+const createAdapterWithKeyManagement = (overrides: {
+  fetchTokens?: ReturnType<typeof vi.fn>
+  createToken?: ReturnType<typeof vi.fn>
+  resolveTokenKey?: ReturnType<typeof vi.fn>
+  deleteToken?: ReturnType<typeof vi.fn>
+  fetchUserGroups?: ReturnType<typeof vi.fn>
+  fetchAvailableModels?: ReturnType<typeof vi.fn>
+} = {}) => ({
+  siteType: SITE_TYPES.NEW_API,
+  keyManagement: {
+    fetchTokens: overrides.fetchTokens ?? vi.fn().mockResolvedValue([]),
+    createToken: overrides.createToken ?? vi.fn(),
+    resolveTokenKey:
+      overrides.resolveTokenKey ??
+      vi.fn(async ({ token }: { token: { key: string } }) => token.key),
+    deleteToken: overrides.deleteToken ?? vi.fn().mockResolvedValue(undefined),
+    fetchUserGroups: overrides.fetchUserGroups ?? vi.fn().mockResolvedValue({}),
+    fetchAvailableModels:
+      overrides.fetchAvailableModels ?? vi.fn().mockResolvedValue([]),
+  },
+})
+```
+
+In the top-level `beforeEach`, reset the adapter mock:
+
+```ts
+vi.mocked(getSiteAdapter).mockReset()
+vi.mocked(getSiteAdapter).mockReturnValue(createAdapterWithKeyManagement() as any)
+vi.mocked(getApiService).mockReset()
+vi.mocked(getApiService).mockReturnValue({} as any)
+```
+
+This file should no longer rely on `getApiService(...)` for token inventory, deletion, reveal, or copy behavior after the test migration is complete.
+
+- [ ] **Step 2: Replace inventory mock setup**
+
+In `tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx`, replace each token inventory setup shaped like:
+
+```ts
+vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+```
+
+or:
+
+```ts
+mockedGetApiService.mockReturnValue({ fetchAccountTokens } as any)
+```
+
+with:
+
+```ts
+vi.mocked(getSiteAdapter).mockReturnValue(
+  createAdapterWithKeyManagement({
+    fetchTokens: fetchAccountTokens,
+  }) as any,
+)
+vi.mocked(getApiService).mockReturnValue({} as any)
+```
+
+Keep existing assertions against `fetchAccountTokens`; the same local mock is now called through `keyManagement.fetchTokens(...)`.
+
+- [ ] **Step 3: Replace secret-resolution mock setup and expectations**
+
+In reveal/copy tests, replace setup shaped like:
+
+```ts
+const resolveApiTokenKey = vi.fn().mockResolvedValue(resolvedKey)
+vi.mocked(getApiService).mockReturnValue({
+  fetchAccountTokens,
+  resolveApiTokenKey,
+} as any)
+```
+
+with:
+
+```ts
+const resolveTokenKey = vi.fn().mockResolvedValue(resolvedKey)
+vi.mocked(getSiteAdapter).mockReturnValue(
+  createAdapterWithKeyManagement({
+    fetchTokens: fetchAccountTokens,
+    resolveTokenKey,
+  }) as any,
+)
+vi.mocked(getApiService).mockReturnValue({} as any)
+```
+
+Replace assertions shaped like:
+
+```ts
+expect(resolveApiTokenKey).toHaveBeenCalledTimes(1)
+```
+
+with:
+
+```ts
+expect(resolveTokenKey).toHaveBeenCalledTimes(1)
+```
+
+For copy-only tests that do not load inventory first, use:
+
+```ts
+const resolveTokenKey = vi.fn().mockResolvedValue("resolved-token-secret")
+vi.mocked(getSiteAdapter).mockReturnValue(
+  createAdapterWithKeyManagement({
+    resolveTokenKey,
+  }) as any,
+)
+vi.mocked(getApiService).mockReturnValue({} as any)
+```
+
+For resolver failure tests, use the same `resolveTokenKey` setup with `mockRejectedValue(...)` and keep the existing toast and analytics assertions unchanged.
+
+- [ ] **Step 4: Replace delete mock setup and expectations**
+
+In each delete test, replace:
+
+```ts
+const deleteApiToken = vi.fn().mockResolvedValue(undefined)
+vi.mocked(getApiService).mockReturnValue({
+  fetchAccountTokens,
+  deleteApiToken,
+} as any)
+```
+
+with:
+
+```ts
+const deleteToken = vi.fn().mockResolvedValue(undefined)
+vi.mocked(getSiteAdapter).mockReturnValue(
+  createAdapterWithKeyManagement({
+    fetchTokens: fetchAccountTokens,
+    deleteToken,
+  }) as any,
+)
+vi.mocked(getApiService).mockReturnValue({} as any)
+```
+
+Replace expectations shaped like:
+
+```ts
+expect(deleteApiToken).toHaveBeenCalledWith(expect.anything(), token.id)
+```
+
+with:
+
+```ts
+expect(deleteToken).toHaveBeenCalledWith({
+  request: expect.anything(),
+  tokenId: token.id,
+})
+```
+
+For the test that asserts the numeric token id `303`, use:
+
+```ts
+expect(deleteToken).toHaveBeenCalledWith({
+  request: expect.anything(),
+  tokenId: 303,
+})
+```
+
+- [ ] **Step 5: Run the hook test and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+```
+
+Expected: FAIL because `useKeyManagement.ts` still calls `service.fetchAccountTokens(...)` and `service.deleteApiToken(...)`.
+
+- [ ] **Step 6: Route inventory loading through key management**
+
+Modify `src/features/KeyManagement/hooks/useKeyManagement.ts`.
+
+Ensure the import from `apiServiceRequest` includes the guard:
+
+```ts
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Replace the load block:
+
+```ts
+const { service, request } = createDisplayAccountApiContext(account)
+const tokens = await service.fetchAccountTokens(request)
+```
+
+with:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(account)
+const tokens = await requireDisplayAccountKeyManagement(
+  account,
+  keyManagement,
+).fetchTokens(request)
+```
+
+Keep the existing non-array validation block.
+
+- [ ] **Step 7: Route delete through key management**
+
+In `handleDeleteToken(...)`, replace:
+
+```ts
+const { service, request } = createDisplayAccountApiContext(account)
+await service.deleteApiToken(request, token.id)
+```
+
+with:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(account)
+await requireDisplayAccountKeyManagement(account, keyManagement).deleteToken({
+  request,
+  tokenId: token.id,
+})
+```
+
+Keep optimistic local removal, managed-site status invalidation, toasts, analytics, and reload behavior unchanged.
+
+- [ ] **Step 8: Run the hook test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Confirm direct legacy calls are gone from the hook**
+
+Run:
+
+```powershell
+rg -n "fetchAccountTokens|deleteApiToken|service\\." src/features/KeyManagement/hooks/useKeyManagement.ts
+```
+
+Expected: no matches for `fetchAccountTokens`, `deleteApiToken`, or `service.`.
+
+- [ ] **Step 10: Commit Key Management page migration**
+
+Run:
+
+```powershell
+git add src/features/KeyManagement/hooks/useKeyManagement.ts tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+git commit -m "refactor(key-management): route page lifecycle through adapters"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 4: Route Group Coverage And Invalid-Token Repair
+
+**Files:**
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+- Modify: `tests/services/accountKeyGroupCoverage.test.ts`
+
+- [ ] **Step 1: Update group coverage tests to mock the adapter registry**
+
+In `tests/services/accountKeyGroupCoverage.test.ts`, replace:
+
+```ts
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+  return {
+    ...actual,
+    getApiService: vi.fn(() => mocks),
+  }
+})
+```
+
+with:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(() => ({
+    keyManagement: {
+      fetchTokens: (...args: unknown[]) => mocks.fetchAccountTokens(...args),
+      fetchUserGroups: (...args: unknown[]) => mocks.fetchUserGroups(...args),
+      createToken: (...args: unknown[]) => mocks.createApiToken(...args),
+      deleteToken: (...args: unknown[]) => mocks.deleteApiToken(...args),
+      resolveTokenKey: vi.fn(),
+      fetchAvailableModels: vi.fn(),
+    },
+  })),
+}))
+```
+
+Keep the `mocks` object names unchanged to reduce churn:
+
+```ts
+const mocks = vi.hoisted(() => ({
+  fetchAccountTokens: vi.fn(),
+  fetchUserGroups: vi.fn(),
+  createApiToken: vi.fn(),
+  deleteApiToken: vi.fn(),
+}))
+```
+
+Update invalid-token deletion assertions from:
+
+```ts
+expect(mocks.deleteApiToken).toHaveBeenCalledWith(expect.anything(), 9)
+```
+
+to:
+
+```ts
+expect(mocks.deleteApiToken).toHaveBeenCalledWith({
+  request: expect.anything(),
+  tokenId: 9,
+})
+```
+
+Use the same object expectation for any other `deleteApiToken` call assertions in this file.
+
+- [ ] **Step 2: Run group coverage tests and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountKeyGroupCoverage.test.ts
+```
+
+Expected: FAIL because `groupCoverage.ts` still imports `getApiService(...)` and calls `service.fetchAccountTokens(...)`, `service.fetchUserGroups(...)`, `service.createApiToken(...)`, and `service.deleteApiToken(...)`.
+
+- [ ] **Step 3: Route group coverage through key management**
+
+Modify `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`.
+
+Replace:
+
+```ts
+import { getApiService } from "~/services/apiService"
+```
+
+with:
+
+```ts
+import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+In `ensureAccountKeysForAvailableGroups(...)`, replace:
+
+```ts
+const service = getApiService(displaySiteData.siteType)
+const request = createAccountApiRequest(account, displaySiteData)
+const accountId = displaySiteData.id || account.id
+
+const tokens = await service.fetchAccountTokens(request)
+```
+
+with:
+
+```ts
+const keyManagement = requireDisplayAccountKeyManagement(
+  displaySiteData,
+  getSiteAdapter(displaySiteData.siteType).keyManagement,
+)
+const request = createAccountApiRequest(account, displaySiteData)
+const accountId = displaySiteData.id || account.id
+
+const tokens = await keyManagement.fetchTokens(request)
+```
+
+Replace:
+
+```ts
+const groupsData = await service.fetchUserGroups(request)
+```
+
+with:
+
+```ts
+const groupsData = await keyManagement.fetchUserGroups(request)
+```
+
+Replace default token creation:
+
+```ts
+await service.createApiToken(request, generateDefaultTokenRequest())
+```
+
+with:
+
+```ts
+await keyManagement.createToken(request, generateDefaultTokenRequest())
+```
+
+Replace group token creation:
+
+```ts
+await service.createApiToken(
+  request,
+  buildGroupDefaultTokenRequest(group),
+)
+```
+
+with:
+
+```ts
+await keyManagement.createToken(request, buildGroupDefaultTokenRequest(group))
+```
+
+- [ ] **Step 4: Route invalid-token deletion through key management**
+
+In `deleteInvalidAccountToken(...)`, replace:
+
+```ts
+const service = getApiService(displaySiteData.siteType)
+const request = createAccountApiRequest(account, displaySiteData)
+await service.deleteApiToken(request, token.tokenId)
+```
+
+with:
+
+```ts
+const keyManagement = requireDisplayAccountKeyManagement(
+  displaySiteData,
+  getSiteAdapter(displaySiteData.siteType).keyManagement,
+)
+const request = createAccountApiRequest(account, displaySiteData)
+await keyManagement.deleteToken({
+  request,
+  tokenId: token.tokenId,
+})
+```
+
+- [ ] **Step 5: Run group coverage tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountKeyGroupCoverage.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Confirm the group coverage module no longer imports the legacy facade**
+
+Run:
+
+```powershell
+rg -n "getApiService|fetchAccountTokens|fetchUserGroups|createApiToken|deleteApiToken" src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+```
+
+Expected: no matches.
+
+- [ ] **Step 7: Commit group coverage migration**
+
+Run:
+
+```powershell
+git add src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts tests/services/accountKeyGroupCoverage.test.ts
+git commit -m "refactor(accounts): audit group keys through adapters"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 5: Route Secondary Token Inventory Surfaces
+
+**Files:**
+- Modify: `src/components/KiloCodeExportDialog.tsx`
+- Modify: `tests/components/KiloCodeExportDialog.test.tsx`
+- Modify: `src/components/dialogs/VerifyApiDialog/index.tsx`
+- Modify: `tests/components/VerifyApiDialog.test.tsx`
+- Modify: `src/components/dialogs/VerifyCliSupportDialog/index.tsx`
+- Modify: `tests/components/VerifyCliSupportDialog.test.tsx`
+- Modify: `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`
+- Modify: `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`
+
+- [ ] **Step 1: Update Kilo Code export tests**
+
+In `tests/components/KiloCodeExportDialog.test.tsx`, add a registry mock after the existing `~/services/apiService` mock:
+
+```ts
+const mockGetSiteAdapter = vi.fn()
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: (...args: unknown[]) => mockGetSiteAdapter(...args),
+}))
+```
+
+In `beforeEach`, add:
+
+```ts
+mockGetSiteAdapter.mockReset()
+mockGetSiteAdapter.mockReturnValue({
+  keyManagement: {
+    fetchTokens: (...args: unknown[]) => mockFetchAccountTokens(...args),
+    createToken: vi.fn(),
+    resolveTokenKey: (...args: unknown[]) => mockResolveApiTokenKey(...args),
+    deleteToken: vi.fn(),
+    fetchUserGroups: (...args: unknown[]) => mockFetchUserGroups(...args),
+    fetchAvailableModels: (...args: unknown[]) =>
+      mockFetchAccountAvailableModels(...args),
+  },
+})
+```
+
+Keep `mockGetApiService` only for any remaining non-inventory legacy service calls in this test file. If `rg -n "mockGetApiService|getApiService" tests/components/KiloCodeExportDialog.test.tsx` shows no remaining uses after this task, remove the dead mock.
+
+- [ ] **Step 2: Update Verify API dialog tests**
+
+In `tests/components/VerifyApiDialog.test.tsx`, replace the token inventory `apiService` mock with an adapter registry mock.
+
+Add:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => mockFetchAccountTokens(...args),
+      createToken: vi.fn(),
+      resolveTokenKey: async ({ token }: { token: { key: string } }) =>
+        token.key,
+      deleteToken: vi.fn(),
+      fetchUserGroups: vi.fn(),
+      fetchAvailableModels: vi.fn(),
+    },
+  }),
+}))
+```
+
+Replace:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: () => ({
+    fetchAccountTokens: (...args: any[]) => mockFetchAccountTokens(...args),
+    resolveApiTokenKey: async (_request: unknown, token: { key: string }) =>
+      token.key,
+  }),
+}))
+```
+
+with:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: () => ({}),
+}))
+```
+
+- [ ] **Step 3: Update Verify CLI support dialog tests**
+
+In `tests/components/VerifyCliSupportDialog.test.tsx`, replace the `apiServiceRequest` mock with a partial mock that exposes the new imports:
+
+```ts
+vi.mock(
+  "~/services/accounts/utils/apiServiceRequest",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/accounts/utils/apiServiceRequest")
+      >()
+
+    return {
+      ...actual,
+      createDisplayAccountApiContext: (account: any) => ({
+        keyManagement: {
+          fetchTokens: (...args: any[]) => mockFetchAccountTokens(...args),
+          createToken: vi.fn(),
+          resolveTokenKey: vi.fn(),
+          deleteToken: vi.fn(),
+          fetchUserGroups: vi.fn(),
+          fetchAvailableModels: vi.fn(),
+        },
+        request: {
+          baseUrl: account.baseUrl,
+          accountId: account.id,
+          auth: {
+            authType: account.authType,
+            userId: account.userId,
+            accessToken: account.token,
+            cookie: account.cookieAuthSessionCookie,
+          },
+        },
+      }),
+      requireDisplayAccountKeyManagement: (
+        _account: unknown,
+        keyManagement: unknown,
+      ) => keyManagement,
+      resolveDisplayAccountTokenForSecret: (...args: any[]) =>
+        mockResolveDisplayAccountTokenForSecret(...args),
+    }
+  },
+)
+```
+
+Replace the `~/services/apiService` mock with:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: () => ({}),
+}))
+```
+
+- [ ] **Step 4: Update Channel dialog tests**
+
+In `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`, replace the token inventory `apiService` mock with a registry-backed key-management mock:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => mockFetchAccountTokens(...args),
+      createToken: vi.fn(),
+      resolveTokenKey: ({ request, token }: any) =>
+        mockResolveApiTokenKey(request, token),
+      deleteToken: vi.fn(),
+      fetchUserGroups: vi.fn(),
+      fetchAvailableModels: vi.fn(),
+    },
+  }),
+}))
+```
+
+Replace the existing `~/services/apiService` mock with:
+
+```ts
+vi.mock("~/services/apiService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/services/apiService")>()
+
+  return {
+    ...actual,
+    getApiService: vi.fn(() => ({})),
+  }
+})
+```
+
+Keep every assertion against `mockFetchAccountTokens`; only the route to that mock changes.
+
+- [ ] **Step 5: Run secondary surface tests and verify expected failures**
+
+Run:
+
+```powershell
+pnpm vitest run tests/components/KiloCodeExportDialog.test.tsx tests/components/VerifyApiDialog.test.tsx tests/components/VerifyCliSupportDialog.test.tsx tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: FAIL because the source components still use `getApiService(...).fetchAccountTokens(...)` or `service.fetchAccountTokens(...)`.
+
+- [ ] **Step 6: Migrate Kilo Code export token inventory loading**
+
+Modify `src/components/KiloCodeExportDialog.tsx`.
+
+Replace:
+
+```ts
+import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import { getApiService } from "~/services/apiService"
+```
+
+with:
+
+```ts
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Delete the `buildFetchTokenArgs(...)` helper.
+
+Replace:
+
+```ts
+const service = getApiService(site.siteType)
+const tokens = await service.fetchAccountTokens(
+  buildFetchTokenArgs(site),
+)
+```
+
+with:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(site)
+const tokens = await requireDisplayAccountKeyManagement(
+  site,
+  keyManagement,
+).fetchTokens(request)
+```
+
+Keep the existing non-array handling and error message behavior.
+
+- [ ] **Step 7: Migrate Verify API dialog token inventory loading**
+
+Modify `src/components/dialogs/VerifyApiDialog/index.tsx`.
+
+Replace:
+
+```ts
+import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import { getApiService } from "~/services/apiService"
+```
+
+with:
+
+```ts
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Replace the token load call:
+
+```ts
+const accountTokens = await getApiService(
+  account.siteType,
+).fetchAccountTokens({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+```
+
+with:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(account)
+const accountTokens = await requireDisplayAccountKeyManagement(
+  account,
+  keyManagement,
+).fetchTokens(request)
+```
+
+Do not change compatible-token filtering, history loading, probe execution, or analytics.
+
+- [ ] **Step 8: Migrate Verify CLI support token inventory loading**
+
+Modify `src/components/dialogs/VerifyCliSupportDialog/index.tsx`.
+
+Replace:
+
+```ts
+import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import { getApiService } from "~/services/apiService"
+```
+
+with:
+
+```ts
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Replace the account-source load call:
+
+```ts
+const accountTokens = await getApiService(
+  account.siteType,
+).fetchAccountTokens({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+```
+
+with:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(account)
+const accountTokens = await requireDisplayAccountKeyManagement(
+  account,
+  keyManagement,
+).fetchTokens(request)
+```
+
+Keep the profile-source branch unchanged.
+
+- [ ] **Step 9: Migrate Channel dialog token inventory loading and refetching**
+
+Modify `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`.
+
+Update the import:
+
+```ts
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+In `openSub2ApiTokenCreationDialog(...)`, replace:
+
+```ts
+const { service, request } = createDisplayAccountApiContext(account)
+const existingTokens = await service.fetchAccountTokens(request)
+```
+
+with:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(account)
+const existingTokens = await requireDisplayAccountKeyManagement(
+  account,
+  keyManagement,
+).fetchTokens(request)
+```
+
+In `openCredentialDuplicateWarning(...)`, replace the service/request locals:
+
+```ts
+let accountApiService:
+  | ReturnType<typeof createDisplayAccountApiContext>["service"]
+  | null = null
+let accountApiRequest:
+  | ReturnType<typeof createDisplayAccountApiContext>["request"]
+  | null = null
+```
+
+with:
+
+```ts
+let accountKeyManagement:
+  | NonNullable<ReturnType<typeof createDisplayAccountApiContext>["keyManagement"]>
+  | null = null
+let accountApiRequest:
+  | ReturnType<typeof createDisplayAccountApiContext>["request"]
+  | null = null
+```
+
+Replace the initial inventory load:
+
+```ts
+const accountApiContext =
+  createDisplayAccountApiContext(displaySiteData)
+accountApiService = accountApiContext.service
+accountApiRequest = accountApiContext.request
+const existingTokens =
+  await accountApiService.fetchAccountTokens(accountApiRequest)
+```
+
+with:
+
+```ts
+const accountApiContext =
+  createDisplayAccountApiContext(displaySiteData)
+accountKeyManagement = requireDisplayAccountKeyManagement(
+  displaySiteData,
+  accountApiContext.keyManagement,
+)
+accountApiRequest = accountApiContext.request
+const existingTokens = await accountKeyManagement.fetchTokens(accountApiRequest)
+```
+
+Replace the refetch block:
+
+```ts
+const refetchedTokens =
+  accountApiService && accountApiRequest
+    ? await accountApiService.fetchAccountTokens(
+        accountApiRequest,
+      )
+    : null
+```
+
+with:
+
+```ts
+const refetchedTokens =
+  accountKeyManagement && accountApiRequest
+    ? await accountKeyManagement.fetchTokens(accountApiRequest)
+    : null
+```
+
+Keep `Array.isArray(...)` guards, token-id diff selection, duplicate warning behavior, and cancellation guards unchanged.
+
+- [ ] **Step 10: Run secondary surface tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/components/KiloCodeExportDialog.test.tsx tests/components/VerifyApiDialog.test.tsx tests/components/VerifyCliSupportDialog.test.tsx tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit secondary surface migration**
+
+Run:
+
+```powershell
+git add src/components/KiloCodeExportDialog.tsx tests/components/KiloCodeExportDialog.test.tsx src/components/dialogs/VerifyApiDialog/index.tsx tests/components/VerifyApiDialog.test.tsx src/components/dialogs/VerifyCliSupportDialog/index.tsx tests/components/VerifyCliSupportDialog.test.tsx src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+git commit -m "refactor(dialogs): load account tokens through adapters"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 6: Final Validation And Scope Audit
+
+**Files:**
+- Review all task-scoped files changed in Tasks 1-5.
+
+- [ ] **Step 1: Run focused adapter and service tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused UI hook and dialog tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx tests/components/KiloCodeExportDialog.test.tsx tests/components/VerifyApiDialog.test.tsx tests/components/VerifyCliSupportDialog.test.tsx tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run related validation for changed source files**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/contracts/keyManagement.ts src/services/apiAdapters/newApi/keyManagement.ts src/services/apiAdapters/sub2api/keyManagement.ts src/services/apiAdapters/aihubmix/keyManagement.ts src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts src/services/accounts/accountOperations.ts src/features/KeyManagement/hooks/useKeyManagement.ts src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts src/components/KiloCodeExportDialog.tsx src/components/dialogs/VerifyApiDialog/index.tsx src/components/dialogs/VerifyCliSupportDialog/index.tsx src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+```
+
+Expected: PASS. If `vitest related` expands to unrelated long-running suites or times out, classify that as tooling and keep the focused suites plus `pnpm compile` as the primary evidence.
+
+- [ ] **Step 4: Run TypeScript compile**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Audit remaining legacy token lifecycle calls in migrated surfaces**
+
+Run:
+
+```powershell
+rg -n "fetchAccountTokens|deleteApiToken|fetchUserGroups|fetchAccountAvailableModels|getApiService\\(" src/features/KeyManagement src/services/accounts/accountKeyAutoProvisioning src/components/KiloCodeExportDialog.tsx src/components/dialogs/VerifyApiDialog src/components/dialogs/VerifyCliSupportDialog src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+```
+
+Expected remaining matches:
+
+```text
+src/components/dialogs/ChannelDialog/hooks/useChannelForm.ts
+```
+
+`useChannelForm.ts` may still use `getApiService(...).fetchUserGroups(...)` for managed-site channel form group loading; that managed-site channel flow is out of scope for this key-management lifecycle slice. No migrated file should match direct `fetchAccountTokens`, `deleteApiToken`, `fetchAccountAvailableModels`, or `getApiService(...)` for account token lifecycle.
+
+- [ ] **Step 6: Run commit gate**
+
+Run:
+
+```powershell
+git status --porcelain=v1
+pnpm run validate:staged
+```
+
+Expected: `validate:staged` passes for task-scoped staged files. Existing unrelated untracked files may remain untracked and must not be staged.
+
+- [ ] **Step 7: Run push gate before publishing**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. This gate is required before pushing or opening a PR because this slice changes shared adapter contracts and multiple token-workflow call sites.
+
+- [ ] **Step 8: Inspect final diff scope**
+
+If tasks were committed individually, run:
+
+```powershell
+git show --stat --oneline HEAD~5..HEAD
+git diff --name-status HEAD~5..HEAD
+```
+
+Expected changed files are limited to:
+
+```text
+src/services/apiAdapters/contracts/keyManagement.ts
+src/services/apiAdapters/newApi/keyManagement.ts
+src/services/apiAdapters/sub2api/keyManagement.ts
+src/services/apiAdapters/aihubmix/keyManagement.ts
+src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts
+src/services/accounts/accountOperations.ts
+src/features/KeyManagement/hooks/useKeyManagement.ts
+src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+src/components/KiloCodeExportDialog.tsx
+src/components/dialogs/VerifyApiDialog/index.tsx
+src/components/dialogs/VerifyCliSupportDialog/index.tsx
+src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+tests/services/apiAdapters/keyManagement.test.ts
+tests/services/apiAdapters/registry.test.ts
+tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx
+tests/services/accountOperations.ensureAccountApiToken.test.ts
+tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+tests/services/accountKeyGroupCoverage.test.ts
+tests/components/KiloCodeExportDialog.test.tsx
+tests/components/VerifyApiDialog.test.tsx
+tests/components/VerifyCliSupportDialog.test.tsx
+tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+No locale files, telemetry schema, settings search files, Playwright tests, redemption logic, managed-site provider/channel CRUD, account completion internals, model pricing assembly, or new site types should be changed.
+
+- [ ] **Step 9: Record execution notes**
+
+Before handing off, report:
+
+```text
+Focused tests:
+- pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+- pnpm vitest run tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx tests/components/KiloCodeExportDialog.test.tsx tests/components/VerifyApiDialog.test.tsx tests/components/VerifyCliSupportDialog.test.tsx tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+
+Validation:
+- pnpm compile
+- pnpm run validate:staged
+- pnpm run validate:push
+
+Telemetry decision:
+- Reuse existing telemetry. No new user action, setting, or analytics field was added.
+
+Settings search decision:
+- None. No settings UI, route, anchor, or search definition changed.
+
+E2E decision:
+- No new Playwright E2E. This refactor changes service-layer routing and hook/component mocked-token loading paths covered by Vitest; browser runtime behavior is unchanged.
+```
+
+---
+
+## Out Of Scope
+
+- Do not add a new site type.
+- Do not migrate redemption or `redeemCode(...)`.
+- Do not migrate managed-site channel CRUD, channel status checks, model sync, provider registration, or `useChannelForm.ts` managed-site group loading.
+- Do not migrate account completion internals such as `fetchSiteStatus(...)`, `fetchSupportCheckIn(...)`, or `getOrCreateAccessToken(...)`.
+- Do not move model pricing assembly, Sub2API estimated pricing, or `PricingResponse` construction.
+- Do not introduce a provisioning policy engine.
+- Do not remove `getApiService(...)` or `ApiServiceCapabilities` globally.
+- Do not add an import guard in this slice.
+- Do not change user-facing copy, locale keys, telemetry schema, settings search entries, or Playwright E2E tests.
+
+## Self-Review
+
+- Spec coverage: Task 1 widens `KeyManagementCapability` and adapter implementations for New API-family, Sub2API, and AIHubMix. Task 2 migrates Add Token model/group bootstrap and Sub2API quick-create group resolution. Task 3 migrates Key Management page inventory and deletion. Task 4 migrates group coverage and invalid-token repair. Task 5 migrates secondary token inventory surfaces. Task 6 covers validation, telemetry, settings search, E2E, and scope audit.
+- Scope control: The plan does not touch redemption, managed-site CRUD, account completion internals, pricing assembly, new site types, locale files, telemetry schema, settings search, or Playwright tests.
+- Type consistency: The plan consistently uses `KeyManagementCapability.fetchTokens(request, options)`, `createToken(request, tokenData)`, `resolveTokenKey({ request, token })`, `deleteToken({ request, tokenId })`, `fetchUserGroups(request)`, and `fetchAvailableModels(request)`.
+- Compatibility: `createDisplayAccountApiContext(...)` remains the display-account request source, so Sub2API auth-session decoration is preserved for account-scoped reads. Stored-account create request behavior remains owned by existing post-save/default-token helpers and is not changed in this slice.

--- a/docs/superpowers/specs/2026-06-19-api-adapter-key-management-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-06-19-api-adapter-key-management-lifecycle-design.md
@@ -1,0 +1,703 @@
+# API Adapter Key Management Lifecycle Design
+
+Date: 2026-06-19
+
+## Purpose
+
+Deepen the existing `keyManagement` Adapter Interface so a newly added account
+site type can define its token lifecycle, group metadata, and token creation
+model metadata in its Adapter Module instead of requiring product Modules to
+call the legacy `getApiService(...)` facade.
+
+Recent adapter slices moved site announcements, runtime model catalog loading,
+account completion, key management list/create/reveal, account refresh,
+Sub2API stored-auth recovery, model pricing, and account data behind
+`getSiteAdapter(siteType)`. Those slices make a new account site type
+detectable, saveable, refreshable, price-aware, and able to create or reveal
+basic API keys. The remaining high-friction account usability path is key
+management after the first key exists: deleting keys, loading group choices,
+loading token model choices, repairing group coverage, and loading token
+inventory from secondary dialogs still reaches through the legacy facade.
+
+## Current Context
+
+The current `SiteAdapter` Interface exposes:
+
+```ts
+type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  modelPricing?: ModelPricingCapability
+  accountData?: AccountDataCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+}
+```
+
+The current `KeyManagementCapability` Interface exposes only:
+
+```ts
+type KeyManagementCapability = {
+  fetchTokens(request, options?): Promise<ApiToken[]>
+  createToken(request, tokenData): Promise<CreateTokenResult>
+  resolveTokenKey({ request, token }): Promise<string>
+}
+```
+
+That already covers the first migration slice for token inventory, token
+creation, and token secret resolution. The remaining legacy key-management
+paths are still spread across product Modules:
+
+- `src/features/KeyManagement/hooks/useKeyManagement.ts`
+  - loads token inventories through `service.fetchAccountTokens(...)`
+  - deletes tokens through `service.deleteApiToken(...)`
+- `src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts`
+  - loads token model choices through `service.fetchAccountAvailableModels(...)`
+  - loads group choices through `service.fetchUserGroups(...)`
+- `src/services/accounts/accountOperations.ts`
+  - `resolveSub2ApiQuickCreateResolution(...)` loads Sub2API groups through
+    `service.fetchUserGroups(...)`
+- `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+  - loads tokens, groups, creates group keys, and deletes invalid tokens through
+    `getApiService(siteType)`
+- secondary token inventory surfaces still call `getApiService(...)` or the
+  transitional `service` from `createDisplayAccountApiContext(...)`:
+  - `src/components/KiloCodeExportDialog.tsx`
+  - `src/components/dialogs/VerifyApiDialog/index.tsx`
+  - `src/components/dialogs/VerifyCliSupportDialog/index.tsx`
+  - `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`
+
+The backend implementations already vary:
+
+- New API-family compatible sites expose token list/create/reveal/delete,
+  available models, and user groups through the compatible implementation plus
+  site-specific overrides.
+- Sub2API supports token list/create/reveal/delete, user groups, and available
+  models, but default creation requires a current group and may require user
+  selection when multiple groups are available.
+- AIHubMix supports token list/create/reveal/delete and available models, but
+  group lookup is unsupported and created API keys must be treated as one-time
+  secrets when the full key is returned.
+
+## Problem
+
+`keyManagement` is currently a real Seam, but the Interface is still too
+shallow for the product workflows that users actually exercise.
+
+Current friction:
+
+1. New non-compatible account site types can implement token list/create/reveal
+   in `apiAdapters`, but still need legacy `apiService` wiring before users can
+   delete keys, load group choices, or load model choices in token dialogs.
+2. Product Modules still need to know which legacy facade method corresponds to
+   each token-adjacent behavior.
+3. Group-aware provisioning and invalid-token repair still mock and call the
+   wide `apiService` facade even though the behavior only needs a narrow
+   key-management Interface.
+4. Secondary token inventory surfaces may skip the Sub2API session-decorated
+   request returned by `createDisplayAccountApiContext(...)`, which increases
+   the chance that a new site type or auth recovery path works in Key
+   Management but fails elsewhere.
+5. Tests for token lifecycle behavior are split between adapter mocks and
+   legacy service mocks, so they do not make the Adapter Interface the common
+   test surface.
+
+Deletion test: if direct product calls to
+`fetchAccountTokens(...)`, `createApiToken(...)`, `deleteApiToken(...)`,
+`fetchUserGroups(...)`, and `fetchAccountAvailableModels(...)` are deleted
+outside `apiAdapters` and backend implementations, the complexity should not
+reappear as raw `siteType` branches in product Modules. Backend token
+lifecycle facts should sit behind `SiteAdapter.keyManagement`.
+
+## Goals
+
+- Deepen the existing `KeyManagementCapability` Interface instead of adding a
+  parallel key metadata capability.
+- Route account-token lifecycle calls through
+  `getSiteAdapter(siteType).keyManagement`:
+  - list tokens
+  - create tokens
+  - reveal or resolve token secrets
+  - delete tokens
+  - load user groups for token creation and group coverage
+  - load available model ids for token model-limit controls
+- Preserve existing request shapes and the split between display-account reads
+  and stored-account create requests.
+- Preserve existing product behavior:
+  - Key Management inventory loading, all-account partial failures, retry, and
+    analytics
+  - token deletion optimistic local removal, reload behavior, toasts, and
+    analytics
+  - Add Token model/group bootstrap behavior and unsupported-group fallback
+  - Sub2API quick-create resolution
+  - group coverage repair results and invalid-token deletion records
+  - AIHubMix one-time secret handling
+  - Sub2API auth-session decoration from `createDisplayAccountApiContext(...)`
+- Provide Adapter implementations for:
+  - New API-family compatible account sites
+  - Sub2API
+  - AIHubMix
+- Keep the legacy `getApiService(...)` facade available for non-migrated
+  capabilities.
+- Add focused Adapter, account-helper, hook, and dialog regression tests.
+
+## Non-Goals
+
+- Do not add a new site type in this slice.
+- Do not migrate redemption or `redeemCode(...)`.
+- Do not migrate managed-site channel CRUD, managed-site channel status checks,
+  managed-site model sync, or managed-site provider registration.
+- Do not migrate account completion internals such as `fetchSiteStatus(...)`,
+  `fetchSupportCheckIn(...)`, or `getOrCreateAccessToken(...)`.
+- Do not move model pricing assembly, Sub2API estimated pricing, or
+  `PricingResponse` construction.
+- Do not introduce a generic provisioning policy engine in this slice.
+  Sub2API group-selection and AIHubMix one-time-secret product semantics stay
+  in account/key workflow Modules while their backend operations move through
+  the Adapter Interface.
+- Do not remove `getApiService(...)` or `ApiServiceCapabilities` globally.
+- Do not add an import guard in this slice.
+- Do not change user-facing copy, locale keys, telemetry schema, settings
+  search entries, or Playwright E2E tests.
+
+## Approaches Considered
+
+### Approach A: Keep The Remaining Calls On `apiService`
+
+This keeps the current behavior and avoids widening `KeyManagementCapability`.
+
+It leaves new site type support split across two Seams: basic token operations
+sit in `apiAdapters`, while delete, groups, and model metadata still require
+legacy facade wiring. That keeps the Interface shallow and makes the next site
+adapter harder to reason about.
+
+### Approach B: Add Separate `keyMetadata` And `keyDeletion` Capabilities
+
+This would avoid adding more methods to `keyManagement`, but it fragments one
+product concept across several small Interfaces. Product Modules would need to
+ask for multiple related capabilities before rendering one token workflow.
+
+That fails the Depth test: the caller learns more Interface surface without
+getting more Leverage.
+
+### Approach C: Deepen `KeyManagementCapability`
+
+Add delete, group, and available-model operations to the existing
+`keyManagement` Interface, then migrate all direct token lifecycle callers to
+that Interface.
+
+This is the recommended path. It keeps one truthful Adapter Seam for account
+token management. The Interface grows, but the caller gets more Leverage:
+token list/create/reveal/delete and creation metadata are all available from
+one Module.
+
+### Approach D: Move All Default-Token Provisioning Policy Into Adapters
+
+Adapters could return a high-level "create default token plan" that hides
+Sub2API group-selection and AIHubMix one-time-secret policy.
+
+That is too much for this slice. Those rules are product semantics tied to
+which workflow is running: background auto-provision, post-save automation, and
+interactive creation do not have identical UX constraints. This slice should
+move backend operations first; a later slice can decide whether a deeper
+provisioning policy Interface is worth introducing.
+
+## Design
+
+### 1. Extend `KeyManagementCapability`
+
+Modify:
+
+```text
+src/services/apiAdapters/contracts/keyManagement.ts
+```
+
+Proposed Interface:
+
+```ts
+import type {
+  ApiServiceRequest,
+  CreateTokenRequest,
+  CreateTokenResult,
+  UserGroupInfo,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+
+export type FetchAccountTokensOptions = {
+  page?: number
+  size?: number
+}
+
+export type ResolveTokenSecretRequest<
+  TToken extends Pick<ApiToken, "id" | "key"> = Pick<ApiToken, "id" | "key">,
+> = {
+  request: ApiServiceRequest
+  token: TToken
+}
+
+export type DeleteTokenRequest = {
+  request: ApiServiceRequest
+  tokenId: number
+}
+
+export type KeyManagementCapability = {
+  fetchTokens(
+    request: ApiServiceRequest,
+    options?: FetchAccountTokensOptions,
+  ): Promise<ApiToken[]>
+  createToken(
+    request: ApiServiceRequest,
+    tokenData: CreateTokenRequest,
+  ): Promise<CreateTokenResult>
+  resolveTokenKey<TToken extends Pick<ApiToken, "id" | "key">>(
+    request: ResolveTokenSecretRequest<TToken>,
+  ): Promise<string>
+  deleteToken(request: DeleteTokenRequest): Promise<boolean | void>
+  fetchUserGroups(
+    request: ApiServiceRequest,
+  ): Promise<Record<string, UserGroupInfo>>
+  fetchAvailableModels(request: ApiServiceRequest): Promise<string[]>
+}
+```
+
+The Interface intentionally reuses existing request and response types. This
+slice changes the Seam, not the backend protocol models.
+
+`fetchUserGroups(...)` should preserve the existing error mode: when the
+upstream does not support group lookup, the Adapter may throw the existing
+`FEATURE_UNSUPPORTED` `ApiError`. Product callers that already treat that as an
+empty group set should continue to do so.
+
+`fetchAvailableModels(...)` should return the same normalized model id list as
+the existing backend helper. If a backend has no model-limit endpoint but token
+creation can continue without model limits, its Adapter should return an empty
+array rather than forcing UI failure.
+
+### 2. Extend New API-Family Key Management
+
+Modify:
+
+```text
+src/services/apiAdapters/newApi/keyManagement.ts
+```
+
+The Adapter should continue binding to the site-scoped legacy facade so
+OneHub, DoneHub, Veloera, AnyRouter, WONG, V-API, VoAPI, Super-API, Rix-API,
+Neo-API, and unknown-compatible behavior is preserved:
+
+```ts
+export function createNewApiKeyManagement(
+  siteType: AccountSiteType,
+): KeyManagementCapability {
+  return {
+    fetchTokens: (request, options) =>
+      getApiService(siteType).fetchAccountTokens(
+        request,
+        options?.page,
+        options?.size,
+      ),
+    createToken: (request, tokenData) =>
+      getApiService(siteType).createApiToken(request, tokenData),
+    resolveTokenKey: ({ request, token }) =>
+      getApiService(siteType).resolveApiTokenKey(request, token),
+    deleteToken: ({ request, tokenId }) =>
+      getApiService(siteType).deleteApiToken(request, tokenId),
+    fetchUserGroups: (request) =>
+      getApiService(siteType).fetchUserGroups(request),
+    fetchAvailableModels: (request) =>
+      getApiService(siteType).fetchAccountAvailableModels(request),
+  }
+}
+```
+
+### 3. Extend Sub2API Key Management
+
+Modify:
+
+```text
+src/services/apiAdapters/sub2api/keyManagement.ts
+```
+
+The Adapter should delegate to existing Sub2API helpers:
+
+```ts
+import {
+  createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
+  fetchAccountTokens,
+  fetchUserGroups,
+  resolveApiTokenKey,
+} from "~/services/apiService/sub2api"
+```
+
+Sub2API behavior must remain unchanged:
+
+- request-level auth-session decoration still comes from
+  `createDisplayAccountApiContext(...)`
+- group lookup drives quick-create decisions
+- token creation still requires a group when product code supplies one
+- token secret resolution still uses the existing Sub2API helper
+- token deletion still uses the existing backend deletion helper
+
+### 4. Extend AIHubMix Key Management
+
+Modify:
+
+```text
+src/services/apiAdapters/aihubmix/keyManagement.ts
+```
+
+The Adapter should delegate to existing AIHubMix helpers:
+
+```ts
+import {
+  createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
+  fetchAccountTokens,
+  fetchUserGroups,
+  resolveApiTokenKey,
+} from "~/services/apiService/aihubmix"
+```
+
+AIHubMix behavior must remain unchanged:
+
+- API origin normalization stays in the AIHubMix implementation.
+- Token-authenticated requests continue sending raw
+  `Authorization: <access_token>` without a `Bearer` prefix.
+- Created keys are still treated as one-time secrets by product workflows.
+- Group lookup can still report unsupported through the existing backend error
+  path.
+- `resolveTokenKey(...)` must not fall back to common `/api/token/{id}/key`
+  behavior.
+
+### 5. Route Key Management Page Inventory And Delete
+
+Modify:
+
+```text
+src/features/KeyManagement/hooks/useKeyManagement.ts
+```
+
+Inventory loading should use:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(account)
+const tokens = await requireDisplayAccountKeyManagement(
+  account,
+  keyManagement,
+).fetchTokens(request)
+```
+
+Token deletion should use:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(account)
+await requireDisplayAccountKeyManagement(account, keyManagement).deleteToken({
+  request,
+  tokenId: token.id,
+})
+```
+
+Preserve all existing Key Management behavior:
+
+- all-account mode continues to isolate per-account failures
+- retry failed accounts continues to load only failed accounts
+- stale request guards still protect selection changes
+- delete still removes the token from local inventory immediately after
+  upstream success
+- managed-site token status invalidation remains unchanged
+- existing analytics event ids, result categories, and privacy properties stay
+  unchanged
+
+### 6. Route Add Token Bootstrap Data
+
+Modify:
+
+```text
+src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts
+```
+
+Load model ids and groups from `keyManagement`:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(currentAccount)
+const capability = requireDisplayAccountKeyManagement(
+  currentAccount,
+  keyManagement,
+)
+
+const [models, groupsData] = await Promise.all([
+  capability.fetchAvailableModels(request),
+  capability.fetchUserGroups(request).catch((error) => {
+    if (isFeatureUnsupportedError(error)) return EMPTY_USER_GROUPS
+    throw error
+  }),
+])
+```
+
+Preserve the existing group defaulting behavior:
+
+- keep an already eligible group selection
+- keep a blank group when restricted groups require a manual choice
+- fall back to `default` when allowed and available
+- fall back to the first allowed available group when `default` is unavailable
+- fall back to the first fetched group when unrestricted groups have no
+  `default`
+- treat unsupported group lookup as no group selection without showing an
+  error
+
+### 7. Route Sub2API Quick-Create Resolution
+
+Modify:
+
+```text
+src/services/accounts/accountOperations.ts
+```
+
+`resolveSub2ApiQuickCreateResolution(...)` should keep its product semantics
+but load groups through the Adapter:
+
+```ts
+const { keyManagement, request } = createDisplayAccountApiContext(account)
+const groups = await requireDisplayAccountKeyManagement(
+  account,
+  keyManagement,
+).fetchUserGroups(request)
+```
+
+Preserve the current resolution contract:
+
+- non-Sub2API accounts throw `sub2api_quick_create_not_applicable`
+- zero groups returns `blocked`
+- one unique normalized group returns `ready`
+- multiple groups returns `selection_required`
+
+### 8. Route Group Coverage And Invalid-Token Repair
+
+Modify:
+
+```text
+src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+```
+
+Replace direct `getApiService(displaySiteData.siteType)` usage with
+`getSiteAdapter(displaySiteData.siteType).keyManagement`.
+
+Preserve the two request shapes:
+
+- inventory and group reads use display-account fields when available
+- token creation and deletion use the same account request shape currently
+  produced by `createAccountApiRequest(...)`
+
+Preserve group coverage behavior:
+
+- unsupported group lookup falls back to legacy one-key coverage
+- empty group responses with an existing token are considered covered
+- empty group responses without tokens create one default token unless the site
+  type is Sub2API or AIHubMix
+- unavailable-group tokens are reported as invalid repair targets
+- failed group creation records the group as missing and continues with later
+  groups
+- invalid-token deletion returns the same typed deletion record
+
+### 9. Route Secondary Token Inventory Surfaces
+
+Migrate token inventory loads from `getApiService(...)` or transitional
+`service.fetchAccountTokens(...)` to `keyManagement.fetchTokens(...)` in:
+
+- `src/components/KiloCodeExportDialog.tsx`
+- `src/components/dialogs/VerifyApiDialog/index.tsx`
+- `src/components/dialogs/VerifyCliSupportDialog/index.tsx`
+- `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`
+
+Each display-account caller should use `createDisplayAccountApiContext(...)`
+so Sub2API continues to receive the session-decorated request.
+
+Preserve each surface's product behavior:
+
+- Kilo Code export keeps token selection, token creation, model probing, export
+  payload generation, and secret redaction unchanged.
+- API verification keeps compatible-token filtering and probe execution
+  unchanged.
+- CLI support verification keeps profile-source behavior unchanged; only
+  account-source token loading moves.
+- Channel dialog keeps existing managed-site channel flow and token selection
+  behavior unchanged.
+
+## Error Handling
+
+Adapter methods should delegate backend errors unchanged.
+
+Product Modules should preserve current error handling:
+
+- Missing `keyManagement` capability should use the existing
+  `createMissingKeyManagementCapabilityError(...)` path.
+- Unsupported group lookup remains non-fatal only in existing callers that
+  already treat `FEATURE_UNSUPPORTED` as an empty group set.
+- Add Token model metadata failures still show the existing localized load
+  failure toast.
+- Key Management inventory failures still populate per-account error state.
+- Delete failures still show the backend/local error message and complete the
+  existing analytics action as failure.
+- Group coverage continues to distinguish unsupported groups from real group
+  fetch failures.
+- AIHubMix token secret unavailability and one-time-secret handling remain in
+  account workflow Modules.
+
+Do not add user-facing copy for missing `keyManagement` sub-operations in this
+slice.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This is an internal architecture migration. It does not add a new user action,
+setting, result category, or analytics field. Existing Key Management,
+verification, Kilo export, and account provisioning telemetry should continue
+to emit from their current owners with the same payload shape and privacy
+constraints.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E in this slice.
+
+The risk is service-layer routing and request preservation for token lifecycle
+operations. Focused Vitest coverage at Adapter, account-helper, hook, and dialog
+levels directly covers that risk. Browser runtime behavior is unchanged.
+
+Existing browser-level Sub2API/DNR coverage remains the right guard for
+extension permission and runtime bundle regressions. Run those broader checks
+only if implementation evidence shows an import-scope change involving
+`src/services/apiService/sub2api/**` and account-storage modules.
+
+## Testing Strategy
+
+Update Adapter tests:
+
+- `tests/services/apiAdapters/keyManagement.test.ts`
+  - New API-family delegates token delete, user groups, and available models
+    through the site-specific `getApiService(siteType)`.
+  - Sub2API delegates token delete, user groups, and available models to
+    Sub2API helpers.
+  - AIHubMix delegates token delete, user groups, and available models to
+    AIHubMix helpers.
+
+Update registry tests:
+
+- New API-family, Sub2API, and AIHubMix `keyManagement` objects expose:
+  - `fetchTokens`
+  - `createToken`
+  - `resolveTokenKey`
+  - `deleteToken`
+  - `fetchUserGroups`
+  - `fetchAvailableModels`
+
+Update account helper tests:
+
+- `tests/services/accountKeyGroupCoverage.test.ts`
+  - group coverage uses `getSiteAdapter(...).keyManagement`
+  - unsupported groups still fall back to one-key coverage
+  - invalid-token deletion uses `keyManagement.deleteToken(...)`
+- `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+  - Sub2API quick-create resolution uses `keyManagement.fetchUserGroups(...)`
+  - existing Sub2API and AIHubMix creation guards remain unchanged
+- `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+  - Sub2API group resolution continues to return ready, blocked, or
+    selection-required results
+  - AIHubMix one-time-secret behavior remains unchanged
+
+Update UI hook/dialog tests:
+
+- `tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx`
+  - inventory loading uses `keyManagement.fetchTokens(...)`
+  - deletion uses `keyManagement.deleteToken(...)`
+  - all-account partial failure, retry, delete analytics, and optimistic local
+    removal remain unchanged
+- `tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx`
+  - model and group bootstrap data use `keyManagement`
+  - unsupported group lookup remains non-fatal
+- `tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx`
+  - prefill flows still receive model and group data
+- `tests/components/KiloCodeExportDialog.test.tsx`
+  - token inventory loading uses `keyManagement.fetchTokens(...)`
+- `tests/components/VerifyApiDialog.test.tsx`
+  - account-source token loading uses `keyManagement.fetchTokens(...)`
+- `tests/components/VerifyCliSupportDialog.test.tsx`
+  - account-source token loading uses `keyManagement.fetchTokens(...)`
+- Existing Channel dialog tests should be updated if their mocks assert
+  `service.fetchAccountTokens(...)`.
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx tests/components/KiloCodeExportDialog.test.tsx tests/components/VerifyApiDialog.test.tsx tests/components/VerifyCliSupportDialog.test.tsx
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Push gate before publishing:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before opening or updating a PR because this slice changes
+shared Adapter contracts and multiple token-workflow callers.
+
+## Rollout
+
+1. Extend `KeyManagementCapability` and Adapter delegation tests.
+2. Implement New API-family, Sub2API, and AIHubMix Adapter methods.
+3. Update registry expectations.
+4. Migrate Key Management page inventory loading and deletion.
+5. Migrate Add Token bootstrap data.
+6. Migrate Sub2API quick-create resolution.
+7. Migrate group coverage and invalid-token repair.
+8. Migrate secondary token inventory surfaces.
+9. Run focused tests after each caller group.
+10. Run `pnpm compile` and `pnpm run validate:staged`.
+11. Inspect the final diff for scope drift.
+12. Run `pnpm run validate:push` before pushing or opening a PR.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may migrate:
+
+- redemption through a `redemption` capability
+- account-completion internals that still call `fetchSiteStatus(...)`,
+  `fetchSupportCheckIn(...)`, and `getOrCreateAccessToken(...)`
+- a deeper product-level default-token provisioning policy Interface, if the
+  next non-compatible site type proves that Sub2API and AIHubMix are not the
+  only special cases
+- model pricing assembly and Sub2API estimated-pricing ownership
+- managed-site channel operations and model sync
+- site detection and route/status probing
+- an import guard that prevents new product Modules from importing the legacy
+  `apiService` facade outside approved adapter/compatibility layers
+
+Do not turn `SiteAdapter` into a second flat `apiService` facade. This slice is
+valid because it makes an already-real Module deeper: one key-management
+Interface now hides the backend token lifecycle operations that otherwise leak
+across multiple product callers.

--- a/src/components/KiloCodeExportDialog.tsx
+++ b/src/components/KiloCodeExportDialog.tsx
@@ -26,9 +26,12 @@ import {
   resolveSub2ApiQuickCreateResolution,
 } from "~/services/accounts/accountOperations"
 import { compareAccountDisplayNames } from "~/services/accounts/utils/accountDisplayName"
-import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
 import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
-import { getApiService } from "~/services/apiService"
 import {
   buildKiloCodeApiConfigs,
   buildKiloCodeSettingsFile,
@@ -151,22 +154,6 @@ function pickNewestToken(tokens: ApiToken[]): ApiToken {
 
     return candidateToken.id > selectedToken.id ? candidateToken : selectedToken
   })
-}
-
-/**
- * Build arguments for `fetchAccountTokens` from display-layer account data.
- */
-function buildFetchTokenArgs(site: DisplaySiteData) {
-  return {
-    baseUrl: site.baseUrl,
-    accountId: site.id,
-    auth: {
-      authType: site.authType,
-      userId: site.userId,
-      accessToken: site.token,
-      cookie: site.cookieAuthSessionCookie,
-    },
-  }
 }
 
 /**
@@ -316,10 +303,11 @@ export function KiloCodeExportDialog({
       }))
 
       try {
-        const service = getApiService(site.siteType)
-        const tokens = await service.fetchAccountTokens(
-          buildFetchTokenArgs(site),
-        )
+        const { keyManagement, request } = createDisplayAccountApiContext(site)
+        const tokens = await requireDisplayAccountKeyManagement(
+          site,
+          keyManagement,
+        ).fetchTokens(request)
         if (!Array.isArray(tokens)) {
           setTokenInventories((prev) => ({
             ...prev,

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -17,6 +17,7 @@ import { selectSingleNewApiTokenByIdDiff } from "~/services/accounts/accountPost
 import { accountStorage } from "~/services/accounts/accountStorage"
 import {
   createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { toManagedSiteChannelAssessmentSignals } from "~/services/managedSites/channelAssessmentSignals"
@@ -104,8 +105,11 @@ export function useChannelDialog() {
       onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
     },
   ): Promise<boolean> => {
-    const { service, request } = createDisplayAccountApiContext(account)
-    const existingTokens = await service.fetchAccountTokens(request)
+    const { keyManagement, request } = createDisplayAccountApiContext(account)
+    const existingTokens = await requireDisplayAccountKeyManagement(
+      account,
+      keyManagement,
+    ).fetchTokens(request)
     if (Array.isArray(existingTokens) && existingTokens.length > 0) {
       return false
     }
@@ -367,9 +371,9 @@ export function useChannelDialog() {
       }
 
       let apiToken = accountToken
-      let accountApiService:
-        | ReturnType<typeof createDisplayAccountApiContext>["service"]
-        | null = null
+      let accountKeyManagement: NonNullable<
+        ReturnType<typeof createDisplayAccountApiContext>["keyManagement"]
+      > | null = null
       let accountApiRequest:
         | ReturnType<typeof createDisplayAccountApiContext>["request"]
         | null = null
@@ -378,10 +382,13 @@ export function useChannelDialog() {
       if (!apiToken) {
         const accountApiContext =
           createDisplayAccountApiContext(displaySiteData)
-        accountApiService = accountApiContext.service
+        accountKeyManagement = requireDisplayAccountKeyManagement(
+          displaySiteData,
+          accountApiContext.keyManagement,
+        )
         accountApiRequest = accountApiContext.request
         const existingTokens =
-          await accountApiService.fetchAccountTokens(accountApiRequest)
+          await accountKeyManagement.fetchTokens(accountApiRequest)
         const existingTokenList = Array.isArray(existingTokens)
           ? existingTokens
           : []
@@ -432,10 +439,8 @@ export function useChannelDialog() {
                 }
 
                 const refetchedTokens =
-                  accountApiService && accountApiRequest
-                    ? await accountApiService.fetchAccountTokens(
-                        accountApiRequest,
-                      )
+                  accountKeyManagement && accountApiRequest
+                    ? await accountKeyManagement.fetchTokens(accountApiRequest)
                     : null
                 if (!shouldContinue()) {
                   return

--- a/src/components/dialogs/VerifyApiDialog/index.tsx
+++ b/src/components/dialogs/VerifyApiDialog/index.tsx
@@ -13,8 +13,11 @@ import {
   SearchableSelect,
 } from "~/components/ui"
 import { Modal } from "~/components/ui/Dialog/Modal"
-import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
-import { getApiService } from "~/services/apiService"
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
 import { identifyProvider } from "~/services/models/utils/modelProviders"
 import { isTokenCompatibleWithModel } from "~/services/models/utils/tokenModelCompatibility"
 import {
@@ -176,18 +179,11 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
   const loadTokens = async () => {
     setIsLoadingTokens(true)
     try {
-      const accountTokens = await getApiService(
-        account.siteType,
-      ).fetchAccountTokens({
-        baseUrl: account.baseUrl,
-        accountId: account.id,
-        auth: {
-          authType: account.authType,
-          userId: account.userId,
-          accessToken: account.token,
-          cookie: account.cookieAuthSessionCookie,
-        },
-      })
+      const { keyManagement, request } = createDisplayAccountApiContext(account)
+      const accountTokens = await requireDisplayAccountKeyManagement(
+        account,
+        keyManagement,
+      ).fetchTokens(request)
 
       const sorted = [...accountTokens].sort((a, b) => {
         const aEnabled = a.status === 1 ? 0 : 1

--- a/src/components/dialogs/VerifyCliSupportDialog/index.tsx
+++ b/src/components/dialogs/VerifyCliSupportDialog/index.tsx
@@ -11,12 +11,15 @@ import {
   SearchableSelect,
 } from "~/components/ui"
 import { Modal } from "~/components/ui/Dialog/Modal"
-import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
 import {
   fetchApiCredentialModelIds,
   normalizeApiCredentialModelIds,
 } from "~/services/apiCredentialProfiles/modelCatalog"
-import { getApiService } from "~/services/apiService"
 import {
   resolveProductAnalyticsErrorCategoryFromError,
   startProductAnalyticsAction,
@@ -169,18 +172,11 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
 
     setIsLoadingTokens(true)
     try {
-      const accountTokens = await getApiService(
-        account.siteType,
-      ).fetchAccountTokens({
-        baseUrl: account.baseUrl,
-        accountId: account.id,
-        auth: {
-          authType: account.authType,
-          userId: account.userId,
-          accessToken: account.token,
-          cookie: account.cookieAuthSessionCookie,
-        },
-      })
+      const { keyManagement, request } = createDisplayAccountApiContext(account)
+      const accountTokens = await requireDisplayAccountKeyManagement(
+        account,
+        keyManagement,
+      ).fetchTokens(request)
 
       const sorted = [...accountTokens].sort((a, b) => {
         const aEnabled = a.status === 1 ? 0 : 1

--- a/src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts
+++ b/src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
-import { createDisplayAccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+} from "~/services/accounts/utils/apiServiceRequest"
 import { API_ERROR_CODES } from "~/services/apiService/common/errors"
 import type { UserGroupInfo } from "~/services/apiService/common/type"
 import type { DisplaySiteData } from "~/types"
@@ -47,12 +50,16 @@ export function useTokenData(
 
     setIsLoading(true)
     try {
-      const { service, request } =
+      const { keyManagement, request } =
         createDisplayAccountApiContext(currentAccount)
+      const capability = requireDisplayAccountKeyManagement(
+        currentAccount,
+        keyManagement,
+      )
 
       const [models, groupsData] = await Promise.all([
-        service.fetchAccountAvailableModels(request),
-        service.fetchUserGroups(request).catch((error) => {
+        capability.fetchAvailableModels(request),
+        capability.fetchUserGroups(request).catch((error) => {
           if (isFeatureUnsupportedError(error)) {
             return EMPTY_USER_GROUPS
           }

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -7,6 +7,7 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { useAccountData } from "~/hooks/useAccountData"
 import {
   createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { formatOptionalSkPrefixSiteTokenAuthKey } from "~/services/apiService/common/apiKey"
@@ -628,8 +629,12 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
       }))
 
       try {
-        const { service, request } = createDisplayAccountApiContext(account)
-        const tokens = await service.fetchAccountTokens(request)
+        const { keyManagement, request } =
+          createDisplayAccountApiContext(account)
+        const tokens = await requireDisplayAccountKeyManagement(
+          account,
+          keyManagement,
+        ).fetchTokens(request)
 
         if (!isEpochActive(loadEpoch)) return null
         if (!isLatestAccountRequest(accountId, requestEpoch)) return null
@@ -1473,8 +1478,14 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
         return
       }
 
-      const { service, request } = createDisplayAccountApiContext(account)
-      await service.deleteApiToken(request, token.id)
+      const { keyManagement, request } = createDisplayAccountApiContext(account)
+      await requireDisplayAccountKeyManagement(
+        account,
+        keyManagement,
+      ).deleteToken({
+        request,
+        tokenId: token.id,
+      })
       clearTokenVisibilityState(token)
       removeTokenFromInventory(token)
       invalidateManagedSiteStatusForToken(token)

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -1,5 +1,6 @@
 import { SITE_TYPES } from "~/constants/siteType"
-import { getApiService } from "~/services/apiService"
+import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { API_ERROR_CODES } from "~/services/apiService/common/errors"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
@@ -84,15 +85,18 @@ export async function ensureAccountKeysForAvailableGroups(params: {
   siteUrlOrigin: string
 }): Promise<AccountKeyCoverageResult> {
   const { account, displaySiteData, accountName, siteUrlOrigin } = params
-  const service = getApiService(displaySiteData.siteType)
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
   const request = createAccountApiRequest(account, displaySiteData)
   const accountId = displaySiteData.id || account.id
 
-  const tokens = await service.fetchAccountTokens(request)
+  const tokens = await keyManagement.fetchTokens(request)
   let groups: string[]
 
   try {
-    const groupsData = await service.fetchUserGroups(request)
+    const groupsData = await keyManagement.fetchUserGroups(request)
     groups = Object.keys(groupsData).map(normalizeGroupName).filter(Boolean)
   } catch (error) {
     if (!isFeatureUnsupportedError(error)) {
@@ -123,7 +127,7 @@ export async function ensureAccountKeysForAvailableGroups(params: {
       throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
     }
 
-    await service.createApiToken(request, generateDefaultTokenRequest())
+    await keyManagement.createToken(request, generateDefaultTokenRequest())
     return {
       created: true,
       availableGroups: [],
@@ -166,7 +170,7 @@ export async function ensureAccountKeysForAvailableGroups(params: {
     if (coveredGroupSet.has(group)) continue
 
     try {
-      await service.createApiToken(
+      await keyManagement.createToken(
         request,
         buildGroupDefaultTokenRequest(group),
       )
@@ -196,9 +200,15 @@ export async function deleteInvalidAccountToken(params: {
   displaySiteData: DisplaySiteData
 }): Promise<AccountKeyRepairDeleteInvalidTokensResult["deleted"][number]> {
   const { token, account, displaySiteData } = params
-  const service = getApiService(displaySiteData.siteType)
+  const keyManagement = requireDisplayAccountKeyManagement(
+    displaySiteData,
+    getSiteAdapter(displaySiteData.siteType).keyManagement,
+  )
   const request = createAccountApiRequest(account, displaySiteData)
-  await service.deleteApiToken(request, token.tokenId)
+  await keyManagement.deleteToken({
+    request,
+    tokenId: token.tokenId,
+  })
   return {
     ...token,
     deletedAt: Date.now(),

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -503,8 +503,11 @@ export async function resolveSub2ApiQuickCreateResolution(
     throw new Error("sub2api_quick_create_not_applicable")
   }
 
-  const { service, request } = createDisplayAccountApiContext(account)
-  const groups = await service.fetchUserGroups(request)
+  const { keyManagement, request } = createDisplayAccountApiContext(account)
+  const groups = await requireDisplayAccountKeyManagement(
+    account,
+    keyManagement,
+  ).fetchUserGroups(request)
   const validGroups = normalizeSub2ApiGroupNames(groups)
 
   if (validGroups.length === 0) {

--- a/src/services/apiAdapters/aihubmix/keyManagement.ts
+++ b/src/services/apiAdapters/aihubmix/keyManagement.ts
@@ -13,6 +13,7 @@ export const aihubmixKeyManagement: KeyManagementCapability = {
   createToken: (request, tokenData) => createApiToken(request, tokenData),
   resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
   deleteToken: ({ request, tokenId }) => deleteApiToken(request, tokenId),
+  // Preserve AIHubMix's explicit FEATURE_UNSUPPORTED group-inventory contract.
   fetchUserGroups: (request) => fetchUserGroups(request),
   fetchAvailableModels: (request) => fetchAccountAvailableModels(request),
 }

--- a/src/services/apiAdapters/aihubmix/keyManagement.ts
+++ b/src/services/apiAdapters/aihubmix/keyManagement.ts
@@ -1,7 +1,10 @@
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
 import {
   createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
   fetchAccountTokens,
+  fetchUserGroups,
   resolveApiTokenKey,
 } from "~/services/apiService/aihubmix"
 
@@ -9,4 +12,7 @@ export const aihubmixKeyManagement: KeyManagementCapability = {
   fetchTokens: (request) => fetchAccountTokens(request),
   createToken: (request, tokenData) => createApiToken(request, tokenData),
   resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
+  deleteToken: ({ request, tokenId }) => deleteApiToken(request, tokenId),
+  fetchUserGroups: (request) => fetchUserGroups(request),
+  fetchAvailableModels: (request) => fetchAccountAvailableModels(request),
 }

--- a/src/services/apiAdapters/contracts/keyManagement.ts
+++ b/src/services/apiAdapters/contracts/keyManagement.ts
@@ -2,6 +2,7 @@ import type {
   ApiServiceRequest,
   CreateTokenRequest,
   CreateTokenResult,
+  UserGroupInfo,
 } from "~/services/apiService/common/type"
 import type { ApiToken } from "~/types"
 
@@ -17,6 +18,11 @@ export type ResolveTokenSecretRequest<
   token: TToken
 }
 
+export type DeleteTokenRequest = {
+  request: ApiServiceRequest
+  tokenId: number
+}
+
 export type KeyManagementCapability = {
   fetchTokens(
     request: ApiServiceRequest,
@@ -29,4 +35,9 @@ export type KeyManagementCapability = {
   resolveTokenKey<TToken extends Pick<ApiToken, "id" | "key">>(
     request: ResolveTokenSecretRequest<TToken>,
   ): Promise<string>
+  deleteToken(request: DeleteTokenRequest): Promise<boolean | void>
+  fetchUserGroups(
+    request: ApiServiceRequest,
+  ): Promise<Record<string, UserGroupInfo>>
+  fetchAvailableModels(request: ApiServiceRequest): Promise<string[]>
 }

--- a/src/services/apiAdapters/newApi/keyManagement.ts
+++ b/src/services/apiAdapters/newApi/keyManagement.ts
@@ -19,5 +19,11 @@ export function createNewApiKeyManagement(
       getApiService(siteType).createApiToken(request, tokenData),
     resolveTokenKey: ({ request, token }) =>
       getApiService(siteType).resolveApiTokenKey(request, token),
+    deleteToken: ({ request, tokenId }) =>
+      getApiService(siteType).deleteApiToken(request, tokenId),
+    fetchUserGroups: (request) =>
+      getApiService(siteType).fetchUserGroups(request),
+    fetchAvailableModels: (request) =>
+      getApiService(siteType).fetchAccountAvailableModels(request),
   }
 }

--- a/src/services/apiAdapters/sub2api/keyManagement.ts
+++ b/src/services/apiAdapters/sub2api/keyManagement.ts
@@ -1,7 +1,10 @@
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
 import {
   createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
   fetchAccountTokens,
+  fetchUserGroups,
   resolveApiTokenKey,
 } from "~/services/apiService/sub2api"
 
@@ -10,4 +13,7 @@ export const sub2ApiKeyManagement: KeyManagementCapability = {
     fetchAccountTokens(request, options?.page, options?.size),
   createToken: (request, tokenData) => createApiToken(request, tokenData),
   resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
+  deleteToken: ({ request, tokenId }) => deleteApiToken(request, tokenId),
+  fetchUserGroups: (request) => fetchUserGroups(request),
+  fetchAvailableModels: (request) => fetchAccountAvailableModels(request),
 }

--- a/tests/components/KiloCodeExportDialog.test.tsx
+++ b/tests/components/KiloCodeExportDialog.test.tsx
@@ -86,16 +86,15 @@ vi.mock("~/services/aiApi/openaiCompatible", () => ({
 }))
 
 const mockFetchAccountTokens = vi.fn()
-const mockGetApiService = vi.fn()
+const mockGetSiteAdapter = vi.fn()
 const mockResolveApiTokenKey = vi.fn()
 const mockFetchAccountAvailableModels = vi.fn()
 const mockFetchUserGroups = vi.fn()
 const mockEnsureAccountApiToken = vi.fn()
 const mockResolveSub2ApiQuickCreateResolution = vi.fn()
 
-vi.mock("~/services/apiService", () => ({
-  // Forward through a typed wrapper so call sites avoid `any[]`.
-  getApiService: (...args: unknown[]) => mockGetApiService(...args),
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: (...args: unknown[]) => mockGetSiteAdapter(...args),
 }))
 
 vi.mock("~/services/accounts/accountOperations", () => ({
@@ -181,10 +180,35 @@ describe("KiloCodeExportDialog", () => {
     mockFetchOpenAICompatibleModelIds.mockReset()
     mockFetchOpenAICompatibleModelIds.mockResolvedValue(["gpt-4o-mini"])
     mockFetchAccountTokens.mockReset()
-    mockGetApiService.mockReset()
+    mockGetSiteAdapter.mockReset()
+    mockGetSiteAdapter.mockReturnValue({
+      keyManagement: {
+        fetchTokens: (...args: unknown[]) => mockFetchAccountTokens(...args),
+        createToken: vi.fn(),
+        resolveTokenKey: (...args: unknown[]) =>
+          mockResolveApiTokenKey(...args),
+        deleteToken: vi.fn(),
+        fetchUserGroups: (...args: unknown[]) => mockFetchUserGroups(...args),
+        fetchAvailableModels: (...args: unknown[]) =>
+          mockFetchAccountAvailableModels(...args),
+      },
+    })
     mockResolveApiTokenKey.mockReset()
     mockResolveApiTokenKey.mockImplementation(
-      async (_request, token: { key: string }) => token.key,
+      async (
+        requestOrPayload: unknown | { token?: { key: string } },
+        token?: { key: string },
+      ) => {
+        if (
+          requestOrPayload &&
+          typeof requestOrPayload === "object" &&
+          "token" in requestOrPayload
+        ) {
+          return (requestOrPayload as { token: { key: string } }).token.key
+        }
+
+        return token?.key
+      },
     )
     mockFetchAccountAvailableModels.mockReset()
     mockFetchAccountAvailableModels.mockResolvedValue([])
@@ -231,10 +255,6 @@ describe("KiloCodeExportDialog", () => {
     mockFetchAccountTokens.mockResolvedValueOnce([
       { id: "1", name: "Default", key: "sk-test" },
     ])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     const sitePicker = await screen.findByPlaceholderText(
       "ui:dialog.kiloCode.placeholders.selectSites",
@@ -314,10 +334,6 @@ describe("KiloCodeExportDialog", () => {
     mockFetchAccountTokens.mockResolvedValueOnce([
       { id: 1, name: "Default", key: "sk-test" },
     ])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
 
@@ -379,10 +395,6 @@ describe("KiloCodeExportDialog", () => {
         return [{ id: 1, name: "Default", key: "sk-test" }]
       },
     )
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
 
@@ -441,10 +453,6 @@ describe("KiloCodeExportDialog", () => {
     mockFetchAccountTokens
       .mockResolvedValueOnce({ items: [] })
       .mockResolvedValueOnce([{ id: 1, name: "Recovered", key: "sk-test" }])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
 
@@ -498,10 +506,6 @@ describe("KiloCodeExportDialog", () => {
     mockFetchOpenAICompatibleModelIds
       .mockRejectedValueOnce(new Error("model load failed"))
       .mockResolvedValueOnce(["gpt-4o-mini"])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
 
@@ -559,10 +563,6 @@ describe("KiloCodeExportDialog", () => {
     mockFetchAccountTokens.mockResolvedValueOnce([
       { id: 1, name: "Default", key: "sk-test" },
     ])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(
       <KiloCodeExportDialog
@@ -608,10 +608,6 @@ describe("KiloCodeExportDialog", () => {
     mockFetchAccountTokens
       .mockResolvedValueOnce([{ id: 1, name: "Token A", key: "sk-a" }])
       .mockResolvedValueOnce([{ id: 2, name: "Token B", key: "sk-b" }])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     const { rerender } = render(
       <KiloCodeExportDialog
@@ -683,10 +679,6 @@ describe("KiloCodeExportDialog", () => {
     mockFetchAccountTokens.mockResolvedValueOnce([
       { id: 1, name: "Default", key: "sk-test" },
     ])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     const { rerender } = render(
       <KiloCodeExportDialog
@@ -741,10 +733,6 @@ describe("KiloCodeExportDialog", () => {
     mockFetchAccountTokens.mockResolvedValueOnce([
       { id: 7, name: "   ", key: "sk-test" },
     ])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(
       <KiloCodeExportDialog
@@ -779,12 +767,6 @@ describe("KiloCodeExportDialog", () => {
     mockFetchAccountTokens
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ id: 11, name: "Created", key: "sk-test" }])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-      fetchAccountAvailableModels: mockFetchAccountAvailableModels,
-      fetchUserGroups: mockFetchUserGroups,
-    })
     mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
       kind: "ready",
       group: "vip",
@@ -848,12 +830,6 @@ describe("KiloCodeExportDialog", () => {
     })
 
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-      fetchAccountAvailableModels: mockFetchAccountAvailableModels,
-      fetchUserGroups: mockFetchUserGroups,
-    })
     mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
       kind: "selection_required",
       allowedGroups: ["default", "vip"],
@@ -932,10 +908,6 @@ describe("KiloCodeExportDialog", () => {
         created_time: 100,
       },
     ])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
     mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
       kind: "selection_required",
       allowedGroups: ["default", "vip"],
@@ -1018,10 +990,6 @@ describe("KiloCodeExportDialog", () => {
         created_at: "2024-04-01T00:00:00.000Z",
       },
     ])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
     mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
       kind: "selection_required",
       allowedGroups: ["default", "vip"],
@@ -1098,10 +1066,6 @@ describe("KiloCodeExportDialog", () => {
         key: "sk-newest",
       },
     ])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
     mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
       kind: "selection_required",
       allowedGroups: ["default", "vip"],
@@ -1162,10 +1126,6 @@ describe("KiloCodeExportDialog", () => {
     })
 
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
     mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
       kind: "blocked",
       message: "   ",
@@ -1214,10 +1174,6 @@ describe("KiloCodeExportDialog", () => {
     })
 
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
 
@@ -1265,10 +1221,6 @@ describe("KiloCodeExportDialog", () => {
       { id: 1, name: "Default", key: "sk-abcd************wxyz" },
     ])
     mockResolveApiTokenKey.mockResolvedValue("sk-full-secret")
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
 
@@ -1322,12 +1274,21 @@ describe("KiloCodeExportDialog", () => {
       { id: 1, name: "Default", key: "sk-abcd************wxyz" },
     ])
     mockResolveApiTokenKey.mockImplementation(
-      async (_request, token: { key: string }) => token.key,
+      async (
+        requestOrPayload: unknown | { token?: { key: string } },
+        token?: { key: string },
+      ) => {
+        if (
+          requestOrPayload &&
+          typeof requestOrPayload === "object" &&
+          "token" in requestOrPayload
+        ) {
+          return (requestOrPayload as { token: { key: string } }).token.key
+        }
+
+        return token?.key
+      },
     )
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
 
@@ -1390,10 +1351,6 @@ describe("KiloCodeExportDialog", () => {
       { id: 1, name: "Default", key: "sk-abcd************wxyz" },
     ])
     mockResolveApiTokenKey.mockResolvedValue("sk-full-secret")
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
 
@@ -1466,10 +1423,6 @@ describe("KiloCodeExportDialog", () => {
     mockResolveApiTokenKey
       .mockResolvedValueOnce("sk-full-secret")
       .mockRejectedValueOnce(new Error("resolve failed"))
-    mockGetApiService.mockReturnValue({
-      fetchAccountTokens: mockFetchAccountTokens,
-      resolveApiTokenKey: mockResolveApiTokenKey,
-    })
 
     render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
 

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -248,12 +248,23 @@ vi.mock("~/services/apiService", async (importOriginal) => {
 
   return {
     ...actual,
-    getApiService: vi.fn(() => ({
-      fetchAccountTokens: (...args: any[]) => mockFetchAccountTokens(...args),
-      resolveApiTokenKey: (...args: any[]) => mockResolveApiTokenKey(...args),
-    })),
+    getApiService: vi.fn(() => ({})),
   }
 })
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => mockFetchAccountTokens(...args),
+      createToken: vi.fn(),
+      resolveTokenKey: ({ request, token }: any) =>
+        mockResolveApiTokenKey(request, token),
+      deleteToken: vi.fn(),
+      fetchUserGroups: vi.fn(),
+      fetchAvailableModels: vi.fn(),
+    },
+  }),
+}))
 
 describe("useChannelDialog", () => {
   beforeEach(() => {

--- a/tests/components/VerifyApiDialog.test.tsx
+++ b/tests/components/VerifyApiDialog.test.tsx
@@ -31,10 +31,20 @@ const mockStartProductAnalyticsAction = vi.fn()
 const mockCompleteProductAnalyticsAction = vi.fn()
 
 vi.mock("~/services/apiService", () => ({
-  getApiService: () => ({
-    fetchAccountTokens: (...args: any[]) => mockFetchAccountTokens(...args),
-    resolveApiTokenKey: async (_request: unknown, token: { key: string }) =>
-      token.key,
+  getApiService: () => ({}),
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => mockFetchAccountTokens(...args),
+      createToken: vi.fn(),
+      resolveTokenKey: async ({ token }: { token: { key: string } }) =>
+        token.key,
+      deleteToken: vi.fn(),
+      fetchUserGroups: vi.fn(),
+      fetchAvailableModels: vi.fn(),
+    },
   }),
 }))
 

--- a/tests/components/VerifyCliSupportDialog.test.tsx
+++ b/tests/components/VerifyCliSupportDialog.test.tsx
@@ -30,17 +30,48 @@ function getCliToolCardTestId(toolId: string) {
 }
 
 vi.mock("~/services/apiService", () => ({
-  getApiService: () => ({
-    fetchAccountTokens: (...args: any[]) => mockFetchAccountTokens(...args),
-    resolveApiTokenKey: async (_request: unknown, token: { key: string }) =>
-      token.key,
-  }),
+  getApiService: () => ({}),
 }))
 
-vi.mock("~/services/accounts/utils/apiServiceRequest", () => ({
-  resolveDisplayAccountTokenForSecret: (...args: any[]) =>
-    mockResolveDisplayAccountTokenForSecret(...args),
-}))
+vi.mock(
+  "~/services/accounts/utils/apiServiceRequest",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/accounts/utils/apiServiceRequest")
+      >()
+
+    return {
+      ...actual,
+      createDisplayAccountApiContext: (account: any) => ({
+        keyManagement: {
+          fetchTokens: (...args: any[]) => mockFetchAccountTokens(...args),
+          createToken: vi.fn(),
+          resolveTokenKey: vi.fn(),
+          deleteToken: vi.fn(),
+          fetchUserGroups: vi.fn(),
+          fetchAvailableModels: vi.fn(),
+        },
+        request: {
+          baseUrl: account.baseUrl,
+          accountId: account.id,
+          auth: {
+            authType: account.authType,
+            userId: account.userId,
+            accessToken: account.token,
+            cookie: account.cookieAuthSessionCookie,
+          },
+        },
+      }),
+      requireDisplayAccountKeyManagement: (
+        _account: unknown,
+        keyManagement: unknown,
+      ) => keyManagement,
+      resolveDisplayAccountTokenForSecret: (...args: any[]) =>
+        mockResolveDisplayAccountTokenForSecret(...args),
+    }
+  },
+)
 
 vi.mock("~/services/productAnalytics/actions", () => ({
   resolveProductAnalyticsErrorCategoryFromError: (error: unknown) =>

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -69,6 +69,10 @@ vi.mock("~/services/apiAdapters/registry", () => ({
       createToken: (...args: any[]) => createApiTokenMock(...args),
       resolveTokenKey: async ({ token }: { token: { key: string } }) =>
         token.key,
+      deleteToken: vi.fn(),
+      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+      fetchAvailableModels: (...args: any[]) =>
+        fetchAccountAvailableModelsMock(...args),
     },
   }),
 }))

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -9,6 +9,7 @@ import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "~/features/KeyManagement/cons
 import { useKeyManagement } from "~/features/KeyManagement/hooks/useKeyManagement"
 import { buildTokenIdentityKey } from "~/features/KeyManagement/utils"
 import { useAccountData } from "~/hooks/useAccountData"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { getApiService } from "~/services/apiService"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import {
@@ -49,6 +50,10 @@ vi.mock("~/hooks/useAccountData", () => ({
 
 vi.mock("~/services/apiService", () => ({
   getApiService: vi.fn(),
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(),
 }))
 
 vi.mock("~/services/managedSites/tokenChannelStatus", () => ({
@@ -105,6 +110,30 @@ const createWrapper = () => {
   )
 }
 
+const createAdapterWithKeyManagement = (
+  overrides: {
+    fetchTokens?: ReturnType<typeof vi.fn>
+    createToken?: ReturnType<typeof vi.fn>
+    resolveTokenKey?: ReturnType<typeof vi.fn>
+    deleteToken?: ReturnType<typeof vi.fn>
+    fetchUserGroups?: ReturnType<typeof vi.fn>
+    fetchAvailableModels?: ReturnType<typeof vi.fn>
+  } = {},
+) => ({
+  siteType: SITE_TYPES.NEW_API,
+  keyManagement: {
+    fetchTokens: overrides.fetchTokens ?? vi.fn().mockResolvedValue([]),
+    createToken: overrides.createToken ?? vi.fn(),
+    resolveTokenKey:
+      overrides.resolveTokenKey ??
+      vi.fn(async ({ token }: { token: { key: string } }) => token.key),
+    deleteToken: overrides.deleteToken ?? vi.fn().mockResolvedValue(undefined),
+    fetchUserGroups: overrides.fetchUserGroups ?? vi.fn().mockResolvedValue({}),
+    fetchAvailableModels:
+      overrides.fetchAvailableModels ?? vi.fn().mockResolvedValue([]),
+  },
+})
+
 type ManagedSiteContextValue = {
   managedSiteType: string
   newApiBaseUrl: string
@@ -156,6 +185,12 @@ describe("useKeyManagement enabled account filtering", () => {
       octopusUsername: "",
       octopusPassword: "",
     })
+    vi.mocked(getSiteAdapter).mockReset()
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement() as any,
+    )
+    vi.mocked(getApiService).mockReset()
+    vi.mocked(getApiService).mockReturnValue({} as any)
   })
 
   it("uses enabledDisplayData from useAccountData for selectors", () => {
@@ -217,8 +252,12 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([])
-    const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -258,8 +297,12 @@ describe("useKeyManagement enabled account filtering", () => {
       })
     })
 
-    const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -303,8 +346,12 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([])
-    const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(
       () => useKeyManagement({ accountId: "disabled" }),
@@ -360,8 +407,12 @@ describe("useKeyManagement enabled account filtering", () => {
       return []
     })
 
-    const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -448,8 +499,12 @@ describe("useKeyManagement enabled account filtering", () => {
       return []
     })
 
-    const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -503,7 +558,12 @@ describe("useKeyManagement enabled account filtering", () => {
 
       throw new Error(`raw failure for ${request?.accountId}`)
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -560,7 +620,12 @@ describe("useKeyManagement enabled account filtering", () => {
     const fetchAccountTokens = vi.fn(async () => {
       throw new ApiError("private unauthorized", 401, "/api/token")
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -605,7 +670,12 @@ describe("useKeyManagement enabled account filtering", () => {
     const fetchAccountTokens = vi.fn(async () => {
       throw new ApiError("private unauthorized", 401, "/api/token")
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -652,7 +722,12 @@ describe("useKeyManagement enabled account filtering", () => {
           }),
       )
       .mockResolvedValue([])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const allAccountsComplete = vi.fn().mockResolvedValue(undefined)
     const singleAccountComplete = vi.fn().mockResolvedValue(undefined)
@@ -743,7 +818,12 @@ describe("useKeyManagement enabled account filtering", () => {
       }
       return []
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -807,7 +887,12 @@ describe("useKeyManagement enabled account filtering", () => {
         "/api/token",
       )
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -870,7 +955,12 @@ describe("useKeyManagement enabled account filtering", () => {
 
       return []
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const initialRefreshComplete = vi.fn().mockResolvedValue(undefined)
     const retryComplete = vi.fn().mockRejectedValue(new Error("analytics down"))
@@ -966,8 +1056,12 @@ describe("useKeyManagement enabled account filtering", () => {
       return []
     })
 
-    const mockedGetApiService = vi.mocked(getApiService)
-    mockedGetApiService.mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1046,7 +1140,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1113,11 +1212,14 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    const resolveApiTokenKey = vi.fn().mockResolvedValue(resolvedKey)
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      resolveApiTokenKey,
-    } as any)
+    const resolveTokenKey = vi.fn().mockResolvedValue(resolvedKey)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        resolveTokenKey,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1140,7 +1242,7 @@ describe("useKeyManagement enabled account filtering", () => {
     await waitFor(() =>
       expect(result.current.visibleKeys.has(tokenIdentityKey)).toBe(true),
     )
-    expect(resolveApiTokenKey).toHaveBeenCalledTimes(1)
+    expect(resolveTokenKey).toHaveBeenCalledTimes(1)
     expect(result.current.getVisibleTokenKey(token)).toBe(resolvedKey)
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
@@ -1169,7 +1271,7 @@ describe("useKeyManagement enabled account filtering", () => {
     await waitFor(() =>
       expect(result.current.visibleKeys.has(tokenIdentityKey)).toBe(true),
     )
-    expect(resolveApiTokenKey).toHaveBeenCalledTimes(1)
+    expect(resolveTokenKey).toHaveBeenCalledTimes(1)
   })
 
   it("reruns managed-site status checks on manual refresh and replaces the prior result", async () => {
@@ -1203,7 +1305,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1267,7 +1374,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1341,7 +1453,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const initialLoadComplete = vi.fn().mockResolvedValue(undefined)
     const manualRefreshComplete = vi
@@ -1405,7 +1522,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1471,7 +1593,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1557,7 +1684,12 @@ describe("useKeyManagement enabled account filtering", () => {
 
       return secondAccountTokens
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1682,7 +1814,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1767,7 +1904,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -1832,7 +1974,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
     getManagedSiteTokenChannelStatusMock
       .mockResolvedValueOnce({
         status: managedSiteTokenChannelStatuses.NOT_ADDED,
@@ -1918,7 +2065,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
     getManagedSiteTokenChannelStatusMock
       .mockResolvedValueOnce({
         status: managedSiteTokenChannelStatuses.ADDED,
@@ -1990,7 +2142,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
     getManagedSiteTokenChannelStatusMock
       .mockReturnValueOnce(initialStatus)
       .mockResolvedValueOnce({
@@ -2067,11 +2224,14 @@ describe("useKeyManagement enabled account filtering", () => {
         }),
       ])
       .mockResolvedValueOnce([])
-    const deleteApiToken = vi.fn().mockResolvedValue(true)
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      deleteApiToken,
-    } as any)
+    const deleteToken = vi.fn().mockResolvedValue(true)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        deleteToken,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true)
 
@@ -2093,7 +2253,10 @@ describe("useKeyManagement enabled account filtering", () => {
     })
 
     await waitFor(() => expect(result.current.tokens).toHaveLength(0))
-    expect(deleteApiToken).toHaveBeenCalledWith(expect.anything(), 303)
+    expect(deleteToken).toHaveBeenCalledWith({
+      request: expect.anything(),
+      tokenId: 303,
+    })
     expect(
       result.current.managedSiteTokenStatuses["delete-acc:303"],
     ).toBeUndefined()
@@ -2142,7 +2305,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result, rerender } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2205,7 +2373,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result, rerender } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2270,7 +2443,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result, rerender } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2335,7 +2513,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result, rerender } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2387,7 +2570,12 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(
       () => useKeyManagement({ accountId: account.id }),
@@ -2412,7 +2600,12 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result, rerender } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2455,7 +2648,12 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2500,7 +2698,12 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result, rerender } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2554,7 +2757,12 @@ describe("useKeyManagement enabled account filtering", () => {
     const fetchAccountTokens = vi.fn().mockResolvedValue({
       items: [],
     })
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2600,9 +2808,13 @@ describe("useKeyManagement enabled account filtering", () => {
       value: { writeText },
     })
 
-    vi.mocked(getApiService).mockReturnValue({
-      resolveApiTokenKey: vi.fn().mockResolvedValue("resolved-token-secret"),
-    } as any)
+    const resolveTokenKey = vi.fn().mockResolvedValue("resolved-token-secret")
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        resolveTokenKey,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2649,9 +2861,13 @@ describe("useKeyManagement enabled account filtering", () => {
       value: { writeText },
     })
 
-    vi.mocked(getApiService).mockReturnValue({
-      resolveApiTokenKey: vi.fn().mockResolvedValue("resolved-token-secret"),
-    } as any)
+    const resolveTokenKey = vi.fn().mockResolvedValue("resolved-token-secret")
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        resolveTokenKey,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2693,18 +2909,22 @@ describe("useKeyManagement enabled account filtering", () => {
       value: { writeText },
     })
 
-    vi.mocked(getApiService).mockReturnValue({
-      resolveApiTokenKey: vi
-        .fn()
-        .mockRejectedValue(
-          new ApiError(
-            "messages:errors.tokenSecretUnavailable",
-            undefined,
-            undefined,
-            API_ERROR_CODES.TOKEN_SECRET_UNAVAILABLE,
-          ),
+    const resolveTokenKey = vi
+      .fn()
+      .mockRejectedValue(
+        new ApiError(
+          "messages:errors.tokenSecretUnavailable",
+          undefined,
+          undefined,
+          API_ERROR_CODES.TOKEN_SECRET_UNAVAILABLE,
         ),
-    } as any)
+      )
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        resolveTokenKey,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2737,11 +2957,11 @@ describe("useKeyManagement enabled account filtering", () => {
       enabledDisplayData: [account],
     } as any)
 
-    let resolveApiTokenKeyPromise: (value: string) => void = () => {}
-    const resolveApiTokenKey = vi.fn().mockImplementation(
+    let resolveTokenKeyPromise: (value: string) => void = () => {}
+    const resolveTokenKey = vi.fn().mockImplementation(
       () =>
         new Promise<string>((resolve) => {
-          resolveApiTokenKeyPromise = resolve
+          resolveTokenKeyPromise = resolve
         }),
     )
     const fetchAccountTokens = vi.fn().mockResolvedValue([
@@ -2754,10 +2974,13 @@ describe("useKeyManagement enabled account filtering", () => {
         expired_time: 0,
       }),
     ])
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      resolveApiTokenKey,
-    } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        resolveTokenKey,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2785,10 +3008,10 @@ describe("useKeyManagement enabled account filtering", () => {
       await result.current.toggleKeyVisibility(account, token)
     })
 
-    expect(resolveApiTokenKey).toHaveBeenCalledTimes(1)
+    expect(resolveTokenKey).toHaveBeenCalledTimes(1)
 
     await act(async () => {
-      resolveApiTokenKeyPromise("resolved-token-secret")
+      resolveTokenKeyPromise("resolved-token-secret")
       await firstReveal
     })
 
@@ -2819,7 +3042,7 @@ describe("useKeyManagement enabled account filtering", () => {
       accountName: account.name,
       expired_time: 0,
     })
-    const resolveApiTokenKey = vi
+    const resolveTokenKey = vi
       .fn()
       .mockRejectedValue(
         new ApiError(
@@ -2829,10 +3052,13 @@ describe("useKeyManagement enabled account filtering", () => {
           API_ERROR_CODES.TOKEN_SECRET_UNAVAILABLE,
         ),
       )
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens: vi.fn().mockResolvedValue([token]),
-      resolveApiTokenKey,
-    } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: vi.fn().mockResolvedValue([token]),
+        resolveTokenKey,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2851,7 +3077,7 @@ describe("useKeyManagement enabled account filtering", () => {
       )
     })
 
-    expect(resolveApiTokenKey).toHaveBeenCalledTimes(1)
+    expect(resolveTokenKey).toHaveBeenCalledTimes(1)
     expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
       "messages:errors.tokenSecretUnavailable",
     )
@@ -2887,11 +3113,14 @@ describe("useKeyManagement enabled account filtering", () => {
       enabledDisplayData: [account],
     } as any)
 
-    const resolveApiTokenKey = vi.fn().mockResolvedValue("resolved-token-key")
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens: vi.fn().mockResolvedValue([token]),
-      resolveApiTokenKey,
-    } as any)
+    const resolveTokenKey = vi.fn().mockResolvedValue("resolved-token-key")
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: vi.fn().mockResolvedValue([token]),
+        resolveTokenKey,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2908,7 +3137,7 @@ describe("useKeyManagement enabled account filtering", () => {
       await result.current.toggleKeyVisibility(account, token)
     })
 
-    expect(resolveApiTokenKey).toHaveBeenCalledTimes(1)
+    expect(resolveTokenKey).toHaveBeenCalledTimes(1)
     expect(result.current.getVisibleTokenKey(token)).toBe("resolved-token-key")
     expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
     expect(trackerCompleteMock).toHaveBeenCalledWith(
@@ -2939,7 +3168,12 @@ describe("useKeyManagement enabled account filtering", () => {
       .fn()
       .mockResolvedValueOnce([token])
       .mockResolvedValueOnce([token])
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -2980,7 +3214,12 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn()
-    vi.mocked(getApiService).mockReturnValue({ fetchAccountTokens } as any)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -3050,11 +3289,14 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([token])
-    const deleteApiToken = vi.fn()
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      deleteApiToken,
-    } as any)
+    const deleteToken = vi.fn()
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        deleteToken,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const confirmSpy = vi.spyOn(window, "confirm")
 
@@ -3073,7 +3315,10 @@ describe("useKeyManagement enabled account filtering", () => {
     })
 
     expect(confirmSpy).not.toHaveBeenCalled()
-    expect(deleteApiToken).toHaveBeenCalledWith(expect.anything(), token.id)
+    expect(deleteToken).toHaveBeenCalledWith({
+      request: expect.anything(),
+      tokenId: token.id,
+    })
     expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
       "keyManagement:messages.deleteSuccess",
     )
@@ -3101,11 +3346,14 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([])
-    const deleteApiToken = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      deleteApiToken,
-    } as any)
+    const deleteToken = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        deleteToken,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -3115,7 +3363,10 @@ describe("useKeyManagement enabled account filtering", () => {
       await result.current.handleDeleteToken(token)
     })
 
-    expect(deleteApiToken).toHaveBeenCalledWith(expect.anything(), token.id)
+    expect(deleteToken).toHaveBeenCalledWith({
+      request: expect.anything(),
+      tokenId: token.id,
+    })
     expect(result.current.tokenInventories[account.id]).toBeUndefined()
     expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
       "keyManagement:messages.deleteSuccess",
@@ -3149,11 +3400,14 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([loadedToken])
-    const deleteApiToken = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      deleteApiToken,
-    } as any)
+    const deleteToken = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        deleteToken,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -3173,10 +3427,10 @@ describe("useKeyManagement enabled account filtering", () => {
       await result.current.handleDeleteToken(staleToken)
     })
 
-    expect(deleteApiToken).toHaveBeenCalledWith(
-      expect.anything(),
-      staleToken.id,
-    )
+    expect(deleteToken).toHaveBeenCalledWith({
+      request: expect.anything(),
+      tokenId: staleToken.id,
+    })
     expect(result.current.tokenInventories[account.id]?.tokens).toEqual([
       loadedToken,
     ])
@@ -3205,11 +3459,14 @@ describe("useKeyManagement enabled account filtering", () => {
       expired_time: 0,
     })
     const fetchAccountTokens = vi.fn().mockResolvedValue([token])
-    const deleteApiToken = vi.fn().mockRejectedValue(new Error("delete boom"))
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      deleteApiToken,
-    } as any)
+    const deleteToken = vi.fn().mockRejectedValue(new Error("delete boom"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        deleteToken,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true)
 
@@ -3263,11 +3520,14 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([token])
-    const deleteApiToken = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      deleteApiToken,
-    } as any)
+    const deleteToken = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        deleteToken,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true)
 
@@ -3287,7 +3547,10 @@ describe("useKeyManagement enabled account filtering", () => {
       await result.current.handleDeleteToken(token)
     })
 
-    expect(deleteApiToken).toHaveBeenCalledWith(expect.anything(), token.id)
+    expect(deleteToken).toHaveBeenCalledWith({
+      request: expect.anything(),
+      tokenId: token.id,
+    })
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.DeleteAccountToken,
@@ -3335,11 +3598,14 @@ describe("useKeyManagement enabled account filtering", () => {
             resolveRefresh = resolve
           }),
       )
-    const deleteApiToken = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      deleteApiToken,
-    } as any)
+    const deleteToken = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        deleteToken,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const { result } = renderHook(() => useKeyManagement(), {
       wrapper: createWrapper(),
@@ -3381,11 +3647,14 @@ describe("useKeyManagement enabled account filtering", () => {
     } as any)
 
     const fetchAccountTokens = vi.fn().mockResolvedValue([token])
-    const deleteApiToken = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getApiService).mockReturnValue({
-      fetchAccountTokens,
-      deleteApiToken,
-    } as any)
+    const deleteToken = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        deleteToken,
+      }) as any,
+    )
+    vi.mocked(getApiService).mockReturnValue({} as any)
 
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true)
 
@@ -3404,7 +3673,10 @@ describe("useKeyManagement enabled account filtering", () => {
       await result.current.handleDeleteToken(token)
     })
 
-    expect(deleteApiToken).toHaveBeenCalledWith(expect.anything(), token.id)
+    expect(deleteToken).toHaveBeenCalledWith({
+      request: expect.anything(),
+      tokenId: token.id,
+    })
     expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
       "keyManagement:messages.deleteSuccess",
     )

--- a/tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx
@@ -37,6 +37,10 @@ vi.mock("react-i18next", async (importOriginal) => {
 vi.mock("~/services/accounts/utils/apiServiceRequest", () => ({
   createDisplayAccountApiContext: (...args: any[]) =>
     createDisplayAccountApiContextMock(...args),
+  requireDisplayAccountKeyManagement: (
+    _account: unknown,
+    keyManagement: unknown,
+  ) => keyManagement,
 }))
 
 const ACCOUNT = {
@@ -93,8 +97,8 @@ describe("useTokenData", () => {
     toastErrorMock.mockReset()
 
     createDisplayAccountApiContextMock.mockReturnValue({
-      service: {
-        fetchAccountAvailableModels: fetchAccountAvailableModelsMock,
+      keyManagement: {
+        fetchAvailableModels: fetchAccountAvailableModelsMock,
         fetchUserGroups: fetchUserGroupsMock,
       },
       request: { accountId: ACCOUNT.id },

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -49,6 +49,10 @@ vi.mock("~/services/apiAdapters/registry", () => ({
         request: unknown
         token: { key: string }
       }) => _params.token.key,
+      deleteToken: vi.fn(),
+      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+      fetchAvailableModels: (...args: any[]) =>
+        fetchAccountAvailableModelsMock(...args),
     },
   }),
 }))

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -67,6 +67,10 @@ vi.mock("~/services/apiAdapters/registry", () => ({
       fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
       createToken: (...args: any[]) => createApiTokenMock(...args),
       resolveTokenKey: (...args: any[]) => resolveApiTokenKeyMock(...args),
+      deleteToken: vi.fn(),
+      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+      fetchAvailableModels: (...args: any[]) =>
+        fetchAccountAvailableModelsMock(...args),
     },
   }),
 }))

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -26,13 +26,18 @@ const mocks = vi.hoisted(() => ({
   deleteApiToken: vi.fn(),
 }))
 
-vi.mock("~/services/apiService", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("~/services/apiService")>()
-  return {
-    ...actual,
-    getApiService: vi.fn(() => mocks),
-  }
-})
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(() => ({
+    keyManagement: {
+      fetchTokens: (...args: unknown[]) => mocks.fetchAccountTokens(...args),
+      fetchUserGroups: (...args: unknown[]) => mocks.fetchUserGroups(...args),
+      createToken: (...args: unknown[]) => mocks.createApiToken(...args),
+      deleteToken: (...args: unknown[]) => mocks.deleteApiToken(...args),
+      resolveTokenKey: vi.fn(),
+      fetchAvailableModels: vi.fn(),
+    },
+  })),
+}))
 
 const account = buildSiteAccount({
   id: "new-api-1",
@@ -280,8 +285,8 @@ describe("ensureAccountKeysForAvailableGroups", () => {
       },
     })
 
-    expect(mocks.deleteApiToken).toHaveBeenCalledWith(
-      expect.objectContaining({
+    expect(mocks.deleteApiToken).toHaveBeenCalledWith({
+      request: expect.objectContaining({
         baseUrl: "https://relay.example.com",
         accountId: "new-api-1",
         auth: expect.objectContaining({
@@ -290,8 +295,8 @@ describe("ensureAccountKeysForAvailableGroups", () => {
           accessToken: "access-token",
         }),
       }),
-      9,
-    )
+      tokenId: 9,
+    })
     expect(result).toEqual(
       expect.objectContaining({
         accountId: "new-api-1",

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -37,6 +37,9 @@ const {
         fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
         createToken: (...args: unknown[]) => createApiTokenMock(...args),
         resolveTokenKey: vi.fn(),
+        deleteToken: vi.fn(),
+        fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
+        fetchAvailableModels: vi.fn(),
       },
     })),
     toastLoadingMock: vi.fn(),
@@ -55,9 +58,7 @@ vi.mock("~/services/apiService", async (importOriginal) => {
   const actual = await importOriginal<typeof import("~/services/apiService")>()
   return {
     ...actual,
-    getApiService: vi.fn(() => ({
-      fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
-    })),
+    getApiService: vi.fn(() => ({})),
   }
 })
 

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -32,6 +32,9 @@ const {
         fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
         createToken: (...args: unknown[]) => createApiTokenMock(...args),
         resolveTokenKey: vi.fn(),
+        deleteToken: vi.fn(),
+        fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
+        fetchAvailableModels: vi.fn(),
       },
     })),
   }
@@ -41,9 +44,7 @@ vi.mock("~/services/apiService", async (importOriginal) => {
   const actual = await importOriginal<typeof import("~/services/apiService")>()
   return {
     ...actual,
-    getApiService: vi.fn(() => ({
-      fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
-    })),
+    getApiService: vi.fn(() => ({})),
   }
 })
 

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -8,25 +8,43 @@ import { AuthTypeEnum, type ApiToken } from "~/types"
 
 const {
   mockAihubmixCreateApiToken,
+  mockAihubmixDeleteApiToken,
+  mockAihubmixFetchAccountAvailableModels,
   mockAihubmixFetchAccountTokens,
+  mockAihubmixFetchUserGroups,
   mockAihubmixResolveApiTokenKey,
   mockCreateApiToken,
+  mockDeleteApiToken,
+  mockFetchAccountAvailableModels,
   mockFetchAccountTokens,
+  mockFetchUserGroups,
   mockGetApiService,
   mockResolveApiTokenKey,
   mockSub2ApiCreateApiToken,
+  mockSub2ApiDeleteApiToken,
+  mockSub2ApiFetchAccountAvailableModels,
   mockSub2ApiFetchAccountTokens,
+  mockSub2ApiFetchUserGroups,
   mockSub2ApiResolveApiTokenKey,
 } = vi.hoisted(() => ({
   mockAihubmixCreateApiToken: vi.fn(),
+  mockAihubmixDeleteApiToken: vi.fn(),
+  mockAihubmixFetchAccountAvailableModels: vi.fn(),
   mockAihubmixFetchAccountTokens: vi.fn(),
+  mockAihubmixFetchUserGroups: vi.fn(),
   mockAihubmixResolveApiTokenKey: vi.fn(),
   mockCreateApiToken: vi.fn(),
+  mockDeleteApiToken: vi.fn(),
+  mockFetchAccountAvailableModels: vi.fn(),
   mockFetchAccountTokens: vi.fn(),
+  mockFetchUserGroups: vi.fn(),
   mockGetApiService: vi.fn(),
   mockResolveApiTokenKey: vi.fn(),
   mockSub2ApiCreateApiToken: vi.fn(),
+  mockSub2ApiDeleteApiToken: vi.fn(),
+  mockSub2ApiFetchAccountAvailableModels: vi.fn(),
   mockSub2ApiFetchAccountTokens: vi.fn(),
+  mockSub2ApiFetchUserGroups: vi.fn(),
   mockSub2ApiResolveApiTokenKey: vi.fn(),
 }))
 
@@ -36,13 +54,19 @@ vi.mock("~/services/apiService", () => ({
 
 vi.mock("~/services/apiService/sub2api", () => ({
   createApiToken: mockSub2ApiCreateApiToken,
+  deleteApiToken: mockSub2ApiDeleteApiToken,
+  fetchAccountAvailableModels: mockSub2ApiFetchAccountAvailableModels,
   fetchAccountTokens: mockSub2ApiFetchAccountTokens,
+  fetchUserGroups: mockSub2ApiFetchUserGroups,
   resolveApiTokenKey: mockSub2ApiResolveApiTokenKey,
 }))
 
 vi.mock("~/services/apiService/aihubmix", () => ({
   createApiToken: mockAihubmixCreateApiToken,
+  deleteApiToken: mockAihubmixDeleteApiToken,
+  fetchAccountAvailableModels: mockAihubmixFetchAccountAvailableModels,
   fetchAccountTokens: mockAihubmixFetchAccountTokens,
+  fetchUserGroups: mockAihubmixFetchUserGroups,
   resolveApiTokenKey: mockAihubmixResolveApiTokenKey,
 }))
 
@@ -71,12 +95,22 @@ const tokenData = {
   group: "",
 }
 
+const userGroups = {
+  default: { desc: "Default", ratio: 1 },
+  vip: { desc: "VIP", ratio: 2 },
+}
+
+const availableModels = ["gpt-4o-mini", "claude-3-haiku"]
+
 describe("apiAdapter keyManagement", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetApiService.mockReturnValue({
       createApiToken: mockCreateApiToken,
+      deleteApiToken: mockDeleteApiToken,
+      fetchAccountAvailableModels: mockFetchAccountAvailableModels,
       fetchAccountTokens: mockFetchAccountTokens,
+      fetchUserGroups: mockFetchUserGroups,
       resolveApiTokenKey: mockResolveApiTokenKey,
     })
   })
@@ -86,6 +120,9 @@ describe("apiAdapter keyManagement", () => {
     mockFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
     mockCreateApiToken.mockResolvedValueOnce(true)
     mockResolveApiTokenKey.mockResolvedValueOnce("sk-real")
+    mockDeleteApiToken.mockResolvedValueOnce(true)
+    mockFetchUserGroups.mockResolvedValueOnce(userGroups)
+    mockFetchAccountAvailableModels.mockResolvedValueOnce(availableModels)
 
     const keyManagement = createNewApiKeyManagement(SITE_TYPES.ONE_HUB)
 
@@ -100,11 +137,30 @@ describe("apiAdapter keyManagement", () => {
     await expect(
       keyManagement.resolveTokenKey({ request, token }),
     ).resolves.toBe("sk-real")
+    await expect(
+      keyManagement.deleteToken({ request, tokenId: token.id }),
+    ).resolves.toBe(true)
+    await expect(keyManagement.fetchUserGroups(request)).resolves.toBe(
+      userGroups,
+    )
+    await expect(keyManagement.fetchAvailableModels(request)).resolves.toBe(
+      availableModels,
+    )
 
-    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.ONE_HUB)
+    expect(mockGetApiService.mock.calls).toEqual([
+      [SITE_TYPES.ONE_HUB],
+      [SITE_TYPES.ONE_HUB],
+      [SITE_TYPES.ONE_HUB],
+      [SITE_TYPES.ONE_HUB],
+      [SITE_TYPES.ONE_HUB],
+      [SITE_TYPES.ONE_HUB],
+    ])
     expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, 2, 25)
     expect(mockCreateApiToken).toHaveBeenCalledWith(request, tokenData)
     expect(mockResolveApiTokenKey).toHaveBeenCalledWith(request, token)
+    expect(mockDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+    expect(mockFetchUserGroups).toHaveBeenCalledWith(request)
+    expect(mockFetchAccountAvailableModels).toHaveBeenCalledWith(request)
   })
 
   it("delegates Sub2API key operations to backend key helpers", async () => {
@@ -112,6 +168,11 @@ describe("apiAdapter keyManagement", () => {
     mockSub2ApiFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
     mockSub2ApiCreateApiToken.mockResolvedValueOnce(token)
     mockSub2ApiResolveApiTokenKey.mockResolvedValueOnce("sk-sub2api")
+    mockSub2ApiDeleteApiToken.mockResolvedValueOnce(true)
+    mockSub2ApiFetchUserGroups.mockResolvedValueOnce(userGroups)
+    mockSub2ApiFetchAccountAvailableModels.mockResolvedValueOnce(
+      availableModels,
+    )
 
     await expect(
       sub2ApiKeyManagement.fetchTokens(request, { page: 3, size: 50 }),
@@ -122,10 +183,22 @@ describe("apiAdapter keyManagement", () => {
     await expect(
       sub2ApiKeyManagement.resolveTokenKey({ request, token }),
     ).resolves.toBe("sk-sub2api")
+    await expect(
+      sub2ApiKeyManagement.deleteToken({ request, tokenId: token.id }),
+    ).resolves.toBe(true)
+    await expect(sub2ApiKeyManagement.fetchUserGroups(request)).resolves.toBe(
+      userGroups,
+    )
+    await expect(
+      sub2ApiKeyManagement.fetchAvailableModels(request),
+    ).resolves.toBe(availableModels)
 
     expect(mockSub2ApiFetchAccountTokens).toHaveBeenCalledWith(request, 3, 50)
     expect(mockSub2ApiCreateApiToken).toHaveBeenCalledWith(request, tokenData)
     expect(mockSub2ApiResolveApiTokenKey).toHaveBeenCalledWith(request, token)
+    expect(mockSub2ApiDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+    expect(mockSub2ApiFetchUserGroups).toHaveBeenCalledWith(request)
+    expect(mockSub2ApiFetchAccountAvailableModels).toHaveBeenCalledWith(request)
   })
 
   it("delegates AIHubMix key operations while preserving fetch option behavior", async () => {
@@ -133,6 +206,11 @@ describe("apiAdapter keyManagement", () => {
     mockAihubmixFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
     mockAihubmixCreateApiToken.mockResolvedValueOnce(token)
     mockAihubmixResolveApiTokenKey.mockResolvedValueOnce("aihubmix-secret")
+    mockAihubmixDeleteApiToken.mockResolvedValueOnce(true)
+    mockAihubmixFetchUserGroups.mockResolvedValueOnce(userGroups)
+    mockAihubmixFetchAccountAvailableModels.mockResolvedValueOnce(
+      availableModels,
+    )
 
     await expect(
       aihubmixKeyManagement.fetchTokens(request, { page: 4, size: 10 }),
@@ -143,9 +221,23 @@ describe("apiAdapter keyManagement", () => {
     await expect(
       aihubmixKeyManagement.resolveTokenKey({ request, token }),
     ).resolves.toBe("aihubmix-secret")
+    await expect(
+      aihubmixKeyManagement.deleteToken({ request, tokenId: token.id }),
+    ).resolves.toBe(true)
+    await expect(aihubmixKeyManagement.fetchUserGroups(request)).resolves.toBe(
+      userGroups,
+    )
+    await expect(
+      aihubmixKeyManagement.fetchAvailableModels(request),
+    ).resolves.toBe(availableModels)
 
     expect(mockAihubmixFetchAccountTokens).toHaveBeenCalledWith(request)
     expect(mockAihubmixCreateApiToken).toHaveBeenCalledWith(request, tokenData)
     expect(mockAihubmixResolveApiTokenKey).toHaveBeenCalledWith(request, token)
+    expect(mockAihubmixDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+    expect(mockAihubmixFetchUserGroups).toHaveBeenCalledWith(request)
+    expect(mockAihubmixFetchAccountAvailableModels).toHaveBeenCalledWith(
+      request,
+    )
   })
 })

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -163,6 +163,18 @@ describe("apiAdapter keyManagement", () => {
     expect(mockFetchAccountAvailableModels).toHaveBeenCalledWith(request)
   })
 
+  it("propagates New API-family key lifecycle errors from the site-specific apiService", async () => {
+    const error = new Error("delete failed")
+    mockDeleteApiToken.mockRejectedValueOnce(error)
+
+    const keyManagement = createNewApiKeyManagement(SITE_TYPES.ONE_HUB)
+
+    await expect(
+      keyManagement.deleteToken({ request, tokenId: token.id }),
+    ).rejects.toBe(error)
+    expect(mockDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+  })
+
   it("delegates Sub2API key operations to backend key helpers", async () => {
     const expectedTokens = [token]
     mockSub2ApiFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
@@ -198,6 +210,16 @@ describe("apiAdapter keyManagement", () => {
     expect(mockSub2ApiResolveApiTokenKey).toHaveBeenCalledWith(request, token)
     expect(mockSub2ApiDeleteApiToken).toHaveBeenCalledWith(request, token.id)
     expect(mockSub2ApiFetchUserGroups).toHaveBeenCalledWith(request)
+    expect(mockSub2ApiFetchAccountAvailableModels).toHaveBeenCalledWith(request)
+  })
+
+  it("propagates Sub2API key inventory errors from backend helpers", async () => {
+    const error = new Error("model inventory failed")
+    mockSub2ApiFetchAccountAvailableModels.mockRejectedValueOnce(error)
+
+    await expect(
+      sub2ApiKeyManagement.fetchAvailableModels(request),
+    ).rejects.toBe(error)
     expect(mockSub2ApiFetchAccountAvailableModels).toHaveBeenCalledWith(request)
   })
 
@@ -239,5 +261,15 @@ describe("apiAdapter keyManagement", () => {
     expect(mockAihubmixFetchAccountAvailableModels).toHaveBeenCalledWith(
       request,
     )
+  })
+
+  it("propagates AIHubMix unsupported group inventory errors", async () => {
+    const error = new Error("groups unsupported")
+    mockAihubmixFetchUserGroups.mockRejectedValueOnce(error)
+
+    await expect(aihubmixKeyManagement.fetchUserGroups(request)).rejects.toBe(
+      error,
+    )
+    expect(mockAihubmixFetchUserGroups).toHaveBeenCalledWith(request)
   })
 })

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -25,6 +25,9 @@ describe("apiAdapters registry", () => {
       fetchTokens: expect.any(Function),
       createToken: expect.any(Function),
       resolveTokenKey: expect.any(Function),
+      deleteToken: expect.any(Function),
+      fetchUserGroups: expect.any(Function),
+      fetchAvailableModels: expect.any(Function),
     })
     expect(adapter.accountRefresh).toEqual({
       fetchCheckInSupport: expect.any(Function),
@@ -69,6 +72,9 @@ describe("apiAdapters registry", () => {
         fetchTokens: expect.any(Function),
         createToken: expect.any(Function),
         resolveTokenKey: expect.any(Function),
+        deleteToken: expect.any(Function),
+        fetchUserGroups: expect.any(Function),
+        fetchAvailableModels: expect.any(Function),
       })
       expect(adapter.accountRefresh).toEqual({
         fetchCheckInSupport: expect.any(Function),
@@ -98,6 +104,9 @@ describe("apiAdapters registry", () => {
       fetchTokens: expect.any(Function),
       createToken: expect.any(Function),
       resolveTokenKey: expect.any(Function),
+      deleteToken: expect.any(Function),
+      fetchUserGroups: expect.any(Function),
+      fetchAvailableModels: expect.any(Function),
     })
     expect(adapter.accountRefresh).toEqual({
       fetchCheckInSupport: expect.any(Function),


### PR DESCRIPTION
## Summary
- Add the planned key-management lifecycle adapter seam and site adapter contract coverage.
- Route Key Management page lifecycle, account token loading, group coverage, and dialog consumers through adapters.
- Update focused tests for adapter-backed token, group, model, and dialog flows.

## Test Plan
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded token key management with support for token deletion, plus retrieval of available user groups and available models.
* **Refactor**
  * Updated token-loading and deletion flows across dialogs, hooks, and key management services to use a dedicated key-management capability via the site adapter.
* **Documentation**
  * Added new plan and design documentation for the key management lifecycle migration.
* **Tests**
  * Updated mocks and assertions to validate the widened key-management adapter interface and updated token flow wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->