### PR TITLE
fix(runtime): translate model sync runtime errors

### DIFF
--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -238,6 +238,7 @@
     "resetConfirmDesc": "Are you sure you want to reset {{name}} to default settings? This operation cannot be undone.",
     "resetFailed": "Failed to reset {{name}}",
     "resetSuccess": "{{name}} has been reset to default settings",
+    "runtimeRequestFailed": "Runtime request failed. Try again later.",
     "saveSettingsFailed": "Failed to save settings",
     "updateFailed": "{{name}} Update failed",
     "updateSuccess": "{{name}} Update successful"

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -238,6 +238,7 @@
     "resetConfirmDesc": "{{name}} を既定設定に戻しますか？ この操作は元に戻せません。",
     "resetFailed": "{{name}} のリセットに失敗しました",
     "resetSuccess": "{{name}} を既定設定にリセットしました",
+    "runtimeRequestFailed": "ランタイムリクエストに失敗しました。後でもう一度お試しください。",
     "saveSettingsFailed": "設定の保存に失敗しました",
     "updateFailed": "{{name}} の更新に失敗しました",
     "updateSuccess": "{{name}} を更新しました"

--- a/src/locales/vi/settings.json
+++ b/src/locales/vi/settings.json
@@ -238,6 +238,7 @@
     "resetConfirmDesc": "Bạn có chắc muốn đặt lại {{name}} về cài đặt mặc định không? Thao tác này không thể hoàn tác.",
     "resetFailed": "Đặt lại {{name}} thất bại",
     "resetSuccess": "{{name}} đã được đặt lại về cài đặt mặc định",
+    "runtimeRequestFailed": "Yêu cầu runtime thất bại. Vui lòng thử lại sau.",
     "saveSettingsFailed": "Lưu cài đặt thất bại",
     "updateFailed": "Cập nhật {{name}} thất bại",
     "updateSuccess": "Cập nhật {{name}} thành công"

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -238,6 +238,7 @@
     "resetConfirmDesc": "确定要将{{name}}重置为默认设置吗？此操作无法撤销。",
     "resetFailed": "重置{{name}}失败",
     "resetSuccess": "{{name}}已重置为默认设置",
+    "runtimeRequestFailed": "运行时请求失败，请稍后重试。",
     "saveSettingsFailed": "保存设置失败",
     "updateFailed": "{{name}}更新失败",
     "updateSuccess": "{{name}}更新成功"

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -238,6 +238,7 @@
     "resetConfirmDesc": "確定要將{{name}}重置為預設設定嗎？此操作無法撤銷。",
     "resetFailed": "重置{{name}}失敗",
     "resetSuccess": "{{name}}已重置為預設設定",
+    "runtimeRequestFailed": "執行階段請求失敗，請稍後再試。",
     "saveSettingsFailed": "儲存設定失敗",
     "updateFailed": "{{name}}更新失敗",
     "updateSuccess": "{{name}}更新成功"

