### PR TITLE
refactor(api-adapters): route account capabilities through adapters

### DIFF
--- a/src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts
+++ b/src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts
@@ -6,7 +6,6 @@ import {
   createDisplayAccountApiContext,
   requireDisplayAccountKeyManagement,
 } from "~/services/accounts/utils/apiServiceRequest"
-import { API_ERROR_CODES } from "~/services/apiService/common/errors"
 import type { UserGroupInfo } from "~/services/apiService/common/type"
 import type { DisplaySiteData } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
@@ -20,12 +19,6 @@ import type { FormData } from "./useTokenForm"
 const logger = createLogger("TokenDataHook")
 
 const EMPTY_USER_GROUPS: Record<string, UserGroupInfo> = {}
-
-const isFeatureUnsupportedError = (error: unknown): boolean =>
-  !!error &&
-  typeof error === "object" &&
-  "code" in error &&
-  (error as { code?: unknown }).code === API_ERROR_CODES.FEATURE_UNSUPPORTED
 
 /**
  * Loads available models and user groups for the selected account when dialog opens.
@@ -59,13 +52,7 @@ export function useTokenData(
 
       const [models, groupsData] = await Promise.all([
         capability.fetchAvailableModels(request),
-        capability.fetchUserGroups(request).catch((error) => {
-          if (isFeatureUnsupportedError(error)) {
-            return EMPTY_USER_GROUPS
-          }
-
-          throw error
-        }),
+        capability.userGroups?.fetch(request) ?? EMPTY_USER_GROUPS,
       ])
 
       setAvailableModels(models)

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -1,7 +1,6 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
-import { API_ERROR_CODES } from "~/services/apiService/common/errors"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { DisplaySiteData, SiteAccount } from "~/types"
@@ -28,12 +27,6 @@ interface AccountKeyCoverageResult {
 
 const normalizeGroupName = (value: unknown) =>
   typeof value === "string" ? value.trim() : ""
-
-const isFeatureUnsupportedError = (error: unknown) =>
-  !!error &&
-  typeof error === "object" &&
-  "code" in error &&
-  (error as { code?: unknown }).code === API_ERROR_CODES.FEATURE_UNSUPPORTED
 
 /**
  * Builds the default auto-provision token payload for one user group.
@@ -93,17 +86,10 @@ export async function ensureAccountKeysForAvailableGroups(params: {
   const accountId = displaySiteData.id || account.id
 
   const tokens = await keyManagement.fetchTokens(request)
-  let groups: string[]
-
-  try {
-    const groupsData = await keyManagement.fetchUserGroups(request)
-    groups = Object.keys(groupsData).map(normalizeGroupName).filter(Boolean)
-  } catch (error) {
-    if (!isFeatureUnsupportedError(error)) {
-      throw error
-    }
-    groups = []
-  }
+  const groupsData = keyManagement.userGroups
+    ? await keyManagement.userGroups.fetch(request)
+    : {}
+  const groups = Object.keys(groupsData).map(normalizeGroupName).filter(Boolean)
 
   const uniqueGroups = Array.from(new Set(groups))
 

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -504,10 +504,15 @@ export async function resolveSub2ApiQuickCreateResolution(
   }
 
   const { keyManagement, request } = createDisplayAccountApiContext(account)
-  const groups = await requireDisplayAccountKeyManagement(
+  const userGroups = requireDisplayAccountKeyManagement(
     account,
     keyManagement,
-  ).fetchUserGroups(request)
+  ).userGroups
+  if (!userGroups) {
+    throw new Error("sub2api_group_inventory_not_implemented")
+  }
+
+  const groups = await userGroups.fetch(request)
   const validGroups = normalizeSub2ApiGroupNames(groups)
 
   if (validGroups.length === 0) {

--- a/src/services/apiAdapters/aihubmix/keyManagement.ts
+++ b/src/services/apiAdapters/aihubmix/keyManagement.ts
@@ -4,7 +4,6 @@ import {
   deleteApiToken,
   fetchAccountAvailableModels,
   fetchAccountTokens,
-  fetchUserGroups,
   resolveApiTokenKey,
   updateApiToken,
 } from "~/services/apiService/aihubmix"
@@ -16,7 +15,5 @@ export const aihubmixKeyManagement: KeyManagementCapability = {
     updateApiToken(request, tokenId, tokenData),
   resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
   deleteToken: ({ request, tokenId }) => deleteApiToken(request, tokenId),
-  // Preserve AIHubMix's explicit FEATURE_UNSUPPORTED group-inventory contract.
-  fetchUserGroups: (request) => fetchUserGroups(request),
   fetchAvailableModels: (request) => fetchAccountAvailableModels(request),
 }

--- a/src/services/apiAdapters/contracts/keyManagement.ts
+++ b/src/services/apiAdapters/contracts/keyManagement.ts
@@ -29,6 +29,10 @@ export type UpdateTokenRequest = {
   tokenData: CreateTokenRequest
 }
 
+export type UserGroupsCapability = {
+  fetch(request: ApiServiceRequest): Promise<Record<string, UserGroupInfo>>
+}
+
 export type KeyManagementCapability = {
   fetchTokens(
     request: ApiServiceRequest,
@@ -43,8 +47,6 @@ export type KeyManagementCapability = {
     request: ResolveTokenSecretRequest<TToken>,
   ): Promise<string>
   deleteToken(request: DeleteTokenRequest): Promise<boolean | void>
-  fetchUserGroups(
-    request: ApiServiceRequest,
-  ): Promise<Record<string, UserGroupInfo>>
   fetchAvailableModels(request: ApiServiceRequest): Promise<string[]>
+  userGroups?: UserGroupsCapability
 }

--- a/src/services/apiAdapters/contracts/redemption.ts
+++ b/src/services/apiAdapters/contracts/redemption.ts
@@ -1,0 +1,10 @@
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+
+export type RedeemCodeRequest = {
+  request: ApiServiceRequest
+  code: string
+}
+
+export type RedemptionCapability = {
+  redeem(request: RedeemCodeRequest): Promise<unknown>
+}

--- a/src/services/apiAdapters/contracts/siteAdapter.ts
+++ b/src/services/apiAdapters/contracts/siteAdapter.ts
@@ -7,6 +7,7 @@ import type { AccountRefreshCapability } from "./accountRefresh"
 import type { KeyManagementCapability } from "./keyManagement"
 import type { ModelCatalogCapability } from "./modelCatalog"
 import type { ModelPricingCapability } from "./modelPricing"
+import type { RedemptionCapability } from "./redemption"
 import type { SiteAnnouncementsCapability } from "./siteAnnouncements"
 import type { SiteNoticeCapability } from "./siteNotice"
 
@@ -24,4 +25,5 @@ export type SiteAdapter = {
   accountCompletion?: AccountCompletionCapability
   keyManagement?: KeyManagementCapability
   accountRefresh?: AccountRefreshCapability
+  redemption?: RedemptionCapability
 }

--- a/src/services/apiAdapters/newApi/index.ts
+++ b/src/services/apiAdapters/newApi/index.ts
@@ -7,6 +7,7 @@ import { createNewApiAccountData } from "./accountData"
 import { createNewApiAccountRefresh } from "./accountRefresh"
 import { createNewApiKeyManagement } from "./keyManagement"
 import { createNewApiModelPricing } from "./modelPricing"
+import { createNewApiRedemption } from "./redemption"
 import { newApiSiteNotice } from "./siteNotice"
 
 export const createNewApiAdapter = (
@@ -21,4 +22,5 @@ export const createNewApiAdapter = (
   keyManagement: createNewApiKeyManagement(siteType),
   accountRefresh: createNewApiAccountRefresh(siteType),
   modelPricing: createNewApiModelPricing(siteType),
+  redemption: createNewApiRedemption(siteType),
 })

--- a/src/services/apiAdapters/newApi/keyManagement.ts
+++ b/src/services/apiAdapters/newApi/keyManagement.ts
@@ -23,9 +23,10 @@ export function createNewApiKeyManagement(
       getApiService(siteType).resolveApiTokenKey(request, token),
     deleteToken: ({ request, tokenId }) =>
       getApiService(siteType).deleteApiToken(request, tokenId),
-    fetchUserGroups: (request) =>
-      getApiService(siteType).fetchUserGroups(request),
     fetchAvailableModels: (request) =>
       getApiService(siteType).fetchAccountAvailableModels(request),
+    userGroups: {
+      fetch: (request) => getApiService(siteType).fetchUserGroups(request),
+    },
   }
 }

--- a/src/services/apiAdapters/newApi/redemption.ts
+++ b/src/services/apiAdapters/newApi/redemption.ts
@@ -1,0 +1,15 @@
+import type { AccountSiteType } from "~/constants/siteType"
+import type { RedemptionCapability } from "~/services/apiAdapters/contracts/redemption"
+import { getApiService } from "~/services/apiService"
+
+/**
+ * Create redemption operations bound to the New API-family site type.
+ */
+export function createNewApiRedemption(
+  siteType: AccountSiteType,
+): RedemptionCapability {
+  return {
+    redeem: ({ request, code }) =>
+      getApiService(siteType).redeemCode(request, code),
+  }
+}

