### PR TITLE
refactor(account-sites): add definition registry

### DIFF
--- a/docs/superpowers/plans/2026-06-22-account-site-definition-registry.md
+++ b/docs/superpowers/plans/2026-06-22-account-site-definition-registry.md
@@ -1,0 +1,1942 @@
+# Account Site Definition Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one account-site definition registry so new account site types start from one registration row while existing onboarding, adapter, profile, and Model List seams keep their current responsibilities.
+
+**Architecture:** Create `src/services/accountSiteDefinitions/` as the stable registration source for site identifiers, account/managed scopes, adapter family, onboarding metadata, product profile overrides, and readiness expectations. Keep `src/constants/siteType.ts` and `src/services/accountSiteOnboarding/**` as compatibility facades/projections, keep runtime backend behavior in `SiteAdapter`, and keep product-profile helper behavior in `accountSiteProfile`.
+
+**Tech Stack:** TypeScript, Vitest, WXT extension services, MSW-backed service tests, pnpm.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-account-site-definition-registry-design.md`
+
+---
+
+## File Structure
+
+Create:
+
+- `src/services/accountSiteDefinitions/identifiers.ts`
+  - Own `SITE_TYPES`, AIHubMix constants, and the broad `SiteType` literal union.
+- `src/services/accountSiteDefinitions/contracts.ts`
+  - Own definition scopes, adapter-family constants, registration data shapes, and projection helper types.
+- `src/services/accountSiteDefinitions/definitions.ts`
+  - Own the account-site and managed-only definition rows.
+- `src/services/accountSiteDefinitions/registry.ts`
+  - Own cloning, lookup, and projection helpers for definitions.
+- `src/services/accountSiteDefinitions/siteTypes.ts`
+  - Export compatibility site-type arrays and `AccountSiteType` / `ManagedSiteType` derived from definition rows.
+- `src/services/accountSiteDefinitions/index.ts`
+  - Public barrel for definition registry callers.
+- `tests/services/accountSiteDefinitions/registry.test.ts`
+  - Direct completeness and projection tests for the definition registry.
+- `tests/services/modelList/accountSources/readiness.definitions.test.ts`
+  - Integration-style tests that compare definition readiness expectations with actual readiness results.
+
+Modify:
+
+- `src/services/accountSiteOnboarding/contracts.ts`
+  - Re-export shared route/detection/adapter-family definition contracts while keeping content-session extractor types local.
+- `src/services/accountSiteOnboarding/siteTypes.ts`
+  - Become a compatibility facade over `accountSiteDefinitions/siteTypes`.
+- `src/constants/siteType.ts`
+  - Continue to export the same public constants and helpers from the facade.
+- `src/services/accountSiteOnboarding/metadata.ts`
+  - Project onboarding metadata from account-site definitions instead of owning a separate metadata table.
+- `src/services/accountSiteOnboarding/registry.ts`
+  - Keep the public onboarding helper names, now backed by definition projections.
+- `tests/services/accountSiteOnboarding/registry.test.ts`
+  - Add coverage that onboarding projections come from defensive definition copies.
+- `tests/services/detectSiteType.test.ts`
+  - Keep current domain/title/compat-header detection behavior.
+- `src/services/accounts/accountSiteProfile/profiles.ts`
+  - Keep the default compatible product profile; stop owning site-specific override rows.
+- `src/services/accounts/accountSiteProfile/registry.ts`
+  - Resolve site-specific profile overrides from account-site definitions.
+- `tests/services/accounts/accountSiteProfile.test.ts`
+  - Assert the profile behavior remains unchanged and overrides are no longer exported by the profile barrel.
+- `src/services/apiAdapters/registry.ts`
+  - Keep routing through `getAccountSiteAdapterFamily(...)`; no behavior change expected after onboarding projection moves.
+- `tests/services/apiAdapters/registry.test.ts`
+  - Keep adapter-family routing coverage.
+- Existing Model List / Key Management tests
+  - Update only if the targeted raw `SITE_TYPES` cleanup changes a touched policy path.
+
+Do not modify:
+
+- `src/services/apiAdapters/**` concrete adapter implementations, except imports required by type movement.
+- `src/services/managedSites/**`
+- `src/services/models/modelSync/**`
+- `src/locales/**`
+- telemetry schemas, privacy allow-lists, settings search definitions, or Playwright E2E tests.
+- persisted schema field names such as `sub2apiAuth`.
+
+---
+
+## Implementation Notes
+
+This is a behavior-preserving registration refactor.
+
+Preserve these public imports:
+
+```ts
+import {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
+  ACCOUNT_SITE_TYPES,
+  ACCOUNT_SITE_TYPE_VALUES,
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  AIHUBMIX_WEB_ORIGIN,
+  MANAGED_SITE_TYPES,
+  SITE_TYPES,
+  isAccountSiteType,
+  isManagedSiteType,
+} from "~/constants/siteType"
+```
+
+Keep this ownership split:
+
+- account-site definitions own stable registration data;
+- onboarding owns projection helpers and content-session extractor ordering;
+- adapters own backend protocol behavior;
+- product profiles own merge behavior and saved-account product helpers;
+- Model List readiness owns runtime route resolution.
+
+Telemetry decision: none. No analytics events or fields change.
+
+Settings search decision: none. No settings UI, anchors, deep links, or search definitions change.
+
+E2E decision: no new Playwright E2E by default. Registry projection and policy routing are deterministic and covered by Vitest.
+
+---
+
+### Task 1: Add Definition Module And Completeness Tests
+
+**Files:**
+
+- Create: `src/services/accountSiteDefinitions/identifiers.ts`
+- Create: `src/services/accountSiteDefinitions/contracts.ts`
+- Create: `src/services/accountSiteDefinitions/definitions.ts`
+- Create: `src/services/accountSiteDefinitions/registry.ts`
+- Create: `src/services/accountSiteDefinitions/siteTypes.ts`
+- Create: `src/services/accountSiteDefinitions/index.ts`
+- Create: `tests/services/accountSiteDefinitions/registry.test.ts`
+
+- [ ] **Step 1: Write failing definition registry tests**
+
+Create `tests/services/accountSiteDefinitions/registry.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
+  ACCOUNT_SITE_DEFINITION_SCOPES,
+  ACCOUNT_SITE_TYPES,
+  AIHUBMIX_HOSTNAMES,
+  MANAGED_SITE_TYPES,
+  SITE_TYPES,
+  getAccountSiteDefinition,
+  getAccountSiteDefinitions,
+  getAccountSiteOnboardingDefinitions,
+  getAccountSiteProductProfileOverride,
+  getAccountSiteReadinessExpectation,
+  getAccountSiteTypeValues,
+  getManagedSiteTypeValues,
+} from "~/services/accountSiteDefinitions"
+import {
+  ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES,
+  ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES,
+  ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS,
+  ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS,
+} from "~/services/accounts/accountSiteProfile"
+import { MODEL_LIST_ACCOUNT_SOURCE_ROUTES } from "~/services/modelList/accountSources/readiness"
+import { AuthTypeEnum } from "~/types"
+
+describe("accountSiteDefinitions registry", () => {
+  it("keeps account site membership as a definition projection", () => {
+    expect(getAccountSiteTypeValues()).toEqual([...ACCOUNT_SITE_TYPES])
+    expect(getAccountSiteTypeValues()).toEqual([
+      SITE_TYPES.ONE_API,
+      SITE_TYPES.NEW_API,
+      SITE_TYPES.ANYROUTER,
+      SITE_TYPES.VELOERA,
+      SITE_TYPES.ONE_HUB,
+      SITE_TYPES.DONE_HUB,
+      SITE_TYPES.V_API,
+      SITE_TYPES.VO_API,
+      SITE_TYPES.SUPER_API,
+      SITE_TYPES.RIX_API,
+      SITE_TYPES.NEO_API,
+      SITE_TYPES.WONG_GONGYI,
+      SITE_TYPES.SUB2API,
+      SITE_TYPES.AIHUBMIX,
+      SITE_TYPES.UNKNOWN,
+    ])
+  })
+
+  it("keeps managed site membership as a definition projection", () => {
+    expect(getManagedSiteTypeValues()).toEqual([...MANAGED_SITE_TYPES])
+    expect(getManagedSiteTypeValues()).toEqual([
+      SITE_TYPES.NEW_API,
+      SITE_TYPES.VELOERA,
+      SITE_TYPES.DONE_HUB,
+      SITE_TYPES.OCTOPUS,
+      SITE_TYPES.AXON_HUB,
+      SITE_TYPES.CLAUDE_CODE_HUB,
+    ])
+  })
+
+  it("contains no duplicate site type definitions", () => {
+    const siteTypes = getAccountSiteDefinitions().map(
+      (definition) => definition.siteType,
+    )
+
+    expect(new Set(siteTypes).size).toBe(siteTypes.length)
+  })
+
+  it("resolves account-scoped definitions for every account site type", () => {
+    for (const siteType of ACCOUNT_SITE_TYPES) {
+      const definition = getAccountSiteDefinition(siteType)
+      expect(definition, `${siteType} definition is missing`).toBeDefined()
+      expect(definition?.scopes).toContain(
+        ACCOUNT_SITE_DEFINITION_SCOPES.Account,
+      )
+      expect(definition?.adapterFamily).toBeTruthy()
+    }
+  })
+
+  it("resolves managed-scoped definitions for every managed site type", () => {
+    for (const siteType of MANAGED_SITE_TYPES) {
+      const definition = getAccountSiteDefinition(siteType)
+      expect(definition, `${siteType} definition is missing`).toBeDefined()
+      expect(definition?.scopes).toContain(
+        ACCOUNT_SITE_DEFINITION_SCOPES.Managed,
+      )
+    }
+  })
+
+  it("projects adapter families from definitions", () => {
+    expect(getAccountSiteDefinition(SITE_TYPES.NEW_API)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    )
+    expect(getAccountSiteDefinition(SITE_TYPES.SUB2API)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api,
+    )
+    expect(getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
+    )
+    expect(getAccountSiteDefinition(SITE_TYPES.OCTOPUS)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+    )
+  })
+
+  it("projects onboarding metadata from definitions", () => {
+    const onboardingDefinitions = getAccountSiteOnboardingDefinitions()
+
+    expect(onboardingDefinitions.map((definition) => definition.siteType)).toEqual(
+      [...ACCOUNT_SITE_TYPES],
+    )
+    expect(
+      onboardingDefinitions.find(
+        (definition) => definition.siteType === SITE_TYPES.AIHUBMIX,
+      )?.detection?.hostnames,
+    ).toEqual([...AIHUBMIX_HOSTNAMES])
+    expect(
+      onboardingDefinitions.find(
+        (definition) => definition.siteType === SITE_TYPES.SUB2API,
+      )?.routes,
+    ).toMatchObject({
+      usagePath: "/usage",
+      redeemPath: "/redeem",
+      siteAnnouncementsPath: "/dashboard",
+    })
+  })
+
+  it("returns defensive copies for definitions and projections", () => {
+    const first = getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)
+    ;(first!.onboarding!.detection!.hostnames as string[]).push(
+      "mutated.example.invalid",
+    )
+    first!.adapterFamily = ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
+
+    const second = getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)
+    expect(second?.adapterFamily).toBe(ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix)
+    expect(second?.onboarding?.detection?.hostnames).toEqual([
+      ...AIHUBMIX_HOSTNAMES,
+    ])
+  })
+
+  it("projects product-profile overrides from definitions", () => {
+    expect(getAccountSiteProductProfileOverride(SITE_TYPES.ANYROUTER)).toMatchObject({
+      auth: {
+        defaultAuthType: AuthTypeEnum.Cookie,
+        defaultAuthHostnames: ["anyrouter.top"],
+      },
+    })
+    expect(getAccountSiteProductProfileOverride(SITE_TYPES.SUB2API)).toMatchObject({
+      authSession: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+        decoratesAccountApiRequests: true,
+      },
+      modelList: {
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.RuntimeKey,
+        statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Token,
+      },
+    })
+    expect(getAccountSiteProductProfileOverride(SITE_TYPES.AIHUBMIX)).toMatchObject({
+      modelList: {
+        displayCapabilitiesSource:
+          ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile,
+      },
+    })
+  })
+
+  it("projects Model List readiness expectations from definitions", () => {
+    expect(getAccountSiteReadinessExpectation(SITE_TYPES.NEW_API)?.modelList).toEqual({
+      expectedRoute: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing,
+    })
+    expect(getAccountSiteReadinessExpectation(SITE_TYPES.SUB2API)?.modelList).toEqual({
+      expectedRoute: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog,
+    })
+    expect(getAccountSiteReadinessExpectation(SITE_TYPES.AIHUBMIX)?.modelList).toEqual({
+      expectedRoute: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteDefinitions/registry.test.ts
+```
+
+Expected: FAIL with an import error for `~/services/accountSiteDefinitions`.
+
+- [ ] **Step 3: Create `identifiers.ts`**
+
+Create `src/services/accountSiteDefinitions/identifiers.ts`:
+
+```ts
+export const SITE_TYPES = {
+  ONE_API: "one-api",
+  NEW_API: "new-api",
+  ANYROUTER: "anyrouter",
+  VELOERA: "Veloera",
+  ONE_HUB: "one-hub",
+  DONE_HUB: "done-hub",
+  V_API: "v-api",
+  VO_API: "VoAPI",
+  SUPER_API: "Super-API",
+  RIX_API: "Rix-Api",
+  NEO_API: "neo-Api",
+  WONG_GONGYI: "wong-gongyi",
+  SUB2API: "sub2api",
+  OCTOPUS: "octopus",
+  AXON_HUB: "axonhub",
+  CLAUDE_CODE_HUB: "claude-code-hub",
+  AIHUBMIX: "AIHubMix",
+  UNKNOWN: "unknown",
+} as const
+
+export type SiteType = (typeof SITE_TYPES)[keyof typeof SITE_TYPES]
+
+export const AIHUBMIX_API_ORIGIN = "https://aihubmix.com"
+export const AIHUBMIX_WEB_ORIGIN = "https://console.aihubmix.com"
+export const AIHUBMIX_LOGIN_PATH = "/sign-in"
+export const AIHUBMIX_HOSTNAMES = [
+  "aihubmix.com",
+  "www.aihubmix.com",
+  "console.aihubmix.com",
+] as const
+```
+
+- [ ] **Step 4: Create `contracts.ts`**
+
+Create `src/services/accountSiteDefinitions/contracts.ts`:
+
+```ts
+import type { AccountSiteProductProfile } from "~/services/accounts/accountSiteProfile/contracts"
+
+import type { SiteType } from "./identifiers"
+
+export type AccountSiteRouteConfig = {
+  loginPath?: string
+  usagePath?: string
+  checkInPath?: string
+  adminCredentialsPath?: string
+  redeemPath?: string
+  siteAnnouncementsPath?: string
+}
+
+export type AccountSiteDetectionMetadata = {
+  titlePatterns?: readonly RegExp[]
+  hostnames?: readonly string[]
+  compatUserIdHeaderNames?: readonly string[]
+}
+
+export const ACCOUNT_SITE_ADAPTER_FAMILIES = {
+  NewApiFamily: "newApiFamily",
+  Sub2Api: "sub2api",
+  Aihubmix: "aihubmix",
+  Unsupported: "unsupported",
+} as const
+
+export type AccountSiteAdapterFamily =
+  (typeof ACCOUNT_SITE_ADAPTER_FAMILIES)[keyof typeof ACCOUNT_SITE_ADAPTER_FAMILIES]
+
+export const ACCOUNT_SITE_DEFINITION_SCOPES = {
+  Account: "account",
+  Managed: "managed",
+} as const
+
+export type AccountSiteDefinitionScope =
+  (typeof ACCOUNT_SITE_DEFINITION_SCOPES)[keyof typeof ACCOUNT_SITE_DEFINITION_SCOPES]
+
+export type AccountSiteDefinitionOnboardingMetadata = {
+  detection?: AccountSiteDetectionMetadata
+  routes?: AccountSiteRouteConfig
+}
+
+export const ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES = {
+  DirectPricing: "direct_pricing",
+  TokenScopedRuntimeCatalog: "token_scoped_runtime_catalog",
+  Unsupported: "unsupported",
+} as const
+
+export type AccountSiteModelListExpectedRoute =
+  (typeof ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES)[keyof typeof ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES]
+
+export type AccountSiteDefinitionReadiness = {
+  modelList?: {
+    expectedRoute: AccountSiteModelListExpectedRoute
+  }
+}
+
+export type AccountSiteDefinition = {
+  siteType: SiteType
+  scopes: readonly AccountSiteDefinitionScope[]
+  adapterFamily: AccountSiteAdapterFamily
+  onboarding?: AccountSiteDefinitionOnboardingMetadata
+  productProfile?: Partial<AccountSiteProductProfile>
+  readiness?: AccountSiteDefinitionReadiness
+}
+```
+
+- [ ] **Step 5: Create definition rows**
+
+Create `src/services/accountSiteDefinitions/definitions.ts`.
+
+Use the existing route and detection values from `src/services/accountSiteOnboarding/metadata.ts`, and place every row in one of these arrays:
+
+```ts
+import {
+  ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES,
+  ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING,
+  ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS,
+  ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING,
+  ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES,
+  ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES,
+  ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS,
+  ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS,
+  ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES,
+} from "~/services/accounts/accountSiteProfile/contracts"
+import { AuthTypeEnum } from "~/types"
+
+import {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
+  ACCOUNT_SITE_DEFINITION_SCOPES,
+  ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES,
+  type AccountSiteDefinition,
+} from "./contracts"
+import {
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  AIHUBMIX_WEB_ORIGIN,
+  SITE_TYPES,
+} from "./identifiers"
+
+function makeTitleRegex(name: string): RegExp {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const pattern = escaped.replace(/-/g, "[-_ ]?")
+  return new RegExp(`\\b${pattern}\\b`, "i")
+}
+
+const DEFAULT_USAGE_PATH = "/console/log"
+const DEFAULT_CHECKIN_PATH = "/console/personal"
+
+export const ACCOUNT_SITE_DEFINITIONS = [
+  {
+    siteType: SITE_TYPES.ONE_API,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_API)] },
+      routes: { usagePath: DEFAULT_USAGE_PATH },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.NEW_API,
+    scopes: [
+      ACCOUNT_SITE_DEFINITION_SCOPES.Account,
+      ACCOUNT_SITE_DEFINITION_SCOPES.Managed,
+    ],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.NEW_API)] },
+      routes: {
+        usagePath: DEFAULT_USAGE_PATH,
+        checkInPath: DEFAULT_CHECKIN_PATH,
+        adminCredentialsPath: DEFAULT_CHECKIN_PATH,
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.ANYROUTER,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [/\\bany\\s*router\\b/i] },
+      routes: { checkInPath: "/console/topup" },
+    },
+    productProfile: {
+      auth: {
+        defaultAuthType: AuthTypeEnum.Cookie,
+        defaultAuthHostnames: ["anyrouter.top"],
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.SUB2API,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUB2API)] },
+      routes: {
+        usagePath: "/usage",
+        redeemPath: "/redeem",
+        siteAnnouncementsPath: "/dashboard",
+      },
+    },
+    productProfile: {
+      auth: {
+        allowedAuthTypes: [AuthTypeEnum.AccessToken],
+        defaultAuthType: AuthTypeEnum.AccessToken,
+        defaultAuthHostnames: [],
+        supportsCookieAuth: false,
+        supportsBuiltInCheckInDetection: false,
+      },
+      authSession: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+        decoratesAccountApiRequests: true,
+        refreshLockScope: ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES.Account,
+      },
+      identity: {
+        usernameRequired: false,
+        storedUserIdentityFields: ["id"],
+      },
+      modelList: {
+        directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Unsupported,
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.RuntimeKey,
+        dashboardEstimateLoader:
+          ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.Sub2Api,
+        statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Token,
+        displayCapabilitiesSource:
+          ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+      },
+      supplementalAuth: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute:
+          ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.TokenScopedRuntimeCatalog,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.AIHUBMIX,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
+    onboarding: {
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.AIHUBMIX)],
+        hostnames: AIHUBMIX_HOSTNAMES,
+      },
+      routes: {
+        loginPath: AIHUBMIX_LOGIN_PATH,
+        usagePath: "/statistics",
+        redeemPath: "/topup",
+        checkInPath: "/",
+        adminCredentialsPath: "/",
+      },
+    },
+    productProfile: {
+      auth: {
+        allowedAuthTypes: [AuthTypeEnum.AccessToken],
+        defaultAuthType: AuthTypeEnum.AccessToken,
+        defaultAuthHostnames: [],
+        supportsCookieAuth: false,
+        supportsBuiltInCheckInDetection: true,
+      },
+      createdToken: {
+        secretHandling:
+          ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING.OneTimeSecretDialog,
+      },
+      identity: {
+        usernameRequired: true,
+        storedUserIdentityFields: ["username"],
+      },
+      modelList: {
+        directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Supported,
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.None,
+        dashboardEstimateLoader:
+          ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.None,
+        statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+        displayCapabilitiesSource:
+          ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile,
+      },
+      tokenForm: {
+        networkLimitPolicy:
+          ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES.SubnetLimit,
+      },
+      urls: {
+        recognizedHostnames: AIHUBMIX_HOSTNAMES,
+        storageOrigin: AIHUBMIX_WEB_ORIGIN,
+        duplicateOrigin: AIHUBMIX_WEB_ORIGIN,
+        managedChannelOrigin: AIHUBMIX_API_ORIGIN,
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+] as const satisfies readonly AccountSiteDefinition[]
+
+export const MANAGED_ONLY_SITE_DEFINITIONS = [
+  {
+    siteType: SITE_TYPES.OCTOPUS,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Managed],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+  },
+  {
+    siteType: SITE_TYPES.AXON_HUB,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Managed],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+  },
+  {
+    siteType: SITE_TYPES.CLAUDE_CODE_HUB,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Managed],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+  },
+] as const satisfies readonly AccountSiteDefinition[]
+
+export const ACCOUNT_SITE_DEFINITION_OVERRIDES = [
+  {
+    siteType: SITE_TYPES.VELOERA,
+    scopes: [
+      ACCOUNT_SITE_DEFINITION_SCOPES.Account,
+      ACCOUNT_SITE_DEFINITION_SCOPES.Managed,
+    ],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.VELOERA)] },
+      routes: {
+        usagePath: "/app/logs/api-usage",
+        checkInPath: "/app/me",
+        redeemPath: "/app/wallet",
+        adminCredentialsPath: "/app/me",
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.DONE_HUB,
+    scopes: [
+      ACCOUNT_SITE_DEFINITION_SCOPES.Account,
+      ACCOUNT_SITE_DEFINITION_SCOPES.Managed,
+    ],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.DONE_HUB)] },
+      routes: {
+        usagePath: "/panel/log",
+        redeemPath: "/panel/topup",
+        adminCredentialsPath: "/panel/profile",
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+] as const satisfies readonly AccountSiteDefinition[]
+```
+
+Then add the remaining account rows in the same file with the current values from `accountSiteOnboarding/metadata.ts`:
+
+```ts
+export const COMPATIBLE_ACCOUNT_SITE_DEFINITIONS = [
+  {
+    siteType: SITE_TYPES.ONE_HUB,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_HUB)] },
+      routes: {
+        usagePath: "/panel/log",
+        redeemPath: "/panel/topup",
+        adminCredentialsPath: "/panel/profile",
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.V_API,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.V_API)] },
+      routes: {
+        usagePath: "/panel/log",
+        checkInPath: "/panel/profile",
+        redeemPath: "/panel/topup",
+        adminCredentialsPath: "/panel/profile",
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.VO_API,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.VO_API)] },
+      routes: { usagePath: DEFAULT_USAGE_PATH, redeemPath: "/wallet" },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.SUPER_API,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUPER_API)] },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.RIX_API,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.RIX_API)] },
+      routes: {
+        usagePath: "/log",
+        checkInPath: "/panel",
+        redeemPath: "/topup",
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.NEO_API,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.NEO_API)] },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.WONG_GONGYI,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [/wong\\s*公益站/i] },
+      routes: { checkInPath: "/console/topup" },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.UNKNOWN,
+    scopes: [ACCOUNT_SITE_DEFINITION_SCOPES.Account],
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.UNKNOWN)] },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+      },
+    },
+  },
+] as const satisfies readonly AccountSiteDefinition[]
+
+export const SITE_TYPE_DEFINITIONS = [
+  ...ACCOUNT_SITE_DEFINITIONS,
+  ...ACCOUNT_SITE_DEFINITION_OVERRIDES,
+  ...COMPATIBLE_ACCOUNT_SITE_DEFINITIONS,
+  ...MANAGED_ONLY_SITE_DEFINITIONS,
+] as const satisfies readonly AccountSiteDefinition[]
+```
+
+- [ ] **Step 6: Create registry projection helpers**
+
+Create `src/services/accountSiteDefinitions/registry.ts`:
+
+```ts
+import { ACCOUNT_SITE_DEFINITION_SCOPES, type AccountSiteDefinition } from "./contracts"
+import { SITE_TYPE_DEFINITIONS } from "./definitions"
+import type { SiteType } from "./identifiers"
+
+const cloneRegExp = (regex: RegExp) => new RegExp(regex.source, regex.flags)
+
+const cloneDefinition = (
+  definition: AccountSiteDefinition,
+): AccountSiteDefinition => ({
+  ...definition,
+  scopes: [...definition.scopes],
+  onboarding: definition.onboarding
+    ? {
+        ...definition.onboarding,
+        detection: definition.onboarding.detection
+          ? {
+              ...definition.onboarding.detection,
+              titlePatterns: definition.onboarding.detection.titlePatterns
+                ? definition.onboarding.detection.titlePatterns.map(cloneRegExp)
+                : undefined,
+              hostnames: definition.onboarding.detection.hostnames
+                ? [...definition.onboarding.detection.hostnames]
+                : undefined,
+              compatUserIdHeaderNames: definition.onboarding.detection
+                .compatUserIdHeaderNames
+                ? [
+                    ...definition.onboarding.detection
+                      .compatUserIdHeaderNames,
+                  ]
+                : undefined,
+            }
+          : undefined,
+        routes: definition.onboarding.routes
+          ? { ...definition.onboarding.routes }
+          : undefined,
+      }
+    : undefined,
+  productProfile: definition.productProfile
+    ? {
+        ...definition.productProfile,
+        auth: definition.productProfile.auth
+          ? {
+              ...definition.productProfile.auth,
+              allowedAuthTypes: definition.productProfile.auth.allowedAuthTypes
+                ? [...definition.productProfile.auth.allowedAuthTypes]
+                : undefined,
+              defaultAuthHostnames: definition.productProfile.auth
+                .defaultAuthHostnames
+                ? [...definition.productProfile.auth.defaultAuthHostnames]
+                : undefined,
+            }
+          : undefined,
+        authSession: definition.productProfile.authSession
+          ? { ...definition.productProfile.authSession }
+          : undefined,
+        createdToken: definition.productProfile.createdToken
+          ? { ...definition.productProfile.createdToken }
+          : undefined,
+        identity: definition.productProfile.identity
+          ? {
+              ...definition.productProfile.identity,
+              storedUserIdentityFields: definition.productProfile.identity
+                .storedUserIdentityFields
+                ? [...definition.productProfile.identity.storedUserIdentityFields]
+                : undefined,
+            }
+          : undefined,
+        modelList: definition.productProfile.modelList
+          ? { ...definition.productProfile.modelList }
+          : undefined,
+        supplementalAuth: definition.productProfile.supplementalAuth
+          ? { ...definition.productProfile.supplementalAuth }
+          : undefined,
+        tokenForm: definition.productProfile.tokenForm
+          ? { ...definition.productProfile.tokenForm }
+          : undefined,
+        urls: definition.productProfile.urls
+          ? {
+              ...definition.productProfile.urls,
+              recognizedHostnames: definition.productProfile.urls
+                .recognizedHostnames
+                ? [...definition.productProfile.urls.recognizedHostnames]
+                : undefined,
+            }
+          : undefined,
+      }
+    : undefined,
+  readiness: definition.readiness
+    ? {
+        modelList: definition.readiness.modelList
+          ? { ...definition.readiness.modelList }
+          : undefined,
+      }
+    : undefined,
+})
+
+export function getAccountSiteDefinitions(): readonly AccountSiteDefinition[] {
+  return SITE_TYPE_DEFINITIONS.map(cloneDefinition)
+}
+
+export function getAccountSiteDefinition(
+  siteType: SiteType | string,
+): AccountSiteDefinition | undefined {
+  const definition = SITE_TYPE_DEFINITIONS.find(
+    (candidate) => candidate.siteType === siteType,
+  )
+
+  return definition ? cloneDefinition(definition) : undefined
+}
+
+export function getAccountSiteTypeValues() {
+  return SITE_TYPE_DEFINITIONS.filter((definition) =>
+    definition.scopes.includes(ACCOUNT_SITE_DEFINITION_SCOPES.Account),
+  ).map((definition) => definition.siteType)
+}
+
+export function getManagedSiteTypeValues() {
+  return SITE_TYPE_DEFINITIONS.filter((definition) =>
+    definition.scopes.includes(ACCOUNT_SITE_DEFINITION_SCOPES.Managed),
+  ).map((definition) => definition.siteType)
+}
+
+export function getAccountSiteOnboardingDefinitions() {
+  return getAccountSiteDefinitions()
+    .filter((definition) =>
+      definition.scopes.includes(ACCOUNT_SITE_DEFINITION_SCOPES.Account),
+    )
+    .map((definition) => ({
+      siteType: definition.siteType,
+      adapterFamily: definition.adapterFamily,
+      detection: definition.onboarding?.detection,
+      routes: definition.onboarding?.routes,
+    }))
+}
+
+export function getAccountSiteProductProfileOverride(siteType: SiteType | string) {
+  return getAccountSiteDefinition(siteType)?.productProfile
+}
+
+export function getAccountSiteReadinessExpectation(siteType: SiteType | string) {
+  return getAccountSiteDefinition(siteType)?.readiness
+}
+```
+
+If TypeScript rejects optional nested arrays in `cloneDefinition`, keep the helper local to this task and adjust only by making clone branches explicit. Do not replace defensive copies with direct references.
+
+- [ ] **Step 7: Create `siteTypes.ts` and barrel exports**
+
+Create `src/services/accountSiteDefinitions/siteTypes.ts`:
+
+```ts
+import {
+  getAccountSiteTypeValues,
+  getManagedSiteTypeValues,
+} from "./registry"
+export {
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  AIHUBMIX_WEB_ORIGIN,
+  SITE_TYPES,
+  type SiteType,
+} from "./identifiers"
+
+export const ACCOUNT_SITE_TYPES = getAccountSiteTypeValues()
+export type AccountSiteType = (typeof ACCOUNT_SITE_TYPES)[number]
+
+export const ACCOUNT_SITE_TYPE_VALUES = [...ACCOUNT_SITE_TYPES]
+
+export const MANAGED_SITE_TYPES = getManagedSiteTypeValues()
+export type ManagedSiteType = (typeof MANAGED_SITE_TYPES)[number]
+```
+
+Create `src/services/accountSiteDefinitions/index.ts`:
+
+```ts
+export * from "./contracts"
+export * from "./identifiers"
+export * from "./registry"
+export * from "./siteTypes"
+```
+
+- [ ] **Step 8: Run definition tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteDefinitions/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit definition module**
+
+Run:
+
+```powershell
+git add src/services/accountSiteDefinitions tests/services/accountSiteDefinitions/registry.test.ts
+git commit -m "refactor(account-sites): add definition registry"
+```
+
+Expected: commit succeeds after `validate:staged`.
+
+---
+
+### Task 2: Preserve Site-Type Compatibility Facades
+
+**Files:**
+
+- Modify: `src/services/accountSiteOnboarding/contracts.ts`
+- Modify: `src/services/accountSiteOnboarding/siteTypes.ts`
+- Modify: `src/constants/siteType.ts`
+- Modify: `tests/services/accountSiteDefinitions/registry.test.ts`
+- Modify: `tests/services/accountSiteOnboarding/registry.test.ts`
+- Modify: `tests/services/detectSiteType.test.ts`
+
+- [ ] **Step 1: Write compatibility assertions**
+
+Append this test to `tests/services/accountSiteDefinitions/registry.test.ts`:
+
+```ts
+  it("keeps the legacy constants facade aligned with definitions", async () => {
+    const legacy = await import("~/constants/siteType")
+
+    expect(legacy.SITE_TYPES).toBe(SITE_TYPES)
+    expect(legacy.ACCOUNT_SITE_TYPES).toEqual(getAccountSiteTypeValues())
+    expect(legacy.ACCOUNT_SITE_TYPE_VALUES).toEqual(getAccountSiteTypeValues())
+    expect(legacy.MANAGED_SITE_TYPES).toEqual(getManagedSiteTypeValues())
+    expect(legacy.isAccountSiteType(SITE_TYPES.AIHUBMIX)).toBe(true)
+    expect(legacy.isAccountSiteType(SITE_TYPES.OCTOPUS)).toBe(false)
+    expect(legacy.isManagedSiteType(SITE_TYPES.OCTOPUS)).toBe(true)
+    expect(legacy.isManagedSiteType(SITE_TYPES.SUB2API)).toBe(false)
+  })
+```
+
+- [ ] **Step 2: Run the compatibility assertion**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteDefinitions/registry.test.ts
+```
+
+Expected: FAIL until the legacy facade is routed through `accountSiteDefinitions`.
+
+- [ ] **Step 3: Route onboarding contracts through definition contracts**
+
+Replace the shared route/detection/adapter-family definitions in `src/services/accountSiteOnboarding/contracts.ts` with re-exports, while keeping content-session extractor types in this file:
+
+```ts
+import type { AccountSiteType } from "./siteTypes"
+
+export {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
+  type AccountSiteAdapterFamily,
+  type AccountSiteDetectionMetadata,
+  type AccountSiteRouteConfig,
+} from "~/services/accountSiteDefinitions/contracts"
+import type {
+  AccountSiteAdapterFamily,
+  AccountSiteDetectionMetadata,
+  AccountSiteRouteConfig,
+} from "~/services/accountSiteDefinitions/contracts"
+
+export type ContentSessionExtractionContext = {
+  url?: string
+  siteTypeHint?: AccountSiteType
+}
+
+export type ContentSessionExtractionResult = {
+  userId: string | number
+  user: Record<string, unknown>
+  accessToken?: string
+  siteTypeHint?: AccountSiteType
+  sub2apiAuth?: {
+    refreshToken: string
+    tokenExpiresAt?: number
+  }
+}
+
+export type ContentSessionExtractor = {
+  id: string
+  canExtract(context: ContentSessionExtractionContext): boolean
+  extract(
+    context: ContentSessionExtractionContext,
+  ): Promise<ContentSessionExtractionResult | null>
+}
+
+export type AccountSiteOnboardingMetadata = {
+  siteType: AccountSiteType
+  adapterFamily: AccountSiteAdapterFamily
+  detection?: AccountSiteDetectionMetadata
+  routes?: AccountSiteRouteConfig
+}
+```
+
+- [ ] **Step 4: Replace onboarding site-type source with re-exports**
+
+Replace `src/services/accountSiteOnboarding/siteTypes.ts` with:
+
+```ts
+export {
+  ACCOUNT_SITE_TYPES,
+  ACCOUNT_SITE_TYPE_VALUES,
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  AIHUBMIX_WEB_ORIGIN,
+  MANAGED_SITE_TYPES,
+  SITE_TYPES,
+  type AccountSiteType,
+  type ManagedSiteType,
+  type SiteType,
+} from "~/services/accountSiteDefinitions/siteTypes"
+```
+
+- [ ] **Step 5: Keep constants facade behavior unchanged**
+
+Inspect `src/constants/siteType.ts`.
+
+Keep its public exports from `~/services/accountSiteOnboarding/siteTypes` and `~/services/accountSiteOnboarding/contracts`. Only change imports if TypeScript reports a cycle or missing type. The helper bodies should remain:
+
+```ts
+export function isAccountSiteType(value: unknown): value is AccountSiteType {
+  return (
+    typeof value === "string" &&
+    ACCOUNT_SITE_TYPE_VALUES.includes(value as AccountSiteType)
+  )
+}
+
+export function isManagedSiteType(value: unknown): value is ManagedSiteType {
+  return (
+    typeof value === "string" &&
+    MANAGED_SITE_TYPES.includes(value as ManagedSiteType)
+  )
+}
+```
+
+- [ ] **Step 6: Run facade and detection tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteDefinitions/registry.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit compatibility facade migration**
+
+Run:
+
+```powershell
+git add src/services/accountSiteOnboarding/contracts.ts src/services/accountSiteOnboarding/siteTypes.ts src/constants/siteType.ts tests/services/accountSiteDefinitions/registry.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts
+git commit -m "refactor(account-sites): route site type facades through definitions"
+```
+
+Expected: commit succeeds after `validate:staged`.
+
+---
+
+### Task 3: Route Onboarding Metadata Through Definitions
+
+**Files:**
+
+- Modify: `src/services/accountSiteOnboarding/metadata.ts`
+- Modify: `src/services/accountSiteOnboarding/registry.ts`
+- Modify: `tests/services/accountSiteOnboarding/registry.test.ts`
+- Modify: `tests/services/detectSiteType.test.ts`
+
+- [ ] **Step 1: Add onboarding projection assertions**
+
+Append this test to `tests/services/accountSiteOnboarding/registry.test.ts`:
+
+```ts
+  it("projects onboarding definitions from the account-site definition registry", async () => {
+    const { getAccountSiteDefinition } = await import(
+      "~/services/accountSiteDefinitions"
+    )
+
+    const aihubmixDefinition = getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)
+    const onboardingDefinition = getAccountSiteOnboardingDefinition(
+      SITE_TYPES.AIHUBMIX,
+    )
+
+    expect(onboardingDefinition).toMatchObject({
+      siteType: SITE_TYPES.AIHUBMIX,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
+      routes: aihubmixDefinition?.onboarding?.routes,
+    })
+    expect(onboardingDefinition?.detection?.hostnames).toEqual([
+      ...AIHUBMIX_HOSTNAMES,
+    ])
+  })
+```
+
+- [ ] **Step 2: Run onboarding registry tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteOnboarding/registry.test.ts
+```
+
+Expected: PASS before implementation or FAIL only if `getAccountSiteDefinition(...)` is not exported correctly. This step locks expected behavior before deleting the local metadata table.
+
+- [ ] **Step 3: Replace the local metadata table with definition projections**
+
+Modify `src/services/accountSiteOnboarding/metadata.ts`.
+
+Keep `DEFAULT_SITE_ROUTE_CONFIG` in this file. Replace local `accountSiteOnboardingMetadata`, `COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE`, and `makeTitleRegex(...)` with projections from definitions:
+
+```ts
+import type {
+  AccountSiteOnboardingMetadata,
+  AccountSiteRouteConfig,
+} from "~/services/accountSiteOnboarding/contracts"
+import { ACCOUNT_SITE_ADAPTER_FAMILIES } from "~/services/accountSiteOnboarding/contracts"
+import {
+  getAccountSiteDefinition,
+  getAccountSiteDefinitions,
+  getAccountSiteOnboardingDefinitions,
+} from "~/services/accountSiteDefinitions"
+
+import type { AccountSiteType } from "./siteTypes"
+```
+
+Use this helper to normalize definition onboarding rows into the legacy shape:
+
+```ts
+const getAccountSiteOnboardingMetadata =
+  (): readonly AccountSiteOnboardingMetadata[] =>
+    getAccountSiteOnboardingDefinitions().map((definition) => ({
+      siteType: definition.siteType as AccountSiteType,
+      adapterFamily: definition.adapterFamily,
+      detection: definition.detection,
+      routes: definition.routes,
+    }))
+```
+
+Then update the exported helpers:
+
+```ts
+export function getAccountSiteMetadata(siteType: AccountSiteType) {
+  const metadata = getAccountSiteOnboardingMetadata().find(
+    (candidate) => candidate.siteType === siteType,
+  )
+
+  if (!metadata) return undefined
+
+  return {
+    ...metadata,
+    detection: cloneDetectionMetadata(metadata.detection),
+    routes: metadata.routes ? { ...metadata.routes } : undefined,
+  }
+}
+
+export function getAccountSiteTitleRuleMetadata(): readonly AccountSiteTitleRuleMetadata[] {
+  return getAccountSiteOnboardingMetadata().flatMap(
+    (metadata) =>
+      metadata.detection?.titlePatterns?.map((regex) => ({
+        name: metadata.siteType,
+        regex,
+      })) ?? [],
+  )
+}
+
+export function getAccountSiteDomainRuleMetadata(): readonly AccountSiteDomainRuleMetadata[] {
+  return getAccountSiteOnboardingMetadata().flatMap((metadata) =>
+    metadata.detection?.hostnames
+      ? [
+          {
+            name: metadata.siteType,
+            hostnames: [...metadata.detection.hostnames],
+          },
+        ]
+      : [],
+  )
+}
+
+export function getAccountSiteRouteOverrideMetadata(
+  siteType: AccountSiteType,
+): AccountSiteRouteOverrideMetadata {
+  return { ...(getAccountSiteMetadata(siteType)?.routes ?? {}) }
+}
+
+export function getAccountSiteAdapterFamilyMetadata(siteType: AccountSiteType) {
+  return (
+    getAccountSiteDefinition(siteType)?.adapterFamily ??
+    ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
+  )
+}
+
+export function getAccountSiteCompatUserIdHeaderRules() {
+  return getAccountSiteDefinitions().flatMap((definition) =>
+    definition.onboarding?.detection?.compatUserIdHeaderNames?.map(
+      (headerName) => ({
+        siteType: definition.siteType as AccountSiteType,
+        headerName,
+      }),
+    ) ?? [],
+  )
+}
+```
+
+Ensure the New API-family compatible header markers are present in definition rows:
+
+```ts
+compatUserIdHeaderNames: ["New-API-User"]
+compatUserIdHeaderNames: ["Veloera-User"]
+compatUserIdHeaderNames: ["X-Api-User"]
+compatUserIdHeaderNames: ["voapi-user"]
+compatUserIdHeaderNames: ["Rix-Api-User"]
+compatUserIdHeaderNames: ["neo-api-user"]
+```
+
+- [ ] **Step 4: Preserve route and detection behavior**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts
+```
+
+Expected: PASS. If compat-header tests fail, add the missing `compatUserIdHeaderNames` to the corresponding definition row instead of restoring `COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE`.
+
+- [ ] **Step 5: Confirm metadata ownership moved**
+
+Run:
+
+```powershell
+rg -n "const accountSiteOnboardingMetadata|COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE|function makeTitleRegex" src/services/accountSiteOnboarding/metadata.ts
+```
+
+Expected: no matches.
+
+- [ ] **Step 6: Commit onboarding projection migration**
+
+Run:
+
+```powershell
+git add src/services/accountSiteDefinitions/definitions.ts src/services/accountSiteOnboarding/metadata.ts src/services/accountSiteOnboarding/registry.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts
+git commit -m "refactor(account-sites): derive onboarding metadata from definitions"
+```
+
+Expected: commit succeeds after `validate:staged`.
+
+---
+
+### Task 4: Route Product Profile Overrides Through Definitions
+
+**Files:**
+
+- Modify: `src/services/accounts/accountSiteProfile/profiles.ts`
+- Modify: `src/services/accounts/accountSiteProfile/registry.ts`
+- Modify: `tests/services/accounts/accountSiteProfile.test.ts`
+- Modify: `tests/services/accountSiteDefinitions/registry.test.ts`
+
+- [ ] **Step 1: Add profile-source assertion**
+
+Append this test to `tests/services/accounts/accountSiteProfile.test.ts`:
+
+```ts
+  it("resolves site-specific overrides from account-site definitions", async () => {
+    const { getAccountSiteProductProfileOverride } = await import(
+      "~/services/accountSiteDefinitions"
+    )
+
+    expect(getAccountSiteProductProfileOverride(SITE_TYPES.SUB2API)).toMatchObject({
+      supplementalAuth: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+      },
+    })
+    expect(getAccountSiteProductProfile(SITE_TYPES.SUB2API)).toMatchObject({
+      supplementalAuth: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+      },
+      modelList: {
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.RuntimeKey,
+      },
+    })
+  })
+```
+
+- [ ] **Step 2: Run profile tests before code movement**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/accountSiteProfile.test.ts tests/services/accountSiteDefinitions/registry.test.ts
+```
+
+Expected: PASS if Task 1 already exposed definition profile overrides.
+
+- [ ] **Step 3: Stop exporting override rows from profile data**
+
+Modify `src/services/accounts/accountSiteProfile/profiles.ts`.
+
+Keep `DEFAULT_ACCOUNT_SITE_PRODUCT_PROFILE`, but remove the `ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES` export and its now-unused imports. The file should start like this:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import { AuthTypeEnum } from "~/types"
+
+import {
+  ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES,
+  ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING,
+  ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS,
+  ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING,
+  ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES,
+  ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES,
+  ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS,
+  ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS,
+  ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES,
+  type AccountSiteProductProfile,
+} from "./contracts"
+```
+
+After removal, the only exported runtime value in `profiles.ts` should be:
+
+```ts
+export const DEFAULT_ACCOUNT_SITE_PRODUCT_PROFILE: AccountSiteProductProfile = {
+  siteType: SITE_TYPES.UNKNOWN,
+  auth: {
+    allowedAuthTypes: [AuthTypeEnum.AccessToken, AuthTypeEnum.Cookie],
+    defaultAuthType: AuthTypeEnum.AccessToken,
+    defaultAuthHostnames: [],
+    supportsCookieAuth: true,
+    supportsBuiltInCheckInDetection: true,
+  },
+  authSession: {
+    kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.None,
+    decoratesAccountApiRequests: false,
+    refreshLockScope: ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES.None,
+  },
+  createdToken: {
+    secretHandling: ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING.ResponseKey,
+  },
+  identity: {
+    usernameRequired: true,
+    storedUserIdentityFields: ["id"],
+  },
+  modelList: {
+    directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Supported,
+    tokenScopedCatalogFallback:
+      ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.None,
+    dashboardEstimateLoader:
+      ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.None,
+    statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+    displayCapabilitiesSource:
+      ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+  },
+  supplementalAuth: {
+    kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.None,
+  },
+  tokenForm: {
+    networkLimitPolicy: ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES.IpList,
+  },
+  urls: {
+    recognizedHostnames: [],
+  },
+}
+```
+
+- [ ] **Step 4: Read overrides from definitions in the profile registry**
+
+Modify `src/services/accounts/accountSiteProfile/registry.ts`.
+
+Replace the import:
+
+```ts
+import {
+  ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES,
+  DEFAULT_ACCOUNT_SITE_PRODUCT_PROFILE,
+} from "./profiles"
+```
+
+with:
+
+```ts
+import { getAccountSiteProductProfileOverride } from "~/services/accountSiteDefinitions"
+
+import { DEFAULT_ACCOUNT_SITE_PRODUCT_PROFILE } from "./profiles"
+```
+
+Replace this call:
+
+```ts
+ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES[siteType]
+```
+
+with:
+
+```ts
+getAccountSiteProductProfileOverride(siteType)
+```
+
+Keep `mergeAccountSiteProductProfile(...)` and `cloneAccountSiteProductProfile(...)` in the profile registry. They are product-profile behavior, not definition behavior.
+
+- [ ] **Step 5: Run profile-focused tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accounts/accountSiteProfile.test.ts tests/services/accountSiteDefinitions/registry.test.ts tests/services/modelList/accountSources/readiness.test.ts tests/services/modelList/accountSources/readiness.routes.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Confirm override ownership moved**
+
+Run:
+
+```powershell
+rg -n "ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES|AIHUBMIX_API_ORIGIN|AIHUBMIX_HOSTNAMES|AIHUBMIX_WEB_ORIGIN" src/services/accounts/accountSiteProfile/profiles.ts
+```
+
+Expected: no matches for `ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES`, `AIHUBMIX_API_ORIGIN`, `AIHUBMIX_HOSTNAMES`, or `AIHUBMIX_WEB_ORIGIN`.
+
+- [ ] **Step 7: Commit product profile projection migration**
+
+Run:
+
+```powershell
+git add src/services/accountSiteDefinitions src/services/accounts/accountSiteProfile/profiles.ts src/services/accounts/accountSiteProfile/registry.ts tests/services/accounts/accountSiteProfile.test.ts tests/services/accountSiteDefinitions/registry.test.ts
+git commit -m "refactor(account-sites): derive product profiles from definitions"
+```
+
+Expected: commit succeeds after `validate:staged`.
+
+---
+
+### Task 5: Add Definition-Backed Readiness Expectations
+
+**Files:**
+
+- Create: `tests/services/modelList/accountSources/readiness.definitions.test.ts`
+- Modify: `src/services/accountSiteDefinitions/contracts.ts`
+- Modify: `src/services/accountSiteDefinitions/registry.ts`
+- Modify: `tests/services/accountSiteDefinitions/registry.test.ts`
+- Modify: `tests/services/apiAdapters/registry.test.ts`
+
+- [ ] **Step 1: Write readiness expectation test**
+
+Create `tests/services/modelList/accountSources/readiness.definitions.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  getAccountSiteReadinessExpectation,
+  getAccountSiteTypeValues,
+} from "~/services/accountSiteDefinitions"
+import {
+  ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES,
+  ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES,
+} from "~/services/accounts/accountSiteProfile"
+import {
+  MODEL_LIST_ACCOUNT_SOURCE_ROUTES,
+  resolveModelListAccountSourceReadiness,
+} from "~/services/modelList/accountSources/readiness"
+
+describe("Model List readiness definition expectations", () => {
+  it("resolves each expected account site route without throwing", () => {
+    for (const siteType of getAccountSiteTypeValues()) {
+      const expectation = getAccountSiteReadinessExpectation(siteType)
+      const readiness = resolveModelListAccountSourceReadiness({ siteType })
+
+      expect(readiness.route, `${siteType} readiness route`).toBe(
+        expectation?.modelList?.expectedRoute,
+      )
+    }
+  })
+
+  it("keeps representative account-site readiness semantics", () => {
+    expect(
+      resolveModelListAccountSourceReadiness({
+        siteType: SITE_TYPES.NEW_API,
+      }),
+    ).toMatchObject({
+      route: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing,
+      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+      displayCapabilitiesSource:
+        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+    })
+
+    expect(
+      resolveModelListAccountSourceReadiness({
+        siteType: SITE_TYPES.SUB2API,
+      }),
+    ).toMatchObject({
+      route: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog,
+      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Token,
+      displayCapabilitiesSource:
+        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+    })
+
+    expect(
+      resolveModelListAccountSourceReadiness({
+        siteType: SITE_TYPES.AIHUBMIX,
+      }),
+    ).toMatchObject({
+      route: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing,
+      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+      displayCapabilitiesSource:
+        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile,
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the readiness expectation test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/modelList/accountSources/readiness.definitions.test.ts
+```
+
+Expected: PASS if the definition rows already include expected routes for every account site type.
+
+- [ ] **Step 3: Keep definition route constants synchronized with runtime route constants**
+
+The definition registry owns expectation constants so `accountSiteDefinitions` does not import `modelList/accountSources/readiness` at runtime. Add this assertion to `tests/services/modelList/accountSources/readiness.definitions.test.ts`:
+
+```ts
+import { ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES } from "~/services/accountSiteDefinitions"
+
+it("keeps definition expectation route constants synchronized with runtime routes", () => {
+  expect(ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES).toEqual({
+    DirectPricing: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing,
+    TokenScopedRuntimeCatalog:
+      MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog,
+    Unsupported: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.Unsupported,
+  })
+})
+```
+
+- [ ] **Step 4: Keep adapter registry behavior covered**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/registry.test.ts tests/services/accountSiteDefinitions/registry.test.ts tests/services/modelList/accountSources/readiness.definitions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit readiness expectation coverage**
+
+Run:
+
+```powershell
+git add src/services/accountSiteDefinitions src/services/modelList/accountSources/readiness.ts tests/services/accountSiteDefinitions/registry.test.ts tests/services/apiAdapters/registry.test.ts tests/services/modelList/accountSources/readiness.definitions.test.ts
+git commit -m "test(model-list): verify definition readiness expectations"
+```
+
+Expected: commit succeeds after `validate:staged`.
+
+---
+
+### Task 6: Classify Raw Site-Type Branches And Run Final Validation
+
+**Files:**
+
+- Modify only task-scoped files if a raw branch is definition-owned and already covered by existing helpers.
+- No source change is required when remaining hits are backend protocol code, response metadata, content-session extractors, managed-site runtime branches, Account Dialog workflow policy, or provider-specific tests.
+
+- [ ] **Step 1: Run raw site-type search**
+
+Run:
+
+```powershell
+rg -n "siteType === SITE_TYPES\\.|siteType !== SITE_TYPES\\.|currentSiteType === SITE_TYPES\\.|managedSiteType === SITE_TYPES\\.|account\\?\\.siteType === SITE_TYPES\\.|account\\.siteType !== SITE_TYPES\\.|site_type === SITE_TYPES\\." src/features src/services
+```
+
+Expected: matches remain. Classify each match before editing.
+
+- [ ] **Step 2: Apply the cleanup rule**
+
+Use this decision table for each match:
+
+```text
+Route through account-site definitions or product profile:
+- static account-site classification
+- auth default policy
+- URL canonicalization policy
+- created-token secret handling policy
+- token-form network-limit policy
+- Model List source-account route or display policy
+
+Leave in place:
+- concrete adapter implementation
+- response-source metadata provider labels
+- content-session extractor internals
+- persisted schema and migration compatibility
+- managed-site runtime behavior
+- Account Dialog workflow tables and UI flow names
+- tests asserting provider-specific behavior
+```
+
+Do not edit managed-site branches in:
+
+```text
+src/services/managedSites/**
+src/services/models/modelSync/**
+src/features/KeyManagement/hooks/useKeyManagement.ts
+```
+
+Do not edit adapter protocol branches in:
+
+```text
+src/services/apiAdapters/**
+src/services/apiService/**
+```
+
+- [ ] **Step 3: Preserve current AIHubMix Model List source metadata**
+
+Inspect `src/features/ModelList/aihubmixModelList.ts`.
+
+Leave this source-metadata guard in place because it checks the returned payload provider, not only product policy:
+
+```ts
+return (
+  account?.siteType === SITE_TYPES.AIHUBMIX &&
+  pricing?.model_list_source?.provider === SITE_TYPES.AIHUBMIX
+)
+```
+
+The surrounding downgrade decision should continue to be profile-driven through:
+
+```ts
+const profile = getAccountSiteModelListProfile(source.account.siteType)
+```
+
+- [ ] **Step 4: Preserve Sub2API quick-create compatibility**
+
+Inspect `src/services/accounts/accountOperations.ts`.
+
+Leave `resolveSub2ApiQuickCreateResolution(...)` scoped to `SITE_TYPES.SUB2API` because the public function name and return type are Sub2API compatibility API:
+
+```ts
+if (account.siteType !== SITE_TYPES.SUB2API) {
+  throw new Error(TOKEN_PROVISIONING_ERRORS.Sub2ApiQuickCreateNotApplicable)
+}
+```
+
+Do not generalize this function in this slice.
+
+- [ ] **Step 5: Run ownership checks**
+
+Run:
+
+```powershell
+rg -n "const accountSiteOnboardingMetadata|ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES|COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE" src/services
+rg -n "ACCOUNT_SITE_TYPES|MANAGED_SITE_TYPES|SITE_TYPES =" src/services/accountSiteOnboarding src/constants src/services/accountSiteDefinitions
+rg -n "getAccountSiteAdapterFamilyMetadata|getAccountSiteRouteOverrideMetadata|getAccountSiteTitleRuleMetadata|getAccountSiteDomainRuleMetadata" src/services tests
+rg -n "provider: SITE_TYPES\\.|sub2apiAuth|contentSession|apiAdapters" src/features src/services tests
+```
+
+Expected:
+
+- no local onboarding metadata table remains outside `accountSiteDefinitions`;
+- no product-profile override table remains in `accountSiteProfile/profiles.ts`;
+- legacy site-type arrays are facades over definition projections;
+- remaining provider/source/schema matches are classified in the final handoff.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountSiteDefinitions/registry.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/accounts/accountSiteProfile.test.ts tests/services/apiAdapters/registry.test.ts tests/services/modelList/accountSources/readiness.test.ts tests/services/modelList/accountSources/readiness.routes.test.ts tests/services/modelList/accountSources/readiness.definitions.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run related tests**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/accountSiteDefinitions/index.ts src/services/accountSiteDefinitions/registry.ts src/services/accountSiteDefinitions/siteTypes.ts src/services/accountSiteOnboarding/registry.ts src/services/accountSiteOnboarding/metadata.ts src/services/accounts/accountSiteProfile/registry.ts src/services/accounts/accountSiteProfile/profiles.ts src/services/apiAdapters/registry.ts src/services/modelList/accountSources/readiness.ts
+```
+
+Expected: PASS. If this expands into a broad unrelated suite and times out, classify the timeout separately and rely on the focused tests plus `pnpm compile`.
+
+- [ ] **Step 8: Run TypeScript compile**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run commit gate**
+
+Stage only task-scoped files, then run:
+
+```powershell
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Run push gate before publishing**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Inspect final diff scope**
+
+Run:
+
+```powershell
+git diff --stat HEAD
+git diff --name-status HEAD
+```
+
+Expected changed paths are limited to:
+
+```text
+src/services/accountSiteDefinitions/**
+src/services/accountSiteOnboarding/contracts.ts
+src/services/accountSiteOnboarding/siteTypes.ts
+src/services/accountSiteOnboarding/metadata.ts
+src/services/accountSiteOnboarding/registry.ts
+src/constants/siteType.ts
+src/services/accounts/accountSiteProfile/profiles.ts
+src/services/accounts/accountSiteProfile/registry.ts
+src/services/modelList/accountSources/readiness.ts
+tests/services/accountSiteDefinitions/**
+tests/services/accountSiteOnboarding/registry.test.ts
+tests/services/detectSiteType.test.ts
+tests/services/accounts/accountSiteProfile.test.ts
+tests/services/apiAdapters/registry.test.ts
+tests/services/modelList/accountSources/readiness*.test.ts
+```
+
+There should be no locale, telemetry, settings search, Playwright, managed-site provider, model-sync, or concrete adapter implementation changes.
+
+- [ ] **Step 12: Final handoff notes**
+
+Report:
+
+```text
+Focused tests:
+- pnpm vitest run tests/services/accountSiteDefinitions/registry.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/accounts/accountSiteProfile.test.ts tests/services/apiAdapters/registry.test.ts tests/services/modelList/accountSources/readiness.test.ts tests/services/modelList/accountSources/readiness.routes.test.ts tests/services/modelList/accountSources/readiness.definitions.test.ts
+
+Related tests:
+- pnpm vitest related --run src/services/accountSiteDefinitions/index.ts src/services/accountSiteDefinitions/registry.ts src/services/accountSiteDefinitions/siteTypes.ts src/services/accountSiteOnboarding/registry.ts src/services/accountSiteOnboarding/metadata.ts src/services/accounts/accountSiteProfile/registry.ts src/services/accounts/accountSiteProfile/profiles.ts src/services/apiAdapters/registry.ts src/services/modelList/accountSources/readiness.ts
+
+Validation:
+- pnpm compile
+- pnpm run validate:staged
+- pnpm run validate:push
+
+Telemetry decision:
+- None. No analytics event or payload changed.
+
+Settings search decision:
+- None. No settings UI, anchor, deep link, or search definition changed.
+
+E2E decision:
+- No Playwright E2E added. Registry projection and policy routing are covered by Vitest.
+```
+
+Also report the remaining raw site-type branch categories from Step 5.
+
+---
+
+## Out Of Scope
+
+- Adding a real new account site type.
+- Rewriting concrete adapters under `src/services/apiAdapters/**`.
+- Moving managed-site runtime configuration or model-sync branches.
+- Renaming persisted `sub2apiAuth`.
+- Renaming user-facing copy or locale keys.
+- Adding telemetry, settings search entries, or Playwright E2E tests by default.
+
+## Self-Review
+
+- Spec coverage: Tasks 1-2 create the account-site definition Module and preserve compatibility exports; Task 3 derives onboarding metadata and adapter-family projection; Task 4 derives product-profile overrides; Task 5 adds Model List readiness expectations; Task 6 covers raw branch classification, validation, and final diff inspection.
+- Scope control: The plan keeps backend behavior in `SiteAdapter`, keeps product-profile helper behavior in `accountSiteProfile`, and leaves managed-site runtime branches out of scope.
+- Type consistency: `ACCOUNT_SITE_DEFINITION_SCOPES`, `ACCOUNT_SITE_ADAPTER_FAMILIES`, `ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES`, `AccountSiteDefinition`, `SiteType`, `AccountSiteType`, and `ManagedSiteType` are introduced before later tasks reference them.
+- Behavior preservation: The plan keeps existing site-type values, route overrides, AIHubMix hostnames/origins, Sub2API supplemental auth, AnyRouter auth default, adapter family routing, and Model List readiness behavior.

--- a/docs/superpowers/specs/2026-06-22-account-site-definition-registry-design.md
+++ b/docs/superpowers/specs/2026-06-22-account-site-definition-registry-design.md
@@ -1,0 +1,623 @@
+# Account Site Definition Registry Design
+
+Date: 2026-06-22
+
+## Purpose
+
+Make a brand-new account site type faster and safer to add by introducing one
+account-site definition registry that owns the stable registration facts for an
+account site type.
+
+Recent slices already moved the high-risk behavior behind narrower seams:
+
+- `src/services/accountSiteOnboarding/` owns detection metadata, route
+  metadata, adapter-family projection, and content-session extractors.
+- `src/services/apiAdapters/` owns backend protocol facts after a site type is
+  known.
+- `src/services/accounts/accountSiteProfile/` owns saved-account product rules.
+- `src/services/modelList/accountSources/` owns Model List account-source
+  readiness.
+
+Those seams reduce runtime branching, but adding a new account site type still
+requires editing several registration surfaces in the right order. This spec
+adds a deeper account-site definition Module so a new site type can start from
+one definition row, while existing consumers continue to use their local seams.
+
+This spec also includes narrow definition-owned policy cleanup. A raw
+`SITE_TYPES` branch is in scope only when a future account site type would add a
+third branch for the same product decision. Backend adapter implementations,
+managed-site runtime behavior, response-source metadata, and persisted schema
+names remain out of scope.
+
+## Current Context
+
+The current checkout has these relevant modules:
+
+- `src/services/accountSiteOnboarding/siteTypes.ts`
+  - owns `SITE_TYPES`, `ACCOUNT_SITE_TYPES`, `ACCOUNT_SITE_TYPE_VALUES`, and
+    `MANAGED_SITE_TYPES`;
+  - this file is the current type-union source.
+- `src/constants/siteType.ts`
+  - re-exports the onboarding site-type constants;
+  - exposes compatibility helpers such as `isAccountSiteType(...)`,
+    `isManagedSiteType(...)`, `ACCOUNT_SITE_TITLE_RULES`,
+    `ACCOUNT_SITE_DOMAIN_RULES`, and `getAccountSiteApiRouter(...)`.
+- `src/services/accountSiteOnboarding/metadata.ts`
+  - owns static onboarding metadata, title/domain detection rules, route
+    overrides, compat user-id header detection, and adapter-family metadata.
+- `src/services/accountSiteOnboarding/registry.ts`
+  - projects onboarding metadata to detection, route, adapter-family, and
+    content-session extractor callers.
+- `src/services/apiAdapters/registry.ts`
+  - resolves adapter family to a concrete `SiteAdapter`.
+- `src/services/accounts/accountSiteProfile/profiles.ts`
+  - owns default saved-account product profile data and overrides for special
+    account site types such as Sub2API, AIHubMix, and AnyRouter.
+- `src/services/modelList/accountSources/readiness.ts`
+  - combines account-site product profile policy with adapter capabilities to
+    resolve direct-pricing, token-scoped runtime-catalog, or unsupported Model
+    List routes.
+
+This split is mostly correct by responsibility:
+
+- onboarding metadata chooses and prepares a site type;
+- adapters describe backend behavior after a site type is known;
+- product profiles describe saved-account product semantics;
+- Model List readiness selects the account-source loading route;
+- UI modules render feature-local workflow state.
+
+The missing piece is registration locality. A new account site type still has
+to know which files provide the source facts and which files are only
+compatibility facades.
+
+## Problem
+
+Adding a new account site type still has a fixed edit tax:
+
+1. Add the literal to `SITE_TYPES`.
+2. Add it to `ACCOUNT_SITE_TYPES` if account workflows are supported.
+3. Add it to `MANAGED_SITE_TYPES` if managed-site workflows are supported.
+4. Add onboarding metadata for detection, route overrides, compat headers, and
+   adapter family.
+5. Add or select product profile policy.
+6. Confirm the adapter-family projection resolves to the intended
+   `SiteAdapter`.
+7. Confirm Model List readiness receives the expected product profile and
+   adapter capabilities.
+8. Search feature code for raw product-policy `SITE_TYPES` branches that would
+   need another case.
+
+The current modules are not wrong individually, but the interface for adding a
+site type is shallow. The caller has to understand too many separate registry
+surfaces.
+
+Deletion test: if `accountSiteOnboarding/metadata.ts`,
+`accountSiteProfile/profiles.ts`, and the account/managed type arrays were
+deleted as independent registration surfaces, the complexity should not
+reappear as a checklist in a plan. It should reappear behind one account-site
+definition interface, with projections feeding onboarding, product profile,
+adapter-family, managed-site classification, and readiness tests.
+
+## Goals
+
+- Add an account-site definition Module that is the source of truth for stable
+  account-site registration facts.
+- Keep current public compatibility exports available from
+  `src/constants/siteType.ts`.
+- Derive account-site and managed-site membership from definitions.
+- Derive onboarding metadata and adapter-family metadata from definitions.
+- Derive product-profile overrides from definitions where the data belongs to
+  stable account-site registration.
+- Add completeness tests that fail when an account site type lacks required
+  definition data.
+- Add readiness expectation tests so a future account site can verify its
+  default Model List route without reading UI hooks.
+- Clean up definition-owned raw `SITE_TYPES` branches in Model List and Key
+  Management product policy paths when they would otherwise grow a third site
+  case.
+- Preserve current behavior for New API-family compatible sites, Sub2API,
+  AIHubMix, AnyRouter, and existing managed site types.
+
+## Non-Goals
+
+- Do not add a new account site type.
+- Do not change external backend behavior, user-facing behavior, copy, locale
+  keys, telemetry schema, settings search definitions, or Playwright E2E tests.
+- Do not move backend protocol implementations out of `src/services/apiAdapters/`.
+- Do not move managed-site provider implementations, channel CRUD, hosted-site
+  settings, or managed-site model sync into the account-site definition
+  registry.
+- Do not move full Account Dialog workflow policy into the definition registry.
+- Do not turn the definition registry into a second `SiteAdapter`.
+- Do not remove compatibility exports such as `SITE_TYPES`,
+  `ACCOUNT_SITE_TYPES`, `MANAGED_SITE_TYPES`, `getAccountSiteApiRouter(...)`,
+  or `isAccountSiteType(...)`.
+- Do not rename persisted schema fields such as `sub2apiAuth`.
+- Do not remove response-source labels such as `provider:
+  SITE_TYPES.AIHUBMIX` when they describe actual response metadata.
+- Do not perform broad UI cleanup or rename feature workflow concepts that are
+  still intentionally provider-specific.
+
+## Approaches Considered
+
+### Approach A: Keep Current Registries And Add A Checklist
+
+The repo could document the edit checklist for adding a site type.
+
+This is too shallow. It preserves the same failure mode: adding a new site type
+still relies on a human remembering every surface. Tests would mostly assert
+the checklist after the fact rather than giving one registration interface.
+
+This should not be the next step.
+
+### Approach B: Make `accountSiteOnboarding` Own Everything
+
+The existing onboarding module could absorb product profiles, account/managed
+classification, adapter families, and Model List expectations.
+
+This gives locality, but the name and seam become misleading. Onboarding
+facts are used before or during site-type detection. Product profile and Model
+List policy are used after a site type is known. A larger onboarding module
+would become a catch-all registry instead of a clear interface.
+
+This should not be the next step.
+
+### Approach C: Add A Dedicated Account-Site Definition Module
+
+Create a definition Module that owns stable registration data and provides
+projections to the existing seams. Onboarding, product profile, adapter
+registry, and Model List readiness keep their current responsibilities, but
+their static registration data comes from one definition source.
+
+This is the recommended path. It improves locality for adding a site type
+without flattening runtime behavior into one large module.
+
+## Design
+
+### 1. Add Account-Site Definition Contracts
+
+Create:
+
+```text
+src/services/accountSiteDefinitions/
+  contracts.ts
+  definitions.ts
+  registry.ts
+  siteTypes.ts
+  index.ts
+```
+
+The exact file split may be adjusted during implementation, but the public
+interface should stay definition-focused.
+
+Proposed contract shape:
+
+```ts
+export const ACCOUNT_SITE_CAPABILITY_SCOPES = {
+  Account: "account",
+  Managed: "managed",
+} as const
+
+export type AccountSiteCapabilityScope =
+  (typeof ACCOUNT_SITE_CAPABILITY_SCOPES)[keyof typeof ACCOUNT_SITE_CAPABILITY_SCOPES]
+
+export type AccountSiteDefinition = {
+  siteType: AccountSiteType
+  scopes: readonly AccountSiteCapabilityScope[]
+  adapterFamily: AccountSiteAdapterFamily
+  onboarding?: AccountSiteOnboardingMetadata
+  productProfile?: Partial<AccountSiteProductProfile>
+  readiness?: {
+    modelList?: {
+      expectedRoute?: ModelListAccountSourceRoute
+    }
+  }
+}
+```
+
+Important interface rules:
+
+- `siteType` remains a stable identifier, not an upstream deployment URL.
+- `scopes` declares whether the site type participates in account workflows,
+  managed-site workflows, or both.
+- `adapterFamily` is stable registration data. Concrete backend behavior still
+  lives in `SiteAdapter`.
+- `onboarding` is detection, route, compat-header, and content-session
+  metadata. It should not include backend request implementations.
+- `productProfile` is only saved-account product policy data. It should not
+  include UI workflow copy, modal behavior, or render state.
+- `readiness.modelList.expectedRoute` is a test expectation, not runtime UI
+  policy.
+
+If implementation reveals import cycles between profile contracts and
+definition data, prefer moving pure data-shape contracts upward into
+`accountSiteDefinitions/contracts.ts` and leaving implementation helpers in
+their current modules. Do not solve cycles by importing runtime registries into
+low-level constants.
+
+### 2. Make Definitions The Source For Site-Type Membership
+
+Move the stable site-type constants and membership projections behind the
+definition registry while keeping compatibility exports.
+
+Target ownership:
+
+- `src/services/accountSiteDefinitions/siteTypes.ts`
+  - owns `SITE_TYPES`;
+  - exports `AccountSiteType` and `ManagedSiteType` derived from definition
+    projections where practical;
+  - exposes account-site and managed-site value arrays.
+- `src/services/accountSiteOnboarding/siteTypes.ts`
+  - becomes a compatibility re-export or thin facade during migration.
+- `src/constants/siteType.ts`
+  - remains the public compatibility facade for existing imports.
+
+The first implementation does not need to rename all imports. It should
+centralize the data source and keep existing public paths working.
+
+Completeness invariant:
+
+- every value in `ACCOUNT_SITE_TYPES` resolves to exactly one account-site
+  definition;
+- every value in `MANAGED_SITE_TYPES` resolves to exactly one definition whose
+  scopes include `Managed`;
+- `SITE_TYPES.UNKNOWN` can remain a compatibility value, but tests should
+  explicitly define whether it is included in account-site projections and why.
+
+### 3. Derive Onboarding Metadata From Definitions
+
+Update `src/services/accountSiteOnboarding/metadata.ts` and
+`src/services/accountSiteOnboarding/registry.ts` so onboarding projections read
+from account-site definitions.
+
+Preserve existing projection helpers:
+
+- `getAccountSiteMetadata(...)`
+- `getAccountSiteTitleRuleMetadata()`
+- `getAccountSiteDomainRuleMetadata()`
+- `getAccountSiteCompatUserIdHeaderRules()`
+- `getAccountSiteRouteOverrideMetadata(...)`
+- `getAccountSiteAdapterFamilyMetadata(...)`
+- `getAccountSiteAdapterFamily(...)`
+- `getContentSessionExtractors()`
+
+These helpers may remain in onboarding because callers already use them, but
+their static source should be definition data.
+
+Behavior to preserve:
+
+- title rules still match existing names and custom patterns;
+- domain rules still recognize AIHubMix hostnames;
+- route overrides stay identical;
+- compat user-id header detection keeps the current unambiguous header set;
+- Sub2API content-session extraction remains before compatible fallback.
+
+### 4. Derive Product Profile Overrides From Definitions
+
+Update `src/services/accounts/accountSiteProfile/profiles.ts` and
+`registry.ts` so product-profile overrides come from definitions or a
+definition-owned projection.
+
+The product profile module should still own merge behavior and helper
+functions such as:
+
+- `getAccountSiteProductProfile(...)`
+- `resolveStoredAccountUserIdentity(...)`
+- `normalizeAccountSiteUrlForStorage(...)`
+- `resolveDefaultAccountAuthType(...)`
+- `resolveAccountSiteTokenFormNetworkLimitPolicy(...)`
+- `getAccountSiteModelListProfile(...)`
+
+The definition registry should own static override data, not product-profile
+runtime behavior.
+
+Preserve current profile behavior:
+
+- default compatible profile requires username, supports access-token and
+  cookie auth, uses `id` identity, supports direct Model List pricing, and uses
+  IP-list token limits;
+- AnyRouter keeps cookie-auth default host policy;
+- Sub2API keeps optional username, refresh-token supplemental auth, account
+  API sidecar decoration, token-scoped Model List fallback, and token-scoped
+  status;
+- AIHubMix keeps username identity, recognized hostnames, split web/API
+  origins, one-time created-token secret handling, subnet-limit token policy,
+  and profile-sourced Model List display capability.
+
+### 5. Keep Adapter Runtime Routing Narrow
+
+Update `src/services/apiAdapters/registry.ts` only as needed to read adapter
+family from the definition projection.
+
+Allowed behavior:
+
+- `NewApiFamily` still creates a New API-family adapter for compatible account
+  site types;
+- `Sub2Api` still returns `sub2ApiAdapter`;
+- `Aihubmix` still returns `aihubmixAdapter`;
+- unsupported families still produce a minimal unsupported adapter.
+
+Do not add full adapter implementations to the definition registry. The
+definition registry answers "which adapter family applies", not "how this
+backend protocol works".
+
+### 6. Add Model List Readiness Definition Expectations
+
+Keep runtime readiness in:
+
+```text
+src/services/modelList/accountSources/readiness.ts
+```
+
+Add tests that compare definition expectations to actual readiness for current
+account site types. This makes future site-type registration failures visible
+before UI hooks are touched.
+
+Examples:
+
+- compatible New API-family account sites should resolve to direct pricing
+  when their adapter family exposes `modelPricing`;
+- Sub2API should resolve to token-scoped runtime catalog when `modelCatalog`
+  exists;
+- AIHubMix should resolve to direct pricing and profile-sourced display
+  capability;
+- unsupported or intentionally incomplete definitions should resolve to a
+  typed unsupported route.
+
+The expectation data should not drive runtime behavior directly. Runtime
+readiness still combines product profile policy with adapter capabilities.
+
+### 7. Clean Up Definition-Owned Raw Site-Type Branches
+
+After the definition registry is in place, run a targeted cleanup for raw
+`SITE_TYPES` branches that represent stable account-site product policy.
+
+In scope:
+
+- Model List account-source display or fallback branches that can be expressed
+  through product profile or readiness metadata.
+- Key Management source-account token-form, created-token secret, or profile
+  export origin branches that can be expressed through product profile helpers.
+- AnyRouter auth-default host branches that should be definition/profile data.
+- Static account-site classification checks that can use
+  `isAccountSiteType(...)`, `isManagedSiteType(...)`, or definition scopes.
+
+Out of scope and allowed to remain:
+
+- concrete adapter implementation code under `src/services/apiAdapters/**`;
+- response-source metadata such as `provider: SITE_TYPES.SUB2API`;
+- content-session extractor implementations where the extractor itself is
+  provider-specific;
+- persisted schema fields such as `sub2apiAuth`;
+- managed-site runtime provider branches for Octopus, DoneHub, Veloera,
+  AxonHub, and Claude Code Hub;
+- feature-local Account Dialog workflow tables where the branch controls UI
+  workflow rather than stable site registration;
+- tests that assert provider-specific behavior.
+
+Cleanup rule: if adding a new account site type would require adding a third
+case to the branch for the same product decision, route it through definition
+or product profile. If the branch describes a backend protocol implementation
+or source metadata label, leave it where it is.
+
+### 8. Keep Compatibility Facades During Migration
+
+The implementation should not force a repo-wide import rewrite.
+
+Compatibility paths that should keep working:
+
+- `~/constants/siteType`
+- `~/services/accountSiteOnboarding/siteTypes`
+- `~/services/accountSiteOnboarding/registry`
+- `~/services/accounts/accountSiteProfile`
+
+The final diff may update imports in touched files when it reduces cycles or
+clarifies ownership, but broad mechanical import churn is not the goal.
+
+### 9. Add Definition Completeness Diagnostics
+
+Add focused tests that make omissions obvious:
+
+- every account site type has one definition;
+- every definition has a declared adapter family;
+- every account-scoped definition has onboarding metadata or an explicit reason
+  it relies on default compatible detection;
+- every account-scoped definition resolves a product profile;
+- every account-scoped definition resolves Model List readiness without
+  throwing;
+- every managed-scoped definition appears in managed-site type projections;
+- no site type appears in account or managed projections without a definition.
+
+These tests should fail with readable assertion messages that identify the
+missing site type and missing registration area.
+
+## Error Handling
+
+Definition lookup should be non-throwing for compatibility callers where the
+current behavior falls back.
+
+Recommended behavior:
+
+- `getAccountSiteDefinition(siteType)` returns `undefined` for unmapped values;
+- projection helpers may use default compatible behavior only where existing
+  behavior already does so;
+- completeness tests, not runtime fallback code, should enforce that known
+  account site types are registered;
+- runtime product helpers should preserve current fallback behavior for
+  `SITE_TYPES.UNKNOWN` and invalid external values.
+
+Do not introduce user-facing errors in this slice. Missing definition data is
+a developer-time regression caught by tests.
+
+## Telemetry Decision
+
+Telemetry decision: none.
+
+This is an internal registration refactor. It should not add analytics fields,
+events, or settings snapshots.
+
+Existing account save, auto-detect, Model List, and Key Management telemetry
+should keep their current owners and payload shapes.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, anchors, deep links, or search definitions change.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E by default.
+
+The primary risk is deterministic registry projection and policy routing.
+Vitest coverage can prove that directly. Add or update Playwright only if the
+implementation changes browser message payloads, extension entrypoint imports,
+navigation behavior, or cross-entrypoint workflows.
+
+## Testing Strategy
+
+Add definition tests:
+
+- `tests/services/accountSiteDefinitions/registry.test.ts`
+  - every account site type resolves one definition;
+  - every managed site type resolves one managed-scoped definition;
+  - no duplicate `siteType` values exist;
+  - adapter-family projection matches current behavior for New API-family,
+    Sub2API, and AIHubMix;
+  - account and managed projections preserve current membership.
+
+Update onboarding tests:
+
+- `tests/services/accountSiteOnboarding/registry.test.ts`
+  - title/domain/route/compat-header projections match existing behavior;
+  - content-session extractor ordering remains Sub2API before compatible
+    fallback.
+- `tests/services/detectSiteType.test.ts`
+  - existing domain, title, and compat-header detection behavior remains
+    unchanged.
+
+Update product profile tests:
+
+- `tests/services/accounts/accountSiteProfile.test.ts`
+  - default compatible, AnyRouter, Sub2API, and AIHubMix profiles remain
+    unchanged;
+  - profile overrides are sourced from definitions;
+  - returned profiles remain defensive copies.
+
+Update adapter registry tests:
+
+- existing adapter registry coverage should prove adapter-family projection
+  still returns New API-family adapters, Sub2API adapter, AIHubMix adapter, and
+  unsupported fallback.
+
+Add Model List readiness expectation tests:
+
+- `tests/services/modelList/accountSources/readiness.test.ts`
+  - readiness results match definition expectations for compatible direct
+    pricing, Sub2API token-scoped runtime catalog, AIHubMix direct pricing, and
+    unsupported capability cases.
+
+Update feature policy tests only where implementation touches those paths:
+
+- Model List display/fallback policy tests should assert profile/readiness
+  consumption instead of raw site-type branching.
+- Key Management token-form or profile-export tests should assert product
+  profile helper behavior if those branches are cleaned up.
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/accountSiteDefinitions/registry.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/accounts/accountSiteProfile.test.ts tests/services/modelList/accountSources/readiness.test.ts
+```
+
+Add changed feature-policy test files to the command when Task 7 cleanup
+touches Model List or Key Management.
+
+Related validation:
+
+```powershell
+pnpm vitest related --run src/services/accountSiteDefinitions/index.ts src/services/accountSiteOnboarding/registry.ts src/services/accountSiteOnboarding/metadata.ts src/services/accounts/accountSiteProfile/registry.ts src/services/accounts/accountSiteProfile/profiles.ts src/services/apiAdapters/registry.ts src/services/modelList/accountSources/readiness.ts
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Push gate before publishing:
+
+```powershell
+pnpm run validate:push
+```
+
+Run `validate:push` before opening or updating a PR because this slice touches
+shared registration, exported constants, adapter routing, product profile data,
+and readiness contracts.
+
+## Migration Completeness Checks
+
+Run:
+
+```powershell
+rg "ACCOUNT_SITE_TYPES|MANAGED_SITE_TYPES|SITE_TYPES =" src/services src/constants tests
+rg "ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES|DEFAULT_ACCOUNT_SITE_PRODUCT_PROFILE" src/services tests
+rg "getAccountSiteAdapterFamilyMetadata|getAccountSiteRouteOverrideMetadata|getAccountSiteTitleRuleMetadata|getAccountSiteDomainRuleMetadata" src/services tests
+rg "siteType === SITE_TYPES\\.|siteType !== SITE_TYPES\\.|currentSiteType === SITE_TYPES\\.|managedSiteType === SITE_TYPES\\." src/features src/services tests
+rg "provider: SITE_TYPES\\.|sub2apiAuth|contentSession|apiAdapters" src/features src/services tests
+```
+
+Expected after implementation:
+
+- account/managed type membership is derived from definitions or a
+  definition-owned projection;
+- onboarding metadata projections read definition data;
+- product profile overrides read definition data or a definition-owned
+  projection;
+- adapter-family resolution reads definition data;
+- Model List readiness tests can verify definition expectations;
+- remaining raw site-type branches are classified as adapter protocol code,
+  response metadata, content-session extractor internals, persisted schema,
+  managed-site runtime branches, feature-local Account Dialog workflow policy,
+  or provider-specific tests.
+
+## Rollout
+
+1. Add account-site definition contracts, site-type projections, and direct
+   registry tests.
+2. Move current site-type membership data behind the definition registry while
+   preserving compatibility exports.
+3. Route onboarding metadata projections through definitions.
+4. Route adapter-family projection through definitions.
+5. Route product-profile override data through definitions while preserving
+   profile helper behavior.
+6. Add Model List readiness expectation tests tied to definitions.
+7. Run targeted raw `SITE_TYPES` searches and migrate only definition-owned
+   product policy branches in Model List and Key Management.
+8. Run focused tests after each migration group.
+9. Run migration completeness searches and classify remaining hits.
+10. Run related tests, `pnpm run validate:staged`, and `pnpm run validate:push`.
+11. Inspect the final diff for broad import churn, unrelated UI cleanup,
+    adapter implementation drift, and unexpected locale/telemetry/settings
+    changes.
+
+## Follow-Up, Not In Scope For This Spec
+
+- Add a concrete new account site type using the definition registry as the
+  first registration step.
+- Add static import guardrails that prevent new product policy branches from
+  importing raw `SITE_TYPES` in feature render modules.
+- Revisit Account Dialog workflow policy once definition-owned product policy
+  cleanup is complete.
+- Consolidate managed-site provider registration only if a new managed site
+  type exposes repeated registration friction comparable to account sites.
+- Move additional profile contracts into account-site definitions only if
+  implementation shows real import-cycle or ownership pressure.
+- Add Playwright coverage for a real new-site tracer bullet if lower-level
+  tests miss browser-runtime integration risk.
+
+The intended seam split is: account-site definitions own stable registration,
+onboarding projects detection and session-preparation facts, adapters own
+backend protocol behavior, account-site product profiles own saved-account
+semantics, Model List readiness resolves source-account routes, and UI modules
+consume feature-local policy results.

--- a/src/services/accountSiteDefinitions/contracts.ts
+++ b/src/services/accountSiteDefinitions/contracts.ts
@@ -1,0 +1,65 @@
+import type { AccountSiteProductProfileOverride } from "~/services/accounts/accountSiteProfile/contracts"
+
+import type { SiteType } from "./identifiers"
+
+export type AccountSiteRouteConfig = {
+  loginPath?: string
+  usagePath?: string
+  checkInPath?: string
+  adminCredentialsPath?: string
+  redeemPath?: string
+  siteAnnouncementsPath?: string
+}
+
+export type AccountSiteDetectionMetadata = {
+  titlePatterns?: readonly RegExp[]
+  hostnames?: readonly string[]
+  compatUserIdHeaderNames?: readonly string[]
+}
+
+export const ACCOUNT_SITE_ADAPTER_FAMILIES = {
+  NewApiFamily: "newApiFamily",
+  Sub2Api: "sub2api",
+  Aihubmix: "aihubmix",
+  Unsupported: "unsupported",
+} as const
+
+export type AccountSiteAdapterFamily =
+  (typeof ACCOUNT_SITE_ADAPTER_FAMILIES)[keyof typeof ACCOUNT_SITE_ADAPTER_FAMILIES]
+
+export const ACCOUNT_SITE_DEFINITION_SCOPES = {
+  Account: "account",
+  Managed: "managed",
+} as const
+
+export type AccountSiteDefinitionScope =
+  (typeof ACCOUNT_SITE_DEFINITION_SCOPES)[keyof typeof ACCOUNT_SITE_DEFINITION_SCOPES]
+
+export type AccountSiteDefinitionOnboardingMetadata = {
+  detection?: AccountSiteDetectionMetadata
+  routes?: AccountSiteRouteConfig
+}
+
+export const ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES = {
+  DirectPricing: "direct_pricing",
+  TokenScopedRuntimeCatalog: "token_scoped_runtime_catalog",
+  Unsupported: "unsupported",
+} as const
+
+export type AccountSiteModelListExpectedRoute =
+  (typeof ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES)[keyof typeof ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES]
+
+export type AccountSiteDefinitionReadiness = {
+  modelList?: {
+    expectedRoute: AccountSiteModelListExpectedRoute
+  }
+}
+
+export type AccountSiteDefinition = {
+  siteType: SiteType
+  scopes: readonly AccountSiteDefinitionScope[]
+  adapterFamily: AccountSiteAdapterFamily
+  onboarding?: AccountSiteDefinitionOnboardingMetadata
+  productProfile?: AccountSiteProductProfileOverride
+  readiness?: AccountSiteDefinitionReadiness
+}

--- a/src/services/accountSiteDefinitions/contracts.ts
+++ b/src/services/accountSiteDefinitions/contracts.ts
@@ -2,7 +2,7 @@ import type { AccountSiteProductProfileOverride } from "~/services/accounts/acco
 
 import type { SiteType } from "./identifiers"
 
-export type AccountSiteRouteConfig = {
+export interface AccountSiteRouteConfig {
   loginPath?: string
   usagePath?: string
   checkInPath?: string
@@ -11,7 +11,7 @@ export type AccountSiteRouteConfig = {
   siteAnnouncementsPath?: string
 }
 
-export type AccountSiteDetectionMetadata = {
+export interface AccountSiteDetectionMetadata {
   titlePatterns?: readonly RegExp[]
   hostnames?: readonly string[]
   compatUserIdHeaderNames?: readonly string[]
@@ -35,7 +35,7 @@ export const ACCOUNT_SITE_DEFINITION_SCOPES = {
 export type AccountSiteDefinitionScope =
   (typeof ACCOUNT_SITE_DEFINITION_SCOPES)[keyof typeof ACCOUNT_SITE_DEFINITION_SCOPES]
 
-export type AccountSiteDefinitionOnboardingMetadata = {
+export interface AccountSiteDefinitionOnboardingMetadata {
   detection?: AccountSiteDetectionMetadata
   routes?: AccountSiteRouteConfig
 }
@@ -49,13 +49,13 @@ export const ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES = {
 export type AccountSiteModelListExpectedRoute =
   (typeof ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES)[keyof typeof ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES]
 
-export type AccountSiteDefinitionReadiness = {
+export interface AccountSiteDefinitionReadiness {
   modelList?: {
     expectedRoute: AccountSiteModelListExpectedRoute
   }
 }
 
-export type AccountSiteDefinition = {
+export interface AccountSiteDefinition {
   siteType: SiteType
   scopes: readonly AccountSiteDefinitionScope[]
   adapterFamily: AccountSiteAdapterFamily

--- a/src/services/accountSiteDefinitions/definitions.ts
+++ b/src/services/accountSiteDefinitions/definitions.ts
@@ -9,7 +9,7 @@ import {
   ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS,
   ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES,
 } from "~/services/accounts/accountSiteProfile/contracts"
-import type { AuthTypeEnum } from "~/types"
+import { AuthTypeEnum } from "~/types/auth"
 
 import {
   ACCOUNT_SITE_ADAPTER_FAMILIES,
@@ -38,8 +38,8 @@ const DEFAULT_USAGE_PATH = "/console/log"
 const DEFAULT_CHECKIN_PATH = "/console/personal"
 
 const ACCOUNT_SITE_AUTH_TYPES = {
-  AccessToken: "access_token" as AuthTypeEnum.AccessToken,
-  Cookie: "cookie" as AuthTypeEnum.Cookie,
+  AccessToken: AuthTypeEnum.AccessToken,
+  Cookie: AuthTypeEnum.Cookie,
 } as const
 
 const ACCOUNT_SCOPE = [ACCOUNT_SITE_DEFINITION_SCOPES.Account] as const

--- a/src/services/accountSiteDefinitions/definitions.ts
+++ b/src/services/accountSiteDefinitions/definitions.ts
@@ -1,0 +1,404 @@
+import {
+  ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES,
+  ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING,
+  ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS,
+  ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING,
+  ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES,
+  ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES,
+  ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS,
+  ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS,
+  ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES,
+} from "~/services/accounts/accountSiteProfile/contracts"
+import type { AuthTypeEnum } from "~/types"
+
+import {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
+  ACCOUNT_SITE_DEFINITION_SCOPES,
+  ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES,
+  type AccountSiteDefinition,
+} from "./contracts"
+import {
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  AIHUBMIX_WEB_ORIGIN,
+  SITE_TYPES,
+} from "./identifiers"
+
+/**
+ * Builds the legacy account-site title matcher for one registered site type.
+ */
+function makeTitleRegex(name: string): RegExp {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const pattern = escaped.replace(/-/g, "[-_ ]?")
+  return new RegExp(`\\b${pattern}\\b`, "i")
+}
+
+const DEFAULT_USAGE_PATH = "/console/log"
+const DEFAULT_CHECKIN_PATH = "/console/personal"
+
+const ACCOUNT_SITE_AUTH_TYPES = {
+  AccessToken: "access_token" as AuthTypeEnum.AccessToken,
+  Cookie: "cookie" as AuthTypeEnum.Cookie,
+} as const
+
+const ACCOUNT_SCOPE = [ACCOUNT_SITE_DEFINITION_SCOPES.Account] as const
+const MANAGED_SCOPE = [ACCOUNT_SITE_DEFINITION_SCOPES.Managed] as const
+const ACCOUNT_AND_MANAGED_SCOPES = [
+  ACCOUNT_SITE_DEFINITION_SCOPES.Account,
+  ACCOUNT_SITE_DEFINITION_SCOPES.Managed,
+] as const
+
+const directPricingReadiness = {
+  modelList: {
+    expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.DirectPricing,
+  },
+} as const
+
+export const ACCOUNT_SITE_TYPE_ORDER = [
+  SITE_TYPES.ONE_API,
+  SITE_TYPES.NEW_API,
+  SITE_TYPES.ANYROUTER,
+  SITE_TYPES.VELOERA,
+  SITE_TYPES.ONE_HUB,
+  SITE_TYPES.DONE_HUB,
+  SITE_TYPES.V_API,
+  SITE_TYPES.VO_API,
+  SITE_TYPES.SUPER_API,
+  SITE_TYPES.RIX_API,
+  SITE_TYPES.NEO_API,
+  SITE_TYPES.WONG_GONGYI,
+  SITE_TYPES.SUB2API,
+  SITE_TYPES.AIHUBMIX,
+  SITE_TYPES.UNKNOWN,
+] as const
+
+export type AccountSiteDefinitionType = (typeof ACCOUNT_SITE_TYPE_ORDER)[number]
+
+export const MANAGED_SITE_TYPE_ORDER = [
+  SITE_TYPES.NEW_API,
+  SITE_TYPES.VELOERA,
+  SITE_TYPES.DONE_HUB,
+  SITE_TYPES.OCTOPUS,
+  SITE_TYPES.AXON_HUB,
+  SITE_TYPES.CLAUDE_CODE_HUB,
+] as const
+
+export type ManagedSiteDefinitionType = (typeof MANAGED_SITE_TYPE_ORDER)[number]
+
+const ACCOUNT_SITE_DEFINITIONS = [
+  {
+    siteType: SITE_TYPES.ONE_API,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_API)] },
+      routes: { usagePath: DEFAULT_USAGE_PATH },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.NEW_API,
+    scopes: ACCOUNT_AND_MANAGED_SCOPES,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.NEW_API)],
+        compatUserIdHeaderNames: ["New-API-User"],
+      },
+      routes: {
+        usagePath: DEFAULT_USAGE_PATH,
+        checkInPath: DEFAULT_CHECKIN_PATH,
+        adminCredentialsPath: DEFAULT_CHECKIN_PATH,
+      },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.ANYROUTER,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [/\bany\s*router\b/i] },
+      routes: { checkInPath: "/console/topup" },
+    },
+    productProfile: {
+      auth: {
+        defaultAuthType: ACCOUNT_SITE_AUTH_TYPES.Cookie,
+        defaultAuthHostnames: ["anyrouter.top"],
+      },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.SUB2API,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUB2API)] },
+      routes: {
+        usagePath: "/usage",
+        redeemPath: "/redeem",
+        siteAnnouncementsPath: "/dashboard",
+      },
+    },
+    productProfile: {
+      auth: {
+        allowedAuthTypes: [ACCOUNT_SITE_AUTH_TYPES.AccessToken],
+        defaultAuthType: ACCOUNT_SITE_AUTH_TYPES.AccessToken,
+        defaultAuthHostnames: [],
+        supportsCookieAuth: false,
+        supportsBuiltInCheckInDetection: false,
+      },
+      authSession: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+        decoratesAccountApiRequests: true,
+        refreshLockScope: ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES.Account,
+      },
+      identity: {
+        usernameRequired: false,
+        storedUserIdentityFields: ["id"],
+      },
+      modelList: {
+        directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Unsupported,
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.RuntimeKey,
+        dashboardEstimateLoader:
+          ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.Sub2Api,
+        statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Token,
+        displayCapabilitiesSource:
+          ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+      },
+      supplementalAuth: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+      },
+    },
+    readiness: {
+      modelList: {
+        expectedRoute:
+          ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.TokenScopedRuntimeCatalog,
+      },
+    },
+  },
+  {
+    siteType: SITE_TYPES.AIHUBMIX,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
+    onboarding: {
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.AIHUBMIX)],
+        hostnames: AIHUBMIX_HOSTNAMES,
+      },
+      routes: {
+        loginPath: AIHUBMIX_LOGIN_PATH,
+        usagePath: "/statistics",
+        redeemPath: "/topup",
+        checkInPath: "/",
+        adminCredentialsPath: "/",
+      },
+    },
+    productProfile: {
+      auth: {
+        allowedAuthTypes: [ACCOUNT_SITE_AUTH_TYPES.AccessToken],
+        defaultAuthType: ACCOUNT_SITE_AUTH_TYPES.AccessToken,
+        defaultAuthHostnames: [],
+        supportsCookieAuth: false,
+        supportsBuiltInCheckInDetection: true,
+      },
+      createdToken: {
+        secretHandling:
+          ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING.OneTimeSecretDialog,
+      },
+      identity: {
+        usernameRequired: true,
+        storedUserIdentityFields: ["username"],
+      },
+      modelList: {
+        directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Supported,
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.None,
+        dashboardEstimateLoader:
+          ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.None,
+        statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+        displayCapabilitiesSource:
+          ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile,
+      },
+      tokenForm: {
+        networkLimitPolicy:
+          ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES.SubnetLimit,
+      },
+      urls: {
+        recognizedHostnames: AIHUBMIX_HOSTNAMES,
+        storageOrigin: AIHUBMIX_WEB_ORIGIN,
+        duplicateOrigin: AIHUBMIX_WEB_ORIGIN,
+        managedChannelOrigin: AIHUBMIX_API_ORIGIN,
+      },
+    },
+    readiness: directPricingReadiness,
+  },
+] as const satisfies readonly AccountSiteDefinition[]
+
+const MANAGED_ONLY_SITE_DEFINITIONS = [
+  {
+    siteType: SITE_TYPES.OCTOPUS,
+    scopes: MANAGED_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+  },
+  {
+    siteType: SITE_TYPES.AXON_HUB,
+    scopes: MANAGED_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+  },
+  {
+    siteType: SITE_TYPES.CLAUDE_CODE_HUB,
+    scopes: MANAGED_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+  },
+] as const satisfies readonly AccountSiteDefinition[]
+
+const ACCOUNT_SITE_DEFINITION_OVERRIDES = [
+  {
+    siteType: SITE_TYPES.VELOERA,
+    scopes: ACCOUNT_AND_MANAGED_SCOPES,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.VELOERA)],
+        compatUserIdHeaderNames: ["Veloera-User"],
+      },
+      routes: {
+        usagePath: "/app/logs/api-usage",
+        checkInPath: "/app/me",
+        redeemPath: "/app/wallet",
+        adminCredentialsPath: "/app/me",
+      },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.DONE_HUB,
+    scopes: ACCOUNT_AND_MANAGED_SCOPES,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.DONE_HUB)] },
+      routes: {
+        usagePath: "/panel/log",
+        redeemPath: "/panel/topup",
+        adminCredentialsPath: "/panel/profile",
+      },
+    },
+    readiness: directPricingReadiness,
+  },
+] as const satisfies readonly AccountSiteDefinition[]
+
+const COMPATIBLE_ACCOUNT_SITE_DEFINITIONS = [
+  {
+    siteType: SITE_TYPES.ONE_HUB,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_HUB)] },
+      routes: {
+        usagePath: "/panel/log",
+        redeemPath: "/panel/topup",
+        adminCredentialsPath: "/panel/profile",
+      },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.V_API,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.V_API)],
+        compatUserIdHeaderNames: ["X-Api-User"],
+      },
+      routes: {
+        usagePath: "/panel/log",
+        checkInPath: "/panel/profile",
+        redeemPath: "/panel/topup",
+        adminCredentialsPath: "/panel/profile",
+      },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.VO_API,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.VO_API)],
+        compatUserIdHeaderNames: ["voapi-user"],
+      },
+      routes: { usagePath: DEFAULT_USAGE_PATH, redeemPath: "/wallet" },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.SUPER_API,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUPER_API)] },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.RIX_API,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.RIX_API)],
+        compatUserIdHeaderNames: ["Rix-Api-User"],
+      },
+      routes: {
+        usagePath: "/log",
+        checkInPath: "/panel",
+        redeemPath: "/topup",
+      },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.NEO_API,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: {
+        titlePatterns: [makeTitleRegex(SITE_TYPES.NEO_API)],
+        compatUserIdHeaderNames: ["neo-api-user"],
+      },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.WONG_GONGYI,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [/wong\s*公益站/i] },
+      routes: { checkInPath: "/console/topup" },
+    },
+    readiness: directPricingReadiness,
+  },
+  {
+    siteType: SITE_TYPES.UNKNOWN,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    onboarding: {
+      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.UNKNOWN)] },
+    },
+    readiness: directPricingReadiness,
+  },
+] as const satisfies readonly AccountSiteDefinition[]
+
+export const SITE_TYPE_DEFINITIONS: readonly AccountSiteDefinition[] = [
+  ...ACCOUNT_SITE_DEFINITIONS,
+  ...ACCOUNT_SITE_DEFINITION_OVERRIDES,
+  ...COMPATIBLE_ACCOUNT_SITE_DEFINITIONS,
+  ...MANAGED_ONLY_SITE_DEFINITIONS,
+]