--- a/src/services/models/modelSync/scheduler.ts
+++ b/src/services/models/modelSync/scheduler.ts
@@ -970,7 +970,8 @@ function toModelSyncFailure(error: unknown) {
   logger.error("Message handling failed", error)
   return {
     success: false as const,
-    error: "settings:messages.runtimeRequestFailed",
+    error:
+      getErrorMessage(error) || t("settings:messages.runtimeRequestFailed"),
   }
 }
 

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -970,7 +970,7 @@ describe("ManagedSiteChannels", () => {
     mockChannels([])
     vi.mocked(sendModelSyncMessage).mockResolvedValue({
       success: false,
-      error: "backend exploded",
+      error: "Runtime request failed",
     } as any)
 
     render(<ManagedSiteChannels />)
@@ -983,6 +983,9 @@ describe("ManagedSiteChannels", () => {
       },
       { timeout: 3000 },
     )
+    expect(
+      screen.queryByText("settings:messages.runtimeRequestFailed"),
+    ).not.toBeInTheDocument()
     expect(toast.error).toHaveBeenCalledWith(
       "managedSiteChannels:alerts.loadError.description",
     )
@@ -1321,7 +1324,7 @@ describe("ManagedSiteChannels", () => {
       if (type === "modelSync:triggerSelected") {
         return {
           success: false,
-          error: "sync failed",
+          error: "Runtime request failed",
         } as any
       }
 
@@ -1355,6 +1358,9 @@ describe("ManagedSiteChannels", () => {
 
     expect(toast.error).toHaveBeenCalledWith(
       "managedSiteChannels:toasts.syncFailed",
+    )
+    expect(toast.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("settings:messages.runtimeRequestFailed"),
     )
     expect(mockTrackProductAnalyticsActionStarted).not.toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteChannels,

--- a/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
+++ b/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
@@ -861,7 +861,10 @@ describe("ManagedSiteModelSync page", () => {
           case ModelSyncMessageTypes.ListChannels:
             channelLoadAttempt += 1
             if (channelLoadAttempt === 1) {
-              return { success: false, error: "channel load failed" }
+              return {
+                success: false,
+                error: "Runtime request failed",
+              }
             }
             return {
               success: true,
@@ -877,7 +880,12 @@ describe("ManagedSiteModelSync page", () => {
 
     render(<ManagedSiteModelSync />)
 
-    expect(await screen.findByText("channel load failed")).toBeInTheDocument()
+    expect(
+      await screen.findByText("Runtime request failed"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("settings:messages.runtimeRequestFailed"),
+    ).not.toBeInTheDocument()
     expect(toast.error).toHaveBeenCalledWith(
       "managedSiteModelSync:messages.error.loadFailed",
     )
@@ -1682,7 +1690,7 @@ describe("ManagedSiteModelSync page", () => {
         if (type === ModelSyncMessageTypes.TriggerAll) {
           return {
             success: false,
-            error: "backend unavailable",
+            error: "Runtime request failed",
           }
         }
 
@@ -1758,6 +1766,9 @@ describe("ManagedSiteModelSync page", () => {
         "managedSiteModelSync:messages.error.syncFailed",
       )
     })
+    expect(toast.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("settings:messages.runtimeRequestFailed"),
+    )
 
     expect(mockStartProductAnalyticsAction).toHaveBeenCalledWith(
       actionBarAnalyticsContext(
@@ -1783,7 +1794,7 @@ describe("ManagedSiteModelSync page", () => {
         if (type === ModelSyncMessageTypes.TriggerSelected) {
           return {
             success: false,
-            error: "permission denied",
+            error: "Runtime request failed",
           }
         }
 
@@ -1863,6 +1874,9 @@ describe("ManagedSiteModelSync page", () => {
         "managedSiteModelSync:messages.error.syncFailed",
       )
     })
+    expect(toast.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("settings:messages.runtimeRequestFailed"),
+    )
 
     expect(mockStartProductAnalyticsAction).toHaveBeenCalledWith(
       actionBarAnalyticsContext(

--- a/tests/services/modelSync/messageHandler.test.ts
+++ b/tests/services/modelSync/messageHandler.test.ts
@@ -87,6 +87,14 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
+vi.mock("~/utils/i18n/core", () => ({
+  t: vi.fn((key: string) =>
+    key === "settings:messages.runtimeRequestFailed"
+      ? "Runtime request failed"
+      : key,
+  ),
+}))
+
 const mockedUserPreferences = userPreferences as unknown as {
   getPreferences: ReturnType<typeof vi.fn>
   savePreferences: ReturnType<typeof vi.fn>
@@ -246,7 +254,7 @@ describe("ManagedSiteModelSync operation helpers", () => {
     await expect(triggerAllModelSync()).rejects.toThrow("scheduler exploded")
   })
 
-  it("returns app-owned listener failure copy instead of raw scheduler errors", async () => {
+  it("returns listener error messages and falls back when they are empty", async () => {
     const executeSyncSpy = vi.spyOn(modelSyncScheduler, "executeSync")
 
     setupManagedSiteModelSyncMessagingListeners()
@@ -259,14 +267,23 @@ describe("ManagedSiteModelSync operation helpers", () => {
     })
     expect(executeSyncSpy).not.toHaveBeenCalled()
 
-    executeSyncSpy.mockRejectedValue(new Error("upstream token secret leaked"))
+    executeSyncSpy.mockRejectedValueOnce(
+      new Error("upstream token secret leaked"),
+    )
     const triggerAllHandler = modelSyncMessageHandlers.get(
       "modelSync:triggerAll",
     )
 
     await expect(triggerAllHandler?.({ data: {} })).resolves.toEqual({
       success: false,
-      error: "settings:messages.runtimeRequestFailed",
+      error: "upstream token secret leaked",
+    })
+
+    executeSyncSpy.mockRejectedValueOnce(new Error(""))
+
+    await expect(triggerAllHandler?.({ data: {} })).resolves.toEqual({
+      success: false,
+      error: "Runtime request failed",
     })
   })
 

--- a/tests/services/runtimeTypedMessagingSetup.test.ts
+++ b/tests/services/runtimeTypedMessagingSetup.test.ts
@@ -40,6 +40,13 @@ describe("typed runtime messaging setup", () => {
       DEFAULT_PREFERENCES: { managedSiteModelSync: {} },
       userPreferences: { getPreferences: vi.fn(), savePreferences: vi.fn() },
     }))
+    vi.doMock("~/utils/i18n/core", () => ({
+      t: vi.fn((key: string) =>
+        key === "settings:messages.runtimeRequestFailed"
+          ? "Runtime request failed"
+          : key,
+      ),
+    }))
     vi.doMock("~/utils/browser/browserApi", async (importOriginal) => {
       const actual =
         await importOriginal<typeof import("~/utils/browser/browserApi")>()
@@ -65,7 +72,7 @@ describe("typed runtime messaging setup", () => {
     expect(getPreferencesHandler).toBeTypeOf("function")
     await expect(getPreferencesHandler!()).resolves.toEqual({
       success: false,
-      error: "settings:messages.runtimeRequestFailed",
+      error: "boom",
     })
   })
 
@@ -112,6 +119,13 @@ describe("typed runtime messaging setup", () => {
     vi.doMock("~/services/preferences/userPreferences", () => ({
       DEFAULT_PREFERENCES: { managedSiteModelSync: {} },
       userPreferences: { getPreferences: vi.fn(), savePreferences: vi.fn() },
+    }))
+    vi.doMock("~/utils/i18n/core", () => ({
+      t: vi.fn((key: string) =>
+        key === "settings:messages.runtimeRequestFailed"
+          ? "Runtime request failed"
+          : key,
+      ),
     }))
     vi.doMock("~/utils/browser/browserApi", async (importOriginal) => {
       const actual =
@@ -238,7 +252,7 @@ describe("typed runtime messaging setup", () => {
     expect(updateSettings).toHaveBeenCalledWith({ enableSync: false })
   })
 
-  it("wraps every model sync typed listener failure with the stable runtime fallback", async () => {
+  it("wraps every model sync typed listener failure with its error message", async () => {
     const onModelSyncMessage: OnMessageMock = vi.fn(() => vi.fn())
 
     vi.doMock("~/services/models/modelSync/messaging", () => ({
@@ -296,23 +310,31 @@ describe("typed runtime messaging setup", () => {
 
     scheduler.setupManagedSiteModelSyncMessagingListeners()
 
-    for (const [type, input] of [
-      ["modelSync:getNextRun", undefined],
-      ["modelSync:triggerAll", undefined],
-      ["modelSync:triggerSelected", { data: { channelIds: [1] } }],
-      ["modelSync:triggerFailedOnly", undefined],
-      ["modelSync:getLastExecution", undefined],
-      ["modelSync:getProgress", undefined],
-      ["modelSync:updateSettings", { data: { settings: {} } }],
-      ["modelSync:getPreferences", undefined],
-      ["modelSync:getChannelUpstreamModelOptions", undefined],
-      ["modelSync:listChannels", undefined],
+    for (const [type, input, error] of [
+      ["modelSync:getNextRun", undefined, "alarm failed"],
+      ["modelSync:triggerAll", undefined, "sync failed"],
+      [
+        "modelSync:triggerSelected",
+        { data: { channelIds: [1] } },
+        "sync failed",
+      ],
+      ["modelSync:triggerFailedOnly", undefined, "failed-only sync failed"],
+      ["modelSync:getLastExecution", undefined, "last execution failed"],
+      ["modelSync:getProgress", undefined, "progress failed"],
+      ["modelSync:updateSettings", { data: { settings: {} } }, "update failed"],
+      ["modelSync:getPreferences", undefined, "prefs failed"],
+      [
+        "modelSync:getChannelUpstreamModelOptions",
+        undefined,
+        "upstream options failed",
+      ],
+      ["modelSync:listChannels", undefined, "list failed"],
     ] as const) {
       await expect(
         getRegisteredHandler(onModelSyncMessage, type)(input),
       ).resolves.toEqual({
         success: false,
-        error: "settings:messages.runtimeRequestFailed",
+        error,
       })
     }
   })


### PR DESCRIPTION
## Summary
- Translate the model sync runtime fallback at the source instead of returning a bare i18n key.
- Align model sync runtime failures with other listeners by preferring `getErrorMessage(error)` and using localized fallback only when no usable error message exists.
- Cover channel loading and model sync UI paths so the literal key is not rendered.

## Root Cause
The typed runtime messaging refactor in #903 introduced a stable app-owned fallback for model sync listener failures, but the listener returned the raw key `settings:messages.runtimeRequestFailed` as the response error instead of resolving it through `t(...)`.

Because that key was a bare string, i18next extraction did not see it as a translation usage and locale checks could not generate or validate the copy. The options UI then treated `response.error` as display-ready text, which is consistent with other runtime handlers, so the untranslated key reached channel loading and model sync error states as plain text.

## Test Plan
- `pnpm vitest run tests/services/runtimeMessaging/result.test.ts tests/services/modelSync/messageHandler.test.ts tests/services/runtimeTypedMessagingSetup.test.ts tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx`
- `pnpm run validate:staged`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added "Runtime request failed" error messages across five languages: English, Japanese, Vietnamese, Simplified Chinese, and Traditional Chinese.

* **Bug Fixes**
  * Enhanced error reporting to display specific error details when available, with a localized fallback message for runtime request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->