### PR TITLE
refactor(account-site): introduce onboarding substrate

### DIFF
--- a/docs/superpowers/plans/2026-06-19-account-site-onboarding-substrate.md
+++ b/docs/superpowers/plans/2026-06-19-account-site-onboarding-substrate.md
@@ -1,0 +1,759 @@
+# Account Site Onboarding Substrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move account-site detection metadata and content-script session extraction into a dedicated onboarding substrate so future account site types can register early onboarding facts without adding raw branches across constants, detection, and content message handlers.
+
+**Architecture:** Add a pre-adapter Module under `src/services/accountSiteOnboarding`. A pure metadata source owns site-type values, detection rules, and route overrides; the runtime registry composes that metadata with ordered content-session extractors. `src/constants/siteType.ts` remains the compatibility facade, `detectSiteType.ts` consumes onboarding projections, and `handleGetUserFromLocalStorage(...)` delegates to extractors.
+
+**Tech Stack:** TypeScript, WXT content scripts, Vitest, jsdom localStorage, MSW, pnpm, existing site-type and account-identity helpers.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-account-site-onboarding-substrate-design.md`
+
+---
+
+## File Structure
+
+Create:
+
+- `src/services/accountSiteOnboarding/siteTypes.ts`
+  - Pure site-type constants and literal-union arrays moved out of the compatibility facade.
+- `src/services/accountSiteOnboarding/contracts.ts`
+  - Shared onboarding registry, detection, route, and content-session extractor Interfaces.
+- `src/services/accountSiteOnboarding/metadata.ts`
+  - Pure static metadata for title/domain detection and route overrides. Must not import content-session extractors.
+- `src/services/accountSiteOnboarding/contentSession/sub2api.ts`
+  - Sub2API localStorage/JWT session extractor and near-expiry token refresh logic.
+- `src/services/accountSiteOnboarding/contentSession/compatibleUser.ts`
+  - Generic compatible `localStorage["user"]` extractor.
+- `src/services/accountSiteOnboarding/registry.ts`
+  - Runtime registry projections plus ordered content-session extractors.
+- `tests/services/accountSiteOnboarding/registry.test.ts`
+  - Metadata and extractor-order projection coverage.
+- `tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts`
+  - Sub2API extractor behavior coverage.
+- `tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts`
+  - Generic compatible extractor behavior coverage.
+
+Modify:
+
+- `src/constants/siteType.ts`
+  - Re-export site-type constants/types and derive public title/domain/route exports from pure onboarding metadata.
+- `tests/constants/siteType.test.ts`
+  - Lock compatibility facade behavior after moving static metadata.
+- `src/services/siteDetection/detectSiteType.ts`
+  - Consume onboarding registry projections for domain, title, and compat user-id header fallback rules.
+- `tests/services/detectSiteType.test.ts`
+  - Keep domain/title/API fallback behavior covered against registry-backed rules.
+- `tests/services/detectSiteType.fallback.test.ts`
+  - Keep mocked fallback-path tests green after import changes.
+- `src/entrypoints/content/messageHandlers/handlers/storage.ts`
+  - Keep `handleGetLocalStorage(...)` unchanged; route user extraction through ordered onboarding extractors.
+- `tests/entrypoints/content/messageHandlers/handlers/storage.test.ts`
+  - Keep response-shape coverage and add extractor-order/error coverage.
+
+Do not modify:
+
+- `src/services/apiAdapters/**`
+- `src/services/apiService/**`
+- `src/services/siteDetection/autoDetectService.ts` unless TypeScript exposes duplicated request shaping that can be locally simplified without changing the message wire shape.
+- Account Dialog UI policy, redemption, managed-site provider/channel logic, telemetry schema, settings search entries, locale files, or Playwright E2E tests.
+
+---
+
+## Implementation Notes
+
+Avoid a runtime import cycle:
+
+- `accountSiteOnboarding/siteTypes.ts` imports nothing.
+- `accountSiteOnboarding/metadata.ts` imports only `siteTypes.ts` and pure helpers.
+- `constants/siteType.ts` imports only `siteTypes.ts` and `metadata.ts`.
+- `accountSiteOnboarding/registry.ts` imports `metadata.ts` and content-session extractors.
+- `detectSiteType.ts` and `storage.ts` import `registry.ts`.
+
+Do not make `constants/siteType.ts` import `registry.ts`; that would pull content-script extraction code into the global constants facade and can create cycles through modules that still import `~/constants/siteType`.
+
+The public compatibility surface stays stable:
+
+```ts
+export {
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  AIHUBMIX_WEB_ORIGIN,
+  ACCOUNT_SITE_TYPES,
+  ACCOUNT_SITE_TYPE_VALUES,
+  MANAGED_SITE_TYPES,
+  SITE_TYPES,
+} from "~/services/accountSiteOnboarding/siteTypes"
+export type {
+  AccountSiteType,
+  ManagedSiteType,
+} from "~/services/accountSiteOnboarding/siteTypes"
+```
+
+The content-session extractor result must keep the existing message response data shape consumed by `autoDetectService`:
+
+```ts
+export type ContentSessionExtractionResult = {
+  userId: string
+  user: Record<string, unknown>
+  accessToken?: string
+  siteTypeHint?: AccountSiteType
+  sub2apiAuth?: {
+    refreshToken: string
+    tokenExpiresAt?: number
+  }
+}
+```
+
+Use `null` for expected "not this extractor" or "not logged in" cases. Let `handleGetUserFromLocalStorage(...)` map no extractor result to `messages:content.userInfoNotFound`, except Sub2API malformed/expired session cases that must preserve `messages:sub2api.loginRequired`.
+
+Telemetry decision: reuse existing. This is an internal routing/refactor slice.
+
+Settings search decision: none. No settings UI or route anchors change.
+
+E2E decision: no new Playwright E2E. Focused Vitest coverage is the right layer unless implementation changes runtime message names, action IDs, or extension entrypoint wiring.
+
+---
+
+### Task 1: Add Pure Onboarding Metadata And Compatibility Facade
+
+**Files:**
+
+- Create `src/services/accountSiteOnboarding/siteTypes.ts`
+- Create `src/services/accountSiteOnboarding/contracts.ts`
+- Create `src/services/accountSiteOnboarding/metadata.ts`
+- Modify `src/constants/siteType.ts`
+- Modify `tests/constants/siteType.test.ts`
+- Create `tests/services/accountSiteOnboarding/registry.test.ts`
+- Create `src/services/accountSiteOnboarding/registry.ts`
+
+- [ ] Step 1: Add failing facade and registry projection tests.
+
+Extend `tests/constants/siteType.test.ts` to assert:
+
+```ts
+expect(isAccountSiteType(SITE_TYPES.SUB2API)).toBe(true)
+expect(isManagedSiteType(SITE_TYPES.CLAUDE_CODE_HUB)).toBe(true)
+expect(getAccountSiteApiRouter(SITE_TYPES.SUB2API)).toMatchObject({
+  usagePath: "/usage",
+  redeemPath: "/redeem",
+  siteAnnouncementsPath: "/dashboard",
+})
+expect(ACCOUNT_SITE_DOMAIN_RULES).toContainEqual({
+  name: SITE_TYPES.AIHUBMIX,
+  hostnames: AIHUBMIX_HOSTNAMES,
+})
+```
+
+Create `tests/services/accountSiteOnboarding/registry.test.ts` with assertions for:
+
+```ts
+expect(getAccountSiteTitleRules().map((rule) => rule.name)).toEqual(
+  ACCOUNT_SITE_TITLE_RULES.map((rule) => rule.name),
+)
+expect(getAccountSiteDomainRules()).toEqual(ACCOUNT_SITE_DOMAIN_RULES)
+expect(getAccountSiteRouteOverrides(SITE_TYPES.AIHUBMIX)).toMatchObject({
+  loginPath: AIHUBMIX_LOGIN_PATH,
+  usagePath: "/statistics",
+  redeemPath: "/topup",
+})
+expect(getContentSessionExtractors().map((extractor) => extractor.id)).toEqual([
+  "sub2api",
+  "compatible-user",
+])
+```
+
+Run the red tests:
+
+```powershell
+pnpm vitest run tests/constants/siteType.test.ts tests/services/accountSiteOnboarding/registry.test.ts
+```
+
+Expected result: new imports fail because the onboarding Module does not exist yet.
+
+- [ ] Step 2: Move pure site-type values into `siteTypes.ts`.
+
+Move these existing exports from `src/constants/siteType.ts` into `src/services/accountSiteOnboarding/siteTypes.ts` without changing values:
+
+```ts
+export const SITE_TYPES = {
+  ONE_API: "one-api",
+  NEW_API: "new-api",
+  ANYROUTER: "anyrouter",
+  VELOERA: "Veloera",
+  ONE_HUB: "one-hub",
+  DONE_HUB: "done-hub",
+  V_API: "v-api",
+  VO_API: "VoAPI",
+  SUPER_API: "Super-API",
+  RIX_API: "Rix-Api",
+  NEO_API: "neo-Api",
+  WONG_GONGYI: "wong-gongyi",
+  SUB2API: "sub2api",
+  OCTOPUS: "octopus",
+  AXON_HUB: "axonhub",
+  CLAUDE_CODE_HUB: "claude-code-hub",
+  AIHUBMIX: "AIHubMix",
+  UNKNOWN: "unknown",
+} as const
+```
+
+Also move `AIHUBMIX_*`, `ACCOUNT_SITE_TYPES`, `ACCOUNT_SITE_TYPE_VALUES`, `MANAGED_SITE_TYPES`, `AccountSiteType`, and `ManagedSiteType`.
+
+- [ ] Step 3: Add onboarding contracts.
+
+Create `src/services/accountSiteOnboarding/contracts.ts`:
+
+```ts
+import type { AccountSiteType } from "./siteTypes"
+
+export type AccountSiteRouteConfig = {
+  loginPath?: string
+  usagePath?: string
+  checkInPath?: string
+  adminCredentialsPath?: string
+  redeemPath?: string
+  siteAnnouncementsPath?: string
+}
+
+export type AccountSiteDetectionMetadata = {
+  titlePatterns?: readonly RegExp[]
+  hostnames?: readonly string[]
+  compatUserIdHeaderNames?: readonly string[]
+}
+
+export type ContentSessionExtractionContext = {
+  url?: string
+  siteTypeHint?: AccountSiteType
+}
+
+export type ContentSessionExtractionResult = {
+  userId: string
+  user: Record<string, unknown>
+  accessToken?: string
+  siteTypeHint?: AccountSiteType
+  sub2apiAuth?: {
+    refreshToken: string
+    tokenExpiresAt?: number
+  }
+}
+
+export type ContentSessionExtractor = {
+  id: string
+  canExtract(context: ContentSessionExtractionContext): boolean
+  extract(
+    context: ContentSessionExtractionContext,
+  ): Promise<ContentSessionExtractionResult | null>
+}
+
+export type AccountSiteOnboardingMetadata = {
+  siteType: AccountSiteType
+  detection?: AccountSiteDetectionMetadata
+  routes?: AccountSiteRouteConfig
+}
+```
+
+- [ ] Step 4: Add pure static metadata.
+
+Create `src/services/accountSiteOnboarding/metadata.ts`. It should include:
+
+- `makeTitleRegex(name: string): RegExp`
+- `DEFAULT_SITE_ROUTE_CONFIG`
+- `accountSiteOnboardingMetadata`
+- `getAccountSiteMetadata(siteType)`
+- `getAccountSiteTitleRuleMetadata()`
+- `getAccountSiteDomainRuleMetadata()`
+- `getAccountSiteRouteOverrideMetadata(siteType)`
+- `getAccountSiteCompatUserIdHeaderRules()`
+
+Populate metadata from the current `ACCOUNT_SITE_TITLE_RULES`, `ACCOUNT_SITE_DOMAIN_RULES`, and `SITE_ROUTE_CONFIGS`. For compat header metadata, convert `COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE` into per-site metadata here or export a normalized array from metadata:
+
+```ts
+export function getAccountSiteCompatUserIdHeaderRules() {
+  return Object.entries(COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE).map(
+    ([headerName, siteType]) => ({ siteType, headerName }),
+  )
+}
+```
+
+This metadata Module may import `COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE`; it must not import `registry.ts` or content-session extractors.
+
+- [ ] Step 5: Convert `siteType.ts` to the compatibility facade.
+
+`src/constants/siteType.ts` should:
+
+- re-export constants/types from `siteTypes.ts`
+- keep `isAccountSiteType(...)` and `isManagedSiteType(...)`
+- derive `ACCOUNT_SITE_TITLE_RULES` from `getAccountSiteTitleRuleMetadata()`
+- derive `ACCOUNT_SITE_DOMAIN_RULES` from `getAccountSiteDomainRuleMetadata()`
+- keep `getSiteRouteConfigForKey(...)` and `getAccountSiteApiRouter(...)` using `merge({}, DEFAULT_SITE_ROUTE_CONFIG, getAccountSiteRouteOverrideMetadata(key))`
+
+Keep the same public export names and object shapes.
+
+- [ ] Step 6: Add registry projections.
+
+Create `src/services/accountSiteOnboarding/registry.ts` with:
+
+```ts
+export function getAccountSiteOnboardingDefinition(siteType: AccountSiteType) {
+  return getAccountSiteMetadata(siteType)
+}
+
+export function getAccountSiteDomainRules() {
+  return getAccountSiteDomainRuleMetadata()
+}
+
+export function getAccountSiteTitleRules() {
+  return getAccountSiteTitleRuleMetadata()
+}
+
+export function getAccountSiteRouteOverrides(siteType: AccountSiteType) {
+  return getAccountSiteRouteOverrideMetadata(siteType)
+}
+
+export function getContentSessionExtractors(): readonly ContentSessionExtractor[] {
+  return [sub2ApiContentSessionExtractor, compatibleUserContentSessionExtractor]
+}
+```
+
+For this task, stub the two extractors in their future files only if TypeScript requires them. The real extractor behavior is implemented in Task 3.
+
+- [ ] Step 7: Run the green tests and commit.
+
+```powershell
+pnpm vitest run tests/constants/siteType.test.ts tests/services/accountSiteOnboarding/registry.test.ts
+```
+
+Expected result: both test files pass.
+
+Commit:
+
+```powershell
+git add src/services/accountSiteOnboarding/siteTypes.ts src/services/accountSiteOnboarding/contracts.ts src/services/accountSiteOnboarding/metadata.ts src/services/accountSiteOnboarding/registry.ts src/constants/siteType.ts tests/constants/siteType.test.ts tests/services/accountSiteOnboarding/registry.test.ts
+git commit -m "refactor(account-site): add onboarding metadata substrate"
+```
+
+---
+
+### Task 2: Route Site Detection Through Onboarding Projections
+
+**Files:**
+
+- Modify `src/services/siteDetection/detectSiteType.ts`
+- Modify `tests/services/detectSiteType.test.ts`
+- Modify `tests/services/detectSiteType.fallback.test.ts`
+- Modify `tests/services/accountSiteOnboarding/registry.test.ts`
+
+- [ ] Step 1: Add failing detection expectations for registry-backed fallback rules.
+
+In `tests/services/accountSiteOnboarding/registry.test.ts`, assert compat fallback projection includes the known header mappings:
+
+```ts
+expect(getAccountSiteCompatUserIdHeaderRules()).toEqual(
+  expect.arrayContaining([
+    { siteType: SITE_TYPES.NEW_API, headerName: "New-Api-User" },
+    { siteType: SITE_TYPES.V_API, headerName: "X-Api-User" },
+  ]),
+)
+```
+
+In `tests/services/detectSiteType.test.ts`, keep or add assertions that:
+
+- AIHubMix domain detection does not fetch title.
+- `New-Api-User` API errors detect `SITE_TYPES.NEW_API`.
+- `X-Api-User` API errors detect `SITE_TYPES.V_API`.
+- generic `User-id` API errors return `SITE_TYPES.UNKNOWN`.
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts
+```
+
+Expected result: either the new registry fallback export fails or tests reveal the old direct import path.
+
+- [ ] Step 2: Change `detectSiteType.ts` imports.
+
+Replace imports of `ACCOUNT_SITE_DOMAIN_RULES`, `ACCOUNT_SITE_TITLE_RULES`, and `COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE` with registry projections:
+
+```ts
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import {
+  getAccountSiteCompatUserIdHeaderRules,
+  getAccountSiteDomainRules,
+  getAccountSiteTitleRules,
+} from "~/services/accountSiteOnboarding/registry"
+```
+
+Build `COMPAT_USER_ID_HEADER_MESSAGE_RULES` from `getAccountSiteCompatUserIdHeaderRules()`:
+
+```ts
+const COMPAT_USER_ID_HEADER_MESSAGE_RULES =
+  getAccountSiteCompatUserIdHeaderRules().map(({ headerName, siteType }) => ({
+    siteType,
+    regex: new RegExp(
+      headerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/-/g, "[-_ ]?"),
+      "i",
+    ),
+  }))
+```
+
+Use `getAccountSiteTitleRules()` in both title matching and API-error whole-message matching. Use `getAccountSiteDomainRules()` in domain matching.
+
+- [ ] Step 3: Run focused detection tests and commit.
+
+```powershell
+pnpm vitest run tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts
+```
+
+Expected result: all three test files pass.
+
+Commit:
+
+```powershell
+git add src/services/siteDetection/detectSiteType.ts tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts tests/services/accountSiteOnboarding/registry.test.ts
+git commit -m "refactor(site-detection): use onboarding metadata projections"
+```
+
+---
+
+### Task 3: Extract Content-Session Readers
+
+**Files:**
+
+- Create `src/services/accountSiteOnboarding/contentSession/sub2api.ts`
+- Create `src/services/accountSiteOnboarding/contentSession/compatibleUser.ts`
+- Modify `src/services/accountSiteOnboarding/registry.ts`
+- Create `tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts`
+- Create `tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts`
+
+- [ ] Step 1: Add failing extractor tests for Sub2API.
+
+Create `tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts` by moving the Sub2API-specific assertions out of the storage-handler test shape. Cover:
+
+- valid `auth_token` + `auth_user` returns `{ userId, user, accessToken, siteTypeHint: SITE_TYPES.SUB2API }`
+- blank `auth_token` returns a typed login-required result or throws the same local login-required error the handler maps to `messages:sub2api.loginRequired`
+- near-expiry token calls `POST /api/v1/auth/refresh`, updates localStorage, and returns refreshed `sub2apiAuth`
+- expired refresh failure returns or throws the same login-required path
+- invalid `auth_user` returns or throws the same login-required path
+
+Use placeholder origins such as `https://sub2.example.invalid`.
+
+- [ ] Step 2: Add failing extractor tests for compatible users.
+
+Create `tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts`. Cover:
+
+```ts
+localStorage.setItem(
+  "user",
+  JSON.stringify({ id: 42, username: "alice", role: "admin" }),
+)
+
+await expect(
+  compatibleUserContentSessionExtractor.extract({
+    url: "https://example.invalid",
+    siteTypeHint: SITE_TYPES.NEW_API,
+  }),
+).resolves.toEqual({
+  userId: "42",
+  user: { id: 42, username: "alice", role: "admin" },
+  siteTypeHint: SITE_TYPES.NEW_API,
+})
+```
+
+Also cover:
+
+- `SITE_TYPES.UNKNOWN` omits `siteTypeHint`
+- AIHubMix username identity still resolves when the explicit site type hint is `SITE_TYPES.AIHUBMIX`
+- missing `user` returns `null`
+- malformed JSON returns `null`
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
+```
+
+Expected result: imports fail until extractor modules are implemented.
+
+- [ ] Step 3: Implement `compatibleUserContentSessionExtractor`.
+
+Create `src/services/accountSiteOnboarding/contentSession/compatibleUser.ts`:
+
+```ts
+import { isAccountSiteType, SITE_TYPES } from "~/constants/siteType"
+import { resolveStoredAccountUserIdentity } from "~/services/accounts/accountIdentity"
+import type { ContentSessionExtractor } from "../contracts"
+
+export const compatibleUserContentSessionExtractor: ContentSessionExtractor = {
+  id: "compatible-user",
+  canExtract: () => true,
+  async extract(context) {
+    const rawUser = localStorage.getItem("user")
+    if (!rawUser) return null
+
+    let user: unknown
+    try {
+      user = JSON.parse(rawUser)
+    } catch {
+      return null
+    }
+
+    const siteType = isAccountSiteType(context.siteTypeHint)
+      ? context.siteTypeHint
+      : SITE_TYPES.UNKNOWN
+    const identity = resolveStoredAccountUserIdentity(user, siteType)
+    if (!identity) return null
+
+    return {
+      ...identity,
+      ...(siteType !== SITE_TYPES.UNKNOWN ? { siteTypeHint: siteType } : {}),
+    }
+  },
+}
+```
+
+- [ ] Step 4: Implement `sub2ApiContentSessionExtractor`.
+
+Move the following logic out of `storage.ts` into `src/services/accountSiteOnboarding/contentSession/sub2api.ts`:
+
+- `SUB2API_AUTH_STORAGE_KEYS`
+- `SUB2API_TOKEN_REFRESH_BUFFER_MS`
+- `Sub2ApiEnvelope`
+- `Sub2ApiRefreshTokenData`
+- `tryParseTimestamp(...)`
+- `refreshSub2ApiTokensIfNeeded(...)`
+- parsing via `parseSub2ApiUserIdentity(...)`
+
+Keep the behavior identical:
+
+- `canExtract(...)` returns true only when both `auth_token` and `auth_user` exist.
+- blank token maps to the login-required path.
+- refresh endpoint is `new URL("/api/v1/auth/refresh", context.url).toString()` when `context.url` is present, otherwise `"/api/v1/auth/refresh"`.
+- successful refresh writes `auth_token`, `refresh_token`, and `token_expires_at` back to localStorage.
+- returned data includes `sub2apiAuth` only when a refresh token is available.
+- no token value is logged.
+
+Use a small local error sentinel so the handler can preserve `messages:sub2api.loginRequired` without string matching:
+
+```ts
+export class Sub2ApiContentSessionLoginRequiredError extends Error {
+  constructor() {
+    super("messages:sub2api.loginRequired")
+  }
+}
+```
+
+- [ ] Step 5: Wire registry extractor order and run tests.
+
+Update `getContentSessionExtractors()` to return:
+
+```ts
+return [sub2ApiContentSessionExtractor, compatibleUserContentSessionExtractor]
+```
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteOnboarding/registry.test.ts tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
+```
+
+Expected result: all registry/extractor tests pass.
+
+Commit:
+
+```powershell
+git add src/services/accountSiteOnboarding/registry.ts src/services/accountSiteOnboarding/contentSession/sub2api.ts src/services/accountSiteOnboarding/contentSession/compatibleUser.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
+git commit -m "refactor(content-session): extract account onboarding readers"
+```
+
+---
+
+### Task 4: Route Content Storage Handler Through Extractors
+
+**Files:**
+
+- Modify `src/entrypoints/content/messageHandlers/handlers/storage.ts`
+- Modify `tests/entrypoints/content/messageHandlers/handlers/storage.test.ts`
+
+- [ ] Step 1: Add failing handler tests for extractor ordering and errors.
+
+In `tests/entrypoints/content/messageHandlers/handlers/storage.test.ts`, mock `~/services/accountSiteOnboarding/registry` in a new describe block or use the real extractors in existing cases. Add coverage that:
+
+- the first extractor returning a result wins and later extractors are not called
+- a false `canExtract(...)` skips that extractor
+- no extractor result returns `{ success: false, error: "messages:content.userInfoNotFound" }`
+- unexpected extractor errors still return `{ success: false, error: "..." }`
+- Sub2API login-required errors still return `"messages:sub2api.loginRequired"`
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
+```
+
+Expected result: ordering/error tests fail because `storage.ts` still owns hard-coded branches.
+
+- [ ] Step 2: Simplify `storage.ts` imports.
+
+Remove these from `src/entrypoints/content/messageHandlers/handlers/storage.ts`:
+
+- `resolveStoredAccountUserIdentity`
+- `parseSub2ApiUserIdentity`
+- `SUB2API_AUTH_STORAGE_KEYS`
+- `SUB2API_TOKEN_REFRESH_BUFFER_MS`
+- `tryParseTimestamp(...)`
+- `refreshSub2ApiTokensIfNeeded(...)`
+- Sub2API envelope types
+
+Keep:
+
+- `handleGetLocalStorage(...)`
+- `getErrorMessage(...)`
+- `t(...)`
+- `isAccountSiteType`
+- `SITE_TYPES`
+
+Add:
+
+```ts
+import {
+  getContentSessionExtractors,
+} from "~/services/accountSiteOnboarding/registry"
+import {
+  Sub2ApiContentSessionLoginRequiredError,
+} from "~/services/accountSiteOnboarding/contentSession/sub2api"
+```
+
+- [ ] Step 3: Route `handleGetUserFromLocalStorage(...)` through extractors.
+
+Replace the current hard-coded Sub2API and generic user branches with:
+
+```ts
+const context = {
+  url: typeof request?.url === "string" ? request.url : undefined,
+  siteTypeHint: isAccountSiteType(request?.siteType)
+    ? request.siteType
+    : SITE_TYPES.UNKNOWN,
+}
+
+for (const extractor of getContentSessionExtractors()) {
+  if (!extractor.canExtract(context)) continue
+  const result = await extractor.extract(context)
+  if (!result) continue
+
+  sendResponse({
+    success: true,
+    data: result,
+  })
+  return
+}
+
+sendResponse({
+  success: false,
+  error: t("messages:content.userInfoNotFound"),
+})
+```
+
+In the surrounding `catch`, preserve the Sub2API login-required mapping:
+
+```ts
+if (error instanceof Sub2ApiContentSessionLoginRequiredError) {
+  sendResponse({
+    success: false,
+    error: t("messages:sub2api.loginRequired"),
+  })
+  return
+}
+sendResponse({ success: false, error: getErrorMessage(error) })
+```
+
+- [ ] Step 4: Run handler and extractor tests.
+
+```powershell
+pnpm vitest run tests/entrypoints/content/messageHandlers/handlers/storage.test.ts tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
+```
+
+Expected result: all listed tests pass.
+
+Commit:
+
+```powershell
+git add src/entrypoints/content/messageHandlers/handlers/storage.ts tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
+git commit -m "refactor(content-session): route storage handler through extractors"
+```
+
+---
+
+### Task 5: Integration Validation And Scope Check
+
+**Files:**
+
+- No new files expected unless prior tasks expose type-only import fallout.
+
+- [ ] Step 1: Run the focused validation set.
+
+```powershell
+pnpm vitest run tests/constants/siteType.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
+```
+
+Expected result: all focused tests pass.
+
+- [ ] Step 2: Run TypeScript validation.
+
+```powershell
+pnpm compile
+```
+
+Expected result: `tsc --noEmit` passes.
+
+- [ ] Step 3: Inspect final diff for scope drift.
+
+```powershell
+git status --porcelain
+git diff --stat HEAD
+git diff HEAD -- src/services/accountSiteOnboarding src/constants/siteType.ts src/services/siteDetection/detectSiteType.ts src/entrypoints/content/messageHandlers/handlers/storage.ts tests/constants/siteType.test.ts tests/services/accountSiteOnboarding tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
+```
+
+Confirm the diff does not touch:
+
+- `src/services/apiAdapters/**`
+- `src/services/apiService/**`
+- Account Dialog UI policy
+- locale files
+- telemetry schemas
+- settings search
+- Playwright E2E
+
+- [ ] Step 4: Run commit gate for task-scoped staged files.
+
+Stage only task-scoped implementation files, then run:
+
+```powershell
+pnpm run validate:staged
+```
+
+Expected result: lint-staged and staged i18n check pass.
+
+- [ ] Step 5: Run push gate before publishing or opening a PR.
+
+```powershell
+pnpm run validate:push
+```
+
+Expected result: `pnpm compile` and `pnpm knip` pass.
+
+- [ ] Step 6: Final handoff.
+
+Report:
+
+- commit hashes created by each task
+- focused Vitest command result
+- `pnpm compile` result
+- `pnpm run validate:staged` result
+- `pnpm run validate:push` result if publishing is next
+- telemetry decision: reused existing
+- E2E decision: no new E2E, focused Vitest is the coverage layer
+- any unrelated pre-existing local files left untouched

--- a/docs/superpowers/specs/2026-06-19-account-site-onboarding-substrate-design.md
+++ b/docs/superpowers/specs/2026-06-19-account-site-onboarding-substrate-design.md
@@ -220,20 +220,14 @@ export type ContentSessionExtractionContext = {
 }
 
 export type ContentSessionExtractionResult = {
-  userId: string
-  username?: string
-  user?: {
-    id?: string | number
-    username?: string
-    balance?: number
-  }
+  userId: string | number
+  user: Record<string, unknown>
   accessToken?: string
   siteTypeHint?: AccountSiteType
   sub2apiAuth?: {
     refreshToken: string
-    tokenExpiresAt?: number | null
+    tokenExpiresAt?: number
   }
-  authType?: AuthTypeEnum
 }
 
 export type ContentSessionExtractor = {

--- a/docs/superpowers/specs/2026-06-19-account-site-onboarding-substrate-design.md
+++ b/docs/superpowers/specs/2026-06-19-account-site-onboarding-substrate-design.md
@@ -1,0 +1,647 @@
+# Account Site Onboarding Substrate Design
+
+Date: 2026-06-19
+
+## Purpose
+
+Move the earliest account-site onboarding facts into a dedicated substrate so a
+new account site type can become identifiable and session-readable without
+threading raw site-type branches through constants, content scripts, and
+auto-detect orchestration.
+
+Recent adapter slices moved account completion, key management, account
+refresh, model pricing, manual account data, account bootstrap, and related
+Sub2API auth-session behavior behind `getSiteAdapter(siteType)`. Those slices
+make a known account site type usable after detection. The remaining
+high-friction path is earlier: choosing the site type and extracting browser
+session identity still require edits in scattered product Modules before the
+Adapter can be used.
+
+This spec defines an account-site onboarding substrate for detection metadata
+and content-session extraction. It intentionally stops before Account Dialog UI
+policy, redemption, and managed-site operations.
+
+## Current Context
+
+The current `SiteAdapter` Interface already exposes backend capabilities for
+known account site types:
+
+```ts
+type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  modelPricing?: ModelPricingCapability
+  accountData?: AccountDataCapability
+  accountBootstrap?: AccountBootstrapCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+}
+```
+
+Those capabilities start after a candidate `AccountSiteType` exists.
+
+Today the pre-adapter onboarding facts are still split across several Modules:
+
+- `src/constants/siteType.ts`
+  - `ACCOUNT_SITE_TYPES` defines the supported account site type universe.
+  - `ACCOUNT_SITE_TITLE_RULES` maps root page titles to site types.
+  - `ACCOUNT_SITE_DOMAIN_RULES` maps known hostnames to site types.
+  - `SITE_ROUTE_CONFIGS` stores static route paths.
+- `src/services/siteDetection/detectSiteType.ts`
+  - domain rules run first.
+  - root title rules run second.
+  - generic `/api/user/self` auth-error probing runs last.
+- `src/entrypoints/content/messageHandlers/handlers/storage.ts`
+  - current-tab and temp-context auto-detect read Sub2API's JWT session from
+    dedicated localStorage keys.
+  - otherwise they read a generic `localStorage["user"]` payload and resolve a
+    compatible account identity.
+- `src/services/siteDetection/autoDetectService.ts`
+  - requests content-script localStorage identity before API fallback.
+  - passes `siteType` hints to the content script, but the content script still
+    owns the extraction branch.
+- Account Dialog Modules still contain UI policy branches for Sub2API and
+  AIHubMix, but those are product policy rather than the substrate covered by
+  this spec.
+
+The current backend differences prove the Seam is real:
+
+- New API-family compatible sites generally expose a `user` object in
+  localStorage and can be identified by title or compatible auth-error
+  headers.
+- Sub2API stores a JWT session in `auth_token`, `refresh_token`,
+  `token_expires_at`, and `auth_user`, and may need proactive token refresh
+  inside the content script before returning identity data.
+- AIHubMix uses fixed hostnames and split API/web origins; current account
+  auto-detect can start from console pages but saved accounts operate against
+  the API origin.
+
+## Problem
+
+Adding a new non-compatible account site type still requires edits before any
+`SiteAdapter` capability can help.
+
+Current friction:
+
+1. Site-type metadata is spread across separate exported arrays and route
+   config objects. A new site type has to remember every registration surface.
+2. `detectSiteType.ts` knows how to order detection strategies, but the rule
+   data is not owned by a single onboarding Module.
+3. `storage.ts` is the largest early runtime branch: Sub2API session extraction
+   and generic compatible user extraction live in one content-script handler.
+4. A new site with different browser-session storage would add a third branch
+   in the content script instead of satisfying a narrow extractor Interface.
+5. Tests for content-session extraction and site-type detection do not share a
+   common Interface that future site types can implement.
+
+Deletion test: if the Sub2API-specific session extraction branch and the
+generic compatible localStorage user branch were deleted from the content
+message handler, the complexity should not reappear as raw `siteType` branches
+in the same handler. It should move behind a site-scoped onboarding extractor
+Interface. Likewise, detection metadata should be registered once and projected
+into title rules, domain rules, route config, and fallback probing.
+
+## Goals
+
+- Add a dedicated account-site onboarding Module that owns:
+  - detection metadata
+  - static route metadata currently tied to site registration
+  - content-session extractor selection
+  - shared extractor result shape
+- Route `detectSiteType.ts` through the onboarding registry for domain/title
+  rules and compatible fallback metadata.
+- Route `handleGetUserFromLocalStorage(...)` through registered content-session
+  extractors instead of hard-coded Sub2API and generic branches.
+- Preserve current behavior:
+  - domain detection still wins over title and API-error probing
+  - root title detection still uses the original HTML title
+  - compatible `/api/user/self` auth-error probing still works for existing
+    compatible site types
+  - Sub2API localStorage extraction still refreshes near-expiry tokens and
+    returns `sub2apiAuth`
+  - generic compatible user extraction still uses
+    `resolveStoredAccountUserIdentity(user, siteType)`
+  - content-script responses keep the same wire shape consumed by
+    `autoDetectService`
+  - `SITE_TYPES`, `ACCOUNT_SITE_TYPES`, `MANAGED_SITE_TYPES`,
+    `getAccountSiteApiRouter(...)`, and public type exports remain available
+    for compatibility
+- Keep `SiteAdapter` focused on backend capabilities after a site type is
+  known.
+- Add focused tests for registry projections, detection ordering, extractor
+  selection, Sub2API session extraction, and compatible localStorage fallback.
+
+## Non-Goals
+
+- Do not add a new account site type in this slice.
+- Do not change Account Dialog UI policy for Sub2API refresh-token fields,
+  AIHubMix one-time-key behavior, cookie-auth visibility, or check-in controls.
+- Do not migrate redemption, managed-site channel operations, managed-site
+  model sync, or managed-site provider registration.
+- Do not remove `SITE_TYPES`, `ACCOUNT_SITE_TYPES`, route helpers, or existing
+  exported detection helpers.
+- Do not move `accountBootstrap`, `accountCompletion`, `accountData`,
+  `keyManagement`, `modelPricing`, or `accountRefresh` into the onboarding
+  substrate.
+- Do not introduce remote detection metadata or plugin-loaded site definitions.
+- Do not change user-facing copy, locale keys, telemetry schema, settings
+  search entries, or Playwright E2E tests.
+
+## Approaches Considered
+
+### Approach A: Keep Adding Branches In Existing Files
+
+This keeps implementation small for one site type, but it preserves the same
+friction. Every new site still has to touch constants, detection rules, route
+config, content-script localStorage parsing, and tests independently.
+
+This should not be the next step.
+
+### Approach B: Put Detection And Session Extraction On `SiteAdapter`
+
+`SiteAdapter` could gain detection rules and content-session extraction.
+
+This blurs the Seam. `SiteAdapter` is selected by `siteType`, but detection and
+content-session extraction are used before or while discovering the site type.
+It would also pull content-script browser runtime concerns into backend
+Adapters.
+
+This should not be the next step.
+
+### Approach C: Add A Separate Account-Site Onboarding Registry
+
+Create a substrate that registers account-site metadata and optional
+content-session extractors. Detection and content-script handlers consume that
+registry, then pass the resulting `siteType` into the existing `SiteAdapter`
+registry.
+
+This is the recommended path. It keeps the pre-adapter facts in one Module,
+gives new site types a clear registration surface, and preserves the existing
+post-detection Adapter architecture.
+
+## Design
+
+### 1. Add Account-Site Onboarding Contracts
+
+Create:
+
+```text
+src/services/accountSiteOnboarding/contracts.ts
+```
+
+Proposed Interface:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import type { AuthTypeEnum } from "~/types"
+
+export type AccountSiteRouteConfig = {
+  loginPath?: string
+  usagePath?: string
+  checkInPath?: string
+  adminCredentialsPath?: string
+  redeemPath?: string
+  siteAnnouncementsPath?: string
+}
+
+export type AccountSiteDetectionMetadata = {
+  titlePatterns?: readonly RegExp[]
+  hostnames?: readonly string[]
+  compatUserIdHeaderNames?: readonly string[]
+}
+
+export type ContentSessionExtractionContext = {
+  url?: string
+  siteTypeHint?: AccountSiteType
+}
+
+export type ContentSessionExtractionResult = {
+  userId: string
+  username?: string
+  user?: {
+    id?: string | number
+    username?: string
+    balance?: number
+  }
+  accessToken?: string
+  siteTypeHint?: AccountSiteType
+  sub2apiAuth?: {
+    refreshToken: string
+    tokenExpiresAt?: number | null
+  }
+  authType?: AuthTypeEnum
+}
+
+export type ContentSessionExtractor = {
+  id: string
+  canExtract(context: ContentSessionExtractionContext): boolean
+  extract(context: ContentSessionExtractionContext):
+    | Promise<ContentSessionExtractionResult | null>
+    | ContentSessionExtractionResult
+    | null
+}
+
+export type AccountSiteOnboardingDefinition = {
+  siteType: AccountSiteType
+  detection?: AccountSiteDetectionMetadata
+  routes?: AccountSiteRouteConfig
+  contentSessionExtractor?: ContentSessionExtractor
+}
+```
+
+The Interface intentionally separates:
+
+- static metadata used to choose a site type
+- browser-session extraction used by content scripts
+- backend capabilities already owned by `SiteAdapter`
+
+`ContentSessionExtractionResult` should match the existing wire contract from
+content script to `autoDetectService`, so the auto-detect orchestrator does not
+need a payload migration in this slice.
+
+### 2. Add The Onboarding Registry
+
+Create:
+
+```text
+src/services/accountSiteOnboarding/registry.ts
+```
+
+The registry should export:
+
+```ts
+export const accountSiteOnboardingDefinitions:
+  readonly AccountSiteOnboardingDefinition[]
+
+export function getAccountSiteOnboardingDefinition(
+  siteType: AccountSiteType,
+): AccountSiteOnboardingDefinition | undefined
+
+export function getAccountSiteDomainRules(): readonly {
+  name: AccountSiteType
+  hostnames: readonly string[]
+}[]
+
+export function getAccountSiteTitleRules(): readonly {
+  name: AccountSiteType
+  regex: RegExp
+}[]
+
+export function getAccountSiteRouteOverrides(
+  siteType: AccountSiteType,
+): AccountSiteRouteConfig | undefined
+
+export function getContentSessionExtractors():
+  readonly ContentSessionExtractor[]
+```
+
+The first implementation can migrate existing metadata without changing public
+exports:
+
+- One API/New API-family title patterns
+- AnyRouter, WONG, and other compatible title patterns
+- AIHubMix hostnames
+- existing static route overrides
+- Sub2API content-session extractor
+- compatible localStorage `user` extractor
+
+Keep `SITE_TYPES.UNKNOWN` registered only where existing public arrays require
+it. It should not have a content-session extractor.
+
+### 3. Keep `siteType.ts` As The Compatibility Facade
+
+Modify:
+
+```text
+src/constants/siteType.ts
+```
+
+Keep the public exports:
+
+- `SITE_TYPES`
+- `ACCOUNT_SITE_TYPES`
+- `ACCOUNT_SITE_TYPE_VALUES`
+- `MANAGED_SITE_TYPES`
+- `ACCOUNT_SITE_TITLE_RULES`
+- `ACCOUNT_SITE_DOMAIN_RULES`
+- `getSiteRouteConfigForKey(...)`
+- `getAccountSiteApiRouter(...)`
+
+But derive title rules, domain rules, and route overrides from the onboarding
+registry where practical. This makes the new registry the source of truth
+without breaking existing callers.
+
+`SITE_TYPES` and the account/managed site type arrays can stay in
+`siteType.ts` for now because they define TypeScript literal unions used across
+the repo. Moving those constants is not needed for this slice.
+
+### 4. Route Site-Type Detection Through Registry Projections
+
+Modify:
+
+```text
+src/services/siteDetection/detectSiteType.ts
+```
+
+Preserve detection ordering:
+
+1. domain metadata
+2. root HTML title metadata
+3. compatible `/api/user/self` auth-error probing
+
+The detector should consume `getAccountSiteDomainRules()` and
+`getAccountSiteTitleRules()` from the onboarding registry or compatibility
+facade, not hard-coded arrays.
+
+For API-error probing, replace the current direct
+`COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE` projection with registry metadata:
+
+```ts
+compatUserIdHeaderNames?: readonly string[]
+```
+
+New API-family compatible sites can keep using the existing compat header map
+while the registry exposes the normalized detection rules consumed by
+`detectSiteType.ts`.
+
+### 5. Extract Sub2API Content-Session Logic
+
+Create:
+
+```text
+src/services/accountSiteOnboarding/contentSession/sub2api.ts
+```
+
+Move the Sub2API-specific localStorage extraction from `storage.ts` into a
+`ContentSessionExtractor`.
+
+Preserve behavior:
+
+- read `auth_token`, `refresh_token`, `token_expires_at`, and `auth_user`
+- refresh tokens near expiry through `/api/v1/auth/refresh`
+- write refreshed tokens back to localStorage
+- parse identity through `parseSub2ApiUserIdentity(...)`
+- return `siteTypeHint: SITE_TYPES.SUB2API`
+- return `sub2apiAuth.refreshToken` and optional `tokenExpiresAt`
+- return login-required failure by producing `null` and letting the caller map
+  it to the existing content error
+
+Keep the no-token logging/security invariant: never log tokens.
+
+### 6. Extract Compatible LocalStorage User Logic
+
+Create:
+
+```text
+src/services/accountSiteOnboarding/contentSession/compatibleUser.ts
+```
+
+Move the generic branch from `storage.ts` into a `ContentSessionExtractor`.
+
+Preserve behavior:
+
+- read `localStorage["user"]`
+- parse JSON defensively
+- use `resolveStoredAccountUserIdentity(user, siteTypeHint)`
+- return `siteTypeHint` when the hint is a known account site type and not
+  `unknown`
+- return `null` when identity cannot be resolved
+
+This extractor should be the fallback for compatible account site types that do
+not provide a dedicated extractor.
+
+### 7. Route Content Message Handling Through Extractors
+
+Modify:
+
+```text
+src/entrypoints/content/messageHandlers/handlers/storage.ts
+```
+
+Keep `handleGetLocalStorage(...)` unchanged.
+
+Replace the hard-coded `handleGetUserFromLocalStorage(...)` branches with:
+
+```ts
+const context = {
+  url: typeof request?.url === "string" ? request.url : undefined,
+  siteTypeHint: isAccountSiteType(request?.siteType)
+    ? request.siteType
+    : SITE_TYPES.UNKNOWN,
+}
+
+for (const extractor of getContentSessionExtractors()) {
+  if (!extractor.canExtract(context)) continue
+  const result = await extractor.extract(context)
+  if (result) {
+    sendResponse({ success: true, data: result })
+    return
+  }
+}
+
+sendResponse({
+  success: false,
+  error: t("messages:content.userInfoNotFound"),
+})
+```
+
+Ordering matters:
+
+1. dedicated exact-site extractors, such as Sub2API
+2. compatible fallback extractor
+
+This preserves Sub2API's specialized session behavior while giving future
+non-compatible sites a clear slot.
+
+### 8. Keep Auto-Detect Wire Shape Stable
+
+`autoDetectService` should not need a payload migration. It should keep sending
+the same runtime/content message request fields:
+
+- `url`
+- `siteType`
+- current-tab or temp-context metadata owned by the existing flow
+
+The content script decides which extractor can handle the request and returns
+the same data shape as today.
+
+If implementation reveals duplicated request shaping in `autoDetectService`,
+the plan may add a small local helper there, but this spec does not require a
+new auto-detect Interface.
+
+### 9. Keep Account Dialog Policy As Follow-Up
+
+Do not move these branches in this slice:
+
+- Sub2API disables cookie auth and built-in check-in
+- Sub2API refresh-token form controls and import action
+- AIHubMix clears saved cookie auth after token import
+- AIHubMix post-save foreground key prompt
+- Sub2API post-save token dialog
+
+Those are product workflow policy, not detection metadata or browser-session
+extraction. They deserve a later `accountSitePolicy` Module that consumes
+adapter/onboarding facts and returns UI policy flags.
+
+## Error Handling
+
+Content-session extractors should not throw for expected "not logged in" or
+"not this site" cases. They should return `null`.
+
+Expected fatal or unexpected failures should be caught by
+`handleGetUserFromLocalStorage(...)` and mapped to the existing response shape:
+
+```ts
+{ success: false, error: getErrorMessage(error) }
+```
+
+Specific behavior to preserve:
+
+- Sub2API missing, expired, or unrefreshable auth returns the existing
+  login-required user-facing error.
+- Generic compatible missing user data returns
+  `messages:content.userInfoNotFound`.
+- Invalid JSON in one extractor should not prevent later fallback extractors
+  unless it represents an unexpected implementation error in that extractor.
+- No token or user payload should be logged.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This is an internal architecture migration. Existing auto-detect analytics
+should continue to report the same strategy, site type, fetch-context, current
+tab, incognito, and failure-stage fields.
+
+Do not add telemetry fields for localStorage key names, hostnames, raw errors,
+tokens, user ids, or backend messages.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E in this slice.
+
+The main risk is deterministic routing and extraction logic. Focused Vitest
+coverage for registry projections, detection ordering, and content-session
+extractors directly covers that risk.
+
+Existing browser-level auto-detect and Sub2API flows remain the broader guard
+for content-script/runtime-message integration. Run them only if implementation
+changes runtime action ids, message payloads, or extension entrypoint imports.
+
+## Testing Strategy
+
+Add registry tests:
+
+- `tests/services/accountSiteOnboarding/registry.test.ts`
+  - title rules include the same account site type names as the old exported
+    title rules.
+  - AIHubMix domain metadata projects to the same hostname set.
+  - route overrides preserve existing paths for Sub2API, AIHubMix, Veloera,
+    OneHub, DoneHub, V-API, Rix-API, AnyRouter, and WONG.
+  - content-session extractors are ordered with Sub2API before compatible
+    fallback.
+
+Update detection tests:
+
+- `tests/services/detectSiteType.test.ts`
+  - domain detection still wins.
+  - title detection still matches existing site title variants.
+  - compatible auth-error fallback still maps known user-id header markers.
+  - unknown detection remains unknown when no metadata matches.
+
+Add extractor tests:
+
+- `tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts`
+  - valid Sub2API localStorage returns identity, access token, site hint, and
+    `sub2apiAuth`.
+  - near-expiry Sub2API token refresh updates localStorage and returns refreshed
+    auth data.
+  - missing or invalid Sub2API auth returns `null` or the existing login
+    required path without logging secrets.
+- `tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts`
+  - compatible `localStorage["user"]` returns the same identity shape as
+    `resolveStoredAccountUserIdentity(...)`.
+  - unknown site type omits `siteTypeHint`.
+  - missing or malformed user payload returns `null`.
+
+Update content handler tests:
+
+- existing storage-handler tests should assert that
+  `handleGetUserFromLocalStorage(...)`:
+  - tries dedicated extractors before compatible fallback
+  - preserves successful response shape
+  - preserves `messages:content.userInfoNotFound` when no extractor returns
+    data
+  - preserves `getErrorMessage(...)` mapping for unexpected extractor errors
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/accountSiteOnboarding/registry.test.ts tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts tests/services/detectSiteType.test.ts tests/entrypoints/content/messageHandlers/storage.test.ts
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Push gate before publishing:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before opening or updating a PR because this slice changes
+shared site-type registration, content-script code, and detection wiring.
+
+## Rollout
+
+1. Add onboarding contracts and registry tests.
+2. Move existing metadata into onboarding definitions while preserving
+   compatibility exports from `siteType.ts`.
+3. Route `detectSiteType.ts` through registry projections.
+4. Extract Sub2API content-session logic into its extractor with focused tests.
+5. Extract compatible `localStorage["user"]` logic into its extractor with
+   focused tests.
+6. Route `handleGetUserFromLocalStorage(...)` through extractor ordering.
+7. Re-run focused tests after each migration group.
+8. Run `pnpm compile` and `pnpm run validate:staged`.
+9. Inspect the final diff for scope drift.
+10. Run `pnpm run validate:push` before pushing or opening a PR.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may migrate:
+
+- Account Dialog site policy for auth method visibility, check-in availability,
+  Sub2API refresh-token controls, AIHubMix access-token behavior, and post-save
+  token prompts.
+- redemption through a `redemption` capability.
+- managed-site channel operations and model sync behind a managed-site-specific
+  Interface.
+- a narrow import guard preventing new product Modules from importing the
+  legacy `apiService` facade outside approved adapter/compatibility layers.
+- adding a new account site type using the reduced onboarding plus Adapter
+  surface.
+
+Do not turn the onboarding substrate into a second `SiteAdapter`. It exists
+because detection metadata and content-session extraction happen before backend
+capabilities can be selected. Once a site type is known, backend protocol work
+should still flow through `getSiteAdapter(siteType)`.

--- a/src/constants/siteType.ts
+++ b/src/constants/siteType.ts
@@ -2,68 +2,31 @@
 // eslint-disable-next-line import/extensions
 import merge from "lodash-es/merge.js"
 
-export const SITE_TYPES = {
-  ONE_API: "one-api",
-  NEW_API: "new-api",
-  ANYROUTER: "anyrouter",
-  VELOERA: "Veloera",
-  ONE_HUB: "one-hub",
-  DONE_HUB: "done-hub",
-  V_API: "v-api",
-  VO_API: "VoAPI",
-  SUPER_API: "Super-API",
-  RIX_API: "Rix-Api",
-  NEO_API: "neo-Api",
-  WONG_GONGYI: "wong-gongyi",
-  SUB2API: "sub2api",
-  OCTOPUS: "octopus",
-  AXON_HUB: "axonhub",
-  CLAUDE_CODE_HUB: "claude-code-hub",
-  AIHUBMIX: "AIHubMix",
-  UNKNOWN: "unknown",
-} as const
+import {
+  DEFAULT_SITE_ROUTE_CONFIG,
+  getAccountSiteDomainRuleMetadata,
+  getAccountSiteRouteOverrideMetadata,
+  getAccountSiteTitleRuleMetadata,
+} from "~/services/accountSiteOnboarding/metadata"
+import {
+  ACCOUNT_SITE_TYPE_VALUES,
+  MANAGED_SITE_TYPES,
+  type AccountSiteType,
+  type ManagedSiteType,
+} from "~/services/accountSiteOnboarding/siteTypes"
 
-export const AIHUBMIX_API_ORIGIN = "https://aihubmix.com"
-export const AIHUBMIX_WEB_ORIGIN = "https://console.aihubmix.com"
-export const AIHUBMIX_LOGIN_PATH = "/sign-in"
-export const AIHUBMIX_HOSTNAMES = [
-  "aihubmix.com",
-  "www.aihubmix.com",
-  "console.aihubmix.com",
-] as const
-
-export const ACCOUNT_SITE_TYPES = [
-  SITE_TYPES.ONE_API,
-  SITE_TYPES.NEW_API,
-  SITE_TYPES.ANYROUTER,
-  SITE_TYPES.VELOERA,
-  SITE_TYPES.ONE_HUB,
-  SITE_TYPES.DONE_HUB,
-  SITE_TYPES.V_API,
-  SITE_TYPES.VO_API,
-  SITE_TYPES.SUPER_API,
-  SITE_TYPES.RIX_API,
-  SITE_TYPES.NEO_API,
-  SITE_TYPES.WONG_GONGYI,
-  SITE_TYPES.SUB2API,
-  SITE_TYPES.AIHUBMIX,
-  SITE_TYPES.UNKNOWN,
-] as const
-
-export type AccountSiteType = (typeof ACCOUNT_SITE_TYPES)[number]
-
-export const ACCOUNT_SITE_TYPE_VALUES = [...ACCOUNT_SITE_TYPES]
-
-export const MANAGED_SITE_TYPES = [
-  SITE_TYPES.NEW_API,
-  SITE_TYPES.VELOERA,
-  SITE_TYPES.DONE_HUB,
-  SITE_TYPES.OCTOPUS,
-  SITE_TYPES.AXON_HUB,
-  SITE_TYPES.CLAUDE_CODE_HUB,
-] as const
-
-export type ManagedSiteType = (typeof MANAGED_SITE_TYPES)[number]
+export {
+  ACCOUNT_SITE_TYPES,
+  ACCOUNT_SITE_TYPE_VALUES,
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  AIHUBMIX_WEB_ORIGIN,
+  MANAGED_SITE_TYPES,
+  SITE_TYPES,
+  type AccountSiteType,
+  type ManagedSiteType,
+} from "~/services/accountSiteOnboarding/siteTypes"
 
 /**
  * Checks whether a value is one of the supported account site type identifiers.
@@ -86,126 +49,9 @@ export function isManagedSiteType(value: unknown): value is ManagedSiteType {
 }
 
 // 定义网站类型及匹配规则
-export const ACCOUNT_SITE_TITLE_RULES = [
-  { name: SITE_TYPES.ONE_API, regex: makeTitleRegex(SITE_TYPES.ONE_API) },
-  { name: SITE_TYPES.NEW_API, regex: makeTitleRegex(SITE_TYPES.NEW_API) },
-  { name: SITE_TYPES.ANYROUTER, regex: /\bany\s*router\b/i },
-  { name: SITE_TYPES.VELOERA, regex: makeTitleRegex(SITE_TYPES.VELOERA) },
-  { name: SITE_TYPES.ONE_HUB, regex: makeTitleRegex(SITE_TYPES.ONE_HUB) },
-  { name: SITE_TYPES.DONE_HUB, regex: makeTitleRegex(SITE_TYPES.DONE_HUB) },
-  { name: SITE_TYPES.V_API, regex: makeTitleRegex(SITE_TYPES.V_API) },
-  { name: SITE_TYPES.VO_API, regex: makeTitleRegex(SITE_TYPES.VO_API) },
-  { name: SITE_TYPES.SUPER_API, regex: makeTitleRegex(SITE_TYPES.SUPER_API) },
-  { name: SITE_TYPES.RIX_API, regex: makeTitleRegex(SITE_TYPES.RIX_API) },
-  { name: SITE_TYPES.NEO_API, regex: makeTitleRegex(SITE_TYPES.NEO_API) },
-  /**
-   * WONG公益站 uses localized titles; match the Chinese keyword with optional spacing.
-   */
-  { name: SITE_TYPES.WONG_GONGYI, regex: /wong\s*公益站/i },
-  { name: SITE_TYPES.SUB2API, regex: makeTitleRegex(SITE_TYPES.SUB2API) },
-  { name: SITE_TYPES.AIHUBMIX, regex: makeTitleRegex(SITE_TYPES.AIHUBMIX) },
-  { name: SITE_TYPES.UNKNOWN, regex: makeTitleRegex(SITE_TYPES.UNKNOWN) },
-] as const
+export const ACCOUNT_SITE_TITLE_RULES = getAccountSiteTitleRuleMetadata()
 
