### PR TITLE
refactor(account-site): harden adapter service boundary

### DIFF
--- a/docs/superpowers/plans/2026-06-19-account-site-adapter-boundary-hardening.md
+++ b/docs/superpowers/plans/2026-06-19-account-site-adapter-boundary-hardening.md
@@ -1,0 +1,1101 @@
+# Account Site Adapter Boundary Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the account-site adapter boundary so account-mainline token flows use `SiteAdapter.keyManagement` and lint blocks new legacy `apiService` dependencies.
+
+**Architecture:** Deepen the existing `KeyManagementCapability` Interface with `updateToken`, migrate the remaining account-mainline create/edit token paths to that Interface, then remove the transitional `service` escape hatch from `createDisplayAccountApiContext`. Keep legacy `getApiService(...)` usage only in backend/adapters and explicitly named non-account-mainline exception zones.
+
+**Tech Stack:** TypeScript, React, Vitest, Testing Library, ESLint flat config, pnpm, existing `SiteAdapter` and account workflow helpers.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-account-site-adapter-boundary-hardening-design.md`
+
+---
+
+## File Structure
+
+Modify:
+
+- `src/services/apiAdapters/contracts/keyManagement.ts`
+  - Add `UpdateTokenRequest` and `KeyManagementCapability.updateToken(...)`.
+- `src/services/apiAdapters/newApi/keyManagement.ts`
+  - Delegate New API-family token updates through `getApiService(siteType).updateApiToken(...)`.
+- `src/services/apiAdapters/sub2api/keyManagement.ts`
+  - Delegate token updates through the existing Sub2API backend helper.
+- `src/services/apiAdapters/aihubmix/keyManagement.ts`
+  - Delegate token updates through the existing AIHubMix backend helper.
+- `tests/services/apiAdapters/keyManagement.test.ts`
+  - Make `updateToken(...)` part of the adapter contract test surface.
+- `src/features/KeyManagement/components/AddTokenDialog/index.tsx`
+  - Route edit-mode submit through `requireDisplayAccountKeyManagement(...).updateToken(...)`.
+- `tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx`
+  - Split adapter update mocks from legacy service update mocks and prove edit mode uses the adapter.
+- `src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts`
+  - Route default-key creation through `requireDisplayAccountKeyManagement(...).createToken(...)`.
+- `tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx`
+  - Split adapter create mocks from legacy service create mocks and prove default create uses the adapter.
+- `tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx`
+  - Keep Sub2API default create coverage on the adapter path.
+- `src/services/accounts/utils/apiServiceRequest.ts`
+  - Remove `getApiService` import and the returned `service` property.
+- `tests/services/accounts/apiServiceRequest.test.ts`
+  - Assert the display-account context returns only adapter-backed fields and the request.
+- `eslint.config.js`
+  - Add account-mainline import guard for the root `apiService` facade. Keep the existing backend-specific `apiService` guard instead of duplicating it.
+
+Do not modify:
+
+- `src/services/managedSites/**`
+- `src/services/models/modelSync/**`
+- `src/services/redemption/**`
+- `src/services/apiCredentialProfiles/**`
+- Account Dialog UI policy, locales, settings search, telemetry schema, or Playwright E2E tests.
+
+---
+
+## Implementation Notes
+
+Preserve behavior while changing the Seam:
+
+- Add Token edit mode should keep the existing success toast, failure toast fallback, analytics success/failure completion, `onSuccess` behavior, and close timing.
+- Model Key default creation should keep group validation, `generateDefaultTokenRequest()` payload generation, retry-after-create inventory refresh, one-time-key UI behavior, and analytics completion.
+- `createDisplayAccountApiContext(...)` should continue to decorate Sub2API display-account requests with `accountSub2ApiAuthSession`.
+- Imports from `~/services/apiService/common/type`, `~/services/apiService/common/apiKey`, and `~/services/apiService/common/errors` stay allowed in this slice.
+
+Intermediate commits should keep the repository type-checkable whenever practical. The task order below avoids removing `service` from the shared helper until the two product callers stop using it.
+
+Telemetry decision: none. This is an internal refactor with no new product event.
+
+Settings search decision: none. No settings UI, target ids, anchors, or search metadata change.
+
+E2E decision: no new Playwright E2E. The risk is adapter routing, helper shape, TypeScript, and lint enforcement; Vitest plus ESLint is the correct layer.
+
+---
+
+### Task 1: Add `updateToken` To The Key Management Adapter Contract
+
+**Files:**
+
+- Modify `tests/services/apiAdapters/keyManagement.test.ts`
+- Modify `src/services/apiAdapters/contracts/keyManagement.ts`
+- Modify `src/services/apiAdapters/newApi/keyManagement.ts`
+- Modify `src/services/apiAdapters/sub2api/keyManagement.ts`
+- Modify `src/services/apiAdapters/aihubmix/keyManagement.ts`
+
+- [ ] **Step 1: Write failing adapter contract tests**
+
+In `tests/services/apiAdapters/keyManagement.test.ts`, extend the hoisted mocks:
+
+```ts
+const {
+  mockAihubmixCreateApiToken,
+  mockAihubmixDeleteApiToken,
+  mockAihubmixFetchAccountAvailableModels,
+  mockAihubmixFetchAccountTokens,
+  mockAihubmixFetchUserGroups,
+  mockAihubmixResolveApiTokenKey,
+  mockAihubmixUpdateApiToken,
+  mockCreateApiToken,
+  mockDeleteApiToken,
+  mockFetchAccountAvailableModels,
+  mockFetchAccountTokens,
+  mockFetchUserGroups,
+  mockGetApiService,
+  mockResolveApiTokenKey,
+  mockSub2ApiCreateApiToken,
+  mockSub2ApiDeleteApiToken,
+  mockSub2ApiFetchAccountAvailableModels,
+  mockSub2ApiFetchAccountTokens,
+  mockSub2ApiFetchUserGroups,
+  mockSub2ApiResolveApiTokenKey,
+  mockSub2ApiUpdateApiToken,
+  mockUpdateApiToken,
+} = vi.hoisted(() => ({
+  mockAihubmixCreateApiToken: vi.fn(),
+  mockAihubmixDeleteApiToken: vi.fn(),
+  mockAihubmixFetchAccountAvailableModels: vi.fn(),
+  mockAihubmixFetchAccountTokens: vi.fn(),
+  mockAihubmixFetchUserGroups: vi.fn(),
+  mockAihubmixResolveApiTokenKey: vi.fn(),
+  mockAihubmixUpdateApiToken: vi.fn(),
+  mockCreateApiToken: vi.fn(),
+  mockDeleteApiToken: vi.fn(),
+  mockFetchAccountAvailableModels: vi.fn(),
+  mockFetchAccountTokens: vi.fn(),
+  mockFetchUserGroups: vi.fn(),
+  mockGetApiService: vi.fn(),
+  mockResolveApiTokenKey: vi.fn(),
+  mockSub2ApiCreateApiToken: vi.fn(),
+  mockSub2ApiDeleteApiToken: vi.fn(),
+  mockSub2ApiFetchAccountAvailableModels: vi.fn(),
+  mockSub2ApiFetchAccountTokens: vi.fn(),
+  mockSub2ApiFetchUserGroups: vi.fn(),
+  mockSub2ApiResolveApiTokenKey: vi.fn(),
+  mockSub2ApiUpdateApiToken: vi.fn(),
+  mockUpdateApiToken: vi.fn(),
+}))
+```
+
+Update the backend mocks:
+
+```ts
+vi.mock("~/services/apiService/sub2api", () => ({
+  createApiToken: mockSub2ApiCreateApiToken,
+  deleteApiToken: mockSub2ApiDeleteApiToken,
+  fetchAccountAvailableModels: mockSub2ApiFetchAccountAvailableModels,
+  fetchAccountTokens: mockSub2ApiFetchAccountTokens,
+  fetchUserGroups: mockSub2ApiFetchUserGroups,
+  resolveApiTokenKey: mockSub2ApiResolveApiTokenKey,
+  updateApiToken: mockSub2ApiUpdateApiToken,
+}))
+
+vi.mock("~/services/apiService/aihubmix", () => ({
+  createApiToken: mockAihubmixCreateApiToken,
+  deleteApiToken: mockAihubmixDeleteApiToken,
+  fetchAccountAvailableModels: mockAihubmixFetchAccountAvailableModels,
+  fetchAccountTokens: mockAihubmixFetchAccountTokens,
+  fetchUserGroups: mockAihubmixFetchUserGroups,
+  resolveApiTokenKey: mockAihubmixResolveApiTokenKey,
+  updateApiToken: mockAihubmixUpdateApiToken,
+}))
+```
+
+In `beforeEach`, return `updateApiToken` from the New API-family service mock:
+
+```ts
+mockGetApiService.mockReturnValue({
+  createApiToken: mockCreateApiToken,
+  deleteApiToken: mockDeleteApiToken,
+  fetchAccountAvailableModels: mockFetchAccountAvailableModels,
+  fetchAccountTokens: mockFetchAccountTokens,
+  fetchUserGroups: mockFetchUserGroups,
+  resolveApiTokenKey: mockResolveApiTokenKey,
+  updateApiToken: mockUpdateApiToken,
+})
+```
+
+Inside `delegates New API-family key operations through the site-specific apiService`, add the update assertion between create and resolve:
+
+```ts
+mockUpdateApiToken.mockResolvedValueOnce(true)
+
+await expect(
+  keyManagement.updateToken({
+    request,
+    tokenId: token.id,
+    tokenData,
+  }),
+).resolves.toBe(true)
+
+expect(mockGetApiService.mock.calls).toEqual([
+  [SITE_TYPES.ONE_HUB],
+  [SITE_TYPES.ONE_HUB],
+  [SITE_TYPES.ONE_HUB],
+  [SITE_TYPES.ONE_HUB],
+  [SITE_TYPES.ONE_HUB],
+  [SITE_TYPES.ONE_HUB],
+  [SITE_TYPES.ONE_HUB],
+])
+expect(mockUpdateApiToken).toHaveBeenCalledWith(request, token.id, tokenData)
+```
+
+Inside `delegates Sub2API key operations to backend key helpers`, add:
+
+```ts
+mockSub2ApiUpdateApiToken.mockResolvedValueOnce(true)
+
+await expect(
+  sub2ApiKeyManagement.updateToken({
+    request,
+    tokenId: token.id,
+    tokenData,
+  }),
+).resolves.toBe(true)
+
+expect(mockSub2ApiUpdateApiToken).toHaveBeenCalledWith(
+  request,
+  token.id,
+  tokenData,
+)
+```
+
+Inside `delegates AIHubMix key operations while preserving fetch option behavior`, add:
+
+```ts
+mockAihubmixUpdateApiToken.mockResolvedValueOnce(true)
+
+await expect(
+  aihubmixKeyManagement.updateToken({
+    request,
+    tokenId: token.id,
+    tokenData,
+  }),
+).resolves.toBe(true)
+
+expect(mockAihubmixUpdateApiToken).toHaveBeenCalledWith(
+  request,
+  token.id,
+  tokenData,
+)
+```
+
+- [ ] **Step 2: Run the adapter test and confirm it fails**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts
+```
+
+Expected result: FAIL because `updateToken` is not implemented on the adapter objects.
+
+- [ ] **Step 3: Add the contract method**
+
+In `src/services/apiAdapters/contracts/keyManagement.ts`, add this type after `DeleteTokenRequest`:
+
+```ts
+export type UpdateTokenRequest = {
+  request: ApiServiceRequest
+  tokenId: number
+  tokenData: CreateTokenRequest
+}
+```
+
+Add `updateToken(...)` after `createToken(...)` in `KeyManagementCapability`:
+
+```ts
+  updateToken(request: UpdateTokenRequest): Promise<boolean | void>
+```
+
+- [ ] **Step 4: Implement `updateToken` in adapters**
+
+In `src/services/apiAdapters/newApi/keyManagement.ts`, add:
+
+```ts
+    updateToken: ({ request, tokenId, tokenData }) =>
+      getApiService(siteType).updateApiToken(request, tokenId, tokenData),
+```
+
+In `src/services/apiAdapters/sub2api/keyManagement.ts`, add `updateApiToken` to the import:
+
+```ts
+import {
+  createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
+  fetchAccountTokens,
+  fetchUserGroups,
+  resolveApiTokenKey,
+  updateApiToken,
+} from "~/services/apiService/sub2api"
+```
+
+Then add:
+
+```ts
+  updateToken: ({ request, tokenId, tokenData }) =>
+    updateApiToken(request, tokenId, tokenData),
+```
+
+In `src/services/apiAdapters/aihubmix/keyManagement.ts`, add `updateApiToken` to the import:
+
+```ts
+import {
+  createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
+  fetchAccountTokens,
+  fetchUserGroups,
+  resolveApiTokenKey,
+  updateApiToken,
+} from "~/services/apiService/aihubmix"
+```
+
+Then add:
+
+```ts
+  updateToken: ({ request, tokenId, tokenData }) =>
+    updateApiToken(request, tokenId, tokenData),
+```
+
+- [ ] **Step 5: Run the adapter test and confirm it passes**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts
+```
+
+Expected result: PASS.
+
+- [ ] **Step 6: Commit the adapter contract**
+
+Run:
+
+```powershell
+git add src/services/apiAdapters/contracts/keyManagement.ts src/services/apiAdapters/newApi/keyManagement.ts src/services/apiAdapters/sub2api/keyManagement.ts src/services/apiAdapters/aihubmix/keyManagement.ts tests/services/apiAdapters/keyManagement.test.ts
+git commit -m "refactor(api-adapters): add token update capability"
+```
+
+Expected result: commit succeeds and the hook passes staged validation for the touched files.
+
+---
+
+### Task 2: Migrate Add Token Edit Mode To `keyManagement.updateToken`
+
+**Files:**
+
+- Modify `tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx`
+- Modify `src/features/KeyManagement/components/AddTokenDialog/index.tsx`
+
+- [ ] **Step 1: Split edit-mode adapter and legacy service mocks**
+
+In `tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx`, add a new hoisted mock:
+
+```ts
+const {
+  createApiTokenMock,
+  updateApiTokenMock,
+  updateTokenMock,
+  fetchAccountAvailableModelsMock,
+  fetchUserGroupsMock,
+  startProductAnalyticsActionMock,
+  toastSuccessMock,
+  toastErrorMock,
+  trackerCompleteMock,
+  createApiCredentialProfileMock,
+} = vi.hoisted(() => ({
+  createApiTokenMock: vi.fn(),
+  updateApiTokenMock: vi.fn(),
+  updateTokenMock: vi.fn(),
+  fetchAccountAvailableModelsMock: vi.fn(),
+  fetchUserGroupsMock: vi.fn(),
+  startProductAnalyticsActionMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  trackerCompleteMock: vi.fn(),
+  createApiCredentialProfileMock: vi.fn(),
+}))
+```
+
+Keep the legacy service mock as a tripwire:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: () => ({
+    updateApiToken: (...args: any[]) => updateApiTokenMock(...args),
+    fetchAccountAvailableModels: (...args: any[]) =>
+      fetchAccountAvailableModelsMock(...args),
+    fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+  }),
+}))
+```
+
+Add `updateToken` to the adapter mock:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: vi.fn(async () => []),
+      createToken: (...args: any[]) => createApiTokenMock(...args),
+      updateToken: (...args: any[]) => updateTokenMock(...args),
+      resolveTokenKey: async ({ token }: { token: { key: string } }) =>
+        token.key,
+      deleteToken: vi.fn(),
+      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+      fetchAvailableModels: (...args: any[]) =>
+        fetchAccountAvailableModelsMock(...args),
+    },
+  }),
+}))
+```
+
+In `beforeEach`, reset both update mocks:
+
+```ts
+updateApiTokenMock.mockReset()
+updateTokenMock.mockReset()
+```
+
+- [ ] **Step 2: Make edit-mode tests expect adapter update**
+
+In every edit-mode test in `AddTokenDialog.prefill.test.tsx`, replace setup calls like:
+
+```ts
+updateApiTokenMock.mockResolvedValueOnce(true)
+```
+
+with:
+
+```ts
+updateTokenMock.mockResolvedValueOnce(true)
+```
+
+Replace failure setup:
+
+```ts
+updateApiTokenMock.mockRejectedValueOnce(new Error("   "))
+```
+
+with:
+
+```ts
+updateTokenMock.mockRejectedValueOnce(new Error("   "))
+```
+
+In `does not apply prefill when editing a token`, replace the update assertion with:
+
+```ts
+await waitFor(() => {
+  expect(updateTokenMock).toHaveBeenCalledTimes(1)
+})
+
+expect(updateTokenMock.mock.calls[0]?.[0]).toMatchObject({
+  tokenId: 123,
+  tokenData: {
+    name: "Existing key",
+    model_limits_enabled: false,
+    model_limits: "",
+  },
+})
+expect(updateApiTokenMock).not.toHaveBeenCalled()
+```
+
+For the other edit-mode success/failure tests, add this after the submit settles:
+
+```ts
+expect(updateApiTokenMock).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 3: Run the Add Token dialog test and confirm it fails**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+```
+
+Expected result: FAIL because edit mode still calls `service.updateApiToken(...)`, so `updateTokenMock` is not called and `updateApiTokenMock` is called.
+
+- [ ] **Step 4: Migrate edit-mode implementation**
+
+In `src/features/KeyManagement/components/AddTokenDialog/index.tsx`, replace:
+
+```ts
+      const { keyManagement, request, service } =
+        createDisplayAccountApiContext(currentAccount)
+
+      if (isEditMode && editingToken) {
+        await service.updateApiToken(request, editingToken.id, tokenData)
+        toast.success(t("dialog.updateSuccess"))
+      } else {
+```
+
+with:
+
+```ts
+      const { keyManagement, request } =
+        createDisplayAccountApiContext(currentAccount)
+
+      if (isEditMode && editingToken) {
+        await requireDisplayAccountKeyManagement(
+          currentAccount,
+          keyManagement,
+        ).updateToken({
+          request,
+          tokenId: editingToken.id,
+          tokenData,
+        })
+        toast.success(t("dialog.updateSuccess"))
+      } else {
+```
+
+- [ ] **Step 5: Run the Add Token dialog test and confirm it passes**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+```
+
+Expected result: PASS.
+
+- [ ] **Step 6: Commit Add Token migration**
+
+Run:
+
+```powershell
+git add src/features/KeyManagement/components/AddTokenDialog/index.tsx tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+git commit -m "refactor(key-management): update tokens through adapters"
+```
+
+Expected result: commit succeeds and the hook passes staged validation for the touched files.
+
+---
+
+### Task 3: Migrate Model Key Default Creation To `keyManagement.createToken`
+
+**Files:**
+
+- Modify `tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx`
+- Modify `tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx`
+- Modify `src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts`
+
+- [ ] **Step 1: Split adapter and legacy create mocks in `ModelKeyDialog.test.tsx`**
+
+In `tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx`, replace the single create mock with two mocks:
+
+```ts
+const {
+  fetchAccountTokensMock,
+  adapterCreateTokenMock,
+  legacyCreateApiTokenMock,
+  toastSuccessMock,
+  toastErrorMock,
+  resolveDisplayAccountTokenForSecretMock,
+  openKeysPageMock,
+  startProductAnalyticsActionMock,
+  completeProductAnalyticsActionMock,
+  trackProductAnalyticsActionStartedMock,
+  createApiCredentialProfileMock,
+} = vi.hoisted(() => ({
+  fetchAccountTokensMock: vi.fn(),
+  adapterCreateTokenMock: vi.fn(),
+  legacyCreateApiTokenMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  resolveDisplayAccountTokenForSecretMock: vi.fn(),
+  openKeysPageMock: vi.fn(),
+  startProductAnalyticsActionMock: vi.fn(),
+  completeProductAnalyticsActionMock: vi.fn(),
+  trackProductAnalyticsActionStartedMock: vi.fn(),
+  createApiCredentialProfileMock: vi.fn(),
+}))
+```
+
+Keep the legacy service mock as a tripwire:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: () => ({
+    createApiToken: (...args: any[]) => legacyCreateApiTokenMock(...args),
+    fetchAccountAvailableModels: vi.fn(async () => []),
+    fetchUserGroups: vi.fn(async () => ({})),
+    updateApiToken: vi.fn(async () => true),
+  }),
+}))
+```
+
+Route the adapter mock to `adapterCreateTokenMock`:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: () => ({
+    keyManagement: {
+      fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
+      createToken: (...args: any[]) => adapterCreateTokenMock(...args),
+      resolveTokenKey: async ({ token }: { token: { key: string } }) =>
+        token.key,
+    },
+  }),
+}))
+```
+
+In `beforeEach`, reset both mocks:
+
+```ts
+adapterCreateTokenMock.mockReset()
+legacyCreateApiTokenMock.mockReset()
+```
+
+Replace each default-create setup in this file by changing the receiver only.
+Examples:
+
+```ts
+adapterCreateTokenMock.mockResolvedValueOnce({
+  ...TOKEN,
+  id: 8,
+  key: "sk-created-full-secret",
+  name: "model-key",
+})
+adapterCreateTokenMock.mockRejectedValueOnce(new Error("create failed"))
+adapterCreateTokenMock.mockResolvedValueOnce(false)
+adapterCreateTokenMock.mockResolvedValueOnce(true)
+```
+
+For assertions that inspect the generated request, keep the existing matcher
+body and change only the mock receiver:
+
+```ts
+expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+expect(adapterCreateTokenMock.mock.calls[0]?.[1]).toMatchObject({
+  group: "default",
+  model_limits_enabled: true,
+  model_limits: "gpt-4",
+})
+expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
+```
+
+For tests that only assert creation happened, use:
+
+```ts
+expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 2: Split adapter and legacy create mocks in the Sub2API test**
+
+In `tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx`, use the same split:
+
+```ts
+const {
+  fetchAccountTokensMock,
+  adapterCreateTokenMock,
+  legacyCreateApiTokenMock,
+  toastSuccessMock,
+  toastErrorMock,
+} = vi.hoisted(() => ({
+  fetchAccountTokensMock: vi.fn(),
+  adapterCreateTokenMock: vi.fn(),
+  legacyCreateApiTokenMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}))
+```
+
+Use `legacyCreateApiTokenMock` in the `~/services/apiService` mock and `adapterCreateTokenMock` in the `~/services/apiAdapters/registry` mock.
+
+Replace create setups and assertions in both Sub2API tests:
+
+```ts
+adapterCreateTokenMock.mockResolvedValueOnce(true)
+
+await waitFor(() => {
+  expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+  expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
+})
+expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 3: Run Model Key dialog tests and confirm they fail**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+```
+
+Expected result: FAIL because `createDefaultKey(...)` still calls `service.createApiToken(...)`, so adapter create mocks are not called and legacy create mocks are called.
+
+- [ ] **Step 4: Migrate Model Key default creation**
+
+In `src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts`, add `requireDisplayAccountKeyManagement` to the existing import:
+
+```ts
+import {
+  canManageDisplayAccountTokens,
+  createDisplayAccountApiContext,
+  fetchDisplayAccountTokens,
+  InvalidTokenPayloadError,
+  requireDisplayAccountKeyManagement,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Replace:
+
+```ts
+        const { service, request } = createDisplayAccountApiContext(account)
+        const tokenRequest = generateDefaultTokenRequest()
+        tokenRequest.group = normalizedGroup
+        const created = await service.createApiToken(request, tokenRequest)
+```
+
+with:
+
+```ts
+        const { keyManagement, request } =
+          createDisplayAccountApiContext(account)
+        const tokenRequest = generateDefaultTokenRequest()
+        tokenRequest.group = normalizedGroup
+        const created = await requireDisplayAccountKeyManagement(
+          account,
+          keyManagement,
+        ).createToken(request, tokenRequest)
+```
+
+- [ ] **Step 5: Run Model Key dialog tests and confirm they pass**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+```
+
+Expected result: PASS.
+
+- [ ] **Step 6: Commit Model Key migration**
+
+Run:
+
+```powershell
+git add src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+git commit -m "refactor(model-list): create default keys through adapters"
+```
+
+Expected result: commit succeeds and the hook passes staged validation for the touched files.
+
+---
+
+### Task 4: Remove `service` From Display Account Context
+
+**Files:**
+
+- Modify `tests/services/accounts/apiServiceRequest.test.ts`
+- Modify `src/services/accounts/utils/apiServiceRequest.ts`
+
+- [ ] **Step 1: Update the context helper test to reject `service`**
+
+In `tests/services/accounts/apiServiceRequest.test.ts`, remove:
+
+```ts
+import { getApiService } from "~/services/apiService"
+```
+
+Remove the `vi.mock("~/services/apiService", ...)` block.
+
+In the `beforeEach`, remove the `service` local variable and these calls:
+
+```ts
+vi.mocked(getApiService).mockReset()
+vi.mocked(getApiService).mockReturnValue(service as any)
+```
+
+Make the key-management mock include all required methods:
+
+```ts
+let updateToken: ReturnType<typeof vi.fn>
+let deleteToken: ReturnType<typeof vi.fn>
+let fetchUserGroups: ReturnType<typeof vi.fn>
+let fetchAvailableModels: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchTokens = vi.fn()
+  createToken = vi.fn()
+  updateToken = vi.fn()
+  resolveTokenKey = vi.fn()
+  deleteToken = vi.fn()
+  fetchUserGroups = vi.fn()
+  fetchAvailableModels = vi.fn()
+  keyManagement = {
+    fetchTokens,
+    createToken,
+    updateToken,
+    resolveTokenKey,
+    deleteToken,
+    fetchUserGroups,
+    fetchAvailableModels,
+  }
+  adapter = { siteType: "new-api", keyManagement }
+
+  vi.mocked(getSiteAdapter).mockReset()
+  vi.mocked(getSiteAdapter).mockReturnValue(adapter as any)
+})
+```
+
+Replace the context assertion in `returns the token array when the API payload is valid` with:
+
+```ts
+expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual({
+  adapter,
+  keyManagement,
+  request: expect.objectContaining(REQUEST),
+})
+expect(createDisplayAccountApiContext(ACCOUNT as any)).not.toHaveProperty(
+  "service",
+)
+```
+
+- [ ] **Step 2: Run the helper test and confirm it fails**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected result: FAIL because `createDisplayAccountApiContext(...)` still returns `service`.
+
+- [ ] **Step 3: Remove the service escape hatch**
+
+In `src/services/accounts/utils/apiServiceRequest.ts`, remove:
+
+```ts
+import { getApiService } from "~/services/apiService"
+```
+
+Replace the return value in `createDisplayAccountApiContext(...)`:
+
+```ts
+  return {
+    service: getApiService(account.siteType),
+    adapter,
+    keyManagement: adapter.keyManagement,
+    request: withDisplayAccountAuthSession(
+      account,
+      buildApiRequestFromDisplayAccount(account),
+    ),
+  }
+```
+
+with:
+
+```ts
+  return {
+    adapter,
+    keyManagement: adapter.keyManagement,
+    request: withDisplayAccountAuthSession(
+      account,
+      buildApiRequestFromDisplayAccount(account),
+    ),
+  }
+```
+
+- [ ] **Step 4: Run the helper test and compile**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts
+pnpm compile
+```
+
+Expected result: both commands PASS. If `pnpm compile` finds another product caller destructuring `service`, migrate that caller only if it is an account-mainline token lifecycle path; otherwise stop and classify it against the spec non-goals.
+
+- [ ] **Step 5: Run the service escape-hatch cleanup check**
+
+Run:
+
+```powershell
+rg "createDisplayAccountApiContext\(.*service|service.*createDisplayAccountApiContext" src/features src/components src/services/accounts
+```
+
+Expected result: no output.
+
+- [ ] **Step 6: Commit helper cleanup**
+
+Run:
+
+```powershell
+git add src/services/accounts/utils/apiServiceRequest.ts tests/services/accounts/apiServiceRequest.test.ts
+git commit -m "refactor(accounts): remove display account service escape hatch"
+```
+
+Expected result: commit succeeds and the hook passes staged validation for the touched files.
+
+---
+
+### Task 5: Add Root Facade ESLint Guardrail
+
+**Files:**
+
+- Modify `eslint.config.js`
+
+- [ ] **Step 1: Add the root facade import pattern**
+
+In `eslint.config.js`, add this constant after `apiServiceBackendImplementationImportPattern`:
+
+```js
+const accountSiteMainlineApiServiceFacadeImportPattern = {
+  regex: "^(?:~/services/apiService|(?:\\.\\./){1,6}(?:services/)?apiService)$",
+  message:
+    "Account-site product flows must use ~/services/apiAdapters or account workflow helpers instead of the legacy apiService facade.",
+}
+```
+
+- [ ] **Step 2: Add the account-mainline config block**
+
+Add this block after the existing backend-specific apiService guard and before the AI API protocol guard:
+
+```js
+  // Guardrails: account-mainline product flows must not import the legacy apiService facade.
+  {
+    files: [
+      "src/features/AccountManagement/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/features/KeyManagement/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/features/ModelList/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/components/dialogs/VerifyApiDialog/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/components/dialogs/VerifyCliSupportDialog/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/components/KiloCodeExportDialog.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/services/accounts/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            accountSiteMainlineApiServiceFacadeImportPattern,
+          ],
+        },
+      ],
+    },
+  },
+```
+
+Do not duplicate `apiServiceBackendImplementationImportPattern` in this block.
+The existing backend-specific guard already applies to these account-mainline
+paths because they are not in its `ignores`. This task only closes the missing
+root facade path. Do not include `~/services/apiService/common/**` in the
+restricted pattern. Shared DTOs, token key normalizers, and common error types
+remain allowed in this slice.
+
+- [ ] **Step 3: Run ESLint for the guarded surfaces**
+
+Run:
+
+```powershell
+pnpm exec eslint eslint.config.js src/services/accounts src/features/KeyManagement src/features/ModelList src/features/AccountManagement src/components/dialogs/VerifyApiDialog src/components/dialogs/VerifyCliSupportDialog src/components/KiloCodeExportDialog.tsx
+```
+
+Expected result: PASS. If ESLint reports a root `~/services/apiService`
+account-mainline import, migrate that import to an adapter/workflow helper if it
+is token lifecycle behavior. If it belongs to a spec non-goal, narrow the
+guarded file glob and document the exception in the config comment. If the
+existing backend-specific guard reports an implementation import such as
+`~/services/apiService/sub2api`, route it through an adapter; do not add a
+second backend-specific pattern to this new block.
+
+- [ ] **Step 4: Run migration completeness checks**
+
+Run:
+
+```powershell
+rg "getApiService\(" src/features src/components src/services/accounts
+rg "service\.(createApiToken|updateApiToken|deleteApiToken|fetchAccountTokens|fetchUserGroups|fetchAccountAvailableModels)" src/features src/components src/services/accounts
+rg "from \"~/services/apiService\"|from \"~/services/apiService/(aihubmix|anyrouter|axonHub|claudeCodeHub|doneHub|octopus|oneHub|sub2api|veloera|wong)" src/features/AccountManagement src/features/KeyManagement src/features/ModelList src/components src/services/accounts
+```
+
+Expected result: no account-mainline hits. Hits under managed-site/modelSync/redemption are outside these command targets or are explicitly non-goals.
+
+- [ ] **Step 5: Commit lint guard**
+
+Run:
+
+```powershell
+git add eslint.config.js
+git commit -m "chore(eslint): guard account site service facade"
+```
+
+Expected result: commit succeeds and the hook passes staged validation for `eslint.config.js`.
+
+---
+
+### Task 6: Final Validation And Scope Audit
+
+**Files:**
+
+- Verify all task-scoped files from Tasks 1-5
+- No new implementation files expected
+
+- [ ] **Step 1: Run focused test suite**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/accounts/apiServiceRequest.test.ts tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+```
+
+Expected result: PASS.
+
+- [ ] **Step 2: Run boundary validation**
+
+Run:
+
+```powershell
+pnpm exec eslint eslint.config.js src/services/accounts src/features/KeyManagement src/features/ModelList src/features/AccountManagement src/components/dialogs/VerifyApiDialog src/components/dialogs/VerifyCliSupportDialog src/components/KiloCodeExportDialog.tsx
+```
+
+Expected result: PASS.
+
+- [ ] **Step 3: Run TypeScript validation**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected result: PASS.
+
+- [ ] **Step 4: Run cleanup checks**
+
+Run:
+
+```powershell
+rg "getApiService\(" src/features src/components src/services/accounts
+rg "service\.(createApiToken|updateApiToken|deleteApiToken|fetchAccountTokens|fetchUserGroups|fetchAccountAvailableModels)" src/features src/components src/services/accounts
+rg "createDisplayAccountApiContext\(.*service|service.*createDisplayAccountApiContext" src/features src/components src/services/accounts
+rg "from \"~/services/apiService\"|from \"~/services/apiService/(aihubmix|anyrouter|axonHub|claudeCodeHub|doneHub|octopus|oneHub|sub2api|veloera|wong)" src/features/AccountManagement src/features/KeyManagement src/features/ModelList src/components src/services/accounts
+```
+
+Expected result: no output for all four commands.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```powershell
+git status --porcelain=v1 -b
+git diff --stat HEAD
+git diff HEAD -- src/services/apiAdapters/contracts/keyManagement.ts src/services/apiAdapters/newApi/keyManagement.ts src/services/apiAdapters/sub2api/keyManagement.ts src/services/apiAdapters/aihubmix/keyManagement.ts src/services/accounts/utils/apiServiceRequest.ts src/features/KeyManagement/components/AddTokenDialog/index.tsx src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts eslint.config.js
+```
+
+Expected result: only task-scoped files are modified. Existing unrelated untracked files may remain and must not be staged.
+
+- [ ] **Step 6: Run staged validation**
+
+If there are task-scoped changes left after the last commit, stage only those files and run:
+
+```powershell
+pnpm run validate:staged
+```
+
+Expected result: PASS. If lint-staged modifies files, inspect `git diff` and commit only task-scoped changes.
+
+- [ ] **Step 7: Run pre-push validation before PR or push**
+
+Because this slice changes ESLint config and shared TypeScript contracts, run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected result: PASS. If `knip` reports unused exports after the interface migration, remove only the stale exports proven unused by the report and rerun `pnpm run validate:push`.
+
+- [ ] **Step 8: Final commit if validation changed files**
+
+If Task 6 produced formatting or export-hygiene fixes, commit them:
+
+```powershell
+git add eslint.config.js src/services/apiAdapters/contracts/keyManagement.ts src/services/apiAdapters/newApi/keyManagement.ts src/services/apiAdapters/sub2api/keyManagement.ts src/services/apiAdapters/aihubmix/keyManagement.ts src/services/accounts/utils/apiServiceRequest.ts src/features/KeyManagement/components/AddTokenDialog/index.tsx src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts tests/services/apiAdapters/keyManagement.test.ts tests/services/accounts/apiServiceRequest.test.ts tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+git commit -m "chore: finish account site adapter boundary validation"
+```
+
+Expected result: commit succeeds. If no files changed, do not create an empty commit.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - `KeyManagementCapability.updateToken` is covered by Task 1.
+  - Add Token edit-mode adapter routing is covered by Task 2.
+  - Model Key default create adapter routing is covered by Task 3.
+  - Removing `createDisplayAccountApiContext(...).service` is covered by Task 4.
+  - ESLint root facade guardrail is covered by Task 5; backend-specific imports remain covered by the existing guard.
+  - Cleanup checks, compile, staged validation, and pre-push validation are covered by Task 6.
+- Placeholder scan:
+  - No unresolved placeholders, deferred implementation notes, or "fill in later" steps.
+- Type consistency:
+  - The plan uses `UpdateTokenRequest`, `updateToken`, `tokenId`, and `tokenData` consistently across tests, contracts, adapters, and product callers.

--- a/docs/superpowers/specs/2026-06-19-account-site-adapter-boundary-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-19-account-site-adapter-boundary-hardening-design.md
@@ -1,0 +1,571 @@
+# Account Site Adapter Boundary Hardening Design
+
+Date: 2026-06-19
+
+## Purpose
+
+Prepare the account-site layer for faster future site-type onboarding by
+turning the recent adapter migration work into enforceable layering rules.
+
+Recent slices moved account-site detection metadata, content-session
+extraction, account bootstrap, account completion, account data, account
+refresh, model pricing, and most key-management lifecycle operations behind
+`getSiteAdapter(siteType)`. Those changes make the Adapter Seam real for
+account-site behavior. The next step is not to add a new site type. It is to
+close the remaining account-mainline escape hatches back to the legacy
+`getApiService(...)` facade and add lint guardrails so new account-site work
+defaults to adapters.
+
+This spec defines a boundary-hardening slice for account-site product flows.
+It intentionally keeps managed-site operations, model sync, redemption, and
+backend implementation modules on their existing paths until those areas get
+their own migration specs.
+
+## Current Context
+
+The current `SiteAdapter` Interface exposes account-site capabilities:
+
+```ts
+type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  modelPricing?: ModelPricingCapability
+  accountData?: AccountDataCapability
+  accountBootstrap?: AccountBootstrapCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+}
+```
+
+The current `KeyManagementCapability` Interface already covers most token
+lifecycle behavior:
+
+```ts
+type KeyManagementCapability = {
+  fetchTokens(request, options?): Promise<ApiToken[]>
+  createToken(request, tokenData): Promise<CreateTokenResult>
+  resolveTokenKey({ request, token }): Promise<string>
+  deleteToken({ request, tokenId }): Promise<boolean | void>
+  fetchUserGroups(request): Promise<Record<string, UserGroupInfo>>
+  fetchAvailableModels(request): Promise<string[]>
+}
+```
+
+One important token lifecycle operation is still missing from the Adapter
+Interface:
+
+- `updateApiToken(request, tokenId, tokenData)`
+
+That gap keeps account UI code dependent on the legacy service facade.
+
+The transitional helper
+`src/services/accounts/utils/apiServiceRequest.ts#createDisplayAccountApiContext`
+currently returns both the new adapter context and the legacy service:
+
+```ts
+{
+  service: getApiService(account.siteType),
+  adapter,
+  keyManagement: adapter.keyManagement,
+  request,
+}
+```
+
+Most account flows now use `keyManagement`, but two account-mainline token
+paths still use the returned `service`:
+
+- `src/features/KeyManagement/components/AddTokenDialog/index.tsx`
+  - edit mode calls `service.updateApiToken(...)`
+- `src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts`
+  - default-key creation calls `service.createApiToken(...)`
+
+Existing ESLint guardrails already prevent product code from importing
+backend-specific `apiService` implementations directly:
+
+```js
+const apiServiceBackendImplementationImportPattern = {
+  regex:
+    "^(?:~/services/apiService|(?:\\.\\./){1,4}apiService)/(?:aihubmix|anyrouter|axonHub|claudeCodeHub|doneHub|octopus|oneHub|sub2api|veloera|wong)$",
+  message:
+    "Do not import backend-specific apiService implementations from product code. Add or use an adapter/workflow module instead.",
+}
+```
+
+That guard is useful, but it is not enough. Account product Modules can still
+reach the broad legacy facade through `createDisplayAccountApiContext(...).service`
+or by importing the root `~/services/apiService` module.
+
+## Problem
+
+The adapter migration has reached the point where the remaining risk is no
+longer missing capability coverage alone. The risk is that future account-site
+work can accidentally bypass the Adapter Seam because the old facade is still
+available in account product code.
+
+Current friction:
+
+1. `createDisplayAccountApiContext(...)` is a shallow Interface because it
+   exposes both the preferred adapter context and the legacy `service`
+   implementation detail.
+2. Token edit still requires `service.updateApiToken(...)` even though token
+   create/list/delete/group/model behavior already sits behind
+   `keyManagement`.
+3. Model List default-key creation bypasses `keyManagement.createToken(...)`,
+   so a new site type could work in Key Management but fail from the model
+   key dialog.
+4. Existing lint rules prevent direct backend-specific imports but do not
+   enforce account-mainline dependency direction.
+5. Legacy exceptions are implicit. Managed-site operations, model sync, and
+   redemption still need `getApiService(...)`, but they are not named as
+   temporary exceptions to the account-site adapter rule.
+
+Deletion test: if `service` were removed from
+`createDisplayAccountApiContext(...)`, account-mainline token workflows should
+not recreate the legacy dependency elsewhere. They should either use
+`SiteAdapter.keyManagement` or fail at compile time until the narrow Adapter
+Interface is deepened.
+
+## Goals
+
+- Deepen `KeyManagementCapability` with token update support:
+  - `updateToken({ request, tokenId, tokenData }): Promise<boolean | void>`
+- Route account-mainline token create and edit flows through
+  `getSiteAdapter(siteType).keyManagement`.
+- Remove the legacy `service` property from
+  `createDisplayAccountApiContext(...)`.
+- Keep `createDisplayAccountApiContext(...)` as the account-scoped request
+  builder and adapter resolver:
+  - `adapter`
+  - `keyManagement`
+  - auth-session-decorated `request`
+- Add ESLint guardrails that make account-mainline code depend on adapters
+  rather than the root `apiService` facade.
+- Name the temporary legacy exception zones explicitly so future work does not
+  infer that new account-site features should extend them.
+- Preserve current behavior for:
+  - Add Token edit mode
+  - Model List default-key creation
+  - AIHubMix one-time key behavior
+  - Sub2API auth-session request decoration
+  - compatible New API-family update/create token behavior
+  - token cache invalidation in existing backend implementations
+- Add focused tests that make `keyManagement` the test surface for account
+  token create/edit paths.
+
+## Non-Goals
+
+- Do not add a new account site type in this slice.
+- Do not remove `getApiService(...)` globally.
+- Do not migrate managed-site channel CRUD, managed-site providers,
+  managed-site model sync, or hosted-site settings.
+- Do not migrate `src/services/redemption/redeemService.ts`.
+- Do not migrate pricing assembly, API credential profile model catalog
+  estimation, or Sub2API estimated pricing.
+- Do not redesign Account Dialog UI policy for Sub2API, AIHubMix, cookie auth,
+  check-in controls, or one-time-key display.
+- Do not move account-site domain types out of
+  `src/services/apiService/common/type.ts` unless token update typing requires
+  a narrow alias.
+- Do not change user-facing copy, locale keys, telemetry schema, settings
+  search entries, or Playwright E2E tests.
+
+## Approaches Considered
+
+### Approach A: Keep The Transitional Service Property
+
+This keeps the implementation tiny because callers can continue to destructure
+`service` when an adapter method is missing.
+
+This should not be the next step. The helper becomes a permanent backdoor from
+account product Modules to the legacy facade. New site-type work would keep
+requiring contributors to know both the Adapter Interface and the legacy
+service method map.
+
+### Approach B: Only Add `updateToken` To `keyManagement`
+
+This fixes Add Token edit mode but leaves the broader layering issue in place.
+`ModelKeyDialog` could still create tokens through `service.createApiToken`, and
+future product code could still reach for `service` from the transitional
+helper.
+
+This is useful but incomplete.
+
+### Approach C: Deepen `keyManagement` And Harden The Account Boundary
+
+Add the missing token update method, migrate the remaining account-mainline
+token create/edit call sites, remove `service` from the display-account
+context helper, and add lint guardrails for account-mainline imports.
+
+This is the recommended path. It turns the recent migration into a stronger
+Interface, improves locality for future site-type token behavior, and makes
+the preferred path enforceable.
+
+## Design
+
+### 1. Deepen `KeyManagementCapability`
+
+Update:
+
+```text
+src/services/apiAdapters/contracts/keyManagement.ts
+```
+
+Add:
+
+```ts
+export type UpdateTokenRequest = {
+  request: ApiServiceRequest
+  tokenId: number
+  tokenData: CreateTokenRequest
+}
+
+export type KeyManagementCapability = {
+  fetchTokens(...)
+  createToken(...)
+  updateToken(request: UpdateTokenRequest): Promise<boolean | void>
+  resolveTokenKey(...)
+  deleteToken(...)
+  fetchUserGroups(...)
+  fetchAvailableModels(...)
+}
+```
+
+`CreateTokenRequest` can remain the token form payload type for both create
+and update in this slice because the existing legacy implementations already
+use that shape for `updateApiToken(...)`.
+
+Adapter implementations should map the new method to the existing backend
+behavior:
+
+- `src/services/apiAdapters/newApi/keyManagement.ts`
+  - `getApiService(siteType).updateApiToken(request, tokenId, tokenData)`
+- `src/services/apiAdapters/sub2api/keyManagement.ts`
+  - `updateApiToken(request, tokenId, tokenData)`
+- `src/services/apiAdapters/aihubmix/keyManagement.ts`
+  - `updateApiToken(request, tokenId, tokenData)`
+
+Do not add product-level branching for site-specific token update quirks. If a
+site needs different update behavior, it belongs in that site's
+`keyManagement` Adapter.
+
+### 2. Remove Legacy `service` From Display Account Context
+
+Update:
+
+```text
+src/services/accounts/utils/apiServiceRequest.ts
+```
+
+The helper should stop importing `getApiService` and return only the adapter
+context used by account-mainline flows:
+
+```ts
+return {
+  adapter,
+  keyManagement: adapter.keyManagement,
+  request: withDisplayAccountAuthSession(
+    account,
+    buildApiRequestFromDisplayAccount(account),
+  ),
+}
+```
+
+Keep `buildApiRequestFromDisplayAccount(...)` and
+`withDisplayAccountAuthSession(...)` behavior unchanged. Sub2API auth-session
+decoration is part of why this helper should stay as the display-account
+request builder.
+
+### 3. Migrate Account-Mainline Token Call Sites
+
+Migrate Add Token edit mode:
+
+```text
+src/features/KeyManagement/components/AddTokenDialog/index.tsx
+```
+
+Current behavior:
+
+```ts
+await service.updateApiToken(request, editingToken.id, tokenData)
+```
+
+Target behavior:
+
+```ts
+await requireDisplayAccountKeyManagement(
+  currentAccount,
+  keyManagement,
+).updateToken({
+  request,
+  tokenId: editingToken.id,
+  tokenData,
+})
+```
+
+Preserve the current edit-mode success toast, analytics result handling, and
+error handling. The migration should only change the backend Seam used by the
+operation.
+
+Migrate Model List default-key creation:
+
+```text
+src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+```
+
+Current behavior:
+
+```ts
+const created = await service.createApiToken(request, tokenRequest)
+```
+
+Target behavior:
+
+```ts
+const created = await requireDisplayAccountKeyManagement(
+  account,
+  keyManagement,
+).createToken(request, tokenRequest)
+```
+
+Preserve:
+
+- group-required validation
+- `canCreateToken` gating
+- `generateDefaultTokenRequest()` output
+- token refresh after create
+- error logging payload
+- user-facing fallback error message
+
+### 4. Explicit Legacy Exception Zones
+
+The lint rule should not pretend the whole repository is ready to stop using
+`getApiService(...)`.
+
+Allowed exception zones for this slice:
+
+- `src/services/apiService/**`
+  - backend implementation and legacy facade owner
+- `src/services/apiAdapters/**`
+  - adapters may wrap legacy backend functions until backend implementations
+    are decomposed further
+- `src/services/apiCredentialProfiles/**`
+  - model catalog and estimated pricing still have their own migration path
+- `src/services/checkin/autoCheckin/**`
+  - background check-in orchestration is outside this account-mainline slice
+- `src/services/managedSites/**`
+  - managed-site channel operations use a separate provider/service Seam
+- `src/services/models/modelSync/**`
+  - managed-site model sync remains a managed-site concern
+- `src/features/BasicSettings/components/tabs/ManagedSite/**`
+  - hosted-site settings remain tied to managed-site service behavior
+- `src/services/redemption/**`
+  - redemption will need its own Adapter capability or workflow owner spec
+
+These exceptions are deliberately named. They are not endorsement for new
+account-site product code to keep using `apiService`.
+
+### 5. Add Account-Mainline Lint Guardrails
+
+Update:
+
+```text
+eslint.config.js
+```
+
+Reuse the existing backend-specific `apiService` import guard. Account-mainline
+paths are not in that guard's current `ignores`, so direct imports such as
+`~/services/apiService/sub2api` and `~/services/apiService/aihubmix` are already
+blocked there.
+
+Add only the missing guard for the root account-site service facade in
+account-mainline product areas. Do not reject shared account-site contract
+modules such as `~/services/apiService/common/type`,
+`~/services/apiService/common/apiKey`, or `~/services/apiService/common/errors`
+in this slice; those are still shared domain/transport contracts used by the
+adapter path.
+
+Suggested scope:
+
+```js
+{
+  files: [
+    "src/features/AccountManagement/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+    "src/features/KeyManagement/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+    "src/features/ModelList/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+    "src/components/dialogs/VerifyApiDialog/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+    "src/components/dialogs/VerifyCliSupportDialog/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+    "src/components/KiloCodeExportDialog.{js,cjs,mjs,jsx,ts,tsx}",
+    "src/services/accounts/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+  ],
+  rules: {
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: [
+              "~/services/apiService",
+              "../apiService",
+              "../../apiService",
+              "../../../apiService",
+            ],
+            message:
+              "Account-site product flows must use ~/services/apiAdapters or account workflow helpers instead of the legacy apiService facade.",
+          },
+        ],
+      },
+    ],
+  },
+}
+```
+
+The exact glob list can be adjusted during implementation if ESLint flat-config
+matching needs narrower entries. The rule should be proven by linting the
+affected files and by confirming no account-mainline imports from the root
+facade remain. The existing backend-specific guard should continue proving that
+account-mainline code cannot import backend implementation modules directly.
+Imports from `apiService/common/**` remain allowed until shared account-site
+DTOs and normalizers get a separate ownership cleanup.
+
+This import guard is preferable to an AST rule for
+`createDisplayAccountApiContext(...).service` because removing `service` from
+the helper makes that escape hatch a TypeScript error. If implementation finds
+another service-returning account helper, add the narrowest lint rule or helper
+change needed to close that specific path.
+
+### 6. Tests
+
+Update existing focused tests rather than adding broad E2E coverage.
+
+Recommended test surfaces:
+
+- `tests/services/apiAdapters/keyManagement.test.ts`
+  - `newApi`, Sub2API, and AIHubMix adapters expose `updateToken(...)`
+  - each adapter delegates to the expected backend update function
+- `tests/services/accounts/apiServiceRequest.test.ts`
+  - `createDisplayAccountApiContext(...)` returns `adapter`,
+    `keyManagement`, and auth-session-decorated `request`
+  - it no longer exposes `service`
+- Add Token dialog tests under `tests/entrypoints/options/pages/KeyManagement/`
+  - edit mode calls `keyManagement.updateToken(...)`
+  - create mode still calls `keyManagement.createToken(...)`
+- Model Key dialog tests under `tests/entrypoints/options/pages/ModelList/`
+  - default-key creation calls `keyManagement.createToken(...)`
+  - missing `keyManagement` still produces the existing unsupported behavior
+
+Tests should mock `getSiteAdapter(...)` and the `keyManagement` Interface
+instead of mocking `getApiService(...)` for these account-mainline paths.
+
+## Migration Completeness Checks
+
+Run these cleanup checks during implementation:
+
+```powershell
+rg "getApiService\(" src/features src/components src/services/accounts
+rg "service\.(createApiToken|updateApiToken|deleteApiToken|fetchAccountTokens|fetchUserGroups|fetchAccountAvailableModels)" src/features src/components src/services/accounts
+rg "from \"~/services/apiService\"|from \"~/services/apiService/(aihubmix|anyrouter|axonHub|claudeCodeHub|doneHub|octopus|oneHub|sub2api|veloera|wong)" src/features/AccountManagement src/features/KeyManagement src/features/ModelList src/components src/services/accounts
+rg "createDisplayAccountApiContext\(.*service|service.*createDisplayAccountApiContext" src/features src/components src/services/accounts
+```
+
+Expected result:
+
+- No account-mainline hits for `getApiService(...)`.
+- No account-mainline hits for token lifecycle calls through a `service`
+  object.
+- No account-mainline imports from the root `~/services/apiService` facade or
+  backend-specific implementation modules.
+- Managed-site, model sync, redemption, and adapter/backend implementation
+  hits may remain in their explicitly allowed zones.
+
+## Validation Plan
+
+Focused validation:
+
+```powershell
+pnpm exec vitest related --run src/services/apiAdapters/contracts/keyManagement.ts src/services/accounts/utils/apiServiceRequest.ts src/features/KeyManagement/components/AddTokenDialog/index.tsx src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+```
+
+Boundary validation:
+
+```powershell
+pnpm exec eslint eslint.config.js src/services/accounts src/features/KeyManagement src/features/ModelList src/features/AccountManagement src/components/dialogs/VerifyApiDialog src/components/dialogs/VerifyCliSupportDialog src/components/KiloCodeExportDialog.tsx
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Run `pnpm run validate:push` before pushing or opening a PR if the
+implementation changes export wiring, lint config behavior, or shared runtime
+contracts in a way that could affect unused exports or compile-wide type
+relationships.
+
+## E2E And Telemetry Decisions
+
+E2E decision: no Playwright E2E should be added for this slice. The behavior
+risk is adapter routing, helper shape, TypeScript coverage, and ESLint
+enforcement. Focused Vitest, TypeScript, and ESLint checks are the right
+coverage layer.
+
+Telemetry decision: none. This is an internal architecture hardening refactor.
+It does not add a new user-visible action, setting, async background flow,
+confirmation path, or result event.
+
+## Risks And Mitigations
+
+Risk: `updateToken(...)` may hide important per-site update semantics behind a
+generic-looking method.
+
+Mitigation: keep the Interface narrow to the existing token form payload and
+put site-specific translation in each Adapter. Do not add product-level
+site-type branches for update behavior.
+
+Risk: the new ESLint guard may catch legitimate legacy areas.
+
+Mitigation: scope the rule to account-mainline product areas first and keep the
+known legacy exception zones explicit. If a caught import is truly managed-site
+or redemption behavior, move it out of the guarded glob or add a narrow
+exception with a comment that names the future migration owner.
+
+Risk: removing `service` from `createDisplayAccountApiContext(...)` may reveal
+additional unplanned account product dependencies.
+
+Mitigation: treat each compile error as a boundary decision. If the behavior is
+account-token lifecycle, deepen or use `keyManagement`. If it belongs to
+redemption, managed-site, or another non-goal area, do not migrate it in this
+slice; route through its current owner outside the guarded account-mainline
+surface.
+
+Risk: tests may continue to mock the old facade even after production code is
+migrated.
+
+Mitigation: update account-mainline tests to mock `getSiteAdapter(...)` and
+`KeyManagementCapability`; use `rg` cleanup checks for stale
+`getApiService(...)` mocks in the migrated files.
+
+## Implementation Notes
+
+- This slice should be one reviewable refactor PR, not multiple small
+  capability PRs.
+- The preferred implementation order is:
+  1. Add failing tests for `updateToken` and no-service display context.
+  2. Add `updateToken` to the Interface and Adapters.
+  3. Migrate Add Token edit mode and Model Key default creation.
+  4. Remove `service` from `createDisplayAccountApiContext(...)`.
+  5. Add the account-mainline lint guard.
+  6. Run cleanup `rg` checks, focused tests, ESLint, compile, and staged
+     validation.
+- Do not broaden the slice into managed-site or redemption migration even if
+  `rg getApiService(...)` still reports those files.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -68,6 +68,12 @@ const apiServiceBackendImplementationImportPattern = {
   message:
     "Do not import backend-specific apiService implementations from product code. Add or use an adapter/workflow module instead.",
 }
+const accountSiteMainlineApiServiceFacadeImportPattern = {
+  regex:
+    "^(?:~/services/apiService|(?:\\.\\./){1,6}(?:services/)?apiService)(?:/index)?$",
+  message:
+    "Account-site product flows must use ~/services/apiAdapters or account workflow helpers instead of the legacy apiService facade.",
+}
 
 export default defineConfig([
   {
@@ -272,6 +278,31 @@ export default defineConfig([
         "error",
         {
           patterns: [apiServiceBackendImplementationImportPattern],
+        },
+      ],
+    },
+  },
+  // Guardrails: account-mainline product flows must not import the legacy apiService facade.
+  // ESLint flat config replaces rule options for narrower matches, so this block
+  // restates the backend implementation guard instead of relying on option merging.
+  {
+    files: [
+      "src/features/AccountManagement/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/features/KeyManagement/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/features/ModelList/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/components/dialogs/VerifyApiDialog/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/components/dialogs/VerifyCliSupportDialog/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/components/KiloCodeExportDialog.{js,cjs,mjs,jsx,ts,tsx}",
+      "src/services/accounts/**/*.{js,cjs,mjs,jsx,ts,tsx}",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            apiServiceBackendImplementationImportPattern,
+            accountSiteMainlineApiServiceFacadeImportPattern,
+          ],
         },
       ],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,7 +70,7 @@ const apiServiceBackendImplementationImportPattern = {
 }
 const accountSiteMainlineApiServiceFacadeImportPattern = {
   regex:
-    "^(?:~/services/apiService|(?:\\.\\./){1,6}(?:services/)?apiService)(?:/index)?$",
+    "^(?:~/services/apiService|(?:\\.\\./)+(?:services/)?apiService)(?:/index)?$",
   message:
     "Account-site product flows must use ~/services/apiAdapters or account workflow helpers instead of the legacy apiService facade.",
 }