--- a/src/services/accountSiteDefinitions/identifiers.ts
+++ b/src/services/accountSiteDefinitions/identifiers.ts
@@ -1,0 +1,31 @@
+export const SITE_TYPES = {
+  ONE_API: "one-api",
+  NEW_API: "new-api",
+  ANYROUTER: "anyrouter",
+  VELOERA: "Veloera",
+  ONE_HUB: "one-hub",
+  DONE_HUB: "done-hub",
+  V_API: "v-api",
+  VO_API: "VoAPI",
+  SUPER_API: "Super-API",
+  RIX_API: "Rix-Api",
+  NEO_API: "neo-Api",
+  WONG_GONGYI: "wong-gongyi",
+  SUB2API: "sub2api",
+  OCTOPUS: "octopus",
+  AXON_HUB: "axonhub",
+  CLAUDE_CODE_HUB: "claude-code-hub",
+  AIHUBMIX: "AIHubMix",
+  UNKNOWN: "unknown",
+} as const
+
+export type SiteType = (typeof SITE_TYPES)[keyof typeof SITE_TYPES]
+
+export const AIHUBMIX_API_ORIGIN = "https://aihubmix.com"
+export const AIHUBMIX_WEB_ORIGIN = "https://console.aihubmix.com"
+export const AIHUBMIX_LOGIN_PATH = "/sign-in"
+export const AIHUBMIX_HOSTNAMES = [
+  "aihubmix.com",
+  "www.aihubmix.com",
+  "console.aihubmix.com",
+] as const