-export const ACCOUNT_SITE_DOMAIN_RULES = [
-  {
-    name: SITE_TYPES.AIHUBMIX,
-    // Domain-first detection avoids treating AIHubMix as a generic
-    // One-API/New-API compatible site based on page title or fallback probes.
-    hostnames: AIHUBMIX_HOSTNAMES,
-  },
-] as const
-
-/**
- * 根据站点名生成正则
- * - 自动处理连字符替换成 [-_ ]?
- * - 加上单词边界 \b，避免误匹配
- */
-function makeTitleRegex(name: string): RegExp {
-  const pattern = name.replace("-", "[-_ ]?")
-  return new RegExp(`\\b${pattern}\\b`, "i")
-}
-
-// 默认的用量路径
-const DEFAULT_LOGIN_PATH = "/login"
-const DEFAULT_USAGE_PATH = "/console/log"
-const DEFAULT_CHECKIN_PATH = "/console/personal"
-const DEFAULT_REDEEM_PATH = "/console/topup"
-const DEFAULT_ADMIN_CREDENTIALS_PATH = DEFAULT_CHECKIN_PATH
-const DEFAULT_SITE_ANNOUNCEMENTS_PATH = "/"
-
-interface SiteRouteConfig {
-  loginPath: string
-  usagePath: string
-  checkInPath: string
-  adminCredentialsPath: string
-  redeemPath: string
-  siteAnnouncementsPath: string
-}
-
-// 定义各站点对应的 API 路径
-const SITE_ROUTE_CONFIGS: Partial<
-  Record<AccountSiteType, Partial<SiteRouteConfig>>
-> & {
-  Default: SiteRouteConfig
-} = {
-  [SITE_TYPES.ONE_API]: { usagePath: DEFAULT_USAGE_PATH },
-  [SITE_TYPES.NEW_API]: {
-    usagePath: DEFAULT_USAGE_PATH,
-    checkInPath: "/console/personal",
-    adminCredentialsPath: "/console/personal",
-  },
-  [SITE_TYPES.VO_API]: { usagePath: DEFAULT_USAGE_PATH, redeemPath: "/wallet" },
-  [SITE_TYPES.VELOERA]: {
-    usagePath: "/app/logs/api-usage",
-    checkInPath: "/app/me",
-    redeemPath: "/app/wallet",
-    adminCredentialsPath: "/app/me",
-  },
-  [SITE_TYPES.ONE_HUB]: {
-    usagePath: "/panel/log",
-    redeemPath: "/panel/topup",
-    adminCredentialsPath: "/panel/profile",
-  },
-  [SITE_TYPES.DONE_HUB]: {
-    usagePath: "/panel/log",
-    redeemPath: "/panel/topup",
-    adminCredentialsPath: "/panel/profile",
-  },
-  [SITE_TYPES.V_API]: {
-    usagePath: "/panel/log",
-    checkInPath: "/panel/profile",
-    redeemPath: "/panel/topup",
-    adminCredentialsPath: "/panel/profile",
-  },
-  [SITE_TYPES.RIX_API]: {
-    usagePath: "/log",
-    checkInPath: "/panel",
-    redeemPath: "/topup",
-  },
-  [SITE_TYPES.ANYROUTER]: { checkInPath: "/console/topup" },
-  [SITE_TYPES.WONG_GONGYI]: { checkInPath: "/console/topup" },
-  [SITE_TYPES.SUB2API]: {
-    usagePath: "/usage",
-    redeemPath: "/redeem",
-    siteAnnouncementsPath: "/dashboard",
-  },
-  [SITE_TYPES.AIHUBMIX]: {
-    loginPath: AIHUBMIX_LOGIN_PATH,
-    usagePath: "/statistics",
-    redeemPath: "/topup",
-    checkInPath: "/",
-    adminCredentialsPath: "/",
-  },
-  Default: {
-    loginPath: DEFAULT_LOGIN_PATH,
-    usagePath: DEFAULT_USAGE_PATH,
-    checkInPath: DEFAULT_CHECKIN_PATH,
-    adminCredentialsPath: DEFAULT_ADMIN_CREDENTIALS_PATH,
-    redeemPath: DEFAULT_REDEEM_PATH,
-    siteAnnouncementsPath: DEFAULT_SITE_ANNOUNCEMENTS_PATH,
-  },
-}
+export const ACCOUNT_SITE_DOMAIN_RULES = getAccountSiteDomainRuleMetadata()
 
 /**
  * 获取站点对应的路径配置对象
@@ -213,7 +59,11 @@ const SITE_ROUTE_CONFIGS: Partial<
  * @returns 对应的路径配置对象，否则返回 Default 的路径配置对象
  */
 export function getSiteRouteConfigForKey(key: AccountSiteType) {
-  return merge({}, SITE_ROUTE_CONFIGS["Default"], SITE_ROUTE_CONFIGS[key])
+  return merge(
+    {},
+    DEFAULT_SITE_ROUTE_CONFIG,
+    getAccountSiteRouteOverrideMetadata(key),
+  )
 }
 
 /**

--- a/src/entrypoints/content/messageHandlers/handlers/storage.ts
+++ b/src/entrypoints/content/messageHandlers/handlers/storage.ts
@@ -1,141 +1,8 @@
 import { isAccountSiteType, SITE_TYPES } from "~/constants/siteType"
-import { resolveStoredAccountUserIdentity } from "~/services/accounts/accountIdentity"
-import { parseSub2ApiUserIdentity } from "~/services/apiService/sub2api/parsing"
+import { Sub2ApiContentSessionLoginRequiredError } from "~/services/accountSiteOnboarding/contentSession/sub2api"
+import { getContentSessionExtractors } from "~/services/accountSiteOnboarding/registry"
 import { getErrorMessage } from "~/utils/core/error"
 import { t } from "~/utils/i18n/core"
-
-/**
- * Sub2API uses a short-lived JWT access token with a refresh-token flow.
- *
- * The dashboard stores auth state in localStorage, and will refresh tokens on its
- * own. But the extension may read localStorage before the dashboard finishes its
- * refresh, so we proactively refresh when the saved expiry timestamp is close.
- *
- * IMPORTANT:
- * - Never log tokens.
- * - Only refresh when expiry info exists (avoid unnecessary refresh-token rotation).
- */
-const SUB2API_AUTH_STORAGE_KEYS = {
-  accessToken: "auth_token",
-  refreshToken: "refresh_token",
-  tokenExpiresAt: "token_expires_at",
-  authUser: "auth_user",
-} as const
-
-// Match upstream buffer: refresh ~2 minutes before expiry.
-const SUB2API_TOKEN_REFRESH_BUFFER_MS = 120 * 1000
-
-type Sub2ApiEnvelope<T> = {
-  code: number
-  message?: string
-  data?: T
-  detail?: string
-}
-
-type Sub2ApiRefreshTokenData = {
-  access_token: string
-  refresh_token: string
-  expires_in: number
-}
-
-const tryParseTimestamp = (value: string | null): number | null => {
-  if (!value) return null
-  const parsed = Number.parseInt(value, 10)
-  return Number.isFinite(parsed) ? parsed : null
-}
-
-const refreshSub2ApiTokensIfNeeded = async (params: {
-  baseUrl: string | null
-  accessToken: string
-  refreshToken: string
-  tokenExpiresAt: number | null
-}): Promise<{
-  accessToken: string
-  refreshToken: string
-  tokenExpiresAt: number
-} | null> => {
-  const { baseUrl, accessToken, refreshToken, tokenExpiresAt } = params
-
-  if (!refreshToken.trim() || tokenExpiresAt === null) return null
-
-  const now = Date.now()
-  const msUntilExpiry = tokenExpiresAt - now
-  if (msUntilExpiry > SUB2API_TOKEN_REFRESH_BUFFER_MS) return null
-  const isExpired = msUntilExpiry <= 0
-
-  const endpoint =
-    typeof baseUrl === "string" && baseUrl.trim()
-      ? new URL("/api/v1/auth/refresh", baseUrl).toString()
-      : "/api/v1/auth/refresh"
-
-  let payload: Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null = null
-  try {
-    const response = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-      },
-      body: JSON.stringify({ refresh_token: refreshToken }),
-    })
-
-    payload = (await response
-      .json()
-      .catch(() => null)) as Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null
-  } catch {
-    if (isExpired) {
-      throw new Error("Sub2API token refresh failed")
-    }
-    return null
-  }
-
-  if (!payload || typeof payload !== "object") {
-    if (isExpired) {
-      throw new Error("Sub2API token refresh failed")
-    }
-    return null
-  }
-
-  if (payload.code !== 0 || !payload.data) {
-    if (isExpired) {
-      throw new Error("Sub2API token refresh failed")
-    }
-    return null
-  }
-
-  const nextAccessToken =
-    typeof payload.data.access_token === "string"
-      ? payload.data.access_token.trim()
-      : ""
-  const nextRefreshToken =
-    typeof payload.data.refresh_token === "string"
-      ? payload.data.refresh_token.trim()
-      : ""
-  const expiresInSeconds =
-    typeof payload.data.expires_in === "number" ? payload.data.expires_in : 0
-
-  if (!nextAccessToken || !nextRefreshToken || expiresInSeconds <= 0) {
-    if (isExpired) {
-      throw new Error("Sub2API token refresh failed")
-    }
-    return null
-  }
-
-  const nextExpiresAt = now + expiresInSeconds * 1000
-
-  localStorage.setItem(SUB2API_AUTH_STORAGE_KEYS.accessToken, nextAccessToken)
-  localStorage.setItem(SUB2API_AUTH_STORAGE_KEYS.refreshToken, nextRefreshToken)
-  localStorage.setItem(
-    SUB2API_AUTH_STORAGE_KEYS.tokenExpiresAt,
-    String(nextExpiresAt),
-  )
-
-  return {
-    accessToken: nextAccessToken,
-    refreshToken: nextRefreshToken,
-    tokenExpiresAt: nextExpiresAt,
-  }
-}
 
 /**
  * Handles requests to get data from localStorage.
@@ -178,118 +45,37 @@ export function handleGetUserFromLocalStorage(
 ) {
   ;(async () => {
     try {
-      const authTokenRaw = localStorage.getItem(
-        SUB2API_AUTH_STORAGE_KEYS.accessToken,
-      )
-      const authUserRaw = localStorage.getItem(
-        SUB2API_AUTH_STORAGE_KEYS.authUser,
-      )
-
-      // Sub2API dashboard: localStorage-backed JWT session + user identity.
-      if (authTokenRaw !== null && authUserRaw !== null) {
-        let accessToken = authTokenRaw?.trim() ?? ""
-        if (!accessToken) {
-          sendResponse({
-            success: false,
-            error: t("messages:sub2api.loginRequired"),
-          })
-          return
-        }
-
-        const refreshTokenRaw = localStorage.getItem(
-          SUB2API_AUTH_STORAGE_KEYS.refreshToken,
-        )
-        let refreshToken = refreshTokenRaw?.trim() ?? ""
-        let tokenExpiresAt = tryParseTimestamp(
-          localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.tokenExpiresAt),
-        )
-        const baseUrl = typeof request?.url === "string" ? request.url : null
-
-        // Best-effort: proactively refresh tokens if the stored expiry is close.
-        // This keeps the extension's token reads in sync with Sub2API's latest
-        // refresh-token implementation.
-        try {
-          const refreshed = await refreshSub2ApiTokensIfNeeded({
-            baseUrl,
-            accessToken,
-            refreshToken,
-            tokenExpiresAt,
-          })
-          if (refreshed?.accessToken) {
-            accessToken = refreshed.accessToken
-            refreshToken = refreshed.refreshToken
-            tokenExpiresAt = refreshed.tokenExpiresAt
-          }
-        } catch {
-          // Fall through: if refresh fails, treat as login required.
-          sendResponse({
-            success: false,
-            error: t("messages:sub2api.loginRequired"),
-          })
-          return
-        }
-
-        try {
-          const authUser = authUserRaw ? JSON.parse(authUserRaw) : null
-          const identity = parseSub2ApiUserIdentity(authUser)
-          sendResponse({
-            success: true,
-            data: {
-              userId: identity.userId,
-              user: {
-                id: identity.userId,
-                username: identity.username,
-                balance: identity.balanceUsd,
-              },
-              accessToken,
-              ...(refreshToken
-                ? {
-                    sub2apiAuth: {
-                      refreshToken,
-                      ...(typeof tokenExpiresAt === "number"
-                        ? { tokenExpiresAt }
-                        : {}),
-                    },
-                  }
-                : {}),
-              siteTypeHint: SITE_TYPES.SUB2API,
-            },
-          })
-          return
-        } catch {
-          sendResponse({
-            success: false,
-            error: t("messages:sub2api.loginRequired"),
-          })
-          return
-        }
+      const context = {
+        url: typeof request?.url === "string" ? request.url : undefined,
+        siteTypeHint: isAccountSiteType(request?.siteType)
+          ? request.siteType
+          : SITE_TYPES.UNKNOWN,
       }
 
-      const userStr = localStorage.getItem("user")
-      const user = userStr ? JSON.parse(userStr) : null
-      const siteType = isAccountSiteType(request?.siteType)
-        ? request.siteType
-        : SITE_TYPES.UNKNOWN
-      const identity = resolveStoredAccountUserIdentity(user, siteType)
+      for (const extractor of getContentSessionExtractors()) {
+        if (!extractor.canExtract(context)) continue
+        const result = await extractor.extract(context)
+        if (!result) continue
 
-      if (!identity) {
         sendResponse({
-          success: false,
-          error: t("messages:content.userInfoNotFound"),
+          success: true,
+          data: result,
         })
         return
       }
 
       sendResponse({
-        success: true,
-        data: {
-          ...identity,
-          ...(siteType !== SITE_TYPES.UNKNOWN
-            ? { siteTypeHint: siteType }
-            : {}),
-        },
+        success: false,
+        error: t("messages:content.userInfoNotFound"),
       })
     } catch (error) {
+      if (error instanceof Sub2ApiContentSessionLoginRequiredError) {
+        sendResponse({
+          success: false,
+          error: t("messages:sub2api.loginRequired"),
+        })
+        return
+      }
       sendResponse({ success: false, error: getErrorMessage(error) })
     }
   })()

--- a/src/entrypoints/content/messageHandlers/handlers/storage.ts
+++ b/src/entrypoints/content/messageHandlers/handlers/storage.ts
@@ -1,5 +1,8 @@
 import { isAccountSiteType, SITE_TYPES } from "~/constants/siteType"
-import { Sub2ApiContentSessionLoginRequiredError } from "~/services/accountSiteOnboarding/contentSession/sub2api"
+import {
+  SUB2API_LOGIN_REQUIRED_I18N_KEY,
+  Sub2ApiContentSessionLoginRequiredError,
+} from "~/services/accountSiteOnboarding/contentSession/sub2api"
 import { getContentSessionExtractors } from "~/services/accountSiteOnboarding/registry"
 import { getErrorMessage } from "~/utils/core/error"
 import { t } from "~/utils/i18n/core"
@@ -72,7 +75,7 @@ export function handleGetUserFromLocalStorage(
       if (error instanceof Sub2ApiContentSessionLoginRequiredError) {
         sendResponse({
           success: false,
-          error: t("messages:sub2api.loginRequired"),
+          error: t(SUB2API_LOGIN_REQUIRED_I18N_KEY),
         })
         return
       }

--- a/src/services/accountSiteOnboarding/contentSession/compatibleUser.ts
+++ b/src/services/accountSiteOnboarding/contentSession/compatibleUser.ts
@@ -3,11 +3,13 @@ import { resolveStoredAccountUserIdentity } from "~/services/accounts/accountIde
 
 import type { ContentSessionExtractor } from "../contracts"
 
+const COMPATIBLE_USER_STORAGE_KEY = "user"
+
 export const compatibleUserContentSessionExtractor: ContentSessionExtractor = {
   id: "compatible-user",
-  canExtract: () => true,
+  canExtract: () => localStorage.getItem(COMPATIBLE_USER_STORAGE_KEY) !== null,
   async extract(context) {
-    const rawUser = localStorage.getItem("user")
+    const rawUser = localStorage.getItem(COMPATIBLE_USER_STORAGE_KEY)
     if (!rawUser) return null
 
     let user: unknown

--- a/src/services/accountSiteOnboarding/contentSession/compatibleUser.ts
+++ b/src/services/accountSiteOnboarding/contentSession/compatibleUser.ts
@@ -1,0 +1,31 @@
+import { isAccountSiteType, SITE_TYPES } from "~/constants/siteType"
+import { resolveStoredAccountUserIdentity } from "~/services/accounts/accountIdentity"
+
+import type { ContentSessionExtractor } from "../contracts"
+
+export const compatibleUserContentSessionExtractor: ContentSessionExtractor = {
+  id: "compatible-user",
+  canExtract: () => true,
+  async extract(context) {
+    const rawUser = localStorage.getItem("user")
+    if (!rawUser) return null
+
+    let user: unknown
+    try {
+      user = JSON.parse(rawUser)
+    } catch {
+      return null
+    }
+
+    const siteType = isAccountSiteType(context.siteTypeHint)
+      ? context.siteTypeHint
+      : SITE_TYPES.UNKNOWN
+    const identity = resolveStoredAccountUserIdentity(user, siteType)
+    if (!identity) return null
+
+    return {
+      ...identity,
+      ...(siteType !== SITE_TYPES.UNKNOWN ? { siteTypeHint: siteType } : {}),
+    }
+  },
+}

--- a/src/services/accountSiteOnboarding/contentSession/sub2api.ts
+++ b/src/services/accountSiteOnboarding/contentSession/sub2api.ts
@@ -1,0 +1,219 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import { parseSub2ApiUserIdentity } from "~/services/apiService/sub2api/parsing"
+
+import type { ContentSessionExtractor } from "../contracts"
+
+/**
+ * Sub2API uses a short-lived JWT access token with a refresh-token flow.
+ *
+ * The dashboard stores auth state in localStorage, and will refresh tokens on its
+ * own. But the extension may read localStorage before the dashboard finishes its
+ * refresh, so we proactively refresh when the saved expiry timestamp is close.
+ *
+ * IMPORTANT:
+ * - Never log tokens.
+ * - Only refresh when expiry info exists (avoid unnecessary refresh-token rotation).
+ */
+const SUB2API_AUTH_STORAGE_KEYS = {
+  accessToken: "auth_token",
+  refreshToken: "refresh_token",
+  tokenExpiresAt: "token_expires_at",
+  authUser: "auth_user",
+} as const
+
+// Match upstream buffer: refresh ~2 minutes before expiry.
+const SUB2API_TOKEN_REFRESH_BUFFER_MS = 120 * 1000
+
+type Sub2ApiEnvelope<T> = {
+  code: number
+  message?: string
+  data?: T
+  detail?: string
+}
+
+type Sub2ApiRefreshTokenData = {
+  access_token: string
+  refresh_token: string
+  expires_in: number
+}
+
+export class Sub2ApiContentSessionLoginRequiredError extends Error {
+  constructor() {
+    super("messages:sub2api.loginRequired")
+  }
+}
+
+const tryParseTimestamp = (value: string | null): number | null => {
+  if (!value) return null
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const refreshSub2ApiTokensIfNeeded = async (params: {
+  baseUrl: string | null
+  accessToken: string
+  refreshToken: string
+  tokenExpiresAt: number | null
+}): Promise<{
+  accessToken: string
+  refreshToken: string
+  tokenExpiresAt: number
+} | null> => {
+  const { baseUrl, accessToken, refreshToken, tokenExpiresAt } = params
+
+  if (!refreshToken.trim() || tokenExpiresAt === null) return null
+
+  const now = Date.now()
+  const msUntilExpiry = tokenExpiresAt - now
+  if (msUntilExpiry > SUB2API_TOKEN_REFRESH_BUFFER_MS) return null
+  const isExpired = msUntilExpiry <= 0
+
+  const endpoint =
+    typeof baseUrl === "string" && baseUrl.trim()
+      ? new URL("/api/v1/auth/refresh", baseUrl).toString()
+      : "/api/v1/auth/refresh"
+
+  let payload: Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null = null
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    })
+
+    payload = (await response
+      .json()
+      .catch(() => null)) as Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null
+  } catch {
+    if (isExpired) {
+      throw new Error("Sub2API token refresh failed")
+    }
+    return null
+  }
+
+  if (!payload || typeof payload !== "object") {
+    if (isExpired) {
+      throw new Error("Sub2API token refresh failed")
+    }
+    return null
+  }
+
+  if (payload.code !== 0 || !payload.data) {
+    if (isExpired) {
+      throw new Error("Sub2API token refresh failed")
+    }
+    return null
+  }
+
+  const nextAccessToken =
+    typeof payload.data.access_token === "string"
+      ? payload.data.access_token.trim()
+      : ""
+  const nextRefreshToken =
+    typeof payload.data.refresh_token === "string"
+      ? payload.data.refresh_token.trim()
+      : ""
+  const expiresInSeconds =
+    typeof payload.data.expires_in === "number" ? payload.data.expires_in : 0
+
+  if (!nextAccessToken || !nextRefreshToken || expiresInSeconds <= 0) {
+    if (isExpired) {
+      throw new Error("Sub2API token refresh failed")
+    }
+    return null
+  }
+
+  const nextExpiresAt = now + expiresInSeconds * 1000
+
+  localStorage.setItem(SUB2API_AUTH_STORAGE_KEYS.accessToken, nextAccessToken)
+  localStorage.setItem(SUB2API_AUTH_STORAGE_KEYS.refreshToken, nextRefreshToken)
+  localStorage.setItem(
+    SUB2API_AUTH_STORAGE_KEYS.tokenExpiresAt,
+    String(nextExpiresAt),
+  )
+
+  return {
+    accessToken: nextAccessToken,
+    refreshToken: nextRefreshToken,
+    tokenExpiresAt: nextExpiresAt,
+  }
+}
+
+export const sub2ApiContentSessionExtractor: ContentSessionExtractor = {
+  id: "sub2api",
+  canExtract: () => {
+    return (
+      localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.accessToken) !== null &&
+      localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.authUser) !== null
+    )
+  },
+  async extract(context) {
+    const authTokenRaw = localStorage.getItem(
+      SUB2API_AUTH_STORAGE_KEYS.accessToken,
+    )
+    const authUserRaw = localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.authUser)
+
+    if (authTokenRaw === null || authUserRaw === null) return null
+
+    let accessToken = authTokenRaw?.trim() ?? ""
+    if (!accessToken) {
+      throw new Sub2ApiContentSessionLoginRequiredError()
+    }
+
+    const refreshTokenRaw = localStorage.getItem(
+      SUB2API_AUTH_STORAGE_KEYS.refreshToken,
+    )
+    let refreshToken = refreshTokenRaw?.trim() ?? ""
+    let tokenExpiresAt = tryParseTimestamp(
+      localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.tokenExpiresAt),
+    )
+    const baseUrl = typeof context.url === "string" ? context.url : null
+
+    try {
+      const refreshed = await refreshSub2ApiTokensIfNeeded({
+        baseUrl,
+        accessToken,
+        refreshToken,
+        tokenExpiresAt,
+      })
+      if (refreshed?.accessToken) {
+        accessToken = refreshed.accessToken
+        refreshToken = refreshed.refreshToken
+        tokenExpiresAt = refreshed.tokenExpiresAt
+      }
+    } catch {
+      throw new Sub2ApiContentSessionLoginRequiredError()
+    }
+
+    try {
+      const authUser = authUserRaw ? JSON.parse(authUserRaw) : null
+      const identity = parseSub2ApiUserIdentity(authUser)
+
+      return {
+        userId: identity.userId,
+        user: {
+          id: identity.userId,
+          username: identity.username,
+          balance: identity.balanceUsd,
+        },
+        accessToken,
+        ...(refreshToken
+          ? {
+              sub2apiAuth: {
+                refreshToken,
+                ...(typeof tokenExpiresAt === "number"
+                  ? { tokenExpiresAt }
+                  : {}),
+              },
+            }
+          : {}),
+        siteTypeHint: SITE_TYPES.SUB2API,
+      }
+    } catch {
+      throw new Sub2ApiContentSessionLoginRequiredError()
+    }
+  },
+}

