### PR TITLE
fix(model-sync): avoid duplicate throttling and poll progress

### DIFF
--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -64,6 +64,7 @@ import StatisticsCard from "./components/StatisticsCard"
  * Unified logger scoped to the Managed Site model sync options dashboard.
  */
 const logger = createLogger("ManagedSiteModelSyncPage")
+const MODEL_SYNC_PROGRESS_POLL_INTERVAL_MS = 5_000
 
 const TAB_INDEX = {
   history: 0,
@@ -491,6 +492,20 @@ export default function ManagedSiteModelSync({
       setRunningChannelId(null)
     }
   }, [progress?.isRunning])
+
+  useEffect(() => {
+    if (!progress?.isRunning) {
+      return
+    }
+
+    const intervalId = setInterval(() => {
+      void loadProgress()
+    }, MODEL_SYNC_PROGRESS_POLL_INTERVAL_MS)
+
+    return () => {
+      clearInterval(intervalId)
+    }
+  }, [loadProgress, progress?.isRunning])
 
   useEffect(() => {
     if (isLoading || hasInitializedTab.current) {

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -566,9 +566,7 @@ const _fetchApi = async <T>(
     )
   }
 
-  const siteRequestLimitKey = resolveSiteRequestLimitKey(baseUrl)
-
-  return await withSiteApiRequestLimit(siteRequestLimitKey, async () => {
+  const executeRequest = async () => {
     const fallback = async () =>
       await executeWithTempWindowFallback(context, async () => {
         if (onlyData) {
@@ -605,7 +603,15 @@ const _fetchApi = async <T>(
       },
       fallback,
     )
-  })
+  }
+
+  if (request.bypassSiteRequestLimit) {
+    return await executeRequest()
+  }
+
+  const siteRequestLimitKey = resolveSiteRequestLimitKey(baseUrl)
+
+  return await withSiteApiRequestLimit(siteRequestLimitKey, executeRequest)
 }
 
 /**

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -86,6 +86,8 @@ export interface ApiTransportRequest {
   accountId?: string
   cookieAuthSessionCookie?: string
   fetchContext?: ApiTransportFetchContext
+  /** Skip the generic per-site limiter when the caller already applies a narrower limiter. */
+  bypassSiteRequestLimit?: boolean
 }
 
 export type ApiServiceRequest = ApiTransportRequest

--- a/src/services/models/modelSync/modelSyncService.ts
+++ b/src/services/models/modelSync/modelSyncService.ts
@@ -111,6 +111,7 @@ export class ModelSyncService {
     return {
       baseUrl: config.baseUrl,
       auth,
+      bypassSiteRequestLimit: true,
     }
   }
 

--- a/src/services/models/modelSync/modelSyncService.ts
+++ b/src/services/models/modelSync/modelSyncService.ts
@@ -108,11 +108,16 @@ export class ModelSyncService {
       auth.userId = config.userId
     }
 
-    return {
+    const request: ApiServiceRequest = {
       baseUrl: config.baseUrl,
       auth,
-      bypassSiteRequestLimit: true,
     }
+
+    if (this.rateLimiter) {
+      request.bypassSiteRequestLimit = true
+    }
+
+    return request
   }
 
   /**

--- a/src/services/models/modelSync/scheduler.ts
+++ b/src/services/models/modelSync/scheduler.ts
@@ -488,6 +488,7 @@ class ModelSyncScheduler {
       completed: 0,
       failed: 0,
     }
+    this.notifyProgress()
 
     let failureCount = 0
     let mappingSuccessCount = 0
@@ -683,6 +684,7 @@ class ModelSyncScheduler {
       completed: 0,
       failed: 0,
     }
+    this.notifyProgress()
 
     let failureCount = 0
 

--- a/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
+++ b/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
@@ -2233,4 +2233,102 @@ describe("ManagedSiteModelSync page", () => {
     unmount()
     expect(removeListener).toHaveBeenCalledWith(listener)
   })
+
+  it("polls background progress while a sync is still running", async () => {
+    vi.useFakeTimers()
+    try {
+      const addListener = vi.spyOn(browser.runtime.onMessage, "addListener")
+      let progressSnapshot = {
+        isRunning: false,
+        completed: 0,
+        total: 0,
+        failed: 0,
+      }
+      mockSendRuntimeMessage.mockImplementation(
+        async (type: string, _data?: any) => {
+          switch (type) {
+            case ModelSyncMessageTypes.GetLastExecution:
+              return {
+                success: true,
+                data: {
+                  items: [],
+                  statistics: {
+                    total: 0,
+                    successCount: 0,
+                    failureCount: 0,
+                    durationMs: 0,
+                    startedAt: 0,
+                    endedAt: 0,
+                  },
+                },
+              }
+            case ModelSyncMessageTypes.GetProgress:
+              return {
+                success: true,
+                data: progressSnapshot,
+              }
+            case ModelSyncMessageTypes.GetNextRun:
+              return { success: true, data: { nextScheduledAt: null } }
+            case ModelSyncMessageTypes.GetPreferences:
+              return {
+                success: true,
+                data: { enableSync: false, intervalMs: 0 },
+              }
+            case ModelSyncMessageTypes.ListChannels:
+              return { success: true, data: { items: [] } }
+            default:
+              return { success: true }
+          }
+        },
+      )
+
+      render(<ManagedSiteModelSync />)
+
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync()
+      })
+
+      expect(addListener).toHaveBeenCalled()
+
+      const listener = addListener.mock.calls.at(-1)?.[0] as (
+        message: any,
+      ) => void
+
+      await act(async () => {
+        listener({
+          type: "MANAGED_SITE_MODEL_SYNC_PROGRESS",
+          payload: {
+            isRunning: true,
+            completed: 0,
+            total: 361,
+            failed: 0,
+          },
+        })
+      })
+
+      const getProgressCallsBefore = mockSendRuntimeMessage.mock.calls.filter(
+        ([type]) => type === ModelSyncMessageTypes.GetProgress,
+      ).length
+
+      progressSnapshot = {
+        isRunning: true,
+        completed: 5,
+        total: 361,
+        failed: 1,
+      }
+
+      await act(async () => {
+        vi.advanceTimersByTime(5_000)
+        await vi.runOnlyPendingTimersAsync()
+      })
+
+      expect(
+        mockSendRuntimeMessage.mock.calls.filter(
+          ([type]) => type === ModelSyncMessageTypes.GetProgress,
+        ).length,
+      ).toBeGreaterThan(getProgressCallsBefore)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -1514,6 +1514,29 @@ describe("apiTransport request helpers", () => {
     },
   )
 
+  it("allows callers with their own limiter to bypass the generic site API limiter", async () => {
+    server.use(
+      http.get("https://example.com/base/api/test", () => {
+        return HttpResponse.json({
+          success: true,
+          data: { ok: true },
+          message: "ok",
+        })
+      }),
+    )
+
+    await fetchApiData(
+      {
+        baseUrl: BASE_URL,
+        auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        bypassSiteRequestLimit: true,
+      },
+      { endpoint: ENDPOINT },
+    )
+
+    expect(mockWithSiteApiRequestLimit).not.toHaveBeenCalled()
+  })
+
   it("fetchApi supports text responses", async () => {
     server.use(
       http.get("https://example.com/base/api/text", () => {

--- a/tests/services/modelSync/modelSyncService.test.ts
+++ b/tests/services/modelSync/modelSyncService.test.ts
@@ -400,6 +400,7 @@ describe("ModelSyncService - siteType routing", () => {
     expect(listAllChannelsMock).toHaveBeenCalledWith(
       {
         baseUrl: runtimeConfig.config.baseUrl,
+        bypassSiteRequestLimit: true,
         auth: {
           authType: "access_token",
           accessToken: runtimeConfig.config.password,
@@ -428,6 +429,7 @@ describe("ModelSyncService - siteType routing", () => {
       1,
       {
         baseUrl: octopusConfig.config.baseUrl,
+        bypassSiteRequestLimit: true,
         auth: {
           authType: "access_token",
           accessToken: "",
@@ -440,6 +442,7 @@ describe("ModelSyncService - siteType routing", () => {
       2,
       {
         baseUrl: cchConfig.config.baseUrl,
+        bypassSiteRequestLimit: true,
         auth: {
           authType: "access_token",
           accessToken: cchConfig.config.adminToken,
@@ -1219,6 +1222,24 @@ describe("ModelSyncService - batching and mapping", () => {
         message: "worker exploded",
       }),
     ])
+  })
+
+  it("marks managed-site API requests as already rate-limited by model sync", async () => {
+    const service = new ModelSyncService(makeExampleRuntimeConfig(), {
+      requestsPerMinute: 120,
+      burst: 5,
+    })
+
+    fetchChannelModelsMock.mockResolvedValueOnce(["gpt-4o"])
+
+    await service.fetchChannelModels(123)
+
+    expect(fetchChannelModelsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bypassSiteRequestLimit: true,
+      }),
+      123,
+    )
   })
 
   it("merges existing channel models with mapping keys before updating model_mapping", async () => {

--- a/tests/services/modelSync/modelSyncService.test.ts
+++ b/tests/services/modelSync/modelSyncService.test.ts
@@ -400,7 +400,6 @@ describe("ModelSyncService - siteType routing", () => {
     expect(listAllChannelsMock).toHaveBeenCalledWith(
       {
         baseUrl: runtimeConfig.config.baseUrl,
-        bypassSiteRequestLimit: true,
         auth: {
           authType: "access_token",
           accessToken: runtimeConfig.config.password,
@@ -429,7 +428,6 @@ describe("ModelSyncService - siteType routing", () => {
       1,
       {
         baseUrl: octopusConfig.config.baseUrl,
-        bypassSiteRequestLimit: true,
         auth: {
           authType: "access_token",
           accessToken: "",
@@ -442,7 +440,6 @@ describe("ModelSyncService - siteType routing", () => {
       2,
       {
         baseUrl: cchConfig.config.baseUrl,
-        bypassSiteRequestLimit: true,
         auth: {
           authType: "access_token",
           accessToken: cchConfig.config.adminToken,
@@ -1236,6 +1233,21 @@ describe("ModelSyncService - batching and mapping", () => {
 
     expect(fetchChannelModelsMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        bypassSiteRequestLimit: true,
+      }),
+      123,
+    )
+  })
+
+  it("keeps the generic site limiter when model sync has no configured limiter", async () => {
+    const service = new ModelSyncService(makeExampleRuntimeConfig())
+
+    fetchChannelModelsMock.mockResolvedValueOnce(["gpt-4o"])
+
+    await service.fetchChannelModels(123)
+
+    expect(fetchChannelModelsMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
         bypassSiteRequestLimit: true,
       }),
       123,

--- a/tests/services/modelSync/scheduler.lifecycle.test.ts
+++ b/tests/services/modelSync/scheduler.lifecycle.test.ts
@@ -479,6 +479,37 @@ describe("modelSyncScheduler lifecycle and edge flows", () => {
     expect(modelSyncScheduler.getProgress()).toBeNull()
   })
 
+  it("notifies listeners as soon as a new-api sync run starts", async () => {
+    const batchStarted = new Promise<void>((resolve) => {
+      mocks.runBatch.mockImplementation(async () => {
+        resolve()
+        return new Promise(() => {})
+      })
+    })
+
+    mocks.listChannels.mockResolvedValue({
+      items: [{ id: 1, name: "Known channel" }],
+      total: 1,
+      type_counts: {},
+    })
+
+    void modelSyncScheduler.executeSync()
+    await batchStarted
+
+    expect(mocks.sendRuntimeMessage).toHaveBeenCalledWith(
+      {
+        type: "MANAGED_SITE_MODEL_SYNC_PROGRESS",
+        payload: {
+          isRunning: true,
+          total: 1,
+          completed: 0,
+          failed: 0,
+        },
+      },
+      { maxAttempts: 1 },
+    )
+  })
+
   it("tracks failed progress updates and skips redirect mapping when a channel sync fails", async () => {
     const failedResult = {
       channelId: 1,


### PR DESCRIPTION
## Summary
- let managed-site model sync bypass the generic per-site API limiter when its own configured limiter is already applied
- notify model-sync progress immediately at run start and poll background progress while the UI sees a running job
- add focused regression coverage for limiter bypass, startup progress push, and running progress polling

## Related Issue
- Refs #1014

## Test Plan
- pnpm vitest run tests/services/apiTransport/request.test.ts tests/services/modelSync/modelSyncService.test.ts tests/services/modelSync/scheduler.lifecycle.test.ts tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model sync now polls running progress every few seconds to keep status up to date.
  * Initial sync progress is emitted immediately when a run starts.
* **Improvements**
  * API requests used by model sync can now skip generic per-site throttling when a more specific rate limit is already applied, improving request flow consistency.
* **Tests**
  * Added coverage for background progress polling, immediate progress notification, and the new bypass throttling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->