--- a/src/services/accountSiteDefinitions/index.ts
+++ b/src/services/accountSiteDefinitions/index.ts
@@ -1,0 +1,3 @@
+export * from "./contracts"
+export * from "./registry"
+export * from "./siteTypes"

--- a/src/services/accountSiteDefinitions/registry.ts
+++ b/src/services/accountSiteDefinitions/registry.ts
@@ -1,0 +1,242 @@
+import {
+  ACCOUNT_SITE_DEFINITION_SCOPES,
+  type AccountSiteDefinition,
+  type AccountSiteDefinitionOnboardingMetadata,
+  type AccountSiteDefinitionReadiness,
+} from "./contracts"
+import {
+  ACCOUNT_SITE_TYPE_ORDER,
+  MANAGED_SITE_TYPE_ORDER,
+  SITE_TYPE_DEFINITIONS,
+  type AccountSiteDefinitionType,
+  type ManagedSiteDefinitionType,
+} from "./definitions"
+import type { SiteType } from "./identifiers"
+
+/**
+ * Clones a regular expression so callers cannot mutate shared matcher state.
+ */
+function cloneRegExp(pattern: RegExp): RegExp {
+  return new RegExp(pattern.source, pattern.flags)
+}
+
+/**
+ * Clones onboarding projection data before exposing it to compatibility callers.
+ */
+function cloneOnboarding(
+  onboarding: AccountSiteDefinitionOnboardingMetadata | undefined,
+): AccountSiteDefinitionOnboardingMetadata | undefined {
+  if (!onboarding) return undefined
+
+  return {
+    detection: onboarding.detection
+      ? {
+          titlePatterns: onboarding.detection.titlePatterns?.map(cloneRegExp),
+          hostnames: onboarding.detection.hostnames
+            ? [...onboarding.detection.hostnames]
+            : undefined,
+          compatUserIdHeaderNames: onboarding.detection.compatUserIdHeaderNames
+            ? [...onboarding.detection.compatUserIdHeaderNames]
+            : undefined,
+        }
+      : undefined,
+    routes: onboarding.routes ? { ...onboarding.routes } : undefined,
+  }
+}
+
+/**
+ * Clones saved-account product policy overrides before profile merging uses them.
+ */
+function cloneProductProfile(
+  productProfile: AccountSiteDefinition["productProfile"],
+): AccountSiteDefinition["productProfile"] {
+  if (!productProfile) return undefined
+
+  return {
+    ...productProfile,
+    auth: productProfile.auth
+      ? {
+          ...productProfile.auth,
+          allowedAuthTypes: productProfile.auth.allowedAuthTypes
+            ? [...productProfile.auth.allowedAuthTypes]
+            : undefined,
+          defaultAuthHostnames: productProfile.auth.defaultAuthHostnames
+            ? [...productProfile.auth.defaultAuthHostnames]
+            : undefined,
+        }
+      : undefined,
+    authSession: productProfile.authSession
+      ? { ...productProfile.authSession }
+      : undefined,
+    createdToken: productProfile.createdToken
+      ? { ...productProfile.createdToken }
+      : undefined,
+    identity: productProfile.identity
+      ? {
+          ...productProfile.identity,
+          storedUserIdentityFields: productProfile.identity
+            .storedUserIdentityFields
+            ? [...productProfile.identity.storedUserIdentityFields]
+            : undefined,
+        }
+      : undefined,
+    modelList: productProfile.modelList
+      ? { ...productProfile.modelList }
+      : undefined,
+    supplementalAuth: productProfile.supplementalAuth
+      ? { ...productProfile.supplementalAuth }
+      : undefined,
+    tokenForm: productProfile.tokenForm
+      ? { ...productProfile.tokenForm }
+      : undefined,
+    urls: productProfile.urls
+      ? {
+          ...productProfile.urls,
+          recognizedHostnames: productProfile.urls.recognizedHostnames
+            ? [...productProfile.urls.recognizedHostnames]
+            : undefined,
+        }
+      : undefined,
+  }
+}
+
+/**
+ * Clones readiness expectation data before exposing it to Model List tests.
+ */
+function cloneReadiness(
+  readiness: AccountSiteDefinitionReadiness | undefined,
+): AccountSiteDefinitionReadiness | undefined {
+  if (!readiness) return undefined
+
+  return {
+    modelList: readiness.modelList ? { ...readiness.modelList } : undefined,
+  }
+}
+
+/**
+ * Clones a complete account-site definition row for registry consumers.
+ */
+function cloneDefinition(
+  definition: AccountSiteDefinition,
+): AccountSiteDefinition {
+  return {
+    ...definition,
+    scopes: [...definition.scopes],
+    onboarding: cloneOnboarding(definition.onboarding),
+    productProfile: cloneProductProfile(definition.productProfile),
+    readiness: cloneReadiness(definition.readiness),
+  }
+}
+
+/**
+ * Checks whether a definition is registered for a specific capability scope.
+ */
+function hasScope(
+  definition: AccountSiteDefinition,
+  scope: (typeof ACCOUNT_SITE_DEFINITION_SCOPES)[keyof typeof ACCOUNT_SITE_DEFINITION_SCOPES],
+) {
+  return definition.scopes.includes(scope)
+}
+
+/**
+ * Sorts projected definitions according to the public compatibility order.
+ */
+function sortByOrder(
+  definitions: readonly AccountSiteDefinition[],
+  order: readonly SiteType[],
+) {
+  return [...definitions].sort(
+    (first, second) =>
+      order.indexOf(first.siteType) - order.indexOf(second.siteType),
+  )
+}
+
+/**
+ * Returns defensive copies of every registered account-site definition row.
+ */
+export function getAccountSiteDefinitions(): readonly AccountSiteDefinition[] {
+  return SITE_TYPE_DEFINITIONS.map(cloneDefinition)
+}
+
+/**
+ * Returns the registered definition for one site type, when known.
+ */
+export function getAccountSiteDefinition(
+  siteType: SiteType | string,
+): AccountSiteDefinition | undefined {
+  const definition = SITE_TYPE_DEFINITIONS.find(
+    (definition) => definition.siteType === siteType,
+  )
+
+  return definition ? cloneDefinition(definition) : undefined
+}
+
+/**
+ * Returns account-scoped site types in the legacy public order.
+ */
+export function getAccountSiteTypeValues(): readonly AccountSiteDefinitionType[] {
+  const accountScopedSiteTypes = new Set(
+    SITE_TYPE_DEFINITIONS.filter((definition) =>
+      hasScope(definition, ACCOUNT_SITE_DEFINITION_SCOPES.Account),
+    ).map((definition) => definition.siteType),
+  )
+
+  return ACCOUNT_SITE_TYPE_ORDER.filter((siteType) =>
+    accountScopedSiteTypes.has(siteType),
+  )
+}
+
+/**
+ * Returns managed-scoped site types in the legacy public order.
+ */
+export function getManagedSiteTypeValues(): readonly ManagedSiteDefinitionType[] {
+  const managedScopedSiteTypes = new Set(
+    SITE_TYPE_DEFINITIONS.filter((definition) =>
+      hasScope(definition, ACCOUNT_SITE_DEFINITION_SCOPES.Managed),
+    ).map((definition) => definition.siteType),
+  )
+
+  return MANAGED_SITE_TYPE_ORDER.filter((siteType) =>
+    managedScopedSiteTypes.has(siteType),
+  )
+}
+
+/**
+ * Projects account-scoped definitions into the onboarding compatibility shape.
+ */
+export function getAccountSiteOnboardingDefinitions() {
+  return sortByOrder(
+    SITE_TYPE_DEFINITIONS.filter((definition) =>
+      hasScope(definition, ACCOUNT_SITE_DEFINITION_SCOPES.Account),
+    ),
+    ACCOUNT_SITE_TYPE_ORDER,
+  ).map((definition) => ({
+    siteType: definition.siteType,
+    adapterFamily: definition.adapterFamily,
+    ...cloneOnboarding(definition.onboarding),
+  }))
+}
+
+/**
+ * Returns the saved-account product profile override for one site type.
+ */
+export function getAccountSiteProductProfileOverride(
+  siteType: SiteType | string,
+) {
+  return cloneProductProfile(
+    SITE_TYPE_DEFINITIONS.find((definition) => definition.siteType === siteType)
+      ?.productProfile,
+  )
+}
+
+/**
+ * Returns the Model List readiness expectation for one site type.
+ */
+export function getAccountSiteReadinessExpectation(
+  siteType: SiteType | string,
+) {
+  return cloneReadiness(
+    SITE_TYPE_DEFINITIONS.find((definition) => definition.siteType === siteType)
+      ?.readiness,
+  )
+}