--- a/src/features/KeyManagement/components/AddTokenDialog/index.tsx
+++ b/src/features/KeyManagement/components/AddTokenDialog/index.tsx
@@ -182,11 +182,18 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
         allow_ips: formData.allowIps.trim() || "",
         group: formData.group,
       }
-      const { keyManagement, request, service } =
+      const { keyManagement, request } =
         createDisplayAccountApiContext(currentAccount)
 
       if (isEditMode && editingToken) {
-        await service.updateApiToken(request, editingToken.id, tokenData)
+        await requireDisplayAccountKeyManagement(
+          currentAccount,
+          keyManagement,
+        ).updateToken({
+          request,
+          tokenId: editingToken.id,
+          tokenData,
+        })
         toast.success(t("dialog.updateSuccess"))
       } else {
         const created = await requireDisplayAccountKeyManagement(

--- a/src/features/KeyManagement/components/AddTokenDialog/index.tsx
+++ b/src/features/KeyManagement/components/AddTokenDialog/index.tsx
@@ -186,7 +186,7 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
         createDisplayAccountApiContext(currentAccount)
 
       if (isEditMode && editingToken) {
-        await requireDisplayAccountKeyManagement(
+        const updated = await requireDisplayAccountKeyManagement(
           currentAccount,
           keyManagement,
         ).updateToken({
@@ -194,6 +194,9 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
           tokenId: editingToken.id,
           tokenData,
         })
+        if (updated === false) {
+          throw new Error(t("dialog.updateFailed"))
+        }
         toast.success(t("dialog.updateSuccess"))
       } else {
         const created = await requireDisplayAccountKeyManagement(

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -9,6 +9,7 @@ import {
   createDisplayAccountApiContext,
   fetchDisplayAccountTokens,
   InvalidTokenPayloadError,
+  requireDisplayAccountKeyManagement,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
@@ -330,10 +331,14 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
       setCreateError(null)
 
       try {
-        const { service, request } = createDisplayAccountApiContext(account)
+        const { keyManagement, request } =
+          createDisplayAccountApiContext(account)
         const tokenRequest = generateDefaultTokenRequest()
         tokenRequest.group = normalizedGroup
-        const created = await service.createApiToken(request, tokenRequest)
+        const created = await requireDisplayAccountKeyManagement(
+          account,
+          keyManagement,
+        ).createToken(request, tokenRequest)
         if (!created) {
           throw new Error("create_token_failed")
         }

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -2,7 +2,6 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
-import { getApiService } from "~/services/apiService"
 import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import type { ApiServiceRequest } from "~/services/apiService/common/type"
 import type { Sub2ApiAuthSessionRequest } from "~/services/apiService/sub2api/authSession"
@@ -90,7 +89,7 @@ const withDisplayAccountAuthSession = (
 }
 
 /**
- * Resolve both the site-specific service and its request DTO for a display account.
+ * Resolve the site adapter and request DTO for a display account.
  */
 export const createDisplayAccountApiContext = (
   account: Pick<
@@ -107,7 +106,6 @@ export const createDisplayAccountApiContext = (
   const adapter = getSiteAdapter(account.siteType)
 
   return {
-    service: getApiService(account.siteType),
     adapter,
     keyManagement: adapter.keyManagement,
     request: withDisplayAccountAuthSession(

--- a/src/services/apiAdapters/aihubmix/keyManagement.ts
+++ b/src/services/apiAdapters/aihubmix/keyManagement.ts
@@ -6,11 +6,14 @@ import {
   fetchAccountTokens,
   fetchUserGroups,
   resolveApiTokenKey,
+  updateApiToken,
 } from "~/services/apiService/aihubmix"
 
 export const aihubmixKeyManagement: KeyManagementCapability = {
   fetchTokens: (request) => fetchAccountTokens(request),
   createToken: (request, tokenData) => createApiToken(request, tokenData),
+  updateToken: ({ request, tokenId, tokenData }) =>
+    updateApiToken(request, tokenId, tokenData),
   resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
   deleteToken: ({ request, tokenId }) => deleteApiToken(request, tokenId),
   // Preserve AIHubMix's explicit FEATURE_UNSUPPORTED group-inventory contract.

--- a/src/services/apiAdapters/contracts/keyManagement.ts
+++ b/src/services/apiAdapters/contracts/keyManagement.ts
@@ -23,6 +23,12 @@ export type DeleteTokenRequest = {
   tokenId: number
 }
 
+export type UpdateTokenRequest = {
+  request: ApiServiceRequest
+  tokenId: number
+  tokenData: CreateTokenRequest
+}
+
 export type KeyManagementCapability = {
   fetchTokens(
     request: ApiServiceRequest,
@@ -32,6 +38,7 @@ export type KeyManagementCapability = {
     request: ApiServiceRequest,
     tokenData: CreateTokenRequest,
   ): Promise<CreateTokenResult>
+  updateToken(request: UpdateTokenRequest): Promise<boolean | void>
   resolveTokenKey<TToken extends Pick<ApiToken, "id" | "key">>(
     request: ResolveTokenSecretRequest<TToken>,
   ): Promise<string>

--- a/src/services/apiAdapters/newApi/keyManagement.ts
+++ b/src/services/apiAdapters/newApi/keyManagement.ts
@@ -17,6 +17,8 @@ export function createNewApiKeyManagement(
       ),
     createToken: (request, tokenData) =>
       getApiService(siteType).createApiToken(request, tokenData),
+    updateToken: ({ request, tokenId, tokenData }) =>
+      getApiService(siteType).updateApiToken(request, tokenId, tokenData),
     resolveTokenKey: ({ request, token }) =>
       getApiService(siteType).resolveApiTokenKey(request, token),
     deleteToken: ({ request, tokenId }) =>

--- a/src/services/apiAdapters/sub2api/keyManagement.ts
+++ b/src/services/apiAdapters/sub2api/keyManagement.ts
@@ -6,12 +6,15 @@ import {
   fetchAccountTokens,
   fetchUserGroups,
   resolveApiTokenKey,
+  updateApiToken,
 } from "~/services/apiService/sub2api"
 
 export const sub2ApiKeyManagement: KeyManagementCapability = {
   fetchTokens: (request, options) =>
     fetchAccountTokens(request, options?.page, options?.size),
   createToken: (request, tokenData) => createApiToken(request, tokenData),
+  updateToken: ({ request, tokenId, tokenData }) =>
+    updateApiToken(request, tokenId, tokenData),
   resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
   deleteToken: ({ request, tokenId }) => deleteApiToken(request, tokenId),
   fetchUserGroups: (request) => fetchUserGroups(request),

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -27,6 +27,7 @@ import {
 const {
   createApiTokenMock,
   updateApiTokenMock,
+  updateTokenMock,
   fetchAccountAvailableModelsMock,
   fetchUserGroupsMock,
   startProductAnalyticsActionMock,
@@ -37,6 +38,7 @@ const {
 } = vi.hoisted(() => ({
   createApiTokenMock: vi.fn(),
   updateApiTokenMock: vi.fn(),
+  updateTokenMock: vi.fn(),
   fetchAccountAvailableModelsMock: vi.fn(),
   fetchUserGroupsMock: vi.fn(),
   startProductAnalyticsActionMock: vi.fn(),
@@ -67,6 +69,7 @@ vi.mock("~/services/apiAdapters/registry", () => ({
     keyManagement: {
       fetchTokens: vi.fn(async () => []),
       createToken: (...args: any[]) => createApiTokenMock(...args),
+      updateToken: (...args: any[]) => updateTokenMock(...args),
       resolveTokenKey: async ({ token }: { token: { key: string } }) =>
         token.key,
       deleteToken: vi.fn(),
@@ -117,6 +120,7 @@ describe("AddTokenDialog prefill", () => {
   beforeEach(() => {
     createApiTokenMock.mockReset()
     updateApiTokenMock.mockReset()
+    updateTokenMock.mockReset()
     fetchAccountAvailableModelsMock.mockReset()
     fetchUserGroupsMock.mockReset()
     startProductAnalyticsActionMock.mockReset()
@@ -266,7 +270,7 @@ describe("AddTokenDialog prefill", () => {
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "default", ratio: 1 },
     })
-    updateApiTokenMock.mockResolvedValueOnce(true)
+    updateTokenMock.mockResolvedValueOnce(true)
 
     const editingToken = {
       id: 123,
@@ -305,14 +309,18 @@ describe("AddTokenDialog prefill", () => {
     )
 
     await waitFor(() => {
-      expect(updateApiTokenMock).toHaveBeenCalledTimes(1)
+      expect(updateTokenMock).toHaveBeenCalledTimes(1)
     })
 
-    expect(updateApiTokenMock.mock.calls[0]?.[2]).toMatchObject({
-      name: "Existing key",
-      model_limits_enabled: false,
-      model_limits: "",
+    expect(updateTokenMock.mock.calls[0]?.[0]).toMatchObject({
+      tokenId: 123,
+      tokenData: {
+        name: "Existing key",
+        model_limits_enabled: false,
+        model_limits: "",
+      },
     })
+    expect(updateApiTokenMock).not.toHaveBeenCalled()
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.UpdateAccountToken,
@@ -376,7 +384,7 @@ describe("AddTokenDialog prefill", () => {
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "default", ratio: 1 },
     })
-    updateApiTokenMock.mockRejectedValueOnce(new Error("   "))
+    updateTokenMock.mockRejectedValueOnce(new Error("   "))
 
     const editingToken = {
       id: 123,
@@ -415,6 +423,7 @@ describe("AddTokenDialog prefill", () => {
         "keyManagement:dialog.updateFailed",
       )
     })
+    expect(updateApiTokenMock).not.toHaveBeenCalled()
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.UpdateAccountToken,
@@ -923,7 +932,7 @@ describe("AddTokenDialog prefill", () => {
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "default", ratio: 1 },
     })
-    updateApiTokenMock.mockResolvedValueOnce(true)
+    updateTokenMock.mockResolvedValueOnce(true)
     let resolveSuccess: () => void = () => undefined
     const onSuccess = vi.fn(
       () =>
@@ -967,6 +976,7 @@ describe("AddTokenDialog prefill", () => {
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledWith()
     })
+    expect(updateApiTokenMock).not.toHaveBeenCalled()
     expect(onClose).not.toHaveBeenCalled()
 
     resolveSuccess()
@@ -981,7 +991,7 @@ describe("AddTokenDialog prefill", () => {
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "default", ratio: 1 },
     })
-    updateApiTokenMock.mockResolvedValueOnce(true)
+    updateTokenMock.mockResolvedValueOnce(true)
     const onSuccess = vi
       .fn()
       .mockRejectedValueOnce(new Error("edit callback failed"))
@@ -1022,6 +1032,7 @@ describe("AddTokenDialog prefill", () => {
       expect(onSuccess).toHaveBeenCalledWith()
       expect(onClose).toHaveBeenCalled()
     })
+    expect(updateApiTokenMock).not.toHaveBeenCalled()
   })
 
   it("closes through the AIHubMix one-time key dialog acknowledgement", async () => {

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -438,6 +438,65 @@ describe("AddTokenDialog prefill", () => {
     )
   })
 
+  it("treats an edit updateToken false result as a failure", async () => {
+    fetchAccountAvailableModelsMock.mockResolvedValueOnce(["gpt-4", "gpt-3.5"])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { desc: "default", ratio: 1 },
+    })
+    updateTokenMock.mockResolvedValueOnce(false)
+
+    const editingToken = {
+      id: 123,
+      accountId: ACCOUNT.id,
+      accountName: ACCOUNT.name,
+      name: "Existing key",
+      remain_quota: -1,
+      expired_time: -1,
+      unlimited_quota: true,
+      model_limits_enabled: false,
+      model_limits: "",
+      allow_ips: "",
+      group: "default",
+    } as any
+
+    const user = userEvent.setup()
+
+    render(
+      <AddTokenDialog
+        isOpen={true}
+        onClose={() => {}}
+        availableAccounts={[ACCOUNT]}
+        preSelectedAccountId={ACCOUNT.id}
+        editingToken={editingToken}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:dialog.updateToken",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "keyManagement:dialog.updateFailed",
+      )
+    })
+    expect(updateApiTokenMock).not.toHaveBeenCalled()
+    expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.UpdateAccountToken,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementDialog,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    })
+    expect(trackerCompleteMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      {
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      },
+    )
+  })
+
   it("shows a one-time key dialog when AIHubMix create returns a full token", async () => {
     fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
@@ -10,12 +10,14 @@ import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
   fetchAccountTokensMock,
-  createApiTokenMock,
+  adapterCreateTokenMock,
+  legacyCreateApiTokenMock,
   toastSuccessMock,
   toastErrorMock,
 } = vi.hoisted(() => ({
   fetchAccountTokensMock: vi.fn(),
-  createApiTokenMock: vi.fn(),
+  adapterCreateTokenMock: vi.fn(),
+  legacyCreateApiTokenMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
 }))
@@ -29,7 +31,7 @@ vi.mock("react-hot-toast", () => ({
 
 vi.mock("~/services/apiService", () => ({
   getApiService: () => ({
-    createApiToken: (...args: any[]) => createApiTokenMock(...args),
+    createApiToken: (...args: any[]) => legacyCreateApiTokenMock(...args),
     fetchAccountAvailableModels: vi.fn(async () => []),
     fetchUserGroups: vi.fn(async () => ({})),
     updateApiToken: vi.fn(async () => true),
@@ -40,7 +42,7 @@ vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteAdapter: () => ({
     keyManagement: {
       fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
-      createToken: (...args: any[]) => createApiTokenMock(...args),
+      createToken: (...args: any[]) => adapterCreateTokenMock(...args),
       resolveTokenKey: async ({ token }: { token: { key: string } }) =>
         token.key,
     },
@@ -54,7 +56,8 @@ const TOKEN = buildSub2ApiToken()
 describe("ModelKeyDialog sub2api support", () => {
   beforeEach(() => {
     fetchAccountTokensMock.mockReset()
-    createApiTokenMock.mockReset()
+    adapterCreateTokenMock.mockReset()
+    legacyCreateApiTokenMock.mockReset()
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
   })
@@ -63,7 +66,7 @@ describe("ModelKeyDialog sub2api support", () => {
     fetchAccountTokensMock
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([TOKEN])
-    createApiTokenMock.mockResolvedValueOnce(true)
+    adapterCreateTokenMock.mockResolvedValueOnce(true)
 
     const user = userEvent.setup()
 
@@ -84,16 +87,22 @@ describe("ModelKeyDialog sub2api support", () => {
     )
 
     await waitFor(() => {
-      expect(createApiTokenMock).toHaveBeenCalledTimes(1)
+      expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+      expect(adapterCreateTokenMock.mock.calls[0]?.[1]).toMatchObject({
+        group: "default",
+        model_limits_enabled: false,
+        model_limits: "",
+      })
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
     })
+    expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
   })
 
   it("refreshes inventory instead of showing one-time UI when Sub2API create returns a token DTO", async () => {
     fetchAccountTokensMock
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([TOKEN])
-    createApiTokenMock.mockResolvedValueOnce({
+    adapterCreateTokenMock.mockResolvedValueOnce({
       ...TOKEN,
       id: 9,
       key: "sk-sub2api-created-full-secret",
@@ -119,9 +128,10 @@ describe("ModelKeyDialog sub2api support", () => {
     )
 
     await waitFor(() => {
-      expect(createApiTokenMock).toHaveBeenCalledTimes(1)
+      expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
     })
+    expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
     expect(
       screen.queryByText("keyManagement:oneTimeKey.title"),
     ).not.toBeInTheDocument()

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -18,7 +18,8 @@ import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
   fetchAccountTokensMock,
-  createApiTokenMock,
+  adapterCreateTokenMock,
+  legacyCreateApiTokenMock,
   toastSuccessMock,
   toastErrorMock,
   resolveDisplayAccountTokenForSecretMock,
@@ -29,7 +30,8 @@ const {
   createApiCredentialProfileMock,
 } = vi.hoisted(() => ({
   fetchAccountTokensMock: vi.fn(),
-  createApiTokenMock: vi.fn(),
+  adapterCreateTokenMock: vi.fn(),
+  legacyCreateApiTokenMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
   resolveDisplayAccountTokenForSecretMock: vi.fn(),
@@ -64,7 +66,7 @@ vi.mock(
 
 vi.mock("~/services/apiService", () => ({
   getApiService: () => ({
-    createApiToken: (...args: any[]) => createApiTokenMock(...args),
+    createApiToken: (...args: any[]) => legacyCreateApiTokenMock(...args),
     fetchAccountAvailableModels: vi.fn(async () => []),
     fetchUserGroups: vi.fn(async () => ({})),
     updateApiToken: vi.fn(async () => true),
@@ -75,7 +77,7 @@ vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteAdapter: () => ({
     keyManagement: {
       fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
-      createToken: (...args: any[]) => createApiTokenMock(...args),
+      createToken: (...args: any[]) => adapterCreateTokenMock(...args),
       resolveTokenKey: async ({ token }: { token: { key: string } }) =>
         token.key,
     },
@@ -161,7 +163,8 @@ describe("ModelKeyDialog", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     fetchAccountTokensMock.mockReset()
-    createApiTokenMock.mockReset()
+    adapterCreateTokenMock.mockReset()
+    legacyCreateApiTokenMock.mockReset()
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
     resolveDisplayAccountTokenForSecretMock.mockReset()
@@ -360,7 +363,7 @@ describe("ModelKeyDialog", () => {
 
   it("shows a one-time key dialog when AIHubMix default create returns a full token", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
-    createApiTokenMock.mockResolvedValueOnce({
+    adapterCreateTokenMock.mockResolvedValueOnce({
       ...TOKEN,
       id: 8,
       key: "sk-created-full-secret",
@@ -408,6 +411,13 @@ describe("ModelKeyDialog", () => {
     ).toHaveValue("sk-created-full-secret")
 
     await waitFor(() => {
+      expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+      expect(adapterCreateTokenMock.mock.calls[0]?.[1]).toMatchObject({
+        group: "default",
+        model_limits_enabled: false,
+        model_limits: "",
+      })
+      expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
       expect(writeText).toHaveBeenCalledWith("sk-created-full-secret")
     })
@@ -418,7 +428,7 @@ describe("ModelKeyDialog", () => {
 
   it("saves an AIHubMix default-created one-time key to an API credential profile without closing the dialog", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
-    createApiTokenMock.mockResolvedValueOnce({
+    adapterCreateTokenMock.mockResolvedValueOnce({
       ...TOKEN,
       id: 8,
       key: "sk-created-full-secret",
@@ -460,6 +470,8 @@ describe("ModelKeyDialog", () => {
     )
 
     await waitFor(() => {
+      expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+      expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
       expect(createApiCredentialProfileMock).toHaveBeenCalledWith({
         name: "AIHubMix - model-key",
         apiType: API_TYPES.OPENAI_COMPATIBLE,
@@ -479,7 +491,7 @@ describe("ModelKeyDialog", () => {
 
   it("keeps AIHubMix created keys unchanged before showing the one-time dialog", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
-    createApiTokenMock.mockResolvedValueOnce({
+    adapterCreateTokenMock.mockResolvedValueOnce({
       ...TOKEN,
       id: 8,
       key: "created-full-secret",
@@ -515,6 +527,8 @@ describe("ModelKeyDialog", () => {
     ).toHaveValue("created-full-secret")
 
     await waitFor(() => {
+      expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+      expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
       expect(writeText).toHaveBeenCalledWith("created-full-secret")
     })
   })
@@ -528,7 +542,7 @@ describe("ModelKeyDialog", () => {
         name: "refreshed",
       },
     ])
-    createApiTokenMock.mockResolvedValueOnce({
+    adapterCreateTokenMock.mockResolvedValueOnce({
       ...TOKEN,
       id: 8,
       key: "sk-created********masked",
@@ -554,6 +568,8 @@ describe("ModelKeyDialog", () => {
     )
 
     await waitFor(() => {
+      expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+      expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
     })
 
@@ -570,7 +586,7 @@ describe("ModelKeyDialog", () => {
 
   it("shows a compatibility error when default create returns an incompatible full token", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
-    createApiTokenMock.mockResolvedValueOnce({
+    adapterCreateTokenMock.mockResolvedValueOnce({
       ...TOKEN,
       id: 8,
       key: "sk-created-full-secret",
@@ -608,6 +624,8 @@ describe("ModelKeyDialog", () => {
       screen.queryByText("keyManagement:oneTimeKey.title"),
     ).not.toBeInTheDocument()
     expect(writeText).not.toHaveBeenCalled()
+    expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+    expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
     expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },
@@ -623,7 +641,7 @@ describe("ModelKeyDialog", () => {
         name: "refreshed",
       },
     ])
-    createApiTokenMock.mockResolvedValueOnce({
+    adapterCreateTokenMock.mockResolvedValueOnce({
       ...TOKEN,
       id: 8,
       key: null,
@@ -649,6 +667,8 @@ describe("ModelKeyDialog", () => {
     )
 
     await waitFor(() => {
+      expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+      expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
     })
 
@@ -675,7 +695,7 @@ describe("ModelKeyDialog", () => {
           name: "refreshed",
         },
       ])
-    createApiTokenMock.mockResolvedValueOnce(true)
+    adapterCreateTokenMock.mockResolvedValueOnce(true)
 
     render(
       <ModelKeyDialog
@@ -696,6 +716,13 @@ describe("ModelKeyDialog", () => {
     await user.click(createButton)
 
     await waitFor(() => {
+      expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+      expect(adapterCreateTokenMock.mock.calls[0]?.[1]).toMatchObject({
+        group: "default",
+        model_limits_enabled: false,
+        model_limits: "",
+      })
+      expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(3)
     })
     setTimeoutSpy.mockRestore()
@@ -715,7 +742,7 @@ describe("ModelKeyDialog", () => {
     fetchAccountTokensMock
       .mockResolvedValueOnce([])
       .mockResolvedValue([{ ...TOKEN, id: 11, group: "vip" }])
-    createApiTokenMock.mockResolvedValueOnce(true)
+    adapterCreateTokenMock.mockResolvedValueOnce(true)
 
     render(
       <ModelKeyDialog
@@ -736,6 +763,8 @@ describe("ModelKeyDialog", () => {
     await user.click(createButton)
 
     await waitFor(() => {
+      expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+      expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(6)
     })
     setTimeoutSpy.mockRestore()
@@ -753,7 +782,7 @@ describe("ModelKeyDialog", () => {
 
   it("shows a create error when the default create request fails", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
-    createApiTokenMock.mockRejectedValueOnce(new Error("create failed"))
+    adapterCreateTokenMock.mockRejectedValueOnce(new Error("create failed"))
 
     const user = userEvent.setup()
 
@@ -776,6 +805,8 @@ describe("ModelKeyDialog", () => {
     expect(
       await screen.findByText("modelList:keyDialog.createFailed"),
     ).toBeInTheDocument()
+    expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+    expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ModelList,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.CreateCompatibleModelKey,
@@ -893,7 +924,7 @@ describe("ModelKeyDialog", () => {
 
   it("shows a create error when the default create request returns false", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
-    createApiTokenMock.mockResolvedValueOnce(false)
+    adapterCreateTokenMock.mockResolvedValueOnce(false)
 
     const user = userEvent.setup()
 
@@ -916,6 +947,8 @@ describe("ModelKeyDialog", () => {
     expect(
       await screen.findByText("modelList:keyDialog.createFailed"),
     ).toBeInTheDocument()
+    expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+    expect(legacyCreateApiTokenMock).not.toHaveBeenCalled()
     expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -2269,9 +2269,6 @@ describe("useAccountDialog save and auto-config flows", () => {
     const fetchAccountTokens = vi
       .fn()
       .mockResolvedValue([createdToken, existingToken])
-    const serviceFetchAccountTokens = vi.fn(() => {
-      throw new Error("service token fetch should not be used")
-    })
 
     vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
       savedSiteAccount,
@@ -2295,9 +2292,6 @@ describe("useAccountDialog save and auto-config flows", () => {
         fetchTokens: fetchAccountTokens,
         createToken: vi.fn(),
         resolveTokenKey: vi.fn(),
-      } as any,
-      service: {
-        fetchAccountTokens: serviceFetchAccountTokens,
       } as any,
       request: { accountId: savedDisplayData.id } as any,
     })
@@ -2338,7 +2332,6 @@ describe("useAccountDialog save and auto-config flows", () => {
     expect(fetchAccountTokens).toHaveBeenCalledWith({
       accountId: savedDisplayData.id,
     })
-    expect(serviceFetchAccountTokens).not.toHaveBeenCalled()
     expect(mockOpenWithAccount).toHaveBeenCalledWith(
       savedDisplayData,
       createdToken,
@@ -2384,9 +2377,6 @@ describe("useAccountDialog save and auto-config flows", () => {
       .fn()
       .mockResolvedValueOnce([existingToken])
       .mockResolvedValueOnce([existingToken])
-    const serviceFetchAccountTokens = vi.fn(() => {
-      throw new Error("service token fetch should not be used")
-    })
 
     vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
       savedSiteAccount,
@@ -2410,9 +2400,6 @@ describe("useAccountDialog save and auto-config flows", () => {
         fetchTokens: fetchAccountTokens,
         createToken: vi.fn(),
         resolveTokenKey: vi.fn(),
-      } as any,
-      service: {
-        fetchAccountTokens: serviceFetchAccountTokens,
       } as any,
       request: { accountId: savedDisplayData.id } as any,
     })
@@ -2447,7 +2434,6 @@ describe("useAccountDialog save and auto-config flows", () => {
     })
 
     expect(mockOpenWithAccount).not.toHaveBeenCalled()
-    expect(serviceFetchAccountTokens).not.toHaveBeenCalled()
     expect(result.current.state.accountPostSaveWorkflowStep).toBe(
       ACCOUNT_POST_SAVE_WORKFLOW_STEPS.Failed,
     )
@@ -2492,9 +2478,6 @@ describe("useAccountDialog save and auto-config flows", () => {
           resolveFetchAccountTokens = resolve
         }),
     )
-    const serviceFetchAccountTokens = vi.fn(() => {
-      throw new Error("service token fetch should not be used")
-    })
 
     vi.spyOn(accountStorage, "getAccountById").mockResolvedValue(
       savedSiteAccount,
@@ -2518,9 +2501,6 @@ describe("useAccountDialog save and auto-config flows", () => {
         fetchTokens: fetchAccountTokens,
         createToken: vi.fn(),
         resolveTokenKey: vi.fn(),
-      } as any,
-      service: {
-        fetchAccountTokens: serviceFetchAccountTokens,
       } as any,
       request: { accountId: savedDisplayData.id } as any,
     })
@@ -2577,7 +2557,6 @@ describe("useAccountDialog save and auto-config flows", () => {
         accountId: savedDisplayData.id,
       })
     })
-    expect(serviceFetchAccountTokens).not.toHaveBeenCalled()
 
     await act(async () => {
       result.current.handlers.handleClose()

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -10,15 +10,10 @@ import {
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
-import { getApiService } from "~/services/apiService"
 import { AuthTypeEnum } from "~/types"
 
 vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteAdapter: vi.fn(),
-}))
-
-vi.mock("~/services/apiService", () => ({
-  getApiService: vi.fn(),
 }))
 
 vi.mock("~/services/accounts/sub2apiAuthSession", () => ({
@@ -52,32 +47,46 @@ const REQUEST = {
 describe("fetchDisplayAccountTokens", () => {
   let fetchTokens: ReturnType<typeof vi.fn>
   let createToken: ReturnType<typeof vi.fn>
+  let updateToken: ReturnType<typeof vi.fn>
   let resolveTokenKey: ReturnType<typeof vi.fn>
+  let deleteToken: ReturnType<typeof vi.fn>
+  let fetchUserGroups: ReturnType<typeof vi.fn>
+  let fetchAvailableModels: ReturnType<typeof vi.fn>
   let keyManagement: {
     fetchTokens: typeof fetchTokens
     createToken: typeof createToken
+    updateToken: typeof updateToken
     resolveTokenKey: typeof resolveTokenKey
+    deleteToken: typeof deleteToken
+    fetchUserGroups: typeof fetchUserGroups
+    fetchAvailableModels: typeof fetchAvailableModels
   }
   let adapter: {
     siteType: string
     keyManagement?: typeof keyManagement
   }
-  let service: {
-    fetchUserGroups: ReturnType<typeof vi.fn>
-  }
 
   beforeEach(() => {
     fetchTokens = vi.fn()
     createToken = vi.fn()
+    updateToken = vi.fn()
     resolveTokenKey = vi.fn()
-    keyManagement = { fetchTokens, createToken, resolveTokenKey }
+    deleteToken = vi.fn()
+    fetchUserGroups = vi.fn()
+    fetchAvailableModels = vi.fn()
+    keyManagement = {
+      fetchTokens,
+      createToken,
+      updateToken,
+      resolveTokenKey,
+      deleteToken,
+      fetchUserGroups,
+      fetchAvailableModels,
+    }
     adapter = { siteType: "new-api", keyManagement }
-    service = { fetchUserGroups: vi.fn() }
 
     vi.mocked(getSiteAdapter).mockReset()
-    vi.mocked(getApiService).mockReset()
     vi.mocked(getSiteAdapter).mockReturnValue(adapter as any)
-    vi.mocked(getApiService).mockReturnValue(service as any)
   })
 
   it("returns the token array when the API payload is valid", async () => {
@@ -88,11 +97,13 @@ describe("fetchDisplayAccountTokens", () => {
     expect(result).toEqual([{ id: 1, key: "sk-test", status: 1 }])
     expect(fetchTokens).toHaveBeenCalledWith(expect.objectContaining(REQUEST))
     expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual({
-      service,
       adapter,
       keyManagement,
       request: expect.objectContaining(REQUEST),
     })
+    expect(createDisplayAccountApiContext(ACCOUNT as any)).not.toHaveProperty(
+      "service",
+    )
     expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual(
       expect.objectContaining({
         request: expect.not.objectContaining({

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -13,6 +13,7 @@ const {
   mockAihubmixFetchAccountTokens,
   mockAihubmixFetchUserGroups,
   mockAihubmixResolveApiTokenKey,
+  mockAihubmixUpdateApiToken,
   mockCreateApiToken,
   mockDeleteApiToken,
   mockFetchAccountAvailableModels,
@@ -26,6 +27,8 @@ const {
   mockSub2ApiFetchAccountTokens,
   mockSub2ApiFetchUserGroups,
   mockSub2ApiResolveApiTokenKey,
+  mockSub2ApiUpdateApiToken,
+  mockUpdateApiToken,
 } = vi.hoisted(() => ({
   mockAihubmixCreateApiToken: vi.fn(),
   mockAihubmixDeleteApiToken: vi.fn(),
@@ -33,6 +36,7 @@ const {
   mockAihubmixFetchAccountTokens: vi.fn(),
   mockAihubmixFetchUserGroups: vi.fn(),
   mockAihubmixResolveApiTokenKey: vi.fn(),
+  mockAihubmixUpdateApiToken: vi.fn(),
   mockCreateApiToken: vi.fn(),
   mockDeleteApiToken: vi.fn(),
   mockFetchAccountAvailableModels: vi.fn(),
@@ -46,6 +50,8 @@ const {
   mockSub2ApiFetchAccountTokens: vi.fn(),
   mockSub2ApiFetchUserGroups: vi.fn(),
   mockSub2ApiResolveApiTokenKey: vi.fn(),
+  mockSub2ApiUpdateApiToken: vi.fn(),
+  mockUpdateApiToken: vi.fn(),
 }))
 
 vi.mock("~/services/apiService", () => ({
@@ -59,6 +65,7 @@ vi.mock("~/services/apiService/sub2api", () => ({
   fetchAccountTokens: mockSub2ApiFetchAccountTokens,
   fetchUserGroups: mockSub2ApiFetchUserGroups,
   resolveApiTokenKey: mockSub2ApiResolveApiTokenKey,
+  updateApiToken: mockSub2ApiUpdateApiToken,
 }))
 
 vi.mock("~/services/apiService/aihubmix", () => ({
@@ -68,6 +75,7 @@ vi.mock("~/services/apiService/aihubmix", () => ({
   fetchAccountTokens: mockAihubmixFetchAccountTokens,
   fetchUserGroups: mockAihubmixFetchUserGroups,
   resolveApiTokenKey: mockAihubmixResolveApiTokenKey,
+  updateApiToken: mockAihubmixUpdateApiToken,
 }))
 
 const request = {
@@ -104,7 +112,7 @@ const availableModels = ["gpt-4o-mini", "claude-3-haiku"]
 
 describe("apiAdapter keyManagement", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     mockGetApiService.mockReturnValue({
       createApiToken: mockCreateApiToken,
       deleteApiToken: mockDeleteApiToken,
@@ -112,6 +120,7 @@ describe("apiAdapter keyManagement", () => {
       fetchAccountTokens: mockFetchAccountTokens,
       fetchUserGroups: mockFetchUserGroups,
       resolveApiTokenKey: mockResolveApiTokenKey,
+      updateApiToken: mockUpdateApiToken,
     })
   })
 
@@ -119,6 +128,7 @@ describe("apiAdapter keyManagement", () => {
     const expectedTokens = [token]
     mockFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
     mockCreateApiToken.mockResolvedValueOnce(true)
+    mockUpdateApiToken.mockResolvedValueOnce(true)
     mockResolveApiTokenKey.mockResolvedValueOnce("sk-real")
     mockDeleteApiToken.mockResolvedValueOnce(true)
     mockFetchUserGroups.mockResolvedValueOnce(userGroups)
@@ -134,6 +144,13 @@ describe("apiAdapter keyManagement", () => {
     await expect(keyManagement.createToken(request, tokenData)).resolves.toBe(
       true,
     )
+    await expect(
+      keyManagement.updateToken({
+        request,
+        tokenId: token.id,
+        tokenData,
+      }),
+    ).resolves.toBe(true)
     await expect(
       keyManagement.resolveTokenKey({ request, token }),
     ).resolves.toBe("sk-real")
@@ -154,9 +171,15 @@ describe("apiAdapter keyManagement", () => {
       [SITE_TYPES.ONE_HUB],
       [SITE_TYPES.ONE_HUB],
       [SITE_TYPES.ONE_HUB],
+      [SITE_TYPES.ONE_HUB],
     ])
     expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, 2, 25)
     expect(mockCreateApiToken).toHaveBeenCalledWith(request, tokenData)
+    expect(mockUpdateApiToken).toHaveBeenCalledWith(
+      request,
+      token.id,
+      tokenData,
+    )
     expect(mockResolveApiTokenKey).toHaveBeenCalledWith(request, token)
     expect(mockDeleteApiToken).toHaveBeenCalledWith(request, token.id)
     expect(mockFetchUserGroups).toHaveBeenCalledWith(request)
@@ -179,6 +202,7 @@ describe("apiAdapter keyManagement", () => {
     const expectedTokens = [token]
     mockSub2ApiFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
     mockSub2ApiCreateApiToken.mockResolvedValueOnce(token)
+    mockSub2ApiUpdateApiToken.mockResolvedValueOnce(true)
     mockSub2ApiResolveApiTokenKey.mockResolvedValueOnce("sk-sub2api")
     mockSub2ApiDeleteApiToken.mockResolvedValueOnce(true)
     mockSub2ApiFetchUserGroups.mockResolvedValueOnce(userGroups)
@@ -192,6 +216,13 @@ describe("apiAdapter keyManagement", () => {
     await expect(
       sub2ApiKeyManagement.createToken(request, tokenData),
     ).resolves.toBe(token)
+    await expect(
+      sub2ApiKeyManagement.updateToken({
+        request,
+        tokenId: token.id,
+        tokenData,
+      }),
+    ).resolves.toBe(true)
     await expect(
       sub2ApiKeyManagement.resolveTokenKey({ request, token }),
     ).resolves.toBe("sk-sub2api")
@@ -207,6 +238,11 @@ describe("apiAdapter keyManagement", () => {
 
     expect(mockSub2ApiFetchAccountTokens).toHaveBeenCalledWith(request, 3, 50)
     expect(mockSub2ApiCreateApiToken).toHaveBeenCalledWith(request, tokenData)
+    expect(mockSub2ApiUpdateApiToken).toHaveBeenCalledWith(
+      request,
+      token.id,
+      tokenData,
+    )
     expect(mockSub2ApiResolveApiTokenKey).toHaveBeenCalledWith(request, token)
     expect(mockSub2ApiDeleteApiToken).toHaveBeenCalledWith(request, token.id)
     expect(mockSub2ApiFetchUserGroups).toHaveBeenCalledWith(request)
@@ -227,6 +263,7 @@ describe("apiAdapter keyManagement", () => {
     const expectedTokens = [token]
     mockAihubmixFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
     mockAihubmixCreateApiToken.mockResolvedValueOnce(token)
+    mockAihubmixUpdateApiToken.mockResolvedValueOnce(true)
     mockAihubmixResolveApiTokenKey.mockResolvedValueOnce("aihubmix-secret")
     mockAihubmixDeleteApiToken.mockResolvedValueOnce(true)
     mockAihubmixFetchUserGroups.mockResolvedValueOnce(userGroups)
@@ -240,6 +277,13 @@ describe("apiAdapter keyManagement", () => {
     await expect(
       aihubmixKeyManagement.createToken(request, tokenData),
     ).resolves.toBe(token)
+    await expect(
+      aihubmixKeyManagement.updateToken({
+        request,
+        tokenId: token.id,
+        tokenData,
+      }),
+    ).resolves.toBe(true)
     await expect(
       aihubmixKeyManagement.resolveTokenKey({ request, token }),
     ).resolves.toBe("aihubmix-secret")
@@ -255,6 +299,11 @@ describe("apiAdapter keyManagement", () => {
 
     expect(mockAihubmixFetchAccountTokens).toHaveBeenCalledWith(request)
     expect(mockAihubmixCreateApiToken).toHaveBeenCalledWith(request, tokenData)
+    expect(mockAihubmixUpdateApiToken).toHaveBeenCalledWith(
+      request,
+      token.id,
+      tokenData,
+    )
     expect(mockAihubmixResolveApiTokenKey).toHaveBeenCalledWith(request, token)
     expect(mockAihubmixDeleteApiToken).toHaveBeenCalledWith(request, token.id)
     expect(mockAihubmixFetchUserGroups).toHaveBeenCalledWith(request)

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -24,6 +24,7 @@ describe("apiAdapters registry", () => {
     expect(adapter.keyManagement).toEqual({
       fetchTokens: expect.any(Function),
       createToken: expect.any(Function),
+      updateToken: expect.any(Function),
       resolveTokenKey: expect.any(Function),
       deleteToken: expect.any(Function),
       fetchUserGroups: expect.any(Function),
@@ -79,6 +80,7 @@ describe("apiAdapters registry", () => {
       expect(adapter.keyManagement).toEqual({
         fetchTokens: expect.any(Function),
         createToken: expect.any(Function),
+        updateToken: expect.any(Function),
         resolveTokenKey: expect.any(Function),
         deleteToken: expect.any(Function),
         fetchUserGroups: expect.any(Function),
@@ -119,6 +121,7 @@ describe("apiAdapters registry", () => {
     expect(adapter.keyManagement).toEqual({
       fetchTokens: expect.any(Function),
       createToken: expect.any(Function),
+      updateToken: expect.any(Function),
       resolveTokenKey: expect.any(Function),
       deleteToken: expect.any(Function),
       fetchUserGroups: expect.any(Function),


### PR DESCRIPTION
## Summary
- Add the account-site adapter boundary hardening spec and execution plan.
- Route token update/default-key/account service paths through adapter-owned capabilities.
- Add ESLint guardrails to keep account flows off the legacy service facade.

## Test Plan
- [x] pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan and architecture spec for hardening account/site token lifecycle boundaries.

* **Bug Fixes**
  * Updated token edit and default token creation flows to use adapter-based key management.
  * Improved handling of failed token updates (including explicit failure when the update result is false).

* **Tests**
  * Expanded/updated tests to verify adapter-based token update/create behavior and prevent legacy API-service paths from being used.

* **Chores**
  * Added ESLint import guardrails to block legacy account/site API-service facade usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->