### PR TITLE
fix(account): add failure diagnostics analytics

### DIFF
--- a/src/features/AccountManagement/AccountManagement.tsx
+++ b/src/features/AccountManagement/AccountManagement.tsx
@@ -21,6 +21,7 @@ import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FAILURE_STAGES,
   PRODUCT_ANALYTICS_FEATURE_IDS,
   PRODUCT_ANALYTICS_MODE_IDS,
   PRODUCT_ANALYTICS_RESULTS,
@@ -130,6 +131,7 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
         successCount: result.success,
         failureCount: result.failed,
         skippedCount,
+        failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
       })
       if (result.failed > 0) {
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -197,6 +199,7 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
         successCount: refreshInsights.successCount,
         failureCount: refreshInsights.failureCount,
         skippedCount: 0,
+        failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
       })
       if (result.failedCount > 0) {
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {

--- a/src/features/AccountManagement/AccountManagement.tsx
+++ b/src/features/AccountManagement/AccountManagement.tsx
@@ -131,7 +131,9 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
         successCount: result.success,
         failureCount: result.failed,
         skippedCount,
-        failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
+        ...(result.failed > 0
+          ? { failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute }
+          : {}),
       })
       if (result.failed > 0) {
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -199,7 +201,9 @@ function AccountManagementContent({ searchQuery }: { searchQuery?: string }) {
         successCount: refreshInsights.successCount,
         failureCount: refreshInsights.failureCount,
         skippedCount: 0,
-        failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
+        ...(result.failedCount > 0
+          ? { failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute }
+          : {}),
       })
       if (result.failedCount > 0) {
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -82,10 +82,12 @@ import {
   startProductAnalyticsAction,
   type ProductAnalyticsActionInsights,
 } from "~/services/productAnalytics/actions"
+import { buildActionFailureDiagnostics } from "~/services/productAnalytics/diagnosticsError"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FAILURE_REASONS,
   PRODUCT_ANALYTICS_FAILURE_STAGES,
   PRODUCT_ANALYTICS_FEATURE_IDS,
   PRODUCT_ANALYTICS_RESULTS,
@@ -1341,7 +1343,13 @@ export function useAccountDialog({
 
         if (!response?.errorCode) {
           analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-            errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            diagnostics: {
+              failure: buildActionFailureDiagnostics({
+                errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+                stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Response,
+                reason: PRODUCT_ANALYTICS_FAILURE_REASONS.InvalidResponseShape,
+              }),
+            },
           })
           toast.error(
             response?.error
@@ -1355,13 +1363,25 @@ export function useAccountDialog({
           case COOKIE_IMPORT_FAILURE_REASONS.PermissionDenied:
             setShowCookiePermissionWarning(true)
             analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-              errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Permission,
+              diagnostics: {
+                failure: buildActionFailureDiagnostics({
+                  errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Permission,
+                  stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Permission,
+                  reason: PRODUCT_ANALYTICS_FAILURE_REASONS.PermissionDenied,
+                }),
+              },
             })
             toast.error(t("messages.importCookiesPermissionDenied"))
             break
           case COOKIE_IMPORT_FAILURE_REASONS.ReadFailed:
             analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-              errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+              diagnostics: {
+                failure: buildActionFailureDiagnostics({
+                  errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+                  stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+                  reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+                }),
+              },
             })
             toast.error(
               response.error
@@ -1382,7 +1402,9 @@ export function useAccountDialog({
         t("messages.importCookiesFailed", { error: getErrorMessage(error) }),
       )
       analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        diagnostics: {
+          failure: buildActionFailureDiagnostics({ error }),
+        },
       })
     } finally {
       setIsImportingCookies(false)
@@ -1545,7 +1567,9 @@ export function useAccountDialog({
         t("messages.operationFailed", { error: getErrorMessage(error) }),
       )
       analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        diagnostics: {
+          failure: buildActionFailureDiagnostics({ error }),
+        },
       })
     } finally {
       setIsImportingSub2apiSession(false)
@@ -1611,10 +1635,14 @@ export function useAccountDialog({
         }),
       )
       analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        diagnostics: {
+          failure: buildActionFailureDiagnostics({
+            error,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Persist,
+          }),
+        },
         insights: {
           ...createAutoDetectAnalyticsInsights(),
-          failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Persist,
         },
       })
       return
