### PR TITLE
fix(analytics): summarize sponsor recommendation impressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,7 @@ Treat telemetry and settings discoverability as related release-readiness checks
 
 - For new or materially changed product behavior, make an explicit telemetry decision before handoff: `none`, `reuse existing`, `add action`, `add settings snapshot`, or `add result/summary event`. Do not default to silent feature work.
 - Add or update product analytics for new user-visible actions, settings, async/background flows, automatic detection branches, confirmation/cancel paths, shortcuts, and recovery actions when the data is needed to understand adoption, success, failure, skipped states, or funnel drop-off.
+- For high-volume, low-meaning telemetry such as passive impressions, prefer persisted daily summary events over per-event capture with short TTL dedupe.
 - Keep analytics privacy-safe: record controlled booleans, enums, counts, durations, and status categories only. Do not record URLs, hosts, paths, raw IDs, names, API keys, tokens, cookies, prompts, responses, user-entered text, backend messages, or stack traces.
 - When adding analytics fields, update the typed event payload, privacy allow-list/sanitizer, snapshot builders, and focused tests together. If telemetry is intentionally not added, state the reason in the final handoff.
 

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -21,6 +21,7 @@ import {
   triggerStartupSettingsSnapshot,
   triggerStartupShieldBypassDailySummary,
   triggerStartupSiteEcosystemSnapshot,
+  triggerStartupSponsorRecommendationsDailySummary,
 } from "~/services/productAnalytics/runtime"
 import { tagStorage } from "~/services/tags/tagStorage"
 import { shouldAutoOpenChangelogForUpdate } from "~/services/updates/changelogIndex"
@@ -218,4 +219,5 @@ async function main() {
   triggerStartupSiteEcosystemSnapshot()
   triggerStartupSettingsSnapshot()
   triggerStartupShieldBypassDailySummary()
+  triggerStartupSponsorRecommendationsDailySummary()
 }

--- a/src/features/AccountManagement/sponsors/SponsorRecommendationsSection.tsx
+++ b/src/features/AccountManagement/sponsors/SponsorRecommendationsSection.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useId, useRef } from "react"
+import { useEffect, useId } from "react"
 import { useTranslation } from "react-i18next"
 