--- a/src/services/accountSiteOnboarding/contentSession/sub2api.ts
+++ b/src/services/accountSiteOnboarding/contentSession/sub2api.ts
@@ -23,6 +23,9 @@ const SUB2API_AUTH_STORAGE_KEYS = {
 
 // Match upstream buffer: refresh ~2 minutes before expiry.
 const SUB2API_TOKEN_REFRESH_BUFFER_MS = 120 * 1000
+const SUB2API_TOKEN_REFRESH_TIMEOUT_MS = 10_000
+
+export const SUB2API_LOGIN_REQUIRED_I18N_KEY = "messages:sub2api.loginRequired"
 
 type Sub2ApiEnvelope<T> = {
   code: number
@@ -39,7 +42,7 @@ type Sub2ApiRefreshTokenData = {
 
 export class Sub2ApiContentSessionLoginRequiredError extends Error {
   constructor() {
-    super("messages:sub2api.loginRequired")
+    super(SUB2API_LOGIN_REQUIRED_I18N_KEY)
   }
 }
 
@@ -48,6 +51,16 @@ const tryParseTimestamp = (value: string | null): number | null => {
   const parsed = Number.parseInt(value, 10)
   return Number.isFinite(parsed) ? parsed : null
 }
+
+const readStoredTokenState = () => ({
+  accessToken:
+    localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.accessToken)?.trim() ?? "",
+  refreshToken:
+    localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.refreshToken)?.trim() ?? "",
+  tokenExpiresAt: tryParseTimestamp(
+    localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.tokenExpiresAt),
+  ),
+})
 
 const refreshSub2ApiTokensIfNeeded = async (params: {
   baseUrl: string | null
@@ -61,22 +74,34 @@ const refreshSub2ApiTokensIfNeeded = async (params: {
 } | null> => {
   const { baseUrl, accessToken, refreshToken, tokenExpiresAt } = params
 
-  if (!refreshToken.trim() || tokenExpiresAt === null) return null
+  if (tokenExpiresAt === null) return null
 
   const now = Date.now()
   const msUntilExpiry = tokenExpiresAt - now
-  if (msUntilExpiry > SUB2API_TOKEN_REFRESH_BUFFER_MS) return null
   const isExpired = msUntilExpiry <= 0
+  if (!refreshToken.trim()) {
+    if (isExpired) {
+      throw new Error("Sub2API token refresh unavailable")
+    }
+    return null
+  }
+  if (msUntilExpiry > SUB2API_TOKEN_REFRESH_BUFFER_MS) return null
 
   const endpoint =
     typeof baseUrl === "string" && baseUrl.trim()
       ? new URL("/api/v1/auth/refresh", baseUrl).toString()
       : "/api/v1/auth/refresh"
 
+  const controller = new AbortController()
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    SUB2API_TOKEN_REFRESH_TIMEOUT_MS,
+  )
   let payload: Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null = null
   try {
     const response = await fetch(endpoint, {
       method: "POST",
+      signal: controller.signal,
       headers: {
         "Content-Type": "application/json",
         ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
@@ -92,6 +117,8 @@ const refreshSub2ApiTokensIfNeeded = async (params: {
       throw new Error("Sub2API token refresh failed")
     }
     return null
+  } finally {
+    clearTimeout(timeoutId)
   }
 
   if (!payload || typeof payload !== "object") {
@@ -144,8 +171,9 @@ const refreshSub2ApiTokensIfNeeded = async (params: {
 
 export const sub2ApiContentSessionExtractor: ContentSessionExtractor = {
   id: "sub2api",
-  canExtract: () => {
+  canExtract: (context) => {
     return (
+      context.siteTypeHint === SITE_TYPES.SUB2API &&
       localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.accessToken) !== null &&
       localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.authUser) !== null
     )
@@ -163,13 +191,7 @@ export const sub2ApiContentSessionExtractor: ContentSessionExtractor = {
       throw new Sub2ApiContentSessionLoginRequiredError()
     }
 
-    const refreshTokenRaw = localStorage.getItem(
-      SUB2API_AUTH_STORAGE_KEYS.refreshToken,
-    )
-    let refreshToken = refreshTokenRaw?.trim() ?? ""
-    let tokenExpiresAt = tryParseTimestamp(
-      localStorage.getItem(SUB2API_AUTH_STORAGE_KEYS.tokenExpiresAt),
-    )
+    let { refreshToken, tokenExpiresAt } = readStoredTokenState()
     const baseUrl = typeof context.url === "string" ? context.url : null
 
     try {
@@ -185,7 +207,18 @@ export const sub2ApiContentSessionExtractor: ContentSessionExtractor = {
         tokenExpiresAt = refreshed.tokenExpiresAt
       }
     } catch {
-      throw new Sub2ApiContentSessionLoginRequiredError()
+      const stored = readStoredTokenState()
+      if (
+        stored.accessToken &&
+        typeof stored.tokenExpiresAt === "number" &&
+        stored.tokenExpiresAt > Date.now()
+      ) {
+        accessToken = stored.accessToken
+        refreshToken = stored.refreshToken
+        tokenExpiresAt = stored.tokenExpiresAt
+      } else {
+        throw new Sub2ApiContentSessionLoginRequiredError()
+      }
     }
 
     try {

--- a/src/services/accountSiteOnboarding/contentSession/sub2api.ts
+++ b/src/services/accountSiteOnboarding/contentSession/sub2api.ts
@@ -23,7 +23,6 @@ const SUB2API_AUTH_STORAGE_KEYS = {
 
 // Match upstream buffer: refresh ~2 minutes before expiry.
 const SUB2API_TOKEN_REFRESH_BUFFER_MS = 120 * 1000
-const SUB2API_TOKEN_REFRESH_TIMEOUT_MS = 10_000
 
 export const SUB2API_LOGIN_REQUIRED_I18N_KEY = "messages:sub2api.loginRequired"
 
@@ -92,16 +91,10 @@ const refreshSub2ApiTokensIfNeeded = async (params: {
       ? new URL("/api/v1/auth/refresh", baseUrl).toString()
       : "/api/v1/auth/refresh"
 
-  const controller = new AbortController()
-  const timeoutId = setTimeout(
-    () => controller.abort(),
-    SUB2API_TOKEN_REFRESH_TIMEOUT_MS,
-  )
   let payload: Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null = null
   try {
     const response = await fetch(endpoint, {
       method: "POST",
-      signal: controller.signal,
       headers: {
         "Content-Type": "application/json",
         ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
@@ -117,8 +110,6 @@ const refreshSub2ApiTokensIfNeeded = async (params: {
       throw new Error("Sub2API token refresh failed")
     }
     return null
-  } finally {
-    clearTimeout(timeoutId)
   }
 
   if (!payload || typeof payload !== "object") {

--- a/src/services/accountSiteOnboarding/contracts.ts
+++ b/src/services/accountSiteOnboarding/contracts.ts
@@ -1,0 +1,46 @@
+import type { AccountSiteType } from "./siteTypes"
+
+export type AccountSiteRouteConfig = {
+  loginPath?: string
+  usagePath?: string
+  checkInPath?: string
+  adminCredentialsPath?: string
+  redeemPath?: string
+  siteAnnouncementsPath?: string
+}
+
+export type AccountSiteDetectionMetadata = {
+  titlePatterns?: readonly RegExp[]
+  hostnames?: readonly string[]
+  compatUserIdHeaderNames?: readonly string[]
+}
+
+export type ContentSessionExtractionContext = {
+  url?: string
+  siteTypeHint?: AccountSiteType
+}
+
+export type ContentSessionExtractionResult = {
+  userId: string | number
+  user: Record<string, unknown>
+  accessToken?: string
+  siteTypeHint?: AccountSiteType
+  sub2apiAuth?: {
+    refreshToken: string
+    tokenExpiresAt?: number
+  }
+}
+
+export type ContentSessionExtractor = {
+  id: string
+  canExtract(context: ContentSessionExtractionContext): boolean
+  extract(
+    context: ContentSessionExtractionContext,
+  ): Promise<ContentSessionExtractionResult | null>
+}
+
+export type AccountSiteOnboardingMetadata = {
+  siteType: AccountSiteType
+  detection?: AccountSiteDetectionMetadata
+  routes?: AccountSiteRouteConfig
+}

--- a/src/services/accountSiteOnboarding/metadata.ts
+++ b/src/services/accountSiteOnboarding/metadata.ts
@@ -1,0 +1,271 @@
+import type {
+  AccountSiteOnboardingMetadata,
+  AccountSiteRouteConfig,
+} from "./contracts"
+import {
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  SITE_TYPES,
+  type AccountSiteType,
+} from "./siteTypes"
+
+type AccountSiteRouteOverrideMetadata = Partial<AccountSiteRouteConfig>
+
+type AccountSiteTitleRuleMetadata = {
+  name: AccountSiteType
+  regex: RegExp
+}
+
+type AccountSiteDomainRuleMetadata = {
+  name: AccountSiteType
+  hostnames: readonly string[]
+}
+
+/**
+ * Clones detection metadata arrays before exposing registry projections.
+ */
+function cloneDetectionMetadata(
+  detection: AccountSiteOnboardingMetadata["detection"],
+) {
+  if (!detection) return undefined
+
+  return {
+    ...detection,
+    titlePatterns: detection.titlePatterns
+      ? [...detection.titlePatterns]
+      : undefined,
+    hostnames: detection.hostnames ? [...detection.hostnames] : undefined,
+    compatUserIdHeaderNames: detection.compatUserIdHeaderNames
+      ? [...detection.compatUserIdHeaderNames]
+      : undefined,
+  }
+}
+
+/**
+ * Error-message detection should only use header names that carry an
+ * unambiguous site-family signal. Generic compatibility headers like `User-id`
+ * are intentionally excluded to avoid over-classifying unrelated deployments.
+ */
+export const COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE = {
+  "New-API-User": SITE_TYPES.NEW_API,
+  "Veloera-User": SITE_TYPES.VELOERA,
+  "X-Api-User": SITE_TYPES.V_API,
+  "voapi-user": SITE_TYPES.VO_API,
+  "Rix-Api-User": SITE_TYPES.RIX_API,
+  "neo-api-user": SITE_TYPES.NEO_API,
+} as const satisfies Record<string, AccountSiteType>
+
+/**
+ * Builds the legacy title-matching pattern for a site type display name.
+ */
+function makeTitleRegex(name: string): RegExp {
+  const pattern = name.replace("-", "[-_ ]?")
+  return new RegExp(`\\b${pattern}\\b`, "i")
+}
+
+const DEFAULT_LOGIN_PATH = "/login"
+const DEFAULT_USAGE_PATH = "/console/log"
+const DEFAULT_CHECKIN_PATH = "/console/personal"
+const DEFAULT_REDEEM_PATH = "/console/topup"
+const DEFAULT_ADMIN_CREDENTIALS_PATH = DEFAULT_CHECKIN_PATH
+const DEFAULT_SITE_ANNOUNCEMENTS_PATH = "/"
+
+export const DEFAULT_SITE_ROUTE_CONFIG = {
+  loginPath: DEFAULT_LOGIN_PATH,
+  usagePath: DEFAULT_USAGE_PATH,
+  checkInPath: DEFAULT_CHECKIN_PATH,
+  adminCredentialsPath: DEFAULT_ADMIN_CREDENTIALS_PATH,
+  redeemPath: DEFAULT_REDEEM_PATH,
+  siteAnnouncementsPath: DEFAULT_SITE_ANNOUNCEMENTS_PATH,
+} as const satisfies Required<AccountSiteRouteConfig>
+
+const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
+  [
+    {
+      siteType: SITE_TYPES.ONE_API,
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_API)] },
+      routes: { usagePath: DEFAULT_USAGE_PATH },
+    },
+    {
+      siteType: SITE_TYPES.NEW_API,
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.NEW_API)],
+      },
+      routes: {
+        usagePath: DEFAULT_USAGE_PATH,
+        checkInPath: "/console/personal",
+        adminCredentialsPath: "/console/personal",
+      },
+    },
+    {
+      siteType: SITE_TYPES.ANYROUTER,
+      detection: { titlePatterns: [/\bany\s*router\b/i] },
+      routes: { checkInPath: "/console/topup" },
+    },
+    {
+      siteType: SITE_TYPES.VELOERA,
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.VELOERA)],
+      },
+      routes: {
+        usagePath: "/app/logs/api-usage",
+        checkInPath: "/app/me",
+        redeemPath: "/app/wallet",
+        adminCredentialsPath: "/app/me",
+      },
+    },
+    {
+      siteType: SITE_TYPES.ONE_HUB,
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_HUB)] },
+      routes: {
+        usagePath: "/panel/log",
+        redeemPath: "/panel/topup",
+        adminCredentialsPath: "/panel/profile",
+      },
+    },
+    {
+      siteType: SITE_TYPES.DONE_HUB,
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.DONE_HUB)] },
+      routes: {
+        usagePath: "/panel/log",
+        redeemPath: "/panel/topup",
+        adminCredentialsPath: "/panel/profile",
+      },
+    },
+    {
+      siteType: SITE_TYPES.V_API,
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.V_API)],
+      },
+      routes: {
+        usagePath: "/panel/log",
+        checkInPath: "/panel/profile",
+        redeemPath: "/panel/topup",
+        adminCredentialsPath: "/panel/profile",
+      },
+    },
+    {
+      siteType: SITE_TYPES.VO_API,
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.VO_API)],
+      },
+      routes: { usagePath: DEFAULT_USAGE_PATH, redeemPath: "/wallet" },
+    },
+    {
+      siteType: SITE_TYPES.SUPER_API,
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUPER_API)] },
+    },
+    {
+      siteType: SITE_TYPES.RIX_API,
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.RIX_API)],
+      },
+      routes: {
+        usagePath: "/log",
+        checkInPath: "/panel",
+        redeemPath: "/topup",
+      },
+    },
+    {
+      siteType: SITE_TYPES.NEO_API,
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.NEO_API)],
+      },
+    },
+    {
+      siteType: SITE_TYPES.WONG_GONGYI,
+      detection: { titlePatterns: [/wong\s*公益站/i] },
+      routes: { checkInPath: "/console/topup" },
+    },
+    {
+      siteType: SITE_TYPES.SUB2API,
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUB2API)] },
+      routes: {
+        usagePath: "/usage",
+        redeemPath: "/redeem",
+        siteAnnouncementsPath: "/dashboard",
+      },
+    },
+    {
+      siteType: SITE_TYPES.AIHUBMIX,
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.AIHUBMIX)],
+        hostnames: AIHUBMIX_HOSTNAMES,
+      },
+      routes: {
+        loginPath: AIHUBMIX_LOGIN_PATH,
+        usagePath: "/statistics",
+        redeemPath: "/topup",
+        checkInPath: "/",
+        adminCredentialsPath: "/",
+      },
+    },
+    {
+      siteType: SITE_TYPES.UNKNOWN,
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.UNKNOWN)] },
+    },
+  ]
+
+/**
+ * Returns the static onboarding metadata for an account site type.
+ */
+export function getAccountSiteMetadata(siteType: AccountSiteType) {
+  const metadata = accountSiteOnboardingMetadata.find(
+    (metadata) => metadata.siteType === siteType,
+  )
+
+  if (!metadata) return undefined
+
+  return {
+    ...metadata,
+    detection: cloneDetectionMetadata(metadata.detection),
+    routes: metadata.routes ? { ...metadata.routes } : undefined,
+  }
+}
+
+/**
+ * Projects title-detection metadata into the legacy rule shape.
+ */
+export function getAccountSiteTitleRuleMetadata(): readonly AccountSiteTitleRuleMetadata[] {
+  return accountSiteOnboardingMetadata.flatMap(
+    (metadata) =>
+      metadata.detection?.titlePatterns?.map((regex) => ({
+        name: metadata.siteType,
+        regex,
+      })) ?? [],
+  )
+}
+
+/**
+ * Projects domain-detection metadata into the legacy rule shape.
+ */
+export function getAccountSiteDomainRuleMetadata(): readonly AccountSiteDomainRuleMetadata[] {
+  return accountSiteOnboardingMetadata.flatMap((metadata) =>
+    metadata.detection?.hostnames
+      ? [
+          {
+            name: metadata.siteType,
+            hostnames: [...metadata.detection.hostnames],
+          },
+        ]
+      : [],
+  )
+}
+
+/**
+ * Returns the route overrides defined by metadata for one account site type.
+ */
+export function getAccountSiteRouteOverrideMetadata(
+  siteType: AccountSiteType,
+): AccountSiteRouteOverrideMetadata {
+  return { ...(getAccountSiteMetadata(siteType)?.routes ?? {}) }
+}
+
+/**
+ * Projects compatible user-id header metadata into normalized rules.
+ */
+export function getAccountSiteCompatUserIdHeaderRules() {
+  return Object.entries(COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE).map(
+    ([headerName, siteType]) => ({ siteType, headerName }),
+  )
+}

