### PR TITLE
refactor(account-site): route adapters from site definitions

### DIFF
--- a/src/constants/siteType.ts
+++ b/src/constants/siteType.ts
@@ -15,6 +15,7 @@ import {
   type ManagedSiteType,
 } from "~/services/accountSiteOnboarding/siteTypes"
 
+export { ACCOUNT_SITE_ADAPTER_FAMILIES } from "~/services/accountSiteOnboarding/contracts"
 export {
   ACCOUNT_SITE_TYPES,
   ACCOUNT_SITE_TYPE_VALUES,

--- a/src/services/accountSiteOnboarding/contracts.ts
+++ b/src/services/accountSiteOnboarding/contracts.ts
@@ -15,6 +15,16 @@ export type AccountSiteDetectionMetadata = {
   compatUserIdHeaderNames?: readonly string[]
 }
 
+export const ACCOUNT_SITE_ADAPTER_FAMILIES = {
+  NewApiFamily: "newApiFamily",
+  Sub2Api: "sub2api",
+  Aihubmix: "aihubmix",
+  Unsupported: "unsupported",
+} as const
+
+export type AccountSiteAdapterFamily =
+  (typeof ACCOUNT_SITE_ADAPTER_FAMILIES)[keyof typeof ACCOUNT_SITE_ADAPTER_FAMILIES]
+
 export type ContentSessionExtractionContext = {
   url?: string
   siteTypeHint?: AccountSiteType
@@ -41,6 +51,7 @@ export type ContentSessionExtractor = {
 
 export type AccountSiteOnboardingMetadata = {
   siteType: AccountSiteType
+  adapterFamily: AccountSiteAdapterFamily
   detection?: AccountSiteDetectionMetadata
   routes?: AccountSiteRouteConfig
 }

--- a/src/services/accountSiteOnboarding/metadata.ts
+++ b/src/services/accountSiteOnboarding/metadata.ts
@@ -2,6 +2,7 @@ import type {
   AccountSiteOnboardingMetadata,
   AccountSiteRouteConfig,
 } from "./contracts"
+import { ACCOUNT_SITE_ADAPTER_FAMILIES } from "./contracts"
 import {
   AIHUBMIX_HOSTNAMES,
   AIHUBMIX_LOGIN_PATH,
@@ -84,11 +85,13 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
   [
     {
       siteType: SITE_TYPES.ONE_API,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_API)] },
       routes: { usagePath: DEFAULT_USAGE_PATH },
     },
     {
       siteType: SITE_TYPES.NEW_API,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: {
         titlePatterns: [makeTitleRegex(SITE_TYPES.NEW_API)],
       },
@@ -100,11 +103,13 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
     },
     {
       siteType: SITE_TYPES.ANYROUTER,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: { titlePatterns: [/\bany\s*router\b/i] },
       routes: { checkInPath: "/console/topup" },
     },
     {
       siteType: SITE_TYPES.VELOERA,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: {
         titlePatterns: [makeTitleRegex(SITE_TYPES.VELOERA)],
       },
@@ -117,6 +122,7 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
     },
     {
       siteType: SITE_TYPES.ONE_HUB,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_HUB)] },
       routes: {
         usagePath: "/panel/log",
@@ -126,6 +132,7 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
     },
     {
       siteType: SITE_TYPES.DONE_HUB,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.DONE_HUB)] },
       routes: {
         usagePath: "/panel/log",
@@ -135,6 +142,7 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
     },
     {
       siteType: SITE_TYPES.V_API,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: {
         titlePatterns: [makeTitleRegex(SITE_TYPES.V_API)],
       },
@@ -147,6 +155,7 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
     },
     {
       siteType: SITE_TYPES.VO_API,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: {
         titlePatterns: [makeTitleRegex(SITE_TYPES.VO_API)],
       },
@@ -154,10 +163,12 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
     },
     {
       siteType: SITE_TYPES.SUPER_API,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUPER_API)] },
     },
     {
       siteType: SITE_TYPES.RIX_API,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: {
         titlePatterns: [makeTitleRegex(SITE_TYPES.RIX_API)],
       },
@@ -169,17 +180,20 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
     },
     {
       siteType: SITE_TYPES.NEO_API,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: {
         titlePatterns: [makeTitleRegex(SITE_TYPES.NEO_API)],
       },
     },
     {
       siteType: SITE_TYPES.WONG_GONGYI,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: { titlePatterns: [/wong\s*公益站/i] },
       routes: { checkInPath: "/console/topup" },
     },
     {
       siteType: SITE_TYPES.SUB2API,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api,
       detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUB2API)] },
       routes: {
         usagePath: "/usage",
@@ -189,6 +203,7 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
     },
     {
       siteType: SITE_TYPES.AIHUBMIX,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
       detection: {
         titlePatterns: [makeTitleRegex(SITE_TYPES.AIHUBMIX)],
         hostnames: AIHUBMIX_HOSTNAMES,
@@ -203,6 +218,7 @@ const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
     },
     {
       siteType: SITE_TYPES.UNKNOWN,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.UNKNOWN)] },
     },
   ]
