### PR TITLE
refactor(account): route quick-create consumers through token provisioning

### DIFF
--- a/docs/superpowers/plans/2026-06-21-default-token-quick-create-consumers.md
+++ b/docs/superpowers/plans/2026-06-21-default-token-quick-create-consumers.md
@@ -1,0 +1,1526 @@
+# Default Token Quick-Create Consumers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Sub2API-specific quick-create product semantics from Copy Key, Kilo export, and Channel Dialog by routing them through the generic default-token provisioning decision interface.
+
+**Architecture:** Keep backend-specific policy in `SiteAdapter.tokenProvisioning` and keep product orchestration in the existing UI/service consumers. Product code handles generic `ready`, `selection_required`, and `blocked` outcomes, while `ensureAccountApiToken(...)` accepts policy-resolved `defaultTokenData` without dropping future token fields.
+
+**Tech Stack:** TypeScript, React, WXT extension services, existing `apiAdapters`, Testing Library, Vitest, `rg`, `pnpm run validate:staged`, `pnpm run validate:push`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-default-token-quick-create-consumers-design.md`
+
+---
+
+## File Structure
+
+- Modify `src/services/accounts/accountOperations.ts`
+  - Adds generic `defaultTokenData` and `explicitGroup` options to `ensureAccountApiToken(...)`.
+  - Keeps `sub2apiGroup` as a temporary compatibility alias.
+  - Passes the full policy-resolved token payload into `tokenProvisioning.resolveDefaultTokenCreation(...)`.
+- Modify `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+  - Adds service tests proving `defaultTokenData` is preserved.
+  - Keeps compatibility tests for `sub2apiGroup` and `resolveSub2ApiQuickCreateResolution(...)`.
+- Modify `src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts`
+  - Imports `resolveDefaultTokenQuickCreateResolution(...)`.
+  - Removes the `account.siteType === "sub2api"` quick-create gate.
+  - Renames Sub2API-specific state to default-token quick-create state.
+- Modify `src/features/AccountManagement/components/CopyKeyDialog/index.tsx`
+  - Renames Add Token dialog bridge variables and handlers to generic quick-create language.
+- Modify `tests/features/AccountManagement/components/CopyKeyDialog.test.tsx`
+  - Adds a non-Sub2API policy-selection regression test.
+  - Ensures the generic resolver path is used by product behavior.
+- Modify `tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx`
+  - Preserves current Sub2API single-group, multi-group, no-group, and one-time-key behavior.
+- Modify `src/components/KiloCodeExportDialog.tsx`
+  - Imports `resolveDefaultTokenQuickCreateResolution(...)`.
+  - Renames Sub2API create context to generic default-token create context.
+  - Passes `defaultTokenData: resolution.tokenData` into `ensureAccountApiToken(...)`.
+- Modify `tests/components/KiloCodeExportDialog.test.tsx`
+  - Mocks the generic resolver.
+  - Asserts full `tokenData` is passed to shared ensure.
+  - Preserves constrained Add Token dialog and blocked-message behavior.
+- Modify `src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx`
+  - Renames `sub2apiTokenDialog` state and methods to `defaultTokenQuickCreateDialog` state and methods.
+- Modify `src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx`
+  - Uses the generic quick-create dialog state to render `AddTokenDialog`.
+- Modify `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`
+  - Imports `resolveDefaultTokenQuickCreateResolution(...)`.
+  - Replaces no-token Sub2API quick-create branching with generic decision handling.
+  - Passes `defaultTokenData` into `ensureAccountApiToken(...)`.
+  - Renames the exported helper `openSub2ApiTokenCreationDialog` to `openDefaultTokenQuickCreateDialogForAccount`.
+- Modify `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`
+  - Mocks the generic resolver.
+  - Updates context state/method names.
+  - Preserves deferred dialog recovery and fail-closed behavior.
+- Modify `tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx`
+  - Only if generic dialog prefill shape changes during implementation.
+- Modify `tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx`
+  - Only if generic dialog prefill shape changes during implementation.
+
+Do not modify:
+
+- `src/services/apiService/**`
+  - Backend token CRUD remains delegated behind `keyManagement`.
+- `src/services/apiAdapters/**`
+  - The token provisioning policy seam already exists; this slice consumes it.
+- `src/locales/**`
+  - Existing Sub2API-named message keys remain the current copy contract.
+- Account Dialog policy behavior in `src/features/AccountManagement/components/AccountDialog/sitePolicy.ts`
+  - Mechanical imports or shared helper renames are allowed only if compile requires them.
+- Repair Missing Keys, Model Key dialog, Verify API, Verify CLI, managed-site providers, telemetry schemas, settings search, or Playwright E2E.
+
+Telemetry decision: reuse existing.
+
+Settings search decision: none.
+
+E2E decision: no new Playwright E2E. The behavioral risk is service/component routing and state recovery, which focused Vitest and Testing Library tests cover directly.
+
+---
+
+### Task 1: Teach Shared Ensure About Generic Policy Token Data
+
+**Files:**
+- Modify: `src/services/accounts/accountOperations.ts`
+- Modify: `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+
+- [ ] **Step 1: Add a failing service test for `defaultTokenData`**
+
+In `tests/services/accountOperations.ensureAccountApiToken.test.ts`, add this test in the `ensureAccountApiToken` coverage near the existing grouped-create tests:
+
+```ts
+it("passes policy-resolved default token data to shared ensure", async () => {
+  const token = buildSub2ApiToken({ id: 42, key: "sk-created" })
+  const policyTokenData = {
+    ...generateDefaultTokenRequest(),
+    name: "Policy Resolved Default Key",
+    group: "vip",
+    remain_quota: 12345,
+  }
+
+  fetchAccountTokensMock.mockResolvedValueOnce([]).mockResolvedValueOnce([token])
+  createApiTokenMock.mockResolvedValueOnce(true)
+  resolveDefaultTokenCreationMock.mockImplementationOnce((request) => ({
+    kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+    tokenData: request.defaultTokenData,
+    oneTimeSecret: false,
+    recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+  }))
+  classifyCreatedTokenMock.mockReturnValueOnce({
+    kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+  })
+
+  await expect(
+    ensureAccountApiToken(ACCOUNT, DISPLAY_ACCOUNT, {
+      toastId: "toast-policy-token-data",
+      defaultTokenData: policyTokenData,
+    }),
+  ).resolves.toEqual(token)
+
+  expect(resolveDefaultTokenCreationMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+      defaultTokenData: policyTokenData,
+    }),
+  )
+  expect(createApiTokenMock).toHaveBeenCalledWith(
+    expect.any(Object),
+    policyTokenData,
+  )
+})
+```
+
+- [ ] **Step 2: Add an explicit `explicitGroup` compatibility test**
+
+In the same test file, add this test next to the existing `sub2apiGroup` test:
+
+```ts
+it("keeps explicitGroup as the generic group-selection alias", async () => {
+  const token = buildSub2ApiToken({ id: 12, key: "sk-vip" })
+
+  fetchAccountTokensMock.mockResolvedValueOnce([]).mockResolvedValueOnce([token])
+  createApiTokenMock.mockResolvedValueOnce(true)
+  resolveDefaultTokenCreationMock.mockImplementationOnce((request) => ({
+    kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+    tokenData: { ...request.defaultTokenData, group: request.explicitGroup },
+    oneTimeSecret: false,
+    recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+  }))
+  classifyCreatedTokenMock.mockReturnValueOnce({
+    kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+  })
+
+  await expect(
+    ensureAccountApiToken(ACCOUNT, DISPLAY_ACCOUNT, {
+      toastId: "toast-explicit-group",
+      explicitGroup: "vip",
+    }),
+  ).resolves.toEqual(token)
+
+  expect(resolveDefaultTokenCreationMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+      explicitGroup: "vip",
+    }),
+  )
+  expect(createApiTokenMock).toHaveBeenCalledWith(
+    expect.any(Object),
+    expect.objectContaining({ group: "vip" }),
+  )
+})
+```
+
+- [ ] **Step 3: Run the focused service test and verify it fails**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Expected: FAIL because `ensureAccountApiToken(...)` does not accept or forward `defaultTokenData` / `explicitGroup` yet.
+
+- [ ] **Step 4: Add the shared ensure option type**
+
+In `src/services/accounts/accountOperations.ts`, place this type near `DefaultTokenQuickCreateResolution`:
+
+```ts
+type EnsureAccountApiTokenOptions = {
+  toastId?: string
+  defaultTokenData?: CreateTokenRequest
+  explicitGroup?: string
+  /**
+   * Temporary compatibility alias for older Sub2API callers.
+   * New product code should pass `defaultTokenData` from policy resolution.
+   */
+  sub2apiGroup?: string
+}
+```
+
+- [ ] **Step 5: Update the `ensureAccountApiToken(...)` signature and policy request**
+
+Replace the `toastIdOrOptions` parameter type:
+
+```ts
+toastIdOrOptions?: string | EnsureAccountApiTokenOptions,
+```
+
+Then replace the no-token decision request with:
+
+```ts
+const defaultTokenData =
+  options.defaultTokenData ?? generateDefaultTokenRequest()
+const explicitGroup = options.explicitGroup ?? options.sub2apiGroup
+
+const decision = requiredTokenProvisioning.resolveDefaultTokenCreation({
+  workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+  defaultTokenData,
+  explicitGroup,
+})
+```
+
+Do not remove `sub2apiGroup` in this task. It is a compatibility alias until cleanup searches prove no old caller remains.
+
+- [ ] **Step 6: Run the focused service test and verify it passes**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the service API change**
+
+Run:
+
+```powershell
+git add src/services/accounts/accountOperations.ts tests/services/accountOperations.ensureAccountApiToken.test.ts
+git commit -m "refactor(accounts): accept generic default token data"
+```
+
+---
+
+### Task 2: Migrate Copy Key Dialog To Generic Quick-Create Decisions
+
+**Files:**
+- Modify: `src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts`
+- Modify: `src/features/AccountManagement/components/CopyKeyDialog/index.tsx`
+- Modify: `tests/features/AccountManagement/components/CopyKeyDialog.test.tsx`
+- Modify: `tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx`
+
+- [ ] **Step 1: Add a failing generic-selection product test**
+
+In `tests/features/AccountManagement/components/CopyKeyDialog.test.tsx`, import the module namespace:
+
+```ts
+import * as accountOperations from "~/services/accounts/accountOperations"
+```
+
+Add this spy near the other test-level spies:
+
+```ts
+const resolveDefaultTokenQuickCreateResolutionSpy = vi.spyOn(
+  accountOperations,
+  "resolveDefaultTokenQuickCreateResolution",
+)
+```
+
+Reset it in `beforeEach`:
+
+```ts
+resolveDefaultTokenQuickCreateResolutionSpy.mockReset()
+```
+
+Then add this test near the current default-key creation tests:
+
+```ts
+it("opens a generic constrained Add Token dialog when default token policy requires selection", async () => {
+  fetchAccountTokensMock.mockResolvedValueOnce([])
+  resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+    kind: "selection_required",
+    allowedGroups: ["default", "vip"],
+  })
+
+  const user = userEvent.setup()
+
+  render(
+    <CopyKeyDialog
+      isOpen={true}
+      onClose={() => {}}
+      account={{
+        ...ACCOUNT,
+        siteType: SITE_TYPES.NEW_API,
+      }}
+    />,
+  )
+
+  await user.click(
+    await screen.findByRole("button", {
+      name: "ui:dialog.copyKey.createKey",
+    }),
+  )
+
+  await screen.findByText("messages:sub2api.createRequiresGroupSelection")
+  expect(resolveDefaultTokenQuickCreateResolutionSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ siteType: SITE_TYPES.NEW_API }),
+  )
+  expect(createApiTokenMock).not.toHaveBeenCalled()
+})
+```
+
+This test deliberately uses a non-Sub2API account. It fails until product code asks the generic resolver instead of checking the site type first.
+
+- [ ] **Step 2: Add a failing full-token-data test for Copy Key**
+
+In the same file, add:
+
+```ts
+it("creates a default key with the full policy-resolved token payload", async () => {
+  const policyTokenData = {
+    name: "Policy Resolved Copy Key",
+    remain_quota: 777,
+    expired_time: -1,
+    unlimited_quota: false,
+    model_limits_enabled: false,
+    model_limits: "",
+    allow_ips: "",
+    group: "vip",
+  }
+
+  fetchAccountTokensMock.mockResolvedValueOnce([]).mockResolvedValueOnce([TOKEN])
+  resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+    kind: "ready",
+    tokenData: policyTokenData,
+  })
+  createApiTokenMock.mockResolvedValueOnce(true)
+
+  const user = userEvent.setup()
+
+  render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+  await user.click(
+    await screen.findByRole("button", {
+      name: "ui:dialog.copyKey.createKey",
+    }),
+  )
+
+  await waitFor(() => {
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      policyTokenData,
+    )
+  })
+})
+```
+
+- [ ] **Step 3: Run Copy Key tests and verify the new tests fail**
+
+Run:
+
+```powershell
+pnpm vitest run tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+```
+
+Expected: FAIL because the hook still imports `resolveSub2ApiQuickCreateResolution(...)`, keeps Sub2API state names, and only resolves policy inside the Sub2API site-type branch.
+
+- [ ] **Step 4: Replace the Sub2API wrapper import in the hook**
+
+In `src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts`, replace:
+
+```ts
+import { resolveSub2ApiQuickCreateResolution } from "~/services/accounts/accountOperations"
+```
+
+with:
+
+```ts
+import { resolveDefaultTokenQuickCreateResolution } from "~/services/accounts/accountOperations"
+```
+
+- [ ] **Step 5: Rename hook state and clear helper**
+
+In `useCopyKeyDialog.ts`, replace the state:
+
+```ts
+const [sub2apiCreateAllowedGroups, setSub2apiCreateAllowedGroups] = useState<
+  string[] | null
+>(null)
+```
+
+with:
+
+```ts
+const [
+  defaultTokenCreateAllowedGroups,
+  setDefaultTokenCreateAllowedGroups,
+] = useState<string[] | null>(null)
+```
+
+Replace `clearSub2ApiCreateAllowedGroups`:
+
+```ts
+const clearDefaultTokenCreateAllowedGroups = useCallback(() => {
+  setDefaultTokenCreateAllowedGroups(null)
+}, [])
+```
+
+Update all hook references:
+
+```text
+clearSub2ApiCreateAllowedGroups -> clearDefaultTokenCreateAllowedGroups
+sub2apiCreateAllowedGroups -> defaultTokenCreateAllowedGroups
+setSub2apiCreateAllowedGroups -> setDefaultTokenCreateAllowedGroups
+```
+
+- [ ] **Step 6: Replace Copy Key default create decision logic**
+
+In `createDefaultKey`, replace the Sub2API-only block:
+
+```ts
+const tokenRequest = generateDefaultTokenRequest()
+if (account.siteType === "sub2api") {
+  const resolution = await resolveSub2ApiQuickCreateResolution(account)
+  if (resolution.kind === "blocked") {
+    setCreateError(resolution.message)
+    return
+  }
+
+  if (resolution.kind === "selection_required") {
+    setSub2apiCreateAllowedGroups(resolution.allowedGroups)
+    return
+  }
+
+  tokenRequest.group = resolution.group
+}
+```
+
+with:
+
+```ts
+const resolution = await resolveDefaultTokenQuickCreateResolution(account)
+if (resolution.kind === "blocked") {
+  setCreateError(resolution.message)
+  return
+}
+
+if (resolution.kind === "selection_required") {
+  setDefaultTokenCreateAllowedGroups(resolution.allowedGroups)
+  return
+}
+
+const tokenRequest = resolution.tokenData
+```
+
+Keep the existing `createToken(...)`, `refreshTokensAfterCreate(...)`, catch, and finally behavior unchanged.
+
+- [ ] **Step 7: Return generic hook fields**
+
+Update the hook return object:
+
+```ts
+defaultTokenCreateAllowedGroups,
+clearDefaultTokenCreateAllowedGroups,
+```
+
+Remove the old returned names:
+
+```ts
+sub2apiCreateAllowedGroups,
+clearSub2ApiCreateAllowedGroups,
+```
+
+- [ ] **Step 8: Rename Copy Key component bridge variables**
+
+In `src/features/AccountManagement/components/CopyKeyDialog/index.tsx`, update the hook destructuring:
+
+```ts
+defaultTokenCreateAllowedGroups,
+clearDefaultTokenCreateAllowedGroups,
+```
+
+Then update the handlers:
+
+```ts
+const handleOpenAddTokenDialog = () => {
+  clearDefaultTokenCreateAllowedGroups()
+  setIsAddTokenDialogOpen(true)
+}
+const handleCloseAddTokenDialog = () => {
+  clearDefaultTokenCreateAllowedGroups()
+  setIsAddTokenDialogOpen(false)
+}
+const handleAddTokenSuccess = (createdToken?: ApiToken) => {
+  clearDefaultTokenCreateAllowedGroups()
+  return refreshTokensAfterCreate(createdToken)
+}
+```
+
+Update the close effect dependency and body:
+
+```ts
+if (!isOpen || !account) {
+  clearDefaultTokenCreateAllowedGroups()
+  setIsAddTokenDialogOpen(false)
+}
+```
+
+Replace `sub2apiQuickCreatePrefill` with:
+
+```ts
+const defaultTokenQuickCreatePrefill =
+  defaultTokenCreateAllowedGroups &&
+  defaultTokenCreateAllowedGroups.length > 0
+    ? {
+        modelId: "",
+        defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        allowedGroups: defaultTokenCreateAllowedGroups,
+      }
+    : undefined
+```
+
+Pass `defaultTokenQuickCreatePrefill` to `AddTokenDialog`.
+
+- [ ] **Step 9: Run Copy Key tests and verify they pass**
+
+Run:
+
+```powershell
+pnpm vitest run tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit the Copy Key migration**
+
+Run:
+
+```powershell
+git add src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts src/features/AccountManagement/components/CopyKeyDialog/index.tsx tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+git commit -m "refactor(copy-key): use generic token quick-create policy"
+```
+
+---
+
+### Task 3: Migrate Kilo Export To Generic Quick-Create Decisions
+
+**Files:**
+- Modify: `src/components/KiloCodeExportDialog.tsx`
+- Modify: `tests/components/KiloCodeExportDialog.test.tsx`
+
+- [ ] **Step 1: Update the account operations mock to expose the generic resolver**
+
+In `tests/components/KiloCodeExportDialog.test.tsx`, replace:
+
+```ts
+const mockResolveSub2ApiQuickCreateResolution = vi.fn()
+```
+
+with:
+
+```ts
+const mockResolveDefaultTokenQuickCreateResolution = vi.fn()
+```
+
+Replace the module mock:
+
+```ts
+vi.mock("~/services/accounts/accountOperations", () => ({
+  ensureAccountApiToken: (...args: unknown[]) =>
+    mockEnsureAccountApiToken(...args),
+  resolveDefaultTokenQuickCreateResolution: (...args: unknown[]) =>
+    mockResolveDefaultTokenQuickCreateResolution(...args),
+}))
+```
+
+Update `beforeEach` to reset the generic mock.
+
+- [ ] **Step 2: Add a failing test for full token payload propagation**
+
+Update the existing ready-state Sub2API Kilo test to use:
+
+```ts
+const policyTokenData = {
+  name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+  remain_quota: 45678,
+  expired_time: -1,
+  unlimited_quota: false,
+  model_limits_enabled: false,
+  model_limits: "",
+  allow_ips: "",
+  group: "vip",
+}
+
+mockResolveDefaultTokenQuickCreateResolution.mockResolvedValueOnce({
+  kind: "ready",
+  tokenData: policyTokenData,
+})
+```
+
+Then assert:
+
+```ts
+expect(mockResolveDefaultTokenQuickCreateResolution).toHaveBeenCalledWith(
+  expect.objectContaining({ id: "b", siteType: "sub2api" }),
+)
+expect(mockEnsureAccountApiToken).toHaveBeenCalledWith(
+  expect.objectContaining({ id: "b", site_type: "sub2api" }),
+  expect.objectContaining({ id: "b", siteType: "sub2api" }),
+  expect.objectContaining({
+    toastId: "kilocode-create-token-b",
+    defaultTokenData: policyTokenData,
+  }),
+)
+```
+
+Remove assertions that expect `sub2apiGroup`.
+
+- [ ] **Step 3: Update Kilo selection and blocked tests to mock the generic resolver**
+
+Replace all test setup calls:
+
+```ts
+mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce(...)
+```
+
+with:
+
+```ts
+mockResolveDefaultTokenQuickCreateResolution.mockResolvedValueOnce(...)
+```
+
+For selection-required tests, keep the existing expected Add Token dialog prefill:
+
+```ts
+expect(addTokenDialogPropsMock).toHaveBeenLastCalledWith(
+  expect.objectContaining({
+    isOpen: true,
+    createPrefill: expect.objectContaining({
+      defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+      allowedGroups: ["default", "vip"],
+    }),
+  }),
+)
+```
+
+- [ ] **Step 4: Run Kilo tests and verify they fail**
+
+Run:
+
+```powershell
+pnpm vitest run tests/components/KiloCodeExportDialog.test.tsx
+```
+
+Expected: FAIL because production still imports the Sub2API wrapper and passes `sub2apiGroup`.
+
+- [ ] **Step 5: Replace the Kilo resolver import**
+
+In `src/components/KiloCodeExportDialog.tsx`, replace:
+
+```ts
+resolveSub2ApiQuickCreateResolution,
+```
+
+with:
+
+```ts
+resolveDefaultTokenQuickCreateResolution,
+```
+
+- [ ] **Step 6: Rename Kilo create context**
+
+Add this type near the component-local state types:
+
+```ts
+type DefaultTokenCreateContext = {
+  siteId: string
+  allowedGroups: string[]
+}
+```
+
+Replace:
+
+```ts
+const [sub2apiCreateContext, setSub2apiCreateContext] = useState<{
+  siteId: string
+  allowedGroups: string[]
+} | null>(null)
+```
+
+with:
+
+```ts
+const [defaultTokenCreateContext, setDefaultTokenCreateContext] =
+  useState<DefaultTokenCreateContext | null>(null)
+```
+
+- [ ] **Step 7: Replace Kilo no-token creation logic**
+
+In `createDefaultTokenForSite`, replace the Sub2API-specific conditional branch inside the `try` block. The replacement starts where the current code declares `let ensuredToken: ApiToken`, covers both the Sub2API wrapper path and the non-Sub2API `ensureAccountApiToken(account, site, toastId)` path, and ends before the existing success toast.
+
+Use this replacement:
+
+```ts
+const resolution = await resolveDefaultTokenQuickCreateResolution(site)
+if (resolution.kind === "blocked") {
+  const userMessage = resolution.message?.trim()
+    ? resolution.message
+    : "Token creation was blocked. Please check site policy or try again."
+
+  toast.error(userMessage, { id: toastId })
+  setTokenInventories((prev) => ({
+    ...prev,
+    [siteId]: {
+      status: "error",
+      tokens: prev[siteId]?.tokens ?? [],
+      errorMessage: userMessage,
+    },
+  }))
+  return
+}
+
+if (resolution.kind === "selection_required") {
+  setDefaultTokenCreateContext({
+    siteId,
+    allowedGroups: resolution.allowedGroups,
+  })
+  setTokenInventories((prev) => ({
+    ...prev,
+    [siteId]: {
+      status: "loaded",
+      tokens: prev[siteId]?.tokens ?? [],
+      errorMessage: undefined,
+    },
+  }))
+  return
+}
+
+const ensuredToken = await ensureAccountApiToken(account, site, {
+  toastId,
+  defaultTokenData: resolution.tokenData,
+})
+```
+
+Keep the existing success toast, `loadTokensForSite(siteId, { preferNewest: true })`, selected-token update, catch, and finally behavior.
+
+- [ ] **Step 8: Rename Kilo Add Token dialog helpers**
+
+Replace:
+
+```ts
+handleCloseSub2ApiCreateDialog
+handleSub2ApiCreateSuccess
+sub2apiQuickCreateSite
+sub2apiQuickCreatePrefill
+sub2apiCreateContext
+```
+
+with:
+
+```ts
+handleCloseDefaultTokenCreateDialog
+handleDefaultTokenCreateSuccess
+defaultTokenQuickCreateSite
+defaultTokenQuickCreatePrefill
+defaultTokenCreateContext
+```
+
+The prefill builder should be:
+
+```ts
+const defaultTokenQuickCreatePrefill =
+  defaultTokenCreateContext &&
+  defaultTokenCreateContext.allowedGroups.length > 0
+    ? {
+        modelId: "",
+        defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        allowedGroups: defaultTokenCreateContext.allowedGroups,
+      }
+    : undefined
+```
+
+Use these generic names in the rendered `AddTokenDialog`.
+
+- [ ] **Step 9: Run Kilo tests and verify they pass**
+
+Run:
+
+```powershell
+pnpm vitest run tests/components/KiloCodeExportDialog.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit the Kilo migration**
+
+Run:
+
+```powershell
+git add src/components/KiloCodeExportDialog.tsx tests/components/KiloCodeExportDialog.test.tsx
+git commit -m "refactor(kilo): use generic token quick-create policy"
+```
+
+---
+
+### Task 4: Rename Channel Dialog Quick-Create State To Generic Product Semantics
+
+**Files:**
+- Modify: `src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx`
+- Modify: `src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx`
+- Modify: `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`
+
+- [ ] **Step 1: Update Channel Dialog context tests to generic names**
+
+In `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`, replace assertions and calls:
+
+```text
+sub2apiTokenDialog -> defaultTokenQuickCreateDialog
+openSub2ApiTokenDialog -> openDefaultTokenQuickCreateDialog
+closeSub2ApiTokenDialog -> closeDefaultTokenQuickCreateDialog
+handleSub2ApiTokenSuccess -> handleDefaultTokenQuickCreateSuccess
+```
+
+For example, replace:
+
+```ts
+expect(result.current.context.sub2apiTokenDialog).toMatchObject({
+  isOpen: true,
+  allowedGroups: ["default", "vip"],
+})
+```
+
+with:
+
+```ts
+expect(result.current.context.defaultTokenQuickCreateDialog).toMatchObject({
+  isOpen: true,
+  allowedGroups: ["default", "vip"],
+})
+```
+
+Replace direct helper calls:
+
+```ts
+result.current.context.openSub2ApiTokenDialog({
+  account,
+  allowedGroups: ["default"],
+})
+await result.current.context.handleSub2ApiTokenSuccess(createdToken)
+```
+
+with:
+
+```ts
+result.current.context.openDefaultTokenQuickCreateDialog({
+  account,
+  allowedGroups: ["default"],
+})
+await result.current.context.handleDefaultTokenQuickCreateSuccess(createdToken)
+```
+
+- [ ] **Step 2: Run Channel tests and verify they fail on old context names**
+
+Run:
+
+```powershell
+pnpm vitest run tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: FAIL because the context still exports Sub2API-named state and methods.
+
+- [ ] **Step 3: Rename context types and state**
+
+In `src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx`, replace:
+
+```ts
+interface Sub2ApiTokenDialogState {
+```
+
+with:
+
+```ts
+interface DefaultTokenQuickCreateDialogState {
+```
+
+Replace context fields:
+
+```ts
+sub2apiTokenDialog: Sub2ApiTokenDialogState
+openSub2ApiTokenDialog: (config: {
+  account: DisplaySiteData
+  allowedGroups: string[]
+  notice?: string
+  onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
+}) => void
+closeSub2ApiTokenDialog: () => void
+handleSub2ApiTokenSuccess: (createdToken?: ApiToken) => Promise<void>
+```
+
+with:
+
+```ts
+defaultTokenQuickCreateDialog: DefaultTokenQuickCreateDialogState
+openDefaultTokenQuickCreateDialog: (config: {
+  account: DisplaySiteData
+  allowedGroups: string[]
+  notice?: string
+  onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
+}) => void
+closeDefaultTokenQuickCreateDialog: () => void
+handleDefaultTokenQuickCreateSuccess: (
+  createdToken?: ApiToken,
+) => Promise<void>
+```
+
+- [ ] **Step 4: Rename provider implementation variables**
+
+Replace state and refs:
+
+```text
+sub2apiTokenDialog -> defaultTokenQuickCreateDialog
+setSub2apiTokenDialog -> setDefaultTokenQuickCreateDialog
+sub2apiTokenDialogSessionIdRef -> defaultTokenQuickCreateDialogSessionIdRef
+sub2apiTokenOnSuccessRef -> defaultTokenQuickCreateOnSuccessRef
+```
+
+Rename callbacks:
+
+```text
+openSub2ApiTokenDialog -> openDefaultTokenQuickCreateDialog
+closeSub2ApiTokenDialog -> closeDefaultTokenQuickCreateDialog
+handleSub2ApiTokenSuccess -> handleDefaultTokenQuickCreateSuccess
+```
+
+The renamed success callback should preserve the existing stale-session guard:
+
+```ts
+const handleDefaultTokenQuickCreateSuccess = useCallback(
+  async (createdToken?: ApiToken) => {
+    const sessionIdAtInvocation = defaultTokenQuickCreateDialog.sessionId
+    if (!defaultTokenQuickCreateDialog.isOpen) {
+      return
+    }
+
+    if (
+      defaultTokenQuickCreateDialogSessionIdRef.current !==
+      sessionIdAtInvocation
+    ) {
+      return
+    }
+
+    const callback = defaultTokenQuickCreateOnSuccessRef.current
+    closeDefaultTokenQuickCreateDialog()
+    await callback?.(createdToken)
+  },
+  [
+    closeDefaultTokenQuickCreateDialog,
+    defaultTokenQuickCreateDialog.isOpen,
+    defaultTokenQuickCreateDialog.sessionId,
+  ],
+)
+```
+
+- [ ] **Step 5: Rename container bridge variables**
+
+In `src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx`, destructure:
+
+```ts
+defaultTokenQuickCreateDialog,
+closeDefaultTokenQuickCreateDialog,
+handleDefaultTokenQuickCreateSuccess,
+```
+
+Build the prefill with:
+
+```ts
+const defaultTokenQuickCreatePrefill =
+  defaultTokenQuickCreateDialog.account &&
+  defaultTokenQuickCreateDialog.allowedGroups.length > 0
+    ? {
+        modelId: "",
+        defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: defaultTokenQuickCreateDialog.allowedGroups.includes("default")
+          ? "default"
+          : defaultTokenQuickCreateDialog.allowedGroups[0] ?? "default",
+        allowedGroups: defaultTokenQuickCreateDialog.allowedGroups,
+      }
+    : undefined
+```
+
+Render `AddTokenDialog` from `defaultTokenQuickCreateDialog` and call the renamed close/success handlers.
+
+- [ ] **Step 6: Update hook imports/destructuring for renamed context API**
+
+In `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`, replace:
+
+```ts
+const { openDialog, openSub2ApiTokenDialog, requestDuplicateChannelWarning } =
+  useChannelDialogContext()
+```
+
+with:
+
+```ts
+const {
+  openDialog,
+  openDefaultTokenQuickCreateDialog,
+  requestDuplicateChannelWarning,
+} = useChannelDialogContext()
+```
+
+Replace all calls to `openSub2ApiTokenDialog` with calls to `openDefaultTokenQuickCreateDialog`.
+
+- [ ] **Step 7: Run Channel tests and verify context rename passes**
+
+Run:
+
+```powershell
+pnpm vitest run tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: PASS. If this fails, fix only naming mistakes in this task; do not migrate resolver behavior until Task 5.
+
+- [ ] **Step 8: Commit the Channel context rename**
+
+Run:
+
+```powershell
+git add src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+git commit -m "refactor(channel): generalize quick-create dialog state"
+```
+
+---
+
+### Task 5: Migrate Channel Dialog No-Token Flow To Generic Decisions
+
+**Files:**
+- Modify: `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`
+- Modify: `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`
+
+- [ ] **Step 1: Change Channel tests to spy on the generic resolver**
+
+In `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`, replace:
+
+```ts
+const resolveSub2ApiQuickCreateResolutionSpy = vi.spyOn(
+  accountOperations,
+  "resolveSub2ApiQuickCreateResolution",
+)
+```
+
+with:
+
+```ts
+const resolveDefaultTokenQuickCreateResolutionSpy = vi.spyOn(
+  accountOperations,
+  "resolveDefaultTokenQuickCreateResolution",
+)
+```
+
+Replace all reset/setup/assertion references to the new spy name.
+
+- [ ] **Step 2: Update no-token selection-required assertions**
+
+Where tests currently mock:
+
+```ts
+resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
+  kind: "selection_required",
+  allowedGroups: ["default", "vip"],
+})
+```
+
+replace with:
+
+```ts
+resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+  kind: "selection_required",
+  allowedGroups: ["default", "vip"],
+})
+```
+
+Keep assertions that the generic dialog state opens:
+
+```ts
+expect(result.current.context.defaultTokenQuickCreateDialog).toMatchObject({
+  isOpen: true,
+  allowedGroups: ["default", "vip"],
+  notice: "messages:sub2api.createRequiresGroupSelection",
+})
+expect(ensureAccountApiTokenSpy).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 3: Add a failing ready-state payload propagation test**
+
+Add this test near the current no-token ensure tests:
+
+```ts
+it("ensures a token with full generic quick-create token data", async () => {
+  const policyTokenData = {
+    name: "Channel Policy Token",
+    remain_quota: 65432,
+    expired_time: -1,
+    unlimited_quota: false,
+    model_limits_enabled: false,
+    model_limits: "",
+    allow_ips: "",
+    group: "ops",
+  }
+  const createdToken = buildApiToken({ id: 30, key: "sk-created" })
+
+  const mockService: Partial<ManagedSiteService> = {
+    messagesKey: "newapi",
+    getConfig: vi.fn(async () => ({
+      baseUrl: "https://managed.example.com",
+      adminToken: "admin-token",
+      userId: "1",
+    })),
+    prepareChannelFormData: vi.fn(),
+    searchChannel: vi.fn(),
+  }
+  getManagedSiteServiceSpy.mockResolvedValue(mockService as ManagedSiteService)
+  getAccountByIdSpy.mockResolvedValue(buildSiteAccount({ site_type: "new-api" }))
+  mockFetchAccountTokens.mockResolvedValueOnce([])
+  resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+    kind: "ready",
+    tokenData: policyTokenData,
+  })
+  ensureAccountApiTokenSpy.mockResolvedValueOnce(createdToken)
+  mockResolveApiTokenKey.mockResolvedValueOnce(createdToken)
+
+  const { result } = renderHook(() => ({
+    dialog: useChannelDialog(),
+    context: useChannelDialogContext(),
+  }))
+
+  await act(async () => {
+    await result.current.dialog.openWithAccount(
+      buildDisplaySiteData({ siteType: "new-api" }),
+      null,
+    )
+  })
+
+  expect(resolveDefaultTokenQuickCreateResolutionSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ siteType: "new-api" }),
+  )
+  expect(ensureAccountApiTokenSpy).toHaveBeenCalledWith(
+    expect.objectContaining({ site_type: "new-api" }),
+    expect.objectContaining({ siteType: "new-api" }),
+    expect.objectContaining({
+      toastId: "toast-id",
+      defaultTokenData: policyTokenData,
+    }),
+  )
+})
+```
+
+- [ ] **Step 4: Rename the exported dialog helper test calls**
+
+Replace direct helper calls that invoke the old Sub2API helper:
+
+```ts
+await result.current.dialog.openSub2ApiTokenCreationDialog(
+  buildDisplaySiteData({ siteType: "sub2api" }),
+)
+```
+
+with:
+
+```ts
+await result.current.dialog.openDefaultTokenQuickCreateDialogForAccount(
+  buildDisplaySiteData({ siteType: "sub2api" }),
+)
+```
+
+Keep the existing expected behaviors:
+
+- returns `false` when tokens already exist;
+- returns `false` and shows the blocked policy message through `toast.error`;
+- opens the generic quick-create dialog on `selection_required`;
+- opens the dialog with a resolved single group when `ready.tokenData.group` is non-empty;
+- preserves caller `onSuccess`.
+
+- [ ] **Step 5: Run Channel tests and verify they fail**
+
+Run:
+
+```powershell
+pnpm vitest run tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: FAIL because production still imports the Sub2API wrapper and uses `sub2apiGroup`.
+
+- [ ] **Step 6: Replace the Channel resolver import**
+
+In `src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts`, replace:
+
+```ts
+import {
+  ensureAccountApiToken,
+  resolveSub2ApiQuickCreateResolution,
+} from "~/services/accounts/accountOperations"
+```
+
+with:
+
+```ts
+import {
+  ensureAccountApiToken,
+  resolveDefaultTokenQuickCreateResolution,
+} from "~/services/accounts/accountOperations"
+```
+
+Remove the `SITE_TYPES` import if it becomes unused.
+
+- [ ] **Step 7: Rename the exported helper and use generic decisions**
+
+Rename:
+
+```ts
+openSub2ApiTokenCreationDialog
+```
+
+to:
+
+```ts
+openDefaultTokenQuickCreateDialogForAccount
+```
+
+Replace its resolver block with:
+
+```ts
+const resolution = await resolveDefaultTokenQuickCreateResolution(account)
+if (resolution.kind === "blocked") {
+  toast.error(resolution.message)
+  return false
+}
+
+if (resolution.kind === "ready") {
+  const selectedGroup = resolution.tokenData.group?.trim()
+  if (!selectedGroup) {
+    return false
+  }
+
+  openDefaultTokenQuickCreateDialog({
+    account,
+    allowedGroups: [selectedGroup],
+    notice: options?.notice,
+    onSuccess: options?.onSuccess,
+  })
+  return true
+}
+
+openDefaultTokenQuickCreateDialog({
+  account,
+  allowedGroups: resolution.allowedGroups,
+  notice:
+    options?.notice ?? t("messages:sub2api.createRequiresGroupSelection"),
+  onSuccess: options?.onSuccess,
+})
+
+return true
+```
+
+This helper still opens a dialog. It should not auto-create a token for ready policies without a group because that would be a different product action.
+
+- [ ] **Step 8: Replace `openWithAccount(...)` no-token branch**
+
+In `openWithAccount(...)`, replace the entire no-token branch that currently checks `displaySiteData.siteType === SITE_TYPES.SUB2API` and calls `resolveSub2ApiQuickCreateResolution(...)`. The replacement starts immediately after the existing inventory fetch assigns `apiToken = existingTokenList.at(-1) ?? null`, stays inside the surrounding `if (!apiToken) { ... }`, and ends before the existing `if (!shouldContinue()) { return cancelOpen() }` check.
+
+Use this replacement:
+
+```ts
+const resolution =
+  await resolveDefaultTokenQuickCreateResolution(displaySiteData)
+if (!shouldContinue()) {
+  return cancelOpen()
+}
+
+if (resolution.kind === "blocked") {
+  toast.error(resolution.message, { id: toastId })
+  return { opened: false }
+}
+
+if (resolution.kind === "selection_required") {
+  if (!shouldContinue()) {
+    return cancelOpen()
+  }
+  toast.dismiss(toastId)
+  openDefaultTokenQuickCreateDialog({
+    account: displaySiteData,
+    allowedGroups: resolution.allowedGroups,
+    notice: t("messages:sub2api.createRequiresGroupSelection"),
+    onSuccess: async (createdToken?: ApiToken) => {
+      if (!shouldContinue()) {
+        return
+      }
+
+      if (createdToken) {
+        await openWithAccount(displaySiteData!, createdToken, onSuccess, options)
+        return
+      }
+
+      if (!shouldContinue()) {
+        return
+      }
+
+      const refetchedTokens =
+        accountKeyManagement && accountApiRequest
+          ? await accountKeyManagement.fetchTokens(accountApiRequest)
+          : null
+      if (!shouldContinue()) {
+        return
+      }
+      const recoveredToken = Array.isArray(refetchedTokens)
+        ? selectSingleNewApiTokenByIdDiff({
+            existingTokenIds,
+            tokens: refetchedTokens,
+          })
+        : null
+
+      if (!recoveredToken) {
+        toast.error(t("messages:accountOperations.createTokenFailed"))
+        return
+      }
+
+      await openWithAccount(displaySiteData!, recoveredToken, onSuccess, options)
+    },
+  })
+  return { opened: false, deferred: true }
+}
+
+apiToken = await ensureAccountApiToken(siteAccount, displaySiteData, {
+  toastId,
+  defaultTokenData: resolution.tokenData,
+})
+```
+
+Keep all `shouldContinue()` checks around async boundaries. Keep duplicate-channel and managed-site behavior outside this block unchanged.
+
+- [ ] **Step 9: Run Channel tests and verify they pass**
+
+Run:
+
+```powershell
+pnpm vitest run tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit the Channel behavior migration**
+
+Run:
+
+```powershell
+git add src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+git commit -m "refactor(channel): use generic token quick-create policy"
+```
+
+---
+
+### Task 6: Cleanup Searches, Related Tests, And Publish Gate
+
+**Files:**
+- Modify only files that cleanup searches prove still contain unexpected quick-create specialization.
+
+- [ ] **Step 1: Run wrapper import cleanup search**
+
+Run:
+
+```powershell
+rg "resolveSub2ApiQuickCreateResolution" src tests
+```
+
+Expected allowed matches:
+
+```text
+src/services/accounts/accountOperations.ts
+tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+If `CopyKeyDialog`, `KiloCodeExportDialog`, `ChannelDialog`, or their tests still appear, replace those imports/mocks with `resolveDefaultTokenQuickCreateResolution(...)`.
+
+- [ ] **Step 2: Run shared ensure option cleanup search**
+
+Run:
+
+```powershell
+rg "sub2apiGroup|explicitGroup|defaultTokenData" src tests
+```
+
+Expected:
+
+- `defaultTokenData` appears in generic consumers and service tests.
+- `explicitGroup` appears in resolver/service policy paths and compatibility tests.
+- `sub2apiGroup` appears only in `src/services/accounts/accountOperations.ts` and compatibility tests, if retained.
+
+If product consumers still pass `sub2apiGroup`, change them to `defaultTokenData: resolution.tokenData`.
+
+- [ ] **Step 3: Run Copy Key and Kilo naming cleanup search**
+
+Run:
+
+```powershell
+rg "sub2apiCreateAllowedGroups|sub2apiCreateContext|sub2apiQuickCreate" src tests
+```
+
+Expected: no matches.
+
+If matches remain in Copy Key or Kilo, rename them to the generic names from Tasks 2 and 3.
+
+- [ ] **Step 4: Run Channel dialog naming cleanup search**
+
+Run:
+
+```powershell
+rg "sub2apiTokenDialog|openSub2ApiTokenDialog|closeSub2ApiTokenDialog|handleSub2ApiTokenSuccess" src tests
+```
+
+Expected: no matches.
+
+If matches remain in Channel Dialog source or tests, rename them to the generic context API from Task 4.
+
+- [ ] **Step 5: Run Sub2API site-type branch audit**
+
+Run:
+
+```powershell
+rg "siteType === [\"']sub2api[\"']|siteType === SITE_TYPES.SUB2API" src/features src/components src/services/accounts
+```
+
+Expected allowed matches include:
+
+- Account Dialog post-save site policy.
+- Repair Missing Keys manual recovery flow.
+- Model Key explicit group/model flow.
+- Service-level wrapper compatibility in `accountOperations.ts`.
+
+Unexpected matches include Copy Key default create, Kilo no-token create, and Channel Dialog no-token create. Remove unexpected matches by routing through generic quick-create decisions.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.ensureAccountApiToken.test.ts tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx tests/components/KiloCodeExportDialog.test.tsx tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run Add Token bridge tests if the prefill contract changed**
+
+Run this if `AddTokenDialog` props, prefill shape, or `useTokenData` behavior changed:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx tests/entrypoints/options/pages/KeyManagement/useTokenData.test.tsx
+```
+
+Expected: PASS.
+
+If no Add Token files changed and the `createPrefill` shape remains `{ modelId, defaultName, group?, allowedGroups }`, record this as not run because the bridge contract was unchanged.
+
+- [ ] **Step 8: Run related validation**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/accounts/accountOperations.ts src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts src/features/AccountManagement/components/CopyKeyDialog/index.tsx src/components/KiloCodeExportDialog.tsx src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run the commit gate**
+
+Run:
+
+```powershell
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Run the push gate**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS.
+
+This push gate is required before PR or remote handoff because the implementation changes shared account operations, cross-feature dialog wiring, and TypeScript service contracts.
+
+- [ ] **Step 11: Commit cleanup fixes if any were needed**
+
+If cleanup searches required final edits, run:
+
+```powershell
+git add src tests
+git commit -m "refactor(accounts): remove specialized quick-create consumers"
+```
+
+If no final edits were needed after the prior task commits, do not create an empty commit.
+
+---
+
+## Final Verification Checklist
+
+- [ ] Copy Key imports `resolveDefaultTokenQuickCreateResolution(...)`.
+- [ ] Copy Key has no `account.siteType === "sub2api"` quick-create gate.
+- [ ] Copy Key stores `defaultTokenCreateAllowedGroups`, not `sub2apiCreateAllowedGroups`.
+- [ ] Kilo imports `resolveDefaultTokenQuickCreateResolution(...)`.
+- [ ] Kilo passes `defaultTokenData: resolution.tokenData` to `ensureAccountApiToken(...)`.
+- [ ] Kilo stores `defaultTokenCreateContext`, not `sub2apiCreateContext`.
+- [ ] Channel Dialog context exposes `defaultTokenQuickCreateDialog`.
+- [ ] Channel Dialog hook uses generic quick-create decisions for no-token account import.
+- [ ] Channel Dialog passes `defaultTokenData: resolution.tokenData` to `ensureAccountApiToken(...)`.
+- [ ] No product consumer imports `resolveSub2ApiQuickCreateResolution(...)`.
+- [ ] `sub2apiGroup` remains only as a documented compatibility alias and test coverage, if retained.
+- [ ] Account Dialog post-save site policy remains semantically unchanged.
+- [ ] Repair, Model Key, Verify API, Verify CLI, and managed-site providers remain outside this slice.
+- [ ] Focused Vitest tests pass.
+- [ ] Related Vitest validation passes.
+- [ ] `pnpm run validate:staged` passes.
+- [ ] `pnpm run validate:push` passes before PR or remote handoff.

--- a/docs/superpowers/specs/2026-06-20-default-token-quick-create-consumers-design.md
+++ b/docs/superpowers/specs/2026-06-20-default-token-quick-create-consumers-design.md
@@ -1,0 +1,620 @@
+# Default Token Quick-Create Consumers Design
+
+Date: 2026-06-20
+
+## Purpose
+
+Make the next account site type faster to add by finishing the consumer-side
+migration from Sub2API-specific default-token quick-create logic to the generic
+`tokenProvisioning` policy seam.
+
+Recent slices added `SiteAdapter.tokenProvisioning` and
+`resolveDefaultTokenQuickCreateResolution(...)`. That seam can already express
+whether default-token creation is ready, blocked, or requires user group
+selection. The remaining friction is that several product entry points still
+call the Sub2API compatibility wrapper or keep Sub2API-named dialog state:
+
+- Copy Key dialog default-key creation.
+- Channel Dialog account-to-managed-site import when no token exists.
+- Kilo Code export default-token creation.
+
+Those flows are exactly the surfaces a new site type must work through after it
+implements `keyManagement` and `tokenProvisioning`. This spec moves the
+quick-create consumers to the generic Interface and treats the remaining
+Sub2API wrapper as a compatibility shim only.
+
+## Current Context
+
+`src/services/apiAdapters/contracts/siteAdapter.ts` already exposes:
+
+```ts
+tokenProvisioning?: TokenProvisioningCapability
+```
+
+`src/services/apiAdapters/contracts/tokenProvisioning.ts` defines generic
+workflow and decision types:
+
+- `TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection`
+- `DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create`
+- `DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired`
+- `DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked`
+- `DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups`
+
+`src/services/accounts/accountOperations.ts` already exports the generic
+resolver:
+
+```ts
+export async function resolveDefaultTokenQuickCreateResolution(
+  account: DisplaySiteData,
+  options: { explicitGroup?: string } = {},
+): Promise<DefaultTokenQuickCreateResolution>
+```
+
+It also keeps the Sub2API wrapper:
+
+```ts
+export async function resolveSub2ApiQuickCreateResolution(account)
+```
+
+The wrapper currently exists for compatibility, but product consumers still use
+it directly. That keeps the site-specific rule at the caller instead of behind
+the Adapter.
+
+## Problem
+
+The Adapter seam is deeper than the consumer code that calls it.
+
+Current friction:
+
+1. Copy Key, Channel Dialog, and Kilo export still branch on Sub2API before
+   asking whether default-token creation is ready, blocked, or needs group
+   selection.
+2. The `ready` decision from `resolveDefaultTokenQuickCreateResolution(...)`
+   returns full `tokenData`, but wrapper consumers reduce it to a Sub2API
+   `group`. A future site type could need policy-adjusted token data beyond a
+   group.
+3. Shared dialog state names such as `sub2apiTokenDialog` and
+   `openSub2ApiTokenDialog` make a generic group-selection UX look
+   Sub2API-only even though `AddTokenDialog` can already accept generic
+   `allowedGroups`.
+4. `ensureAccountApiToken(...)` still names its explicit group option
+   `sub2apiGroup`, so generic consumers must either keep a site-specific option
+   name or add a compatibility bridge.
+5. Tests assert wrapper usage in multiple places, so future implementation can
+   appear behavior-correct while still keeping the wrong seam.
+
+Deletion test: if `resolveSub2ApiQuickCreateResolution(...)` were deleted from
+consumer code, the complexity should not reappear as raw `siteType ===
+SITE_TYPES.SUB2API` checks. It should concentrate in
+`resolveDefaultTokenQuickCreateResolution(...)`,
+`TokenProvisioningCapability`, and a generic quick-create group-selection
+dialog bridge.
+
+## Goals
+
+- Route all default-token quick-create consumers through
+  `resolveDefaultTokenQuickCreateResolution(...)`.
+- Preserve current behavior for Sub2API:
+  - auto-create when exactly one valid current group is available;
+  - open the constrained Add Token dialog when multiple groups are available;
+  - show the existing blocked/no-group messages;
+  - recover a newly created token by created response or inventory refetch as
+    each consumer currently does.
+- Preserve current behavior for New API-family sites:
+  - zero-click default token creation still calls `ensureAccountApiToken(...)`
+    when no token exists;
+  - no group-selection dialog is shown unless policy asks for it.
+- Preserve current behavior for AIHubMix:
+  - blocked one-time-secret policy continues to surface through existing
+    messages and one-time-key flows;
+  - this slice does not make background or export flows silently create
+    AIHubMix keys.
+- Rename consumer state and dialog bridge concepts from Sub2API-specific names
+  to default-token quick-create names where they are no longer Sub2API-only.
+- Keep compatibility wrappers only where they protect old callers/tests during
+  the migration, and prevent new production consumers from importing them.
+- Add focused tests that prove the consumers use the generic Interface and that
+  Sub2API behavior is unchanged.
+- Add cleanup search checks so this slice does not leave another round of
+  Sub2API-specific quick-create consumers behind.
+
+## Non-Goals
+
+- Do not add a new account site type.
+- Do not redesign `TokenProvisioningCapability`.
+- Do not change `KeyManagementCapability` or raw token CRUD.
+- Do not move `generateDefaultTokenRequest()` or change its default payload.
+- Do not change user-facing copy or locale keys in this slice; existing
+  Sub2API-named messages may remain if they are the current user-facing
+  contract.
+- Do not migrate Account Dialog site policy into backend adapters.
+- Do not redesign Account Dialog post-save auto-configuration. Rename or reuse
+  generic dialog helpers only if needed to avoid duplicate quick-create dialog
+  plumbing.
+- Do not migrate Repair Missing Keys manual Sub2API recovery. It is a repair
+  workflow, not a default-token quick-create consumer.
+- Do not migrate Model Key dialog default creation. It requires an explicit
+  model/group input and is not a quick-create resolver consumer.
+- Do not migrate Verify API or Verify CLI dialogs. They only load or resolve
+  existing tokens.
+- Do not migrate managed-site providers. They already call
+  `ensureAccountApiToken(...)`, which uses the shared policy path.
+- Do not add telemetry, settings search entries, or Playwright E2E coverage
+  unless implementation changes user-visible browser-level behavior beyond this
+  routing refactor.
+
+## Approaches Considered
+
+### Approach A: Replace Only The Wrapper Calls
+
+This would update Copy Key, Channel Dialog, and Kilo export to call
+`resolveDefaultTokenQuickCreateResolution(...)`, while leaving
+`sub2apiGroup`, `sub2apiTokenDialog`, and similar names in place.
+
+This is too shallow. It improves behavior for new site types but preserves
+Sub2API terminology in the Interface that future callers will copy.
+
+### Approach B: Move Full Token Creation Into Adapters
+
+Adapters could own "create default key and recover it" workflows directly.
+
+This would put product orchestration, toasts, Add Token dialogs, inventory
+refresh, channel opening, and export state behind backend Adapters. That would
+make the Adapter Interface broad and harder to test.
+
+### Approach C: Generalize Consumer Routing And Dialog Bridge
+
+Consumers ask `resolveDefaultTokenQuickCreateResolution(...)` for a decision,
+then keep their local orchestration. Shared group-selection dialog state is
+renamed to default-token quick-create language. `ensureAccountApiToken(...)`
+accepts a generic explicit group option while keeping the old option as a
+temporary compatibility alias.
+
+This is the recommended path. It keeps backend-specific policy behind the
+Adapter seam and product behavior in product Modules, while removing the
+remaining Sub2API-only consumer Interface.
+
+## Design
+
+### 1. Keep The Generic Resolver As The Consumer Interface
+
+Do not create a second resolver. The consumer Interface for default-token
+quick-create decisions is:
+
+```ts
+resolveDefaultTokenQuickCreateResolution(account, {
+  explicitGroup,
+})
+```
+
+Consumers must handle all three result kinds:
+
+- `ready`: use the returned `tokenData` as the default token payload.
+- `selection_required`: open a constrained Add Token dialog with
+  `allowedGroups`.
+- `blocked`: show or store the returned `message`.
+
+Important: consumers must not reduce `ready.tokenData` to only `group`. The
+whole payload is policy output and must be preserved.
+
+`resolveSub2ApiQuickCreateResolution(...)` may remain in
+`accountOperations.ts` during this slice for service-level compatibility tests,
+but product consumers must stop importing it.
+
+### 2. Add A Generic Token Payload Option To Shared Ensure
+
+Modify `ensureAccountApiToken(...)` so the option shape accepts a generic
+policy-resolved token payload:
+
+```ts
+import type { CreateTokenRequest } from "~/services/apiService/common/type"
+
+toastIdOrOptions?:
+  | string
+  | {
+      toastId?: string
+      defaultTokenData?: CreateTokenRequest
+      explicitGroup?: string
+      sub2apiGroup?: string
+    }
+```
+
+Resolution order when no existing token is found:
+
+```ts
+const defaultTokenData =
+  options.defaultTokenData ??
+  generateDefaultTokenRequest()
+const explicitGroup = options.explicitGroup ?? options.sub2apiGroup
+```
+
+Then pass both `defaultTokenData` and `explicitGroup` into
+`requiredTokenProvisioning.resolveDefaultTokenCreation(...)`. This preserves the
+full policy-resolved token payload instead of narrowing future policy output to
+only `group`.
+
+This keeps old call sites working while new consumers use the generic option.
+The implementation should add a short comment marking `sub2apiGroup` as a
+temporary compatibility alias. New code should prefer `defaultTokenData`; use
+`explicitGroup` only when the caller truly has a user-selected group but no full
+policy decision. Do not remove compatibility aliases in this slice unless all
+current callers and tests are safely migrated and the removal is verified by
+TypeScript.
+
+### 3. Generalize Copy Key Dialog Quick-Create State
+
+Modify:
+
+```text
+src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+src/features/AccountManagement/components/CopyKeyDialog/index.tsx
+```
+
+Target behavior:
+
+- Import `resolveDefaultTokenQuickCreateResolution(...)`.
+- Remove the `account.siteType === "sub2api"` gate before quick-create
+  resolution.
+- Call the resolver for the default-key create action when no explicit group is
+  already provided by the Add Token dialog.
+- On `blocked`, set the existing create error to `resolution.message`.
+- On `selection_required`, store generic allowed groups state and open
+  `AddTokenDialog` with a constrained `createPrefill`.
+- On `ready`, call `keyManagement.createToken(request, resolution.tokenData)`.
+- Preserve one-time-key handling through `refreshTokensAfterCreate(...)`.
+
+Rename hook and component state from Sub2API language to generic quick-create
+language:
+
+- `sub2apiCreateAllowedGroups` -> `defaultTokenCreateAllowedGroups`
+- `setSub2apiCreateAllowedGroups` -> `setDefaultTokenCreateAllowedGroups`
+- `clearSub2ApiCreateAllowedGroups` -> `clearDefaultTokenCreateAllowedGroups`
+- `sub2apiQuickCreatePrefill` -> `defaultTokenQuickCreatePrefill`
+
+The rendered Add Token dialog may keep existing Sub2API message keys for the
+notice if the current only selection-required site is Sub2API. Do not introduce
+new locale keys in this slice.
+
+### 4. Generalize Kilo Export Quick-Create State
+
+Modify:
+
+```text
+src/components/KiloCodeExportDialog.tsx
+```
+
+Target behavior:
+
+- Import `resolveDefaultTokenQuickCreateResolution(...)`.
+- Replace `sub2apiCreateContext` with a generic default-token create context:
+
+```ts
+type DefaultTokenCreateContext = {
+  siteId: string
+  allowedGroups: string[]
+}
+```
+
+- When a selected account has no tokens, ask the generic resolver.
+- On `blocked`, preserve the existing toast and token-inventory error state.
+- On `selection_required`, store the generic create context and open the
+  constrained `AddTokenDialog`.
+- On `ready`, call `ensureAccountApiToken(account, site, {
+  toastId,
+  defaultTokenData: resolution.tokenData,
+})`.
+- Preserve the current newest-token selection after create.
+- Preserve error/loading inventory state transitions.
+
+Do not pass only `resolution.tokenData.group`; doing so would recreate the
+Sub2API-shaped Interface at the call site and lose future policy-owned token
+fields.
+
+### 5. Generalize Channel Dialog Token Creation Bridge
+
+Modify:
+
+```text
+src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
+src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
+```
+
+Target behavior:
+
+- Import `resolveDefaultTokenQuickCreateResolution(...)`.
+- Replace the no-token Sub2API branch in `openWithAccount(...)` with a generic
+  decision branch.
+- On `blocked`, show `resolution.message` and do not open the channel dialog.
+- On `selection_required`, open the constrained Add Token dialog and keep the
+  deferred channel-open behavior.
+- On `ready`, call `ensureAccountApiToken(..., {
+  toastId,
+  defaultTokenData: resolution.tokenData,
+})`.
+- Preserve existing `shouldContinue()` cancellation checks before and after
+  async work.
+- Preserve token recovery after Add Token success:
+  - use the created token when `AddTokenDialog` returns it;
+  - otherwise refetch inventory and select a single new token by ID diff;
+  - fail closed on missing, ambiguous, or non-array refetch results.
+
+Rename shared dialog context concepts from Sub2API-specific language to
+default-token quick-create language:
+
+- `Sub2ApiTokenDialogState` -> `DefaultTokenQuickCreateDialogState`
+- `sub2apiTokenDialog` -> `defaultTokenQuickCreateDialog`
+- `openSub2ApiTokenDialog` -> `openDefaultTokenQuickCreateDialog`
+- `closeSub2ApiTokenDialog` -> `closeDefaultTokenQuickCreateDialog`
+- `handleSub2ApiTokenSuccess` -> `handleDefaultTokenQuickCreateSuccess`
+- `sub2apiTokenDialogPrefill` -> `defaultTokenQuickCreatePrefill`
+
+Keep compatibility aliases only if they materially reduce patch risk in
+existing Account Dialog or Repair flows. If aliases are kept, mark them as
+temporary and ensure new code uses the generic names.
+
+### 6. Account Dialog Post-Save Boundary
+
+Account Dialog post-save Sub2API key creation is related but has its own site
+policy seam:
+
+```text
+src/features/AccountManagement/components/AccountDialog/sitePolicy.ts
+src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+src/features/AccountManagement/components/AccountDialog/index.tsx
+```
+
+This slice should not move Account Dialog post-save behavior into
+`tokenProvisioning` or redesign auto-configuration. However, if the Channel
+Dialog quick-create context is renamed generically, Account Dialog may need
+mechanical updates to call the renamed helper. That is in scope only as a
+consumer of the shared generic dialog bridge.
+
+Do not change Account Dialog policy decisions:
+
+- `openSub2ApiTokenDialogPostSave` may remain in `sitePolicy.ts` for this
+  slice.
+- `shouldOpenSub2ApiTokenDialogForAccountDialogSite(...)` may remain.
+- `postSaveSub2ApiAllowedGroups` and post-save session names may remain unless
+  implementation is already touching them solely because of the shared dialog
+  helper rename.
+
+This prevents the slice from becoming a broader Account Dialog policy rewrite.
+
+### 7. Explicit Out-Of-Scope Related Entrypoints
+
+During implementation, inspect but do not migrate these unless a compile error
+forces a mechanical rename:
+
+- `src/features/KeyManagement/components/RepairMissingKeysDialog.tsx`
+  - It opens a manual recovery flow for repair results. It is not a
+    quick-create resolver consumer.
+- `src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts`
+  - It creates a model key from an explicit user-selected group and does not
+    use quick-create policy.
+- `src/components/dialogs/VerifyApiDialog/**`
+  - Existing-token load/resolve only.
+- `src/components/dialogs/VerifyCliSupportDialog/**`
+  - Existing-token load/resolve only.
+- `src/services/accounts/accountKeyAutoProvisioning/**`
+  - Background and repair policies already use `tokenProvisioning`.
+- `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+  - Post-save token provisioning already uses `tokenProvisioning`.
+- `src/services/managedSites/providers/**`
+  - Providers call `ensureAccountApiToken(...)`; they should not own
+    quick-create decision logic.
+
+## Error Handling
+
+Keep policy reason mapping in `accountOperations.ts`.
+
+Consumer behavior:
+
+- `blocked`
+  - Show/store `resolution.message`.
+  - Do not call `keyManagement.createToken(...)`.
+  - Do not call `ensureAccountApiToken(...)`.
+- `selection_required`
+  - Open a constrained `AddTokenDialog`.
+  - Do not create a token until the user confirms the dialog.
+- `ready`
+  - Use policy-provided `tokenData`.
+  - Preserve current create/refetch/selection behavior in the consumer.
+- resolver throws
+  - Existing consumer error handling should catch and surface the local
+    fallback message.
+
+Do not add new user-facing copy. Existing Sub2API-named message keys can remain
+as the current translation contract until a separate copy cleanup is planned.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This slice changes routing and naming behind existing user actions. It does not
+add a new action, setting, async workflow, or product analytics field. Existing
+Copy Key, Channel Dialog, Kilo export, and Add Token telemetry should continue
+to emit from their current owners.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E by default.
+
+The main risk is service/component routing and state preservation, not browser
+runtime behavior. Focused Vitest and Testing Library coverage can exercise the
+resolver decisions, constrained Add Token dialog path, and token recovery
+behavior directly.
+
+## Testing Strategy
+
+Update service tests:
+
+- `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+  - `resolveDefaultTokenQuickCreateResolution(...)` remains the primary
+    service-level decision Interface.
+  - `ensureAccountApiToken(...)` accepts `defaultTokenData`.
+  - `explicitGroup` and `sub2apiGroup` remain compatibility aliases only if
+    kept.
+  - `resolveSub2ApiQuickCreateResolution(...)` tests can remain as wrapper
+    compatibility tests, but product tests must not depend on it.
+
+Update Copy Key tests:
+
+- `tests/features/AccountManagement/components/CopyKeyDialog.test.tsx`
+- `tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx`
+
+Required assertions:
+
+- Copy Key default create calls the generic resolver path through adapter
+  policy.
+- A single Sub2API group still creates with that group.
+- Multiple groups still open the constrained Add Token dialog.
+- No groups still shows the existing blocked message.
+- One-time key behavior for AIHubMix custom token creation remains unchanged.
+- Generic state names are used in hook/component tests when exposed.
+
+Update Kilo export tests:
+
+- `tests/components/KiloCodeExportDialog.test.tsx`
+
+Required assertions:
+
+- Kilo default create mocks `resolveDefaultTokenQuickCreateResolution(...)`, not
+  the Sub2API wrapper.
+- A `ready` decision passes full `tokenData` into the shared ensure path.
+- A `selection_required` decision opens the constrained Add Token dialog and
+  refreshes/selects the newest token after success.
+- A `blocked` decision preserves token inventory error state.
+
+Update Channel Dialog tests:
+
+- `tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx`
+
+Required assertions:
+
+- Channel Dialog mocks the generic resolver.
+- No-token `selection_required` opens the generic quick-create dialog state.
+- Dialog success with a returned token continues opening the channel.
+- Dialog success without a returned token refetches and selects one new token.
+- Missing, ambiguous, or non-array refetch still fails closed.
+- Existing-token paths do not call the quick-create resolver.
+
+Update Add Token dialog bridge tests if names change:
+
+- `tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx`
+- `tests/entrypoints/options/pages/KeyManagement/useTokenData.test.ts`
+
+These should cover only prefill/allowed-group behavior needed by the generic
+quick-create dialog. Do not broaden into token CRUD behavior already covered by
+Key Management tests.
+
+Do not add Account Dialog tests unless the implementation mechanically renames
+shared quick-create dialog APIs used by Account Dialog post-save:
+
+- `tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx`
+- `tests/features/AccountManagement/components/AccountDialog.test.tsx`
+- `tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts`
+
+## Migration Completeness Checks
+
+Run these cleanup searches during implementation:
+
+```powershell
+rg "resolveSub2ApiQuickCreateResolution" src tests
+rg "sub2apiGroup|explicitGroup|defaultTokenData" src tests
+rg "sub2apiCreateAllowedGroups|sub2apiCreateContext|sub2apiQuickCreate" src tests
+rg "sub2apiTokenDialog|openSub2ApiTokenDialog|closeSub2ApiTokenDialog|handleSub2ApiTokenSuccess" src tests
+rg "siteType === [\"']sub2api[\"']|siteType === SITE_TYPES.SUB2API" src/features src/components src/services/accounts
+```
+
+Expected after implementation:
+
+- No product consumer imports `resolveSub2ApiQuickCreateResolution(...)`.
+- `resolveSub2ApiQuickCreateResolution(...)` appears only in
+  `src/services/accounts/accountOperations.ts` and its compatibility tests, if
+  the wrapper is retained.
+- consumer quick-create paths pass `defaultTokenData` rather than only
+  `explicitGroup` or `sub2apiGroup`.
+- `sub2apiGroup` appears only as a documented compatibility alias in
+  `ensureAccountApiToken(...)` and compatibility tests, if retained.
+- Copy Key, Channel Dialog, and Kilo export use generic quick-create state
+  names.
+- Sub2API-specific names may remain in:
+  - Account Dialog post-save site policy;
+  - Repair Missing Keys manual recovery flow;
+  - translation keys;
+  - compatibility tests for the wrapper.
+
+## Validation Plan
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.ensureAccountApiToken.test.ts tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx tests/components/KiloCodeExportDialog.test.tsx tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+```
+
+If shared Add Token dialog names or props are touched:
+
+```powershell
+pnpm vitest run tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx tests/entrypoints/options/pages/KeyManagement/useTokenData.test.ts
+```
+
+Related validation:
+
+```powershell
+pnpm vitest related --run src/services/accounts/accountOperations.ts src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts src/features/AccountManagement/components/CopyKeyDialog/index.tsx src/components/KiloCodeExportDialog.tsx src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Push gate before PR or remote handoff:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before publishing because this slice touches shared
+account operations and cross-feature dialog wiring.
+
+## Rollout
+
+1. Update service-level tests for generic `defaultTokenData` and wrapper
+   compatibility.
+2. Add or adjust Copy Key tests to assert generic resolver behavior.
+3. Migrate Copy Key hook/component state and resolver calls.
+4. Add or adjust Kilo export tests to assert generic resolver behavior.
+5. Migrate Kilo export state and resolver calls.
+6. Add or adjust Channel Dialog tests to assert generic resolver behavior and
+   generic quick-create dialog state.
+7. Migrate Channel Dialog context, container, and hook names.
+8. Apply mechanical updates to Account Dialog or Repair only if shared dialog
+   API renames require them; do not change their workflow semantics.
+9. Run cleanup searches and remove unexpected Sub2API quick-create consumer
+   references.
+10. Run focused tests, related validation, `validate:staged`, and
+    `validate:push`.
+
+## Follow-Up, Not In Scope For This Spec
+
+Later slices may:
+
+- remove `resolveSub2ApiQuickCreateResolution(...)` after all compatibility
+  tests and external callers are gone;
+- remove `explicitGroup` or `sub2apiGroup` from `ensureAccountApiToken(...)`
+  after full `defaultTokenData` propagation proves no callers need the aliases;
+- rename Sub2API-specific translation keys to generic group-selection copy;
+- generalize Account Dialog post-save naming once the dialog site-policy seam
+  is ready for that cleanup;
+- generalize Repair Missing Keys manual Sub2API recovery naming;
+- consolidate account-site registration metadata across onboarding,
+  `apiAdapters/registry.ts`, and site-type constants.

--- a/src/components/KiloCodeExportDialog.tsx
+++ b/src/components/KiloCodeExportDialog.tsx
@@ -23,8 +23,9 @@ import { useAccountData } from "~/hooks/useAccountData"
 import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
   ensureAccountApiToken,
-  resolveSub2ApiQuickCreateResolution,
+  resolveDefaultTokenQuickCreateResolution,
 } from "~/services/accounts/accountOperations"
+import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
 import { compareAccountDisplayNames } from "~/services/accounts/utils/accountDisplayName"
 import {
   createDisplayAccountApiContext,
@@ -57,6 +58,20 @@ const kiloCodeAccountExportAnalyticsContext = {
     PRODUCT_ANALYTICS_SURFACE_IDS.OptionsAccountTokenKiloCodeExportDialog,
 }
 
+const KILO_CODE_INVENTORY_STATUSES = {
+  Idle: "idle",
+  Loading: "loading",
+  Loaded: "loaded",
+  Error: "error",
+} as const
+
+/**
+ * Builds the stable toast id used while Kilo Code export creates a missing token.
+ */
+export function buildKiloCodeCreateTokenToastId(siteId: string) {
+  return `kilocode-create-token-${siteId}`
+}
+
 interface KiloCodeExportDialogProps {
   isOpen: boolean
   onClose: () => void
@@ -71,7 +86,8 @@ interface KiloCodeExportDialogProps {
   initialSelectedTokenIdsBySite?: Record<string, string[]>
 }
 
-type TokenLoadStatus = "idle" | "loading" | "loaded" | "error"
+type TokenLoadStatus =
+  (typeof KILO_CODE_INVENTORY_STATUSES)[keyof typeof KILO_CODE_INVENTORY_STATUSES]
 
 interface TokenInventoryState {
   status: TokenLoadStatus
@@ -79,7 +95,13 @@ interface TokenInventoryState {
   errorMessage?: string
 }
 
-type ModelLoadStatus = "idle" | "loading" | "loaded" | "error"
+type DefaultTokenCreateContext = {
+  siteId: string
+  allowedGroups: string[]
+}
+
+type ModelLoadStatus =
+  (typeof KILO_CODE_INVENTORY_STATUSES)[keyof typeof KILO_CODE_INVENTORY_STATUSES]
 
 interface ModelInventoryState {
   status: ModelLoadStatus
@@ -204,10 +226,8 @@ export function KiloCodeExportDialog({
   const [isCreatingToken, setIsCreatingToken] = useState<
     Record<string, boolean>
   >({})
-  const [sub2apiCreateContext, setSub2apiCreateContext] = useState<{
-    siteId: string
-    allowedGroups: string[]
-  } | null>(null)
+  const [defaultTokenCreateContext, setDefaultTokenCreateContext] =
+    useState<DefaultTokenCreateContext | null>(null)
 
   const [modelInventories, setModelInventories] = useState<
     Record<string, ModelInventoryState>
@@ -234,7 +254,7 @@ export function KiloCodeExportDialog({
     setCurrentApiConfigName("")
     setTokenInventories({})
     setIsCreatingToken({})
-    setSub2apiCreateContext(null)
+    setDefaultTokenCreateContext(null)
     setModelInventories({})
     setSelectedModelIdByToken({})
     modelLoadsInFlightRef.current.clear()
@@ -274,7 +294,12 @@ export function KiloCodeExportDialog({
 
   const getTokenInventory = useCallback(
     (siteId: string): TokenInventoryState => {
-      return tokenInventories[siteId] ?? { status: "idle", tokens: [] }
+      return (
+        tokenInventories[siteId] ?? {
+          status: KILO_CODE_INVENTORY_STATUSES.Idle,
+          tokens: [],
+        }
+      )
     },
     [tokenInventories],
   )
@@ -282,7 +307,10 @@ export function KiloCodeExportDialog({
   const getModelInventory = useCallback(
     (tokenSelectionKey: string): ModelInventoryState => {
       return (
-        modelInventories[tokenSelectionKey] ?? { status: "idle", modelIds: [] }
+        modelInventories[tokenSelectionKey] ?? {
+          status: KILO_CODE_INVENTORY_STATUSES.Idle,
+          modelIds: [],
+        }
       )
     },
     [modelInventories],
@@ -296,7 +324,7 @@ export function KiloCodeExportDialog({
       setTokenInventories((prev) => ({
         ...prev,
         [siteId]: {
-          status: "loading",
+          status: KILO_CODE_INVENTORY_STATUSES.Loading,
           tokens: prev[siteId]?.tokens ?? [],
           errorMessage: undefined,
         },
@@ -312,7 +340,7 @@ export function KiloCodeExportDialog({
           setTokenInventories((prev) => ({
             ...prev,
             [siteId]: {
-              status: "error",
+              status: KILO_CODE_INVENTORY_STATUSES.Error,
               tokens: [],
               errorMessage: t("ui:dialog.kiloCode.messages.loadTokensFailed"),
             },
@@ -322,7 +350,11 @@ export function KiloCodeExportDialog({
 
         setTokenInventories((prev) => ({
           ...prev,
-          [siteId]: { status: "loaded", tokens, errorMessage: undefined },
+          [siteId]: {
+            status: KILO_CODE_INVENTORY_STATUSES.Loaded,
+            tokens,
+            errorMessage: undefined,
+          },
         }))
 
         // UX: default-select the first token (common case is "one token per site"),
@@ -353,7 +385,7 @@ export function KiloCodeExportDialog({
         setTokenInventories((prev) => ({
           ...prev,
           [siteId]: {
-            status: "error",
+            status: KILO_CODE_INVENTORY_STATUSES.Error,
             tokens: [],
             errorMessage: t("ui:dialog.kiloCode.messages.loadTokensFailed"),
           },
@@ -372,14 +404,14 @@ export function KiloCodeExportDialog({
       if (modelLoadsInFlightRef.current.has(tokenSelectionKey)) return
 
       const existingStatus = modelInventories[tokenSelectionKey]?.status
-      if (existingStatus === "loaded") return
+      if (existingStatus === KILO_CODE_INVENTORY_STATUSES.Loaded) return
 
       modelLoadsInFlightRef.current.add(tokenSelectionKey)
 
       setModelInventories((prev) => ({
         ...prev,
         [tokenSelectionKey]: {
-          status: "loading",
+          status: KILO_CODE_INVENTORY_STATUSES.Loading,
           modelIds: prev[tokenSelectionKey]?.modelIds ?? [],
           errorMessage: undefined,
         },
@@ -404,7 +436,7 @@ export function KiloCodeExportDialog({
         setModelInventories((prev) => ({
           ...prev,
           [tokenSelectionKey]: {
-            status: "loaded",
+            status: KILO_CODE_INVENTORY_STATUSES.Loaded,
             modelIds: normalized,
             errorMessage: undefined,
           },
@@ -422,7 +454,7 @@ export function KiloCodeExportDialog({
         setModelInventories((prev) => ({
           ...prev,
           [tokenSelectionKey]: {
-            status: "error",
+            status: KILO_CODE_INVENTORY_STATUSES.Error,
             modelIds: prev[tokenSelectionKey]?.modelIds ?? [],
             errorMessage: t("ui:dialog.kiloCode.messages.loadModelsFailed"),
           },
@@ -442,60 +474,59 @@ export function KiloCodeExportDialog({
       return
     }
 
-    const toastId = `kilocode-create-token-${siteId}`
+    const toastId = buildKiloCodeCreateTokenToastId(siteId)
 
     setIsCreatingToken((prev) => ({ ...prev, [siteId]: true }))
     setTokenInventories((prev) => ({
       ...prev,
-      [siteId]: { status: "loading", tokens: prev[siteId]?.tokens ?? [] },
+      [siteId]: {
+        status: KILO_CODE_INVENTORY_STATUSES.Loading,
+        tokens: prev[siteId]?.tokens ?? [],
+      },
     }))
 
     try {
-      let ensuredToken: ApiToken
-      if (site.siteType === "sub2api") {
-        const resolution = await resolveSub2ApiQuickCreateResolution(site)
-        if (resolution.kind === "blocked") {
-          const userMessage = resolution.message?.trim()
-            ? resolution.message
-            : "Token creation was blocked. Please check site policy or try again."
+      const resolution = await resolveDefaultTokenQuickCreateResolution(site)
+      if (resolution.kind === TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked) {
+        const userMessage = resolution.message?.trim()
+          ? resolution.message
+          : t("ui:dialog.kiloCode.messages.createTokenBlockedFallback")
 
-          toast.error(userMessage, { id: toastId })
-          setTokenInventories((prev) => ({
-            ...prev,
-            [siteId]: {
-              status: "error",
-              tokens: prev[siteId]?.tokens ?? [],
-              errorMessage: userMessage,
-            },
-          }))
-          return
-        }
-
-        if (resolution.kind === "selection_required") {
-          setSub2apiCreateContext({
-            siteId,
-            allowedGroups: resolution.allowedGroups,
-          })
-          setTokenInventories((prev) => ({
-            ...prev,
-            [siteId]: {
-              status: "loaded",
-              tokens: prev[siteId]?.tokens ?? [],
-              errorMessage: undefined,
-            },
-          }))
-          return
-        }
-
-        // Sub2API stays zero-click only when upstream currently exposes exactly
-        // one valid group after the user has triggered creation.
-        ensuredToken = await ensureAccountApiToken(account, site, {
-          toastId,
-          sub2apiGroup: resolution.group,
-        })
-      } else {
-        ensuredToken = await ensureAccountApiToken(account, site, toastId)
+        toast.error(userMessage, { id: toastId })
+        setTokenInventories((prev) => ({
+          ...prev,
+          [siteId]: {
+            status: KILO_CODE_INVENTORY_STATUSES.Error,
+            tokens: prev[siteId]?.tokens ?? [],
+            errorMessage: userMessage,
+          },
+        }))
+        return
       }
+
+      if (
+        resolution.kind ===
+        TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired
+      ) {
+        setDefaultTokenCreateContext({
+          siteId,
+          allowedGroups: resolution.allowedGroups,
+        })
+        setTokenInventories((prev) => ({
+          ...prev,
+          [siteId]: {
+            status: KILO_CODE_INVENTORY_STATUSES.Loaded,
+            tokens: prev[siteId]?.tokens ?? [],
+            errorMessage: undefined,
+          },
+        }))
+        return
+      }
+
+      const ensuredToken = await ensureAccountApiToken(account, site, {
+        toastId,
+        defaultTokenData: resolution.tokenData,
+      })
 
       toast.success(t("ui:dialog.kiloCode.messages.tokenCreated"), {
         id: toastId,
@@ -514,7 +545,7 @@ export function KiloCodeExportDialog({
       setTokenInventories((prev) => ({
         ...prev,
         [siteId]: {
-          status: "error",
+          status: KILO_CODE_INVENTORY_STATUSES.Error,
           tokens: prev[siteId]?.tokens ?? [],
           errorMessage: t("ui:dialog.kiloCode.messages.createTokenFailed"),
         },
@@ -567,8 +598,9 @@ export function KiloCodeExportDialog({
     if (selectedSiteIds.length === 0) return
 
     for (const siteId of selectedSiteIds) {
-      const status = tokenInventories[siteId]?.status ?? "idle"
-      if (status === "idle") {
+      const status =
+        tokenInventories[siteId]?.status ?? KILO_CODE_INVENTORY_STATUSES.Idle
+      if (status === KILO_CODE_INVENTORY_STATUSES.Idle) {
         void loadTokensForSite(siteId)
       }
     }
@@ -580,7 +612,11 @@ export function KiloCodeExportDialog({
 
     for (const siteId of selectedSiteIds) {
       const inventory = tokenInventories[siteId]
-      if (!inventory || inventory.status !== "loaded") continue
+      if (
+        !inventory ||
+        inventory.status !== KILO_CODE_INVENTORY_STATUSES.Loaded
+      )
+        continue
 
       const tokenIds = selectedTokenIdsBySite[siteId] ?? []
       for (const tokenId of tokenIds) {
@@ -591,8 +627,9 @@ export function KiloCodeExportDialog({
 
         const tokenSelectionKey = getTokenSelectionKey(siteId, token.id)
         const modelStatus =
-          modelInventories[tokenSelectionKey]?.status ?? "idle"
-        if (modelStatus === "idle") {
+          modelInventories[tokenSelectionKey]?.status ??
+          KILO_CODE_INVENTORY_STATUSES.Idle
+        if (modelStatus === KILO_CODE_INVENTORY_STATUSES.Idle) {
           void loadModelsForToken(siteId, token)
         }
       }
@@ -821,27 +858,28 @@ export function KiloCodeExportDialog({
     }
   }
 
-  const handleCloseSub2ApiCreateDialog = () => {
-    setSub2apiCreateContext(null)
+  const handleCloseDefaultTokenCreateDialog = () => {
+    setDefaultTokenCreateContext(null)
   }
 
-  const handleSub2ApiCreateSuccess = async () => {
-    if (!sub2apiCreateContext) return
+  const handleDefaultTokenCreateSuccess = async () => {
+    if (!defaultTokenCreateContext) return
 
-    const { siteId } = sub2apiCreateContext
-    setSub2apiCreateContext(null)
+    const { siteId } = defaultTokenCreateContext
+    setDefaultTokenCreateContext(null)
     await loadTokensForSite(siteId, { preferNewest: true })
   }
 
-  const sub2apiQuickCreateSite = sub2apiCreateContext
-    ? displayById.get(sub2apiCreateContext.siteId)
+  const defaultTokenQuickCreateSite = defaultTokenCreateContext
+    ? displayById.get(defaultTokenCreateContext.siteId)
     : undefined
-  const sub2apiQuickCreatePrefill =
-    sub2apiCreateContext && sub2apiCreateContext.allowedGroups.length > 0
+  const defaultTokenQuickCreatePrefill =
+    defaultTokenCreateContext &&
+    defaultTokenCreateContext.allowedGroups.length > 0
       ? {
           modelId: "",
           defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-          allowedGroups: sub2apiCreateContext.allowedGroups,
+          allowedGroups: defaultTokenCreateContext.allowedGroups,
         }
       : undefined
 
@@ -849,7 +887,14 @@ export function KiloCodeExportDialog({
     const siteId = site.id
     const siteName = getSiteDisplayName(site)
     const inventory = getTokenInventory(siteId)
-    const isLoadingTokens = inventory.status === "loading"
+    const isLoadingTokens =
+      inventory.status === KILO_CODE_INVENTORY_STATUSES.Loading
+    const isTokenInventoryIdle =
+      inventory.status === KILO_CODE_INVENTORY_STATUSES.Idle
+    const isTokenInventoryLoaded =
+      inventory.status === KILO_CODE_INVENTORY_STATUSES.Loaded
+    const isTokenInventoryError =
+      inventory.status === KILO_CODE_INVENTORY_STATUSES.Error
     const isCreating = Boolean(isCreatingToken[siteId])
 
     const selectedTokenIds = selectedTokenIdsBySite[siteId] ?? []
@@ -860,62 +905,60 @@ export function KiloCodeExportDialog({
       }),
     )
 
-    const statusBadge =
-      inventory.status === "error" ? (
-        <Badge variant="danger" size="sm">
-          {t("common:status.error")}
-        </Badge>
-      ) : inventory.status === "loading" || inventory.status === "idle" ? (
-        <Badge variant="info" size="sm">
-          {t("common:status.loading")}
-        </Badge>
-      ) : inventory.tokens.length === 0 ? (
-        <Badge variant="warning" size="sm">
-          {t("ui:dialog.kiloCode.messages.noTokensTitle")}
-        </Badge>
-      ) : (
-        <Badge variant="success" size="sm">
-          {t("common:status.success")}
-        </Badge>
-      )
+    const statusBadge = isTokenInventoryError ? (
+      <Badge variant="danger" size="sm">
+        {t("common:status.error")}
+      </Badge>
+    ) : isLoadingTokens || isTokenInventoryIdle ? (
+      <Badge variant="info" size="sm">
+        {t("common:status.loading")}
+      </Badge>
+    ) : inventory.tokens.length === 0 ? (
+      <Badge variant="warning" size="sm">
+        {t("ui:dialog.kiloCode.messages.noTokensTitle")}
+      </Badge>
+    ) : (
+      <Badge variant="success" size="sm">
+        {t("common:status.success")}
+      </Badge>
+    )
 
-    const actionButton =
-      inventory.status === "error" ? (
-        <Button
-          size="sm"
-          type="button"
-          variant="secondary"
-          onClick={() => loadTokensForSite(siteId)}
-          disabled={isLoadingTokens || isCreating}
-          loading={isLoadingTokens}
-        >
-          {t("common:actions.retry")}
-        </Button>
-      ) : inventory.status === "loaded" && inventory.tokens.length === 0 ? (
-        <Button
-          size="sm"
-          type="button"
-          variant="secondary"
-          onClick={() => createDefaultTokenForSite(siteId)}
-          disabled={isCreating}
-          loading={isCreating}
-        >
-          {isCreating
-            ? t("common:status.creating")
-            : t("ui:dialog.kiloCode.actions.createDefaultToken")}
-        </Button>
-      ) : inventory.status === "loaded" && inventory.tokens.length > 0 ? (
-        <Button
-          size="sm"
-          type="button"
-          variant="ghost"
-          onClick={() => loadTokensForSite(siteId)}
-          disabled={isLoadingTokens || isCreating}
-          loading={isLoadingTokens}
-        >
-          {t("common:actions.refresh")}
-        </Button>
-      ) : null
+    const actionButton = isTokenInventoryError ? (
+      <Button
+        size="sm"
+        type="button"
+        variant="secondary"
+        onClick={() => loadTokensForSite(siteId)}
+        disabled={isLoadingTokens || isCreating}
+        loading={isLoadingTokens}
+      >
+        {t("common:actions.retry")}
+      </Button>
+    ) : isTokenInventoryLoaded && inventory.tokens.length === 0 ? (
+      <Button
+        size="sm"
+        type="button"
+        variant="secondary"
+        onClick={() => createDefaultTokenForSite(siteId)}
+        disabled={isCreating}
+        loading={isCreating}
+      >
+        {isCreating
+          ? t("common:status.creating")
+          : t("ui:dialog.kiloCode.actions.createDefaultToken")}
+      </Button>
+    ) : isTokenInventoryLoaded && inventory.tokens.length > 0 ? (
+      <Button
+        size="sm"
+        type="button"
+        variant="ghost"
+        onClick={() => loadTokensForSite(siteId)}
+        disabled={isLoadingTokens || isCreating}
+        loading={isLoadingTokens}
+      >
+        {t("common:actions.refresh")}
+      </Button>
+    ) : null
 
     return (
       <Card key={siteId} padding="sm" className="space-y-2">
@@ -934,7 +977,7 @@ export function KiloCodeExportDialog({
               {site.baseUrl}
             </div>
             {statusBadge}
-            {inventory.status === "loaded" && inventory.tokens.length > 0 && (
+            {isTokenInventoryLoaded && inventory.tokens.length > 0 && (
               <Badge
                 variant="secondary"
                 size="sm"
@@ -947,26 +990,26 @@ export function KiloCodeExportDialog({
           <div className="flex shrink-0 items-center gap-2">{actionButton}</div>
         </div>
 
-        {inventory.status === "error" && (
+        {isTokenInventoryError && (
           <div className="text-sm text-red-700 dark:text-red-300">
             {inventory.errorMessage ||
               t("ui:dialog.kiloCode.messages.loadTokensFailed")}
           </div>
         )}
 
-        {(inventory.status === "idle" || inventory.status === "loading") && (
+        {(isTokenInventoryIdle || isLoadingTokens) && (
           <div className="dark:text-dark-text-tertiary text-sm text-gray-500">
             {t("ui:dialog.kiloCode.messages.loadingTokens")}
           </div>
         )}
 
-        {inventory.status === "loaded" && inventory.tokens.length === 0 && (
+        {isTokenInventoryLoaded && inventory.tokens.length === 0 && (
           <div className="dark:text-dark-text-tertiary text-sm text-gray-500">
             {t("ui:dialog.kiloCode.messages.noTokensDescription")}
           </div>
         )}
 
-        {inventory.status === "loaded" && inventory.tokens.length > 0 && (
+        {isTokenInventoryLoaded && inventory.tokens.length > 0 && (
           <div className="space-y-3">
             <FormField label={t("common:labels.apiKey")}>
               <CompactMultiSelect
@@ -1000,6 +1043,18 @@ export function KiloCodeExportDialog({
                         getModelInventory(tokenSelectionKey)
                       const selectedModelId =
                         selectedModelIdByToken[tokenSelectionKey] ?? ""
+                      const isModelInventoryIdle =
+                        modelInventory.status ===
+                        KILO_CODE_INVENTORY_STATUSES.Idle
+                      const isModelInventoryLoading =
+                        modelInventory.status ===
+                        KILO_CODE_INVENTORY_STATUSES.Loading
+                      const isModelInventoryLoaded =
+                        modelInventory.status ===
+                        KILO_CODE_INVENTORY_STATUSES.Loaded
+                      const isModelInventoryError =
+                        modelInventory.status ===
+                        KILO_CODE_INVENTORY_STATUSES.Error
 
                       const modelOptions = Array.from(
                         new Set(
@@ -1013,25 +1068,23 @@ export function KiloCodeExportDialog({
                         .sort((a, b) => a.localeCompare(b))
                         .map((id) => ({ value: id, label: id }))
 
-                      const statusBadge =
-                        modelInventory.status === "error" ? (
-                          <Badge variant="danger" size="sm">
-                            {t("common:status.error")}
-                          </Badge>
-                        ) : modelInventory.status === "loading" ||
-                          modelInventory.status === "idle" ? (
-                          <Badge variant="info" size="sm">
-                            {t("common:status.loading")}
-                          </Badge>
-                        ) : modelInventory.modelIds.length === 0 ? (
-                          <Badge variant="warning" size="sm">
-                            {t("ui:dialog.kiloCode.messages.noModelsTitle")}
-                          </Badge>
-                        ) : (
-                          <Badge variant="success" size="sm">
-                            {t("common:status.success")}
-                          </Badge>
-                        )
+                      const statusBadge = isModelInventoryError ? (
+                        <Badge variant="danger" size="sm">
+                          {t("common:status.error")}
+                        </Badge>
+                      ) : isModelInventoryLoading || isModelInventoryIdle ? (
+                        <Badge variant="info" size="sm">
+                          {t("common:status.loading")}
+                        </Badge>
+                      ) : modelInventory.modelIds.length === 0 ? (
+                        <Badge variant="warning" size="sm">
+                          {t("ui:dialog.kiloCode.messages.noModelsTitle")}
+                        </Badge>
+                      ) : (
+                        <Badge variant="success" size="sm">
+                          {t("common:status.success")}
+                        </Badge>
+                      )
 
                       return (
                         <div key={tokenSelectionKey} className="space-y-1">
@@ -1049,7 +1102,7 @@ export function KiloCodeExportDialog({
                               {statusBadge}
                             </div>
                             <div className="flex shrink-0 items-center gap-2">
-                              {modelInventory.status === "error" && (
+                              {isModelInventoryError && (
                                 <Button
                                   size="sm"
                                   type="button"
@@ -1071,8 +1124,8 @@ export function KiloCodeExportDialog({
                                     }))
                                   }}
                                   placeholder={
-                                    modelInventory.status === "loading" ||
-                                    modelInventory.status === "idle"
+                                    isModelInventoryLoading ||
+                                    isModelInventoryIdle
                                       ? t("common:status.loading")
                                       : t(
                                           "ui:dialog.kiloCode.placeholders.modelId",
@@ -1085,7 +1138,7 @@ export function KiloCodeExportDialog({
                             </div>
                           </div>
 
-                          {modelInventory.status === "error" && (
+                          {isModelInventoryError && (
                             <div className="text-sm text-red-700 dark:text-red-300">
                               {modelInventory.errorMessage ||
                                 t(
@@ -1094,7 +1147,7 @@ export function KiloCodeExportDialog({
                             </div>
                           )}
 
-                          {modelInventory.status === "loaded" &&
+                          {isModelInventoryLoaded &&
                             modelInventory.modelIds.length === 0 && (
                               <div className="dark:text-dark-text-tertiary text-sm text-gray-500">
                                 {t(
@@ -1268,15 +1321,17 @@ export function KiloCodeExportDialog({
           </div>
         </Alert>
       </Modal>
-      {sub2apiQuickCreateSite && sub2apiQuickCreatePrefill ? (
+      {defaultTokenQuickCreateSite && defaultTokenQuickCreatePrefill ? (
         <AddTokenDialog
           isOpen={true}
-          onClose={handleCloseSub2ApiCreateDialog}
-          availableAccounts={[sub2apiQuickCreateSite]}
-          preSelectedAccountId={sub2apiQuickCreateSite.id}
-          createPrefill={sub2apiQuickCreatePrefill}
-          prefillNotice={t("messages:sub2api.createRequiresGroupSelection")}
-          onSuccess={handleSub2ApiCreateSuccess}
+          onClose={handleCloseDefaultTokenCreateDialog}
+          availableAccounts={[defaultTokenQuickCreateSite]}
+          preSelectedAccountId={defaultTokenQuickCreateSite.id}
+          createPrefill={defaultTokenQuickCreatePrefill}
+          prefillNotice={t(
+            "messages:tokenProvisioning.createRequiresGroupSelection",
+          )}
+          onSuccess={handleDefaultTokenCreateSuccess}
         />
       ) : null}
     </>

--- a/src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
+++ b/src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
@@ -1,6 +1,9 @@
 import { useChannelDialogContext } from "~/components/dialogs/ChannelDialog/context/ChannelDialogContext"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
-import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import {
+  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+  resolvePreferredDefaultUserGroup,
+} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 
 import { ChannelDialog } from "./ChannelDialog"
 
@@ -10,22 +13,23 @@ import { ChannelDialog } from "./ChannelDialog"
 export function ChannelDialogContainer() {
   const {
     state,
-    sub2apiTokenDialog,
+    defaultTokenQuickCreateDialog,
     closeDialog,
-    closeSub2ApiTokenDialog,
+    closeDefaultTokenQuickCreateDialog,
     handleSuccess,
-    handleSub2ApiTokenSuccess,
+    handleDefaultTokenQuickCreateSuccess,
   } = useChannelDialogContext()
 
-  const sub2apiTokenDialogPrefill =
-    sub2apiTokenDialog.account && sub2apiTokenDialog.allowedGroups.length > 0
+  const defaultTokenQuickCreatePrefill =
+    defaultTokenQuickCreateDialog.account &&
+    defaultTokenQuickCreateDialog.allowedGroups.length > 0
       ? {
           modelId: "",
           defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-          group: sub2apiTokenDialog.allowedGroups.includes("default")
-            ? "default"
-            : sub2apiTokenDialog.allowedGroups[0] ?? "default",
-          allowedGroups: sub2apiTokenDialog.allowedGroups,
+          group: resolvePreferredDefaultUserGroup(
+            defaultTokenQuickCreateDialog.allowedGroups,
+          ),
+          allowedGroups: defaultTokenQuickCreateDialog.allowedGroups,
         }
       : undefined
 
@@ -45,15 +49,16 @@ export function ChannelDialogContainer() {
         onSuccess={handleSuccess}
         onMutationOutcome={state.onMutationOutcome ?? undefined}
       />
-      {sub2apiTokenDialog.account && sub2apiTokenDialogPrefill ? (
+      {defaultTokenQuickCreateDialog.account &&
+      defaultTokenQuickCreatePrefill ? (
         <AddTokenDialog
-          isOpen={sub2apiTokenDialog.isOpen}
-          onClose={closeSub2ApiTokenDialog}
-          availableAccounts={[sub2apiTokenDialog.account]}
-          preSelectedAccountId={sub2apiTokenDialog.account.id}
-          createPrefill={sub2apiTokenDialogPrefill}
-          prefillNotice={sub2apiTokenDialog.notice}
-          onSuccess={handleSub2ApiTokenSuccess}
+          isOpen={defaultTokenQuickCreateDialog.isOpen}
+          onClose={closeDefaultTokenQuickCreateDialog}
+          availableAccounts={[defaultTokenQuickCreateDialog.account]}
+          preSelectedAccountId={defaultTokenQuickCreateDialog.account.id}
+          createPrefill={defaultTokenQuickCreatePrefill}
+          prefillNotice={defaultTokenQuickCreateDialog.notice}
+          onSuccess={handleDefaultTokenQuickCreateSuccess}
         />
       ) : null}
     </>

--- a/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
+++ b/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
@@ -12,9 +12,17 @@ import type { ManagedSiteChannelAssessmentSignals } from "~/services/managedSite
 import type { ApiToken, DisplaySiteData } from "~/types"
 import type { ChannelFormData, ManagedSiteChannel } from "~/types/managedSite"
 
+export const CHANNEL_DIALOG_MUTATION_RESULTS = {
+  Success: "success",
+  Failure: "failure",
+} as const
+
+export type ChannelDialogMutationResult =
+  (typeof CHANNEL_DIALOG_MUTATION_RESULTS)[keyof typeof CHANNEL_DIALOG_MUTATION_RESULTS]
+
 type ChannelDialogMutationOutcomeHandler = (outcome: {
   mode: DialogMode
-  result: "success" | "failure"
+  result: ChannelDialogMutationResult
   siteType: string
 }) => void
 
@@ -46,7 +54,7 @@ interface DuplicateChannelWarningState {
   existingChannelName: string | null
 }
 
-interface Sub2ApiTokenDialogState {
+interface DefaultTokenQuickCreateDialogState {
   isOpen: boolean
   sessionId: number
   account: DisplaySiteData | null
@@ -58,7 +66,7 @@ interface Sub2ApiTokenDialogState {
 interface ChannelDialogContextValue {
   state: ChannelDialogState
   duplicateChannelWarning: DuplicateChannelWarningState
-  sub2apiTokenDialog: Sub2ApiTokenDialogState
+  defaultTokenQuickCreateDialog: DefaultTokenQuickCreateDialogState
   openDialog: (config: {
     mode?: DialogMode
     channel?: ManagedSiteChannel | null
@@ -75,14 +83,16 @@ interface ChannelDialogContextValue {
   }) => void
   closeDialog: () => void
   handleSuccess: (result: any) => void
-  openSub2ApiTokenDialog: (config: {
+  openDefaultTokenQuickCreateDialog: (config: {
     account: DisplaySiteData
     allowedGroups: string[]
     notice?: string
     onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
   }) => void
-  closeSub2ApiTokenDialog: () => void
-  handleSub2ApiTokenSuccess: (createdToken?: ApiToken) => Promise<void>
+  closeDefaultTokenQuickCreateDialog: () => void
+  handleDefaultTokenQuickCreateSuccess: (
+    createdToken?: ApiToken,
+  ) => Promise<void>
   requestDuplicateChannelWarning: (options: {
     existingChannelName: string
   }) => Promise<boolean>
@@ -112,8 +122,8 @@ export function ChannelDialogProvider({
       isOpen: false,
       existingChannelName: null,
     })
-  const [sub2apiTokenDialog, setSub2apiTokenDialog] =
-    useState<Sub2ApiTokenDialogState>({
+  const [defaultTokenQuickCreateDialog, setDefaultTokenQuickCreateDialog] =
+    useState<DefaultTokenQuickCreateDialogState>({
       isOpen: false,
       sessionId: 0,
       account: null,
@@ -121,8 +131,12 @@ export function ChannelDialogProvider({
       notice: undefined,
       onSuccessCallback: null,
     })
-  const sub2apiTokenDialogSessionIdRef = useRef(sub2apiTokenDialog.sessionId)
-  const sub2apiTokenOnSuccessRef = useRef(sub2apiTokenDialog.onSuccessCallback)
+  const defaultTokenQuickCreateDialogSessionIdRef = useRef(
+    defaultTokenQuickCreateDialog.sessionId,
+  )
+  const defaultTokenQuickCreateOnSuccessRef = useRef(
+    defaultTokenQuickCreateDialog.onSuccessCallback,
+  )
 
   const openDialog = useCallback(
     (config: {
@@ -177,18 +191,19 @@ export function ChannelDialogProvider({
     [closeDialog],
   )
 
-  const openSub2ApiTokenDialog = useCallback(
+  const openDefaultTokenQuickCreateDialog = useCallback(
     (config: {
       account: DisplaySiteData
       allowedGroups: string[]
       notice?: string
       onSuccess?: (createdToken?: ApiToken) => void | Promise<void>
     }) => {
-      const nextSessionId = sub2apiTokenDialogSessionIdRef.current + 1
+      const nextSessionId =
+        defaultTokenQuickCreateDialogSessionIdRef.current + 1
       const nextOnSuccess = config.onSuccess ?? null
-      sub2apiTokenDialogSessionIdRef.current = nextSessionId
-      sub2apiTokenOnSuccessRef.current = nextOnSuccess
-      setSub2apiTokenDialog(() => ({
+      defaultTokenQuickCreateDialogSessionIdRef.current = nextSessionId
+      defaultTokenQuickCreateOnSuccessRef.current = nextOnSuccess
+      setDefaultTokenQuickCreateDialog(() => ({
         isOpen: true,
         sessionId: nextSessionId,
         account: config.account,
@@ -200,11 +215,11 @@ export function ChannelDialogProvider({
     [],
   )
 
-  const closeSub2ApiTokenDialog = useCallback(() => {
-    const nextSessionId = sub2apiTokenDialogSessionIdRef.current + 1
-    sub2apiTokenDialogSessionIdRef.current = nextSessionId
-    sub2apiTokenOnSuccessRef.current = null
-    setSub2apiTokenDialog(() => ({
+  const closeDefaultTokenQuickCreateDialog = useCallback(() => {
+    const nextSessionId = defaultTokenQuickCreateDialogSessionIdRef.current + 1
+    defaultTokenQuickCreateDialogSessionIdRef.current = nextSessionId
+    defaultTokenQuickCreateOnSuccessRef.current = null
+    setDefaultTokenQuickCreateDialog(() => ({
       isOpen: false,
       sessionId: nextSessionId,
       account: null,
@@ -214,25 +229,28 @@ export function ChannelDialogProvider({
     }))
   }, [])
 
-  const handleSub2ApiTokenSuccess = useCallback(
+  const handleDefaultTokenQuickCreateSuccess = useCallback(
     async (createdToken?: ApiToken) => {
-      const sessionIdAtInvocation = sub2apiTokenDialog.sessionId
-      if (!sub2apiTokenDialog.isOpen) {
+      const sessionIdAtInvocation = defaultTokenQuickCreateDialog.sessionId
+      if (!defaultTokenQuickCreateDialog.isOpen) {
         return
       }
 
-      if (sub2apiTokenDialogSessionIdRef.current !== sessionIdAtInvocation) {
+      if (
+        defaultTokenQuickCreateDialogSessionIdRef.current !==
+        sessionIdAtInvocation
+      ) {
         return
       }
 
-      const callback = sub2apiTokenOnSuccessRef.current
-      closeSub2ApiTokenDialog()
+      const callback = defaultTokenQuickCreateOnSuccessRef.current
+      closeDefaultTokenQuickCreateDialog()
       await callback?.(createdToken)
     },
     [
-      closeSub2ApiTokenDialog,
-      sub2apiTokenDialog.isOpen,
-      sub2apiTokenDialog.sessionId,
+      closeDefaultTokenQuickCreateDialog,
+      defaultTokenQuickCreateDialog.isOpen,
+      defaultTokenQuickCreateDialog.sessionId,
     ],
   )
 
@@ -283,13 +301,13 @@ export function ChannelDialogProvider({
       value={{
         state,
         duplicateChannelWarning,
-        sub2apiTokenDialog,
+        defaultTokenQuickCreateDialog,
         openDialog,
         closeDialog,
         handleSuccess,
-        openSub2ApiTokenDialog,
-        closeSub2ApiTokenDialog,
-        handleSub2ApiTokenSuccess,
+        openDefaultTokenQuickCreateDialog,
+        closeDefaultTokenQuickCreateDialog,
+        handleDefaultTokenQuickCreateSuccess,
         requestDuplicateChannelWarning,
         resolveDuplicateChannelWarning,
       }}

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -11,15 +11,20 @@ import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   ensureAccountApiToken,
-  resolveSub2ApiQuickCreateResolution,
+  resolveDefaultTokenQuickCreateResolution,
 } from "~/services/accounts/accountOperations"
 import { selectSingleNewApiTokenByIdDiff } from "~/services/accounts/accountPostSaveWorkflow"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
 import {
   createDisplayAccountApiContext,
   requireDisplayAccountKeyManagement,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  API_CREDENTIAL_PROFILE_SYNTHETIC_ACCOUNT_ID_PREFIX,
+  buildApiCredentialProfileSyntheticAccountId,
+} from "~/services/apiCredentialProfiles/syntheticAccount"
 import { toManagedSiteChannelAssessmentSignals } from "~/services/managedSites/channelAssessmentSignals"
 import { getManagedSiteChannelExactMatch } from "~/services/managedSites/channelMatch"
 import { resolveManagedSiteChannelMatch } from "~/services/managedSites/channelMatchResolver"
@@ -95,10 +100,13 @@ function getApiTokenIds(tokens: ApiToken[]): number[] {
  */
 export function useChannelDialog() {
   const { t } = useTranslation(["messages", "channelDialog"])
-  const { openDialog, openSub2ApiTokenDialog, requestDuplicateChannelWarning } =
-    useChannelDialogContext()
+  const {
+    openDialog,
+    openDefaultTokenQuickCreateDialog,
+    requestDuplicateChannelWarning,
+  } = useChannelDialogContext()
 
-  const openSub2ApiTokenCreationDialog = async (
+  const openDefaultTokenQuickCreateDialogForAccount = async (
     account: DisplaySiteData,
     options?: {
       notice?: string
@@ -114,23 +122,33 @@ export function useChannelDialog() {
       return false
     }
 
-    const resolution = await resolveSub2ApiQuickCreateResolution(account)
-    if (resolution.kind === "blocked") {
+    const resolution = await resolveDefaultTokenQuickCreateResolution(account)
+    if (resolution.kind === TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked) {
       toast.error(resolution.message)
       return false
     }
 
-    openSub2ApiTokenDialog({
+    if (resolution.kind === TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready) {
+      const selectedGroup = resolution.tokenData.group?.trim()
+      if (!selectedGroup) {
+        return false
+      }
+
+      openDefaultTokenQuickCreateDialog({
+        account,
+        allowedGroups: [selectedGroup],
+        notice: options?.notice,
+        onSuccess: options?.onSuccess,
+      })
+      return true
+    }
+
+    openDefaultTokenQuickCreateDialog({
       account,
-      allowedGroups:
-        resolution.kind === "selection_required"
-          ? resolution.allowedGroups
-          : [resolution.group],
+      allowedGroups: resolution.allowedGroups,
       notice:
         options?.notice ??
-        (resolution.kind === "selection_required"
-          ? t("messages:sub2api.createRequiresGroupSelection")
-          : undefined),
+        t("messages:tokenProvisioning.createRequiresGroupSelection"),
       onSuccess: options?.onSuccess,
     })
 
@@ -142,9 +160,9 @@ export function useChannelDialog() {
     baseUrl: string
   }): DisplaySiteData => {
     return {
-      id: `api-credential-profile:${options.name}`,
+      id: buildApiCredentialProfileSyntheticAccountId(options.name),
       name: options.name,
-      username: "api-credential-profile",
+      username: API_CREDENTIAL_PROFILE_SYNTHETIC_ACCOUNT_ID_PREFIX,
       balance: { USD: 0, CNY: 0 },
       todayConsumption: { USD: 0, CNY: 0 },
       todayIncome: { USD: 0, CNY: 0 },
@@ -398,88 +416,84 @@ export function useChannelDialog() {
       }
 
       if (!apiToken) {
-        if (displaySiteData.siteType === SITE_TYPES.SUB2API) {
-          const resolution =
-            await resolveSub2ApiQuickCreateResolution(displaySiteData)
+        const resolution =
+          await resolveDefaultTokenQuickCreateResolution(displaySiteData)
+        if (!shouldContinue()) {
+          return cancelOpen()
+        }
+
+        if (resolution.kind === TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked) {
+          toast.error(resolution.message, { id: toastId })
+          return { opened: false }
+        }
+
+        if (
+          resolution.kind ===
+          TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired
+        ) {
           if (!shouldContinue()) {
             return cancelOpen()
           }
+          toast.dismiss(toastId)
+          openDefaultTokenQuickCreateDialog({
+            account: displaySiteData,
+            allowedGroups: resolution.allowedGroups,
+            notice: t(
+              "messages:tokenProvisioning.createRequiresGroupSelection",
+            ),
+            onSuccess: async (createdToken?: ApiToken) => {
+              if (!shouldContinue()) {
+                return
+              }
 
-          if (resolution.kind === "blocked") {
-            toast.error(resolution.message, { id: toastId })
-            return { opened: false }
-          }
-
-          if (resolution.kind === "selection_required") {
-            if (!shouldContinue()) {
-              return cancelOpen()
-            }
-            toast.dismiss(toastId)
-            openSub2ApiTokenDialog({
-              account: displaySiteData,
-              allowedGroups: resolution.allowedGroups,
-              notice: t("messages:sub2api.createRequiresGroupSelection"),
-              onSuccess: async (createdToken?: ApiToken) => {
-                if (!shouldContinue()) {
-                  return
-                }
-
-                if (createdToken) {
-                  await openWithAccount(
-                    displaySiteData!,
-                    createdToken,
-                    onSuccess,
-                    options,
-                  )
-                  return
-                }
-
-                if (!shouldContinue()) {
-                  return
-                }
-
-                const refetchedTokens =
-                  accountKeyManagement && accountApiRequest
-                    ? await accountKeyManagement.fetchTokens(accountApiRequest)
-                    : null
-                if (!shouldContinue()) {
-                  return
-                }
-                const recoveredToken = Array.isArray(refetchedTokens)
-                  ? selectSingleNewApiTokenByIdDiff({
-                      existingTokenIds,
-                      tokens: refetchedTokens,
-                    })
-                  : null
-
-                if (!recoveredToken) {
-                  toast.error(t("messages:accountOperations.createTokenFailed"))
-                  return
-                }
-
+              if (createdToken) {
                 await openWithAccount(
                   displaySiteData!,
-                  recoveredToken,
+                  createdToken,
                   onSuccess,
                   options,
                 )
-              },
-            })
-            return { opened: false, deferred: true }
-          }
+                return
+              }
 
-          apiToken = await ensureAccountApiToken(siteAccount, displaySiteData, {
-            toastId,
-            sub2apiGroup: resolution.group,
+              if (!shouldContinue()) {
+                return
+              }
+
+              const refetchedTokens =
+                accountKeyManagement && accountApiRequest
+                  ? await accountKeyManagement.fetchTokens(accountApiRequest)
+                  : null
+              if (!shouldContinue()) {
+                return
+              }
+              const recoveredToken = Array.isArray(refetchedTokens)
+                ? selectSingleNewApiTokenByIdDiff({
+                    existingTokenIds,
+                    tokens: refetchedTokens,
+                  })
+                : null
+
+              if (!recoveredToken) {
+                toast.error(t("messages:accountOperations.createTokenFailed"))
+                return
+              }
+
+              await openWithAccount(
+                displaySiteData!,
+                recoveredToken,
+                onSuccess,
+                options,
+              )
+            },
           })
-        } else {
-          // Ensure API token exists
-          apiToken = await ensureAccountApiToken(
-            siteAccount,
-            displaySiteData,
-            toastId,
-          )
+          return { opened: false, deferred: true }
         }
+
+        apiToken = await ensureAccountApiToken(siteAccount, displaySiteData, {
+          toastId,
+          defaultTokenData: resolution.tokenData,
+        })
       }
       if (!shouldContinue()) {
         return cancelOpen()
@@ -672,7 +686,7 @@ export function useChannelDialog() {
 
   return {
     openWithAccount,
-    openSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount,
     openWithCredentials,
     openWithCustom,
   }

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -131,6 +131,7 @@ export function useChannelDialog() {
     if (resolution.kind === TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready) {
       const selectedGroup = resolution.tokenData.group?.trim()
       if (!selectedGroup) {
+        toast.error(t("messages:tokenProvisioning.createRequiresGroup"))
         return false
       }
 

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelForm.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelForm.ts
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import {
+  CHANNEL_DIALOG_MUTATION_RESULTS,
+  type ChannelDialogMutationResult,
+} from "~/components/dialogs/ChannelDialog/context/ChannelDialogContext"
 import { mergeUniqueOptions } from "~/components/dialogs/ChannelDialog/utils/selectOptions"
 import type { CompactMultiSelectOption } from "~/components/ui"
 import { DEFAULT_CLAUDE_CODE_HUB_CHANNEL_FIELDS } from "~/constants/claudeCodeHub"
@@ -29,6 +33,12 @@ import { createLogger } from "~/utils/core/logger"
  */
 const logger = createLogger("ChannelFormHook")
 
+const createDefaultChannelGroupOptions = (): CompactMultiSelectOption[] =>
+  DEFAULT_CHANNEL_FIELDS.groups.map((group) => ({
+    label: group,
+    value: group,
+  }))
+
 const isAccessTokenManagedConfig = (
   config: ManagedSiteConfig,
 ): config is Extract<
@@ -44,7 +54,7 @@ export interface UseChannelFormProps {
   onSuccess?: (response: any) => void
   onMutationOutcome?: (outcome: {
     mode: DialogMode
-    result: "success" | "failure"
+    result: ChannelDialogMutationResult
     siteType: string
   }) => void
   initialValues?: Partial<ChannelFormData>
@@ -224,7 +234,7 @@ export function useChannelForm({
         return
       }
       if (service.siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
-        const fallback = [{ label: "default", value: "default" }]
+        const fallback = createDefaultChannelGroupOptions()
         const preselectedGroups = (
           initialValues?.groups ??
           initialGroups ??
@@ -242,7 +252,7 @@ export function useChannelForm({
 
       if (!hasConfig) {
         logger.warn("No valid managed-site configuration")
-        const fallback = [{ label: "default", value: "default" }]
+        const fallback = createDefaultChannelGroupOptions()
         setAvailableGroups(mergeUniqueOptions(fallback, preselectedGroups))
         return
       }
@@ -251,7 +261,7 @@ export function useChannelForm({
       if (!config) {
         setAvailableGroups(
           mergeUniqueOptions(
-            [{ label: "default", value: "default" }],
+            createDefaultChannelGroupOptions(),
             preselectedGroups,
           ),
         )
@@ -276,15 +286,22 @@ export function useChannelForm({
         value: group,
       }))
 
-      if (!groupOptions.some((option) => option.value === "default")) {
-        groupOptions.push({ label: "default", value: "default" })
+      const defaultGroupOptions = createDefaultChannelGroupOptions()
+      for (const defaultGroupOption of defaultGroupOptions) {
+        if (
+          !groupOptions.some(
+            (option) => option.value === defaultGroupOption.value,
+          )
+        ) {
+          groupOptions.push(defaultGroupOption)
+        }
       }
 
       groupOptions = mergeUniqueOptions(groupOptions, preselectedGroups)
       setAvailableGroups(groupOptions)
     } catch (error) {
       logger.error("Failed to load groups", error)
-      const fallback = [{ label: "default", value: "default" }]
+      const fallback = createDefaultChannelGroupOptions()
       const preselectedGroups = (
         initialValues?.groups ??
         initialGroups ??
@@ -437,7 +454,7 @@ export function useChannelForm({
 
         onMutationOutcome?.({
           mode,
-          result: "success",
+          result: CHANNEL_DIALOG_MUTATION_RESULTS.Success,
           siteType: service.siteType,
         })
         onSuccess?.(normalizedResponse)
@@ -455,7 +472,7 @@ export function useChannelForm({
           : SITE_TYPES.NEW_API)
       onMutationOutcome?.({
         mode,
-        result: "failure",
+        result: CHANNEL_DIALOG_MUTATION_RESULTS.Failure,
         siteType,
       })
       toast.error(

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -80,9 +80,10 @@ function Button({
     analyticsAction?: ProductAnalyticsScopedActionConfig
   }) {
   const Comp = asChild ? Slot.Root : "button"
+  const isDisabled = Boolean(disabled || loading)
   const analytics = useProductAnalyticsActionTracking({
     analyticsAction,
-    disabled: Boolean(disabled || loading),
+    disabled: isDisabled,
   })
   const trackingProps = analytics.getActionTrackingProps()
 
@@ -105,7 +106,7 @@ function Button({
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
     onClick?.(event)
 
-    if (event.defaultPrevented || disabled || loading || !analyticsAction) {
+    if (event.defaultPrevented || isDisabled || !analyticsAction) {
       return
     }
 
@@ -116,7 +117,7 @@ function Button({
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, bleed, className }))}
-      disabled={disabled}
+      disabled={isDisabled}
       onClick={handleClick}
       {...props}
     >

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -741,8 +741,10 @@ export function useAccountDialog({
   const currentTabCookieImportContextRef =
     useRef<CurrentTabCookieImportContext | null>(null)
 
-  const { openWithAccount: openChannelDialog, openSub2ApiTokenCreationDialog } =
-    useChannelDialog()
+  const {
+    openWithAccount: openChannelDialog,
+    openDefaultTokenQuickCreateDialogForAccount,
+  } = useChannelDialog()
 
   const invalidatePostSaveAutoConfigRun = useCallback(() => {
     postSaveAutoConfigRunRef.current += 1
@@ -1974,7 +1976,9 @@ export function useAccountDialog({
             }) &&
             savedDisplaySiteData
           ) {
-            await openSub2ApiTokenCreationDialog(savedDisplaySiteData)
+            await openDefaultTokenQuickCreateDialogForAccount(
+              savedDisplaySiteData,
+            )
           }
         } catch (error) {
           logger.error("Post-save Sub2API token dialog failed", {

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -15,7 +15,10 @@ import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testId
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
 import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
 import { buildOneTimeApiKeyProfileSaveAction } from "~/features/KeyManagement/utils/apiCredentialProfileSaveAction"
-import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import {
+  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+  resolvePreferredDefaultUserGroup,
+} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import type { DisplaySiteData } from "~/types"
 import { createLogger } from "~/utils/core/logger"
 import {
@@ -169,9 +172,9 @@ export default function AccountDialog({
       ? {
           modelId: "",
           defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-          group: state.postSaveSub2ApiAllowedGroups.includes("default")
-            ? "default"
-            : state.postSaveSub2ApiAllowedGroups[0] ?? "default",
+          group: resolvePreferredDefaultUserGroup(
+            state.postSaveSub2ApiAllowedGroups,
+          ),
           allowedGroups: state.postSaveSub2ApiAllowedGroups,
         }
       : undefined
@@ -398,7 +401,7 @@ export default function AccountDialog({
           availableAccounts={[state.postSaveSub2ApiAccount]}
           preSelectedAccountId={state.postSaveSub2ApiAccount.id}
           createPrefill={postSaveSub2ApiCreatePrefill}
-          prefillNotice={t("sub2api.createRequiresGroupSelection")}
+          prefillNotice={t("tokenProvisioning.createRequiresGroupSelection")}
           onSuccess={
             postSaveSub2ApiDialogHandlers?.onSuccess ??
             handlers.handlePostSaveSub2ApiTokenCreated

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -3,8 +3,8 @@ import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { shouldShowOneTimeKeyDialogForCreatedToken } from "~/features/KeyManagement/utils"
-import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
-import { resolveSub2ApiQuickCreateResolution } from "~/services/accounts/accountOperations"
+import { resolveDefaultTokenQuickCreateResolution } from "~/services/accounts/accountOperations"
+import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
 import {
   canManageDisplayAccountTokens,
   createDisplayAccountApiContext,
@@ -65,9 +65,8 @@ export function useCopyKeyDialog(
   const [isCreating, setIsCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const [oneTimeToken, setOneTimeToken] = useState<ApiToken | null>(null)
-  const [sub2apiCreateAllowedGroups, setSub2apiCreateAllowedGroups] = useState<
-    string[] | null
-  >(null)
+  const [defaultTokenCreateAllowedGroups, setDefaultTokenCreateAllowedGroups] =
+    useState<string[] | null>(null)
   const [copiedTokenId, setCopiedTokenId] = useState<number | null>(null)
   const [expandedTokens, setExpandedTokens] = useState<Set<number>>(new Set())
   const copiedTokenResetTimeoutRef = useRef<ReturnType<
@@ -86,8 +85,8 @@ export function useCopyKeyDialog(
     copiedTokenResetTimeoutRef.current = null
   }, [])
 
-  const clearSub2ApiCreateAllowedGroups = useCallback(() => {
-    setSub2apiCreateAllowedGroups(null)
+  const clearDefaultTokenCreateAllowedGroups = useCallback(() => {
+    setDefaultTokenCreateAllowedGroups(null)
   }, [])
 
   const fetchTokens = useCallback(async () => {
@@ -96,7 +95,7 @@ export function useCopyKeyDialog(
     setIsLoading(true)
     setError(null)
     setCreateError(null)
-    clearSub2ApiCreateAllowedGroups()
+    clearDefaultTokenCreateAllowedGroups()
 
     try {
       const tokensResponse = await fetchDisplayAccountTokens(account)
@@ -116,7 +115,7 @@ export function useCopyKeyDialog(
     } finally {
       setIsLoading(false)
     }
-  }, [account, clearSub2ApiCreateAllowedGroups, t])
+  }, [account, clearDefaultTokenCreateAllowedGroups, t])
 
   useEffect(() => {
     if (isOpen && account) {
@@ -128,14 +127,14 @@ export function useCopyKeyDialog(
       setIsCreating(false)
       setCreateError(null)
       setOneTimeToken(null)
-      clearSub2ApiCreateAllowedGroups()
+      clearDefaultTokenCreateAllowedGroups()
       setCopiedTokenId(null)
       setExpandedTokens(new Set())
     }
   }, [
     account,
     clearCopiedTokenResetTimeout,
-    clearSub2ApiCreateAllowedGroups,
+    clearDefaultTokenCreateAllowedGroups,
     fetchTokens,
     isOpen,
   ])
@@ -266,27 +265,25 @@ export function useCopyKeyDialog(
 
     setIsCreating(true)
     setCreateError(null)
-    clearSub2ApiCreateAllowedGroups()
+    clearDefaultTokenCreateAllowedGroups()
 
     try {
       const { keyManagement, request } = createDisplayAccountApiContext(account)
-      const tokenRequest = generateDefaultTokenRequest()
-      if (account.siteType === "sub2api") {
-        // Sub2API quick-create may skip the chooser only when the current
-        // upstream group set has collapsed to a single valid option.
-        const resolution = await resolveSub2ApiQuickCreateResolution(account)
-        if (resolution.kind === "blocked") {
-          setCreateError(resolution.message)
-          return
-        }
-
-        if (resolution.kind === "selection_required") {
-          setSub2apiCreateAllowedGroups(resolution.allowedGroups)
-          return
-        }
-
-        tokenRequest.group = resolution.group
+      const resolution = await resolveDefaultTokenQuickCreateResolution(account)
+      if (resolution.kind === TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked) {
+        setCreateError(resolution.message)
+        return
       }
+
+      if (
+        resolution.kind ===
+        TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired
+      ) {
+        setDefaultTokenCreateAllowedGroups(resolution.allowedGroups)
+        return
+      }
+
+      const tokenRequest = resolution.tokenData
 
       const created = await requireDisplayAccountKeyManagement(
         account,
@@ -316,7 +313,7 @@ export function useCopyKeyDialog(
   }, [
     account,
     canCreateDefaultKey,
-    clearSub2ApiCreateAllowedGroups,
+    clearDefaultTokenCreateAllowedGroups,
     isCreating,
     refreshTokensAfterCreate,
     t,
@@ -341,7 +338,7 @@ export function useCopyKeyDialog(
     isCreating,
     createError,
     oneTimeToken,
-    sub2apiCreateAllowedGroups,
+    defaultTokenCreateAllowedGroups,
     copiedTokenId,
     expandedTokens,
     canCreateDefaultKey,
@@ -350,7 +347,7 @@ export function useCopyKeyDialog(
     createDefaultKey,
     refreshTokensAfterCreate,
     toggleTokenExpansion,
-    clearSub2ApiCreateAllowedGroups,
+    clearDefaultTokenCreateAllowedGroups,
     clearOneTimeToken: () => setOneTimeToken(null),
   }
 }

--- a/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
@@ -46,7 +46,7 @@ export default function CopyKeyDialog({
     isCreating,
     createError,
     oneTimeToken,
-    sub2apiCreateAllowedGroups,
+    defaultTokenCreateAllowedGroups,
     copiedTokenId,
     expandedTokens,
     canCreateDefaultKey,
@@ -55,7 +55,7 @@ export default function CopyKeyDialog({
     createDefaultKey,
     refreshTokensAfterCreate,
     toggleTokenExpansion,
-    clearSub2ApiCreateAllowedGroups,
+    clearDefaultTokenCreateAllowedGroups,
     clearOneTimeToken,
   } = useCopyKeyDialog(isOpen, account)
   const oneTimeKeySaveAction =
@@ -73,15 +73,15 @@ export default function CopyKeyDialog({
       : undefined
 
   const handleOpenAddTokenDialog = () => {
-    clearSub2ApiCreateAllowedGroups()
+    clearDefaultTokenCreateAllowedGroups()
     setIsAddTokenDialogOpen(true)
   }
   const handleCloseAddTokenDialog = () => {
-    clearSub2ApiCreateAllowedGroups()
+    clearDefaultTokenCreateAllowedGroups()
     setIsAddTokenDialogOpen(false)
   }
   const handleAddTokenSuccess = (createdToken?: ApiToken) => {
-    clearSub2ApiCreateAllowedGroups()
+    clearDefaultTokenCreateAllowedGroups()
     return refreshTokensAfterCreate(createdToken)
   }
 
@@ -95,31 +95,32 @@ export default function CopyKeyDialog({
 
   useEffect(() => {
     if (!isOpen || !account) {
-      clearSub2ApiCreateAllowedGroups()
+      clearDefaultTokenCreateAllowedGroups()
       setIsAddTokenDialogOpen(false)
     }
-  }, [account, clearSub2ApiCreateAllowedGroups, isOpen])
+  }, [account, clearDefaultTokenCreateAllowedGroups, isOpen])
 
   useEffect(() => {
     if (
       !isMountedRef.current ||
       !isOpen ||
       !account ||
-      !sub2apiCreateAllowedGroups ||
-      sub2apiCreateAllowedGroups.length === 0
+      !defaultTokenCreateAllowedGroups ||
+      defaultTokenCreateAllowedGroups.length === 0
     ) {
       return
     }
 
     setIsAddTokenDialogOpen(true)
-  }, [account, isOpen, sub2apiCreateAllowedGroups])
+  }, [account, defaultTokenCreateAllowedGroups, isOpen])
 
-  const sub2apiQuickCreatePrefill =
-    sub2apiCreateAllowedGroups && sub2apiCreateAllowedGroups.length > 0
+  const defaultTokenQuickCreatePrefill =
+    defaultTokenCreateAllowedGroups &&
+    defaultTokenCreateAllowedGroups.length > 0
       ? {
           modelId: "",
           defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-          allowedGroups: sub2apiCreateAllowedGroups,
+          allowedGroups: defaultTokenCreateAllowedGroups,
         }
       : undefined
 
@@ -185,10 +186,10 @@ export default function CopyKeyDialog({
           onClose={handleCloseAddTokenDialog}
           availableAccounts={[account]}
           preSelectedAccountId={account.id}
-          createPrefill={sub2apiQuickCreatePrefill}
+          createPrefill={defaultTokenQuickCreatePrefill}
           prefillNotice={
-            sub2apiQuickCreatePrefill
-              ? t("sub2api.createRequiresGroupSelection")
+            defaultTokenQuickCreatePrefill
+              ? t("tokenProvisioning.createRequiresGroupSelection")
               : undefined
           }
           onSuccess={handleAddTokenSuccess}

--- a/src/features/ApiCredentialProfiles/utils/exportShims.ts
+++ b/src/features/ApiCredentialProfiles/utils/exportShims.ts
@@ -1,4 +1,8 @@
 import { SITE_TYPES } from "~/constants/siteType"
+import {
+  API_CREDENTIAL_PROFILE_SYNTHETIC_ACCOUNT_ID_PREFIX,
+  buildApiCredentialProfileSyntheticAccountId,
+} from "~/services/apiCredentialProfiles/syntheticAccount"
 import type { ApiVerificationApiType } from "~/services/verification/aiApiVerification"
 import {
   AuthTypeEnum,
@@ -36,9 +40,9 @@ export function createExportAccount(
   profile: ApiCredentialProfile,
 ): DisplaySiteData {
   return {
-    id: `api-credential-profile:${profile.id}`,
+    id: buildApiCredentialProfileSyntheticAccountId(profile.id),
     name: profile.name,
-    username: "api-credential-profile",
+    username: API_CREDENTIAL_PROFILE_SYNTHETIC_ACCOUNT_ID_PREFIX,
     balance: { USD: 0, CNY: 0 },
     todayConsumption: { USD: 0, CNY: 0 },
     todayIncome: { USD: 0, CNY: 0 },

--- a/src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts
+++ b/src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenData.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { DEFAULT_USER_GROUP_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
   createDisplayAccountApiContext,
   requireDisplayAccountKeyManagement,
@@ -85,8 +86,11 @@ export function useTokenData(
             return prev
           }
 
-          if (allowedGroupSet.has("default") && groupsData.default) {
-            return { ...prev, group: "default" }
+          if (
+            allowedGroupSet.has(DEFAULT_USER_GROUP_NAME) &&
+            groupsData[DEFAULT_USER_GROUP_NAME]
+          ) {
+            return { ...prev, group: DEFAULT_USER_GROUP_NAME }
           }
 
           const firstAllowedGroup = normalizedAllowedGroups.find(
@@ -98,8 +102,8 @@ export function useTokenData(
             : prev
         }
 
-        if (groupsData.default) {
-          return { ...prev, group: "default" }
+        if (groupsData[DEFAULT_USER_GROUP_NAME]) {
+          return { ...prev, group: DEFAULT_USER_GROUP_NAME }
         }
 
         const firstGroup = Object.keys(groupsData)[0]

--- a/src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenForm.ts
+++ b/src/features/KeyManagement/components/AddTokenDialog/hooks/useTokenForm.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 
 import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
+import { DEFAULT_USER_GROUP_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import type { AccountToken } from "~/types"
 
 // We duplicate some types here to avoid circular dependencies
@@ -60,7 +61,7 @@ const initialFormData: FormData = {
   modelLimitsEnabled: false,
   modelLimits: [],
   allowIps: "",
-  group: "default",
+  group: DEFAULT_USER_GROUP_NAME,
 }
 
 const isValidIpList = (ips: string): boolean => {
@@ -154,7 +155,7 @@ export function useTokenForm({
             ? editingToken.model_limits.split(",")
             : [],
           allowIps: editingToken.allow_ips || "",
-          group: editingToken.group || "default",
+          group: editingToken.group || DEFAULT_USER_GROUP_NAME,
         })
       } else {
         const defaultAccountId =
@@ -246,7 +247,9 @@ export function useTokenForm({
       allowedGroups.includes(normalizedSelectedGroup)
 
     if (requireGroup && (!normalizedSelectedGroup || !isRestrictedGroupValid)) {
-      newErrors.group = t("messages:sub2api.createRequiresGroupSelection")
+      newErrors.group = t(
+        "messages:tokenProvisioning.createRequiresGroupSelection",
+      )
     }
 
     setErrors(newErrors)

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -260,7 +260,7 @@ function getRepairProgressResult(progress: AccountKeyRepairProgress) {
 export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
   const { isOpen, onClose, accounts, startOnOpen } = props
   const { t } = useTranslation(["keyManagement", "common"])
-  const { openSub2ApiTokenCreationDialog } = useChannelDialog()
+  const { openDefaultTokenQuickCreateDialogForAccount } = useChannelDialog()
 
   const [progress, setProgress] = useState<AccountKeyRepairProgress | null>(
     null,
@@ -531,7 +531,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
 
     setOpeningSub2ApiAccountId(accountId)
     try {
-      await openSub2ApiTokenCreationDialog(account)
+      await openDefaultTokenQuickCreateDialogForAccount(account)
     } finally {
       setOpeningSub2ApiAccountId((current) =>
         current === accountId ? null : current,

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -172,8 +172,6 @@
   },
   "sub2api": {
     "createRequiresAvailableGroup": "This account has no group available for key creation. Check the account's available groups and try again.",
-    "createRequiresGroup": "Key creation requires a confirmed group. Choose an available group before continuing.",
-    "createRequiresGroupSelection": "This account has multiple available groups. Choose one before creating the key.",
     "groupMissing": "Sub2API group '{{group}}' is no longer available. Refresh the group list and try again.",
     "loginRequired": "Please log in to the Sub2API dashboard first (so the extension can read auth_token/auth_user from localStorage) and try again.",
     "refreshTokenInvalid": "Sub2API refresh token is invalid/rotated. Re-import the session from the dashboard (recommended: incognito/private window) or paste an updated refresh_token, then try again."
@@ -225,6 +223,10 @@
       "shareSnapshotDownloaded": "Snapshot downloaded",
       "urlCopied": "{{accountName}} URL copied to clipboard"
     }
+  },
+  "tokenProvisioning": {
+    "createRequiresGroup": "Key creation requires a confirmed group. Choose an available group before continuing.",
+    "createRequiresGroupSelection": "This account has multiple available groups. Choose one before creating the key."
   },
   "veloera": {
     "channelExists": "Channel {{channelName}} already exists, no need to import again",

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -265,6 +265,7 @@
         "accountNotFound": "Account not found.",
         "copiedApiConfigs": "apiConfigs copied to clipboard",
         "copyFailed": "Copy failed",
+        "createTokenBlockedFallback": "Token creation was blocked. Check the site policy and try again.",
         "createTokenFailed": "Failed to create token.",
         "downloadedSettings": "Settings file downloaded",
         "downloadFailed": "Failed to download settings file",

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -172,8 +172,6 @@
   },
   "sub2api": {
     "createRequiresAvailableGroup": "このアカウントにはキー作成に使えるグループがありません。利用可能なグループ設定を確認してから再試行してください。",
-    "createRequiresGroup": "キー作成にはグループの確定が必要です。続行する前に利用可能なグループを選択してください。",
-    "createRequiresGroupSelection": "このアカウントには利用可能なグループが複数あります。キーを作成する前に 1 つ選択してください。",
     "groupMissing": "Sub2API グループ '{{group}}' は現在利用できません。グループ一覧を更新して再試行してください。",
     "loginRequired": "先に Sub2API ダッシュボードへログインして（拡張機能が localStorage から auth_token / auth_user を読めるようにして）、再試行してください。",
     "refreshTokenInvalid": "Sub2API の Refresh Token が無効または更新済みです。ダッシュボードからセッションを再取り込み（推奨: シークレット / プライベートウィンドウ）するか、新しい refresh_token を貼り付けて再試行してください。"
@@ -221,6 +219,10 @@
       "shareSnapshotDownloaded": "スナップショットをダウンロードしました",
       "urlCopied": "{{accountName}} の URL をクリップボードにコピーしました"
     }
+  },
+  "tokenProvisioning": {
+    "createRequiresGroup": "キー作成にはグループの確定が必要です。続行する前に利用可能なグループを選択してください。",
+    "createRequiresGroupSelection": "このアカウントには利用可能なグループが複数あります。キーを作成する前に 1 つ選択してください。"
   },
   "veloera": {
     "channelExists": "チャネル {{channelName}} はすでに存在するため、再インポートは不要です",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -261,6 +261,7 @@
         "accountNotFound": "アカウントが見つかりません。",
         "copiedApiConfigs": "apiConfigs をクリップボードにコピーしました",
         "copyFailed": "コピーに失敗しました",
+        "createTokenBlockedFallback": "トークンの作成がブロックされました。サイトポリシーを確認してから再試行してください。",
         "createTokenFailed": "トークンの作成に失敗しました。",
         "downloadedSettings": "設定ファイルをダウンロードしました",
         "downloadFailed": "設定ファイルのダウンロードに失敗しました",

--- a/src/locales/vi/messages.json
+++ b/src/locales/vi/messages.json
@@ -172,8 +172,6 @@
   },
   "sub2api": {
     "createRequiresAvailableGroup": "Tài khoản hiện tại không có nhóm khả dụng để tạo khóa, vui lòng kiểm tra tình trạng nhóm của tài khoản trước khi thử lại.",
-    "createRequiresGroup": "Cần xác định nhóm trước khi tạo khóa, vui lòng chọn một nhóm khả dụng trước khi tiếp tục.",
-    "createRequiresGroupSelection": "Tài khoản hiện tại có nhiều nhóm khả dụng, vui lòng chọn nhóm muốn sử dụng trước khi tạo khóa.",
     "groupMissing": "Nhóm Sub2API \"{{group}}\" không còn khả dụng. Vui lòng làm mới danh sách nhóm rồi thử lại.",
     "loginRequired": "Vui lòng đăng nhập vào bảng điều khiển Sub2API (tiện ích sẽ đọc auth_token/auth_user để nhập phiên) rồi thử lại.",
     "refreshTokenInvalid": "refresh_token của Sub2API đã hết hạn/bị xoay vòng. Vui lòng nhập lại phiên từ bảng điều khiển (khuyến nghị dùng cửa sổ ẩn danh/riêng tư) hoặc dán refresh_token mới rồi thử lại."
@@ -221,6 +219,10 @@
       "shareSnapshotDownloaded": "Đã tải xuống ảnh chụp nhanh",
       "urlCopied": "Đã sao chép URL của {{accountName}} vào khay nhớ tạm"
     }
+  },
+  "tokenProvisioning": {
+    "createRequiresGroup": "Cần xác định nhóm trước khi tạo khóa, vui lòng chọn một nhóm khả dụng trước khi tiếp tục.",
+    "createRequiresGroupSelection": "Tài khoản hiện tại có nhiều nhóm khả dụng, vui lòng chọn nhóm muốn sử dụng trước khi tạo khóa."
   },
   "veloera": {
     "channelExists": "Kênh {{channelName}} đã tồn tại, không cần nhập lại",

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -261,6 +261,7 @@
         "accountNotFound": "Không tìm thấy tài khoản.",
         "copiedApiConfigs": "Đã sao chép apiConfigs",
         "copyFailed": "Sao chép thất bại",
+        "createTokenBlockedFallback": "Việc tạo API Key đã bị chặn. Vui lòng kiểm tra chính sách trang web rồi thử lại.",
         "createTokenFailed": "Tạo API Key thất bại.",
         "downloadedSettings": "Đã tải xuống tệp cài đặt",
         "downloadFailed": "Tải tệp cài đặt thất bại",

--- a/src/locales/zh-CN/messages.json
+++ b/src/locales/zh-CN/messages.json
@@ -172,8 +172,6 @@
   },
   "sub2api": {
     "createRequiresAvailableGroup": "当前账号没有可用于创建密钥的分组，请先确认账号分组情况后再试。",
-    "createRequiresGroup": "创建密钥前需要先确定分组，请先选择一个可用分组后再继续。",
-    "createRequiresGroupSelection": "当前账号有多个可用分组，请先选择要使用的分组，再创建密钥。",
     "groupMissing": "Sub2API 分组“{{group}}”已不可用。请刷新分组列表后重试。",
     "loginRequired": "请先登录 Sub2API 控制台（插件会读取 auth_token/auth_user 用于导入会话）后再重试。",
     "refreshTokenInvalid": "Sub2API refresh_token 已失效/已轮转。请从控制台重新导入会话（推荐无痕/隐私窗口），或粘贴新的 refresh_token 后重试。"
@@ -221,6 +219,10 @@
       "shareSnapshotDownloaded": "快照已下载",
       "urlCopied": "{{accountName}} 的 URL 已复制到剪贴板"
     }
+  },
+  "tokenProvisioning": {
+    "createRequiresGroup": "创建密钥前需要先确定分组，请先选择一个可用分组后再继续。",
+    "createRequiresGroupSelection": "当前账号有多个可用分组，请先选择要使用的分组，再创建密钥。"
   },
   "veloera": {
     "channelExists": "渠道 {{channelName}} 已存在，无需再次导入",

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -261,6 +261,7 @@
         "accountNotFound": "未找到账号。",
         "copiedApiConfigs": "已复制 apiConfigs",
         "copyFailed": "复制失败",
+        "createTokenBlockedFallback": "密钥创建被阻止。请检查站点策略后重试。",
         "createTokenFailed": "创建密钥失败。",
         "downloadedSettings": "已下载设置文件",
         "downloadFailed": "设置文件下载失败",

--- a/src/locales/zh-TW/messages.json
+++ b/src/locales/zh-TW/messages.json
@@ -172,8 +172,6 @@
   },
   "sub2api": {
     "createRequiresAvailableGroup": "目前這個帳號沒有可用於建立金鑰的分組，請先確認帳號分組情況後再試。",
-    "createRequiresGroup": "建立金鑰前需要先確認分組，請先選擇一個可用分組後再繼續。",
-    "createRequiresGroupSelection": "目前這個帳號有多個可用分組。請先選擇要使用的分組，再建立金鑰。",
     "groupMissing": "Sub2API 分組“{{group}}”已不可用。請重新整理分組列表後重試。",
     "loginRequired": "請先登入 Sub2API 控制台（外掛會讀取 auth_token/auth_user 用於匯入會話）後再重試。",
     "refreshTokenInvalid": "Sub2API refresh_token 已失效/已輪轉。請從控制台重新匯入會話（推薦無痕/隱私視窗），或貼上新的 refresh_token 後重試。"
@@ -221,6 +219,10 @@
       "shareSnapshotDownloaded": "快照已下載",
       "urlCopied": "{{accountName}} 的 URL 已複製到剪貼簿"
     }
+  },
+  "tokenProvisioning": {
+    "createRequiresGroup": "建立金鑰前需要先確認分組，請先選擇一個可用分組後再繼續。",
+    "createRequiresGroupSelection": "目前這個帳號有多個可用分組。請先選擇要使用的分組，再建立金鑰。"
   },
   "veloera": {
     "channelExists": "渠道 {{channelName}} 已存在，無需再次匯入",

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -261,6 +261,7 @@
         "accountNotFound": "未找到帳號。",
         "copiedApiConfigs": "已複製 apiConfigs",
         "copyFailed": "複製失敗",
+        "createTokenBlockedFallback": "金鑰建立被阻止。請檢查站點策略後再試一次。",
         "createTokenFailed": "建立金鑰失敗。",
         "downloadedSettings": "已下載設定檔案",
         "downloadFailed": "設定檔案下載失敗",

--- a/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
@@ -18,6 +18,23 @@ export const DEFAULT_AUTO_PROVISION_TOKEN_NAME = "user group (auto)"
 export const DEFAULT_USER_GROUP_NAME = "default"
 
 /**
+ * Selects the preferred default user group from a constrained group list.
+ */
+export function resolvePreferredDefaultUserGroup(
+  allowedGroups: readonly string[],
+): string {
+  const normalizedGroups = allowedGroups
+    .map((group) => group.trim())
+    .filter(Boolean)
+
+  if (normalizedGroups.includes(DEFAULT_USER_GROUP_NAME)) {
+    return DEFAULT_USER_GROUP_NAME
+  }
+
+  return normalizedGroups[0] ?? DEFAULT_USER_GROUP_NAME
+}
+
+/**
  * Generates the default token payload used by key auto-provisioning flows.
  *
  * Default token definition MUST remain stable (see OpenSpec requirements).
@@ -97,7 +114,7 @@ export async function ensureDefaultApiTokenForAccount(params: {
       throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
     }
 
-    throw new Error(t("messages:sub2api.createRequiresGroup"))
+    throw new Error(t("messages:tokenProvisioning.createRequiresGroup"))
   }
 
   const createApiTokenResult = await keyManagement.createToken(

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -134,7 +134,7 @@ export async function ensureAccountKeysForAvailableGroups(params: {
         throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
       }
 
-      throw new Error(t("messages:sub2api.createRequiresGroup"))
+      throw new Error(t("messages:tokenProvisioning.createRequiresGroup"))
     }
 
     const createResult = await keyManagement.createToken(

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -25,6 +25,11 @@ import {
   getAutoDetectCompletionFailureReason,
 } from "~/services/accounts/autoDetectCompletion/completion"
 import {
+  TOKEN_QUICK_CREATE_RESOLUTION_KINDS,
+  type DefaultTokenQuickCreateResolution,
+  type Sub2ApiQuickCreateResolution,
+} from "~/services/accounts/tokenQuickCreateResolution"
+import {
   createDisplayAccountApiContext,
   requireDisplayAccountKeyManagement,
   requireDisplayAccountTokenProvisioning,
@@ -391,12 +396,12 @@ export function isValidAccount({
 
 type TagIdsInput = string[] | undefined
 
-export interface ValidateAndSaveAccountOptions {
+interface ValidateAndSaveAccountOptions {
   skipAutoProvisionKeyOnAccountAdd?: boolean
   deferDataRefresh?: boolean
 }
 
-export interface ValidateAndUpdateAccountOptions {
+interface ValidateAndUpdateAccountOptions {
   deferDataRefresh?: boolean
 }
 
@@ -472,19 +477,16 @@ function resolveExchangeRate(input: string): number {
   return parsePositiveExchangeRate(input) ?? UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
 }
 
-export type Sub2ApiQuickCreateResolution =
-  | { kind: "ready"; group: string }
-  | { kind: "selection_required"; allowedGroups: string[] }
-  | { kind: "blocked"; message: string }
-
-export type DefaultTokenQuickCreateResolution =
-  | { kind: "ready"; tokenData: CreateTokenRequest }
-  | { kind: "selection_required"; allowedGroups: string[] }
-  | {
-      kind: "blocked"
-      reason: TokenProvisioningBlockReason
-      message: string
-    }
+type EnsureAccountApiTokenOptions = {
+  toastId?: string
+  defaultTokenData?: CreateTokenRequest
+  explicitGroup?: string
+  /**
+   * Temporary compatibility alias for older Sub2API callers.
+   * New product code should pass `defaultTokenData` from policy resolution.
+   */
+  sub2apiGroup?: string
+}
 
 const getDefaultTokenProvisioningBlockMessage = (
   reason: TokenProvisioningBlockReason,
@@ -497,7 +499,7 @@ const getDefaultTokenProvisioningBlockMessage = (
     return t("messages:aihubmix.createRequiresOneTimeKeyDialog")
   }
 
-  return t("messages:sub2api.createRequiresGroup")
+  return t("messages:tokenProvisioning.createRequiresGroup")
 }
 
 /**
@@ -531,13 +533,19 @@ export async function resolveDefaultTokenQuickCreateResolution(
   })
 
   if (decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create) {
-    return { kind: "ready", tokenData: decision.tokenData }
+    return {
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+      tokenData: decision.tokenData,
+    }
   }
 
   if (
     decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired
   ) {
-    return { kind: "selection_required", allowedGroups: decision.allowedGroups }
+    return {
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
+      allowedGroups: decision.allowedGroups,
+    }
   }
 
   if (decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups) {
@@ -547,7 +555,7 @@ export async function resolveDefaultTokenQuickCreateResolution(
   }
 
   return {
-    kind: "blocked",
+    kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked,
     reason: decision.reason,
     message: getDefaultTokenProvisioningBlockMessage(decision.reason),
   }
@@ -565,18 +573,26 @@ export async function resolveSub2ApiQuickCreateResolution(
 
   const resolution = await resolveDefaultTokenQuickCreateResolution(account)
 
-  if (resolution.kind === "ready") {
-    return { kind: "ready", group: resolution.tokenData.group }
+  if (resolution.kind === TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready) {
+    return {
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+      group: resolution.tokenData.group,
+    }
   }
 
-  if (resolution.kind === "selection_required") {
+  if (
+    resolution.kind === TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired
+  ) {
     return {
-      kind: "selection_required",
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: resolution.allowedGroups,
     }
   }
 
-  return { kind: "blocked", message: resolution.message }
+  return {
+    kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked,
+    message: resolution.message,
+  }
 }
 
 /**
@@ -1220,7 +1236,7 @@ export function isValidExchangeRate(rate: string): boolean {
 export async function ensureAccountApiToken(
   account: SiteAccount,
   displaySiteData: DisplaySiteData,
-  toastIdOrOptions?: string | { toastId?: string; sub2apiGroup?: string },
+  toastIdOrOptions?: string | EnsureAccountApiTokenOptions,
 ): Promise<ApiToken> {
   const options =
     typeof toastIdOrOptions === "string"
@@ -1265,10 +1281,14 @@ export async function ensureAccountApiToken(
   let apiToken: ApiToken | undefined = tokens.at(-1)
 
   if (!apiToken) {
+    const defaultTokenData =
+      options.defaultTokenData ?? generateDefaultTokenRequest()
+    const explicitGroup = options.explicitGroup ?? options.sub2apiGroup
+
     const decision = requiredTokenProvisioning.resolveDefaultTokenCreation({
       workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
-      defaultTokenData: generateDefaultTokenRequest(),
-      explicitGroup: options.sub2apiGroup,
+      defaultTokenData,
+      explicitGroup,
     })
 
     if (decision.kind !== DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create) {
@@ -1280,7 +1300,7 @@ export async function ensureAccountApiToken(
         throw new Error(t("messages:aihubmix.createRequiresOneTimeKeyDialog"))
       }
 
-      throw new Error(t("messages:sub2api.createRequiresGroup"))
+      throw new Error(t("messages:tokenProvisioning.createRequiresGroup"))
     }
 
     const createApiTokenResult = await keyManagement.createToken(

--- a/src/services/accounts/tokenQuickCreateResolution.ts
+++ b/src/services/accounts/tokenQuickCreateResolution.ts
@@ -1,0 +1,37 @@
+import type { TokenProvisioningBlockReason } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import type { CreateTokenRequest } from "~/services/apiService/common/type"
+
+/**
+ * Resolution kinds shared by default-token quick-create policy and legacy Sub2API wrappers.
+ */
+export const TOKEN_QUICK_CREATE_RESOLUTION_KINDS = {
+  Ready: "ready",
+  SelectionRequired: "selection_required",
+  Blocked: "blocked",
+} as const
+
+export type Sub2ApiQuickCreateResolution =
+  | { kind: typeof TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready; group: string }
+  | {
+      kind: typeof TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired
+      allowedGroups: string[]
+    }
+  | {
+      kind: typeof TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked
+      message: string
+    }
+
+export type DefaultTokenQuickCreateResolution =
+  | {
+      kind: typeof TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready
+      tokenData: CreateTokenRequest
+    }
+  | {
+      kind: typeof TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired
+      allowedGroups: string[]
+    }
+  | {
+      kind: typeof TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked
+      reason: TokenProvisioningBlockReason
+      message: string
+    }

--- a/src/services/apiCredentialProfiles/syntheticAccount.ts
+++ b/src/services/apiCredentialProfiles/syntheticAccount.ts
@@ -1,0 +1,9 @@
+export const API_CREDENTIAL_PROFILE_SYNTHETIC_ACCOUNT_ID_PREFIX =
+  "api-credential-profile"
+
+/**
+ * Builds the synthetic account id used when a credential profile is adapted to account-based flows.
+ */
+export function buildApiCredentialProfileSyntheticAccountId(profileId: string) {
+  return `${API_CREDENTIAL_PROFILE_SYNTHETIC_ACCOUNT_ID_PREFIX}:${profileId}`
+}

--- a/tests/components/Button.test.tsx
+++ b/tests/components/Button.test.tsx
@@ -63,6 +63,23 @@ describe("Button", () => {
     ).toHaveLength(1)
   })
 
+  it("disables user interaction while loading", async () => {
+    const onClick = vi.fn()
+
+    render(
+      <Button loading onClick={onClick}>
+        Save
+      </Button>,
+    )
+
+    const button = await screen.findByRole("button", { name: /Save/ })
+    expect(button).toBeDisabled()
+
+    fireEvent.click(button)
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
   it("tracks controlled analytics action without reading button text", async () => {
     const onClick = vi.fn()
 

--- a/tests/components/KiloCodeExportDialog.test.tsx
+++ b/tests/components/KiloCodeExportDialog.test.tsx
@@ -292,6 +292,14 @@ describe("KiloCodeExportDialog", () => {
         name: "ui:dialog.kiloCode.actions.downloadSettings",
       }),
     ).not.toBeDisabled()
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.refresh" }),
+    )
+
+    await waitFor(() => {
+      expect(mockFetchAccountTokens).toHaveBeenCalledTimes(2)
+    })
   })
 
   it("disables export actions when there is nothing exportable", async () => {
@@ -892,6 +900,13 @@ describe("KiloCodeExportDialog", () => {
       allowedGroups: ["default", "vip"],
     })
     expect(latestDialogProps?.createPrefill).not.toHaveProperty("group")
+
+    await user.click(
+      await screen.findByRole("button", { name: "mock-add-token-close" }),
+    )
+    expect(
+      screen.queryByTestId("mock-add-token-dialog"),
+    ).not.toBeInTheDocument()
   })
 
   it("uses the newest created token after constrained Sub2API creation regardless of fetch order", async () => {
@@ -1174,6 +1189,51 @@ describe("KiloCodeExportDialog", () => {
       })
     })
     expect(await screen.findByText(fallbackMessage)).toBeInTheDocument()
+  })
+
+  it("uses the blocked Sub2API create message when one is available", async () => {
+    const user = userEvent.setup()
+    const site = createDisplayAccount({
+      id: "b",
+      name: "Site B",
+      baseUrl: "https://b.test",
+      siteType: "sub2api",
+    })
+
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [createSiteAccount(site)],
+      enabledDisplayData: [site],
+    })
+
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+    mockResolveDefaultTokenQuickCreateResolution.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked,
+      message: "Policy blocked",
+    })
+
+    render(<KiloCodeExportDialog isOpen={true} onClose={() => {}} />)
+
+    const sitePicker = await screen.findByPlaceholderText(
+      "ui:dialog.kiloCode.placeholders.selectSites",
+    )
+    await user.click(sitePicker)
+    await user.clear(sitePicker)
+    await user.type(sitePicker, "Site B")
+    await user.keyboard("{ArrowDown}")
+    await user.click(await screen.findByRole("option", { name: "Site B" }))
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.kiloCode.actions.createDefaultToken",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("Policy blocked", {
+        id: buildKiloCodeCreateTokenToastId("b"),
+      })
+    })
+    expect(await screen.findByText("Policy blocked")).toBeInTheDocument()
   })
 
   it("shows accountNotFound feedback when token creation is requested without a backing account", async () => {

--- a/tests/components/KiloCodeExportDialog.test.tsx
+++ b/tests/components/KiloCodeExportDialog.test.tsx
@@ -1,9 +1,13 @@
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { KiloCodeExportDialog } from "~/components/KiloCodeExportDialog"
+import {
+  buildKiloCodeCreateTokenToastId,
+  KiloCodeExportDialog,
+} from "~/components/KiloCodeExportDialog"
 import { SITE_TYPES } from "~/constants/siteType"
 import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
@@ -91,7 +95,7 @@ const mockResolveApiTokenKey = vi.fn()
 const mockFetchAccountAvailableModels = vi.fn()
 const mockFetchUserGroups = vi.fn()
 const mockEnsureAccountApiToken = vi.fn()
-const mockResolveSub2ApiQuickCreateResolution = vi.fn()
+const mockResolveDefaultTokenQuickCreateResolution = vi.fn()
 
 vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteAdapter: (...args: unknown[]) => mockGetSiteAdapter(...args),
@@ -100,8 +104,8 @@ vi.mock("~/services/apiAdapters/registry", () => ({
 vi.mock("~/services/accounts/accountOperations", () => ({
   ensureAccountApiToken: (...args: unknown[]) =>
     mockEnsureAccountApiToken(...args),
-  resolveSub2ApiQuickCreateResolution: (...args: unknown[]) =>
-    mockResolveSub2ApiQuickCreateResolution(...args),
+  resolveDefaultTokenQuickCreateResolution: (...args: unknown[]) =>
+    mockResolveDefaultTokenQuickCreateResolution(...args),
 }))
 
 const createDisplayAccount = (
@@ -215,7 +219,7 @@ describe("KiloCodeExportDialog", () => {
     mockFetchUserGroups.mockReset()
     mockFetchUserGroups.mockResolvedValue({})
     mockEnsureAccountApiToken.mockReset()
-    mockResolveSub2ApiQuickCreateResolution.mockReset()
+    mockResolveDefaultTokenQuickCreateResolution.mockReset()
   })
 
   it("auto loads tokens after selecting sites and enables export actions", async () => {
@@ -767,9 +771,20 @@ describe("KiloCodeExportDialog", () => {
     mockFetchAccountTokens
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ id: 11, name: "Created", key: "sk-test" }])
-    mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
-      kind: "ready",
+    const policyTokenData = {
+      name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+      remain_quota: 45678,
+      expired_time: -1,
+      unlimited_quota: false,
+      model_limits_enabled: false,
+      model_limits: "",
+      allow_ips: "",
       group: "vip",
+    }
+
+    mockResolveDefaultTokenQuickCreateResolution.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+      tokenData: policyTokenData,
     })
     mockEnsureAccountApiToken.mockResolvedValueOnce({
       id: 11,
@@ -801,15 +816,15 @@ describe("KiloCodeExportDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockResolveSub2ApiQuickCreateResolution).toHaveBeenCalledWith(
+      expect(mockResolveDefaultTokenQuickCreateResolution).toHaveBeenCalledWith(
         expect.objectContaining({ id: "b", siteType: "sub2api" }),
       )
       expect(mockEnsureAccountApiToken).toHaveBeenCalledWith(
         expect.objectContaining({ id: "b", site_type: "sub2api" }),
         expect.objectContaining({ id: "b", siteType: "sub2api" }),
         expect.objectContaining({
-          toastId: "kilocode-create-token-b",
-          sub2apiGroup: "vip",
+          toastId: buildKiloCodeCreateTokenToastId("b"),
+          defaultTokenData: policyTokenData,
         }),
       )
     })
@@ -830,8 +845,8 @@ describe("KiloCodeExportDialog", () => {
     })
 
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
-      kind: "selection_required",
+    mockResolveDefaultTokenQuickCreateResolution.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
     mockFetchUserGroups.mockResolvedValueOnce({
@@ -864,7 +879,9 @@ describe("KiloCodeExportDialog", () => {
 
     expect(mockEnsureAccountApiToken).not.toHaveBeenCalled()
     expect(
-      await screen.findByText("messages:sub2api.createRequiresGroupSelection"),
+      await screen.findByText(
+        "messages:tokenProvisioning.createRequiresGroupSelection",
+      ),
     ).toBeInTheDocument()
     expect(addTokenDialogPropsMock).toHaveBeenCalled()
 
@@ -908,8 +925,8 @@ describe("KiloCodeExportDialog", () => {
         created_time: 100,
       },
     ])
-    mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
-      kind: "selection_required",
+    mockResolveDefaultTokenQuickCreateResolution.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -990,8 +1007,8 @@ describe("KiloCodeExportDialog", () => {
         created_at: "2024-04-01T00:00:00.000Z",
       },
     ])
-    mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
-      kind: "selection_required",
+    mockResolveDefaultTokenQuickCreateResolution.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -1066,8 +1083,8 @@ describe("KiloCodeExportDialog", () => {
         key: "sk-newest",
       },
     ])
-    mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
-      kind: "selection_required",
+    mockResolveDefaultTokenQuickCreateResolution.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -1126,8 +1143,8 @@ describe("KiloCodeExportDialog", () => {
     })
 
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    mockResolveSub2ApiQuickCreateResolution.mockResolvedValueOnce({
-      kind: "blocked",
+    mockResolveDefaultTokenQuickCreateResolution.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked,
       message: "   ",
     })
 
@@ -1149,11 +1166,11 @@ describe("KiloCodeExportDialog", () => {
     )
 
     const fallbackMessage =
-      "Token creation was blocked. Please check site policy or try again."
+      "ui:dialog.kiloCode.messages.createTokenBlockedFallback"
 
     await waitFor(() => {
       expect(toastErrorMock).toHaveBeenCalledWith(fallbackMessage, {
-        id: "kilocode-create-token-b",
+        id: buildKiloCodeCreateTokenToastId("b"),
       })
     })
     expect(await screen.findByText(fallbackMessage)).toBeInTheDocument()

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -865,6 +865,102 @@ describe("useChannelDialog", () => {
     )
   })
 
+  it("surfaces blocked default-token creation while opening from an account", async () => {
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
+    )
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked,
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
+      message: "No valid upstream groups are available",
+    })
+
+    const { result } = await renderChannelDialogHook()
+
+    let openResult: Awaited<
+      ReturnType<typeof result.current.dialog.openWithAccount>
+    > | null = null
+    await act(async () => {
+      openResult = await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: SITE_TYPES.SUB2API }),
+        null,
+      )
+    })
+
+    expect(openResult).toEqual({ opened: false })
+    expect(mockToastError).toHaveBeenCalledWith(
+      "No valid upstream groups are available",
+      { id: "toast-id" },
+    )
+    expect(ensureAccountApiTokenSpy).not.toHaveBeenCalled()
+    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
+    expect(result.current.context.state.isOpen).toBe(false)
+  })
+
+  it("cancels account opening when the caller continuation guard cancels after quick-create resolution", async () => {
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
+    )
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+
+    let shouldContinueCalls = 0
+    const { result } = await renderChannelDialogHook()
+
+    let openResult: Awaited<
+      ReturnType<typeof result.current.dialog.openWithAccount>
+    > | null = null
+    await act(async () => {
+      openResult = await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: SITE_TYPES.SUB2API }),
+        null,
+        undefined,
+        {
+          shouldContinue: () => {
+            shouldContinueCalls += 1
+            return shouldContinueCalls < 2
+          },
+        },
+      )
+    })
+
+    expect(openResult).toEqual({ opened: false })
+    expect(mockToastDismiss).toHaveBeenCalledWith("toast-id")
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      false,
+    )
+    expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
   it("resumes Sub2API channel opening with the single new refetched token when AddTokenDialog does not return one", async () => {
     const existingToken = buildApiToken({
       id: 3,
@@ -916,6 +1012,67 @@ describe("useChannelDialog", () => {
       await result.current.context.handleDefaultTokenQuickCreateSuccess()
     })
 
+    expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "account-id",
+      }),
+      expect.objectContaining({
+        id: createdToken.id,
+        key: createdToken.key,
+      }),
+    )
+    expect(result.current.context.state).toMatchObject({
+      isOpen: true,
+      initialValues: {
+        key: createdToken.key,
+      },
+    })
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it("resumes Sub2API channel opening with a token returned from AddTokenDialog", async () => {
+    const createdToken = buildApiToken({
+      id: 11,
+      key: "sk-created-11",
+      name: "Created token",
+    })
+    const prepareChannelFormDataMock = vi.fn(
+      async (_account: DisplaySiteData, token: ApiToken) =>
+        buildPreparedFormData({
+          key: token.key,
+        }),
+    )
+    const mockService = buildManagedSiteServiceMock({
+      prepareChannelFormData: prepareChannelFormDataMock,
+    })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
+    )
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: SITE_TYPES.SUB2API }),
+        null,
+      )
+    })
+
+    await act(async () => {
+      await result.current.context.handleDefaultTokenQuickCreateSuccess(
+        createdToken,
+      )
+    })
+
+    expect(mockFetchAccountTokens).toHaveBeenCalledTimes(1)
     expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "account-id",
@@ -1438,6 +1595,41 @@ describe("useChannelDialog", () => {
       allowedGroups: ["ops"],
       notice: "Use the audited group",
     })
+  })
+
+  it("shows feedback when a resolved quick-create group is empty", async () => {
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+      tokenData: {
+        name: "Default token",
+        remain_quota: 500000,
+        expired_time: -1,
+        unlimited_quota: false,
+        model_limits_enabled: false,
+        model_limits: "",
+        allow_ips: "",
+        group: "   ",
+      },
+    })
+
+    const { result } = await renderChannelDialogHook()
+
+    let didOpen = true
+    await act(async () => {
+      didOpen =
+        await result.current.dialog.openDefaultTokenQuickCreateDialogForAccount(
+          buildDisplaySiteData({ siteType: "sub2api" }),
+        )
+    })
+
+    expect(didOpen).toBe(false)
+    expect(mockToastError).toHaveBeenCalledWith(
+      "messages:tokenProvisioning.createRequiresGroup",
+    )
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      false,
+    )
   })
 
   it("shows an operation failure toast when the account details cannot be loaded", async () => {

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -9,6 +9,8 @@ import { DIALOG_MODES } from "~/constants/dialogModes"
 import { SITE_TYPES } from "~/constants/siteType"
 import * as accountOperations from "~/services/accounts/accountOperations"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
+import { TOKEN_PROVISIONING_BLOCK_REASONS } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import {
   MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS,
   MatchResolutionUnresolvedError,
@@ -52,9 +54,9 @@ const ensureAccountApiTokenSpy = vi.spyOn(
   accountOperations,
   "ensureAccountApiToken",
 )
-const resolveSub2ApiQuickCreateResolutionSpy = vi.spyOn(
+const resolveDefaultTokenQuickCreateResolutionSpy = vi.spyOn(
   accountOperations,
-  "resolveSub2ApiQuickCreateResolution",
+  "resolveDefaultTokenQuickCreateResolution",
 )
 
 const buildSiteAccount = (
@@ -275,7 +277,7 @@ describe("useChannelDialog", () => {
     ensureAccountApiTokenSpy.mockImplementation(() => {
       throw new Error("ensureAccountApiToken should not be called in this test")
     })
-    resolveSub2ApiQuickCreateResolutionSpy.mockReset()
+    resolveDefaultTokenQuickCreateResolutionSpy.mockReset()
     mockFetchAccountTokens.mockReset()
     mockFetchAccountTokens.mockResolvedValue([])
     mockResolveApiTokenKey.mockReset()
@@ -692,8 +694,8 @@ describe("useChannelDialog", () => {
     getAccountByIdSpy.mockResolvedValue(
       buildSiteAccount({ site_type: "sub2api" }),
     )
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -713,10 +715,10 @@ describe("useChannelDialog", () => {
       )
     })
 
-    expect(result.current.context.sub2apiTokenDialog).toMatchObject({
+    expect(result.current.context.defaultTokenQuickCreateDialog).toMatchObject({
       isOpen: true,
       allowedGroups: ["default", "vip"],
-      notice: "messages:sub2api.createRequiresGroupSelection",
+      notice: "messages:tokenProvisioning.createRequiresGroupSelection",
     })
     expect(ensureAccountApiTokenSpy).not.toHaveBeenCalled()
     expect(mockToastDismiss).toHaveBeenCalledWith("toast-id")
@@ -759,8 +761,8 @@ describe("useChannelDialog", () => {
     mockFetchAccountTokens
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([buildApiToken()])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -780,16 +782,87 @@ describe("useChannelDialog", () => {
       )
     })
 
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      true,
+    )
 
     await act(async () => {
-      await result.current.context.handleSub2ApiTokenSuccess()
+      await result.current.context.handleDefaultTokenQuickCreateSuccess()
     })
 
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(false)
-    expect(resolveSub2ApiQuickCreateResolutionSpy).toHaveBeenCalledTimes(1)
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      false,
+    )
+    expect(resolveDefaultTokenQuickCreateResolutionSpy).toHaveBeenCalledTimes(1)
     expect(ensureAccountApiTokenSpy).not.toHaveBeenCalled()
     expect(mockFetchAccountTokens).toHaveBeenCalledTimes(2)
+  })
+
+  it("ensures a token with full generic quick-create token data", async () => {
+    const policyTokenData = {
+      name: "Channel Policy Token",
+      remain_quota: 65432,
+      expired_time: -1,
+      unlimited_quota: false,
+      model_limits_enabled: false,
+      model_limits: "",
+      allow_ips: "",
+      group: "ops",
+    }
+    const createdToken = buildApiToken({ id: 30, key: "sk-created" })
+
+    const mockService: Partial<ManagedSiteService> = {
+      messagesKey: "newapi",
+      getConfig: vi.fn(async () => ({
+        baseUrl: "https://managed.example.com",
+        adminToken: "admin-token",
+        userId: "1",
+      })),
+      prepareChannelFormData: vi.fn(async () =>
+        buildPreparedFormData({
+          key: createdToken.key,
+        }),
+      ),
+      searchChannel: vi.fn(async () => ({
+        items: [],
+        total: 0,
+        type_counts: {},
+      })),
+    }
+    getManagedSiteServiceSpy.mockResolvedValue(
+      mockService as ManagedSiteService,
+    )
+    getAccountByIdSpy.mockResolvedValue(
+      buildSiteAccount({ site_type: "new-api" }),
+    )
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+      tokenData: policyTokenData,
+    })
+    ensureAccountApiTokenSpy.mockResolvedValueOnce(createdToken)
+    mockResolveApiTokenKey.mockResolvedValueOnce(createdToken)
+
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData({ siteType: "new-api" }),
+        null,
+      )
+    })
+
+    expect(resolveDefaultTokenQuickCreateResolutionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ siteType: "new-api" }),
+    )
+    expect(ensureAccountApiTokenSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ site_type: "new-api" }),
+      expect.objectContaining({ siteType: "new-api" }),
+      expect.objectContaining({
+        toastId: "toast-id",
+        defaultTokenData: policyTokenData,
+      }),
+    )
   })
 
   it("resumes Sub2API channel opening with the single new refetched token when AddTokenDialog does not return one", async () => {
@@ -821,8 +894,8 @@ describe("useChannelDialog", () => {
     mockFetchAccountTokens
       .mockResolvedValueOnce([existingToken, undefined] as ApiToken[])
       .mockResolvedValueOnce([createdToken, existingToken])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -835,10 +908,12 @@ describe("useChannelDialog", () => {
       )
     })
 
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      true,
+    )
 
     await act(async () => {
-      await result.current.context.handleSub2ApiTokenSuccess()
+      await result.current.context.handleDefaultTokenQuickCreateSuccess()
     })
 
     expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
@@ -881,8 +956,8 @@ describe("useChannelDialog", () => {
       buildSiteAccount({ site_type: "sub2api" }),
     )
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -899,16 +974,22 @@ describe("useChannelDialog", () => {
     })
 
     expect(openResult).toEqual({ opened: false, deferred: true })
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      true,
+    )
 
     act(() => {
-      result.current.context.closeSub2ApiTokenDialog()
+      result.current.context.closeDefaultTokenQuickCreateDialog()
     })
 
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(false)
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      false,
+    )
 
     await act(async () => {
-      await result.current.context.handleSub2ApiTokenSuccess(createdToken)
+      await result.current.context.handleDefaultTokenQuickCreateSuccess(
+        createdToken,
+      )
     })
 
     expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
@@ -937,25 +1018,25 @@ describe("useChannelDialog", () => {
     const { result } = await renderChannelDialogHook()
 
     act(() => {
-      result.current.context.openSub2ApiTokenDialog({
+      result.current.context.openDefaultTokenQuickCreateDialog({
         account: sessionAAccount,
         allowedGroups: ["default"],
         onSuccess: sessionAOnSuccess,
       })
     })
 
-    expect(result.current.context.sub2apiTokenDialog).toMatchObject({
+    expect(result.current.context.defaultTokenQuickCreateDialog).toMatchObject({
       isOpen: true,
       account: sessionAAccount,
       allowedGroups: ["default"],
     })
 
     const sessionASuccessHandler =
-      result.current.context.handleSub2ApiTokenSuccess
+      result.current.context.handleDefaultTokenQuickCreateSuccess
 
     await act(async () => {
-      result.current.context.closeSub2ApiTokenDialog()
-      result.current.context.openSub2ApiTokenDialog({
+      result.current.context.closeDefaultTokenQuickCreateDialog()
+      result.current.context.openDefaultTokenQuickCreateDialog({
         account: sessionBAccount,
         allowedGroups: ["vip"],
         onSuccess: sessionBOnSuccess,
@@ -963,7 +1044,7 @@ describe("useChannelDialog", () => {
       await sessionASuccessHandler(createdToken)
     })
 
-    expect(result.current.context.sub2apiTokenDialog).toMatchObject({
+    expect(result.current.context.defaultTokenQuickCreateDialog).toMatchObject({
       isOpen: true,
       account: sessionBAccount,
       allowedGroups: ["vip"],
@@ -1008,8 +1089,8 @@ describe("useChannelDialog", () => {
     mockFetchAccountTokens
       .mockResolvedValueOnce([existingToken, undefined] as ApiToken[])
       .mockResolvedValueOnce([existingToken, ambiguousTokenA, ambiguousTokenB])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -1022,10 +1103,12 @@ describe("useChannelDialog", () => {
       )
     })
 
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      true,
+    )
 
     await act(async () => {
-      await result.current.context.handleSub2ApiTokenSuccess()
+      await result.current.context.handleDefaultTokenQuickCreateSuccess()
     })
 
     expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
@@ -1052,8 +1135,8 @@ describe("useChannelDialog", () => {
       buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
     )
     mockFetchAccountTokens.mockResolvedValueOnce([]).mockResolvedValueOnce(null)
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -1066,10 +1149,12 @@ describe("useChannelDialog", () => {
       )
     })
 
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(true)
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      true,
+    )
 
     await act(async () => {
-      await result.current.context.handleSub2ApiTokenSuccess()
+      await result.current.context.handleDefaultTokenQuickCreateSuccess()
     })
 
     expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
@@ -1101,8 +1186,8 @@ describe("useChannelDialog", () => {
       buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
     )
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -1121,7 +1206,9 @@ describe("useChannelDialog", () => {
     shouldContinue = false
 
     await act(async () => {
-      await result.current.context.handleSub2ApiTokenSuccess(createdToken)
+      await result.current.context.handleDefaultTokenQuickCreateSuccess(
+        createdToken,
+      )
     })
 
     expect(prepareChannelFormDataMock).not.toHaveBeenCalled()
@@ -1147,8 +1234,8 @@ describe("useChannelDialog", () => {
       buildSiteAccount({ site_type: SITE_TYPES.SUB2API }),
     )
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -1170,7 +1257,7 @@ describe("useChannelDialog", () => {
     })
 
     await act(async () => {
-      await result.current.context.handleSub2ApiTokenSuccess()
+      await result.current.context.handleDefaultTokenQuickCreateSuccess()
     })
 
     expect(mockFetchAccountTokens).toHaveBeenCalledTimes(1)
@@ -1208,8 +1295,8 @@ describe("useChannelDialog", () => {
     mockFetchAccountTokens
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([createdToken, existingToken])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -1231,7 +1318,7 @@ describe("useChannelDialog", () => {
     })
 
     await act(async () => {
-      await result.current.context.handleSub2ApiTokenSuccess()
+      await result.current.context.handleDefaultTokenQuickCreateSuccess()
     })
 
     expect(mockFetchAccountTokens).toHaveBeenCalledTimes(2)
@@ -1247,20 +1334,24 @@ describe("useChannelDialog", () => {
 
     let didOpen = false
     await act(async () => {
-      didOpen = await result.current.dialog.openSub2ApiTokenCreationDialog(
-        buildDisplaySiteData({ siteType: "sub2api" }),
-      )
+      didOpen =
+        await result.current.dialog.openDefaultTokenQuickCreateDialogForAccount(
+          buildDisplaySiteData({ siteType: "sub2api" }),
+        )
     })
 
     expect(didOpen).toBe(false)
-    expect(resolveSub2ApiQuickCreateResolutionSpy).not.toHaveBeenCalled()
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(false)
+    expect(resolveDefaultTokenQuickCreateResolutionSpy).not.toHaveBeenCalled()
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      false,
+    )
   })
 
   it("surfaces blocked Sub2API quick-create resolutions without opening the dialog", async () => {
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "blocked",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked,
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.AvailableGroupRequired,
       message: "No valid upstream groups are available",
     })
 
@@ -1268,24 +1359,27 @@ describe("useChannelDialog", () => {
 
     let didOpen = true
     await act(async () => {
-      didOpen = await result.current.dialog.openSub2ApiTokenCreationDialog(
-        buildDisplaySiteData({ siteType: "sub2api" }),
-      )
+      didOpen =
+        await result.current.dialog.openDefaultTokenQuickCreateDialogForAccount(
+          buildDisplaySiteData({ siteType: "sub2api" }),
+        )
     })
 
     expect(didOpen).toBe(false)
     expect(mockToastError).toHaveBeenCalledWith(
       "No valid upstream groups are available",
     )
-    expect(result.current.context.sub2apiTokenDialog.isOpen).toBe(false)
+    expect(result.current.context.defaultTokenQuickCreateDialog.isOpen).toBe(
+      false,
+    )
   })
 
   it("opens the Sub2API quick-create dialog with the default notice and resumes the caller callback", async () => {
     const onSuccess = vi.fn(async () => {})
 
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "selection_required",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
 
@@ -1293,21 +1387,22 @@ describe("useChannelDialog", () => {
 
     let didOpen = false
     await act(async () => {
-      didOpen = await result.current.dialog.openSub2ApiTokenCreationDialog(
-        buildDisplaySiteData({ siteType: "sub2api" }),
-        { onSuccess },
-      )
+      didOpen =
+        await result.current.dialog.openDefaultTokenQuickCreateDialogForAccount(
+          buildDisplaySiteData({ siteType: "sub2api" }),
+          { onSuccess },
+        )
     })
 
     expect(didOpen).toBe(true)
-    expect(result.current.context.sub2apiTokenDialog).toMatchObject({
+    expect(result.current.context.defaultTokenQuickCreateDialog).toMatchObject({
       isOpen: true,
       allowedGroups: ["default", "vip"],
-      notice: "messages:sub2api.createRequiresGroupSelection",
+      notice: "messages:tokenProvisioning.createRequiresGroupSelection",
     })
 
     await act(async () => {
-      await result.current.context.handleSub2ApiTokenSuccess()
+      await result.current.context.handleDefaultTokenQuickCreateSuccess()
     })
 
     expect(onSuccess).toHaveBeenCalledTimes(1)
@@ -1315,21 +1410,30 @@ describe("useChannelDialog", () => {
 
   it("opens the Sub2API quick-create dialog with a resolved single group and preserves a custom notice", async () => {
     mockFetchAccountTokens.mockResolvedValueOnce([])
-    resolveSub2ApiQuickCreateResolutionSpy.mockResolvedValueOnce({
-      kind: "ready",
-      group: "ops",
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+      tokenData: {
+        name: "Default token",
+        remain_quota: 500000,
+        expired_time: -1,
+        unlimited_quota: false,
+        model_limits_enabled: false,
+        model_limits: "",
+        allow_ips: "",
+        group: "ops",
+      },
     })
 
     const { result } = await renderChannelDialogHook()
 
     await act(async () => {
-      await result.current.dialog.openSub2ApiTokenCreationDialog(
+      await result.current.dialog.openDefaultTokenQuickCreateDialogForAccount(
         buildDisplaySiteData({ siteType: "sub2api" }),
         { notice: "Use the audited group" },
       )
     })
 
-    expect(result.current.context.sub2apiTokenDialog).toMatchObject({
+    expect(result.current.context.defaultTokenQuickCreateDialog).toMatchObject({
       isOpen: true,
       allowedGroups: ["ops"],
       notice: "Use the audited group",
@@ -1522,6 +1626,19 @@ describe("useChannelDialog", () => {
       mockService as ManagedSiteService,
     )
     mockFetchAccountTokens.mockResolvedValueOnce({ items: [] })
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+      tokenData: {
+        name: "Default token",
+        remain_quota: 500000,
+        expired_time: -1,
+        unlimited_quota: false,
+        model_limits_enabled: false,
+        model_limits: "",
+        allow_ips: "",
+        group: "",
+      },
+    })
     ensureAccountApiTokenSpy.mockResolvedValueOnce(
       buildApiToken({
         key: "ensured-token",
@@ -1546,7 +1663,9 @@ describe("useChannelDialog", () => {
       expect.objectContaining({
         id: "account-id",
       }),
-      "toast-id",
+      expect.objectContaining({
+        toastId: "toast-id",
+      }),
     )
     expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/components/dialogs/ChannelDialog/ChannelDialogContainer.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/ChannelDialogContainer.test.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  ChannelDialogContainer,
+  ChannelDialogProvider,
+  useChannelDialogContext,
+} from "~/components/dialogs/ChannelDialog"
+import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
+import { render, screen, waitFor } from "~~/tests/test-utils/render"
+
+const addTokenDialogPropsMock = vi.hoisted(() => vi.fn())
+
+vi.mock("~/components/dialogs/ChannelDialog/components/ChannelDialog", () => ({
+  ChannelDialog: () => <div data-testid="mock-channel-dialog" />,
+}))
+
+vi.mock("~/features/KeyManagement/components/AddTokenDialog", () => ({
+  default: (props: {
+    isOpen: boolean
+    createPrefill?: Record<string, unknown>
+    prefillNotice?: string
+  }) => {
+    addTokenDialogPropsMock(props)
+
+    if (!props.isOpen) return null
+
+    return (
+      <div data-testid="mock-add-token-dialog">
+        {props.prefillNotice ? <div>{props.prefillNotice}</div> : null}
+      </div>
+    )
+  },
+}))
+
+const buildDisplaySiteData = (): DisplaySiteData => ({
+  id: "account-id",
+  name: "Account",
+  username: "user",
+  balance: { USD: 0, CNY: 0 },
+  todayConsumption: { USD: 0, CNY: 0 },
+  todayIncome: { USD: 0, CNY: 0 },
+  todayTokens: { upload: 0, download: 0 },
+  health: { status: SiteHealthStatus.Healthy },
+  siteType: "sub2api",
+  baseUrl: "https://example.invalid",
+  token: "access-token",
+  userId: "1",
+  authType: AuthTypeEnum.AccessToken,
+  checkIn: { enableDetection: false },
+})
+
+function OpenDefaultTokenQuickCreateDialog({
+  allowedGroups,
+}: {
+  allowedGroups: string[]
+}) {
+  const { openDefaultTokenQuickCreateDialog } = useChannelDialogContext()
+
+  useEffect(() => {
+    openDefaultTokenQuickCreateDialog({
+      account: buildDisplaySiteData(),
+      allowedGroups,
+      notice: "Choose a group",
+    })
+  }, [allowedGroups, openDefaultTokenQuickCreateDialog])
+
+  return null
+}
+
+describe("ChannelDialogContainer", () => {
+  it("renders AddTokenDialog with default-token prefill for non-empty allowed groups", async () => {
+    addTokenDialogPropsMock.mockReset()
+
+    render(
+      <ChannelDialogProvider>
+        <OpenDefaultTokenQuickCreateDialog allowedGroups={["vip"]} />
+        <ChannelDialogContainer />
+      </ChannelDialogProvider>,
+    )
+
+    expect(await screen.findByTestId("mock-add-token-dialog")).toBeVisible()
+    expect(await screen.findByText("Choose a group")).toBeVisible()
+
+    await waitFor(() => {
+      expect(addTokenDialogPropsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isOpen: true,
+          createPrefill: {
+            modelId: "",
+            defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+            group: "vip",
+            allowedGroups: ["vip"],
+          },
+          prefillNotice: "Choose a group",
+        }),
+      )
+    })
+  })
+
+  it("does not render AddTokenDialog when allowed groups are empty", async () => {
+    addTokenDialogPropsMock.mockReset()
+
+    render(
+      <ChannelDialogProvider>
+        <OpenDefaultTokenQuickCreateDialog allowedGroups={[]} />
+        <ChannelDialogContainer />
+      </ChannelDialogProvider>,
+    )
+
+    await waitFor(() => {
+      expect(addTokenDialogPropsMock).not.toHaveBeenCalled()
+    })
+    expect(
+      screen.queryByTestId("mock-add-token-dialog"),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/dialogs/ChannelDialog/useChannelForm.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/useChannelForm.test.tsx
@@ -2,6 +2,7 @@ import type { FormEvent } from "react"
 import toast from "react-hot-toast"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { CHANNEL_DIALOG_MUTATION_RESULTS } from "~/components/dialogs/ChannelDialog/context/ChannelDialogContext"
 import { useChannelForm } from "~/components/dialogs/ChannelDialog/hooks/useChannelForm"
 import { DEFAULT_CLAUDE_CODE_HUB_CHANNEL_FIELDS } from "~/constants/claudeCodeHub"
 import { DIALOG_MODES } from "~/constants/dialogModes"
@@ -422,7 +423,7 @@ describe("useChannelForm", () => {
 
     expect(onMutationOutcome).toHaveBeenCalledWith({
       mode: DIALOG_MODES.ADD,
-      result: "success",
+      result: CHANNEL_DIALOG_MUTATION_RESULTS.Success,
       siteType: SITE_TYPES.NEW_API,
     })
   })
@@ -464,7 +465,7 @@ describe("useChannelForm", () => {
 
     expect(onMutationOutcome).toHaveBeenCalledWith({
       mode: DIALOG_MODES.EDIT,
-      result: "failure",
+      result: CHANNEL_DIALOG_MUTATION_RESULTS.Failure,
       siteType: SITE_TYPES.NEW_API,
     })
   })

--- a/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+++ b/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
@@ -32,8 +32,8 @@ const { sendRuntimeActionMessageMock, runtimeMessageState } = vi.hoisted(
     },
   }),
 )
-const { mockOpenSub2ApiTokenCreationDialog } = vi.hoisted(() => ({
-  mockOpenSub2ApiTokenCreationDialog: vi.fn(),
+const { mockOpenDefaultTokenQuickCreateDialogForAccount } = vi.hoisted(() => ({
+  mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
 }))
 const {
   mockTrackProductAnalyticsActionCompleted,
@@ -79,7 +79,8 @@ vi.mock(
 vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
-    openSub2ApiTokenCreationDialog: mockOpenSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount:
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
   }),
 }))
 
@@ -515,7 +516,7 @@ function createDeferred<T>() {
 
 describe("KeyManagement repair missing keys entry point", () => {
   beforeEach(() => {
-    mockOpenSub2ApiTokenCreationDialog.mockReset()
+    mockOpenDefaultTokenQuickCreateDialogForAccount.mockReset()
     mockTrackProductAnalyticsActionCompleted.mockReset()
     mockTrackProductAnalyticsActionStarted.mockReset()
   })
@@ -987,7 +988,9 @@ describe("KeyManagement repair missing keys entry point", () => {
     )
 
     await waitFor(() => {
-      expect(mockOpenSub2ApiTokenCreationDialog).toHaveBeenCalledWith(
+      expect(
+        mockOpenDefaultTokenQuickCreateDialogForAccount,
+      ).toHaveBeenCalledWith(
         expect.objectContaining({
           id: "account-enabled-2",
           siteType: "sub2api",
@@ -1033,7 +1036,9 @@ describe("KeyManagement repair missing keys entry point", () => {
         name: "keyManagement:dialog.createToken",
       }),
     ).not.toBeInTheDocument()
-    expect(mockOpenSub2ApiTokenCreationDialog).not.toHaveBeenCalled()
+    expect(
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
+    ).not.toHaveBeenCalled()
   })
 
   it("switches between account coverage and invalid key views", async () => {

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -1331,7 +1331,9 @@ describe("AddTokenDialog prefill", () => {
 
     expect(createApiTokenMock).not.toHaveBeenCalled()
     expect(
-      await screen.findByText("messages:sub2api.createRequiresGroupSelection"),
+      await screen.findByText(
+        "messages:tokenProvisioning.createRequiresGroupSelection",
+      ),
     ).toBeInTheDocument()
 
     await user.click(groupTrigger as HTMLElement)

--- a/tests/features/AccountManagement/components/AccountDialog.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialog.test.tsx
@@ -845,7 +845,7 @@ describe("AccountDialog", () => {
       }),
     )
     expect(screen.getByTestId("post-save-add-token-notice")).toHaveTextContent(
-      "messages:sub2api.createRequiresGroupSelection",
+      "messages:tokenProvisioning.createRequiresGroupSelection",
     )
     expect(
       screen.getByTestId("post-save-add-token-one-time"),

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -248,7 +248,9 @@ describe("CopyKeyDialog sub2api support", () => {
 
     expect(createApiTokenMock).not.toHaveBeenCalled()
     expect(
-      await screen.findByText("messages:sub2api.createRequiresGroupSelection"),
+      await screen.findByText(
+        "messages:tokenProvisioning.createRequiresGroupSelection",
+      ),
     ).toBeInTheDocument()
   })
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -656,7 +656,7 @@ describe("CopyKeyDialog", () => {
 
     const user = userEvent.setup()
 
-    render(
+    const { rerender } = render(
       <CopyKeyDialog
         isOpen={true}
         onClose={() => {}}
@@ -680,6 +680,24 @@ describe("CopyKeyDialog", () => {
       expect.objectContaining({ siteType: SITE_TYPES.NEW_API }),
     )
     expect(createApiTokenMock).not.toHaveBeenCalled()
+
+    rerender(
+      <CopyKeyDialog
+        isOpen={false}
+        onClose={() => {}}
+        account={{
+          ...ACCOUNT,
+          siteType: SITE_TYPES.NEW_API,
+        }}
+      />,
+    )
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "messages:tokenProvisioning.createRequiresGroupSelection",
+        ),
+      ).not.toBeInTheDocument()
+    })
   })
 
   it("creates a default key with the full policy-resolved token payload", async () => {

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -5,6 +5,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
+import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import * as accountOperations from "~/services/accounts/accountOperations"
+import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
 import {
   CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
@@ -195,6 +198,14 @@ vi.mock(
   }),
 )
 
+const actualResolveDefaultTokenQuickCreateResolution =
+  accountOperations.resolveDefaultTokenQuickCreateResolution
+
+const resolveDefaultTokenQuickCreateResolutionSpy = vi.spyOn(
+  accountOperations,
+  "resolveDefaultTokenQuickCreateResolution",
+)
+
 const ACCOUNT = {
   id: "acc-1",
   name: "Example",
@@ -252,6 +263,22 @@ describe("CopyKeyDialog", () => {
     completeProductAnalyticsActionMock.mockResolvedValue(undefined)
     resolveApiTokenKeyMock.mockImplementation(
       async ({ token }: { token: { key: string } }) => token.key,
+    )
+    resolveDefaultTokenQuickCreateResolutionSpy.mockReset()
+    resolveDefaultTokenQuickCreateResolutionSpy.mockImplementation(
+      async (account, options) => {
+        if (account.siteType === SITE_TYPES.SUB2API) {
+          return actualResolveDefaultTokenQuickCreateResolution(
+            account,
+            options,
+          )
+        }
+
+        return {
+          kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+          tokenData: generateDefaultTokenRequest(),
+        }
+      },
     )
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
@@ -620,6 +647,80 @@ describe("CopyKeyDialog", () => {
     expect(createApiTokenMock).not.toHaveBeenCalled()
   })
 
+  it("opens a generic constrained Add Token dialog when default token policy requires selection", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
+      allowedGroups: ["default", "vip"],
+    })
+
+    const user = userEvent.setup()
+
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{
+          ...ACCOUNT,
+          siteType: SITE_TYPES.NEW_API,
+        }}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.copyKey.createKey",
+      }),
+    )
+
+    await screen.findByText(
+      "messages:tokenProvisioning.createRequiresGroupSelection",
+    )
+    expect(resolveDefaultTokenQuickCreateResolutionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ siteType: SITE_TYPES.NEW_API }),
+    )
+    expect(createApiTokenMock).not.toHaveBeenCalled()
+  })
+
+  it("creates a default key with the full policy-resolved token payload", async () => {
+    const policyTokenData = {
+      name: "Policy Resolved Copy Key",
+      remain_quota: 777,
+      expired_time: -1,
+      unlimited_quota: false,
+      model_limits_enabled: false,
+      model_limits: "",
+      allow_ips: "",
+      group: "vip",
+    }
+
+    fetchAccountTokensMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([TOKEN])
+    resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+      tokenData: policyTokenData,
+    })
+    createApiTokenMock.mockResolvedValueOnce(true)
+
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.copyKey.createKey",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(createApiTokenMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        policyTokenData,
+      )
+    })
+  })
+
   it("requires manual Sub2API group selection when quick create cannot pick one", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({
@@ -657,7 +758,9 @@ describe("CopyKeyDialog", () => {
       }),
     )
 
-    await screen.findByText("messages:sub2api.createRequiresGroupSelection")
+    await screen.findByText(
+      "messages:tokenProvisioning.createRequiresGroupSelection",
+    )
     expect(fetchUserGroupsMock).toHaveBeenCalled()
     expect(createApiTokenMock).not.toHaveBeenCalled()
   })

--- a/tests/features/AccountManagement/hooks/useAccountDialog.analytics.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.analytics.test.tsx
@@ -31,7 +31,7 @@ import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 const {
   mockAutoDetectAccount,
   mockOpenWithAccount,
-  mockOpenSub2ApiTokenCreationDialog,
+  mockOpenDefaultTokenQuickCreateDialogForAccount,
   mockToastError,
   mockToastSuccess,
   mockStartProductAnalyticsAction,
@@ -43,7 +43,7 @@ const {
 } = vi.hoisted(() => ({
   mockAutoDetectAccount: vi.fn(),
   mockOpenWithAccount: vi.fn(),
-  mockOpenSub2ApiTokenCreationDialog: vi.fn(),
+  mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
   mockToastError: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockStartProductAnalyticsAction: vi.fn(),
@@ -68,7 +68,8 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: mockOpenWithAccount,
-    openSub2ApiTokenCreationDialog: mockOpenSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount:
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
   }),
 }))
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx
@@ -11,7 +11,7 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: vi.fn(),
-    openSub2ApiTokenCreationDialog: vi.fn(),
+    openDefaultTokenQuickCreateDialogForAccount: vi.fn(),
   }),
 }))
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
@@ -41,7 +41,7 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: vi.fn(),
-    openSub2ApiTokenCreationDialog: vi.fn(),
+    openDefaultTokenQuickCreateDialogForAccount: vi.fn(),
   }),
 }))
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.duplicateAccountWarning.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.duplicateAccountWarning.test.tsx
@@ -11,12 +11,11 @@ import { server } from "~~/tests/msw/server"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
-const { mockOpenWithAccount, mockOpenSub2ApiTokenCreationDialog } = vi.hoisted(
-  () => ({
+const { mockOpenWithAccount, mockOpenDefaultTokenQuickCreateDialogForAccount } =
+  vi.hoisted(() => ({
     mockOpenWithAccount: vi.fn(),
-    mockOpenSub2ApiTokenCreationDialog: vi.fn(),
-  }),
-)
+    mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
+  }))
 
 vi.mock("react-hot-toast", () => ({
   default: {
@@ -30,7 +29,8 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: mockOpenWithAccount,
-    openSub2ApiTokenCreationDialog: mockOpenSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount:
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
   }),
 }))
 
@@ -848,8 +848,12 @@ describe("useAccountDialog duplicate account warning", () => {
       await result.current.handlers.handleSaveAccount()
     })
 
-    expect(mockOpenSub2ApiTokenCreationDialog).toHaveBeenCalledTimes(1)
-    expect(mockOpenSub2ApiTokenCreationDialog).toHaveBeenCalledWith(
+    expect(
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
+    ).toHaveBeenCalledTimes(1)
+    expect(
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
+    ).toHaveBeenCalledWith(
       expect.objectContaining({
         siteType: "sub2api",
         baseUrl: "https://sub2.example.com",
@@ -872,7 +876,7 @@ describe("useAccountDialog duplicate account warning", () => {
         }),
       ),
     )
-    mockOpenSub2ApiTokenCreationDialog.mockRejectedValueOnce(
+    mockOpenDefaultTokenQuickCreateDialogForAccount.mockRejectedValueOnce(
       new Error("dialog failed"),
     )
 
@@ -912,7 +916,9 @@ describe("useAccountDialog duplicate account warning", () => {
     })
 
     expect(saveResult).toMatchObject({ success: true })
-    expect(mockOpenSub2ApiTokenCreationDialog).toHaveBeenCalledTimes(1)
+    expect(
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
+    ).toHaveBeenCalledTimes(1)
 
     const savedAccounts = await accountStorage.getAllAccounts()
     expect(savedAccounts).toHaveLength(1)

--- a/tests/features/AccountManagement/hooks/useAccountDialog.excludeFromTotalBalance.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.excludeFromTotalBalance.test.tsx
@@ -9,12 +9,11 @@ import { AuthTypeEnum, SiteHealthStatus } from "~/types"
 import { server } from "~~/tests/msw/server"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
-const { mockOpenWithAccount, mockOpenSub2ApiTokenCreationDialog } = vi.hoisted(
-  () => ({
+const { mockOpenWithAccount, mockOpenDefaultTokenQuickCreateDialogForAccount } =
+  vi.hoisted(() => ({
     mockOpenWithAccount: vi.fn(),
-    mockOpenSub2ApiTokenCreationDialog: vi.fn(),
-  }),
-)
+    mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
+  }))
 
 vi.mock("react-hot-toast", () => ({
   default: {
@@ -28,7 +27,8 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: mockOpenWithAccount,
-    openSub2ApiTokenCreationDialog: mockOpenSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount:
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
   }),
 }))
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.importCookies.test.tsx
@@ -22,12 +22,11 @@ import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 type OnTabActivated = typeof import("~/utils/browser/browserApi").onTabActivated
 type OnTabUpdated = typeof import("~/utils/browser/browserApi").onTabUpdated
 
-const { mockOpenWithAccount, mockOpenSub2ApiTokenCreationDialog } = vi.hoisted(
-  () => ({
+const { mockOpenWithAccount, mockOpenDefaultTokenQuickCreateDialogForAccount } =
+  vi.hoisted(() => ({
     mockOpenWithAccount: vi.fn(),
-    mockOpenSub2ApiTokenCreationDialog: vi.fn(),
-  }),
-)
+    mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
+  }))
 
 const { mockOpenSettingsTab } = vi.hoisted(() => ({
   mockOpenSettingsTab: vi.fn(),
@@ -68,7 +67,8 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: mockOpenWithAccount,
-    openSub2ApiTokenCreationDialog: mockOpenSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount:
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
   }),
 }))
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.manualBalanceUsd.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.manualBalanceUsd.test.tsx
@@ -7,18 +7,18 @@ import { accountStorage } from "~/services/accounts/accountStorage"
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
 import { renderHook, waitFor } from "~~/tests/test-utils/render"
 
-const { mockOpenWithAccount, mockOpenSub2ApiTokenCreationDialog } = vi.hoisted(
-  () => ({
+const { mockOpenWithAccount, mockOpenDefaultTokenQuickCreateDialogForAccount } =
+  vi.hoisted(() => ({
     mockOpenWithAccount: vi.fn(),
-    mockOpenSub2ApiTokenCreationDialog: vi.fn(),
-  }),
-)
+    mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
+  }))
 
 vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: mockOpenWithAccount,
-    openSub2ApiTokenCreationDialog: mockOpenSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount:
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
   }),
 }))
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.redetectPreservesCustomData.test.tsx
@@ -18,11 +18,11 @@ import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 const {
   mockAutoDetectAccount,
   mockOpenWithAccount,
-  mockOpenSub2ApiTokenCreationDialog,
+  mockOpenDefaultTokenQuickCreateDialogForAccount,
 } = vi.hoisted(() => ({
   mockAutoDetectAccount: vi.fn(),
   mockOpenWithAccount: vi.fn(),
-  mockOpenSub2ApiTokenCreationDialog: vi.fn(),
+  mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -37,7 +37,8 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: mockOpenWithAccount,
-    openSub2ApiTokenCreationDialog: mockOpenSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount:
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
   }),
 }))
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -42,7 +42,7 @@ const {
   mockInspectAccountTokenInventory,
   mockEnsureAccountTokenForPostSaveWorkflow,
   mockOpenWithAccount,
-  mockOpenSub2ApiTokenCreationDialog,
+  mockOpenDefaultTokenQuickCreateDialogForAccount,
   mockGetManagedSiteConfig,
   mockOpenSettingsTab,
   mockStartProductAnalyticsAction,
@@ -54,7 +54,7 @@ const {
   mockInspectAccountTokenInventory: vi.fn(),
   mockEnsureAccountTokenForPostSaveWorkflow: vi.fn(),
   mockOpenWithAccount: vi.fn(),
-  mockOpenSub2ApiTokenCreationDialog: vi.fn(),
+  mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
   mockGetManagedSiteConfig: vi.fn(),
   mockOpenSettingsTab: vi.fn().mockResolvedValue(undefined),
   mockStartProductAnalyticsAction: vi.fn(),
@@ -79,7 +79,8 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: mockOpenWithAccount,
-    openSub2ApiTokenCreationDialog: mockOpenSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount:
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
   }),
 }))
 
@@ -403,9 +404,9 @@ describe("useAccountDialog save and auto-config flows", () => {
         skipAutoProvisionKeyOnAccountAdd: false,
       },
     )
-    expect(mockOpenSub2ApiTokenCreationDialog).toHaveBeenCalledWith(
-      savedDisplayData,
-    )
+    expect(
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
+    ).toHaveBeenCalledWith(savedDisplayData)
     expect(toast.success).toHaveBeenCalledWith("Saved successfully")
   })
 
@@ -782,7 +783,7 @@ describe("useAccountDialog save and auto-config flows", () => {
     vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValue(
       savedDisplayData,
     )
-    mockOpenSub2ApiTokenCreationDialog.mockRejectedValueOnce(
+    mockOpenDefaultTokenQuickCreateDialogForAccount.mockRejectedValueOnce(
       new Error("dialog boot failed"),
     )
 
@@ -813,9 +814,9 @@ describe("useAccountDialog save and auto-config flows", () => {
         accountId: "saved-account-id",
       }),
     )
-    expect(mockOpenSub2ApiTokenCreationDialog).toHaveBeenCalledWith(
-      savedDisplayData,
-    )
+    expect(
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
+    ).toHaveBeenCalledWith(savedDisplayData)
     expect(toast.success).toHaveBeenCalledWith("Saved successfully")
     expect(toast.error).not.toHaveBeenCalled()
     expect(result.current.state.isSaving).toBe(false)
@@ -1681,7 +1682,9 @@ describe("useAccountDialog save and auto-config flows", () => {
 
     expect(mockValidateAndSaveAccount).toHaveBeenCalledTimes(1)
     expect(mockOpenWithAccount).not.toHaveBeenCalled()
-    expect(mockOpenSub2ApiTokenCreationDialog).not.toHaveBeenCalled()
+    expect(
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
+    ).not.toHaveBeenCalled()
     expect(toast.error).toHaveBeenCalledWith(
       "accountDialog:messages.saveAccountFailed",
     )
@@ -3202,7 +3205,9 @@ describe("useAccountDialog save and auto-config flows", () => {
         shouldContinue: expect.any(Function),
       }),
     )
-    expect(mockOpenSub2ApiTokenCreationDialog).not.toHaveBeenCalled()
+    expect(
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
+    ).not.toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalledWith(
       "messages:toast.error.findAccountDetailsFailed",
     )
@@ -3331,7 +3336,9 @@ describe("useAccountDialog save and auto-config flows", () => {
         shouldContinue: expect.any(Function),
       }),
     )
-    expect(mockOpenSub2ApiTokenCreationDialog).not.toHaveBeenCalled()
+    expect(
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
+    ).not.toHaveBeenCalled()
   })
 
   it("reports a missing saved account during auto-config instead of opening the channel dialog", async () => {

--- a/tests/features/AccountManagement/hooks/useAccountDialog.sponsorPrefill.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.sponsorPrefill.test.tsx
@@ -28,7 +28,7 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: vi.fn(),
-    openSub2ApiTokenCreationDialog: vi.fn(),
+    openDefaultTokenQuickCreateDialogForAccount: vi.fn(),
   }),
 }))
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
@@ -11,12 +11,12 @@ import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
 const {
   mockOpenWithAccount,
-  mockOpenSub2ApiTokenCreationDialog,
+  mockOpenDefaultTokenQuickCreateDialogForAccount,
   mockToastError,
   mockToastSuccess,
 } = vi.hoisted(() => ({
   mockOpenWithAccount: vi.fn(),
-  mockOpenSub2ApiTokenCreationDialog: vi.fn(),
+  mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
   mockToastError: vi.fn(),
   mockToastSuccess: vi.fn(),
 }))
@@ -33,7 +33,8 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
   useChannelDialog: () => ({
     openWithAccount: mockOpenWithAccount,
-    openSub2ApiTokenCreationDialog: mockOpenSub2ApiTokenCreationDialog,
+    openDefaultTokenQuickCreateDialogForAccount:
+      mockOpenDefaultTokenQuickCreateDialogForAccount,
   }),
 }))
 

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -285,7 +285,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     })
 
     await expect(runCoverage()).rejects.toThrow(
-      "messages:sub2api.createRequiresGroup",
+      "messages:tokenProvisioning.createRequiresGroup",
     )
 
     expect(mocks.createApiToken).not.toHaveBeenCalled()

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -10,6 +10,7 @@ import {
   ensureAccountApiToken,
   resolveSub2ApiQuickCreateResolution,
 } from "~/services/accounts/accountOperations"
+import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
 import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
 import {
   CREATED_TOKEN_SECRET_DECISION_KINDS,
@@ -245,7 +246,7 @@ describe("accountOperations Sub2API token creation guards", () => {
         account: SITE_ACCOUNT,
         displaySiteData: DISPLAY_ACCOUNT,
       }),
-    ).rejects.toThrow("messages:sub2api.createRequiresGroup")
+    ).rejects.toThrow("messages:tokenProvisioning.createRequiresGroup")
 
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
     expect(createApiTokenMock).not.toHaveBeenCalled()
@@ -275,7 +276,7 @@ describe("accountOperations Sub2API token creation guards", () => {
 
     await expect(
       ensureAccountApiToken(SITE_ACCOUNT, DISPLAY_ACCOUNT),
-    ).rejects.toThrow("messages:sub2api.createRequiresGroup")
+    ).rejects.toThrow("messages:tokenProvisioning.createRequiresGroup")
 
     expect(toastLoadingMock).toHaveBeenCalled()
     expect(createApiTokenMock).not.toHaveBeenCalled()
@@ -318,6 +319,84 @@ describe("accountOperations Sub2API token creation guards", () => {
     )
   })
 
+  it("keeps explicitGroup as the generic group-selection alias", async () => {
+    const token = buildSub2ApiToken({ id: 12, key: "sk-vip" })
+
+    fetchAccountTokensMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([token])
+    createApiTokenMock.mockResolvedValueOnce(true)
+    resolveDefaultTokenCreationMock.mockImplementationOnce((request) => ({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+      tokenData: { ...request.defaultTokenData, group: request.explicitGroup },
+      oneTimeSecret: false,
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+    }))
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+    })
+
+    await expect(
+      ensureAccountApiToken(SITE_ACCOUNT, DISPLAY_ACCOUNT, {
+        toastId: "toast-explicit-group",
+        explicitGroup: "vip",
+      }),
+    ).resolves.toEqual(token)
+
+    expect(resolveDefaultTokenCreationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        explicitGroup: "vip",
+      }),
+    )
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ group: "vip" }),
+    )
+  })
+
+  it("passes policy-resolved default token data to shared ensure", async () => {
+    const token = buildSub2ApiToken({ id: 42, key: "sk-created" })
+    const policyTokenData = {
+      ...generateDefaultTokenRequest(),
+      name: "Policy Resolved Default Key",
+      group: "vip",
+      remain_quota: 12345,
+    }
+
+    fetchAccountTokensMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([token])
+    createApiTokenMock.mockResolvedValueOnce(true)
+    resolveDefaultTokenCreationMock.mockImplementationOnce((request) => ({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+      tokenData: request.defaultTokenData,
+      oneTimeSecret: false,
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+    }))
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+    })
+
+    await expect(
+      ensureAccountApiToken(SITE_ACCOUNT, DISPLAY_ACCOUNT, {
+        toastId: "toast-policy-token-data",
+        defaultTokenData: policyTokenData,
+      }),
+    ).resolves.toEqual(token)
+
+    expect(resolveDefaultTokenCreationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData: policyTokenData,
+      }),
+    )
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      policyTokenData,
+    )
+  })
+
   it("resolves quick-create group selection through token provisioning policy", async () => {
     resolveDefaultTokenCreationMock
       .mockReturnValueOnce({
@@ -340,7 +419,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     await expect(
       resolveDefaultTokenQuickCreateResolution(DISPLAY_ACCOUNT),
     ).resolves.toEqual({
-      kind: "selection_required",
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
   })
@@ -359,7 +438,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     await expect(
       resolveSub2ApiQuickCreateResolution(DISPLAY_ACCOUNT),
     ).resolves.toEqual({
-      kind: "blocked",
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked,
       message: "messages:sub2api.createRequiresAvailableGroup",
     })
   })
@@ -382,7 +461,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     await expect(
       resolveSub2ApiQuickCreateResolution(DISPLAY_ACCOUNT),
     ).resolves.toEqual({
-      kind: "selection_required",
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.SelectionRequired,
       allowedGroups: ["default", "vip"],
     })
   })
@@ -406,7 +485,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     await expect(
       resolveSub2ApiQuickCreateResolution(DISPLAY_ACCOUNT),
     ).resolves.toEqual({
-      kind: "ready",
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
       group: "vip",
     })
   })
@@ -496,7 +575,7 @@ describe("accountOperations Sub2API token creation guards", () => {
     await expect(
       resolveDefaultTokenQuickCreateResolution(displayAccount as any),
     ).resolves.toEqual({
-      kind: "blocked",
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.OneTimeSecretRequired,
       message: "messages:aihubmix.createRequiresOneTimeKeyDialog",
     })
@@ -516,9 +595,9 @@ describe("accountOperations Sub2API token creation guards", () => {
     await expect(
       resolveDefaultTokenQuickCreateResolution(displayAccount as any),
     ).resolves.toEqual({
-      kind: "blocked",
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Blocked,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
-      message: "messages:sub2api.createRequiresGroup",
+      message: "messages:tokenProvisioning.createRequiresGroup",
     })
   })
 })


### PR DESCRIPTION
## Summary
- Routes Copy Key, Kilo export, and Channel Dialog default-token creation through the generic token provisioning quick-create resolution.
- Preserves policy-resolved token payloads when ensuring missing account tokens.
- Adds shared naming/default-group cleanup and focused coverage for generic and Sub2API-compatible paths.

## Test Plan
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unified default-token quick-create flows across key dialogs, with consistent ready/selection-required/blocked handling.
  * Added clearer “token creation blocked” guidance for Kilo Code exports.

* **Bug Fixes**
  * Improved deterministic selection for “newest token” to avoid ordering inconsistencies.
  * Fixed duplicate in-flight model/inventory loads in the Kilo Code export dialog.

* **Documentation**
  * Updated user-facing wording and localization from Sub2API-specific text to generic token-provisioning terminology.
  * Adjusted default group selection to use the shared default group name consistently.

* **Tests**
  * Updated suites to reflect the new dialog and resolution behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->