--- a/src/services/accountSiteOnboarding/metadata.ts
+++ b/src/services/accountSiteOnboarding/metadata.ts
@@ -59,7 +59,8 @@ export const COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE = {
  * Builds the legacy title-matching pattern for a site type display name.
  */
 function makeTitleRegex(name: string): RegExp {
-  const pattern = name.replace("-", "[-_ ]?")
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const pattern = escaped.replace(/-/g, "[-_ ]?")
   return new RegExp(`\\b${pattern}\\b`, "i")
 }
 

--- a/src/services/accountSiteOnboarding/registry.ts
+++ b/src/services/accountSiteOnboarding/registry.ts
@@ -1,0 +1,53 @@
+import { compatibleUserContentSessionExtractor } from "./contentSession/compatibleUser"
+import { sub2ApiContentSessionExtractor } from "./contentSession/sub2api"
+import type { ContentSessionExtractor } from "./contracts"
+import {
+  getAccountSiteCompatUserIdHeaderRules as getAccountSiteCompatUserIdHeaderRuleMetadata,
+  getAccountSiteDomainRuleMetadata,
+  getAccountSiteMetadata,
+  getAccountSiteRouteOverrideMetadata,
+  getAccountSiteTitleRuleMetadata,
+} from "./metadata"
+import type { AccountSiteType } from "./siteTypes"
+
+/**
+ * Returns the onboarding definition for one account site type.
+ */
+export function getAccountSiteOnboardingDefinition(siteType: AccountSiteType) {
+  return getAccountSiteMetadata(siteType)
+}
+
+/**
+ * Returns domain-detection rules for account site onboarding.
+ */
+export function getAccountSiteDomainRules() {
+  return getAccountSiteDomainRuleMetadata()
+}
+
+/**
+ * Returns title-detection rules for account site onboarding.
+ */
+export function getAccountSiteTitleRules() {
+  return getAccountSiteTitleRuleMetadata()
+}
+
+/**
+ * Returns compat user-id header detection rules for account site onboarding.
+ */
+export function getAccountSiteCompatUserIdHeaderRules() {
+  return getAccountSiteCompatUserIdHeaderRuleMetadata()
+}
+
+/**
+ * Returns route overrides for one account site type.
+ */
+export function getAccountSiteRouteOverrides(siteType: AccountSiteType) {
+  return getAccountSiteRouteOverrideMetadata(siteType)
+}
+
+/**
+ * Returns content-session extractors in account onboarding priority order.
+ */
+export function getContentSessionExtractors(): readonly ContentSessionExtractor[] {
+  return [sub2ApiContentSessionExtractor, compatibleUserContentSessionExtractor]
+}

--- a/src/services/accountSiteOnboarding/siteTypes.ts
+++ b/src/services/accountSiteOnboarding/siteTypes.ts
@@ -1,0 +1,62 @@
+export const SITE_TYPES = {
+  ONE_API: "one-api",
+  NEW_API: "new-api",
+  ANYROUTER: "anyrouter",
+  VELOERA: "Veloera",
+  ONE_HUB: "one-hub",
+  DONE_HUB: "done-hub",
+  V_API: "v-api",
+  VO_API: "VoAPI",
+  SUPER_API: "Super-API",
+  RIX_API: "Rix-Api",
+  NEO_API: "neo-Api",
+  WONG_GONGYI: "wong-gongyi",
+  SUB2API: "sub2api",
+  OCTOPUS: "octopus",
+  AXON_HUB: "axonhub",
+  CLAUDE_CODE_HUB: "claude-code-hub",
+  AIHUBMIX: "AIHubMix",
+  UNKNOWN: "unknown",
+} as const
+
+export const AIHUBMIX_API_ORIGIN = "https://aihubmix.com"
+export const AIHUBMIX_WEB_ORIGIN = "https://console.aihubmix.com"
+export const AIHUBMIX_LOGIN_PATH = "/sign-in"
+export const AIHUBMIX_HOSTNAMES = [
+  "aihubmix.com",
+  "www.aihubmix.com",
+  "console.aihubmix.com",
+] as const
+
+export const ACCOUNT_SITE_TYPES = [
+  SITE_TYPES.ONE_API,
+  SITE_TYPES.NEW_API,
+  SITE_TYPES.ANYROUTER,
+  SITE_TYPES.VELOERA,
+  SITE_TYPES.ONE_HUB,
+  SITE_TYPES.DONE_HUB,
+  SITE_TYPES.V_API,
+  SITE_TYPES.VO_API,
+  SITE_TYPES.SUPER_API,
+  SITE_TYPES.RIX_API,
+  SITE_TYPES.NEO_API,
+  SITE_TYPES.WONG_GONGYI,
+  SITE_TYPES.SUB2API,
+  SITE_TYPES.AIHUBMIX,
+  SITE_TYPES.UNKNOWN,
+] as const
+
+export type AccountSiteType = (typeof ACCOUNT_SITE_TYPES)[number]
+
+export const ACCOUNT_SITE_TYPE_VALUES = [...ACCOUNT_SITE_TYPES]
+
+export const MANAGED_SITE_TYPES = [
+  SITE_TYPES.NEW_API,
+  SITE_TYPES.VELOERA,
+  SITE_TYPES.DONE_HUB,
+  SITE_TYPES.OCTOPUS,
+  SITE_TYPES.AXON_HUB,
+  SITE_TYPES.CLAUDE_CODE_HUB,
+] as const
+
+export type ManagedSiteType = (typeof MANAGED_SITE_TYPES)[number]

--- a/src/services/apiService/common/compatHeaders.ts
+++ b/src/services/apiService/common/compatHeaders.ts
@@ -1,4 +1,1 @@
-export {
-  COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE,
-  buildCompatUserIdHeaders,
-} from "~/services/apiTransport/compatHeaders"
+export { buildCompatUserIdHeaders } from "~/services/apiTransport/compatHeaders"

--- a/src/services/apiTransport/compatHeaders.ts
+++ b/src/services/apiTransport/compatHeaders.ts
@@ -1,4 +1,8 @@
-import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import { COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE } from "~/services/accountSiteOnboarding/metadata"
+import {
+  SITE_TYPES,
+  type AccountSiteType,
+} from "~/services/accountSiteOnboarding/siteTypes"
 
 /**
  * Compatibility headers for One-API/New-API family deployments.
@@ -22,19 +26,7 @@ const COMPAT_USER_ID_HEADER_TO_SITE_TYPE = {
   "neo-api-user": SITE_TYPES.NEO_API,
 } as const satisfies Record<string, AccountSiteType>
 
-/**
- * Error-message detection should only use header names that carry an
- * unambiguous site-family signal. Generic compatibility headers like `User-id`
- * are intentionally excluded to avoid over-classifying unrelated deployments.
- */
-export const COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE = {
-  "New-API-User": SITE_TYPES.NEW_API,
-  "Veloera-User": SITE_TYPES.VELOERA,
-  "X-Api-User": SITE_TYPES.V_API,
-  "voapi-user": SITE_TYPES.VO_API,
-  "Rix-Api-User": SITE_TYPES.RIX_API,
-  "neo-api-user": SITE_TYPES.NEO_API,
-} as const satisfies Record<string, AccountSiteType>
+export { COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE }
 
 const COMPAT_USER_ID_HEADER_NAMES = Object.keys(
   COMPAT_USER_ID_HEADER_TO_SITE_TYPE,

--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -1,10 +1,9 @@
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 import {
-  ACCOUNT_SITE_DOMAIN_RULES,
-  ACCOUNT_SITE_TITLE_RULES,
-  SITE_TYPES,
-  type AccountSiteType,
-} from "~/constants/siteType"
-import { COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE } from "~/services/apiService/common/compatHeaders"
+  getAccountSiteCompatUserIdHeaderRules,
+  getAccountSiteDomainRules,
+  getAccountSiteTitleRules,
+} from "~/services/accountSiteOnboarding/registry"
 import { ApiError } from "~/services/apiService/common/errors"
 import { fetchApi, fetchApiData } from "~/services/apiService/common/utils"
 import { AuthTypeEnum } from "~/types"
@@ -16,15 +15,14 @@ import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("DetectSiteType")
-const COMPAT_USER_ID_HEADER_MESSAGE_RULES = Object.entries(
-  COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE,
-).map(([headerName, siteType]) => ({
-  siteType,
-  regex: new RegExp(
-    headerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/-/g, "[-_ ]?"),
-    "i",
-  ),
-}))
+const COMPAT_USER_ID_HEADER_MESSAGE_RULES =
+  getAccountSiteCompatUserIdHeaderRules().map(({ headerName, siteType }) => ({
+    siteType,
+    regex: new RegExp(
+      headerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/-/g, "[-_ ]?"),
+      "i",
+    ),
+  }))
 
 /**
  * Fetch the raw HTML title from the site root.
@@ -103,7 +101,7 @@ function detectAccountSiteTypeFromApiErrorMessage(
     }
   }
 
-  for (const rule of ACCOUNT_SITE_TITLE_RULES) {
+  for (const rule of getAccountSiteTitleRules()) {
     if (rule.regex.test(normalizedMessage)) {
       return rule.name
     }
@@ -141,14 +139,14 @@ async function getAccountSiteUserIdType(url: string): Promise<AccountSiteType> {
 
 /**
  * detectAccountSiteTypeFromDomain parses the URL hostname and compares it
- * case-insensitively against ACCOUNT_SITE_DOMAIN_RULES. It returns the matched
+ * case-insensitively against account-site domain rules. It returns the matched
  * AccountSiteType rule name, or SITE_TYPES.UNKNOWN when parsing fails or no
  * domain rule matches.
  */
 function detectAccountSiteTypeFromDomain(url: string): AccountSiteType {
   try {
     const hostname = new URL(url).hostname.toLowerCase()
-    const matchedRule = ACCOUNT_SITE_DOMAIN_RULES.find((rule) =>
+    const matchedRule = getAccountSiteDomainRules().find((rule) =>
       rule.hostnames.some((allowedHostname) => allowedHostname === hostname),
     )
     return matchedRule?.name ?? SITE_TYPES.UNKNOWN
@@ -166,7 +164,7 @@ export const getAccountSiteType = async (
   }
 
   const title = await fetchSiteOriginalTitle(url)
-  for (const rule of ACCOUNT_SITE_TITLE_RULES) {
+  for (const rule of getAccountSiteTitleRules()) {
     if (rule.regex.test(title)) {
       return rule.name
     }

--- a/tests/constants/siteType.test.ts
+++ b/tests/constants/siteType.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  ACCOUNT_SITE_DOMAIN_RULES,
+  AIHUBMIX_HOSTNAMES,
   getAccountSiteApiRouter,
   isAccountSiteType,
   isManagedSiteType,
@@ -60,6 +62,21 @@ describe("siteType constants", () => {
       redeemPath: "/topup",
       adminCredentialsPath: "/",
       siteAnnouncementsPath: "/",
+    })
+  })
+
+  it("returns Sub2API account page route overrides", () => {
+    expect(getAccountSiteApiRouter(SITE_TYPES.SUB2API)).toMatchObject({
+      usagePath: "/usage",
+      redeemPath: "/redeem",
+      siteAnnouncementsPath: "/dashboard",
+    })
+  })
+
+  it("includes AIHubMix domain detection rules", () => {
+    expect(ACCOUNT_SITE_DOMAIN_RULES).toContainEqual({
+      name: SITE_TYPES.AIHUBMIX,
+      hostnames: AIHUBMIX_HOSTNAMES,
     })
   })
 })

--- a/tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
+++ b/tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
@@ -87,7 +87,7 @@ describe("content storage handler", () => {
 
     const response = await new Promise<any>((resolve) => {
       handleGetUserFromLocalStorage(
-        { url: "https://sub2.example.com" },
+        { url: "https://sub2.example.com", siteType: "sub2api" },
         resolve,
       )
     })
@@ -113,7 +113,7 @@ describe("content storage handler", () => {
 
     const response = await new Promise<any>((resolve) => {
       handleGetUserFromLocalStorage(
-        { url: "https://sub2.example.com" },
+        { url: "https://sub2.example.com", siteType: "sub2api" },
         resolve,
       )
     })
@@ -152,7 +152,7 @@ describe("content storage handler", () => {
 
     const response = await new Promise<any>((resolve) => {
       handleGetUserFromLocalStorage(
-        { url: "https://sub2.example.com" },
+        { url: "https://sub2.example.com", siteType: "sub2api" },
         resolve,
       )
     })
@@ -206,7 +206,7 @@ describe("content storage handler", () => {
     vi.stubGlobal("fetch", fetchMock as any)
 
     const response = await new Promise<any>((resolve) => {
-      handleGetUserFromLocalStorage({}, resolve)
+      handleGetUserFromLocalStorage({ siteType: "sub2api" }, resolve)
     })
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -253,7 +253,7 @@ describe("content storage handler", () => {
 
     const response = await new Promise<any>((resolve) => {
       handleGetUserFromLocalStorage(
-        { url: "https://sub2.example.com" },
+        { url: "https://sub2.example.com", siteType: "sub2api" },
         resolve,
       )
     })
@@ -289,7 +289,7 @@ describe("content storage handler", () => {
 
     const response = await new Promise<any>((resolve) => {
       handleGetUserFromLocalStorage(
-        { url: "https://sub2.example.com" },
+        { url: "https://sub2.example.com", siteType: "sub2api" },
         resolve,
       )
     })
@@ -319,7 +319,7 @@ describe("content storage handler", () => {
 
     const response = await new Promise<any>((resolve) => {
       handleGetUserFromLocalStorage(
-        { url: "https://sub2.example.com" },
+        { url: "https://sub2.example.com", siteType: "sub2api" },
         resolve,
       )
     })
@@ -342,7 +342,7 @@ describe("content storage handler", () => {
 
     const response = await new Promise<any>((resolve) => {
       handleGetUserFromLocalStorage(
-        { url: "https://sub2.example.com" },
+        { url: "https://sub2.example.com", siteType: "sub2api" },
         resolve,
       )
     })
@@ -363,7 +363,7 @@ describe("content storage handler", () => {
 
     const response = await new Promise<any>((resolve) => {
       handleGetUserFromLocalStorage(
-        { url: "https://sub2.example.com" },
+        { url: "https://sub2.example.com", siteType: "sub2api" },
         resolve,
       )
     })
@@ -391,6 +391,38 @@ describe("content storage handler", () => {
           username: "alice",
           role: "admin",
         },
+      },
+    })
+  })
+
+  it("falls through to compatible user extraction when non-Sub2API storage also has Sub2API keys", async () => {
+    localStorage.setItem("auth_token", "jwt-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "sub2-user", balance: 1.5 }),
+    )
+    localStorage.setItem(
+      "user",
+      JSON.stringify({ id: "user-1", username: "alice", role: "admin" }),
+    )
+
+    const response = await new Promise<any>((resolve) => {
+      handleGetUserFromLocalStorage(
+        { url: "https://example.com", siteType: "new-api" },
+        resolve,
+      )
+    })
+
+    expect(response).toEqual({
+      success: true,
+      data: {
+        userId: "user-1",
+        user: {
+          id: "user-1",
+          username: "alice",
+          role: "admin",
+        },
+        siteTypeHint: "new-api",
       },
     })
   })

--- a/tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
+++ b/tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
@@ -4,15 +4,18 @@ import {
   handleGetLocalStorage,
   handleGetUserFromLocalStorage,
 } from "~/entrypoints/content/messageHandlers/handlers/storage"
+import { compatibleUserContentSessionExtractor } from "~/services/accountSiteOnboarding/contentSession/compatibleUser"
+import {
+  sub2ApiContentSessionExtractor,
+  Sub2ApiContentSessionLoginRequiredError,
+} from "~/services/accountSiteOnboarding/contentSession/sub2api"
 
-const { mockFetchUserInfo } = vi.hoisted(() => ({
-  mockFetchUserInfo: vi.fn(),
+const { mockGetContentSessionExtractors } = vi.hoisted(() => ({
+  mockGetContentSessionExtractors: vi.fn(),
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: vi.fn(() => ({
-    fetchUserInfo: mockFetchUserInfo,
-  })),
+vi.mock("~/services/accountSiteOnboarding/registry", () => ({
+  getContentSessionExtractors: mockGetContentSessionExtractors,
 }))
 
 vi.mock("~/utils/i18n/core", () => ({
@@ -25,6 +28,10 @@ describe("content storage handler", () => {
     vi.restoreAllMocks()
     localStorage.clear()
     vi.clearAllMocks()
+    mockGetContentSessionExtractors.mockReturnValue([
+      sub2ApiContentSessionExtractor,
+      compatibleUserContentSessionExtractor,
+    ])
   })
 
   it("returns a single localStorage key when requested directly", () => {
@@ -95,7 +102,6 @@ describe("content storage handler", () => {
     expect(response.data?.accessToken).toBe("jwt-token")
     expect(response.data?.siteTypeHint).toBe("sub2api")
     expect(response.data?.sub2apiAuth).toBeUndefined()
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("returns loginRequired when the saved Sub2API access token is blank", async () => {
@@ -114,7 +120,6 @@ describe("content storage handler", () => {
 
     expect(response.success).toBe(false)
     expect(response.error).toBe("messages:sub2api.loginRequired")
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("refreshes Sub2API access token when token_expires_at is close", async () => {
@@ -169,7 +174,6 @@ describe("content storage handler", () => {
       refreshToken: "new-refresh",
       tokenExpiresAt: now + 3600 * 1000,
     })
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
 
     nowSpy.mockRestore()
   })
@@ -257,7 +261,6 @@ describe("content storage handler", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(response.success).toBe(false)
     expect(response.error).toBe("messages:sub2api.loginRequired")
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
 
     nowSpy.mockRestore()
   })
@@ -298,7 +301,6 @@ describe("content storage handler", () => {
       refreshToken: "old-refresh",
       tokenExpiresAt: now + 60_000,
     })
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
 
     nowSpy.mockRestore()
   })
@@ -353,7 +355,6 @@ describe("content storage handler", () => {
     })
     expect(response.data?.accessToken).toBe("jwt-token")
     expect(response.data?.siteTypeHint).toBe("sub2api")
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("returns loginRequired when Sub2API keys exist but auth_user is invalid", async () => {
@@ -369,7 +370,6 @@ describe("content storage handler", () => {
 
     expect(response.success).toBe(false)
     expect(response.error).toBe("messages:sub2api.loginRequired")
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("returns the standard local user payload when a non-Sub2API user exists", async () => {
@@ -393,7 +393,6 @@ describe("content storage handler", () => {
         },
       },
     })
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("normalizes numeric standard local user ids to string identities", async () => {
@@ -417,7 +416,6 @@ describe("content storage handler", () => {
         },
       },
     })
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("uses AIHubMix localStorage username as the account identity", async () => {
@@ -444,7 +442,6 @@ describe("content storage handler", () => {
         },
       },
     })
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("does not infer AIHubMix identity from url without an explicit site type", async () => {
@@ -462,7 +459,6 @@ describe("content storage handler", () => {
 
     expect(response.success).toBe(false)
     expect(response.error).toBe("messages:content.userInfoNotFound")
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("returns userInfoNotFound when no user payload exists", async () => {
@@ -472,7 +468,6 @@ describe("content storage handler", () => {
 
     expect(response.success).toBe(false)
     expect(response.error).toBe("messages:content.userInfoNotFound")
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
   it("returns a structured error when reading localStorage throws during user lookup", async () => {
@@ -488,6 +483,167 @@ describe("content storage handler", () => {
       success: false,
       error: "localStorage unavailable",
     })
-    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+  })
+
+  describe("content session extractor routing", () => {
+    it("uses the first extractor result and does not call later extractors", async () => {
+      const firstExtractor = {
+        id: "first",
+        canExtract: vi.fn(() => true),
+        extract: vi.fn().mockResolvedValue({
+          userId: "first-user",
+          user: { id: "first-user", username: "first" },
+        }),
+      }
+      const laterExtractor = {
+        id: "later",
+        canExtract: vi.fn(() => true),
+        extract: vi.fn().mockResolvedValue({
+          userId: "later-user",
+          user: { id: "later-user", username: "later" },
+        }),
+      }
+      mockGetContentSessionExtractors.mockReturnValue([
+        firstExtractor,
+        laterExtractor,
+      ])
+
+      const response = await new Promise<any>((resolve) => {
+        handleGetUserFromLocalStorage(
+          { url: "https://example.invalid", siteType: "new-api" },
+          resolve,
+        )
+      })
+
+      expect(response).toEqual({
+        success: true,
+        data: {
+          userId: "first-user",
+          user: { id: "first-user", username: "first" },
+        },
+      })
+      expect(firstExtractor.canExtract).toHaveBeenCalledWith({
+        url: "https://example.invalid",
+        siteTypeHint: "new-api",
+      })
+      expect(firstExtractor.extract).toHaveBeenCalledWith({
+        url: "https://example.invalid",
+        siteTypeHint: "new-api",
+      })
+      expect(laterExtractor.canExtract).not.toHaveBeenCalled()
+      expect(laterExtractor.extract).not.toHaveBeenCalled()
+    })
+
+    it("skips extractors whose canExtract returns false", async () => {
+      const skippedExtractor = {
+        id: "skipped",
+        canExtract: vi.fn(() => false),
+        extract: vi.fn(),
+      }
+      const matchingExtractor = {
+        id: "matching",
+        canExtract: vi.fn(() => true),
+        extract: vi.fn().mockResolvedValue({
+          userId: "matching-user",
+          user: { id: "matching-user" },
+        }),
+      }
+      mockGetContentSessionExtractors.mockReturnValue([
+        skippedExtractor,
+        matchingExtractor,
+      ])
+
+      const response = await new Promise<any>((resolve) => {
+        handleGetUserFromLocalStorage(
+          { url: "https://example.invalid", siteType: "not-a-site-type" },
+          resolve,
+        )
+      })
+
+      expect(response).toEqual({
+        success: true,
+        data: {
+          userId: "matching-user",
+          user: { id: "matching-user" },
+        },
+      })
+      expect(skippedExtractor.extract).not.toHaveBeenCalled()
+      expect(matchingExtractor.canExtract).toHaveBeenCalledWith({
+        url: "https://example.invalid",
+        siteTypeHint: "unknown",
+      })
+      expect(matchingExtractor.extract).toHaveBeenCalledWith({
+        url: "https://example.invalid",
+        siteTypeHint: "unknown",
+      })
+    })
+
+    it("returns userInfoNotFound when no extractor returns a result", async () => {
+      mockGetContentSessionExtractors.mockReturnValue([
+        {
+          id: "empty",
+          canExtract: vi.fn(() => true),
+          extract: vi.fn().mockResolvedValue(null),
+        },
+      ])
+
+      const response = await new Promise<any>((resolve) => {
+        handleGetUserFromLocalStorage(
+          { url: "https://example.invalid" },
+          resolve,
+        )
+      })
+
+      expect(response).toEqual({
+        success: false,
+        error: "messages:content.userInfoNotFound",
+      })
+    })
+
+    it("returns structured errors from unexpected extractor failures", async () => {
+      mockGetContentSessionExtractors.mockReturnValue([
+        {
+          id: "throws",
+          canExtract: vi.fn(() => true),
+          extract: vi.fn().mockRejectedValue(new Error("extractor failed")),
+        },
+      ])
+
+      const response = await new Promise<any>((resolve) => {
+        handleGetUserFromLocalStorage(
+          { url: "https://example.invalid" },
+          resolve,
+        )
+      })
+
+      expect(response).toEqual({
+        success: false,
+        error: "extractor failed",
+      })
+    })
+
+    it("preserves Sub2API loginRequired mapping from extractor errors", async () => {
+      mockGetContentSessionExtractors.mockReturnValue([
+        {
+          id: "sub2api",
+          canExtract: vi.fn(() => true),
+          extract: vi
+            .fn()
+            .mockRejectedValue(new Sub2ApiContentSessionLoginRequiredError()),
+        },
+      ])
+
+      const response = await new Promise<any>((resolve) => {
+        handleGetUserFromLocalStorage(
+          { url: "https://example.invalid" },
+          resolve,
+        )
+      })
+
+      expect(response).toEqual({
+        success: false,
+        error: "messages:sub2api.loginRequired",
+      })
+    })
   })
 })

--- a/tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { compatibleUserContentSessionExtractor } from "~/services/accountSiteOnboarding/contentSession/compatibleUser"
+
+function createLocalStorageMock() {
+  const store = new Map<string, string>()
+
+  return {
+    clear: vi.fn(() => {
+      store.clear()
+    }),
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key)
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, String(value))
+    }),
+    get length() {
+      return store.size
+    },
+  }
+}
+
+describe("compatibleUserContentSessionExtractor", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    vi.stubGlobal("localStorage", createLocalStorageMock())
+  })
+
+  it("resolves compatible users with an explicit site type hint", async () => {
+    localStorage.setItem(
+      "user",
+      JSON.stringify({ id: 42, username: "alice", role: "admin" }),
+    )
+
+    await expect(
+      compatibleUserContentSessionExtractor.extract({
+        url: "https://example.invalid",
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).resolves.toEqual({
+      userId: "42",
+      user: { id: 42, username: "alice", role: "admin" },
+      siteTypeHint: SITE_TYPES.NEW_API,
+    })
+  })
+
+  it("omits siteTypeHint when the explicit site type is unknown", async () => {
+    localStorage.setItem(
+      "user",
+      JSON.stringify({ id: 42, username: "alice", role: "admin" }),
+    )
+
+    await expect(
+      compatibleUserContentSessionExtractor.extract({
+        url: "https://example.invalid",
+        siteTypeHint: SITE_TYPES.UNKNOWN,
+      }),
+    ).resolves.toEqual({
+      userId: "42",
+      user: { id: 42, username: "alice", role: "admin" },
+    })
+  })
+
+  it("uses AIHubMix username identity with an explicit AIHubMix hint", async () => {
+    localStorage.setItem(
+      "user",
+      JSON.stringify({ username: "aihubmix-user", display_name: "Alice" }),
+    )
+
+    await expect(
+      compatibleUserContentSessionExtractor.extract({
+        url: "https://console.aihubmix.example.invalid",
+        siteTypeHint: SITE_TYPES.AIHUBMIX,
+      }),
+    ).resolves.toEqual({
+      userId: "aihubmix-user",
+      user: { username: "aihubmix-user", display_name: "Alice" },
+      siteTypeHint: SITE_TYPES.AIHUBMIX,
+    })
+  })
+
+  it("returns null when user storage is missing", async () => {
+    await expect(
+      compatibleUserContentSessionExtractor.extract({
+        url: "https://example.invalid",
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).resolves.toBeNull()
+  })
+
+  it("returns null when user storage is malformed JSON", async () => {
+    localStorage.setItem("user", "not-json")
+
+    await expect(
+      compatibleUserContentSessionExtractor.extract({
+        url: "https://example.invalid",
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).resolves.toBeNull()
+  })
+})

--- a/tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
@@ -65,6 +65,23 @@ describe("compatibleUserContentSessionExtractor", () => {
     })
   })
 
+  it("omits siteTypeHint when the explicit site type is not account-compatible", async () => {
+    localStorage.setItem(
+      "user",
+      JSON.stringify({ id: 42, username: "alice", role: "admin" }),
+    )
+
+    await expect(
+      compatibleUserContentSessionExtractor.extract({
+        url: "https://example.invalid",
+        siteTypeHint: "not-a-site-type" as typeof SITE_TYPES.UNKNOWN,
+      }),
+    ).resolves.toEqual({
+      userId: "42",
+      user: { id: 42, username: "alice", role: "admin" },
+    })
+  })
+
   it("uses AIHubMix username identity with an explicit AIHubMix hint", async () => {
     localStorage.setItem(
       "user",

--- a/tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/compatibleUser.test.ts
@@ -102,4 +102,22 @@ describe("compatibleUserContentSessionExtractor", () => {
       }),
     ).resolves.toBeNull()
   })
+
+  it("can extract compatible user storage when the user key exists", () => {
+    expect(
+      compatibleUserContentSessionExtractor.canExtract({
+        url: "https://example.invalid",
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).toBe(false)
+
+    localStorage.setItem("user", JSON.stringify({ id: 42 }))
+
+    expect(
+      compatibleUserContentSessionExtractor.canExtract({
+        url: "https://example.invalid",
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).toBe(true)
+  })
 })

--- a/tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts
@@ -189,6 +189,54 @@ describe("sub2ApiContentSessionExtractor", () => {
     ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
   })
 
+  it("keeps a still-valid token when the refresh request rejects", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now + 60_000))
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")))
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).resolves.toMatchObject({
+      accessToken: "old-token",
+      sub2apiAuth: {
+        refreshToken: "old-refresh",
+        tokenExpiresAt: now + 60_000,
+      },
+    })
+  })
+
+  it("throws login-required when refresh request rejects and the token is expired", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now - 1))
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")))
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
+  })
+
   it("keeps a still-valid token when the refresh response is not JSON", async () => {
     const now = 1_700_000_000_000
     vi.spyOn(Date, "now").mockReturnValue(now)
@@ -222,6 +270,35 @@ describe("sub2ApiContentSessionExtractor", () => {
         tokenExpiresAt: now + 60_000,
       },
     })
+  })
+
+  it("throws login-required when an expired refresh response is not JSON", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now - 1))
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("not-json", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      ) as any,
+    )
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
   })
 
   it("keeps a still-valid token when refreshed token fields are incomplete", async () => {
@@ -272,6 +349,66 @@ describe("sub2ApiContentSessionExtractor", () => {
       JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
     )
     localStorage.setItem("token_expires_at", String(now - 1))
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
+  })
+
+  it("keeps a still-valid token when no refresh token is stored", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("token_expires_at", String(now + 60_000))
+
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock as any)
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).resolves.toMatchObject({
+      accessToken: "old-token",
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("throws login-required when an expired refresh response has invalid token field types", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now - 1))
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            data: {
+              access_token: 123,
+              refresh_token: null,
+              expires_in: "3600",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ) as any,
+    )
 
     await expect(
       sub2ApiContentSessionExtractor.extract({

--- a/tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts
@@ -280,44 +280,6 @@ describe("sub2ApiContentSessionExtractor", () => {
     ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
   })
 
-  it("bounds stalled refresh requests and reports login-required for expired tokens", async () => {
-    vi.useFakeTimers()
-    const now = 1_700_000_000_000
-    vi.spyOn(Date, "now").mockReturnValue(now)
-
-    localStorage.setItem("auth_token", "old-token")
-    localStorage.setItem(
-      "auth_user",
-      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
-    )
-    localStorage.setItem("refresh_token", "old-refresh")
-    localStorage.setItem("token_expires_at", String(now - 1))
-
-    const fetchMock = vi.fn(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => {
-            reject(new DOMException("Aborted", "AbortError"))
-          })
-        }),
-    )
-    vi.stubGlobal("fetch", fetchMock as any)
-
-    const extraction = sub2ApiContentSessionExtractor.extract({
-      url: "https://sub2.example.invalid",
-    })
-    const expectedRejection = expect(extraction).rejects.toBeInstanceOf(
-      Sub2ApiContentSessionLoginRequiredError,
-    )
-
-    await vi.advanceTimersByTimeAsync(10_000)
-
-    await expectedRejection
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-
-    vi.useRealTimers()
-  })
-
   it("uses refreshed tokens saved by a concurrent extraction before reporting login-required", async () => {
     const now = 1_700_000_000_000
     vi.spyOn(Date, "now").mockReturnValue(now)

--- a/tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  sub2ApiContentSessionExtractor,
+  Sub2ApiContentSessionLoginRequiredError,
+} from "~/services/accountSiteOnboarding/contentSession/sub2api"
+
+function createLocalStorageMock() {
+  const store = new Map<string, string>()
+
+  return {
+    clear: vi.fn(() => {
+      store.clear()
+    }),
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key)
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, String(value))
+    }),
+    get length() {
+      return store.size
+    },
+  }
+}
+
+describe("sub2ApiContentSessionExtractor", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    vi.stubGlobal("localStorage", createLocalStorageMock())
+  })
+
+  it("returns the Sub2API user payload when auth_token and auth_user are valid", async () => {
+    localStorage.setItem("auth_token", "jwt-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).resolves.toEqual({
+      userId: 123,
+      user: {
+        id: 123,
+        username: "alice",
+        balance: 1.5,
+      },
+      accessToken: "jwt-token",
+      siteTypeHint: SITE_TYPES.SUB2API,
+    })
+  })
+
+  it("throws login-required when the saved access token is blank", async () => {
+    localStorage.setItem("auth_token", "   ")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
+  })
+
+  it("refreshes near-expiry tokens and returns refreshed auth metadata", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now + 60_000))
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          code: 0,
+          data: {
+            access_token: "new-token",
+            refresh_token: "new-refresh",
+            expires_in: 3600,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    vi.stubGlobal("fetch", fetchMock as any)
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).resolves.toEqual({
+      userId: 123,
+      user: {
+        id: 123,
+        username: "alice",
+        balance: 1.5,
+      },
+      accessToken: "new-token",
+      sub2apiAuth: {
+        refreshToken: "new-refresh",
+        tokenExpiresAt: now + 3600 * 1000,
+      },
+      siteTypeHint: SITE_TYPES.SUB2API,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sub2.example.invalid/api/v1/auth/refresh",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          Authorization: "Bearer old-token",
+        }),
+        body: JSON.stringify({ refresh_token: "old-refresh" }),
+      }),
+    )
+    expect(localStorage.getItem("auth_token")).toBe("new-token")
+    expect(localStorage.getItem("refresh_token")).toBe("new-refresh")
+    expect(localStorage.getItem("token_expires_at")).toBe(
+      String(now + 3600 * 1000),
+    )
+  })
+
+  it("throws login-required when refresh fails and the token is expired", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now - 1))
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ code: 1, message: "invalid" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock as any)
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
+  })
+
+  it("throws login-required when auth_user is invalid", async () => {
+    localStorage.setItem("auth_token", "jwt-token")
+    localStorage.setItem("auth_user", "not-json")
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
+  })
+})

--- a/tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/sub2api.test.ts
@@ -57,6 +57,33 @@ describe("sub2ApiContentSessionExtractor", () => {
     })
   })
 
+  it("only claims Sub2API storage when the context is for Sub2API", () => {
+    localStorage.setItem("auth_token", "jwt-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+
+    expect(
+      sub2ApiContentSessionExtractor.canExtract({
+        url: "https://sub2.example.invalid",
+        siteTypeHint: SITE_TYPES.SUB2API,
+      }),
+    ).toBe(true)
+    expect(
+      sub2ApiContentSessionExtractor.canExtract({
+        url: "https://one-api.example.invalid",
+        siteTypeHint: SITE_TYPES.ONE_API,
+      }),
+    ).toBe(false)
+    expect(
+      sub2ApiContentSessionExtractor.canExtract({
+        url: "https://example.invalid",
+        siteTypeHint: SITE_TYPES.UNKNOWN,
+      }),
+    ).toBe(false)
+  })
+
   it("throws login-required when the saved access token is blank", async () => {
     localStorage.setItem("auth_token", "   ")
     localStorage.setItem(
@@ -160,6 +187,184 @@ describe("sub2ApiContentSessionExtractor", () => {
         url: "https://sub2.example.invalid",
       }),
     ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
+  })
+
+  it("keeps a still-valid token when the refresh response is not JSON", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now + 60_000))
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("not-json", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      ) as any,
+    )
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).resolves.toMatchObject({
+      accessToken: "old-token",
+      sub2apiAuth: {
+        refreshToken: "old-refresh",
+        tokenExpiresAt: now + 60_000,
+      },
+    })
+  })
+
+  it("keeps a still-valid token when refreshed token fields are incomplete", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now + 60_000))
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            data: { access_token: "", refresh_token: "", expires_in: 0 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ) as any,
+    )
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).resolves.toMatchObject({
+      accessToken: "old-token",
+      sub2apiAuth: {
+        refreshToken: "old-refresh",
+        tokenExpiresAt: now + 60_000,
+      },
+    })
+  })
+
+  it("throws login-required when an expired token has no refresh token", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("token_expires_at", String(now - 1))
+
+    await expect(
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ).rejects.toBeInstanceOf(Sub2ApiContentSessionLoginRequiredError)
+  })
+
+  it("bounds stalled refresh requests and reports login-required for expired tokens", async () => {
+    vi.useFakeTimers()
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now - 1))
+
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"))
+          })
+        }),
+    )
+    vi.stubGlobal("fetch", fetchMock as any)
+
+    const extraction = sub2ApiContentSessionExtractor.extract({
+      url: "https://sub2.example.invalid",
+    })
+    const expectedRejection = expect(extraction).rejects.toBeInstanceOf(
+      Sub2ApiContentSessionLoginRequiredError,
+    )
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    await expectedRejection
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
+
+  it("uses refreshed tokens saved by a concurrent extraction before reporting login-required", async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(now)
+
+    localStorage.setItem("auth_token", "old-token")
+    localStorage.setItem(
+      "auth_user",
+      JSON.stringify({ id: 123, username: "alice", balance: 1.5 }),
+    )
+    localStorage.setItem("refresh_token", "old-refresh")
+    localStorage.setItem("token_expires_at", String(now - 1))
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            data: {
+              access_token: "new-token",
+              refresh_token: "new-refresh",
+              expires_in: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 1, message: "invalid" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+    vi.stubGlobal("fetch", fetchMock as any)
+
+    const [firstResult, secondResult] = await Promise.all([
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+      sub2ApiContentSessionExtractor.extract({
+        url: "https://sub2.example.invalid",
+      }),
+    ])
+
+    expect(firstResult?.accessToken).toBe("new-token")
+    expect(secondResult?.accessToken).toBe("new-token")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it("throws login-required when auth_user is invalid", async () => {

--- a/tests/services/accountSiteOnboarding/registry.test.ts
+++ b/tests/services/accountSiteOnboarding/registry.test.ts
@@ -31,6 +31,37 @@ describe("account site onboarding registry", () => {
     expect(titleRuleNames).toContain(SITE_TYPES.AIHUBMIX)
   })
 
+  it("matches hyphenated site titles through generated title rules", () => {
+    const titleRules = getAccountSiteTitleRules()
+
+    expect(
+      titleRules
+        .find((rule) => rule.name === SITE_TYPES.ONE_HUB)
+        ?.regex.test("One Hub"),
+    ).toBe(true)
+    expect(
+      titleRules
+        .find((rule) => rule.name === SITE_TYPES.ONE_HUB)
+        ?.regex.test("one_hub"),
+    ).toBe(true)
+  })
+
+  it("returns title rule object copies", () => {
+    const firstRule = getAccountSiteTitleRules().find(
+      (rule) => rule.name === SITE_TYPES.SUB2API,
+    )
+
+    firstRule!.name = SITE_TYPES.UNKNOWN
+    firstRule!.regex = /mutated/i
+
+    const nextRule = getAccountSiteTitleRules().find(
+      (rule) => rule.name === SITE_TYPES.SUB2API,
+    )
+
+    expect(nextRule?.name).toBe(SITE_TYPES.SUB2API)
+    expect(nextRule?.regex.test(SITE_TYPES.SUB2API)).toBe(true)
+  })
+
   it("projects account site domain rules from metadata", () => {
     expect(getAccountSiteDomainRules()).toEqual(ACCOUNT_SITE_DOMAIN_RULES)
     expect(getAccountSiteDomainRules()).toContainEqual({
@@ -92,6 +123,20 @@ describe("account site onboarding registry", () => {
     ).toBe(false)
   })
 
+  it("returns domain rule object copies", () => {
+    const firstRule = getAccountSiteDomainRules().find(
+      (rule) => rule.name === SITE_TYPES.AIHUBMIX,
+    )
+
+    firstRule!.name = SITE_TYPES.UNKNOWN
+
+    expect(
+      getAccountSiteDomainRules().find(
+        (rule) => rule.name === SITE_TYPES.AIHUBMIX,
+      )?.name,
+    ).toBe(SITE_TYPES.AIHUBMIX)
+  })
+
   it("returns onboarding definition detection array copies", () => {
     const firstDefinition = getAccountSiteOnboardingDefinition(
       SITE_TYPES.AIHUBMIX,
@@ -116,5 +161,9 @@ describe("account site onboarding registry", () => {
     expect(
       getContentSessionExtractors().map((extractor) => extractor.id),
     ).toEqual(["sub2api", "compatible-user"])
+  })
+
+  it("returns empty route overrides for site types without route metadata", () => {
+    expect(getAccountSiteRouteOverrides(SITE_TYPES.UNKNOWN)).toEqual({})
   })
 })

--- a/tests/services/accountSiteOnboarding/registry.test.ts
+++ b/tests/services/accountSiteOnboarding/registry.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ACCOUNT_SITE_DOMAIN_RULES,
+  ACCOUNT_SITE_TITLE_RULES,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  SITE_TYPES,
+} from "~/constants/siteType"
+import {
+  getAccountSiteCompatUserIdHeaderRules,
+  getAccountSiteDomainRules,
+  getAccountSiteOnboardingDefinition,
+  getAccountSiteRouteOverrides,
+  getAccountSiteTitleRules,
+  getContentSessionExtractors,
+} from "~/services/accountSiteOnboarding/registry"
+
+describe("account site onboarding registry", () => {
+  it("projects account site title rules from metadata", () => {
+    const titleRuleNames = getAccountSiteTitleRules().map((rule) => rule.name)
+
+    expect(titleRuleNames).toEqual(
+      ACCOUNT_SITE_TITLE_RULES.map((rule) => rule.name),
+    )
+    expect(titleRuleNames.slice(0, 2)).toEqual([
+      SITE_TYPES.ONE_API,
+      SITE_TYPES.NEW_API,
+    ])
+    expect(titleRuleNames).toContain(SITE_TYPES.SUB2API)
+    expect(titleRuleNames).toContain(SITE_TYPES.AIHUBMIX)
+  })
+
+  it("projects account site domain rules from metadata", () => {
+    expect(getAccountSiteDomainRules()).toEqual(ACCOUNT_SITE_DOMAIN_RULES)
+    expect(getAccountSiteDomainRules()).toContainEqual({
+      name: SITE_TYPES.AIHUBMIX,
+      hostnames: [...AIHUBMIX_HOSTNAMES],
+    })
+  })
+
+  it("projects compat user-id header fallback rules from metadata", () => {
+    expect(getAccountSiteCompatUserIdHeaderRules()).toEqual(
+      expect.arrayContaining([
+        { siteType: SITE_TYPES.NEW_API, headerName: "New-API-User" },
+        { siteType: SITE_TYPES.V_API, headerName: "X-Api-User" },
+      ]),
+    )
+  })
+
+  it("returns account site route overrides from metadata", () => {
+    expect(getAccountSiteRouteOverrides(SITE_TYPES.AIHUBMIX)).toMatchObject({
+      loginPath: AIHUBMIX_LOGIN_PATH,
+      usagePath: "/statistics",
+      redeemPath: "/topup",
+    })
+  })
+
+  it("returns route override copies instead of mutable metadata objects", () => {
+    const firstRoutes = getAccountSiteRouteOverrides(SITE_TYPES.AIHUBMIX)
+    firstRoutes.loginPath = "/mutated"
+
+    expect(getAccountSiteRouteOverrides(SITE_TYPES.AIHUBMIX).loginPath).toBe(
+      AIHUBMIX_LOGIN_PATH,
+    )
+  })
+
+  it("returns onboarding definition copies instead of mutable metadata objects", () => {
+    const firstDefinition = getAccountSiteOnboardingDefinition(
+      SITE_TYPES.AIHUBMIX,
+    )
+
+    firstDefinition!.routes!.loginPath = "/mutated"
+
+    expect(
+      getAccountSiteOnboardingDefinition(SITE_TYPES.AIHUBMIX)?.routes
+        ?.loginPath,
+    ).toBe(AIHUBMIX_LOGIN_PATH)
+  })
+
+  it("returns domain rule hostname array copies", () => {
+    const firstRule = getAccountSiteDomainRules().find(
+      (rule) => rule.name === SITE_TYPES.AIHUBMIX,
+    )
+
+    ;(firstRule!.hostnames as string[]).push("mutated.example.invalid")
+
+    expect(
+      getAccountSiteDomainRules()
+        .find((rule) => rule.name === SITE_TYPES.AIHUBMIX)
+        ?.hostnames.includes("mutated.example.invalid"),
+    ).toBe(false)
+  })
+
+  it("returns onboarding definition detection array copies", () => {
+    const firstDefinition = getAccountSiteOnboardingDefinition(
+      SITE_TYPES.AIHUBMIX,
+    )
+
+    ;(firstDefinition!.detection!.hostnames as string[]).push(
+      "mutated.example.invalid",
+    )
+    ;(firstDefinition!.detection!.titlePatterns as RegExp[]).push(/mutated/i)
+
+    const nextDefinition = getAccountSiteOnboardingDefinition(
+      SITE_TYPES.AIHUBMIX,
+    )
+
+    expect(
+      nextDefinition?.detection?.hostnames?.includes("mutated.example.invalid"),
+    ).toBe(false)
+    expect(nextDefinition?.detection?.titlePatterns).toHaveLength(1)
+  })
+
+  it("returns content session extractors in onboarding order", () => {
+    expect(
+      getContentSessionExtractors().map((extractor) => extractor.id),
+    ).toEqual(["sub2api", "compatible-user"])
+  })
+})

--- a/tests/services/apiTransport/compatHeaders.test.ts
+++ b/tests/services/apiTransport/compatHeaders.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
+import { getAccountSiteCompatUserIdHeaderRules } from "~/services/accountSiteOnboarding/metadata"
 import {
   buildCompatUserIdHeaders,
   COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE,
@@ -17,5 +18,23 @@ describe("compat user-id headers", () => {
     expect(COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE["X-Api-User"]).toBe(
       SITE_TYPES.V_API,
     )
+  })
+
+  it("derives error-header detection signals from onboarding metadata", () => {
+    expect(getAccountSiteCompatUserIdHeaderRules()).toContainEqual({
+      headerName: "New-API-User",
+      siteType: SITE_TYPES.NEW_API,
+    })
+    expect(getAccountSiteCompatUserIdHeaderRules()).toContainEqual({
+      headerName: "X-Api-User",
+      siteType: SITE_TYPES.V_API,
+    })
+    expect(
+      Object.fromEntries(
+        getAccountSiteCompatUserIdHeaderRules().map(
+          ({ headerName, siteType }) => [headerName, siteType],
+        ),
+      ),
+    ).toEqual(COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE)
   })
 })


### PR DESCRIPTION
## Summary
- Document the account-site onboarding substrate plan and design.
- Introduce account-site onboarding metadata, route/detection projections, and registry helpers.
- Route content-session localStorage account extraction through ordered onboarding extractors.

## Test Plan
- pnpm run validate:push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced an account-site onboarding substrate to centralize site detection metadata and content-session extraction.

* **Improvements**
  * Updated site detection to use registry-driven title, domain, and compatible user-id header rules.
  * Refined user content-session extraction to route through prioritized extractors with first-match behavior.

* **Bug Fixes**
  * Improved Sub2API “login required” handling with consistent localized messaging.

* **Documentation**
  * Added onboarding design and implementation plan docs.

* **Tests**
  * Expanded Vitest coverage for registry projections and extractor routing, including Sub2API refresh and compatibility fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->