### PR TITLE
refactor(account): route dialog rules through site policy

### DIFF
--- a/docs/superpowers/plans/2026-06-20-account-dialog-site-policy.md
+++ b/docs/superpowers/plans/2026-06-20-account-dialog-site-policy.md
@@ -1,0 +1,1074 @@
+# Account Dialog Site Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move Account Dialog site-specific UI/workflow rules into a feature-local policy module so adding the next account site type does not require scattered `SITE_TYPES.X` branches in `useAccountDialog.ts`.
+
+**Architecture:** Keep `useAccountDialog.ts` as the React/browser/toast/analytics orchestrator, but route draft normalization, cookie-import eligibility, Sub2API refresh-token persistence, and post-save prompt decisions through `src/features/AccountManagement/components/AccountDialog/sitePolicy.ts`. Do not move UI policy onto backend `SiteAdapter`.
+
+**Tech Stack:** TypeScript, React hooks, Vitest, Testing Library, existing Account Dialog hook tests, pnpm.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-account-dialog-site-policy-design.md`
+
+---
+
+## File Structure
+
+Create:
+
+- `src/features/AccountManagement/components/AccountDialog/sitePolicy.ts`
+  - Own the Account Dialog site policy table and pure helpers.
+- `tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts`
+  - Cover policy defaults and site-specific draft normalization without React.
+
+Modify:
+
+- `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+  - Replace inline Sub2API/AIHubMix policy decisions with policy helper calls.
+- `tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx`
+  - Keep Sub2API constraint and stored-account hydration coverage green.
+- `tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx`
+  - Keep auto-detect merge, Sub2API, AIHubMix, and cookie auto-import coverage green.
+- `tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx`
+  - Add or preserve coverage that cookie import behavior remains browser-side and policy-gated.
+- `tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx`
+  - Keep Sub2API refresh-token payload, Sub2API post-save dialog, and AIHubMix deferred success coverage green.
+- `tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx`
+  - Keep default auth behavior coverage green if policy changes affect initial draft/auth flows.
+
+Do not modify:
+
+- `src/services/apiAdapters/**`
+- `src/services/accountSiteOnboarding/**`
+- `src/services/managedSites/**`
+- `src/constants/siteType.ts`
+- `src/locales/**`
+- telemetry schema or analytics payload types
+- Playwright E2E tests, unless implementation exposes a browser-only regression that unit/hook tests cannot cover
+
+---
+
+## Implementation Notes
+
+This is a refactor-only slice. Preserve existing user-visible behavior:
+
+- Sub2API Account Dialog state is access-token-only, clears saved cookie session data, and disables built-in check-in detection.
+- Leaving Sub2API clears Sub2API refresh-token draft state.
+- Stored Sub2API accounts hydrate refresh-token mode only for Sub2API-compatible stored accounts.
+- Sub2API detected refresh-token data is captured but refresh-token mode remains opt-in.
+- Sub2API save includes `sub2apiAuth` only when refresh-token mode is enabled and a nonblank refresh token exists.
+- Sub2API post-save token creation dialog still opens for normal add saves with display data, and still skips during auto-config.
+- AIHubMix detected browser-session accounts save as access-token accounts and clear saved cookie session data.
+- AIHubMix post-save foreground key prompt and deferred success behavior remain unchanged.
+- Compatible cookie-auth accounts still auto-import cookies after successful auto-detect when cookie auth is selected and no session cookie has already been captured.
+
+Keep side effects in the hook:
+
+- browser permission checks
+- runtime messages
+- cookie import
+- Sub2API session import
+- toasts
+- analytics
+- post-save dialogs and callbacks
+
+The policy module must stay pure. It should not import React, browser APIs, storage, analytics, logger, toast, or runtime messaging.
+
+Telemetry decision: reuse existing. No new user action or analytics field is introduced.
+
+Settings search decision: none. This slice does not add, move, rename, or delete settings UI.
+
+E2E decision: no new Playwright E2E by default. The risk is policy mapping and hook state transitions, covered by pure unit tests plus existing hook tests.
+
+---
+
+### Task 1: Add The Pure Account Dialog Site Policy Module
+
+**Files:**
+
+- Create `tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts`
+- Create `src/features/AccountManagement/components/AccountDialog/sitePolicy.ts`
+
+- [ ] **Step 1: Write failing policy tests**
+
+Add a focused test file with placeholder data only:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  createEmptyAccountDialogDraft,
+  type AccountDialogDraft,
+} from "~/features/AccountManagement/components/AccountDialog/models"
+import {
+  buildSub2ApiAuthFromAccountDialogDraft,
+  getAccountDialogSitePolicy,
+  normalizeAccountDialogDraftForSitePolicy,
+  shouldAutoImportCookieAuthForAccountDialogSite,
+  shouldDeferAccountSaveSuccessForAccountDialogSite,
+  shouldOpenSub2ApiTokenDialogForAccountDialogSite,
+} from "~/features/AccountManagement/components/AccountDialog/sitePolicy"
+import { AuthTypeEnum } from "~/types"
+
+function createDraft(
+  overrides: Partial<AccountDialogDraft> = {},
+): AccountDialogDraft {
+  return {
+    ...createEmptyAccountDialogDraft(),
+    siteName: "Example",
+    username: "user@example.invalid",
+    accessToken: "access-token",
+    userId: "user-id",
+    siteType: SITE_TYPES.UNKNOWN,
+    authType: AuthTypeEnum.Cookie,
+    cookieAuthSessionCookie: "session=example",
+    checkIn: {
+      ...createEmptyAccountDialogDraft().checkIn,
+      enableDetection: true,
+      autoCheckInEnabled: true,
+    },
+    sub2apiUseRefreshToken: true,
+    sub2apiRefreshToken: " refresh-token ",
+    sub2apiTokenExpiresAt: 123456,
+    ...overrides,
+  }
+}
+
+describe("Account Dialog site policy", () => {
+  it("keeps compatible site behavior as the default policy", () => {
+    const policy = getAccountDialogSitePolicy(SITE_TYPES.UNKNOWN)
+    const draft = createDraft()
+
+    const normalized = normalizeAccountDialogDraftForSitePolicy({
+      draft,
+      policy,
+    })
+
+    expect(normalized.authType).toBe(AuthTypeEnum.Cookie)
+    expect(normalized.cookieAuthSessionCookie).toBe("session=example")
+    expect(normalized.checkIn.enableDetection).toBe(true)
+    expect(normalized.checkIn.autoCheckInEnabled).toBe(true)
+    expect(normalized.sub2apiUseRefreshToken).toBe(false)
+    expect(normalized.sub2apiRefreshToken).toBe("")
+    expect(normalized.sub2apiTokenExpiresAt).toBeNull()
+    expect(
+      shouldAutoImportCookieAuthForAccountDialogSite({
+        policy,
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "",
+        url: "https://example.invalid",
+      }),
+    ).toBe(true)
+  })
+
+  it("normalizes Sub2API dialogs to access-token auth and inactive built-in check-in", () => {
+    const policy = getAccountDialogSitePolicy(SITE_TYPES.SUB2API)
+    const normalized = normalizeAccountDialogDraftForSitePolicy({
+      draft: createDraft({ siteType: SITE_TYPES.SUB2API }),
+      policy,
+    })
+
+    expect(normalized.authType).toBe(AuthTypeEnum.AccessToken)
+    expect(normalized.cookieAuthSessionCookie).toBe("")
+    expect(normalized.checkIn.enableDetection).toBe(false)
+    expect(normalized.checkIn.autoCheckInEnabled).toBe(false)
+    expect(normalized.sub2apiUseRefreshToken).toBe(true)
+    expect(normalized.sub2apiRefreshToken).toBe(" refresh-token ")
+    expect(normalized.sub2apiTokenExpiresAt).toBe(123456)
+    expect(
+      shouldAutoImportCookieAuthForAccountDialogSite({
+        policy,
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "",
+        url: "https://example.invalid",
+      }),
+    ).toBe(false)
+  })
+
+  it("normalizes AIHubMix detected browser sessions to saved access-token accounts", () => {
+    const policy = getAccountDialogSitePolicy(SITE_TYPES.AIHUBMIX)
+    const normalized = normalizeAccountDialogDraftForSitePolicy({
+      draft: createDraft({ siteType: SITE_TYPES.AIHUBMIX }),
+      policy,
+    })
+
+    expect(normalized.authType).toBe(AuthTypeEnum.AccessToken)
+    expect(normalized.cookieAuthSessionCookie).toBe("")
+    expect(normalized.checkIn.enableDetection).toBe(true)
+    expect(normalized.sub2apiUseRefreshToken).toBe(false)
+    expect(normalized.sub2apiRefreshToken).toBe("")
+    expect(normalized.sub2apiTokenExpiresAt).toBeNull()
+    expect(
+      shouldAutoImportCookieAuthForAccountDialogSite({
+        policy,
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "",
+        url: "https://example.invalid",
+      }),
+    ).toBe(false)
+  })
+
+  it("builds Sub2API refresh-token payloads only when the policy and draft enable them", () => {
+    const sub2apiPolicy = getAccountDialogSitePolicy(SITE_TYPES.SUB2API)
+    const defaultPolicy = getAccountDialogSitePolicy(SITE_TYPES.UNKNOWN)
+
+    expect(
+      buildSub2ApiAuthFromAccountDialogDraft({
+        draft: createDraft({ siteType: SITE_TYPES.SUB2API }),
+        policy: sub2apiPolicy,
+      }),
+    ).toEqual({
+      refreshToken: "refresh-token",
+      tokenExpiresAt: 123456,
+    })
+
+    expect(
+      buildSub2ApiAuthFromAccountDialogDraft({
+        draft: createDraft({ siteType: SITE_TYPES.SUB2API }),
+        policy: defaultPolicy,
+      }),
+    ).toBeUndefined()
+
+    expect(
+      buildSub2ApiAuthFromAccountDialogDraft({
+        draft: createDraft({
+          siteType: SITE_TYPES.SUB2API,
+          sub2apiUseRefreshToken: false,
+        }),
+        policy: sub2apiPolicy,
+      }),
+    ).toBeUndefined()
+  })
+
+  it("keeps post-save decisions policy-driven", () => {
+    expect(
+      shouldOpenSub2ApiTokenDialogForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.SUB2API),
+        skipSub2ApiKeyPrompt: false,
+        hasDisplayData: true,
+      }),
+    ).toBe(true)
+
+    expect(
+      shouldOpenSub2ApiTokenDialogForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.SUB2API),
+        skipSub2ApiKeyPrompt: true,
+        hasDisplayData: true,
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldDeferAccountSaveSuccessForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.AIHUBMIX),
+        isAddMode: true,
+        autoProvisionKeyOnAccountAdd: true,
+        skipAutoProvisionKeyOnAccountAdd: false,
+      }),
+    ).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Implement `sitePolicy.ts`**
+
+Start with a small table and pure helpers. Keep the table local and explicit:
+
+```ts
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import type { AccountDialogDraft } from "~/features/AccountManagement/components/AccountDialog/models"
+import { AuthTypeEnum, type Sub2ApiAuthConfig } from "~/types"
+
+export type AccountDialogSitePolicy = {
+  siteType: AccountSiteType
+  forceAccessTokenAuth: boolean
+  allowCookieAuthSession: boolean
+  allowCookieAutoImport: boolean
+  allowBuiltInCheckInDetection: boolean
+  sub2apiRefreshToken: {
+    enabled: boolean
+  }
+  postSave: {
+    openSub2ApiTokenDialog: boolean
+    deferSuccessForAihubmixOneTimeKey: boolean
+  }
+}
+
+const DEFAULT_ACCOUNT_DIALOG_SITE_POLICY: AccountDialogSitePolicy = {
+  siteType: SITE_TYPES.UNKNOWN,
+  forceAccessTokenAuth: false,
+  allowCookieAuthSession: true,
+  allowCookieAutoImport: true,
+  allowBuiltInCheckInDetection: true,
+  sub2apiRefreshToken: {
+    enabled: false,
+  },
+  postSave: {
+    openSub2ApiTokenDialog: false,
+    deferSuccessForAihubmixOneTimeKey: false,
+  },
+}
+
+const ACCOUNT_DIALOG_SITE_POLICY_OVERRIDES: Partial<
+  Record<AccountSiteType, Partial<AccountDialogSitePolicy>>
+> = {
+  [SITE_TYPES.SUB2API]: {
+    siteType: SITE_TYPES.SUB2API,
+    forceAccessTokenAuth: true,
+    allowCookieAuthSession: false,
+    allowCookieAutoImport: false,
+    allowBuiltInCheckInDetection: false,
+    sub2apiRefreshToken: {
+      enabled: true,
+    },
+    postSave: {
+      openSub2ApiTokenDialog: true,
+      deferSuccessForAihubmixOneTimeKey: false,
+    },
+  },
+  [SITE_TYPES.AIHUBMIX]: {
+    siteType: SITE_TYPES.AIHUBMIX,
+    forceAccessTokenAuth: true,
+    allowCookieAuthSession: false,
+    allowCookieAutoImport: false,
+    postSave: {
+      openSub2ApiTokenDialog: false,
+      deferSuccessForAihubmixOneTimeKey: true,
+    },
+  },
+}
+
+export function getAccountDialogSitePolicy(
+  siteType: AccountSiteType,
+): AccountDialogSitePolicy {
+  const override = ACCOUNT_DIALOG_SITE_POLICY_OVERRIDES[siteType]
+
+  return {
+    ...DEFAULT_ACCOUNT_DIALOG_SITE_POLICY,
+    ...override,
+    siteType,
+    sub2apiRefreshToken: {
+      ...DEFAULT_ACCOUNT_DIALOG_SITE_POLICY.sub2apiRefreshToken,
+      ...override?.sub2apiRefreshToken,
+    },
+    postSave: {
+      ...DEFAULT_ACCOUNT_DIALOG_SITE_POLICY.postSave,
+      ...override?.postSave,
+    },
+  }
+}
+
+export function normalizeAccountDialogDraftForSitePolicy(params: {
+  draft: AccountDialogDraft
+  policy: AccountDialogSitePolicy
+}): AccountDialogDraft {
+  const { draft, policy } = params
+  const nextDraft: AccountDialogDraft = {
+    ...draft,
+    authType: policy.forceAccessTokenAuth
+      ? AuthTypeEnum.AccessToken
+      : draft.authType,
+    cookieAuthSessionCookie: policy.allowCookieAuthSession
+      ? draft.cookieAuthSessionCookie
+      : "",
+    checkIn: policy.allowBuiltInCheckInDetection
+      ? draft.checkIn
+      : {
+          ...draft.checkIn,
+          enableDetection: false,
+          autoCheckInEnabled: false,
+        },
+    sub2apiUseRefreshToken: policy.sub2apiRefreshToken.enabled
+      ? draft.sub2apiUseRefreshToken
+      : false,
+    sub2apiRefreshToken: policy.sub2apiRefreshToken.enabled
+      ? draft.sub2apiRefreshToken
+      : "",
+    sub2apiTokenExpiresAt: policy.sub2apiRefreshToken.enabled
+      ? draft.sub2apiTokenExpiresAt
+      : null,
+  }
+
+  return arePolicyDraftFieldsEquivalent(draft, nextDraft) ? draft : nextDraft
+}
+
+export function shouldAutoImportCookieAuthForAccountDialogSite(params: {
+  policy: AccountDialogSitePolicy
+  authType: AuthTypeEnum
+  cookieAuthSessionCookie: string
+  url: string
+}): boolean {
+  return (
+    params.policy.allowCookieAutoImport &&
+    params.authType === AuthTypeEnum.Cookie &&
+    !params.cookieAuthSessionCookie.trim() &&
+    Boolean(params.url.trim())
+  )
+}
+
+export function buildSub2ApiAuthFromAccountDialogDraft(params: {
+  draft: AccountDialogDraft
+  policy: AccountDialogSitePolicy
+}): Sub2ApiAuthConfig | undefined {
+  const refreshToken = params.draft.sub2apiRefreshToken.trim()
+
+  if (
+    !params.policy.sub2apiRefreshToken.enabled ||
+    !params.draft.sub2apiUseRefreshToken ||
+    !refreshToken
+  ) {
+    return undefined
+  }
+
+  return {
+    refreshToken,
+    ...(typeof params.draft.sub2apiTokenExpiresAt === "number"
+      ? { tokenExpiresAt: params.draft.sub2apiTokenExpiresAt }
+      : {}),
+  }
+}
+
+export function shouldOpenSub2ApiTokenDialogForAccountDialogSite(params: {
+  policy: AccountDialogSitePolicy
+  skipSub2ApiKeyPrompt: boolean
+  hasDisplayData: boolean
+}): boolean {
+  return (
+    params.policy.postSave.openSub2ApiTokenDialog &&
+    !params.skipSub2ApiKeyPrompt &&
+    params.hasDisplayData
+  )
+}
+
+export function shouldDeferAccountSaveSuccessForAccountDialogSite(params: {
+  policy: AccountDialogSitePolicy
+  isAddMode: boolean
+  autoProvisionKeyOnAccountAdd: boolean
+  skipAutoProvisionKeyOnAccountAdd: boolean
+}): boolean {
+  return (
+    params.policy.postSave.deferSuccessForAihubmixOneTimeKey &&
+    params.isAddMode &&
+    params.autoProvisionKeyOnAccountAdd &&
+    !params.skipAutoProvisionKeyOnAccountAdd
+  )
+}
+
+function arePolicyDraftFieldsEquivalent(
+  left: AccountDialogDraft,
+  right: AccountDialogDraft,
+): boolean {
+  return (
+    left.authType === right.authType &&
+    left.cookieAuthSessionCookie === right.cookieAuthSessionCookie &&
+    left.checkIn.enableDetection === right.checkIn.enableDetection &&
+    left.checkIn.autoCheckInEnabled === right.checkIn.autoCheckInEnabled &&
+    left.sub2apiUseRefreshToken === right.sub2apiUseRefreshToken &&
+    left.sub2apiRefreshToken === right.sub2apiRefreshToken &&
+    left.sub2apiTokenExpiresAt === right.sub2apiTokenExpiresAt
+  )
+}
+```
+
+Adjust exact helper names if implementation reveals a clearer local convention, but keep the exported surface small and pure.
+
+- [ ] **Step 3: Run the new focused test**
+
+```text
+pnpm vitest run tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts
+```
+
+- [ ] **Step 4: Commit this task**
+
+```text
+git add src/features/AccountManagement/components/AccountDialog/sitePolicy.ts tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts
+git commit -m "refactor(account): add dialog site policy"
+```
+
+---
+
+### Task 2: Route Draft Normalization And Stored Account Hydration Through Policy
+
+**Files:**
+
+- Modify `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+- Modify `tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx`
+
+- [ ] **Step 1: Import policy helpers**
+
+Add imports near the Account Dialog model imports:
+
+```ts
+import {
+  getAccountDialogSitePolicy,
+  normalizeAccountDialogDraftForSitePolicy,
+} from "~/features/AccountManagement/components/AccountDialog/sitePolicy"
+```
+
+- [ ] **Step 2: Replace the two site-type effects with one policy normalization effect**
+
+Replace the Sub2API-specific effects:
+
+```ts
+// Enforce Sub2API constraints: JWT-only (access token), no built-in check-in.
+useEffect(() => {
+  if (siteType !== SITE_TYPES.SUB2API) return
+
+  updateDraft((prev) => applySub2ApiDraftConstraints(prev))
+}, [siteType, updateDraft])
+
+useEffect(() => {
+  if (siteType === SITE_TYPES.SUB2API) return
+
+  updateDraft((prev) => clearSub2ApiRefreshTokenState(prev))
+}, [siteType, updateDraft])
+```
+
+With:
+
+```ts
+useEffect(() => {
+  const policy = getAccountDialogSitePolicy(siteType)
+
+  updateDraft((prev) =>
+    normalizeAccountDialogDraftForSitePolicy({
+      draft: prev,
+      policy,
+    }),
+  )
+}, [siteType, updateDraft])
+```
+
+This keeps the hook responsible for the timing of normalization and moves the rules out of the hook.
+
+- [ ] **Step 3: Normalize prefilled draft state**
+
+In `resetForm(...)`, normalize the draft created from sponsor/current-site prefill:
+
+```ts
+const nextSiteType = nextPrefill?.siteType ?? SITE_TYPES.UNKNOWN
+const policy = getAccountDialogSitePolicy(nextSiteType)
+
+setDraft(
+  normalizeAccountDialogDraftForSitePolicy({
+    draft: {
+      ...createEmptyAccountDialogDraft(),
+      siteType: nextSiteType,
+      authType: normalizedPrefillAuthType || AuthTypeEnum.AccessToken,
+    },
+    policy,
+  }),
+)
+```
+
+Keep `hasExplicitAuthTypeRef.current` unchanged so explicit prefill auth decisions still behave the same before policy normalization.
+
+- [ ] **Step 4: Normalize edit-mode stored account hydration**
+
+In `loadAccountData(...)`, compute policy after resolving stored site type:
+
+```ts
+const normalizedSiteType = resolveStoredSiteType(
+  siteAccount.site_type,
+  Boolean(siteAccount.sub2apiAuth),
+)
+const policy = getAccountDialogSitePolicy(normalizedSiteType)
+const hasActiveSub2ApiRefreshToken =
+  policy.sub2apiRefreshToken.enabled && Boolean(refreshToken.trim())
+```
+
+Build the draft with policy-aware refresh-token fields:
+
+```ts
+const nextDraft = normalizeAccountDialogDraftForSitePolicy({
+  draft: {
+    siteName: siteAccount.site_name,
+    username: siteAccount.account_info.username,
+    accessToken: siteAccount.account_info.access_token,
+    userId: normalizeAccountIdentity(siteAccount.account_info.id) ?? "",
+    exchangeRate: siteAccount.exchange_rate.toString(),
+    manualBalanceUsd: siteAccount.manualBalanceUsd ?? "",
+    notes: siteAccount.notes || "",
+    tagIds: siteAccount.tagIds || [],
+    excludeFromTotalBalance: siteAccount.excludeFromTotalBalance === true,
+    excludeFromTodayIncome: siteAccount.excludeFromTodayIncome === true,
+    checkIn: {
+      enableDetection: siteAccount.checkIn?.enableDetection ?? false,
+      autoCheckInEnabled: siteAccount.checkIn?.autoCheckInEnabled ?? true,
+      siteStatus: {
+        isCheckedInToday:
+          siteAccount.checkIn?.siteStatus?.isCheckedInToday ?? false,
+        lastCheckInDate: siteAccount.checkIn?.siteStatus?.lastCheckInDate,
+      },
+      customCheckIn: {
+        url: siteAccount.checkIn?.customCheckIn?.url ?? "",
+        turnstilePreTrigger:
+          siteAccount.checkIn?.customCheckIn?.turnstilePreTrigger,
+        redeemUrl: siteAccount.checkIn?.customCheckIn?.redeemUrl ?? "",
+        openRedeemWithCheckIn:
+          siteAccount.checkIn?.customCheckIn?.openRedeemWithCheckIn ?? true,
+        isCheckedInToday:
+          siteAccount.checkIn?.customCheckIn?.isCheckedInToday ?? false,
+        lastCheckInDate:
+          siteAccount.checkIn?.customCheckIn?.lastCheckInDate,
+      },
+    },
+    siteType: normalizedSiteType,
+    authType: siteAccount.authType || AuthTypeEnum.AccessToken,
+    cookieAuthSessionCookie: siteAccount.cookieAuth?.sessionCookie || "",
+    sub2apiUseRefreshToken: hasActiveSub2ApiRefreshToken,
+    sub2apiRefreshToken: hasActiveSub2ApiRefreshToken ? refreshToken : "",
+    sub2apiTokenExpiresAt: hasActiveSub2ApiRefreshToken
+      ? siteAccount.sub2apiAuth?.tokenExpiresAt ?? null
+      : null,
+  },
+  policy,
+})
+
+setDraft(nextDraft)
+```
+
+Keep `resolveStoredSiteType(...)` local to the hook for now. It is legacy hydration compatibility, not general dialog policy.
+
+- [ ] **Step 5: Remove only now-unused local helpers**
+
+After the hook compiles, delete:
+
+- `applySub2ApiDraftConstraints(...)`
+- `clearSub2ApiRefreshTokenState(...)`
+
+Do not delete `areDraftsEquivalent(...)` yet if `buildDraftFromAutoDetectResult(...)` still uses it. If it becomes unused, remove it in the task where the final caller disappears.
+
+- [ ] **Step 6: Run focused tests**
+
+```text
+pnpm vitest run tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+```
+
+- [ ] **Step 7: Commit this task**
+
+```text
+git add src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+git commit -m "refactor(account): apply dialog site policy to drafts"
+```
+
+---
+
+### Task 3: Route Auto-Detect Merge And Cookie Auto-Import Through Policy
+
+**Files:**
+
+- Modify `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+- Modify `tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx`
+- Modify `tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx`
+
+- [ ] **Step 1: Import cookie policy helper**
+
+Extend the policy import:
+
+```ts
+import {
+  getAccountDialogSitePolicy,
+  normalizeAccountDialogDraftForSitePolicy,
+  shouldAutoImportCookieAuthForAccountDialogSite,
+} from "~/features/AccountManagement/components/AccountDialog/sitePolicy"
+```
+
+- [ ] **Step 2: Make `buildDraftFromAutoDetectResult(...)` policy-aware**
+
+Change the helper signature:
+
+```ts
+function buildDraftFromAutoDetectResult(params: {
+  draft: AccountDialogDraft
+  resultData: NonNullable<Awaited<ReturnType<typeof autoDetectAccount>>["data"]>
+  nextSiteType: AccountSiteType
+  nextCheckIn: CheckInConfig
+  preserveExistingCheckIn: boolean
+  mode: DialogMode
+  policy: AccountDialogSitePolicy
+}): AccountDialogDraft
+```
+
+Use policy instead of hard-coded Sub2API/AIHubMix auth and cookie decisions:
+
+```ts
+const nextDraft: AccountDialogDraft = {
+  ...draft,
+  username: resultData.username,
+  accessToken: resultData.accessToken,
+  userId: resultData.userId,
+  siteName: resultData.siteName,
+  exchangeRate: resultData.exchangeRate
+    ? resultData.exchangeRate.toString()
+    : mode === DIALOG_MODES.ADD
+      ? ""
+      : draft.exchangeRate,
+  siteType: nextSiteType,
+  authType:
+    resultData.authType ??
+    (policy.forceAccessTokenAuth ? AuthTypeEnum.AccessToken : draft.authType),
+  cookieAuthSessionCookie: policy.allowCookieAuthSession
+    ? draft.cookieAuthSessionCookie
+    : "",
+  checkIn: preserveExistingCheckIn
+    ? deepOverride(nextCheckIn, draft.checkIn)
+    : nextCheckIn,
+  sub2apiRefreshToken:
+    policy.sub2apiRefreshToken.enabled && resultData.sub2apiAuth
+      ? resultData.sub2apiAuth.refreshToken
+      : draft.sub2apiRefreshToken,
+  sub2apiTokenExpiresAt:
+    policy.sub2apiRefreshToken.enabled && resultData.sub2apiAuth
+      ? resultData.sub2apiAuth.tokenExpiresAt ?? null
+      : draft.sub2apiTokenExpiresAt,
+}
+
+return normalizeAccountDialogDraftForSitePolicy({
+  draft: nextDraft,
+  policy,
+})
+```
+
+Remove the inline comment that mentions AIHubMix inside the hook. The policy table is now the place that documents the saved access-token rule.
+
+- [ ] **Step 3: Replace inline Sub2API check-in override**
+
+In `handleAutoDetect`, compute policy immediately after `nextSiteType`:
+
+```ts
+const nextSiteType = isAccountSiteType(resultData.siteType)
+  ? resultData.siteType
+  : siteType
+const policy = getAccountDialogSitePolicy(nextSiteType)
+```
+
+Then pass the raw detected check-in into `buildDraftFromAutoDetectResult(...)`:
+
+```ts
+setDraft((prev) =>
+  buildDraftFromAutoDetectResult({
+    draft: prev,
+    resultData,
+    nextSiteType,
+    nextCheckIn: detectedCheckIn,
+    preserveExistingCheckIn,
+    mode,
+    policy,
+  }),
+)
+```
+
+`normalizeAccountDialogDraftForSitePolicy(...)` should disable built-in check-in for Sub2API.
+
+- [ ] **Step 4: Replace inline cookie auto-import skip branches**
+
+Replace:
+
+```ts
+if (
+  authType === AuthTypeEnum.Cookie &&
+  resultData.siteType !== SITE_TYPES.SUB2API &&
+  resultData.siteType !== SITE_TYPES.AIHUBMIX &&
+  !cookieAuthSessionCookie.trim() &&
+  url.trim()
+) {
+```
+
+With:
+
+```ts
+if (
+  shouldAutoImportCookieAuthForAccountDialogSite({
+    policy,
+    authType,
+    cookieAuthSessionCookie,
+    url,
+  })
+) {
+```
+
+Keep the runtime message body, warning toast, and logger unchanged.
+
+- [ ] **Step 5: Update hook-level assertions only if needed**
+
+Existing tests already cover the important behavior:
+
+- Sub2API detected accounts are access-token-only, cookie-cleared, and check-in-disabled.
+- AIHubMix detected accounts are access-token-only and skip cookie import.
+- Compatible cookie-auth detected accounts still auto-import cookies.
+
+If assertions depend on branch location, update them to assert visible state/runtime messages instead of implementation detail.
+
+- [ ] **Step 6: Run focused tests**
+
+```text
+pnpm vitest run tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
+```
+
+- [ ] **Step 7: Commit this task**
+
+```text
+git add src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
+git commit -m "refactor(account): route auto-detect through dialog site policy"
+```
+
+---
+
+### Task 4: Route Save Payload And Post-Save Decisions Through Policy
+
+**Files:**
+
+- Modify `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+- Modify `tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx`
+
+- [ ] **Step 1: Import save/post-save policy helpers**
+
+Extend the policy import:
+
+```ts
+import {
+  buildSub2ApiAuthFromAccountDialogDraft,
+  getAccountDialogSitePolicy,
+  normalizeAccountDialogDraftForSitePolicy,
+  shouldAutoImportCookieAuthForAccountDialogSite,
+  shouldDeferAccountSaveSuccessForAccountDialogSite,
+  shouldOpenSub2ApiTokenDialogForAccountDialogSite,
+} from "~/features/AccountManagement/components/AccountDialog/sitePolicy"
+```
+
+- [ ] **Step 2: Replace `isAihubmixNormalSaveForegroundKeyFlow(...)`**
+
+Remove the helper that directly checks `siteType === SITE_TYPES.AIHUBMIX`.
+
+In `handleSaveAccount(...)`, compute once near the top of the `try` block:
+
+```ts
+const policy = getAccountDialogSitePolicy(siteType)
+const shouldDeferSuccessForSitePolicy =
+  shouldDeferAccountSaveSuccessForAccountDialogSite({
+    policy,
+    isAddMode: mode === DIALOG_MODES.ADD,
+    autoProvisionKeyOnAccountAdd,
+    skipAutoProvisionKeyOnAccountAdd:
+      options?.skipAutoProvisionKeyOnAccountAdd === true,
+  })
+```
+
+Use that value in the `validateAndSaveAccount(...)` options:
+
+```ts
+skipAutoProvisionKeyOnAccountAdd:
+  options?.skipAutoProvisionKeyOnAccountAdd === true ||
+  shouldDeferSuccessForSitePolicy,
+```
+
+- [ ] **Step 3: Replace inline `sub2apiAuth` assembly**
+
+Replace:
+
+```ts
+const sub2apiAuth: Sub2ApiAuthConfig | undefined =
+  siteType === SITE_TYPES.SUB2API &&
+  sub2apiUseRefreshToken &&
+  sub2apiRefreshToken.trim()
+    ? {
+        refreshToken: sub2apiRefreshToken.trim(),
+        ...(typeof sub2apiTokenExpiresAt === "number"
+          ? { tokenExpiresAt: sub2apiTokenExpiresAt }
+          : {}),
+      }
+    : undefined
+```
+
+With:
+
+```ts
+const sub2apiAuth = buildSub2ApiAuthFromAccountDialogDraft({
+  draft,
+  policy,
+})
+```
+
+If `draft` is not already directly available in this scope, either use the existing state object if present or build the minimal object from current state through a small local helper. Prefer reusing the existing `draft` state variable over duplicating field reads.
+
+- [ ] **Step 4: Replace deferred success branch**
+
+Replace direct calls to `shouldDeferAccountSaveSuccess(options)` in the success path with the policy-derived `shouldDeferSuccessForSitePolicy`.
+
+Keep `pendingAihubmixPostSaveSuccessRef`, `handleAihubmixNormalSaveForegroundKeyFlow(...)`, and `openAihubmixPostSaveKeyPrompt(...)` names for now. They describe a concrete existing post-save workflow, not a reusable policy abstraction.
+
+- [ ] **Step 5: Replace Sub2API post-save dialog branch**
+
+Replace:
+
+```ts
+siteType === SITE_TYPES.SUB2API &&
+options?.skipSub2ApiKeyPrompt !== true &&
+savedDisplayData
+```
+
+With:
+
+```ts
+shouldOpenSub2ApiTokenDialogForAccountDialogSite({
+  policy,
+  skipSub2ApiKeyPrompt: options?.skipSub2ApiKeyPrompt === true,
+  hasDisplayData: Boolean(savedDisplayData),
+})
+```
+
+Keep the dialog opening, allowed-group loading, and failure handling unchanged.
+
+- [ ] **Step 6: Update tests only where assertions depend on implementation**
+
+Keep these visible behaviors covered:
+
+- `validateAndSaveAccount(...)` receives trimmed `sub2apiAuth` only for Sub2API refresh-token mode.
+- Sub2API refresh token is not persisted until the mode is explicitly enabled.
+- Sub2API post-save dialog still opens on normal save and still skips during auto-config.
+- AIHubMix foreground key prompt still opens, defers `onSuccess`, completes/cancels correctly, and respects `skipAutoProvisionKeyOnAccountAdd`.
+
+- [ ] **Step 7: Run focused tests**
+
+```text
+pnpm vitest run tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+```
+
+- [ ] **Step 8: Commit this task**
+
+```text
+git add src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+git commit -m "refactor(account): route save decisions through dialog site policy"
+```
+
+---
+
+### Task 5: Remove Stale Inline Policy Branches And Verify Residual Site-Type Checks
+
+**Files:**
+
+- Modify `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+- Modify tests only if stale implementation-specific expectations remain
+
+- [ ] **Step 1: Search for remaining raw site policy branches**
+
+Run:
+
+```text
+rg -n "SITE_TYPES\\.(SUB2API|AIHUBMIX)|siteType ===|siteType !==|nextSiteType ===|resultData\\.siteType" src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+```
+
+Classify each remaining hit as one of:
+
+- acceptable non-policy orchestration;
+- legacy compatibility normalization;
+- stale policy branch that should move into `sitePolicy.ts`.
+
+- [ ] **Step 2: Keep these residual branches acceptable**
+
+These can remain in `useAccountDialog.ts` after this slice:
+
+- `RuntimeActionIds.ContentGetUserFromLocalStorage` payload with `siteType: SITE_TYPES.SUB2API` inside the specifically named Sub2API session import flow.
+- `resolveStoredSiteType(...)` fallback from legacy persisted `sub2apiAuth` to `SITE_TYPES.SUB2API`.
+- AIHubMix concrete workflow names and display fallback text in the AIHubMix foreground key prompt flow.
+- Test data and expected user-facing site labels.
+
+Do not force every concrete site name out of the hook. The goal is to remove Account Dialog policy decisions from scattered branches, not to hide all existing concrete workflow names.
+
+- [ ] **Step 3: Move any stale branch into policy**
+
+If the search still finds one of these decisions inline, move it behind a policy helper:
+
+- auth mode forcing
+- saved cookie session clearing
+- cookie auto-import eligibility
+- built-in check-in disabling
+- Sub2API refresh-token payload eligibility
+- Sub2API post-save dialog eligibility
+- AIHubMix deferred success eligibility
+
+- [ ] **Step 4: Remove unused imports and helpers**
+
+Remove unused imports:
+
+- `Sub2ApiAuthConfig` from `useAccountDialog.ts` if only the policy helper builds it.
+- `SITE_TYPES.SUB2API` / `SITE_TYPES.AIHUBMIX` uses only if they became dead in the hook.
+
+Remove local helper functions if unused:
+
+- `areDraftsEquivalent(...)`
+- `shouldDeferAccountSaveSuccess(...)`
+
+Keep helpers that still own hook-local workflow compatibility, such as `resolveStoredSiteType(...)`.
+
+- [ ] **Step 5: Run the complete focused Account Dialog policy regression set**
+
+```text
+pnpm vitest run tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+```
+
+- [ ] **Step 6: Commit this task if it produced additional code/test cleanup**
+
+```text
+git add src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+git commit -m "refactor(account): remove inline dialog site policy branches"
+```
+
+If this task only verifies the previous commits and produces no diff, do not create an empty commit.
+
+---
+
+### Task 6: Final Validation And Handoff
+
+**Files:**
+
+- No new files expected.
+
+- [ ] **Step 1: Run TypeScript validation**
+
+```text
+pnpm compile
+```
+
+- [ ] **Step 2: Run staged validation before the final commit or handoff**
+
+Stage only task-scoped files, then run:
+
+```text
+pnpm run validate:staged
+```
+
+- [ ] **Step 3: Run push-gate validation before publishing**
+
+Because this refactor touches a large hook, a new exported module, and several tests, run the pre-push-equivalent gate before pushing or opening/updating a PR:
+
+```text
+pnpm run validate:push
+```
+
+- [ ] **Step 4: Inspect the final diff**
+
+```text
+git diff --stat HEAD
+git diff HEAD -- src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts src/features/AccountManagement/components/AccountDialog/sitePolicy.ts tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+```
+
+Confirm:
+
+- no adapter, onboarding, managed-site, locale, telemetry schema, or E2E files changed;
+- no new user-facing copy was introduced;
+- the policy module has no side effects;
+- raw Account Dialog policy decisions are no longer scattered across the hook;
+- residual concrete Sub2API/AIHubMix references are only workflow names, legacy compatibility, message payloads, or tests.
+
+- [ ] **Step 5: Final handoff summary**
+
+Report:
+
+- the commits created;
+- focused tests run;
+- `pnpm compile`, `pnpm run validate:staged`, and `pnpm run validate:push` results;
+- E2E decision: not added, because the risk is covered by pure policy and hook tests;
+- telemetry decision: reused existing, no schema changes;
+- any residual raw site-type checks that intentionally remain in `useAccountDialog.ts`.