-import {
-  getSponsorRecommendationImpressionKey,
-  trackSponsorRecommendationsImpression,
-} from "~/features/AccountManagement/sponsors/analytics"
+import { trackSponsorRecommendationsImpression } from "~/features/AccountManagement/sponsors/analytics"
 import {
   SPONSOR_RECOMMENDATION_SURFACES,
   type SponsorRecommendationSurface,
@@ -38,21 +35,12 @@ export function SponsorRecommendationsSection({
 }: SponsorRecommendationsSectionProps) {
   const { t } = useTranslation("account")
   const headingId = useId()
-  const trackedImpressionKeys = useRef(new Set<string>())
   const showVisibleHeader =
     surface !== SPONSOR_RECOMMENDATION_SURFACES.AddAccountDialog
 
   useEffect(() => {
     if (items.length === 0) return
-
-    const impressionKey = getSponsorRecommendationImpressionKey({
-      items,
-      surface,
-    })
-    if (trackedImpressionKeys.current.has(impressionKey)) return
-
-    trackedImpressionKeys.current.add(impressionKey)
-    trackSponsorRecommendationsImpression({ items, surface })
+    void trackSponsorRecommendationsImpression({ items, surface })
   }, [items, surface])
 
   if (items.length === 0) {

--- a/src/features/AccountManagement/sponsors/analytics.ts
+++ b/src/features/AccountManagement/sponsors/analytics.ts
@@ -25,6 +25,7 @@ import {
   type ProductAnalyticsSponsorSupportStatus,
   type ProductAnalyticsSurfaceId,
 } from "~/services/productAnalytics/events"
+import { recordSponsorRecommendationsSummary } from "~/services/productAnalytics/sponsorRecommendationsSummary"
 
 export const SPONSOR_RECOMMENDATION_ACTION_KINDS = {
   ApiCredentialProfilesFallback:
@@ -55,8 +56,8 @@ const SPONSOR_ACTION_TO_PRODUCT_ANALYTICS_ACTION = {
     PRODUCT_ANALYTICS_ACTION_IDS.OpenSponsorProvider,
 } satisfies Record<SponsorRecommendationActionKind, ProductAnalyticsActionId>
 
-/** Tracks a visible sponsor recommendation set using only controlled fields. */
-export function trackSponsorRecommendationsImpression({
+/** Records a visible sponsor recommendation set into the daily summary. */
+export async function trackSponsorRecommendationsImpression({
   surface,
   items,
 }: {
@@ -64,25 +65,20 @@ export function trackSponsorRecommendationsImpression({
   items: SponsorRecommendation[]
 }) {
   if (items.length === 0) return
+  const supportedItemCount = items.filter(
+    (item) => item.supportStatus === SPONSOR_SUPPORT_STATUS.Supported,
+  ).length
 
-  void trackProductAnalyticsEvent(
-    PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
-    {
-      feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.SponsorRecommendations,
-      action_id: PRODUCT_ANALYTICS_ACTION_IDS.ViewSponsorRecommendations,
-      surface_id: resolveProductAnalyticsSponsorSurface(surface),
-      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
-      result: PRODUCT_ANALYTICS_RESULTS.Success,
-      item_count: items.length,
-      sponsor_catalog_source: resolveSponsorCatalogSource(items),
-      sponsor_supported_count: items.filter(
-        (item) => item.supportStatus === SPONSOR_SUPPORT_STATUS.Supported,
-      ).length,
-      sponsor_unsupported_count: items.filter(
-        (item) => item.supportStatus === SPONSOR_SUPPORT_STATUS.Unsupported,
-      ).length,
-    },
-  )
+  await recordSponsorRecommendationsSummary({
+    impressionCount: 1,
+    itemTotal: items.length,
+    supportedItemTotal: supportedItemCount,
+    unsupportedItemTotal: items.length - supportedItemCount,
+    addAccountSurfaceCount:
+      surface === SPONSOR_RECOMMENDATION_SURFACES.AddAccountDialog ? 1 : 0,
+    newcomerSurfaceCount:
+      surface === SPONSOR_RECOMMENDATION_SURFACES.Newcomer ? 1 : 0,
+  })
 }
 
 /** Tracks a sponsor recommendation click without reading URLs or display copy. */
@@ -117,32 +113,6 @@ export function trackSponsorRecommendationClick({
       sponsor_support_status: resolveSponsorSupportStatus(item),
     },
   )
-}
-
-/** Builds a stable key for deduplicating rendered sponsor impression sets. */
-export function getSponsorRecommendationImpressionKey({
-  items,
-  surface,
-}: {
-  items: SponsorRecommendation[]
-  surface: SponsorRecommendationSurface
-}) {
-  return [
-    surface,
-    ...items.map((item) =>
-      [
-        item.id,
-        item.rank,
-        item.source,
-        item.supportStatus,
-        item.actions.bookmarkFallback ? "bookmark" : "no-bookmark",
-        item.actions.apiCredentialProfileFallback ? "api" : "no-api",
-        item.actions.addAccount ? "add-account" : "no-add-account",
-        item.selectedLocale ?? "unknown-locale",
-        String(item.schemaVersion),
-      ].join(":"),
-    ),
-  ].join("|")
 }
 
 /** Maps sponsor recommendation surfaces into the product analytics taxonomy. */

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -41,6 +41,8 @@ export const PRODUCT_ANALYTICS_EVENTS = {
   FeatureActionStarted: "feature_action_started",
   FeatureActionCompleted: "feature_action_completed",
   ShieldBypassSummaryCaptured: "shield_bypass_summary_captured",
+  SponsorRecommendationsDailySummaryCaptured:
+    "sponsor_recommendations_daily_summary_captured",
   AutoCheckinRunSummaryCaptured: "auto_checkin_run_summary_captured",
   AutoCheckinAccountGroupCaptured: "auto_checkin_account_group_captured",
   SettingChanged: "setting_changed",
@@ -991,6 +993,17 @@ export type ProductAnalyticsEventPayloadMap = {
     temp_window_fetch_failure_count?: number
     temp_window_turnstile_fetch_success_count?: number
     temp_window_turnstile_fetch_failure_count?: number
+  }
+  [PRODUCT_ANALYTICS_EVENTS.SponsorRecommendationsDailySummaryCaptured]: {
+    feature_id: typeof PRODUCT_ANALYTICS_FEATURE_IDS.SponsorRecommendations
+    entrypoint: typeof PRODUCT_ANALYTICS_ENTRYPOINTS.Background
+    day: string
+    impression_count: number
+    item_total: number
+    supported_item_total: number
+    unsupported_item_total: number
+    add_account_surface_count: number
+    newcomer_surface_count: number
   }
   [PRODUCT_ANALYTICS_EVENTS.AutoCheckinRunSummaryCaptured]: {
     run_kind: ProductAnalyticsAutoCheckinRunKind

--- a/src/services/productAnalytics/privacy.ts
+++ b/src/services/productAnalytics/privacy.ts
@@ -151,6 +151,17 @@ const EVENT_ALLOWED_KEYS = {
     "temp_window_turnstile_fetch_success_count",
     "temp_window_turnstile_fetch_failure_count",
   ],
+  [PRODUCT_ANALYTICS_EVENTS.SponsorRecommendationsDailySummaryCaptured]: [
+    "feature_id",
+    "entrypoint",
+    "day",
+    "impression_count",
+    "item_total",
+    "supported_item_total",
+    "unsupported_item_total",
+    "add_account_surface_count",
+    "newcomer_surface_count",
+  ],
   [PRODUCT_ANALYTICS_EVENTS.AutoCheckinRunSummaryCaptured]: [
     "run_kind",
     "entrypoint",

--- a/src/services/productAnalytics/runtime.ts
+++ b/src/services/productAnalytics/runtime.ts
@@ -4,6 +4,7 @@ import {
   USER_PREFERENCES_STORAGE_KEYS,
 } from "~/services/core/storageKeys"
 import { userPreferences } from "~/services/preferences/userPreferences"
+import { flushSponsorRecommendationsDailySummary } from "~/services/productAnalytics/sponsorRecommendationsSummary"
 import {
   hasStorageChangedListener,
   onStorageChanged,
@@ -32,7 +33,6 @@ import {
   buildSiteEcosystemAnalyticsEvents,
   shouldSendSiteEcosystemSnapshot,
 } from "./siteEcosystem"
-import { flushSponsorRecommendationsDailySummary } from "./sponsorRecommendationsSummary"
 import { productAnalyticsState } from "./state"
 
 const logger = createLogger("ProductAnalyticsRuntime")

--- a/src/services/productAnalytics/runtime.ts
+++ b/src/services/productAnalytics/runtime.ts
@@ -32,6 +32,7 @@ import {
   buildSiteEcosystemAnalyticsEvents,
   shouldSendSiteEcosystemSnapshot,
 } from "./siteEcosystem"
+import { flushSponsorRecommendationsDailySummary } from "./sponsorRecommendationsSummary"
 import { productAnalyticsState } from "./state"
 
 const logger = createLogger("ProductAnalyticsRuntime")
@@ -253,6 +254,20 @@ function flushShieldBypassDailySummaryBestEffort() {
 }
 
 /**
+ * Starts sponsor recommendations summary capture without failing background startup.
+ */
+function flushSponsorRecommendationsDailySummaryBestEffort() {
+  void flushSponsorRecommendationsDailySummary().catch((error) => {
+    if (isDevBuild()) {
+      logger.debug(
+        "Product analytics sponsor recommendations summary failed",
+        error,
+      )
+    }
+  })
+}
+
+/**
  * Watches local account storage changes and debounces site ecosystem snapshot capture.
  */
 export function setupProductAnalyticsAccountChangeListener() {
@@ -375,4 +390,11 @@ export function triggerStartupSettingsSnapshot() {
  */
 export function triggerStartupShieldBypassDailySummary() {
   flushShieldBypassDailySummaryBestEffort()
+}
+
+/**
+ * Triggers the startup sponsor recommendations summary flush in the background worker.
+ */
+export function triggerStartupSponsorRecommendationsDailySummary() {
+  flushSponsorRecommendationsDailySummaryBestEffort()
 }

--- a/src/services/productAnalytics/sponsorRecommendationsSummary.ts
+++ b/src/services/productAnalytics/sponsorRecommendationsSummary.ts
@@ -1,14 +1,14 @@
-import { productAnalyticsClient } from "./client"
+import { productAnalyticsClient } from "~/services/productAnalytics/client"
 import {
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_EVENTS,
   PRODUCT_ANALYTICS_FEATURE_IDS,
-} from "./events"
+} from "~/services/productAnalytics/events"
 import {
   productAnalyticsState,
   type ProductAnalyticsSponsorRecommendationsSummaryPatch,
   type ProductAnalyticsSponsorRecommendationsSummaryState,
-} from "./state"
+} from "~/services/productAnalytics/state"
 
 /**
  * Formats timestamps into the UTC day bucket used for daily summaries.
@@ -89,8 +89,7 @@ export async function flushSponsorRecommendationsDailySummary(): Promise<boolean
   )
   if (!captured) return false
 
-  await productAnalyticsState.replaceSponsorRecommendationsSummaryState(
+  return await productAnalyticsState.replaceSponsorRecommendationsSummaryState(
     emptySummary(today),
   )
-  return true
 }

--- a/src/services/productAnalytics/sponsorRecommendationsSummary.ts
+++ b/src/services/productAnalytics/sponsorRecommendationsSummary.ts
@@ -1,0 +1,96 @@
+import { productAnalyticsClient } from "./client"
+import {
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_EVENTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+} from "./events"
+import {
+  productAnalyticsState,
+  type ProductAnalyticsSponsorRecommendationsSummaryPatch,
+  type ProductAnalyticsSponsorRecommendationsSummaryState,
+} from "./state"
+
+/**
+ * Formats timestamps into the UTC day bucket used for daily summaries.
+ */
+function getUtcDay(timestamp = Date.now()) {
+  return new Date(timestamp).toISOString().slice(0, 10)
+}
+
+/**
+ * Builds an empty sponsor recommendation daily summary for the given UTC day.
+ */
+function emptySummary(
+  day = getUtcDay(),
+): ProductAnalyticsSponsorRecommendationsSummaryState {
+  return {
+    day,
+    impressionCount: 0,
+    itemTotal: 0,
+    supportedItemTotal: 0,
+    unsupportedItemTotal: 0,
+    addAccountSurfaceCount: 0,
+    newcomerSurfaceCount: 0,
+  }
+}
+
+/**
+ * Checks whether a summary contains any sponsor recommendation impressions.
+ */
+function hasSummaryActivity(
+  summary: ProductAnalyticsSponsorRecommendationsSummaryState,
+) {
+  return (summary.impressionCount ?? 0) > 0
+}
+
+/**
+ * Converts local sponsor recommendation counters into analytics properties.
+ */
+function buildSummaryProperties(
+  summary: ProductAnalyticsSponsorRecommendationsSummaryState,
+) {
+  return {
+    feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.SponsorRecommendations,
+    entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+    day: summary.day ?? getUtcDay(),
+    impression_count: summary.impressionCount ?? 0,
+    item_total: summary.itemTotal ?? 0,
+    supported_item_total: summary.supportedItemTotal ?? 0,
+    unsupported_item_total: summary.unsupportedItemTotal ?? 0,
+    add_account_surface_count: summary.addAccountSurfaceCount ?? 0,
+    newcomer_surface_count: summary.newcomerSurfaceCount ?? 0,
+  }
+}
+
+/**
+ * Persists a sponsor recommendation summary increment for the current day.
+ */
+export async function recordSponsorRecommendationsSummary(
+  patch: ProductAnalyticsSponsorRecommendationsSummaryPatch,
+) {
+  await productAnalyticsState.incrementSponsorRecommendationsSummary(patch)
+}
+
+/**
+ * Sends the previous UTC day's sponsor recommendations summary when active.
+ */
+export async function flushSponsorRecommendationsDailySummary(): Promise<boolean> {
+  const summary =
+    await productAnalyticsState.getSponsorRecommendationsSummaryState()
+  const today = getUtcDay()
+
+  if (!summary.day || summary.day === today || !hasSummaryActivity(summary)) {
+    return false
+  }
+
+  const captured = await productAnalyticsClient.capture(
+    PRODUCT_ANALYTICS_EVENTS.SponsorRecommendationsDailySummaryCaptured,
+    buildSummaryProperties(summary),
+  )
+  if (!captured) return false
+
+  await productAnalyticsState.replaceSponsorRecommendationsSummaryState(
+    emptySummary(today),
+  )
+  return true
+}

--- a/src/services/productAnalytics/state.ts
+++ b/src/services/productAnalytics/state.ts
@@ -13,6 +13,7 @@ interface ProductAnalyticsState {
   lastSiteEcosystemSnapshotAt?: number
   lastSettingsSnapshotAt?: number
   shieldBypassSummary?: ProductAnalyticsShieldBypassSummaryState
+  sponsorRecommendationsSummary?: ProductAnalyticsSponsorRecommendationsSummaryState
 }
 
 type ProductAnalyticsStatePatch = Partial<ProductAnalyticsState>
@@ -30,6 +31,21 @@ export type ProductAnalyticsShieldBypassSummaryState = {
 
 export type ProductAnalyticsShieldBypassSummaryPatch = Omit<
   ProductAnalyticsShieldBypassSummaryState,
+  "day"
+>
+
+export type ProductAnalyticsSponsorRecommendationsSummaryState = {
+  day?: string
+  impressionCount?: number
+  itemTotal?: number
+  supportedItemTotal?: number
+  unsupportedItemTotal?: number
+  addAccountSurfaceCount?: number
+  newcomerSurfaceCount?: number
+}
+
+export type ProductAnalyticsSponsorRecommendationsSummaryPatch = Omit<
+  ProductAnalyticsSponsorRecommendationsSummaryState,
   "day"
 >
 
@@ -81,6 +97,42 @@ export function normalizeShieldBypassSummaryState(
 }
 
 /**
+ * Keeps only valid sponsor recommendation daily summary fields from storage.
+ */
+export function normalizeSponsorRecommendationsSummaryState(
+  value: unknown,
+): ProductAnalyticsSponsorRecommendationsSummaryState | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined
+  }
+
+  const state = value as ProductAnalyticsSponsorRecommendationsSummaryState
+  const normalized: ProductAnalyticsSponsorRecommendationsSummaryState = {}
+
+  if (typeof state.day === "string" && /^\d{4}-\d{2}-\d{2}$/.test(state.day)) {
+    normalized.day = state.day
+  }
+
+  const countKeys = [
+    "impressionCount",
+    "itemTotal",
+    "supportedItemTotal",
+    "unsupportedItemTotal",
+    "addAccountSurfaceCount",
+    "newcomerSurfaceCount",
+  ] as const
+
+  for (const key of countKeys) {
+    const count = normalizeCount(state[key])
+    if (typeof count === "number") {
+      normalized[key] = count
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined
+}
+
+/**
  * Keeps only analytics runtime state from persisted analytics state payloads.
  */
 export function normalizeProductAnalyticsState(
@@ -112,6 +164,14 @@ export function normalizeProductAnalyticsState(
   )
   if (shieldBypassSummary) {
     normalized.shieldBypassSummary = shieldBypassSummary
+  }
+
+  const sponsorRecommendationsSummary =
+    normalizeSponsorRecommendationsSummaryState(
+      state.sponsorRecommendationsSummary,
+    )
+  if (sponsorRecommendationsSummary) {
+    normalized.sponsorRecommendationsSummary = sponsorRecommendationsSummary
   }
 
   return normalized
@@ -242,6 +302,69 @@ class ProductAnalyticsStateService {
       return true
     } catch (error) {
       logger.warn("Failed to increment shield bypass summary state", error)
+      return false
+    }
+  }
+
+  async getSponsorRecommendationsSummaryState(): Promise<ProductAnalyticsSponsorRecommendationsSummaryState> {
+    const state = await this.getState()
+    return state.sponsorRecommendationsSummary ?? {}
+  }
+
+  async replaceSponsorRecommendationsSummaryState(
+    nextSummary: ProductAnalyticsSponsorRecommendationsSummaryState,
+  ): Promise<boolean> {
+    try {
+      await this.withStorageWriteLock(async () => {
+        await this.saveState({
+          sponsorRecommendationsSummary:
+            normalizeSponsorRecommendationsSummaryState(nextSummary) ?? {},
+        })
+      })
+      return true
+    } catch (error) {
+      logger.warn("Failed to replace sponsor recommendations summary", error)
+      return false
+    }
+  }
+
+  async incrementSponsorRecommendationsSummary(
+    patch: ProductAnalyticsSponsorRecommendationsSummaryPatch,
+  ): Promise<boolean> {
+    try {
+      await this.withStorageWriteLock(async () => {
+        const state = await this.getState()
+        const today = new Date().toISOString().slice(0, 10)
+        const current =
+          state.sponsorRecommendationsSummary?.day === today
+            ? state.sponsorRecommendationsSummary
+            : { day: today }
+        const nextSummary: ProductAnalyticsSponsorRecommendationsSummaryState =
+          {
+            ...current,
+            day: today,
+          }
+
+        for (const [key, value] of Object.entries(patch) as Array<
+          [
+            keyof ProductAnalyticsSponsorRecommendationsSummaryPatch,
+            number | undefined,
+          ]
+        >) {
+          if (typeof value !== "number" || !Number.isFinite(value)) continue
+          nextSummary[key] = Math.max(0, (nextSummary[key] ?? 0) + value)
+        }
+
+        await this.saveState({
+          sponsorRecommendationsSummary:
+            normalizeSponsorRecommendationsSummaryState(nextSummary) ?? {
+              day: today,
+            },
+        })
+      })
+      return true
+    } catch (error) {
+      logger.warn("Failed to increment sponsor recommendations summary", error)
       return false
     }
   }

--- a/tests/entrypoints/background/changelogOnUpdate.test.ts
+++ b/tests/entrypoints/background/changelogOnUpdate.test.ts
@@ -31,6 +31,9 @@ describe("background onInstalled changelog opening", () => {
   let setPendingVersionMock: ReturnType<typeof vi.fn>
   let setLastSeenOptionalPermissionsMock: ReturnType<typeof vi.fn>
   let shouldAutoOpenChangelogForUpdateMock: ReturnType<typeof vi.fn>
+  let triggerStartupSponsorRecommendationsDailySummaryMock: ReturnType<
+    typeof vi.fn
+  >
   let isTestModeMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
@@ -56,6 +59,7 @@ describe("background onInstalled changelog opening", () => {
     setPendingVersionMock = vi.fn().mockResolvedValue(undefined)
     setLastSeenOptionalPermissionsMock = vi.fn().mockResolvedValue(undefined)
     shouldAutoOpenChangelogForUpdateMock = vi.fn().mockResolvedValue(true)
+    triggerStartupSponsorRecommendationsDailySummaryMock = vi.fn()
     isTestModeMock = vi.fn().mockReturnValue(true)
 
     vi.resetModules()
@@ -132,7 +136,8 @@ describe("background onInstalled changelog opening", () => {
       setupProductAnalyticsPreferencesChangeListener: vi.fn(),
       triggerStartupSettingsSnapshot: vi.fn(),
       triggerStartupShieldBypassDailySummary: vi.fn(),
-      triggerStartupSponsorRecommendationsDailySummary: vi.fn(),
+      triggerStartupSponsorRecommendationsDailySummary:
+        triggerStartupSponsorRecommendationsDailySummaryMock,
       triggerStartupSiteEcosystemSnapshot: vi.fn(),
     }))
     vi.doMock("~/services/tags/tagStorage", () => ({
@@ -216,6 +221,15 @@ describe("background onInstalled changelog opening", () => {
     expect(setPendingVersionMock).toHaveBeenCalledWith("2.39.0")
     expect(getDocsChangelogUrlMock).not.toHaveBeenCalled()
     expect(createTabMock).not.toHaveBeenCalled()
+  })
+
+  it("triggers sponsor recommendations summary capture during background startup", async () => {
+    await import("~/entrypoints/background/index")
+    await flushPromises()
+
+    expect(
+      triggerStartupSponsorRecommendationsDailySummaryMock,
+    ).toHaveBeenCalledTimes(1)
   })
 
   it("passes current and previous versions to the changelog index gate", async () => {

--- a/tests/entrypoints/background/changelogOnUpdate.test.ts
+++ b/tests/entrypoints/background/changelogOnUpdate.test.ts
@@ -132,6 +132,7 @@ describe("background onInstalled changelog opening", () => {
       setupProductAnalyticsPreferencesChangeListener: vi.fn(),
       triggerStartupSettingsSnapshot: vi.fn(),
       triggerStartupShieldBypassDailySummary: vi.fn(),
+      triggerStartupSponsorRecommendationsDailySummary: vi.fn(),
       triggerStartupSiteEcosystemSnapshot: vi.fn(),
     }))
     vi.doMock("~/services/tags/tagStorage", () => ({

--- a/tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx
+++ b/tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -18,9 +19,12 @@ import { PRODUCT_ANALYTICS_EVENTS } from "~/services/productAnalytics/events"
 import { AuthTypeEnum } from "~/types"
 import { render, screen } from "~~/tests/test-utils/render"
 
-const { trackProductAnalyticsEventMock } = vi.hoisted(() => ({
-  trackProductAnalyticsEventMock: vi.fn(),
-}))
+const { recordSponsorSummaryMock, trackProductAnalyticsEventMock } = vi.hoisted(
+  () => ({
+    recordSponsorSummaryMock: vi.fn(),
+    trackProductAnalyticsEventMock: vi.fn(),
+  }),
+)
 
 vi.mock("~/services/productAnalytics/events", async (importOriginal) => {
   const actual =
@@ -32,6 +36,10 @@ vi.mock("~/services/productAnalytics/events", async (importOriginal) => {
       trackProductAnalyticsEventMock(...args),
   }
 })
+
+vi.mock("~/services/productAnalytics/sponsorRecommendationsSummary", () => ({
+  recordSponsorRecommendationsSummary: recordSponsorSummaryMock,
+}))
 
 const onContinueAddAccount = vi.fn()
 const onOpenBookmarkManager = vi.fn()
@@ -118,6 +126,8 @@ describe("SponsorRecommendationsSection", () => {
   beforeEach(() => {
     vi.unstubAllGlobals()
     trackProductAnalyticsEventMock.mockReset()
+    recordSponsorSummaryMock.mockReset()
+    recordSponsorSummaryMock.mockResolvedValue(undefined)
     onContinueAddAccount.mockReset()
     onOpenBookmarkManager.mockReset()
     onOpenApiCredentialProfiles.mockReset()
@@ -361,7 +371,7 @@ describe("SponsorRecommendationsSection", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("tracks one safe impression for a non-empty rendered recommendation set without rerender duplicates", () => {
+  it("records rendered recommendation impressions into the daily summary", async () => {
     const { rerender } = renderSection([
       createSupportedSponsor(),
       createUnsupportedSponsor({
@@ -388,44 +398,51 @@ describe("SponsorRecommendationsSection", () => {
       />,
     )
 
-    expect(trackProductAnalyticsEventMock).toHaveBeenCalledTimes(1)
-    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
-      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
-      expect.objectContaining({
-        feature_id: "sponsor_recommendations",
-        action_id: "view_sponsor_recommendations",
-        surface_id:
-          "options_account_management_add_account_sponsor_recommendations",
-        entrypoint: "options",
-        result: "success",
-        item_count: 2,
-        sponsor_catalog_source: "mixed",
-        sponsor_supported_count: 1,
-        sponsor_unsupported_count: 1,
-      }),
-    )
+    await waitFor(() => {
+      expect(recordSponsorSummaryMock).toHaveBeenCalledTimes(2)
+    })
+    expect(recordSponsorSummaryMock).toHaveBeenNthCalledWith(1, {
+      impressionCount: 1,
+      itemTotal: 2,
+      supportedItemTotal: 1,
+      unsupportedItemTotal: 1,
+      addAccountSurfaceCount: 1,
+      newcomerSurfaceCount: 0,
+    })
+    expect(recordSponsorSummaryMock).toHaveBeenNthCalledWith(2, {
+      impressionCount: 1,
+      itemTotal: 2,
+      supportedItemTotal: 1,
+      unsupportedItemTotal: 1,
+      addAccountSurfaceCount: 1,
+      newcomerSurfaceCount: 0,
+    })
+    expect(trackProductAnalyticsEventMock).not.toHaveBeenCalled()
   })
 
   it("does not track impressions when no recommendations are available", () => {
     renderSection([])
 
+    expect(recordSponsorSummaryMock).not.toHaveBeenCalled()
     expect(trackProductAnalyticsEventMock).not.toHaveBeenCalled()
   })
 
-  it("tracks newcomer recommendation impressions with a distinct surface", () => {
+  it("records newcomer recommendation impressions with a distinct surface count", async () => {
     renderSection(
       [createSupportedSponsor()],
       SPONSOR_RECOMMENDATION_SURFACES.Newcomer,
     )
 
-    expect(trackProductAnalyticsEventMock).toHaveBeenCalledWith(
-      PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
-      expect.objectContaining({
-        action_id: "view_sponsor_recommendations",
-        surface_id:
-          "options_account_management_newcomer_sponsor_recommendations",
-      }),
-    )
+    await waitFor(() => {
+      expect(recordSponsorSummaryMock).toHaveBeenCalledWith({
+        impressionCount: 1,
+        itemTotal: 1,
+        supportedItemTotal: 1,
+        unsupportedItemTotal: 0,
+        addAccountSurfaceCount: 0,
+        newcomerSurfaceCount: 1,
+      })
+    })
   })
 
   it("tracks safe sponsor click metadata without leaking URLs, provider names, or promo notes", async () => {
@@ -439,6 +456,9 @@ describe("SponsorRecommendationsSection", () => {
         rank: 2,
       }),
     ])
+    await waitFor(() => {
+      expect(recordSponsorSummaryMock).toHaveBeenCalledTimes(1)
+    })
     trackProductAnalyticsEventMock.mockClear()
 
     await user.click(
@@ -524,6 +544,9 @@ describe("SponsorRecommendationsSection", () => {
       [createSupportedSponsor()],
       SPONSOR_RECOMMENDATION_SURFACES.Newcomer,
     )
+    await waitFor(() => {
+      expect(recordSponsorSummaryMock).toHaveBeenCalledTimes(1)
+    })
     trackProductAnalyticsEventMock.mockClear()
 
     await user.click(
@@ -601,6 +624,9 @@ describe("SponsorRecommendationsSection", () => {
         rank: 3,
       }),
     ])
+    await waitFor(() => {
+      expect(recordSponsorSummaryMock).toHaveBeenCalledTimes(1)
+    })
     trackProductAnalyticsEventMock.mockClear()
 
     await user.click(

--- a/tests/services/productAnalytics/runtime.test.ts
+++ b/tests/services/productAnalytics/runtime.test.ts
@@ -23,6 +23,7 @@ const {
   mockLoggerDebug,
   mockOnProductAnalyticsMessage,
   preferenceMocks,
+  flushSponsorRecommendationsDailySummaryMock,
   stateMocks,
 } = vi.hoisted(() => ({
   captureMock: vi.fn(),
@@ -31,6 +32,7 @@ const {
   mockIsDevBuild: vi.fn(() => false),
   mockLoggerDebug: vi.fn(),
   mockOnProductAnalyticsMessage: vi.fn(() => vi.fn()),
+  flushSponsorRecommendationsDailySummaryMock: vi.fn(),
   preferenceMocks: {
     isEnabled: vi.fn(),
   },
@@ -46,6 +48,11 @@ vi.mock("~/services/productAnalytics/client", () => ({
   productAnalyticsClient: {
     capture: captureMock,
   },
+}))
+
+vi.mock("~/services/productAnalytics/sponsorRecommendationsSummary", () => ({
+  flushSponsorRecommendationsDailySummary:
+    flushSponsorRecommendationsDailySummaryMock,
 }))
 
 vi.mock("~/utils/core/environment", () => ({
@@ -136,6 +143,7 @@ describe("product analytics runtime", () => {
     stateMocks.setLastSiteEcosystemSnapshotAt.mockResolvedValue(true)
     getAllAccountsMock.mockResolvedValue([])
     getPreferencesMock.mockResolvedValue(createDefaultPreferences())
+    flushSponsorRecommendationsDailySummaryMock.mockResolvedValue(true)
     mockIsDevBuild.mockReturnValue(false)
   })
 
@@ -482,6 +490,25 @@ describe("product analytics runtime", () => {
 
     expect(mockLoggerDebug).toHaveBeenCalledWith(
       "Product analytics shield bypass summary failed",
+      expect.any(Error),
+    )
+  })
+
+  it("logs startup sponsor recommendations summary failures in dev builds", async () => {
+    mockIsDevBuild.mockReturnValue(true)
+    flushSponsorRecommendationsDailySummaryMock.mockRejectedValueOnce(
+      new Error("sponsor summary unavailable"),
+    )
+
+    const { triggerStartupSponsorRecommendationsDailySummary } = await import(
+      "~/services/productAnalytics/runtime"
+    )
+
+    triggerStartupSponsorRecommendationsDailySummary()
+    await vi.runAllTimersAsync()
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      "Product analytics sponsor recommendations summary failed",
       expect.any(Error),
     )
   })

--- a/tests/services/productAnalytics/sponsorRecommendationsSummary.test.ts
+++ b/tests/services/productAnalytics/sponsorRecommendationsSummary.test.ts
@@ -142,6 +142,30 @@ describe("sponsor recommendations product analytics summary", () => {
     ).not.toHaveBeenCalled()
   })
 
+  it("reports failure when rolling the uploaded summary forward fails", async () => {
+    stateMocks.replaceSponsorRecommendationsSummaryState.mockResolvedValue(
+      false,
+    )
+    const { flushSponsorRecommendationsDailySummary } = await import(
+      "~/services/productAnalytics/sponsorRecommendationsSummary"
+    )
+
+    await expect(flushSponsorRecommendationsDailySummary()).resolves.toBe(false)
+
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(
+      stateMocks.replaceSponsorRecommendationsSummaryState,
+    ).toHaveBeenCalledWith({
+      day: "2026-05-12",
+      impressionCount: 0,
+      itemTotal: 0,
+      supportedItemTotal: 0,
+      unsupportedItemTotal: 0,
+      addAccountSurfaceCount: 0,
+      newcomerSurfaceCount: 0,
+    })
+  })
+
   it("does not upload an empty previous-day summary", async () => {
     stateMocks.getSponsorRecommendationsSummaryState.mockResolvedValue({
       day: "2026-05-11",

--- a/tests/services/productAnalytics/sponsorRecommendationsSummary.test.ts
+++ b/tests/services/productAnalytics/sponsorRecommendationsSummary.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_EVENTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+} from "~/services/productAnalytics/events"
+
+const { captureMock, stateMocks } = vi.hoisted(() => ({
+  captureMock: vi.fn(),
+  stateMocks: {
+    getSponsorRecommendationsSummaryState: vi.fn(),
+    incrementSponsorRecommendationsSummary: vi.fn(),
+    replaceSponsorRecommendationsSummaryState: vi.fn(),
+  },
+}))
+
+vi.mock("~/services/productAnalytics/client", () => ({
+  productAnalyticsClient: {
+    capture: captureMock,
+  },
+}))
+
+vi.mock("~/services/productAnalytics/state", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/productAnalytics/state")>()
+  return {
+    ...actual,
+    productAnalyticsState: {
+      ...actual.productAnalyticsState,
+      ...stateMocks,
+    },
+  }
+})
+
+describe("sponsor recommendations product analytics summary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-05-12T08:00:00.000Z"))
+    captureMock.mockResolvedValue(true)
+    stateMocks.getSponsorRecommendationsSummaryState.mockResolvedValue({
+      day: "2026-05-11",
+      impressionCount: 7,
+      itemTotal: 14,
+      supportedItemTotal: 9,
+      unsupportedItemTotal: 5,
+      addAccountSurfaceCount: 4,
+      newcomerSurfaceCount: 3,
+    })
+    stateMocks.incrementSponsorRecommendationsSummary.mockResolvedValue(true)
+    stateMocks.replaceSponsorRecommendationsSummaryState.mockResolvedValue(true)
+  })
+
+  it("records sponsor recommendation impressions locally instead of sending per-impression analytics", async () => {
+    const { recordSponsorRecommendationsSummary } = await import(
+      "~/services/productAnalytics/sponsorRecommendationsSummary"
+    )
+
+    await recordSponsorRecommendationsSummary({
+      impressionCount: 1,
+      itemTotal: 2,
+      supportedItemTotal: 1,
+      unsupportedItemTotal: 1,
+      addAccountSurfaceCount: 1,
+    })
+
+    expect(
+      stateMocks.incrementSponsorRecommendationsSummary,
+    ).toHaveBeenCalledWith({
+      impressionCount: 1,
+      itemTotal: 2,
+      supportedItemTotal: 1,
+      unsupportedItemTotal: 1,
+      addAccountSurfaceCount: 1,
+    })
+    expect(captureMock).not.toHaveBeenCalled()
+  })
+
+  it("uploads one daily summary and rolls the local state forward", async () => {
+    const { flushSponsorRecommendationsDailySummary } = await import(
+      "~/services/productAnalytics/sponsorRecommendationsSummary"
+    )
+
+    await expect(flushSponsorRecommendationsDailySummary()).resolves.toBe(true)
+
+    expect(captureMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_EVENTS.SponsorRecommendationsDailySummaryCaptured,
+      {
+        feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.SponsorRecommendations,
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+        day: "2026-05-11",
+        impression_count: 7,
+        item_total: 14,
+        supported_item_total: 9,
+        unsupported_item_total: 5,
+        add_account_surface_count: 4,
+        newcomer_surface_count: 3,
+      },
+    )
+    expect(
+      stateMocks.replaceSponsorRecommendationsSummaryState,
+    ).toHaveBeenCalledWith({
+      day: "2026-05-12",
+      impressionCount: 0,
+      itemTotal: 0,
+      supportedItemTotal: 0,
+      unsupportedItemTotal: 0,
+      addAccountSurfaceCount: 0,
+      newcomerSurfaceCount: 0,
+    })
+  })
+
+  it("keeps same-day summary local until the next UTC day", async () => {
+    stateMocks.getSponsorRecommendationsSummaryState.mockResolvedValue({
+      day: "2026-05-12",
+      impressionCount: 5,
+    })
+    const { flushSponsorRecommendationsDailySummary } = await import(
+      "~/services/productAnalytics/sponsorRecommendationsSummary"
+    )
+
+    await expect(flushSponsorRecommendationsDailySummary()).resolves.toBe(false)
+
+    expect(captureMock).not.toHaveBeenCalled()
+    expect(
+      stateMocks.replaceSponsorRecommendationsSummaryState,
+    ).not.toHaveBeenCalled()
+  })
+
+  it("does not roll local state forward when daily summary upload fails", async () => {
+    captureMock.mockResolvedValue(false)
+    const { flushSponsorRecommendationsDailySummary } = await import(
+      "~/services/productAnalytics/sponsorRecommendationsSummary"
+    )
+
+    await expect(flushSponsorRecommendationsDailySummary()).resolves.toBe(false)
+
+    expect(captureMock).toHaveBeenCalledTimes(1)
+    expect(
+      stateMocks.replaceSponsorRecommendationsSummaryState,
+    ).not.toHaveBeenCalled()
+  })
+
+  it("does not upload an empty previous-day summary", async () => {
+    stateMocks.getSponsorRecommendationsSummaryState.mockResolvedValue({
+      day: "2026-05-11",
+      impressionCount: 0,
+    })
+    const { flushSponsorRecommendationsDailySummary } = await import(
+      "~/services/productAnalytics/sponsorRecommendationsSummary"
+    )
+
+    await expect(flushSponsorRecommendationsDailySummary()).resolves.toBe(false)
+
+    expect(captureMock).not.toHaveBeenCalled()
+    expect(
+      stateMocks.replaceSponsorRecommendationsSummaryState,
+    ).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/productAnalytics/state.test.ts
+++ b/tests/services/productAnalytics/state.test.ts
@@ -6,6 +6,7 @@ import { PRODUCT_ANALYTICS_STORAGE_KEYS } from "~/services/core/storageKeys"
 import {
   normalizeProductAnalyticsState,
   normalizeShieldBypassSummaryState,
+  normalizeSponsorRecommendationsSummaryState,
   productAnalyticsState,
 } from "~/services/productAnalytics/state"
 
@@ -129,6 +130,59 @@ describe("productAnalyticsState", () => {
     )
   })
 
+  it("increments sponsor recommendations summary counts for the current UTC day", async () => {
+    await productAnalyticsState.incrementSponsorRecommendationsSummary({
+      impressionCount: 1,
+      itemTotal: 2,
+      supportedItemTotal: 1,
+      unsupportedItemTotal: 1,
+      addAccountSurfaceCount: 1,
+    })
+    await productAnalyticsState.incrementSponsorRecommendationsSummary({
+      impressionCount: 1,
+      itemTotal: 1,
+      supportedItemTotal: 1,
+      newcomerSurfaceCount: 1,
+    })
+
+    await expect(productAnalyticsState.getState()).resolves.toEqual(
+      expect.objectContaining({
+        sponsorRecommendationsSummary: {
+          day: "2026-05-12",
+          impressionCount: 2,
+          itemTotal: 3,
+          supportedItemTotal: 2,
+          unsupportedItemTotal: 1,
+          addAccountSurfaceCount: 1,
+          newcomerSurfaceCount: 1,
+        },
+      }),
+    )
+  })
+
+  it("rolls sponsor recommendations summary counts to a new UTC day", async () => {
+    await productAnalyticsState.replaceSponsorRecommendationsSummaryState({
+      day: "2026-05-11",
+      impressionCount: 9,
+      itemTotal: 18,
+    })
+
+    await productAnalyticsState.incrementSponsorRecommendationsSummary({
+      impressionCount: 1,
+      itemTotal: 2,
+    })
+
+    await expect(productAnalyticsState.getState()).resolves.toEqual(
+      expect.objectContaining({
+        sponsorRecommendationsSummary: {
+          day: "2026-05-12",
+          impressionCount: 1,
+          itemTotal: 2,
+        },
+      }),
+    )
+  })
+
   it("normalizes persisted analytics state timestamps", () => {
     expect(
       normalizeProductAnalyticsState({
@@ -153,6 +207,24 @@ describe("productAnalyticsState", () => {
       day: "2026-05-12",
       promptShownCount: 2,
       tempWindowFetchSuccessCount: 1,
+    })
+  })
+
+  it("normalizes persisted sponsor recommendations summary counts", () => {
+    expect(
+      normalizeSponsorRecommendationsSummaryState({
+        day: "2026-05-12",
+        impressionCount: 2.8,
+        itemTotal: 4,
+        supportedItemTotal: -1,
+        unsupportedItemTotal: Number.NaN,
+        addAccountSurfaceCount: 1,
+      }),
+    ).toEqual({
+      day: "2026-05-12",
+      impressionCount: 2,
+      itemTotal: 4,
+      addAccountSurfaceCount: 1,
     })
   })
 })

--- a/tests/services/productAnalytics/state.test.ts
+++ b/tests/services/productAnalytics/state.test.ts
@@ -12,6 +12,9 @@ import {
 
 describe("productAnalyticsState", () => {
   const storage = new Storage({ area: "local" })
+  const analyticsStorage = (
+    productAnalyticsState as unknown as { storage: Storage }
+  ).storage
 
   beforeEach(async () => {
     vi.useFakeTimers()
@@ -181,6 +184,44 @@ describe("productAnalyticsState", () => {
         },
       }),
     )
+  })
+
+  it("reports sponsor recommendations summary replacement write failures", async () => {
+    const storageSetSpy = vi
+      .spyOn(analyticsStorage, "set")
+      .mockRejectedValueOnce(new Error("write failed"))
+
+    await expect(
+      productAnalyticsState.replaceSponsorRecommendationsSummaryState({
+        day: "2026-05-12",
+        impressionCount: 1,
+      }),
+    ).resolves.toBe(false)
+
+    await expect(
+      storage.get(PRODUCT_ANALYTICS_STORAGE_KEYS.PRODUCT_ANALYTICS_STATE),
+    ).resolves.toBeUndefined()
+
+    storageSetSpy.mockRestore()
+  })
+
+  it("reports sponsor recommendations summary increment write failures", async () => {
+    const storageSetSpy = vi
+      .spyOn(analyticsStorage, "set")
+      .mockRejectedValueOnce(new Error("write failed"))
+
+    await expect(
+      productAnalyticsState.incrementSponsorRecommendationsSummary({
+        impressionCount: 1,
+        itemTotal: 2,
+      }),
+    ).resolves.toBe(false)
+
+    await expect(
+      storage.get(PRODUCT_ANALYTICS_STORAGE_KEYS.PRODUCT_ANALYTICS_STATE),
+    ).resolves.toBeUndefined()
+
+    storageSetSpy.mockRestore()
   })
 
   it("normalizes persisted analytics state timestamps", () => {


### PR DESCRIPTION
## Summary
- Replace per-render sponsor recommendation impression events with a persisted daily summary event.
- Flush previous-day sponsor recommendation summaries from the background startup path.
- Document the project telemetry preference for high-volume low-meaning impressions.

## Test Plan
- pnpm vitest --run tests/services/productAnalytics/state.test.ts tests/services/productAnalytics/sponsorRecommendationsSummary.test.ts tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx tests/services/productAnalytics/events.test.ts tests/services/productAnalytics/privacy.test.ts
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated telemetry guidelines for high-volume, low-meaning events to use persisted daily summaries with short TTL deduplication.
* **New Features**
  * Sponsor recommendations impressions are now recorded as daily summaries, including automatic flushing during background startup.
  * Added a new sponsor recommendations daily summary analytics event with day and per-surface counts.
* **Bug Fixes**
  * Adjusted sponsor recommendations impression tracking to reliably record daily summary activity when recommendations are present.
* **Tests**
  * Added/updated unit and component tests to cover summary recording, flushing behavior, and analytics state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->