### PR TITLE
refactor(api-adapters): add account bootstrap capability

### DIFF
--- a/docs/superpowers/plans/2026-06-19-api-adapter-account-bootstrap.md
+++ b/docs/superpowers/plans/2026-06-19-api-adapter-account-bootstrap.md
@@ -1,0 +1,1282 @@
+# API Adapter Account Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `SiteAdapter.accountBootstrap` capability so API-fallback user discovery, site-name/status probing, account-site route resolution, and account-completion bootstrap facts stop depending on product-level `getApiService(...)` calls.
+
+**Architecture:** Introduce `AccountBootstrapCapability` as a deep Adapter Interface for early account-site facts. Existing backend modules remain delegated implementations; product modules ask `getSiteAdapter(siteType).accountBootstrap`, while route resolver keeps URL joining/cache and account completion keeps workflow semantics.
+
+**Tech Stack:** TypeScript, WXT extension services, existing `apiAdapters`, Vitest, `pnpm run validate:staged`, `pnpm run validate:push`.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-api-adapter-account-bootstrap-design.md`
+
+---
+
+## File Structure
+
+- Create `src/services/apiAdapters/contracts/accountBootstrap.ts`
+  - Defines `AccountBootstrapCapability`, `AccountBootstrapRouteKind`, and `AccountBootstrapRouteTarget`.
+- Modify `src/services/apiAdapters/contracts/siteAdapter.ts`
+  - Adds optional `accountBootstrap`.
+- Create `src/services/apiAdapters/accountRoutes.ts`
+  - Shared static account-route path resolver used by bootstrap adapters and route-resolver fallback.
+- Create `src/services/apiAdapters/newApi/accountBootstrap.ts`
+  - Delegates bootstrap facts to the site-bound New API-family `getApiService(siteType)`.
+- Create `src/services/apiAdapters/sub2api/accountBootstrap.ts`
+  - Delegates bootstrap facts to Sub2API backend helpers.
+- Create `src/services/apiAdapters/aihubmix/accountBootstrap.ts`
+  - Delegates bootstrap facts to AIHubMix backend helpers.
+- Modify `src/services/apiAdapters/newApi/index.ts`
+  - Registers `accountBootstrap: createNewApiAccountBootstrap(siteType)`.
+- Modify `src/services/apiAdapters/sub2api/index.ts`
+  - Registers `accountBootstrap: sub2ApiAccountBootstrap`.
+- Modify `src/services/apiAdapters/aihubmix/index.ts`
+  - Registers `accountBootstrap: aihubmixAccountBootstrap`.
+- Create `tests/services/apiAdapters/accountBootstrap.test.ts`
+  - Covers delegation and route-path behavior for New API-family, Sub2API, and AIHubMix.
+- Modify `tests/services/apiAdapters/registry.test.ts`
+  - Verifies bootstrap capability presence for supported adapters and omission for unsupported adapters.
+- Modify `src/services/siteDetection/autoDetectService.ts`
+  - Uses `accountBootstrap.fetchUserInfo(...)` for direct API fallback.
+- Modify `tests/services/autoDetectService.test.ts`
+  - Mocks `getSiteAdapter(...).accountBootstrap.fetchUserInfo(...)`.
+- Modify `src/services/accounts/siteName.ts`
+  - Uses `accountBootstrap.fetchSiteStatus(...)` for site-name status probing.
+- Modify `tests/services/accountOperations.test.ts`
+  - Updates `getSiteName(...)` expectations to the adapter path.
+- Modify `src/services/accounts/utils/siteRouteResolver.ts`
+  - Uses `accountBootstrap.resolveRoutePath(...)` for static route paths and `accountBootstrap.fetchSiteStatus(...)` for cached New API default-theme probing.
+- Modify `tests/services/accounts/siteRouteResolver.test.ts`
+  - Updates route tests to mock adapter bootstrap status and route path methods.
+- Modify `src/services/apiAdapters/newApi/accountCompletion.ts`
+  - Uses `createNewApiAccountBootstrap(detected.siteType)` internally.
+- Modify `src/services/apiAdapters/sub2api/accountCompletion.ts`
+  - Uses `sub2ApiAccountBootstrap` internally.
+- Modify `src/services/apiAdapters/aihubmix/accountCompletion.ts`
+  - Uses `aihubmixAccountBootstrap` internally.
+- Modify account-completion tests:
+  - `tests/services/apiAdapters/newApi/accountCompletion.test.ts`
+  - `tests/services/apiAdapters/sub2api/accountCompletion.test.ts`
+  - `tests/services/apiAdapters/aihubmix/accountCompletion.test.ts`
+
+Do not modify:
+
+- `src/services/apiService/**` backend behavior except import-only fallout if TypeScript requires it.
+- `src/constants/siteType.ts` or `src/services/siteDetection/detectSiteType.ts`.
+- `src/services/accounts/utils/apiServiceRequest.ts`; it still creates service requests from saved accounts until that slice migrates.
+- locale files, telemetry schemas, settings search files, Playwright tests, redemption code, managed-site provider/channel CRUD, or new site-type definitions.
+
+---
+
+### Task 1: Add Account Bootstrap Contract And Adapter Implementations
+
+**Files:**
+
+- Create: `src/services/apiAdapters/contracts/accountBootstrap.ts`
+- Modify: `src/services/apiAdapters/contracts/siteAdapter.ts`
+- Create: `src/services/apiAdapters/accountRoutes.ts`
+- Create: `src/services/apiAdapters/newApi/accountBootstrap.ts`
+- Create: `src/services/apiAdapters/sub2api/accountBootstrap.ts`
+- Create: `src/services/apiAdapters/aihubmix/accountBootstrap.ts`
+- Modify: `src/services/apiAdapters/newApi/index.ts`
+- Modify: `src/services/apiAdapters/sub2api/index.ts`
+- Modify: `src/services/apiAdapters/aihubmix/index.ts`
+- Create: `tests/services/apiAdapters/accountBootstrap.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Add failing adapter tests for the new capability**
+
+Create `tests/services/apiAdapters/accountBootstrap.test.ts` with hoisted mocks for the existing backend delegates:
+
+```ts
+const {
+  mockAihubmixExtractDefaultExchangeRate,
+  mockAihubmixFetchSiteStatus,
+  mockAihubmixFetchSupportCheckIn,
+  mockAihubmixFetchUserInfo,
+  mockAihubmixGetOrCreateAccessToken,
+  mockExtractDefaultExchangeRate,
+  mockFetchSiteStatus,
+  mockFetchSupportCheckIn,
+  mockFetchUserInfo,
+  mockGetApiService,
+  mockGetOrCreateAccessToken,
+  mockSub2ApiExtractDefaultExchangeRate,
+  mockSub2ApiFetchSiteStatus,
+  mockSub2ApiFetchSupportCheckIn,
+  mockSub2ApiFetchUserInfo,
+  mockSub2ApiGetOrCreateAccessToken,
+} = vi.hoisted(() => ({
+  mockAihubmixExtractDefaultExchangeRate: vi.fn(),
+  mockAihubmixFetchSiteStatus: vi.fn(),
+  mockAihubmixFetchSupportCheckIn: vi.fn(),
+  mockAihubmixFetchUserInfo: vi.fn(),
+  mockAihubmixGetOrCreateAccessToken: vi.fn(),
+  mockExtractDefaultExchangeRate: vi.fn(),
+  mockFetchSiteStatus: vi.fn(),
+  mockFetchSupportCheckIn: vi.fn(),
+  mockFetchUserInfo: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockGetOrCreateAccessToken: vi.fn(),
+  mockSub2ApiExtractDefaultExchangeRate: vi.fn(),
+  mockSub2ApiFetchSiteStatus: vi.fn(),
+  mockSub2ApiFetchSupportCheckIn: vi.fn(),
+  mockSub2ApiFetchUserInfo: vi.fn(),
+  mockSub2ApiGetOrCreateAccessToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  extractDefaultExchangeRate: mockSub2ApiExtractDefaultExchangeRate,
+  fetchSiteStatus: mockSub2ApiFetchSiteStatus,
+  fetchSupportCheckIn: mockSub2ApiFetchSupportCheckIn,
+  fetchUserInfo: mockSub2ApiFetchUserInfo,
+  getOrCreateAccessToken: mockSub2ApiGetOrCreateAccessToken,
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  extractDefaultExchangeRate: mockAihubmixExtractDefaultExchangeRate,
+  fetchSiteStatus: mockAihubmixFetchSiteStatus,
+  fetchSupportCheckIn: mockAihubmixFetchSupportCheckIn,
+  fetchUserInfo: mockAihubmixFetchUserInfo,
+  getOrCreateAccessToken: mockAihubmixGetOrCreateAccessToken,
+}))
+```
+
+Use request and response fixtures with example domains only:
+
+```ts
+const request = {
+  baseUrl: "https://example.invalid",
+  auth: { authType: AuthTypeEnum.Cookie },
+}
+
+const userInfo = { id: 1, username: "tester" }
+const tokenInfo = { username: "tester", access_token: "token" }
+const siteStatus = { system_name: "Example Portal", checkin_enabled: true }
+```
+
+Add a New API-family delegation test:
+
+```ts
+const accountBootstrap = createNewApiAccountBootstrap(SITE_TYPES.VELOERA)
+
+mockFetchUserInfo.mockResolvedValueOnce(userInfo)
+mockGetOrCreateAccessToken.mockResolvedValueOnce(tokenInfo)
+mockFetchSiteStatus.mockResolvedValueOnce(siteStatus)
+mockFetchSupportCheckIn.mockResolvedValueOnce(true)
+mockExtractDefaultExchangeRate.mockReturnValueOnce(7.25)
+
+await expect(accountBootstrap.fetchUserInfo(request)).resolves.toBe(userInfo)
+await expect(accountBootstrap.getOrCreateAccessToken(request)).resolves.toBe(
+  tokenInfo,
+)
+await expect(accountBootstrap.fetchSiteStatus(request)).resolves.toBe(
+  siteStatus,
+)
+await expect(accountBootstrap.fetchCheckInSupport(request)).resolves.toBe(true)
+expect(accountBootstrap.extractDefaultExchangeRate(siteStatus)).toBe(7.25)
+expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.VELOERA)
+```
+
+Add static route path assertions that do not require a network/status probe:
+
+```ts
+await expect(
+  accountBootstrap.resolveRoutePath(
+    { baseUrl: "https://example.invalid", siteType: SITE_TYPES.VELOERA },
+    "checkIn",
+  ),
+).resolves.toBe("/app/me")
+```
+
+Add Sub2API and AIHubMix tests with the same delegation shape, asserting module-level helper calls rather than `getApiService(...)`. For route paths, assert:
+
+```ts
+await expect(
+  sub2ApiAccountBootstrap.resolveRoutePath(
+    { baseUrl: "https://sub2.example.invalid", siteType: SITE_TYPES.SUB2API },
+    "login",
+  ),
+).resolves.toBe("/login")
+
+await expect(
+  aihubmixAccountBootstrap.resolveRoutePath(
+    { baseUrl: "https://aihubmix.example.invalid", siteType: SITE_TYPES.AIHUBMIX },
+    "login",
+  ),
+).resolves.toBe("/sign-in")
+```
+
+- [ ] **Step 2: Update registry tests for bootstrap support**
+
+In `tests/services/apiAdapters/registry.test.ts`, add `accountBootstrap` to supported adapter expectations:
+
+```ts
+expect(adapter.accountBootstrap).toEqual({
+  fetchUserInfo: expect.any(Function),
+  getOrCreateAccessToken: expect.any(Function),
+  fetchSiteStatus: expect.any(Function),
+  fetchCheckInSupport: expect.any(Function),
+  extractDefaultExchangeRate: expect.any(Function),
+  resolveRoutePath: expect.any(Function),
+})
+```
+
+Apply this to:
+
+- the New API-family loop
+- the Sub2API adapter test
+- the AIHubMix adapter test
+
+Keep the unsupported adapter expectation strict:
+
+```ts
+expect(adapter.accountBootstrap).toBeUndefined()
+```
+
+- [ ] **Step 3: Run the adapter tests and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountBootstrap.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because the contract and adapter implementations do not exist yet.
+
+- [ ] **Step 4: Add the account bootstrap contract**
+
+Create `src/services/apiAdapters/contracts/accountBootstrap.ts`:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import type {
+  AccessTokenInfo,
+  ApiServiceRequest,
+  SiteStatusInfo,
+  UserInfo,
+} from "~/services/apiService/common/type"
+
+export type AccountBootstrapRouteKind =
+  | "login"
+  | "usage"
+  | "checkIn"
+  | "adminCredentials"
+  | "redeem"
+  | "siteAnnouncements"
+
+export type AccountBootstrapRouteTarget = {
+  baseUrl: string
+  siteType: AccountSiteType
+}
+
+export type AccountBootstrapCapability = {
+  fetchUserInfo(request: ApiServiceRequest): Promise<UserInfo>
+  getOrCreateAccessToken(request: ApiServiceRequest): Promise<AccessTokenInfo>
+  fetchSiteStatus(request: ApiServiceRequest): Promise<SiteStatusInfo | null>
+  fetchCheckInSupport(
+    request: ApiServiceRequest,
+  ): Promise<boolean | undefined>
+  extractDefaultExchangeRate(siteStatus: SiteStatusInfo | null): number | null
+  resolveRoutePath(
+    target: AccountBootstrapRouteTarget,
+    route: AccountBootstrapRouteKind,
+  ): Promise<string>
+}
+```
+
+Modify `src/services/apiAdapters/contracts/siteAdapter.ts`:
+
+```ts
+import type { AccountBootstrapCapability } from "./accountBootstrap"
+
+export type SiteAdapter = {
+  // existing fields
+  accountBootstrap?: AccountBootstrapCapability
+}
+```
+
+- [ ] **Step 5: Add shared static route-path resolution**
+
+Create `src/services/apiAdapters/accountRoutes.ts`:
+
+```ts
+import { getAccountSiteApiRouter } from "~/constants/siteType"
+
+import type {
+  AccountBootstrapRouteKind,
+  AccountBootstrapRouteTarget,
+} from "./contracts/accountBootstrap"
+
+export function resolveStaticAccountRoutePath(
+  target: AccountBootstrapRouteTarget,
+  route: AccountBootstrapRouteKind,
+): string {
+  const router = getAccountSiteApiRouter(target.siteType)
+
+  switch (route) {
+    case "login":
+      return router.routes.login
+    case "usage":
+      return router.routes.usage ?? router.routes.login
+    case "checkIn":
+      return router.routes.checkIn ?? router.routes.login
+    case "adminCredentials":
+      return router.routes.adminCredentials ?? router.routes.login
+    case "redeem":
+      return router.routes.redeem ?? router.routes.login
+    case "siteAnnouncements":
+      return router.routes.siteAnnouncements ?? router.routes.login
+  }
+}
+```
+
+Use existing route field names from `getAccountSiteApiRouter(...)`; if TypeScript exposes slightly different optional property names, adapt the switch to the existing router type rather than changing the router contract.
+
+- [ ] **Step 6: Implement New API-family bootstrap**
+
+Create `src/services/apiAdapters/newApi/accountBootstrap.ts`:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import { getApiService } from "~/services/apiService"
+
+export function createNewApiAccountBootstrap(
+  siteType: AccountSiteType,
+): AccountBootstrapCapability {
+  const apiService = getApiService(siteType)
+
+  return {
+    fetchUserInfo: (request) => apiService.fetchUserInfo(request),
+    getOrCreateAccessToken: (request) =>
+      apiService.getOrCreateAccessToken(request),
+    fetchSiteStatus: (request) => apiService.fetchSiteStatus(request),
+    fetchCheckInSupport: (request) =>
+      apiService.fetchSupportCheckIn(request),
+    extractDefaultExchangeRate: (siteStatus) =>
+      apiService.extractDefaultExchangeRate(siteStatus),
+    resolveRoutePath: (target, route) =>
+      Promise.resolve(resolveStaticAccountRoutePath(target, route)),
+  }
+}
+```
+
+- [ ] **Step 7: Implement Sub2API bootstrap**
+
+Create `src/services/apiAdapters/sub2api/accountBootstrap.ts`:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import {
+  extractDefaultExchangeRate,
+  fetchSiteStatus,
+  fetchSupportCheckIn,
+  fetchUserInfo,
+  getOrCreateAccessToken,
+} from "~/services/apiService/sub2api"
+
+export const sub2ApiAccountBootstrap: AccountBootstrapCapability = {
+  fetchUserInfo: (request) => fetchUserInfo(request),
+  getOrCreateAccessToken: (request) => getOrCreateAccessToken(request),
+  fetchSiteStatus: (request) => fetchSiteStatus(request),
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  extractDefaultExchangeRate: (siteStatus) =>
+    extractDefaultExchangeRate(siteStatus),
+  resolveRoutePath: (target, route) =>
+    Promise.resolve(
+      resolveStaticAccountRoutePath(
+        { ...target, siteType: SITE_TYPES.SUB2API },
+        route,
+      ),
+    ),
+}
+```
+
+- [ ] **Step 8: Implement AIHubMix bootstrap**
+
+Create `src/services/apiAdapters/aihubmix/accountBootstrap.ts`:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import {
+  extractDefaultExchangeRate,
+  fetchSiteStatus,
+  fetchSupportCheckIn,
+  fetchUserInfo,
+  getOrCreateAccessToken,
+} from "~/services/apiService/aihubmix"
+
+export const aihubmixAccountBootstrap: AccountBootstrapCapability = {
+  fetchUserInfo: (request) => fetchUserInfo(request),
+  getOrCreateAccessToken: (request) => getOrCreateAccessToken(request),
+  fetchSiteStatus: (request) => fetchSiteStatus(request),
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  extractDefaultExchangeRate: (siteStatus) =>
+    extractDefaultExchangeRate(siteStatus),
+  resolveRoutePath: (target, route) =>
+    Promise.resolve(
+      resolveStaticAccountRoutePath(
+        { ...target, siteType: SITE_TYPES.AIHUBMIX },
+        route,
+      ),
+    ),
+}
+```
+
+Do not move AIHubMix web-origin login URL joining into this adapter. `resolveRoutePath(...)` returns `"/sign-in"`; `siteRouteResolver` remains responsible for choosing `AIHUBMIX_WEB_ORIGIN` for login URLs.
+
+- [ ] **Step 9: Register the capability on adapters**
+
+Modify `src/services/apiAdapters/newApi/index.ts`:
+
+```ts
+import { createNewApiAccountBootstrap } from "./accountBootstrap"
+
+export const createNewApiAdapter = (
+  siteType = SITE_TYPES.NEW_API,
+): SiteAdapter => ({
+  siteType,
+  family: "newApiFamily",
+  accountBootstrap: createNewApiAccountBootstrap(siteType),
+  // existing capabilities
+})
+```
+
+Modify `src/services/apiAdapters/sub2api/index.ts`:
+
+```ts
+import { sub2ApiAccountBootstrap } from "./accountBootstrap"
+
+export const sub2ApiAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.SUB2API,
+  family: "sub2api",
+  accountBootstrap: sub2ApiAccountBootstrap,
+  // existing capabilities
+}
+```
+
+Modify `src/services/apiAdapters/aihubmix/index.ts`:
+
+```ts
+import { aihubmixAccountBootstrap } from "./accountBootstrap"
+
+export const aihubmixAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.AIHUBMIX,
+  accountBootstrap: aihubmixAccountBootstrap,
+  // existing capabilities
+}
+```
+
+- [ ] **Step 10: Run adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountBootstrap.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit Task 1**
+
+Inspect the diff for only the files in this task, then commit:
+
+```powershell
+git status --porcelain=v1
+git diff -- src/services/apiAdapters tests/services/apiAdapters
+git add src/services/apiAdapters/contracts/accountBootstrap.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/accountRoutes.ts src/services/apiAdapters/newApi/accountBootstrap.ts src/services/apiAdapters/sub2api/accountBootstrap.ts src/services/apiAdapters/aihubmix/accountBootstrap.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/sub2api/index.ts src/services/apiAdapters/aihubmix/index.ts tests/services/apiAdapters/accountBootstrap.test.ts tests/services/apiAdapters/registry.test.ts
+git commit -m "refactor(api-adapters): add account bootstrap capability"
+```
+
+---
+
+### Task 2: Route API-Fallback User Discovery Through Account Bootstrap
+
+**Files:**
+
+- Modify: `src/services/siteDetection/autoDetectService.ts`
+- Modify: `tests/services/autoDetectService.test.ts`
+
+- [ ] **Step 1: Change auto-detect tests to mock the adapter path**
+
+In `tests/services/autoDetectService.test.ts`, replace the `~/services/apiService` mock with:
+
+```ts
+const {
+  mockFetchUserInfo,
+  mockGetSiteAdapter,
+  // existing mocks
+} = vi.hoisted(() => ({
+  mockFetchUserInfo: vi.fn(),
+  mockGetSiteAdapter: vi.fn(),
+  // existing mocks
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: mockGetSiteAdapter,
+}))
+```
+
+In `beforeEach`, return the bootstrap capability:
+
+```ts
+mockGetSiteAdapter.mockReturnValue({
+  accountBootstrap: {
+    fetchUserInfo: mockFetchUserInfo,
+  },
+})
+```
+
+Update existing assertions so API fallback still verifies unchanged request shape:
+
+```ts
+expect(mockGetSiteAdapter).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+expect(mockFetchUserInfo).toHaveBeenCalledWith({
+  baseUrl: "https://example.com/console",
+  auth: {
+    authType: AuthTypeEnum.Cookie,
+  },
+  fetchContext: currentTabFetchContext,
+})
+```
+
+Add a missing-capability regression:
+
+```ts
+it("falls back when the detected site type has no account bootstrap capability", async () => {
+  browserAny.runtime = null
+  mockGetSiteAdapter.mockReturnValueOnce({})
+  mockGetActiveOrAllTabs.mockResolvedValue([
+    {
+      id: 1,
+      active: true,
+      url: "https://example.com/home",
+    },
+  ])
+  browserAny.tabs.sendMessage.mockResolvedValueOnce({
+    success: false,
+    error: "no local storage user",
+  })
+
+  const result = await autoDetectSmart("https://example.com/console")
+
+  expect(result.success).toBe(false)
+  expect(mockFetchUserInfo).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run the auto-detect test and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/autoDetectService.test.ts
+```
+
+Expected: FAIL because `autoDetectService` still imports `getApiService(...)`.
+
+- [ ] **Step 3: Implement adapter-backed API fallback**
+
+Modify `src/services/siteDetection/autoDetectService.ts`:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+Remove the `getApiService` import if it becomes unused.
+
+Add a small local helper near `getUserDataViaAPI(...)`:
+
+```ts
+function getAccountBootstrapForApiFallback(siteType: AccountSiteType) {
+  return getSiteAdapter(siteType).accountBootstrap
+}
+```
+
+Replace the direct legacy call:
+
+```ts
+const accountBootstrap = getAccountBootstrapForApiFallback(siteType)
+if (!accountBootstrap) {
+  console.warn("Account bootstrap capability is unavailable", {
+    siteType,
+    hasFetchContext: Boolean(fetchContext),
+  })
+  return null
+}
+
+const userInfo = await accountBootstrap.fetchUserInfo({
+  baseUrl: url,
+  auth: {
+    authType: AuthTypeEnum.Cookie,
+  },
+  ...(fetchContext ? { fetchContext } : {}),
+})
+```
+
+Keep the existing `try/catch`, user-id normalization, access-token extraction, fetch-context propagation, reload-hint behavior, background fallback, and auto-detect metadata unchanged.
+
+- [ ] **Step 4: Run auto-detect tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/autoDetectService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Inspect and commit:
+
+```powershell
+git status --porcelain=v1
+git diff -- src/services/siteDetection/autoDetectService.ts tests/services/autoDetectService.test.ts
+git add src/services/siteDetection/autoDetectService.ts tests/services/autoDetectService.test.ts
+git commit -m "refactor(site-detection): use account bootstrap for user discovery"
+```
+
+---
+
+### Task 3: Route Site Name And Account Routes Through Account Bootstrap
+
+**Files:**
+
+- Modify: `src/services/accounts/siteName.ts`
+- Modify: `tests/services/accountOperations.test.ts`
+- Modify: `src/services/accounts/utils/siteRouteResolver.ts`
+- Modify: `tests/services/accounts/siteRouteResolver.test.ts`
+
+- [ ] **Step 1: Update `getSiteName(...)` tests to expect adapter status probing**
+
+In `tests/services/accountOperations.test.ts`, keep `mockGetApiService` for unrelated account-operation coverage, but change `beforeEach` so the adapter also exposes bootstrap status:
+
+```ts
+mockGetSiteAdapter.mockReturnValue({
+  accountData: {
+    fetchData: mockFetchAccountData,
+  },
+  accountBootstrap: {
+    fetchSiteStatus: mockFetchSiteStatus,
+  },
+})
+```
+
+Update the site-type-hint assertion:
+
+```ts
+const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
+expect(vi.mocked(getSiteAdapter)).toHaveBeenCalledWith(SITE_TYPES.SUB2API)
+```
+
+Keep the existing request assertion:
+
+```ts
+expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+  baseUrl: "https://example.com",
+  auth: { authType: AuthTypeEnum.None },
+})
+```
+
+Add a missing-capability fallback:
+
+```ts
+it("falls back to the domain when site-type hint has no bootstrap status probe", async () => {
+  mockGetSiteAdapter.mockReturnValueOnce({})
+
+  const result = await getSiteName(
+    "https://api.example.com/dashboard",
+    SITE_TYPES.NEW_API,
+  )
+
+  expect(result).toBe("Example")
+  expect(mockFetchSiteStatus).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Update route resolver tests to mock bootstrap status and routes**
+
+In `tests/services/accounts/siteRouteResolver.test.ts`, add adapter registry mocks:
+
+```ts
+const {
+  mockFetchSiteStatus,
+  mockGetSiteAdapter,
+  mockResolveRoutePath,
+} = vi.hoisted(() => ({
+  mockFetchSiteStatus: vi.fn(),
+  mockGetSiteAdapter: vi.fn(),
+  mockResolveRoutePath: vi.fn(),
+}))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: mockGetSiteAdapter,
+}))
+```
+
+In `beforeEach`, return default static route behavior:
+
+```ts
+mockResolveRoutePath.mockImplementation((_target, route) => {
+  const paths = {
+    adminCredentials: "/console/personal",
+    checkIn: "/console/personal",
+    login: "/login",
+    redeem: "/console/topup",
+    siteAnnouncements: "/console",
+    usage: "/console/log",
+  }
+  return Promise.resolve(paths[route as keyof typeof paths])
+})
+
+mockGetSiteAdapter.mockReturnValue({
+  accountBootstrap: {
+    fetchSiteStatus: mockFetchSiteStatus,
+    resolveRoutePath: mockResolveRoutePath,
+  },
+})
+```
+
+Replace `globalThis.fetch` helpers with bootstrap status helpers:
+
+```ts
+const mockDefaultNewApiThemeStatus = () =>
+  mockFetchSiteStatus.mockResolvedValue({
+    theme: "default",
+  })
+```
+
+Update assertions:
+
+```ts
+expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+  baseUrl: "https://new-api.example",
+  auth: { authType: AuthTypeEnum.None },
+})
+
+expect(mockResolveRoutePath).toHaveBeenCalledWith(
+  { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+  SITE_ROUTE_KINDS.CheckIn,
+)
+```
+
+Keep assertions that non-New API sites do not probe status:
+
+```ts
+expect(mockFetchSiteStatus).not.toHaveBeenCalled()
+```
+
+Update the cache-bound test to assert `mockFetchSiteStatus` call count instead of `fetch` call count.
+
+Add missing-capability fallback:
+
+```ts
+it("falls back to static route config when account bootstrap is missing", async () => {
+  mockGetSiteAdapter.mockReturnValueOnce({})
+
+  await expect(
+    resolveAccountSiteRouteUrl(
+      { baseUrl: "https://veloera.example", siteType: SITE_TYPES.VELOERA },
+      SITE_ROUTE_KINDS.CheckIn,
+    ),
+  ).resolves.toBe("https://veloera.example/app/me")
+})
+```
+
+- [ ] **Step 3: Run site-name and route tests and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.test.ts tests/services/accounts/siteRouteResolver.test.ts
+```
+
+Expected: FAIL because both production modules still call the legacy facade or `fetch`.
+
+- [ ] **Step 4: Implement adapter-backed site-name status probing**
+
+Modify `src/services/accounts/siteName.ts`:
+
+```ts
+import {
+  isAccountSiteType,
+  type AccountSiteType,
+} from "~/constants/siteType"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+Remove `getApiService` if unused.
+
+When `siteStatusInfo` is missing and `siteTypeHint` is usable:
+
+```ts
+if (!siteStatusInfo && siteTypeHint && isAccountSiteType(siteTypeHint)) {
+  try {
+    const accountBootstrap = getSiteAdapter(siteTypeHint).accountBootstrap
+    resolvedSiteStatus = accountBootstrap
+      ? await accountBootstrap.fetchSiteStatus({
+          baseUrl,
+          auth: { authType: AuthTypeEnum.None },
+        })
+      : null
+  } catch {
+    resolvedSiteStatus = null
+  }
+}
+```
+
+If `siteTypeHint` is already typed as `AccountSiteType` in the function signature, keep the guard only if callers can pass plain strings today. Preserve all existing title/default-name/domain fallback logic.
+
+- [ ] **Step 5: Implement adapter-backed route resolution**
+
+Modify `src/services/accounts/utils/siteRouteResolver.ts`:
+
+```ts
+import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+Replace the status probe with a capability-aware helper:
+
+```ts
+const fetchNewApiFrontendTheme = async (
+  baseUrl: string,
+  accountBootstrap?: Pick<AccountBootstrapCapability, "fetchSiteStatus">,
+): Promise<string | undefined> => {
+  if (!accountBootstrap) {
+    return undefined
+  }
+
+  const normalizedBaseUrl = normalizeBaseUrlForCache(baseUrl)
+  const cached = getCachedTheme(normalizedBaseUrl)
+  if (cached) {
+    return cached
+  }
+
+  try {
+    const statusInfo = await accountBootstrap.fetchSiteStatus({
+      baseUrl,
+      auth: { authType: AuthTypeEnum.None },
+    })
+    const theme =
+      typeof statusInfo?.theme === "string" ? statusInfo.theme : undefined
+    setCachedTheme(normalizedBaseUrl, theme)
+    return theme
+  } catch {
+    setCachedTheme(normalizedBaseUrl, undefined)
+    return undefined
+  }
+}
+```
+
+Update `resolveAccountSiteRoutePath(...)`:
+
+```ts
+export async function resolveAccountSiteRoutePath(
+  target: AccountSiteRouteTarget,
+  route: SiteRouteKind,
+): Promise<string> {
+  const accountBootstrap = getSiteAdapter(target.siteType).accountBootstrap
+  const staticPath = accountBootstrap
+    ? await accountBootstrap.resolveRoutePath(target, route)
+    : resolveStaticAccountRoutePath(target, route)
+
+  if (target.siteType !== SITE_TYPES.NEW_API || route === "siteAnnouncements") {
+    return staticPath
+  }
+
+  const theme = await fetchNewApiFrontendTheme(
+    target.baseUrl,
+    accountBootstrap,
+  )
+
+  if (theme === NEW_API_FRONTEND_THEMES.Default) {
+    return NEW_API_DEFAULT_THEME_ROUTE_PATHS[route] ?? staticPath
+  }
+
+  return staticPath
+}
+```
+
+Keep:
+
+- `joinUrl(...)`
+- `resolveAccountSiteRouteUrl(...)`
+- `resolveAccountSiteLoginUrl(...)`
+- AIHubMix login origin override
+- `getBestEffortLoginUrl(...)`
+- cache clear helper and cache limits
+
+- [ ] **Step 6: Run site-name and route tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.test.ts tests/services/accounts/siteRouteResolver.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+Inspect and commit:
+
+```powershell
+git status --porcelain=v1
+git diff -- src/services/accounts/siteName.ts src/services/accounts/utils/siteRouteResolver.ts tests/services/accountOperations.test.ts tests/services/accounts/siteRouteResolver.test.ts
+git add src/services/accounts/siteName.ts src/services/accounts/utils/siteRouteResolver.ts tests/services/accountOperations.test.ts tests/services/accounts/siteRouteResolver.test.ts
+git commit -m "refactor(accounts): route bootstrap status and routes through adapters"
+```
+
+---
+
+### Task 4: Deepen Account Completion To Use Sibling Bootstrap
+
+**Files:**
+
+- Modify: `src/services/apiAdapters/newApi/accountCompletion.ts`
+- Modify: `src/services/apiAdapters/sub2api/accountCompletion.ts`
+- Modify: `src/services/apiAdapters/aihubmix/accountCompletion.ts`
+- Modify: `tests/services/apiAdapters/newApi/accountCompletion.test.ts`
+- Modify: `tests/services/apiAdapters/sub2api/accountCompletion.test.ts`
+- Modify: `tests/services/apiAdapters/aihubmix/accountCompletion.test.ts`
+
+- [ ] **Step 1: Update New API account-completion tests to mock sibling bootstrap**
+
+In `tests/services/apiAdapters/newApi/accountCompletion.test.ts`, replace direct `getApiService(...)` mocking with a module mock for the sibling bootstrap:
+
+```ts
+const {
+  mockCreateNewApiAccountBootstrap,
+  mockExtractDefaultExchangeRate,
+  mockFetchCheckInSupport,
+  mockFetchSiteStatus,
+  mockFetchUserInfo,
+  mockGetOrCreateAccessToken,
+} = vi.hoisted(() => ({
+  mockCreateNewApiAccountBootstrap: vi.fn(),
+  mockExtractDefaultExchangeRate: vi.fn(),
+  mockFetchCheckInSupport: vi.fn(),
+  mockFetchSiteStatus: vi.fn(),
+  mockFetchUserInfo: vi.fn(),
+  mockGetOrCreateAccessToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiAdapters/newApi/accountBootstrap", () => ({
+  createNewApiAccountBootstrap: mockCreateNewApiAccountBootstrap,
+}))
+```
+
+In `beforeEach`:
+
+```ts
+mockCreateNewApiAccountBootstrap.mockReturnValue({
+  extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+  fetchCheckInSupport: mockFetchCheckInSupport,
+  fetchSiteStatus: mockFetchSiteStatus,
+  fetchUserInfo: mockFetchUserInfo,
+  getOrCreateAccessToken: mockGetOrCreateAccessToken,
+  resolveRoutePath: vi.fn(),
+})
+```
+
+Update assertions:
+
+```ts
+expect(mockCreateNewApiAccountBootstrap).toHaveBeenCalledWith(
+  SITE_TYPES.NEW_API,
+)
+```
+
+Keep all existing request-shape assertions for user info, token creation, site status, check-in support, exchange-rate fallback, username validation, and access-token validation.
+
+- [ ] **Step 2: Update Sub2API account-completion tests to mock sibling bootstrap**
+
+In `tests/services/apiAdapters/sub2api/accountCompletion.test.ts`, replace direct `getApiService(...)` mocking with:
+
+```ts
+vi.mock("~/services/apiAdapters/sub2api/accountBootstrap", () => ({
+  sub2ApiAccountBootstrap: {
+    extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+    fetchCheckInSupport: mockFetchSupportCheckIn,
+    fetchSiteStatus: mockFetchSiteStatus,
+    fetchUserInfo: mockFetchUserInfo,
+    getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    resolveRoutePath: vi.fn(),
+  },
+}))
+```
+
+Keep assertions that:
+
+- detected access token is required
+- site status uses `AuthTypeEnum.AccessToken`
+- exchange rate uses bootstrap extraction
+- check-in remains disabled
+- detected `sub2apiAuth` is preserved
+- `getOrCreateAccessToken(...)` is not called by completion
+
+- [ ] **Step 3: Update AIHubMix account-completion tests to mock sibling bootstrap**
+
+In `tests/services/apiAdapters/aihubmix/accountCompletion.test.ts`, replace direct `getApiService(...)` mocking with:
+
+```ts
+vi.mock("~/services/apiAdapters/aihubmix/accountBootstrap", () => ({
+  aihubmixAccountBootstrap: {
+    extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+    fetchCheckInSupport: mockFetchSupportCheckIn,
+    fetchSiteStatus: mockFetchSiteStatus,
+    fetchUserInfo: mockFetchUserInfo,
+    getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    resolveRoutePath: vi.fn(),
+  },
+}))
+```
+
+Keep assertions that:
+
+- detected token data skips token fallback
+- missing detected token calls `getOrCreateAccessToken(...)`
+- site status uses cookie auth
+- check-in uses `status.checkin_enabled` when available
+- check-in fallback calls `fetchCheckInSupport(...)`
+- username and access token validation are unchanged
+- exchange rate fallback is unchanged
+
+- [ ] **Step 4: Run account-completion tests and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+```
+
+Expected: FAIL because account-completion implementations still call `getApiService(...)`.
+
+- [ ] **Step 5: Use New API sibling bootstrap inside account completion**
+
+Modify `src/services/apiAdapters/newApi/accountCompletion.ts`:
+
+```ts
+import { createNewApiAccountBootstrap } from "./accountBootstrap"
+```
+
+Replace:
+
+```ts
+const apiService = getApiService(detected.siteType)
+```
+
+with:
+
+```ts
+const accountBootstrap = createNewApiAccountBootstrap(detected.siteType)
+```
+
+Replace method calls:
+
+- `apiService.fetchUserInfo(...)` -> `accountBootstrap.fetchUserInfo(...)`
+- `apiService.getOrCreateAccessToken(...)` -> `accountBootstrap.getOrCreateAccessToken(...)`
+- `apiService.fetchSiteStatus(...)` -> `accountBootstrap.fetchSiteStatus(...)`
+- `apiService.fetchSupportCheckIn(...)` -> `accountBootstrap.fetchCheckInSupport(...)`
+- `apiService.extractDefaultExchangeRate(...)` -> `accountBootstrap.extractDefaultExchangeRate(...)`
+
+Remove the `getApiService` import.
+
+- [ ] **Step 6: Use Sub2API sibling bootstrap inside account completion**
+
+Modify `src/services/apiAdapters/sub2api/accountCompletion.ts`:
+
+```ts
+import { sub2ApiAccountBootstrap } from "./accountBootstrap"
+```
+
+Replace:
+
+- `service.fetchSiteStatus(...)` -> `sub2ApiAccountBootstrap.fetchSiteStatus(...)`
+- `service.extractDefaultExchangeRate(...)` -> `sub2ApiAccountBootstrap.extractDefaultExchangeRate(...)`
+
+Remove `getApiService` and `SITE_TYPES` imports if unused.
+
+- [ ] **Step 7: Use AIHubMix sibling bootstrap inside account completion**
+
+Modify `src/services/apiAdapters/aihubmix/accountCompletion.ts`:
+
+```ts
+import { aihubmixAccountBootstrap } from "./accountBootstrap"
+```
+
+Replace:
+
+- `service.getOrCreateAccessToken(...)` -> `aihubmixAccountBootstrap.getOrCreateAccessToken(...)`
+- `service.fetchSiteStatus(...)` -> `aihubmixAccountBootstrap.fetchSiteStatus(...)`
+- `service.fetchSupportCheckIn(...)` -> `aihubmixAccountBootstrap.fetchCheckInSupport(...)`
+- `service.extractDefaultExchangeRate(...)` -> `aihubmixAccountBootstrap.extractDefaultExchangeRate(...)`
+
+Remove `getApiService` and `SITE_TYPES` imports if unused.
+
+- [ ] **Step 8: Run account-completion tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 4**
+
+Inspect and commit:
+
+```powershell
+git status --porcelain=v1
+git diff -- src/services/apiAdapters/newApi/accountCompletion.ts src/services/apiAdapters/sub2api/accountCompletion.ts src/services/apiAdapters/aihubmix/accountCompletion.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+git add src/services/apiAdapters/newApi/accountCompletion.ts src/services/apiAdapters/sub2api/accountCompletion.ts src/services/apiAdapters/aihubmix/accountCompletion.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+git commit -m "refactor(api-adapters): use bootstrap in account completion"
+```
+
+---
+
+### Task 5: Integration Validation And Deletion Audit
+
+**Files:**
+
+- No planned source edits. If validation exposes code issues, fix only the task-scoped files from Tasks 1-4.
+
+- [ ] **Step 1: Run focused adapter and account tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountBootstrap.test.ts tests/services/apiAdapters/registry.test.ts
+pnpm vitest run tests/services/autoDetectService.test.ts tests/services/accountOperations.test.ts tests/services/accounts/siteRouteResolver.test.ts
+pnpm vitest run tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run related-file validation for the migrated service files**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/contracts/accountBootstrap.ts src/services/apiAdapters/accountRoutes.ts src/services/apiAdapters/newApi/accountBootstrap.ts src/services/apiAdapters/sub2api/accountBootstrap.ts src/services/apiAdapters/aihubmix/accountBootstrap.ts src/services/siteDetection/autoDetectService.ts src/services/accounts/siteName.ts src/services/accounts/utils/siteRouteResolver.ts src/services/apiAdapters/newApi/accountCompletion.ts src/services/apiAdapters/sub2api/accountCompletion.ts src/services/apiAdapters/aihubmix/accountCompletion.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run TypeScript compile**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Audit for migrated product-level legacy facade calls**
+
+Run:
+
+```powershell
+rg -n "getApiService\\(|fetchUserInfo\\(|getOrCreateAccessToken\\(|fetchSiteStatus\\(|fetchSupportCheckIn\\(|extractDefaultExchangeRate\\(" src/services/siteDetection src/services/accounts src/services/apiAdapters -g "*.ts"
+```
+
+Expected remaining calls:
+
+- `src/services/apiAdapters/**/accountBootstrap.ts`
+- other already-owned adapter/backend-delegation modules where `getApiService(siteType)` is the intentional compatibility shim
+- `src/services/accounts/utils/apiServiceRequest.ts`, which is outside this slice
+- `src/services/apiService/**`, if included by a broader search
+
+Unexpected calls to fix before handoff:
+
+- `src/services/siteDetection/autoDetectService.ts` direct `getApiService(...)`
+- `src/services/accounts/siteName.ts` direct `getApiService(...)`
+- `src/services/accounts/utils/siteRouteResolver.ts` direct `getApiService(...)`
+- `src/services/apiAdapters/*/accountCompletion.ts` direct `getApiService(...)`
+
+- [ ] **Step 5: Run commit-gate validation**
+
+Stage only task-scoped files that remain uncommitted, then run:
+
+```powershell
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+If no files are staged because Tasks 1-4 were already committed, run:
+
+```powershell
+pnpm run validate:staged
+```
+
+and record whether it reports no staged files or validates the final staged set. Do not stage unrelated untracked handoff files.
+
+- [ ] **Step 6: Run push-gate validation**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS.
+
+This slice touches shared service contracts, exports, adapter wiring, and TypeScript types, so `validate:push` is the right final gate.
+
+- [ ] **Step 7: Final diff and history audit**
+
+Run:
+
+```powershell
+git status --porcelain=v1
+git log --oneline -5
+```
+
+Confirm:
+
+- only task-scoped files were modified in the new commits
+- pre-existing unrelated untracked files remain untracked and unstaged
+- no locale, telemetry, settings search, Playwright, or `apiService` backend behavior churn slipped in
+
+---
+
+## Review Checklist
+
+- [ ] `SiteAdapter.accountBootstrap` exists and is optional.
+- [ ] New API-family, Sub2API, and AIHubMix adapters expose `accountBootstrap`.
+- [ ] Unsupported adapters omit `accountBootstrap`.
+- [ ] `autoDetectService` uses `accountBootstrap.fetchUserInfo(...)` for API fallback and keeps request/fetch-context behavior unchanged.
+- [ ] `getSiteName(...)` uses `accountBootstrap.fetchSiteStatus(...)` when a site-type hint exists and preserves all title/domain fallbacks.
+- [ ] `siteRouteResolver` uses `accountBootstrap.resolveRoutePath(...)` for static route paths and `accountBootstrap.fetchSiteStatus(...)` for New API default-theme probing.
+- [ ] New API default-theme route cache TTL, max size, and cache-clear test helper are preserved.
+- [ ] AIHubMix login URL still resolves against `https://console.aihubmix.com`.
+- [ ] Account-completion adapters use sibling bootstrap implementations instead of calling `getApiService(...)` directly.
+- [ ] Existing account-completion error classification and fallback semantics are preserved.
+- [ ] Tests cover missing bootstrap capability in best-effort product helpers.
+- [ ] Final validation includes focused Vitest tests, `pnpm compile`, `pnpm run validate:staged`, and `pnpm run validate:push`.
+
+## Out Of Scope
+
+- Adding a new site type.
+- Removing `getApiService(...)`.
+- Migrating saved-account request creation in `src/services/accounts/utils/apiServiceRequest.ts`.
+- Moving site-type detection rules behind adapters.
+- Migrating redemption, managed-site channel operations, managed-site model sync, or provider registration.
+- Changing telemetry, settings search, locale strings, or Playwright E2E coverage.