--- a/docs/superpowers/specs/2026-06-20-account-dialog-site-policy-design.md
+++ b/docs/superpowers/specs/2026-06-20-account-dialog-site-policy-design.md
@@ -1,0 +1,415 @@
+# Account Dialog Site Policy Design
+
+## Purpose
+
+Make new account site types faster to add by moving Account Dialog
+site-specific UI and workflow rules into a dedicated policy Module.
+
+Recent adapter work moved account data, account refresh, account bootstrap,
+account completion, key management, model pricing, redemption, and onboarding
+facts behind explicit seams. The remaining high-friction path is the Account
+Dialog itself: it still decides several site-specific rules inline while users
+manually add, auto-detect, edit, save, and post-configure accounts.
+
+This spec covers only the Account Dialog policy substrate. It does not add a
+new site type and does not implement the registration consolidation slice.
+
+## Current Context
+
+Current `main` has the prerequisite adapter and onboarding work:
+
+- `src/services/accountSiteOnboarding/` owns account-site detection metadata,
+  route metadata, and content-session extractors.
+- `src/services/apiAdapters/` owns post-detection backend capabilities through
+  `getSiteAdapter(siteType)`.
+- `src/services/accounts/utils/apiServiceRequest.ts` now returns an adapter,
+  adapter-backed `keyManagement`, and an account-scoped request. It no longer
+  exposes the legacy root `apiService` facade to account-mainline callers.
+- Account-mainline ESLint guardrails block new direct imports of the legacy
+  root `apiService` facade in Account Management, Key Management, Model List,
+  verification dialogs, Kilo export, and account services.
+
+The Account Dialog still contains policy decisions that vary by account site
+type:
+
+- `applySub2ApiDraftConstraints(...)` forces Sub2API to access-token auth,
+  clears cookie-auth session data, and disables built-in check-in detection.
+- `clearSub2ApiRefreshTokenState(...)` clears Sub2API refresh-token fields when
+  the selected site type changes away from Sub2API.
+- `buildDraftFromAutoDetectResult(...)` forces Sub2API and AIHubMix detected
+  accounts to access-token auth and clears saved cookie-auth session data.
+- Cookie auto-import after auto-detect skips Sub2API and AIHubMix.
+- Save payload construction only persists `sub2apiAuth` for Sub2API.
+- Post-save flows have inline Sub2API token-creation dialog behavior and
+  AIHubMix one-time key behavior.
+- Existing stored-account hydration only restores Sub2API refresh-token state
+  for Sub2API accounts.
+
+The scattered branches are individually small, but they increase the number of
+places a future account site type must touch. They also make it hard to tell
+which rules are UI policy, which rules are persistence payload rules, and which
+rules belong in backend adapters.
+
+## Problem
+
+The Account Dialog is still a shallow site-policy Module. Callers and tests
+must know many individual site-type conditions instead of asking one local
+Interface for dialog behavior.
+
+Current friction:
+
+1. Site-specific draft normalization is split across effects, auto-detect
+   merge helpers, edit-mode hydration, and setter handlers.
+2. Auth mode policy is implicit. Sub2API and AIHubMix both force saved
+   access-token accounts in some paths, but the reason is embedded in UI
+   branching.
+3. Cookie-auth policy is implicit. Cookie import is available broadly, then
+   disabled or skipped by inline exceptions.
+4. Sub2API refresh-token support is both a form policy and a persistence
+   policy, but the relevant checks are spread across draft state, import,
+   validation, save payload construction, and cleanup.
+5. Post-save behavior is site-specific but not expressed as policy. Sub2API
+   may open a token creation dialog; AIHubMix may defer success until the user
+   handles a one-time key prompt.
+6. The next special site type would likely add another set of `SITE_TYPES.X`
+   branches inside `useAccountDialog.ts`.
+
+Deletion test: if the inline Sub2API and AIHubMix checks were deleted from
+`useAccountDialog.ts`, the logic should not reappear as new raw branches in the
+same hook. It should reappear behind a small Account Dialog policy Interface
+that the hook can call at draft normalization, auto-detect merge, save payload,
+and post-save decision points.
+
+## Goals
+
+- Add a dedicated Account Dialog site policy Module that owns dialog-scoped
+  site-type rules.
+- Keep the policy Module local to Account Management. It should describe UI and
+  workflow policy, not backend protocol behavior.
+- Preserve current behavior for:
+  - Sub2API access-token-only Account Dialog state.
+  - Sub2API built-in check-in disabled state.
+  - Sub2API refresh-token import, persistence, validation, and cleanup.
+  - Sub2API post-save token creation dialog.
+  - AIHubMix access-token saved-account state after browser-session
+    auto-detect.
+  - AIHubMix saved cookie-auth session clearing.
+  - AIHubMix one-time key post-save prompt and deferred success behavior.
+  - Cookie auto-import for compatible non-Sub2API, non-AIHubMix cookie-auth
+    accounts.
+  - Existing edit-mode stored-account hydration.
+- Make adding a new Account Dialog policy variation a matter of extending one
+  policy table/helper instead of adding branches across the hook.
+- Keep tests focused on the policy Interface and the hook integration points
+  that consume it.
+
+## Non-Goals
+
+- Do not add a new account site type.
+- Do not change user-facing Account Dialog behavior.
+- Do not redesign Account Dialog layout, copy, locale keys, or visual states.
+- Do not move detection metadata, route metadata, or content-session
+  extractors out of `src/services/accountSiteOnboarding/`.
+- Do not move backend capabilities out of `src/services/apiAdapters/`.
+- Do not change `SiteAdapter` in this slice.
+- Do not migrate managed-site providers, managed-site model sync, channel CRUD,
+  or hosted-site settings.
+- Do not consolidate account-site registration metadata. That is a separate
+  follow-up slice.
+- Do not change telemetry schema. Existing Account Dialog analytics actions
+  should continue to fire from the same user actions.
+- Do not add Playwright E2E coverage unless implementation reveals a real
+  browser-only risk.
+
+## Approaches Considered
+
+### Approach A: Keep Inline Branches In `useAccountDialog`
+
+This is the smallest immediate change, but it preserves the current tax for
+new site types. Every special account site has to be understood across draft
+normalization, auto-detect, save, and post-save paths.
+
+This should not be the next step.
+
+### Approach B: Put Dialog Policy On `SiteAdapter`
+
+`SiteAdapter` already describes backend capabilities after the site type is
+known, so it is tempting to add Account Dialog flags there.
+
+This blurs the seam. Account Dialog policy includes UI state, form visibility,
+post-save prompts, and browser cookie import decisions. Those are not backend
+protocol facts, and putting them on `SiteAdapter` would make backend adapters
+know about Account Management UI.
+
+This should not be the next step.
+
+### Approach C: Add A Local Account Dialog Site Policy Module
+
+Create a feature-local policy Module that maps `AccountSiteType` to the rules
+the Account Dialog needs. `useAccountDialog.ts` continues to own React state,
+side effects, analytics, toasts, and orchestration, but it asks the policy
+Module for site-specific decisions.
+
+This is the recommended path. It deepens the Account Dialog policy Interface
+without moving UI concerns into backend adapters or reopening the legacy
+`apiService` facade.
+
+## Design
+
+### 1. Add A Feature-Local Policy Module
+
+Create:
+
+```text
+src/features/AccountManagement/components/AccountDialog/sitePolicy.ts
+```
+
+The Module should export a small Interface centered on Account Dialog behavior:
+
+```ts
+export type AccountDialogSitePolicy = {
+  siteType: AccountSiteType
+  forceAccessTokenAuth: boolean
+  allowCookieAuthSession: boolean
+  allowCookieAutoImport: boolean
+  allowBuiltInCheckInDetection: boolean
+  sub2apiRefreshToken: {
+    enabled: boolean
+    clearWhenInactive: boolean
+  }
+  postSave: {
+    openSub2ApiTokenDialog: boolean
+    deferSuccessForAihubmixOneTimeKey: boolean
+  }
+}
+```
+
+The exact property names can be refined during implementation, but the
+Interface must stay dialog-focused. It should answer questions the Account
+Dialog currently answers with raw `SITE_TYPES.SUB2API` and
+`SITE_TYPES.AIHUBMIX` checks.
+
+Suggested exported helpers:
+
+```ts
+export function getAccountDialogSitePolicy(
+  siteType: AccountSiteType,
+): AccountDialogSitePolicy
+
+export function applyAccountDialogSitePolicyToDraft(params: {
+  draft: AccountDialogDraft
+  policy: AccountDialogSitePolicy
+}): AccountDialogDraft
+
+export function clearInactiveSitePolicyState(params: {
+  draft: AccountDialogDraft
+  policy: AccountDialogSitePolicy
+}): AccountDialogDraft
+```
+
+Default policy should represent New API-family compatible behavior:
+
+- access-token and cookie-auth modes may remain user-selected;
+- cookie auto-import remains allowed for cookie-auth flows;
+- built-in check-in detection remains allowed;
+- Sub2API refresh-token fields are inactive;
+- post-save does not require a site-specific prompt.
+
+Sub2API policy:
+
+- force access-token auth;
+- disallow saved cookie-auth session data;
+- disallow cookie auto-import;
+- disallow built-in check-in detection;
+- enable refresh-token draft state and persistence;
+- open the Sub2API token creation flow after successful add when not skipped.
+
+AIHubMix policy:
+
+- force saved access-token auth after auto-detect/import because browser
+  session data is only used to obtain an access token;
+- disallow saved cookie-auth session data;
+- disallow cookie auto-import after detection;
+- keep Sub2API refresh-token state inactive;
+- defer normal add success when one-time key auto-provisioning needs foreground
+  user acknowledgement.
+
+### 2. Replace Draft Normalization Branches
+
+`useAccountDialog.ts` should stop owning the specific Sub2API normalization
+rules directly.
+
+Replace:
+
+- `applySub2ApiDraftConstraints(...)`
+- `clearSub2ApiRefreshTokenState(...)`
+- inline Sub2API check-in overrides in auto-detect merge
+- inline Sub2API/AIHubMix saved cookie clearing in auto-detect merge
+
+With policy helpers that apply the same state transitions.
+
+The hook should still own when normalization runs:
+
+- when selected `siteType` changes;
+- when edit-mode account data is loaded;
+- when auto-detect returns a site type;
+- when the user toggles Sub2API refresh-token mode.
+
+### 3. Keep Save Payload Assembly In The Hook, But Ask Policy
+
+The hook can keep constructing the `validateAndSaveAccount(...)` and
+`validateAndUpdateAccount(...)` arguments. This slice should not move the whole
+save workflow.
+
+The Sub2API payload decision should become policy-driven:
+
+- if policy enables refresh-token persistence and the toggle/token are valid,
+  include `sub2apiAuth`;
+- otherwise omit `sub2apiAuth`.
+
+This preserves the existing account operations contract while removing the raw
+site-type branch from the hook.
+
+### 4. Keep Browser/Permission Side Effects In The Hook, But Ask Policy
+
+Cookie permission requests, cookie import messaging, tab inspection, runtime
+messages, toasts, and telemetry should remain in `useAccountDialog.ts`.
+
+The policy should only answer whether the current site type allows cookie
+auto-import or saved cookie-auth session data. The hook continues to perform
+the actual browser work.
+
+### 5. Keep Post-Save Effects In The Hook, But Route Decisions Through Policy
+
+Post-save workflows remain orchestrated by the hook because they touch React
+state, dialogs, toasts, and callbacks.
+
+Policy should decide:
+
+- whether a successful add should defer `onSuccess` for AIHubMix one-time key
+  flow;
+- whether a successful add should open the Sub2API token creation dialog;
+- whether Sub2API-specific skip options apply to the current site type.
+
+This keeps site-specific post-save behavior visible without requiring the hook
+to branch on concrete site type values.
+
+### 6. Test The Policy Interface Directly
+
+Add focused unit coverage for the policy Module:
+
+- default compatible policy allows existing cookie-auth and check-in behavior;
+- Sub2API policy forces access-token auth, clears cookies, disables built-in
+  check-in, and keeps refresh-token state only while active;
+- AIHubMix policy forces saved access-token auth, clears saved cookies, and
+  disables cookie auto-import;
+- unknown site type follows default compatible policy unless implementation
+  needs a stricter unsupported policy.
+
+The policy tests should use placeholder account names and example domains only.
+
+### 7. Preserve Hook-Level Regression Tests
+
+Update existing hook tests only where their assertions currently depend on
+inline helper names or exact branch placement.
+
+Relevant existing suites include:
+
+- `tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx`
+- `tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx`
+- `tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx`
+- `tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx`
+
+The implementation plan should prefer existing tests plus targeted policy unit
+tests over broad new E2E coverage.
+
+## Error Handling
+
+The policy Module should be pure and should not throw for ordinary unsupported
+or unknown site types. It should return a default policy for any
+`AccountSiteType` that does not need special Account Dialog behavior.
+
+Existing runtime error handling remains with the hook and called services:
+
+- cookie permission failures continue to produce existing permission feedback;
+- auto-detect failures continue through the current detailed error handling;
+- save failures continue through `validateAndSaveAccount(...)` /
+  `validateAndUpdateAccount(...)`;
+- post-save workflow failures continue to use existing toast and logger paths.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This is a refactor-only slice. It should not introduce new user actions or new
+analytics fields. Existing Account Dialog telemetry should continue to be
+emitted from the hook at the same user action points.
+
+## Settings Search Decision
+
+No settings search changes.
+
+The slice does not add, rename, move, or remove settings UI.
+
+## E2E Decision
+
+Do not add Playwright E2E by default.
+
+The primary risk is policy mapping and hook state transitions, which can be
+covered by focused unit and hook tests. Add E2E only if implementation changes
+browser-level cookie import behavior, extension permission behavior, or
+cross-entrypoint post-save dialog behavior beyond the current wiring.
+
+## Validation Plan
+
+Focused validation should include:
+
+```text
+pnpm vitest run tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+pnpm vitest run tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx
+pnpm vitest run tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
+pnpm vitest run tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+```
+
+Add the new policy test file to the focused command once implementation names
+are known.
+
+Because this touches Account Management hook behavior and shared TypeScript
+types, final implementation validation should include:
+
+```text
+pnpm compile
+pnpm run validate:staged
+```
+
+If the implementation also touches exports, ESLint guardrails, or shared
+service contracts, broaden to:
+
+```text
+pnpm run validate:push
+```
+
+## Rollout
+
+1. Add the policy Module and direct unit tests.
+2. Replace draft normalization branches in `useAccountDialog.ts` with policy
+   helper calls.
+3. Replace cookie auto-import, save-payload, and post-save decision branches
+   with policy checks.
+4. Keep the hook as the orchestrator for React state, browser work, analytics,
+   toasts, and dialogs.
+5. Run focused hook and policy tests.
+6. Run compile and staged validation.
+7. Inspect the diff for scope drift.
+
+## Follow-Up, Not In Scope For This Spec
+
+- Consolidate account-site registration metadata across onboarding,
+  `apiAdapters/registry.ts`, and site-type constants.
+- Revisit managed-site provider/model-sync seams if the next new site type
+  needs admin-managed support.
+- Revisit Model List catalog/pricing assembly if the next new site type needs
+  non-standard runtime model discovery or estimated pricing.
+- Consider a lint guard or search check for new raw `SITE_TYPES.SUB2API` /
+  `SITE_TYPES.AIHUBMIX` branches in Account Dialog once the policy Module is
+  established.

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -13,6 +13,15 @@ import {
 } from "~/constants/siteType"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import {
+  buildSub2ApiAuthFromAccountDialogDraft,
+  getAccountDialogSitePolicy,
+  normalizeAccountDialogDraftForSitePolicy,
+  shouldAutoImportCookieAuthForAccountDialogSite,
+  shouldDeferAccountSaveSuccessForAccountDialogSite,
+  shouldOpenSub2ApiTokenDialogForAccountDialogSite,
+  type AccountDialogSitePolicy,
+} from "~/features/AccountManagement/components/AccountDialog/sitePolicy"
+import {
   isAccountAuthType,
   normalizeOptionalAccountAuthType,
   resolveDefaultAccountAuthType,
@@ -92,7 +101,6 @@ import {
   type CheckInConfig,
   type DisplaySiteData,
   type SiteAccount,
-  type Sub2ApiAuthConfig,
 } from "~/types"
 import type { AccountSaveResponse } from "~/types/serviceResponse"
 import { deepOverride } from "~/utils"
@@ -360,6 +368,7 @@ export function useAccountDialog({
   const sub2apiUseRefreshToken = draft.sub2apiUseRefreshToken
   const sub2apiRefreshToken = draft.sub2apiRefreshToken
   const sub2apiTokenExpiresAt = draft.sub2apiTokenExpiresAt
+  const currentSitePolicy = getAccountDialogSitePolicy(siteType)
   // Keep URL state readable inside async tab-detection guards without rerendering.
   selectedSiteUrlRef.current = url
   const isDetected =
@@ -700,17 +709,15 @@ export function useAccountDialog({
       duplicateAccountWarningResolverRef.current = null
     }, [t, updateWarnOnDuplicateAccountAdd])
 
-  // Enforce Sub2API constraints: JWT-only (access token), no built-in check-in.
   useEffect(() => {
-    if (siteType !== SITE_TYPES.SUB2API) return
+    const policy = getAccountDialogSitePolicy(siteType)
 
-    updateDraft((prev) => applySub2ApiDraftConstraints(prev))
-  }, [siteType, updateDraft])
-
-  useEffect(() => {
-    if (siteType === SITE_TYPES.SUB2API) return
-
-    updateDraft((prev) => clearSub2ApiRefreshTokenState(prev))
+    updateDraft((prev) =>
+      normalizeAccountDialogDraftForSitePolicy({
+        draft: prev,
+        policy,
+      }),
+    )
   }, [siteType, updateDraft])
 
   // useRef 保存跨渲染引用
@@ -856,13 +863,19 @@ export function useAccountDialog({
         nextPrefill?.authType,
       )
       const nextSiteType = nextPrefill?.siteType ?? SITE_TYPES.UNKNOWN
+      const policy = getAccountDialogSitePolicy(nextSiteType)
       hasExplicitAuthTypeRef.current = Boolean(normalizedPrefillAuthType)
       setUrl(nextPrefill?.siteUrl ?? "")
-      setDraft({
-        ...createEmptyAccountDialogDraft(),
-        siteType: nextSiteType,
-        authType: normalizedPrefillAuthType || AuthTypeEnum.AccessToken,
-      })
+      setDraft(
+        normalizeAccountDialogDraftForSitePolicy({
+          draft: {
+            ...createEmptyAccountDialogDraft(),
+            siteType: nextSiteType,
+            authType: normalizedPrefillAuthType || AuthTypeEnum.AccessToken,
+          },
+          policy,
+        }),
+      )
       const nextFlowState = getInitialFlowState(mode)
       setPhase(nextFlowState.phase)
       setFormSource(
@@ -894,57 +907,69 @@ export function useAccountDialog({
             siteAccount.site_type,
             Boolean(siteAccount.sub2apiAuth),
           )
+          const policy = getAccountDialogSitePolicy(normalizedSiteType)
+          const hasActiveSub2ApiRefreshToken =
+            policy.allowSub2ApiRefreshTokenState && Boolean(refreshToken.trim())
           hasExplicitAuthTypeRef.current = true
-          setDraft({
-            siteName: siteAccount.site_name,
-            username: siteAccount.account_info.username,
-            accessToken: siteAccount.account_info.access_token,
-            userId: normalizeAccountIdentity(siteAccount.account_info.id) ?? "",
-            exchangeRate: siteAccount.exchange_rate.toString(),
-            manualBalanceUsd: siteAccount.manualBalanceUsd ?? "",
-            notes: siteAccount.notes || "",
-            tagIds: siteAccount.tagIds || [],
-            excludeFromTotalBalance:
-              siteAccount.excludeFromTotalBalance === true,
-            excludeFromTodayIncome: siteAccount.excludeFromTodayIncome === true,
-            checkIn: {
-              enableDetection: siteAccount.checkIn?.enableDetection ?? false,
-              autoCheckInEnabled:
-                siteAccount.checkIn?.autoCheckInEnabled ?? true,
-              siteStatus: {
-                isCheckedInToday:
-                  siteAccount.checkIn?.siteStatus?.isCheckedInToday ?? false,
-                lastCheckInDate:
-                  siteAccount.checkIn?.siteStatus?.lastCheckInDate,
+          setDraft(
+            normalizeAccountDialogDraftForSitePolicy({
+              draft: {
+                siteName: siteAccount.site_name,
+                username: siteAccount.account_info.username,
+                accessToken: siteAccount.account_info.access_token,
+                userId:
+                  normalizeAccountIdentity(siteAccount.account_info.id) ?? "",
+                exchangeRate: siteAccount.exchange_rate.toString(),
+                manualBalanceUsd: siteAccount.manualBalanceUsd ?? "",
+                notes: siteAccount.notes || "",
+                tagIds: siteAccount.tagIds || [],
+                excludeFromTotalBalance:
+                  siteAccount.excludeFromTotalBalance === true,
+                excludeFromTodayIncome:
+                  siteAccount.excludeFromTodayIncome === true,
+                checkIn: {
+                  enableDetection:
+                    siteAccount.checkIn?.enableDetection ?? false,
+                  autoCheckInEnabled:
+                    siteAccount.checkIn?.autoCheckInEnabled ?? true,
+                  siteStatus: {
+                    isCheckedInToday:
+                      siteAccount.checkIn?.siteStatus?.isCheckedInToday ??
+                      false,
+                    lastCheckInDate:
+                      siteAccount.checkIn?.siteStatus?.lastCheckInDate,
+                  },
+                  customCheckIn: {
+                    url: siteAccount.checkIn?.customCheckIn?.url ?? "",
+                    turnstilePreTrigger:
+                      siteAccount.checkIn?.customCheckIn?.turnstilePreTrigger,
+                    redeemUrl:
+                      siteAccount.checkIn?.customCheckIn?.redeemUrl ?? "",
+                    openRedeemWithCheckIn:
+                      siteAccount.checkIn?.customCheckIn
+                        ?.openRedeemWithCheckIn ?? true,
+                    isCheckedInToday:
+                      siteAccount.checkIn?.customCheckIn?.isCheckedInToday ??
+                      false,
+                    lastCheckInDate:
+                      siteAccount.checkIn?.customCheckIn?.lastCheckInDate,
+                  },
+                },
+                siteType: normalizedSiteType,
+                authType: siteAccount.authType || AuthTypeEnum.AccessToken,
+                cookieAuthSessionCookie:
+                  siteAccount.cookieAuth?.sessionCookie || "",
+                sub2apiUseRefreshToken: hasActiveSub2ApiRefreshToken,
+                sub2apiRefreshToken: hasActiveSub2ApiRefreshToken
+                  ? refreshToken
+                  : "",
+                sub2apiTokenExpiresAt: hasActiveSub2ApiRefreshToken
+                  ? siteAccount.sub2apiAuth?.tokenExpiresAt ?? null
+                  : null,
               },
-              customCheckIn: {
-                url: siteAccount.checkIn?.customCheckIn?.url ?? "",
-                turnstilePreTrigger:
-                  siteAccount.checkIn?.customCheckIn?.turnstilePreTrigger,
-                redeemUrl: siteAccount.checkIn?.customCheckIn?.redeemUrl ?? "",
-                openRedeemWithCheckIn:
-                  siteAccount.checkIn?.customCheckIn?.openRedeemWithCheckIn ??
-                  true,
-                isCheckedInToday:
-                  siteAccount.checkIn?.customCheckIn?.isCheckedInToday ?? false,
-                lastCheckInDate:
-                  siteAccount.checkIn?.customCheckIn?.lastCheckInDate,
-              },
-            },
-            siteType: normalizedSiteType,
-            authType: siteAccount.authType || AuthTypeEnum.AccessToken,
-            cookieAuthSessionCookie:
-              siteAccount.cookieAuth?.sessionCookie || "",
-            sub2apiUseRefreshToken:
-              normalizedSiteType === SITE_TYPES.SUB2API &&
-              Boolean(refreshToken.trim()),
-            sub2apiRefreshToken:
-              normalizedSiteType === SITE_TYPES.SUB2API ? refreshToken : "",
-            sub2apiTokenExpiresAt:
-              normalizedSiteType === SITE_TYPES.SUB2API
-                ? siteAccount.sub2apiAuth?.tokenExpiresAt ?? null
-                : null,
-          })
+              policy,
+            }),
+          )
           enterForm(ACCOUNT_DIALOG_FORM_SOURCES.EXISTING_ACCOUNT)
         }
       } catch (error) {
@@ -1256,26 +1281,22 @@ export function useAccountDialog({
     }
   }, [cookieAuthPermissionState.granted, refreshCookieAuthPermissionState, t])
 
-  const isAihubmixNormalSaveForegroundKeyFlow = useCallback(
-    (options?: {
-      skipSub2ApiKeyPrompt?: boolean
-      skipAutoProvisionKeyOnAccountAdd?: boolean
-    }) =>
-      mode === DIALOG_MODES.ADD &&
-      siteType === SITE_TYPES.AIHUBMIX &&
-      autoProvisionKeyOnAccountAdd &&
-      options?.skipAutoProvisionKeyOnAccountAdd !== true,
-    [autoProvisionKeyOnAccountAdd, mode, siteType],
-  )
-
   const shouldDeferAccountSaveSuccess = useCallback(
-    (result: AccountSaveResponse) =>
-      mode === DIALOG_MODES.ADD &&
-      siteType === SITE_TYPES.AIHUBMIX &&
-      autoProvisionKeyOnAccountAdd &&
-      result.success === true &&
-      typeof result.accountId === "string" &&
-      result.accountId.trim().length > 0,
+    (result: AccountSaveResponse) => {
+      const policy = getAccountDialogSitePolicy(siteType)
+
+      return (
+        shouldDeferAccountSaveSuccessForAccountDialogSite({
+          policy,
+          isAddMode: mode === DIALOG_MODES.ADD,
+          autoProvisionKeyOnAccountAdd,
+          skipAutoProvisionKeyOnAccountAdd: false,
+        }) &&
+        result.success === true &&
+        typeof result.accountId === "string" &&
+        result.accountId.trim().length > 0
+      )
+    },
     [autoProvisionKeyOnAccountAdd, mode, siteType],
   )
 
@@ -1655,35 +1676,27 @@ export function useAccountDialog({
         const nextSiteType = isAccountSiteType(resultData.siteType)
           ? resultData.siteType
           : siteType
-        const nextCheckIn =
-          nextSiteType === SITE_TYPES.SUB2API
-            ? {
-                ...detectedCheckIn,
-                enableDetection: false,
-                autoCheckInEnabled: false,
-              }
-            : detectedCheckIn
+        const policy = getAccountDialogSitePolicy(nextSiteType)
 
         setDraft((prev) =>
           buildDraftFromAutoDetectResult({
             draft: prev,
             resultData,
             nextSiteType,
-            nextCheckIn,
+            nextCheckIn: detectedCheckIn,
             preserveExistingCheckIn,
             mode,
+            policy,
           }),
         )
 
-        // Attempt to auto-import session cookies after detection for cookie-auth
-        // accounts. AIHubMix uses cookies only during access-token import, so it
-        // should not keep a saved cookie-auth session.
         if (
-          authType === AuthTypeEnum.Cookie &&
-          resultData.siteType !== SITE_TYPES.SUB2API &&
-          resultData.siteType !== SITE_TYPES.AIHUBMIX &&
-          !cookieAuthSessionCookie.trim() &&
-          url.trim()
+          shouldAutoImportCookieAuthForAccountDialogSite({
+            policy,
+            authType,
+            cookieAuthSessionCookie,
+            url,
+          })
         ) {
           try {
             const cookieResponse = await sendRuntimeMessage({
@@ -1782,17 +1795,19 @@ export function useAccountDialog({
 
     try {
       setIsSaving(true)
-      const sub2apiAuth: Sub2ApiAuthConfig | undefined =
-        siteType === SITE_TYPES.SUB2API &&
-        sub2apiUseRefreshToken &&
-        sub2apiRefreshToken.trim()
-          ? {
-              refreshToken: sub2apiRefreshToken.trim(),
-              ...(typeof sub2apiTokenExpiresAt === "number"
-                ? { tokenExpiresAt: sub2apiTokenExpiresAt }
-                : {}),
-            }
-          : undefined
+      const policy = getAccountDialogSitePolicy(siteType)
+      const shouldDeferSuccessForSitePolicy =
+        shouldDeferAccountSaveSuccessForAccountDialogSite({
+          policy,
+          isAddMode: mode === DIALOG_MODES.ADD,
+          autoProvisionKeyOnAccountAdd,
+          skipAutoProvisionKeyOnAccountAdd:
+            options?.skipAutoProvisionKeyOnAccountAdd === true,
+        })
+      const sub2apiAuth = buildSub2ApiAuthFromAccountDialogDraft({
+        draft,
+        policy,
+      })
 
       const result =
         mode === DIALOG_MODES.ADD
@@ -1817,7 +1832,7 @@ export function useAccountDialog({
                 deferDataRefresh: true,
                 skipAutoProvisionKeyOnAccountAdd:
                   options?.skipAutoProvisionKeyOnAccountAdd === true ||
-                  isAihubmixNormalSaveForegroundKeyFlow(options),
+                  shouldDeferSuccessForSitePolicy,
               },
             )
           : await validateAndUpdateAccount(
@@ -1852,11 +1867,13 @@ export function useAccountDialog({
       analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Success)
       isAnalyticsActionCompleted = true
 
-      if (
-        typeof result.accountId === "string" &&
-        result.accountId.trim().length > 0
-      ) {
-        schedulePostSaveAccountRefresh(result.accountId.trim())
+      const savedAccountId =
+        typeof result.accountId === "string" && result.accountId.trim().length
+          ? result.accountId.trim()
+          : null
+
+      if (savedAccountId) {
+        schedulePostSaveAccountRefresh(savedAccountId)
       }
 
       const feedbackMessage =
@@ -1932,33 +1949,36 @@ export function useAccountDialog({
         toast.success(feedbackMessage)
       }
 
-      if (
-        isAihubmixNormalSaveForegroundKeyFlow(options) &&
-        typeof result.accountId === "string" &&
-        result.accountId.trim().length > 0
-      ) {
+      if (shouldDeferSuccessForSitePolicy && savedAccountId) {
         await handleAihubmixNormalSaveForegroundKeyFlow({
-          accountId: result.accountId,
+          accountId: savedAccountId,
           accountName: siteName.trim() || SITE_TYPES.AIHUBMIX,
         })
       }
 
+      const skipSub2ApiKeyPrompt = options?.skipSub2ApiKeyPrompt === true
       if (
-        siteType === SITE_TYPES.SUB2API &&
-        !options?.skipSub2ApiKeyPrompt &&
-        typeof result.accountId === "string" &&
-        result.accountId.trim().length > 0
+        savedAccountId &&
+        policy.openSub2ApiTokenDialogPostSave &&
+        !skipSub2ApiKeyPrompt
       ) {
         try {
           const savedDisplaySiteData =
-            (await accountStorage.getDisplayDataById(result.accountId)) ?? null
+            (await accountStorage.getDisplayDataById(savedAccountId)) ?? null
 
-          if (savedDisplaySiteData) {
+          if (
+            shouldOpenSub2ApiTokenDialogForAccountDialogSite({
+              policy,
+              skipSub2ApiKeyPrompt,
+              hasDisplayData: Boolean(savedDisplaySiteData),
+            }) &&
+            savedDisplaySiteData
+          ) {
             await openSub2ApiTokenCreationDialog(savedDisplaySiteData)
           }
         } catch (error) {
           logger.error("Post-save Sub2API token dialog failed", {
-            accountId: result.accountId,
+            accountId: savedAccountId,
             error: getErrorMessage(error),
           })
         }
@@ -2528,7 +2548,7 @@ export function useAccountDialog({
     exchangeRate,
   })
   const isSub2ApiRefreshTokenValid =
-    siteType !== SITE_TYPES.SUB2API ||
+    !currentSitePolicy.allowSub2ApiRefreshTokenState ||
     !sub2apiUseRefreshToken ||
     !!sub2apiRefreshToken.trim()
   const isManualBalanceUsdInvalid =
@@ -2764,48 +2784,6 @@ function getInitialFlowState(mode: DialogMode): {
 }
 
 /**
- * Enforces the runtime constraints required by Sub2API-backed accounts.
- */
-function applySub2ApiDraftConstraints(
-  draft: AccountDialogDraft,
-): AccountDialogDraft {
-  const nextDraft: AccountDialogDraft = {
-    ...draft,
-    authType: AuthTypeEnum.AccessToken,
-    cookieAuthSessionCookie: "",
-    checkIn: {
-      ...draft.checkIn,
-      enableDetection: false,
-      autoCheckInEnabled: false,
-    },
-  }
-
-  return areDraftsEquivalent(draft, nextDraft) ? draft : nextDraft
-}
-
-/**
- * Clears refresh-token-only fields when the selected site type is no longer Sub2API.
- */
-function clearSub2ApiRefreshTokenState(
-  draft: AccountDialogDraft,
-): AccountDialogDraft {
-  if (
-    !draft.sub2apiUseRefreshToken &&
-    !draft.sub2apiRefreshToken &&
-    draft.sub2apiTokenExpiresAt === null
-  ) {
-    return draft
-  }
-
-  return {
-    ...draft,
-    sub2apiUseRefreshToken: false,
-    sub2apiRefreshToken: "",
-    sub2apiTokenExpiresAt: null,
-  }
-}
-
-/**
  * Merges auto-detected account data into the current draft while preserving user-owned fields when requested.
  */
 function buildDraftFromAutoDetectResult(params: {
@@ -2815,6 +2793,7 @@ function buildDraftFromAutoDetectResult(params: {
   nextCheckIn: CheckInConfig
   preserveExistingCheckIn: boolean
   mode: DialogMode
+  policy: AccountDialogSitePolicy
 }): AccountDialogDraft {
   const {
     draft,
@@ -2823,6 +2802,7 @@ function buildDraftFromAutoDetectResult(params: {
     nextCheckIn,
     preserveExistingCheckIn,
     mode,
+    policy,
   } = params
 
   const nextDraft: AccountDialogDraft = {
@@ -2839,51 +2819,27 @@ function buildDraftFromAutoDetectResult(params: {
     siteType: nextSiteType,
     authType:
       resultData.authType ??
-      // AIHubMix auto-detect may start from a cookie-auth browser session, but
-      // the saved account must use the retrieved access token.
-      (nextSiteType === SITE_TYPES.SUB2API ||
-      nextSiteType === SITE_TYPES.AIHUBMIX
-        ? AuthTypeEnum.AccessToken
-        : draft.authType),
-    cookieAuthSessionCookie:
-      nextSiteType === SITE_TYPES.SUB2API ||
-      nextSiteType === SITE_TYPES.AIHUBMIX
-        ? ""
-        : draft.cookieAuthSessionCookie,
+      (policy.forceAccessTokenAuth ? AuthTypeEnum.AccessToken : draft.authType),
+    cookieAuthSessionCookie: policy.allowCookieAuthSession
+      ? draft.cookieAuthSessionCookie
+      : "",
     checkIn: preserveExistingCheckIn
       ? deepOverride(nextCheckIn, draft.checkIn)
       : nextCheckIn,
     sub2apiRefreshToken:
-      resultData.siteType === SITE_TYPES.SUB2API && resultData.sub2apiAuth
+      policy.allowSub2ApiRefreshTokenState && resultData.sub2apiAuth
         ? resultData.sub2apiAuth.refreshToken
         : draft.sub2apiRefreshToken,
     sub2apiTokenExpiresAt:
-      resultData.siteType === SITE_TYPES.SUB2API && resultData.sub2apiAuth
+      policy.allowSub2ApiRefreshTokenState && resultData.sub2apiAuth
         ? resultData.sub2apiAuth.tokenExpiresAt ?? null
         : draft.sub2apiTokenExpiresAt,
   }
 
-  return nextSiteType === SITE_TYPES.SUB2API
-    ? applySub2ApiDraftConstraints(nextDraft)
-    : nextDraft
-}
-
-/**
- * Avoids unnecessary draft updates when Sub2API normalization would not change the effective values.
- */
-function areDraftsEquivalent(
-  left: AccountDialogDraft,
-  right: AccountDialogDraft,
-): boolean {
-  return (
-    left.authType === right.authType &&
-    left.cookieAuthSessionCookie === right.cookieAuthSessionCookie &&
-    left.checkIn.enableDetection === right.checkIn.enableDetection &&
-    left.checkIn.autoCheckInEnabled === right.checkIn.autoCheckInEnabled &&
-    left.sub2apiUseRefreshToken === right.sub2apiUseRefreshToken &&
-    left.sub2apiRefreshToken === right.sub2apiRefreshToken &&
-    left.sub2apiTokenExpiresAt === right.sub2apiTokenExpiresAt
-  )
+  return normalizeAccountDialogDraftForSitePolicy({
+    draft: nextDraft,
+    policy,
+  })
 }
 
 /**

--- a/src/features/AccountManagement/components/AccountDialog/sitePolicy.ts
+++ b/src/features/AccountManagement/components/AccountDialog/sitePolicy.ts
@@ -1,0 +1,204 @@
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import type { AccountDialogDraft } from "~/features/AccountManagement/components/AccountDialog/models"
+import { AuthTypeEnum, type Sub2ApiAuthConfig } from "~/types"
+
+/**
+ * Describes site-specific account-dialog behavior that must stay pure and UI-free.
+ */
+export interface AccountDialogSitePolicy {
+  forceAccessTokenAuth: boolean
+  allowCookieAuthSession: boolean
+  allowCookieAutoImport: boolean
+  allowBuiltInCheckInDetection: boolean
+  allowSub2ApiRefreshTokenState: boolean
+  openSub2ApiTokenDialogPostSave: boolean
+  deferSuccessForOneTimeKeyPostSaveFlow: boolean
+}
+
+const DEFAULT_ACCOUNT_DIALOG_SITE_POLICY: AccountDialogSitePolicy = {
+  forceAccessTokenAuth: false,
+  allowCookieAuthSession: true,
+  allowCookieAutoImport: true,
+  allowBuiltInCheckInDetection: true,
+  allowSub2ApiRefreshTokenState: false,
+  openSub2ApiTokenDialogPostSave: false,
+  deferSuccessForOneTimeKeyPostSaveFlow: false,
+}
+
+const ACCOUNT_DIALOG_SITE_POLICIES: Partial<
+  Record<AccountSiteType, AccountDialogSitePolicy>
+> = {
+  [SITE_TYPES.SUB2API]: {
+    forceAccessTokenAuth: true,
+    allowCookieAuthSession: false,
+    allowCookieAutoImport: false,
+    allowBuiltInCheckInDetection: false,
+    allowSub2ApiRefreshTokenState: true,
+    openSub2ApiTokenDialogPostSave: true,
+    deferSuccessForOneTimeKeyPostSaveFlow: false,
+  },
+  [SITE_TYPES.AIHUBMIX]: {
+    forceAccessTokenAuth: true,
+    allowCookieAuthSession: false,
+    allowCookieAutoImport: false,
+    allowBuiltInCheckInDetection: true,
+    allowSub2ApiRefreshTokenState: false,
+    openSub2ApiTokenDialogPostSave: false,
+    deferSuccessForOneTimeKeyPostSaveFlow: true,
+  },
+}
+
+/**
+ * Resolves account-dialog behavior rules for the selected account site type.
+ */
+export function getAccountDialogSitePolicy(
+  siteType: AccountSiteType,
+): AccountDialogSitePolicy {
+  return {
+    ...(ACCOUNT_DIALOG_SITE_POLICIES[siteType] ??
+      DEFAULT_ACCOUNT_DIALOG_SITE_POLICY),
+  }
+}
+
+/**
+ * Applies pure site policy constraints to a draft while preserving identity for no-op updates.
+ */
+export function normalizeAccountDialogDraftForSitePolicy(params: {
+  draft: AccountDialogDraft
+  policy: AccountDialogSitePolicy
+}): AccountDialogDraft {
+  const { draft, policy } = params
+  const nextDraft: AccountDialogDraft = {
+    ...draft,
+    authType: policy.forceAccessTokenAuth
+      ? AuthTypeEnum.AccessToken
+      : draft.authType,
+    cookieAuthSessionCookie: policy.allowCookieAuthSession
+      ? draft.cookieAuthSessionCookie
+      : "",
+    checkIn: {
+      ...draft.checkIn,
+      enableDetection: policy.allowBuiltInCheckInDetection
+        ? draft.checkIn.enableDetection
+        : false,
+      autoCheckInEnabled: policy.allowBuiltInCheckInDetection
+        ? draft.checkIn.autoCheckInEnabled
+        : false,
+    },
+    sub2apiUseRefreshToken: policy.allowSub2ApiRefreshTokenState
+      ? draft.sub2apiUseRefreshToken
+      : false,
+    sub2apiRefreshToken: policy.allowSub2ApiRefreshTokenState
+      ? draft.sub2apiRefreshToken
+      : "",
+    sub2apiTokenExpiresAt: policy.allowSub2ApiRefreshTokenState
+      ? draft.sub2apiTokenExpiresAt
+      : null,
+  }
+
+  return arePolicyDraftFieldsEquivalent(draft, nextDraft) ? draft : nextDraft
+}
+
+/**
+ * Determines whether the dialog should auto-import a browser cookie session.
+ */
+export function shouldAutoImportCookieAuthForAccountDialogSite(params: {
+  policy: AccountDialogSitePolicy
+  authType: AuthTypeEnum
+  cookieAuthSessionCookie: string
+  url: string
+}): boolean {
+  const { policy, authType, cookieAuthSessionCookie, url } = params
+
+  return (
+    policy.allowCookieAutoImport &&
+    authType === AuthTypeEnum.Cookie &&
+    cookieAuthSessionCookie.trim().length === 0 &&
+    url.trim().length > 0
+  )
+}
+
+/**
+ * Builds Sub2API refresh-token auth payloads when the site policy allows them.
+ */
+export function buildSub2ApiAuthFromAccountDialogDraft(params: {
+  draft: AccountDialogDraft
+  policy: AccountDialogSitePolicy
+}): Sub2ApiAuthConfig | undefined {
+  const { draft, policy } = params
+  const refreshToken = draft.sub2apiRefreshToken.trim()
+
+  if (
+    !policy.allowSub2ApiRefreshTokenState ||
+    !draft.sub2apiUseRefreshToken ||
+    !refreshToken
+  ) {
+    return undefined
+  }
+
+  return {
+    refreshToken,
+    ...(typeof draft.sub2apiTokenExpiresAt === "number"
+      ? { tokenExpiresAt: draft.sub2apiTokenExpiresAt }
+      : {}),
+  }
+}
+
+/**
+ * Determines whether a saved account should open the Sub2API token creation dialog.
+ */
+export function shouldOpenSub2ApiTokenDialogForAccountDialogSite(params: {
+  policy: AccountDialogSitePolicy
+  skipSub2ApiKeyPrompt: boolean
+  hasDisplayData: boolean
+}): boolean {
+  const { policy, skipSub2ApiKeyPrompt, hasDisplayData } = params
+
+  return (
+    policy.openSub2ApiTokenDialogPostSave &&
+    !skipSub2ApiKeyPrompt &&
+    hasDisplayData
+  )
+}
+
+/**
+ * Determines whether success feedback should wait for the one-time key post-save flow.
+ */
+export function shouldDeferAccountSaveSuccessForAccountDialogSite(params: {
+  policy: AccountDialogSitePolicy
+  isAddMode: boolean
+  autoProvisionKeyOnAccountAdd: boolean
+  skipAutoProvisionKeyOnAccountAdd: boolean
+}): boolean {
+  const {
+    policy,
+    isAddMode,
+    autoProvisionKeyOnAccountAdd,
+    skipAutoProvisionKeyOnAccountAdd,
+  } = params
+
+  return (
+    policy.deferSuccessForOneTimeKeyPostSaveFlow &&
+    isAddMode &&
+    autoProvisionKeyOnAccountAdd &&
+    !skipAutoProvisionKeyOnAccountAdd
+  )
+}
+
+/**
+ * Compares only draft fields that this policy module owns.
+ */
+function arePolicyDraftFieldsEquivalent(
+  left: AccountDialogDraft,
+  right: AccountDialogDraft,
+): boolean {
+  return (
+    left.authType === right.authType &&
+    left.cookieAuthSessionCookie === right.cookieAuthSessionCookie &&
+    left.checkIn.enableDetection === right.checkIn.enableDetection &&
+    left.checkIn.autoCheckInEnabled === right.checkIn.autoCheckInEnabled &&
+    left.sub2apiUseRefreshToken === right.sub2apiUseRefreshToken &&
+    left.sub2apiRefreshToken === right.sub2apiRefreshToken &&
+    left.sub2apiTokenExpiresAt === right.sub2apiTokenExpiresAt
+  )
+}

--- a/tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts
+++ b/tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  createEmptyAccountDialogDraft,
+  type AccountDialogDraft,
+} from "~/features/AccountManagement/components/AccountDialog/models"
+import {
+  buildSub2ApiAuthFromAccountDialogDraft,
+  getAccountDialogSitePolicy,
+  normalizeAccountDialogDraftForSitePolicy,
+  shouldAutoImportCookieAuthForAccountDialogSite,
+  shouldDeferAccountSaveSuccessForAccountDialogSite,
+  shouldOpenSub2ApiTokenDialogForAccountDialogSite,
+} from "~/features/AccountManagement/components/AccountDialog/sitePolicy"
+import { AuthTypeEnum } from "~/types"
+
+function createDraft(
+  overrides: Partial<AccountDialogDraft> = {},
+): AccountDialogDraft {
+  return {
+    ...createEmptyAccountDialogDraft(),
+    siteName: "Example",
+    username: "user@example.invalid",
+    accessToken: "access-token",
+    userId: "user-id",
+    siteType: SITE_TYPES.UNKNOWN,
+    authType: AuthTypeEnum.Cookie,
+    cookieAuthSessionCookie: "session=example",
+    checkIn: {
+      ...createEmptyAccountDialogDraft().checkIn,
+      enableDetection: true,
+      autoCheckInEnabled: true,
+    },
+    sub2apiUseRefreshToken: true,
+    sub2apiRefreshToken: " refresh-token ",
+    sub2apiTokenExpiresAt: 123456,
+    ...overrides,
+  }
+}
+
+describe("Account Dialog site policy", () => {
+  it("returns independent policy objects for callers", () => {
+    const firstSub2ApiPolicy = getAccountDialogSitePolicy(SITE_TYPES.SUB2API)
+    firstSub2ApiPolicy.allowCookieAutoImport = true
+
+    expect(
+      getAccountDialogSitePolicy(SITE_TYPES.SUB2API).allowCookieAutoImport,
+    ).toBe(false)
+
+    const firstDefaultPolicy = getAccountDialogSitePolicy(SITE_TYPES.UNKNOWN)
+    firstDefaultPolicy.forceAccessTokenAuth = true
+
+    expect(
+      getAccountDialogSitePolicy(SITE_TYPES.UNKNOWN).forceAccessTokenAuth,
+    ).toBe(false)
+  })
+
+  it("keeps compatible site behavior as the default policy", () => {
+    const policy = getAccountDialogSitePolicy(SITE_TYPES.UNKNOWN)
+    const draft = createDraft()
+
+    const normalized = normalizeAccountDialogDraftForSitePolicy({
+      draft,
+      policy,
+    })
+
+    expect(normalized.authType).toBe(AuthTypeEnum.Cookie)
+    expect(normalized.cookieAuthSessionCookie).toBe("session=example")
+    expect(normalized.checkIn.enableDetection).toBe(true)
+    expect(normalized.checkIn.autoCheckInEnabled).toBe(true)
+    expect(normalized.sub2apiUseRefreshToken).toBe(false)
+    expect(normalized.sub2apiRefreshToken).toBe("")
+    expect(normalized.sub2apiTokenExpiresAt).toBeNull()
+    expect(
+      shouldAutoImportCookieAuthForAccountDialogSite({
+        policy,
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "",
+        url: "https://example.invalid",
+      }),
+    ).toBe(true)
+  })
+
+  it("preserves draft identity when site policy normalization is a no-op", () => {
+    const policy = getAccountDialogSitePolicy(SITE_TYPES.SUB2API)
+    const draft = createDraft({
+      siteType: SITE_TYPES.SUB2API,
+      authType: AuthTypeEnum.AccessToken,
+      cookieAuthSessionCookie: "",
+      checkIn: {
+        ...createEmptyAccountDialogDraft().checkIn,
+        enableDetection: false,
+        autoCheckInEnabled: false,
+      },
+    })
+
+    expect(
+      normalizeAccountDialogDraftForSitePolicy({
+        draft,
+        policy,
+      }),
+    ).toBe(draft)
+  })
+
+  it("normalizes Sub2API dialogs to access-token auth and inactive built-in check-in", () => {
+    const policy = getAccountDialogSitePolicy(SITE_TYPES.SUB2API)
+    const normalized = normalizeAccountDialogDraftForSitePolicy({
+      draft: createDraft({ siteType: SITE_TYPES.SUB2API }),
+      policy,
+    })
+
+    expect(normalized.authType).toBe(AuthTypeEnum.AccessToken)
+    expect(normalized.cookieAuthSessionCookie).toBe("")
+    expect(normalized.checkIn.enableDetection).toBe(false)
+    expect(normalized.checkIn.autoCheckInEnabled).toBe(false)
+    expect(normalized.sub2apiUseRefreshToken).toBe(true)
+    expect(normalized.sub2apiRefreshToken).toBe(" refresh-token ")
+    expect(normalized.sub2apiTokenExpiresAt).toBe(123456)
+    expect(
+      shouldAutoImportCookieAuthForAccountDialogSite({
+        policy,
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "",
+        url: "https://example.invalid",
+      }),
+    ).toBe(false)
+  })
+
+  it("normalizes AIHubMix detected browser sessions to saved access-token accounts", () => {
+    const policy = getAccountDialogSitePolicy(SITE_TYPES.AIHUBMIX)
+    const normalized = normalizeAccountDialogDraftForSitePolicy({
+      draft: createDraft({ siteType: SITE_TYPES.AIHUBMIX }),
+      policy,
+    })
+
+    expect(normalized.authType).toBe(AuthTypeEnum.AccessToken)
+    expect(normalized.cookieAuthSessionCookie).toBe("")
+    expect(normalized.checkIn.enableDetection).toBe(true)
+    expect(normalized.sub2apiUseRefreshToken).toBe(false)
+    expect(normalized.sub2apiRefreshToken).toBe("")
+    expect(normalized.sub2apiTokenExpiresAt).toBeNull()
+    expect(
+      shouldAutoImportCookieAuthForAccountDialogSite({
+        policy,
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "",
+        url: "https://example.invalid",
+      }),
+    ).toBe(false)
+  })
+
+  it("keeps cookie auto-import behind all required guards", () => {
+    const policy = getAccountDialogSitePolicy(SITE_TYPES.UNKNOWN)
+
+    expect(
+      shouldAutoImportCookieAuthForAccountDialogSite({
+        policy,
+        authType: AuthTypeEnum.AccessToken,
+        cookieAuthSessionCookie: "",
+        url: "https://example.invalid",
+      }),
+    ).toBe(false)
+    expect(
+      shouldAutoImportCookieAuthForAccountDialogSite({
+        policy,
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "session=example",
+        url: "https://example.invalid",
+      }),
+    ).toBe(false)
+    expect(
+      shouldAutoImportCookieAuthForAccountDialogSite({
+        policy,
+        authType: AuthTypeEnum.Cookie,
+        cookieAuthSessionCookie: "",
+        url: " ",
+      }),
+    ).toBe(false)
+  })
+
+  it("builds Sub2API refresh-token payloads only when the policy and draft enable them", () => {
+    const sub2apiPolicy = getAccountDialogSitePolicy(SITE_TYPES.SUB2API)
+    const defaultPolicy = getAccountDialogSitePolicy(SITE_TYPES.UNKNOWN)
+
+    expect(
+      buildSub2ApiAuthFromAccountDialogDraft({
+        draft: createDraft({ siteType: SITE_TYPES.SUB2API }),
+        policy: sub2apiPolicy,
+      }),
+    ).toEqual({
+      refreshToken: "refresh-token",
+      tokenExpiresAt: 123456,
+    })
+
+    expect(
+      buildSub2ApiAuthFromAccountDialogDraft({
+        draft: createDraft({ siteType: SITE_TYPES.SUB2API }),
+        policy: defaultPolicy,
+      }),
+    ).toBeUndefined()
+
+    expect(
+      buildSub2ApiAuthFromAccountDialogDraft({
+        draft: createDraft({
+          siteType: SITE_TYPES.SUB2API,
+          sub2apiUseRefreshToken: false,
+        }),
+        policy: sub2apiPolicy,
+      }),
+    ).toBeUndefined()
+  })
+
+  it("keeps post-save decisions policy-driven", () => {
+    expect(
+      shouldOpenSub2ApiTokenDialogForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.SUB2API),
+        skipSub2ApiKeyPrompt: false,
+        hasDisplayData: true,
+      }),
+    ).toBe(true)
+
+    expect(
+      shouldOpenSub2ApiTokenDialogForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.SUB2API),
+        skipSub2ApiKeyPrompt: true,
+        hasDisplayData: true,
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldOpenSub2ApiTokenDialogForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.UNKNOWN),
+        skipSub2ApiKeyPrompt: false,
+        hasDisplayData: true,
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldOpenSub2ApiTokenDialogForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.SUB2API),
+        skipSub2ApiKeyPrompt: false,
+        hasDisplayData: false,
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldDeferAccountSaveSuccessForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.AIHUBMIX),
+        isAddMode: true,
+        autoProvisionKeyOnAccountAdd: true,
+        skipAutoProvisionKeyOnAccountAdd: false,
+      }),
+    ).toBe(true)
+
+    expect(
+      shouldDeferAccountSaveSuccessForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.UNKNOWN),
+        isAddMode: true,
+        autoProvisionKeyOnAccountAdd: true,
+        skipAutoProvisionKeyOnAccountAdd: false,
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldDeferAccountSaveSuccessForAccountDialogSite({
+        policy: getAccountDialogSitePolicy(SITE_TYPES.AIHUBMIX),
+        isAddMode: true,
+        autoProvisionKeyOnAccountAdd: true,
+        skipAutoProvisionKeyOnAccountAdd: true,
+      }),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add the Account Dialog site-policy spec and implementation plan.
- Introduce a pure Account Dialog site policy module with focused unit coverage.
- Route Account Dialog draft normalization, auto-detect, cookie import, save payload, and post-save decisions through the policy helpers.

## Test Plan
- [x] pnpm vitest run tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
- [x] pnpm run validate:staged
- [x] pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured Account Dialog to use a dedicated site policy module for managing account type-specific behavior and decision-making.
  * Account Dialog now applies policy-driven rules for authentication, token handling, and post-save dialog flows.

* **Tests**
  * Added comprehensive test suite for the new site policy module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->