--- a/src/services/apiAdapters/sub2api/keyManagement.ts
+++ b/src/services/apiAdapters/sub2api/keyManagement.ts
@@ -17,6 +17,8 @@ export const sub2ApiKeyManagement: KeyManagementCapability = {
     updateApiToken(request, tokenId, tokenData),
   resolveTokenKey: ({ request, token }) => resolveApiTokenKey(request, token),
   deleteToken: ({ request, tokenId }) => deleteApiToken(request, tokenId),
-  fetchUserGroups: (request) => fetchUserGroups(request),
   fetchAvailableModels: (request) => fetchAccountAvailableModels(request),
+  userGroups: {
+    fetch: (request) => fetchUserGroups(request),
+  },
 }

--- a/src/services/apiService/aihubmix/index.ts
+++ b/src/services/apiService/aihubmix/index.ts
@@ -24,7 +24,6 @@ import {
   type SiteStatusInfo,
   type TodayIncomeData,
   type TodayUsageData,
-  type UserGroupInfo,
   type UserInfo,
 } from "~/services/apiService/common/type"
 import { fetchApiData } from "~/services/apiService/common/utils"
@@ -668,23 +667,6 @@ export async function searchApiTokens(
   )
   return extractTokenItems(payload).map((token) =>
     normalizeToken(token, request.auth?.userId),
-  )
-}
-
-/**
- * AIHubMix key creation does not use One-API style groups. Surface this as an
- * explicit unsupported capability so callers do not confuse it with an empty
- * but otherwise supported group inventory. The create-key docs list no `group`
- * request field: https://docs.aihubmix.com/en/api/CliEndpoints/create-key
- */
-export async function fetchUserGroups(
-  _request: ApiServiceRequest,
-): Promise<Record<string, UserGroupInfo>> {
-  throw new ApiError(
-    "aihubmix_user_groups_unsupported",
-    undefined,
-    undefined,
-    API_ERROR_CODES.FEATURE_UNSUPPORTED,
   )
 }
 