--- a/docs/superpowers/specs/2026-06-19-api-adapter-account-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-06-19-api-adapter-account-bootstrap-design.md
@@ -1,0 +1,743 @@
+# API Adapter Account Bootstrap Design
+
+Date: 2026-06-19
+
+## Purpose
+
+Move account-site bootstrap behavior behind the `apiAdapters` Seam so a newly
+added account site type can become detectable, nameable, route-aware, and
+account-completion-ready from its Adapter Module.
+
+Recent adapter slices moved site announcements, runtime model catalog loading,
+account completion, key management, saved-account refresh, Sub2API stored-auth
+recovery, model pricing, manual account data loading, and key-management
+lifecycle behavior behind `getSiteAdapter(siteType)`. Those slices make an
+account usable after the site type and first account data are known. The
+remaining high-friction onboarding path is earlier: the product still needs
+legacy facade calls and raw site-type branches to discover the current user,
+probe site status, derive display names, and resolve account-site web routes.
+
+This spec defines an `accountBootstrap` Adapter capability for those early
+account-site facts.
+
+## Current Context
+
+The current `SiteAdapter` Interface exposes:
+
+```ts
+type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  modelPricing?: ModelPricingCapability
+  accountData?: AccountDataCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+}
+```
+
+The current account bootstrap behavior is split across several product Modules:
+
+- `src/services/siteDetection/autoDetectService.ts`
+  - `getUserDataViaAPI(...)` calls
+    `getApiService(siteType).fetchUserInfo(...)`.
+  - Background and current-tab detection use content-script/runtime data first,
+    then fall back to the same legacy facade call.
+- `src/services/accounts/siteName.ts`
+  - `getSiteName(...)` calls
+    `getApiService(siteTypeHint).fetchSiteStatus(...)` when a site-type hint is
+    available.
+- `src/services/accounts/utils/siteRouteResolver.ts`
+  - New API default-theme routing probes
+    `getApiService(SITE_TYPES.NEW_API).fetchSiteStatus(...)`.
+  - AIHubMix login routing is hard-coded in the resolver.
+  - New API theme route overrides are hard-coded in the resolver.
+- `src/services/apiAdapters/*/accountCompletion.ts`
+  - Adapter-facing account completion still calls legacy facade methods inside
+    Adapter implementations:
+    - `fetchUserInfo(...)`
+    - `getOrCreateAccessToken(...)`
+    - `fetchSiteStatus(...)`
+    - `fetchSupportCheckIn(...)`
+    - `extractDefaultExchangeRate(...)`
+
+The backend implementations already vary:
+
+- New API-family compatible sites use `/api/user/self`, `/api/status`, token
+  creation/list fallback, status-driven check-in support, and default-theme
+  route probing through the compatible implementation plus site-specific
+  overrides.
+- Sub2API reads identity and access-token state from its JWT/browser-session
+  model and uses dedicated status and auth-session recovery logic.
+- AIHubMix uses `https://aihubmix.com` as the API origin, may start from
+  `console.aihubmix.com`, sends raw `Authorization: <access_token>`, and uses a
+  different web origin for login.
+
+## Problem
+
+The current adapter migration makes later account workflows deep, but the first
+steps for adding a new account site type are still shallow and scattered.
+
+Current friction:
+
+1. A new non-compatible account site type still needs legacy `apiService`
+   methods before automatic detection can fetch the current user through the
+   API fallback.
+2. Site display-name resolution and account route resolution still know
+   backend-specific status and route facts outside the Adapter Module.
+3. `accountCompletion` is an Adapter-facing Interface, but its implementations
+   still call the wide legacy facade for bootstrap facts. That means a new
+   Adapter still needs to add methods to the facade before account completion
+   can be implemented.
+4. Tests for early account onboarding mock `getApiService(...)`, even though
+   the product behavior only needs narrow bootstrap facts.
+5. Raw `SITE_TYPES.NEW_API` and `SITE_TYPES.AIHUBMIX` route/status branches in
+   product Modules make the next route-sensitive site type likely to add a
+   third copy of the same kind of branching.
+
+Deletion test: if direct product calls to `fetchUserInfo(...)`,
+`fetchSiteStatus(...)`, `getOrCreateAccessToken(...)`,
+`fetchSupportCheckIn(...)`, and `extractDefaultExchangeRate(...)` are deleted
+outside `apiAdapters` and backend implementations, the complexity should not
+reappear as raw `siteType` branches in product Modules. Account-site bootstrap
+facts should sit behind `SiteAdapter.accountBootstrap`.
+
+## Goals
+
+- Add a narrow `accountBootstrap` Adapter capability.
+- Route API-fallback user discovery in `autoDetectService` through
+  `getSiteAdapter(siteType).accountBootstrap`.
+- Route account-site display-name status probing through the Adapter.
+- Route account-site web route resolution through the Adapter for route kinds
+  currently handled by `siteRouteResolver`.
+- Deepen `accountCompletion` implementations so they use the bootstrap
+  capability instead of calling the legacy `getApiService(...)` facade.
+- Preserve existing behavior:
+  - current-tab content-script detection remains the first choice when the
+    target origin matches
+  - background temp-context detection remains the second choice when available
+  - API fallback uses cookie auth with the same fetch context
+  - current-tab reload hints and analytics-safe context fields remain unchanged
+  - AIHubMix API-origin normalization and console login routing remain
+    unchanged
+  - New API default-theme route probing remains cached and bounded
+  - `getSiteName(...)` still prefers non-default tab titles and falls back to a
+    domain-derived name
+  - account completion keeps current auth, check-in, exchange-rate, username,
+    and access-token validation semantics
+- Provide Adapter implementations for:
+  - New API-family compatible account sites
+  - Sub2API
+  - AIHubMix
+- Keep the legacy `getApiService(...)` facade available for non-migrated
+  capabilities and backend delegation.
+- Add focused Adapter, auto-detect, route, site-name, and account-completion
+  regression tests.
+
+## Non-Goals
+
+- Do not add a new site type in this slice.
+- Do not migrate domain/title site-type detection rules from
+  `src/constants/siteType.ts` or `src/services/siteDetection/detectSiteType.ts`.
+- Do not move browser current-tab content-script localStorage reads behind the
+  Adapter. Those are browser messaging concerns, not backend protocol calls.
+- Do not migrate default token provisioning policy, Sub2API group-selection
+  policy, or AIHubMix one-time-secret workflow.
+- Do not migrate redemption, managed-site channel operations, managed-site
+  model sync, or managed-site provider registration.
+- Do not remove `getApiService(...)` or `ApiServiceCapabilities` globally.
+- Do not add an import guard in this slice.
+- Do not change user-facing copy, locale keys, telemetry schema, settings
+  search entries, or Playwright E2E tests.
+
+## Approaches Considered
+
+### Approach A: Add Only `accountDiscovery`
+
+Add an Adapter capability only for `fetchUserInfo(...)` and migrate
+`autoDetectService`.
+
+This is too shallow. It removes one legacy facade call, but leaves site status,
+route probing, display-name probing, exchange-rate extraction, and completion
+token bootstrap split across product Modules and account-completion Adapters.
+The next site type would still require several non-adapter edits before the
+first account is usable.
+
+### Approach B: Add Separate `siteStatus`, `siteRoutes`, And `tokenBootstrap`
+
+Split each operation into its own capability.
+
+This keeps each Interface tiny, but it fragments one account-onboarding concept
+across multiple optional slots. Callers would need to learn several capability
+names to complete one account bootstrap workflow, and tests would still mock a
+collection of shallow Interfaces.
+
+### Approach C: Add One `accountBootstrap` Capability
+
+Add one Adapter capability for early account-site facts: user discovery, access
+token bootstrap, site status, exchange-rate extraction, check-in support, and
+web route resolution.
+
+This is the recommended path. It creates one truthful Adapter Seam for the
+early account onboarding flow. The Interface is broader than a single method,
+but it gives caller Leverage: auto-detect, site-name resolution, route
+resolution, and account completion can all depend on one deep Module.
+
+## Design
+
+### 1. Add `AccountBootstrapCapability`
+
+Create:
+
+```text
+src/services/apiAdapters/contracts/accountBootstrap.ts
+```
+
+Proposed Interface:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import type {
+  AccessTokenInfo,
+  ApiServiceRequest,
+  SiteStatusInfo,
+  UserInfo,
+} from "~/services/apiService/common/type"
+
+export type AccountBootstrapRouteKind =
+  | "login"
+  | "usage"
+  | "checkIn"
+  | "adminCredentials"
+  | "redeem"
+  | "siteAnnouncements"
+
+export type AccountBootstrapRouteTarget = {
+  baseUrl: string
+  siteType: AccountSiteType
+}
+
+export type AccountBootstrapCapability = {
+  fetchUserInfo(request: ApiServiceRequest): Promise<UserInfo>
+  getOrCreateAccessToken(
+    request: ApiServiceRequest,
+  ): Promise<AccessTokenInfo>
+  fetchSiteStatus(request: ApiServiceRequest): Promise<SiteStatusInfo | null>
+  fetchCheckInSupport(
+    request: ApiServiceRequest,
+  ): Promise<boolean | undefined>
+  extractDefaultExchangeRate(siteStatus: SiteStatusInfo | null): number | null
+  resolveRoutePath(
+    target: AccountBootstrapRouteTarget,
+    route: AccountBootstrapRouteKind,
+  ): Promise<string>
+}
+```
+
+The Interface intentionally reuses existing request and response types. This
+slice changes the Seam, not the upstream protocol models.
+
+`resolveRoutePath(...)` returns a path, not a full URL. Product code still owns
+normalizing the user-supplied base URL and joining the path into a final URL.
+This keeps browser/navigation behavior in the route resolver while moving
+backend route facts into the Adapter.
+
+Capability presence is the support signal. A missing `accountBootstrap`
+capability means the site type cannot participate in API-fallback auto-detect,
+site-status display-name probing, Adapter-owned account completion, or
+Adapter-owned route resolution.
+
+### 2. Extend `SiteAdapter`
+
+Modify:
+
+```text
+src/services/apiAdapters/contracts/siteAdapter.ts
+```
+
+Add:
+
+```ts
+accountBootstrap?: AccountBootstrapCapability
+```
+
+Expected support after this slice:
+
+- New API-family Adapters expose `accountBootstrap`.
+- Sub2API exposes `accountBootstrap`.
+- AIHubMix exposes `accountBootstrap`.
+- Unsupported Adapters omit `accountBootstrap`.
+
+### 3. Add New API-Family Account Bootstrap Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/newApi/accountBootstrap.ts
+```
+
+The Adapter should bind to the site-scoped legacy facade:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import { SITE_TYPES } from "~/constants/siteType"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import { getApiService } from "~/services/apiService"
+
+export const createNewApiAccountBootstrap = (
+  siteType: AccountSiteType,
+): AccountBootstrapCapability => {
+  const apiService = getApiService(siteType)
+
+  return {
+    fetchUserInfo: (request) => apiService.fetchUserInfo(request),
+    getOrCreateAccessToken: (request) =>
+      apiService.getOrCreateAccessToken(request),
+    fetchSiteStatus: (request) => apiService.fetchSiteStatus(request),
+    fetchCheckInSupport: (request) =>
+      apiService.fetchSupportCheckIn(request),
+    extractDefaultExchangeRate: (siteStatus) =>
+      apiService.extractDefaultExchangeRate(siteStatus),
+    resolveRoutePath: (target, route) =>
+      resolveNewApiFamilyRoutePath({
+        target,
+        route,
+        fetchSiteStatus: (request) => apiService.fetchSiteStatus(request),
+      }),
+  }
+}
+```
+
+`resolveNewApiFamilyRoutePath(...)` can live in the Adapter implementation or
+remain private to `siteRouteResolver` while being supplied with the Adapter
+capability. The important contract is that New API default-theme probing uses
+the Adapter's `fetchSiteStatus(...)`, preserves the existing bounded cache, and
+falls back to static route config when probing fails.
+
+Delegating through `getApiService(siteType)` preserves current One API/New
+API-compatible override behavior for AnyRouter, Veloera, OneHub, DoneHub,
+V-API, VoAPI, Super-API, Rix-API, Neo-API, WONG, and unknown-compatible sites.
+
+### 4. Add Sub2API Account Bootstrap Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/sub2api/accountBootstrap.ts
+```
+
+The Adapter should delegate to existing Sub2API implementation functions:
+
+```ts
+import {
+  extractDefaultExchangeRate,
+  fetchSiteStatus,
+  fetchSupportCheckIn,
+  fetchUserInfo,
+  getOrCreateAccessToken,
+} from "~/services/apiService/sub2api"
+```
+
+Route resolution should keep the existing static Sub2API route config from
+`getAccountSiteApiRouter(SITE_TYPES.SUB2API)`.
+
+Sub2API behavior must remain unchanged:
+
+- API-fallback user discovery still uses cookie auth and may fail when the
+  browser-session/JWT context is unavailable.
+- Access-token recovery and refresh-token re-sync stay in the Sub2API
+  implementation.
+- Status probing keeps the current Sub2API endpoint and default exchange-rate
+  extraction.
+- Check-in support remains disabled.
+- Existing Sub2API route paths remain unchanged.
+
+### 5. Add AIHubMix Account Bootstrap Adapter
+
+Create:
+
+```text
+src/services/apiAdapters/aihubmix/accountBootstrap.ts
+```
+
+The Adapter should delegate to existing AIHubMix implementation functions:
+
+```ts
+import {
+  extractDefaultExchangeRate,
+  fetchSiteStatus,
+  fetchSupportCheckIn,
+  fetchUserInfo,
+  getOrCreateAccessToken,
+} from "~/services/apiService/aihubmix"
+```
+
+Route resolution should preserve AIHubMix's split origin behavior:
+
+- API requests use `AIHUBMIX_API_ORIGIN`.
+- Login route resolution uses `AIHUBMIX_WEB_ORIGIN`.
+- Other account-site route paths keep the current AIHubMix route config.
+
+AIHubMix behavior must remain unchanged:
+
+- API origin normalization stays in AIHubMix implementation and account URL
+  normalization helpers.
+- Token-authenticated requests continue sending raw
+  `Authorization: <access_token>` without a `Bearer` prefix.
+- `getOrCreateAccessToken(...)` still reuses `fetchUserInfo(...)`.
+- Check-in support remains disabled.
+- Login routing from `console.aihubmix.com` still resolves to
+  `https://console.aihubmix.com/sign-in`.
+
+### 6. Route API-Fallback User Discovery Through The Adapter
+
+Modify:
+
+```text
+src/services/siteDetection/autoDetectService.ts
+```
+
+Replace the legacy facade call in `getUserDataViaAPI(...)`:
+
+```ts
+const userInfo = await getApiService(siteType).fetchUserInfo(...)
+```
+
+with:
+
+```ts
+const accountBootstrap = getSiteAdapter(siteType).accountBootstrap
+const userInfo = await requireAccountBootstrapCapability(
+  siteType,
+  accountBootstrap,
+).fetchUserInfo(...)
+```
+
+Preserve the request shape:
+
+```ts
+{
+  baseUrl: url,
+  auth: {
+    authType: AuthTypeEnum.Cookie,
+  },
+  ...(fetchContext ? { fetchContext } : {}),
+}
+```
+
+Missing capability should behave like the current failed API fallback:
+
+- log a warning with the site type and safe fetch context summary
+- return `null`
+- let the existing fallback chain continue
+
+Do not change current-tab content-script data reads or background runtime
+message payloads.
+
+### 7. Route Site Display-Name Status Probing Through The Adapter
+
+Modify:
+
+```text
+src/services/accounts/siteName.ts
+```
+
+Replace:
+
+```ts
+getApiService(siteTypeHint).fetchSiteStatus(...)
+```
+
+with:
+
+```ts
+getSiteAdapter(siteTypeHint).accountBootstrap?.fetchSiteStatus(...)
+```
+
+Use a local capability guard only when `siteTypeHint` is an account site type.
+If the capability is missing or the status probe fails, keep the current
+domain-prefix fallback.
+
+Preserve existing display-name behavior:
+
+- non-default browser tab title wins
+- no site-type hint means no status probe
+- pre-fetched `siteStatusInfo` avoids a redundant status probe
+- default-like upstream `system_name` falls back to the domain name
+- invalid URLs fall back to the raw input prefix
+
+### 8. Route Account-Site Route Resolution Through The Adapter
+
+Modify:
+
+```text
+src/services/accounts/utils/siteRouteResolver.ts
+```
+
+Keep product ownership of:
+
+- base URL normalization
+- final `joinUrl(...)`
+- best-effort login fallback when no site-type hint exists
+- bounded New API theme cache
+- cache clearing for tests
+
+Move route path selection to `accountBootstrap.resolveRoutePath(...)` when the
+capability exists.
+
+For New API default-theme probing:
+
+- keep `SITE_ROUTE_THEME_CACHE_TTL_MS`
+- keep `SITE_ROUTE_THEME_CACHE_MAX_ENTRIES`
+- key the cache by normalized base URL
+- fetch status through `accountBootstrap.fetchSiteStatus(...)`
+- fall back to static paths when status probing fails
+
+For AIHubMix login routing:
+
+- `resolveAccountSiteLoginUrl(...)` should continue resolving
+  `SITE_TYPES.AIHUBMIX` login URLs against `AIHUBMIX_WEB_ORIGIN`
+- `getBestEffortLoginUrl(...)` should continue using the AIHubMix hostname
+  allow-list when no site-type hint exists
+
+If the capability is missing, fall back to static route config from
+`getAccountSiteApiRouter(siteType)`.
+
+### 9. Deepen Account Completion Implementations
+
+Modify:
+
+```text
+src/services/apiAdapters/newApi/accountCompletion.ts
+src/services/apiAdapters/sub2api/accountCompletion.ts
+src/services/apiAdapters/aihubmix/accountCompletion.ts
+```
+
+Each Adapter should use its sibling `accountBootstrap` implementation for:
+
+- `fetchUserInfo(...)`
+- `getOrCreateAccessToken(...)`
+- `fetchSiteStatus(...)`
+- `fetchCheckInSupport(...)`
+- `extractDefaultExchangeRate(...)`
+
+The `AccountCompletionCapability` Interface should not grow in this slice.
+Account completion remains the product workflow Interface; account bootstrap
+becomes an internal Adapter dependency for backend facts.
+
+Preserve current completion behavior:
+
+- New API-family cookie auth fetches token info via `fetchUserInfo(...)`.
+- New API-family access-token auth calls `getOrCreateAccessToken(...)`.
+- New API-family status failure maps to `SiteStatusFetchFailed`.
+- New API-family check-in support uses `status.checkin_enabled` when present
+  and `fetchCheckInSupport(...)` otherwise.
+- Sub2API requires a detected access token and disables check-in.
+- Sub2API preserves detected `sub2apiAuth`.
+- AIHubMix uses detected token info when available and falls back to
+  `getOrCreateAccessToken(...)`.
+- AIHubMix validates username and access token before returning completion
+  data.
+- All implementations keep exchange-rate fallback to
+  `UI_CONSTANTS.EXCHANGE_RATE.DEFAULT`.
+
+### 10. Keep Site-Type Detection Rules Separate
+
+Do not move:
+
+- `ACCOUNT_SITE_TITLE_RULES`
+- `ACCOUNT_SITE_DOMAIN_RULES`
+- `COMPAT_USER_ID_HEADER_TO_SITE_TYPE`
+- `fetchSiteOriginalTitle(...)`
+- `getAccountSiteUserIdType(...)`
+- `detectAccountSiteTypeFromDomain(...)`
+
+Those rules decide which Adapter to use. The new `accountBootstrap` capability
+starts after a candidate `AccountSiteType` exists.
+
+## Error Handling
+
+Adapter methods should delegate backend errors unchanged.
+
+Product behavior should stay as it is today:
+
+- API-fallback user discovery catches backend errors, logs them, and returns
+  `null`.
+- Current-tab reload hint behavior remains tied to content-script receiver
+  availability and generic fallback failure.
+- Site-name status probing failures fall back to domain-derived names.
+- Route status probing failures fall back to static route paths.
+- Account completion wraps token-fetch and site-status failures in
+  `AutoDetectCompletionError` through existing helpers.
+- Missing `accountBootstrap` capability is non-fatal in best-effort helpers
+  (`autoDetectService`, `siteName`, route resolver), but account-completion
+  Adapters for supported site types should fail tests if their sibling
+  capability is missing.
+
+Do not add user-facing copy for missing `accountBootstrap` in this slice.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This is an internal architecture migration. It does not add a new user action,
+setting, result category, or analytics field. Existing auto-detect analytics
+fields should remain unchanged:
+
+- strategy
+- site type
+- fetch context kind
+- incognito context used
+- current-tab matched
+- failure reason mapping
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E in this slice.
+
+The risk is service-layer routing, request preservation, fallback behavior, and
+route/status probing. Focused Vitest coverage at Adapter, auto-detect,
+site-name, route, and account-completion levels directly covers that risk.
+Browser runtime behavior is unchanged because content-script and background
+message entry points keep their existing payloads.
+
+Run broader browser-level checks only if implementation evidence shows an
+import-scope change involving background/content entrypoints or Sub2API
+browser-session recovery.
+
+## Testing Strategy
+
+Add Adapter tests:
+
+- `tests/services/apiAdapters/accountBootstrap.test.ts`
+  - New API-family delegates user info, access-token bootstrap, site status,
+    check-in support, and exchange-rate extraction through
+    `getApiService(siteType)`.
+  - New API-family route path resolution preserves static paths for non-New
+    API-family variants and default-theme paths for `SITE_TYPES.NEW_API`.
+  - Sub2API delegates bootstrap calls to Sub2API helpers.
+  - AIHubMix delegates bootstrap calls to AIHubMix helpers and preserves
+    console login path behavior.
+
+Update registry tests:
+
+- New API-family Adapters expose `accountBootstrap`.
+- Sub2API exposes `accountBootstrap`.
+- AIHubMix exposes `accountBootstrap`.
+- Unsupported Adapters omit `accountBootstrap`.
+
+Update auto-detect tests:
+
+- `tests/services/autoDetectService.test.ts`
+  - API fallback uses `getSiteAdapter(...).accountBootstrap.fetchUserInfo(...)`
+    with the unchanged cookie-auth request shape.
+  - Current-tab success still avoids API fallback.
+  - Background success still avoids API fallback.
+  - API fallback preserves current-tab and browser-context fetch contexts.
+  - Missing `accountBootstrap` returns the same user-data-missing behavior as a
+    failed backend fetch.
+  - AIHubMix API-origin normalization remains unchanged.
+
+Update site-name tests:
+
+- Existing `getSiteName(...)` tests should assert status probing uses
+  `accountBootstrap.fetchSiteStatus(...)`.
+- Existing fallback tests should remain unchanged:
+  - custom tab title wins
+  - no site-type hint avoids status probing
+  - provided site status avoids status probing
+  - failed status probing falls back to the domain
+
+Update route resolver tests:
+
+- `tests/services/accounts/siteRouteResolver.test.ts`
+  - New API default-theme route probing goes through
+    `accountBootstrap.fetchSiteStatus(...)`.
+  - Static routes are preserved for non-New API site types.
+  - cached theme probes remain bounded.
+  - AIHubMix login routing remains centralized and uses the web origin.
+  - missing `accountBootstrap` falls back to static route config.
+
+Update account-completion tests:
+
+- `tests/services/apiAdapters/newApi/accountCompletion.test.ts`
+  - completion calls the New API-family bootstrap Adapter rather than mocking
+    legacy `getApiService(...)` directly.
+  - token-fetch, site-status, check-in support, username, access-token, and
+    exchange-rate behavior remains unchanged.
+- `tests/services/apiAdapters/sub2api/accountCompletion.test.ts`
+  - completion uses Sub2API bootstrap Adapter functions and preserves detected
+    `sub2apiAuth`.
+- `tests/services/apiAdapters/aihubmix/accountCompletion.test.ts`
+  - completion uses AIHubMix bootstrap Adapter functions and preserves detected
+    token fast path plus fallback token creation.
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/accountBootstrap.test.ts tests/services/apiAdapters/registry.test.ts tests/services/autoDetectService.test.ts tests/services/accounts/siteRouteResolver.test.ts tests/services/accountOperations.test.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Push gate before publishing:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before opening or updating a PR because this slice changes
+shared Adapter contracts, auto-detect routing, and account completion internals.
+
+## Rollout
+
+1. Add the `accountBootstrap` contract and Adapter delegation tests.
+2. Implement New API-family, Sub2API, and AIHubMix bootstrap Adapters.
+3. Extend `SiteAdapter` and registry expectations.
+4. Migrate API-fallback user discovery in `autoDetectService`.
+5. Migrate site-name status probing.
+6. Migrate route path resolution while preserving route cache behavior.
+7. Deepen account-completion Adapter implementations to use bootstrap
+   dependencies.
+8. Run focused tests after each caller group.
+9. Run `pnpm compile` and `pnpm run validate:staged`.
+10. Inspect the final diff for scope drift.
+11. Run `pnpm run validate:push` before pushing or opening a PR.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may migrate:
+
+- default token provisioning policy
+- Account Dialog site policy for Sub2API refresh-token fields, AIHubMix
+  access-token behavior, cookie import, and check-in control visibility
+- redemption through a `redemption` capability
+- managed-site channel operations and model sync
+- a narrow import guard preventing new product Modules from importing the
+  legacy `apiService` facade outside approved adapter/compatibility layers
+- adding a new account site type using the reduced Adapter surface
+
+Do not turn `SiteAdapter` into a second flat `apiService` facade. This slice is
+valid because it makes an already-real account onboarding Module deeper:
+auto-detect, route/status/name probing, and account completion all get more
+Leverage from one account bootstrap Interface, while backend-specific knowledge
+gets better Locality inside each Adapter.

