### PR TITLE
refactor(key-management): split repair missing keys dialog

### DIFF
--- a/src/features/KeyManagement/components/RepairAccountCoverageList.tsx
+++ b/src/features/KeyManagement/components/RepairAccountCoverageList.tsx
@@ -1,0 +1,149 @@
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
+import type { TFunction } from "i18next"
+
+import { Badge, Button, EmptyState } from "~/components/ui"
+import type { AccountKeyRepairAccountResult } from "~/types/accountKeyAutoProvisioning"
+import {
+  ACCOUNT_KEY_REPAIR_OUTCOMES,
+  ACCOUNT_KEY_REPAIR_SKIP_REASONS,
+} from "~/types/accountKeyAutoProvisioning"
+
+import {
+  getCoverageGroupLabel,
+  getRepairOutcomeLabel,
+  getSkipReasonLabel,
+  OUTCOME_BADGE_VARIANTS,
+} from "./repairMissingKeysDialogHelpers"
+
+interface RepairAccountCoverageListProps {
+  accountIds: Set<string>
+  filteredResults: AccountKeyRepairAccountResult[]
+  openingSub2ApiAccountId: string | null
+  onOpenSub2ApiTokenDialog: (accountId: string) => void
+  t: TFunction
+}
+
+/**
+ * Renders per-account repair outcomes and group coverage details.
+ */
+export function RepairAccountCoverageList({
+  accountIds,
+  filteredResults,
+  openingSub2ApiAccountId,
+  onOpenSub2ApiTokenDialog,
+  t,
+}: RepairAccountCoverageListProps) {
+  if (filteredResults.length === 0) {
+    return (
+      <EmptyState
+        icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+        title={t("keyManagement:repairMissingKeys.noMatchingResults")}
+        className="py-10"
+      />
+    )
+  }
+
+  return (
+    <ul className="dark:divide-dark-bg-tertiary divide-y">
+      {filteredResults.map((result) => {
+        const outcomeLabel = getRepairOutcomeLabel(t, result.outcome)
+        const details =
+          result.outcome === ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped
+            ? getSkipReasonLabel(t, result.skipReason)
+            : result.outcome === ACCOUNT_KEY_REPAIR_OUTCOMES.Failed
+              ? result.errorMessage || ""
+              : ""
+        const canCreateSub2ApiKey =
+          result.outcome === ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped &&
+          result.skipReason === ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api &&
+          accountIds.has(result.accountId)
+
+        const badgeVariant = OUTCOME_BADGE_VARIANTS[result.outcome]
+
+        return (
+          <li
+            key={`${result.accountId}-${result.finishedAt}`}
+            className="px-4 py-3"
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0 space-y-1">
+                <div className="flex min-w-0 items-center gap-2">
+                  <div className="truncate text-sm font-medium">
+                    {result.accountName}
+                  </div>
+                  <Badge
+                    variant="outline"
+                    size="sm"
+                    className="dark:border-dark-bg-tertiary shrink-0 border-gray-200 px-2 py-0.5 text-[11px] font-medium"
+                    title={result.siteType}
+                  >
+                    {result.siteType}
+                  </Badge>
+                </div>
+                <div className="dark:text-dark-text-secondary truncate text-xs text-gray-500">
+                  {result.siteUrlOrigin}
+                </div>
+              </div>
+              <Badge
+                variant={badgeVariant}
+                size="sm"
+                className="shrink-0 border-transparent"
+              >
+                {outcomeLabel}
+              </Badge>
+            </div>
+
+            {canCreateSub2ApiKey ? (
+              <div className="mt-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onOpenSub2ApiTokenDialog(result.accountId)}
+                  disabled={openingSub2ApiAccountId === result.accountId}
+                  loading={openingSub2ApiAccountId === result.accountId}
+                >
+                  {t("keyManagement:dialog.createToken")}
+                </Button>
+              </div>
+            ) : null}
+
+            {details ? (
+              <div
+                className={[
+                  "mt-2 text-xs",
+                  result.outcome === ACCOUNT_KEY_REPAIR_OUTCOMES.Failed
+                    ? "text-red-700 dark:text-red-300"
+                    : "dark:text-dark-text-secondary text-gray-500",
+                ].join(" ")}
+              >
+                {details}
+              </div>
+            ) : null}
+
+            {result.availableGroups ? (
+              <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                <Badge variant="outline" size="sm">
+                  {t("keyManagement:repairMissingKeys.coverage.groupsCovered", {
+                    covered: result.coveredGroups?.length ?? 0,
+                    total: result.availableGroups.length,
+                  })}
+                </Badge>
+                {(result.createdGroups ?? []).map((group) => (
+                  <Badge key={group} variant="success" size="sm">
+                    {getCoverageGroupLabel(t, "createdGroup", group)}
+                  </Badge>
+                ))}
+                {(result.missingGroups ?? []).map((group) => (
+                  <Badge key={group} variant="warning" size="sm">
+                    {getCoverageGroupLabel(t, "missingGroup", group)}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/features/KeyManagement/components/RepairInvalidKeysDeleteConfirm.tsx
+++ b/src/features/KeyManagement/components/RepairInvalidKeysDeleteConfirm.tsx
@@ -1,0 +1,79 @@
+import type { TFunction } from "i18next"
+import { useMemo } from "react"
+
+import { DestructiveConfirmDialog } from "~/components/ui"
+import type { AccountKeyRepairInvalidToken } from "~/types/accountKeyAutoProvisioning"
+
+import { getInvalidTokenKey } from "./repairMissingKeysDialogHelpers"
+
+interface RepairInvalidKeysDeleteConfirmProps {
+  isOpen: boolean
+  isWorking: boolean
+  selectedInvalidTokens: AccountKeyRepairInvalidToken[]
+  onClose: () => void
+  onConfirm: () => void
+  t: TFunction
+}
+
+/**
+ * Shows the destructive confirmation dialog for selected invalid keys.
+ */
+export function RepairInvalidKeysDeleteConfirm({
+  isOpen,
+  isWorking,
+  selectedInvalidTokens,
+  onClose,
+  onConfirm,
+  t,
+}: RepairInvalidKeysDeleteConfirmProps) {
+  const details = useMemo(() => {
+    const previewTokens = selectedInvalidTokens.slice(0, 5)
+    const hiddenCount = selectedInvalidTokens.length - previewTokens.length
+
+    return (
+      <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-tertiary/40 rounded-md border border-gray-200 bg-gray-50 p-3">
+        <ul className="space-y-2 text-sm">
+          {previewTokens.map((token) => (
+            <li
+              key={getInvalidTokenKey(token)}
+              className="min-w-0 text-gray-700 dark:text-gray-300"
+            >
+              <span className="font-medium">{token.tokenName}</span>
+              <span className="dark:text-dark-text-secondary text-gray-500">
+                {" "}
+                · {token.accountName}
+              </span>
+            </li>
+          ))}
+        </ul>
+        {hiddenCount > 0 ? (
+          <p className="dark:text-dark-text-secondary mt-2 text-xs text-gray-500">
+            {t("keyManagement:repairMissingKeys.deleteConfirm.more", {
+              count: hiddenCount,
+            })}
+          </p>
+        ) : null}
+      </div>
+    )
+  }, [selectedInvalidTokens, t])
+
+  return (
+    <DestructiveConfirmDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title={t("keyManagement:repairMissingKeys.deleteConfirm.title", {
+        count: selectedInvalidTokens.length,
+      })}
+      description={t(
+        "keyManagement:repairMissingKeys.deleteConfirm.description",
+      )}
+      confirmLabel={t("keyManagement:repairMissingKeys.deleteConfirm.confirm")}
+      cancelLabel={t("common:actions.cancel")}
+      details={details}
+      isWorking={isWorking}
+      size="md"
+      confirmButtonTestId="repair-invalid-keys-confirm-delete"
+    />
+  )
+}

--- a/src/features/KeyManagement/components/RepairInvalidKeysList.tsx
+++ b/src/features/KeyManagement/components/RepairInvalidKeysList.tsx
@@ -1,0 +1,194 @@
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
+import type { TFunction } from "i18next"
+
+import { Alert, Badge, Button, Checkbox, EmptyState } from "~/components/ui"
+import type { AccountKeyRepairInvalidToken } from "~/types/accountKeyAutoProvisioning"
+
+import {
+  getInvalidTokenKey,
+  getInvalidTokenReasonLabel,
+} from "./repairMissingKeysDialogHelpers"
+
+interface RepairInvalidKeysListProps {
+  deleteResultMessage: string
+  filteredInvalidTokens: AccountKeyRepairInvalidToken[]
+  invalidTokens: AccountKeyRepairInvalidToken[]
+  selectedInvalidTokenKeys: Set<string>
+  selectedInvalidTokens: AccountKeyRepairInvalidToken[]
+  onOpenDeleteConfirm: () => void
+  onSelectedInvalidTokenKeysChange: (
+    updater: Set<string> | ((previous: Set<string>) => Set<string>),
+  ) => void
+  t: TFunction
+}
+
+/**
+ * Renders invalid keys with selection, empty states, and delete feedback.
+ */
+export function RepairInvalidKeysList({
+  deleteResultMessage,
+  filteredInvalidTokens,
+  invalidTokens,
+  selectedInvalidTokenKeys,
+  selectedInvalidTokens,
+  onOpenDeleteConfirm,
+  onSelectedInvalidTokenKeysChange,
+  t,
+}: RepairInvalidKeysListProps) {
+  if (invalidTokens.length === 0) {
+    return (
+      <div>
+        {deleteResultMessage ? (
+          <div className="px-4 pt-4">
+            <Alert description={deleteResultMessage} />
+          </div>
+        ) : null}
+        <EmptyState
+          icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+          title={t("keyManagement:repairMissingKeys.invalidKeys.emptyTitle")}
+          description={t(
+            "keyManagement:repairMissingKeys.invalidKeys.emptyDescription",
+          )}
+          className="py-10"
+        />
+      </div>
+    )
+  }
+
+  if (filteredInvalidTokens.length === 0) {
+    return (
+      <div>
+        {deleteResultMessage ? (
+          <div className="px-4 pt-4">
+            <Alert description={deleteResultMessage} />
+          </div>
+        ) : null}
+        <EmptyState
+          icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+          title={t("keyManagement:repairMissingKeys.noMatchingResults")}
+          className="py-10"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {deleteResultMessage ? (
+        <div className="px-4 pt-4">
+          <Alert description={deleteResultMessage} />
+        </div>
+      ) : null}
+
+      <div className="dark:border-dark-bg-tertiary space-y-2 border-b border-gray-200 px-4 py-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <label className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={
+                filteredInvalidTokens.length > 0 &&
+                selectedInvalidTokens.length === filteredInvalidTokens.length
+              }
+              onCheckedChange={(checked) => {
+                onSelectedInvalidTokenKeysChange(
+                  checked
+                    ? new Set(filteredInvalidTokens.map(getInvalidTokenKey))
+                    : new Set(),
+                )
+              }}
+              aria-label={t(
+                "keyManagement:repairMissingKeys.invalidKeys.selectAll",
+              )}
+            />
+            {t("keyManagement:repairMissingKeys.invalidKeys.selectAll")}
+          </label>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {t("keyManagement:repairMissingKeys.invalidKeys.selectedCount", {
+                count: selectedInvalidTokens.length,
+              })}
+            </span>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              disabled={selectedInvalidTokens.length === 0}
+              onClick={onOpenDeleteConfirm}
+            >
+              {t("keyManagement:repairMissingKeys.invalidKeys.deleteSelected")}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <ul className="dark:divide-dark-bg-tertiary divide-y">
+        {filteredInvalidTokens.map((token) => {
+          const tokenKey = getInvalidTokenKey(token)
+
+          return (
+            <li
+              key={`${token.accountId}-${token.tokenId}-${token.group}`}
+              className="px-4 py-3"
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex min-w-0 gap-3">
+                  <Checkbox
+                    checked={selectedInvalidTokenKeys.has(tokenKey)}
+                    onCheckedChange={(checked) => {
+                      onSelectedInvalidTokenKeysChange((previous) => {
+                        const next = new Set(previous)
+                        if (checked) {
+                          next.add(tokenKey)
+                        } else {
+                          next.delete(tokenKey)
+                        }
+                        return next
+                      })
+                    }}
+                    aria-label={token.tokenName}
+                    className="mt-0.5 shrink-0"
+                  />
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <div className="truncate text-sm font-medium">
+                        {token.tokenName}
+                      </div>
+                      <Badge
+                        variant="warning"
+                        size="sm"
+                        className="shrink-0 border-transparent"
+                      >
+                        {t("keyManagement:repairMissingKeys.invalidKeys.badge")}
+                      </Badge>
+                      <Badge
+                        variant="outline"
+                        size="sm"
+                        className="dark:border-dark-bg-tertiary shrink-0 border-gray-200 px-2 py-0.5 text-[11px] font-medium"
+                        title={token.group}
+                      >
+                        {token.group}
+                      </Badge>
+                    </div>
+                    <div className="dark:text-dark-text-secondary truncate text-xs text-gray-500">
+                      {token.accountName} · {token.siteUrlOrigin}
+                    </div>
+                  </div>
+                </div>
+                <Badge
+                  variant="outline"
+                  size="sm"
+                  className="dark:border-dark-bg-tertiary shrink-0 border-gray-200 px-2 py-0.5 text-[11px] font-medium"
+                  title={token.siteType}
+                >
+                  {token.siteType}
+                </Badge>
+              </div>
+              <div className="mt-2 text-xs text-amber-700 dark:text-amber-200">
+                {getInvalidTokenReasonLabel(t, token)}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -1,5 +1,5 @@
 import { ShieldCheck } from "lucide-react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
@@ -13,125 +13,25 @@ import {
   Modal,
   Spinner,
 } from "~/components/ui"
-import { RuntimeMessageTypes } from "~/constants/runtimeActions"
-import {
-  AccountKeyRepairMessageTypes,
-  sendAccountKeyRepairMessage,
-} from "~/services/accounts/accountKeyAutoProvisioning/messaging"
-import {
-  trackProductAnalyticsActionCompleted,
-  trackProductAnalyticsActionStarted,
-} from "~/services/productAnalytics/actions"
-import {
-  PRODUCT_ANALYTICS_ACTION_IDS,
-  PRODUCT_ANALYTICS_ENTRYPOINTS,
-  PRODUCT_ANALYTICS_ERROR_CATEGORIES,
-  PRODUCT_ANALYTICS_FEATURE_IDS,
-  PRODUCT_ANALYTICS_RESULTS,
-  PRODUCT_ANALYTICS_STATUS_KINDS,
-  PRODUCT_ANALYTICS_SURFACE_IDS,
-} from "~/services/productAnalytics/events"
 import type { DisplaySiteData } from "~/types"
-import type {
-  AccountKeyRepairOutcome,
-  AccountKeyRepairProgress,
-} from "~/types/accountKeyAutoProvisioning"
+import type { AccountKeyRepairOutcome } from "~/types/accountKeyAutoProvisioning"
 import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
-import { onRuntimeMessage } from "~/utils/browser/browserApi"
 
 import { RepairInvalidKeysDeleteConfirm } from "./RepairInvalidKeysDeleteConfirm"
 import {
-  getInvalidTokenKey,
   REPAIR_RESULT_VIEWS,
   type RepairResultView,
 } from "./repairMissingKeysDialogHelpers"
 import { RepairMissingKeysProgressCard } from "./RepairMissingKeysProgressCard"
 import { RepairMissingKeysResultsPanel } from "./RepairMissingKeysResultsPanel"
-
-const repairMissingKeysAnalyticsContext = {
-  featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
-  actionId: PRODUCT_ANALYTICS_ACTION_IDS.RepairMissingAccountKeys,
-  surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRepairDialog,
-  entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
-}
-
-const deleteInvalidKeysAnalyticsContext = {
-  featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
-  actionId: PRODUCT_ANALYTICS_ACTION_IDS.DeleteInvalidAccountTokens,
-  surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRepairDialog,
-  entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
-}
-
-/**
- * Counts accounts that are eligible for the repair attempt at the dialog boundary.
- */
-function getEligibleAccountCountFromAccounts(accounts: DisplaySiteData[]) {
-  return accounts.filter((account) => !account.disabled).length
-}
-
-/**
- * Builds sanitized analytics insights when the repair job cannot start.
- */
-function getRepairStartFailureInsights(
-  progress: AccountKeyRepairProgress | null,
-  accounts: DisplaySiteData[],
-) {
-  return {
-    itemCount:
-      progress?.totals.eligibleAccounts ??
-      getEligibleAccountCountFromAccounts(accounts),
-    selectedCount: 0,
-    successCount: 0,
-    failureCount: progress?.summary.failed ?? 0,
-    statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
-  }
-}
+import { useInvalidKeyDeletion } from "./useInvalidKeyDeletion"
+import { useRepairMissingKeysJob } from "./useRepairMissingKeysJob"
 
 interface RepairMissingKeysDialogProps {
   isOpen: boolean
   onClose: () => void
   accounts: DisplaySiteData[]
   startOnOpen: boolean
-}
-
-/**
- * Extracts privacy-safe count metrics from repair progress.
- */
-function getRepairProgressInsightCounts(progress: AccountKeyRepairProgress) {
-  return {
-    itemCount: progress.totals.eligibleAccounts,
-    selectedCount:
-      progress.totals.processedEligibleAccounts ??
-      progress.totals.processedAccounts,
-    successCount: progress.summary.created,
-    failureCount: progress.summary.failed,
-  }
-}
-
-/**
- * Maps terminal repair progress into a coarse health status.
- */
-function getRepairProgressStatusKind(progress: AccountKeyRepairProgress) {
-  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
-    return PRODUCT_ANALYTICS_STATUS_KINDS.Error
-  }
-  if (progress.summary.failed > 0) {
-    return PRODUCT_ANALYTICS_STATUS_KINDS.Warning
-  }
-  return PRODUCT_ANALYTICS_STATUS_KINDS.Healthy
-}
-
-/**
- * Maps terminal repair progress into the product analytics result enum.
- */
-function getRepairProgressResult(progress: AccountKeyRepairProgress) {
-  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
-    return PRODUCT_ANALYTICS_RESULTS.Failure
-  }
-  if (progress.summary.failed > 0) {
-    return PRODUCT_ANALYTICS_RESULTS.Failure
-  }
-  return PRODUCT_ANALYTICS_RESULTS.Success
 }
 
 /**
@@ -142,10 +42,6 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
   const { t } = useTranslation(["keyManagement", "common"])
   const { openDefaultTokenQuickCreateDialogForAccount } = useChannelDialog()
 
-  const [progress, setProgress] = useState<AccountKeyRepairProgress | null>(
-    null,
-  )
-  const [error, setError] = useState<string>("")
   const [searchTerm, setSearchTerm] = useState("")
   const [outcomeFilter, setOutcomeFilter] =
     useState<AccountKeyRepairOutcome | null>(null)
@@ -155,22 +51,13 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
   const [openingSub2ApiAccountId, setOpeningSub2ApiAccountId] = useState<
     string | null
   >(null)
-  const [selectedInvalidTokenKeys, setSelectedInvalidTokenKeys] = useState<
-    Set<string>
-  >(() => new Set())
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
-  const [isDeletingInvalidKeys, setIsDeletingInvalidKeys] = useState(false)
-  const [deleteResultMessage, setDeleteResultMessage] = useState("")
-  const [isStarting, setIsStarting] = useState(false)
-  const startedAnalyticsJobIdRef = useRef<string | null>(null)
-  const completedAnalyticsJobIdRef = useRef<string | null>(null)
-  const progressRef = useRef<AccountKeyRepairProgress | null>(null)
-  const accountsRef = useRef(accounts)
-  const isDialogOpenRef = useRef(isOpen)
-  const startInFlightRef = useRef(false)
-  const startRequestIdRef = useRef(0)
-
-  isDialogOpenRef.current = isOpen
+  const { error, handleStartAudit, isStarting, progress, setProgress } =
+    useRepairMissingKeysJob({
+      accounts,
+      isOpen,
+      startOnOpen,
+      t,
+    })
 
   const disabledAccountIds = useMemo(() => {
     return new Set(
@@ -248,135 +135,22 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     })
   }, [invalidTokens, searchTerm])
 
-  const selectedInvalidTokens = useMemo(() => {
-    return filteredInvalidTokens.filter((token) =>
-      selectedInvalidTokenKeys.has(getInvalidTokenKey(token)),
-    )
-  }, [filteredInvalidTokens, selectedInvalidTokenKeys])
-
-  const handleDeleteInvalidKeys = async () => {
-    const tokensToDelete = selectedInvalidTokens
-    if (tokensToDelete.length === 0) {
-      return
-    }
-
-    setIsDeletingInvalidKeys(true)
-    setDeleteResultMessage("")
-    void trackProductAnalyticsActionStarted(deleteInvalidKeysAnalyticsContext)
-    try {
-      const response = await sendAccountKeyRepairMessage(
-        AccountKeyRepairMessageTypes.DeleteInvalidTokens,
-        { tokens: tokensToDelete },
-      )
-
-      if (!response?.success || !response.data) {
-        setDeleteResultMessage(t("repairMissingKeys.invalidKeys.deleteFailed"))
-        setIsDeleteConfirmOpen(false)
-        void trackProductAnalyticsActionCompleted({
-          ...deleteInvalidKeysAnalyticsContext,
-          result: PRODUCT_ANALYTICS_RESULTS.Failure,
-          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-          insights: {
-            itemCount: tokensToDelete.length,
-            selectedCount: tokensToDelete.length,
-            successCount: 0,
-            failureCount: tokensToDelete.length,
-            statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
-          },
-        })
-        return
-      }
-
-      const deletedKeys = new Set(response.data.deleted.map(getInvalidTokenKey))
-      setSelectedInvalidTokenKeys((previous) => {
-        const next = new Set(previous)
-        for (const key of deletedKeys) {
-          next.delete(key)
-        }
-        return next
-      })
-      setProgress((current) => {
-        if (!current) return current
-
-        let removedInvalidTokenCount = 0
-        const nextResults = current.results.map((result) => {
-          const nextInvalidTokens = result.invalidTokens?.filter((token) => {
-            const shouldRemove = deletedKeys.has(getInvalidTokenKey(token))
-            if (shouldRemove) {
-              removedInvalidTokenCount += 1
-            }
-            return !shouldRemove
-          })
-
-          return {
-            ...result,
-            invalidTokens: nextInvalidTokens,
-          }
-        })
-
-        return {
-          ...current,
-          summary: {
-            ...current.summary,
-            invalidKeys: Math.max(
-              0,
-              (current.summary.invalidKeys ?? 0) - removedInvalidTokenCount,
-            ),
-            deletedKeys:
-              (current.summary.deletedKeys ?? 0) + response.data.deleted.length,
-            deleteFailed:
-              (current.summary.deleteFailed ?? 0) + response.data.failed.length,
-          },
-          results: nextResults,
-        }
-      })
-      setDeleteResultMessage(
-        response.data.failed.length > 0
-          ? t("repairMissingKeys.invalidKeys.deletePartial", {
-              deleted: response.data.deleted.length,
-              failed: response.data.failed.length,
-            })
-          : t("repairMissingKeys.invalidKeys.deleteSuccess", {
-              count: response.data.deleted.length,
-            }),
-      )
-      setIsDeleteConfirmOpen(false)
-      void trackProductAnalyticsActionCompleted({
-        ...deleteInvalidKeysAnalyticsContext,
-        result:
-          response.data.failed.length > 0
-            ? PRODUCT_ANALYTICS_RESULTS.Failure
-            : PRODUCT_ANALYTICS_RESULTS.Success,
-        insights: {
-          itemCount: tokensToDelete.length,
-          selectedCount: tokensToDelete.length,
-          successCount: response.data.deleted.length,
-          failureCount: response.data.failed.length,
-          statusKind:
-            response.data.failed.length > 0
-              ? PRODUCT_ANALYTICS_STATUS_KINDS.Warning
-              : PRODUCT_ANALYTICS_STATUS_KINDS.Healthy,
-        },
-      })
-    } catch {
-      setDeleteResultMessage(t("repairMissingKeys.invalidKeys.deleteFailed"))
-      setIsDeleteConfirmOpen(false)
-      void trackProductAnalyticsActionCompleted({
-        ...deleteInvalidKeysAnalyticsContext,
-        result: PRODUCT_ANALYTICS_RESULTS.Failure,
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: {
-          itemCount: tokensToDelete.length,
-          selectedCount: tokensToDelete.length,
-          successCount: 0,
-          failureCount: tokensToDelete.length,
-          statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
-        },
-      })
-    } finally {
-      setIsDeletingInvalidKeys(false)
-    }
-  }
+  const {
+    deleteResultMessage,
+    handleDeleteInvalidKeys,
+    isDeleteConfirmOpen,
+    isDeletingInvalidKeys,
+    resetInvalidKeyDeletionState,
+    selectedInvalidTokenKeys,
+    selectedInvalidTokens,
+    setIsDeleteConfirmOpen,
+    setSelectedInvalidTokenKeys,
+  } = useInvalidKeyDeletion({
+    filteredInvalidTokens,
+    invalidTokens,
+    setProgress,
+    t,
+  })
 
   const handleOpenSub2ApiTokenDialog = async (accountId: string) => {
     const account = accountById.get(accountId)
@@ -410,201 +184,14 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     return counts
   }, [visibleResults])
 
-  const handleStartAudit = useCallback(async () => {
-    if (startInFlightRef.current) {
-      return
-    }
-
-    startInFlightRef.current = true
-    const requestId = startRequestIdRef.current + 1
-    startRequestIdRef.current = requestId
-
-    setIsStarting(true)
-    setError("")
-    try {
-      const response = await sendAccountKeyRepairMessage(
-        AccountKeyRepairMessageTypes.Start,
-      )
-      if (response?.success && response.data) {
-        startedAnalyticsJobIdRef.current = response.data.jobId
-        void trackProductAnalyticsActionStarted(
-          repairMissingKeysAnalyticsContext,
-        )
-        if (
-          isDialogOpenRef.current &&
-          startRequestIdRef.current === requestId
-        ) {
-          setProgress(response.data)
-        }
-        return
-      }
-
-      void trackProductAnalyticsActionCompleted({
-        ...repairMissingKeysAnalyticsContext,
-        result: PRODUCT_ANALYTICS_RESULTS.Failure,
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: getRepairStartFailureInsights(
-          progressRef.current,
-          accountsRef.current,
-        ),
-      })
-      if (isDialogOpenRef.current && startRequestIdRef.current === requestId) {
-        setError(t("repairMissingKeys.messages.startFailed"))
-      }
-    } catch {
-      void trackProductAnalyticsActionCompleted({
-        ...repairMissingKeysAnalyticsContext,
-        result: PRODUCT_ANALYTICS_RESULTS.Failure,
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: getRepairStartFailureInsights(
-          progressRef.current,
-          accountsRef.current,
-        ),
-      })
-      if (isDialogOpenRef.current && startRequestIdRef.current === requestId) {
-        setError(t("repairMissingKeys.messages.startFailed"))
-      }
-    } finally {
-      if (startRequestIdRef.current === requestId) {
-        startInFlightRef.current = false
-        if (isDialogOpenRef.current) {
-          setIsStarting(false)
-        }
-      }
-    }
-  }, [t])
-
-  useEffect(() => {
-    isDialogOpenRef.current = isOpen
-    if (isOpen) {
-      setIsStarting(startInFlightRef.current)
-    } else {
-      setIsStarting(false)
-    }
-  }, [isOpen])
-
-  useEffect(() => {
-    return () => {
-      isDialogOpenRef.current = false
-      startRequestIdRef.current += 1
-      startInFlightRef.current = false
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!isOpen) {
-      startedAnalyticsJobIdRef.current = null
-      completedAnalyticsJobIdRef.current = null
-    }
-  }, [isOpen])
-
   useEffect(() => {
     if (!isOpen) {
       setSearchTerm("")
       setOutcomeFilter(null)
       setActiveView(REPAIR_RESULT_VIEWS.AccountCoverage)
-      setSelectedInvalidTokenKeys(new Set())
-      setIsDeleteConfirmOpen(false)
-      setDeleteResultMessage("")
+      resetInvalidKeyDeletionState()
     }
-  }, [isOpen])
-
-  useEffect(() => {
-    const currentInvalidTokenKeys = new Set(
-      invalidTokens.map(getInvalidTokenKey),
-    )
-    setSelectedInvalidTokenKeys((previous) => {
-      const next = new Set(
-        [...previous].filter((key) => currentInvalidTokenKeys.has(key)),
-      )
-      return next.size === previous.size ? previous : next
-    })
-  }, [invalidTokens])
-
-  useEffect(() => {
-    if (isDeleteConfirmOpen && selectedInvalidTokens.length === 0) {
-      setIsDeleteConfirmOpen(false)
-    }
-  }, [isDeleteConfirmOpen, selectedInvalidTokens.length])
-
-  useEffect(() => {
-    progressRef.current = progress
-  }, [progress])
-
-  useEffect(() => {
-    accountsRef.current = accounts
-  }, [accounts])
-
-  useEffect(() => {
-    if (!isOpen) return
-
-    return onRuntimeMessage((message) => {
-      if (message?.type !== RuntimeMessageTypes.AccountKeyRepairProgress) return
-      const payload = message?.payload as AccountKeyRepairProgress | undefined
-      if (!payload) return
-      setProgress(payload)
-    })
-  }, [isOpen])
-
-  useEffect(() => {
-    if (!isOpen) return
-
-    let cancelled = false
-    setError("")
-
-    void (async () => {
-      try {
-        const response = await sendAccountKeyRepairMessage(
-          AccountKeyRepairMessageTypes.GetProgress,
-        )
-        if (cancelled) return
-        if (response?.success && response.data) {
-          setProgress(response.data)
-        }
-      } catch {
-        if (!cancelled) {
-          setError(t("repairMissingKeys.messages.loadFailed"))
-        }
-      }
-    })()
-
-    return () => {
-      cancelled = true
-    }
-  }, [isOpen, t])
-
-  useEffect(() => {
-    if (!isOpen) return
-    if (!startOnOpen) return
-
-    void handleStartAudit()
-  }, [handleStartAudit, isOpen, startOnOpen])
-
-  useEffect(() => {
-    if (!progress) return
-    if (
-      progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Completed &&
-      progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Failed
-    ) {
-      return
-    }
-    if (startedAnalyticsJobIdRef.current !== progress.jobId) return
-    if (completedAnalyticsJobIdRef.current === progress.jobId) return
-
-    completedAnalyticsJobIdRef.current = progress.jobId
-
-    void trackProductAnalyticsActionCompleted({
-      ...repairMissingKeysAnalyticsContext,
-      result: getRepairProgressResult(progress),
-      ...(progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed
-        ? { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown }
-        : {}),
-      insights: {
-        ...getRepairProgressInsightCounts(progress),
-        statusKind: getRepairProgressStatusKind(progress),
-      },
-    })
-  }, [progress])
+  }, [isOpen, resetInvalidKeyDeletionState])
 
   return (
     <Modal

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -1,11 +1,8 @@
-import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
-import type { TFunction } from "i18next"
-import { ShieldCheck, TriangleAlert } from "lucide-react"
+import { ShieldCheck } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
-import { ResponsiveToggleGroup } from "~/components/ResponsiveButtonGroup"
 import {
   Alert,
   Badge,
@@ -13,16 +10,8 @@ import {
   Card,
   CardContent,
   CardFooter,
-  CardHeader,
-  CardTitle,
-  Checkbox,
-  DestructiveConfirmDialog,
-  EmptyState,
-  Input,
-  Label,
   Modal,
   Spinner,
-  TagFilter,
 } from "~/components/ui"
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import {
@@ -44,18 +33,20 @@ import {
 } from "~/services/productAnalytics/events"
 import type { DisplaySiteData } from "~/types"
 import type {
-  AccountKeyRepairInvalidToken,
   AccountKeyRepairOutcome,
   AccountKeyRepairProgress,
-  AccountKeyRepairSkipReason,
 } from "~/types/accountKeyAutoProvisioning"
-import {
-  ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
-  ACCOUNT_KEY_REPAIR_JOB_STATES,
-  ACCOUNT_KEY_REPAIR_OUTCOMES,
-  ACCOUNT_KEY_REPAIR_SKIP_REASONS,
-} from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
+
+import { RepairInvalidKeysDeleteConfirm } from "./RepairInvalidKeysDeleteConfirm"
+import {
+  getInvalidTokenKey,
+  REPAIR_RESULT_VIEWS,
+  type RepairResultView,
+} from "./repairMissingKeysDialogHelpers"
+import { RepairMissingKeysProgressCard } from "./RepairMissingKeysProgressCard"
+import { RepairMissingKeysResultsPanel } from "./RepairMissingKeysResultsPanel"
 
 const repairMissingKeysAnalyticsContext = {
   featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
@@ -101,117 +92,6 @@ interface RepairMissingKeysDialogProps {
   onClose: () => void
   accounts: DisplaySiteData[]
   startOnOpen: boolean
-}
-
-/**
- * Returns the localized skip reason label used when a repair result is skipped.
- */
-function getSkipReasonLabel(
-  t: TFunction,
-  reason: AccountKeyRepairSkipReason | undefined,
-) {
-  if (!reason) return ""
-  switch (reason) {
-    case ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api:
-      return t("keyManagement:repairMissingKeys.skipReasons.sub2api")
-    case ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey:
-      return t("keyManagement:repairMissingKeys.skipReasons.aihubmixOneTimeKey")
-    case ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth:
-      return t("keyManagement:repairMissingKeys.skipReasons.noneAuth")
-  }
-}
-
-type BadgeVariant = React.ComponentProps<typeof Badge>["variant"]
-const REPAIR_RESULT_VIEWS = {
-  AccountCoverage: "accountCoverage",
-  InvalidKeys: "invalidKeys",
-} as const
-
-type RepairResultView =
-  (typeof REPAIR_RESULT_VIEWS)[keyof typeof REPAIR_RESULT_VIEWS]
-
-const OUTCOME_BADGE_VARIANTS: Record<AccountKeyRepairOutcome, BadgeVariant> = {
-  [ACCOUNT_KEY_REPAIR_OUTCOMES.Created]: "success",
-  [ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad]: "info",
-  [ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped]: "warning",
-  [ACCOUNT_KEY_REPAIR_OUTCOMES.Failed]: "danger",
-}
-
-/**
- * Returns the localized outcome label shown for each repair result row.
- */
-function getRepairOutcomeLabel(t: TFunction, outcome: AccountKeyRepairOutcome) {
-  switch (outcome) {
-    case ACCOUNT_KEY_REPAIR_OUTCOMES.Created:
-      return t("keyManagement:repairMissingKeys.outcomes.created")
-    case ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad:
-      return t("keyManagement:repairMissingKeys.outcomes.alreadyHad")
-    case ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped:
-      return t("keyManagement:repairMissingKeys.outcomes.skipped")
-    case ACCOUNT_KEY_REPAIR_OUTCOMES.Failed:
-      return t("keyManagement:repairMissingKeys.outcomes.failed")
-  }
-}
-
-/**
- * Returns the localized view switch label.
- */
-function getRepairResultViewLabel(t: TFunction, view: RepairResultView) {
-  switch (view) {
-    case REPAIR_RESULT_VIEWS.AccountCoverage:
-      return t("keyManagement:repairMissingKeys.views.accountCoverage")
-    case REPAIR_RESULT_VIEWS.InvalidKeys:
-      return t("keyManagement:repairMissingKeys.views.invalidKeys")
-  }
-}
-
-/**
- * Keeps group names visible if i18n returns the missing-key fallback instead of
- * interpolated copy.
- */
-function getCoverageGroupLabel(
-  t: TFunction,
-  key: "createdGroup" | "missingGroup",
-  group: string,
-) {
-  const [translationKey, label] =
-    key === "createdGroup"
-      ? [
-          "keyManagement:repairMissingKeys.coverage.createdGroup",
-          t("keyManagement:repairMissingKeys.coverage.createdGroup", {
-            group,
-          }),
-        ]
-      : [
-          "keyManagement:repairMissingKeys.coverage.missingGroup",
-          t("keyManagement:repairMissingKeys.coverage.missingGroup", {
-            group,
-          }),
-        ]
-
-  return label === translationKey ? group : label
-}
-
-/**
- * Returns the localized reason shown for invalid keys.
- */
-function getInvalidTokenReasonLabel(
-  t: TFunction,
-  token: AccountKeyRepairInvalidToken,
-) {
-  switch (token.reason) {
-    case ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable:
-      return t("keyManagement:repairMissingKeys.invalidKeys.groupUnavailable", {
-        group: token.group,
-      })
-  }
-}
-
-/**
- * Builds a stable selection key for an invalid token within an account.
- */
-function getInvalidTokenKey(token: AccountKeyRepairInvalidToken) {
-  return `${token.accountId}:${token.tokenId}`
 }
 
 /**
@@ -302,6 +182,10 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     return new Map(accounts.map((account) => [account.id, account]))
   }, [accounts])
 
+  const accountIds = useMemo(() => {
+    return new Set(accounts.map((account) => account.id))
+  }, [accounts])
+
   const visibleResults = useMemo(() => {
     if (!progress) return []
     return progress.results.filter(
@@ -369,37 +253,6 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
       selectedInvalidTokenKeys.has(getInvalidTokenKey(token)),
     )
   }, [filteredInvalidTokens, selectedInvalidTokenKeys])
-
-  const deleteConfirmDetails = useMemo(() => {
-    const previewTokens = selectedInvalidTokens.slice(0, 5)
-    const hiddenCount = selectedInvalidTokens.length - previewTokens.length
-
-    return (
-      <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-tertiary/40 rounded-md border border-gray-200 bg-gray-50 p-3">
-        <ul className="space-y-2 text-sm">
-          {previewTokens.map((token) => (
-            <li
-              key={getInvalidTokenKey(token)}
-              className="min-w-0 text-gray-700 dark:text-gray-300"
-            >
-              <span className="font-medium">{token.tokenName}</span>
-              <span className="dark:text-dark-text-secondary text-gray-500">
-                {" "}
-                · {token.accountName}
-              </span>
-            </li>
-          ))}
-        </ul>
-        {hiddenCount > 0 ? (
-          <p className="dark:text-dark-text-secondary mt-2 text-xs text-gray-500">
-            {t("repairMissingKeys.deleteConfirm.more", {
-              count: hiddenCount,
-            })}
-          </p>
-        ) : null}
-      </div>
-    )
-  }, [selectedInvalidTokens, t])
 
   const handleDeleteInvalidKeys = async () => {
     const tokensToDelete = selectedInvalidTokens
@@ -556,37 +409,6 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
 
     return counts
   }, [visibleResults])
-
-  const eligibleTotal = progress?.totals.eligibleAccounts ?? 0
-  const processedTotal =
-    progress?.totals.processedEligibleAccounts ??
-    progress?.totals.processedAccounts ??
-    0
-  const progressMax = Math.max(1, eligibleTotal)
-
-  const progressPercent = useMemo(() => {
-    if (eligibleTotal <= 0) return 0
-    return Math.min(100, Math.round((processedTotal / eligibleTotal) * 100))
-  }, [eligibleTotal, processedTotal])
-
-  const progressBarColor = useMemo(() => {
-    if (!progress) {
-      return "bg-blue-600 dark:bg-blue-500"
-    }
-    if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
-      return "bg-red-600 dark:bg-red-500"
-    }
-    if (
-      progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Completed &&
-      progress.summary.failed > 0
-    ) {
-      return "bg-amber-600 dark:bg-amber-500"
-    }
-    if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Completed) {
-      return "bg-emerald-600 dark:bg-emerald-500"
-    }
-    return "bg-blue-600 dark:bg-blue-500"
-  }, [progress])
 
   const handleStartAudit = useCallback(async () => {
     if (startInFlightRef.current) {
@@ -873,581 +695,47 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
 
       {progress && progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Idle ? (
         <div className="space-y-4">
-          <Card>
-            <CardContent padding="md" spacing="none" className="space-y-4">
-              <div className="space-y-2">
-                <div
-                  data-testid="repair-missing-keys-progress-header"
-                  className="flex flex-wrap items-center justify-between gap-2"
-                >
-                  <div className="min-w-0 text-xs text-gray-600 dark:text-gray-400">
-                    <span>{t("repairMissingKeys.progressLabel")}</span>
-                  </div>
-                  <div
-                    data-testid="repair-missing-keys-progress-actions"
-                    className="flex flex-wrap items-center justify-end gap-3 text-xs text-gray-600 dark:text-gray-400"
-                  >
-                    <span>
-                      {processedTotal}/{eligibleTotal} ({progressPercent}%)
-                    </span>
-                    {progress.state !==
-                    ACCOUNT_KEY_REPAIR_JOB_STATES.Running ? (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => void handleStartAudit()}
-                        disabled={isStarting}
-                        loading={isStarting}
-                      >
-                        {t("repairMissingKeys.actions.rerun")}
-                      </Button>
-                    ) : null}
-                  </div>
-                </div>
-                <div
-                  className="dark:bg-dark-bg-tertiary h-2 w-full rounded-full bg-gray-100"
-                  role="progressbar"
-                  aria-label={t("repairMissingKeys.progressLabel")}
-                  aria-valuemin={0}
-                  aria-valuemax={progressMax}
-                  aria-valuenow={Math.min(processedTotal, progressMax)}
-                  aria-valuetext={`${processedTotal}/${eligibleTotal} (${progressPercent}%)`}
-                >
-                  <div
-                    className={`h-2 rounded-full transition-all ${progressBarColor}`}
-                    style={{ width: `${progressPercent}%` }}
-                  />
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    {t("repairMissingKeys.totalsLabels.enabledAccounts")}
-                  </p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                    {progress.totals.enabledAccounts}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    {t("repairMissingKeys.totalsLabels.eligibleAccounts")}
-                  </p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                    {progress.totals.eligibleAccounts}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    {t("repairMissingKeys.totalsLabels.processedAccounts")}
-                  </p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                    {processedTotal}
-                  </p>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    {t("repairMissingKeys.outcomes.created")}
-                  </p>
-                  <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
-                    {progress.summary.created}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    {t("repairMissingKeys.outcomes.alreadyHad")}
-                  </p>
-                  <p className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-                    {progress.summary.alreadyHad}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    {t("repairMissingKeys.outcomes.skipped")}
-                  </p>
-                  <p className="text-2xl font-bold text-amber-600 dark:text-amber-400">
-                    {progress.summary.skipped}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    {t("repairMissingKeys.outcomes.failed")}
-                  </p>
-                  <p className="text-2xl font-bold text-red-600 dark:text-red-400">
-                    {progress.summary.failed}
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <ResponsiveToggleGroup
-            aria-label={t("repairMissingKeys.views.label")}
-            value={activeView}
-            onValueChange={setActiveView}
-            buttonSize="sm"
-            className="w-full"
-            options={[
-              {
-                value: REPAIR_RESULT_VIEWS.AccountCoverage,
-                label: getRepairResultViewLabel(
-                  t,
-                  REPAIR_RESULT_VIEWS.AccountCoverage,
-                ),
-                leftIcon: (
-                  <ShieldCheck
-                    aria-hidden="true"
-                    data-testid="repair-missing-keys-account-coverage-view-icon"
-                    className="h-4 w-4"
-                  />
-                ),
-              },
-              {
-                value: REPAIR_RESULT_VIEWS.InvalidKeys,
-                label: (
-                  <>
-                    {getRepairResultViewLabel(
-                      t,
-                      REPAIR_RESULT_VIEWS.InvalidKeys,
-                    )}
-                    {invalidTokens.length > 0 ? (
-                      <Badge
-                        variant="warning"
-                        size="sm"
-                        className="ml-2"
-                        aria-hidden="true"
-                      >
-                        {invalidTokens.length}
-                      </Badge>
-                    ) : null}
-                  </>
-                ),
-                leftIcon: (
-                  <TriangleAlert
-                    aria-hidden="true"
-                    data-testid="repair-missing-keys-invalid-keys-view-icon"
-                    className="h-4 w-4"
-                  />
-                ),
-              },
-            ]}
+          <RepairMissingKeysProgressCard
+            progress={progress}
+            isStarting={isStarting}
+            onStartAudit={() => void handleStartAudit()}
+            t={t}
           />
 
-          <Card>
-            <CardHeader
-              data-testid="repair-missing-keys-results-header"
-              padding="sm"
-              className="flex flex-col gap-2 space-y-0 sm:flex-row sm:items-center sm:justify-between"
-            >
-              <div
-                data-testid="repair-missing-keys-result-heading-row"
-                className="flex h-9 items-center"
-              >
-                <div
-                  data-testid="repair-missing-keys-result-heading"
-                  className="flex items-baseline gap-2"
-                >
-                  <CardTitle className="text-sm">
-                    {t("repairMissingKeys.resultsTitle")}
-                  </CardTitle>
-                  <span
-                    data-testid="repair-missing-keys-result-count"
-                    className="text-xs leading-none text-gray-500 tabular-nums dark:text-gray-400"
-                  >
-                    {activeView === REPAIR_RESULT_VIEWS.AccountCoverage
-                      ? `${filteredResults.length}/${visibleResults.length}`
-                      : `${filteredInvalidTokens.length}/${invalidTokens.length}`}
-                  </span>
-                </div>
-              </div>
-
-              <div className="w-full sm:w-80">
-                <Label htmlFor="repair-missing-keys-search" className="sr-only">
-                  {t("repairMissingKeys.searchLabel")}
-                </Label>
-                <Input
-                  id="repair-missing-keys-search"
-                  type="text"
-                  placeholder={t("repairMissingKeys.searchPlaceholder")}
-                  aria-label={t("repairMissingKeys.searchLabel")}
-                  value={searchTerm}
-                  onChange={(event) => setSearchTerm(event.target.value)}
-                  leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
-                  rightIcon={
-                    searchTerm ? (
-                      <button
-                        type="button"
-                        onClick={() => setSearchTerm("")}
-                        className="dark:hover:bg-dark-bg-tertiary rounded p-1 hover:bg-gray-100"
-                        aria-label={t("common:actions.clear")}
-                      >
-                        <XMarkIcon className="h-4 w-4" />
-                      </button>
-                    ) : null
-                  }
-                  containerClassName="w-full"
-                />
-              </div>
-            </CardHeader>
-
-            {activeView === REPAIR_RESULT_VIEWS.AccountCoverage ? (
-              <CardContent
-                padding="sm"
-                spacing="none"
-                className="dark:border-dark-bg-tertiary border-b border-gray-200"
-              >
-                <div className="space-y-2">
-                  <TagFilter
-                    mode="single"
-                    value={outcomeFilter}
-                    onChange={(value) =>
-                      setOutcomeFilter(value as AccountKeyRepairOutcome | null)
-                    }
-                    allCount={visibleResults.length}
-                    options={[
-                      {
-                        value: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
-                        label: t("repairMissingKeys.outcomes.created"),
-                        count: outcomeCounts.created,
-                        variant: "success",
-                      },
-                      {
-                        value: ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad,
-                        label: t("repairMissingKeys.outcomes.alreadyHad"),
-                        count: outcomeCounts.alreadyHad,
-                        variant: "info",
-                      },
-                      {
-                        value: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
-                        label: t("repairMissingKeys.outcomes.skipped"),
-                        count: outcomeCounts.skipped,
-                        variant: "warning",
-                      },
-                      {
-                        value: ACCOUNT_KEY_REPAIR_OUTCOMES.Failed,
-                        label: t("repairMissingKeys.outcomes.failed"),
-                        count: outcomeCounts.failed,
-                        variant: "danger",
-                      },
-                    ]}
-                  />
-                </div>
-              </CardContent>
-            ) : null}
-
-            <CardContent padding="none" spacing="none">
-              <div className="max-h-[60vh] overflow-y-auto md:max-h-[min(70vh,48rem)]">
-                {activeView === REPAIR_RESULT_VIEWS.InvalidKeys ? (
-                  <div>
-                    {deleteResultMessage ? (
-                      <div className="px-4 pt-4">
-                        <Alert description={deleteResultMessage} />
-                      </div>
-                    ) : null}
-
-                    {invalidTokens.length === 0 ? (
-                      <EmptyState
-                        icon={<MagnifyingGlassIcon className="h-12 w-12" />}
-                        title={t("repairMissingKeys.invalidKeys.emptyTitle")}
-                        description={t(
-                          "repairMissingKeys.invalidKeys.emptyDescription",
-                        )}
-                        className="py-10"
-                      />
-                    ) : filteredInvalidTokens.length === 0 ? (
-                      <EmptyState
-                        icon={<MagnifyingGlassIcon className="h-12 w-12" />}
-                        title={t("repairMissingKeys.noMatchingResults")}
-                        className="py-10"
-                      />
-                    ) : (
-                      <>
-                        <div className="dark:border-dark-bg-tertiary space-y-2 border-b border-gray-200 px-4 py-3">
-                          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                            <label className="flex items-center gap-2 text-sm">
-                              <Checkbox
-                                checked={
-                                  filteredInvalidTokens.length > 0 &&
-                                  selectedInvalidTokens.length ===
-                                    filteredInvalidTokens.length
-                                }
-                                onCheckedChange={(checked) => {
-                                  setSelectedInvalidTokenKeys(
-                                    checked
-                                      ? new Set(
-                                          filteredInvalidTokens.map(
-                                            getInvalidTokenKey,
-                                          ),
-                                        )
-                                      : new Set(),
-                                  )
-                                }}
-                                aria-label={t(
-                                  "repairMissingKeys.invalidKeys.selectAll",
-                                )}
-                              />
-                              {t("repairMissingKeys.invalidKeys.selectAll")}
-                            </label>
-                            <div className="flex items-center gap-2">
-                              <span className="text-xs text-gray-500 dark:text-gray-400">
-                                {t(
-                                  "repairMissingKeys.invalidKeys.selectedCount",
-                                  {
-                                    count: selectedInvalidTokens.length,
-                                  },
-                                )}
-                              </span>
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="destructive"
-                                disabled={selectedInvalidTokens.length === 0}
-                                onClick={() => setIsDeleteConfirmOpen(true)}
-                              >
-                                {t(
-                                  "repairMissingKeys.invalidKeys.deleteSelected",
-                                )}
-                              </Button>
-                            </div>
-                          </div>
-                        </div>
-
-                        <ul className="dark:divide-dark-bg-tertiary divide-y">
-                          {filteredInvalidTokens.map((token) => {
-                            const tokenKey = getInvalidTokenKey(token)
-
-                            return (
-                              <li
-                                key={`${token.accountId}-${token.tokenId}-${token.group}`}
-                                className="px-4 py-3"
-                              >
-                                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                                  <div className="flex min-w-0 gap-3">
-                                    <Checkbox
-                                      checked={selectedInvalidTokenKeys.has(
-                                        tokenKey,
-                                      )}
-                                      onCheckedChange={(checked) => {
-                                        setSelectedInvalidTokenKeys(
-                                          (previous) => {
-                                            const next = new Set(previous)
-                                            if (checked) {
-                                              next.add(tokenKey)
-                                            } else {
-                                              next.delete(tokenKey)
-                                            }
-                                            return next
-                                          },
-                                        )
-                                      }}
-                                      aria-label={token.tokenName}
-                                      className="mt-0.5 shrink-0"
-                                    />
-                                    <div className="min-w-0 space-y-1">
-                                      <div className="flex min-w-0 flex-wrap items-center gap-2">
-                                        <div className="truncate text-sm font-medium">
-                                          {token.tokenName}
-                                        </div>
-                                        <Badge
-                                          variant="warning"
-                                          size="sm"
-                                          className="shrink-0 border-transparent"
-                                        >
-                                          {t(
-                                            "repairMissingKeys.invalidKeys.badge",
-                                          )}
-                                        </Badge>
-                                        <Badge
-                                          variant="outline"
-                                          size="sm"
-                                          className="dark:border-dark-bg-tertiary shrink-0 border-gray-200 px-2 py-0.5 text-[11px] font-medium"
-                                          title={token.group}
-                                        >
-                                          {token.group}
-                                        </Badge>
-                                      </div>
-                                      <div className="dark:text-dark-text-secondary truncate text-xs text-gray-500">
-                                        {token.accountName} ·{" "}
-                                        {token.siteUrlOrigin}
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <Badge
-                                    variant="outline"
-                                    size="sm"
-                                    className="dark:border-dark-bg-tertiary shrink-0 border-gray-200 px-2 py-0.5 text-[11px] font-medium"
-                                    title={token.siteType}
-                                  >
-                                    {token.siteType}
-                                  </Badge>
-                                </div>
-                                <div className="mt-2 text-xs text-amber-700 dark:text-amber-200">
-                                  {getInvalidTokenReasonLabel(t, token)}
-                                </div>
-                              </li>
-                            )
-                          })}
-                        </ul>
-                      </>
-                    )}
-                  </div>
-                ) : filteredResults.length === 0 ? (
-                  <EmptyState
-                    icon={<MagnifyingGlassIcon className="h-12 w-12" />}
-                    title={t("repairMissingKeys.noMatchingResults")}
-                    className="py-10"
-                  />
-                ) : (
-                  <ul className="dark:divide-dark-bg-tertiary divide-y">
-                    {filteredResults.map((result) => {
-                      const outcomeLabel = getRepairOutcomeLabel(
-                        t,
-                        result.outcome,
-                      )
-                      const details =
-                        result.outcome === ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped
-                          ? getSkipReasonLabel(t, result.skipReason)
-                          : result.outcome ===
-                              ACCOUNT_KEY_REPAIR_OUTCOMES.Failed
-                            ? result.errorMessage || ""
-                            : ""
-                      const canCreateSub2ApiKey =
-                        result.outcome ===
-                          ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped &&
-                        result.skipReason ===
-                          ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api &&
-                        accountById.has(result.accountId)
-
-                      const badgeVariant =
-                        OUTCOME_BADGE_VARIANTS[result.outcome]
-
-                      return (
-                        <li
-                          key={`${result.accountId}-${result.finishedAt}`}
-                          className="px-4 py-3"
-                        >
-                          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                            <div className="min-w-0 space-y-1">
-                              <div className="flex min-w-0 items-center gap-2">
-                                <div className="truncate text-sm font-medium">
-                                  {result.accountName}
-                                </div>
-                                <Badge
-                                  variant="outline"
-                                  size="sm"
-                                  className="dark:border-dark-bg-tertiary shrink-0 border-gray-200 px-2 py-0.5 text-[11px] font-medium"
-                                  title={result.siteType}
-                                >
-                                  {result.siteType}
-                                </Badge>
-                              </div>
-                              <div className="dark:text-dark-text-secondary truncate text-xs text-gray-500">
-                                {result.siteUrlOrigin}
-                              </div>
-                            </div>
-                            <Badge
-                              variant={badgeVariant}
-                              size="sm"
-                              className="shrink-0 border-transparent"
-                            >
-                              {outcomeLabel}
-                            </Badge>
-                          </div>
-
-                          {canCreateSub2ApiKey ? (
-                            <div className="mt-2">
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="outline"
-                                onClick={() =>
-                                  void handleOpenSub2ApiTokenDialog(
-                                    result.accountId,
-                                  )
-                                }
-                                disabled={
-                                  openingSub2ApiAccountId === result.accountId
-                                }
-                                loading={
-                                  openingSub2ApiAccountId === result.accountId
-                                }
-                              >
-                                {t("dialog.createToken")}
-                              </Button>
-                            </div>
-                          ) : null}
-
-                          {details ? (
-                            <div
-                              className={[
-                                "mt-2 text-xs",
-                                result.outcome ===
-                                ACCOUNT_KEY_REPAIR_OUTCOMES.Failed
-                                  ? "text-red-700 dark:text-red-300"
-                                  : "dark:text-dark-text-secondary text-gray-500",
-                              ].join(" ")}
-                            >
-                              {details}
-                            </div>
-                          ) : null}
-
-                          {result.availableGroups ? (
-                            <div className="mt-2 flex flex-wrap gap-2 text-xs">
-                              <Badge variant="outline" size="sm">
-                                {t("repairMissingKeys.coverage.groupsCovered", {
-                                  covered: result.coveredGroups?.length ?? 0,
-                                  total: result.availableGroups.length,
-                                })}
-                              </Badge>
-                              {(result.createdGroups ?? []).map((group) => (
-                                <Badge key={group} variant="success" size="sm">
-                                  {getCoverageGroupLabel(
-                                    t,
-                                    "createdGroup",
-                                    group,
-                                  )}
-                                </Badge>
-                              ))}
-                              {(result.missingGroups ?? []).map((group) => (
-                                <Badge key={group} variant="warning" size="sm">
-                                  {getCoverageGroupLabel(
-                                    t,
-                                    "missingGroup",
-                                    group,
-                                  )}
-                                </Badge>
-                              ))}
-                            </div>
-                          ) : null}
-                        </li>
-                      )
-                    })}
-                  </ul>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <RepairMissingKeysResultsPanel
+            accountIds={accountIds}
+            activeView={activeView}
+            deleteResultMessage={deleteResultMessage}
+            filteredInvalidTokens={filteredInvalidTokens}
+            filteredResults={filteredResults}
+            invalidTokens={invalidTokens}
+            openingSub2ApiAccountId={openingSub2ApiAccountId}
+            outcomeCounts={outcomeCounts}
+            outcomeFilter={outcomeFilter}
+            searchTerm={searchTerm}
+            selectedInvalidTokenKeys={selectedInvalidTokenKeys}
+            selectedInvalidTokens={selectedInvalidTokens}
+            visibleResults={visibleResults}
+            onActiveViewChange={setActiveView}
+            onOpenDeleteConfirm={() => setIsDeleteConfirmOpen(true)}
+            onOpenSub2ApiTokenDialog={(accountId) =>
+              void handleOpenSub2ApiTokenDialog(accountId)
+            }
+            onOutcomeFilterChange={setOutcomeFilter}
+            onSearchTermChange={setSearchTerm}
+            onSelectedInvalidTokenKeysChange={setSelectedInvalidTokenKeys}
+            t={t}
+          />
         </div>
       ) : null}
 
-      <DestructiveConfirmDialog
+      <RepairInvalidKeysDeleteConfirm
         isOpen={isDeleteConfirmOpen}
+        isWorking={isDeletingInvalidKeys}
+        selectedInvalidTokens={selectedInvalidTokens}
         onClose={() => setIsDeleteConfirmOpen(false)}
         onConfirm={() => void handleDeleteInvalidKeys()}
-        title={t("repairMissingKeys.deleteConfirm.title", {
-          count: selectedInvalidTokens.length,
-        })}
-        description={t("repairMissingKeys.deleteConfirm.description")}
-        confirmLabel={t("repairMissingKeys.deleteConfirm.confirm")}
-        cancelLabel={t("common:actions.cancel")}
-        details={deleteConfirmDetails}
-        isWorking={isDeletingInvalidKeys}
-        size="md"
-        confirmButtonTestId="repair-invalid-keys-confirm-delete"
+        t={t}
       />
     </Modal>
   )

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -146,7 +146,6 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
     setIsDeleteConfirmOpen,
     setSelectedInvalidTokenKeys,
   } = useInvalidKeyDeletion({
-    filteredInvalidTokens,
     invalidTokens,
     setProgress,
     t,

--- a/src/features/KeyManagement/components/RepairMissingKeysProgressCard.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysProgressCard.tsx
@@ -1,0 +1,150 @@
+import type { TFunction } from "i18next"
+
+import { Button, Card, CardContent } from "~/components/ui"
+import type { AccountKeyRepairProgress } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
+
+import {
+  getRepairProgressBarColor,
+  getRepairProgressTotals,
+} from "./repairMissingKeysDialogHelpers"
+
+interface RepairMissingKeysProgressCardProps {
+  progress: AccountKeyRepairProgress
+  isStarting: boolean
+  onStartAudit: () => void
+  t: TFunction
+}
+
+/**
+ * Shows repair job progress, totals, outcome counts, and rerun action.
+ */
+export function RepairMissingKeysProgressCard({
+  progress,
+  isStarting,
+  onStartAudit,
+  t,
+}: RepairMissingKeysProgressCardProps) {
+  const { eligibleTotal, processedTotal, progressMax, progressPercent } =
+    getRepairProgressTotals(progress)
+  const progressBarColor = getRepairProgressBarColor(progress)
+
+  return (
+    <Card>
+      <CardContent padding="md" spacing="none" className="space-y-4">
+        <div className="space-y-2">
+          <div
+            data-testid="repair-missing-keys-progress-header"
+            className="flex flex-wrap items-center justify-between gap-2"
+          >
+            <div className="min-w-0 text-xs text-gray-600 dark:text-gray-400">
+              <span>{t("keyManagement:repairMissingKeys.progressLabel")}</span>
+            </div>
+            <div
+              data-testid="repair-missing-keys-progress-actions"
+              className="flex flex-wrap items-center justify-end gap-3 text-xs text-gray-600 dark:text-gray-400"
+            >
+              <span>
+                {processedTotal}/{eligibleTotal} ({progressPercent}%)
+              </span>
+              {progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Running ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onStartAudit}
+                  disabled={isStarting}
+                  loading={isStarting}
+                >
+                  {t("keyManagement:repairMissingKeys.actions.rerun")}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+          <div
+            className="dark:bg-dark-bg-tertiary h-2 w-full rounded-full bg-gray-100"
+            role="progressbar"
+            aria-label={t("keyManagement:repairMissingKeys.progressLabel")}
+            aria-valuemin={0}
+            aria-valuemax={progressMax}
+            aria-valuenow={Math.min(processedTotal, progressMax)}
+            aria-valuetext={`${processedTotal}/${eligibleTotal} (${progressPercent}%)`}
+          >
+            <div
+              className={`h-2 rounded-full transition-all ${progressBarColor}`}
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {t(
+                "keyManagement:repairMissingKeys.totalsLabels.enabledAccounts",
+              )}
+            </p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              {progress.totals.enabledAccounts}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {t(
+                "keyManagement:repairMissingKeys.totalsLabels.eligibleAccounts",
+              )}
+            </p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              {progress.totals.eligibleAccounts}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {t(
+                "keyManagement:repairMissingKeys.totalsLabels.processedAccounts",
+              )}
+            </p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">
+              {processedTotal}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {t("keyManagement:repairMissingKeys.outcomes.created")}
+            </p>
+            <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
+              {progress.summary.created}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {t("keyManagement:repairMissingKeys.outcomes.alreadyHad")}
+            </p>
+            <p className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+              {progress.summary.alreadyHad}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {t("keyManagement:repairMissingKeys.outcomes.skipped")}
+            </p>
+            <p className="text-2xl font-bold text-amber-600 dark:text-amber-400">
+              {progress.summary.skipped}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {t("keyManagement:repairMissingKeys.outcomes.failed")}
+            </p>
+            <p className="text-2xl font-bold text-red-600 dark:text-red-400">
+              {progress.summary.failed}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/KeyManagement/components/RepairMissingKeysResultsPanel.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysResultsPanel.tsx
@@ -1,0 +1,270 @@
+import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
+import type { TFunction } from "i18next"
+import { ShieldCheck, TriangleAlert } from "lucide-react"
+import type { Dispatch, SetStateAction } from "react"
+
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  ResponsiveToggleGroup,
+  TagFilter,
+} from "~/components/ui"
+import type {
+  AccountKeyRepairAccountResult,
+  AccountKeyRepairInvalidToken,
+  AccountKeyRepairOutcome,
+} from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_OUTCOMES } from "~/types/accountKeyAutoProvisioning"
+
+import { RepairAccountCoverageList } from "./RepairAccountCoverageList"
+import { RepairInvalidKeysList } from "./RepairInvalidKeysList"
+import {
+  getRepairResultViewLabel,
+  REPAIR_RESULT_VIEWS,
+  type RepairResultView,
+} from "./repairMissingKeysDialogHelpers"
+
+interface RepairMissingKeysResultsPanelProps {
+  accountIds: Set<string>
+  activeView: RepairResultView
+  deleteResultMessage: string
+  filteredInvalidTokens: AccountKeyRepairInvalidToken[]
+  filteredResults: AccountKeyRepairAccountResult[]
+  invalidTokens: AccountKeyRepairInvalidToken[]
+  openingSub2ApiAccountId: string | null
+  outcomeCounts: Record<AccountKeyRepairOutcome, number>
+  outcomeFilter: AccountKeyRepairOutcome | null
+  searchTerm: string
+  selectedInvalidTokenKeys: Set<string>
+  selectedInvalidTokens: AccountKeyRepairInvalidToken[]
+  visibleResults: AccountKeyRepairAccountResult[]
+  onActiveViewChange: (view: RepairResultView) => void
+  onOpenDeleteConfirm: () => void
+  onOpenSub2ApiTokenDialog: (accountId: string) => void
+  onOutcomeFilterChange: (outcome: AccountKeyRepairOutcome | null) => void
+  onSearchTermChange: (value: string) => void
+  onSelectedInvalidTokenKeysChange: Dispatch<SetStateAction<Set<string>>>
+  t: TFunction
+}
+
+/**
+ * Coordinates result view switching, search, filtering, and result lists.
+ */
+export function RepairMissingKeysResultsPanel({
+  accountIds,
+  activeView,
+  deleteResultMessage,
+  filteredInvalidTokens,
+  filteredResults,
+  invalidTokens,
+  openingSub2ApiAccountId,
+  outcomeCounts,
+  outcomeFilter,
+  searchTerm,
+  selectedInvalidTokenKeys,
+  selectedInvalidTokens,
+  visibleResults,
+  onActiveViewChange,
+  onOpenDeleteConfirm,
+  onOpenSub2ApiTokenDialog,
+  onOutcomeFilterChange,
+  onSearchTermChange,
+  onSelectedInvalidTokenKeysChange,
+  t,
+}: RepairMissingKeysResultsPanelProps) {
+  return (
+    <>
+      <ResponsiveToggleGroup
+        aria-label={t("keyManagement:repairMissingKeys.views.label")}
+        value={activeView}
+        onValueChange={onActiveViewChange}
+        buttonSize="sm"
+        className="w-full"
+        options={[
+          {
+            value: REPAIR_RESULT_VIEWS.AccountCoverage,
+            label: getRepairResultViewLabel(
+              t,
+              REPAIR_RESULT_VIEWS.AccountCoverage,
+            ),
+            leftIcon: (
+              <ShieldCheck
+                aria-hidden="true"
+                data-testid="repair-missing-keys-account-coverage-view-icon"
+                className="h-4 w-4"
+              />
+            ),
+          },
+          {
+            value: REPAIR_RESULT_VIEWS.InvalidKeys,
+            label: (
+              <>
+                {getRepairResultViewLabel(t, REPAIR_RESULT_VIEWS.InvalidKeys)}
+                {invalidTokens.length > 0 ? (
+                  <Badge
+                    variant="warning"
+                    size="sm"
+                    className="ml-2"
+                    aria-hidden="true"
+                  >
+                    {invalidTokens.length}
+                  </Badge>
+                ) : null}
+              </>
+            ),
+            leftIcon: (
+              <TriangleAlert
+                aria-hidden="true"
+                data-testid="repair-missing-keys-invalid-keys-view-icon"
+                className="h-4 w-4"
+              />
+            ),
+          },
+        ]}
+      />
+
+      <Card>
+        <CardHeader
+          data-testid="repair-missing-keys-results-header"
+          padding="sm"
+          className="flex flex-col gap-2 space-y-0 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div
+            data-testid="repair-missing-keys-result-heading-row"
+            className="flex h-9 items-center"
+          >
+            <div
+              data-testid="repair-missing-keys-result-heading"
+              className="flex items-baseline gap-2"
+            >
+              <CardTitle className="text-sm">
+                {t("keyManagement:repairMissingKeys.resultsTitle")}
+              </CardTitle>
+              <span
+                data-testid="repair-missing-keys-result-count"
+                className="text-xs leading-none text-gray-500 tabular-nums dark:text-gray-400"
+              >
+                {activeView === REPAIR_RESULT_VIEWS.AccountCoverage
+                  ? `${filteredResults.length}/${visibleResults.length}`
+                  : `${filteredInvalidTokens.length}/${invalidTokens.length}`}
+              </span>
+            </div>
+          </div>
+
+          <div className="w-full sm:w-80">
+            <Label htmlFor="repair-missing-keys-search" className="sr-only">
+              {t("keyManagement:repairMissingKeys.searchLabel")}
+            </Label>
+            <Input
+              id="repair-missing-keys-search"
+              type="text"
+              placeholder={t(
+                "keyManagement:repairMissingKeys.searchPlaceholder",
+              )}
+              aria-label={t("keyManagement:repairMissingKeys.searchLabel")}
+              value={searchTerm}
+              onChange={(event) => onSearchTermChange(event.target.value)}
+              leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+              rightIcon={
+                searchTerm ? (
+                  <button
+                    type="button"
+                    onClick={() => onSearchTermChange("")}
+                    className="dark:hover:bg-dark-bg-tertiary rounded p-1 hover:bg-gray-100"
+                    aria-label={t("common:actions.clear")}
+                  >
+                    <XMarkIcon className="h-4 w-4" />
+                  </button>
+                ) : null
+              }
+              containerClassName="w-full"
+            />
+          </div>
+        </CardHeader>
+
+        {activeView === REPAIR_RESULT_VIEWS.AccountCoverage ? (
+          <CardContent
+            padding="sm"
+            spacing="none"
+            className="dark:border-dark-bg-tertiary border-b border-gray-200"
+          >
+            <div className="space-y-2">
+              <TagFilter
+                mode="single"
+                value={outcomeFilter}
+                onChange={(value) =>
+                  onOutcomeFilterChange(value as AccountKeyRepairOutcome | null)
+                }
+                allCount={visibleResults.length}
+                options={[
+                  {
+                    value: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
+                    label: t(
+                      "keyManagement:repairMissingKeys.outcomes.created",
+                    ),
+                    count: outcomeCounts.created,
+                    variant: "success",
+                  },
+                  {
+                    value: ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad,
+                    label: t(
+                      "keyManagement:repairMissingKeys.outcomes.alreadyHad",
+                    ),
+                    count: outcomeCounts.alreadyHad,
+                    variant: "info",
+                  },
+                  {
+                    value: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
+                    label: t(
+                      "keyManagement:repairMissingKeys.outcomes.skipped",
+                    ),
+                    count: outcomeCounts.skipped,
+                    variant: "warning",
+                  },
+                  {
+                    value: ACCOUNT_KEY_REPAIR_OUTCOMES.Failed,
+                    label: t("keyManagement:repairMissingKeys.outcomes.failed"),
+                    count: outcomeCounts.failed,
+                    variant: "danger",
+                  },
+                ]}
+              />
+            </div>
+          </CardContent>
+        ) : null}
+
+        <CardContent padding="none" spacing="none">
+          <div className="max-h-[60vh] overflow-y-auto md:max-h-[min(70vh,48rem)]">
+            {activeView === REPAIR_RESULT_VIEWS.InvalidKeys ? (
+              <RepairInvalidKeysList
+                deleteResultMessage={deleteResultMessage}
+                filteredInvalidTokens={filteredInvalidTokens}
+                invalidTokens={invalidTokens}
+                selectedInvalidTokenKeys={selectedInvalidTokenKeys}
+                selectedInvalidTokens={selectedInvalidTokens}
+                onOpenDeleteConfirm={onOpenDeleteConfirm}
+                onSelectedInvalidTokenKeysChange={
+                  onSelectedInvalidTokenKeysChange
+                }
+                t={t}
+              />
+            ) : (
+              <RepairAccountCoverageList
+                accountIds={accountIds}
+                filteredResults={filteredResults}
+                openingSub2ApiAccountId={openingSub2ApiAccountId}
+                onOpenSub2ApiTokenDialog={onOpenSub2ApiTokenDialog}
+                t={t}
+              />
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  )
+}

--- a/src/features/KeyManagement/components/repairMissingKeysDialogHelpers.ts
+++ b/src/features/KeyManagement/components/repairMissingKeysDialogHelpers.ts
@@ -1,0 +1,181 @@
+import type { TFunction } from "i18next"
+
+import type {
+  AccountKeyRepairInvalidToken,
+  AccountKeyRepairOutcome,
+  AccountKeyRepairProgress,
+  AccountKeyRepairSkipReason,
+} from "~/types/accountKeyAutoProvisioning"
+import {
+  ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
+  ACCOUNT_KEY_REPAIR_JOB_STATES,
+  ACCOUNT_KEY_REPAIR_OUTCOMES,
+  ACCOUNT_KEY_REPAIR_SKIP_REASONS,
+} from "~/types/accountKeyAutoProvisioning"
+
+export const REPAIR_RESULT_VIEWS = {
+  AccountCoverage: "accountCoverage",
+  InvalidKeys: "invalidKeys",
+} as const
+
+export type RepairResultView =
+  (typeof REPAIR_RESULT_VIEWS)[keyof typeof REPAIR_RESULT_VIEWS]
+
+export type RepairBadgeVariant =
+  | "default"
+  | "secondary"
+  | "destructive"
+  | "outline"
+  | "success"
+  | "warning"
+  | "info"
+  | "danger"
+
+export const OUTCOME_BADGE_VARIANTS: Record<
+  AccountKeyRepairOutcome,
+  RepairBadgeVariant
+> = {
+  [ACCOUNT_KEY_REPAIR_OUTCOMES.Created]: "success",
+  [ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad]: "info",
+  [ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped]: "warning",
+  [ACCOUNT_KEY_REPAIR_OUTCOMES.Failed]: "danger",
+}
+
+/**
+ * Returns the localized skip reason label used when a repair result is skipped.
+ */
+export function getSkipReasonLabel(
+  t: TFunction,
+  reason: AccountKeyRepairSkipReason | undefined,
+) {
+  if (!reason) return ""
+  switch (reason) {
+    case ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api:
+      return t("keyManagement:repairMissingKeys.skipReasons.sub2api")
+    case ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey:
+      return t("keyManagement:repairMissingKeys.skipReasons.aihubmixOneTimeKey")
+    case ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth:
+      return t("keyManagement:repairMissingKeys.skipReasons.noneAuth")
+  }
+}
+
+/**
+ * Returns the localized outcome label shown for each repair result row.
+ */
+export function getRepairOutcomeLabel(
+  t: TFunction,
+  outcome: AccountKeyRepairOutcome,
+) {
+  switch (outcome) {
+    case ACCOUNT_KEY_REPAIR_OUTCOMES.Created:
+      return t("keyManagement:repairMissingKeys.outcomes.created")
+    case ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad:
+      return t("keyManagement:repairMissingKeys.outcomes.alreadyHad")
+    case ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped:
+      return t("keyManagement:repairMissingKeys.outcomes.skipped")
+    case ACCOUNT_KEY_REPAIR_OUTCOMES.Failed:
+      return t("keyManagement:repairMissingKeys.outcomes.failed")
+  }
+}
+
+/**
+ * Returns the localized view switch label.
+ */
+export function getRepairResultViewLabel(t: TFunction, view: RepairResultView) {
+  switch (view) {
+    case REPAIR_RESULT_VIEWS.AccountCoverage:
+      return t("keyManagement:repairMissingKeys.views.accountCoverage")
+    case REPAIR_RESULT_VIEWS.InvalidKeys:
+      return t("keyManagement:repairMissingKeys.views.invalidKeys")
+  }
+}
+
+/**
+ * Keeps group names visible if i18n returns the missing-key fallback instead of
+ * interpolated copy.
+ */
+export function getCoverageGroupLabel(
+  t: TFunction,
+  key: "createdGroup" | "missingGroup",
+  group: string,
+) {
+  const [translationKey, label] =
+    key === "createdGroup"
+      ? [
+          "keyManagement:repairMissingKeys.coverage.createdGroup",
+          t("keyManagement:repairMissingKeys.coverage.createdGroup", {
+            group,
+          }),
+        ]
+      : [
+          "keyManagement:repairMissingKeys.coverage.missingGroup",
+          t("keyManagement:repairMissingKeys.coverage.missingGroup", {
+            group,
+          }),
+        ]
+
+  return label === translationKey ? group : label
+}
+
+/**
+ * Returns the localized reason shown for invalid keys.
+ */
+export function getInvalidTokenReasonLabel(
+  t: TFunction,
+  token: AccountKeyRepairInvalidToken,
+) {
+  switch (token.reason) {
+    case ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable:
+      return t("keyManagement:repairMissingKeys.invalidKeys.groupUnavailable", {
+        group: token.group,
+      })
+  }
+}
+
+/**
+ * Builds a stable selection key for an invalid token within an account.
+ */
+export function getInvalidTokenKey(token: AccountKeyRepairInvalidToken) {
+  return `${token.accountId}:${token.tokenId}`
+}
+
+/**
+ * Derives progress bar values from repair progress totals.
+ */
+export function getRepairProgressTotals(progress: AccountKeyRepairProgress) {
+  const eligibleTotal = progress.totals.eligibleAccounts
+  const processedTotal =
+    progress.totals.processedEligibleAccounts ??
+    progress.totals.processedAccounts
+  const progressMax = Math.max(1, eligibleTotal)
+  const progressPercent =
+    eligibleTotal <= 0
+      ? 0
+      : Math.min(100, Math.round((processedTotal / eligibleTotal) * 100))
+
+  return {
+    eligibleTotal,
+    processedTotal,
+    progressMax,
+    progressPercent,
+  }
+}
+
+/**
+ * Returns the progress bar color class for the current repair state.
+ */
+export function getRepairProgressBarColor(progress: AccountKeyRepairProgress) {
+  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
+    return "bg-red-600 dark:bg-red-500"
+  }
+  if (
+    progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Completed &&
+    progress.summary.failed > 0
+  ) {
+    return "bg-amber-600 dark:bg-amber-500"
+  }
+  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Completed) {
+    return "bg-emerald-600 dark:bg-emerald-500"
+  }
+  return "bg-blue-600 dark:bg-blue-500"
+}

--- a/src/features/KeyManagement/components/useInvalidKeyDeletion.ts
+++ b/src/features/KeyManagement/components/useInvalidKeyDeletion.ts
@@ -1,0 +1,234 @@
+import type { TFunction } from "i18next"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react"
+
+import {
+  AccountKeyRepairMessageTypes,
+  sendAccountKeyRepairMessage,
+} from "~/services/accounts/accountKeyAutoProvisioning/messaging"
+import {
+  trackProductAnalyticsActionCompleted,
+  trackProductAnalyticsActionStarted,
+} from "~/services/productAnalytics/actions"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_RESULTS,
+  PRODUCT_ANALYTICS_STATUS_KINDS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+} from "~/services/productAnalytics/events"
+import type {
+  AccountKeyRepairInvalidToken,
+  AccountKeyRepairProgress,
+} from "~/types/accountKeyAutoProvisioning"
+
+import { getInvalidTokenKey } from "./repairMissingKeysDialogHelpers"
+
+const deleteInvalidKeysAnalyticsContext = {
+  featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+  actionId: PRODUCT_ANALYTICS_ACTION_IDS.DeleteInvalidAccountTokens,
+  surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRepairDialog,
+  entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+}
+
+interface UseInvalidKeyDeletionOptions {
+  invalidTokens: AccountKeyRepairInvalidToken[]
+  filteredInvalidTokens: AccountKeyRepairInvalidToken[]
+  setProgress: Dispatch<SetStateAction<AccountKeyRepairProgress | null>>
+  t: TFunction
+}
+
+/**
+ * Manages invalid-key selection, deletion, feedback, and delete analytics.
+ */
+export function useInvalidKeyDeletion({
+  invalidTokens,
+  filteredInvalidTokens,
+  setProgress,
+  t,
+}: UseInvalidKeyDeletionOptions) {
+  const [selectedInvalidTokenKeys, setSelectedInvalidTokenKeys] = useState<
+    Set<string>
+  >(() => new Set())
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
+  const [isDeletingInvalidKeys, setIsDeletingInvalidKeys] = useState(false)
+  const [deleteResultMessage, setDeleteResultMessage] = useState("")
+
+  const selectedInvalidTokens = useMemo(() => {
+    return filteredInvalidTokens.filter((token) =>
+      selectedInvalidTokenKeys.has(getInvalidTokenKey(token)),
+    )
+  }, [filteredInvalidTokens, selectedInvalidTokenKeys])
+
+  useEffect(() => {
+    const currentInvalidTokenKeys = new Set(
+      invalidTokens.map(getInvalidTokenKey),
+    )
+    setSelectedInvalidTokenKeys((previous) => {
+      const next = new Set(
+        [...previous].filter((key) => currentInvalidTokenKeys.has(key)),
+      )
+      return next.size === previous.size ? previous : next
+    })
+  }, [invalidTokens])
+
+  useEffect(() => {
+    if (isDeleteConfirmOpen && selectedInvalidTokens.length === 0) {
+      setIsDeleteConfirmOpen(false)
+    }
+  }, [isDeleteConfirmOpen, selectedInvalidTokens.length])
+
+  const resetInvalidKeyDeletionState = useCallback(() => {
+    setSelectedInvalidTokenKeys(new Set())
+    setIsDeleteConfirmOpen(false)
+    setDeleteResultMessage("")
+  }, [])
+
+  const handleDeleteInvalidKeys = useCallback(async () => {
+    const tokensToDelete = selectedInvalidTokens
+    if (tokensToDelete.length === 0) {
+      return
+    }
+
+    setIsDeletingInvalidKeys(true)
+    setDeleteResultMessage("")
+    void trackProductAnalyticsActionStarted(deleteInvalidKeysAnalyticsContext)
+    try {
+      const response = await sendAccountKeyRepairMessage(
+        AccountKeyRepairMessageTypes.DeleteInvalidTokens,
+        { tokens: tokensToDelete },
+      )
+
+      if (!response?.success || !response.data) {
+        setDeleteResultMessage(
+          t("keyManagement:repairMissingKeys.invalidKeys.deleteFailed"),
+        )
+        setIsDeleteConfirmOpen(false)
+        void trackProductAnalyticsActionCompleted({
+          ...deleteInvalidKeysAnalyticsContext,
+          result: PRODUCT_ANALYTICS_RESULTS.Failure,
+          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+          insights: {
+            itemCount: tokensToDelete.length,
+            selectedCount: tokensToDelete.length,
+            successCount: 0,
+            failureCount: tokensToDelete.length,
+            statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
+          },
+        })
+        return
+      }
+
+      const deletedKeys = new Set(response.data.deleted.map(getInvalidTokenKey))
+      setSelectedInvalidTokenKeys((previous) => {
+        const next = new Set(previous)
+        for (const key of deletedKeys) {
+          next.delete(key)
+        }
+        return next
+      })
+      setProgress((current) => {
+        if (!current) return current
+
+        let removedInvalidTokenCount = 0
+        const nextResults = current.results.map((result) => {
+          const nextInvalidTokens = result.invalidTokens?.filter((token) => {
+            const shouldRemove = deletedKeys.has(getInvalidTokenKey(token))
+            if (shouldRemove) {
+              removedInvalidTokenCount += 1
+            }
+            return !shouldRemove
+          })
+
+          return {
+            ...result,
+            invalidTokens: nextInvalidTokens,
+          }
+        })
+
+        return {
+          ...current,
+          summary: {
+            ...current.summary,
+            invalidKeys: Math.max(
+              0,
+              (current.summary.invalidKeys ?? 0) - removedInvalidTokenCount,
+            ),
+            deletedKeys:
+              (current.summary.deletedKeys ?? 0) + response.data.deleted.length,
+            deleteFailed:
+              (current.summary.deleteFailed ?? 0) + response.data.failed.length,
+          },
+          results: nextResults,
+        }
+      })
+      setDeleteResultMessage(
+        response.data.failed.length > 0
+          ? t("keyManagement:repairMissingKeys.invalidKeys.deletePartial", {
+              deleted: response.data.deleted.length,
+              failed: response.data.failed.length,
+            })
+          : t("keyManagement:repairMissingKeys.invalidKeys.deleteSuccess", {
+              count: response.data.deleted.length,
+            }),
+      )
+      setIsDeleteConfirmOpen(false)
+      void trackProductAnalyticsActionCompleted({
+        ...deleteInvalidKeysAnalyticsContext,
+        result:
+          response.data.failed.length > 0
+            ? PRODUCT_ANALYTICS_RESULTS.Failure
+            : PRODUCT_ANALYTICS_RESULTS.Success,
+        insights: {
+          itemCount: tokensToDelete.length,
+          selectedCount: tokensToDelete.length,
+          successCount: response.data.deleted.length,
+          failureCount: response.data.failed.length,
+          statusKind:
+            response.data.failed.length > 0
+              ? PRODUCT_ANALYTICS_STATUS_KINDS.Warning
+              : PRODUCT_ANALYTICS_STATUS_KINDS.Healthy,
+        },
+      })
+    } catch {
+      setDeleteResultMessage(
+        t("keyManagement:repairMissingKeys.invalidKeys.deleteFailed"),
+      )
+      setIsDeleteConfirmOpen(false)
+      void trackProductAnalyticsActionCompleted({
+        ...deleteInvalidKeysAnalyticsContext,
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        insights: {
+          itemCount: tokensToDelete.length,
+          selectedCount: tokensToDelete.length,
+          successCount: 0,
+          failureCount: tokensToDelete.length,
+          statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
+        },
+      })
+    } finally {
+      setIsDeletingInvalidKeys(false)
+    }
+  }, [selectedInvalidTokens, setProgress, t])
+
+  return {
+    deleteResultMessage,
+    handleDeleteInvalidKeys,
+    isDeleteConfirmOpen,
+    isDeletingInvalidKeys,
+    resetInvalidKeyDeletionState,
+    selectedInvalidTokenKeys,
+    selectedInvalidTokens,
+    setIsDeleteConfirmOpen,
+    setSelectedInvalidTokenKeys,
+  }
+}

--- a/src/features/KeyManagement/components/useInvalidKeyDeletion.ts
+++ b/src/features/KeyManagement/components/useInvalidKeyDeletion.ts
@@ -41,7 +41,6 @@ const deleteInvalidKeysAnalyticsContext = {
 
 interface UseInvalidKeyDeletionOptions {
   invalidTokens: AccountKeyRepairInvalidToken[]
-  filteredInvalidTokens: AccountKeyRepairInvalidToken[]
   setProgress: Dispatch<SetStateAction<AccountKeyRepairProgress | null>>
   t: TFunction
 }
@@ -51,7 +50,6 @@ interface UseInvalidKeyDeletionOptions {
  */
 export function useInvalidKeyDeletion({
   invalidTokens,
-  filteredInvalidTokens,
   setProgress,
   t,
 }: UseInvalidKeyDeletionOptions) {
@@ -63,10 +61,10 @@ export function useInvalidKeyDeletion({
   const [deleteResultMessage, setDeleteResultMessage] = useState("")
 
   const selectedInvalidTokens = useMemo(() => {
-    return filteredInvalidTokens.filter((token) =>
+    return invalidTokens.filter((token) =>
       selectedInvalidTokenKeys.has(getInvalidTokenKey(token)),
     )
-  }, [filteredInvalidTokens, selectedInvalidTokenKeys])
+  }, [invalidTokens, selectedInvalidTokenKeys])
 
   useEffect(() => {
     const currentInvalidTokenKeys = new Set(
@@ -93,6 +91,10 @@ export function useInvalidKeyDeletion({
   }, [])
 
   const handleDeleteInvalidKeys = useCallback(async () => {
+    if (isDeletingInvalidKeys) {
+      return
+    }
+
     const tokensToDelete = selectedInvalidTokens
     if (tokensToDelete.length === 0) {
       return
@@ -218,7 +220,7 @@ export function useInvalidKeyDeletion({
     } finally {
       setIsDeletingInvalidKeys(false)
     }
-  }, [selectedInvalidTokens, setProgress, t])
+  }, [isDeletingInvalidKeys, selectedInvalidTokens, setProgress, t])
 
   return {
     deleteResultMessage,

--- a/src/features/KeyManagement/components/useRepairMissingKeysJob.ts
+++ b/src/features/KeyManagement/components/useRepairMissingKeysJob.ts
@@ -248,7 +248,10 @@ export function useRepairMissingKeysJob({
         if (cancelled) return
         if (response?.success && response.data) {
           setProgress(response.data)
+          return
         }
+
+        setError(t("keyManagement:repairMissingKeys.messages.loadFailed"))
       } catch {
         if (!cancelled) {
           setError(t("keyManagement:repairMissingKeys.messages.loadFailed"))

--- a/src/features/KeyManagement/components/useRepairMissingKeysJob.ts
+++ b/src/features/KeyManagement/components/useRepairMissingKeysJob.ts
@@ -1,0 +1,304 @@
+import type { TFunction } from "i18next"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { RuntimeMessageTypes } from "~/constants/runtimeActions"
+import {
+  AccountKeyRepairMessageTypes,
+  sendAccountKeyRepairMessage,
+} from "~/services/accounts/accountKeyAutoProvisioning/messaging"
+import {
+  trackProductAnalyticsActionCompleted,
+  trackProductAnalyticsActionStarted,
+} from "~/services/productAnalytics/actions"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_RESULTS,
+  PRODUCT_ANALYTICS_STATUS_KINDS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+} from "~/services/productAnalytics/events"
+import type { DisplaySiteData } from "~/types"
+import type { AccountKeyRepairProgress } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
+import { onRuntimeMessage } from "~/utils/browser/browserApi"
+
+const repairMissingKeysAnalyticsContext = {
+  featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+  actionId: PRODUCT_ANALYTICS_ACTION_IDS.RepairMissingAccountKeys,
+  surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRepairDialog,
+  entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+}
+
+/**
+ * Counts accounts that are eligible for the repair attempt at the dialog boundary.
+ */
+function getEligibleAccountCountFromAccounts(accounts: DisplaySiteData[]) {
+  return accounts.filter((account) => !account.disabled).length
+}
+
+/**
+ * Builds sanitized analytics insights when the repair job cannot start.
+ */
+function getRepairStartFailureInsights(
+  progress: AccountKeyRepairProgress | null,
+  accounts: DisplaySiteData[],
+) {
+  return {
+    itemCount:
+      progress?.totals.eligibleAccounts ??
+      getEligibleAccountCountFromAccounts(accounts),
+    selectedCount: 0,
+    successCount: 0,
+    failureCount: progress?.summary.failed ?? 0,
+    statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
+  }
+}
+
+/**
+ * Extracts privacy-safe count metrics from repair progress.
+ */
+function getRepairProgressInsightCounts(progress: AccountKeyRepairProgress) {
+  return {
+    itemCount: progress.totals.eligibleAccounts,
+    selectedCount:
+      progress.totals.processedEligibleAccounts ??
+      progress.totals.processedAccounts,
+    successCount: progress.summary.created,
+    failureCount: progress.summary.failed,
+  }
+}
+
+/**
+ * Maps terminal repair progress into a coarse health status.
+ */
+function getRepairProgressStatusKind(progress: AccountKeyRepairProgress) {
+  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
+    return PRODUCT_ANALYTICS_STATUS_KINDS.Error
+  }
+  if (progress.summary.failed > 0) {
+    return PRODUCT_ANALYTICS_STATUS_KINDS.Warning
+  }
+  return PRODUCT_ANALYTICS_STATUS_KINDS.Healthy
+}
+
+/**
+ * Maps terminal repair progress into the product analytics result enum.
+ */
+function getRepairProgressResult(progress: AccountKeyRepairProgress) {
+  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
+    return PRODUCT_ANALYTICS_RESULTS.Failure
+  }
+  if (progress.summary.failed > 0) {
+    return PRODUCT_ANALYTICS_RESULTS.Failure
+  }
+  return PRODUCT_ANALYTICS_RESULTS.Success
+}
+
+interface UseRepairMissingKeysJobOptions {
+  accounts: DisplaySiteData[]
+  isOpen: boolean
+  startOnOpen: boolean
+  t: TFunction
+}
+
+/**
+ * Manages repair job loading, starting, progress subscriptions, and analytics.
+ */
+export function useRepairMissingKeysJob({
+  accounts,
+  isOpen,
+  startOnOpen,
+  t,
+}: UseRepairMissingKeysJobOptions) {
+  const [progress, setProgress] = useState<AccountKeyRepairProgress | null>(
+    null,
+  )
+  const [error, setError] = useState<string>("")
+  const [isStarting, setIsStarting] = useState(false)
+  const startedAnalyticsJobIdRef = useRef<string | null>(null)
+  const completedAnalyticsJobIdRef = useRef<string | null>(null)
+  const progressRef = useRef<AccountKeyRepairProgress | null>(null)
+  const accountsRef = useRef(accounts)
+  const isDialogOpenRef = useRef(isOpen)
+  const startInFlightRef = useRef(false)
+  const startRequestIdRef = useRef(0)
+
+  isDialogOpenRef.current = isOpen
+
+  const handleStartAudit = useCallback(async () => {
+    if (startInFlightRef.current) {
+      return
+    }
+
+    startInFlightRef.current = true
+    const requestId = startRequestIdRef.current + 1
+    startRequestIdRef.current = requestId
+
+    setIsStarting(true)
+    setError("")
+    try {
+      const response = await sendAccountKeyRepairMessage(
+        AccountKeyRepairMessageTypes.Start,
+      )
+      if (response?.success && response.data) {
+        startedAnalyticsJobIdRef.current = response.data.jobId
+        void trackProductAnalyticsActionStarted(
+          repairMissingKeysAnalyticsContext,
+        )
+        if (
+          isDialogOpenRef.current &&
+          startRequestIdRef.current === requestId
+        ) {
+          setProgress(response.data)
+        }
+        return
+      }
+
+      void trackProductAnalyticsActionCompleted({
+        ...repairMissingKeysAnalyticsContext,
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        insights: getRepairStartFailureInsights(
+          progressRef.current,
+          accountsRef.current,
+        ),
+      })
+      if (isDialogOpenRef.current && startRequestIdRef.current === requestId) {
+        setError(t("keyManagement:repairMissingKeys.messages.startFailed"))
+      }
+    } catch {
+      void trackProductAnalyticsActionCompleted({
+        ...repairMissingKeysAnalyticsContext,
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        insights: getRepairStartFailureInsights(
+          progressRef.current,
+          accountsRef.current,
+        ),
+      })
+      if (isDialogOpenRef.current && startRequestIdRef.current === requestId) {
+        setError(t("keyManagement:repairMissingKeys.messages.startFailed"))
+      }
+    } finally {
+      if (startRequestIdRef.current === requestId) {
+        startInFlightRef.current = false
+        if (isDialogOpenRef.current) {
+          setIsStarting(false)
+        }
+      }
+    }
+  }, [t])
+
+  useEffect(() => {
+    isDialogOpenRef.current = isOpen
+    if (isOpen) {
+      setIsStarting(startInFlightRef.current)
+    } else {
+      setIsStarting(false)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    return () => {
+      isDialogOpenRef.current = false
+      startRequestIdRef.current += 1
+      startInFlightRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) {
+      startedAnalyticsJobIdRef.current = null
+      completedAnalyticsJobIdRef.current = null
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    progressRef.current = progress
+  }, [progress])
+
+  useEffect(() => {
+    accountsRef.current = accounts
+  }, [accounts])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    return onRuntimeMessage((message) => {
+      if (message?.type !== RuntimeMessageTypes.AccountKeyRepairProgress) return
+      const payload = message?.payload as AccountKeyRepairProgress | undefined
+      if (!payload) return
+      setProgress(payload)
+    })
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    let cancelled = false
+    setError("")
+
+    void (async () => {
+      try {
+        const response = await sendAccountKeyRepairMessage(
+          AccountKeyRepairMessageTypes.GetProgress,
+        )
+        if (cancelled) return
+        if (response?.success && response.data) {
+          setProgress(response.data)
+        }
+      } catch {
+        if (!cancelled) {
+          setError(t("keyManagement:repairMissingKeys.messages.loadFailed"))
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, t])
+
+  useEffect(() => {
+    if (!isOpen) return
+    if (!startOnOpen) return
+
+    void handleStartAudit()
+  }, [handleStartAudit, isOpen, startOnOpen])
+
+  useEffect(() => {
+    if (!progress) return
+    if (
+      progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Completed &&
+      progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Failed
+    ) {
+      return
+    }
+    if (startedAnalyticsJobIdRef.current !== progress.jobId) return
+    if (completedAnalyticsJobIdRef.current === progress.jobId) return
+
+    completedAnalyticsJobIdRef.current = progress.jobId
+
+    void trackProductAnalyticsActionCompleted({
+      ...repairMissingKeysAnalyticsContext,
+      result: getRepairProgressResult(progress),
+      ...(progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed
+        ? { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown }
+        : {}),
+      insights: {
+        ...getRepairProgressInsightCounts(progress),
+        statusKind: getRepairProgressStatusKind(progress),
+      },
+    })
+  }, [progress])
+
+  return {
+    error,
+    handleStartAudit,
+    isStarting,
+    progress,
+    setProgress,
+  }
+}

--- a/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
+++ b/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
@@ -367,6 +367,9 @@ describe("AutoCheckin account actions", () => {
       expect(openButton).toBeDisabled()
     })
 
+    await waitFor(() => {
+      expect(rejectOpen).toBeDefined()
+    })
     rejectOpen?.(new Error("popup blocked"))
 
     await waitFor(() => {

--- a/tests/features/KeyManagement/components/RepairAccountCoverageList.test.tsx
+++ b/tests/features/KeyManagement/components/RepairAccountCoverageList.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { TFunction } from "i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { RepairAccountCoverageList } from "~/features/KeyManagement/components/RepairAccountCoverageList"
+import type { AccountKeyRepairAccountResult } from "~/types/accountKeyAutoProvisioning"
+import {
+  ACCOUNT_KEY_REPAIR_OUTCOMES,
+  ACCOUNT_KEY_REPAIR_SKIP_REASONS,
+} from "~/types/accountKeyAutoProvisioning"
+
+const t = ((key: string, options?: Record<string, unknown>) => {
+  if (key === "keyManagement:repairMissingKeys.coverage.groupsCovered") {
+    return `${options?.covered}/${options?.total} groups`
+  }
+  if (key === "keyManagement:repairMissingKeys.coverage.createdGroup") {
+    return `created ${options?.group}`
+  }
+  if (key === "keyManagement:repairMissingKeys.coverage.missingGroup") {
+    return `missing ${options?.group}`
+  }
+
+  return key
+}) as TFunction
+
+function buildResult(
+  overrides: Partial<AccountKeyRepairAccountResult> = {},
+): AccountKeyRepairAccountResult {
+  return {
+    accountId: "account-1",
+    accountName: "Example Account",
+    siteType: SITE_TYPES.NEW_API,
+    siteUrlOrigin: "https://account.example.invalid",
+    outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
+    finishedAt: 1,
+    ...overrides,
+  }
+}
+
+function renderList(
+  props: Partial<Parameters<typeof RepairAccountCoverageList>[0]> = {},
+) {
+  return render(
+    <RepairAccountCoverageList
+      accountIds={new Set(["account-1"])}
+      filteredResults={[buildResult()]}
+      openingSub2ApiAccountId={null}
+      onOpenSub2ApiTokenDialog={vi.fn()}
+      t={t}
+      {...props}
+    />,
+  )
+}
+
+describe("RepairAccountCoverageList", () => {
+  it("renders the empty state when no account results match", () => {
+    renderList({ filteredResults: [] })
+
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.noMatchingResults"),
+    ).toBeInTheDocument()
+  })
+
+  it("renders account details, outcome details, and coverage groups", () => {
+    renderList({
+      filteredResults: [
+        buildResult({
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Failed,
+          errorMessage: "Could not create missing key",
+          availableGroups: ["default", "vip", "trial"],
+          coveredGroups: ["default"],
+          createdGroups: ["default"],
+          missingGroups: ["vip"],
+        }),
+      ],
+    })
+
+    expect(screen.getByText("Example Account")).toBeInTheDocument()
+    expect(screen.getByText(SITE_TYPES.NEW_API)).toBeInTheDocument()
+    expect(
+      screen.getByText("https://account.example.invalid"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.outcomes.failed"),
+    ).toBeInTheDocument()
+    expect(screen.getByText("Could not create missing key")).toBeInTheDocument()
+    expect(screen.getByText("1/3 groups")).toBeInTheDocument()
+    expect(screen.getByText("created default")).toBeInTheDocument()
+    expect(screen.getByText("missing vip")).toBeInTheDocument()
+  })
+
+  it("shows the Sub2API create-token action only for current skipped accounts", async () => {
+    const user = userEvent.setup()
+    const onOpenSub2ApiTokenDialog = vi.fn()
+
+    renderList({
+      accountIds: new Set(["account-1"]),
+      filteredResults: [
+        buildResult({
+          accountId: "account-1",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
+          skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
+        }),
+        buildResult({
+          accountId: "account-2",
+          accountName: "Removed Account",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
+          skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
+          finishedAt: 2,
+        }),
+        buildResult({
+          accountId: "account-3",
+          accountName: "None Auth Account",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
+          skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.NoneAuth,
+          finishedAt: 3,
+        }),
+      ],
+      onOpenSub2ApiTokenDialog,
+    })
+
+    const createButtons = screen.getAllByRole("button", {
+      name: "keyManagement:dialog.createToken",
+    })
+    expect(createButtons).toHaveLength(1)
+
+    await user.click(createButtons[0])
+
+    expect(onOpenSub2ApiTokenDialog).toHaveBeenCalledWith("account-1")
+    expect(onOpenSub2ApiTokenDialog).toHaveBeenCalledTimes(1)
+  })
+
+  it("disables the Sub2API create-token action while that account is opening", () => {
+    renderList({
+      filteredResults: [
+        buildResult({
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
+          skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
+        }),
+      ],
+      openingSub2ApiAccountId: "account-1",
+    })
+
+    expect(
+      screen.getByText("keyManagement:dialog.createToken").closest("button"),
+    ).toBeDisabled()
+  })
+})

--- a/tests/features/KeyManagement/components/RepairInvalidKeysDeleteConfirm.test.tsx
+++ b/tests/features/KeyManagement/components/RepairInvalidKeysDeleteConfirm.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { TFunction } from "i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { RepairInvalidKeysDeleteConfirm } from "~/features/KeyManagement/components/RepairInvalidKeysDeleteConfirm"
+import type { AccountKeyRepairInvalidToken } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS } from "~/types/accountKeyAutoProvisioning"
+
+const t = ((key: string, options?: Record<string, unknown>) => {
+  if (key === "keyManagement:repairMissingKeys.deleteConfirm.title") {
+    return `Delete ${options?.count} invalid keys`
+  }
+  if (key === "keyManagement:repairMissingKeys.deleteConfirm.more") {
+    return `${options?.count} more invalid keys hidden`
+  }
+
+  return key
+}) as TFunction
+
+function buildToken(index: number): AccountKeyRepairInvalidToken {
+  return {
+    accountId: `account-${index}`,
+    accountName: `Account ${index}`,
+    siteType: SITE_TYPES.NEW_API,
+    siteUrlOrigin: `https://account-${index}.example.invalid`,
+    tokenId: index,
+    tokenName: `Token ${index}`,
+    group: "missing-group",
+    reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+  }
+}
+
+function renderConfirm(
+  props: Partial<Parameters<typeof RepairInvalidKeysDeleteConfirm>[0]> = {},
+) {
+  return render(
+    <RepairInvalidKeysDeleteConfirm
+      isOpen={true}
+      isWorking={false}
+      selectedInvalidTokens={[buildToken(1)]}
+      onClose={vi.fn()}
+      onConfirm={vi.fn()}
+      t={t}
+      {...props}
+    />,
+  )
+}
+
+describe("RepairInvalidKeysDeleteConfirm", () => {
+  it("previews the first five selected tokens and shows the hidden count", () => {
+    renderConfirm({
+      selectedInvalidTokens: Array.from({ length: 7 }, (_, index) =>
+        buildToken(index + 1),
+      ),
+    })
+
+    expect(
+      screen.getByRole("dialog", { name: "Delete 7 invalid keys" }),
+    ).toBeInTheDocument()
+    for (let index = 1; index <= 5; index += 1) {
+      expect(screen.getByText(`Token ${index}`)).toBeInTheDocument()
+      expect(screen.getByText(`· Account ${index}`)).toBeInTheDocument()
+    }
+    expect(screen.queryByText("Token 6")).toBeNull()
+    expect(screen.queryByText("Token 7")).toBeNull()
+    expect(screen.getByText("2 more invalid keys hidden")).toBeInTheDocument()
+  })
+
+  it("omits the hidden-count message when five or fewer tokens are selected", () => {
+    renderConfirm({
+      selectedInvalidTokens: Array.from({ length: 5 }, (_, index) =>
+        buildToken(index + 1),
+      ),
+    })
+
+    expect(screen.queryByText(/more invalid keys hidden/)).toBeNull()
+  })
+
+  it("passes confirm, cancel, and working state through the dialog surface", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onConfirm = vi.fn()
+    const { rerender } = renderConfirm({ onClose, onConfirm })
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.cancel" }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.deleteConfirm.confirm",
+      }),
+    )
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <RepairInvalidKeysDeleteConfirm
+        isOpen={true}
+        isWorking={true}
+        selectedInvalidTokens={[buildToken(1)]}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        t={t}
+      />,
+    )
+
+    expect(
+      screen.getByRole("button", { name: "common:actions.cancel" }),
+    ).toBeDisabled()
+    expect(
+      screen.getByTestId("repair-invalid-keys-confirm-delete"),
+    ).toBeDisabled()
+  })
+})

--- a/tests/features/KeyManagement/components/RepairInvalidKeysList.test.tsx
+++ b/tests/features/KeyManagement/components/RepairInvalidKeysList.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { TFunction } from "i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { RepairInvalidKeysList } from "~/features/KeyManagement/components/RepairInvalidKeysList"
+import type { AccountKeyRepairInvalidToken } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS } from "~/types/accountKeyAutoProvisioning"
+
+const t = ((key: string, options?: Record<string, unknown>) => {
+  if (key === "keyManagement:repairMissingKeys.invalidKeys.selectedCount") {
+    return `${options?.count} selected`
+  }
+  if (key === "keyManagement:repairMissingKeys.invalidKeys.groupUnavailable") {
+    return `group unavailable: ${options?.group}`
+  }
+
+  return key
+}) as TFunction
+
+function buildToken(
+  overrides: Partial<AccountKeyRepairInvalidToken> = {},
+): AccountKeyRepairInvalidToken {
+  return {
+    accountId: "account-1",
+    accountName: "Example Account",
+    siteType: SITE_TYPES.NEW_API,
+    siteUrlOrigin: "https://account.example.invalid",
+    tokenId: 1,
+    tokenName: "Token 1",
+    group: "missing-group",
+    reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+    ...overrides,
+  }
+}
+
+function renderList(
+  props: Partial<Parameters<typeof RepairInvalidKeysList>[0]> = {},
+) {
+  const token = buildToken()
+
+  return render(
+    <RepairInvalidKeysList
+      deleteResultMessage=""
+      filteredInvalidTokens={[token]}
+      invalidTokens={[token]}
+      selectedInvalidTokenKeys={new Set()}
+      selectedInvalidTokens={[]}
+      onOpenDeleteConfirm={vi.fn()}
+      onSelectedInvalidTokenKeysChange={vi.fn()}
+      t={t}
+      {...props}
+    />,
+  )
+}
+
+describe("RepairInvalidKeysList", () => {
+  it("renders the invalid-list empty state and delete result message", () => {
+    renderList({
+      deleteResultMessage: "Deleted 2 stale keys",
+      filteredInvalidTokens: [],
+      invalidTokens: [],
+    })
+
+    expect(screen.getByText("Deleted 2 stale keys")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "keyManagement:repairMissingKeys.invalidKeys.emptyTitle",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "keyManagement:repairMissingKeys.invalidKeys.emptyDescription",
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("renders the filtered empty state when invalid keys exist but none match", () => {
+    renderList({
+      filteredInvalidTokens: [],
+      invalidTokens: [buildToken()],
+    })
+
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.noMatchingResults"),
+    ).toBeInTheDocument()
+  })
+
+  it("selects all visible invalid keys and clears selection", async () => {
+    const user = userEvent.setup()
+    const onSelectedInvalidTokenKeysChange = vi.fn()
+
+    const { rerender } = renderList({
+      filteredInvalidTokens: [
+        buildToken({
+          accountId: "account-1",
+          tokenId: 1,
+          tokenName: "Token 1",
+        }),
+        buildToken({
+          accountId: "account-2",
+          tokenId: 2,
+          tokenName: "Token 2",
+        }),
+      ],
+      invalidTokens: [
+        buildToken({
+          accountId: "account-1",
+          tokenId: 1,
+          tokenName: "Token 1",
+        }),
+        buildToken({
+          accountId: "account-2",
+          tokenId: 2,
+          tokenName: "Token 2",
+        }),
+      ],
+      selectedInvalidTokenKeys: new Set(),
+      selectedInvalidTokens: [],
+      onSelectedInvalidTokenKeysChange,
+    })
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.selectAll",
+      }),
+    )
+
+    expect(onSelectedInvalidTokenKeysChange).toHaveBeenCalledWith(
+      new Set(["account-1:1", "account-2:2"]),
+    )
+
+    const firstToken = buildToken({
+      accountId: "account-1",
+      tokenId: 1,
+      tokenName: "Token 1",
+    })
+    const secondToken = buildToken({
+      accountId: "account-2",
+      tokenId: 2,
+      tokenName: "Token 2",
+    })
+    rerender(
+      <RepairInvalidKeysList
+        deleteResultMessage=""
+        filteredInvalidTokens={[firstToken, secondToken]}
+        invalidTokens={[firstToken, secondToken]}
+        selectedInvalidTokenKeys={new Set(["account-1:1", "account-2:2"])}
+        selectedInvalidTokens={[firstToken, secondToken]}
+        onOpenDeleteConfirm={vi.fn()}
+        onSelectedInvalidTokenKeysChange={onSelectedInvalidTokenKeysChange}
+        t={t}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.selectAll",
+      }),
+    )
+
+    expect(onSelectedInvalidTokenKeysChange).toHaveBeenLastCalledWith(new Set())
+  })
+
+  it("updates individual token selection", async () => {
+    const user = userEvent.setup()
+    const onSelectedInvalidTokenKeysChange = vi.fn()
+
+    const { rerender } = renderList({ onSelectedInvalidTokenKeysChange })
+
+    await user.click(screen.getByRole("checkbox", { name: "Token 1" }))
+
+    const updater = onSelectedInvalidTokenKeysChange.mock.calls[0]?.[0]
+    expect(updater).toBeTypeOf("function")
+    expect(updater(new Set())).toEqual(new Set(["account-1:1"]))
+
+    const selectedToken = buildToken()
+    rerender(
+      <RepairInvalidKeysList
+        deleteResultMessage=""
+        filteredInvalidTokens={[selectedToken]}
+        invalidTokens={[selectedToken]}
+        selectedInvalidTokenKeys={new Set(["account-1:1"])}
+        selectedInvalidTokens={[selectedToken]}
+        onOpenDeleteConfirm={vi.fn()}
+        onSelectedInvalidTokenKeysChange={onSelectedInvalidTokenKeysChange}
+        t={t}
+      />,
+    )
+
+    await user.click(screen.getByRole("checkbox", { name: "Token 1" }))
+
+    const removeUpdater = onSelectedInvalidTokenKeysChange.mock.calls[1]?.[0]
+    expect(removeUpdater).toBeTypeOf("function")
+    expect(removeUpdater(new Set(["account-1:1"]))).toEqual(new Set())
+  })
+
+  it("enables delete only when tokens are selected and opens confirmation", async () => {
+    const user = userEvent.setup()
+    const onOpenDeleteConfirm = vi.fn()
+    const selectedToken = buildToken()
+    const { rerender } = renderList({ onOpenDeleteConfirm })
+
+    expect(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    ).toBeDisabled()
+
+    rerender(
+      <RepairInvalidKeysList
+        deleteResultMessage=""
+        filteredInvalidTokens={[selectedToken]}
+        invalidTokens={[selectedToken]}
+        selectedInvalidTokenKeys={new Set(["account-1:1"])}
+        selectedInvalidTokens={[selectedToken]}
+        onOpenDeleteConfirm={onOpenDeleteConfirm}
+        onSelectedInvalidTokenKeysChange={vi.fn()}
+        t={t}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    )
+
+    expect(onOpenDeleteConfirm).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/features/KeyManagement/components/RepairMissingKeysProgressCard.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysProgressCard.test.tsx
@@ -103,9 +103,9 @@ describe("RepairMissingKeysProgressCard", () => {
     )
 
     expect(
-      screen
-        .getByText("keyManagement:repairMissingKeys.actions.rerun")
-        .closest("button"),
+      screen.getByRole("button", {
+        name: /keyManagement:repairMissingKeys\.actions\.rerun/,
+      }),
     ).toBeDisabled()
   })
 

--- a/tests/features/KeyManagement/components/RepairMissingKeysProgressCard.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysProgressCard.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { TFunction } from "i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import { RepairMissingKeysProgressCard } from "~/features/KeyManagement/components/RepairMissingKeysProgressCard"
+import type { AccountKeyRepairProgress } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
+
+const t = ((key: string) => key) as TFunction
+
+function buildProgress(
+  overrides: Partial<AccountKeyRepairProgress> = {},
+): AccountKeyRepairProgress {
+  return {
+    jobId: "job-1",
+    state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    totals: {
+      enabledAccounts: 5,
+      eligibleAccounts: 4,
+      processedAccounts: 2,
+      processedEligibleAccounts: 2,
+    },
+    summary: {
+      created: 1,
+      alreadyHad: 1,
+      skipped: 1,
+      failed: 0,
+    },
+    results: [],
+    ...overrides,
+  }
+}
+
+function renderCard(
+  props: Partial<Parameters<typeof RepairMissingKeysProgressCard>[0]> = {},
+) {
+  return render(
+    <RepairMissingKeysProgressCard
+      progress={buildProgress()}
+      isStarting={false}
+      onStartAudit={vi.fn()}
+      t={t}
+      {...props}
+    />,
+  )
+}
+
+describe("RepairMissingKeysProgressCard", () => {
+  it("renders progressbar ARIA values and progress totals", () => {
+    renderCard()
+
+    const progressbar = screen.getByRole("progressbar", {
+      name: "keyManagement:repairMissingKeys.progressLabel",
+    })
+
+    expect(progressbar).toHaveAttribute("aria-valuemin", "0")
+    expect(progressbar).toHaveAttribute("aria-valuemax", "4")
+    expect(progressbar).toHaveAttribute("aria-valuenow", "2")
+    expect(progressbar).toHaveAttribute("aria-valuetext", "2/4 (50%)")
+    expect(screen.getByText("2/4 (50%)")).toBeInTheDocument()
+  })
+
+  it("hides rerun while running and shows it after terminal states", async () => {
+    const user = userEvent.setup()
+    const onStartAudit = vi.fn()
+    const { rerender } = renderCard({ onStartAudit })
+
+    expect(
+      screen.queryByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.rerun",
+      }),
+    ).toBeNull()
+
+    rerender(
+      <RepairMissingKeysProgressCard
+        progress={buildProgress({
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+        })}
+        isStarting={false}
+        onStartAudit={onStartAudit}
+        t={t}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.rerun",
+      }),
+    )
+
+    expect(onStartAudit).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <RepairMissingKeysProgressCard
+        progress={buildProgress({
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Failed,
+        })}
+        isStarting={true}
+        onStartAudit={onStartAudit}
+        t={t}
+      />,
+    )
+
+    expect(
+      screen
+        .getByText("keyManagement:repairMissingKeys.actions.rerun")
+        .closest("button"),
+    ).toBeDisabled()
+  })
+
+  it("renders state-derived processed totals and outcome counts", () => {
+    renderCard({
+      progress: buildProgress({
+        totals: {
+          enabledAccounts: 8,
+          eligibleAccounts: 6,
+          processedAccounts: 5,
+        },
+        summary: {
+          created: 2,
+          alreadyHad: 3,
+          skipped: 4,
+          failed: 1,
+        },
+      }),
+    })
+
+    expect(
+      screen.getByText(
+        "keyManagement:repairMissingKeys.totalsLabels.enabledAccounts",
+      ).nextElementSibling,
+    ).toHaveTextContent("8")
+    expect(
+      screen.getByText(
+        "keyManagement:repairMissingKeys.totalsLabels.eligibleAccounts",
+      ).nextElementSibling,
+    ).toHaveTextContent("6")
+    expect(
+      screen.getByText(
+        "keyManagement:repairMissingKeys.totalsLabels.processedAccounts",
+      ).nextElementSibling,
+    ).toHaveTextContent("5")
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.outcomes.created")
+        .nextElementSibling,
+    ).toHaveTextContent("2")
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.outcomes.alreadyHad")
+        .nextElementSibling,
+    ).toHaveTextContent("3")
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.outcomes.skipped")
+        .nextElementSibling,
+    ).toHaveTextContent("4")
+    expect(
+      screen.getByText("keyManagement:repairMissingKeys.outcomes.failed")
+        .nextElementSibling,
+    ).toHaveTextContent("1")
+  })
+})

--- a/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { TFunction } from "i18next"
+import { useState } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
@@ -111,17 +112,61 @@ function renderPanel(
   )
 }
 
+function renderPanelWithSearchState({
+  onSearchTermChange = vi.fn(),
+  ...props
+}: Partial<Parameters<typeof RepairMissingKeysResultsPanel>[0]> = {}) {
+  function StatefulPanel() {
+    const [searchTerm, setSearchTerm] = useState("Example")
+    const handleSearchTermChange = (value: string) => {
+      setSearchTerm(value)
+      onSearchTermChange(value)
+    }
+
+    return (
+      <RepairMissingKeysResultsPanel
+        accountIds={new Set(["account-1"])}
+        activeView={REPAIR_RESULT_VIEWS.AccountCoverage}
+        deleteResultMessage=""
+        filteredInvalidTokens={[buildToken()]}
+        filteredResults={[buildResult()]}
+        invalidTokens={[buildToken()]}
+        openingSub2ApiAccountId={null}
+        outcomeCounts={{
+          created: 1,
+          alreadyHad: 0,
+          skipped: 0,
+          failed: 0,
+        }}
+        outcomeFilter={null}
+        searchTerm={searchTerm}
+        selectedInvalidTokenKeys={new Set()}
+        selectedInvalidTokens={[]}
+        visibleResults={[buildResult()]}
+        onActiveViewChange={vi.fn()}
+        onOpenDeleteConfirm={vi.fn()}
+        onOpenSub2ApiTokenDialog={vi.fn()}
+        onOutcomeFilterChange={vi.fn()}
+        onSearchTermChange={handleSearchTermChange}
+        onSelectedInvalidTokenKeysChange={vi.fn()}
+        t={t}
+        {...props}
+      />
+    )
+  }
+
+  return render(<StatefulPanel />)
+}
+
 describe("RepairMissingKeysResultsPanel", () => {
   it("renders account coverage counts, search controls, and outcome filters", async () => {
     const user = userEvent.setup()
     const onActiveViewChange = vi.fn()
     const onOutcomeFilterChange = vi.fn()
-    const onSearchTermChange = vi.fn()
 
     renderPanel({
       onActiveViewChange,
       onOutcomeFilterChange,
-      onSearchTermChange,
     })
 
     expect(
@@ -153,19 +198,6 @@ describe("RepairMissingKeysResultsPanel", () => {
       REPAIR_RESULT_VIEWS.InvalidKeys,
     )
 
-    await user.type(
-      screen.getByRole("textbox", {
-        name: "keyManagement:repairMissingKeys.searchLabel",
-      }),
-      " 1",
-    )
-    expect(onSearchTermChange).toHaveBeenLastCalledWith("Example1")
-
-    await user.click(
-      screen.getByRole("button", { name: "common:actions.clear" }),
-    )
-    expect(onSearchTermChange).toHaveBeenLastCalledWith("")
-
     await user.click(
       screen.getByRole("button", {
         name: /keyManagement:repairMissingKeys\.outcomes\.created/,
@@ -174,6 +206,27 @@ describe("RepairMissingKeysResultsPanel", () => {
     expect(onOutcomeFilterChange).toHaveBeenCalledWith(
       ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
     )
+  })
+
+  it("forwards controlled search updates and clear actions", async () => {
+    const user = userEvent.setup()
+    const onSearchTermChange = vi.fn()
+
+    renderPanelWithSearchState({ onSearchTermChange })
+
+    const searchInput = screen.getByRole("textbox", {
+      name: "keyManagement:repairMissingKeys.searchLabel",
+    })
+    expect(searchInput).toHaveValue("Example")
+
+    await user.type(searchInput, " 1")
+    expect(onSearchTermChange).toHaveBeenLastCalledWith("Example 1")
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
+    expect(onSearchTermChange).toHaveBeenLastCalledWith("")
+    expect(searchInput).toHaveValue("")
   })
 
   it("routes invalid-key view selection and delete actions", async () => {

--- a/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { TFunction } from "i18next"
+import { describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { REPAIR_RESULT_VIEWS } from "~/features/KeyManagement/components/repairMissingKeysDialogHelpers"
+import { RepairMissingKeysResultsPanel } from "~/features/KeyManagement/components/RepairMissingKeysResultsPanel"
+import type {
+  AccountKeyRepairAccountResult,
+  AccountKeyRepairInvalidToken,
+} from "~/types/accountKeyAutoProvisioning"
+import {
+  ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
+  ACCOUNT_KEY_REPAIR_OUTCOMES,
+} from "~/types/accountKeyAutoProvisioning"
+
+const t = ((key: string, options?: Record<string, unknown>) => {
+  if (key === "keyManagement:repairMissingKeys.coverage.groupsCovered") {
+    return `${options?.covered}/${options?.total} groups`
+  }
+  if (key === "keyManagement:repairMissingKeys.invalidKeys.selectedCount") {
+    return `${options?.count} selected`
+  }
+  if (key === "keyManagement:repairMissingKeys.invalidKeys.groupUnavailable") {
+    return `group unavailable: ${options?.group}`
+  }
+
+  return key
+}) as TFunction
+
+function buildResult(
+  overrides: Partial<AccountKeyRepairAccountResult> = {},
+): AccountKeyRepairAccountResult {
+  return {
+    accountId: "account-1",
+    accountName: "Example Account",
+    siteType: SITE_TYPES.NEW_API,
+    siteUrlOrigin: "https://account.example.invalid",
+    outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
+    finishedAt: 1,
+    ...overrides,
+  }
+}
+
+function buildToken(
+  overrides: Partial<AccountKeyRepairInvalidToken> = {},
+): AccountKeyRepairInvalidToken {
+  return {
+    accountId: "account-1",
+    accountName: "Example Account",
+    siteType: SITE_TYPES.NEW_API,
+    siteUrlOrigin: "https://account.example.invalid",
+    tokenId: 1,
+    tokenName: "Token 1",
+    group: "missing-group",
+    reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+    ...overrides,
+  }
+}
+
+function renderPanel(
+  props: Partial<Parameters<typeof RepairMissingKeysResultsPanel>[0]> = {},
+) {
+  const selectedToken = buildToken()
+
+  return render(
+    <RepairMissingKeysResultsPanel
+      accountIds={new Set(["account-1"])}
+      activeView={REPAIR_RESULT_VIEWS.AccountCoverage}
+      deleteResultMessage=""
+      filteredInvalidTokens={[selectedToken]}
+      filteredResults={[buildResult()]}
+      invalidTokens={[
+        selectedToken,
+        buildToken({
+          accountId: "account-2",
+          tokenId: 2,
+          tokenName: "Token 2",
+        }),
+      ]}
+      openingSub2ApiAccountId={null}
+      outcomeCounts={{
+        created: 1,
+        alreadyHad: 1,
+        skipped: 0,
+        failed: 0,
+      }}
+      outcomeFilter={null}
+      searchTerm="Example"
+      selectedInvalidTokenKeys={new Set()}
+      selectedInvalidTokens={[]}
+      visibleResults={[
+        buildResult(),
+        buildResult({
+          accountId: "account-2",
+          accountName: "Second Account",
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad,
+          finishedAt: 2,
+        }),
+      ]}
+      onActiveViewChange={vi.fn()}
+      onOpenDeleteConfirm={vi.fn()}
+      onOpenSub2ApiTokenDialog={vi.fn()}
+      onOutcomeFilterChange={vi.fn()}
+      onSearchTermChange={vi.fn()}
+      onSelectedInvalidTokenKeysChange={vi.fn()}
+      t={t}
+      {...props}
+    />,
+  )
+}
+
+describe("RepairMissingKeysResultsPanel", () => {
+  it("renders account coverage counts, search controls, and outcome filters", async () => {
+    const user = userEvent.setup()
+    const onActiveViewChange = vi.fn()
+    const onOutcomeFilterChange = vi.fn()
+    const onSearchTermChange = vi.fn()
+
+    renderPanel({
+      onActiveViewChange,
+      onOutcomeFilterChange,
+      onSearchTermChange,
+    })
+
+    expect(
+      screen.getByRole("group", {
+        name: "keyManagement:repairMissingKeys.views.label",
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.views.accountCoverage",
+      }),
+    ).toHaveAttribute("aria-pressed", "true")
+    expect(
+      screen.getByRole("button", {
+        name: /keyManagement:repairMissingKeys\.views\.invalidKeys/,
+      }),
+    ).toHaveAttribute("aria-pressed", "false")
+    expect(
+      screen.getByTestId("repair-missing-keys-result-count"),
+    ).toHaveTextContent("1/2")
+    expect(screen.getByText("Example Account")).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /keyManagement:repairMissingKeys\.views\.invalidKeys/,
+      }),
+    )
+    expect(onActiveViewChange).toHaveBeenCalledWith(
+      REPAIR_RESULT_VIEWS.InvalidKeys,
+    )
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: "keyManagement:repairMissingKeys.searchLabel",
+      }),
+      " 1",
+    )
+    expect(onSearchTermChange).toHaveBeenLastCalledWith("Example1")
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    )
+    expect(onSearchTermChange).toHaveBeenLastCalledWith("")
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /keyManagement:repairMissingKeys\.outcomes\.created/,
+      }),
+    )
+    expect(onOutcomeFilterChange).toHaveBeenCalledWith(
+      ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
+    )
+  })
+
+  it("routes invalid-key view selection and delete actions", async () => {
+    const user = userEvent.setup()
+    const selectedToken = buildToken()
+    const onOpenDeleteConfirm = vi.fn()
+    const onSelectedInvalidTokenKeysChange = vi.fn()
+
+    renderPanel({
+      activeView: REPAIR_RESULT_VIEWS.InvalidKeys,
+      deleteResultMessage: "Deleted 1 invalid key",
+      filteredInvalidTokens: [selectedToken],
+      selectedInvalidTokenKeys: new Set(["account-1:1"]),
+      selectedInvalidTokens: [selectedToken],
+      onOpenDeleteConfirm,
+      onSelectedInvalidTokenKeysChange,
+    })
+
+    expect(
+      screen.getByRole("button", {
+        name: /keyManagement:repairMissingKeys\.views\.invalidKeys/,
+      }),
+    ).toHaveAttribute("aria-pressed", "true")
+    expect(
+      screen.getByTestId("repair-missing-keys-result-count"),
+    ).toHaveTextContent("1/2")
+    expect(screen.getByText("Deleted 1 invalid key")).toBeInTheDocument()
+    expect(screen.getByText("Token 1")).toBeInTheDocument()
+    expect(screen.getByText("1 selected")).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.invalidKeys.deleteSelected",
+      }),
+    )
+    expect(onOpenDeleteConfirm).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole("checkbox", { name: "Token 1" }))
+
+    const removeUpdater = onSelectedInvalidTokenKeysChange.mock.calls[0]?.[0]
+    expect(removeUpdater).toBeTypeOf("function")
+    expect(removeUpdater(new Set(["account-1:1"]))).toEqual(new Set())
+  })
+})

--- a/tests/features/KeyManagement/components/repairMissingKeysDialogHelpers.test.ts
+++ b/tests/features/KeyManagement/components/repairMissingKeysDialogHelpers.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getRepairProgressBarColor,
+  getRepairProgressTotals,
+} from "~/features/KeyManagement/components/repairMissingKeysDialogHelpers"
+import type { AccountKeyRepairProgress } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
+
+function buildProgress(
+  overrides: Partial<AccountKeyRepairProgress> = {},
+): AccountKeyRepairProgress {
+  return {
+    jobId: "job-1",
+    state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    totals: {
+      enabledAccounts: 1,
+      eligibleAccounts: 1,
+      processedAccounts: 0,
+    },
+    summary: {
+      created: 0,
+      alreadyHad: 0,
+      skipped: 0,
+      failed: 0,
+    },
+    results: [],
+    ...overrides,
+  }
+}
+
+describe("repairMissingKeysDialogHelpers", () => {
+  it("uses a zero progress percentage when no account is eligible", () => {
+    expect(
+      getRepairProgressTotals(
+        buildProgress({
+          totals: {
+            enabledAccounts: 1,
+            eligibleAccounts: 0,
+            processedAccounts: 0,
+          },
+        }),
+      ),
+    ).toEqual({
+      eligibleTotal: 0,
+      processedTotal: 0,
+      progressMax: 1,
+      progressPercent: 0,
+    })
+  })
+
+  it("uses the warning progress color for completed runs with failures", () => {
+    expect(
+      getRepairProgressBarColor(
+        buildProgress({
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+          summary: {
+            created: 1,
+            alreadyHad: 0,
+            skipped: 0,
+            failed: 1,
+          },
+        }),
+      ),
+    ).toBe("bg-amber-600 dark:bg-amber-500")
+  })
+})

--- a/tests/features/KeyManagement/components/useInvalidKeyDeletion.test.tsx
+++ b/tests/features/KeyManagement/components/useInvalidKeyDeletion.test.tsx
@@ -137,6 +137,26 @@ describe("useInvalidKeyDeletion", () => {
     expect(progress.summary.deletedKeys).toBe(2)
   })
 
+  it("skips deletion when no invalid tokens are selected", async () => {
+    const setProgress = vi.fn()
+
+    const { result } = renderHook(() =>
+      useInvalidKeyDeletion({
+        invalidTokens: [visibleToken],
+        setProgress,
+        t: testI18n.t,
+      }),
+    )
+
+    await act(async () => {
+      await result.current.handleDeleteInvalidKeys()
+    })
+
+    expect(sendAccountKeyRepairMessageMock).not.toHaveBeenCalled()
+    expect(setProgress).not.toHaveBeenCalled()
+    expect(result.current.isDeletingInvalidKeys).toBe(false)
+  })
+
   it("ignores repeated delete submissions while a delete request is in flight", async () => {
     let resolveDelete:
       | ((

--- a/tests/features/KeyManagement/components/useInvalidKeyDeletion.test.tsx
+++ b/tests/features/KeyManagement/components/useInvalidKeyDeletion.test.tsx
@@ -1,0 +1,185 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { useInvalidKeyDeletion } from "~/features/KeyManagement/components/useInvalidKeyDeletion"
+import {
+  AccountKeyRepairMessageTypes,
+  sendAccountKeyRepairMessage,
+} from "~/services/accounts/accountKeyAutoProvisioning/messaging"
+import {
+  ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
+  ACCOUNT_KEY_REPAIR_JOB_STATES,
+  ACCOUNT_KEY_REPAIR_OUTCOMES,
+  type AccountKeyRepairInvalidToken,
+  type AccountKeyRepairProgress,
+} from "~/types/accountKeyAutoProvisioning"
+import { testI18n } from "~~/tests/test-utils/i18n"
+
+vi.mock("~/services/accounts/accountKeyAutoProvisioning/messaging", () => ({
+  AccountKeyRepairMessageTypes: {
+    Start: "accountKeyRepair:start",
+    GetProgress: "accountKeyRepair:getProgress",
+    DeleteInvalidTokens: "accountKeyRepair:deleteInvalidTokens",
+  },
+  sendAccountKeyRepairMessage: vi.fn(),
+}))
+
+vi.mock("~/services/productAnalytics/actions", () => ({
+  trackProductAnalyticsActionCompleted: vi.fn(),
+  trackProductAnalyticsActionStarted: vi.fn(),
+}))
+
+const sendAccountKeyRepairMessageMock = vi.mocked(sendAccountKeyRepairMessage)
+
+function createInvalidToken(
+  overrides: Partial<AccountKeyRepairInvalidToken>,
+): AccountKeyRepairInvalidToken {
+  return {
+    accountId: "account-1",
+    accountName: "Account 1",
+    siteType: SITE_TYPES.NEW_API,
+    siteUrlOrigin: "https://one.example.invalid",
+    tokenId: 1,
+    tokenName: "Token 1",
+    group: "default",
+    reason: ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS.GroupUnavailable,
+    ...overrides,
+  }
+}
+
+function createProgress(
+  invalidTokens: AccountKeyRepairInvalidToken[],
+): AccountKeyRepairProgress {
+  return {
+    jobId: "job-1",
+    state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+    totals: {
+      enabledAccounts: 1,
+      eligibleAccounts: 1,
+      processedAccounts: 1,
+    },
+    summary: {
+      created: 0,
+      alreadyHad: 0,
+      skipped: 0,
+      failed: 0,
+      invalidKeys: invalidTokens.length,
+    },
+    results: [
+      {
+        accountId: "account-1",
+        accountName: "Account 1",
+        siteType: SITE_TYPES.NEW_API,
+        siteUrlOrigin: "https://one.example.invalid",
+        outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.AlreadyHad,
+        invalidTokens,
+        finishedAt: 1,
+      },
+    ],
+  }
+}
+
+describe("useInvalidKeyDeletion", () => {
+  const visibleToken = createInvalidToken({
+    tokenId: 1,
+    tokenName: "Visible token",
+  })
+  const hiddenToken = createInvalidToken({
+    tokenId: 2,
+    tokenName: "Hidden token",
+    group: "hidden",
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("deletes selected invalid tokens even when filters hide some selections", async () => {
+    sendAccountKeyRepairMessageMock.mockResolvedValue({
+      success: true,
+      data: {
+        deleted: [
+          { ...visibleToken, deletedAt: 1 },
+          { ...hiddenToken, deletedAt: 1 },
+        ],
+        failed: [],
+      },
+    })
+    let progress = createProgress([visibleToken, hiddenToken])
+    const setProgress = vi.fn((updater) => {
+      progress = typeof updater === "function" ? updater(progress) : updater
+    })
+
+    const { result } = renderHook(() =>
+      useInvalidKeyDeletion({
+        invalidTokens: [visibleToken, hiddenToken],
+        setProgress,
+        t: testI18n.t,
+      }),
+    )
+
+    act(() => {
+      result.current.setSelectedInvalidTokenKeys(
+        new Set(["account-1:1", "account-1:2"]),
+      )
+    })
+
+    await act(async () => {
+      await result.current.handleDeleteInvalidKeys()
+    })
+
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.DeleteInvalidTokens,
+      { tokens: [visibleToken, hiddenToken] },
+    )
+    expect(progress.summary.invalidKeys).toBe(0)
+    expect(progress.summary.deletedKeys).toBe(2)
+  })
+
+  it("ignores repeated delete submissions while a delete request is in flight", async () => {
+    let resolveDelete:
+      | ((
+          value: Awaited<ReturnType<typeof sendAccountKeyRepairMessage>>,
+        ) => void)
+      | undefined
+    sendAccountKeyRepairMessageMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDelete = resolve
+      }) as ReturnType<typeof sendAccountKeyRepairMessage>,
+    )
+    const setProgress = vi.fn()
+
+    const { result } = renderHook(() =>
+      useInvalidKeyDeletion({
+        invalidTokens: [visibleToken],
+        setProgress,
+        t: testI18n.t,
+      }),
+    )
+
+    act(() => {
+      result.current.setSelectedInvalidTokenKeys(new Set(["account-1:1"]))
+    })
+
+    void act(() => {
+      void result.current.handleDeleteInvalidKeys()
+    })
+    await waitFor(() => {
+      expect(result.current.isDeletingInvalidKeys).toBe(true)
+    })
+
+    await act(async () => {
+      await result.current.handleDeleteInvalidKeys()
+    })
+
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveDelete?.({
+        success: true,
+        data: { deleted: [{ ...visibleToken, deletedAt: 1 }], failed: [] },
+      })
+    })
+  })
+})

--- a/tests/features/KeyManagement/components/useRepairMissingKeysJob.test.tsx
+++ b/tests/features/KeyManagement/components/useRepairMissingKeysJob.test.tsx
@@ -1,0 +1,75 @@
+import { waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { useRepairMissingKeysJob } from "~/features/KeyManagement/components/useRepairMissingKeysJob"
+import {
+  AccountKeyRepairMessageTypes,
+  sendAccountKeyRepairMessage,
+} from "~/services/accounts/accountKeyAutoProvisioning/messaging"
+import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+import { testI18n } from "~~/tests/test-utils/i18n"
+import { renderHook } from "~~/tests/test-utils/render"
+
+vi.mock("~/services/accounts/accountKeyAutoProvisioning/messaging", () => ({
+  AccountKeyRepairMessageTypes: {
+    Start: "accountKeyRepair:start",
+    GetProgress: "accountKeyRepair:getProgress",
+    DeleteInvalidTokens: "accountKeyRepair:deleteInvalidTokens",
+  },
+  sendAccountKeyRepairMessage: vi.fn(),
+}))
+
+vi.mock("~/services/productAnalytics/actions", () => ({
+  trackProductAnalyticsActionCompleted: vi.fn(),
+  trackProductAnalyticsActionStarted: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/browserApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/utils/browser/browserApi")>()),
+  onRuntimeMessage: vi.fn(() => vi.fn()),
+}))
+
+const sendAccountKeyRepairMessageMock = vi.mocked(sendAccountKeyRepairMessage)
+
+describe("useRepairMissingKeysJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows the load failure message when progress loading returns an unsuccessful response", async () => {
+    sendAccountKeyRepairMessageMock.mockResolvedValue({
+      success: false,
+      error: "load failed",
+    })
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [
+          {
+            id: "account-1",
+            name: "Account 1",
+            siteType: SITE_TYPES.NEW_API,
+            baseUrl: "https://one.example.invalid",
+            token: "token",
+            authType: AuthTypeEnum.AccessToken,
+            disabled: false,
+            health: { status: SiteHealthStatus.Healthy },
+          } as any,
+        ],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(
+        "keyManagement:repairMissingKeys.messages.loadFailed",
+      )
+    })
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.GetProgress,
+    )
+  })
+})

--- a/tests/features/KeyManagement/components/useRepairMissingKeysJob.test.tsx
+++ b/tests/features/KeyManagement/components/useRepairMissingKeysJob.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from "@testing-library/react"
+import { act, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
@@ -7,7 +7,18 @@ import {
   AccountKeyRepairMessageTypes,
   sendAccountKeyRepairMessage,
 } from "~/services/accounts/accountKeyAutoProvisioning/messaging"
+import {
+  trackProductAnalyticsActionCompleted,
+  trackProductAnalyticsActionStarted,
+} from "~/services/productAnalytics/actions"
+import {
+  PRODUCT_ANALYTICS_RESULTS,
+  PRODUCT_ANALYTICS_STATUS_KINDS,
+} from "~/services/productAnalytics/events"
+import type { DisplaySiteData } from "~/types"
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+import type { AccountKeyRepairProgress } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
 import { testI18n } from "~~/tests/test-utils/i18n"
 import { renderHook } from "~~/tests/test-utils/render"
 
@@ -31,6 +42,58 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => ({
 }))
 
 const sendAccountKeyRepairMessageMock = vi.mocked(sendAccountKeyRepairMessage)
+const trackProductAnalyticsActionCompletedMock = vi.mocked(
+  trackProductAnalyticsActionCompleted,
+)
+const trackProductAnalyticsActionStartedMock = vi.mocked(
+  trackProductAnalyticsActionStarted,
+)
+
+function buildAccount(
+  overrides: Partial<DisplaySiteData> = {},
+): DisplaySiteData {
+  return {
+    id: "account-1",
+    name: "Account 1",
+    username: "user@example.invalid",
+    balance: { USD: 0, CNY: 0 },
+    todayConsumption: { USD: 0, CNY: 0 },
+    todayIncome: { USD: 0, CNY: 0 },
+    todayTokens: { upload: 0, download: 0 },
+    health: { status: SiteHealthStatus.Healthy },
+    siteType: SITE_TYPES.NEW_API,
+    baseUrl: "https://one.example.invalid",
+    token: "token",
+    userId: "user-1",
+    authType: AuthTypeEnum.AccessToken,
+    disabled: false,
+    checkIn: { enableDetection: false },
+    ...overrides,
+  }
+}
+
+function buildProgress(
+  overrides: Partial<AccountKeyRepairProgress> = {},
+): AccountKeyRepairProgress {
+  return {
+    jobId: "job-1",
+    state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    totals: {
+      enabledAccounts: 2,
+      eligibleAccounts: 2,
+      processedAccounts: 1,
+      processedEligibleAccounts: 1,
+    },
+    summary: {
+      created: 1,
+      alreadyHad: 0,
+      skipped: 0,
+      failed: 0,
+    },
+    results: [],
+    ...overrides,
+  }
+}
 
 describe("useRepairMissingKeysJob", () => {
   beforeEach(() => {
@@ -45,18 +108,7 @@ describe("useRepairMissingKeysJob", () => {
 
     const { result } = renderHook(() =>
       useRepairMissingKeysJob({
-        accounts: [
-          {
-            id: "account-1",
-            name: "Account 1",
-            siteType: SITE_TYPES.NEW_API,
-            baseUrl: "https://one.example.invalid",
-            token: "token",
-            authType: AuthTypeEnum.AccessToken,
-            disabled: false,
-            health: { status: SiteHealthStatus.Healthy },
-          } as any,
-        ],
+        accounts: [buildAccount()],
         isOpen: true,
         startOnOpen: false,
         t: testI18n.t,
@@ -70,6 +122,174 @@ describe("useRepairMissingKeysJob", () => {
     })
     expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledWith(
       AccountKeyRepairMessageTypes.GetProgress,
+    )
+  })
+
+  it("loads existing progress successfully when opened", async () => {
+    const progress = buildProgress({
+      jobId: "existing-job",
+      totals: {
+        enabledAccounts: 3,
+        eligibleAccounts: 2,
+        processedAccounts: 2,
+      },
+    })
+    sendAccountKeyRepairMessageMock.mockResolvedValue({
+      success: true,
+      data: progress,
+    })
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.progress).toEqual(progress)
+    })
+    expect(result.current.error).toBe("")
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.GetProgress,
+    )
+  })
+
+  it("shows the load failure message when progress loading rejects", async () => {
+    sendAccountKeyRepairMessageMock.mockRejectedValue(new Error("network down"))
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(
+        "keyManagement:repairMissingKeys.messages.loadFailed",
+      )
+    })
+  })
+
+  it("auto-starts on open and tracks failed terminal progress with warning status", async () => {
+    sendAccountKeyRepairMessageMock.mockImplementation(async (type) => {
+      if (type === AccountKeyRepairMessageTypes.Start) {
+        return {
+          success: true,
+          data: buildProgress({ jobId: "started-job" }),
+        }
+      }
+
+      return {
+        success: true,
+        data: buildProgress({ jobId: "existing-job" }),
+      }
+    })
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: true,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(trackProductAnalyticsActionStartedMock).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(result.current.progress?.jobId).toBe("started-job")
+    })
+
+    act(() => {
+      result.current.setProgress(
+        buildProgress({
+          jobId: "started-job",
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+          totals: {
+            enabledAccounts: 3,
+            eligibleAccounts: 3,
+            processedAccounts: 3,
+            processedEligibleAccounts: 3,
+          },
+          summary: {
+            created: 2,
+            alreadyHad: 0,
+            skipped: 0,
+            failed: 1,
+          },
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(trackProductAnalyticsActionCompletedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result: PRODUCT_ANALYTICS_RESULTS.Failure,
+          insights: expect.objectContaining({
+            itemCount: 3,
+            selectedCount: 3,
+            successCount: 2,
+            failureCount: 1,
+            statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Warning,
+          }),
+        }),
+      )
+    })
+  })
+
+  it("ignores duplicate start requests while a start is already in flight", async () => {
+    let resolveStart:
+      | ((value: { success: true; data: AccountKeyRepairProgress }) => void)
+      | undefined
+
+    sendAccountKeyRepairMessageMock.mockImplementation((type) => {
+      if (type === AccountKeyRepairMessageTypes.Start) {
+        return new Promise((resolve) => {
+          resolveStart = resolve
+        })
+      }
+
+      return Promise.resolve({
+        success: true,
+        data: buildProgress(),
+      })
+    })
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: false,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current?.handleStartAudit).toBeTypeOf("function")
+    })
+
+    await act(async () => {
+      const firstStart = result.current.handleStartAudit()
+      const secondStart = result.current.handleStartAudit()
+
+      resolveStart?.({
+        success: true,
+        data: buildProgress({ jobId: "started-once" }),
+      })
+
+      await Promise.all([firstStart, secondStart])
+    })
+
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledTimes(1)
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.Start,
     )
   })
 })


### PR DESCRIPTION
## Summary
- Split the repair-missing-keys dialog into focused result, progress, invalid-key, and account-coverage components.
- Extract repair job orchestration and invalid-key deletion state into dedicated hooks.
- Keep the dialog focused on filtering, modal composition, and Sub2API quick-create wiring.

## Test Plan
- pnpm exec tsc --noEmit --pretty false
- pnpm run i18n:extract:ci
- pnpm vitest related --run src/features/KeyManagement/components/RepairMissingKeysDialog.tsx tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account-key repair progress card with a rerun/start action, progress bar, and detailed enabled/eligible/processed + outcome counts.
  * Added a results panel with search, view switching (coverage vs invalid keys), and outcome filtering.
  * Added invalid-key bulk selection with a destructive confirmation dialog, token preview with “hidden items” messaging, and per-token delete workflow.
  * Added coverage badges and a conditional “create token” action for skipped accounts (disabled while opening).

* **Refactor**
  * Split the repair-missing-keys dialog into dedicated hooks and smaller UI components for clearer behavior and state reset.

* **Tests**
  * Added comprehensive unit tests for the new UI components and hooks, plus improved an existing autosign-in failure test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->