### PR TITLE
fix(accounts): preserve cookie session for key management

### DIFF
--- a/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
+++ b/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
@@ -4,7 +4,10 @@ import type { BrowserContext, Page } from "@playwright/test"
 
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { SITE_TYPES } from "~/constants/siteType"
-import { getKeyManagementTokenRowTestId } from "~/features/KeyManagement/testIds"
+import {
+  getKeyManagementTokenRowTestId,
+  KEY_MANAGEMENT_TEST_IDS,
+} from "~/features/KeyManagement/testIds"
 import { OPTIONAL_PERMISSION_IDS } from "~/services/permissions/permissionManager"
 import { AuthTypeEnum } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
@@ -313,6 +316,16 @@ test("isolates same-site cookie and access-token accounts through account refres
         ),
       ).toHaveCount(0)
 
+      expectTokenDnrFallbackSequence(
+        localSite.tokenRequests,
+        ACCOUNT_A_SESSION_COOKIE,
+      )
+      expectOnlyTargetTokenRequests(
+        localSite.tokenRequests,
+        ACCOUNT_A_SESSION_COOKIE,
+      )
+      localSite.clearTokenRequests()
+
       await openKeyManagementForAccount({
         page,
         extensionId,
@@ -335,9 +348,9 @@ test("isolates same-site cookie and access-token accounts through account refres
 
       expectTokenDnrFallbackSequence(
         localSite.tokenRequests,
-        ACCOUNT_A_SESSION_COOKIE,
+        ACCOUNT_B_SESSION_COOKIE,
       )
-      expectTokenDnrFallbackSequence(
+      expectOnlyTargetTokenRequests(
         localSite.tokenRequests,
         ACCOUNT_B_SESSION_COOKIE,
       )
@@ -350,7 +363,7 @@ test("isolates same-site cookie and access-token accounts through account refres
         page,
         extensionId,
       })
-      await page.getByRole("button", { name: "Expand all" }).click()
+      await page.getByTestId(KEY_MANAGEMENT_TEST_IDS.expandAllButton).click()
       await expect(
         page.getByTestId(
           getKeyManagementTokenRowTestId(
@@ -891,6 +904,21 @@ function expectTokenDnrFallbackSequence(
   ).toHaveLength(0)
 }
 
+function expectOnlyTargetTokenRequests(
+  requests: CapturedTokenRequest[],
+  targetSessionCookie: string,
+) {
+  expect(
+    requests.filter(
+      (request) =>
+        request.responseStatus === 200 &&
+        request.matchedSessionCookie &&
+        request.matchedSessionCookie !== targetSessionCookie,
+    ),
+    `${targetSessionCookie} non-target token-list requests`,
+  ).toHaveLength(0)
+}
+
 function extractCompatUserIdHeader(headers: http.IncomingHttpHeaders) {
   const rawValue =
     headers["new-api-user"] ??
@@ -956,6 +984,10 @@ async function openKeyManagementForAllAccounts(params: {
   )
   await waitForExtensionRoot(params.page)
   await expectPermissionOnboardingHidden(params.page)
-  await params.page.getByRole("combobox").click()
-  await params.page.getByRole("option", { name: "All accounts" }).click()
+  await params.page
+    .getByTestId(KEY_MANAGEMENT_TEST_IDS.accountScopeSelect)
+    .click()
+  await params.page
+    .getByTestId(KEY_MANAGEMENT_TEST_IDS.accountScopeAllOption)
+    .click()
 }

--- a/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
+++ b/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
@@ -2,7 +2,9 @@ import http from "node:http"
 import type { AddressInfo, Socket } from "node:net"
 import type { BrowserContext, Page } from "@playwright/test"
 
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { SITE_TYPES } from "~/constants/siteType"
+import { getKeyManagementTokenRowTestId } from "~/features/KeyManagement/testIds"
 import { OPTIONAL_PERMISSION_IDS } from "~/services/permissions/permissionManager"
 import { AuthTypeEnum } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
@@ -30,6 +32,7 @@ import {
   getServiceWorker,
   requestAndExpectOptionalPermissions,
 } from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 import { openAccountManagementPage } from "~~/e2e/utils/realSite/accountAdd"
 
 const BROWSER_CURRENT_SESSION_COOKIE = "session=browser-current"
@@ -286,6 +289,92 @@ test("isolates same-site cookie and access-token accounts through account refres
     for (const request of authenticatedSelfRequests) {
       expect(request.cookieHeader).not.toContain(BROWSER_CURRENT_SESSION_COOKIE)
     }
+
+    await test.step("load each cookie account token list from Key Management", async () => {
+      localSite.clearTokenRequests()
+
+      await openKeyManagementForAccount({
+        page,
+        extensionId,
+        accountId: savedAccounts[0].id,
+      })
+      await expect(
+        page.getByTestId(
+          getKeyManagementTokenRowTestId(
+            ACCOUNT_BY_SESSION_COOKIE[ACCOUNT_A_SESSION_COOKIE].tokenId,
+          ),
+        ),
+      ).toBeVisible()
+      await expect(
+        page.getByTestId(
+          getKeyManagementTokenRowTestId(
+            ACCOUNT_BY_SESSION_COOKIE[ACCOUNT_B_SESSION_COOKIE].tokenId,
+          ),
+        ),
+      ).toHaveCount(0)
+
+      await openKeyManagementForAccount({
+        page,
+        extensionId,
+        accountId: savedAccounts[1].id,
+      })
+      await expect(
+        page.getByTestId(
+          getKeyManagementTokenRowTestId(
+            ACCOUNT_BY_SESSION_COOKIE[ACCOUNT_B_SESSION_COOKIE].tokenId,
+          ),
+        ),
+      ).toBeVisible()
+      await expect(
+        page.getByTestId(
+          getKeyManagementTokenRowTestId(
+            ACCOUNT_BY_SESSION_COOKIE[ACCOUNT_A_SESSION_COOKIE].tokenId,
+          ),
+        ),
+      ).toHaveCount(0)
+
+      expectTokenDnrFallbackSequence(
+        localSite.tokenRequests,
+        ACCOUNT_A_SESSION_COOKIE,
+      )
+      expectTokenDnrFallbackSequence(
+        localSite.tokenRequests,
+        ACCOUNT_B_SESSION_COOKIE,
+      )
+    })
+
+    await test.step("load all same-site cookie account token lists from Key Management", async () => {
+      localSite.clearTokenRequests()
+
+      await openKeyManagementForAllAccounts({
+        page,
+        extensionId,
+      })
+      await page.getByRole("button", { name: "Expand all" }).click()
+      await expect(
+        page.getByTestId(
+          getKeyManagementTokenRowTestId(
+            ACCOUNT_BY_SESSION_COOKIE[ACCOUNT_A_SESSION_COOKIE].tokenId,
+          ),
+        ),
+      ).toBeVisible()
+      await expect(
+        page.getByTestId(
+          getKeyManagementTokenRowTestId(
+            ACCOUNT_BY_SESSION_COOKIE[ACCOUNT_B_SESSION_COOKIE].tokenId,
+          ),
+        ),
+      ).toBeVisible()
+
+      expectTokenDnrFallbackSequence(
+        localSite.tokenRequests,
+        ACCOUNT_A_SESSION_COOKIE,
+      )
+      expectTokenDnrFallbackSequence(
+        localSite.tokenRequests,
+        ACCOUNT_B_SESSION_COOKIE,
+      )
+    })
   } finally {
     await closeOtherPages(context, page)
     await localSite.close()
@@ -354,10 +443,17 @@ type CapturedSelfRequest = {
   responseStatus: number
 }
 
+type CapturedTokenRequest = CapturedSelfRequest & {
+  userIdHeader: string | null
+  mismatch: boolean
+}
+
 type DnrCaptureNewApiServer = {
   origin: string
   selfRequests: CapturedSelfRequest[]
+  tokenRequests: CapturedTokenRequest[]
   clearSelfRequests: () => void
+  clearTokenRequests: () => void
   waitForAuthenticatedSessionRequest: (
     sessionCookie: string,
   ) => Promise<CapturedSelfRequest>
@@ -369,6 +465,7 @@ type DnrCaptureNewApiServer = {
 
 async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
   const selfRequests: CapturedSelfRequest[] = []
+  const tokenRequests: CapturedTokenRequest[] = []
   const sockets = new Set<Socket>()
   const waiters: Array<{
     matches: (request: CapturedSelfRequest) => boolean
@@ -470,6 +567,74 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
       return
     }
 
+    if (method === "GET" && url.pathname === "/api/token/") {
+      const cookieHeader = request.headers.cookie ?? ""
+      const authorizationHeader = request.headers.authorization ?? ""
+      const matchedSessionCookie = matchAccountSessionCookie(cookieHeader)
+      const matchedAccessToken = matchAccessToken(authorizationHeader)
+      const account =
+        (matchedSessionCookie
+          ? ACCOUNT_BY_SESSION_COOKIE[matchedSessionCookie]
+          : null) ??
+        (matchedAccessToken
+          ? ACCOUNT_BY_ACCESS_TOKEN[matchedAccessToken]
+          : null)
+      const userIdHeader = extractCompatUserIdHeader(request.headers)
+      const mismatch = Boolean(
+        account && userIdHeader && userIdHeader !== account.id,
+      )
+      const captured: CapturedTokenRequest = {
+        cookieHeader,
+        matchedSessionCookie,
+        matchedAccessToken,
+        userIdHeader,
+        mismatch,
+        responseStatus: account && !mismatch ? 200 : 401,
+      }
+      tokenRequests.push(captured)
+
+      if (!account) {
+        sendJson(401, {
+          success: false,
+          message: "missing account session cookie",
+        })
+        return
+      }
+
+      if (mismatch) {
+        sendJson(401, {
+          success: false,
+          message: `cookie and userid mismatch: cookie=${account.id} header=${userIdHeader}`,
+        })
+        return
+      }
+
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: [
+          {
+            id: account.tokenId,
+            user_id: Number(account.id),
+            key: account.tokenKey,
+            status: 1,
+            name: account.tokenName,
+            created_time: 1_700_000_000,
+            accessed_time: 1_700_000_000,
+            expired_time: -1,
+            remain_quota: -1,
+            unlimited_quota: true,
+            model_limits_enabled: false,
+            model_limits: "",
+            allow_ips: "",
+            used_quota: 0,
+            group: "default",
+          },
+        ],
+      })
+      return
+    }
+
     if (method === "GET" && url.pathname === "/api/log/self/stat") {
       sendJson(200, {
         success: true,
@@ -567,8 +732,12 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
   return {
     origin,
     selfRequests,
+    tokenRequests,
     clearSelfRequests: () => {
       selfRequests.splice(0)
+    },
+    clearTokenRequests: () => {
+      tokenRequests.splice(0)
     },
     waitForAuthenticatedSessionRequest: (sessionCookie) =>
       waitForAuthenticatedRequest(
@@ -586,33 +755,59 @@ async function startDnrCaptureNewApiServer(): Promise<DnrCaptureNewApiServer> {
 
 const ACCOUNT_BY_SESSION_COOKIE: Record<
   string,
-  { id: string; username: string; quota: number }
+  {
+    id: string
+    username: string
+    quota: number
+    tokenId: number
+    tokenName: string
+    tokenKey: string
+  }
 > = {
   [ACCOUNT_A_SESSION_COOKIE]: {
     id: "201",
     username: "cookie-user-a",
     quota: 33_000,
+    tokenId: 2011,
+    tokenName: "Cookie User A Key",
+    tokenKey: "sk-cookie-user-a",
   },
   [ACCOUNT_B_SESSION_COOKIE]: {
     id: "202",
     username: "cookie-user-b",
     quota: 44_000,
+    tokenId: 2021,
+    tokenName: "Cookie User B Key",
+    tokenKey: "sk-cookie-user-b",
   },
 }
 
 const ACCOUNT_BY_ACCESS_TOKEN: Record<
   string,
-  { id: string; username: string; quota: number }
+  {
+    id: string
+    username: string
+    quota: number
+    tokenId: number
+    tokenName: string
+    tokenKey: string
+  }
 > = {
   [ACCESS_TOKEN_A]: {
     id: "301",
     username: "token-user-a",
     quota: 55_000,
+    tokenId: 3011,
+    tokenName: "Token User A Key",
+    tokenKey: "sk-token-user-a",
   },
   [ACCESS_TOKEN_B]: {
     id: "302",
     username: "token-user-b",
     quota: 66_000,
+    tokenId: 3021,
+    tokenName: "Token User B Key",
+    tokenKey: "sk-token-user-b",
   },
 }
 
@@ -667,6 +862,48 @@ function expectCookieDnrFallbackSequence(
   }
 }
 
+function expectTokenDnrFallbackSequence(
+  requests: CapturedTokenRequest[],
+  targetSessionCookie: string,
+) {
+  const account = ACCOUNT_BY_SESSION_COOKIE[targetSessionCookie]
+  const success = requests.find(
+    (request) =>
+      request.responseStatus === 200 &&
+      request.matchedSessionCookie === targetSessionCookie &&
+      request.userIdHeader === account.id,
+  )
+
+  expect(
+    success,
+    `${targetSessionCookie} token list request with matching cookie/user id`,
+  ).toEqual(
+    expect.objectContaining({
+      cookieHeader: expect.stringContaining(targetSessionCookie),
+      mismatch: false,
+      userIdHeader: account.id,
+    }),
+  )
+
+  expect(
+    requests.filter((request) => request.mismatch),
+    `${targetSessionCookie} token list cookie/user-id mismatches`,
+  ).toHaveLength(0)
+}
+
+function extractCompatUserIdHeader(headers: http.IncomingHttpHeaders) {
+  const rawValue =
+    headers["new-api-user"] ??
+    headers["user-id"] ??
+    headers["x-api-user"] ??
+    headers["veloera-user"] ??
+    headers["voapi-user"]
+  if (Array.isArray(rawValue)) {
+    return rawValue[0] ?? null
+  }
+  return rawValue ?? null
+}
+
 function matchAccessToken(authorizationHeader: string) {
   const match = /^Bearer\s+(.+)$/iu.exec(authorizationHeader.trim())
   const token = match?.[1] ?? authorizationHeader.trim()
@@ -696,4 +933,29 @@ async function seedBrowserCurrentLoginCookie(
       expires: Math.floor(Date.now() / 1000) + 3600,
     },
   ])
+}
+
+async function openKeyManagementForAccount(params: {
+  page: Page
+  extensionId: string
+  accountId: string
+}) {
+  await params.page.goto(
+    `chrome-extension://${params.extensionId}/${OPTIONS_PAGE_PATH}#keys?accountId=${params.accountId}`,
+  )
+  await waitForExtensionRoot(params.page)
+  await expectPermissionOnboardingHidden(params.page)
+}
+
+async function openKeyManagementForAllAccounts(params: {
+  page: Page
+  extensionId: string
+}) {
+  await params.page.goto(
+    `chrome-extension://${params.extensionId}/${OPTIONS_PAGE_PATH}#keys`,
+  )
+  await waitForExtensionRoot(params.page)
+  await expectPermissionOnboardingHidden(params.page)
+  await params.page.getByRole("combobox").click()
+  await params.page.getByRole("option", { name: "All accounts" }).click()
 }

--- a/src/components/ui/SearchableSelect.tsx
+++ b/src/components/ui/SearchableSelect.tsx
@@ -103,6 +103,11 @@ export interface SearchableSelectProps
    * Optional class applied to the internal option list.
    */
   listClassName?: string
+
+  /**
+   * Optional stable test id resolver for option rows.
+   */
+  getOptionTestId?: (option: SearchableSelectOption) => string | undefined
 }
 
 /**
@@ -128,6 +133,7 @@ export const SearchableSelect = React.forwardRef<
     onOpenChange,
     portalContainer,
     listClassName,
+    getOptionTestId,
     className,
     disabled,
     ...buttonProps
@@ -251,6 +257,7 @@ export const SearchableSelect = React.forwardRef<
                 <CommandItem
                   key={option.value}
                   value={option.label}
+                  data-testid={getOptionTestId?.(option)}
                   disabled={option.disabled}
                   onSelect={() => {
                     if (option.disabled) return

--- a/src/features/KeyManagement/components/AccountSelectorPanel.tsx
+++ b/src/features/KeyManagement/components/AccountSelectorPanel.tsx
@@ -2,6 +2,7 @@ import type { Ref } from "react"
 import { useTranslation } from "react-i18next"
 
 import { Badge, Button, Heading3, SearchableSelect } from "~/components/ui"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import type { AccountToken, DisplaySiteData } from "~/types"
 
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "../constants"
@@ -60,6 +61,7 @@ export function AccountSelectorPanel({
         <Heading3 className="mb-1">{t("selectAccount")}</Heading3>
         <SearchableSelect
           ref={selectorTriggerRef}
+          data-testid={KEY_MANAGEMENT_TEST_IDS.accountScopeSelect}
           options={[
             ...(displayData.length > 0
               ? [
@@ -78,6 +80,11 @@ export function AccountSelectorPanel({
           onChange={setSelectedAccount}
           open={selectorOpen}
           onOpenChange={onSelectorOpenChange}
+          getOptionTestId={(option) =>
+            option.value === KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE
+              ? KEY_MANAGEMENT_TEST_IDS.accountScopeAllOption
+              : undefined
+          }
           placeholder={t("pleaseSelectAccount")}
         />
       </div>

--- a/src/features/KeyManagement/components/TokenList.tsx
+++ b/src/features/KeyManagement/components/TokenList.tsx
@@ -707,6 +707,7 @@ export function TokenList(props: TokenListProps) {
               size="sm"
               variant="outline"
               type="button"
+              data-testid={KEY_MANAGEMENT_TEST_IDS.expandAllButton}
               onClick={expandAll}
               leftIcon={<ChevronDownIcon className="h-4 w-4" />}
             >

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -14,6 +14,9 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   oneTimeKeyCloseButton: "key-management-one-time-key-close-button",
   oneTimeKeySaveButton: "key-management-one-time-key-save-button",
   deleteTokenConfirmButton: "key-management-delete-token-confirm-button",
+  accountScopeSelect: "key-management-account-scope-select",
+  accountScopeAllOption: "key-management-account-scope-all-option",
+  expandAllButton: "key-management-expand-all-button",
 } as const
 
 export const KEY_MANAGEMENT_TOKEN_ROW_TEST_ID_PREFIX =

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -1547,6 +1547,7 @@ class AccountStorageService {
         can_check_in: normalized.can_check_in,
         supports_check_in: normalized.supports_check_in,
         authType: normalized.authType,
+        cookieAuthSessionCookie: normalized.cookieAuth?.sessionCookie,
       }
     }
 

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -134,6 +134,7 @@ const createAccount = (overrides: Partial<SiteAccount> = {}): SiteAccount => {
     created_at: overrides.created_at ?? Date.now(),
     notes: overrides.notes ?? "",
     manualBalanceUsd: overrides.manualBalanceUsd,
+    cookieAuth: overrides.cookieAuth,
     sub2apiAuth: overrides.sub2apiAuth,
     tagIds: overrides.tagIds ?? [],
     tags: overrides.tags,
@@ -306,6 +307,30 @@ describe("accountStorage core behaviors", () => {
     expect(display.todayTokens.upload).toBe(600)
     expect(display.todayTokens.download).toBe(400)
     expect(display.created_at).toBe(1_700_000_000_000)
+  })
+
+  it("convertToDisplayData should preserve cookie auth session cookies", () => {
+    const account = createAccount({
+      authType: AuthTypeEnum.Cookie,
+      account_info: {
+        id: "201",
+        access_token: "",
+        username: "cookie-user",
+        quota: 1_000_000,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+      cookieAuth: {
+        sessionCookie: "session=user-a",
+      },
+    })
+
+    const display = accountStorage.convertToDisplayData(account)
+
+    expect(display.cookieAuthSessionCookie).toBe("session=user-a")
   })
 
   it("convertToDisplayData should handle arrays", () => {


### PR DESCRIPTION
## Summary
- preserve cookie-auth session cookies when projecting stored accounts into display account data
- extend the DNR-required Chromium E2E flow to verify Key Management token list isolation for same-site cookie accounts
- add a focused account storage regression test for cookie session projection

## Test Plan
- pnpm exec vitest --run tests/services/accountStorage.test.ts
- $env:AAH_E2E_BUILD_VARIANT='dnr-required'; pnpm exec playwright test e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts --project=chromium --workers=1 --timeout=120000
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved account data handling to retain cookie-auth session cookie details in Key Management account display data.

* **Tests**
  * Added end-to-end coverage for token-list loading and strict cookie/DNR isolation behavior in the Key Management UI.
  * Added unit test coverage to ensure authentication session cookie data is preserved during account storage → display-data conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->