--- a/src/services/accounts/siteName.ts
+++ b/src/services/accounts/siteName.ts
@@ -1,5 +1,9 @@
-import { ACCOUNT_SITE_TITLE_RULES, SITE_TYPES } from "~/constants/siteType"
-import { getApiService } from "~/services/apiService"
+import {
+  ACCOUNT_SITE_TITLE_RULES,
+  isAccountSiteType,
+  SITE_TYPES,
+} from "~/constants/siteType"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { AuthTypeEnum } from "~/types"
 
 /**
@@ -86,14 +90,21 @@ export async function getSiteName(
   // 4. 仅在已知 siteType 时才请求站点状态，避免为未知站点增加额外探测请求。
   if (siteTypeHint) {
     let resolvedSiteStatus = siteStatusInfo
-    if (!resolvedSiteStatus) {
+    if (
+      !resolvedSiteStatus &&
+      siteTypeHint &&
+      isAccountSiteType(siteTypeHint)
+    ) {
       try {
-        resolvedSiteStatus = await getApiService(siteTypeHint).fetchSiteStatus({
-          baseUrl: hostWithProtocol,
-          auth: {
-            authType: AuthTypeEnum.None,
-          },
-        })
+        const accountBootstrap = getSiteAdapter(siteTypeHint).accountBootstrap
+        resolvedSiteStatus = accountBootstrap
+          ? await accountBootstrap.fetchSiteStatus({
+              baseUrl: hostWithProtocol,
+              auth: {
+                authType: AuthTypeEnum.None,
+              },
+            })
+          : null
       } catch {
         resolvedSiteStatus = null
       }

--- a/src/services/accounts/utils/siteRouteResolver.ts
+++ b/src/services/accounts/utils/siteRouteResolver.ts
@@ -6,21 +6,18 @@ import {
   type AccountSiteType,
 } from "~/constants/siteType"
 import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
-import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import {
+  ACCOUNT_BOOTSTRAP_ROUTE_KINDS,
+  type AccountBootstrapCapability,
+  type AccountBootstrapRouteKind,
+} from "~/services/apiAdapters/contracts/accountBootstrap"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { AuthTypeEnum } from "~/types"
 import { joinUrl } from "~/utils/core/url"
 
-export const SITE_ROUTE_KINDS = {
-  Login: "login",
-  Usage: "usage",
-  CheckIn: "checkIn",
-  AdminCredentials: "adminCredentials",
-  Redeem: "redeem",
-  SiteAnnouncements: "siteAnnouncements",
-} as const
+export const SITE_ROUTE_KINDS = ACCOUNT_BOOTSTRAP_ROUTE_KINDS
 
-type SiteRouteKind = (typeof SITE_ROUTE_KINDS)[keyof typeof SITE_ROUTE_KINDS]
+type SiteRouteKind = AccountBootstrapRouteKind
 
 type RouteTarget = {
   baseUrl: string

--- a/src/services/accounts/utils/siteRouteResolver.ts
+++ b/src/services/accounts/utils/siteRouteResolver.ts
@@ -5,7 +5,9 @@ import {
   SITE_TYPES,
   type AccountSiteType,
 } from "~/constants/siteType"
-import { getApiService } from "~/services/apiService"
+import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { AuthTypeEnum } from "~/types"
 import { joinUrl } from "~/utils/core/url"
 
@@ -102,37 +104,19 @@ export function getBestEffortLoginUrl(siteUrl: string): string {
 }
 
 /**
- * Resolve the legacy/static route path for a supported account site type.
- * @param siteType Account site type.
- * @param route Named route kind.
- * @returns Static path from the site route configuration.
- */
-function getStaticRoutePath(siteType: AccountSiteType, route: SiteRouteKind) {
-  const config = getAccountSiteApiRouter(siteType)
-  switch (route) {
-    case SITE_ROUTE_KINDS.Login:
-      return config.loginPath
-    case SITE_ROUTE_KINDS.Usage:
-      return config.usagePath
-    case SITE_ROUTE_KINDS.CheckIn:
-      return config.checkInPath
-    case SITE_ROUTE_KINDS.AdminCredentials:
-      return config.adminCredentialsPath
-    case SITE_ROUTE_KINDS.Redeem:
-      return config.redeemPath
-    case SITE_ROUTE_KINDS.SiteAnnouncements:
-      return config.siteAnnouncementsPath
-  }
-}
-
-/**
  * Fetch the current New API frontend theme, cached briefly per base URL.
  * @param baseUrl New API deployment base URL.
+ * @param accountBootstrap Account bootstrap status capability.
  * @returns Frontend theme identifier when available.
  */
 async function fetchNewApiFrontendTheme(
   baseUrl: string,
+  accountBootstrap?: Pick<AccountBootstrapCapability, "fetchSiteStatus">,
 ): Promise<string | undefined> {
+  if (!accountBootstrap) {
+    return undefined
+  }
+
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
   const cached = themeCache.get(normalizedBaseUrl)
   const now = Date.now()
@@ -141,7 +125,7 @@ async function fetchNewApiFrontendTheme(
   }
 
   try {
-    const statusInfo = await getApiService(SITE_TYPES.NEW_API).fetchSiteStatus({
+    const statusInfo = await accountBootstrap.fetchSiteStatus({
       baseUrl: normalizedBaseUrl,
       auth: { authType: AuthTypeEnum.None },
     })
@@ -165,7 +149,10 @@ async function resolveAccountSiteRoutePath(
   target: Pick<RouteTarget, "baseUrl" | "siteType">,
   route: SiteRouteKind,
 ): Promise<string> {
-  const staticPath = getStaticRoutePath(target.siteType, route)
+  const accountBootstrap = getSiteAdapter(target.siteType).accountBootstrap
+  const staticPath = accountBootstrap?.resolveRoutePath
+    ? await accountBootstrap.resolveRoutePath(target, route)
+    : resolveStaticAccountRoutePath(target, route)
 
   if (
     target.siteType !== SITE_TYPES.NEW_API ||
@@ -174,9 +161,9 @@ async function resolveAccountSiteRoutePath(
     return staticPath
   }
 
-  const theme = await fetchNewApiFrontendTheme(target.baseUrl)
+  const theme = await fetchNewApiFrontendTheme(target.baseUrl, accountBootstrap)
   if (theme === NEW_API_FRONTEND_THEMES.Default) {
-    return NEW_API_DEFAULT_THEME_ROUTE_PATHS[route]
+    return NEW_API_DEFAULT_THEME_ROUTE_PATHS[route] ?? staticPath
   }
 
   return staticPath

--- a/src/services/apiAdapters/accountRoutes.ts
+++ b/src/services/apiAdapters/accountRoutes.ts
@@ -1,0 +1,31 @@
+import { getAccountSiteApiRouter } from "~/constants/siteType"
+
+import type {
+  AccountBootstrapRouteKind,
+  AccountBootstrapRouteTarget,
+} from "./contracts/accountBootstrap"
+
+/**
+ * Resolve account bootstrap route paths from the existing static site router.
+ */
+export function resolveStaticAccountRoutePath(
+  target: AccountBootstrapRouteTarget,
+  route: AccountBootstrapRouteKind,
+): string {
+  const router = getAccountSiteApiRouter(target.siteType)
+
+  switch (route) {
+    case "login":
+      return router.loginPath
+    case "usage":
+      return router.usagePath ?? router.loginPath
+    case "checkIn":
+      return router.checkInPath ?? router.loginPath
+    case "adminCredentials":
+      return router.adminCredentialsPath ?? router.loginPath
+    case "redeem":
+      return router.redeemPath ?? router.loginPath
+    case "siteAnnouncements":
+      return router.siteAnnouncementsPath ?? router.loginPath
+  }
+}

--- a/src/services/apiAdapters/accountRoutes.ts
+++ b/src/services/apiAdapters/accountRoutes.ts
@@ -1,8 +1,9 @@
 import { getAccountSiteApiRouter } from "~/constants/siteType"
 
-import type {
-  AccountBootstrapRouteKind,
-  AccountBootstrapRouteTarget,
+import {
+  ACCOUNT_BOOTSTRAP_ROUTE_KINDS,
+  type AccountBootstrapRouteKind,
+  type AccountBootstrapRouteTarget,
 } from "./contracts/accountBootstrap"
 
 /**
@@ -15,17 +16,17 @@ export function resolveStaticAccountRoutePath(
   const router = getAccountSiteApiRouter(target.siteType)
 
   switch (route) {
-    case "login":
+    case ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Login:
       return router.loginPath
-    case "usage":
+    case ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Usage:
       return router.usagePath ?? router.loginPath
-    case "checkIn":
+    case ACCOUNT_BOOTSTRAP_ROUTE_KINDS.CheckIn:
       return router.checkInPath ?? router.loginPath
-    case "adminCredentials":
+    case ACCOUNT_BOOTSTRAP_ROUTE_KINDS.AdminCredentials:
       return router.adminCredentialsPath ?? router.loginPath
-    case "redeem":
+    case ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Redeem:
       return router.redeemPath ?? router.loginPath
-    case "siteAnnouncements":
+    case ACCOUNT_BOOTSTRAP_ROUTE_KINDS.SiteAnnouncements:
       return router.siteAnnouncementsPath ?? router.loginPath
   }
 }

--- a/src/services/apiAdapters/aihubmix/accountBootstrap.ts
+++ b/src/services/apiAdapters/aihubmix/accountBootstrap.ts
@@ -1,0 +1,25 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import {
+  extractDefaultExchangeRate,
+  fetchSiteStatus,
+  fetchSupportCheckIn,
+  fetchUserInfo,
+  getOrCreateAccessToken,
+} from "~/services/apiService/aihubmix"
+
+import { resolveStaticAccountRoutePath } from "../accountRoutes"
+
+export const aihubmixAccountBootstrap: AccountBootstrapCapability = {
+  fetchUserInfo: (request) => fetchUserInfo(request),
+  getOrCreateAccessToken: (request) => getOrCreateAccessToken(request),
+  fetchSiteStatus: (request) => fetchSiteStatus(request),
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  extractDefaultExchangeRate: (siteStatus) =>
+    extractDefaultExchangeRate(siteStatus),
+  resolveRoutePath: async (target, route) =>
+    resolveStaticAccountRoutePath(
+      { ...target, siteType: SITE_TYPES.AIHUBMIX },
+      route,
+    ),
+}

--- a/src/services/apiAdapters/aihubmix/accountCompletion.ts
+++ b/src/services/apiAdapters/aihubmix/accountCompletion.ts
@@ -1,10 +1,9 @@
 import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
-import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
-import { getApiService } from "~/services/apiService"
 import { AuthTypeEnum } from "~/types"
 
 import type { AccountCompletionCapability } from "../contracts/accountCompletion"
+import { aihubmixAccountBootstrap } from "./accountBootstrap"
 
 const getDetectedTokenInfo = (
   detected: Parameters<AccountCompletionCapability["complete"]>[0]["detected"],
@@ -19,13 +18,12 @@ const getDetectedTokenInfo = (
 
 export const aihubmixAccountCompletion: AccountCompletionCapability = {
   async complete(request, helpers) {
-    const service = getApiService(SITE_TYPES.AIHUBMIX)
     const { url, detected, context } = request
 
     let tokenInfo: unknown = getDetectedTokenInfo(detected, helpers.trimString)
     if (!tokenInfo) {
       try {
-        tokenInfo = await service.getOrCreateAccessToken(
+        tokenInfo = await aihubmixAccountBootstrap.getOrCreateAccessToken(
           helpers.createServiceRequest({
             baseUrl: url,
             context,
@@ -45,7 +43,7 @@ export const aihubmixAccountCompletion: AccountCompletionCapability = {
 
     let siteStatus = null
     try {
-      siteStatus = await service.fetchSiteStatus(
+      siteStatus = await aihubmixAccountBootstrap.fetchSiteStatus(
         helpers.createServiceRequest({
           baseUrl: url,
           context,
@@ -64,8 +62,8 @@ export const aihubmixAccountCompletion: AccountCompletionCapability = {
     const checkSupport =
       typeof siteStatus?.checkin_enabled === "boolean"
         ? siteStatus.checkin_enabled
-        : await service
-            .fetchSupportCheckIn(
+        : await aihubmixAccountBootstrap
+            .fetchCheckInSupport(
               helpers.createServiceRequest({
                 baseUrl: url,
                 context,
@@ -98,7 +96,7 @@ export const aihubmixAccountCompletion: AccountCompletionCapability = {
       accessToken,
       userId: detected.userId.toString(),
       exchangeRate:
-        service.extractDefaultExchangeRate(siteStatus) ??
+        aihubmixAccountBootstrap.extractDefaultExchangeRate(siteStatus) ??
         UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
       authType: AuthTypeEnum.AccessToken,
       checkIn: helpers.createInitialCheckInConfig({

--- a/src/services/apiAdapters/aihubmix/index.ts
+++ b/src/services/apiAdapters/aihubmix/index.ts
@@ -1,6 +1,7 @@
 import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
+import { aihubmixAccountBootstrap } from "./accountBootstrap"
 import { aihubmixAccountCompletion } from "./accountCompletion"
 import { aihubmixAccountData } from "./accountData"
 import { aihubmixAccountRefresh } from "./accountRefresh"
@@ -10,6 +11,7 @@ import { aihubmixModelPricing } from "./modelPricing"
 export const aihubmixAdapter: SiteAdapter = {
   siteType: SITE_TYPES.AIHUBMIX,
   accountData: aihubmixAccountData,
+  accountBootstrap: aihubmixAccountBootstrap,
   accountCompletion: aihubmixAccountCompletion,
   keyManagement: aihubmixKeyManagement,
   accountRefresh: aihubmixAccountRefresh,

--- a/src/services/apiAdapters/contracts/accountBootstrap.ts
+++ b/src/services/apiAdapters/contracts/accountBootstrap.ts
@@ -6,13 +6,17 @@ import type {
   UserInfo,
 } from "~/services/apiService/common/type"
 
+export const ACCOUNT_BOOTSTRAP_ROUTE_KINDS = {
+  Login: "login",
+  Usage: "usage",
+  CheckIn: "checkIn",
+  AdminCredentials: "adminCredentials",
+  Redeem: "redeem",
+  SiteAnnouncements: "siteAnnouncements",
+} as const
+
 export type AccountBootstrapRouteKind =
-  | "login"
-  | "usage"
-  | "checkIn"
-  | "adminCredentials"
-  | "redeem"
-  | "siteAnnouncements"
+  (typeof ACCOUNT_BOOTSTRAP_ROUTE_KINDS)[keyof typeof ACCOUNT_BOOTSTRAP_ROUTE_KINDS]
 
 export type AccountBootstrapRouteTarget = {
   baseUrl: string

--- a/src/services/apiAdapters/contracts/accountBootstrap.ts
+++ b/src/services/apiAdapters/contracts/accountBootstrap.ts
@@ -1,0 +1,32 @@
+import type { AccountSiteType } from "~/constants/siteType"
+import type {
+  AccessTokenInfo,
+  ApiServiceRequest,
+  SiteStatusInfo,
+  UserInfo,
+} from "~/services/apiService/common/type"
+
+export type AccountBootstrapRouteKind =
+  | "login"
+  | "usage"
+  | "checkIn"
+  | "adminCredentials"
+  | "redeem"
+  | "siteAnnouncements"
+
+export type AccountBootstrapRouteTarget = {
+  baseUrl: string
+  siteType: AccountSiteType
+}
+
+export type AccountBootstrapCapability = {
+  fetchUserInfo(request: ApiServiceRequest): Promise<UserInfo>
+  getOrCreateAccessToken(request: ApiServiceRequest): Promise<AccessTokenInfo>
+  fetchSiteStatus(request: ApiServiceRequest): Promise<SiteStatusInfo | null>
+  fetchCheckInSupport(request: ApiServiceRequest): Promise<boolean | undefined>
+  extractDefaultExchangeRate(siteStatus: SiteStatusInfo | null): number | null
+  resolveRoutePath(
+    target: AccountBootstrapRouteTarget,
+    route: AccountBootstrapRouteKind,
+  ): Promise<string>
+}

--- a/src/services/apiAdapters/contracts/siteAdapter.ts
+++ b/src/services/apiAdapters/contracts/siteAdapter.ts
@@ -1,5 +1,6 @@
 import type { AccountSiteType } from "~/constants/siteType"
 
+import type { AccountBootstrapCapability } from "./accountBootstrap"
 import type { AccountCompletionCapability } from "./accountCompletion"
 import type { AccountDataCapability } from "./accountData"
 import type { AccountRefreshCapability } from "./accountRefresh"
@@ -19,6 +20,7 @@ export type SiteAdapter = {
   modelCatalog?: ModelCatalogCapability
   modelPricing?: ModelPricingCapability
   accountData?: AccountDataCapability
+  accountBootstrap?: AccountBootstrapCapability
   accountCompletion?: AccountCompletionCapability
   keyManagement?: KeyManagementCapability
   accountRefresh?: AccountRefreshCapability

--- a/src/services/apiAdapters/newApi/accountBootstrap.ts
+++ b/src/services/apiAdapters/newApi/accountBootstrap.ts
@@ -1,0 +1,26 @@
+import type { AccountSiteType } from "~/constants/siteType"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import { getApiService } from "~/services/apiService"
+
+import { resolveStaticAccountRoutePath } from "../accountRoutes"
+
+/**
+ * Create account-bootstrap operations bound to the New API-family site type.
+ */
+export function createNewApiAccountBootstrap(
+  siteType: AccountSiteType,
+): AccountBootstrapCapability {
+  return {
+    fetchUserInfo: (request) => getApiService(siteType).fetchUserInfo(request),
+    getOrCreateAccessToken: (request) =>
+      getApiService(siteType).getOrCreateAccessToken(request),
+    fetchSiteStatus: (request) =>
+      getApiService(siteType).fetchSiteStatus(request),
+    fetchCheckInSupport: (request) =>
+      getApiService(siteType).fetchSupportCheckIn(request),
+    extractDefaultExchangeRate: (siteStatus) =>
+      getApiService(siteType).extractDefaultExchangeRate(siteStatus),
+    resolveRoutePath: async (target, route) =>
+      resolveStaticAccountRoutePath(target, route),
+  }
+}

--- a/src/services/apiAdapters/newApi/accountCompletion.ts
+++ b/src/services/apiAdapters/newApi/accountCompletion.ts
@@ -1,14 +1,14 @@
 import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
 import { UI_CONSTANTS } from "~/constants/ui"
-import { getApiService } from "~/services/apiService"
 import { AuthTypeEnum } from "~/types"
 
 import type { AccountCompletionCapability } from "../contracts/accountCompletion"
+import { createNewApiAccountBootstrap } from "./accountBootstrap"
 
 export const newApiAccountCompletion: AccountCompletionCapability = {
   async complete(request, helpers) {
     const { url, requestedAuthType, detected, context } = request
-    const apiService = getApiService(detected.siteType)
+    const accountBootstrap = createNewApiAccountBootstrap(detected.siteType)
 
     const createRequest = (
       auth: Parameters<typeof helpers.createServiceRequest>[0]["auth"],
@@ -21,7 +21,7 @@ export const newApiAccountCompletion: AccountCompletionCapability = {
 
     const fetchTokenInfo = () => {
       if (requestedAuthType === AuthTypeEnum.Cookie) {
-        return apiService.fetchUserInfo(
+        return accountBootstrap.fetchUserInfo(
           createRequest({
             authType: AuthTypeEnum.Cookie,
             userId: detected.userId,
@@ -30,7 +30,7 @@ export const newApiAccountCompletion: AccountCompletionCapability = {
       }
 
       if (requestedAuthType === AuthTypeEnum.AccessToken) {
-        return apiService.getOrCreateAccessToken(
+        return accountBootstrap.getOrCreateAccessToken(
           createRequest({
             authType: AuthTypeEnum.Cookie,
             userId: detected.userId,
@@ -43,7 +43,7 @@ export const newApiAccountCompletion: AccountCompletionCapability = {
 
     const tokenPromise = fetchTokenInfo()
 
-    const siteStatusPromise = apiService
+    const siteStatusPromise = accountBootstrap
       .fetchSiteStatus(
         createRequest({
           authType: requestedAuthType || AuthTypeEnum.None,
@@ -59,8 +59,8 @@ export const newApiAccountCompletion: AccountCompletionCapability = {
     const checkSupportPromise = siteStatusPromise.then((siteStatus) =>
       typeof siteStatus?.checkin_enabled === "boolean"
         ? siteStatus.checkin_enabled
-        : apiService
-            .fetchSupportCheckIn(
+        : accountBootstrap
+            .fetchCheckInSupport(
               createRequest({
                 authType: AuthTypeEnum.None,
               }),
@@ -107,7 +107,7 @@ export const newApiAccountCompletion: AccountCompletionCapability = {
       accessToken,
       userId: detected.userId.toString(),
       exchangeRate:
-        apiService.extractDefaultExchangeRate(siteStatus) ??
+        accountBootstrap.extractDefaultExchangeRate(siteStatus) ??
         UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
       authType: requestedAuthType,
       checkIn: helpers.createInitialCheckInConfig({

--- a/src/services/apiAdapters/newApi/index.ts
+++ b/src/services/apiAdapters/newApi/index.ts
@@ -1,6 +1,7 @@
 import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
+import { createNewApiAccountBootstrap } from "./accountBootstrap"
 import { newApiAccountCompletion } from "./accountCompletion"
 import { createNewApiAccountData } from "./accountData"
 import { createNewApiAccountRefresh } from "./accountRefresh"
@@ -15,6 +16,7 @@ export const createNewApiAdapter = (
   family: "newApiFamily",
   siteNotice: newApiSiteNotice,
   accountData: createNewApiAccountData(siteType),
+  accountBootstrap: createNewApiAccountBootstrap(siteType),
   accountCompletion: newApiAccountCompletion,
   keyManagement: createNewApiKeyManagement(siteType),
   accountRefresh: createNewApiAccountRefresh(siteType),

--- a/src/services/apiAdapters/sub2api/accountBootstrap.ts
+++ b/src/services/apiAdapters/sub2api/accountBootstrap.ts
@@ -1,4 +1,5 @@
 import { SITE_TYPES } from "~/constants/siteType"
+import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
 import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
 import {
   extractDefaultExchangeRate,
@@ -7,8 +8,6 @@ import {
   fetchUserInfo,
   getOrCreateAccessToken,
 } from "~/services/apiService/sub2api"
-
-import { resolveStaticAccountRoutePath } from "../accountRoutes"
 
 export const sub2ApiAccountBootstrap: AccountBootstrapCapability = {
   fetchUserInfo: (request) => fetchUserInfo(request),

--- a/src/services/apiAdapters/sub2api/accountBootstrap.ts
+++ b/src/services/apiAdapters/sub2api/accountBootstrap.ts
@@ -1,0 +1,25 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import {
+  extractDefaultExchangeRate,
+  fetchSiteStatus,
+  fetchSupportCheckIn,
+  fetchUserInfo,
+  getOrCreateAccessToken,
+} from "~/services/apiService/sub2api"
+
+import { resolveStaticAccountRoutePath } from "../accountRoutes"
+
+export const sub2ApiAccountBootstrap: AccountBootstrapCapability = {
+  fetchUserInfo: (request) => fetchUserInfo(request),
+  getOrCreateAccessToken: (request) => getOrCreateAccessToken(request),
+  fetchSiteStatus: (request) => fetchSiteStatus(request),
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  extractDefaultExchangeRate: (siteStatus) =>
+    extractDefaultExchangeRate(siteStatus),
+  resolveRoutePath: async (target, route) =>
+    resolveStaticAccountRoutePath(
+      { ...target, siteType: SITE_TYPES.SUB2API },
+      route,
+    ),
+}

--- a/src/services/apiAdapters/sub2api/accountCompletion.ts
+++ b/src/services/apiAdapters/sub2api/accountCompletion.ts
@@ -1,14 +1,12 @@
 import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
-import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
-import { getApiService } from "~/services/apiService"
 import { AuthTypeEnum } from "~/types"
 
 import type { AccountCompletionCapability } from "../contracts/accountCompletion"
+import { sub2ApiAccountBootstrap } from "./accountBootstrap"
 
 export const sub2ApiAccountCompletion: AccountCompletionCapability = {
   async complete(request, helpers) {
-    const service = getApiService(SITE_TYPES.SUB2API)
     const { url, detected, context } = request
 
     const accessToken = helpers.trimString(detected.accessToken)
@@ -21,7 +19,7 @@ export const sub2ApiAccountCompletion: AccountCompletionCapability = {
 
     let siteStatus = null
     try {
-      siteStatus = await service.fetchSiteStatus(
+      siteStatus = await sub2ApiAccountBootstrap.fetchSiteStatus(
         helpers.createServiceRequest({
           baseUrl: url,
           context,
@@ -43,7 +41,7 @@ export const sub2ApiAccountCompletion: AccountCompletionCapability = {
       accessToken,
       userId: detected.userId.toString(),
       exchangeRate:
-        service.extractDefaultExchangeRate(siteStatus) ??
+        sub2ApiAccountBootstrap.extractDefaultExchangeRate(siteStatus) ??
         UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
       authType: AuthTypeEnum.AccessToken,
       checkIn: helpers.createInitialCheckInConfig({

--- a/src/services/apiAdapters/sub2api/accountCompletion.ts
+++ b/src/services/apiAdapters/sub2api/accountCompletion.ts
@@ -1,9 +1,9 @@
 import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
 import { UI_CONSTANTS } from "~/constants/ui"
+import { sub2ApiAccountBootstrap } from "~/services/apiAdapters/sub2api/accountBootstrap"
 import { AuthTypeEnum } from "~/types"
 
 import type { AccountCompletionCapability } from "../contracts/accountCompletion"
-import { sub2ApiAccountBootstrap } from "./accountBootstrap"
 
 export const sub2ApiAccountCompletion: AccountCompletionCapability = {
   async complete(request, helpers) {

--- a/src/services/apiAdapters/sub2api/index.ts
+++ b/src/services/apiAdapters/sub2api/index.ts
@@ -1,6 +1,7 @@
 import { SITE_TYPES } from "~/constants/siteType"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
+import { sub2ApiAccountBootstrap } from "./accountBootstrap"
 import { sub2ApiAccountCompletion } from "./accountCompletion"
 import { sub2ApiAccountData } from "./accountData"
 import { sub2ApiAccountRefresh } from "./accountRefresh"
@@ -14,6 +15,7 @@ export const sub2ApiAdapter: SiteAdapter = {
   siteAnnouncements: sub2ApiSiteAnnouncements,
   modelCatalog: sub2ApiModelCatalog,
   accountData: sub2ApiAccountData,
+  accountBootstrap: sub2ApiAccountBootstrap,
   accountCompletion: sub2ApiAccountCompletion,
   keyManagement: sub2ApiKeyManagement,
   accountRefresh: sub2ApiAccountRefresh,

--- a/src/services/apiAdapters/sub2api/index.ts
+++ b/src/services/apiAdapters/sub2api/index.ts
@@ -1,7 +1,7 @@
 import { SITE_TYPES } from "~/constants/siteType"
+import { sub2ApiAccountBootstrap } from "~/services/apiAdapters/sub2api/accountBootstrap"
 
 import type { SiteAdapter } from "../contracts/siteAdapter"
-import { sub2ApiAccountBootstrap } from "./accountBootstrap"
 import { sub2ApiAccountCompletion } from "./accountCompletion"
 import { sub2ApiAccountData } from "./accountData"
 import { sub2ApiAccountRefresh } from "./accountRefresh"

--- a/src/services/siteDetection/autoDetectService.ts
+++ b/src/services/siteDetection/autoDetectService.ts
@@ -22,6 +22,7 @@ import {
   type AccountSiteType,
 } from "~/constants/siteType"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import {
   API_SERVICE_FETCH_CONTEXT_KINDS,
   summarizeApiServiceFetchContext,
@@ -40,7 +41,6 @@ import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
 
-import { getApiService } from "../apiService"
 import { getAccountSiteType } from "./detectSiteType"
 
 /**
@@ -235,6 +235,15 @@ async function combineUserDataAndSiteType(
 }
 
 /**
+ * Resolve the account-bootstrap capability used by API fallback.
+ * @param siteType Detected site type used to select an adapter.
+ * @returns Account-bootstrap capability when supported.
+ */
+function getAccountBootstrapForApiFallback(siteType: AccountSiteType) {
+  return getSiteAdapter(siteType).accountBootstrap
+}
+
+/**
  * Fetch user data via upstream API (cookie-based).
  * @param url Base site URL used for API calls.
  * @param siteType Detected site type used to select an API implementation.
@@ -254,7 +263,16 @@ async function getUserDataViaAPI(
       })
     }
 
-    const userInfo = await getApiService(siteType).fetchUserInfo({
+    const accountBootstrap = getAccountBootstrapForApiFallback(siteType)
+    if (!accountBootstrap) {
+      logger.warn("Account bootstrap capability is unavailable", {
+        siteType,
+        hasFetchContext: Boolean(fetchContext),
+      })
+      return null
+    }
+
+    const userInfo = await accountBootstrap.fetchUserInfo({
       baseUrl: url,
       auth: {
         authType: AuthTypeEnum.Cookie,

--- a/tests/services/accountOperations.autoDetectAccount.test.ts
+++ b/tests/services/accountOperations.autoDetectAccount.test.ts
@@ -22,6 +22,7 @@ const {
   mockFetchSupportCheckIn,
   mockExtractDefaultExchangeRate,
   mockFetchUserInfo,
+  mockCreateNewApiAccountBootstrap,
   mockGetOrCreateAccessToken,
 } = vi.hoisted(() => ({
   mockAutoDetectSmart: vi.fn(),
@@ -30,6 +31,7 @@ const {
   mockFetchSupportCheckIn: vi.fn(),
   mockExtractDefaultExchangeRate: vi.fn(),
   mockFetchUserInfo: vi.fn(),
+  mockCreateNewApiAccountBootstrap: vi.fn(),
   mockGetOrCreateAccessToken: vi.fn(),
 }))
 
@@ -46,19 +48,31 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
-vi.mock("~/services/apiService", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("~/services/apiService")>()
-  return {
-    ...actual,
-    getApiService: vi.fn(() => ({
-      fetchSiteStatus: mockFetchSiteStatus,
-      fetchSupportCheckIn: mockFetchSupportCheckIn,
-      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
-      fetchUserInfo: mockFetchUserInfo,
-      getOrCreateAccessToken: mockGetOrCreateAccessToken,
-    })),
-  }
-})
+vi.mock("~/services/apiAdapters/newApi/accountBootstrap", () => ({
+  createNewApiAccountBootstrap: mockCreateNewApiAccountBootstrap,
+}))
+
+vi.mock("~/services/apiAdapters/sub2api/accountBootstrap", () => ({
+  sub2ApiAccountBootstrap: {
+    extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+    fetchCheckInSupport: mockFetchSupportCheckIn,
+    fetchSiteStatus: mockFetchSiteStatus,
+    fetchUserInfo: mockFetchUserInfo,
+    getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    resolveRoutePath: vi.fn(),
+  },
+}))
+
+vi.mock("~/services/apiAdapters/aihubmix/accountBootstrap", () => ({
+  aihubmixAccountBootstrap: {
+    extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+    fetchCheckInSupport: mockFetchSupportCheckIn,
+    fetchSiteStatus: mockFetchSiteStatus,
+    fetchUserInfo: mockFetchUserInfo,
+    getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    resolveRoutePath: vi.fn(),
+  },
+}))
 
 const currentTabFetchContext = (origin: string) => ({
   kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
@@ -80,6 +94,14 @@ const browserFetchContext = () => ({
 describe("accountOperations autoDetectAccount", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCreateNewApiAccountBootstrap.mockReturnValue({
+      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+      fetchCheckInSupport: mockFetchSupportCheckIn,
+      fetchSiteStatus: mockFetchSiteStatus,
+      fetchUserInfo: mockFetchUserInfo,
+      getOrCreateAccessToken: mockGetOrCreateAccessToken,
+      resolveRoutePath: vi.fn(),
+    })
   })
 
   it("returns a validation error when the URL is blank", async () => {

--- a/tests/services/accountOperations.test.ts
+++ b/tests/services/accountOperations.test.ts
@@ -11,7 +11,6 @@ import {
   parseManualQuotaFromUsd,
   validateAndUpdateAccount,
 } from "~/services/accounts/accountOperations"
-import { getApiService } from "~/services/apiService"
 import { AuthTypeEnum } from "~/types"
 
 const {
@@ -66,6 +65,9 @@ describe("accountOperations", () => {
     mockGetSiteAdapter.mockReturnValue({
       accountData: {
         fetchData: mockFetchAccountData,
+      },
+      accountBootstrap: {
+        fetchSiteStatus: mockFetchSiteStatus,
       },
     })
   })
@@ -474,12 +476,29 @@ describe("accountOperations", () => {
       })
 
       const result = await getSiteName(
-        "https://sub2.example.com/console",
+        "https://example.com/console",
         SITE_TYPES.SUB2API,
       )
 
       expect(result).toBe("Sub2 Portal")
-      expect(vi.mocked(getApiService)).toHaveBeenCalledWith(SITE_TYPES.SUB2API)
+      const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
+      expect(vi.mocked(getSiteAdapter)).toHaveBeenCalledWith(SITE_TYPES.SUB2API)
+      expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+        baseUrl: "https://example.com",
+        auth: { authType: AuthTypeEnum.None },
+      })
+    })
+
+    it("falls back to the domain when site-type hint has no bootstrap status probe", async () => {
+      mockGetSiteAdapter.mockReturnValueOnce({})
+
+      const result = await getSiteName(
+        "https://api.example.com/dashboard",
+        SITE_TYPES.NEW_API,
+      )
+
+      expect(result).toBe("Example")
+      expect(mockFetchSiteStatus).not.toHaveBeenCalled()
     })
 
     it("falls back to system_name when a default tab title is paired with a site-type hint", async () => {

--- a/tests/services/accounts/siteRouteResolver.test.ts
+++ b/tests/services/accounts/siteRouteResolver.test.ts
@@ -8,26 +8,42 @@ import {
   resolveAccountSiteRouteUrl,
   SITE_ROUTE_KINDS,
 } from "~/services/accounts/utils/siteRouteResolver"
+import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
+import { AuthTypeEnum } from "~/types"
+
+const { mockFetchSiteStatus, mockGetSiteAdapter, mockResolveRoutePath } =
+  vi.hoisted(() => ({
+    mockFetchSiteStatus: vi.fn(),
+    mockGetSiteAdapter: vi.fn(),
+    mockResolveRoutePath: vi.fn(),
+  }))
+
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: mockGetSiteAdapter,
+}))
 
 describe("siteRouteResolver", () => {
   beforeEach(() => {
     clearSiteRouteThemeCacheForTests()
     vi.restoreAllMocks()
+    mockFetchSiteStatus.mockReset()
+    mockGetSiteAdapter.mockReset()
+    mockResolveRoutePath.mockReset()
+    mockResolveRoutePath.mockImplementation((target, route) =>
+      Promise.resolve(resolveStaticAccountRoutePath(target, route)),
+    )
+    mockGetSiteAdapter.mockReturnValue({
+      accountBootstrap: {
+        fetchSiteStatus: mockFetchSiteStatus,
+        resolveRoutePath: mockResolveRoutePath,
+      },
+    })
   })
 
   const mockDefaultNewApiThemeStatus = () =>
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          success: true,
-          message: "",
-          data: { theme: "default" },
-        }),
-        {
-          headers: { "content-type": "application/json" },
-        },
-      ),
-    )
+    mockFetchSiteStatus.mockResolvedValue({
+      theme: "default",
+    })
 
   it("uses New API default frontend routes when /api/status reports the default theme", async () => {
     mockDefaultNewApiThemeStatus()
@@ -62,10 +78,18 @@ describe("siteRouteResolver", () => {
         SITE_ROUTE_KINDS.Login,
       ),
     ).resolves.toBe("https://new-api.example/sign-in")
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith({
+      baseUrl: "https://new-api.example",
+      auth: { authType: AuthTypeEnum.None },
+    })
+    expect(mockResolveRoutePath).toHaveBeenCalledWith(
+      { baseUrl: "https://new-api.example", siteType: SITE_TYPES.NEW_API },
+      SITE_ROUTE_KINDS.CheckIn,
+    )
   })
 
   it("keeps classic New API routes when /api/status is unavailable", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"))
+    mockFetchSiteStatus.mockRejectedValue(new Error("offline"))
 
     await expect(
       resolveAccountSiteRouteUrl(
@@ -88,8 +112,6 @@ describe("siteRouteResolver", () => {
   })
 
   it("uses static route config for non-New API sites without probing /api/status", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch")
-
     await expect(
       resolveAccountSiteRouteUrl(
         { baseUrl: "https://veloera.example", siteType: SITE_TYPES.VELOERA },
@@ -97,7 +119,35 @@ describe("siteRouteResolver", () => {
       ),
     ).resolves.toBe("https://veloera.example/app/me")
 
-    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).not.toHaveBeenCalled()
+  })
+
+  it("falls back to static route config when account bootstrap is missing", async () => {
+    mockGetSiteAdapter.mockReturnValueOnce({})
+
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://veloera.example", siteType: SITE_TYPES.VELOERA },
+        SITE_ROUTE_KINDS.CheckIn,
+      ),
+    ).resolves.toBe("https://veloera.example/app/me")
+  })
+
+  it("falls back to static route config when account bootstrap has no route resolver", async () => {
+    mockGetSiteAdapter.mockReturnValueOnce({
+      accountBootstrap: {
+        fetchSiteStatus: mockFetchSiteStatus,
+      },
+    })
+
+    await expect(
+      resolveAccountSiteRouteUrl(
+        { baseUrl: "https://veloera.example", siteType: SITE_TYPES.VELOERA },
+        SITE_ROUTE_KINDS.CheckIn,
+      ),
+    ).resolves.toBe("https://veloera.example/app/me")
+    expect(mockResolveRoutePath).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).not.toHaveBeenCalled()
   })
 
   it("resolves login URLs through the route resolver when a site type hint is available", async () => {
@@ -112,19 +162,15 @@ describe("siteRouteResolver", () => {
   })
 
   it("uses best-effort login routing when no site type hint is available", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch")
-
     await expect(
       resolveAccountSiteLoginUrl("https://unknown.example/dashboard"),
     ).resolves.toBe("https://unknown.example/login")
     expect(getBestEffortLoginUrl("not-a-url")).toBe("not-a-url")
-    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).not.toHaveBeenCalled()
   })
 
   it("bounds cached New API theme probes for many account sites", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockRejectedValue(new Error("offline"))
+    mockFetchSiteStatus.mockRejectedValue(new Error("offline"))
 
     for (let index = 0; index < 101; index += 1) {
       await resolveAccountSiteRouteUrl(
@@ -145,12 +191,10 @@ describe("siteRouteResolver", () => {
       SITE_ROUTE_KINDS.Usage,
     )
 
-    expect(fetchSpy).toHaveBeenCalledTimes(102)
+    expect(mockFetchSiteStatus).toHaveBeenCalledTimes(102)
   })
 
   it("keeps AIHubMix login routing centralized in the route resolver", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch")
-
     await expect(
       resolveAccountSiteLoginUrl(
         "https://aihubmix.com/statistics",
@@ -160,6 +204,6 @@ describe("siteRouteResolver", () => {
     expect(
       getBestEffortLoginUrl("https://console.aihubmix.com/statistics"),
     ).toBe("https://console.aihubmix.com/sign-in")
-    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/apiAdapters/accountBootstrap.test.ts
+++ b/tests/services/apiAdapters/accountBootstrap.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { aihubmixAccountBootstrap } from "~/services/apiAdapters/aihubmix/accountBootstrap"
+import { createNewApiAccountBootstrap } from "~/services/apiAdapters/newApi/accountBootstrap"
+import { sub2ApiAccountBootstrap } from "~/services/apiAdapters/sub2api/accountBootstrap"
+import { AuthTypeEnum } from "~/types"
+
+const {
+  mockAihubmixExtractDefaultExchangeRate,
+  mockAihubmixFetchSiteStatus,
+  mockAihubmixFetchSupportCheckIn,
+  mockAihubmixFetchUserInfo,
+  mockAihubmixGetOrCreateAccessToken,
+  mockExtractDefaultExchangeRate,
+  mockFetchSiteStatus,
+  mockFetchSupportCheckIn,
+  mockFetchUserInfo,
+  mockGetApiService,
+  mockGetOrCreateAccessToken,
+  mockSub2ApiExtractDefaultExchangeRate,
+  mockSub2ApiFetchSiteStatus,
+  mockSub2ApiFetchSupportCheckIn,
+  mockSub2ApiFetchUserInfo,
+  mockSub2ApiGetOrCreateAccessToken,
+} = vi.hoisted(() => ({
+  mockAihubmixExtractDefaultExchangeRate: vi.fn(),
+  mockAihubmixFetchSiteStatus: vi.fn(),
+  mockAihubmixFetchSupportCheckIn: vi.fn(),
+  mockAihubmixFetchUserInfo: vi.fn(),
+  mockAihubmixGetOrCreateAccessToken: vi.fn(),
+  mockExtractDefaultExchangeRate: vi.fn(),
+  mockFetchSiteStatus: vi.fn(),
+  mockFetchSupportCheckIn: vi.fn(),
+  mockFetchUserInfo: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockGetOrCreateAccessToken: vi.fn(),
+  mockSub2ApiExtractDefaultExchangeRate: vi.fn(),
+  mockSub2ApiFetchSiteStatus: vi.fn(),
+  mockSub2ApiFetchSupportCheckIn: vi.fn(),
+  mockSub2ApiFetchUserInfo: vi.fn(),
+  mockSub2ApiGetOrCreateAccessToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+
+vi.mock("~/services/apiService/sub2api", () => ({
+  extractDefaultExchangeRate: mockSub2ApiExtractDefaultExchangeRate,
+  fetchSiteStatus: mockSub2ApiFetchSiteStatus,
+  fetchSupportCheckIn: mockSub2ApiFetchSupportCheckIn,
+  fetchUserInfo: mockSub2ApiFetchUserInfo,
+  getOrCreateAccessToken: mockSub2ApiGetOrCreateAccessToken,
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  extractDefaultExchangeRate: mockAihubmixExtractDefaultExchangeRate,
+  fetchSiteStatus: mockAihubmixFetchSiteStatus,
+  fetchSupportCheckIn: mockAihubmixFetchSupportCheckIn,
+  fetchUserInfo: mockAihubmixFetchUserInfo,
+  getOrCreateAccessToken: mockAihubmixGetOrCreateAccessToken,
+}))
+
+const request = {
+  baseUrl: "https://example.invalid",
+  auth: { authType: AuthTypeEnum.Cookie },
+}
+const userInfo = { id: 1, username: "tester" }
+const tokenInfo = { username: "tester", access_token: "token" }
+const siteStatus = { system_name: "Example Portal", checkin_enabled: true }
+
+describe("account bootstrap adapters", () => {
+  it("delegates New API-family bootstrap operations to the site API service", async () => {
+    const accountBootstrap = createNewApiAccountBootstrap(SITE_TYPES.VELOERA)
+    mockGetApiService.mockReturnValue({
+      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+      fetchSiteStatus: mockFetchSiteStatus,
+      fetchSupportCheckIn: mockFetchSupportCheckIn,
+      fetchUserInfo: mockFetchUserInfo,
+      getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    })
+    mockFetchUserInfo.mockResolvedValue(userInfo)
+    mockGetOrCreateAccessToken.mockResolvedValue(tokenInfo)
+    mockFetchSiteStatus.mockResolvedValue(siteStatus)
+    mockFetchSupportCheckIn.mockResolvedValue(true)
+    mockExtractDefaultExchangeRate.mockReturnValue(500000)
+
+    await expect(accountBootstrap.fetchUserInfo(request)).resolves.toBe(
+      userInfo,
+    )
+    await expect(
+      accountBootstrap.getOrCreateAccessToken(request),
+    ).resolves.toBe(tokenInfo)
+    await expect(accountBootstrap.fetchSiteStatus(request)).resolves.toBe(
+      siteStatus,
+    )
+    await expect(accountBootstrap.fetchCheckInSupport(request)).resolves.toBe(
+      true,
+    )
+    expect(accountBootstrap.extractDefaultExchangeRate(siteStatus)).toBe(500000)
+    await expect(
+      accountBootstrap.resolveRoutePath(
+        { baseUrl: "https://example.invalid", siteType: SITE_TYPES.VELOERA },
+        "checkIn",
+      ),
+    ).resolves.toBe("/app/me")
+
+    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.VELOERA)
+    expect(mockFetchUserInfo).toHaveBeenCalledWith(request)
+    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith(request)
+    expect(mockFetchSiteStatus).toHaveBeenCalledWith(request)
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(request)
+    expect(mockExtractDefaultExchangeRate).toHaveBeenCalledWith(siteStatus)
+  })
+
+  it("delegates Sub2API bootstrap operations to Sub2API helpers", async () => {
+    mockSub2ApiFetchUserInfo.mockResolvedValue(userInfo)
+    mockSub2ApiGetOrCreateAccessToken.mockResolvedValue(tokenInfo)
+    mockSub2ApiFetchSiteStatus.mockResolvedValue(siteStatus)
+    mockSub2ApiFetchSupportCheckIn.mockResolvedValue(false)
+    mockSub2ApiExtractDefaultExchangeRate.mockReturnValue(1000000)
+
+    await expect(sub2ApiAccountBootstrap.fetchUserInfo(request)).resolves.toBe(
+      userInfo,
+    )
+    await expect(
+      sub2ApiAccountBootstrap.getOrCreateAccessToken(request),
+    ).resolves.toBe(tokenInfo)
+    await expect(
+      sub2ApiAccountBootstrap.fetchSiteStatus(request),
+    ).resolves.toBe(siteStatus)
+    await expect(
+      sub2ApiAccountBootstrap.fetchCheckInSupport(request),
+    ).resolves.toBe(false)
+    expect(sub2ApiAccountBootstrap.extractDefaultExchangeRate(siteStatus)).toBe(
+      1000000,
+    )
+    await expect(
+      sub2ApiAccountBootstrap.resolveRoutePath(
+        {
+          baseUrl: "https://sub2.example.invalid",
+          siteType: SITE_TYPES.SUB2API,
+        },
+        "login",
+      ),
+    ).resolves.toBe("/login")
+
+    expect(mockSub2ApiFetchUserInfo).toHaveBeenCalledWith(request)
+    expect(mockSub2ApiGetOrCreateAccessToken).toHaveBeenCalledWith(request)
+    expect(mockSub2ApiFetchSiteStatus).toHaveBeenCalledWith(request)
+    expect(mockSub2ApiFetchSupportCheckIn).toHaveBeenCalledWith(request)
+    expect(mockSub2ApiExtractDefaultExchangeRate).toHaveBeenCalledWith(
+      siteStatus,
+    )
+    expect(mockGetApiService).not.toHaveBeenCalled()
+  })
+
+  it("delegates AIHubMix bootstrap operations to AIHubMix helpers", async () => {
+    mockAihubmixFetchUserInfo.mockResolvedValue(userInfo)
+    mockAihubmixGetOrCreateAccessToken.mockResolvedValue(tokenInfo)
+    mockAihubmixFetchSiteStatus.mockResolvedValue(siteStatus)
+    mockAihubmixFetchSupportCheckIn.mockResolvedValue(undefined)
+    mockAihubmixExtractDefaultExchangeRate.mockReturnValue(null)
+
+    await expect(aihubmixAccountBootstrap.fetchUserInfo(request)).resolves.toBe(
+      userInfo,
+    )
+    await expect(
+      aihubmixAccountBootstrap.getOrCreateAccessToken(request),
+    ).resolves.toBe(tokenInfo)
+    await expect(
+      aihubmixAccountBootstrap.fetchSiteStatus(request),
+    ).resolves.toBe(siteStatus)
+    await expect(
+      aihubmixAccountBootstrap.fetchCheckInSupport(request),
+    ).resolves.toBeUndefined()
+    expect(
+      aihubmixAccountBootstrap.extractDefaultExchangeRate(siteStatus),
+    ).toBe(null)
+    await expect(
+      aihubmixAccountBootstrap.resolveRoutePath(
+        {
+          baseUrl: "https://aihubmix.example.invalid",
+          siteType: SITE_TYPES.AIHUBMIX,
+        },
+        "login",
+      ),
+    ).resolves.toBe("/sign-in")
+
+    expect(mockAihubmixFetchUserInfo).toHaveBeenCalledWith(request)
+    expect(mockAihubmixGetOrCreateAccessToken).toHaveBeenCalledWith(request)
+    expect(mockAihubmixFetchSiteStatus).toHaveBeenCalledWith(request)
+    expect(mockAihubmixFetchSupportCheckIn).toHaveBeenCalledWith(request)
+    expect(mockAihubmixExtractDefaultExchangeRate).toHaveBeenCalledWith(
+      siteStatus,
+    )
+    expect(mockGetApiService).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/apiAdapters/accountBootstrap.test.ts
+++ b/tests/services/apiAdapters/accountBootstrap.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
+import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
 import { aihubmixAccountBootstrap } from "~/services/apiAdapters/aihubmix/accountBootstrap"
+import { ACCOUNT_BOOTSTRAP_ROUTE_KINDS } from "~/services/apiAdapters/contracts/accountBootstrap"
 import { createNewApiAccountBootstrap } from "~/services/apiAdapters/newApi/accountBootstrap"
 import { sub2ApiAccountBootstrap } from "~/services/apiAdapters/sub2api/accountBootstrap"
 import { AuthTypeEnum } from "~/types"
@@ -71,6 +73,10 @@ const tokenInfo = { username: "tester", access_token: "token" }
 const siteStatus = { system_name: "Example Portal", checkin_enabled: true }
 
 describe("account bootstrap adapters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it("delegates New API-family bootstrap operations to the site API service", async () => {
     const accountBootstrap = createNewApiAccountBootstrap(SITE_TYPES.VELOERA)
     mockGetApiService.mockReturnValue({
@@ -102,7 +108,7 @@ describe("account bootstrap adapters", () => {
     await expect(
       accountBootstrap.resolveRoutePath(
         { baseUrl: "https://example.invalid", siteType: SITE_TYPES.VELOERA },
-        "checkIn",
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.CheckIn,
       ),
     ).resolves.toBe("/app/me")
 
@@ -112,6 +118,50 @@ describe("account bootstrap adapters", () => {
     expect(mockFetchSiteStatus).toHaveBeenCalledWith(request)
     expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(request)
     expect(mockExtractDefaultExchangeRate).toHaveBeenCalledWith(siteStatus)
+  })
+
+  it("resolves static account route paths from shared route kinds", () => {
+    const target = {
+      baseUrl: "https://sub2.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+    }
+
+    expect(
+      resolveStaticAccountRoutePath(
+        target,
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Login,
+      ),
+    ).toBe("/login")
+    expect(
+      resolveStaticAccountRoutePath(
+        target,
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Usage,
+      ),
+    ).toBe("/usage")
+    expect(
+      resolveStaticAccountRoutePath(
+        target,
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.CheckIn,
+      ),
+    ).toBe("/console/personal")
+    expect(
+      resolveStaticAccountRoutePath(
+        target,
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.AdminCredentials,
+      ),
+    ).toBe("/console/personal")
+    expect(
+      resolveStaticAccountRoutePath(
+        target,
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Redeem,
+      ),
+    ).toBe("/redeem")
+    expect(
+      resolveStaticAccountRoutePath(
+        target,
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.SiteAnnouncements,
+      ),
+    ).toBe("/dashboard")
   })
 
   it("delegates Sub2API bootstrap operations to Sub2API helpers", async () => {
@@ -142,9 +192,18 @@ describe("account bootstrap adapters", () => {
           baseUrl: "https://sub2.example.invalid",
           siteType: SITE_TYPES.SUB2API,
         },
-        "login",
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Login,
       ),
     ).resolves.toBe("/login")
+    await expect(
+      sub2ApiAccountBootstrap.resolveRoutePath(
+        {
+          baseUrl: "https://sub2.example.invalid",
+          siteType: SITE_TYPES.SUB2API,
+        },
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.SiteAnnouncements,
+      ),
+    ).resolves.toBe("/dashboard")
 
     expect(mockSub2ApiFetchUserInfo).toHaveBeenCalledWith(request)
     expect(mockSub2ApiGetOrCreateAccessToken).toHaveBeenCalledWith(request)
@@ -184,7 +243,7 @@ describe("account bootstrap adapters", () => {
           baseUrl: "https://aihubmix.example.invalid",
           siteType: SITE_TYPES.AIHUBMIX,
         },
-        "login",
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Login,
       ),
     ).resolves.toBe("/sign-in")
 

--- a/tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/aihubmix/accountCompletion.test.ts
@@ -16,18 +16,25 @@ const {
   mockExtractDefaultExchangeRate,
   mockFetchSiteStatus,
   mockFetchSupportCheckIn,
-  mockGetApiService,
+  mockFetchUserInfo,
   mockGetOrCreateAccessToken,
 } = vi.hoisted(() => ({
   mockExtractDefaultExchangeRate: vi.fn(),
   mockFetchSiteStatus: vi.fn(),
   mockFetchSupportCheckIn: vi.fn(),
-  mockGetApiService: vi.fn(),
+  mockFetchUserInfo: vi.fn(),
   mockGetOrCreateAccessToken: vi.fn(),
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: mockGetApiService,
+vi.mock("~/services/apiAdapters/aihubmix/accountBootstrap", () => ({
+  aihubmixAccountBootstrap: {
+    extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+    fetchCheckInSupport: mockFetchSupportCheckIn,
+    fetchSiteStatus: mockFetchSiteStatus,
+    fetchUserInfo: mockFetchUserInfo,
+    getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    resolveRoutePath: vi.fn(),
+  },
 }))
 
 const currentTabFetchContext = {
@@ -93,12 +100,6 @@ const helpers = {
 describe("aihubmixAccountCompletion", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetApiService.mockReturnValue({
-      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
-      fetchSiteStatus: mockFetchSiteStatus,
-      fetchSupportCheckIn: mockFetchSupportCheckIn,
-      getOrCreateAccessToken: mockGetOrCreateAccessToken,
-    })
   })
 
   it("uses detected access-token data and probes status with Cookie auth", async () => {
@@ -128,7 +129,6 @@ describe("aihubmixAccountCompletion", () => {
       helpers,
     )
 
-    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.AIHUBMIX)
     expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
     expect(mockFetchSiteStatus).toHaveBeenCalledWith({
       baseUrl: "https://aihubmix.com",

--- a/tests/services/apiAdapters/newApi/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/newApi/accountCompletion.test.ts
@@ -13,23 +13,23 @@ import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/ty
 import { AuthTypeEnum } from "~/types"
 
 const {
+  mockCreateNewApiAccountBootstrap,
   mockExtractDefaultExchangeRate,
+  mockFetchCheckInSupport,
   mockFetchSiteStatus,
-  mockFetchSupportCheckIn,
   mockFetchUserInfo,
-  mockGetApiService,
   mockGetOrCreateAccessToken,
 } = vi.hoisted(() => ({
+  mockCreateNewApiAccountBootstrap: vi.fn(),
   mockExtractDefaultExchangeRate: vi.fn(),
+  mockFetchCheckInSupport: vi.fn(),
   mockFetchSiteStatus: vi.fn(),
-  mockFetchSupportCheckIn: vi.fn(),
   mockFetchUserInfo: vi.fn(),
-  mockGetApiService: vi.fn(),
   mockGetOrCreateAccessToken: vi.fn(),
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: mockGetApiService,
+vi.mock("~/services/apiAdapters/newApi/accountBootstrap", () => ({
+  createNewApiAccountBootstrap: mockCreateNewApiAccountBootstrap,
 }))
 
 const currentTabFetchContext = {
@@ -95,12 +95,13 @@ const helpers = {
 describe("newApiAccountCompletion", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetApiService.mockReturnValue({
+    mockCreateNewApiAccountBootstrap.mockReturnValue({
       extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+      fetchCheckInSupport: mockFetchCheckInSupport,
       fetchSiteStatus: mockFetchSiteStatus,
-      fetchSupportCheckIn: mockFetchSupportCheckIn,
       fetchUserInfo: mockFetchUserInfo,
       getOrCreateAccessToken: mockGetOrCreateAccessToken,
+      resolveRoutePath: vi.fn(),
     })
   })
 
@@ -131,7 +132,9 @@ describe("newApiAccountCompletion", () => {
       helpers,
     )
 
-    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(mockCreateNewApiAccountBootstrap).toHaveBeenCalledWith(
+      SITE_TYPES.NEW_API,
+    )
     expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
       baseUrl: "https://new.example.com",
       fetchContext: currentTabFetchContext,
@@ -147,7 +150,7 @@ describe("newApiAccountCompletion", () => {
         authType: AuthTypeEnum.AccessToken,
       },
     })
-    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+    expect(mockFetchCheckInSupport).not.toHaveBeenCalled()
     expect(mockExtractDefaultExchangeRate).toHaveBeenCalledWith({
       system_name: "  Token Portal  ",
       checkin_enabled: true,
@@ -188,7 +191,7 @@ describe("newApiAccountCompletion", () => {
     mockFetchSiteStatus.mockResolvedValueOnce({
       system_name: "Cookie Portal",
     })
-    mockFetchSupportCheckIn.mockResolvedValueOnce(true)
+    mockFetchCheckInSupport.mockResolvedValueOnce(true)
     mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
 
     const result = await newApiAccountCompletion.complete(
@@ -218,7 +221,7 @@ describe("newApiAccountCompletion", () => {
         authType: AuthTypeEnum.Cookie,
       },
     })
-    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
+    expect(mockFetchCheckInSupport).toHaveBeenCalledWith({
       baseUrl: "https://cookie.example.com",
       auth: {
         authType: AuthTypeEnum.None,
@@ -367,7 +370,7 @@ describe("newApiAccountCompletion", () => {
       AUTO_DETECT_FAILURE_REASONS.SiteStatusFetchFailed,
       siteStatusError,
     )
-    expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()
+    expect(mockFetchCheckInSupport).not.toHaveBeenCalled()
   })
 
   it("falls back to disabled check-in detection when support probing fails", async () => {
@@ -379,7 +382,7 @@ describe("newApiAccountCompletion", () => {
     mockFetchSiteStatus.mockResolvedValueOnce({
       system_name: "Token Portal",
     })
-    mockFetchSupportCheckIn.mockRejectedValueOnce(supportError)
+    mockFetchCheckInSupport.mockRejectedValueOnce(supportError)
     mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
 
     const result = await newApiAccountCompletion.complete(

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { SITE_TYPES } from "~/constants/siteType"
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 
 describe("apiAdapters registry", () => {
@@ -32,6 +32,14 @@ describe("apiAdapters registry", () => {
     expect(adapter.accountRefresh).toEqual({
       fetchCheckInSupport: expect.any(Function),
       refreshAccount: expect.any(Function),
+    })
+    expect(adapter.accountBootstrap).toEqual({
+      fetchUserInfo: expect.any(Function),
+      getOrCreateAccessToken: expect.any(Function),
+      fetchSiteStatus: expect.any(Function),
+      fetchCheckInSupport: expect.any(Function),
+      extractDefaultExchangeRate: expect.any(Function),
+      resolveRoutePath: expect.any(Function),
     })
     expect(adapter.accountData).toEqual({
       fetchData: expect.any(Function),
@@ -80,6 +88,14 @@ describe("apiAdapters registry", () => {
         fetchCheckInSupport: expect.any(Function),
         refreshAccount: expect.any(Function),
       })
+      expect(adapter.accountBootstrap).toEqual({
+        fetchUserInfo: expect.any(Function),
+        getOrCreateAccessToken: expect.any(Function),
+        fetchSiteStatus: expect.any(Function),
+        fetchCheckInSupport: expect.any(Function),
+        extractDefaultExchangeRate: expect.any(Function),
+        resolveRoutePath: expect.any(Function),
+      })
       expect(adapter.accountData).toEqual({
         fetchData: expect.any(Function),
       })
@@ -112,6 +128,14 @@ describe("apiAdapters registry", () => {
       fetchCheckInSupport: expect.any(Function),
       refreshAccount: expect.any(Function),
     })
+    expect(adapter.accountBootstrap).toEqual({
+      fetchUserInfo: expect.any(Function),
+      getOrCreateAccessToken: expect.any(Function),
+      fetchSiteStatus: expect.any(Function),
+      fetchCheckInSupport: expect.any(Function),
+      extractDefaultExchangeRate: expect.any(Function),
+      resolveRoutePath: expect.any(Function),
+    })
     expect(adapter.accountData).toEqual({
       fetchData: expect.any(Function),
     })
@@ -121,5 +145,14 @@ describe("apiAdapters registry", () => {
     expect(adapter.siteNotice).toBeUndefined()
     expect(adapter.siteAnnouncements).toBeUndefined()
     expect(adapter.modelCatalog).toBeUndefined()
+  })
+
+  it("returns an unsupported adapter without account bootstrap", () => {
+    const adapter = getSiteAdapter(SITE_TYPES.OCTOPUS as AccountSiteType)
+
+    expect(adapter).toEqual({
+      siteType: SITE_TYPES.OCTOPUS,
+    })
+    expect(adapter.accountBootstrap).toBeUndefined()
   })
 })

--- a/tests/services/apiAdapters/sub2api/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/sub2api/accountCompletion.test.ts
@@ -16,19 +16,24 @@ const {
   mockFetchSiteStatus,
   mockFetchSupportCheckIn,
   mockFetchUserInfo,
-  mockGetApiService,
   mockGetOrCreateAccessToken,
 } = vi.hoisted(() => ({
   mockExtractDefaultExchangeRate: vi.fn(),
   mockFetchSiteStatus: vi.fn(),
   mockFetchSupportCheckIn: vi.fn(),
   mockFetchUserInfo: vi.fn(),
-  mockGetApiService: vi.fn(),
   mockGetOrCreateAccessToken: vi.fn(),
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: mockGetApiService,
+vi.mock("~/services/apiAdapters/sub2api/accountBootstrap", () => ({
+  sub2ApiAccountBootstrap: {
+    extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
+    fetchCheckInSupport: mockFetchSupportCheckIn,
+    fetchSiteStatus: mockFetchSiteStatus,
+    fetchUserInfo: mockFetchUserInfo,
+    getOrCreateAccessToken: mockGetOrCreateAccessToken,
+    resolveRoutePath: vi.fn(),
+  },
 }))
 
 const currentTabFetchContext = {
@@ -94,13 +99,6 @@ const helpers = {
 describe("sub2ApiAccountCompletion", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetApiService.mockReturnValue({
-      extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
-      fetchSiteStatus: mockFetchSiteStatus,
-      fetchSupportCheckIn: mockFetchSupportCheckIn,
-      fetchUserInfo: mockFetchUserInfo,
-      getOrCreateAccessToken: mockGetOrCreateAccessToken,
-    })
   })
 
   it("uses detected access-token data and disables check-in", async () => {
@@ -135,7 +133,6 @@ describe("sub2ApiAccountCompletion", () => {
       helpers,
     )
 
-    expect(mockGetApiService).toHaveBeenCalledWith(SITE_TYPES.SUB2API)
     expect(mockFetchUserInfo).not.toHaveBeenCalled()
     expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
     expect(mockFetchSupportCheckIn).not.toHaveBeenCalled()

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -15,6 +15,7 @@ const {
   mockGetActiveOrAllTabs,
   mockGetActiveTabs,
   mockGetAccountSiteType,
+  mockGetSiteAdapter,
   mockIsMessageReceiverUnavailableError,
   mockSendRuntimeMessage,
 } = vi.hoisted(() => ({
@@ -22,14 +23,13 @@ const {
   mockGetActiveOrAllTabs: vi.fn(),
   mockGetActiveTabs: vi.fn(),
   mockGetAccountSiteType: vi.fn(),
+  mockGetSiteAdapter: vi.fn(),
   mockIsMessageReceiverUnavailableError: vi.fn(),
   mockSendRuntimeMessage: vi.fn(),
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: vi.fn(() => ({
-    fetchUserInfo: mockFetchUserInfo,
-  })),
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: mockGetSiteAdapter,
 }))
 
 vi.mock("~/services/siteDetection/detectSiteType", () => ({
@@ -76,6 +76,11 @@ describe("autoDetectSmart", () => {
     mockGetActiveTabs.mockResolvedValue([])
     mockIsMessageReceiverUnavailableError.mockReturnValue(false)
     mockSendRuntimeMessage.mockResolvedValue(null)
+    mockGetSiteAdapter.mockReturnValue({
+      accountBootstrap: {
+        fetchUserInfo: mockFetchUserInfo,
+      },
+    })
     mockFetchUserInfo.mockResolvedValue({
       id: 1,
       username: "tester",
@@ -244,10 +249,11 @@ describe("autoDetectSmart", () => {
         },
       },
     })
+    expect(mockGetSiteAdapter).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
     expect(mockFetchUserInfo).toHaveBeenCalledWith({
       baseUrl: "https://example.com/console",
       auth: {
-        authType: expect.any(String),
+        authType: AuthTypeEnum.Cookie,
       },
       fetchContext: {
         kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
@@ -280,6 +286,7 @@ describe("autoDetectSmart", () => {
 
     expect(result.success).toBe(false)
     expect(result.data).toBeUndefined()
+    expect(mockGetSiteAdapter).toHaveBeenCalledWith(SITE_TYPES.SUB2API)
     expect(mockFetchUserInfo).toHaveBeenCalledWith(
       expect.objectContaining({
         auth: {
@@ -298,6 +305,28 @@ describe("autoDetectSmart", () => {
         origin: "https://sub2.example.com",
       },
     })
+  })
+
+  it("falls back when the detected site type has no account bootstrap capability", async () => {
+    browserAny.runtime = null
+    mockGetSiteAdapter.mockReturnValue({})
+    mockGetActiveOrAllTabs.mockResolvedValue([
+      {
+        id: 1,
+        active: true,
+        url: "https://example.com/home",
+      },
+    ])
+    browserAny.tabs.sendMessage.mockResolvedValueOnce({
+      success: false,
+      error: "no local storage user",
+    })
+
+    const result = await autoDetectSmart("https://example.com/console")
+
+    expect(result.success).toBe(false)
+    expect(mockGetSiteAdapter).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("keeps current-tab context when content script fails with a non-receiver error and API fallback succeeds", async () => {
@@ -877,10 +906,11 @@ describe("autoDetectSmart", () => {
         },
       },
     })
+    expect(mockGetSiteAdapter).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
     expect(mockFetchUserInfo).toHaveBeenCalledWith({
       baseUrl: "https://example.com/console",
       auth: {
-        authType: expect.any(String),
+        authType: AuthTypeEnum.Cookie,
       },
       fetchContext: {
         kind: API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT,
@@ -1160,7 +1190,7 @@ describe("autoDetectSmart", () => {
     expect(mockFetchUserInfo).toHaveBeenCalledWith({
       baseUrl: "not a url",
       auth: {
-        authType: expect.any(String),
+        authType: AuthTypeEnum.Cookie,
       },
     })
   })


### PR DESCRIPTION
## Summary
- Add SiteAdapter.accountBootstrap for early account-site user/status/token/route facts.
- Route auto-detect fallback, site-name status probing, and account route resolution through account bootstrap.
- Reuse sibling bootstrap implementations inside New API, Sub2API, and AIHubMix account completion.

## Test Plan
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced adapter-backed account bootstrap to improve early user/site discovery and account route targeting across supported site types.
* **Bug Fixes**
  * Improved site name resolution and account route resolution behavior, including more reliable handling of default-theme routing.
* **Refactor**
  * Centralized account bootstrap and probing so account flows consistently leverage the active site adapter.
* **Tests**
  * Updated and expanded tests for adapter wiring, auto-detection, site name, route resolution, and account completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->