### PR TITLE
refactor(api-adapters): add token provisioning policy

### DIFF
--- a/docs/superpowers/plans/2026-06-20-api-adapter-account-token-provisioning-policy.md
+++ b/docs/superpowers/plans/2026-06-20-api-adapter-account-token-provisioning-policy.md
@@ -1,0 +1,1893 @@
+# API Adapter Account Token Provisioning Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move account default-token provisioning policy behind `SiteAdapter.tokenProvisioning` so the next account site type can define creation, group, one-time-secret, and repair eligibility rules in one adapter-owned place.
+
+**Architecture:** Keep raw token CRUD in `SiteAdapter.keyManagement`; add a pure policy capability that returns stable decisions and reason codes. Account workflow modules continue to own storage, request construction, UI result mapping, telemetry, and calls to `keyManagement`.
+
+**Tech Stack:** TypeScript, WXT extension services, existing `apiAdapters`, Vitest, `pnpm run validate:staged`, `pnpm run validate:push`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-api-adapter-account-token-provisioning-policy-design.md`
+
+---
+
+## File Structure
+
+- Create `src/services/apiAdapters/contracts/tokenProvisioning.ts`
+  - Defines workflow names, block reason codes, decision unions, and `TokenProvisioningCapability`.
+- Modify `src/services/apiAdapters/contracts/siteAdapter.ts`
+  - Adds optional `tokenProvisioning?: TokenProvisioningCapability`.
+- Create `src/services/apiAdapters/newApi/tokenProvisioning.ts`
+  - New API-family compatible policy: ungrouped default creation is allowed, inventory tokens are usable, repair is eligible.
+- Create `src/services/apiAdapters/sub2api/tokenProvisioning.ts`
+  - Group-required policy: explicit groups create, interactive/post-save flows can auto-select one group or request selection, repair is skipped.
+- Create `src/services/apiAdapters/aihubmix/tokenProvisioning.ts`
+  - One-time-secret policy: only post-save creation is allowed, created tokens must include a full unmasked key, repair is skipped.
+- Modify `src/services/apiAdapters/newApi/index.ts`
+  - Wires `createNewApiTokenProvisioning(siteType)` into new API-family adapters.
+- Modify `src/services/apiAdapters/sub2api/index.ts`
+  - Wires `sub2ApiTokenProvisioning`.
+- Modify `src/services/apiAdapters/aihubmix/index.ts`
+  - Wires `aihubmixTokenProvisioning`.
+- Modify `tests/services/apiAdapters/tokenProvisioning.test.ts`
+  - Covers policy behavior directly.
+- Modify `tests/services/apiAdapters/registry.test.ts`
+  - Verifies supported account adapters expose the new policy capability.
+- Modify `src/services/accounts/utils/apiServiceRequest.ts`
+  - Adds `requireDisplayAccountTokenProvisioning(...)` and returns `tokenProvisioning` from `createDisplayAccountApiContext(...)`.
+- Create `src/services/accounts/utils/tokenProvisioning.ts`
+  - Shared helper that re-invokes a policy decision after fetching user groups only when the policy asks for them.
+- Modify `tests/services/accounts/apiServiceRequest.test.ts`
+  - Covers the new context property and missing-capability error.
+- Modify `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+  - Routes inventory usability, creation decisions, created-token classification, group selection, and one-time-secret handling through policy.
+- Modify `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+  - Updates adapter mocks and preserves existing post-save result behavior.
+- Modify `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+  - Routes background default token creation through policy.
+- Modify `src/services/accounts/accountOperations.ts`
+  - Adds generic quick-create resolution, keeps the Sub2API compatibility wrapper, and routes `ensureAccountApiToken(...)` through policy.
+- Modify `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+  - Preserves existing grouped creation, Sub2API group-selection, and AIHubMix blocking behavior.
+- Modify `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+  - Routes empty-group/no-token fallback through policy.
+- Modify `tests/services/accountKeyGroupCoverage.test.ts`
+  - Verifies policy-driven empty-group fallback and unchanged invalid-token deletion behavior.
+- Modify `src/services/accounts/accountKeyAutoProvisioning/repair.ts`
+  - Routes site-specific repair skip reasons through policy while keeping `noneAuth` in repair.
+- Modify `tests/services/accountKeyRepair.test.ts`
+  - Verifies policy-driven Sub2API and AIHubMix skip reasons.
+
+Do not modify:
+
+- `src/services/apiService/**`
+  - Backend token functions remain delegated implementations behind `keyManagement`.
+- `src/locales/**`
+  - This slice reuses existing messages and result codes.
+- telemetry schemas, settings search files, Playwright E2E tests, managed-site providers, managed-site channel CRUD, model pricing, model catalog, redemption, site announcements, account bootstrap, account data, account refresh, or account completion.
+- new site-type definitions.
+
+Telemetry decision: reuse existing.
+
+Settings search decision: none.
+
+E2E decision: no new Playwright E2E. The risk is service-layer policy routing and existing result mapping, which focused Vitest coverage exercises directly.
+
+---
+
+### Task 1: Add Token Provisioning Policy Contract And Adapter Policies
+
+**Files:**
+- Create: `src/services/apiAdapters/contracts/tokenProvisioning.ts`
+- Modify: `src/services/apiAdapters/contracts/siteAdapter.ts`
+- Create: `src/services/apiAdapters/newApi/tokenProvisioning.ts`
+- Create: `src/services/apiAdapters/sub2api/tokenProvisioning.ts`
+- Create: `src/services/apiAdapters/aihubmix/tokenProvisioning.ts`
+- Modify: `src/services/apiAdapters/newApi/index.ts`
+- Modify: `src/services/apiAdapters/sub2api/index.ts`
+- Modify: `src/services/apiAdapters/aihubmix/index.ts`
+- Modify: `tests/services/apiAdapters/tokenProvisioning.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write the failing policy tests**
+
+Create `tests/services/apiAdapters/tokenProvisioning.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { TOKEN_PROVISIONING_BLOCK_REASONS, TOKEN_PROVISIONING_WORKFLOWS } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import { aihubmixTokenProvisioning } from "~/services/apiAdapters/aihubmix/tokenProvisioning"
+import { createNewApiTokenProvisioning } from "~/services/apiAdapters/newApi/tokenProvisioning"
+import {
+  normalizeTokenProvisioningGroupNames,
+  sub2ApiTokenProvisioning,
+} from "~/services/apiAdapters/sub2api/tokenProvisioning"
+import type { ApiToken } from "~/types"
+
+const defaultTokenData = {
+  name: "All API Hub Auto Provisioned Key",
+  remain_quota: 500000,
+  expired_time: -1,
+  unlimited_quota: false,
+  model_limits_enabled: false,
+  model_limits: "",
+  allow_ips: "",
+  group: "",
+}
+
+const token = (overrides: Partial<ApiToken> = {}): ApiToken =>
+  ({
+    id: 1,
+    name: "default key",
+    key: "sk-full-secret",
+    status: 1,
+    remain_quota: 500000,
+    unlimited_quota: false,
+    expired_time: -1,
+    created_time: 1,
+    accessed_time: 1,
+    used_quota: 0,
+    models: "",
+    subnet: "",
+    ...overrides,
+  }) as ApiToken
+
+describe("tokenProvisioning policies", () => {
+  it("allows new API-family default creation and inventory recovery", () => {
+    const policy = createNewApiTokenProvisioning("new-api")
+
+    expect(
+      policy.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
+        defaultTokenData,
+      }),
+    ).toEqual({
+      kind: "create",
+      tokenData: defaultTokenData,
+      oneTimeSecret: false,
+      recoverCreatedToken: "inventory_refetch",
+    })
+    expect(
+      policy.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        result: true,
+      }),
+    ).toEqual({ kind: "needs_inventory_refetch" })
+    expect(
+      policy.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        result: token(),
+      }),
+    ).toEqual({
+      kind: "usable",
+      token: token(),
+      oneTimeSecret: false,
+    })
+    expect(policy.isInventoryTokenUsable({
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+      token: token({ key: "masked sk-abc" }),
+    })).toBe(true)
+    expect(policy.getRepairPolicy()).toEqual({ kind: "eligible" })
+  })
+
+  it("normalizes Sub2API group names", () => {
+    expect(
+      normalizeTokenProvisioningGroupNames({
+        " default ": { desc: "Default", ratio: 1 },
+        vip: { desc: "VIP", ratio: 1 },
+        "": { desc: "Blank", ratio: 1 },
+        default: { desc: "Duplicate", ratio: 1 },
+      }),
+    ).toEqual(["default", "vip"])
+  })
+
+  it("requires Sub2API groups for interactive and post-save creation", () => {
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData,
+      }),
+    ).toEqual({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
+    })
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection,
+        defaultTokenData,
+      }),
+    ).toEqual({ kind: "needs_user_groups" })
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        defaultTokenData,
+        userGroups: { vip: { desc: "VIP", ratio: 1 } },
+      }),
+    ).toEqual({
+      kind: "create",
+      tokenData: { ...defaultTokenData, group: "vip" },
+      oneTimeSecret: false,
+      recoverCreatedToken: "inventory_refetch",
+    })
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection,
+        defaultTokenData,
+        userGroups: {
+          default: { desc: "Default", ratio: 1 },
+          vip: { desc: "VIP", ratio: 1 },
+        },
+      }),
+    ).toEqual({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
+    })
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        defaultTokenData,
+        userGroups: {},
+      }),
+    ).toEqual({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
+    })
+    expect(sub2ApiTokenProvisioning.getRepairPolicy()).toEqual({
+      kind: "skipped",
+      skipReason: "sub2api",
+    })
+  })
+
+  it("requires AIHubMix post-save one-time full secrets", () => {
+    expect(
+      aihubmixTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
+        defaultTokenData,
+      }),
+    ).toEqual({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
+    })
+    expect(
+      aihubmixTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        defaultTokenData,
+      }),
+    ).toEqual({
+      kind: "create",
+      tokenData: defaultTokenData,
+      oneTimeSecret: true,
+      recoverCreatedToken: "created_response_first",
+    })
+    expect(
+      aihubmixTokenProvisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        result: token({ key: "sk-full-aihubmix-secret" }),
+      }),
+    ).toEqual({
+      kind: "usable",
+      token: token({ key: "sk-full-aihubmix-secret" }),
+      oneTimeSecret: true,
+    })
+    expect(
+      aihubmixTokenProvisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        result: token({ key: "sk-****masked" }),
+      }),
+    ).toEqual({
+      kind: "unavailable",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
+    })
+    expect(aihubmixTokenProvisioning.isInventoryTokenUsable({
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+      token: token({ key: "sk-****masked" }),
+    })).toBe(false)
+    expect(aihubmixTokenProvisioning.getRepairPolicy()).toEqual({
+      kind: "skipped",
+      skipReason: "aihubmixOneTimeKey",
+    })
+  })
+})
+```
+
+Update `tests/services/apiAdapters/registry.test.ts` expectations for supported adapters:
+
+```ts
+expect(adapter.tokenProvisioning).toEqual(expect.any(Object))
+expect(adapter.tokenProvisioning?.resolveDefaultTokenCreation).toEqual(
+  expect.any(Function),
+)
+expect(adapter.tokenProvisioning?.classifyCreatedToken).toEqual(
+  expect.any(Function),
+)
+expect(adapter.tokenProvisioning?.isInventoryTokenUsable).toEqual(
+  expect.any(Function),
+)
+expect(adapter.tokenProvisioning?.getRepairPolicy).toEqual(expect.any(Function))
+```
+
+For unsupported adapters in the same file, assert:
+
+```ts
+expect(adapter.tokenProvisioning).toBeUndefined()
+```
+
+- [ ] **Step 2: Run the failing policy tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/tokenProvisioning.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: FAIL because `contracts/tokenProvisioning.ts` and the adapter policy modules do not exist yet.
+
+- [ ] **Step 3: Add the policy contract**
+
+Create `src/services/apiAdapters/contracts/tokenProvisioning.ts`:
+
+```ts
+import type {
+  CreateTokenRequest,
+  CreateTokenResult,
+  UserGroupInfo,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+import type { AccountKeyRepairSkipReason } from "~/types/accountKeyAutoProvisioning"
+
+export const TOKEN_PROVISIONING_WORKFLOWS = {
+  BackgroundAutoProvision: "background_auto_provision",
+  SharedEnsure: "shared_ensure",
+  QuickCreateSelection: "quick_create_selection",
+  PostSaveAutomation: "post_save_automation",
+  Repair: "repair",
+} as const
+
+export type TokenProvisioningWorkflow =
+  (typeof TOKEN_PROVISIONING_WORKFLOWS)[keyof typeof TOKEN_PROVISIONING_WORKFLOWS]
+
+export const TOKEN_PROVISIONING_BLOCK_REASONS = {
+  GroupRequired: "group_required",
+  AvailableGroupRequired: "available_group_required",
+  GroupSelectionRequired: "group_selection_required",
+  OneTimeSecretRequired: "one_time_secret_required",
+  CreateFailed: "create_failed",
+  CreatedTokenSecretUnavailable: "created_token_secret_unavailable",
+} as const
+
+export type TokenProvisioningBlockReason =
+  (typeof TOKEN_PROVISIONING_BLOCK_REASONS)[keyof typeof TOKEN_PROVISIONING_BLOCK_REASONS]
+
+export type ResolveDefaultTokenCreationRequest = {
+  workflow: TokenProvisioningWorkflow
+  defaultTokenData: CreateTokenRequest
+  explicitGroup?: string
+  userGroups?: Record<string, UserGroupInfo>
+}
+
+export type DefaultTokenCreationDecision =
+  | {
+      kind: "create"
+      tokenData: CreateTokenRequest
+      oneTimeSecret: boolean
+      recoverCreatedToken: "created_response_first" | "inventory_refetch"
+    }
+  | { kind: "needs_user_groups" }
+  | {
+      kind: "selection_required"
+      allowedGroups: string[]
+      reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired
+    }
+  | {
+      kind: "blocked"
+      reason: TokenProvisioningBlockReason
+    }
+
+export type CreatedTokenSecretDecision =
+  | { kind: "usable"; token: ApiToken; oneTimeSecret: boolean }
+  | {
+      kind: "failed"
+      reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed
+    }
+  | {
+      kind: "unavailable"
+      reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable
+    }
+  | { kind: "needs_inventory_refetch" }
+
+export type TokenProvisioningRepairPolicy =
+  | { kind: "eligible" }
+  | {
+      kind: "skipped"
+      skipReason: Extract<
+        AccountKeyRepairSkipReason,
+        "sub2api" | "aihubmixOneTimeKey"
+      >
+    }
+
+export type TokenProvisioningCapability = {
+  isInventoryTokenUsable(params: {
+    workflow: TokenProvisioningWorkflow
+    token: ApiToken
+  }): boolean
+  resolveDefaultTokenCreation(
+    request: ResolveDefaultTokenCreationRequest,
+  ): DefaultTokenCreationDecision
+  classifyCreatedToken(params: {
+    workflow: TokenProvisioningWorkflow
+    result: CreateTokenResult
+  }): CreatedTokenSecretDecision
+  getRepairPolicy(): TokenProvisioningRepairPolicy
+}
+```
+
+Modify `src/services/apiAdapters/contracts/siteAdapter.ts`:
+
+```ts
+import type { TokenProvisioningCapability } from "./tokenProvisioning"
+
+export type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  modelPricing?: ModelPricingCapability
+  accountData?: AccountDataCapability
+  accountBootstrap?: AccountBootstrapCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  tokenProvisioning?: TokenProvisioningCapability
+  accountRefresh?: AccountRefreshCapability
+  redemption?: RedemptionCapability
+}
+```
+
+- [ ] **Step 4: Add concrete policy implementations**
+
+Create `src/services/apiAdapters/newApi/tokenProvisioning.ts`:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  type TokenProvisioningCapability,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import type { ApiToken } from "~/types"
+
+const isCreatedApiToken = (result: unknown): result is ApiToken =>
+  typeof result === "object" &&
+  result !== null &&
+  "id" in result &&
+  "key" in result
+
+export const createNewApiTokenProvisioning = (
+  _siteType: AccountSiteType,
+): TokenProvisioningCapability => ({
+  isInventoryTokenUsable: () => true,
+  resolveDefaultTokenCreation: ({ defaultTokenData }) => ({
+    kind: "create",
+    tokenData: defaultTokenData,
+    oneTimeSecret: false,
+    recoverCreatedToken: "inventory_refetch",
+  }),
+  classifyCreatedToken: ({ result }) => {
+    if (isCreatedApiToken(result)) {
+      return { kind: "usable", token: result, oneTimeSecret: false }
+    }
+
+    if (result) {
+      return { kind: "needs_inventory_refetch" }
+    }
+
+    return {
+      kind: "failed",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+    }
+  },
+  getRepairPolicy: () => ({ kind: "eligible" }),
+})
+```
+
+Create `src/services/apiAdapters/sub2api/tokenProvisioning.ts`:
+
+```ts
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+  type TokenProvisioningCapability,
+  type TokenProvisioningWorkflow,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import type { ApiToken } from "~/types"
+
+const isCreatedApiToken = (result: unknown): result is ApiToken =>
+  typeof result === "object" &&
+  result !== null &&
+  "id" in result &&
+  "key" in result
+
+const GROUP_SELECTION_WORKFLOWS = new Set<TokenProvisioningWorkflow>([
+  TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection,
+  TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+])
+
+export function normalizeTokenProvisioningGroupNames(
+  groups: Record<string, unknown>,
+): string[] {
+  return Array.from(
+    new Set(
+      Object.keys(groups)
+        .map((group) => group.trim())
+        .filter(Boolean),
+    ),
+  )
+}
+
+export const sub2ApiTokenProvisioning: TokenProvisioningCapability = {
+  isInventoryTokenUsable: () => true,
+  resolveDefaultTokenCreation: ({
+    workflow,
+    defaultTokenData,
+    explicitGroup,
+    userGroups,
+  }) => {
+    const normalizedExplicitGroup = explicitGroup?.trim() ?? ""
+
+    if (normalizedExplicitGroup) {
+      return {
+        kind: "create",
+        tokenData: { ...defaultTokenData, group: normalizedExplicitGroup },
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }
+    }
+
+    if (!GROUP_SELECTION_WORKFLOWS.has(workflow)) {
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
+      }
+    }
+
+    if (!userGroups) {
+      return { kind: "needs_user_groups" }
+    }
+
+    const validGroups = normalizeTokenProvisioningGroupNames(userGroups)
+
+    if (validGroups.length === 0) {
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
+      }
+    }
+
+    if (validGroups.length === 1) {
+      return {
+        kind: "create",
+        tokenData: { ...defaultTokenData, group: validGroups[0] },
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }
+    }
+
+    return {
+      kind: "selection_required",
+      allowedGroups: validGroups,
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
+    }
+  },
+  classifyCreatedToken: ({ result }) => {
+    if (isCreatedApiToken(result)) {
+      return { kind: "usable", token: result, oneTimeSecret: false }
+    }
+
+    if (result) {
+      return { kind: "needs_inventory_refetch" }
+    }
+
+    return {
+      kind: "failed",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+    }
+  },
+  getRepairPolicy: () => ({ kind: "skipped", skipReason: "sub2api" }),
+}
+```
+
+Create `src/services/apiAdapters/aihubmix/tokenProvisioning.ts`:
+
+```ts
+import {
+  hasUsableApiTokenKey,
+  isMaskedApiTokenKey,
+} from "~/services/apiService/common/apiKey"
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+  type TokenProvisioningCapability,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import type { ApiToken } from "~/types"
+
+const isCreatedApiToken = (result: unknown): result is ApiToken =>
+  typeof result === "object" &&
+  result !== null &&
+  "id" in result &&
+  "key" in result
+
+const hasUsableFullTokenSecret = (token: Pick<ApiToken, "key">): boolean =>
+  hasUsableApiTokenKey(token.key) && !isMaskedApiTokenKey(token.key)
+
+export const aihubmixTokenProvisioning: TokenProvisioningCapability = {
+  isInventoryTokenUsable: ({ token }) => hasUsableFullTokenSecret(token),
+  resolveDefaultTokenCreation: ({ workflow, defaultTokenData }) => {
+    if (workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation) {
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
+      }
+    }
+
+    return {
+      kind: "create",
+      tokenData: defaultTokenData,
+      oneTimeSecret: true,
+      recoverCreatedToken: "created_response_first",
+    }
+  },
+  classifyCreatedToken: ({ result }) => {
+    if (!result) {
+      return {
+        kind: "failed",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+      }
+    }
+
+    if (isCreatedApiToken(result) && hasUsableFullTokenSecret(result)) {
+      return { kind: "usable", token: result, oneTimeSecret: true }
+    }
+
+    return {
+      kind: "unavailable",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
+    }
+  },
+  getRepairPolicy: () => ({
+    kind: "skipped",
+    skipReason: "aihubmixOneTimeKey",
+  }),
+}
+```
+
+- [ ] **Step 5: Wire policies into adapters**
+
+Modify `src/services/apiAdapters/newApi/index.ts`:
+
+```ts
+import { createNewApiTokenProvisioning } from "./tokenProvisioning"
+
+export const createNewApiAdapter = (
+  siteType: AccountSiteType = SITE_TYPES.NEW_API,
+): SiteAdapter => ({
+  siteType,
+  family: "newApiFamily",
+  siteNotice: newApiSiteNotice,
+  accountData: createNewApiAccountData(siteType),
+  accountBootstrap: createNewApiAccountBootstrap(siteType),
+  accountCompletion: newApiAccountCompletion,
+  keyManagement: createNewApiKeyManagement(siteType),
+  tokenProvisioning: createNewApiTokenProvisioning(siteType),
+  accountRefresh: createNewApiAccountRefresh(siteType),
+  modelPricing: createNewApiModelPricing(siteType),
+  redemption: createNewApiRedemption(siteType),
+})
+```
+
+Modify `src/services/apiAdapters/sub2api/index.ts`:
+
+```ts
+import { sub2ApiTokenProvisioning } from "./tokenProvisioning"
+
+export const sub2ApiAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.SUB2API,
+  family: "sub2api",
+  siteAnnouncements: sub2ApiSiteAnnouncements,
+  modelCatalog: sub2ApiModelCatalog,
+  accountData: sub2ApiAccountData,
+  accountBootstrap: sub2ApiAccountBootstrap,
+  accountCompletion: sub2ApiAccountCompletion,
+  keyManagement: sub2ApiKeyManagement,
+  tokenProvisioning: sub2ApiTokenProvisioning,
+  accountRefresh: sub2ApiAccountRefresh,
+}
+```
+
+Modify `src/services/apiAdapters/aihubmix/index.ts`:
+
+```ts
+import { aihubmixTokenProvisioning } from "./tokenProvisioning"
+
+export const aihubmixAdapter: SiteAdapter = {
+  siteType: SITE_TYPES.AIHUBMIX,
+  accountData: aihubmixAccountData,
+  accountBootstrap: aihubmixAccountBootstrap,
+  accountCompletion: aihubmixAccountCompletion,
+  keyManagement: aihubmixKeyManagement,
+  tokenProvisioning: aihubmixTokenProvisioning,
+  accountRefresh: aihubmixAccountRefresh,
+  modelPricing: aihubmixModelPricing,
+}
+```
+
+- [ ] **Step 6: Run policy and registry tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/tokenProvisioning.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the adapter policy foundation**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiAdapters/contracts/tokenProvisioning.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/tokenProvisioning.ts src/services/apiAdapters/sub2api/tokenProvisioning.ts src/services/apiAdapters/aihubmix/tokenProvisioning.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/sub2api/index.ts src/services/apiAdapters/aihubmix/index.ts tests/services/apiAdapters/tokenProvisioning.test.ts tests/services/apiAdapters/registry.test.ts
+git commit -m "feat(api-adapters): add token provisioning policy"
+```
+
+Expected: one commit containing only the adapter contract, policy modules, adapter wiring, and adapter tests.
+
+---
+
+### Task 2: Add Shared Token Provisioning Helpers
+
+**Files:**
+- Modify: `src/services/accounts/utils/apiServiceRequest.ts`
+- Create: `src/services/accounts/utils/tokenProvisioning.ts`
+- Modify: `tests/services/accounts/apiServiceRequest.test.ts`
+
+- [ ] **Step 1: Write failing helper tests**
+
+In `tests/services/accounts/apiServiceRequest.test.ts`, extend the test setup:
+
+```ts
+let tokenProvisioning: {
+  isInventoryTokenUsable: ReturnType<typeof vi.fn>
+  resolveDefaultTokenCreation: ReturnType<typeof vi.fn>
+  classifyCreatedToken: ReturnType<typeof vi.fn>
+  getRepairPolicy: ReturnType<typeof vi.fn>
+}
+
+beforeEach(() => {
+  tokenProvisioning = {
+    isInventoryTokenUsable: vi.fn(),
+    resolveDefaultTokenCreation: vi.fn(),
+    classifyCreatedToken: vi.fn(),
+    getRepairPolicy: vi.fn(),
+  }
+  adapter = { siteType: "new-api", keyManagement, tokenProvisioning }
+})
+```
+
+Update the existing `createDisplayAccountApiContext(...)` expectation:
+
+```ts
+expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual({
+  adapter,
+  keyManagement,
+  tokenProvisioning,
+  request: expect.objectContaining(REQUEST),
+})
+```
+
+Add a missing-capability test:
+
+```ts
+it("throws when adapter token provisioning is not implemented", async () => {
+  const { requireDisplayAccountTokenProvisioning } = await import(
+    "~/services/accounts/utils/apiServiceRequest"
+  )
+
+  expect(() =>
+    requireDisplayAccountTokenProvisioning(
+      { siteType: "unsupported" } as any,
+      undefined,
+    ),
+  ).toThrow("tokenProvisioning is not implemented for unsupported")
+})
+```
+
+- [ ] **Step 2: Run the failing helper tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: FAIL because `createDisplayAccountApiContext(...)` does not return `tokenProvisioning` and `requireDisplayAccountTokenProvisioning(...)` is not exported.
+
+- [ ] **Step 3: Implement the context helper**
+
+In `src/services/accounts/utils/apiServiceRequest.ts`, add:
+
+```ts
+import type { TokenProvisioningCapability } from "~/services/apiAdapters/contracts/tokenProvisioning"
+
+export const createMissingTokenProvisioningCapabilityError = (
+  siteType: string,
+) => new Error(`tokenProvisioning is not implemented for ${siteType}`)
+
+export const requireDisplayAccountTokenProvisioning = (
+  account: Pick<DisplaySiteData, "siteType">,
+  tokenProvisioning: TokenProvisioningCapability | undefined,
+): TokenProvisioningCapability => {
+  if (!tokenProvisioning) {
+    throw createMissingTokenProvisioningCapabilityError(account.siteType)
+  }
+
+  return tokenProvisioning
+}
+```
+
+Update `createDisplayAccountApiContext(...)` to return the policy reference:
+
+```ts
+export function createDisplayAccountApiContext(account: DisplaySiteData) {
+  const adapter = getSiteAdapter(account.siteType)
+  const request = withDisplayAccountAuthSession(account, {
+    baseUrl: account.baseUrl,
+    accountId: account.id,
+    auth: buildDisplayAccountAuthConfig(account),
+  })
+
+  return {
+    adapter,
+    keyManagement: adapter.keyManagement,
+    tokenProvisioning: adapter.tokenProvisioning,
+    request,
+  }
+}
+```
+
+- [ ] **Step 4: Add the user-group re-resolution helper**
+
+Create `src/services/accounts/utils/tokenProvisioning.ts`:
+
+```ts
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import type {
+  DefaultTokenCreationDecision,
+  ResolveDefaultTokenCreationRequest,
+  TokenProvisioningCapability,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+
+export async function resolveDefaultTokenCreationWithUserGroups(params: {
+  keyManagement: KeyManagementCapability
+  tokenProvisioning: TokenProvisioningCapability
+  request: ApiServiceRequest
+  decisionRequest: ResolveDefaultTokenCreationRequest
+  missingUserGroupsMessage: string
+}): Promise<DefaultTokenCreationDecision> {
+  const decision = params.tokenProvisioning.resolveDefaultTokenCreation(
+    params.decisionRequest,
+  )
+
+  if (decision.kind !== "needs_user_groups") {
+    return decision
+  }
+
+  if (!params.keyManagement.userGroups) {
+    throw new Error(params.missingUserGroupsMessage)
+  }
+
+  const userGroups = await params.keyManagement.userGroups.fetch(params.request)
+
+  return params.tokenProvisioning.resolveDefaultTokenCreation({
+    ...params.decisionRequest,
+    userGroups,
+  })
+}
+```
+
+- [ ] **Step 5: Run helper tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the shared helpers**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/utils/apiServiceRequest.ts src/services/accounts/utils/tokenProvisioning.ts tests/services/accounts/apiServiceRequest.test.ts
+git commit -m "feat(accounts): add token provisioning helpers"
+```
+
+Expected: one commit containing only the helper changes and focused tests.
+
+---
+
+### Task 3: Route Post-Save Account Token Ensure Through Policy
+
+**Files:**
+- Modify: `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+- Modify: `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+
+- [ ] **Step 1: Update the post-save test adapter mock**
+
+In `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`, extend hoisted mocks:
+
+```ts
+const mocks = vi.hoisted(() => ({
+  fetchAccountTokens: vi.fn(),
+  createApiToken: vi.fn(),
+  fetchUserGroups: vi.fn(),
+  isInventoryTokenUsable: vi.fn(),
+  resolveDefaultTokenCreation: vi.fn(),
+  classifyCreatedToken: vi.fn(),
+  getRepairPolicy: vi.fn(),
+}))
+```
+
+Update the adapter mock:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn(() => ({
+    keyManagement: {
+      fetchTokens: (...args: unknown[]) => mocks.fetchAccountTokens(...args),
+      createToken: (...args: unknown[]) => mocks.createApiToken(...args),
+      userGroups: {
+        fetch: (...args: unknown[]) => mocks.fetchUserGroups(...args),
+      },
+      updateToken: vi.fn(),
+      resolveTokenKey: vi.fn(),
+      deleteToken: vi.fn(),
+      fetchAvailableModels: vi.fn(),
+    },
+    tokenProvisioning: {
+      isInventoryTokenUsable: (...args: unknown[]) =>
+        mocks.isInventoryTokenUsable(...args),
+      resolveDefaultTokenCreation: (...args: unknown[]) =>
+        mocks.resolveDefaultTokenCreation(...args),
+      classifyCreatedToken: (...args: unknown[]) =>
+        mocks.classifyCreatedToken(...args),
+      getRepairPolicy: (...args: unknown[]) => mocks.getRepairPolicy(...args),
+    },
+  })),
+}))
+```
+
+Set default policy behavior in `beforeEach`:
+
+```ts
+mocks.isInventoryTokenUsable.mockImplementation(({ token }) => Boolean(token.key))
+mocks.resolveDefaultTokenCreation.mockImplementation(({ defaultTokenData }) => ({
+  kind: "create",
+  tokenData: defaultTokenData,
+  oneTimeSecret: false,
+  recoverCreatedToken: "inventory_refetch",
+}))
+mocks.classifyCreatedToken.mockImplementation(({ result }) =>
+  typeof result === "object" && result !== null
+    ? { kind: "usable", token: result, oneTimeSecret: false }
+    : result
+      ? { kind: "needs_inventory_refetch" }
+      : { kind: "failed", reason: "create_failed" },
+)
+```
+
+Add one routing assertion to an existing creates-token test:
+
+```ts
+expect(mocks.resolveDefaultTokenCreation).toHaveBeenCalledWith(
+  expect.objectContaining({
+    workflow: "post_save_automation",
+    defaultTokenData: expect.objectContaining({
+      name: "All API Hub Auto Provisioned Key",
+    }),
+  }),
+)
+expect(mocks.classifyCreatedToken).toHaveBeenCalledWith(
+  expect.objectContaining({
+    workflow: "post_save_automation",
+  }),
+)
+```
+
+- [ ] **Step 2: Run the failing post-save tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+```
+
+Expected: FAIL because the workflow still uses raw site-type branches and does not call `tokenProvisioning`.
+
+- [ ] **Step 3: Route inventory and creation through policy**
+
+In `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`, import:
+
+```ts
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+  type DefaultTokenCreationDecision,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import {
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  requireDisplayAccountTokenProvisioning,
+} from "~/services/accounts/utils/apiServiceRequest"
+import { resolveDefaultTokenCreationWithUserGroups } from "~/services/accounts/utils/tokenProvisioning"
+```
+
+Add workflow-local result mapping:
+
+```ts
+const mapBlockedDecisionToPostSaveError = (
+  decision: Extract<DefaultTokenCreationDecision, { kind: "blocked" }>,
+) => ({
+  kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Error,
+  code:
+    decision.reason ===
+      TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired ||
+    decision.reason ===
+      TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable
+      ? ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable
+      : ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+  message:
+    decision.reason === TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
+      ? "messages:aihubmix.createRequiresOneTimeKeyDialog"
+      : decision.reason ===
+          TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired
+        ? "messages:sub2api.createRequiresAvailableGroup"
+        : "messages:accountOperations.createTokenFailed",
+})
+```
+
+When resolving the adapter context, require both capabilities:
+
+```ts
+const { keyManagement, request, tokenProvisioning } =
+  createDisplayAccountApiContext(displaySiteData)
+const requiredKeyManagement = requireDisplayAccountKeyManagement(
+  displaySiteData,
+  keyManagement,
+)
+const requiredTokenProvisioning = requireDisplayAccountTokenProvisioning(
+  displaySiteData,
+  tokenProvisioning,
+)
+```
+
+In inventory inspection, replace the AIHubMix key check with:
+
+```ts
+const hasUsableSecret =
+  existingToken !== null &&
+  requiredTokenProvisioning.isInventoryTokenUsable({
+    workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+    token: existingToken,
+  })
+```
+
+In token creation, replace Sub2API and AIHubMix site-type branches with:
+
+```ts
+const decision = await resolveDefaultTokenCreationWithUserGroups({
+  keyManagement: requiredKeyManagement,
+  tokenProvisioning: requiredTokenProvisioning,
+  request,
+  decisionRequest: {
+    workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+    defaultTokenData: generateDefaultTokenRequest(),
+  },
+  missingUserGroupsMessage: "sub2api_group_inventory_not_implemented",
+})
+
+if (decision.kind === "selection_required") {
+  return {
+    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+    allowedGroups: decision.allowedGroups,
+  }
+}
+
+if (decision.kind === "blocked") {
+  return mapBlockedDecisionToPostSaveError(decision)
+}
+
+if (decision.kind === "needs_user_groups") {
+  return {
+    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Error,
+    code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+    message: "messages:sub2api.createRequiresAvailableGroup",
+  }
+}
+
+const createResult = await requiredKeyManagement.createToken(
+  request,
+  decision.tokenData,
+)
+const createdTokenDecision = requiredTokenProvisioning.classifyCreatedToken({
+  workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+  result: createResult,
+})
+```
+
+Handle created-token classification:
+
+```ts
+if (createdTokenDecision.kind === "usable") {
+  return {
+    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+    token: createdTokenDecision.token,
+    oneTimeSecret: createdTokenDecision.oneTimeSecret,
+  }
+}
+
+if (createdTokenDecision.kind === "failed") {
+  return {
+    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Error,
+    code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+    message: "messages:accountOperations.createTokenFailed",
+  }
+}
+
+if (createdTokenDecision.kind === "unavailable") {
+  return {
+    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Error,
+    code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+    message: "messages:aihubmix.createRequiresOneTimeKeyDialog",
+  }
+}
+
+const refreshedInventory = await inspectAccountTokenInventory({
+  keyManagement: requiredKeyManagement,
+  request,
+  tokenProvisioning: requiredTokenProvisioning,
+})
+```
+
+- [ ] **Step 4: Run post-save tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+```
+
+Expected: PASS with unchanged external result kinds and messages.
+
+- [ ] **Step 5: Commit the post-save routing**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+git commit -m "refactor(accounts): route post-save token policy through adapters"
+```
+
+Expected: one commit containing only post-save workflow and test changes.
+
+---
+
+### Task 4: Route Background And Shared Default Token Ensure Through Policy
+
+**Files:**
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+- Modify: `src/services/accounts/accountOperations.ts`
+- Modify: `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+
+- [ ] **Step 1: Add shared-ensure tests for generic policy routing**
+
+In `tests/services/accountOperations.ensureAccountApiToken.test.ts`, update the adapter mock to include `tokenProvisioning`:
+
+```ts
+tokenProvisioning: {
+  isInventoryTokenUsable: vi.fn(() => true),
+  resolveDefaultTokenCreation: (...args: unknown[]) =>
+    mocks.resolveDefaultTokenCreation(...args),
+  classifyCreatedToken: (...args: unknown[]) =>
+    mocks.classifyCreatedToken(...args),
+  getRepairPolicy: vi.fn(() => ({ kind: "eligible" })),
+}
+```
+
+Set defaults in `beforeEach`:
+
+```ts
+mocks.resolveDefaultTokenCreation.mockImplementation(({ defaultTokenData }) => ({
+  kind: "create",
+  tokenData: defaultTokenData,
+  oneTimeSecret: false,
+  recoverCreatedToken: "inventory_refetch",
+}))
+mocks.classifyCreatedToken.mockImplementation(({ result }) =>
+  typeof result === "object" && result !== null
+    ? { kind: "usable", token: result, oneTimeSecret: false }
+    : result
+      ? { kind: "needs_inventory_refetch" }
+      : { kind: "failed", reason: "create_failed" },
+)
+```
+
+Add a routing assertion to the grouped Sub2API creation test:
+
+```ts
+expect(mocks.resolveDefaultTokenCreation).toHaveBeenCalledWith(
+  expect.objectContaining({
+    workflow: "shared_ensure",
+    explicitGroup: "vip",
+  }),
+)
+expect(mocks.createApiToken).toHaveBeenCalledWith(
+  expect.any(Object),
+  expect.objectContaining({ group: "vip" }),
+)
+```
+
+Add a generic quick-create resolver test:
+
+```ts
+it("resolves quick-create group selection through token provisioning policy", async () => {
+  mocks.resolveDefaultTokenCreation
+    .mockReturnValueOnce({ kind: "needs_user_groups" })
+    .mockReturnValueOnce({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+      reason: "group_selection_required",
+    })
+  mocks.fetchUserGroups.mockResolvedValueOnce({
+    default: { desc: "Default", ratio: 1 },
+    vip: { desc: "VIP", ratio: 1 },
+  })
+
+  const { resolveDefaultTokenQuickCreateResolution } = await import(
+    "~/services/accounts/accountOperations"
+  )
+
+  await expect(
+    resolveDefaultTokenQuickCreateResolution(DISPLAY_ACCOUNT),
+  ).resolves.toEqual({
+    kind: "selection_required",
+    allowedGroups: ["default", "vip"],
+  })
+})
+```
+
+- [ ] **Step 2: Run the failing shared-ensure tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Expected: FAIL because `accountOperations.ts` does not export `resolveDefaultTokenQuickCreateResolution(...)` and does not call `tokenProvisioning`.
+
+- [ ] **Step 3: Route background default ensure through policy**
+
+In `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`, import policy helpers:
+
+```ts
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import {
+  requireDisplayAccountKeyManagement,
+  requireDisplayAccountTokenProvisioning,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+After resolving adapter context, require policy:
+
+```ts
+const tokenProvisioning = requireDisplayAccountTokenProvisioning(
+  displaySiteData,
+  adapter.tokenProvisioning,
+)
+```
+
+Replace the Sub2API and AIHubMix site-type block before create with:
+
+```ts
+const decision = tokenProvisioning.resolveDefaultTokenCreation({
+  workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
+  defaultTokenData: generateDefaultTokenRequest(),
+})
+
+if (decision.kind !== "create") {
+  if (
+    decision.kind === "blocked" &&
+    decision.reason === TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
+  ) {
+    throw new Error("messages:aihubmix.createRequiresOneTimeKeyDialog")
+  }
+
+  throw new Error("messages:sub2api.createRequiresGroup")
+}
+
+const createResult = await keyManagement.createToken(request, decision.tokenData)
+const createdTokenDecision = tokenProvisioning.classifyCreatedToken({
+  workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
+  result: createResult,
+})
+
+if (createdTokenDecision.kind === "failed") {
+  throw new Error("create_token_failed")
+}
+```
+
+When deciding whether to refetch inventory:
+
+```ts
+if (createdTokenDecision.kind === "usable") {
+  return createdTokenDecision.token
+}
+
+if (createdTokenDecision.kind === "unavailable") {
+  throw new Error("token_not_found")
+}
+
+const refreshedTokens = await keyManagement.fetchTokens(request)
+```
+
+- [ ] **Step 4: Add generic quick-create resolver and route shared ensure**
+
+In `src/services/accounts/accountOperations.ts`, add imports:
+
+```ts
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+  type TokenProvisioningBlockReason,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import { resolveDefaultTokenCreationWithUserGroups } from "~/services/accounts/utils/tokenProvisioning"
+```
+
+Add result types:
+
+```ts
+export type DefaultTokenQuickCreateResolution =
+  | { kind: "ready"; tokenData: CreateTokenRequest }
+  | { kind: "selection_required"; allowedGroups: string[] }
+  | {
+      kind: "blocked"
+      reason: TokenProvisioningBlockReason
+      message: string
+    }
+```
+
+Add reason-to-message mapping:
+
+```ts
+const getDefaultTokenProvisioningBlockMessage = (
+  reason: TokenProvisioningBlockReason,
+): string => {
+  if (reason === TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired) {
+    return "messages:sub2api.createRequiresAvailableGroup"
+  }
+
+  if (reason === TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired) {
+    return "messages:aihubmix.createRequiresOneTimeKeyDialog"
+  }
+
+  return "messages:sub2api.createRequiresGroup"
+}
+```
+
+Add generic quick-create resolution:
+
+```ts
+export async function resolveDefaultTokenQuickCreateResolution(
+  account: DisplaySiteData,
+  options: { explicitGroup?: string } = {},
+): Promise<DefaultTokenQuickCreateResolution> {
+  const { keyManagement, request, tokenProvisioning } =
+    createDisplayAccountApiContext(account)
+  const requiredKeyManagement = requireDisplayAccountKeyManagement(
+    account,
+    keyManagement,
+  )
+  const requiredTokenProvisioning = requireDisplayAccountTokenProvisioning(
+    account,
+    tokenProvisioning,
+  )
+  const decision = await resolveDefaultTokenCreationWithUserGroups({
+    keyManagement: requiredKeyManagement,
+    tokenProvisioning: requiredTokenProvisioning,
+    request,
+    decisionRequest: {
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection,
+      defaultTokenData: generateDefaultTokenRequest(),
+      explicitGroup: options.explicitGroup,
+    },
+    missingUserGroupsMessage: "sub2api_group_inventory_not_implemented",
+  })
+
+  if (decision.kind === "create") {
+    return { kind: "ready", tokenData: decision.tokenData }
+  }
+
+  if (decision.kind === "selection_required") {
+    return {
+      kind: "selection_required",
+      allowedGroups: decision.allowedGroups,
+    }
+  }
+
+  if (decision.kind === "needs_user_groups") {
+    throw new Error("sub2api_group_inventory_not_implemented")
+  }
+
+  return {
+    kind: "blocked",
+    reason: decision.reason,
+    message: getDefaultTokenProvisioningBlockMessage(decision.reason),
+  }
+}
+```
+
+Keep the compatibility wrapper:
+
+```ts
+export async function resolveSub2ApiQuickCreateResolution(
+  account: DisplaySiteData,
+): Promise<Sub2ApiQuickCreateResolution> {
+  if (account.siteType !== SITE_TYPES.SUB2API) {
+    throw new Error("sub2api_quick_create_not_applicable")
+  }
+
+  const resolution = await resolveDefaultTokenQuickCreateResolution(account)
+
+  if (resolution.kind === "ready") {
+    return { kind: "ready", group: resolution.tokenData.group }
+  }
+
+  if (resolution.kind === "selection_required") {
+    return {
+      kind: "selection_required",
+      allowedGroups: resolution.allowedGroups,
+    }
+  }
+
+  return { kind: "blocked", message: resolution.message }
+}
+```
+
+In `ensureAccountApiToken(...)`, replace site-type creation branches with:
+
+```ts
+const decision = requiredTokenProvisioning.resolveDefaultTokenCreation({
+  workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+  defaultTokenData: generateDefaultTokenRequest(),
+  explicitGroup: options.sub2apiGroup,
+})
+
+if (decision.kind !== "create") {
+  if (
+    decision.kind === "blocked" &&
+    decision.reason === TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
+  ) {
+    throw new Error("messages:aihubmix.createRequiresOneTimeKeyDialog")
+  }
+
+  throw new Error("messages:sub2api.createRequiresGroup")
+}
+
+const createResult = await keyManagement.createToken(createRequest, decision.tokenData)
+const createdTokenDecision = requiredTokenProvisioning.classifyCreatedToken({
+  workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+  result: createResult,
+})
+```
+
+Return created or refetched tokens:
+
+```ts
+if (createdTokenDecision.kind === "usable") {
+  return createdTokenDecision.token
+}
+
+if (createdTokenDecision.kind === "failed") {
+  throw new Error("messages:accountOperations.createTokenFailed")
+}
+
+if (createdTokenDecision.kind === "unavailable") {
+  throw new Error("messages:aihubmix.createRequiresOneTimeKeyDialog")
+}
+
+const refreshedTokens = await keyManagement.fetchTokens(displayRequest)
+```
+
+- [ ] **Step 5: Run shared ensure tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run related default-token tests**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountOperations.ts tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit background and shared ensure routing**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountOperations.ts tests/services/accountOperations.ensureAccountApiToken.test.ts
+git commit -m "refactor(accounts): route default token creation policy through adapters"
+```
+
+Expected: one commit containing only background/shared default-token routing and tests.
+
+---
+
+### Task 5: Route Group Coverage And Repair Through Policy
+
+**Files:**
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/repair.ts`
+- Modify: `tests/services/accountKeyGroupCoverage.test.ts`
+- Modify: `tests/services/accountKeyRepair.test.ts`
+
+- [ ] **Step 1: Update group coverage tests for policy routing**
+
+In `tests/services/accountKeyGroupCoverage.test.ts`, extend the adapter mock:
+
+```ts
+tokenProvisioning: {
+  isInventoryTokenUsable: vi.fn(() => true),
+  resolveDefaultTokenCreation: (...args: unknown[]) =>
+    mocks.resolveDefaultTokenCreation(...args),
+  classifyCreatedToken: (...args: unknown[]) =>
+    mocks.classifyCreatedToken(...args),
+  getRepairPolicy: vi.fn(() => ({ kind: "eligible" })),
+}
+```
+
+Set defaults:
+
+```ts
+mocks.resolveDefaultTokenCreation.mockImplementation(({ defaultTokenData }) => ({
+  kind: "create",
+  tokenData: defaultTokenData,
+  oneTimeSecret: false,
+  recoverCreatedToken: "inventory_refetch",
+}))
+mocks.classifyCreatedToken.mockReturnValue({ kind: "needs_inventory_refetch" })
+```
+
+Add a route assertion to the empty-group fallback test:
+
+```ts
+expect(mocks.resolveDefaultTokenCreation).toHaveBeenCalledWith(
+  expect.objectContaining({
+    workflow: "repair",
+    defaultTokenData: generateDefaultTokenRequest(),
+  }),
+)
+```
+
+- [ ] **Step 2: Update repair tests for policy skip routing**
+
+In `tests/services/accountKeyRepair.test.ts`, mock `getSiteAdapter` so Sub2API and AIHubMix return policy skip decisions:
+
+```ts
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn((siteType: string) => ({
+    siteType,
+    tokenProvisioning:
+      siteType === SITE_TYPES.SUB2API
+        ? {
+            getRepairPolicy: () => ({
+              kind: "skipped",
+              skipReason: "sub2api",
+            }),
+          }
+        : siteType === SITE_TYPES.AIHUBMIX
+          ? {
+              getRepairPolicy: () => ({
+                kind: "skipped",
+                skipReason: "aihubmixOneTimeKey",
+              }),
+            }
+          : {
+              getRepairPolicy: () => ({ kind: "eligible" }),
+            },
+  })),
+}))
+```
+
+Keep existing expectations:
+
+```ts
+expect(progress.results).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({
+      accountId: "sub2api-1",
+      outcome: "skipped",
+      skipReason: "sub2api",
+    }),
+    expect.objectContaining({
+      accountId: "aihubmix-1",
+      outcome: "skipped",
+      skipReason: "aihubmixOneTimeKey",
+    }),
+  ]),
+)
+```
+
+- [ ] **Step 3: Run the failing group coverage and repair tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts
+```
+
+Expected: FAIL because group coverage and repair still branch on raw site types.
+
+- [ ] **Step 4: Route group coverage empty-group fallback through policy**
+
+In `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`, import:
+
+```ts
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import { requireDisplayAccountTokenProvisioning } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+After resolving `keyManagement`, require policy:
+
+```ts
+const tokenProvisioning = requireDisplayAccountTokenProvisioning(
+  displaySiteData,
+  adapter.tokenProvisioning,
+)
+```
+
+Replace the no-token empty-group site-type branch with:
+
+```ts
+const decision = tokenProvisioning.resolveDefaultTokenCreation({
+  workflow: TOKEN_PROVISIONING_WORKFLOWS.Repair,
+  defaultTokenData: generateDefaultTokenRequest(),
+})
+
+if (decision.kind !== "create") {
+  if (
+    decision.kind === "blocked" &&
+    decision.reason === TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
+  ) {
+    throw new Error("messages:aihubmix.createRequiresOneTimeKeyDialog")
+  }
+
+  throw new Error("messages:sub2api.createRequiresGroup")
+}
+
+const createResult = await keyManagement.createToken(request, decision.tokenData)
+const createdTokenDecision = tokenProvisioning.classifyCreatedToken({
+  workflow: TOKEN_PROVISIONING_WORKFLOWS.Repair,
+  result: createResult,
+})
+
+if (createdTokenDecision.kind === "failed") {
+  throw new Error("create_token_failed")
+}
+```
+
+Preserve the returned result shape:
+
+```ts
+return {
+  created: true,
+  availableGroups: [],
+  coveredGroups: [],
+  createdGroups: [decision.tokenData.group],
+  missingGroups: [],
+  invalidTokens: [],
+}
+```
+
+- [ ] **Step 5: Route repair skip reason through policy**
+
+In `src/services/accounts/accountKeyAutoProvisioning/repair.ts`, import:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+```
+
+Replace the Sub2API and AIHubMix branches in `getSkipReason(...)` with:
+
+```ts
+function getSkipReason(
+  account: SiteAccount,
+): AccountKeyRepairSkipReason | null {
+  const policy = getSiteAdapter(account.site_type).tokenProvisioning
+    ?.getRepairPolicy()
+
+  if (policy?.kind === "skipped") {
+    return policy.skipReason
+  }
+
+  if (account.authType === AuthTypeEnum.None) {
+    return "noneAuth"
+  }
+
+  return null
+}
+```
+
+- [ ] **Step 6: Run group coverage and repair tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit group coverage and repair routing**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts src/services/accounts/accountKeyAutoProvisioning/repair.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts
+git commit -m "refactor(accounts): use token provisioning policy for key repair"
+```
+
+Expected: one commit containing only group coverage, repair, and focused tests.
+
+---
+
+### Task 6: Final Validation And Scope Audit
+
+**Files:**
+- No new source files beyond prior tasks.
+- Validate all task-scoped files and inspect the final diff.
+
+- [ ] **Step 1: Run focused policy and workflow tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/tokenProvisioning.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accounts/apiServiceRequest.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run related validation**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/contracts/tokenProvisioning.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/tokenProvisioning.ts src/services/apiAdapters/sub2api/tokenProvisioning.ts src/services/apiAdapters/aihubmix/tokenProvisioning.ts src/services/accounts/utils/apiServiceRequest.ts src/services/accounts/utils/tokenProvisioning.ts src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts src/services/accounts/accountKeyAutoProvisioning/repair.ts src/services/accounts/accountOperations.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the commit gate**
+
+Stage only task-scoped files, then run:
+
+```powershell
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the push gate before PR or push**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. This gate is required before publishing because the slice changes shared adapter contracts and account workflow routing.
+
+- [ ] **Step 5: Inspect final scope**
+
+Run:
+
+```powershell
+git status --porcelain
+git diff --stat HEAD~5..HEAD
+git diff --name-only HEAD~5..HEAD
+```
+
+Expected changed paths are limited to:
+
+```text
+src/services/apiAdapters/contracts/tokenProvisioning.ts
+src/services/apiAdapters/contracts/siteAdapter.ts
+src/services/apiAdapters/newApi/tokenProvisioning.ts
+src/services/apiAdapters/sub2api/tokenProvisioning.ts
+src/services/apiAdapters/aihubmix/tokenProvisioning.ts
+src/services/apiAdapters/newApi/index.ts
+src/services/apiAdapters/sub2api/index.ts
+src/services/apiAdapters/aihubmix/index.ts
+src/services/accounts/utils/apiServiceRequest.ts
+src/services/accounts/utils/tokenProvisioning.ts
+src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+src/services/accounts/accountKeyAutoProvisioning/repair.ts
+src/services/accounts/accountOperations.ts
+tests/services/apiAdapters/tokenProvisioning.test.ts
+tests/services/apiAdapters/registry.test.ts
+tests/services/accounts/apiServiceRequest.test.ts
+tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+tests/services/accountOperations.ensureAccountApiToken.test.ts
+tests/services/accountKeyGroupCoverage.test.ts
+tests/services/accountKeyRepair.test.ts
+```
+
+No locale, telemetry, settings search, Playwright, managed-site, `apiService/**`, or new site-type files should appear.
+
+- [ ] **Step 6: Final commit or PR handoff**
+
+If all task commits already exist, do not squash locally unless the publication workflow requires it. If this plan is executed as one integrated branch and the previous task commits were not made, commit the final isolated diff:
+
+```powershell
+git add src/services/apiAdapters/contracts/tokenProvisioning.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/apiAdapters/newApi/tokenProvisioning.ts src/services/apiAdapters/sub2api/tokenProvisioning.ts src/services/apiAdapters/aihubmix/tokenProvisioning.ts src/services/apiAdapters/newApi/index.ts src/services/apiAdapters/sub2api/index.ts src/services/apiAdapters/aihubmix/index.ts src/services/accounts/utils/apiServiceRequest.ts src/services/accounts/utils/tokenProvisioning.ts src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts src/services/accounts/accountKeyAutoProvisioning/repair.ts src/services/accounts/accountOperations.ts tests/services/apiAdapters/tokenProvisioning.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accounts/apiServiceRequest.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts
+git commit -m "refactor(api-adapters): centralize token provisioning policy"
+```
+
+Expected: either the task commits are already present, or one final commit contains only the listed task-scoped files.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Adds `tokenProvisioning` policy capability: Task 1.
+  - Keeps token CRUD in `keyManagement`: all tasks use `keyManagement` for list/create/delete and policy only for decisions.
+  - New API-family policy: Task 1.
+  - Sub2API group policy and compatibility wrapper: Tasks 1 and 4.
+  - AIHubMix one-time-secret policy: Tasks 1, 3, and 4.
+  - Post-save, background, shared ensure, group coverage, and repair routing: Tasks 3, 4, and 5.
+  - No UI copy, locale, telemetry, settings, Playwright, managed-site, or new site-type changes: File Structure and Task 6.
+- Type consistency:
+  - `TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection` is intentionally added beyond the spec draft to keep interactive group selection separate from non-interactive shared ensure.
+  - `DefaultTokenCreationDecision.kind === "needs_user_groups"` is intentionally added beyond the spec draft so workflows fetch `keyManagement.userGroups` only when a policy requests it.
+  - `TokenProvisioningCapability` stays pure: no storage, no backend calls, no UI, no telemetry.
+- Validation:
+  - Focused Vitest tests after each task.
+  - `pnpm run validate:staged` before local handoff.
+  - `pnpm run validate:push` before push or PR because shared contracts change.

--- a/docs/superpowers/specs/2026-06-20-api-adapter-account-token-provisioning-policy-design.md
+++ b/docs/superpowers/specs/2026-06-20-api-adapter-account-token-provisioning-policy-design.md
@@ -1,0 +1,845 @@
+# API Adapter Account Token Provisioning Policy Design
+
+Date: 2026-06-20
+
+## Purpose
+
+Make the next account site type faster to add by moving default API-token
+provisioning policy behind the `SiteAdapter` Seam.
+
+Recent slices moved account-site onboarding metadata, account bootstrap,
+account completion, account data, account refresh, model pricing, model catalog
+loading, and token lifecycle operations behind `getSiteAdapter(siteType)`.
+Those changes make an account site detectable, saveable, refreshable, and able
+to list/create/update/delete/reveal API keys through `SiteAdapter.keyManagement`.
+
+The remaining friction is not a missing backend operation. The friction is
+product policy around when All API Hub is allowed to create a default key:
+
+- compatible sites can usually create an ungrouped default key and recover it
+  from either the create response or a follow-up inventory read.
+- Sub2API requires a current upstream group; some workflows can auto-select the
+  only group, but must ask the user when multiple groups exist.
+- AIHubMix can create a key only when the workflow can show the one-time full
+  secret immediately; background helpers and repair jobs must not create a key
+  that can only be recovered as a masked inventory row.
+
+Those rules are currently duplicated across account workflow Modules. This spec
+adds a narrow `tokenProvisioning` Adapter capability that describes those rules
+without moving raw token CRUD out of `keyManagement`.
+
+## Current Context
+
+The current `SiteAdapter` Interface exposes account-site capabilities:
+
+```ts
+type SiteAdapter = {
+  siteType: AccountSiteType
+  family?: SiteBackendFamily
+  siteNotice?: SiteNoticeCapability
+  siteAnnouncements?: SiteAnnouncementsCapability
+  modelCatalog?: ModelCatalogCapability
+  modelPricing?: ModelPricingCapability
+  accountData?: AccountDataCapability
+  accountBootstrap?: AccountBootstrapCapability
+  accountCompletion?: AccountCompletionCapability
+  keyManagement?: KeyManagementCapability
+  accountRefresh?: AccountRefreshCapability
+  redemption?: RedemptionCapability
+}
+```
+
+`KeyManagementCapability` is already a real Adapter Interface for backend token
+operations:
+
+```ts
+type KeyManagementCapability = {
+  fetchTokens(request, options?): Promise<ApiToken[]>
+  createToken(request, tokenData): Promise<CreateTokenResult>
+  updateToken(request): Promise<boolean | void>
+  resolveTokenKey(request): Promise<string>
+  deleteToken(request): Promise<boolean | void>
+  fetchAvailableModels(request): Promise<string[]>
+  userGroups?: UserGroupsCapability
+}
+```
+
+Current policy decisions still live in product Modules:
+
+- `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+  - treats AIHubMix inventory tokens as usable only when the key is unmasked
+  - routes Sub2API through `resolveSub2ApiQuickCreateResolution(...)`
+  - marks AIHubMix created keys as one-time secrets
+- `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+  - blocks Sub2API implicit default-key creation
+  - blocks AIHubMix implicit default-key creation
+- `src/services/accounts/accountOperations.ts`
+  - `resolveSub2ApiQuickCreateResolution(...)` is hard-coded to Sub2API
+  - `ensureAccountApiToken(...)` accepts only a Sub2API group override
+  - AIHubMix creation is blocked outside the one-time-key dialog path
+- `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+  - uses `keyManagement`, but still branches for Sub2API and AIHubMix when no
+    groups exist
+- `src/services/accounts/accountKeyAutoProvisioning/repair.ts`
+  - skips Sub2API and AIHubMix with site-type-specific reasons
+
+The backend operation Seam is already strong enough. The product policy Seam is
+still shallow.
+
+## Problem
+
+Adding another non-compatible account site type would still require editing
+several account workflow Modules even after its Adapter implements
+`keyManagement`.
+
+Current friction:
+
+1. Default-key creation rules are duplicated across post-save automation,
+   background provisioning, shared token ensure, group coverage, and repair.
+2. The policy is encoded as raw `SITE_TYPES.SUB2API` and
+   `SITE_TYPES.AIHUBMIX` checks, so a new site type with similar constraints
+   must copy the same branches.
+3. Group resolution is named after Sub2API even though the concept is broader:
+   "default key creation requires a current upstream group".
+4. One-time-secret behavior is named after AIHubMix even though the concept is
+   broader: "created keys are usable only when the create response includes the
+   full secret".
+5. Tests prove individual branches, but not a shared policy Interface that new
+   Adapters can satisfy.
+
+Deletion test: if the raw Sub2API and AIHubMix token-provisioning branches were
+deleted from account workflow Modules, the complexity should reappear only in
+the new `tokenProvisioning` Adapter capability and its tests. It should not
+reappear as another set of site-type checks in each workflow.
+
+## Goals
+
+- Add a narrow `tokenProvisioning` Adapter capability.
+- Keep backend token operations in `keyManagement`.
+- Move account-token provisioning decisions behind `tokenProvisioning`:
+  - whether an existing inventory token is usable for a workflow
+  - whether default token creation can happen without user input
+  - whether group selection is required, auto-resolvable, or blocked
+  - whether a created key must be treated as a one-time secret
+  - whether account-key repair is eligible for the site type
+- Preserve existing product behavior:
+  - New API-family default token creation continues to work without group input
+  - Sub2API still refuses silent ungrouped creation
+  - Sub2API post-save creation auto-selects exactly one current group
+  - Sub2API post-save creation asks the user when multiple groups exist
+  - AIHubMix background/default repair creation remains blocked
+  - AIHubMix post-save creation remains allowed only when a full one-time
+    secret can be shown
+  - group coverage and invalid-token deletion results remain unchanged
+  - Sub2API auth-session request decoration remains owned by
+    `createDisplayAccountApiContext(...)`
+- Provide Adapter implementations for:
+  - New API-family compatible account sites
+  - Sub2API
+  - AIHubMix
+- Add focused policy, workflow, and repair tests.
+
+## Non-Goals
+
+- Do not add a new site type in this slice.
+- Do not redesign `KeyManagementCapability`.
+- Do not move token list/create/update/delete/reveal operations out of
+  `keyManagement`.
+- Do not migrate model pricing, runtime model catalog, redemption, site
+  announcements, account data, account refresh, account bootstrap, or account
+  completion.
+- Do not migrate managed-site channel CRUD, managed-site providers, or
+  managed-site model sync.
+- Do not change the default token payload produced by
+  `generateDefaultTokenRequest()`.
+- Do not change Account Dialog UI copy, one-time-key dialog UI, locale keys,
+  telemetry schema, settings search, or Playwright E2E coverage.
+- Do not add an import guard in this slice.
+
+## Approaches Considered
+
+### Approach A: Keep Site-Type Branches In Account Workflows
+
+This keeps the implementation small, but it leaves the next new account site
+type dependent on edits in every workflow that can create or repair a key.
+
+This should not be the next step. The Adapter Seam would cover token CRUD but
+not the product policy that decides when CRUD is safe.
+
+### Approach B: Move Full Provisioning Workflows Into Adapters
+
+Adapters could expose methods such as `ensureDefaultToken(...)` or
+`ensurePostSaveToken(...)`.
+
+This hides too much product behavior behind backend Adapters. The workflows
+own UI state, toasts, progress snapshots, one-time-key acknowledgement, and
+repair result persistence. Moving full workflows into Adapters would make the
+Adapter Interface broad and difficult to test.
+
+### Approach C: Add A Small `tokenProvisioning` Policy Capability
+
+Add an Adapter capability that answers policy questions while product workflow
+Modules continue to own orchestration, storage, UI state, and calls to
+`keyManagement`.
+
+This is the recommended path. It makes `SiteAdapter` deeper without turning it
+into a second flat `apiService` facade: the Adapter owns site-specific policy,
+while account workflow Modules keep product orchestration.
+
+## Design
+
+### 1. Add `TokenProvisioningCapability`
+
+Create:
+
+```text
+src/services/apiAdapters/contracts/tokenProvisioning.ts
+```
+
+Proposed types:
+
+```ts
+import type {
+  CreateTokenRequest,
+  CreateTokenResult,
+  UserGroupInfo,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+
+export const TOKEN_PROVISIONING_WORKFLOWS = {
+  BackgroundAutoProvision: "background_auto_provision",
+  SharedEnsure: "shared_ensure",
+  PostSaveAutomation: "post_save_automation",
+  Repair: "repair",
+} as const
+
+export type TokenProvisioningWorkflow =
+  (typeof TOKEN_PROVISIONING_WORKFLOWS)[keyof typeof TOKEN_PROVISIONING_WORKFLOWS]
+
+export const TOKEN_PROVISIONING_BLOCK_REASONS = {
+  GroupRequired: "group_required",
+  AvailableGroupRequired: "available_group_required",
+  GroupSelectionRequired: "group_selection_required",
+  OneTimeSecretRequired: "one_time_secret_required",
+  CreateFailed: "create_failed",
+  CreatedTokenSecretUnavailable: "created_token_secret_unavailable",
+} as const
+
+export type TokenProvisioningBlockReason =
+  (typeof TOKEN_PROVISIONING_BLOCK_REASONS)[keyof typeof TOKEN_PROVISIONING_BLOCK_REASONS]
+
+export type ResolveDefaultTokenCreationRequest = {
+  workflow: TokenProvisioningWorkflow
+  defaultTokenData: CreateTokenRequest
+  explicitGroup?: string
+  userGroups?: Record<string, UserGroupInfo>
+}
+
+export type DefaultTokenCreationDecision =
+  | {
+      kind: "create"
+      tokenData: CreateTokenRequest
+      oneTimeSecret: boolean
+      recoverCreatedToken: "created_response_first" | "inventory_refetch"
+    }
+  | {
+      kind: "selection_required"
+      allowedGroups: string[]
+      reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired
+    }
+  | {
+      kind: "blocked"
+      reason: TokenProvisioningBlockReason
+    }
+
+export type CreatedTokenSecretDecision =
+  | { kind: "usable"; token: ApiToken; oneTimeSecret: boolean }
+  | {
+      kind: "failed"
+      reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed
+    }
+  | {
+      kind: "unavailable"
+      reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable
+    }
+  | { kind: "needs_inventory_refetch" }
+
+export type TokenProvisioningRepairPolicy =
+  | { kind: "eligible" }
+  | { kind: "skipped"; skipReason: "sub2api" | "aihubmixOneTimeKey" }
+
+export type TokenProvisioningCapability = {
+  isInventoryTokenUsable(params: {
+    workflow: TokenProvisioningWorkflow
+    token: ApiToken
+  }): boolean
+  resolveDefaultTokenCreation(
+    request: ResolveDefaultTokenCreationRequest,
+  ): DefaultTokenCreationDecision
+  classifyCreatedToken(params: {
+    workflow: TokenProvisioningWorkflow
+    result: CreateTokenResult
+  }): CreatedTokenSecretDecision
+  getRepairPolicy(): TokenProvisioningRepairPolicy
+}
+```
+
+The exact type names can be refined during implementation, but the Interface
+should keep these constraints:
+
+- The capability returns stable reason codes, not translated strings.
+- The capability does not call backend APIs.
+- The capability does not read storage.
+- The capability does not show UI or send telemetry.
+- The capability accepts existing `keyManagement.userGroups` output instead of
+  fetching groups itself.
+- The capability receives `generateDefaultTokenRequest()` output instead of
+  owning the default payload.
+
+### 2. Extend `SiteAdapter`
+
+Modify:
+
+```text
+src/services/apiAdapters/contracts/siteAdapter.ts
+```
+
+Add:
+
+```ts
+tokenProvisioning?: TokenProvisioningCapability
+```
+
+Capability presence is the support signal for account-token provisioning
+policy. Account site Adapters that support `keyManagement` should expose this
+capability. Unsupported account-site Adapters may omit it and let callers use
+the existing missing-capability error path.
+
+### 3. Add New API-Family Policy
+
+Create:
+
+```text
+src/services/apiAdapters/newApi/tokenProvisioning.ts
+```
+
+New API-family behavior:
+
+- existing inventory tokens are usable for all current workflows
+- default token creation is allowed for all current workflows
+- group selection is not required
+- created tokens may be used from the create response when present
+- otherwise callers may recover the token from a follow-up inventory read
+- account-key repair is eligible
+
+Expected decision shape:
+
+```ts
+export const newApiTokenProvisioning: TokenProvisioningCapability = {
+  isInventoryTokenUsable: () => true,
+  resolveDefaultTokenCreation: ({ defaultTokenData }) => ({
+    kind: "create",
+    tokenData: defaultTokenData,
+    oneTimeSecret: false,
+    recoverCreatedToken: "inventory_refetch",
+  }),
+  classifyCreatedToken: ({ result }) =>
+    isCreatedApiToken(result)
+      ? { kind: "usable", token: result, oneTimeSecret: false }
+      : result
+        ? { kind: "needs_inventory_refetch" }
+        : { kind: "failed", reason: "create_failed" },
+  getRepairPolicy: () => ({ kind: "eligible" }),
+}
+```
+
+Wire it through:
+
+```text
+src/services/apiAdapters/newApi/index.ts
+```
+
+### 4. Add Sub2API Policy
+
+Create:
+
+```text
+src/services/apiAdapters/sub2api/tokenProvisioning.ts
+```
+
+Sub2API behavior:
+
+- existing inventory tokens are usable for all current workflows
+- default token creation requires a current upstream group
+- post-save automation may auto-select exactly one available group
+- post-save automation must return `selection_required` when multiple groups
+  are available
+- shared/background helpers may create only when an explicit group is supplied
+- empty group inventory is blocked
+- created tokens may be recovered by follow-up inventory read
+- account-key repair remains skipped with `sub2api`
+
+Group normalization should move out of `accountOperations.ts` and become part
+of this policy Module:
+
+```ts
+export function normalizeTokenProvisioningGroupNames(
+  groups: Record<string, unknown>,
+): string[]
+```
+
+Expected decision shape:
+
+```ts
+resolveDefaultTokenCreation({
+  workflow,
+  defaultTokenData,
+  explicitGroup,
+  userGroups,
+}) {
+  const normalizedExplicitGroup = explicitGroup?.trim() ?? ""
+  if (normalizedExplicitGroup) {
+    return {
+      kind: "create",
+      tokenData: { ...defaultTokenData, group: normalizedExplicitGroup },
+      oneTimeSecret: false,
+      recoverCreatedToken: "inventory_refetch",
+    }
+  }
+
+  const validGroups = normalizeTokenProvisioningGroupNames(userGroups ?? {})
+  if (validGroups.length === 0) {
+    return { kind: "blocked", reason: "available_group_required" }
+  }
+
+  if (workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation) {
+    return { kind: "blocked", reason: "group_required" }
+  }
+
+  if (validGroups.length === 1) {
+    return {
+      kind: "create",
+      tokenData: { ...defaultTokenData, group: validGroups[0] },
+      oneTimeSecret: false,
+      recoverCreatedToken: "inventory_refetch",
+    }
+  }
+
+  return {
+    kind: "selection_required",
+    allowedGroups: validGroups,
+    reason: "group_selection_required",
+  }
+}
+```
+
+Wire it through:
+
+```text
+src/services/apiAdapters/sub2api/index.ts
+```
+
+### 5. Add AIHubMix Policy
+
+Create:
+
+```text
+src/services/apiAdapters/aihubmix/tokenProvisioning.ts
+```
+
+AIHubMix behavior:
+
+- an existing inventory token is usable only when it contains a full unmasked
+  secret
+- background/default/shared/repair creation is blocked because those workflows
+  cannot guarantee one-time-secret acknowledgement
+- post-save automation may create a token because the one-time-key flow can
+  show the created full secret immediately
+- the create result must include a full unmasked token secret
+- created keys are one-time secrets
+- account-key repair remains skipped with `aihubmixOneTimeKey`
+
+The policy should reuse the existing API-key helpers:
+
+```ts
+hasUsableApiTokenKey(...)
+isMaskedApiTokenKey(...)
+```
+
+Expected decision shape:
+
+```ts
+resolveDefaultTokenCreation({ workflow, defaultTokenData }) {
+  if (workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation) {
+    return { kind: "blocked", reason: "one_time_secret_required" }
+  }
+
+  return {
+    kind: "create",
+    tokenData: defaultTokenData,
+    oneTimeSecret: true,
+    recoverCreatedToken: "created_response_first",
+  }
+}
+
+classifyCreatedToken({ result }) {
+  if (!result) {
+    return { kind: "failed", reason: "create_failed" }
+  }
+
+  if (isCreatedApiToken(result) && hasUsableFullTokenSecret(result)) {
+    return { kind: "usable", token: result, oneTimeSecret: true }
+  }
+
+  return {
+    kind: "unavailable",
+    reason: "created_token_secret_unavailable",
+  }
+}
+```
+
+Wire it through:
+
+```text
+src/services/apiAdapters/aihubmix/index.ts
+```
+
+### 6. Add A Shared Requirement Helper
+
+Create or extend a small helper near the existing display-account context:
+
+```text
+src/services/accounts/utils/apiServiceRequest.ts
+```
+
+Add:
+
+```ts
+export const createMissingTokenProvisioningCapabilityError = (
+  siteType: string,
+) => new Error(`tokenProvisioning is not implemented for ${siteType}`)
+
+export const requireDisplayAccountTokenProvisioning = (
+  account: Pick<DisplaySiteData, "siteType">,
+  tokenProvisioning: TokenProvisioningCapability | undefined,
+): TokenProvisioningCapability => {
+  if (!tokenProvisioning) {
+    throw createMissingTokenProvisioningCapabilityError(account.siteType)
+  }
+
+  return tokenProvisioning
+}
+```
+
+`createDisplayAccountApiContext(...)` may include
+`tokenProvisioning: adapter.tokenProvisioning` for consistency with
+`keyManagement`, but it should continue to be primarily a request builder and
+adapter resolver. Do not add backend operations to this helper.
+
+### 7. Route Post-Save Token Ensure Through Policy
+
+Modify:
+
+```text
+src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+```
+
+`inspectAccountTokenInventory(...)` should ask policy whether the inventory
+token is usable:
+
+```ts
+const tokenProvisioning = requireDisplayAccountTokenProvisioning(
+  displaySiteData,
+  getSiteAdapter(displaySiteData.siteType).tokenProvisioning,
+)
+
+hasUsableSecret: tokenProvisioning.isInventoryTokenUsable({
+  workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+  token: existingToken,
+})
+```
+
+`createDefaultToken(...)` should:
+
+1. build `generateDefaultTokenRequest()`
+2. pass the workflow, optional explicit group, and optional user groups to
+   `tokenProvisioning.resolveDefaultTokenCreation(...)`
+3. create only when the decision is `create`
+4. classify the create result with `classifyCreatedToken(...)`
+5. refetch inventory only when the decision says `needs_inventory_refetch`
+
+`ensureAccountTokenForPostSaveWorkflow(...)` should preserve existing result
+kinds:
+
+- policy `selection_required` maps to
+  `ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired`
+- policy `available_group_required`, `group_required`, `create_failed`, or
+  ordinary create failure maps to `TokenCreationFailed`
+- policy `one_time_secret_required` or `created_token_secret_unavailable` maps
+  to `TokenSecretUnavailable`
+- policy-created AIHubMix tokens still return `oneTimeSecret: true`
+
+This keeps UI behavior stable while removing raw Sub2API and AIHubMix policy
+branches from the workflow Module.
+
+### 8. Route Background Default Token Ensure Through Policy
+
+Modify:
+
+```text
+src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+```
+
+`ensureDefaultApiTokenForAccount(...)` should use:
+
+```ts
+TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision
+```
+
+The function should preserve current errors:
+
+- Sub2API policy `group_required` maps to
+  `messages:sub2api.createRequiresGroup`
+- AIHubMix policy `one_time_secret_required` maps to
+  `messages:aihubmix.createRequiresOneTimeKeyDialog`
+- create failure still throws `create_token_failed`
+- no inventory token after create still throws `token_not_found`
+
+The default token request payload remains owned by
+`generateDefaultTokenRequest()` and must not change.
+
+### 9. Route Shared Token Ensure Through Policy
+
+Modify:
+
+```text
+src/services/accounts/accountOperations.ts
+```
+
+Replace `resolveSub2ApiQuickCreateResolution(...)` with a site-agnostic
+helper:
+
+```ts
+export type DefaultTokenQuickCreateResolution =
+  | { kind: "ready"; tokenData: CreateTokenRequest }
+  | { kind: "selection_required"; allowedGroups: string[] }
+  | { kind: "blocked"; reason: TokenProvisioningBlockReason; message: string }
+
+export async function resolveDefaultTokenQuickCreateResolution(
+  account: DisplayAccountTokenProvisioningInput,
+  options?: { explicitGroup?: string },
+): Promise<DefaultTokenQuickCreateResolution>
+```
+
+Implementation should:
+
+- get `keyManagement` and `tokenProvisioning` from the Adapter
+- fetch `keyManagement.userGroups` only when the policy needs group data or
+  when the site exposes `userGroups`
+- call `resolveDefaultTokenCreation(...)` with
+  `TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure`
+- translate policy reason codes to existing messages
+
+Keep a compatibility wrapper for old call sites/tests during this slice:
+
+```ts
+export async function resolveSub2ApiQuickCreateResolution(account) {
+  if (account.siteType !== SITE_TYPES.SUB2API) {
+    throw new Error("sub2api_quick_create_not_applicable")
+  }
+
+  const resolution = await resolveDefaultTokenQuickCreateResolution(account)
+  ...
+}
+```
+
+`ensureAccountApiToken(...)` should use `resolveDefaultTokenCreation(...)`
+instead of raw `displaySiteData.siteType` checks. Existing option
+`sub2apiGroup` can remain as a compatibility input in this slice, but should be
+translated into a generic `explicitGroup` before calling the policy.
+
+### 10. Route Group Coverage And Repair Through Policy
+
+Modify:
+
+```text
+src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+src/services/accounts/accountKeyAutoProvisioning/repair.ts
+```
+
+`ensureAccountKeysForAvailableGroups(...)` should ask policy how to handle the
+empty-group and no-token case instead of checking Sub2API and AIHubMix
+directly.
+
+Preserve existing behavior:
+
+- if groups are empty and tokens exist, the account is covered
+- if groups are empty and no tokens exist, New API-family creates one default
+  token
+- if groups are empty and no tokens exist, Sub2API reports the existing group
+  required error
+- if groups are empty and no tokens exist, AIHubMix reports the existing
+  one-time-secret required error
+- unavailable-group tokens remain invalid repair targets
+- failed group creation records missing groups and continues
+- invalid-token deletion still uses `keyManagement.deleteToken(...)`
+
+`repair.ts#getSkipReason(...)` should ask:
+
+```ts
+getSiteAdapter(account.site_type).tokenProvisioning?.getRepairPolicy()
+```
+
+Mapping must preserve current skip reasons:
+
+- Sub2API -> `sub2api`
+- AIHubMix -> `aihubmixOneTimeKey`
+- none auth remains `noneAuth` and is still owned by repair because it depends
+  on stored-account auth state, not site provisioning policy
+
+## Error Handling
+
+The policy capability should return reason codes. Workflow Modules remain
+responsible for mapping those codes to existing localized messages and result
+kinds.
+
+Required mappings:
+
+- `group_required`
+  - `messages:sub2api.createRequiresGroup` in background/shared helpers
+- `available_group_required`
+  - `messages:sub2api.createRequiresAvailableGroup` in post-save quick-create
+- `group_selection_required`
+  - selection-required result with the existing allowed-group list
+- `one_time_secret_required`
+  - `messages:aihubmix.createRequiresOneTimeKeyDialog`
+- `create_failed`
+  - existing create-failed message or `create_token_failed`, depending on the
+    workflow's current behavior
+- `created_token_secret_unavailable`
+  - `ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable`
+
+Missing `tokenProvisioning` should be treated as a programming/configuration
+error like missing `keyManagement`.
+
+Do not add user-facing copy in this slice.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This is an internal routing and policy-locality refactor. It does not add a
+new user-visible action or analytics field. Existing account save, post-save
+automation, repair, and key-management telemetry should continue to emit from
+their current owners with the same sanitized payloads.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E in this slice.
+
+The primary risk is service-layer policy routing and preservation of existing
+result mappings. Focused Vitest tests at Adapter, account workflow, and repair
+levels cover that directly. Browser runtime behavior is unchanged.
+
+## Testing Strategy
+
+Add Adapter policy tests:
+
+- `tests/services/apiAdapters/tokenProvisioning.test.ts`
+  - New API-family allows ungrouped default token creation in every current
+    workflow and is repair eligible
+  - Sub2API requires a group, auto-selects exactly one group for post-save,
+    returns selection-required for multiple groups, and is skipped for repair
+  - AIHubMix blocks non-post-save creation, allows post-save one-time creation,
+    rejects masked create results, and is skipped for repair
+  - group normalization trims, dedupes, and drops blank group names
+
+Update registry tests:
+
+- `tests/services/apiAdapters/registry.test.ts`
+  - New API-family, Sub2API, and AIHubMix expose `tokenProvisioning`
+  - unsupported Adapters omit `tokenProvisioning`
+
+Update account workflow tests:
+
+- `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+  - post-save workflow uses `tokenProvisioning`
+  - Sub2API single-group, multi-group, and no-group results remain unchanged
+  - AIHubMix one-time-secret and masked-secret results remain unchanged
+- `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+  - shared ensure maps generic policy decisions back to existing Sub2API and
+    AIHubMix errors
+  - compatibility `sub2apiGroup` still creates a grouped token
+  - generic quick-create helper supports policy-driven group selection
+- `tests/services/accountKeyGroupCoverage.test.ts`
+  - empty-group fallback uses policy instead of raw site-type checks
+  - invalid-token deletion behavior remains unchanged
+- `tests/services/accountKeyRepair.test.ts`
+  - repair skip reasons are resolved through `tokenProvisioning`
+  - none-auth skip remains repair-owned
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/tokenProvisioning.test.ts tests/services/apiAdapters/registry.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts
+```
+
+Related validation:
+
+```powershell
+pnpm vitest related --run src/services/apiAdapters/contracts/tokenProvisioning.ts src/services/apiAdapters/contracts/siteAdapter.ts src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts src/services/accounts/accountKeyAutoProvisioning/repair.ts src/services/accounts/accountOperations.ts
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Push gate before publishing:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before opening or updating a PR because this slice changes
+shared Adapter contracts and cross-module account workflow routing.
+
+## Rollout
+
+1. Add `TokenProvisioningCapability` contract and failing policy tests.
+2. Add New API-family, Sub2API, and AIHubMix policy Modules.
+3. Wire `tokenProvisioning` into `SiteAdapter` and the registry expectations.
+4. Route post-save token ensure through policy.
+5. Route background default token ensure through policy.
+6. Add the generic quick-create resolver and keep the Sub2API compatibility
+   wrapper.
+7. Route `ensureAccountApiToken(...)` through policy.
+8. Route group coverage empty-group/default-token behavior through policy.
+9. Route repair skip reasons through policy.
+10. Run focused tests after each workflow group.
+11. Run related validation, `validate:staged`, and `validate:push` before PR.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may:
+
+- remove the Sub2API-named compatibility wrapper once call sites move to the
+  generic quick-create resolver
+- add UI support for a non-Sub2API backend that requires user group selection
+- generalize one-time-secret acknowledgement if another backend behaves like
+  AIHubMix
+- move account identity and URL normalization into adapter-owned policy
+- migrate Model List fallback behavior out of UI hooks
+- migrate managed-site runtime/provider registration
+
+Do not turn `tokenProvisioning` into a full workflow runner. Its job is to
+answer site-specific policy questions. Account workflow Modules still own
+requests, persistence, UI state, progress reporting, toasts, telemetry, and
+calls to `keyManagement`.

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -13,6 +13,7 @@ import {
   requireDisplayAccountKeyManagement,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { TOKEN_PROVISIONING_ERRORS } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
@@ -292,7 +293,7 @@ export function useCopyKeyDialog(
         keyManagement,
       ).createToken(request, tokenRequest)
       if (!created) {
-        throw new Error("create_token_failed")
+        throw new Error(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
       }
 
       await refreshTokensAfterCreate(

--- a/src/features/KeyManagement/KeyManagement.tsx
+++ b/src/features/KeyManagement/KeyManagement.tsx
@@ -20,6 +20,7 @@ import {
   type ManagedSiteTokenChannelStatus,
 } from "~/services/managedSites/tokenChannelStatus"
 import type { AccountToken } from "~/types"
+import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
 import { openModelsPage, pushWithinOptionsPage } from "~/utils/navigation"
 
 import { AccountSelectorPanel } from "./components/AccountSelectorPanel"
@@ -164,7 +165,7 @@ export default function KeyManagement(props: {
         if (cancelled) return
         if (!response?.success || !response?.data) return
 
-        if (response.data.state === "running") {
+        if (response.data.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Running) {
           setRepairStartOnOpen(false)
           setIsRepairOpen(true)
         }

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -49,6 +49,7 @@ import type {
   AccountKeyRepairProgress,
   AccountKeyRepairSkipReason,
 } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
 
 const repairMissingKeysAnalyticsContext = {
@@ -106,11 +107,11 @@ function getSkipReasonLabel(
 ) {
   if (!reason) return ""
   switch (reason) {
-    case "sub2api":
+    case ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api:
       return t("keyManagement:repairMissingKeys.skipReasons.sub2api")
-    case "aihubmixOneTimeKey":
+    case ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey:
       return t("keyManagement:repairMissingKeys.skipReasons.aihubmixOneTimeKey")
-    case "noneAuth":
+    case ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth:
       return t("keyManagement:repairMissingKeys.skipReasons.noneAuth")
   }
 }
@@ -1301,7 +1302,8 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
                             : ""
                       const canCreateSub2ApiKey =
                         result.outcome === "skipped" &&
-                        result.skipReason === "sub2api" &&
+                        result.skipReason ===
+                          ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api &&
                         accountById.has(result.accountId)
 
                       const badgeVariant =

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -49,7 +49,12 @@ import type {
   AccountKeyRepairProgress,
   AccountKeyRepairSkipReason,
 } from "~/types/accountKeyAutoProvisioning"
-import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
+import {
+  ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
+  ACCOUNT_KEY_REPAIR_JOB_STATES,
+  ACCOUNT_KEY_REPAIR_OUTCOMES,
+  ACCOUNT_KEY_REPAIR_SKIP_REASONS,
+} from "~/types/accountKeyAutoProvisioning"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
 
 const repairMissingKeysAnalyticsContext = {
@@ -126,10 +131,10 @@ type RepairResultView =
   (typeof REPAIR_RESULT_VIEWS)[keyof typeof REPAIR_RESULT_VIEWS]
 
 const OUTCOME_BADGE_VARIANTS: Record<AccountKeyRepairOutcome, BadgeVariant> = {
-  created: "success",
-  alreadyHad: "info",
-  skipped: "warning",
-  failed: "danger",
+  [ACCOUNT_KEY_REPAIR_OUTCOMES.Created]: "success",
+  [ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad]: "info",
+  [ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped]: "warning",
+  [ACCOUNT_KEY_REPAIR_OUTCOMES.Failed]: "danger",
 }
 
 /**
@@ -137,13 +142,13 @@ const OUTCOME_BADGE_VARIANTS: Record<AccountKeyRepairOutcome, BadgeVariant> = {
  */
 function getRepairOutcomeLabel(t: TFunction, outcome: AccountKeyRepairOutcome) {
   switch (outcome) {
-    case "created":
+    case ACCOUNT_KEY_REPAIR_OUTCOMES.Created:
       return t("keyManagement:repairMissingKeys.outcomes.created")
-    case "alreadyHad":
+    case ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad:
       return t("keyManagement:repairMissingKeys.outcomes.alreadyHad")
-    case "skipped":
+    case ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped:
       return t("keyManagement:repairMissingKeys.outcomes.skipped")
-    case "failed":
+    case ACCOUNT_KEY_REPAIR_OUTCOMES.Failed:
       return t("keyManagement:repairMissingKeys.outcomes.failed")
   }
 }
@@ -195,7 +200,7 @@ function getInvalidTokenReasonLabel(
   token: AccountKeyRepairInvalidToken,
 ) {
   switch (token.reason) {
-    case "groupUnavailable":
+    case ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable:
       return t("keyManagement:repairMissingKeys.invalidKeys.groupUnavailable", {
         group: token.group,
       })
@@ -227,7 +232,7 @@ function getRepairProgressInsightCounts(progress: AccountKeyRepairProgress) {
  * Maps terminal repair progress into a coarse health status.
  */
 function getRepairProgressStatusKind(progress: AccountKeyRepairProgress) {
-  if (progress.state === "failed") {
+  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
     return PRODUCT_ANALYTICS_STATUS_KINDS.Error
   }
   if (progress.summary.failed > 0) {
@@ -240,7 +245,7 @@ function getRepairProgressStatusKind(progress: AccountKeyRepairProgress) {
  * Maps terminal repair progress into the product analytics result enum.
  */
 function getRepairProgressResult(progress: AccountKeyRepairProgress) {
-  if (progress.state === "failed") {
+  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
     return PRODUCT_ANALYTICS_RESULTS.Failure
   }
   if (progress.summary.failed > 0) {
@@ -568,13 +573,16 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     if (!progress) {
       return "bg-blue-600 dark:bg-blue-500"
     }
-    if (progress.state === "failed") {
+    if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
       return "bg-red-600 dark:bg-red-500"
     }
-    if (progress.state === "completed" && progress.summary.failed > 0) {
+    if (
+      progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Completed &&
+      progress.summary.failed > 0
+    ) {
       return "bg-amber-600 dark:bg-amber-500"
     }
-    if (progress.state === "completed") {
+    if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Completed) {
       return "bg-emerald-600 dark:bg-emerald-500"
     }
     return "bg-blue-600 dark:bg-blue-500"
@@ -752,7 +760,12 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
 
   useEffect(() => {
     if (!progress) return
-    if (progress.state !== "completed" && progress.state !== "failed") return
+    if (
+      progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Completed &&
+      progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Failed
+    ) {
+      return
+    }
     if (startedAnalyticsJobIdRef.current !== progress.jobId) return
     if (completedAnalyticsJobIdRef.current === progress.jobId) return
 
@@ -761,7 +774,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     void trackProductAnalyticsActionCompleted({
       ...repairMissingKeysAnalyticsContext,
       result: getRepairProgressResult(progress),
-      ...(progress.state === "failed"
+      ...(progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed
         ? { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown }
         : {}),
       insights: {
@@ -782,7 +795,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
             <h2 className="text-base font-semibold">
               {t("repairMissingKeys.title")}
             </h2>
-            {progress?.state === "running" ? (
+            {progress?.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Running ? (
               <Badge
                 variant="info"
                 size="sm"
@@ -791,7 +804,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
                 <Spinner size="sm" className="h-3.5 w-3.5" />
                 {t("common:status.processing")}
               </Badge>
-            ) : progress?.state === "failed" ? (
+            ) : progress?.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed ? (
               <Badge
                 variant="danger"
                 size="sm"
@@ -799,7 +812,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
               >
                 {t("common:status.failed")}
               </Badge>
-            ) : progress?.state === "completed" ? (
+            ) : progress?.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Completed ? (
               <Badge
                 variant={progress.summary.failed > 0 ? "warning" : "success"}
                 size="sm"
@@ -824,7 +837,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     >
       {error ? <Alert variant="destructive" description={error} /> : null}
 
-      {!progress || progress.state === "idle" ? (
+      {!progress || progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Idle ? (
         <Card variant="outlined" className="overflow-hidden">
           <CardContent padding="default" className="space-y-4">
             <div className="flex items-start gap-3">
@@ -858,7 +871,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
         </Card>
       ) : null}
 
-      {progress && progress.state !== "idle" ? (
+      {progress && progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Idle ? (
         <div className="space-y-4">
           <Card>
             <CardContent padding="md" spacing="none" className="space-y-4">
@@ -877,7 +890,8 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
                     <span>
                       {processedTotal}/{eligibleTotal} ({progressPercent}%)
                     </span>
-                    {progress.state !== "running" ? (
+                    {progress.state !==
+                    ACCOUNT_KEY_REPAIR_JOB_STATES.Running ? (
                       <Button
                         type="button"
                         variant="outline"
@@ -1096,25 +1110,25 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
                     allCount={visibleResults.length}
                     options={[
                       {
-                        value: "created",
+                        value: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
                         label: t("repairMissingKeys.outcomes.created"),
                         count: outcomeCounts.created,
                         variant: "success",
                       },
                       {
-                        value: "alreadyHad",
+                        value: ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad,
                         label: t("repairMissingKeys.outcomes.alreadyHad"),
                         count: outcomeCounts.alreadyHad,
                         variant: "info",
                       },
                       {
-                        value: "skipped",
+                        value: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
                         label: t("repairMissingKeys.outcomes.skipped"),
                         count: outcomeCounts.skipped,
                         variant: "warning",
                       },
                       {
-                        value: "failed",
+                        value: ACCOUNT_KEY_REPAIR_OUTCOMES.Failed,
                         label: t("repairMissingKeys.outcomes.failed"),
                         count: outcomeCounts.failed,
                         variant: "danger",
@@ -1295,13 +1309,15 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
                         result.outcome,
                       )
                       const details =
-                        result.outcome === "skipped"
+                        result.outcome === ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped
                           ? getSkipReasonLabel(t, result.skipReason)
-                          : result.outcome === "failed"
+                          : result.outcome ===
+                              ACCOUNT_KEY_REPAIR_OUTCOMES.Failed
                             ? result.errorMessage || ""
                             : ""
                       const canCreateSub2ApiKey =
-                        result.outcome === "skipped" &&
+                        result.outcome ===
+                          ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped &&
                         result.skipReason ===
                           ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api &&
                         accountById.has(result.accountId)
@@ -1369,7 +1385,8 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
                             <div
                               className={[
                                 "mt-2 text-xs",
-                                result.outcome === "failed"
+                                result.outcome ===
+                                ACCOUNT_KEY_REPAIR_OUTCOMES.Failed
                                   ? "text-red-700 dark:text-red-300"
                                   : "dark:text-dark-text-secondary text-gray-500",
                               ].join(" ")}

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -12,6 +12,7 @@ import {
   requireDisplayAccountKeyManagement,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { TOKEN_PROVISIONING_ERRORS } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import { isTokenCompatibleWithModel } from "~/services/models/utils/tokenModelCompatibility"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
@@ -340,7 +341,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
           keyManagement,
         ).createToken(request, tokenRequest)
         if (!created) {
-          throw new Error("create_token_failed")
+          throw new Error(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
         }
 
         return await refreshTokensAfterCreate(

--- a/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
@@ -3,6 +3,7 @@ import {
   requireDisplayAccountTokenProvisioning,
 } from "~/services/accounts/utils/apiServiceRequest"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_ERRORS,
@@ -107,15 +108,22 @@ export async function ensureDefaultApiTokenForAccount(params: {
     result: createApiTokenResult,
   })
 
-  if (createdTokenDecision.kind === "usable") {
+  if (
+    createdTokenDecision.kind === CREATED_TOKEN_SECRET_DECISION_KINDS.Usable
+  ) {
     return { token: createdTokenDecision.token, created: true }
   }
 
-  if (createdTokenDecision.kind === "failed") {
+  if (
+    createdTokenDecision.kind === CREATED_TOKEN_SECRET_DECISION_KINDS.Failed
+  ) {
     throw new Error(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
   }
 
-  if (createdTokenDecision.kind === "unavailable") {
+  if (
+    createdTokenDecision.kind ===
+    CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable
+  ) {
     throw new Error(TOKEN_PROVISIONING_ERRORS.TokenNotFound)
   }
 

--- a/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
@@ -1,5 +1,11 @@
-import { SITE_TYPES } from "~/constants/siteType"
-import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  requireDisplayAccountKeyManagement,
+  requireDisplayAccountTokenProvisioning,
+} from "~/services/accounts/utils/apiServiceRequest"
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
@@ -26,12 +32,6 @@ export function generateDefaultTokenRequest(): CreateTokenRequest {
   }
 }
 
-const isCreatedApiToken = (value: unknown): value is ApiToken =>
-  !!value &&
-  typeof value === "object" &&
-  typeof (value as Partial<ApiToken>).id === "number" &&
-  typeof (value as Partial<ApiToken>).key === "string"
-
 /**
  * Ensures that an API token exists for the supplied account by checking the
  * remote token inventory and lazily issuing a default token when none exist.
@@ -43,9 +43,14 @@ export async function ensureDefaultApiTokenForAccount(params: {
   displaySiteData: DisplaySiteData
 }): Promise<{ token: ApiToken; created: boolean }> {
   const { account, displaySiteData } = params
+  const adapter = getSiteAdapter(displaySiteData.siteType)
   const keyManagement = requireDisplayAccountKeyManagement(
     displaySiteData,
-    getSiteAdapter(displaySiteData.siteType).keyManagement,
+    adapter.keyManagement,
+  )
+  const tokenProvisioning = requireDisplayAccountTokenProvisioning(
+    displaySiteData,
+    adapter.tokenProvisioning,
   )
   const displayAccountRequest = {
     baseUrl: displaySiteData.baseUrl,
@@ -75,26 +80,41 @@ export async function ensureDefaultApiTokenForAccount(params: {
     return { token: apiToken, created: false }
   }
 
-  if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
+  const decision = tokenProvisioning.resolveDefaultTokenCreation({
+    workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
+    defaultTokenData: generateDefaultTokenRequest(),
+  })
+
+  if (decision.kind !== "create") {
+    if (
+      decision.kind === "blocked" &&
+      decision.reason === TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
+    ) {
+      throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
+    }
+
     throw new Error(t("messages:sub2api.createRequiresGroup"))
   }
 
-  if (displaySiteData.siteType === SITE_TYPES.AIHUBMIX) {
-    throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
-  }
-
-  const newTokenData = generateDefaultTokenRequest()
   const createApiTokenResult = await keyManagement.createToken(
     createAccountRequest,
-    newTokenData,
+    decision.tokenData,
   )
+  const createdTokenDecision = tokenProvisioning.classifyCreatedToken({
+    workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
+    result: createApiTokenResult,
+  })
 
-  if (!createApiTokenResult) {
+  if (createdTokenDecision.kind === "usable") {
+    return { token: createdTokenDecision.token, created: true }
+  }
+
+  if (createdTokenDecision.kind === "failed") {
     throw new Error("create_token_failed")
   }
 
-  if (isCreatedApiToken(createApiTokenResult)) {
-    return { token: createApiTokenResult, created: true }
+  if (createdTokenDecision.kind === "unavailable") {
+    throw new Error("token_not_found")
   }
 
   // Backends such as AIHubMix may only expose the full API key in the create

--- a/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
@@ -15,6 +15,7 @@ import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
 import { t } from "~/utils/i18n/core"
 
 export const DEFAULT_AUTO_PROVISION_TOKEN_NAME = "user group (auto)"
+export const DEFAULT_USER_GROUP_NAME = "default"
 
 /**
  * Generates the default token payload used by key auto-provisioning flows.

--- a/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
@@ -4,6 +4,7 @@ import {
 } from "~/services/accounts/utils/apiServiceRequest"
 import {
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_ERRORS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
@@ -110,11 +111,11 @@ export async function ensureDefaultApiTokenForAccount(params: {
   }
 
   if (createdTokenDecision.kind === "failed") {
-    throw new Error("create_token_failed")
+    throw new Error(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
   }
 
   if (createdTokenDecision.kind === "unavailable") {
-    throw new Error("token_not_found")
+    throw new Error(TOKEN_PROVISIONING_ERRORS.TokenNotFound)
   }
 
   // Backends such as AIHubMix may only expose the full API key in the create
@@ -124,7 +125,7 @@ export async function ensureDefaultApiTokenForAccount(params: {
   apiToken = updatedTokens.at(-1)
 
   if (!apiToken) {
-    throw new Error("token_not_found")
+    throw new Error(TOKEN_PROVISIONING_ERRORS.TokenNotFound)
   }
 
   return { token: apiToken, created: true }

--- a/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
@@ -3,6 +3,7 @@ import {
   requireDisplayAccountTokenProvisioning,
 } from "~/services/accounts/utils/apiServiceRequest"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_ERRORS,
   TOKEN_PROVISIONING_WORKFLOWS,
@@ -86,9 +87,9 @@ export async function ensureDefaultApiTokenForAccount(params: {
     defaultTokenData: generateDefaultTokenRequest(),
   })
 
-  if (decision.kind !== "create") {
+  if (decision.kind !== DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create) {
     if (
-      decision.kind === "blocked" &&
+      decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked &&
       decision.reason === TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
     ) {
       throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -3,6 +3,7 @@ import {
   requireDisplayAccountTokenProvisioning,
 } from "~/services/accounts/utils/apiServiceRequest"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_ERRORS,
@@ -144,7 +145,9 @@ export async function ensureAccountKeysForAvailableGroups(params: {
       result: createResult,
     })
 
-    if (createdTokenDecision.kind === "failed") {
+    if (
+      createdTokenDecision.kind === CREATED_TOKEN_SECRET_DECISION_KINDS.Failed
+    ) {
       throw new Error(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
     }
 

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -22,6 +22,7 @@ import { t } from "~/utils/i18n/core"
 
 import {
   DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+  DEFAULT_USER_GROUP_NAME,
   generateDefaultTokenRequest,
 } from "./ensureDefaultToken"
 
@@ -46,7 +47,7 @@ export function buildGroupDefaultTokenRequest(
   return {
     ...generateDefaultTokenRequest(),
     name:
-      group && group !== "default"
+      group && group !== DEFAULT_USER_GROUP_NAME
         ? `${group} group (auto)`
         : DEFAULT_AUTO_PROVISION_TOKEN_NAME,
     group,

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -1,5 +1,11 @@
-import { SITE_TYPES } from "~/constants/siteType"
-import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  requireDisplayAccountKeyManagement,
+  requireDisplayAccountTokenProvisioning,
+} from "~/services/accounts/utils/apiServiceRequest"
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
@@ -78,9 +84,14 @@ export async function ensureAccountKeysForAvailableGroups(params: {
   siteUrlOrigin: string
 }): Promise<AccountKeyCoverageResult> {
   const { account, displaySiteData, accountName, siteUrlOrigin } = params
+  const adapter = getSiteAdapter(displaySiteData.siteType)
   const keyManagement = requireDisplayAccountKeyManagement(
     displaySiteData,
-    getSiteAdapter(displaySiteData.siteType).keyManagement,
+    adapter.keyManagement,
+  )
+  const tokenProvisioning = requireDisplayAccountTokenProvisioning(
+    displaySiteData,
+    adapter.tokenProvisioning,
   )
   const request = createAccountApiRequest(account, displaySiteData)
   const accountId = displaySiteData.id || account.id
@@ -105,20 +116,41 @@ export async function ensureAccountKeysForAvailableGroups(params: {
       }
     }
 
-    if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
+    const decision = tokenProvisioning.resolveDefaultTokenCreation({
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.Repair,
+      defaultTokenData: generateDefaultTokenRequest(),
+    })
+
+    if (decision.kind !== "create") {
+      if (
+        decision.kind === "blocked" &&
+        decision.reason ===
+          TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
+      ) {
+        throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
+      }
+
       throw new Error(t("messages:sub2api.createRequiresGroup"))
     }
 
-    if (displaySiteData.siteType === SITE_TYPES.AIHUBMIX) {
-      throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
+    const createResult = await keyManagement.createToken(
+      request,
+      decision.tokenData,
+    )
+    const createdTokenDecision = tokenProvisioning.classifyCreatedToken({
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.Repair,
+      result: createResult,
+    })
+
+    if (createdTokenDecision.kind === "failed") {
+      throw new Error("create_token_failed")
     }
 
-    await keyManagement.createToken(request, generateDefaultTokenRequest())
     return {
       created: true,
       availableGroups: [],
       coveredGroups: [],
-      createdGroups: [""],
+      createdGroups: [decision.tokenData.group],
       missingGroups: [],
       invalidTokens: [],
     }

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -4,6 +4,7 @@ import {
 } from "~/services/accounts/utils/apiServiceRequest"
 import {
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_ERRORS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
@@ -143,7 +144,7 @@ export async function ensureAccountKeysForAvailableGroups(params: {
     })
 
     if (createdTokenDecision.kind === "failed") {
-      throw new Error("create_token_failed")
+      throw new Error(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
     }
 
     return {

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -3,6 +3,7 @@ import {
   requireDisplayAccountTokenProvisioning,
 } from "~/services/accounts/utils/apiServiceRequest"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_ERRORS,
   TOKEN_PROVISIONING_WORKFLOWS,
@@ -122,9 +123,9 @@ export async function ensureAccountKeysForAvailableGroups(params: {
       defaultTokenData: generateDefaultTokenRequest(),
     })
 
-    if (decision.kind !== "create") {
+    if (decision.kind !== DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create) {
       if (
-        decision.kind === "blocked" &&
+        decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked &&
         decision.reason ===
           TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
       ) {

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -13,6 +13,10 @@ import type {
   AccountKeyRepairProgress,
   AccountKeyRepairSkipReason,
 } from "~/types/accountKeyAutoProvisioning"
+import {
+  ACCOUNT_KEY_REPAIR_ERRORS,
+  ACCOUNT_KEY_REPAIR_SKIP_REASONS,
+} from "~/types/accountKeyAutoProvisioning"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { safeRandomUUID } from "~/utils/core/identifier"
@@ -86,7 +90,7 @@ function getSkipReason(
   }
 
   if (account.authType === AuthTypeEnum.None) {
-    return "noneAuth"
+    return ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth
   }
 
   return null
@@ -276,7 +280,7 @@ class AccountKeyRepairRunner {
           !hasToken &&
           !hasCookie)
       ) {
-        throw new Error("invalid_display_site_data")
+        throw new Error(ACCOUNT_KEY_REPAIR_ERRORS.InvalidDisplaySiteData)
       }
 
       const result = await ensureAccountKeysForAvailableGroups({
@@ -508,7 +512,7 @@ export async function deleteInvalidAccountTokens(
     if (!account || !displaySiteData) {
       failed.push({
         ...token,
-        errorMessage: "account_not_found",
+        errorMessage: ACCOUNT_KEY_REPAIR_ERRORS.AccountNotFound,
       })
       continue
     }
@@ -523,7 +527,8 @@ export async function deleteInvalidAccountTokens(
     } catch (error) {
       failed.push({
         ...token,
-        errorMessage: getErrorMessage(error) || "delete_failed",
+        errorMessage:
+          getErrorMessage(error) || ACCOUNT_KEY_REPAIR_ERRORS.DeleteFailed,
       })
     }
   }

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -1,8 +1,8 @@
 import { Storage } from "@plasmohq/storage"
 
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
-import { SITE_TYPES } from "~/constants/siteType"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS } from "~/services/core/storageKeys"
 import type { DisplaySiteData, SiteAccount } from "~/types"
 import { AuthTypeEnum } from "~/types"
@@ -77,12 +77,12 @@ function getOriginKey(siteUrl: string): string {
 function getSkipReason(
   account: SiteAccount,
 ): AccountKeyRepairSkipReason | null {
-  if (account.site_type === SITE_TYPES.SUB2API) {
-    return "sub2api"
-  }
+  const policy = getSiteAdapter(
+    account.site_type,
+  ).tokenProvisioning?.getRepairPolicy()
 
-  if (account.site_type === SITE_TYPES.AIHUBMIX) {
-    return "aihubmixOneTimeKey"
+  if (policy?.kind === "skipped") {
+    return policy.skipReason
   }
 
   if (account.authType === AuthTypeEnum.None) {

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -16,6 +16,8 @@ import type {
 } from "~/types/accountKeyAutoProvisioning"
 import {
   ACCOUNT_KEY_REPAIR_ERRORS,
+  ACCOUNT_KEY_REPAIR_JOB_STATES,
+  ACCOUNT_KEY_REPAIR_OUTCOMES,
   ACCOUNT_KEY_REPAIR_SKIP_REASONS,
 } from "~/types/accountKeyAutoProvisioning"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
@@ -44,7 +46,7 @@ const logger = createLogger("AccountKeyRepair")
 function createIdleProgress(): AccountKeyRepairProgress {
   return {
     jobId: "idle",
-    state: "idle",
+    state: ACCOUNT_KEY_REPAIR_JOB_STATES.Idle,
     totals: {
       enabledAccounts: 0,
       eligibleAccounts: 0,
@@ -132,7 +134,7 @@ class AccountKeyRepairRunner {
     const now = Date.now()
     const progress: AccountKeyRepairProgress = {
       jobId: safeRandomUUID("accountKeyRepair"),
-      state: "running",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
       startedAt: now,
       updatedAt: now,
       totals: {
@@ -192,7 +194,7 @@ class AccountKeyRepairRunner {
               displaySiteDataById.get(account.id)?.name ?? account.site_name,
             siteType: account.site_type,
             siteUrlOrigin: getOriginKey(account.site_url),
-            outcome: "skipped",
+            outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
             skipReason,
             finishedAt: Date.now(),
           })
@@ -225,7 +227,7 @@ class AccountKeyRepairRunner {
 
       this.updateProgress((prev) => ({
         ...prev,
-        state: "completed",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
         finishedAt: Date.now(),
       }))
       await this.persistAndNotify()
@@ -233,7 +235,7 @@ class AccountKeyRepairRunner {
       logger.error("Repair run failed", error)
       this.updateProgress((prev) => ({
         ...prev,
-        state: "failed",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Failed,
         finishedAt: Date.now(),
         lastError: getErrorMessage(error),
       }))
@@ -298,10 +300,10 @@ class AccountKeyRepairRunner {
         siteUrlOrigin: originKey,
         outcome:
           !result.created && result.missingGroups.length > 0
-            ? "failed"
+            ? ACCOUNT_KEY_REPAIR_OUTCOMES.Failed
             : result.created
-              ? "created"
-              : "alreadyHad",
+              ? ACCOUNT_KEY_REPAIR_OUTCOMES.Created
+              : ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad,
         availableGroups: result.availableGroups,
         coveredGroups: result.coveredGroups,
         createdGroups: result.createdGroups,
@@ -315,7 +317,7 @@ class AccountKeyRepairRunner {
         accountName,
         siteType: account.site_type,
         siteUrlOrigin: originKey,
-        outcome: "failed",
+        outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Failed,
         errorMessage: getErrorMessage(error),
         finishedAt: Date.now(),
       })
@@ -340,23 +342,24 @@ class AccountKeyRepairRunner {
 
       const nextSummary = { ...prev.summary }
       switch (result.outcome) {
-        case "created":
+        case ACCOUNT_KEY_REPAIR_OUTCOMES.Created:
           nextSummary.created += 1
           break
-        case "alreadyHad":
+        case ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad:
           nextSummary.alreadyHad += 1
           break
-        case "skipped":
+        case ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped:
           nextSummary.skipped += 1
           break
-        case "failed":
+        case ACCOUNT_KEY_REPAIR_OUTCOMES.Failed:
           nextSummary.failed += 1
           break
         default:
           break
       }
 
-      const isEligibleOutcome = result.outcome !== "skipped"
+      const isEligibleOutcome =
+        result.outcome !== ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped
       const availableGroupCount = result.availableGroups?.length ?? 0
       const coveredGroupCount = result.coveredGroups?.length ?? 0
       const createdKeyCount = result.createdGroups?.length ?? 0

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -2,6 +2,7 @@ import { Storage } from "@plasmohq/storage"
 
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { TOKEN_PROVISIONING_REPAIR_POLICY_KINDS } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS } from "~/services/core/storageKeys"
 import type { DisplaySiteData, SiteAccount } from "~/types"
@@ -85,7 +86,7 @@ function getSkipReason(
     account.site_type,
   ).tokenProvisioning?.getRepairPolicy()
 
-  if (policy?.kind === "skipped") {
+  if (policy?.kind === TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped) {
     return policy.skipReason
   }
 

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -38,6 +38,11 @@ import { runPerKeySequential } from "./perOriginQueue"
 
 const logger = createLogger("AccountKeyRepair")
 
+const getInvalidTokenDeleteErrorMessage = (error: unknown) => {
+  const message = getErrorMessage(error)
+  return message === "{}" ? "" : message
+}
+
 /**
  * Creates a default idle progress snapshot used when no repair job has started
  * yet (or when the stored progress blob is missing).
@@ -532,7 +537,8 @@ export async function deleteInvalidAccountTokens(
       failed.push({
         ...token,
         errorMessage:
-          getErrorMessage(error) || ACCOUNT_KEY_REPAIR_ERRORS.DeleteFailed,
+          getInvalidTokenDeleteErrorMessage(error) ||
+          ACCOUNT_KEY_REPAIR_ERRORS.DeleteFailed,
       })
     }
   }

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -42,6 +42,7 @@ import { resolveDefaultTokenCreationWithUserGroups } from "~/services/accounts/u
 import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
 import {
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_ERRORS,
   TOKEN_PROVISIONING_WORKFLOWS,
   type TokenProvisioningBlockReason,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
@@ -61,6 +62,7 @@ import {
   type SiteAccount,
   type Sub2ApiAuthConfig,
 } from "~/types"
+import { ACCOUNT_KEY_REPAIR_ERRORS } from "~/types/accountKeyAutoProvisioning"
 import type {
   AccountSaveResponse,
   AccountValidationResponse,
@@ -522,7 +524,8 @@ export async function resolveDefaultTokenQuickCreateResolution(
       defaultTokenData: generateDefaultTokenRequest(),
       explicitGroup: options.explicitGroup,
     },
-    missingUserGroupsMessage: "sub2api_group_inventory_not_implemented",
+    missingUserGroupsMessage:
+      TOKEN_PROVISIONING_ERRORS.Sub2ApiGroupInventoryNotImplemented,
   })
 
   if (decision.kind === "create") {
@@ -534,7 +537,9 @@ export async function resolveDefaultTokenQuickCreateResolution(
   }
 
   if (decision.kind === "needs_user_groups") {
-    throw new Error("sub2api_group_inventory_not_implemented")
+    throw new Error(
+      TOKEN_PROVISIONING_ERRORS.Sub2ApiGroupInventoryNotImplemented,
+    )
   }
 
   return {
@@ -551,7 +556,7 @@ export async function resolveSub2ApiQuickCreateResolution(
   account: DisplaySiteData,
 ): Promise<Sub2ApiQuickCreateResolution> {
   if (account.siteType !== SITE_TYPES.SUB2API) {
-    throw new Error("sub2api_quick_create_not_applicable")
+    throw new Error(TOKEN_PROVISIONING_ERRORS.Sub2ApiQuickCreateNotApplicable)
   }
 
   const resolution = await resolveDefaultTokenQuickCreateResolution(account)
@@ -1368,7 +1373,7 @@ async function autoProvisionKeyOnAccountAdd(
         !hasToken &&
         !hasCookie)
     ) {
-      throw new Error("invalid_display_site_data")
+      throw new Error(ACCOUNT_KEY_REPAIR_ERRORS.InvalidDisplaySiteData)
     }
 
     const { created } = await ensureDefaultApiTokenForAccount({

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -27,6 +27,7 @@ import {
 import {
   createDisplayAccountApiContext,
   requireDisplayAccountKeyManagement,
+  requireDisplayAccountTokenProvisioning,
 } from "~/services/accounts/utils/apiServiceRequest"
 import {
   analyzeAutoDetectError,
@@ -37,8 +38,15 @@ import {
   type AutoDetectFailureReason,
 } from "~/services/accounts/utils/autoDetectUtils"
 import { normalizeAccountSiteUrlForStorage } from "~/services/accounts/utils/siteUrlNormalization"
+import { resolveDefaultTokenCreationWithUserGroups } from "~/services/accounts/utils/tokenProvisioning"
 import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+  type TokenProvisioningBlockReason,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import {
   DEFAULT_PREFERENCES,
   userPreferences,
@@ -69,12 +77,6 @@ const logger = createLogger("AccountOperations")
 export const MANUAL_ADD_ACCOUNT_DATA_FETCH_TIMEOUT_MS = 20000
 
 export { extractDomainPrefix, getSiteName } from "~/services/accounts/siteName"
-
-const isCreatedApiToken = (value: unknown): value is ApiToken =>
-  !!value &&
-  typeof value === "object" &&
-  typeof (value as Partial<ApiToken>).id === "number" &&
-  typeof (value as Partial<ApiToken>).key === "string"
 
 /**
  * Pins analytics metadata to the final site type selected for account handling.
@@ -471,65 +473,101 @@ export type Sub2ApiQuickCreateResolution =
   | { kind: "selection_required"; allowedGroups: string[] }
   | { kind: "blocked"; message: string }
 
-const normalizeSub2ApiGroupNames = (
-  groups: Record<string, unknown>,
-): string[] => {
-  return Array.from(
-    new Set(
-      Object.keys(groups)
-        .map((group) => group.trim())
-        .filter(Boolean),
-    ),
-  )
+export type DefaultTokenQuickCreateResolution =
+  | { kind: "ready"; tokenData: CreateTokenRequest }
+  | { kind: "selection_required"; allowedGroups: string[] }
+  | {
+      kind: "blocked"
+      reason: TokenProvisioningBlockReason
+      message: string
+    }
+
+const getDefaultTokenProvisioningBlockMessage = (
+  reason: TokenProvisioningBlockReason,
+): string => {
+  if (reason === TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired) {
+    return t("messages:sub2api.createRequiresAvailableGroup")
+  }
+
+  if (reason === TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired) {
+    return t("messages:aihubmix.createRequiresOneTimeKeyDialog")
+  }
+
+  return t("messages:sub2api.createRequiresGroup")
 }
 
 /**
- * Resolves the current Sub2API quick-create state from upstream groups without
- * guessing a fallback group when multiple choices exist.
+ * Resolves the current default-token quick-create state from adapter policy.
+ */
+export async function resolveDefaultTokenQuickCreateResolution(
+  account: DisplaySiteData,
+  options: { explicitGroup?: string } = {},
+): Promise<DefaultTokenQuickCreateResolution> {
+  const { keyManagement, request, tokenProvisioning } =
+    createDisplayAccountApiContext(account)
+  const requiredKeyManagement = requireDisplayAccountKeyManagement(
+    account,
+    keyManagement,
+  )
+  const requiredTokenProvisioning = requireDisplayAccountTokenProvisioning(
+    account,
+    tokenProvisioning,
+  )
+  const decision = await resolveDefaultTokenCreationWithUserGroups({
+    keyManagement: requiredKeyManagement,
+    tokenProvisioning: requiredTokenProvisioning,
+    request,
+    decisionRequest: {
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection,
+      defaultTokenData: generateDefaultTokenRequest(),
+      explicitGroup: options.explicitGroup,
+    },
+    missingUserGroupsMessage: "sub2api_group_inventory_not_implemented",
+  })
+
+  if (decision.kind === "create") {
+    return { kind: "ready", tokenData: decision.tokenData }
+  }
+
+  if (decision.kind === "selection_required") {
+    return { kind: "selection_required", allowedGroups: decision.allowedGroups }
+  }
+
+  if (decision.kind === "needs_user_groups") {
+    throw new Error("sub2api_group_inventory_not_implemented")
+  }
+
+  return {
+    kind: "blocked",
+    reason: decision.reason,
+    message: getDefaultTokenProvisioningBlockMessage(decision.reason),
+  }
+}
+
+/**
+ * Resolves the current Sub2API quick-create state through default-token policy.
  */
 export async function resolveSub2ApiQuickCreateResolution(
-  account: Pick<
-    DisplaySiteData,
-    | "siteType"
-    | "baseUrl"
-    | "id"
-    | "authType"
-    | "userId"
-    | "token"
-    | "cookieAuthSessionCookie"
-  >,
+  account: DisplaySiteData,
 ): Promise<Sub2ApiQuickCreateResolution> {
   if (account.siteType !== SITE_TYPES.SUB2API) {
     throw new Error("sub2api_quick_create_not_applicable")
   }
 
-  const { keyManagement, request } = createDisplayAccountApiContext(account)
-  const userGroups = requireDisplayAccountKeyManagement(
-    account,
-    keyManagement,
-  ).userGroups
-  if (!userGroups) {
-    throw new Error("sub2api_group_inventory_not_implemented")
+  const resolution = await resolveDefaultTokenQuickCreateResolution(account)
+
+  if (resolution.kind === "ready") {
+    return { kind: "ready", group: resolution.tokenData.group }
   }
 
-  const groups = await userGroups.fetch(request)
-  const validGroups = normalizeSub2ApiGroupNames(groups)
-
-  if (validGroups.length === 0) {
+  if (resolution.kind === "selection_required") {
     return {
-      kind: "blocked",
-      message: t("messages:sub2api.createRequiresAvailableGroup"),
+      kind: "selection_required",
+      allowedGroups: resolution.allowedGroups,
     }
   }
 
-  if (validGroups.length === 1) {
-    return { kind: "ready", group: validGroups[0] }
-  }
-
-  return {
-    kind: "selection_required",
-    allowedGroups: validGroups,
-  }
+  return { kind: "blocked", message: resolution.message }
 }
 
 /**
@@ -1184,9 +1222,14 @@ export async function ensureAccountApiToken(
     id: options.toastId,
   })
 
+  const context = createDisplayAccountApiContext(displaySiteData)
   const keyManagement = requireDisplayAccountKeyManagement(
     displaySiteData,
-    getSiteAdapter(displaySiteData.siteType).keyManagement,
+    context.keyManagement,
+  )
+  const requiredTokenProvisioning = requireDisplayAccountTokenProvisioning(
+    displaySiteData,
+    context.tokenProvisioning,
   )
   const displayAccountRequest = {
     baseUrl: displaySiteData.baseUrl,
@@ -1213,38 +1256,41 @@ export async function ensureAccountApiToken(
   let apiToken: ApiToken | undefined = tokens.at(-1)
 
   if (!apiToken) {
-    const newTokenData = generateDefaultTokenRequest()
-    if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
-      const normalizedGroup =
-        typeof options.sub2apiGroup === "string"
-          ? options.sub2apiGroup.trim()
-          : ""
+    const decision = requiredTokenProvisioning.resolveDefaultTokenCreation({
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+      defaultTokenData: generateDefaultTokenRequest(),
+      explicitGroup: options.sub2apiGroup,
+    })
 
-      // Sub2API key creation must use a current upstream-valid group. The UI
-      // may auto-resolve the only valid group, but this shared helper must not
-      // silently create an ungrouped key.
-      if (!normalizedGroup) {
-        throw new Error(t("messages:sub2api.createRequiresGroup"))
+    if (decision.kind !== "create") {
+      if (
+        decision.kind === "blocked" &&
+        decision.reason ===
+          TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
+      ) {
+        throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
       }
 
-      newTokenData.group = normalizedGroup
-    }
-
-    if (displaySiteData.siteType === SITE_TYPES.AIHUBMIX) {
-      throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
+      throw new Error(t("messages:sub2api.createRequiresGroup"))
     }
 
     const createApiTokenResult = await keyManagement.createToken(
       createAccountRequest,
-      newTokenData,
+      decision.tokenData,
+    )
+    const createdTokenDecision = requiredTokenProvisioning.classifyCreatedToken(
+      {
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        result: createApiTokenResult,
+      },
     )
 
-    if (!createApiTokenResult) {
+    if (createdTokenDecision.kind === "usable") {
+      apiToken = createdTokenDecision.token
+    } else if (createdTokenDecision.kind === "failed") {
       throw new Error(t("messages:accountOperations.createTokenFailed"))
-    }
-
-    if (isCreatedApiToken(createApiTokenResult)) {
-      apiToken = createApiTokenResult
+    } else if (createdTokenDecision.kind === "unavailable") {
+      throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
     } else {
       // Do not assume a created key can be read back in full. AIHubMix returns
       // complete API keys only at creation time and may list masked keys here.

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -41,6 +41,7 @@ import { normalizeAccountSiteUrlForStorage } from "~/services/accounts/utils/sit
 import { resolveDefaultTokenCreationWithUserGroups } from "~/services/accounts/utils/tokenProvisioning"
 import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_ERRORS,
   TOKEN_PROVISIONING_WORKFLOWS,
@@ -528,15 +529,17 @@ export async function resolveDefaultTokenQuickCreateResolution(
       TOKEN_PROVISIONING_ERRORS.Sub2ApiGroupInventoryNotImplemented,
   })
 
-  if (decision.kind === "create") {
+  if (decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create) {
     return { kind: "ready", tokenData: decision.tokenData }
   }
 
-  if (decision.kind === "selection_required") {
+  if (
+    decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired
+  ) {
     return { kind: "selection_required", allowedGroups: decision.allowedGroups }
   }
 
-  if (decision.kind === "needs_user_groups") {
+  if (decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups) {
     throw new Error(
       TOKEN_PROVISIONING_ERRORS.Sub2ApiGroupInventoryNotImplemented,
     )
@@ -1267,9 +1270,9 @@ export async function ensureAccountApiToken(
       explicitGroup: options.sub2apiGroup,
     })
 
-    if (decision.kind !== "create") {
+    if (decision.kind !== DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create) {
       if (
-        decision.kind === "blocked" &&
+        decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked &&
         decision.reason ===
           TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired
       ) {

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -41,6 +41,7 @@ import { normalizeAccountSiteUrlForStorage } from "~/services/accounts/utils/sit
 import { resolveDefaultTokenCreationWithUserGroups } from "~/services/accounts/utils/tokenProvisioning"
 import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_ERRORS,
@@ -1293,11 +1294,18 @@ export async function ensureAccountApiToken(
       },
     )
 
-    if (createdTokenDecision.kind === "usable") {
+    if (
+      createdTokenDecision.kind === CREATED_TOKEN_SECRET_DECISION_KINDS.Usable
+    ) {
       apiToken = createdTokenDecision.token
-    } else if (createdTokenDecision.kind === "failed") {
+    } else if (
+      createdTokenDecision.kind === CREATED_TOKEN_SECRET_DECISION_KINDS.Failed
+    ) {
       throw new Error(t("messages:accountOperations.createTokenFailed"))
-    } else if (createdTokenDecision.kind === "unavailable") {
+    } else if (
+      createdTokenDecision.kind ===
+      CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable
+    ) {
       throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
     } else {
       // Do not assume a created key can be read back in full. AIHubMix returns

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -1,12 +1,16 @@
-import { SITE_TYPES } from "~/constants/siteType"
 import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
-import { resolveSub2ApiQuickCreateResolution } from "~/services/accounts/accountOperations"
-import { requireDisplayAccountKeyManagement } from "~/services/accounts/utils/apiServiceRequest"
-import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import {
-  hasUsableApiTokenKey,
-  isMaskedApiTokenKey,
-} from "~/services/apiService/common/apiKey"
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  requireDisplayAccountTokenProvisioning,
+} from "~/services/accounts/utils/apiServiceRequest"
+import { resolveDefaultTokenCreationWithUserGroups } from "~/services/accounts/utils/tokenProvisioning"
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+  type DefaultTokenCreationDecision,
+  type TokenProvisioningBlockReason,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import type { ApiServiceRequest } from "~/services/apiService/common/type"
 import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
 import { t } from "~/utils/i18n/core"
@@ -18,15 +22,6 @@ import {
   type AccountTokenInventoryState,
   type EnsureAccountTokenResult,
 } from "./constants"
-
-const isCreatedApiToken = (value: unknown): value is ApiToken =>
-  !!value &&
-  typeof value === "object" &&
-  typeof (value as Partial<ApiToken>).id === "number" &&
-  typeof (value as Partial<ApiToken>).key === "string"
-
-const hasUsableFullTokenSecret = (token: ApiToken): boolean =>
-  hasUsableApiTokenKey(token.key) && !isMaskedApiTokenKey(token.key)
 
 const isApiTokenWithValidId = (value: unknown): value is ApiToken =>
   !!value &&
@@ -65,19 +60,6 @@ const buildCreateRequest = (account: SiteAccount): ApiServiceRequest => ({
   },
 })
 
-const buildDisplayAccountRequest = (
-  displaySiteData: DisplaySiteData,
-): ApiServiceRequest => ({
-  baseUrl: displaySiteData.baseUrl,
-  accountId: displaySiteData.id,
-  auth: {
-    authType: displaySiteData.authType,
-    userId: displaySiteData.userId,
-    accessToken: displaySiteData.token,
-    cookie: displaySiteData.cookieAuthSessionCookie,
-  },
-})
-
 /**
  * Inspects whether the saved account already has a token and whether that
  * inventory value is usable as a secret for follow-up automation.
@@ -86,13 +68,16 @@ export async function inspectAccountTokenInventory(params: {
   displaySiteData: DisplaySiteData
 }): Promise<AccountTokenInventoryState> {
   const { displaySiteData } = params
+  const context = createDisplayAccountApiContext(displaySiteData)
   const keyManagement = requireDisplayAccountKeyManagement(
     displaySiteData,
-    getSiteAdapter(displaySiteData.siteType).keyManagement,
+    context.keyManagement,
   )
-  const tokens = await keyManagement.fetchTokens(
-    buildDisplayAccountRequest(displaySiteData),
+  const tokenProvisioning = requireDisplayAccountTokenProvisioning(
+    displaySiteData,
+    context.tokenProvisioning,
   )
+  const tokens = await keyManagement.fetchTokens(context.request)
   const existingTokens = sanitizeApiTokens(tokens)
   const existingTokenIds = getTokenIds(existingTokens)
   const existingToken = existingTokens.at(-1)
@@ -108,9 +93,41 @@ export async function inspectAccountTokenInventory(params: {
     kind: ACCOUNT_TOKEN_INVENTORY_STATE_KINDS.Present,
     token: existingToken,
     existingTokenIds,
-    hasUsableSecret:
-      displaySiteData.siteType !== SITE_TYPES.AIHUBMIX ||
-      hasUsableFullTokenSecret(existingToken),
+    hasUsableSecret: tokenProvisioning.isInventoryTokenUsable({
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+      token: existingToken,
+    }),
+  }
+}
+
+const blockPostSaveTokenCreation = (params?: {
+  reason?: TokenProvisioningBlockReason
+}): EnsureAccountTokenResult => {
+  const reason = params?.reason
+
+  if (
+    reason === TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired ||
+    reason === TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable
+  ) {
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
+      message: t("messages:aihubmix.createRequiresOneTimeKeyDialog"),
+    }
+  }
+
+  if (reason === TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired) {
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+      message: t("messages:sub2api.createRequiresAvailableGroup"),
+    }
+  }
+
+  return {
+    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+    code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+    message: t("messages:accountOperations.createTokenFailed"),
   }
 }
 
@@ -120,48 +137,68 @@ export async function inspectAccountTokenInventory(params: {
 async function createDefaultToken(params: {
   account: SiteAccount
   displaySiteData: DisplaySiteData
-  group?: string
+  decision: Extract<DefaultTokenCreationDecision, { kind: "create" }>
   existingTokenIds: number[]
-}): Promise<ApiToken | null> {
-  const { account, displaySiteData, group, existingTokenIds } = params
+}): Promise<EnsureAccountTokenResult> {
+  const { account, displaySiteData, decision, existingTokenIds } = params
+  const context = createDisplayAccountApiContext(displaySiteData)
   const keyManagement = requireDisplayAccountKeyManagement(
     displaySiteData,
-    getSiteAdapter(displaySiteData.siteType).keyManagement,
+    context.keyManagement,
   )
-  const tokenData = generateDefaultTokenRequest()
-  if (typeof group === "string") {
-    tokenData.group = group
-  }
+  const tokenProvisioning = requireDisplayAccountTokenProvisioning(
+    displaySiteData,
+    context.tokenProvisioning,
+  )
 
   const created = await keyManagement.createToken(
     buildCreateRequest(account),
-    tokenData,
+    decision.tokenData,
   )
+  const createdTokenDecision = tokenProvisioning.classifyCreatedToken({
+    workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+    result: created,
+  })
 
-  if (!created) {
-    return null
+  if (createdTokenDecision.kind === "usable") {
+    return {
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdTokenDecision.token,
+      created: true,
+      oneTimeSecret: createdTokenDecision.oneTimeSecret,
+    }
   }
 
-  if (isCreatedApiToken(created)) {
-    return created
+  if (createdTokenDecision.kind === "failed") {
+    return blockPostSaveTokenCreation({ reason: createdTokenDecision.reason })
   }
 
-  if (displaySiteData.siteType === SITE_TYPES.AIHUBMIX) {
-    return null
+  if (createdTokenDecision.kind === "unavailable") {
+    return blockPostSaveTokenCreation({ reason: createdTokenDecision.reason })
   }
 
-  const updatedTokens = await keyManagement.fetchTokens(
-    buildDisplayAccountRequest(displaySiteData),
-  )
+  const updatedTokens = await keyManagement.fetchTokens(context.request)
 
   const sanitizedUpdatedTokens = sanitizeApiTokens(updatedTokens)
 
-  return sanitizedUpdatedTokens.length > 0
-    ? selectSingleNewApiTokenByIdDiff({
-        existingTokenIds,
-        tokens: sanitizedUpdatedTokens,
-      })
-    : null
+  const token =
+    sanitizedUpdatedTokens.length > 0
+      ? selectSingleNewApiTokenByIdDiff({
+          existingTokenIds,
+          tokens: sanitizedUpdatedTokens,
+        })
+      : null
+
+  if (!token) {
+    return blockPostSaveTokenCreation()
+  }
+
+  return {
+    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+    token,
+    created: true,
+    oneTimeSecret: decision.oneTimeSecret,
+  }
 }
 
 /**
@@ -186,84 +223,51 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
     }
   }
 
-  if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
-    const resolution =
-      await resolveSub2ApiQuickCreateResolution(displaySiteData)
-
-    if (resolution.kind === "blocked") {
-      return {
-        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
-        code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
-        message: resolution.message,
-      }
-    }
-
-    if (resolution.kind === "selection_required") {
-      return {
-        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
-        allowedGroups: resolution.allowedGroups,
-        existingTokenIds,
-      }
-    }
-
-    const token = await createDefaultToken({
-      account,
-      displaySiteData,
-      group: resolution.group,
-      existingTokenIds,
-    })
-
-    if (!token) {
-      return {
-        kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
-        code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
-        message: t("messages:accountOperations.createTokenFailed"),
-      }
-    }
-
-    return {
-      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
-      token,
-      created: true,
-      oneTimeSecret: false,
-    }
-  }
-
-  const token = await createDefaultToken({
-    account,
+  const context = createDisplayAccountApiContext(displaySiteData)
+  const keyManagement = requireDisplayAccountKeyManagement(
     displaySiteData,
-    existingTokenIds,
+    context.keyManagement,
+  )
+  const tokenProvisioning = requireDisplayAccountTokenProvisioning(
+    displaySiteData,
+    context.tokenProvisioning,
+  )
+  const defaultTokenData = generateDefaultTokenRequest()
+  const decision = await resolveDefaultTokenCreationWithUserGroups({
+    keyManagement,
+    tokenProvisioning,
+    request: context.request,
+    decisionRequest: {
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+      defaultTokenData,
+    },
+    missingUserGroupsMessage: t(
+      "messages:sub2api.createRequiresAvailableGroup",
+    ),
   })
 
-  if (!token) {
+  if (decision.kind === "selection_required") {
     return {
-      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
-      code:
-        displaySiteData.siteType === SITE_TYPES.AIHUBMIX
-          ? ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable
-          : ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
-      message:
-        displaySiteData.siteType === SITE_TYPES.AIHUBMIX
-          ? t("messages:aihubmix.createRequiresOneTimeKeyDialog")
-          : t("messages:accountOperations.createTokenFailed"),
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
+      allowedGroups: decision.allowedGroups,
+      existingTokenIds,
     }
   }
 
-  if (
-    displaySiteData.siteType === SITE_TYPES.AIHUBMIX &&
-    !hasUsableFullTokenSecret(token)
-  ) {
-    return {
-      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
-      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenSecretUnavailable,
-      message: t("messages:aihubmix.createRequiresOneTimeKeyDialog"),
-    }
+  if (decision.kind === "blocked") {
+    return blockPostSaveTokenCreation({ reason: decision.reason })
   }
 
-  return {
-    kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
-    token,
-    created: true,
-    oneTimeSecret: displaySiteData.siteType === SITE_TYPES.AIHUBMIX,
+  if (decision.kind === "needs_user_groups") {
+    return blockPostSaveTokenCreation({
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
+    })
   }
+
+  return createDefaultToken({
+    account,
+    displaySiteData,
+    decision,
+    existingTokenIds,
+  })
 }

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -6,6 +6,7 @@ import {
 } from "~/services/accounts/utils/apiServiceRequest"
 import { resolveDefaultTokenCreationWithUserGroups } from "~/services/accounts/utils/tokenProvisioning"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_WORKFLOWS,
@@ -164,7 +165,9 @@ async function createDefaultToken(params: {
     result: created,
   })
 
-  if (createdTokenDecision.kind === "usable") {
+  if (
+    createdTokenDecision.kind === CREATED_TOKEN_SECRET_DECISION_KINDS.Usable
+  ) {
     return {
       kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
       token: createdTokenDecision.token,
@@ -173,11 +176,16 @@ async function createDefaultToken(params: {
     }
   }
 
-  if (createdTokenDecision.kind === "failed") {
+  if (
+    createdTokenDecision.kind === CREATED_TOKEN_SECRET_DECISION_KINDS.Failed
+  ) {
     return blockPostSaveTokenCreation({ reason: createdTokenDecision.reason })
   }
 
-  if (createdTokenDecision.kind === "unavailable") {
+  if (
+    createdTokenDecision.kind ===
+    CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable
+  ) {
     return blockPostSaveTokenCreation({ reason: createdTokenDecision.reason })
   }
 

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -6,6 +6,7 @@ import {
 } from "~/services/accounts/utils/apiServiceRequest"
 import { resolveDefaultTokenCreationWithUserGroups } from "~/services/accounts/utils/tokenProvisioning"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_WORKFLOWS,
   type DefaultTokenCreationDecision,
@@ -137,7 +138,10 @@ const blockPostSaveTokenCreation = (params?: {
 async function createDefaultToken(params: {
   account: SiteAccount
   displaySiteData: DisplaySiteData
-  decision: Extract<DefaultTokenCreationDecision, { kind: "create" }>
+  decision: Extract<
+    DefaultTokenCreationDecision,
+    { kind: typeof DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create }
+  >
   existingTokenIds: number[]
 }): Promise<EnsureAccountTokenResult> {
   const { account, displaySiteData, decision, existingTokenIds } = params
@@ -246,7 +250,9 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
     ),
   })
 
-  if (decision.kind === "selection_required") {
+  if (
+    decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired
+  ) {
     return {
       kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Sub2ApiSelectionRequired,
       allowedGroups: decision.allowedGroups,
@@ -254,11 +260,11 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
     }
   }
 
-  if (decision.kind === "blocked") {
+  if (decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked) {
     return blockPostSaveTokenCreation({ reason: decision.reason })
   }
 
-  if (decision.kind === "needs_user_groups") {
+  if (decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups) {
     return blockPostSaveTokenCreation({
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
     })

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -1,6 +1,7 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import type { TokenProvisioningCapability } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { formatOptionalSkPrefixSiteToken } from "~/services/apiService/common/apiKey"
 import type { ApiServiceRequest } from "~/services/apiService/common/type"
@@ -26,6 +27,21 @@ export const requireDisplayAccountKeyManagement = (
   }
 
   return keyManagement
+}
+
+export const createMissingTokenProvisioningCapabilityError = (
+  siteType: string,
+) => new Error(`tokenProvisioning is not implemented for ${siteType}`)
+
+export const requireDisplayAccountTokenProvisioning = (
+  account: Pick<DisplaySiteData, "siteType">,
+  tokenProvisioning: TokenProvisioningCapability | undefined,
+): TokenProvisioningCapability => {
+  if (!tokenProvisioning) {
+    throw createMissingTokenProvisioningCapabilityError(account.siteType)
+  }
+
+  return tokenProvisioning
 }
 
 export class InvalidTokenPayloadError extends Error {
@@ -108,6 +124,7 @@ export const createDisplayAccountApiContext = (
   return {
     adapter,
     keyManagement: adapter.keyManagement,
+    tokenProvisioning: adapter.tokenProvisioning,
     request: withDisplayAccountAuthSession(
       account,
       buildApiRequestFromDisplayAccount(account),

--- a/src/services/accounts/utils/tokenProvisioning.ts
+++ b/src/services/accounts/utils/tokenProvisioning.ts
@@ -1,8 +1,9 @@
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
-import type {
-  DefaultTokenCreationDecision,
-  ResolveDefaultTokenCreationRequest,
-  TokenProvisioningCapability,
+import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
+  type DefaultTokenCreationDecision,
+  type ResolveDefaultTokenCreationRequest,
+  type TokenProvisioningCapability,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 
@@ -21,7 +22,7 @@ export async function resolveDefaultTokenCreationWithUserGroups(params: {
     params.decisionRequest,
   )
 
-  if (decision.kind !== "needs_user_groups") {
+  if (decision.kind !== DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups) {
     return decision
   }
 

--- a/src/services/accounts/utils/tokenProvisioning.ts
+++ b/src/services/accounts/utils/tokenProvisioning.ts
@@ -1,0 +1,38 @@
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import type {
+  DefaultTokenCreationDecision,
+  ResolveDefaultTokenCreationRequest,
+  TokenProvisioningCapability,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+
+/**
+ * Resolves default-token creation, fetching user groups only when the policy
+ * requires them for a second pass.
+ */
+export async function resolveDefaultTokenCreationWithUserGroups(params: {
+  keyManagement: KeyManagementCapability
+  tokenProvisioning: TokenProvisioningCapability
+  request: ApiServiceRequest
+  decisionRequest: ResolveDefaultTokenCreationRequest
+  missingUserGroupsMessage: string
+}): Promise<DefaultTokenCreationDecision> {
+  const decision = params.tokenProvisioning.resolveDefaultTokenCreation(
+    params.decisionRequest,
+  )
+
+  if (decision.kind !== "needs_user_groups") {
+    return decision
+  }
+
+  if (!params.keyManagement.userGroups) {
+    throw new Error(params.missingUserGroupsMessage)
+  }
+
+  const userGroups = await params.keyManagement.userGroups.fetch(params.request)
+
+  return params.tokenProvisioning.resolveDefaultTokenCreation({
+    ...params.decisionRequest,
+    userGroups,
+  })
+}

--- a/src/services/apiAdapters/aihubmix/index.ts
+++ b/src/services/apiAdapters/aihubmix/index.ts
@@ -7,6 +7,7 @@ import { aihubmixAccountData } from "./accountData"
 import { aihubmixAccountRefresh } from "./accountRefresh"
 import { aihubmixKeyManagement } from "./keyManagement"
 import { aihubmixModelPricing } from "./modelPricing"
+import { aihubmixTokenProvisioning } from "./tokenProvisioning"
 
 export const aihubmixAdapter: SiteAdapter = {
   siteType: SITE_TYPES.AIHUBMIX,
@@ -14,6 +15,7 @@ export const aihubmixAdapter: SiteAdapter = {
   accountBootstrap: aihubmixAccountBootstrap,
   accountCompletion: aihubmixAccountCompletion,
   keyManagement: aihubmixKeyManagement,
+  tokenProvisioning: aihubmixTokenProvisioning,
   accountRefresh: aihubmixAccountRefresh,
   modelPricing: aihubmixModelPricing,
 }

--- a/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
+++ b/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
@@ -1,5 +1,6 @@
 import {
   isCreatedApiToken,
+  TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_WORKFLOWS,
   type TokenProvisioningCapability,
@@ -28,7 +29,7 @@ export const aihubmixTokenProvisioning: TokenProvisioningCapability = {
       kind: "create",
       tokenData: defaultTokenData,
       oneTimeSecret: true,
-      recoverCreatedToken: "created_response_first",
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     }
   },
   classifyCreatedToken: ({ result }) => {

--- a/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
+++ b/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
@@ -10,6 +10,7 @@ import {
   isMaskedApiTokenKey,
 } from "~/services/apiService/common/apiKey"
 import type { ApiToken } from "~/types"
+import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
 
 const hasUsableFullTokenSecret = (token: ApiToken): boolean =>
   hasUsableApiTokenKey(token.key) && !isMaskedApiTokenKey(token.key)
@@ -55,6 +56,6 @@ export const aihubmixTokenProvisioning: TokenProvisioningCapability = {
   },
   getRepairPolicy: () => ({
     kind: "skipped",
-    skipReason: "aihubmixOneTimeKey",
+    skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
   }),
 }

--- a/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
+++ b/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
@@ -1,0 +1,59 @@
+import {
+  isCreatedApiToken,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+  type TokenProvisioningCapability,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import {
+  hasUsableApiTokenKey,
+  isMaskedApiTokenKey,
+} from "~/services/apiService/common/apiKey"
+import type { ApiToken } from "~/types"
+
+const hasUsableFullTokenSecret = (token: ApiToken): boolean =>
+  hasUsableApiTokenKey(token.key) && !isMaskedApiTokenKey(token.key)
+
+export const aihubmixTokenProvisioning: TokenProvisioningCapability = {
+  isInventoryTokenUsable: ({ token }) => hasUsableFullTokenSecret(token),
+  resolveDefaultTokenCreation: ({ defaultTokenData, workflow }) => {
+    if (workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation) {
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
+      }
+    }
+
+    // AIHubMix only exposes the full key in the create response; later reads can be masked.
+    return {
+      kind: "create",
+      tokenData: defaultTokenData,
+      oneTimeSecret: true,
+      recoverCreatedToken: "created_response_first",
+    }
+  },
+  classifyCreatedToken: ({ result }) => {
+    if (!result) {
+      return {
+        kind: "failed",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+      }
+    }
+
+    if (isCreatedApiToken(result) && hasUsableFullTokenSecret(result)) {
+      return {
+        kind: "usable",
+        token: result,
+        oneTimeSecret: true,
+      }
+    }
+
+    return {
+      kind: "unavailable",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
+    }
+  },
+  getRepairPolicy: () => ({
+    kind: "skipped",
+    skipReason: "aihubmixOneTimeKey",
+  }),
+}

--- a/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
+++ b/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
@@ -1,4 +1,5 @@
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   isCreatedApiToken,
   TOKEN_CREATION_SECRET_RECOVERY,
@@ -38,21 +39,21 @@ export const aihubmixTokenProvisioning: TokenProvisioningCapability = {
   classifyCreatedToken: ({ result }) => {
     if (!result) {
       return {
-        kind: "failed",
+        kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
       }
     }
 
     if (isCreatedApiToken(result) && hasUsableFullTokenSecret(result)) {
       return {
-        kind: "usable",
+        kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
         token: result,
         oneTimeSecret: true,
       }
     }
 
     return {
-      kind: "unavailable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
     }
   },

--- a/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
+++ b/src/services/apiAdapters/aihubmix/tokenProvisioning.ts
@@ -1,7 +1,9 @@
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   isCreatedApiToken,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
   TOKEN_PROVISIONING_WORKFLOWS,
   type TokenProvisioningCapability,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
@@ -20,14 +22,14 @@ export const aihubmixTokenProvisioning: TokenProvisioningCapability = {
   resolveDefaultTokenCreation: ({ defaultTokenData, workflow }) => {
     if (workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation) {
       return {
-        kind: "blocked",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
       }
     }
 
     // AIHubMix only exposes the full key in the create response; later reads can be masked.
     return {
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: defaultTokenData,
       oneTimeSecret: true,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
@@ -55,7 +57,7 @@ export const aihubmixTokenProvisioning: TokenProvisioningCapability = {
     }
   },
   getRepairPolicy: () => ({
-    kind: "skipped",
+    kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
     skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
   }),
 }

--- a/src/services/apiAdapters/contracts/siteAdapter.ts
+++ b/src/services/apiAdapters/contracts/siteAdapter.ts
@@ -10,6 +10,7 @@ import type { ModelPricingCapability } from "./modelPricing"
 import type { RedemptionCapability } from "./redemption"
 import type { SiteAnnouncementsCapability } from "./siteAnnouncements"
 import type { SiteNoticeCapability } from "./siteNotice"
+import type { TokenProvisioningCapability } from "./tokenProvisioning"
 
 export type SiteBackendFamily = "newApiFamily" | "sub2api"
 
@@ -24,6 +25,7 @@ export type SiteAdapter = {
   accountBootstrap?: AccountBootstrapCapability
   accountCompletion?: AccountCompletionCapability
   keyManagement?: KeyManagementCapability
+  tokenProvisioning?: TokenProvisioningCapability
   accountRefresh?: AccountRefreshCapability
   redemption?: RedemptionCapability
 }

--- a/src/services/apiAdapters/contracts/tokenProvisioning.ts
+++ b/src/services/apiAdapters/contracts/tokenProvisioning.ts
@@ -44,6 +44,14 @@ export const TOKEN_CREATION_SECRET_RECOVERY = {
 export type TokenCreationSecretRecovery =
   (typeof TOKEN_CREATION_SECRET_RECOVERY)[keyof typeof TOKEN_CREATION_SECRET_RECOVERY]
 
+export const TOKEN_PROVISIONING_ERRORS = {
+  CreateTokenFailed: "create_token_failed",
+  Sub2ApiGroupInventoryNotImplemented:
+    "sub2api_group_inventory_not_implemented",
+  Sub2ApiQuickCreateNotApplicable: "sub2api_quick_create_not_applicable",
+  TokenNotFound: "token_not_found",
+} as const
+
 export type DefaultTokenCreationDecision =
   | {
       kind: "create"

--- a/src/services/apiAdapters/contracts/tokenProvisioning.ts
+++ b/src/services/apiAdapters/contracts/tokenProvisioning.ts
@@ -52,23 +52,30 @@ export const TOKEN_PROVISIONING_ERRORS = {
   TokenNotFound: "token_not_found",
 } as const
 
+export const DEFAULT_TOKEN_CREATION_DECISION_KINDS = {
+  Create: "create",
+  NeedsUserGroups: "needs_user_groups",
+  SelectionRequired: "selection_required",
+  Blocked: "blocked",
+} as const
+
 export type DefaultTokenCreationDecision =
   | {
-      kind: "create"
+      kind: typeof DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create
       tokenData: CreateTokenRequest
       oneTimeSecret: boolean
       recoverCreatedToken: TokenCreationSecretRecovery
     }
   | {
-      kind: "needs_user_groups"
+      kind: typeof DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups
     }
   | {
-      kind: "selection_required"
+      kind: typeof DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired
       allowedGroups: string[]
       reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired
     }
   | {
-      kind: "blocked"
+      kind: typeof DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked
       reason: TokenProvisioningBlockReason
     }
 
@@ -95,12 +102,17 @@ export type TokenProvisioningRepairSkipReason = Extract<
   "sub2api" | "aihubmixOneTimeKey"
 >
 
+export const TOKEN_PROVISIONING_REPAIR_POLICY_KINDS = {
+  Eligible: "eligible",
+  Skipped: "skipped",
+} as const
+
 export type TokenProvisioningRepairPolicy =
   | {
-      kind: "eligible"
+      kind: typeof TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible
     }
   | {
-      kind: "skipped"
+      kind: typeof TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped
       skipReason: TokenProvisioningRepairSkipReason
     }
 

--- a/src/services/apiAdapters/contracts/tokenProvisioning.ts
+++ b/src/services/apiAdapters/contracts/tokenProvisioning.ts
@@ -36,9 +36,13 @@ export type ResolveDefaultTokenCreationRequest = {
   userGroups?: Record<string, UserGroupInfo>
 }
 
+export const TOKEN_CREATION_SECRET_RECOVERY = {
+  InventoryRefetch: "inventory_refetch",
+  CreatedResponseFirst: "created_response_first",
+} as const
+
 export type TokenCreationSecretRecovery =
-  | "inventory_refetch"
-  | "created_response_first"
+  (typeof TOKEN_CREATION_SECRET_RECOVERY)[keyof typeof TOKEN_CREATION_SECRET_RECOVERY]
 
 export type DefaultTokenCreationDecision =
   | {

--- a/src/services/apiAdapters/contracts/tokenProvisioning.ts
+++ b/src/services/apiAdapters/contracts/tokenProvisioning.ts
@@ -4,7 +4,7 @@ import type {
   UserGroupInfo,
 } from "~/services/apiService/common/type"
 import type { ApiToken } from "~/types"
-import type { AccountKeyRepairSkipReason } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
 
 export const TOKEN_PROVISIONING_WORKFLOWS = {
   BackgroundAutoProvision: "background_auto_provision",
@@ -104,10 +104,9 @@ export type CreatedTokenSecretDecision =
       kind: typeof CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch
     }
 
-export type TokenProvisioningRepairSkipReason = Extract<
-  AccountKeyRepairSkipReason,
-  "sub2api" | "aihubmixOneTimeKey"
->
+export type TokenProvisioningRepairSkipReason =
+  | typeof ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api
+  | typeof ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey
 
 export const TOKEN_PROVISIONING_REPAIR_POLICY_KINDS = {
   Eligible: "eligible",

--- a/src/services/apiAdapters/contracts/tokenProvisioning.ts
+++ b/src/services/apiAdapters/contracts/tokenProvisioning.ts
@@ -79,22 +79,29 @@ export type DefaultTokenCreationDecision =
       reason: TokenProvisioningBlockReason
     }
 
+export const CREATED_TOKEN_SECRET_DECISION_KINDS = {
+  Usable: "usable",
+  Failed: "failed",
+  Unavailable: "unavailable",
+  NeedsInventoryRefetch: "needs_inventory_refetch",
+} as const
+
 export type CreatedTokenSecretDecision =
   | {
-      kind: "usable"
+      kind: typeof CREATED_TOKEN_SECRET_DECISION_KINDS.Usable
       token: ApiToken
       oneTimeSecret: boolean
     }
   | {
-      kind: "failed"
+      kind: typeof CREATED_TOKEN_SECRET_DECISION_KINDS.Failed
       reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed
     }
   | {
-      kind: "unavailable"
+      kind: typeof CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable
       reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable
     }
   | {
-      kind: "needs_inventory_refetch"
+      kind: typeof CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch
     }
 
 export type TokenProvisioningRepairSkipReason = Extract<

--- a/src/services/apiAdapters/contracts/tokenProvisioning.ts
+++ b/src/services/apiAdapters/contracts/tokenProvisioning.ts
@@ -1,0 +1,114 @@
+import type {
+  CreateTokenRequest,
+  CreateTokenResult,
+  UserGroupInfo,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+import type { AccountKeyRepairSkipReason } from "~/types/accountKeyAutoProvisioning"
+
+export const TOKEN_PROVISIONING_WORKFLOWS = {
+  BackgroundAutoProvision: "background_auto_provision",
+  SharedEnsure: "shared_ensure",
+  QuickCreateSelection: "quick_create_selection",
+  PostSaveAutomation: "post_save_automation",
+  Repair: "repair",
+} as const
+
+export type TokenProvisioningWorkflow =
+  (typeof TOKEN_PROVISIONING_WORKFLOWS)[keyof typeof TOKEN_PROVISIONING_WORKFLOWS]
+
+export const TOKEN_PROVISIONING_BLOCK_REASONS = {
+  GroupRequired: "group_required",
+  AvailableGroupRequired: "available_group_required",
+  GroupSelectionRequired: "group_selection_required",
+  OneTimeSecretRequired: "one_time_secret_required",
+  CreateFailed: "create_failed",
+  CreatedTokenSecretUnavailable: "created_token_secret_unavailable",
+} as const
+
+export type TokenProvisioningBlockReason =
+  (typeof TOKEN_PROVISIONING_BLOCK_REASONS)[keyof typeof TOKEN_PROVISIONING_BLOCK_REASONS]
+
+export type ResolveDefaultTokenCreationRequest = {
+  workflow: TokenProvisioningWorkflow
+  defaultTokenData: CreateTokenRequest
+  explicitGroup?: string
+  userGroups?: Record<string, UserGroupInfo>
+}
+
+export type TokenCreationSecretRecovery =
+  | "inventory_refetch"
+  | "created_response_first"
+
+export type DefaultTokenCreationDecision =
+  | {
+      kind: "create"
+      tokenData: CreateTokenRequest
+      oneTimeSecret: boolean
+      recoverCreatedToken: TokenCreationSecretRecovery
+    }
+  | {
+      kind: "needs_user_groups"
+    }
+  | {
+      kind: "selection_required"
+      allowedGroups: string[]
+      reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired
+    }
+  | {
+      kind: "blocked"
+      reason: TokenProvisioningBlockReason
+    }
+
+export type CreatedTokenSecretDecision =
+  | {
+      kind: "usable"
+      token: ApiToken
+      oneTimeSecret: boolean
+    }
+  | {
+      kind: "failed"
+      reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed
+    }
+  | {
+      kind: "unavailable"
+      reason: typeof TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable
+    }
+  | {
+      kind: "needs_inventory_refetch"
+    }
+
+export type TokenProvisioningRepairSkipReason = Extract<
+  AccountKeyRepairSkipReason,
+  "sub2api" | "aihubmixOneTimeKey"
+>
+
+export type TokenProvisioningRepairPolicy =
+  | {
+      kind: "eligible"
+    }
+  | {
+      kind: "skipped"
+      skipReason: TokenProvisioningRepairSkipReason
+    }
+
+export type TokenProvisioningCapability = {
+  isInventoryTokenUsable(params: {
+    workflow: TokenProvisioningWorkflow
+    token: ApiToken
+  }): boolean
+  resolveDefaultTokenCreation(
+    request: ResolveDefaultTokenCreationRequest,
+  ): DefaultTokenCreationDecision
+  classifyCreatedToken(params: {
+    workflow: TokenProvisioningWorkflow
+    result: CreateTokenResult
+  }): CreatedTokenSecretDecision
+  getRepairPolicy(): TokenProvisioningRepairPolicy
+}
+
+export const isCreatedApiToken = (value: unknown): value is ApiToken =>
+  !!value &&
+  typeof value === "object" &&
+  typeof (value as Partial<ApiToken>).id === "number" &&
+  typeof (value as Partial<ApiToken>).key === "string"

--- a/src/services/apiAdapters/newApi/index.ts
+++ b/src/services/apiAdapters/newApi/index.ts
@@ -9,6 +9,7 @@ import { createNewApiKeyManagement } from "./keyManagement"
 import { createNewApiModelPricing } from "./modelPricing"
 import { createNewApiRedemption } from "./redemption"
 import { newApiSiteNotice } from "./siteNotice"
+import { createNewApiTokenProvisioning } from "./tokenProvisioning"
 
 export const createNewApiAdapter = (
   siteType: AccountSiteType = SITE_TYPES.NEW_API,
@@ -20,6 +21,7 @@ export const createNewApiAdapter = (
   accountBootstrap: createNewApiAccountBootstrap(siteType),
   accountCompletion: newApiAccountCompletion,
   keyManagement: createNewApiKeyManagement(siteType),
+  tokenProvisioning: createNewApiTokenProvisioning(siteType),
   accountRefresh: createNewApiAccountRefresh(siteType),
   modelPricing: createNewApiModelPricing(siteType),
   redemption: createNewApiRedemption(siteType),

--- a/src/services/apiAdapters/newApi/tokenProvisioning.ts
+++ b/src/services/apiAdapters/newApi/tokenProvisioning.ts
@@ -1,0 +1,37 @@
+import type { AccountSiteType } from "~/constants/siteType"
+import {
+  isCreatedApiToken,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  type TokenProvisioningCapability,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+
+export const createNewApiTokenProvisioning = (
+  _siteType: AccountSiteType,
+): TokenProvisioningCapability => ({
+  isInventoryTokenUsable: () => true,
+  resolveDefaultTokenCreation: ({ defaultTokenData }) => ({
+    kind: "create",
+    tokenData: defaultTokenData,
+    oneTimeSecret: false,
+    recoverCreatedToken: "inventory_refetch",
+  }),
+  classifyCreatedToken: ({ result }) => {
+    if (isCreatedApiToken(result)) {
+      return {
+        kind: "usable",
+        token: result,
+        oneTimeSecret: false,
+      }
+    }
+
+    if (result) {
+      return { kind: "needs_inventory_refetch" }
+    }
+
+    return {
+      kind: "failed",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+    }
+  },
+  getRepairPolicy: () => ({ kind: "eligible" }),
+})

--- a/src/services/apiAdapters/newApi/tokenProvisioning.ts
+++ b/src/services/apiAdapters/newApi/tokenProvisioning.ts
@@ -1,5 +1,6 @@
 import type { AccountSiteType } from "~/constants/siteType"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   isCreatedApiToken,
   TOKEN_CREATION_SECRET_RECOVERY,
@@ -21,18 +22,18 @@ export const createNewApiTokenProvisioning = (
   classifyCreatedToken: ({ result }) => {
     if (isCreatedApiToken(result)) {
       return {
-        kind: "usable",
+        kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
         token: result,
         oneTimeSecret: false,
       }
     }
 
     if (result) {
-      return { kind: "needs_inventory_refetch" }
+      return { kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch }
     }
 
     return {
-      kind: "failed",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
     }
   },

--- a/src/services/apiAdapters/newApi/tokenProvisioning.ts
+++ b/src/services/apiAdapters/newApi/tokenProvisioning.ts
@@ -1,8 +1,10 @@
 import type { AccountSiteType } from "~/constants/siteType"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   isCreatedApiToken,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
   type TokenProvisioningCapability,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 
@@ -11,7 +13,7 @@ export const createNewApiTokenProvisioning = (
 ): TokenProvisioningCapability => ({
   isInventoryTokenUsable: () => true,
   resolveDefaultTokenCreation: ({ defaultTokenData }) => ({
-    kind: "create",
+    kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
     tokenData: defaultTokenData,
     oneTimeSecret: false,
     recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -34,5 +36,7 @@ export const createNewApiTokenProvisioning = (
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
     }
   },
-  getRepairPolicy: () => ({ kind: "eligible" }),
+  getRepairPolicy: () => ({
+    kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
+  }),
 })

--- a/src/services/apiAdapters/newApi/tokenProvisioning.ts
+++ b/src/services/apiAdapters/newApi/tokenProvisioning.ts
@@ -1,6 +1,7 @@
 import type { AccountSiteType } from "~/constants/siteType"
 import {
   isCreatedApiToken,
+  TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   type TokenProvisioningCapability,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
@@ -13,7 +14,7 @@ export const createNewApiTokenProvisioning = (
     kind: "create",
     tokenData: defaultTokenData,
     oneTimeSecret: false,
-    recoverCreatedToken: "inventory_refetch",
+    recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
   }),
   classifyCreatedToken: ({ result }) => {
     if (isCreatedApiToken(result)) {

--- a/src/services/apiAdapters/sub2api/index.ts
+++ b/src/services/apiAdapters/sub2api/index.ts
@@ -8,6 +8,7 @@ import { sub2ApiAccountRefresh } from "./accountRefresh"
 import { sub2ApiKeyManagement } from "./keyManagement"
 import { sub2ApiModelCatalog } from "./modelCatalog"
 import { sub2ApiSiteAnnouncements } from "./siteAnnouncements"
+import { sub2ApiTokenProvisioning } from "./tokenProvisioning"
 
 export const sub2ApiAdapter: SiteAdapter = {
   siteType: SITE_TYPES.SUB2API,
@@ -18,5 +19,6 @@ export const sub2ApiAdapter: SiteAdapter = {
   accountBootstrap: sub2ApiAccountBootstrap,
   accountCompletion: sub2ApiAccountCompletion,
   keyManagement: sub2ApiKeyManagement,
+  tokenProvisioning: sub2ApiTokenProvisioning,
   accountRefresh: sub2ApiAccountRefresh,
 }

--- a/src/services/apiAdapters/sub2api/tokenProvisioning.ts
+++ b/src/services/apiAdapters/sub2api/tokenProvisioning.ts
@@ -1,5 +1,6 @@
 import {
   isCreatedApiToken,
+  TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_WORKFLOWS,
   type TokenProvisioningCapability,
@@ -13,7 +14,7 @@ const createWithGroup = (
   kind: "create" as const,
   tokenData: { ...defaultTokenData, group },
   oneTimeSecret: false,
-  recoverCreatedToken: "inventory_refetch" as const,
+  recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
 })
 
 export const normalizeTokenProvisioningGroupNames = (

--- a/src/services/apiAdapters/sub2api/tokenProvisioning.ts
+++ b/src/services/apiAdapters/sub2api/tokenProvisioning.ts
@@ -1,7 +1,9 @@
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   isCreatedApiToken,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
   TOKEN_PROVISIONING_WORKFLOWS,
   type TokenProvisioningCapability,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
@@ -12,7 +14,7 @@ const createWithGroup = (
   defaultTokenData: CreateTokenRequest,
   group: string,
 ) => ({
-  kind: "create" as const,
+  kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
   tokenData: { ...defaultTokenData, group },
   oneTimeSecret: false,
   recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -53,19 +55,19 @@ export const sub2ApiTokenProvisioning: TokenProvisioningCapability = {
       workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation
     ) {
       return {
-        kind: "blocked",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
       }
     }
 
     if (!userGroups) {
-      return { kind: "needs_user_groups" }
+      return { kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups }
     }
 
     const groups = normalizeTokenProvisioningGroupNames(userGroups)
     if (groups.length === 0) {
       return {
-        kind: "blocked",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
       }
     }
@@ -75,7 +77,7 @@ export const sub2ApiTokenProvisioning: TokenProvisioningCapability = {
     }
 
     return {
-      kind: "selection_required",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
       allowedGroups: groups,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
     }
@@ -99,7 +101,7 @@ export const sub2ApiTokenProvisioning: TokenProvisioningCapability = {
     }
   },
   getRepairPolicy: () => ({
-    kind: "skipped",
+    kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
     skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
   }),
 }

--- a/src/services/apiAdapters/sub2api/tokenProvisioning.ts
+++ b/src/services/apiAdapters/sub2api/tokenProvisioning.ts
@@ -1,0 +1,103 @@
+import {
+  isCreatedApiToken,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+  type TokenProvisioningCapability,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import type { CreateTokenRequest } from "~/services/apiService/common/type"
+
+const createWithGroup = (
+  defaultTokenData: CreateTokenRequest,
+  group: string,
+) => ({
+  kind: "create" as const,
+  tokenData: { ...defaultTokenData, group },
+  oneTimeSecret: false,
+  recoverCreatedToken: "inventory_refetch" as const,
+})
+
+export const normalizeTokenProvisioningGroupNames = (
+  groups: Record<string, unknown>,
+): string[] => {
+  const seen = new Set<string>()
+  const normalizedGroups: string[] = []
+
+  for (const group of Object.keys(groups)) {
+    const normalizedGroup = group.trim()
+    if (!normalizedGroup || seen.has(normalizedGroup)) continue
+
+    seen.add(normalizedGroup)
+    normalizedGroups.push(normalizedGroup)
+  }
+
+  return normalizedGroups
+}
+
+export const sub2ApiTokenProvisioning: TokenProvisioningCapability = {
+  isInventoryTokenUsable: () => true,
+  resolveDefaultTokenCreation: ({
+    defaultTokenData,
+    explicitGroup,
+    userGroups,
+    workflow,
+  }) => {
+    const normalizedExplicitGroup = explicitGroup?.trim()
+    if (normalizedExplicitGroup) {
+      return createWithGroup(defaultTokenData, normalizedExplicitGroup)
+    }
+
+    if (
+      workflow !== TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection &&
+      workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation
+    ) {
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
+      }
+    }
+
+    if (!userGroups) {
+      return { kind: "needs_user_groups" }
+    }
+
+    const groups = normalizeTokenProvisioningGroupNames(userGroups)
+    if (groups.length === 0) {
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
+      }
+    }
+
+    if (groups.length === 1) {
+      return createWithGroup(defaultTokenData, groups[0])
+    }
+
+    return {
+      kind: "selection_required",
+      allowedGroups: groups,
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
+    }
+  },
+  classifyCreatedToken: ({ result }) => {
+    if (isCreatedApiToken(result)) {
+      return {
+        kind: "usable",
+        token: result,
+        oneTimeSecret: false,
+      }
+    }
+
+    if (result) {
+      return { kind: "needs_inventory_refetch" }
+    }
+
+    return {
+      kind: "failed",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+    }
+  },
+  getRepairPolicy: () => ({
+    kind: "skipped",
+    skipReason: "sub2api",
+  }),
+}

--- a/src/services/apiAdapters/sub2api/tokenProvisioning.ts
+++ b/src/services/apiAdapters/sub2api/tokenProvisioning.ts
@@ -1,4 +1,5 @@
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   isCreatedApiToken,
   TOKEN_CREATION_SECRET_RECOVERY,
@@ -85,18 +86,18 @@ export const sub2ApiTokenProvisioning: TokenProvisioningCapability = {
   classifyCreatedToken: ({ result }) => {
     if (isCreatedApiToken(result)) {
       return {
-        kind: "usable",
+        kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
         token: result,
         oneTimeSecret: false,
       }
     }
 
     if (result) {
-      return { kind: "needs_inventory_refetch" }
+      return { kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch }
     }
 
     return {
-      kind: "failed",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
     }
   },

--- a/src/services/apiAdapters/sub2api/tokenProvisioning.ts
+++ b/src/services/apiAdapters/sub2api/tokenProvisioning.ts
@@ -6,6 +6,7 @@ import {
   type TokenProvisioningCapability,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
+import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
 
 const createWithGroup = (
   defaultTokenData: CreateTokenRequest,
@@ -99,6 +100,6 @@ export const sub2ApiTokenProvisioning: TokenProvisioningCapability = {
   },
   getRepairPolicy: () => ({
     kind: "skipped",
-    skipReason: "sub2api",
+    skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
   }),
 }

--- a/src/types/accountKeyAutoProvisioning.ts
+++ b/src/types/accountKeyAutoProvisioning.ts
@@ -12,10 +12,20 @@ export type AccountKeyRepairOutcome =
   | "skipped"
   | "failed"
 
+export const ACCOUNT_KEY_REPAIR_SKIP_REASONS = {
+  Sub2Api: "sub2api",
+  AihubmixOneTimeKey: "aihubmixOneTimeKey",
+  NoneAuth: "noneAuth",
+} as const
+
 export type AccountKeyRepairSkipReason =
-  | "sub2api"
-  | "aihubmixOneTimeKey"
-  | "noneAuth"
+  (typeof ACCOUNT_KEY_REPAIR_SKIP_REASONS)[keyof typeof ACCOUNT_KEY_REPAIR_SKIP_REASONS]
+
+export const ACCOUNT_KEY_REPAIR_ERRORS = {
+  AccountNotFound: "account_not_found",
+  DeleteFailed: "delete_failed",
+  InvalidDisplaySiteData: "invalid_display_site_data",
+} as const
 
 export const ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS = {
   GroupUnavailable: "groupUnavailable",

--- a/src/types/accountKeyAutoProvisioning.ts
+++ b/src/types/accountKeyAutoProvisioning.ts
@@ -1,16 +1,24 @@
 import type { AccountSiteType } from "~/constants/siteType"
 
+export const ACCOUNT_KEY_REPAIR_JOB_STATES = {
+  Idle: "idle",
+  Running: "running",
+  Completed: "completed",
+  Failed: "failed",
+} as const
+
 export type AccountKeyRepairJobState =
-  | "idle"
-  | "running"
-  | "completed"
-  | "failed"
+  (typeof ACCOUNT_KEY_REPAIR_JOB_STATES)[keyof typeof ACCOUNT_KEY_REPAIR_JOB_STATES]
+
+export const ACCOUNT_KEY_REPAIR_OUTCOMES = {
+  Created: "created",
+  AlreadyHad: "alreadyHad",
+  Skipped: "skipped",
+  Failed: "failed",
+} as const
 
 export type AccountKeyRepairOutcome =
-  | "created"
-  | "alreadyHad"
-  | "skipped"
-  | "failed"
+  (typeof ACCOUNT_KEY_REPAIR_OUTCOMES)[keyof typeof ACCOUNT_KEY_REPAIR_OUTCOMES]
 
 export const ACCOUNT_KEY_REPAIR_SKIP_REASONS = {
   Sub2Api: "sub2api",

--- a/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+++ b/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
@@ -10,6 +10,9 @@ import {
   PRODUCT_ANALYTICS_STATUS_KINDS,
 } from "~/services/productAnalytics/events"
 import {
+  ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
+  ACCOUNT_KEY_REPAIR_JOB_STATES,
+  ACCOUNT_KEY_REPAIR_OUTCOMES,
   ACCOUNT_KEY_REPAIR_SKIP_REASONS,
   type AccountKeyRepairProgress,
 } from "~/types/accountKeyAutoProvisioning"
@@ -165,7 +168,7 @@ vi.mock("~/features/KeyManagement/components/AddTokenDialog", () => ({
 
 const idleProgress: AccountKeyRepairProgress = {
   jobId: "idle",
-  state: "idle",
+  state: ACCOUNT_KEY_REPAIR_JOB_STATES.Idle,
   totals: {
     enabledAccounts: 2,
     eligibleAccounts: 2,
@@ -182,7 +185,7 @@ const idleProgress: AccountKeyRepairProgress = {
 
 const startProgress: AccountKeyRepairProgress = {
   jobId: "job-1",
-  state: "running",
+  state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
   startedAt: 1,
   updatedAt: 1,
   totals: {
@@ -202,7 +205,7 @@ const startProgress: AccountKeyRepairProgress = {
       accountName: "Disabled Site",
       siteType: "unknown",
       siteUrlOrigin: "https://disabled.example.com",
-      outcome: "skipped",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
       skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth,
       finishedAt: 1,
     },
@@ -211,7 +214,7 @@ const startProgress: AccountKeyRepairProgress = {
       accountName: "Enabled Site",
       siteType: "unknown",
       siteUrlOrigin: "https://enabled.example.com",
-      outcome: "created",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
       finishedAt: 1,
     },
   ],
@@ -220,7 +223,7 @@ const startProgress: AccountKeyRepairProgress = {
 const completedProgress: AccountKeyRepairProgress = {
   ...startProgress,
   jobId: "job-1",
-  state: "completed",
+  state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
   finishedAt: 2,
   totals: {
     enabledAccounts: 2,
@@ -240,7 +243,7 @@ const completedProgress: AccountKeyRepairProgress = {
       accountName: "Enabled Site",
       siteType: "unknown",
       siteUrlOrigin: "https://enabled.example.com",
-      outcome: "created",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
       finishedAt: 1,
     },
     {
@@ -248,7 +251,7 @@ const completedProgress: AccountKeyRepairProgress = {
       accountName: "Another Site",
       siteType: "unknown",
       siteUrlOrigin: "https://another.example.com",
-      outcome: "created",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
       finishedAt: 2,
     },
   ],
@@ -256,7 +259,7 @@ const completedProgress: AccountKeyRepairProgress = {
 
 const multiOutcomeProgress: AccountKeyRepairProgress = {
   jobId: "job-2",
-  state: "running",
+  state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
   startedAt: 1,
   updatedAt: 1,
   totals: {
@@ -276,7 +279,7 @@ const multiOutcomeProgress: AccountKeyRepairProgress = {
       accountName: "Enabled Site",
       siteType: "unknown",
       siteUrlOrigin: "https://enabled.example.com",
-      outcome: "created",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
       finishedAt: 1,
     },
     {
@@ -284,7 +287,7 @@ const multiOutcomeProgress: AccountKeyRepairProgress = {
       accountName: "Another Site",
       siteType: "unknown",
       siteUrlOrigin: "https://another.example.com",
-      outcome: "failed",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Failed,
       errorMessage: "boom",
       finishedAt: 2,
     },
@@ -294,14 +297,14 @@ const multiOutcomeProgress: AccountKeyRepairProgress = {
 const failedProgress: AccountKeyRepairProgress = {
   ...multiOutcomeProgress,
   jobId: "job-1",
-  state: "failed",
+  state: ACCOUNT_KEY_REPAIR_JOB_STATES.Failed,
   finishedAt: 2,
   lastError: "raw backend detail",
 }
 
 const inflatedProgress: AccountKeyRepairProgress = {
   jobId: "job-3",
-  state: "running",
+  state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
   startedAt: 1,
   updatedAt: 1,
   totals: {
@@ -322,7 +325,7 @@ const inflatedProgress: AccountKeyRepairProgress = {
       accountName: "Disabled Site",
       siteType: "unknown",
       siteUrlOrigin: "https://disabled.example.com",
-      outcome: "skipped",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
       skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth,
       finishedAt: 1,
     },
@@ -331,7 +334,7 @@ const inflatedProgress: AccountKeyRepairProgress = {
       accountName: "Enabled Site",
       siteType: "unknown",
       siteUrlOrigin: "https://enabled.example.com",
-      outcome: "created",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
       finishedAt: 1,
     },
     {
@@ -339,7 +342,7 @@ const inflatedProgress: AccountKeyRepairProgress = {
       accountName: "Another Site",
       siteType: "unknown",
       siteUrlOrigin: "https://another.example.com",
-      outcome: "alreadyHad",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad,
       finishedAt: 2,
     },
     {
@@ -347,7 +350,7 @@ const inflatedProgress: AccountKeyRepairProgress = {
       accountName: "Another Disabled Site",
       siteType: "unknown",
       siteUrlOrigin: "https://disabled-2.example.com",
-      outcome: "skipped",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
       skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
       finishedAt: 2,
     },
@@ -356,7 +359,7 @@ const inflatedProgress: AccountKeyRepairProgress = {
       accountName: "Third Site",
       siteType: "unknown",
       siteUrlOrigin: "https://third.example.com",
-      outcome: "created",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
       finishedAt: 3,
     },
   ],
@@ -364,7 +367,7 @@ const inflatedProgress: AccountKeyRepairProgress = {
 
 const sub2apiSkippedProgress: AccountKeyRepairProgress = {
   jobId: "job-4",
-  state: "completed",
+  state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
   startedAt: 1,
   updatedAt: 1,
   finishedAt: 1,
@@ -386,7 +389,7 @@ const sub2apiSkippedProgress: AccountKeyRepairProgress = {
       accountName: "Another Site",
       siteType: "sub2api",
       siteUrlOrigin: "https://another.example.com",
-      outcome: "skipped",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
       skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
       finishedAt: 1,
     },
@@ -395,7 +398,7 @@ const sub2apiSkippedProgress: AccountKeyRepairProgress = {
 
 const aihubmixSkippedProgress: AccountKeyRepairProgress = {
   jobId: "job-5",
-  state: "completed",
+  state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
   startedAt: 1,
   updatedAt: 1,
   finishedAt: 1,
@@ -417,7 +420,7 @@ const aihubmixSkippedProgress: AccountKeyRepairProgress = {
       accountName: "AIHubMix",
       siteType: "AIHubMix",
       siteUrlOrigin: "https://aihubmix.com",
-      outcome: "skipped",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
       skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
       finishedAt: 1,
     },
@@ -426,7 +429,7 @@ const aihubmixSkippedProgress: AccountKeyRepairProgress = {
 
 const coverageProgress: AccountKeyRepairProgress = {
   jobId: "job-coverage",
-  state: "completed",
+  state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
   startedAt: 1,
   updatedAt: 2,
   finishedAt: 2,
@@ -452,7 +455,7 @@ const coverageProgress: AccountKeyRepairProgress = {
       accountName: "Enabled Site",
       siteType: "new-api",
       siteUrlOrigin: "https://enabled.example.com",
-      outcome: "created",
+      outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
       availableGroups: ["default", "vip"],
       coveredGroups: ["default", "vip"],
       createdGroups: ["vip"],
@@ -466,7 +469,7 @@ const coverageProgress: AccountKeyRepairProgress = {
           tokenId: 9,
           tokenName: "old group key",
           group: "old",
-          reason: "groupUnavailable",
+          reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
         },
       ],
       finishedAt: 2,
@@ -492,7 +495,7 @@ const multiInvalidKeysProgress: AccountKeyRepairProgress = {
         tokenId: index + 1,
         tokenName: `old group key ${index + 1}`,
         group: `old-${index + 1}`,
-        reason: "groupUnavailable",
+        reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
       })),
       missingGroups: ["legacy"],
     },
@@ -767,7 +770,7 @@ describe("KeyManagement repair missing keys entry point", () => {
           accountName: "Another Site",
           siteType: "unknown",
           siteUrlOrigin: "https://another.example.com",
-          outcome: "alreadyHad",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad,
           finishedAt: 2,
         },
       ],

--- a/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+++ b/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
@@ -829,6 +829,48 @@ describe("KeyManagement repair missing keys entry point", () => {
     expect(progressBar).toHaveAttribute("aria-valuenow", "3")
   })
 
+  it("shows the none-auth skip reason for skipped accounts", async () => {
+    const visibleNoneAuthProgress: AccountKeyRepairProgress = {
+      ...startProgress,
+      results: [
+        {
+          ...startProgress.results[0],
+          accountId: "account-enabled",
+          accountName: "Enabled Site",
+        },
+      ],
+    }
+
+    sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
+      if (message === AccountKeyRepairMessageTypes.GetProgress) {
+        return { success: true, data: idleProgress }
+      }
+      if (message === AccountKeyRepairMessageTypes.Start) {
+        return { success: true, data: visibleNoneAuthProgress }
+      }
+      return { success: false }
+    })
+
+    render(<KeyManagement />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:repairMissingKeys.action",
+      }),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.start",
+      }),
+    )
+
+    expect(await screen.findByText("Enabled Site")).toBeInTheDocument()
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.skipReasons.noneAuth"),
+    ).toBeInTheDocument()
+  })
+
   it("supports search and outcome filtering in the dialog", async () => {
     sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
       if (message === AccountKeyRepairMessageTypes.GetProgress) {

--- a/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+++ b/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
@@ -9,7 +9,10 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_STATUS_KINDS,
 } from "~/services/productAnalytics/events"
-import type { AccountKeyRepairProgress } from "~/types/accountKeyAutoProvisioning"
+import {
+  ACCOUNT_KEY_REPAIR_SKIP_REASONS,
+  type AccountKeyRepairProgress,
+} from "~/types/accountKeyAutoProvisioning"
 import {
   act,
   fireEvent,
@@ -200,7 +203,7 @@ const startProgress: AccountKeyRepairProgress = {
       siteType: "unknown",
       siteUrlOrigin: "https://disabled.example.com",
       outcome: "skipped",
-      skipReason: "noneAuth",
+      skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth,
       finishedAt: 1,
     },
     {
@@ -320,7 +323,7 @@ const inflatedProgress: AccountKeyRepairProgress = {
       siteType: "unknown",
       siteUrlOrigin: "https://disabled.example.com",
       outcome: "skipped",
-      skipReason: "noneAuth",
+      skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth,
       finishedAt: 1,
     },
     {
@@ -345,7 +348,7 @@ const inflatedProgress: AccountKeyRepairProgress = {
       siteType: "unknown",
       siteUrlOrigin: "https://disabled-2.example.com",
       outcome: "skipped",
-      skipReason: "sub2api",
+      skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
       finishedAt: 2,
     },
     {
@@ -384,7 +387,7 @@ const sub2apiSkippedProgress: AccountKeyRepairProgress = {
       siteType: "sub2api",
       siteUrlOrigin: "https://another.example.com",
       outcome: "skipped",
-      skipReason: "sub2api",
+      skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
       finishedAt: 1,
     },
   ],
@@ -415,7 +418,7 @@ const aihubmixSkippedProgress: AccountKeyRepairProgress = {
       siteType: "AIHubMix",
       siteUrlOrigin: "https://aihubmix.com",
       outcome: "skipped",
-      skipReason: "aihubmixOneTimeKey",
+      skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
       finishedAt: 1,
     },
   ],

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -24,6 +24,75 @@ const {
   toastErrorMock: vi.fn(),
 }))
 
+const normalizeGroupNames = (groups: Record<string, unknown>): string[] =>
+  Array.from(
+    new Set(
+      Object.keys(groups)
+        .map((group) => group.trim())
+        .filter(Boolean),
+    ),
+  )
+
+const createSub2ApiTokenProvisioningMock = () => ({
+  isInventoryTokenUsable: vi.fn(() => true),
+  resolveDefaultTokenCreation: vi.fn((request: any) => {
+    const explicitGroup =
+      typeof request.explicitGroup === "string"
+        ? request.explicitGroup.trim()
+        : ""
+
+    if (explicitGroup) {
+      return {
+        kind: "create",
+        tokenData: { ...request.defaultTokenData, group: explicitGroup },
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }
+    }
+
+    if (
+      request.workflow !== "quick_create_selection" &&
+      request.workflow !== "post_save_automation"
+    ) {
+      return { kind: "blocked", reason: "group_required" }
+    }
+
+    if (!request.userGroups) {
+      return { kind: "needs_user_groups" }
+    }
+
+    const allowedGroups = normalizeGroupNames(request.userGroups)
+
+    if (allowedGroups.length === 0) {
+      return { kind: "blocked", reason: "available_group_required" }
+    }
+
+    if (allowedGroups.length === 1) {
+      return {
+        kind: "create",
+        tokenData: { ...request.defaultTokenData, group: allowedGroups[0] },
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }
+    }
+
+    return {
+      kind: "selection_required",
+      allowedGroups,
+      reason: "group_selection_required",
+    }
+  }),
+  classifyCreatedToken: vi.fn(({ result }: any) =>
+    result
+      ? { kind: "needs_inventory_refetch" }
+      : { kind: "failed", reason: "create_failed" },
+  ),
+  getRepairPolicy: vi.fn(() => ({
+    kind: "skipped" as const,
+    skipReason: "sub2api" as const,
+  })),
+})
+
 vi.mock("react-hot-toast", () => ({
   default: {
     success: toastSuccessMock,
@@ -56,6 +125,7 @@ vi.mock("~/services/apiAdapters/registry", () => ({
         fetch: (...args: any[]) => fetchUserGroupsMock(...args),
       },
     },
+    tokenProvisioning: createSub2ApiTokenProvisioningMock(),
   }),
 }))
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
@@ -98,9 +99,9 @@ const createSub2ApiTokenProvisioningMock = () => ({
   }),
   classifyCreatedToken: vi.fn(({ result }: any) =>
     result
-      ? { kind: "needs_inventory_refetch" }
+      ? { kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch }
       : {
-          kind: "failed",
+          kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
           reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
         },
   ),

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
+import { TOKEN_CREATION_SECRET_RECOVERY } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import {
   buildSub2ApiAccount,
   buildSub2ApiToken,
@@ -46,7 +47,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
         kind: "create",
         tokenData: { ...request.defaultTokenData, group: explicitGroup },
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       }
     }
 
@@ -72,7 +73,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
         kind: "create",
         tokenData: { ...request.defaultTokenData, group: allowedGroups[0] },
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       }
     }
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
@@ -49,7 +51,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
 
     if (explicitGroup) {
       return {
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: { ...request.defaultTokenData, group: explicitGroup },
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -61,27 +63,27 @@ const createSub2ApiTokenProvisioningMock = () => ({
       request.workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation
     ) {
       return {
-        kind: "blocked",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
       }
     }
 
     if (!request.userGroups) {
-      return { kind: "needs_user_groups" }
+      return { kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups }
     }
 
     const allowedGroups = normalizeGroupNames(request.userGroups)
 
     if (allowedGroups.length === 0) {
       return {
-        kind: "blocked",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
       }
     }
 
     if (allowedGroups.length === 1) {
       return {
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: { ...request.defaultTokenData, group: allowedGroups[0] },
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -89,7 +91,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
     }
 
     return {
-      kind: "selection_required",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
       allowedGroups,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
     }
@@ -103,7 +105,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
         },
   ),
   getRepairPolicy: vi.fn(() => ({
-    kind: "skipped" as const,
+    kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
     skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
   })),
 })

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -2,7 +2,12 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
-import { TOKEN_CREATION_SECRET_RECOVERY } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import {
+  TOKEN_CREATION_SECRET_RECOVERY,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
 import {
   buildSub2ApiAccount,
   buildSub2ApiToken,
@@ -52,10 +57,13 @@ const createSub2ApiTokenProvisioningMock = () => ({
     }
 
     if (
-      request.workflow !== "quick_create_selection" &&
-      request.workflow !== "post_save_automation"
+      request.workflow !== TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection &&
+      request.workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation
     ) {
-      return { kind: "blocked", reason: "group_required" }
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
+      }
     }
 
     if (!request.userGroups) {
@@ -65,7 +73,10 @@ const createSub2ApiTokenProvisioningMock = () => ({
     const allowedGroups = normalizeGroupNames(request.userGroups)
 
     if (allowedGroups.length === 0) {
-      return { kind: "blocked", reason: "available_group_required" }
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
+      }
     }
 
     if (allowedGroups.length === 1) {
@@ -80,17 +91,20 @@ const createSub2ApiTokenProvisioningMock = () => ({
     return {
       kind: "selection_required",
       allowedGroups,
-      reason: "group_selection_required",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
     }
   }),
   classifyCreatedToken: vi.fn(({ result }: any) =>
     result
       ? { kind: "needs_inventory_refetch" }
-      : { kind: "failed", reason: "create_failed" },
+      : {
+          kind: "failed",
+          reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+        },
   ),
   getRepairPolicy: vi.fn(() => ({
     kind: "skipped" as const,
-    skipReason: "sub2api" as const,
+    skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
   })),
 })
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -5,7 +5,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
-import { TOKEN_CREATION_SECRET_RECOVERY } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import {
+  TOKEN_CREATION_SECRET_RECOVERY,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -17,6 +21,7 @@ import {
 } from "~/services/productAnalytics/events"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { AuthTypeEnum } from "~/types"
+import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
@@ -74,10 +79,13 @@ const createSub2ApiTokenProvisioningMock = () => ({
     }
 
     if (
-      request.workflow !== "quick_create_selection" &&
-      request.workflow !== "post_save_automation"
+      request.workflow !== TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection &&
+      request.workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation
     ) {
-      return { kind: "blocked", reason: "group_required" }
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
+      }
     }
 
     if (!request.userGroups) {
@@ -87,7 +95,10 @@ const createSub2ApiTokenProvisioningMock = () => ({
     const allowedGroups = normalizeGroupNames(request.userGroups)
 
     if (allowedGroups.length === 0) {
-      return { kind: "blocked", reason: "available_group_required" }
+      return {
+        kind: "blocked",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
+      }
     }
 
     if (allowedGroups.length === 1) {
@@ -102,17 +113,20 @@ const createSub2ApiTokenProvisioningMock = () => ({
     return {
       kind: "selection_required",
       allowedGroups,
-      reason: "group_selection_required",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
     }
   }),
   classifyCreatedToken: vi.fn(({ result }: any) =>
     result
       ? { kind: "needs_inventory_refetch" }
-      : { kind: "failed", reason: "create_failed" },
+      : {
+          kind: "failed",
+          reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+        },
   ),
   getRepairPolicy: vi.fn(() => ({
     kind: "skipped" as const,
-    skipReason: "sub2api" as const,
+    skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
   })),
 })
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -282,6 +282,25 @@ describe("CopyKeyDialog", () => {
     })
   })
 
+  it("shows a create failure when default key creation returns false", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(false)
+
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.copyKey.createKey",
+      }),
+    )
+
+    expect(
+      await screen.findByText("ui:dialog.copyKey.createFailed"),
+    ).toBeInTheDocument()
+  })
+
   it("shows a one-time key dialog when AIHubMix create returns a full token", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     createApiTokenMock.mockResolvedValueOnce({

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
+import { TOKEN_CREATION_SECRET_RECOVERY } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -68,7 +69,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
         kind: "create",
         tokenData: { ...request.defaultTokenData, group: explicitGroup },
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       }
     }
 
@@ -94,7 +95,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
         kind: "create",
         tokenData: { ...request.defaultTokenData, group: allowedGroups[0] },
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       }
     }
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -6,8 +6,10 @@ import { SITE_TYPES } from "~/constants/siteType"
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
@@ -71,7 +73,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
 
     if (explicitGroup) {
       return {
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: { ...request.defaultTokenData, group: explicitGroup },
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -83,27 +85,27 @@ const createSub2ApiTokenProvisioningMock = () => ({
       request.workflow !== TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation
     ) {
       return {
-        kind: "blocked",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
       }
     }
 
     if (!request.userGroups) {
-      return { kind: "needs_user_groups" }
+      return { kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups }
     }
 
     const allowedGroups = normalizeGroupNames(request.userGroups)
 
     if (allowedGroups.length === 0) {
       return {
-        kind: "blocked",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
       }
     }
 
     if (allowedGroups.length === 1) {
       return {
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: { ...request.defaultTokenData, group: allowedGroups[0] },
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -111,7 +113,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
     }
 
     return {
-      kind: "selection_required",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
       allowedGroups,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
     }
@@ -125,7 +127,7 @@ const createSub2ApiTokenProvisioningMock = () => ({
         },
   ),
   getRepairPolicy: vi.fn(() => ({
-    kind: "skipped" as const,
+    kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
     skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
   })),
 })

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -46,6 +46,75 @@ const {
   createApiCredentialProfileMock: vi.fn(),
 }))
 
+const normalizeGroupNames = (groups: Record<string, unknown>): string[] =>
+  Array.from(
+    new Set(
+      Object.keys(groups)
+        .map((group) => group.trim())
+        .filter(Boolean),
+    ),
+  )
+
+const createSub2ApiTokenProvisioningMock = () => ({
+  isInventoryTokenUsable: vi.fn(() => true),
+  resolveDefaultTokenCreation: vi.fn((request: any) => {
+    const explicitGroup =
+      typeof request.explicitGroup === "string"
+        ? request.explicitGroup.trim()
+        : ""
+
+    if (explicitGroup) {
+      return {
+        kind: "create",
+        tokenData: { ...request.defaultTokenData, group: explicitGroup },
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }
+    }
+
+    if (
+      request.workflow !== "quick_create_selection" &&
+      request.workflow !== "post_save_automation"
+    ) {
+      return { kind: "blocked", reason: "group_required" }
+    }
+
+    if (!request.userGroups) {
+      return { kind: "needs_user_groups" }
+    }
+
+    const allowedGroups = normalizeGroupNames(request.userGroups)
+
+    if (allowedGroups.length === 0) {
+      return { kind: "blocked", reason: "available_group_required" }
+    }
+
+    if (allowedGroups.length === 1) {
+      return {
+        kind: "create",
+        tokenData: { ...request.defaultTokenData, group: allowedGroups[0] },
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }
+    }
+
+    return {
+      kind: "selection_required",
+      allowedGroups,
+      reason: "group_selection_required",
+    }
+  }),
+  classifyCreatedToken: vi.fn(({ result }: any) =>
+    result
+      ? { kind: "needs_inventory_refetch" }
+      : { kind: "failed", reason: "create_failed" },
+  ),
+  getRepairPolicy: vi.fn(() => ({
+    kind: "skipped" as const,
+    skipReason: "sub2api" as const,
+  })),
+})
+
 vi.mock("react-hot-toast", () => ({
   default: {
     success: toastSuccessMock,
@@ -74,6 +143,7 @@ vi.mock("~/services/apiAdapters/registry", () => ({
         fetch: (...args: any[]) => fetchUserGroupsMock(...args),
       },
     },
+    tokenProvisioning: createSub2ApiTokenProvisioningMock(),
   }),
 }))
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -6,6 +6,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
@@ -120,9 +121,9 @@ const createSub2ApiTokenProvisioningMock = () => ({
   }),
   classifyCreatedToken: vi.fn(({ result }: any) =>
     result
-      ? { kind: "needs_inventory_refetch" }
+      ? { kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch }
       : {
-          kind: "failed",
+          kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
           reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
         },
   ),

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -2293,6 +2293,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         createToken: vi.fn(),
         resolveTokenKey: vi.fn(),
       } as any,
+      tokenProvisioning: undefined,
       request: { accountId: savedDisplayData.id } as any,
     })
     mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
@@ -2401,6 +2402,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         createToken: vi.fn(),
         resolveTokenKey: vi.fn(),
       } as any,
+      tokenProvisioning: undefined,
       request: { accountId: savedDisplayData.id } as any,
     })
     mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({
@@ -2502,6 +2504,7 @@ describe("useAccountDialog save and auto-config flows", () => {
         createToken: vi.fn(),
         resolveTokenKey: vi.fn(),
       } as any,
+      tokenProvisioning: undefined,
       request: { accountId: savedDisplayData.id } as any,
     })
     mockEnsureAccountTokenForPostSaveWorkflow.mockResolvedValue({

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -11,9 +11,11 @@ import {
   ensureAccountKeysForAvailableGroups,
 } from "~/services/accounts/accountKeyAutoProvisioning/groupCoverage"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_ERRORS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum } from "~/types"
@@ -51,7 +53,9 @@ vi.mock("~/services/apiAdapters/registry", () => ({
         mocks.resolveDefaultTokenCreation(...args),
       classifyCreatedToken: (...args: unknown[]) =>
         mocks.classifyCreatedToken(...args),
-      getRepairPolicy: vi.fn(() => ({ kind: "eligible" })),
+      getRepairPolicy: vi.fn(() => ({
+        kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
+      })),
     },
   })),
 }))
@@ -103,7 +107,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     mocks.classifyCreatedToken.mockReset()
     mocks.resolveDefaultTokenCreation.mockImplementation(
       ({ defaultTokenData }) => ({
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: defaultTokenData,
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -223,7 +227,9 @@ describe("ensureAccountKeysForAvailableGroups", () => {
           mocks.resolveDefaultTokenCreation(...args),
         classifyCreatedToken: (...args: unknown[]) =>
           mocks.classifyCreatedToken(...args),
-        getRepairPolicy: vi.fn(() => ({ kind: "eligible" })),
+        getRepairPolicy: vi.fn(() => ({
+          kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
+        })),
       },
     })
     mocks.createApiToken.mockResolvedValue(true)
@@ -258,7 +264,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     mocks.fetchAccountTokens.mockResolvedValue([])
     mocks.fetchUserGroups.mockResolvedValue({})
     mocks.resolveDefaultTokenCreation.mockReturnValueOnce({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
     })
 
@@ -273,7 +279,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     mocks.fetchAccountTokens.mockResolvedValue([])
     mocks.fetchUserGroups.mockResolvedValue({})
     mocks.resolveDefaultTokenCreation.mockReturnValueOnce({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
     })
 

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -11,6 +11,7 @@ import {
   ensureAccountKeysForAvailableGroups,
 } from "~/services/accounts/accountKeyAutoProvisioning/groupCoverage"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
@@ -114,7 +115,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
       }),
     )
     mocks.classifyCreatedToken.mockReturnValue({
-      kind: "needs_inventory_refetch",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
     })
   })
 
@@ -295,7 +296,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     mocks.fetchUserGroups.mockResolvedValue({})
     mocks.createApiToken.mockResolvedValueOnce(false)
     mocks.classifyCreatedToken.mockReturnValueOnce({
-      kind: "failed",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
     })
 

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -10,6 +10,10 @@ import {
   deleteInvalidAccountToken,
   ensureAccountKeysForAvailableGroups,
 } from "~/services/accounts/accountKeyAutoProvisioning/groupCoverage"
+import {
+  TOKEN_CREATION_SECRET_RECOVERY,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum } from "~/types"
 import { ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS } from "~/types/accountKeyAutoProvisioning"
 import {
@@ -100,7 +104,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
         kind: "create",
         tokenData: defaultTokenData,
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       }),
     )
     mocks.classifyCreatedToken.mockReturnValue({
@@ -246,6 +250,48 @@ describe("ensureAccountKeysForAvailableGroups", () => {
       }),
     )
     expect(mocks.fetchUserGroups).not.toHaveBeenCalled()
+  })
+
+  it("blocks legacy one-key repair when policy requires a one-time secret dialog", async () => {
+    mocks.fetchAccountTokens.mockResolvedValue([])
+    mocks.fetchUserGroups.mockResolvedValue({})
+    mocks.resolveDefaultTokenCreation.mockReturnValueOnce({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
+    })
+
+    await expect(runCoverage()).rejects.toThrow(
+      "messages:aihubmix.createRequiresOneTimeKeyDialog",
+    )
+
+    expect(mocks.createApiToken).not.toHaveBeenCalled()
+  })
+
+  it("blocks legacy one-key repair when policy rejects default creation", async () => {
+    mocks.fetchAccountTokens.mockResolvedValue([])
+    mocks.fetchUserGroups.mockResolvedValue({})
+    mocks.resolveDefaultTokenCreation.mockReturnValueOnce({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
+    })
+
+    await expect(runCoverage()).rejects.toThrow(
+      "messages:sub2api.createRequiresGroup",
+    )
+
+    expect(mocks.createApiToken).not.toHaveBeenCalled()
+  })
+
+  it("fails legacy one-key repair when token creation is rejected", async () => {
+    mocks.fetchAccountTokens.mockResolvedValue([])
+    mocks.fetchUserGroups.mockResolvedValue({})
+    mocks.createApiToken.mockResolvedValueOnce(false)
+    mocks.classifyCreatedToken.mockReturnValueOnce({
+      kind: "failed",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+    })
+
+    await expect(runCoverage()).rejects.toThrow("create_token_failed")
   })
 
   it("treats empty group responses as legacy one-key coverage when a token already exists", async () => {

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -23,6 +23,8 @@ const mocks = vi.hoisted(() => ({
   fetchUserGroups: vi.fn(),
   createApiToken: vi.fn(),
   deleteApiToken: vi.fn(),
+  resolveDefaultTokenCreation: vi.fn(),
+  classifyCreatedToken: vi.fn(),
 }))
 
 vi.mock("~/services/apiAdapters/registry", () => ({
@@ -36,6 +38,14 @@ vi.mock("~/services/apiAdapters/registry", () => ({
       deleteToken: (...args: unknown[]) => mocks.deleteApiToken(...args),
       resolveTokenKey: vi.fn(),
       fetchAvailableModels: vi.fn(),
+    },
+    tokenProvisioning: {
+      isInventoryTokenUsable: vi.fn(() => true),
+      resolveDefaultTokenCreation: (...args: unknown[]) =>
+        mocks.resolveDefaultTokenCreation(...args),
+      classifyCreatedToken: (...args: unknown[]) =>
+        mocks.classifyCreatedToken(...args),
+      getRepairPolicy: vi.fn(() => ({ kind: "eligible" })),
     },
   })),
 }))
@@ -83,6 +93,19 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     mocks.fetchUserGroups.mockReset()
     mocks.createApiToken.mockReset()
     mocks.deleteApiToken.mockReset()
+    mocks.resolveDefaultTokenCreation.mockReset()
+    mocks.classifyCreatedToken.mockReset()
+    mocks.resolveDefaultTokenCreation.mockImplementation(
+      ({ defaultTokenData }) => ({
+        kind: "create",
+        tokenData: defaultTokenData,
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }),
+    )
+    mocks.classifyCreatedToken.mockReturnValue({
+      kind: "needs_inventory_refetch",
+    })
   })
 
   it("creates missing group keys and reports tokens tied to unavailable groups", async () => {
@@ -188,6 +211,14 @@ describe("ensureAccountKeysForAvailableGroups", () => {
         resolveTokenKey: vi.fn(),
         fetchAvailableModels: vi.fn(),
       },
+      tokenProvisioning: {
+        isInventoryTokenUsable: vi.fn(() => true),
+        resolveDefaultTokenCreation: (...args: unknown[]) =>
+          mocks.resolveDefaultTokenCreation(...args),
+        classifyCreatedToken: (...args: unknown[]) =>
+          mocks.classifyCreatedToken(...args),
+        getRepairPolicy: vi.fn(() => ({ kind: "eligible" })),
+      },
     })
     mocks.createApiToken.mockResolvedValue(true)
 
@@ -207,6 +238,12 @@ describe("ensureAccountKeysForAvailableGroups", () => {
         accountId: "new-api-1",
       }),
       generateDefaultTokenRequest(),
+    )
+    expect(mocks.resolveDefaultTokenCreation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflow: "repair",
+        defaultTokenData: generateDefaultTokenRequest(),
+      }),
     )
     expect(mocks.fetchUserGroups).not.toHaveBeenCalled()
   })

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -13,6 +13,8 @@ import {
 import {
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_ERRORS,
+  TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum } from "~/types"
 import { ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS } from "~/types/accountKeyAutoProvisioning"
@@ -245,7 +247,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     )
     expect(mocks.resolveDefaultTokenCreation).toHaveBeenCalledWith(
       expect.objectContaining({
-        workflow: "repair",
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.Repair,
         defaultTokenData: generateDefaultTokenRequest(),
       }),
     )
@@ -291,7 +293,9 @@ describe("ensureAccountKeysForAvailableGroups", () => {
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
     })
 
-    await expect(runCoverage()).rejects.toThrow("create_token_failed")
+    await expect(runCoverage()).rejects.toThrow(
+      TOKEN_PROVISIONING_ERRORS.CreateTokenFailed,
+    )
   })
 
   it("treats empty group responses as legacy one-key coverage when a token already exists", async () => {

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -7,6 +7,8 @@ import { AuthTypeEnum } from "~/types"
 import {
   ACCOUNT_KEY_REPAIR_ERRORS,
   ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
+  ACCOUNT_KEY_REPAIR_JOB_STATES,
+  ACCOUNT_KEY_REPAIR_OUTCOMES,
   ACCOUNT_KEY_REPAIR_SKIP_REASONS,
 } from "~/types/accountKeyAutoProvisioning"
 import {
@@ -115,7 +117,7 @@ describe("accountKeyRepair", () => {
 
     await expect(accountKeyRepairRunner.getProgress()).resolves.toEqual({
       jobId: "idle",
-      state: "idle",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Idle,
       totals: {
         enabledAccounts: 0,
         eligibleAccounts: 0,
@@ -135,7 +137,7 @@ describe("accountKeyRepair", () => {
   it("returns stored progress snapshots when a previous repair run was persisted", async () => {
     mocks.storageMap.set("accountKeyRepair_progress", {
       jobId: "job-stored",
-      state: "completed",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
       totals: {
         enabledAccounts: 4,
         eligibleAccounts: 3,
@@ -148,7 +150,9 @@ describe("accountKeyRepair", () => {
         skipped: 1,
         failed: 0,
       },
-      results: [{ accountId: "acc-1", outcome: "created" }],
+      results: [
+        { accountId: "acc-1", outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created },
+      ],
     })
 
     const { accountKeyRepairRunner } = await import(
@@ -157,7 +161,7 @@ describe("accountKeyRepair", () => {
 
     await expect(accountKeyRepairRunner.getProgress()).resolves.toMatchObject({
       jobId: "job-stored",
-      state: "completed",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
       summary: {
         created: 1,
         alreadyHad: 1,
@@ -281,12 +285,12 @@ describe("accountKeyRepair", () => {
     const started = await accountKeyRepairRunner.start()
     expect(started).toMatchObject({
       jobId: "job-123",
-      state: "running",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
     })
 
     await vi.waitFor(async () => {
       const progress = await accountKeyRepairRunner.getProgress()
-      expect(progress.state).toBe("completed")
+      expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
     })
 
     const progress = await accountKeyRepairRunner.getProgress()
@@ -312,24 +316,24 @@ describe("accountKeyRepair", () => {
       expect.arrayContaining([
         expect.objectContaining({
           accountId: "sub2api-1",
-          outcome: "skipped",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
           skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
           siteUrlOrigin: "https://sub2api.example.com",
         }),
         expect.objectContaining({
           accountId: "aihubmix-1",
-          outcome: "skipped",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
           skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
           siteUrlOrigin: "https://aihubmix.com",
         }),
         expect.objectContaining({
           accountId: "new-api-1",
-          outcome: "created",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
           siteUrlOrigin: "https://shared.example.com",
         }),
         expect.objectContaining({
           accountId: "bad-cookie-1",
-          outcome: "failed",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Failed,
           errorMessage: ACCOUNT_KEY_REPAIR_ERRORS.InvalidDisplaySiteData,
           siteUrlOrigin: "https://cookie.example.com",
         }),
@@ -405,7 +409,7 @@ describe("accountKeyRepair", () => {
 
     await vi.waitFor(async () => {
       const progress = await accountKeyRepairRunner.getProgress()
-      expect(progress.state).toBe("completed")
+      expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
     })
 
     const progress = await accountKeyRepairRunner.getProgress()
@@ -422,7 +426,7 @@ describe("accountKeyRepair", () => {
     expect(progress.results).toEqual([
       expect.objectContaining({
         accountId: "new-api-1",
-        outcome: "created",
+        outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
         availableGroups: ["default", "vip"],
         coveredGroups: ["default", "vip"],
         createdGroups: ["vip"],
@@ -487,7 +491,7 @@ describe("accountKeyRepair", () => {
 
     await vi.waitFor(async () => {
       const progress = await accountKeyRepairRunner.getProgress()
-      expect(progress.state).toBe("completed")
+      expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
     })
 
     const progress = await accountKeyRepairRunner.getProgress()
@@ -502,7 +506,7 @@ describe("accountKeyRepair", () => {
     expect(progress.results).toEqual([
       expect.objectContaining({
         accountId: "new-api-1",
-        outcome: "failed",
+        outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Failed,
         availableGroups: ["default", "vip"],
         coveredGroups: ["default"],
         missingGroups: ["vip"],
@@ -662,7 +666,7 @@ describe("accountKeyRepair", () => {
 
     mocks.storageMap.set("accountKeyRepair_progress", {
       jobId: "job-stored",
-      state: "completed",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
       startedAt: 100,
       updatedAt: 200,
       finishedAt: 300,
@@ -690,7 +694,7 @@ describe("accountKeyRepair", () => {
           accountName: "Relay Account",
           siteType: SITE_TYPES.NEW_API,
           siteUrlOrigin: "https://relay.example.com",
-          outcome: "created",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
           availableGroups: ["default", "vip"],
           coveredGroups: ["default", "vip"],
           createdGroups: ["vip"],
@@ -722,7 +726,7 @@ describe("accountKeyRepair", () => {
 
     expect(mocks.storageMap.get("accountKeyRepair_progress")).toMatchObject({
       jobId: "job-stored",
-      state: "completed",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
       totals: {
         enabledAccounts: 1,
         eligibleAccounts: 1,
@@ -744,7 +748,7 @@ describe("accountKeyRepair", () => {
       results: [
         expect.objectContaining({
           accountId: "new-api-1",
-          outcome: "created",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
           invalidTokens: [invalidTokens[1]],
         }),
       ],
@@ -826,7 +830,7 @@ describe("accountKeyRepair", () => {
 
     mocks.storageMap.set("accountKeyRepair_progress", {
       jobId: "job-stored",
-      state: "completed",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
       startedAt: 100,
       updatedAt: 200,
       finishedAt: 300,
@@ -854,7 +858,7 @@ describe("accountKeyRepair", () => {
           accountName: "Relay Account",
           siteType: SITE_TYPES.NEW_API,
           siteUrlOrigin: "https://relay.example.com",
-          outcome: "created",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
           availableGroups: ["default", "vip"],
           coveredGroups: ["default", "vip"],
           createdGroups: ["vip"],
@@ -1019,7 +1023,7 @@ describe("accountKeyRepair", () => {
 
     await vi.waitFor(async () => {
       const progress = await accountKeyRepairRunner.getProgress()
-      expect(progress.state).toBe("completed")
+      expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
     })
 
     const progress = await accountKeyRepairRunner.getProgress()
@@ -1045,12 +1049,12 @@ describe("accountKeyRepair", () => {
       expect.arrayContaining([
         expect.objectContaining({
           accountId: "none-auth-1",
-          outcome: "skipped",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
           skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth,
         }),
         expect.objectContaining({
           accountId: "cookie-1",
-          outcome: "alreadyHad",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad,
           siteUrlOrigin: "https://cookie.example.com",
         }),
       ]),
@@ -1137,7 +1141,7 @@ describe("accountKeyRepair", () => {
 
     await vi.waitFor(async () => {
       const progress = await accountKeyRepairRunner.getProgress()
-      expect(progress.state).toBe("completed")
+      expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
     })
   })
 
@@ -1151,17 +1155,17 @@ describe("accountKeyRepair", () => {
     const started = await accountKeyRepairRunner.start()
     expect(started).toMatchObject({
       jobId: "job-123",
-      state: "running",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
     })
 
     await vi.waitFor(async () => {
       const progress = await accountKeyRepairRunner.getProgress()
-      expect(progress.state).toBe("failed")
+      expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Failed)
     })
 
     await expect(accountKeyRepairRunner.getProgress()).resolves.toMatchObject({
       jobId: "job-123",
-      state: "failed",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Failed,
       lastError: "boom",
     })
   })
@@ -1178,7 +1182,7 @@ describe("accountKeyRepair", () => {
       success: true,
       data: expect.objectContaining({
         jobId: "job-123",
-        state: "running",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
       }),
     })
 
@@ -1194,7 +1198,7 @@ describe("accountKeyRepair", () => {
       success: true,
       data: expect.objectContaining({
         jobId: "job-123",
-        state: "running",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
       }),
     })
   })

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
+import { TOKEN_PROVISIONING_REPAIR_POLICY_KINDS } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum } from "~/types"
 import {
   ACCOUNT_KEY_REPAIR_ERRORS,
@@ -63,19 +64,21 @@ vi.mock("~/services/apiAdapters/registry", () => ({
       siteType === SITE_TYPES.SUB2API
         ? {
             getRepairPolicy: () => ({
-              kind: "skipped",
+              kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
               skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
             }),
           }
         : siteType === SITE_TYPES.AIHUBMIX
           ? {
               getRepairPolicy: () => ({
-                kind: "skipped",
+                kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
                 skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
               }),
             }
           : {
-              getRepairPolicy: () => ({ kind: "eligible" }),
+              getRepairPolicy: () => ({
+                kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
+              }),
             },
   })),
 }))

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -52,6 +52,30 @@ vi.mock("~/services/accounts/accountKeyAutoProvisioning/groupCoverage", () => ({
   deleteInvalidAccountToken: mocks.deleteInvalidAccountToken,
 }))
 
+vi.mock("~/services/apiAdapters/registry", () => ({
+  getSiteAdapter: vi.fn((siteType: string) => ({
+    siteType,
+    tokenProvisioning:
+      siteType === SITE_TYPES.SUB2API
+        ? {
+            getRepairPolicy: () => ({
+              kind: "skipped",
+              skipReason: "sub2api",
+            }),
+          }
+        : siteType === SITE_TYPES.AIHUBMIX
+          ? {
+              getRepairPolicy: () => ({
+                kind: "skipped",
+                skipReason: "aihubmixOneTimeKey",
+              }),
+            }
+          : {
+              getRepairPolicy: () => ({ kind: "eligible" }),
+            },
+  })),
+}))
+
 vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("~/utils/browser/browserApi")>()

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import { AuthTypeEnum } from "~/types"
-import { ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS } from "~/types/accountKeyAutoProvisioning"
+import {
+  ACCOUNT_KEY_REPAIR_ERRORS,
+  ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
+  ACCOUNT_KEY_REPAIR_SKIP_REASONS,
+} from "~/types/accountKeyAutoProvisioning"
 import {
   buildDisplaySiteData,
   buildSiteAccount,
@@ -60,14 +64,14 @@ vi.mock("~/services/apiAdapters/registry", () => ({
         ? {
             getRepairPolicy: () => ({
               kind: "skipped",
-              skipReason: "sub2api",
+              skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
             }),
           }
         : siteType === SITE_TYPES.AIHUBMIX
           ? {
               getRepairPolicy: () => ({
                 kind: "skipped",
-                skipReason: "aihubmixOneTimeKey",
+                skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
               }),
             }
           : {
@@ -306,13 +310,13 @@ describe("accountKeyRepair", () => {
         expect.objectContaining({
           accountId: "sub2api-1",
           outcome: "skipped",
-          skipReason: "sub2api",
+          skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
           siteUrlOrigin: "https://sub2api.example.com",
         }),
         expect.objectContaining({
           accountId: "aihubmix-1",
           outcome: "skipped",
-          skipReason: "aihubmixOneTimeKey",
+          skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
           siteUrlOrigin: "https://aihubmix.com",
         }),
         expect.objectContaining({
@@ -323,7 +327,7 @@ describe("accountKeyRepair", () => {
         expect.objectContaining({
           accountId: "bad-cookie-1",
           outcome: "failed",
-          errorMessage: "invalid_display_site_data",
+          errorMessage: ACCOUNT_KEY_REPAIR_ERRORS.InvalidDisplaySiteData,
           siteUrlOrigin: "https://cookie.example.com",
         }),
       ]),
@@ -923,7 +927,7 @@ describe("accountKeyRepair", () => {
         failed: [
           {
             ...invalidToken,
-            errorMessage: "account_not_found",
+            errorMessage: ACCOUNT_KEY_REPAIR_ERRORS.AccountNotFound,
           },
         ],
       },
@@ -1039,7 +1043,7 @@ describe("accountKeyRepair", () => {
         expect.objectContaining({
           accountId: "none-auth-1",
           outcome: "skipped",
-          skipReason: "noneAuth",
+          skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth,
         }),
         expect.objectContaining({
           accountId: "cookie-1",

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -942,6 +942,69 @@ describe("accountKeyRepair", () => {
     expect(mocks.deleteInvalidAccountToken).not.toHaveBeenCalled()
   })
 
+  it("uses the delete-failed fallback when invalid token deletion rejects without a message", async () => {
+    const account = buildSiteAccount({
+      id: "new-api-1",
+      site_type: "new-api",
+      site_url: "https://relay.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "101",
+        access_token: "access-token",
+        username: "valid",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const displayAccount = buildDisplaySiteData({
+      id: account.id,
+      name: "Relay Account",
+      baseUrl: account.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "101",
+      token: "access-token",
+    })
+    const invalidToken = {
+      accountId: "new-api-1",
+      accountName: "Relay Account",
+      siteType: SITE_TYPES.NEW_API,
+      siteUrlOrigin: "https://relay.example.com",
+      tokenId: 9,
+      tokenName: "old one",
+      group: "old",
+      reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+    }
+
+    mocks.getAllAccounts.mockResolvedValue([account])
+    mocks.convertToDisplayData.mockReturnValue([displayAccount])
+    mocks.deleteInvalidAccountToken.mockRejectedValueOnce({})
+
+    const { deleteInvalidAccountTokens } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await expect(
+      deleteInvalidAccountTokens({ tokens: [invalidToken] }),
+    ).resolves.toEqual({
+      success: true,
+      data: {
+        deleted: [],
+        failed: [
+          {
+            ...invalidToken,
+            errorMessage: ACCOUNT_KEY_REPAIR_ERRORS.DeleteFailed,
+          },
+        ],
+      },
+    })
+  })
+
   it("skips none-auth accounts, ignores disabled accounts, and falls back to per-account display conversion", async () => {
     const noneAuthAccount = buildSiteAccount({
       id: "none-auth-1",

--- a/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
+++ b/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_PREFERENCES,
   userPreferences,
 } from "~/services/preferences/userPreferences"
-import { AuthTypeEnum, type CheckInConfig } from "~/types"
+import { AuthTypeEnum, type CheckInConfig, type DisplaySiteData } from "~/types"
 
 const {
   fetchAccountDataMock,
@@ -368,7 +368,9 @@ describe("accountOperations auto-provision key on add", () => {
   })
 
   it("shows failure feedback when saved account display data is invalid for auto-provision", async () => {
-    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValueOnce({
+    // Intentionally omit required DisplaySiteData fields to exercise the
+    // defensive validation branch used when storage returns malformed data.
+    const invalidDisplaySiteData: Partial<DisplaySiteData> = {
       id: "invalid-display-account",
       name: "Invalid Display",
       siteType: SITE_TYPES.NEW_API,
@@ -377,7 +379,10 @@ describe("accountOperations auto-provision key on add", () => {
       userId: "1",
       token: "",
       cookieAuthSessionCookie: "",
-    } as any)
+    }
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValueOnce(
+      invalidDisplaySiteData as DisplaySiteData,
+    )
 
     const result = await validateAndSaveAccount(
       "https://api.example.com",

--- a/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
+++ b/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
@@ -366,4 +366,41 @@ describe("accountOperations auto-provision key on add", () => {
     expect(toastSuccessMock).not.toHaveBeenCalled()
     expect(toastErrorMock).toHaveBeenCalledTimes(1)
   })
+
+  it("shows failure feedback when saved account display data is invalid for auto-provision", async () => {
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValueOnce({
+      id: "invalid-display-account",
+      name: "Invalid Display",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://api.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      userId: "1",
+      token: "",
+      cookieAuthSessionCookie: "",
+    } as any)
+
+    const result = await validateAndSaveAccount(
+      "https://api.example.com",
+      "Test Site",
+      "tester",
+      "test-token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      "unknown",
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result.success).toBe(true)
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(ensureDefaultApiTokenForAccountMock).not.toHaveBeenCalled()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -12,6 +12,7 @@ import {
 } from "~/services/accounts/accountOperations"
 import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
@@ -212,11 +213,17 @@ describe("accountOperations Sub2API token creation guards", () => {
     )
     classifyCreatedTokenMock.mockImplementation(({ result }) =>
       typeof result === "object" && result !== null
-        ? { kind: "usable", token: result, oneTimeSecret: false }
+        ? {
+            kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+            token: result,
+            oneTimeSecret: false,
+          }
         : result
-          ? { kind: "needs_inventory_refetch" }
+          ? {
+              kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+            }
           : {
-              kind: "failed",
+              kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
               reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
             },
     )
@@ -535,11 +542,17 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     )
     classifyCreatedTokenMock.mockImplementation(({ result }) =>
       typeof result === "object" && result !== null
-        ? { kind: "usable", token: result, oneTimeSecret: false }
+        ? {
+            kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+            token: result,
+            oneTimeSecret: false,
+          }
         : result
-          ? { kind: "needs_inventory_refetch" }
+          ? {
+              kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+            }
           : {
-              kind: "failed",
+              kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
               reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
             },
     )
@@ -871,7 +884,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     })
     createApiTokenMock.mockResolvedValueOnce(true)
     classifyCreatedTokenMock.mockReturnValueOnce({
-      kind: "unavailable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
     })
 
@@ -892,7 +905,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     })
     createApiTokenMock.mockResolvedValueOnce(true)
     classifyCreatedTokenMock.mockReturnValueOnce({
-      kind: "unavailable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
     })
 

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -12,9 +12,11 @@ import {
 } from "~/services/accounts/accountOperations"
 import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_ERRORS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum } from "~/types"
@@ -65,7 +67,9 @@ const {
             resolveDefaultTokenCreationMock(...args),
           classifyCreatedToken: (...args: unknown[]) =>
             classifyCreatedTokenMock(...args),
-          getRepairPolicy: vi.fn(() => ({ kind: "eligible" as const })),
+          getRepairPolicy: vi.fn(() => ({
+            kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
+          })),
         },
       }),
     ),
@@ -200,7 +204,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     toastLoadingMock.mockReset()
     resolveDefaultTokenCreationMock.mockImplementation(
       ({ defaultTokenData }) => ({
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: defaultTokenData,
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -225,7 +229,7 @@ describe("accountOperations Sub2API token creation guards", () => {
   it("blocks implicit Sub2API default-token creation in background helpers", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
     })
 
@@ -258,7 +262,7 @@ describe("accountOperations Sub2API token creation guards", () => {
   it("blocks shared token ensure when no Sub2API group has been resolved", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
     })
 
@@ -278,7 +282,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     createApiTokenMock.mockResolvedValueOnce(true)
     resolveDefaultTokenCreationMock.mockImplementationOnce(
       ({ defaultTokenData, explicitGroup }) => ({
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: { ...defaultTokenData, group: explicitGroup },
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -309,9 +313,11 @@ describe("accountOperations Sub2API token creation guards", () => {
 
   it("resolves quick-create group selection through token provisioning policy", async () => {
     resolveDefaultTokenCreationMock
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
-        kind: "selection_required",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
         allowedGroups: ["default", "vip"],
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
       })
@@ -334,9 +340,11 @@ describe("accountOperations Sub2API token creation guards", () => {
 
   it("reports when Sub2API quick-create has no valid current groups", async () => {
     resolveDefaultTokenCreationMock
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
-        kind: "blocked",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({})
@@ -351,9 +359,11 @@ describe("accountOperations Sub2API token creation guards", () => {
 
   it("requires explicit selection when Sub2API quick-create has multiple groups", async () => {
     resolveDefaultTokenCreationMock
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
-        kind: "selection_required",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
         allowedGroups: ["default", "vip"],
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
       })
@@ -372,9 +382,11 @@ describe("accountOperations Sub2API token creation guards", () => {
 
   it("resolves a ready state when Sub2API quick-create has exactly one unique group", async () => {
     resolveDefaultTokenCreationMock
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: { ...generateDefaultTokenRequest(), group: "vip" },
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -394,7 +406,7 @@ describe("accountOperations Sub2API token creation guards", () => {
 
   it("rejects quick-create resolution when Sub2API group inventory is missing", async () => {
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "needs_user_groups",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
     })
     getSiteAdapterMock.mockReturnValueOnce({
       siteType: SITE_TYPES.SUB2API,
@@ -413,7 +425,9 @@ describe("accountOperations Sub2API token creation guards", () => {
           resolveDefaultTokenCreationMock(...args),
         classifyCreatedToken: (...args: unknown[]) =>
           classifyCreatedTokenMock(...args),
-        getRepairPolicy: vi.fn(() => ({ kind: "eligible" as const })),
+        getRepairPolicy: vi.fn(() => ({
+          kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
+        })),
       },
     })
 
@@ -432,8 +446,12 @@ describe("accountOperations Sub2API token creation guards", () => {
     )
 
     resolveDefaultTokenCreationMock
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "Default", ratio: 1 },
     })
@@ -464,7 +482,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     )
 
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
     })
 
@@ -484,7 +502,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     )
 
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
     })
 
@@ -509,7 +527,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     toastLoadingMock.mockReset()
     resolveDefaultTokenCreationMock.mockImplementation(
       ({ defaultTokenData }) => ({
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: defaultTokenData,
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -682,7 +700,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
     })
 
@@ -805,7 +823,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
     })
 
@@ -846,7 +864,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: generateDefaultTokenRequest(),
       oneTimeSecret: true,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
@@ -867,7 +885,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: generateDefaultTokenRequest(),
       oneTimeSecret: true,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -11,6 +11,10 @@ import {
   resolveSub2ApiQuickCreateResolution,
 } from "~/services/accounts/accountOperations"
 import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
+import {
+  TOKEN_CREATION_SECRET_RECOVERY,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum } from "~/types"
 import {
   buildSiteAccount,
@@ -197,7 +201,7 @@ describe("accountOperations Sub2API token creation guards", () => {
         kind: "create",
         tokenData: defaultTokenData,
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       }),
     )
     classifyCreatedTokenMock.mockImplementation(({ result }) =>
@@ -217,7 +221,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
       kind: "blocked",
-      reason: "group_required",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
     })
 
     await expect(
@@ -250,7 +254,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
       kind: "blocked",
-      reason: "group_required",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
     })
 
     await expect(
@@ -272,7 +276,7 @@ describe("accountOperations Sub2API token creation guards", () => {
         kind: "create",
         tokenData: { ...defaultTokenData, group: explicitGroup },
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       }),
     )
 
@@ -328,7 +332,7 @@ describe("accountOperations Sub2API token creation guards", () => {
       .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
         kind: "blocked",
-        reason: "available_group_required",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({})
 
@@ -368,7 +372,7 @@ describe("accountOperations Sub2API token creation guards", () => {
         kind: "create",
         tokenData: { ...generateDefaultTokenRequest(), group: "vip" },
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({
       " vip ": { desc: "VIP", ratio: 2 },
@@ -415,6 +419,25 @@ describe("accountOperations Sub2API token creation guards", () => {
     expect(fetchUserGroupsMock).not.toHaveBeenCalled()
   })
 
+  it("rejects default quick-create resolution when policy still needs groups after lookup", async () => {
+    const { resolveDefaultTokenQuickCreateResolution } = await import(
+      "~/services/accounts/accountOperations"
+    )
+
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { desc: "Default", ratio: 1 },
+    })
+
+    await expect(
+      resolveDefaultTokenQuickCreateResolution(DISPLAY_ACCOUNT),
+    ).rejects.toThrow("sub2api_group_inventory_not_implemented")
+
+    expect(fetchUserGroupsMock).toHaveBeenCalledTimes(1)
+  })
+
   it("rejects quick-create resolution for non-Sub2API accounts", async () => {
     const { displayAccount } = createNonSub2ApiAccounts()
 
@@ -423,6 +446,46 @@ describe("accountOperations Sub2API token creation guards", () => {
     ).rejects.toThrow("sub2api_quick_create_not_applicable")
 
     expect(fetchUserGroupsMock).not.toHaveBeenCalled()
+  })
+
+  it("reports one-time secret policy blocks through default quick-create resolution", async () => {
+    const { displayAccount } = createAIHubMixAccounts()
+    const { resolveDefaultTokenQuickCreateResolution } = await import(
+      "~/services/accounts/accountOperations"
+    )
+
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
+    })
+
+    await expect(
+      resolveDefaultTokenQuickCreateResolution(displayAccount as any),
+    ).resolves.toEqual({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
+      message: "messages:aihubmix.createRequiresOneTimeKeyDialog",
+    })
+  })
+
+  it("reports generic policy blocks through default quick-create resolution", async () => {
+    const { displayAccount } = createNonSub2ApiAccounts()
+    const { resolveDefaultTokenQuickCreateResolution } = await import(
+      "~/services/accounts/accountOperations"
+    )
+
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
+    })
+
+    await expect(
+      resolveDefaultTokenQuickCreateResolution(displayAccount as any),
+    ).resolves.toEqual({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
+      message: "messages:sub2api.createRequiresGroup",
+    })
   })
 })
 
@@ -440,7 +503,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
         kind: "create",
         tokenData: defaultTokenData,
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       }),
     )
     classifyCreatedTokenMock.mockImplementation(({ result }) =>
@@ -608,7 +671,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
       kind: "blocked",
-      reason: "one_time_secret_required",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
     })
 
     await expect(
@@ -731,7 +794,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
       kind: "blocked",
-      reason: "one_time_secret_required",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
     })
 
     await expect(
@@ -764,6 +827,51 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     ).resolves.toEqual(existingToken)
 
     expect(createApiTokenMock).not.toHaveBeenCalled()
+  })
+
+  it("blocks shared token ensure when created token secret cannot be recovered", async () => {
+    const { displayAccount, siteAccount } = createAIHubMixAccounts()
+
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "create",
+      tokenData: generateDefaultTokenRequest(),
+      oneTimeSecret: true,
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
+    })
+    createApiTokenMock.mockResolvedValueOnce(true)
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: "unavailable",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
+    })
+
+    await expect(
+      ensureAccountApiToken(siteAccount as any, displayAccount as any),
+    ).rejects.toThrow("messages:aihubmix.createRequiresOneTimeKeyDialog")
+  })
+
+  it("fails background token ensure when created token secret cannot be recovered", async () => {
+    const { displayAccount, siteAccount } = createAIHubMixAccounts()
+
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "create",
+      tokenData: generateDefaultTokenRequest(),
+      oneTimeSecret: true,
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
+    })
+    createApiTokenMock.mockResolvedValueOnce(true)
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: "unavailable",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
+    })
+
+    await expect(
+      ensureDefaultApiTokenForAccount({
+        account: siteAccount as any,
+        displaySiteData: displayAccount as any,
+      }),
+    ).rejects.toThrow("token_not_found")
   })
 
   it("fails when default token creation reports false", async () => {

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -14,6 +14,8 @@ import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
 import {
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_ERRORS,
+  TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum } from "~/types"
 import {
@@ -209,7 +211,10 @@ describe("accountOperations Sub2API token creation guards", () => {
         ? { kind: "usable", token: result, oneTimeSecret: false }
         : result
           ? { kind: "needs_inventory_refetch" }
-          : { kind: "failed", reason: "create_failed" },
+          : {
+              kind: "failed",
+              reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+            },
     )
 
     const testAccounts = createTestAccounts()
@@ -292,7 +297,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     )
     expect(resolveDefaultTokenCreationMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        workflow: "shared_ensure",
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
         explicitGroup: "vip",
       }),
     )
@@ -308,7 +313,7 @@ describe("accountOperations Sub2API token creation guards", () => {
       .mockReturnValueOnce({
         kind: "selection_required",
         allowedGroups: ["default", "vip"],
-        reason: "group_selection_required",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "Default", ratio: 1 },
@@ -350,7 +355,7 @@ describe("accountOperations Sub2API token creation guards", () => {
       .mockReturnValueOnce({
         kind: "selection_required",
         allowedGroups: ["default", "vip"],
-        reason: "group_selection_required",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "Default", ratio: 1 },
@@ -414,7 +419,9 @@ describe("accountOperations Sub2API token creation guards", () => {
 
     await expect(
       resolveSub2ApiQuickCreateResolution(DISPLAY_ACCOUNT),
-    ).rejects.toThrow("sub2api_group_inventory_not_implemented")
+    ).rejects.toThrow(
+      TOKEN_PROVISIONING_ERRORS.Sub2ApiGroupInventoryNotImplemented,
+    )
 
     expect(fetchUserGroupsMock).not.toHaveBeenCalled()
   })
@@ -433,7 +440,9 @@ describe("accountOperations Sub2API token creation guards", () => {
 
     await expect(
       resolveDefaultTokenQuickCreateResolution(DISPLAY_ACCOUNT),
-    ).rejects.toThrow("sub2api_group_inventory_not_implemented")
+    ).rejects.toThrow(
+      TOKEN_PROVISIONING_ERRORS.Sub2ApiGroupInventoryNotImplemented,
+    )
 
     expect(fetchUserGroupsMock).toHaveBeenCalledTimes(1)
   })
@@ -443,7 +452,7 @@ describe("accountOperations Sub2API token creation guards", () => {
 
     await expect(
       resolveSub2ApiQuickCreateResolution(displayAccount as any),
-    ).rejects.toThrow("sub2api_quick_create_not_applicable")
+    ).rejects.toThrow(TOKEN_PROVISIONING_ERRORS.Sub2ApiQuickCreateNotApplicable)
 
     expect(fetchUserGroupsMock).not.toHaveBeenCalled()
   })
@@ -511,7 +520,10 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
         ? { kind: "usable", token: result, oneTimeSecret: false }
         : result
           ? { kind: "needs_inventory_refetch" }
-          : { kind: "failed", reason: "create_failed" },
+          : {
+              kind: "failed",
+              reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+            },
     )
   })
 
@@ -871,7 +883,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
         account: siteAccount as any,
         displaySiteData: displayAccount as any,
       }),
-    ).rejects.toThrow("token_not_found")
+    ).rejects.toThrow(TOKEN_PROVISIONING_ERRORS.TokenNotFound)
   })
 
   it("fails when default token creation reports false", async () => {
@@ -885,7 +897,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
         account: siteAccount as any,
         displaySiteData: displayAccount as any,
       }),
-    ).rejects.toThrow("create_token_failed")
+    ).rejects.toThrow(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
   })
 
   it("fails when the token inventory is still empty after a successful create", async () => {
@@ -899,6 +911,6 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
         account: siteAccount as any,
         displaySiteData: displayAccount as any,
       }),
-    ).rejects.toThrow("token_not_found")
+    ).rejects.toThrow(TOKEN_PROVISIONING_ERRORS.TokenNotFound)
   })
 })

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -22,17 +22,23 @@ const {
   fetchAccountTokensMock,
   createApiTokenMock,
   fetchUserGroupsMock,
+  resolveDefaultTokenCreationMock,
+  classifyCreatedTokenMock,
   getSiteAdapterMock,
   toastLoadingMock,
 } = vi.hoisted(() => {
   const fetchAccountTokensMock = vi.fn()
   const createApiTokenMock = vi.fn()
   const fetchUserGroupsMock = vi.fn()
+  const resolveDefaultTokenCreationMock = vi.fn()
+  const classifyCreatedTokenMock = vi.fn()
 
   return {
     fetchAccountTokensMock,
     createApiTokenMock,
     fetchUserGroupsMock,
+    resolveDefaultTokenCreationMock,
+    classifyCreatedTokenMock,
     getSiteAdapterMock: vi.fn(
       (): SiteAdapter => ({
         siteType: SITE_TYPES.SUB2API,
@@ -46,6 +52,14 @@ const {
           userGroups: {
             fetch: (...args: unknown[]) => fetchUserGroupsMock(...args),
           },
+        },
+        tokenProvisioning: {
+          isInventoryTokenUsable: vi.fn(() => true),
+          resolveDefaultTokenCreation: (...args: unknown[]) =>
+            resolveDefaultTokenCreationMock(...args),
+          classifyCreatedToken: (...args: unknown[]) =>
+            classifyCreatedTokenMock(...args),
+          getRepairPolicy: vi.fn(() => ({ kind: "eligible" as const })),
         },
       }),
     ),
@@ -174,8 +188,25 @@ describe("accountOperations Sub2API token creation guards", () => {
     fetchAccountTokensMock.mockReset()
     createApiTokenMock.mockReset()
     fetchUserGroupsMock.mockReset()
+    resolveDefaultTokenCreationMock.mockReset()
+    classifyCreatedTokenMock.mockReset()
     getSiteAdapterMock.mockClear()
     toastLoadingMock.mockReset()
+    resolveDefaultTokenCreationMock.mockImplementation(
+      ({ defaultTokenData }) => ({
+        kind: "create",
+        tokenData: defaultTokenData,
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }),
+    )
+    classifyCreatedTokenMock.mockImplementation(({ result }) =>
+      typeof result === "object" && result !== null
+        ? { kind: "usable", token: result, oneTimeSecret: false }
+        : result
+          ? { kind: "needs_inventory_refetch" }
+          : { kind: "failed", reason: "create_failed" },
+    )
 
     const testAccounts = createTestAccounts()
     DISPLAY_ACCOUNT = testAccounts.displayAccount
@@ -184,6 +215,10 @@ describe("accountOperations Sub2API token creation guards", () => {
 
   it("blocks implicit Sub2API default-token creation in background helpers", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "blocked",
+      reason: "group_required",
+    })
 
     await expect(
       ensureDefaultApiTokenForAccount({
@@ -213,6 +248,10 @@ describe("accountOperations Sub2API token creation guards", () => {
 
   it("blocks shared token ensure when no Sub2API group has been resolved", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "blocked",
+      reason: "group_required",
+    })
 
     await expect(
       ensureAccountApiToken(SITE_ACCOUNT, DISPLAY_ACCOUNT),
@@ -228,6 +267,14 @@ describe("accountOperations Sub2API token creation guards", () => {
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([token])
     createApiTokenMock.mockResolvedValueOnce(true)
+    resolveDefaultTokenCreationMock.mockImplementationOnce(
+      ({ defaultTokenData, explicitGroup }) => ({
+        kind: "create",
+        tokenData: { ...defaultTokenData, group: explicitGroup },
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }),
+    )
 
     await expect(
       ensureAccountApiToken(SITE_ACCOUNT, DISPLAY_ACCOUNT, {
@@ -239,9 +286,50 @@ describe("accountOperations Sub2API token creation guards", () => {
       expect.anything(),
       expect.objectContaining({ group: "vip" }),
     )
+    expect(resolveDefaultTokenCreationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflow: "shared_ensure",
+        explicitGroup: "vip",
+      }),
+    )
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ group: "vip" }),
+    )
+  })
+
+  it("resolves quick-create group selection through token provisioning policy", async () => {
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({
+        kind: "selection_required",
+        allowedGroups: ["default", "vip"],
+        reason: "group_selection_required",
+      })
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { desc: "Default", ratio: 1 },
+      vip: { desc: "VIP", ratio: 1 },
+    })
+
+    const { resolveDefaultTokenQuickCreateResolution } = await import(
+      "~/services/accounts/accountOperations"
+    )
+
+    await expect(
+      resolveDefaultTokenQuickCreateResolution(DISPLAY_ACCOUNT),
+    ).resolves.toEqual({
+      kind: "selection_required",
+      allowedGroups: ["default", "vip"],
+    })
   })
 
   it("reports when Sub2API quick-create has no valid current groups", async () => {
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({
+        kind: "blocked",
+        reason: "available_group_required",
+      })
     fetchUserGroupsMock.mockResolvedValueOnce({})
 
     await expect(
@@ -253,6 +341,13 @@ describe("accountOperations Sub2API token creation guards", () => {
   })
 
   it("requires explicit selection when Sub2API quick-create has multiple groups", async () => {
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({
+        kind: "selection_required",
+        allowedGroups: ["default", "vip"],
+        reason: "group_selection_required",
+      })
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { desc: "Default", ratio: 1 },
       vip: { desc: "VIP", ratio: 2 },
@@ -267,6 +362,14 @@ describe("accountOperations Sub2API token creation guards", () => {
   })
 
   it("resolves a ready state when Sub2API quick-create has exactly one unique group", async () => {
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({
+        kind: "create",
+        tokenData: { ...generateDefaultTokenRequest(), group: "vip" },
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      })
     fetchUserGroupsMock.mockResolvedValueOnce({
       " vip ": { desc: "VIP", ratio: 2 },
       vip: { desc: "VIP duplicate", ratio: 3 },
@@ -281,6 +384,9 @@ describe("accountOperations Sub2API token creation guards", () => {
   })
 
   it("rejects quick-create resolution when Sub2API group inventory is missing", async () => {
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "needs_user_groups",
+    })
     getSiteAdapterMock.mockReturnValueOnce({
       siteType: SITE_TYPES.SUB2API,
       keyManagement: {
@@ -291,6 +397,14 @@ describe("accountOperations Sub2API token creation guards", () => {
         deleteToken: vi.fn(),
         fetchAvailableModels: vi.fn(),
         userGroups: undefined,
+      },
+      tokenProvisioning: {
+        isInventoryTokenUsable: vi.fn(() => true),
+        resolveDefaultTokenCreation: (...args: unknown[]) =>
+          resolveDefaultTokenCreationMock(...args),
+        classifyCreatedToken: (...args: unknown[]) =>
+          classifyCreatedTokenMock(...args),
+        getRepairPolicy: vi.fn(() => ({ kind: "eligible" as const })),
       },
     })
 
@@ -317,8 +431,25 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     fetchAccountTokensMock.mockReset()
     createApiTokenMock.mockReset()
     fetchUserGroupsMock.mockReset()
+    resolveDefaultTokenCreationMock.mockReset()
+    classifyCreatedTokenMock.mockReset()
     getSiteAdapterMock.mockClear()
     toastLoadingMock.mockReset()
+    resolveDefaultTokenCreationMock.mockImplementation(
+      ({ defaultTokenData }) => ({
+        kind: "create",
+        tokenData: defaultTokenData,
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }),
+    )
+    classifyCreatedTokenMock.mockImplementation(({ result }) =>
+      typeof result === "object" && result !== null
+        ? { kind: "usable", token: result, oneTimeSecret: false }
+        : result
+          ? { kind: "needs_inventory_refetch" }
+          : { kind: "failed", reason: "create_failed" },
+    )
   })
 
   it("keeps the default auto-provision token payload stable", () => {
@@ -475,6 +606,10 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     const { displayAccount, siteAccount } = createAIHubMixAccounts()
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "blocked",
+      reason: "one_time_secret_required",
+    })
 
     await expect(
       ensureDefaultApiTokenForAccount({
@@ -594,6 +729,10 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     const { displayAccount, siteAccount } = createAIHubMixAccounts()
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "blocked",
+      reason: "one_time_secret_required",
+    })
 
     await expect(
       ensureAccountApiToken(siteAccount as any, displayAccount as any),

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
@@ -172,7 +173,10 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
         ? { kind: "usable", token: result, oneTimeSecret: false }
         : result
           ? { kind: "needs_inventory_refetch" }
-          : { kind: "failed", reason: "create_failed" },
+          : {
+              kind: "failed",
+              reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+            },
     )
     getRepairPolicyMock.mockReturnValue({ kind: "eligible" })
   })
@@ -301,7 +305,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     )
     expect(resolveDefaultTokenCreationMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        workflow: "post_save_automation",
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
         defaultTokenData: expect.objectContaining({
           name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
         }),
@@ -309,7 +313,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     )
     expect(classifyCreatedTokenMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        workflow: "post_save_automation",
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
       }),
     )
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
@@ -663,7 +667,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       .mockReturnValueOnce({
         kind: "selection_required",
         allowedGroups: ["default", "vip"],
-        reason: "group_selection_required",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { ratio: 1 },

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -13,6 +13,10 @@ import {
   inspectAccountTokenInventory,
   selectSingleNewApiTokenByIdDiff,
 } from "~/services/accounts/accountPostSaveWorkflow"
+import {
+  TOKEN_CREATION_SECRET_RECOVERY,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
 
@@ -160,7 +164,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
         kind: "create",
         tokenData: defaultTokenData,
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       }),
     )
     classifyCreatedTokenMock.mockImplementation(({ result }) =>
@@ -452,7 +456,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       kind: "create",
       tokenData: buildDefaultTokenData(),
       oneTimeSecret: true,
-      recoverCreatedToken: "created_response_first",
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     })
     classifyCreatedTokenMock.mockReturnValueOnce({
       kind: "usable",
@@ -521,7 +525,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       kind: "create",
       tokenData: buildDefaultTokenData(),
       oneTimeSecret: true,
-      recoverCreatedToken: "created_response_first",
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     })
     classifyCreatedTokenMock.mockReturnValueOnce({
       kind: "usable",
@@ -556,11 +560,11 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       kind: "create",
       tokenData: buildDefaultTokenData(),
       oneTimeSecret: true,
-      recoverCreatedToken: "created_response_first",
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     })
     classifyCreatedTokenMock.mockReturnValueOnce({
       kind: "unavailable",
-      reason: "created_token_secret_unavailable",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
     })
     createApiTokenMock.mockResolvedValueOnce(true)
 
@@ -588,11 +592,11 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       kind: "create",
       tokenData: buildDefaultTokenData(),
       oneTimeSecret: true,
-      recoverCreatedToken: "created_response_first",
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     })
     classifyCreatedTokenMock.mockReturnValueOnce({
       kind: "unavailable",
-      reason: "created_token_secret_unavailable",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
     })
     createApiTokenMock.mockResolvedValueOnce(
       buildToken({ id: 8, key: "sk-***masked***" }),
@@ -623,7 +627,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
         kind: "create",
         tokenData: buildDefaultTokenData({ group: "vip" }),
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
     createApiTokenMock.mockResolvedValueOnce(true)
@@ -690,7 +694,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
         kind: "blocked",
-        reason: "available_group_required",
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({})
 
@@ -719,7 +723,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
         kind: "create",
         tokenData: buildDefaultTokenData({ group: "vip" }),
         oneTimeSecret: false,
-        recoverCreatedToken: "inventory_refetch",
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
     createApiTokenMock.mockResolvedValueOnce(true)
@@ -736,5 +740,35 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       message: "messages:accountOperations.createTokenFailed",
     })
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("blocks Sub2API when policy still needs groups after current group lookup", async () => {
+    const displayAccount = buildDisplayAccount({
+      siteType: SITE_TYPES.SUB2API,
+      baseUrl: "https://sub2.example.com",
+    })
+    const account = buildStoredAccount(displayAccount)
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({
+        kind: "needs_user_groups",
+      })
+      .mockReturnValueOnce({
+        kind: "needs_user_groups",
+      })
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Blocked,
+      code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
+      message: "messages:sub2api.createRequiresAvailableGroup",
+    })
+    expect(fetchUserGroupsMock).toHaveBeenCalledTimes(1)
+    expect(createApiTokenMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -14,6 +14,7 @@ import {
   selectSingleNewApiTokenByIdDiff,
 } from "~/services/accounts/accountPostSaveWorkflow"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
@@ -172,11 +173,17 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     )
     classifyCreatedTokenMock.mockImplementation(({ result }) =>
       typeof result === "object" && result !== null
-        ? { kind: "usable", token: result, oneTimeSecret: false }
+        ? {
+            kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+            token: result,
+            oneTimeSecret: false,
+          }
         : result
-          ? { kind: "needs_inventory_refetch" }
+          ? {
+              kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+            }
           : {
-              kind: "failed",
+              kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
               reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
             },
     )
@@ -467,7 +474,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     })
     classifyCreatedTokenMock.mockReturnValueOnce({
-      kind: "usable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
       token: createdToken,
       oneTimeSecret: true,
     })
@@ -536,7 +543,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     })
     classifyCreatedTokenMock.mockReturnValueOnce({
-      kind: "usable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
       token: createdToken,
       oneTimeSecret: true,
     })
@@ -571,7 +578,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     })
     classifyCreatedTokenMock.mockReturnValueOnce({
-      kind: "unavailable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
     })
     createApiTokenMock.mockResolvedValueOnce(true)
@@ -603,7 +610,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     })
     classifyCreatedTokenMock.mockReturnValueOnce({
-      kind: "unavailable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
     })
     createApiTokenMock.mockResolvedValueOnce(

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -14,8 +14,10 @@ import {
   selectSingleNewApiTokenByIdDiff,
 } from "~/services/accounts/accountPostSaveWorkflow"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
@@ -162,7 +164,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     )
     resolveDefaultTokenCreationMock.mockImplementation(
       ({ defaultTokenData }) => ({
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: defaultTokenData,
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -178,7 +180,9 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
               reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
             },
     )
-    getRepairPolicyMock.mockReturnValue({ kind: "eligible" })
+    getRepairPolicyMock.mockReturnValue({
+      kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
+    })
   })
 
   it("selects the single newly created token by id diff even when it is not the last refetched token", () => {
@@ -457,7 +461,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     })
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: buildDefaultTokenData(),
       oneTimeSecret: true,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
@@ -526,7 +530,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     ])
     isInventoryTokenUsableMock.mockReturnValueOnce(false)
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: buildDefaultTokenData(),
       oneTimeSecret: true,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
@@ -561,7 +565,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: buildDefaultTokenData(),
       oneTimeSecret: true,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
@@ -593,7 +597,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: buildDefaultTokenData(),
       oneTimeSecret: true,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
@@ -626,9 +630,11 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     const createdToken = buildToken({ id: 9, key: "sk-sub2", group: "vip" })
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: buildDefaultTokenData({ group: "vip" }),
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -663,9 +669,11 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
-        kind: "selection_required",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
         allowedGroups: ["default", "vip"],
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
       })
@@ -695,9 +703,11 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
-        kind: "blocked",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
         reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
       })
     fetchUserGroupsMock.mockResolvedValueOnce({})
@@ -722,9 +732,11 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock
-      .mockReturnValueOnce({ kind: "needs_user_groups" })
       .mockReturnValueOnce({
-        kind: "create",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
         tokenData: buildDefaultTokenData({ group: "vip" }),
         oneTimeSecret: false,
         recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -756,10 +768,10 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
     resolveDefaultTokenCreationMock
       .mockReturnValueOnce({
-        kind: "needs_user_groups",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
       })
       .mockReturnValueOnce({
-        kind: "needs_user_groups",
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
       })
 
     await expect(

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
-import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import {
+  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+  generateDefaultTokenRequest,
+} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
   ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES,
   ACCOUNT_TOKEN_INVENTORY_STATE_KINDS,
@@ -17,16 +20,28 @@ const {
   fetchAccountTokensMock,
   createApiTokenMock,
   fetchUserGroupsMock,
+  isInventoryTokenUsableMock,
+  resolveDefaultTokenCreationMock,
+  classifyCreatedTokenMock,
+  getRepairPolicyMock,
   getSiteAdapterMock,
 } = vi.hoisted(() => {
   const fetchAccountTokensMock = vi.fn()
   const createApiTokenMock = vi.fn()
   const fetchUserGroupsMock = vi.fn()
+  const isInventoryTokenUsableMock = vi.fn()
+  const resolveDefaultTokenCreationMock = vi.fn()
+  const classifyCreatedTokenMock = vi.fn()
+  const getRepairPolicyMock = vi.fn()
 
   return {
     fetchAccountTokensMock,
     createApiTokenMock,
     fetchUserGroupsMock,
+    isInventoryTokenUsableMock,
+    resolveDefaultTokenCreationMock,
+    classifyCreatedTokenMock,
+    getRepairPolicyMock,
     getSiteAdapterMock: vi.fn(() => ({
       keyManagement: {
         fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
@@ -37,6 +52,15 @@ const {
         userGroups: {
           fetch: (...args: unknown[]) => fetchUserGroupsMock(...args),
         },
+      },
+      tokenProvisioning: {
+        isInventoryTokenUsable: (...args: unknown[]) =>
+          isInventoryTokenUsableMock(...args),
+        resolveDefaultTokenCreation: (...args: unknown[]) =>
+          resolveDefaultTokenCreationMock(...args),
+        classifyCreatedToken: (...args: unknown[]) =>
+          classifyCreatedTokenMock(...args),
+        getRepairPolicy: (...args: unknown[]) => getRepairPolicyMock(...args),
       },
     })),
   }
@@ -113,12 +137,40 @@ const buildStoredAccount = (
     },
   })
 
+const buildDefaultTokenData = (overrides = {}) => ({
+  ...generateDefaultTokenRequest(),
+  ...overrides,
+})
+
 describe("ensureAccountTokenForPostSaveWorkflow", () => {
   beforeEach(() => {
     fetchAccountTokensMock.mockReset()
     createApiTokenMock.mockReset()
     fetchUserGroupsMock.mockReset()
+    isInventoryTokenUsableMock.mockReset()
+    resolveDefaultTokenCreationMock.mockReset()
+    classifyCreatedTokenMock.mockReset()
+    getRepairPolicyMock.mockReset()
     getSiteAdapterMock.mockClear()
+    isInventoryTokenUsableMock.mockImplementation(({ token }) =>
+      Boolean(token.key),
+    )
+    resolveDefaultTokenCreationMock.mockImplementation(
+      ({ defaultTokenData }) => ({
+        kind: "create",
+        tokenData: defaultTokenData,
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      }),
+    )
+    classifyCreatedTokenMock.mockImplementation(({ result }) =>
+      typeof result === "object" && result !== null
+        ? { kind: "usable", token: result, oneTimeSecret: false }
+        : result
+          ? { kind: "needs_inventory_refetch" }
+          : { kind: "failed", reason: "create_failed" },
+    )
+    getRepairPolicyMock.mockReturnValue({ kind: "eligible" })
   })
 
   it("selects the single newly created token by id diff even when it is not the last refetched token", () => {
@@ -198,6 +250,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     })
     const maskedToken = buildToken({ id: 8, key: "sk-***masked***" })
     fetchAccountTokensMock.mockResolvedValueOnce([maskedToken])
+    isInventoryTokenUsableMock.mockReturnValueOnce(false)
 
     await expect(
       inspectAccountTokenInventory({
@@ -240,6 +293,19 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       expect.objectContaining({
         name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
         group: "",
+      }),
+    )
+    expect(resolveDefaultTokenCreationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflow: "post_save_automation",
+        defaultTokenData: expect.objectContaining({
+          name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        }),
+      }),
+    )
+    expect(classifyCreatedTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflow: "post_save_automation",
       }),
     )
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
@@ -382,6 +448,17 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
     })
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "create",
+      tokenData: buildDefaultTokenData(),
+      oneTimeSecret: true,
+      recoverCreatedToken: "created_response_first",
+    })
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: "usable",
+      token: createdToken,
+      oneTimeSecret: true,
+    })
     createApiTokenMock.mockResolvedValueOnce(createdToken)
 
     await expect(
@@ -409,6 +486,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       key: "sk-aihubmix-existing-full-secret",
     })
     fetchAccountTokensMock.mockResolvedValueOnce([existingToken])
+    isInventoryTokenUsableMock.mockReturnValueOnce(true)
 
     await expect(
       ensureAccountTokenForPostSaveWorkflow({
@@ -438,6 +516,18 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     fetchAccountTokensMock.mockResolvedValueOnce([
       buildToken({ id: 8, key: "sk-***masked***" }),
     ])
+    isInventoryTokenUsableMock.mockReturnValueOnce(false)
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "create",
+      tokenData: buildDefaultTokenData(),
+      oneTimeSecret: true,
+      recoverCreatedToken: "created_response_first",
+    })
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: "usable",
+      token: createdToken,
+      oneTimeSecret: true,
+    })
     createApiTokenMock.mockResolvedValueOnce(createdToken)
 
     await expect(
@@ -462,6 +552,16 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     })
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "create",
+      tokenData: buildDefaultTokenData(),
+      oneTimeSecret: true,
+      recoverCreatedToken: "created_response_first",
+    })
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: "unavailable",
+      reason: "created_token_secret_unavailable",
+    })
     createApiTokenMock.mockResolvedValueOnce(true)
 
     await expect(
@@ -484,6 +584,16 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     })
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock.mockReturnValueOnce({
+      kind: "create",
+      tokenData: buildDefaultTokenData(),
+      oneTimeSecret: true,
+      recoverCreatedToken: "created_response_first",
+    })
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: "unavailable",
+      reason: "created_token_secret_unavailable",
+    })
     createApiTokenMock.mockResolvedValueOnce(
       buildToken({ id: 8, key: "sk-***masked***" }),
     )
@@ -507,6 +617,14 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     const account = buildStoredAccount(displayAccount)
     const createdToken = buildToken({ id: 9, key: "sk-sub2", group: "vip" })
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({
+        kind: "create",
+        tokenData: buildDefaultTokenData({ group: "vip" }),
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      })
     fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
     createApiTokenMock.mockResolvedValueOnce(true)
     fetchAccountTokensMock.mockResolvedValueOnce([createdToken])
@@ -536,6 +654,13 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     })
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({
+        kind: "selection_required",
+        allowedGroups: ["default", "vip"],
+        reason: "group_selection_required",
+      })
     fetchUserGroupsMock.mockResolvedValueOnce({
       default: { ratio: 1 },
       vip: { ratio: 2 },
@@ -561,6 +686,12 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     })
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({
+        kind: "blocked",
+        reason: "available_group_required",
+      })
     fetchUserGroupsMock.mockResolvedValueOnce({})
 
     await expect(
@@ -582,6 +713,14 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     })
     const account = buildStoredAccount(displayAccount)
     fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({ kind: "needs_user_groups" })
+      .mockReturnValueOnce({
+        kind: "create",
+        tokenData: buildDefaultTokenData({ group: "vip" }),
+        oneTimeSecret: false,
+        recoverCreatedToken: "inventory_refetch",
+      })
     fetchUserGroupsMock.mockResolvedValueOnce({ vip: { ratio: 1 } })
     createApiTokenMock.mockResolvedValueOnce(true)
     fetchAccountTokensMock.mockResolvedValueOnce(null)

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -52,6 +52,12 @@ describe("fetchDisplayAccountTokens", () => {
   let deleteToken: ReturnType<typeof vi.fn>
   let fetchUserGroups: ReturnType<typeof vi.fn>
   let fetchAvailableModels: ReturnType<typeof vi.fn>
+  let tokenProvisioning: {
+    isInventoryTokenUsable: ReturnType<typeof vi.fn>
+    resolveDefaultTokenCreation: ReturnType<typeof vi.fn>
+    classifyCreatedToken: ReturnType<typeof vi.fn>
+    getRepairPolicy: ReturnType<typeof vi.fn>
+  }
   let keyManagement: {
     fetchTokens: typeof fetchTokens
     createToken: typeof createToken
@@ -66,6 +72,7 @@ describe("fetchDisplayAccountTokens", () => {
   let adapter: {
     siteType: string
     keyManagement?: typeof keyManagement
+    tokenProvisioning?: typeof tokenProvisioning
   }
 
   beforeEach(() => {
@@ -87,7 +94,13 @@ describe("fetchDisplayAccountTokens", () => {
         fetch: fetchUserGroups,
       },
     }
-    adapter = { siteType: "new-api", keyManagement }
+    tokenProvisioning = {
+      isInventoryTokenUsable: vi.fn(),
+      resolveDefaultTokenCreation: vi.fn(),
+      classifyCreatedToken: vi.fn(),
+      getRepairPolicy: vi.fn(),
+    }
+    adapter = { siteType: "new-api", keyManagement, tokenProvisioning }
 
     vi.mocked(getSiteAdapter).mockReset()
     vi.mocked(getSiteAdapter).mockReturnValue(adapter as any)
@@ -103,6 +116,7 @@ describe("fetchDisplayAccountTokens", () => {
     expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual({
       adapter,
       keyManagement,
+      tokenProvisioning,
       request: expect.objectContaining(REQUEST),
     })
     expect(createDisplayAccountApiContext(ACCOUNT as any)).not.toHaveProperty(
@@ -253,6 +267,19 @@ describe("fetchDisplayAccountTokens", () => {
         siteType: "unsupported",
       } as any),
     ).rejects.toThrow("keyManagement is not implemented for unsupported")
+  })
+
+  it("throws when adapter token provisioning is not implemented", async () => {
+    const { requireDisplayAccountTokenProvisioning } = await import(
+      "~/services/accounts/utils/apiServiceRequest"
+    )
+
+    expect(() =>
+      requireDisplayAccountTokenProvisioning(
+        { siteType: "unsupported" } as any,
+        undefined,
+      ),
+    ).toThrow("tokenProvisioning is not implemented for unsupported")
   })
 
   it("only allows token management for enabled accounts with complete auth context", () => {

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -15,6 +15,17 @@ vi.mock("~/services/apiService", () => ({
   })),
 }))
 
+const expectTokenProvisioningCapability = (
+  adapter: ReturnType<typeof getSiteAdapter>,
+) => {
+  expect(adapter.tokenProvisioning).toEqual({
+    resolveDefaultTokenCreation: expect.any(Function),
+    classifyCreatedToken: expect.any(Function),
+    isInventoryTokenUsable: expect.any(Function),
+    getRepairPolicy: expect.any(Function),
+  })
+}
+
 describe("apiAdapters registry", () => {
   it("returns a Sub2API Adapter with account-scoped siteAnnouncements", () => {
     const adapter = getSiteAdapter(SITE_TYPES.SUB2API)
@@ -59,6 +70,7 @@ describe("apiAdapters registry", () => {
     expect(adapter.accountData).toEqual({
       fetchData: expect.any(Function),
     })
+    expectTokenProvisioningCapability(adapter)
     expect(adapter.modelPricing).toBeUndefined()
     expect(adapter.redemption).toBeUndefined()
     expect(adapter.siteNotice).toBeUndefined()
@@ -118,6 +130,7 @@ describe("apiAdapters registry", () => {
       expect(adapter.accountData).toEqual({
         fetchData: expect.any(Function),
       })
+      expectTokenProvisioningCapability(adapter)
       expect(adapter.modelPricing).toEqual({
         fetchPricing: expect.any(Function),
       })
@@ -187,6 +200,7 @@ describe("apiAdapters registry", () => {
     expect(adapter.accountData).toEqual({
       fetchData: expect.any(Function),
     })
+    expectTokenProvisioningCapability(adapter)
     expect(adapter.modelPricing).toEqual({
       fetchPricing: expect.any(Function),
     })
@@ -196,12 +210,19 @@ describe("apiAdapters registry", () => {
     expect(adapter.modelCatalog).toBeUndefined()
   })
 
-  it("returns an unsupported adapter without account bootstrap", () => {
-    const adapter = getSiteAdapter(SITE_TYPES.OCTOPUS as AccountSiteType)
+  it("returns unsupported adapters without account capabilities", () => {
+    for (const siteType of [
+      SITE_TYPES.OCTOPUS,
+      SITE_TYPES.AXON_HUB,
+      SITE_TYPES.CLAUDE_CODE_HUB,
+    ]) {
+      const adapter = getSiteAdapter(siteType as AccountSiteType)
 
-    expect(adapter).toEqual({
-      siteType: SITE_TYPES.OCTOPUS,
-    })
-    expect(adapter.accountBootstrap).toBeUndefined()
+      expect(adapter).toEqual({
+        siteType,
+      })
+      expect(adapter.accountBootstrap).toBeUndefined()
+      expect(adapter.tokenProvisioning).toBeUndefined()
+    }
   })
 })

--- a/tests/services/apiAdapters/tokenProvisioning.test.ts
+++ b/tests/services/apiAdapters/tokenProvisioning.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { aihubmixTokenProvisioning } from "~/services/apiAdapters/aihubmix/tokenProvisioning"
+import {
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_WORKFLOWS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+import { createNewApiTokenProvisioning } from "~/services/apiAdapters/newApi/tokenProvisioning"
+import {
+  normalizeTokenProvisioningGroupNames,
+  sub2ApiTokenProvisioning,
+} from "~/services/apiAdapters/sub2api/tokenProvisioning"
+import type { CreateTokenRequest } from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+
+const defaultTokenData: CreateTokenRequest = {
+  name: "Example default token",
+  remain_quota: 500000,
+  expired_time: -1,
+  unlimited_quota: false,
+  model_limits_enabled: false,
+  model_limits: "",
+  allow_ips: "",
+  group: "",
+}
+
+const token = (overrides: Partial<ApiToken> = {}): ApiToken =>
+  ({
+    id: 123,
+    user_id: 456,
+    key: "sk-example-secret",
+    status: 1,
+    name: "Example token",
+    created_time: 1700000000,
+    accessed_time: 0,
+    expired_time: -1,
+    remain_quota: 500000,
+    unlimited_quota: false,
+    model_limits_enabled: false,
+    model_limits: "",
+    allow_ips: "",
+    used_quota: 0,
+    group: "",
+    ...overrides,
+  }) as ApiToken
+
+describe("apiAdapter tokenProvisioning", () => {
+  it("allows New API-family default creation and inventory recovery", () => {
+    const provisioning = createNewApiTokenProvisioning(SITE_TYPES.NEW_API)
+    const createdToken = token()
+    const maskedToken = token({ key: "sk-****abcd" })
+
+    expect(
+      provisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
+        defaultTokenData,
+      }),
+    ).toEqual({
+      kind: "create",
+      tokenData: defaultTokenData,
+      oneTimeSecret: false,
+      recoverCreatedToken: "inventory_refetch",
+    })
+
+    expect(
+      provisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        result: true,
+      }),
+    ).toEqual({ kind: "needs_inventory_refetch" })
+
+    expect(
+      provisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        result: createdToken,
+      }),
+    ).toEqual({
+      kind: "usable",
+      token: createdToken,
+      oneTimeSecret: false,
+    })
+
+    expect(
+      provisioning.isInventoryTokenUsable({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        token: maskedToken,
+      }),
+    ).toBe(true)
+    expect(provisioning.getRepairPolicy()).toEqual({ kind: "eligible" })
+  })
+
+  it("normalizes token provisioning group names", () => {
+    expect(
+      normalizeTokenProvisioningGroupNames({
+        " default ": { desc: "Default", ratio: 1 },
+        default: { desc: "Duplicate", ratio: 1 },
+        "": { desc: "Blank", ratio: 1 },
+        " vip ": { desc: "VIP", ratio: 2 },
+        "   ": { desc: "Whitespace", ratio: 1 },
+      }),
+    ).toEqual(["default", "vip"])
+  })
+
+  it("requires Sub2API groups before creating default tokens", () => {
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData,
+      }),
+    ).toEqual({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
+    })
+
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection,
+        defaultTokenData,
+      }),
+    ).toEqual({ kind: "needs_user_groups" })
+
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        defaultTokenData,
+        userGroups: {
+          " default ": { desc: "Default", ratio: 1 },
+        },
+      }),
+    ).toEqual({
+      kind: "create",
+      tokenData: { ...defaultTokenData, group: "default" },
+      oneTimeSecret: false,
+      recoverCreatedToken: "inventory_refetch",
+    })
+
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection,
+        defaultTokenData,
+        userGroups: {
+          " vip ": { desc: "VIP", ratio: 2 },
+          default: { desc: "Default", ratio: 1 },
+          " vip": { desc: "Duplicate", ratio: 2 },
+        },
+      }),
+    ).toEqual({
+      kind: "selection_required",
+      allowedGroups: ["vip", "default"],
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
+    })
+
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        defaultTokenData,
+        userGroups: {
+          " ": { desc: "Blank", ratio: 1 },
+        },
+      }),
+    ).toEqual({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
+    })
+
+    expect(sub2ApiTokenProvisioning.getRepairPolicy()).toEqual({
+      kind: "skipped",
+      skipReason: "sub2api",
+    })
+  })
+
+  it("uses explicit Sub2API groups and classifies created token responses", () => {
+    const createdToken = token({ group: "vip" })
+
+    expect(
+      sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData,
+        explicitGroup: " vip ",
+      }),
+    ).toEqual({
+      kind: "create",
+      tokenData: { ...defaultTokenData, group: "vip" },
+      oneTimeSecret: false,
+      recoverCreatedToken: "inventory_refetch",
+    })
+
+    expect(
+      sub2ApiTokenProvisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        result: createdToken,
+      }),
+    ).toEqual({
+      kind: "usable",
+      token: createdToken,
+      oneTimeSecret: false,
+    })
+
+    expect(
+      sub2ApiTokenProvisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        result: true,
+      }),
+    ).toEqual({ kind: "needs_inventory_refetch" })
+
+    expect(
+      sub2ApiTokenProvisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        result: false,
+      }),
+    ).toEqual({
+      kind: "failed",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+    })
+  })
+
+  it("requires AIHubMix one-time created secrets", () => {
+    const fullToken = token({ key: "aihubmix-full-secret" })
+    const maskedToken = token({ key: "aihubmix****cret" })
+
+    expect(
+      aihubmixTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
+        defaultTokenData,
+      }),
+    ).toEqual({
+      kind: "blocked",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
+    })
+
+    expect(
+      aihubmixTokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        defaultTokenData,
+      }),
+    ).toEqual({
+      kind: "create",
+      tokenData: defaultTokenData,
+      oneTimeSecret: true,
+      recoverCreatedToken: "created_response_first",
+    })
+
+    expect(
+      aihubmixTokenProvisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        result: false,
+      }),
+    ).toEqual({
+      kind: "failed",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+    })
+
+    expect(
+      aihubmixTokenProvisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        result: fullToken,
+      }),
+    ).toEqual({
+      kind: "usable",
+      token: fullToken,
+      oneTimeSecret: true,
+    })
+
+    expect(
+      aihubmixTokenProvisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        result: maskedToken,
+      }),
+    ).toEqual({
+      kind: "unavailable",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
+    })
+
+    expect(
+      aihubmixTokenProvisioning.isInventoryTokenUsable({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        token: maskedToken,
+      }),
+    ).toBe(false)
+
+    expect(aihubmixTokenProvisioning.getRepairPolicy()).toEqual({
+      kind: "skipped",
+      skipReason: "aihubmixOneTimeKey",
+    })
+  })
+})

--- a/tests/services/apiAdapters/tokenProvisioning.test.ts
+++ b/tests/services/apiAdapters/tokenProvisioning.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import { aihubmixTokenProvisioning } from "~/services/apiAdapters/aihubmix/tokenProvisioning"
 import {
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { createNewApiTokenProvisioning } from "~/services/apiAdapters/newApi/tokenProvisioning"
@@ -59,7 +61,7 @@ describe("apiAdapter tokenProvisioning", () => {
         defaultTokenData,
       }),
     ).toEqual({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: defaultTokenData,
       oneTimeSecret: false,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -99,7 +101,9 @@ describe("apiAdapter tokenProvisioning", () => {
         token: maskedToken,
       }),
     ).toBe(true)
-    expect(provisioning.getRepairPolicy()).toEqual({ kind: "eligible" })
+    expect(provisioning.getRepairPolicy()).toEqual({
+      kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
+    })
   })
 
   it("normalizes token provisioning group names", () => {
@@ -121,7 +125,7 @@ describe("apiAdapter tokenProvisioning", () => {
         defaultTokenData,
       }),
     ).toEqual({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
     })
 
@@ -130,7 +134,9 @@ describe("apiAdapter tokenProvisioning", () => {
         workflow: TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection,
         defaultTokenData,
       }),
-    ).toEqual({ kind: "needs_user_groups" })
+    ).toEqual({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+    })
 
     expect(
       sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
@@ -141,7 +147,7 @@ describe("apiAdapter tokenProvisioning", () => {
         },
       }),
     ).toEqual({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: { ...defaultTokenData, group: "default" },
       oneTimeSecret: false,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -158,7 +164,7 @@ describe("apiAdapter tokenProvisioning", () => {
         },
       }),
     ).toEqual({
-      kind: "selection_required",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
       allowedGroups: ["vip", "default"],
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
     })
@@ -172,12 +178,12 @@ describe("apiAdapter tokenProvisioning", () => {
         },
       }),
     ).toEqual({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
     })
 
     expect(sub2ApiTokenProvisioning.getRepairPolicy()).toEqual({
-      kind: "skipped",
+      kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
       skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
     })
   })
@@ -199,7 +205,7 @@ describe("apiAdapter tokenProvisioning", () => {
         explicitGroup: " vip ",
       }),
     ).toEqual({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: { ...defaultTokenData, group: "vip" },
       oneTimeSecret: false,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
@@ -244,7 +250,7 @@ describe("apiAdapter tokenProvisioning", () => {
         defaultTokenData,
       }),
     ).toEqual({
-      kind: "blocked",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
     })
 
@@ -254,7 +260,7 @@ describe("apiAdapter tokenProvisioning", () => {
         defaultTokenData,
       }),
     ).toEqual({
-      kind: "create",
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
       tokenData: defaultTokenData,
       oneTimeSecret: true,
       recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
@@ -299,7 +305,7 @@ describe("apiAdapter tokenProvisioning", () => {
     ).toBe(false)
 
     expect(aihubmixTokenProvisioning.getRepairPolicy()).toEqual({
-      kind: "skipped",
+      kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
       skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
     })
   })

--- a/tests/services/apiAdapters/tokenProvisioning.test.ts
+++ b/tests/services/apiAdapters/tokenProvisioning.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import { aihubmixTokenProvisioning } from "~/services/apiAdapters/aihubmix/tokenProvisioning"
 import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
   TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
@@ -73,7 +74,7 @@ describe("apiAdapter tokenProvisioning", () => {
         result: false,
       }),
     ).toEqual({
-      kind: "failed",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
     })
 
@@ -82,7 +83,9 @@ describe("apiAdapter tokenProvisioning", () => {
         workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
         result: true,
       }),
-    ).toEqual({ kind: "needs_inventory_refetch" })
+    ).toEqual({
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+    })
 
     expect(
       provisioning.classifyCreatedToken({
@@ -90,7 +93,7 @@ describe("apiAdapter tokenProvisioning", () => {
         result: createdToken,
       }),
     ).toEqual({
-      kind: "usable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
       token: createdToken,
       oneTimeSecret: false,
     })
@@ -217,7 +220,7 @@ describe("apiAdapter tokenProvisioning", () => {
         result: createdToken,
       }),
     ).toEqual({
-      kind: "usable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
       token: createdToken,
       oneTimeSecret: false,
     })
@@ -227,7 +230,9 @@ describe("apiAdapter tokenProvisioning", () => {
         workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
         result: true,
       }),
-    ).toEqual({ kind: "needs_inventory_refetch" })
+    ).toEqual({
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+    })
 
     expect(
       sub2ApiTokenProvisioning.classifyCreatedToken({
@@ -235,7 +240,7 @@ describe("apiAdapter tokenProvisioning", () => {
         result: false,
       }),
     ).toEqual({
-      kind: "failed",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
     })
   })
@@ -272,7 +277,7 @@ describe("apiAdapter tokenProvisioning", () => {
         result: false,
       }),
     ).toEqual({
-      kind: "failed",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
     })
 
@@ -282,7 +287,7 @@ describe("apiAdapter tokenProvisioning", () => {
         result: fullToken,
       }),
     ).toEqual({
-      kind: "usable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
       token: fullToken,
       oneTimeSecret: true,
     })
@@ -293,7 +298,7 @@ describe("apiAdapter tokenProvisioning", () => {
         result: maskedToken,
       }),
     ).toEqual({
-      kind: "unavailable",
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Unavailable,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
     })
 

--- a/tests/services/apiAdapters/tokenProvisioning.test.ts
+++ b/tests/services/apiAdapters/tokenProvisioning.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import { aihubmixTokenProvisioning } from "~/services/apiAdapters/aihubmix/tokenProvisioning"
 import {
+  TOKEN_CREATION_SECRET_RECOVERY,
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
@@ -60,7 +61,17 @@ describe("apiAdapter tokenProvisioning", () => {
       kind: "create",
       tokenData: defaultTokenData,
       oneTimeSecret: false,
-      recoverCreatedToken: "inventory_refetch",
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+    })
+
+    expect(
+      provisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        result: false,
+      }),
+    ).toEqual({
+      kind: "failed",
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
     })
 
     expect(
@@ -132,7 +143,7 @@ describe("apiAdapter tokenProvisioning", () => {
       kind: "create",
       tokenData: { ...defaultTokenData, group: "default" },
       oneTimeSecret: false,
-      recoverCreatedToken: "inventory_refetch",
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
     })
 
     expect(
@@ -174,6 +185,13 @@ describe("apiAdapter tokenProvisioning", () => {
     const createdToken = token({ group: "vip" })
 
     expect(
+      sub2ApiTokenProvisioning.isInventoryTokenUsable({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        token: token({ key: "sk-****abcd" }),
+      }),
+    ).toBe(true)
+
+    expect(
       sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
         workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
         defaultTokenData,
@@ -183,7 +201,7 @@ describe("apiAdapter tokenProvisioning", () => {
       kind: "create",
       tokenData: { ...defaultTokenData, group: "vip" },
       oneTimeSecret: false,
-      recoverCreatedToken: "inventory_refetch",
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
     })
 
     expect(
@@ -238,7 +256,7 @@ describe("apiAdapter tokenProvisioning", () => {
       kind: "create",
       tokenData: defaultTokenData,
       oneTimeSecret: true,
-      recoverCreatedToken: "created_response_first",
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
     })
 
     expect(

--- a/tests/services/apiAdapters/tokenProvisioning.test.ts
+++ b/tests/services/apiAdapters/tokenProvisioning.test.ts
@@ -14,6 +14,7 @@ import {
 } from "~/services/apiAdapters/sub2api/tokenProvisioning"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import type { ApiToken } from "~/types"
+import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
 
 const defaultTokenData: CreateTokenRequest = {
   name: "Example default token",
@@ -177,7 +178,7 @@ describe("apiAdapter tokenProvisioning", () => {
 
     expect(sub2ApiTokenProvisioning.getRepairPolicy()).toEqual({
       kind: "skipped",
-      skipReason: "sub2api",
+      skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
     })
   })
 
@@ -299,7 +300,7 @@ describe("apiAdapter tokenProvisioning", () => {
 
     expect(aihubmixTokenProvisioning.getRepairPolicy()).toEqual({
       kind: "skipped",
-      skipReason: "aihubmixOneTimeKey",
+      skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
     })
   })
 })


### PR DESCRIPTION
## Summary
- add adapter-owned token provisioning policy contracts for New API-family, Sub2API, and AIHubMix accounts
- route account token creation, post-save recovery, and repair eligibility through the policy capability
- add focused Vitest coverage for policy decisions and migrated account workflows

## Test Plan
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Improvements**
  * Token auto-provisioning is now policy-driven across API adapters, providing consistent default-token create/selection-required/blocked behavior.
  * Sub2API now follows policy-based group selection/requirements, and AIHubmix enforces one-time secret rules and policy-driven repair skipping.
* **Bug Fixes**
  * Standardized repair job state, outcomes, skip reasons, and error messages to keep UI and workflow results consistent.
* **Tests**
  * Expanded automated coverage for provisioning decisions, repair behavior, and related UI flows.
* **Documentation**
  * Added design and implementation plans for the token provisioning policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->