@@ -1635,12 +1663,25 @@ export function useAccountDialog({
         setDetectionError(result.detailedError || null)
         enterForm(ACCOUNT_DIALOG_FORM_SOURCES.MANUAL)
         analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-          errorCategory: getAutoDetectAnalyticsErrorCategory(
-            result.detailedError?.type,
-          ),
+          diagnostics: {
+            failure: {
+              ...buildActionFailureDiagnostics({
+                errorCategory: getAutoDetectAnalyticsErrorCategory(
+                  result.detailedError?.type,
+                ),
+                stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
+                reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+              }),
+              ...(result.autoDetectFailureReason
+                ? {
+                    accountAutoDetectFailureReason:
+                      result.autoDetectFailureReason,
+                  }
+                : {}),
+            },
+          },
           insights: {
             ...createAutoDetectAnalyticsInsights(result),
-            failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
             ...(result.autoDetectFailureReason
               ? {
                   accountAutoDetectFailureReason:
@@ -1757,13 +1798,18 @@ export function useAccountDialog({
       setDetectionError(detectionError)
       enterForm(ACCOUNT_DIALOG_FORM_SOURCES.MANUAL)
       analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-        errorCategory: getAutoDetectAnalyticsErrorCategory(
-          detectionError.type,
-          error,
-        ),
+        diagnostics: {
+          failure: buildActionFailureDiagnostics({
+            error,
+            errorCategory: getAutoDetectAnalyticsErrorCategory(
+              detectionError.type,
+              error,
+            ),
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
+          }),
+        },
         insights: {
           ...createAutoDetectAnalyticsInsights(),
-          failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
         },
       })
     } finally {
@@ -1870,7 +1916,11 @@ export function useAccountDialog({
 
       if (!result.success) {
         analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+          diagnostics: {
+            failure: buildActionFailureDiagnostics({
+              error: new Error(result.message || t("messages.saveFailed")),
+            }),
+          },
         })
         isAnalyticsActionCompleted = true
         throw new Error(result.message || t("messages.saveFailed"))
@@ -2002,7 +2052,11 @@ export function useAccountDialog({
     } catch (error: any) {
       if (!isAnalyticsActionCompleted) {
         analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+          diagnostics: {
+            failure: buildActionFailureDiagnostics({
+              error,
+            }),
+          },
         })
       }
       toast.error(

--- a/src/features/AccountManagement/hooks/AccountActionsContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountActionsContext.tsx
@@ -15,14 +15,16 @@ import {
 } from "~/services/checkin/externalCheckInMessaging"
 import { buildAccountRefreshDiagnostics } from "~/services/productAnalytics/accountRefresh"
 import {
-  resolveProductAnalyticsErrorCategoryFromError,
   startProductAnalyticsAction,
   type ProductAnalyticsActionContext,
 } from "~/services/productAnalytics/actions"
+import { buildActionFailureDiagnostics } from "~/services/productAnalytics/diagnosticsError"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FAILURE_REASONS,
+  PRODUCT_ANALYTICS_FAILURE_STAGES,
   PRODUCT_ANALYTICS_FEATURE_IDS,
   PRODUCT_ANALYTICS_MODE_IDS,
   PRODUCT_ANALYTICS_RESULTS,
@@ -379,8 +381,14 @@ export const AccountActionsProvider = ({
 
         if (!response?.success || !response.data) {
           analyticsCompleted = true
+          const failure = buildActionFailureDiagnostics({
+            errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.InvalidResponseShape,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Response,
+          })
           tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-            errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            diagnostics: { failure },
+            errorCategory: failure.category,
           })
           throw new Error(
             response?.success === false ? response.error : "Empty response",
@@ -391,8 +399,14 @@ export const AccountActionsProvider = ({
 
         if (response.data.failedCount > 0) {
           analyticsCompleted = true
-          tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
+          const failure = buildActionFailureDiagnostics({
             errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
+          })
+          tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
+            diagnostics: { failure },
+            errorCategory: failure.category,
           })
           toast.error(
             t("messages:errors.operation.failed", {
@@ -407,8 +421,10 @@ export const AccountActionsProvider = ({
         logger.error("Error opening external check-ins", error)
         if (!analyticsCompleted) {
           analyticsCompleted = true
+          const failure = buildActionFailureDiagnostics({ error })
           tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-            errorCategory: resolveProductAnalyticsErrorCategoryFromError(error),
+            diagnostics: { failure },
+            errorCategory: failure.category,
           })
         }
         toast.error(

--- a/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
+++ b/tests/entrypoints/options/AccountAndBookmarkPages.test.tsx
@@ -320,7 +320,7 @@ describe("options AccountManagement page", () => {
             failure: {
               category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
               reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
-              stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+              stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
             },
             outcome: {
               itemCount: 3,
@@ -518,7 +518,7 @@ describe("options AccountManagement page", () => {
           failure: {
             category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
             reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
-            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
           },
           outcome: {
             itemCount: 3,

--- a/tests/features/AccountManagement/AccountManagement.analytics.test.tsx
+++ b/tests/features/AccountManagement/AccountManagement.analytics.test.tsx
@@ -160,7 +160,7 @@ describe("AccountManagement refresh analytics", () => {
             },
             failure: {
               category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-              stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+              stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
               reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
             },
           },
@@ -218,7 +218,7 @@ describe("AccountManagement refresh analytics", () => {
             },
             failure: {
               category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-              stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+              stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
               reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
             },
           },

--- a/tests/features/AccountManagement/hooks/AccountActionsContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountActionsContext.test.tsx
@@ -814,7 +814,16 @@ describe("AccountActionsContext", () => {
     expectExternalCheckInAnalyticsStarted()
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
-      { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },
+      {
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Execute,
+          },
+        },
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      },
     )
   })
 
@@ -843,7 +852,16 @@ describe("AccountActionsContext", () => {
     expectExternalCheckInAnalyticsStarted()
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
-      { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },
+      {
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.InvalidResponseShape,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Response,
+          },
+        },
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+      },
     )
   })
 
@@ -867,7 +885,16 @@ describe("AccountActionsContext", () => {
     )
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
-      { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Permission },
+      {
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Permission,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.PermissionDenied,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+          },
+        },
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Permission,
+      },
     )
     expect(
       JSON.stringify(mockCompleteProductAnalyticsAction.mock.calls),
@@ -901,7 +928,16 @@ describe("AccountActionsContext", () => {
     expectExternalCheckInAnalyticsStarted()
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
-      { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },
+      {
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+          },
+        },
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      },
     )
   })
 })

--- a/tests/features/AccountManagement/hooks/useAccountDialog.analytics.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.analytics.test.tsx
@@ -19,6 +19,7 @@ import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FAILURE_REASONS,
   PRODUCT_ANALYTICS_FAILURE_STAGES,
   PRODUCT_ANALYTICS_FEATURE_IDS,
   PRODUCT_ANALYTICS_RESULTS,
@@ -363,9 +364,16 @@ describe("useAccountDialog analytics", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Auth,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Auth,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+            accountAutoDetectFailureReason:
+              AUTO_DETECT_FAILURE_REASONS.UserDataMissing,
+          },
+        },
         insights: {
-          failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
           accountAutoDetectFailureReason:
             AUTO_DETECT_FAILURE_REASONS.UserDataMissing,
           requestedAuthMode: AuthTypeEnum.AccessToken,
@@ -413,9 +421,16 @@ describe("useAccountDialog analytics", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+            accountAutoDetectFailureReason:
+              AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
+          },
+        },
         insights: {
-          failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
           accountAutoDetectFailureReason:
             AUTO_DETECT_FAILURE_REASONS.UsernameMissing,
           requestedAuthMode: AuthTypeEnum.AccessToken,
@@ -456,9 +471,16 @@ describe("useAccountDialog analytics", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+            accountAutoDetectFailureReason:
+              AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+          },
+        },
         insights: {
-          failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
           requestedAuthMode: AuthTypeEnum.AccessToken,
           accountAutoDetectFailureReason:
             AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
@@ -509,9 +531,14 @@ describe("useAccountDialog analytics", () => {
       expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
         PRODUCT_ANALYTICS_RESULTS.Failure,
         {
-          errorCategory,
+          diagnostics: {
+            failure: {
+              category: errorCategory,
+              stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
+              reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+            },
+          },
           insights: {
-            failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
             requestedAuthMode: AuthTypeEnum.AccessToken,
           },
         },
@@ -546,9 +573,14 @@ describe("useAccountDialog analytics", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+          },
+        },
         insights: {
-          failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
           requestedAuthMode: AuthTypeEnum.AccessToken,
         },
       },
@@ -649,10 +681,15 @@ describe("useAccountDialog analytics", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Persist,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+          },
+        },
         insights: {
           requestedAuthMode: AuthTypeEnum.AccessToken,
-          failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Persist,
         },
       },
     )
@@ -726,9 +763,14 @@ describe("useAccountDialog analytics", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+          },
+        },
         insights: {
-          failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
           requestedAuthMode: AuthTypeEnum.AccessToken,
         },
       },
@@ -762,9 +804,14 @@ describe("useAccountDialog analytics", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.RateLimit,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.RateLimit,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.RateLimited,
+          },
+        },
         insights: {
-          failureStage: PRODUCT_ANALYTICS_FAILURE_STAGES.Detection,
           requestedAuthMode: AuthTypeEnum.AccessToken,
         },
       },
@@ -822,7 +869,118 @@ describe("useAccountDialog analytics", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Permission,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Permission,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Permission,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.PermissionDenied,
+          },
+        },
+      },
+    )
+    expectNoSensitiveAnalyticsFields()
+  })
+
+  it("tracks cookie import responses without a failure code as invalid responses", async () => {
+    const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
+    vi.mocked(sendRuntimeMessage).mockResolvedValueOnce({
+      success: false,
+      error: "private backend message",
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await setUrlAndWait(result, "https://private.example.com")
+
+    await act(async () => {
+      await result.current.handlers.handleImportCookieAuthSessionCookie()
+    })
+
+    expectStartedAction(PRODUCT_ANALYTICS_ACTION_IDS.ImportAccountCookies)
+    expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      {
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Response,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.InvalidResponseShape,
+          },
+        },
+      },
+    )
+    expectNoSensitiveAnalyticsFields()
+  })
+
+  it("tracks cookie read failures with request diagnostics", async () => {
+    const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
+    vi.mocked(sendRuntimeMessage).mockResolvedValueOnce({
+      success: false,
+      errorCode: COOKIE_IMPORT_FAILURE_REASONS.ReadFailed,
+      error: "private read failure",
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await setUrlAndWait(result, "https://private.example.com")
+
+    await act(async () => {
+      await result.current.handlers.handleImportCookieAuthSessionCookie()
+    })
+
+    expectStartedAction(PRODUCT_ANALYTICS_ACTION_IDS.ImportAccountCookies)
+    expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      {
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+          },
+        },
+      },
+    )
+    expectNoSensitiveAnalyticsFields()
+  })
+
+  it("tracks thrown cookie import errors with sanitized diagnostics", async () => {
+    const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
+    vi.mocked(sendRuntimeMessage).mockRejectedValueOnce(
+      Object.assign(new Error("private cookie failure"), { statusCode: 403 }),
+    )
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await setUrlAndWait(result, "https://private.example.com")
+
+    await act(async () => {
+      await result.current.handlers.handleImportCookieAuthSessionCookie()
+    })
+
+    expectStartedAction(PRODUCT_ANALYTICS_ACTION_IDS.ImportAccountCookies)
+    expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      {
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Auth,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.AuthInvalid,
+          },
+        },
       },
     )
     expectNoSensitiveAnalyticsFields()