@@ -260,6 +276,16 @@ export function getAccountSiteRouteOverrideMetadata(
   siteType: AccountSiteType,
 ): AccountSiteRouteOverrideMetadata {
   return { ...(getAccountSiteMetadata(siteType)?.routes ?? {}) }
+}
+
+/**
+ * Returns the adapter family declared by account-site metadata.
+ */
+export function getAccountSiteAdapterFamilyMetadata(siteType: AccountSiteType) {
+  return (
+    getAccountSiteMetadata(siteType)?.adapterFamily ??
+    ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
+  )
 }
 
 /**

--- a/src/services/accountSiteOnboarding/metadata.ts
+++ b/src/services/accountSiteOnboarding/metadata.ts
@@ -1,8 +1,9 @@
 import type {
   AccountSiteOnboardingMetadata,
   AccountSiteRouteConfig,
-} from "./contracts"
-import { ACCOUNT_SITE_ADAPTER_FAMILIES } from "./contracts"
+} from "~/services/accountSiteOnboarding/contracts"
+import { ACCOUNT_SITE_ADAPTER_FAMILIES } from "~/services/accountSiteOnboarding/contracts"
+
 import {
   AIHUBMIX_HOSTNAMES,
   AIHUBMIX_LOGIN_PATH,
@@ -282,10 +283,11 @@ export function getAccountSiteRouteOverrideMetadata(
  * Returns the adapter family declared by account-site metadata.
  */
 export function getAccountSiteAdapterFamilyMetadata(siteType: AccountSiteType) {
-  return (
-    getAccountSiteMetadata(siteType)?.adapterFamily ??
-    ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
+  const metadata = accountSiteOnboardingMetadata.find(
+    (metadata) => metadata.siteType === siteType,
   )
+
+  return metadata?.adapterFamily ?? ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
 }
 
 /**

--- a/src/services/accountSiteOnboarding/registry.ts
+++ b/src/services/accountSiteOnboarding/registry.ts
@@ -1,6 +1,3 @@
-import { compatibleUserContentSessionExtractor } from "./contentSession/compatibleUser"
-import { sub2ApiContentSessionExtractor } from "./contentSession/sub2api"
-import type { ContentSessionExtractor } from "./contracts"
 import {
   getAccountSiteAdapterFamilyMetadata,
   getAccountSiteCompatUserIdHeaderRules as getAccountSiteCompatUserIdHeaderRuleMetadata,
@@ -8,7 +5,11 @@ import {
   getAccountSiteMetadata,
   getAccountSiteRouteOverrideMetadata,
   getAccountSiteTitleRuleMetadata,
-} from "./metadata"
+} from "~/services/accountSiteOnboarding/metadata"
+
+import { compatibleUserContentSessionExtractor } from "./contentSession/compatibleUser"
+import { sub2ApiContentSessionExtractor } from "./contentSession/sub2api"
+import type { ContentSessionExtractor } from "./contracts"
 import type { AccountSiteType } from "./siteTypes"
 
 /**

--- a/src/services/accountSiteOnboarding/registry.ts
+++ b/src/services/accountSiteOnboarding/registry.ts
@@ -2,6 +2,7 @@ import { compatibleUserContentSessionExtractor } from "./contentSession/compatib
 import { sub2ApiContentSessionExtractor } from "./contentSession/sub2api"
 import type { ContentSessionExtractor } from "./contracts"
 import {
+  getAccountSiteAdapterFamilyMetadata,
   getAccountSiteCompatUserIdHeaderRules as getAccountSiteCompatUserIdHeaderRuleMetadata,
   getAccountSiteDomainRuleMetadata,
   getAccountSiteMetadata,
@@ -36,6 +37,13 @@ export function getAccountSiteTitleRules() {
  */
 export function getAccountSiteCompatUserIdHeaderRules() {
   return getAccountSiteCompatUserIdHeaderRuleMetadata()
+}
+
+/**
+ * Returns the adapter family declared for one account site type.
+ */
+export function getAccountSiteAdapterFamily(siteType: AccountSiteType) {
+  return getAccountSiteAdapterFamilyMetadata(siteType)
 }
 
 /**

--- a/src/services/apiAdapters/registry.ts
+++ b/src/services/apiAdapters/registry.ts
@@ -1,25 +1,13 @@
-import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
+  type AccountSiteType,
+} from "~/constants/siteType"
+import { getAccountSiteAdapterFamily } from "~/services/accountSiteOnboarding/registry"
 
 import { aihubmixAdapter } from "./aihubmix"
 import type { SiteAdapter } from "./contracts/siteAdapter"
 import { createNewApiAdapter } from "./newApi"
 import { sub2ApiAdapter } from "./sub2api"
-
-const newApiFamilySiteTypes = new Set<AccountSiteType>([
-  SITE_TYPES.ONE_API,
-  SITE_TYPES.NEW_API,
-  SITE_TYPES.ANYROUTER,
-  SITE_TYPES.VELOERA,
-  SITE_TYPES.ONE_HUB,
-  SITE_TYPES.DONE_HUB,
-  SITE_TYPES.V_API,
-  SITE_TYPES.VO_API,
-  SITE_TYPES.SUPER_API,
-  SITE_TYPES.RIX_API,
-  SITE_TYPES.NEO_API,
-  SITE_TYPES.WONG_GONGYI,
-  SITE_TYPES.UNKNOWN,
-])
 
 const createNewApiFamilyAdapter = (siteType: AccountSiteType): SiteAdapter =>
   createNewApiAdapter(siteType)
@@ -32,15 +20,17 @@ const createUnsupportedAdapter = (siteType: AccountSiteType): SiteAdapter => ({
  * Resolve the narrow capability adapter for an account site type.
  */
 export function getSiteAdapter(siteType: AccountSiteType): SiteAdapter {
-  if (siteType === SITE_TYPES.SUB2API) {
+  const adapterFamily = getAccountSiteAdapterFamily(siteType)
+
+  if (adapterFamily === ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api) {
     return sub2ApiAdapter
   }
 
-  if (siteType === SITE_TYPES.AIHUBMIX) {
+  if (adapterFamily === ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix) {
     return aihubmixAdapter
   }
 
-  if (newApiFamilySiteTypes.has(siteType)) {
+  if (adapterFamily === ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily) {
     return createNewApiFamilyAdapter(siteType)
   }
 

--- a/tests/services/accountSiteOnboarding/registry.test.ts
+++ b/tests/services/accountSiteOnboarding/registry.test.ts
@@ -7,6 +7,7 @@ import {
   AIHUBMIX_HOSTNAMES,
   AIHUBMIX_LOGIN_PATH,
   SITE_TYPES,
+  type AccountSiteType,
 } from "~/constants/siteType"
 import {
   getAccountSiteAdapterFamily,
@@ -171,6 +172,12 @@ describe("account site onboarding registry", () => {
     )
     expect(getAccountSiteAdapterFamily(SITE_TYPES.AIHUBMIX)).toBe(
       ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
+    )
+  })
+
+  it("falls back to unsupported adapter family for unmapped site types", () => {
+    expect(getAccountSiteAdapterFamily("unmapped" as AccountSiteType)).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
     )
   })
 

--- a/tests/services/accountSiteOnboarding/registry.test.ts
+++ b/tests/services/accountSiteOnboarding/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
   ACCOUNT_SITE_DOMAIN_RULES,
   ACCOUNT_SITE_TITLE_RULES,
   AIHUBMIX_HOSTNAMES,
@@ -8,6 +9,7 @@ import {
   SITE_TYPES,
 } from "~/constants/siteType"
 import {
+  getAccountSiteAdapterFamily,
   getAccountSiteCompatUserIdHeaderRules,
   getAccountSiteDomainRules,
   getAccountSiteOnboardingDefinition,
@@ -155,6 +157,21 @@ describe("account site onboarding registry", () => {
       nextDefinition?.detection?.hostnames?.includes("mutated.example.invalid"),
     ).toBe(false)
     expect(nextDefinition?.detection?.titlePatterns).toHaveLength(1)
+  })
+
+  it("projects adapter families from account site metadata", () => {
+    expect(getAccountSiteAdapterFamily(SITE_TYPES.NEW_API)).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    )
+    expect(getAccountSiteAdapterFamily(SITE_TYPES.V_API)).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    )
+    expect(getAccountSiteAdapterFamily(SITE_TYPES.SUB2API)).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api,
+    )
+    expect(getAccountSiteAdapterFamily(SITE_TYPES.AIHUBMIX)).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
+    )
   })
 
   it("returns content session extractors in onboarding order", () => {

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -84,7 +84,7 @@ describe("apiAdapters registry", () => {
     )
     expect(adapter).toMatchObject({
       siteType: SITE_TYPES.OCTOPUS,
-      family: "newApiFamily",
+      family: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
     })
   })
 
@@ -93,7 +93,7 @@ describe("apiAdapters registry", () => {
 
     expect(adapter).toMatchObject({
       siteType: SITE_TYPES.SUB2API,
-      family: "sub2api",
+      family: ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api,
     })
     expect(adapter.siteAnnouncements).toEqual({
       fetch: expect.any(Function),
@@ -157,7 +157,7 @@ describe("apiAdapters registry", () => {
 
       expect(adapter).toMatchObject({
         siteType,
-        family: "newApiFamily",
+        family: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
       })
       expect(adapter.siteNotice).toEqual({
         fetch: expect.any(Function),

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -1,13 +1,58 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
+  SITE_TYPES,
+  type AccountSiteType,
+} from "~/constants/siteType"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { getApiService } from "~/services/apiService"
 import { AuthTypeEnum } from "~/types"
 
-const { redeemCodeMock } = vi.hoisted(() => ({
+const { getAccountSiteAdapterFamilyMock, redeemCodeMock } = vi.hoisted(() => ({
+  getAccountSiteAdapterFamilyMock: vi.fn((siteType: AccountSiteType) => {
+    if (siteType === SITE_TYPES.SUB2API) {
+      return ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api
+    }
+
+    if (siteType === SITE_TYPES.AIHUBMIX) {
+      return ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix
+    }
+
+    if (
+      [
+        SITE_TYPES.ONE_API,
+        SITE_TYPES.NEW_API,
+        SITE_TYPES.ANYROUTER,
+        SITE_TYPES.VELOERA,
+        SITE_TYPES.ONE_HUB,
+        SITE_TYPES.DONE_HUB,
+        SITE_TYPES.V_API,
+        SITE_TYPES.VO_API,
+        SITE_TYPES.SUPER_API,
+        SITE_TYPES.RIX_API,
+        SITE_TYPES.NEO_API,
+        SITE_TYPES.WONG_GONGYI,
+        SITE_TYPES.UNKNOWN,
+      ].includes(siteType)
+    ) {
+      return ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily
+    }
+
+    return ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
+  }),
   redeemCodeMock: vi.fn(),
 }))
+
+vi.mock(
+  "~/services/accountSiteOnboarding/registry",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("~/services/accountSiteOnboarding/registry")
+    >()),
+    getAccountSiteAdapterFamily: getAccountSiteAdapterFamilyMock,
+  }),
+)
 
 vi.mock("~/services/apiService", () => ({
   getApiService: vi.fn(() => ({
@@ -27,6 +72,22 @@ const expectTokenProvisioningCapability = (
 }
 
 describe("apiAdapters registry", () => {
+  it("routes compatible account sites through the onboarding adapter-family projection", () => {
+    getAccountSiteAdapterFamilyMock.mockReturnValueOnce(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    )
+
+    const adapter = getSiteAdapter(SITE_TYPES.OCTOPUS as AccountSiteType)
+
+    expect(getAccountSiteAdapterFamilyMock).toHaveBeenCalledWith(
+      SITE_TYPES.OCTOPUS,
+    )
+    expect(adapter).toMatchObject({
+      siteType: SITE_TYPES.OCTOPUS,
+      family: "newApiFamily",
+    })
+  })
+
   it("returns a Sub2API Adapter with account-scoped siteAnnouncements", () => {
     const adapter = getSiteAdapter(SITE_TYPES.SUB2API)
 


### PR DESCRIPTION
## Summary
- Add account-site adapter-family metadata to the onboarding definition.
- Route \\getSiteAdapter(...)\\ through the account-site registry projection instead of a duplicated local site-type set.
- Cover the new projection and adapter registry routing with focused tests.

## Test Plan
- pnpm vitest run tests/services/accountSiteOnboarding/registry.test.ts tests/services/apiAdapters/registry.test.ts
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an adapter family classification for account site onboarding, including new metadata fields and adapter-family-aware adapter selection.

* **Tests**
  * Added/updated unit tests to validate adapter family mapping from multiple site types and fallback to “Unsupported,” and to ensure adapter routing uses the new classification logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->