--- a/src/services/apiService/index.ts
+++ b/src/services/apiService/index.ts
@@ -41,7 +41,6 @@ const strictOverrideSites = new Set<ApiOverrideSite>([
 type ApiServiceCapabilities = {
   keyManagement: boolean
   modelPricing: boolean
-  redeemCode: boolean
   siteAnnouncements: boolean
 }
 
@@ -50,7 +49,6 @@ type ApiServiceCapabilityOverrides = Partial<ApiServiceCapabilities>
 const defaultApiServiceCapabilities: ApiServiceCapabilities = {
   keyManagement: true,
   modelPricing: true,
-  redeemCode: true,
   siteAnnouncements: true,
 }
 
@@ -59,10 +57,6 @@ const siteCapabilityOverrides: Partial<
 > = {
   [SITE_TYPES.SUB2API]: {
     modelPricing: false,
-    redeemCode: false,
-  },
-  [SITE_TYPES.AIHUBMIX]: {
-    redeemCode: false,
   },
 }
 

--- a/src/services/redemption/redeemService.ts
+++ b/src/services/redemption/redeemService.ts
@@ -1,6 +1,6 @@
 import { UI_CONSTANTS } from "~/constants/ui"
 import { accountStorage } from "~/services/accounts/accountStorage"
-import { getApiService } from "~/services/apiService"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import type { DisplaySiteData } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
 import { formatMoneyFixed } from "~/utils/core/money"
@@ -9,7 +9,7 @@ import { t } from "~/utils/i18n/core"
 interface RedeemResult {
   success: boolean
   message: string
-  creditedAmount?: number
+  creditedAmount?: unknown
   account?: DisplaySiteData
 }
 
@@ -44,16 +44,16 @@ class RedeemService {
         }
       }
 
-      const service = getApiService(account.site_type)
-      if (!service.capabilities.redeemCode) {
+      const redemption = getSiteAdapter(account.site_type).redemption
+      if (!redemption) {
         return {
           success: false,
           message: t("redemptionAssist:messages.redeemFailed"),
         }
       }
 
-      const creditedAmount = await service.redeemCode(
-        {
+      const creditedAmount = await redemption.redeem({
+        request: {
           baseUrl: account.site_url,
           accountId,
           auth: {
@@ -64,7 +64,7 @@ class RedeemService {
           },
         },
         code,
-      )
+      })
 
       const displayAccount =
         (await accountStorage.getDisplayDataById(accountId)) ??

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -73,9 +73,11 @@ vi.mock("~/services/apiAdapters/registry", () => ({
       resolveTokenKey: async ({ token }: { token: { key: string } }) =>
         token.key,
       deleteToken: vi.fn(),
-      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
       fetchAvailableModels: (...args: any[]) =>
         fetchAccountAvailableModelsMock(...args),
+      userGroups: {
+        fetch: (...args: any[]) => fetchUserGroupsMock(...args),
+      },
     },
   }),
 }))

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -5,7 +5,6 @@ import { Z_INDEX } from "~/components/ui"
 import { SITE_TYPES } from "~/constants/siteType"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
-import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
@@ -65,7 +64,7 @@ vi.mock("~/services/apiService", () => ({
 }))
 
 vi.mock("~/services/apiAdapters/registry", () => ({
-  getSiteAdapter: () => ({
+  getSiteAdapter: (siteType: string) => ({
     keyManagement: {
       fetchTokens: vi.fn(async () => []),
       createToken: (...args: any[]) => createApiTokenMock(...args),
@@ -75,9 +74,12 @@ vi.mock("~/services/apiAdapters/registry", () => ({
       deleteToken: vi.fn(),
       fetchAvailableModels: (...args: any[]) =>
         fetchAccountAvailableModelsMock(...args),
-      userGroups: {
-        fetch: (...args: any[]) => fetchUserGroupsMock(...args),
-      },
+      userGroups:
+        siteType === SITE_TYPES.AIHUBMIX
+          ? undefined
+          : {
+              fetch: (...args: any[]) => fetchUserGroupsMock(...args),
+            },
     },
   }),
 }))
@@ -1149,14 +1151,6 @@ describe("AddTokenDialog prefill", () => {
 
   it("creates tokens without rendering or requiring group selection when the site has no groups", async () => {
     fetchAccountAvailableModelsMock.mockResolvedValueOnce(["gpt-4"])
-    fetchUserGroupsMock.mockRejectedValueOnce(
-      new ApiError(
-        "aihubmix_user_groups_unsupported",
-        undefined,
-        undefined,
-        API_ERROR_CODES.FEATURE_UNSUPPORTED,
-      ),
-    )
     createApiTokenMock.mockResolvedValueOnce(true)
 
     const user = userEvent.setup()
@@ -1165,8 +1159,8 @@ describe("AddTokenDialog prefill", () => {
       <AddTokenDialog
         isOpen={true}
         onClose={() => {}}
-        availableAccounts={[ACCOUNT]}
-        preSelectedAccountId={ACCOUNT.id}
+        availableAccounts={[AIHUBMIX_ACCOUNT]}
+        preSelectedAccountId={AIHUBMIX_ACCOUNT.id}
         createPrefill={{ modelId: "gpt-4", defaultName: "group-less token" }}
       />,
     )
@@ -1174,6 +1168,7 @@ describe("AddTokenDialog prefill", () => {
     await screen.findByLabelText(/keyManagement:dialog\.tokenName/)
 
     expect(screen.queryByText("keyManagement:dialog.groupLabel")).toBeNull()
+    expect(fetchUserGroupsMock).not.toHaveBeenCalled()
 
     await user.click(
       screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
@@ -1192,14 +1187,6 @@ describe("AddTokenDialog prefill", () => {
 
   it("lets AIHubMix submit subnet values for backend validation", async () => {
     fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
-    fetchUserGroupsMock.mockRejectedValueOnce(
-      new ApiError(
-        "aihubmix_user_groups_unsupported",
-        undefined,
-        undefined,
-        API_ERROR_CODES.FEATURE_UNSUPPORTED,
-      ),
-    )
     createApiTokenMock.mockResolvedValueOnce(true)
 
     const user = userEvent.setup()
@@ -1224,6 +1211,7 @@ describe("AddTokenDialog prefill", () => {
       screen.getByText("keyManagement:dialog.subnetExample"),
     ).toBeInTheDocument()
     expect(screen.queryByText("keyManagement:dialog.ipExample")).toBeNull()
+    expect(fetchUserGroupsMock).not.toHaveBeenCalled()
 
     await user.click(
       screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),

--- a/tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx
@@ -2,7 +2,6 @@ import { useState } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useTokenData } from "~/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData"
-import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import { AuthTypeEnum } from "~/types"
 import { renderHook, waitFor } from "~~/tests/test-utils/render"
 
@@ -99,7 +98,9 @@ describe("useTokenData", () => {
     createDisplayAccountApiContextMock.mockReturnValue({
       keyManagement: {
         fetchAvailableModels: fetchAccountAvailableModelsMock,
-        fetchUserGroups: fetchUserGroupsMock,
+        userGroups: {
+          fetch: fetchUserGroupsMock,
+        },
       },
       request: { accountId: ACCOUNT.id },
     })
@@ -235,16 +236,14 @@ describe("useTokenData", () => {
     })
   })
 
-  it("treats unsupported group capability as no group selection without showing an error", async () => {
+  it("treats missing group capability as no group selection without showing an error", async () => {
     fetchAccountAvailableModelsMock.mockResolvedValue(["gpt-4o-mini"])
-    fetchUserGroupsMock.mockRejectedValue(
-      new ApiError(
-        "groups_unsupported",
-        undefined,
-        undefined,
-        API_ERROR_CODES.FEATURE_UNSUPPORTED,
-      ),
-    )
+    createDisplayAccountApiContextMock.mockReturnValue({
+      keyManagement: {
+        fetchAvailableModels: fetchAccountAvailableModelsMock,
+      },
+      request: { accountId: ACCOUNT.id },
+    })
 
     const { result } = renderSubject({
       isOpen: true,
@@ -257,6 +256,7 @@ describe("useTokenData", () => {
     })
 
     expect(result.current.groups).toEqual({})
+    expect(fetchUserGroupsMock).not.toHaveBeenCalled()
     expect(toastErrorMock).not.toHaveBeenCalled()
   })
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -50,9 +50,11 @@ vi.mock("~/services/apiAdapters/registry", () => ({
         token: { key: string }
       }) => _params.token.key,
       deleteToken: vi.fn(),
-      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
       fetchAvailableModels: (...args: any[]) =>
         fetchAccountAvailableModelsMock(...args),
+      userGroups: {
+        fetch: (...args: any[]) => fetchUserGroupsMock(...args),
+      },
     },
   }),
 }))

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -68,9 +68,11 @@ vi.mock("~/services/apiAdapters/registry", () => ({
       createToken: (...args: any[]) => createApiTokenMock(...args),
       resolveTokenKey: (...args: any[]) => resolveApiTokenKeyMock(...args),
       deleteToken: vi.fn(),
-      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
       fetchAvailableModels: (...args: any[]) =>
         fetchAccountAvailableModelsMock(...args),
+      userGroups: {
+        fetch: (...args: any[]) => fetchUserGroupsMock(...args),
+      },
     },
   }),
 }))

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -10,7 +10,6 @@ import {
   deleteInvalidAccountToken,
   ensureAccountKeysForAvailableGroups,
 } from "~/services/accounts/accountKeyAutoProvisioning/groupCoverage"
-import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import { AuthTypeEnum } from "~/types"
 import { ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS } from "~/types/accountKeyAutoProvisioning"
 import {
@@ -30,7 +29,9 @@ vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteAdapter: vi.fn(() => ({
     keyManagement: {
       fetchTokens: (...args: unknown[]) => mocks.fetchAccountTokens(...args),
-      fetchUserGroups: (...args: unknown[]) => mocks.fetchUserGroups(...args),
+      userGroups: {
+        fetch: (...args: unknown[]) => mocks.fetchUserGroups(...args),
+      },
       createToken: (...args: unknown[]) => mocks.createApiToken(...args),
       deleteToken: (...args: unknown[]) => mocks.deleteApiToken(...args),
       resolveTokenKey: vi.fn(),
@@ -174,16 +175,20 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     ])
   })
 
-  it("falls back to one-key behavior when group lookup is unsupported", async () => {
+  it("falls back to one-key behavior when group lookup capability is missing", async () => {
     mocks.fetchAccountTokens.mockResolvedValue([])
-    mocks.fetchUserGroups.mockRejectedValue(
-      new ApiError(
-        "unsupported",
-        undefined,
-        "/api/user/self/groups",
-        API_ERROR_CODES.FEATURE_UNSUPPORTED,
-      ),
-    )
+    const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
+    ;(
+      getSiteAdapter as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValueOnce({
+      keyManagement: {
+        fetchTokens: (...args: unknown[]) => mocks.fetchAccountTokens(...args),
+        createToken: (...args: unknown[]) => mocks.createApiToken(...args),
+        deleteToken: (...args: unknown[]) => mocks.deleteApiToken(...args),
+        resolveTokenKey: vi.fn(),
+        fetchAvailableModels: vi.fn(),
+      },
+    })
     mocks.createApiToken.mockResolvedValue(true)
 
     const result = await runCoverage()
@@ -203,6 +208,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
       }),
       generateDefaultTokenRequest(),
     )
+    expect(mocks.fetchUserGroups).not.toHaveBeenCalled()
   })
 
   it("treats empty group responses as legacy one-key coverage when a token already exists", async () => {

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -38,8 +38,10 @@ const {
         createToken: (...args: unknown[]) => createApiTokenMock(...args),
         resolveTokenKey: vi.fn(),
         deleteToken: vi.fn(),
-        fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
         fetchAvailableModels: vi.fn(),
+        userGroups: {
+          fetch: (...args: unknown[]) => fetchUserGroupsMock(...args),
+        },
       },
     })),
     toastLoadingMock: vi.fn(),

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -10,6 +10,7 @@ import {
   ensureAccountApiToken,
   resolveSub2ApiQuickCreateResolution,
 } from "~/services/accounts/accountOperations"
+import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
 import { AuthTypeEnum } from "~/types"
 import {
   buildSiteAccount,
@@ -32,18 +33,22 @@ const {
     fetchAccountTokensMock,
     createApiTokenMock,
     fetchUserGroupsMock,
-    getSiteAdapterMock: vi.fn(() => ({
-      keyManagement: {
-        fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
-        createToken: (...args: unknown[]) => createApiTokenMock(...args),
-        resolveTokenKey: vi.fn(),
-        deleteToken: vi.fn(),
-        fetchAvailableModels: vi.fn(),
-        userGroups: {
-          fetch: (...args: unknown[]) => fetchUserGroupsMock(...args),
+    getSiteAdapterMock: vi.fn(
+      (): SiteAdapter => ({
+        siteType: SITE_TYPES.SUB2API,
+        keyManagement: {
+          fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+          createToken: (...args: unknown[]) => createApiTokenMock(...args),
+          updateToken: vi.fn(),
+          resolveTokenKey: vi.fn(),
+          deleteToken: vi.fn(),
+          fetchAvailableModels: vi.fn(),
+          userGroups: {
+            fetch: (...args: unknown[]) => fetchUserGroupsMock(...args),
+          },
         },
-      },
-    })),
+      }),
+    ),
     toastLoadingMock: vi.fn(),
   }
 })
@@ -273,6 +278,27 @@ describe("accountOperations Sub2API token creation guards", () => {
       kind: "ready",
       group: "vip",
     })
+  })
+
+  it("rejects quick-create resolution when Sub2API group inventory is missing", async () => {
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.SUB2API,
+      keyManagement: {
+        fetchTokens: vi.fn(),
+        createToken: vi.fn(),
+        updateToken: vi.fn(),
+        resolveTokenKey: vi.fn(),
+        deleteToken: vi.fn(),
+        fetchAvailableModels: vi.fn(),
+        userGroups: undefined,
+      },
+    })
+
+    await expect(
+      resolveSub2ApiQuickCreateResolution(DISPLAY_ACCOUNT),
+    ).rejects.toThrow("sub2api_group_inventory_not_implemented")
+
+    expect(fetchUserGroupsMock).not.toHaveBeenCalled()
   })
 
   it("rejects quick-create resolution for non-Sub2API accounts", async () => {

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -33,8 +33,10 @@ const {
         createToken: (...args: unknown[]) => createApiTokenMock(...args),
         resolveTokenKey: vi.fn(),
         deleteToken: vi.fn(),
-        fetchUserGroups: (...args: unknown[]) => fetchUserGroupsMock(...args),
         fetchAvailableModels: vi.fn(),
+        userGroups: {
+          fetch: (...args: unknown[]) => fetchUserGroupsMock(...args),
+        },
       },
     })),
   }

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -58,8 +58,10 @@ describe("fetchDisplayAccountTokens", () => {
     updateToken: typeof updateToken
     resolveTokenKey: typeof resolveTokenKey
     deleteToken: typeof deleteToken
-    fetchUserGroups: typeof fetchUserGroups
     fetchAvailableModels: typeof fetchAvailableModels
+    userGroups: {
+      fetch: typeof fetchUserGroups
+    }
   }
   let adapter: {
     siteType: string
@@ -80,8 +82,10 @@ describe("fetchDisplayAccountTokens", () => {
       updateToken,
       resolveTokenKey,
       deleteToken,
-      fetchUserGroups,
       fetchAvailableModels,
+      userGroups: {
+        fetch: fetchUserGroups,
+      },
     }
     adapter = { siteType: "new-api", keyManagement }
 

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -11,7 +11,6 @@ const {
   mockAihubmixDeleteApiToken,
   mockAihubmixFetchAccountAvailableModels,
   mockAihubmixFetchAccountTokens,
-  mockAihubmixFetchUserGroups,
   mockAihubmixResolveApiTokenKey,
   mockAihubmixUpdateApiToken,
   mockCreateApiToken,
@@ -34,7 +33,6 @@ const {
   mockAihubmixDeleteApiToken: vi.fn(),
   mockAihubmixFetchAccountAvailableModels: vi.fn(),
   mockAihubmixFetchAccountTokens: vi.fn(),
-  mockAihubmixFetchUserGroups: vi.fn(),
   mockAihubmixResolveApiTokenKey: vi.fn(),
   mockAihubmixUpdateApiToken: vi.fn(),
   mockCreateApiToken: vi.fn(),
@@ -73,7 +71,6 @@ vi.mock("~/services/apiService/aihubmix", () => ({
   deleteApiToken: mockAihubmixDeleteApiToken,
   fetchAccountAvailableModels: mockAihubmixFetchAccountAvailableModels,
   fetchAccountTokens: mockAihubmixFetchAccountTokens,
-  fetchUserGroups: mockAihubmixFetchUserGroups,
   resolveApiTokenKey: mockAihubmixResolveApiTokenKey,
   updateApiToken: mockAihubmixUpdateApiToken,
 }))
@@ -157,7 +154,7 @@ describe("apiAdapter keyManagement", () => {
     await expect(
       keyManagement.deleteToken({ request, tokenId: token.id }),
     ).resolves.toBe(true)
-    await expect(keyManagement.fetchUserGroups(request)).resolves.toBe(
+    await expect(keyManagement.userGroups?.fetch(request)).resolves.toBe(
       userGroups,
     )
     await expect(keyManagement.fetchAvailableModels(request)).resolves.toBe(
@@ -229,7 +226,7 @@ describe("apiAdapter keyManagement", () => {
     await expect(
       sub2ApiKeyManagement.deleteToken({ request, tokenId: token.id }),
     ).resolves.toBe(true)
-    await expect(sub2ApiKeyManagement.fetchUserGroups(request)).resolves.toBe(
+    await expect(sub2ApiKeyManagement.userGroups?.fetch(request)).resolves.toBe(
       userGroups,
     )
     await expect(
@@ -266,7 +263,6 @@ describe("apiAdapter keyManagement", () => {
     mockAihubmixUpdateApiToken.mockResolvedValueOnce(true)
     mockAihubmixResolveApiTokenKey.mockResolvedValueOnce("aihubmix-secret")
     mockAihubmixDeleteApiToken.mockResolvedValueOnce(true)
-    mockAihubmixFetchUserGroups.mockResolvedValueOnce(userGroups)
     mockAihubmixFetchAccountAvailableModels.mockResolvedValueOnce(
       availableModels,
     )
@@ -290,9 +286,7 @@ describe("apiAdapter keyManagement", () => {
     await expect(
       aihubmixKeyManagement.deleteToken({ request, tokenId: token.id }),
     ).resolves.toBe(true)
-    await expect(aihubmixKeyManagement.fetchUserGroups(request)).resolves.toBe(
-      userGroups,
-    )
+    expect(aihubmixKeyManagement.userGroups).toBeUndefined()
     await expect(
       aihubmixKeyManagement.fetchAvailableModels(request),
     ).resolves.toBe(availableModels)
@@ -306,19 +300,8 @@ describe("apiAdapter keyManagement", () => {
     )
     expect(mockAihubmixResolveApiTokenKey).toHaveBeenCalledWith(request, token)
     expect(mockAihubmixDeleteApiToken).toHaveBeenCalledWith(request, token.id)
-    expect(mockAihubmixFetchUserGroups).toHaveBeenCalledWith(request)
     expect(mockAihubmixFetchAccountAvailableModels).toHaveBeenCalledWith(
       request,
     )
-  })
-
-  it("propagates AIHubMix unsupported group inventory errors", async () => {
-    const error = new Error("groups unsupported")
-    mockAihubmixFetchUserGroups.mockRejectedValueOnce(error)
-
-    await expect(aihubmixKeyManagement.fetchUserGroups(request)).rejects.toBe(
-      error,
-    )
-    expect(mockAihubmixFetchUserGroups).toHaveBeenCalledWith(request)
   })
 })

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -27,8 +27,10 @@ describe("apiAdapters registry", () => {
       updateToken: expect.any(Function),
       resolveTokenKey: expect.any(Function),
       deleteToken: expect.any(Function),
-      fetchUserGroups: expect.any(Function),
       fetchAvailableModels: expect.any(Function),
+      userGroups: {
+        fetch: expect.any(Function),
+      },
     })
     expect(adapter.accountRefresh).toEqual({
       fetchCheckInSupport: expect.any(Function),
@@ -83,8 +85,10 @@ describe("apiAdapters registry", () => {
         updateToken: expect.any(Function),
         resolveTokenKey: expect.any(Function),
         deleteToken: expect.any(Function),
-        fetchUserGroups: expect.any(Function),
         fetchAvailableModels: expect.any(Function),
+        userGroups: {
+          fetch: expect.any(Function),
+        },
       })
       expect(adapter.accountRefresh).toEqual({
         fetchCheckInSupport: expect.any(Function),
@@ -124,9 +128,9 @@ describe("apiAdapters registry", () => {
       updateToken: expect.any(Function),
       resolveTokenKey: expect.any(Function),
       deleteToken: expect.any(Function),
-      fetchUserGroups: expect.any(Function),
       fetchAvailableModels: expect.any(Function),
     })
+    expect(adapter.keyManagement?.userGroups).toBeUndefined()
     expect(adapter.accountRefresh).toEqual({
       fetchCheckInSupport: expect.any(Function),
       refreshAccount: expect.any(Function),

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import { getApiService } from "~/services/apiService"
+import { AuthTypeEnum } from "~/types"
+
+const { redeemCodeMock } = vi.hoisted(() => ({
+  redeemCodeMock: vi.fn(),
+}))
+
+vi.mock("~/services/apiService", () => ({
+  getApiService: vi.fn(() => ({
+    redeemCode: redeemCodeMock,
+  })),
+}))
 
 describe("apiAdapters registry", () => {
   it("returns a Sub2API Adapter with account-scoped siteAnnouncements", () => {
@@ -115,6 +127,31 @@ describe("apiAdapters registry", () => {
       expect(adapter.siteAnnouncements).toBeUndefined()
       expect(adapter.modelCatalog).toBeUndefined()
     }
+  })
+
+  it("binds New API family redemption to the selected site type", async () => {
+    redeemCodeMock.mockResolvedValueOnce(500)
+
+    const adapter = getSiteAdapter(SITE_TYPES.VELOERA)
+    const request = {
+      baseUrl: "https://example.invalid",
+      accountId: "account-1",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        userId: "user-1",
+        accessToken: "access-token",
+      },
+    }
+
+    await expect(
+      adapter.redemption?.redeem({
+        request,
+        code: "example-code",
+      }),
+    ).resolves.toBe(500)
+
+    expect(getApiService).toHaveBeenCalledWith(SITE_TYPES.VELOERA)
+    expect(redeemCodeMock).toHaveBeenCalledWith(request, "example-code")
   })
 
   it("returns an AIHubMix Adapter with account completion and key management", () => {

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -48,6 +48,7 @@ describe("apiAdapters registry", () => {
       fetchData: expect.any(Function),
     })
     expect(adapter.modelPricing).toBeUndefined()
+    expect(adapter.redemption).toBeUndefined()
     expect(adapter.siteNotice).toBeUndefined()
   })
 
@@ -108,6 +109,9 @@ describe("apiAdapters registry", () => {
       expect(adapter.modelPricing).toEqual({
         fetchPricing: expect.any(Function),
       })
+      expect(adapter.redemption).toEqual({
+        redeem: expect.any(Function),
+      })
       expect(adapter.siteAnnouncements).toBeUndefined()
       expect(adapter.modelCatalog).toBeUndefined()
     }
@@ -149,6 +153,7 @@ describe("apiAdapters registry", () => {
     expect(adapter.modelPricing).toEqual({
       fetchPricing: expect.any(Function),
     })
+    expect(adapter.redemption).toBeUndefined()
     expect(adapter.siteNotice).toBeUndefined()
     expect(adapter.siteAnnouncements).toBeUndefined()
     expect(adapter.modelCatalog).toBeUndefined()

--- a/tests/services/apiService/aihubmix/index.test.ts
+++ b/tests/services/apiService/aihubmix/index.test.ts
@@ -19,7 +19,6 @@ import {
   fetchTodayIncome,
   fetchTodayUsage,
   fetchTokenById,
-  fetchUserGroups,
   fetchUserInfo,
   getOrCreateAccessToken,
   refreshAccountData,
@@ -777,26 +776,6 @@ describe("apiService AIHubMix", () => {
         },
       },
     )
-  })
-
-  it("explicitly marks user groups unsupported without calling common group endpoints", async () => {
-    server.use(
-      http.get("https://aihubmix.com/api/user/self/groups", () =>
-        HttpResponse.json(
-          {
-            success: false,
-            message: "AIHubMix has no group endpoint",
-            data: null,
-          },
-          { status: 500 },
-        ),
-      ),
-    )
-
-    await expect(fetchUserGroups(baseRequest)).rejects.toMatchObject({
-      code: API_ERROR_CODES.FEATURE_UNSUPPORTED,
-      message: "aihubmix_user_groups_unsupported",
-    })
   })
 
   it("maps token detail, create, update, and delete to documented endpoints", async () => {

--- a/tests/services/apiService/index.test.ts
+++ b/tests/services/apiService/index.test.ts
@@ -261,14 +261,12 @@ describe("apiService index wrapper", () => {
     expect(getApiService(undefined).capabilities).toEqual({
       keyManagement: true,
       modelPricing: true,
-      redeemCode: true,
       siteAnnouncements: true,
     })
 
     expect(getApiService(SITE_TYPES.ONE_HUB).capabilities).toEqual({
       keyManagement: true,
       modelPricing: true,
-      redeemCode: true,
       siteAnnouncements: true,
     })
   })
@@ -277,16 +275,14 @@ describe("apiService index wrapper", () => {
     expect(getApiService(SITE_TYPES.SUB2API).capabilities).toEqual({
       keyManagement: true,
       modelPricing: false,
-      redeemCode: false,
       siteAnnouncements: true,
     })
   })
 
-  it("should expose AIHubMix capability overrides", () => {
+  it("should expose AIHubMix default apiService capabilities", () => {
     expect(getApiService(SITE_TYPES.AIHUBMIX).capabilities).toEqual({
       keyManagement: true,
       modelPricing: true,
-      redeemCode: false,
       siteAnnouncements: true,
     })
   })

--- a/tests/services/redeemService.test.ts
+++ b/tests/services/redeemService.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { accountStorage } from "~/services/accounts/accountStorage"
-import { getApiService } from "~/services/apiService"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { redeemService } from "~/services/redemption/redeemService"
 
 vi.mock("~/services/accounts/accountStorage", () => ({
@@ -13,8 +13,8 @@ vi.mock("~/services/accounts/accountStorage", () => ({
   },
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: vi.fn(),
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(),
 }))
 
 describe("redeemService.redeemCodeForAccount", () => {
@@ -31,7 +31,7 @@ describe("redeemService.redeemCodeForAccount", () => {
 
     expect(result.success).toBe(false)
     expect(result.message).toBe("messages:storage.accountNotFound")
-    expect(getApiService).not.toHaveBeenCalled()
+    expect(getSiteAdapter).not.toHaveBeenCalled()
   })
 
   it("rejects disabled accounts and does not call the API service", async () => {
@@ -50,7 +50,7 @@ describe("redeemService.redeemCodeForAccount", () => {
 
     expect(result.success).toBe(false)
     expect(result.message).toBe("messages:storage.accountDisabled")
-    expect(getApiService).not.toHaveBeenCalled()
+    expect(getSiteAdapter).not.toHaveBeenCalled()
   })
 
   it("redeems successfully and prefers stored display data when available", async () => {
@@ -72,7 +72,7 @@ describe("redeemService.redeemCodeForAccount", () => {
       id: "account-1",
       site_name: "Example Site",
     }
-    const redeemCode = vi.fn().mockResolvedValue(12345)
+    const redeem = vi.fn().mockResolvedValue(12345)
 
     ;(
       accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
@@ -80,18 +80,17 @@ describe("redeemService.redeemCodeForAccount", () => {
     ;(
       accountStorage.getDisplayDataById as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce(displayData)
-    ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      capabilities: {
-        redeemCode: true,
+    ;(getSiteAdapter as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      redemption: {
+        redeem,
       },
-      redeemCode,
     })
 
     const result = await redeemService.redeemCodeForAccount("account-1", "CODE")
 
-    expect(getApiService).toHaveBeenCalledWith("new-api")
-    expect(redeemCode).toHaveBeenCalledWith(
-      {
+    expect(getSiteAdapter).toHaveBeenCalledWith("new-api")
+    expect(redeem).toHaveBeenCalledWith({
+      request: {
         baseUrl: "https://example.com",
         accountId: "account-1",
         auth: {
@@ -101,8 +100,8 @@ describe("redeemService.redeemCodeForAccount", () => {
           cookie: "session=abc",
         },
       },
-      "CODE",
-    )
+      code: "CODE",
+    })
     expect(accountStorage.getDisplayDataById).toHaveBeenCalledWith("account-1")
     expect(accountStorage.convertToDisplayData).not.toHaveBeenCalled()
     expect(result).toEqual({
@@ -129,7 +128,7 @@ describe("redeemService.redeemCodeForAccount", () => {
       id: "account-2",
       site_name: "Converted Site",
     }
-    const redeemCode = vi.fn().mockResolvedValue("unexpected")
+    const redeem = vi.fn().mockResolvedValue("unexpected")
 
     ;(
       accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
@@ -140,17 +139,16 @@ describe("redeemService.redeemCodeForAccount", () => {
     ;(
       accountStorage.convertToDisplayData as unknown as ReturnType<typeof vi.fn>
     ).mockReturnValueOnce(convertedDisplayData)
-    ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      capabilities: {
-        redeemCode: true,
+    ;(getSiteAdapter as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      redemption: {
+        redeem,
       },
-      redeemCode,
     })
 
     const result = await redeemService.redeemCodeForAccount("account-2", "CODE")
 
-    expect(redeemCode).toHaveBeenCalledWith(
-      {
+    expect(redeem).toHaveBeenCalledWith({
+      request: {
         baseUrl: "https://one-api.example.com",
         accountId: "account-2",
         auth: {
@@ -160,8 +158,8 @@ describe("redeemService.redeemCodeForAccount", () => {
           cookie: undefined,
         },
       },
-      "CODE",
-    )
+      code: "CODE",
+    })
     expect(accountStorage.convertToDisplayData).toHaveBeenCalledWith(account)
     expect(result).toEqual({
       success: true,
@@ -183,16 +181,15 @@ describe("redeemService.redeemCodeForAccount", () => {
         access_token: "token-3",
       },
     }
-    const redeemCode = vi.fn().mockRejectedValue(new Error("backend exploded"))
+    const redeem = vi.fn().mockRejectedValue(new Error("backend exploded"))
 
     ;(
       accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce(account)
-    ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      capabilities: {
-        redeemCode: true,
+    ;(getSiteAdapter as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      redemption: {
+        redeem,
       },
-      redeemCode,
     })
 
     const result = await redeemService.redeemCodeForAccount("account-3", "CODE")
@@ -216,16 +213,15 @@ describe("redeemService.redeemCodeForAccount", () => {
       },
     }
     const blankError = new Error("")
-    const redeemCode = vi.fn().mockRejectedValue(blankError)
+    const redeem = vi.fn().mockRejectedValue(blankError)
 
     ;(
       accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce(account)
-    ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      capabilities: {
-        redeemCode: true,
+    ;(getSiteAdapter as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      redemption: {
+        redeem,
       },
-      redeemCode,
     })
 
     const result = await redeemService.redeemCodeForAccount("account-4", "CODE")
@@ -248,17 +244,12 @@ describe("redeemService.redeemCodeForAccount", () => {
         access_token: "token-sub2api",
       },
     }
-    const redeemCode = vi.fn()
+    const redeem = vi.fn()
 
     ;(
       accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce(account)
-    ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      capabilities: {
-        redeemCode: false,
-      },
-      redeemCode,
-    })
+    ;(getSiteAdapter as unknown as ReturnType<typeof vi.fn>).mockReturnValue({})
 
     const result = await redeemService.redeemCodeForAccount("sub2api-1", "CODE")
 
@@ -266,7 +257,7 @@ describe("redeemService.redeemCodeForAccount", () => {
       success: false,
       message: "redemptionAssist:messages.redeemFailed",
     })
-    expect(redeemCode).not.toHaveBeenCalled()
+    expect(redeem).not.toHaveBeenCalled()
   })
 
   it("returns a local failure for unsupported AIHubMix redemption", async () => {
@@ -281,17 +272,12 @@ describe("redeemService.redeemCodeForAccount", () => {
         access_token: "token-aihubmix",
       },
     }
-    const redeemCode = vi.fn()
+    const redeem = vi.fn()
 
     ;(
       accountStorage.getAccountById as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce(account)
-    ;(getApiService as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      capabilities: {
-        redeemCode: false,
-      },
-      redeemCode,
-    })
+    ;(getSiteAdapter as unknown as ReturnType<typeof vi.fn>).mockReturnValue({})
 
     const result = await redeemService.redeemCodeForAccount(
       "aihubmix-1",
@@ -302,6 +288,6 @@ describe("redeemService.redeemCodeForAccount", () => {
       success: false,
       message: "redemptionAssist:messages.redeemFailed",
     })
-    expect(redeemCode).not.toHaveBeenCalled()
+    expect(redeem).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Model user groups as an optional key-management capability so unsupported sites can keep token flows available without fake group data.
- Route redemption through site adapters and remove the legacy Sub2API/AIHubMix redemption facade behavior.

## Test Plan
- pnpm run validate:push
- git push pre-push validation: pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added redemption capability to site adapters, enabling redemption via adapter-backed modules.
* **Refactor**
  * Restructured key-management user-group fetching to use a nested, optional `userGroups.fetch` capability across adapters.
* **Bug Fixes**
  * Improved handling when user-group inventory is missing: token dialogs and related flows now avoid unsupported-feature errors and behave consistently; Sub2API quick-create shows a clear “not implemented” failure when groups aren’t available.
* **Removals**
  * Removed direct user-group fetching from the AIHubMix key-management adapter and removed `redeemCode` from API service capabilities.
* **Tests**
  * Updated mocks and assertions to match the new capability shapes and redemption routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->