@@ -939,7 +1097,7 @@ describe("useAccountDialog analytics", () => {
   it("tracks Sub2API import runtime errors as failures without raw error text", async () => {
     const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
     vi.mocked(sendRuntimeMessage).mockRejectedValueOnce(
-      new Error("private backend error"),
+      Object.assign(new Error("private backend error"), { statusCode: 401 }),
     )
 
     const { result } = renderAddHook()
@@ -966,7 +1124,13 @@ describe("useAccountDialog analytics", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Auth,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.AuthInvalid,
+          },
+        },
       },
     )
     expectNoSensitiveAnalyticsFields()

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -21,6 +21,8 @@ import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FAILURE_REASONS,
+  PRODUCT_ANALYTICS_FAILURE_STAGES,
   PRODUCT_ANALYTICS_FEATURE_IDS,
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
@@ -904,7 +906,7 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
   })
 
-  it("tracks failed account saves with a controlled category and no backend message", async () => {
+  it("tracks failed account saves with controlled diagnostics and no backend message", async () => {
     mockValidateAndSaveAccount.mockResolvedValueOnce({
       success: false,
       message: "backend leaked details",
@@ -927,7 +929,13 @@ describe("useAccountDialog save and auto-config flows", () => {
     expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.Unknown,
+          },
+        },
       },
     )
     expect(mockCompleteProductAnalyticsAction).not.toHaveBeenCalledWith(
@@ -3242,6 +3250,61 @@ describe("useAccountDialog save and auto-config flows", () => {
 
     expect(toast.success).not.toHaveBeenCalled()
     expect(result.current.state.isSaving).toBe(false)
+  })
+
+  it("tracks create-account failures with a sanitized failure reason", async () => {
+    mockValidateAndSaveAccount.mockRejectedValueOnce(
+      Object.assign(new Error("private backend https://private.example.com"), {
+        code: "HTTP_401",
+      }),
+    )
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://api.example.com")
+      result.current.setters.setSiteName("Example")
+      result.current.setters.setUsername("private-user")
+      result.current.setters.setAccessToken("private-token")
+      result.current.setters.setUserId("1")
+      result.current.setters.setExchangeRate("7")
+      result.current.setters.setSiteType("one-api")
+    })
+
+    await expect(
+      act(async () => {
+        await result.current.handlers.handleSaveAccount()
+      }),
+    ).rejects.toThrow("private backend")
+
+    expect(mockStartProductAnalyticsAction).toHaveBeenCalledWith({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AccountManagement,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.CreateAccount,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsAccountManagementPage,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    })
+    expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      {
+        diagnostics: {
+          failure: {
+            category: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Auth,
+            stage: PRODUCT_ANALYTICS_FAILURE_STAGES.Request,
+            reason: PRODUCT_ANALYTICS_FAILURE_REASONS.AuthInvalid,
+          },
+        },
+      },
+    )
+    expect(
+      JSON.stringify(mockCompleteProductAnalyticsAction.mock.calls),
+    ).not.toContain("private backend")
+    expect(
+      JSON.stringify(mockCompleteProductAnalyticsAction.mock.calls),
+    ).not.toContain("private.example.com")
   })
 
   it("uses the saveFailed fallback when edit-mode updates return unsuccessful without a message", async () => {


### PR DESCRIPTION
## Summary
- Add privacy-safe failure diagnostics for create-account, account dialog import, auto-detect, external check-in, and refresh failure analytics.
- Classify response, permission, detection, persist, request, and execute-stage failures without recording backend messages or raw errors.
- Extend focused analytics tests for the new diagnostics payloads and privacy expectations.

## Test Plan
- pnpm vitest --run tests/features/AccountManagement/AccountManagement.analytics.test.tsx tests/features/AccountManagement/hooks/AccountActionsContext.test.tsx
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the analytics payloads for account management flows, adding richer structured failure diagnostics across account refresh, external check-ins, and account dialog/session import scenarios.

* **Tests**
  * Updated analytics test expectations to match the new diagnostics-based failure shape and failure stage values.
  * Added/expanded coverage to ensure error details are properly sanitized in analytics for sensitive backend messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->