--- a/src/services/accountSiteDefinitions/registry.ts
+++ b/src/services/accountSiteDefinitions/registry.ts
@@ -21,6 +21,13 @@ function cloneRegExp(pattern: RegExp): RegExp {
 }
 
 /**
+ * Clones an optional readonly array while preserving absent optional fields.
+ */
+function cloneArray<Item>(items: readonly Item[] | undefined) {
+  return items ? [...items] : undefined
+}
+
+/**
  * Clones onboarding projection data before exposing it to compatibility callers.
  */
 function cloneOnboarding(
@@ -32,12 +39,10 @@ function cloneOnboarding(
     detection: onboarding.detection
       ? {
           titlePatterns: onboarding.detection.titlePatterns?.map(cloneRegExp),
-          hostnames: onboarding.detection.hostnames
-            ? [...onboarding.detection.hostnames]
-            : undefined,
-          compatUserIdHeaderNames: onboarding.detection.compatUserIdHeaderNames
-            ? [...onboarding.detection.compatUserIdHeaderNames]
-            : undefined,
+          hostnames: cloneArray(onboarding.detection.hostnames),
+          compatUserIdHeaderNames: cloneArray(
+            onboarding.detection.compatUserIdHeaderNames,
+          ),
         }
       : undefined,
     routes: onboarding.routes ? { ...onboarding.routes } : undefined,
@@ -57,12 +62,10 @@ function cloneProductProfile(
     auth: productProfile.auth
       ? {
           ...productProfile.auth,
-          allowedAuthTypes: productProfile.auth.allowedAuthTypes
-            ? [...productProfile.auth.allowedAuthTypes]
-            : undefined,
-          defaultAuthHostnames: productProfile.auth.defaultAuthHostnames
-            ? [...productProfile.auth.defaultAuthHostnames]
-            : undefined,
+          allowedAuthTypes: cloneArray(productProfile.auth.allowedAuthTypes),
+          defaultAuthHostnames: cloneArray(
+            productProfile.auth.defaultAuthHostnames,
+          ),
         }
       : undefined,
     authSession: productProfile.authSession
@@ -74,10 +77,9 @@ function cloneProductProfile(
     identity: productProfile.identity
       ? {
           ...productProfile.identity,
-          storedUserIdentityFields: productProfile.identity
-            .storedUserIdentityFields
-            ? [...productProfile.identity.storedUserIdentityFields]
-            : undefined,
+          storedUserIdentityFields: cloneArray(
+            productProfile.identity.storedUserIdentityFields,
+          ),
         }
       : undefined,
     modelList: productProfile.modelList
@@ -92,9 +94,9 @@ function cloneProductProfile(
     urls: productProfile.urls
       ? {
           ...productProfile.urls,
-          recognizedHostnames: productProfile.urls.recognizedHostnames
-            ? [...productProfile.urls.recognizedHostnames]
-            : undefined,
+          recognizedHostnames: cloneArray(
+            productProfile.urls.recognizedHostnames,
+          ),
         }
       : undefined,
   }

--- a/src/services/accountSiteDefinitions/siteTypes.ts
+++ b/src/services/accountSiteDefinitions/siteTypes.ts
@@ -1,0 +1,23 @@
+import { ACCOUNT_SITE_TYPE_ORDER, MANAGED_SITE_TYPE_ORDER } from "./definitions"
+import { SITE_TYPES } from "./identifiers"
+import { getAccountSiteTypeValues, getManagedSiteTypeValues } from "./registry"
+
+export {
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  AIHUBMIX_WEB_ORIGIN,
+} from "./identifiers"
+
+export { SITE_TYPES }
+
+export type AccountSiteType = (typeof ACCOUNT_SITE_TYPE_ORDER)[number]
+export const ACCOUNT_SITE_TYPES = getAccountSiteTypeValues() as readonly [
+  ...typeof ACCOUNT_SITE_TYPE_ORDER,
+]
+export const ACCOUNT_SITE_TYPE_VALUES = [...ACCOUNT_SITE_TYPES]
+
+export type ManagedSiteType = (typeof MANAGED_SITE_TYPE_ORDER)[number]
+export const MANAGED_SITE_TYPES = getManagedSiteTypeValues() as readonly [
+  ...typeof MANAGED_SITE_TYPE_ORDER,
+]

--- a/src/services/accountSiteOnboarding/contracts.ts
+++ b/src/services/accountSiteOnboarding/contracts.ts
@@ -1,29 +1,17 @@
+import type {
+  AccountSiteAdapterFamily,
+  AccountSiteDetectionMetadata,
+  AccountSiteRouteConfig,
+} from "~/services/accountSiteDefinitions/contracts"
+
 import type { AccountSiteType } from "./siteTypes"
 
-export type AccountSiteRouteConfig = {
-  loginPath?: string
-  usagePath?: string
-  checkInPath?: string
-  adminCredentialsPath?: string
-  redeemPath?: string
-  siteAnnouncementsPath?: string
-}
-
-export type AccountSiteDetectionMetadata = {
-  titlePatterns?: readonly RegExp[]
-  hostnames?: readonly string[]
-  compatUserIdHeaderNames?: readonly string[]
-}
-
-export const ACCOUNT_SITE_ADAPTER_FAMILIES = {
-  NewApiFamily: "newApiFamily",
-  Sub2Api: "sub2api",
-  Aihubmix: "aihubmix",
-  Unsupported: "unsupported",
-} as const
-
-export type AccountSiteAdapterFamily =
-  (typeof ACCOUNT_SITE_ADAPTER_FAMILIES)[keyof typeof ACCOUNT_SITE_ADAPTER_FAMILIES]
+export {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
+  type AccountSiteAdapterFamily,
+  type AccountSiteDetectionMetadata,
+  type AccountSiteRouteConfig,
+} from "~/services/accountSiteDefinitions/contracts"
 
 export type ContentSessionExtractionContext = {
   url?: string

--- a/src/services/accountSiteOnboarding/metadata.ts
+++ b/src/services/accountSiteOnboarding/metadata.ts
@@ -1,15 +1,15 @@
+import {
+  getAccountSiteDefinition,
+  getAccountSiteDefinitions,
+  getAccountSiteOnboardingDefinitions,
+} from "~/services/accountSiteDefinitions"
 import type {
   AccountSiteOnboardingMetadata,
   AccountSiteRouteConfig,
 } from "~/services/accountSiteOnboarding/contracts"
 import { ACCOUNT_SITE_ADAPTER_FAMILIES } from "~/services/accountSiteOnboarding/contracts"
 
-import {
-  AIHUBMIX_HOSTNAMES,
-  AIHUBMIX_LOGIN_PATH,
-  SITE_TYPES,
-  type AccountSiteType,
-} from "./siteTypes"
+import type { AccountSiteType } from "./siteTypes"
 
 type AccountSiteRouteOverrideMetadata = Partial<AccountSiteRouteConfig>
 
@@ -43,29 +43,6 @@ function cloneDetectionMetadata(
   }
 }
 
-/**
- * Error-message detection should only use header names that carry an
- * unambiguous site-family signal. Generic compatibility headers like `User-id`
- * are intentionally excluded to avoid over-classifying unrelated deployments.
- */
-export const COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE = {
-  "New-API-User": SITE_TYPES.NEW_API,
-  "Veloera-User": SITE_TYPES.VELOERA,
-  "X-Api-User": SITE_TYPES.V_API,
-  "voapi-user": SITE_TYPES.VO_API,
-  "Rix-Api-User": SITE_TYPES.RIX_API,
-  "neo-api-user": SITE_TYPES.NEO_API,
-} as const satisfies Record<string, AccountSiteType>
-
-/**
- * Builds the legacy title-matching pattern for a site type display name.
- */
-function makeTitleRegex(name: string): RegExp {
-  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  const pattern = escaped.replace(/-/g, "[-_ ]?")
-  return new RegExp(`\\b${pattern}\\b`, "i")
-}
-
 const DEFAULT_LOGIN_PATH = "/login"
 const DEFAULT_USAGE_PATH = "/console/log"
 const DEFAULT_CHECKIN_PATH = "/console/personal"
@@ -82,153 +59,20 @@ export const DEFAULT_SITE_ROUTE_CONFIG = {
   siteAnnouncementsPath: DEFAULT_SITE_ANNOUNCEMENTS_PATH,
 } as const satisfies Required<AccountSiteRouteConfig>
 
-const accountSiteOnboardingMetadata: readonly AccountSiteOnboardingMetadata[] =
-  [
-    {
-      siteType: SITE_TYPES.ONE_API,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_API)] },
-      routes: { usagePath: DEFAULT_USAGE_PATH },
-    },
-    {
-      siteType: SITE_TYPES.NEW_API,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: {
-        titlePatterns: [makeTitleRegex(SITE_TYPES.NEW_API)],
-      },
-      routes: {
-        usagePath: DEFAULT_USAGE_PATH,
-        checkInPath: "/console/personal",
-        adminCredentialsPath: "/console/personal",
-      },
-    },
-    {
-      siteType: SITE_TYPES.ANYROUTER,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: { titlePatterns: [/\bany\s*router\b/i] },
-      routes: { checkInPath: "/console/topup" },
-    },
-    {
-      siteType: SITE_TYPES.VELOERA,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: {
-        titlePatterns: [makeTitleRegex(SITE_TYPES.VELOERA)],
-      },
-      routes: {
-        usagePath: "/app/logs/api-usage",
-        checkInPath: "/app/me",
-        redeemPath: "/app/wallet",
-        adminCredentialsPath: "/app/me",
-      },
-    },
-    {
-      siteType: SITE_TYPES.ONE_HUB,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.ONE_HUB)] },
-      routes: {
-        usagePath: "/panel/log",
-        redeemPath: "/panel/topup",
-        adminCredentialsPath: "/panel/profile",
-      },
-    },
-    {
-      siteType: SITE_TYPES.DONE_HUB,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.DONE_HUB)] },
-      routes: {
-        usagePath: "/panel/log",
-        redeemPath: "/panel/topup",
-        adminCredentialsPath: "/panel/profile",
-      },
-    },
-    {
-      siteType: SITE_TYPES.V_API,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: {
-        titlePatterns: [makeTitleRegex(SITE_TYPES.V_API)],
-      },
-      routes: {
-        usagePath: "/panel/log",
-        checkInPath: "/panel/profile",
-        redeemPath: "/panel/topup",
-        adminCredentialsPath: "/panel/profile",
-      },
-    },
-    {
-      siteType: SITE_TYPES.VO_API,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: {
-        titlePatterns: [makeTitleRegex(SITE_TYPES.VO_API)],
-      },
-      routes: { usagePath: DEFAULT_USAGE_PATH, redeemPath: "/wallet" },
-    },
-    {
-      siteType: SITE_TYPES.SUPER_API,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUPER_API)] },
-    },
-    {
-      siteType: SITE_TYPES.RIX_API,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: {
-        titlePatterns: [makeTitleRegex(SITE_TYPES.RIX_API)],
-      },
-      routes: {
-        usagePath: "/log",
-        checkInPath: "/panel",
-        redeemPath: "/topup",
-      },
-    },
-    {
-      siteType: SITE_TYPES.NEO_API,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: {
-        titlePatterns: [makeTitleRegex(SITE_TYPES.NEO_API)],
-      },
-    },
-    {
-      siteType: SITE_TYPES.WONG_GONGYI,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: { titlePatterns: [/wong\s*公益站/i] },
-      routes: { checkInPath: "/console/topup" },
-    },
-    {
-      siteType: SITE_TYPES.SUB2API,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api,
-      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.SUB2API)] },
-      routes: {
-        usagePath: "/usage",
-        redeemPath: "/redeem",
-        siteAnnouncementsPath: "/dashboard",
-      },
-    },
-    {
-      siteType: SITE_TYPES.AIHUBMIX,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
-      detection: {
-        titlePatterns: [makeTitleRegex(SITE_TYPES.AIHUBMIX)],
-        hostnames: AIHUBMIX_HOSTNAMES,
-      },
-      routes: {
-        loginPath: AIHUBMIX_LOGIN_PATH,
-        usagePath: "/statistics",
-        redeemPath: "/topup",
-        checkInPath: "/",
-        adminCredentialsPath: "/",
-      },
-    },
-    {
-      siteType: SITE_TYPES.UNKNOWN,
-      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-      detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.UNKNOWN)] },
-    },
-  ]
+const getAccountSiteOnboardingMetadata =
+  (): readonly AccountSiteOnboardingMetadata[] =>
+    getAccountSiteOnboardingDefinitions().map((definition) => ({
+      siteType: definition.siteType as AccountSiteType,
+      adapterFamily: definition.adapterFamily,
+      detection: definition.detection,
+      routes: definition.routes,
+    }))
 
 /**
  * Returns the static onboarding metadata for an account site type.
  */
 export function getAccountSiteMetadata(siteType: AccountSiteType) {
-  const metadata = accountSiteOnboardingMetadata.find(
+  const metadata = getAccountSiteOnboardingMetadata().find(
     (metadata) => metadata.siteType === siteType,
   )
 
@@ -245,7 +89,7 @@ export function getAccountSiteMetadata(siteType: AccountSiteType) {
  * Projects title-detection metadata into the legacy rule shape.
  */
 export function getAccountSiteTitleRuleMetadata(): readonly AccountSiteTitleRuleMetadata[] {
-  return accountSiteOnboardingMetadata.flatMap(
+  return getAccountSiteOnboardingMetadata().flatMap(
     (metadata) =>
       metadata.detection?.titlePatterns?.map((regex) => ({
         name: metadata.siteType,
@@ -258,7 +102,7 @@ export function getAccountSiteTitleRuleMetadata(): readonly AccountSiteTitleRule
  * Projects domain-detection metadata into the legacy rule shape.
  */
 export function getAccountSiteDomainRuleMetadata(): readonly AccountSiteDomainRuleMetadata[] {
-  return accountSiteOnboardingMetadata.flatMap((metadata) =>
+  return getAccountSiteOnboardingMetadata().flatMap((metadata) =>
     metadata.detection?.hostnames
       ? [
           {
@@ -283,18 +127,23 @@ export function getAccountSiteRouteOverrideMetadata(
  * Returns the adapter family declared by account-site metadata.
  */
 export function getAccountSiteAdapterFamilyMetadata(siteType: AccountSiteType) {
-  const metadata = accountSiteOnboardingMetadata.find(
-    (metadata) => metadata.siteType === siteType,
+  return (
+    getAccountSiteDefinition(siteType)?.adapterFamily ??
+    ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
   )
-
-  return metadata?.adapterFamily ?? ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
 }
 
 /**
  * Projects compatible user-id header metadata into normalized rules.
  */
 export function getAccountSiteCompatUserIdHeaderRules() {
-  return Object.entries(COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE).map(
-    ([headerName, siteType]) => ({ siteType, headerName }),
+  return getAccountSiteDefinitions().flatMap(
+    (definition) =>
+      definition.onboarding?.detection?.compatUserIdHeaderNames?.map(
+        (headerName) => ({
+          siteType: definition.siteType as AccountSiteType,
+          headerName,
+        }),
+      ) ?? [],
   )
 }

--- a/src/services/accountSiteOnboarding/siteTypes.ts
+++ b/src/services/accountSiteOnboarding/siteTypes.ts
@@ -1,62 +1,12 @@
-export const SITE_TYPES = {
-  ONE_API: "one-api",
-  NEW_API: "new-api",
-  ANYROUTER: "anyrouter",
-  VELOERA: "Veloera",
-  ONE_HUB: "one-hub",
-  DONE_HUB: "done-hub",
-  V_API: "v-api",
-  VO_API: "VoAPI",
-  SUPER_API: "Super-API",
-  RIX_API: "Rix-Api",
-  NEO_API: "neo-Api",
-  WONG_GONGYI: "wong-gongyi",
-  SUB2API: "sub2api",
-  OCTOPUS: "octopus",
-  AXON_HUB: "axonhub",
-  CLAUDE_CODE_HUB: "claude-code-hub",
-  AIHUBMIX: "AIHubMix",
-  UNKNOWN: "unknown",
-} as const
-
-export const AIHUBMIX_API_ORIGIN = "https://aihubmix.com"
-export const AIHUBMIX_WEB_ORIGIN = "https://console.aihubmix.com"
-export const AIHUBMIX_LOGIN_PATH = "/sign-in"
-export const AIHUBMIX_HOSTNAMES = [
-  "aihubmix.com",
-  "www.aihubmix.com",
-  "console.aihubmix.com",
-] as const
-
-export const ACCOUNT_SITE_TYPES = [
-  SITE_TYPES.ONE_API,
-  SITE_TYPES.NEW_API,
-  SITE_TYPES.ANYROUTER,
-  SITE_TYPES.VELOERA,
-  SITE_TYPES.ONE_HUB,
-  SITE_TYPES.DONE_HUB,
-  SITE_TYPES.V_API,
-  SITE_TYPES.VO_API,
-  SITE_TYPES.SUPER_API,
-  SITE_TYPES.RIX_API,
-  SITE_TYPES.NEO_API,
-  SITE_TYPES.WONG_GONGYI,
-  SITE_TYPES.SUB2API,
-  SITE_TYPES.AIHUBMIX,
-  SITE_TYPES.UNKNOWN,
-] as const
-
-export type AccountSiteType = (typeof ACCOUNT_SITE_TYPES)[number]
-
-export const ACCOUNT_SITE_TYPE_VALUES = [...ACCOUNT_SITE_TYPES]
-
-export const MANAGED_SITE_TYPES = [
-  SITE_TYPES.NEW_API,
-  SITE_TYPES.VELOERA,
-  SITE_TYPES.DONE_HUB,
-  SITE_TYPES.OCTOPUS,
-  SITE_TYPES.AXON_HUB,
-  SITE_TYPES.CLAUDE_CODE_HUB,
-] as const
-
-export type ManagedSiteType = (typeof MANAGED_SITE_TYPES)[number]
+export {
+  ACCOUNT_SITE_TYPES,
+  ACCOUNT_SITE_TYPE_VALUES,
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_LOGIN_PATH,
+  AIHUBMIX_WEB_ORIGIN,
+  MANAGED_SITE_TYPES,
+  SITE_TYPES,
+  type AccountSiteType,
+  type ManagedSiteType,
+} from "~/services/accountSiteDefinitions/siteTypes"

--- a/src/services/accounts/accountSiteProfile/contracts.ts
+++ b/src/services/accounts/accountSiteProfile/contracts.ts
@@ -128,3 +128,16 @@ export type AccountSiteProductProfile = {
   tokenForm: AccountSiteTokenFormProfile
   urls: AccountSiteUrlProfile
 }
+
+type AccountSiteProductProfileOverrideSource = Omit<
+  AccountSiteProductProfile,
+  "siteType"
+>
+
+export type AccountSiteProductProfileOverride = {
+  [Key in keyof AccountSiteProductProfileOverrideSource]?: AccountSiteProductProfileOverrideSource[Key] extends readonly (infer Item)[]
+    ? readonly Item[]
+    : AccountSiteProductProfileOverrideSource[Key] extends object
+      ? Partial<AccountSiteProductProfileOverrideSource[Key]>
+      : AccountSiteProductProfileOverrideSource[Key]
+}

--- a/src/services/accounts/accountSiteProfile/profiles.ts
+++ b/src/services/accounts/accountSiteProfile/profiles.ts
@@ -1,10 +1,4 @@
-import {
-  AIHUBMIX_API_ORIGIN,
-  AIHUBMIX_HOSTNAMES,
-  AIHUBMIX_WEB_ORIGIN,
-  SITE_TYPES,
-  type AccountSiteType,
-} from "~/constants/siteType"
+import { SITE_TYPES } from "~/constants/siteType"
 import { AuthTypeEnum } from "~/types"
 
 import {
@@ -59,85 +53,5 @@ export const DEFAULT_ACCOUNT_SITE_PRODUCT_PROFILE: AccountSiteProductProfile = {
   },
   urls: {
     recognizedHostnames: [],
-  },
-}
-
-export const ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES: Partial<
-  Record<AccountSiteType, Partial<AccountSiteProductProfile>>
-> = {
-  [SITE_TYPES.ANYROUTER]: {
-    auth: {
-      ...DEFAULT_ACCOUNT_SITE_PRODUCT_PROFILE.auth,
-      defaultAuthType: AuthTypeEnum.Cookie,
-      defaultAuthHostnames: ["anyrouter.top"],
-    },
-  },
-  [SITE_TYPES.SUB2API]: {
-    auth: {
-      allowedAuthTypes: [AuthTypeEnum.AccessToken],
-      defaultAuthType: AuthTypeEnum.AccessToken,
-      defaultAuthHostnames: [],
-      supportsCookieAuth: false,
-      supportsBuiltInCheckInDetection: false,
-    },
-    authSession: {
-      kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
-      decoratesAccountApiRequests: true,
-      refreshLockScope: ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES.Account,
-    },
-    identity: {
-      usernameRequired: false,
-      storedUserIdentityFields: ["id"],
-    },
-    modelList: {
-      directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Unsupported,
-      tokenScopedCatalogFallback:
-        ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.RuntimeKey,
-      dashboardEstimateLoader:
-        ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.Sub2Api,
-      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Token,
-      displayCapabilitiesSource:
-        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
-    },
-    supplementalAuth: {
-      kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
-    },
-  },
-  [SITE_TYPES.AIHUBMIX]: {
-    auth: {
-      allowedAuthTypes: [AuthTypeEnum.AccessToken],
-      defaultAuthType: AuthTypeEnum.AccessToken,
-      defaultAuthHostnames: [],
-      supportsCookieAuth: false,
-      supportsBuiltInCheckInDetection: true,
-    },
-    createdToken: {
-      secretHandling:
-        ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING.OneTimeSecretDialog,
-    },
-    identity: {
-      usernameRequired: true,
-      storedUserIdentityFields: ["username"],
-    },
-    modelList: {
-      directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Supported,
-      tokenScopedCatalogFallback:
-        ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.None,
-      dashboardEstimateLoader:
-        ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.None,
-      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
-      displayCapabilitiesSource:
-        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile,
-    },
-    tokenForm: {
-      networkLimitPolicy:
-        ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES.SubnetLimit,
-    },
-    urls: {
-      recognizedHostnames: AIHUBMIX_HOSTNAMES,
-      storageOrigin: AIHUBMIX_WEB_ORIGIN,
-      duplicateOrigin: AIHUBMIX_WEB_ORIGIN,
-      managedChannelOrigin: AIHUBMIX_API_ORIGIN,
-    },
   },
 }

--- a/src/services/accounts/accountSiteProfile/registry.ts
+++ b/src/services/accounts/accountSiteProfile/registry.ts
@@ -1,10 +1,11 @@
 import type { AccountSiteType } from "~/constants/siteType"
+import { getAccountSiteProductProfileOverride } from "~/services/accountSiteDefinitions"
 
-import type { AccountSiteProductProfile } from "./contracts"
-import {
-  ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES,
-  DEFAULT_ACCOUNT_SITE_PRODUCT_PROFILE,
-} from "./profiles"
+import type {
+  AccountSiteProductProfile,
+  AccountSiteProductProfileOverride,
+} from "./contracts"
+import { DEFAULT_ACCOUNT_SITE_PRODUCT_PROFILE } from "./profiles"
 
 type DeepMutable<T> = {
   -readonly [P in keyof T]: T[P] extends readonly (infer U)[]
@@ -45,7 +46,7 @@ const mergeReadonlyArray = <T>(
 
 const mergeAccountSiteProductProfile = (
   siteType: AccountSiteType,
-  override: Partial<AccountSiteProductProfile> | undefined,
+  override: AccountSiteProductProfileOverride | undefined,
 ): AccountSiteProductProfile => {
   const merged: DeepMutable<AccountSiteProductProfile> = {
     siteType,
@@ -111,7 +112,7 @@ export function getAccountSiteProductProfile(
   return cloneAccountSiteProductProfile(
     mergeAccountSiteProductProfile(
       siteType,
-      ACCOUNT_SITE_PRODUCT_PROFILE_OVERRIDES[siteType],
+      getAccountSiteProductProfileOverride(siteType),
     ),
   )
 }

--- a/src/services/apiTransport/compatHeaders.ts
+++ b/src/services/apiTransport/compatHeaders.ts
@@ -1,4 +1,3 @@
-import { getAccountSiteCompatUserIdHeaderRules } from "~/services/accountSiteOnboarding/metadata"
 import {
   SITE_TYPES,
   type AccountSiteType,
@@ -25,13 +24,6 @@ const COMPAT_USER_ID_HEADER_TO_SITE_TYPE = {
   "Rix-Api-User": SITE_TYPES.RIX_API,
   "neo-api-user": SITE_TYPES.NEO_API,
 } as const satisfies Record<string, AccountSiteType>
-
-export const COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE = Object.fromEntries(
-  getAccountSiteCompatUserIdHeaderRules().map(({ headerName, siteType }) => [
-    headerName,
-    siteType,
-  ]),
-) as Record<string, AccountSiteType>
 
 const COMPAT_USER_ID_HEADER_NAMES = Object.keys(
   COMPAT_USER_ID_HEADER_TO_SITE_TYPE,

--- a/src/services/apiTransport/compatHeaders.ts
+++ b/src/services/apiTransport/compatHeaders.ts
@@ -1,4 +1,4 @@
-import { COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE } from "~/services/accountSiteOnboarding/metadata"
+import { getAccountSiteCompatUserIdHeaderRules } from "~/services/accountSiteOnboarding/metadata"
 import {
   SITE_TYPES,
   type AccountSiteType,
@@ -26,7 +26,12 @@ const COMPAT_USER_ID_HEADER_TO_SITE_TYPE = {
   "neo-api-user": SITE_TYPES.NEO_API,
 } as const satisfies Record<string, AccountSiteType>
 
-export { COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE }
+export const COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE = Object.fromEntries(
+  getAccountSiteCompatUserIdHeaderRules().map(({ headerName, siteType }) => [
+    headerName,
+    siteType,
+  ]),
+) as Record<string, AccountSiteType>
 
 const COMPAT_USER_ID_HEADER_NAMES = Object.keys(
   COMPAT_USER_ID_HEADER_TO_SITE_TYPE,

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,5 @@
+export enum AuthTypeEnum {
+  AccessToken = "access_token",
+  Cookie = "cookie",
+  None = "none",
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ import {
   DATA_TYPE_INCOME,
 } from "~/constants"
 import type { AccountSiteType } from "~/constants/siteType"
+import type { AuthTypeEnum } from "~/types/auth"
 import { TempWindowHealthStatusCode } from "~/types/tempWindow"
 import type { TurnstilePreTrigger } from "~/types/turnstile"
 
@@ -539,11 +540,7 @@ export const DASHBOARD_TAB_TYPES = [
 ] as const
 export type DashboardTabType = (typeof DASHBOARD_TAB_TYPES)[number]
 
-export enum AuthTypeEnum {
-  AccessToken = "access_token",
-  Cookie = "cookie",
-  None = "none",
-}
+export { AuthTypeEnum } from "~/types/auth"
 export type { AccountToken } from "~/types/accountToken"
 export type { TempWindowHealthStatusCode } from "~/types/tempWindow"
 export { TEMP_WINDOW_HEALTH_STATUS_CODES } from "~/types/tempWindow"

--- a/tests/services/accountSiteDefinitions/registry.test.ts
+++ b/tests/services/accountSiteDefinitions/registry.test.ts
@@ -1,0 +1,527 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ACCOUNT_SITE_TYPE_VALUES as LEGACY_ACCOUNT_SITE_TYPE_VALUES,
+  ACCOUNT_SITE_TYPES as LEGACY_ACCOUNT_SITE_TYPES,
+  MANAGED_SITE_TYPES as LEGACY_MANAGED_SITE_TYPES,
+} from "~/constants/siteType"
+import { getAccountSiteProductProfile } from "~/services/accounts/accountSiteProfile"
+import {
+  ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES,
+  ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING,
+  ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS,
+  ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING,
+  ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES,
+  ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES,
+  ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS,
+  ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS,
+  ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES,
+} from "~/services/accounts/accountSiteProfile/contracts"
+import {
+  ACCOUNT_SITE_ADAPTER_FAMILIES,
+  ACCOUNT_SITE_DEFINITION_SCOPES,
+  ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES,
+  ACCOUNT_SITE_TYPE_VALUES,
+  ACCOUNT_SITE_TYPES,
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_HOSTNAMES,
+  AIHUBMIX_WEB_ORIGIN,
+  getAccountSiteDefinition,
+  getAccountSiteDefinitions,
+  getAccountSiteOnboardingDefinitions,
+  getAccountSiteProductProfileOverride,
+  getAccountSiteReadinessExpectation,
+  getAccountSiteTypeValues,
+  getManagedSiteTypeValues,
+  MANAGED_SITE_TYPES,
+  SITE_TYPES,
+  type AccountSiteDefinition,
+  type AccountSiteType,
+  type ManagedSiteType,
+} from "~/services/accountSiteDefinitions"
+import {
+  ACCOUNT_SITE_TYPE_ORDER,
+  MANAGED_SITE_TYPE_ORDER,
+  SITE_TYPE_DEFINITIONS,
+} from "~/services/accountSiteDefinitions/definitions"
+import type { SiteType } from "~/services/accountSiteDefinitions/identifiers"
+import {
+  getAccountSiteAdapterFamily as getLegacyAccountSiteAdapterFamily,
+  getAccountSiteOnboardingDefinition as getLegacyAccountSiteOnboardingDefinition,
+  getAccountSiteRouteOverrides as getLegacyAccountSiteRouteOverrides,
+} from "~/services/accountSiteOnboarding/registry"
+import { MODEL_LIST_ACCOUNT_SOURCE_ROUTES } from "~/services/modelList/accountSources/readiness"
+import { AuthTypeEnum } from "~/types"
+
+type ExpectExact<T, Expected> = [T] extends [Expected]
+  ? [Expected] extends [T]
+    ? true
+    : never
+  : never
+
+type ExpectedAccountSiteType =
+  | typeof SITE_TYPES.ONE_API
+  | typeof SITE_TYPES.NEW_API
+  | typeof SITE_TYPES.ANYROUTER
+  | typeof SITE_TYPES.VELOERA
+  | typeof SITE_TYPES.ONE_HUB
+  | typeof SITE_TYPES.DONE_HUB
+  | typeof SITE_TYPES.V_API
+  | typeof SITE_TYPES.VO_API
+  | typeof SITE_TYPES.SUPER_API
+  | typeof SITE_TYPES.RIX_API
+  | typeof SITE_TYPES.NEO_API
+  | typeof SITE_TYPES.WONG_GONGYI
+  | typeof SITE_TYPES.SUB2API
+  | typeof SITE_TYPES.AIHUBMIX
+  | typeof SITE_TYPES.UNKNOWN
+
+type ExpectedManagedSiteType =
+  | typeof SITE_TYPES.NEW_API
+  | typeof SITE_TYPES.VELOERA
+  | typeof SITE_TYPES.DONE_HUB
+  | typeof SITE_TYPES.OCTOPUS
+  | typeof SITE_TYPES.AXON_HUB
+  | typeof SITE_TYPES.CLAUDE_CODE_HUB
+
+const accountSiteTypeIsExact: ExpectExact<
+  AccountSiteType,
+  ExpectedAccountSiteType
+> = true
+const managedSiteTypeIsExact: ExpectExact<
+  ManagedSiteType,
+  ExpectedManagedSiteType
+> = true
+const accountSiteTypeDoesNotWidenToAllSiteTypes: SiteType extends AccountSiteType
+  ? never
+  : true = true
+const managedSiteTypeDoesNotWidenToAllSiteTypes: SiteType extends ManagedSiteType
+  ? never
+  : true = true
+const typeAssertions = [
+  accountSiteTypeIsExact,
+  managedSiteTypeIsExact,
+  accountSiteTypeDoesNotWidenToAllSiteTypes,
+  managedSiteTypeDoesNotWidenToAllSiteTypes,
+] as const
+const productProfileSiteTypeIsForbidden: "siteType" extends keyof NonNullable<
+  AccountSiteDefinition["productProfile"]
+>
+  ? never
+  : true = true
+
+describe("account site definition registry", () => {
+  it("keeps public site type aliases exact", () => {
+    expect([...typeAssertions, productProfileSiteTypeIsForbidden]).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+    ])
+  })
+
+  it("keeps scoped definitions covered exactly once by order constants", () => {
+    const accountScopedDefinitions = SITE_TYPE_DEFINITIONS.filter(
+      (definition) =>
+        definition.scopes.includes(ACCOUNT_SITE_DEFINITION_SCOPES.Account),
+    )
+    const managedScopedDefinitions = SITE_TYPE_DEFINITIONS.filter(
+      (definition) =>
+        definition.scopes.includes(ACCOUNT_SITE_DEFINITION_SCOPES.Managed),
+    )
+
+    expect(new Set(ACCOUNT_SITE_TYPE_ORDER).size).toBe(
+      ACCOUNT_SITE_TYPE_ORDER.length,
+    )
+    expect(new Set(MANAGED_SITE_TYPE_ORDER).size).toBe(
+      MANAGED_SITE_TYPE_ORDER.length,
+    )
+    expect([...ACCOUNT_SITE_TYPE_ORDER].sort()).toEqual(
+      accountScopedDefinitions.map((definition) => definition.siteType).sort(),
+    )
+    expect([...MANAGED_SITE_TYPE_ORDER].sort()).toEqual(
+      managedScopedDefinitions.map((definition) => definition.siteType).sort(),
+    )
+  })
+
+  it("matches current legacy site-type surfaces", () => {
+    expect(ACCOUNT_SITE_TYPES).toEqual(LEGACY_ACCOUNT_SITE_TYPES)
+    expect(ACCOUNT_SITE_TYPE_VALUES).toEqual(LEGACY_ACCOUNT_SITE_TYPE_VALUES)
+    expect(MANAGED_SITE_TYPES).toEqual(LEGACY_MANAGED_SITE_TYPES)
+  })
+
+  it("keeps the legacy constants facade aligned with definitions", async () => {
+    const legacy = await import("~/constants/siteType")
+
+    expect(legacy.SITE_TYPES).toBe(SITE_TYPES)
+    expect(legacy.ACCOUNT_SITE_TYPES).toEqual(getAccountSiteTypeValues())
+    expect(legacy.ACCOUNT_SITE_TYPE_VALUES).toEqual(getAccountSiteTypeValues())
+    expect(legacy.MANAGED_SITE_TYPES).toEqual(getManagedSiteTypeValues())
+    expect(legacy.isAccountSiteType(SITE_TYPES.AIHUBMIX)).toBe(true)
+    expect(legacy.isAccountSiteType(SITE_TYPES.OCTOPUS)).toBe(false)
+    expect(legacy.isManagedSiteType(SITE_TYPES.OCTOPUS)).toBe(true)
+    expect(legacy.isManagedSiteType(SITE_TYPES.SUB2API)).toBe(false)
+  })
+
+  it("matches current legacy onboarding adapter families", () => {
+    for (const siteType of ACCOUNT_SITE_TYPES) {
+      expect(getAccountSiteDefinition(siteType)?.adapterFamily).toBe(
+        getLegacyAccountSiteAdapterFamily(siteType),
+      )
+    }
+  })
+
+  it("matches current legacy onboarding route metadata", () => {
+    for (const siteType of ACCOUNT_SITE_TYPES) {
+      const routes = getAccountSiteOnboardingDefinitions().find(
+        (definition) => definition.siteType === siteType,
+      )?.routes
+
+      expect(routes ?? {}).toEqual(getLegacyAccountSiteRouteOverrides(siteType))
+      expect(
+        getAccountSiteDefinition(siteType)?.onboarding?.routes ?? {},
+      ).toEqual(
+        getLegacyAccountSiteOnboardingDefinition(siteType)?.routes ?? {},
+      )
+    }
+  })
+
+  it("matches current product-profile behavior for overridden sites", () => {
+    const anyrouterOverride = getAccountSiteProductProfileOverride(
+      SITE_TYPES.ANYROUTER,
+    )
+    const sub2apiOverride = getAccountSiteProductProfileOverride(
+      SITE_TYPES.SUB2API,
+    )
+    const aihubmixOverride = getAccountSiteProductProfileOverride(
+      SITE_TYPES.AIHUBMIX,
+    )
+
+    const anyrouterProfile = getAccountSiteProductProfile(SITE_TYPES.ANYROUTER)
+    expect(anyrouterProfile.auth.defaultAuthType).toBe(
+      anyrouterOverride?.auth?.defaultAuthType,
+    )
+    expect(anyrouterProfile.auth.defaultAuthHostnames).toEqual(
+      anyrouterOverride?.auth?.defaultAuthHostnames,
+    )
+    expect(getAccountSiteProductProfile(SITE_TYPES.SUB2API)).toMatchObject({
+      auth: sub2apiOverride?.auth,
+      authSession: sub2apiOverride?.authSession,
+      identity: sub2apiOverride?.identity,
+      modelList: sub2apiOverride?.modelList,
+      supplementalAuth: sub2apiOverride?.supplementalAuth,
+    })
+    expect(getAccountSiteProductProfile(SITE_TYPES.AIHUBMIX)).toMatchObject({
+      auth: aihubmixOverride?.auth,
+      createdToken: aihubmixOverride?.createdToken,
+      identity: aihubmixOverride?.identity,
+      modelList: aihubmixOverride?.modelList,
+      tokenForm: aihubmixOverride?.tokenForm,
+      urls: aihubmixOverride?.urls,
+    })
+  })
+
+  it("projects account site types in the public order", () => {
+    expect(getAccountSiteTypeValues()).toEqual(ACCOUNT_SITE_TYPES)
+    expect(getAccountSiteTypeValues()).toEqual([
+      SITE_TYPES.ONE_API,
+      SITE_TYPES.NEW_API,
+      SITE_TYPES.ANYROUTER,
+      SITE_TYPES.VELOERA,
+      SITE_TYPES.ONE_HUB,
+      SITE_TYPES.DONE_HUB,
+      SITE_TYPES.V_API,
+      SITE_TYPES.VO_API,
+      SITE_TYPES.SUPER_API,
+      SITE_TYPES.RIX_API,
+      SITE_TYPES.NEO_API,
+      SITE_TYPES.WONG_GONGYI,
+      SITE_TYPES.SUB2API,
+      SITE_TYPES.AIHUBMIX,
+      SITE_TYPES.UNKNOWN,
+    ])
+  })
+
+  it("projects managed site types in the public order", () => {
+    expect(getManagedSiteTypeValues()).toEqual(MANAGED_SITE_TYPES)
+    expect(getManagedSiteTypeValues()).toEqual([
+      SITE_TYPES.NEW_API,
+      SITE_TYPES.VELOERA,
+      SITE_TYPES.DONE_HUB,
+      SITE_TYPES.OCTOPUS,
+      SITE_TYPES.AXON_HUB,
+      SITE_TYPES.CLAUDE_CODE_HUB,
+    ])
+  })
+
+  it("defines every site type once", () => {
+    const siteTypes = getAccountSiteDefinitions().map(
+      (definition) => definition.siteType,
+    )
+
+    expect(new Set(siteTypes).size).toBe(siteTypes.length)
+  })
+
+  it("gives every account site account scope and an adapter family", () => {
+    for (const definition of getAccountSiteDefinitions().filter((definition) =>
+      definition.scopes.includes(ACCOUNT_SITE_DEFINITION_SCOPES.Account),
+    )) {
+      expect(definition.scopes).toContain(
+        ACCOUNT_SITE_DEFINITION_SCOPES.Account,
+      )
+      expect(definition.adapterFamily).toBeTruthy()
+    }
+  })
+
+  it("gives every managed site managed scope", () => {
+    for (const siteType of MANAGED_SITE_TYPES) {
+      expect(getAccountSiteDefinition(siteType)?.scopes).toContain(
+        ACCOUNT_SITE_DEFINITION_SCOPES.Managed,
+      )
+    }
+  })
+
+  it("projects representative adapter families", () => {
+    expect(getAccountSiteDefinition(SITE_TYPES.NEW_API)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    )
+    expect(getAccountSiteDefinition(SITE_TYPES.SUB2API)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api,
+    )
+    expect(getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
+    )
+    expect(getAccountSiteDefinition(SITE_TYPES.OCTOPUS)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+    )
+  })
+
+  it("projects onboarding metadata", () => {
+    const onboardingDefinitions = getAccountSiteOnboardingDefinitions()
+
+    expect(
+      onboardingDefinitions.map((definition) => definition.siteType),
+    ).toEqual(ACCOUNT_SITE_TYPES)
+    expect(
+      onboardingDefinitions.find(
+        (definition) => definition.siteType === SITE_TYPES.AIHUBMIX,
+      )?.detection?.hostnames,
+    ).toEqual(AIHUBMIX_HOSTNAMES)
+    expect(
+      onboardingDefinitions.find(
+        (definition) => definition.siteType === SITE_TYPES.SUB2API,
+      )?.routes,
+    ).toMatchObject({
+      usagePath: "/usage",
+      redeemPath: "/redeem",
+      siteAnnouncementsPath: "/dashboard",
+    })
+  })
+
+  it("returns defensive definition and projection copies", () => {
+    const definition = getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)
+    const onboardingDefinition = getAccountSiteOnboardingDefinitions().find(
+      (definition) => definition.siteType === SITE_TYPES.AIHUBMIX,
+    )
+
+    ;(definition!.onboarding!.detection!.hostnames as string[]).push(
+      "mutated.example.invalid",
+    )
+    definition!.adapterFamily = ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
+    ;(onboardingDefinition!.detection!.hostnames as string[]).push(
+      "mutated.example.invalid",
+    )
+    onboardingDefinition!.adapterFamily =
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
+
+    expect(
+      getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)?.onboarding?.detection
+        ?.hostnames,
+    ).not.toContain("mutated.example.invalid")
+    expect(getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
+    )
+    expect(
+      getAccountSiteOnboardingDefinitions().find(
+        (definition) => definition.siteType === SITE_TYPES.AIHUBMIX,
+      )?.detection?.hostnames,
+    ).not.toContain("mutated.example.invalid")
+    expect(
+      getAccountSiteOnboardingDefinitions().find(
+        (definition) => definition.siteType === SITE_TYPES.AIHUBMIX,
+      )?.adapterFamily,
+    ).toBe(ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix)
+  })
+
+  it("returns defensive RegExp copies for onboarding detection", () => {
+    const firstDefinition = getAccountSiteDefinition(SITE_TYPES.SUB2API)
+    const secondDefinition = getAccountSiteDefinition(SITE_TYPES.SUB2API)
+    const firstOnboardingDefinition =
+      getAccountSiteOnboardingDefinitions().find(
+        (definition) => definition.siteType === SITE_TYPES.SUB2API,
+      )
+    const secondOnboardingDefinition =
+      getAccountSiteOnboardingDefinitions().find(
+        (definition) => definition.siteType === SITE_TYPES.SUB2API,
+      )
+
+    expect(firstDefinition?.onboarding?.detection?.titlePatterns?.[0]).not.toBe(
+      secondDefinition?.onboarding?.detection?.titlePatterns?.[0],
+    )
+    expect(firstOnboardingDefinition?.detection?.titlePatterns?.[0]).not.toBe(
+      secondOnboardingDefinition?.detection?.titlePatterns?.[0],
+    )
+  })
+
+  it("returns defensive product-profile override copies", () => {
+    const aihubmixProfile = getAccountSiteProductProfileOverride(
+      SITE_TYPES.AIHUBMIX,
+    )
+    const sub2apiProfile = getAccountSiteProductProfileOverride(
+      SITE_TYPES.SUB2API,
+    )
+
+    ;(aihubmixProfile!.urls!.recognizedHostnames as string[]).push(
+      "mutated.example.invalid",
+    )
+    ;(sub2apiProfile!.auth!.allowedAuthTypes as AuthTypeEnum[]).push(
+      AuthTypeEnum.Cookie,
+    )
+    ;(sub2apiProfile!.identity!.storedUserIdentityFields as string[]).push(
+      "mutated",
+    )
+
+    expect(
+      getAccountSiteProductProfileOverride(SITE_TYPES.AIHUBMIX)?.urls
+        ?.recognizedHostnames,
+    ).not.toContain("mutated.example.invalid")
+    expect(
+      getAccountSiteProductProfileOverride(SITE_TYPES.SUB2API)?.auth
+        ?.allowedAuthTypes,
+    ).toEqual([AuthTypeEnum.AccessToken])
+    expect(
+      getAccountSiteProductProfileOverride(SITE_TYPES.SUB2API)?.identity
+        ?.storedUserIdentityFields,
+    ).toEqual(["id"])
+  })
+
+  it("returns defensive readiness expectation copies", () => {
+    const readiness = getAccountSiteReadinessExpectation(SITE_TYPES.SUB2API)
+
+    readiness!.modelList!.expectedRoute =
+      MODEL_LIST_ACCOUNT_SOURCE_ROUTES.Unsupported
+
+    expect(
+      getAccountSiteReadinessExpectation(SITE_TYPES.SUB2API)?.modelList
+        ?.expectedRoute,
+    ).toBe(MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog)
+  })
+
+  it("projects product-profile overrides", () => {
+    expect(
+      getAccountSiteProductProfileOverride(SITE_TYPES.ANYROUTER),
+    ).toMatchObject({
+      auth: {
+        defaultAuthType: AuthTypeEnum.Cookie,
+        defaultAuthHostnames: ["anyrouter.top"],
+      },
+    })
+    expect(
+      getAccountSiteProductProfileOverride(SITE_TYPES.SUB2API),
+    ).toMatchObject({
+      auth: {
+        allowedAuthTypes: [AuthTypeEnum.AccessToken],
+        defaultAuthType: AuthTypeEnum.AccessToken,
+        defaultAuthHostnames: [],
+        supportsCookieAuth: false,
+        supportsBuiltInCheckInDetection: false,
+      },
+      authSession: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+        decoratesAccountApiRequests: true,
+        refreshLockScope: ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES.Account,
+      },
+      identity: {
+        usernameRequired: false,
+        storedUserIdentityFields: ["id"],
+      },
+      modelList: {
+        directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Unsupported,
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.RuntimeKey,
+        dashboardEstimateLoader:
+          ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.Sub2Api,
+        statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Token,
+        displayCapabilitiesSource:
+          ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+      },
+      supplementalAuth: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+      },
+    })
+    expect(
+      getAccountSiteProductProfileOverride(SITE_TYPES.AIHUBMIX),
+    ).toMatchObject({
+      auth: {
+        allowedAuthTypes: [AuthTypeEnum.AccessToken],
+        defaultAuthType: AuthTypeEnum.AccessToken,
+        defaultAuthHostnames: [],
+        supportsCookieAuth: false,
+        supportsBuiltInCheckInDetection: true,
+      },
+      createdToken: {
+        secretHandling:
+          ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING.OneTimeSecretDialog,
+      },
+      identity: {
+        usernameRequired: true,
+        storedUserIdentityFields: ["username"],
+      },
+      modelList: {
+        directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Supported,
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.None,
+        dashboardEstimateLoader:
+          ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.None,
+        statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+        displayCapabilitiesSource:
+          ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile,
+      },
+      tokenForm: {
+        networkLimitPolicy:
+          ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES.SubnetLimit,
+      },
+      urls: {
+        recognizedHostnames: AIHUBMIX_HOSTNAMES,
+        storageOrigin: AIHUBMIX_WEB_ORIGIN,
+        duplicateOrigin: AIHUBMIX_WEB_ORIGIN,
+        managedChannelOrigin: AIHUBMIX_API_ORIGIN,
+      },
+    })
+  })
+
+  it("projects model-list readiness expectations", () => {
+    expect(
+      getAccountSiteReadinessExpectation(SITE_TYPES.NEW_API)?.modelList
+        ?.expectedRoute,
+    ).toBe(MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing)
+    expect(
+      getAccountSiteReadinessExpectation(SITE_TYPES.SUB2API)?.modelList
+        ?.expectedRoute,
+    ).toBe(MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog)
+    expect(
+      getAccountSiteReadinessExpectation(SITE_TYPES.AIHUBMIX)?.modelList
+        ?.expectedRoute,
+    ).toBe(MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing)
+  })
+
+  it("keeps definition expectation route constants synchronized with runtime routes", () => {
+    expect(ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES).toEqual({
+      DirectPricing: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing,
+      TokenScopedRuntimeCatalog:
+        MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog,
+      Unsupported: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.Unsupported,
+    })
+  })
+})

--- a/tests/services/accountSiteOnboarding/registry.test.ts
+++ b/tests/services/accountSiteOnboarding/registry.test.ts
@@ -112,6 +112,26 @@ describe("account site onboarding registry", () => {
     ).toBe(AIHUBMIX_LOGIN_PATH)
   })
 
+  it("projects onboarding definitions from the account-site definition registry", async () => {
+    const { getAccountSiteDefinition } = await import(
+      "~/services/accountSiteDefinitions"
+    )
+
+    const aihubmixDefinition = getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)
+    const onboardingDefinition = getAccountSiteOnboardingDefinition(
+      SITE_TYPES.AIHUBMIX,
+    )
+
+    expect(onboardingDefinition).toMatchObject({
+      siteType: SITE_TYPES.AIHUBMIX,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
+      routes: aihubmixDefinition?.onboarding?.routes,
+    })
+    expect(onboardingDefinition?.detection?.hostnames).toEqual([
+      ...AIHUBMIX_HOSTNAMES,
+    ])
+  })
+
   it("returns domain rule hostname array copies", () => {
     const firstRule = getAccountSiteDomainRules().find(
       (rule) => rule.name === SITE_TYPES.AIHUBMIX,

--- a/tests/services/accounts/accountSiteProfile.test.ts
+++ b/tests/services/accounts/accountSiteProfile.test.ts
@@ -96,6 +96,29 @@ describe("accountSiteProfile", () => {
     )
   })
 
+  it("resolves site-specific overrides from account-site definitions", async () => {
+    const { getAccountSiteProductProfileOverride } = await import(
+      "~/services/accountSiteDefinitions"
+    )
+
+    expect(
+      getAccountSiteProductProfileOverride(SITE_TYPES.SUB2API),
+    ).toMatchObject({
+      supplementalAuth: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+      },
+    })
+    expect(getAccountSiteProductProfile(SITE_TYPES.SUB2API)).toMatchObject({
+      supplementalAuth: {
+        kind: ACCOUNT_SITE_SUPPLEMENTAL_AUTH_KINDS.Sub2ApiRefreshToken,
+      },
+      modelList: {
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.RuntimeKey,
+      },
+    })
+  })
+
   it("resolves Model List source-account policy", () => {
     expect(
       shouldUseAccountSiteRuntimeKeyCatalogFallback({

--- a/tests/services/apiTransport/compatHeaders.test.ts
+++ b/tests/services/apiTransport/compatHeaders.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { getAccountSiteCompatUserIdHeaderRules } from "~/services/accountSiteOnboarding/metadata"
-import {
-  buildCompatUserIdHeaders,
-  COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE,
-} from "~/services/apiTransport/compatHeaders"
+import { buildCompatUserIdHeaders } from "~/services/apiTransport/compatHeaders"
 
 describe("compat user-id headers", () => {
   it("includes the V-API X-Api-User compatibility header", () => {
@@ -14,10 +11,24 @@ describe("compat user-id headers", () => {
     })
   })
 
+  it("keeps the broad User-id compatibility header in request fan-out", () => {
+    expect(buildCompatUserIdHeaders(123)).toMatchObject({
+      "User-id": "123",
+    })
+  })
+
   it("uses X-Api-User as a V-API detection signal", () => {
-    expect(COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE["X-Api-User"]).toBe(
-      SITE_TYPES.V_API,
-    )
+    expect(getAccountSiteCompatUserIdHeaderRules()).toContainEqual({
+      headerName: "X-Api-User",
+      siteType: SITE_TYPES.V_API,
+    })
+  })
+
+  it("keeps the generic User-id header out of detection rules", () => {
+    expect(getAccountSiteCompatUserIdHeaderRules()).not.toContainEqual({
+      headerName: "User-id",
+      siteType: SITE_TYPES.NEW_API,
+    })
   })
 
   it("derives error-header detection signals from onboarding metadata", () => {
@@ -30,11 +41,16 @@ describe("compat user-id headers", () => {
       siteType: SITE_TYPES.V_API,
     })
     expect(
-      Object.fromEntries(
-        getAccountSiteCompatUserIdHeaderRules().map(
-          ({ headerName, siteType }) => [headerName, siteType],
-        ),
-      ),
-    ).toEqual(COMPAT_USER_ID_ERROR_HEADER_TO_SITE_TYPE)
+      getAccountSiteCompatUserIdHeaderRules().map((rule) => rule.headerName),
+    ).toEqual(
+      expect.arrayContaining([
+        "New-API-User",
+        "Veloera-User",
+        "X-Api-User",
+        "voapi-user",
+        "Rix-Api-User",
+        "neo-api-user",
+      ]),
+    )
   })
 })

--- a/tests/services/modelList/accountSources/readiness.definitions.test.ts
+++ b/tests/services/modelList/accountSources/readiness.definitions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES,
+  ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES,
+} from "~/services/accounts/accountSiteProfile"
+import {
+  getAccountSiteReadinessExpectation,
+  getAccountSiteTypeValues,
+} from "~/services/accountSiteDefinitions"
+import {
+  MODEL_LIST_ACCOUNT_SOURCE_ROUTES,
+  resolveModelListAccountSourceReadiness,
+} from "~/services/modelList/accountSources/readiness"
+
+describe("Model List readiness definition expectations", () => {
+  it("resolves each expected account site route without throwing", () => {
+    for (const siteType of getAccountSiteTypeValues()) {
+      const expectation = getAccountSiteReadinessExpectation(siteType)
+      const readiness = resolveModelListAccountSourceReadiness({ siteType })
+
+      expect(readiness.route, `${siteType} readiness route`).toBe(
+        expectation?.modelList?.expectedRoute,
+      )
+    }
+  })
+
+  it("keeps representative account-site readiness semantics", () => {
+    expect(
+      resolveModelListAccountSourceReadiness({ siteType: SITE_TYPES.NEW_API }),
+    ).toMatchObject({
+      route: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing,
+      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+      displayCapabilitiesSource:
+        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+    })
+    expect(
+      resolveModelListAccountSourceReadiness({ siteType: SITE_TYPES.SUB2API }),
+    ).toMatchObject({
+      route: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog,
+      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Token,
+      displayCapabilitiesSource:
+        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+    })
+    expect(
+      resolveModelListAccountSourceReadiness({ siteType: SITE_TYPES.AIHUBMIX }),
+    ).toMatchObject({
+      route: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing,
+      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+      displayCapabilitiesSource:
+        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add account-site definition registry as the shared source for site type, onboarding, adapter family, product profile override, readiness, and compat-header facts
- route existing onboarding, account-site profile, compat header, and legacy site-type facades through registry projections
- add registry/parity/readiness tests and keep the spec/plan artifacts in a separate docs commit

## Test Plan
- pnpm vitest run tests/services/accountSiteDefinitions/registry.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/accounts/accountSiteProfile.test.ts tests/services/apiAdapters/registry.test.ts tests/services/modelList/accountSources/readiness.test.ts tests/services/modelList/accountSources/readiness.routes.test.ts tests/services/modelList/accountSources/readiness.definitions.test.ts
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized account-site definitions, onboarding metadata, product-profile overrides, and model-list readiness expectations into a single read-only registry to ensure consistent routing and adapter-family behavior across supported site types.

* **Tests**
  * Added/expanded test coverage to verify definition ordering, projection alignment with legacy values, correct override resolution, readiness expectation behavior, and defensive-copying so callers can't mutate cached data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->