### PR TITLE
feat(model-list): filter and sort by verification results

### DIFF
--- a/src/components/dialogs/VerifyApiDialog/VerificationHistorySummary.tsx
+++ b/src/components/dialogs/VerifyApiDialog/VerificationHistorySummary.tsx
@@ -1,8 +1,12 @@
 import { useTranslation } from "react-i18next"
 
-import type { ApiVerificationHistorySummary } from "~/services/verification/verificationResultHistory"
+import {
+  getVerificationSummaryLatencyMs,
+  type ApiVerificationHistorySummary,
+} from "~/services/verification/verificationResultHistory"
 import { formatLocaleDateTime } from "~/utils/core/formatters"
 
+import { formatLatency } from "./utils"
 import { VerificationStatusBadge } from "./VerificationStatusBadge"
 
 type VerificationHistorySummaryProps = {
@@ -25,6 +29,7 @@ export function VerificationHistorySummary({
   const verificationTimestampIso = summary
     ? new Date(summary.verifiedAt).toISOString()
     : undefined
+  const latencyMs = getVerificationSummaryLatencyMs(summary)
 
   return (
     <div
@@ -34,6 +39,11 @@ export function VerificationHistorySummary({
     >
       <span className="sr-only">{t("verifyDialog.history.lastVerified")}</span>
       <VerificationStatusBadge status={summary?.status ?? "unverified"} />
+      {latencyMs !== null ? (
+        <span className="dark:text-dark-text-tertiary truncate text-[11px] text-gray-500 sm:text-xs">
+          {formatLatency(latencyMs)}
+        </span>
+      ) : null}
       {verificationTimestamp ? (
         <span className="inline-flex min-w-0 items-center gap-1.5">
           <span

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -57,9 +57,12 @@ import {
   type ModelListVerificationResultFilter,
 } from "./verificationResultFilters"
 
-type ModelListDisplayedResultCountFilters = Parameters<
-  ReturnType<typeof useModelListData>["getFilteredResultCount"]
->[0] & {
+type ModelListDisplayedResultCountBaseFilters = NonNullable<
+  Parameters<ReturnType<typeof useModelListData>["getFilteredResultCount"]>[0]
+>
+
+interface ModelListDisplayedResultCountFilters
+  extends ModelListDisplayedResultCountBaseFilters {
   selectedVerificationResults?: ModelListVerificationResultFilter[]
 }
 

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -50,7 +50,18 @@ import { ProviderTabs } from "./components/ProviderTabs"
 import { StatusIndicator } from "./components/StatusIndicator"
 import { MODEL_LIST_GROUP_SELECTION_SCOPES } from "./groupSelectionScopes"
 import { useModelListData } from "./hooks/useModelListData"
+import { MODEL_LIST_SORT_MODES } from "./sortModes"
 import { MODEL_LIST_TEST_IDS } from "./testIds"
+import {
+  applyVerificationResultView,
+  type ModelListVerificationResultFilter,
+} from "./verificationResultFilters"
+
+type ModelListDisplayedResultCountFilters = Parameters<
+  ReturnType<typeof useModelListData>["getFilteredResultCount"]
+>[0] & {
+  selectedVerificationResults?: ModelListVerificationResultFilter[]
+}
 
 /**
  * Model list page showing pricing details with filtering by account, provider, and group.
@@ -98,6 +109,8 @@ export default function ModelList(props: {
     setShowRatioColumn,
     showEndpointTypes,
     setShowEndpointTypes,
+    selectedVerificationResults,
+    setSelectedVerificationResults,
 
     // Data state
     pricingData,
@@ -235,6 +248,47 @@ export default function ModelList(props: {
   }, [filteredModels])
   const { summariesByKey: verificationSummariesByKey } =
     useVerificationResultHistorySummaries(modelVerificationTargets)
+  const displayedModels = useMemo(
+    () =>
+      applyVerificationResultView(filteredModels, {
+        selectedResults: selectedVerificationResults,
+        shouldSortByLatency:
+          sortMode === MODEL_LIST_SORT_MODES.VERIFICATION_LATENCY_ASC,
+        verificationSummariesByKey,
+      }),
+    [
+      filteredModels,
+      selectedVerificationResults,
+      sortMode,
+      verificationSummariesByKey,
+    ],
+  )
+  const getDisplayedResultCount = useCallback(
+    (filters: ModelListDisplayedResultCountFilters = {}) => {
+      const baseCount = getFilteredResultCount(filters)
+      if (
+        !filters.selectedVerificationResults &&
+        filters.sortMode !== MODEL_LIST_SORT_MODES.VERIFICATION_LATENCY_ASC
+      ) {
+        return baseCount
+      }
+
+      const selectedResults =
+        filters.selectedVerificationResults ?? selectedVerificationResults
+      return applyVerificationResultView(filteredModels, {
+        selectedResults,
+        shouldSortByLatency:
+          filters.sortMode === MODEL_LIST_SORT_MODES.VERIFICATION_LATENCY_ASC,
+        verificationSummariesByKey,
+      }).length
+    },
+    [
+      filteredModels,
+      getFilteredResultCount,
+      selectedVerificationResults,
+      verificationSummariesByKey,
+    ],
+  )
 
   const [verifyContext, setVerifyContext] = useState<{
     account: DisplaySiteData
@@ -308,8 +362,8 @@ export default function ModelList(props: {
   }
 
   const batchVerifyItems = useMemo(
-    () => createBatchVerifyModelItems(filteredModels),
-    [filteredModels],
+    () => createBatchVerifyModelItems(displayedModels),
+    [displayedModels],
   )
 
   const handleOpenBatchVerify = () => {
@@ -597,8 +651,10 @@ export default function ModelList(props: {
             showEndpointTypes={showEndpointTypes}
             setShowEndpointTypes={setShowEndpointTypes}
             totalModels={totalModels}
-            filteredModels={filteredModels}
-            getFilteredResultCount={getFilteredResultCount}
+            filteredModels={displayedModels}
+            getFilteredResultCount={getDisplayedResultCount}
+            selectedVerificationResults={selectedVerificationResults}
+            setSelectedVerificationResults={setSelectedVerificationResults}
             onBatchVerifyModels={
               canBatchVerifyModels ? handleOpenBatchVerify : undefined
             }
@@ -614,7 +670,7 @@ export default function ModelList(props: {
             <Tab.Panels>
               <Tab.Panel>
                 <ModelDisplay
-                  models={filteredModels}
+                  models={displayedModels}
                   verificationSummariesByKey={verificationSummariesByKey}
                   onVerifyModel={handleVerifyModel}
                   onVerifyCliSupport={handleVerifyCliSupport}
@@ -639,7 +695,7 @@ export default function ModelList(props: {
               {providers.map((provider) => (
                 <Tab.Panel key={provider}>
                   <ModelDisplay
-                    models={filteredModels}
+                    models={displayedModels}
                     verificationSummariesByKey={verificationSummariesByKey}
                     onVerifyModel={handleVerifyModel}
                     onVerifyCliSupport={handleVerifyCliSupport}

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -125,6 +125,7 @@ export default function ModelList(props: {
     filteredModels,
     accountSummaryCountsByAccountId,
     allProvidersFilteredCount,
+    getFilteredModels,
     getFilteredResultCount,
     availableGroups,
     availableAccountGroupsByAccountId,
@@ -275,7 +276,12 @@ export default function ModelList(props: {
 
       const selectedResults =
         filters.selectedVerificationResults ?? selectedVerificationResults
-      return applyVerificationResultView(filteredModels, {
+      const {
+        selectedVerificationResults: _selectedVerificationResults,
+        ...baseFilters
+      } = filters
+
+      return applyVerificationResultView(getFilteredModels(baseFilters), {
         selectedResults,
         shouldSortByLatency:
           filters.sortMode === MODEL_LIST_SORT_MODES.VERIFICATION_LATENCY_ASC,
@@ -283,7 +289,7 @@ export default function ModelList(props: {
       }).length
     },
     [
-      filteredModels,
+      getFilteredModels,
       getFilteredResultCount,
       selectedVerificationResults,
       verificationSummariesByKey,

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -361,8 +361,14 @@ export function ControlPanel({
           />
         )}
 
-        <div className="mb-4 flex flex-col gap-4 lg:flex-row">
-          <FormField label={t("searchModels")} className="flex-1">
+        <div
+          className="mb-4 flex flex-col gap-4 lg:flex-row lg:flex-wrap"
+          data-testid="model-list-filter-row"
+        >
+          <FormField
+            label={t("searchModels")}
+            className="min-w-[16rem] flex-1 lg:basis-[18rem]"
+          >
             <Input
               type="text"
               placeholder={t("searchPlaceholder")}
@@ -403,6 +409,7 @@ export function ControlPanel({
                   options={groupOptions}
                   selected={selectedGroups}
                   onChange={handleGroupSelectionChange}
+                  size="default"
                   displayMode="summary"
                   placeholder={t("allGroups")}
                   emptyMessage={t("allGroups")}
@@ -421,6 +428,7 @@ export function ControlPanel({
               options={verificationResultOptions}
               selected={selectedVerificationResults}
               onChange={handleVerificationResultSelectionChange}
+              size="default"
               displayMode="summary"
               placeholder={t("verificationResults.all")}
               emptyMessage={t("verificationResults.none")}

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -159,7 +159,11 @@ export function ControlPanel({
   const isAllAccountsSource =
     selectedSourceValue === ALL_ACCOUNTS_SOURCE_VALUE ||
     selectedSource?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS
-  const supportsPriceSorting = sourceCapabilities.supportsPricing
+  const supportsLatencySorting =
+    sourceCapabilities.supportsCredentialVerification ||
+    sourceCapabilities.supportsBatchCredentialVerification
+  const supportsSortControls =
+    sourceCapabilities.supportsPricing || supportsLatencySorting
   const isPriceComparisonActive =
     isAllAccountsSource &&
     sortMode === MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST &&
@@ -182,18 +186,26 @@ export function ControlPanel({
       value: MODEL_LIST_SORT_MODES.DEFAULT,
       label: t("sortOptions.default"),
     },
-    {
-      value: MODEL_LIST_SORT_MODES.PRICE_ASC,
-      label: t("sortOptions.priceAsc"),
-    },
-    {
-      value: MODEL_LIST_SORT_MODES.PRICE_DESC,
-      label: t("sortOptions.priceDesc"),
-    },
-    {
-      value: MODEL_LIST_SORT_MODES.VERIFICATION_LATENCY_ASC,
-      label: t("sortOptions.verificationLatencyAsc"),
-    },
+    ...(sourceCapabilities.supportsPricing
+      ? [
+          {
+            value: MODEL_LIST_SORT_MODES.PRICE_ASC,
+            label: t("sortOptions.priceAsc"),
+          },
+          {
+            value: MODEL_LIST_SORT_MODES.PRICE_DESC,
+            label: t("sortOptions.priceDesc"),
+          },
+        ]
+      : []),
+    ...(supportsLatencySorting
+      ? [
+          {
+            value: MODEL_LIST_SORT_MODES.VERIFICATION_LATENCY_ASC,
+            label: t("sortOptions.verificationLatencyAsc"),
+          },
+        ]
+      : []),
     ...(selectedSource?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS
       ? [
           {
@@ -380,7 +392,7 @@ export function ControlPanel({
             />
           </FormField>
 
-          {supportsPriceSorting && (
+          {supportsSortControls && (
             <FormField label={t("sortBy")} className="w-full lg:w-72">
               <SearchableSelect
                 options={sortOptions}

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -41,6 +41,10 @@ import {
   type ModelListSortMode,
 } from "~/features/ModelList/sortModes"
 import { MODEL_LIST_TEST_IDS } from "~/features/ModelList/testIds"
+import {
+  DEFAULT_MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+  type ModelListVerificationResultFilter,
+} from "~/features/ModelList/verificationResultFilters"
 import { trackProductAnalyticsActionCompleted } from "~/services/productAnalytics/actions"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -62,6 +66,10 @@ interface ControlPanelProps {
   setSearchTerm: (term: string) => void
   sortMode: ModelListSortMode
   setSortMode: (mode: ModelListSortMode) => void
+  selectedVerificationResults?: ModelListVerificationResultFilter[]
+  setSelectedVerificationResults?: (
+    results: ModelListVerificationResultFilter[],
+  ) => void
   selectedBillingMode: ModelListBillingMode
   setSelectedBillingMode: (mode: ModelListBillingMode) => void
   selectedGroups: string[]
@@ -81,6 +89,7 @@ interface ControlPanelProps {
     sortMode?: ModelListSortMode
     selectedBillingMode?: ModelListBillingMode
     selectedGroups?: string[]
+    selectedVerificationResults?: ModelListVerificationResultFilter[]
   }) => number
   onBatchVerifyModels?: () => void
 }
@@ -96,6 +105,8 @@ interface ControlPanelProps {
  * @param props.setSearchTerm Setter to update search keyword.
  * @param props.sortMode Active sort mode.
  * @param props.setSortMode Setter for sort mode.
+ * @param props.selectedVerificationResults Active verification-result filters.
+ * @param props.setSelectedVerificationResults Setter for verification-result filters.
  * @param props.selectedBillingMode Active billing-mode filter value.
  * @param props.setSelectedBillingMode Setter for billing-mode filter.
  * @param props.selectedGroups Active candidate group filter set.
@@ -123,6 +134,8 @@ export function ControlPanel({
   setSearchTerm,
   sortMode,
   setSortMode,
+  selectedVerificationResults = DEFAULT_MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+  setSelectedVerificationResults = () => {},
   selectedBillingMode,
   setSelectedBillingMode,
   selectedGroups,
@@ -177,6 +190,10 @@ export function ControlPanel({
       value: MODEL_LIST_SORT_MODES.PRICE_DESC,
       label: t("sortOptions.priceDesc"),
     },
+    {
+      value: MODEL_LIST_SORT_MODES.VERIFICATION_LATENCY_ASC,
+      label: t("sortOptions.verificationLatencyAsc"),
+    },
     ...(selectedSource?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS
       ? [
           {
@@ -200,6 +217,20 @@ export function ControlPanel({
       label: t("ui:billing.perCall"),
     },
   ]
+  const verificationResultOptions = [
+    {
+      value: "pass",
+      label: t("verificationResults.filters.pass"),
+    },
+    {
+      value: "fail",
+      label: t("verificationResults.filters.fail"),
+    },
+    {
+      value: "unverified",
+      label: t("verificationResults.filters.unverified"),
+    },
+  ]
 
   const handleCopyModelNames = () => {
     if (filteredModels.length === 0) {
@@ -219,6 +250,7 @@ export function ControlPanel({
       sortMode: ModelListSortMode
       selectedBillingMode: ModelListBillingMode
       selectedGroups: string[]
+      selectedVerificationResults: ModelListVerificationResultFilter[]
     }> = {},
   ) => {
     const nextSearchTerm = nextFilters.searchTerm ?? searchTerm
@@ -226,17 +258,24 @@ export function ControlPanel({
     const nextSelectedBillingMode =
       nextFilters.selectedBillingMode ?? selectedBillingMode
     const nextSelectedGroups = nextFilters.selectedGroups ?? selectedGroups
+    const nextSelectedVerificationResults =
+      nextFilters.selectedVerificationResults ?? selectedVerificationResults
     const filterCount =
       (nextSearchTerm.trim() ? 1 : 0) +
       (nextSortMode !== MODEL_LIST_SORT_MODES.DEFAULT ? 1 : 0) +
       (nextSelectedBillingMode !== MODEL_LIST_BILLING_MODES.ALL ? 1 : 0) +
-      nextSelectedGroups.length
+      nextSelectedGroups.length +
+      (nextSelectedVerificationResults.length ===
+      verificationResultOptions.length
+        ? 0
+        : 1)
     const resultCount =
       getFilteredResultCount?.({
         searchTerm: nextSearchTerm,
         sortMode: nextSortMode,
         selectedBillingMode: nextSelectedBillingMode,
         selectedGroups: nextSelectedGroups,
+        selectedVerificationResults: nextSelectedVerificationResults,
       }) ?? filteredModels.length
 
     void trackProductAnalyticsActionCompleted({
@@ -277,6 +316,13 @@ export function ControlPanel({
     setSelectedGroups(groups)
     trackFilterChange(PRODUCT_ANALYTICS_MODE_IDS.GroupFilter, {
       selectedGroups: groups,
+    })
+  }
+  const handleVerificationResultSelectionChange = (results: string[]) => {
+    const nextResults = results as ModelListVerificationResultFilter[]
+    setSelectedVerificationResults(nextResults)
+    trackFilterChange(PRODUCT_ANALYTICS_MODE_IDS.StatusFilter, {
+      selectedVerificationResults: nextResults,
     })
   }
   const handleEnablePriceComparison = () => {
@@ -366,6 +412,20 @@ export function ControlPanel({
                 </p>
               </FormField>
             )}
+
+          <FormField
+            label={t("verificationResults.label")}
+            className="w-full lg:w-64"
+          >
+            <CompactMultiSelect
+              options={verificationResultOptions}
+              selected={selectedVerificationResults}
+              onChange={handleVerificationResultSelectionChange}
+              displayMode="summary"
+              placeholder={t("verificationResults.all")}
+              emptyMessage={t("verificationResults.none")}
+            />
+          </FormField>
         </div>
 
         <ProductAnalyticsScope

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -891,7 +891,7 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     [baseFilteredRawModels, getAccountFilteredRawModels],
   )
 
-  const getFilteredResultCount = useCallback(
+  const getFilteredModels = useCallback(
     (overrides: FilterOverrides = {}) => {
       const baseModels = resolveCalculatedModels({
         rawItems: getAccountFilteredRawModels(
@@ -909,13 +909,13 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
       })
 
       if (selectedProvider === MODEL_PROVIDER_FILTER_VALUES.ALL) {
-        return baseModels.length
+        return baseModels
       }
 
       return baseModels.filter(
         (item) =>
           filterModelsByProvider([item.model], selectedProvider).length > 0,
-      ).length
+      )
     },
     [
       getAccountFilteredRawModels,
@@ -926,6 +926,11 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
       selectedSource?.capabilities.supportsGroupFiltering,
       showRealPrice,
     ],
+  )
+
+  const getFilteredResultCount = useCallback(
+    (overrides: FilterOverrides = {}) => getFilteredModels(overrides).length,
+    [getFilteredModels],
   )
 
   const accountSummaryCountsByAccountId = useMemo(() => {
@@ -1164,6 +1169,7 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     baseFilteredModels,
     allProvidersFilteredCount: baseFilteredModels.length,
     getProviderFilteredCount,
+    getFilteredModels,
     getFilteredResultCount,
     availableGroups,
     availableAccountGroupsByAccountId,

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -10,6 +10,7 @@ import {
   type ModelManagementSource,
 } from "~/features/ModelList/modelManagementSources"
 import {
+  isModelListPriceSortMode,
   MODEL_LIST_SORT_MODES,
   type ModelListSortMode,
 } from "~/features/ModelList/sortModes"
@@ -1120,26 +1121,24 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
       return a.index - b.index
     }
 
-    const sortedWithIndices =
-      sortMode === MODEL_LIST_SORT_MODES.DEFAULT
-        ? indexedItems
-        : (() => {
-            const pricedItems = indexedItems
-              .filter(
-                (
-                  item,
-                ): item is (typeof indexedItems)[number] & {
-                  priceKey: ComparablePriceKey
-                } => !!item.priceKey && hasComparablePriceValue(item.priceKey),
-              )
-              .sort(comparePricedRows)
-
-            const missingPriceItems = indexedItems.filter(
-              (item) =>
-                !item.priceKey || !hasComparablePriceValue(item.priceKey),
+    const sortedWithIndices = !isModelListPriceSortMode(sortMode)
+      ? indexedItems
+      : (() => {
+          const pricedItems = indexedItems
+            .filter(
+              (
+                item,
+              ): item is (typeof indexedItems)[number] & {
+                priceKey: ComparablePriceKey
+              } => !!item.priceKey && hasComparablePriceValue(item.priceKey),
             )
-            return [...pricedItems, ...missingPriceItems]
-          })()
+            .sort(comparePricedRows)
+
+          const missingPriceItems = indexedItems.filter(
+            (item) => !item.priceKey || !hasComparablePriceValue(item.priceKey),
+          )
+          return [...pricedItems, ...missingPriceItems]
+        })()
 
     return sortedWithIndices.map(({ item, itemKey }) => ({
       ...item,

--- a/src/features/ModelList/hooks/useModelListData.ts
+++ b/src/features/ModelList/hooks/useModelListData.ts
@@ -21,7 +21,7 @@ import {
   toProfileSourceValue,
   type ModelManagementSource,
 } from "../modelManagementSources"
-import { MODEL_LIST_SORT_MODES } from "../sortModes"
+import { isModelListPriceSortMode, MODEL_LIST_SORT_MODES } from "../sortModes"
 import { useFilteredModels } from "./useFilteredModels"
 import { useModelData } from "./useModelData"
 import { useModelListState } from "./useModelListState"
@@ -233,7 +233,7 @@ export function useModelListData(routeParams?: Record<string, string>) {
 
   useEffect(() => {
     if (!sourceCapabilities.supportsPricing) {
-      if (sortMode !== MODEL_LIST_SORT_MODES.DEFAULT) {
+      if (isModelListPriceSortMode(sortMode)) {
         setSortMode(MODEL_LIST_SORT_MODES.DEFAULT)
       }
       return

--- a/src/features/ModelList/hooks/useModelListState.ts
+++ b/src/features/ModelList/hooks/useModelListState.ts
@@ -5,6 +5,10 @@ import {
   type ModelListSortMode,
 } from "~/features/ModelList/sortModes"
 import {
+  DEFAULT_MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+  type ModelListVerificationResultFilter,
+} from "~/features/ModelList/verificationResultFilters"
+import {
   MODEL_PROVIDER_FILTER_VALUES,
   type ModelProviderFilterValue,
 } from "~/services/models/utils/modelProviders"
@@ -37,6 +41,10 @@ export function useModelListState() {
   ] = useState<Record<string, string[]>>({}) // "所有账号"模式下按账号排除的分组；空对象表示所有账号都保留全部可用分组
   const [allAccountsFilterAccountIds, setAllAccountsFilterAccountIds] =
     useState<string[]>([]) // 在"所有账号"模式下用于临时筛选一个或多个账号
+  const [selectedVerificationResults, setSelectedVerificationResults] =
+    useState<ModelListVerificationResultFilter[]>(
+      DEFAULT_MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+    )
 
   // 显示选项
   const [showRealPrice, setShowRealPrice] = useState(false) // 是否显示真实价格
@@ -60,6 +68,8 @@ export function useModelListState() {
     setAllAccountsExcludedGroupsByAccountId,
     allAccountsFilterAccountIds,
     setAllAccountsFilterAccountIds,
+    selectedVerificationResults,
+    setSelectedVerificationResults,
     showRealPrice,
     setShowRealPrice,
     showRatioColumn,

--- a/src/features/ModelList/sortModes.ts
+++ b/src/features/ModelList/sortModes.ts
@@ -3,7 +3,17 @@ export const MODEL_LIST_SORT_MODES = {
   PRICE_ASC: "price-asc",
   PRICE_DESC: "price-desc",
   MODEL_CHEAPEST_FIRST: "model-cheapest-first",
+  VERIFICATION_LATENCY_ASC: "verification-latency-asc",
 } as const
 
 export type ModelListSortMode =
   (typeof MODEL_LIST_SORT_MODES)[keyof typeof MODEL_LIST_SORT_MODES]
+
+/** Returns true when the sort mode depends on model pricing metadata. */
+export function isModelListPriceSortMode(sortMode: ModelListSortMode) {
+  return (
+    sortMode === MODEL_LIST_SORT_MODES.PRICE_ASC ||
+    sortMode === MODEL_LIST_SORT_MODES.PRICE_DESC ||
+    sortMode === MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST
+  )
+}

--- a/src/features/ModelList/verificationResultFilters.ts
+++ b/src/features/ModelList/verificationResultFilters.ts
@@ -1,0 +1,102 @@
+import {
+  getModelItemKey,
+  type CalculatedModelItem,
+} from "~/features/ModelList/hooks/useFilteredModels"
+import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
+import {
+  createAccountModelVerificationHistoryTarget,
+  createProfileModelVerificationHistoryTarget,
+  getVerificationSummaryLatencyMs,
+  serializeVerificationHistoryTarget,
+  type ApiVerificationHistorySummary,
+} from "~/services/verification/verificationResultHistory"
+
+export const MODEL_LIST_VERIFICATION_RESULT_FILTERS = {
+  PASS: "pass",
+  FAIL: "fail",
+  UNVERIFIED: "unverified",
+} as const
+
+export type ModelListVerificationResultFilter =
+  (typeof MODEL_LIST_VERIFICATION_RESULT_FILTERS)[keyof typeof MODEL_LIST_VERIFICATION_RESULT_FILTERS]
+
+export const DEFAULT_MODEL_LIST_VERIFICATION_RESULT_FILTERS = Object.values(
+  MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+)
+
+/** Builds the verification history lookup key for a model-list row. */
+function getVerificationSummaryKeyForModelItem(item: CalculatedModelItem) {
+  const modelId = item.model.model_name?.trim()
+  if (!modelId) return null
+
+  const historyTarget =
+    item.source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE
+      ? createProfileModelVerificationHistoryTarget(
+          item.source.profile.id,
+          modelId,
+        )
+      : createAccountModelVerificationHistoryTarget(
+          item.source.account.id,
+          modelId,
+        )
+
+  return historyTarget
+    ? serializeVerificationHistoryTarget(historyTarget)
+    : null
+}
+
+/** Applies verification-result filtering and optional latency sorting. */
+export function applyVerificationResultView(
+  models: CalculatedModelItem[],
+  params: {
+    selectedResults: ModelListVerificationResultFilter[]
+    shouldSortByLatency: boolean
+    verificationSummariesByKey: Record<string, ApiVerificationHistorySummary>
+  },
+) {
+  const selectedResultSet = new Set(params.selectedResults)
+  const indexedModels = models.map((item, index) => {
+    const summaryKey = getVerificationSummaryKeyForModelItem(item)
+    const summary = summaryKey
+      ? params.verificationSummariesByKey[summaryKey]
+      : undefined
+
+    return {
+      item,
+      index,
+      itemKey: getModelItemKey(item),
+      result:
+        summary?.status ?? MODEL_LIST_VERIFICATION_RESULT_FILTERS.UNVERIFIED,
+      latencyMs: getVerificationSummaryLatencyMs(summary),
+    }
+  })
+
+  const filteredModels = indexedModels.filter((entry) =>
+    selectedResultSet.has(entry.result),
+  )
+
+  if (!params.shouldSortByLatency) {
+    return filteredModels.map(({ item }) => item)
+  }
+
+  return [...filteredModels]
+    .sort((a, b) => {
+      if (
+        a.latencyMs !== null &&
+        b.latencyMs !== null &&
+        a.latencyMs !== b.latencyMs
+      ) {
+        return a.latencyMs - b.latencyMs
+      }
+
+      if (a.latencyMs !== null) return -1
+      if (b.latencyMs !== null) return 1
+
+      if (a.itemKey !== b.itemKey) {
+        return a.index - b.index
+      }
+
+      return a.index - b.index
+    })
+    .map(({ item }) => item)
+}

--- a/src/features/ModelList/verificationResultFilters.ts
+++ b/src/features/ModelList/verificationResultFilters.ts
@@ -89,12 +89,8 @@ export function applyVerificationResultView(
         return a.latencyMs - b.latencyMs
       }
 
-      if (a.latencyMs !== null) return -1
-      if (b.latencyMs !== null) return 1
-
-      if (a.itemKey !== b.itemKey) {
-        return a.index - b.index
-      }
+      if (a.latencyMs !== null && b.latencyMs === null) return -1
+      if (a.latencyMs === null && b.latencyMs !== null) return 1
 
       return a.index - b.index
     })

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -204,7 +204,8 @@
     "default": "Default Order",
     "modelCheapestFirst": "Cheapest First Per Model",
     "priceAsc": "Price: Low to High",
-    "priceDesc": "Price: High to Low"
+    "priceDesc": "Price: High to Low",
+    "verificationLatencyAsc": "Test latency: Low to High"
   },
   "sourceLabels": {
     "profileBadge": "Profile: {{name}} · {{host}}",
@@ -256,5 +257,15 @@
     "officialPriceMissing": "This model is not in the price table.",
     "pricingSourceUnavailable": "Price data is unavailable for this source."
   },
-  "userGroup": "User Group"
+  "userGroup": "User Group",
+  "verificationResults": {
+    "all": "All test results",
+    "filters": {
+      "fail": "Failed",
+      "pass": "Passed",
+      "unverified": "Untested"
+    },
+    "label": "Test result",
+    "none": "No test results selected"
+  }
 }

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -197,7 +197,8 @@
     "default": "デフォルト順",
     "modelCheapestFirst": "同一モデルの最安値を優先",
     "priceAsc": "価格の安い順",
-    "priceDesc": "価格の高い順"
+    "priceDesc": "価格の高い順",
+    "verificationLatencyAsc": "テスト遅延の低い順"
   },
   "sourceLabels": {
     "profileBadge": "プロファイル: {{name}} · {{host}}",
@@ -248,5 +249,15 @@
     "officialPriceMissing": "このモデルは料金表にありません。",
     "pricingSourceUnavailable": "このソースの料金データは利用できません。"
   },
-  "userGroup": "ユーザーグループ"
+  "userGroup": "ユーザーグループ",
+  "verificationResults": {
+    "all": "すべてのテスト結果",
+    "filters": {
+      "fail": "失敗",
+      "pass": "成功",
+      "unverified": "未テスト"
+    },
+    "label": "テスト結果",
+    "none": "テスト結果が選択されていません"
+  }
 }

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -197,7 +197,8 @@
     "default": "Thứ tự mặc định",
     "modelCheapestFirst": "Ưu tiên giá thấp nhất của cùng mô hình",
     "priceAsc": "Giá từ thấp đến cao",
-    "priceDesc": "Giá từ cao xuống thấp"
+    "priceDesc": "Giá từ cao xuống thấp",
+    "verificationLatencyAsc": "Độ trễ kiểm thử từ thấp đến cao"
   },
   "sourceLabels": {
     "profileBadge": "Thông tin xác thực: {{name}} · {{host}}",
@@ -248,5 +249,15 @@
     "officialPriceMissing": "Mô hình này không có trong bảng giá.",
     "pricingSourceUnavailable": "Dữ liệu giá không khả dụng cho nguồn này."
   },
-  "userGroup": "Nhóm người dùng"
+  "userGroup": "Nhóm người dùng",
+  "verificationResults": {
+    "all": "Tất cả kết quả kiểm thử",
+    "filters": {
+      "fail": "Thất bại",
+      "pass": "Thành công",
+      "unverified": "Chưa kiểm thử"
+    },
+    "label": "Kết quả kiểm thử",
+    "none": "Chưa chọn kết quả kiểm thử"
+  }
 }

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -197,7 +197,8 @@
     "default": "默认顺序",
     "modelCheapestFirst": "同模型最低价优先",
     "priceAsc": "价格从低到高",
-    "priceDesc": "价格从高到低"
+    "priceDesc": "价格从高到低",
+    "verificationLatencyAsc": "测试延迟从低到高"
   },
   "sourceLabels": {
     "profileBadge": "凭据：{{name}} · {{host}}",
@@ -248,5 +249,15 @@
     "officialPriceMissing": "此模型不在价格表中。",
     "pricingSourceUnavailable": "此来源的价格数据不可用。"
   },
-  "userGroup": "用户分组"
+  "userGroup": "用户分组",
+  "verificationResults": {
+    "all": "全部测试结果",
+    "filters": {
+      "fail": "失败",
+      "pass": "成功",
+      "unverified": "未测试"
+    },
+    "label": "测试结果",
+    "none": "未选择测试结果"
+  }
 }

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -197,7 +197,8 @@
     "default": "預設順序",
     "modelCheapestFirst": "同模型最低價優先",
     "priceAsc": "價格由低到高",
-    "priceDesc": "價格由高到低"
+    "priceDesc": "價格由高到低",
+    "verificationLatencyAsc": "測試延遲由低到高"
   },
   "sourceLabels": {
     "profileBadge": "憑據：{{name}} · {{host}}",
@@ -248,5 +249,15 @@
     "officialPriceMissing": "此模型不在價格表中。",
     "pricingSourceUnavailable": "此來源的價格資料不可用。"
   },
-  "userGroup": "使用者分組"
+  "userGroup": "使用者分組",
+  "verificationResults": {
+    "all": "全部測試結果",
+    "filters": {
+      "fail": "失敗",
+      "pass": "成功",
+      "unverified": "未測試"
+    },
+    "label": "測試結果",
+    "none": "未選擇測試結果"
+  }
 }

--- a/src/services/verification/verificationResultHistory/index.ts
+++ b/src/services/verification/verificationResultHistory/index.ts
@@ -18,6 +18,7 @@ export {
   createProfileVerificationHistoryTarget,
   createVerificationHistorySummary,
   deriveVerificationHistoryStatus,
+  getVerificationSummaryLatencyMs,
   serializeVerificationHistoryTarget,
   toPersistedProbeSummary,
 } from "./utils"

--- a/src/services/verification/verificationResultHistory/utils.ts
+++ b/src/services/verification/verificationResultHistory/utils.ts
@@ -234,6 +234,20 @@ export function toPersistedProbeSummary(
   }
 }
 
+/** Sums persisted probe latencies into the user-visible verification latency. */
+export function getVerificationSummaryLatencyMs(
+  summary?: ApiVerificationHistorySummary | null,
+) {
+  if (!summary) return null
+
+  const latencyMs = summary.probes.reduce(
+    (total, probe) => total + (probe.latencyMs || 0),
+    0,
+  )
+
+  return Number.isFinite(latencyMs) && latencyMs > 0 ? latencyMs : null
+}
+
 /**
  * Creates a sanitized verification history summary from probe results.
  * @param params - Verification history inputs for a completed run.

--- a/tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
@@ -110,8 +110,12 @@ describe("ControlPanel profile capabilities", () => {
     expect(
       await screen.findByText("modelList:sortOptions.verificationLatencyAsc"),
     ).toBeInTheDocument()
-    expect(sortSelect).not.toHaveTextContent("modelList:sortOptions.priceAsc")
-    expect(sortSelect).not.toHaveTextContent("modelList:sortOptions.priceDesc")
+    expect(
+      screen.queryByText("modelList:sortOptions.priceAsc"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("modelList:sortOptions.priceDesc"),
+    ).not.toBeInTheDocument()
     expect(
       await screen.findByText("modelList:endpointTypes"),
     ).toBeInTheDocument()
@@ -166,8 +170,12 @@ describe("ControlPanel profile capabilities", () => {
     expect(
       await screen.findByText("modelList:sortOptions.verificationLatencyAsc"),
     ).toBeInTheDocument()
-    expect(sortSelect).not.toHaveTextContent("modelList:sortOptions.priceAsc")
-    expect(sortSelect).not.toHaveTextContent("modelList:sortOptions.priceDesc")
+    expect(
+      screen.queryByText("modelList:sortOptions.priceAsc"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("modelList:sortOptions.priceDesc"),
+    ).not.toBeInTheDocument()
   })
 
   it("keeps pricing controls but hides the ratio toggle when ratio display is unsupported", async () => {

--- a/tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
@@ -104,8 +104,14 @@ describe("ControlPanel profile capabilities", () => {
     expect(screen.queryByText("modelList:userGroup")).not.toBeInTheDocument()
     expect(screen.queryByText("modelList:realAmount")).not.toBeInTheDocument()
     expect(screen.queryByText("modelList:showRatio")).not.toBeInTheDocument()
-    expect(screen.queryByText("modelList:sortBy")).not.toBeInTheDocument()
     expect(screen.queryByText("modelList:billingMode")).not.toBeInTheDocument()
+    const [sortSelect] = await screen.findAllByRole("combobox")
+    fireEvent.click(sortSelect)
+    expect(
+      await screen.findByText("modelList:sortOptions.verificationLatencyAsc"),
+    ).toBeInTheDocument()
+    expect(sortSelect).not.toHaveTextContent("modelList:sortOptions.priceAsc")
+    expect(sortSelect).not.toHaveTextContent("modelList:sortOptions.priceDesc")
     expect(
       await screen.findByText("modelList:endpointTypes"),
     ).toBeInTheDocument()
@@ -152,10 +158,16 @@ describe("ControlPanel profile capabilities", () => {
       await screen.findByText("modelList:searchModels"),
     ).toBeInTheDocument()
     expect(screen.queryByText("modelList:userGroup")).not.toBeInTheDocument()
-    expect(screen.queryByText("modelList:sortBy")).not.toBeInTheDocument()
     expect(screen.queryByText("modelList:billingMode")).not.toBeInTheDocument()
     expect(screen.queryByText("modelList:realAmount")).not.toBeInTheDocument()
     expect(screen.queryByText("modelList:showRatio")).not.toBeInTheDocument()
+    const [sortSelect] = await screen.findAllByRole("combobox")
+    fireEvent.click(sortSelect)
+    expect(
+      await screen.findByText("modelList:sortOptions.verificationLatencyAsc"),
+    ).toBeInTheDocument()
+    expect(sortSelect).not.toHaveTextContent("modelList:sortOptions.priceAsc")
+    expect(sortSelect).not.toHaveTextContent("modelList:sortOptions.priceDesc")
   })
 
   it("keeps pricing controls but hides the ratio toggle when ratio display is unsupported", async () => {
@@ -706,6 +718,7 @@ describe("ControlPanel profile capabilities", () => {
       sortMode: MODEL_LIST_SORT_MODES.DEFAULT,
       selectedBillingMode: MODEL_LIST_BILLING_MODES.TOKEN_BASED,
       selectedGroups: [],
+      selectedVerificationResults: ["pass", "fail", "unverified"],
     })
     expect(trackProductAnalyticsActionCompletedMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ModelList,

--- a/tests/entrypoints/options/pages/ModelList/ModelList.emptyStateActions.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelList.emptyStateActions.test.tsx
@@ -21,6 +21,8 @@ vi.mock("~/services/models/utils/modelProviders", () => ({
 vi.mock("~/services/verification/verificationResultHistory", () => ({
   createAccountModelVerificationHistoryTarget: vi.fn(() => "account-target"),
   createProfileModelVerificationHistoryTarget: vi.fn(() => "profile-target"),
+  serializeVerificationHistoryTarget: vi.fn((target) => String(target)),
+  getVerificationSummaryLatencyMs: vi.fn(() => null),
   useVerificationResultHistorySummaries: vi.fn(() => ({
     summariesByKey: {},
   })),

--- a/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
@@ -11,6 +11,7 @@ import {
   toAihubmixCatalogFallbackCapabilities,
 } from "~/features/ModelList/modelManagementSources"
 import { MODEL_LIST_SORT_MODES } from "~/features/ModelList/sortModes"
+import { DEFAULT_MODEL_LIST_VERIFICATION_RESULT_FILTERS } from "~/features/ModelList/verificationResultFilters"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
@@ -44,6 +45,8 @@ vi.mock("~/services/models/utils/modelProviders", async (importOriginal) => {
 vi.mock("~/services/verification/verificationResultHistory", () => ({
   createAccountModelVerificationHistoryTarget: vi.fn(() => "account-target"),
   createProfileModelVerificationHistoryTarget: vi.fn(() => "profile-target"),
+  serializeVerificationHistoryTarget: vi.fn((target) => String(target)),
+  getVerificationSummaryLatencyMs: vi.fn(() => null),
   useVerificationResultHistorySummaries: vi.fn(() => ({
     summariesByKey: {},
   })),
@@ -281,7 +284,7 @@ vi.mock("~/features/ModelList/components/ModelKeyDialog", () => ({
 }))
 
 function buildState(overrides: Record<string, any> = {}) {
-  return {
+  const state: Record<string, any> = {
     accounts: [ACCOUNT, SECOND_ACCOUNT],
     profiles: [PROFILE],
     selectedSource: ACCOUNT_SOURCE,
@@ -300,6 +303,8 @@ function buildState(overrides: Record<string, any> = {}) {
     setSelectedBillingMode: vi.fn(),
     selectedGroups: [],
     setSelectedGroups: vi.fn(),
+    selectedVerificationResults: DEFAULT_MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+    setSelectedVerificationResults: vi.fn(),
 
     showRealPrice: false,
     setShowRealPrice: vi.fn(),
@@ -338,6 +343,9 @@ function buildState(overrides: Record<string, any> = {}) {
     setAllAccountsFilterAccountIds: mockSetAllAccountsFilterAccountIds,
     ...overrides,
   }
+  state.getFilteredModels ??= vi.fn(() => state.filteredModels)
+
+  return state
 }
 
 describe("ModelList page flows", () => {

--- a/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
@@ -332,6 +332,50 @@ describe("useFilteredModels", () => {
     expect(result.current.getProviderFilteredCount("Gemini")).toBe(1)
   })
 
+  it("estimates filtered models and counts from pending filters", async () => {
+    const account = createDisplayAccount({
+      id: "account-pending-filter-estimate",
+      balance: { USD: 5, CNY: 35 },
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingData: createPricingResponse([
+        {
+          model_name: "gpt-4o-mini",
+          model_description: "Fast OpenAI model",
+          enable_groups: ["default"],
+        },
+        {
+          model_name: "claude-3-5-sonnet",
+          model_description: "Batch reasoning model",
+          enable_groups: ["default"],
+        },
+        {
+          model_name: "gemini-1.5-pro",
+          model_description: "Batch multimodal model",
+          enable_groups: ["default"],
+        },
+      ]),
+      selectedSource: createAccountSource(account),
+      selectedProvider: "Claude",
+    })
+
+    await waitFor(() =>
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual(["claude-3-5-sonnet"]),
+    )
+
+    expect(
+      result.current
+        .getFilteredModels({ searchTerm: "batch" })
+        .map((item) => item.model.model_name),
+    ).toEqual(["claude-3-5-sonnet"])
+    expect(result.current.getFilteredResultCount({ searchTerm: "batch" })).toBe(
+      1,
+    )
+  })
+
   it("skips malformed account pricing payloads while keeping valid account models and groups", async () => {
     const accountA = createDisplayAccount({
       id: "account-valid",

--- a/tests/features/ModelList/ModelList.test.tsx
+++ b/tests/features/ModelList/ModelList.test.tsx
@@ -75,7 +75,27 @@ vi.mock("~/features/ModelList/components/BatchVerifyModelsDialog", () => ({
 }))
 
 vi.mock("~/features/ModelList/components/ControlPanel", () => ({
-  ControlPanel: () => <div data-testid="control-panel" />,
+  ControlPanel: ({
+    getFilteredResultCount,
+  }: {
+    getFilteredResultCount?: (filters: {
+      searchTerm?: string
+      selectedVerificationResults?: string[]
+    }) => number
+  }) => (
+    <button
+      type="button"
+      data-testid="control-panel"
+      onClick={() =>
+        getFilteredResultCount?.({
+          searchTerm: "target",
+          selectedVerificationResults: ["pass"],
+        })
+      }
+    >
+      control-panel
+    </button>
+  ),
 }))
 
 vi.mock("~/features/ModelList/components/Footer", () => ({
@@ -333,5 +353,44 @@ describe("ModelList", () => {
       "gpt-test",
     )
     expect(screen.getByTestId("verify-api-dialog")).toHaveTextContent("vip")
+  })
+
+  it("estimates verification result counts from pending base filters", async () => {
+    const user = userEvent.setup()
+    const getFilteredModels = vi.fn((filters?: { searchTerm?: string }) => {
+      const matchingModelName =
+        filters?.searchTerm === "target" ? "gpt-target" : "gpt-other"
+      return [
+        {
+          model: {
+            model_name: matchingModelName,
+            quota_type: 0,
+            model_ratio: 1,
+            model_price: 0,
+            completion_ratio: 1,
+            enable_groups: ["vip"],
+            supported_endpoint_types: [],
+          },
+          source: ACCOUNT_SOURCE,
+          calculatedPrice: {},
+          groupRatios: {},
+        },
+      ]
+    })
+
+    mockUseModelListData.mockReturnValue({
+      ...createModelListData(),
+      filteredModels: getFilteredModels(),
+      getFilteredModels,
+      getFilteredResultCount: vi.fn(() => 1),
+    })
+
+    render(<ModelList />)
+
+    await user.click(screen.getByTestId("control-panel"))
+
+    expect(getFilteredModels).toHaveBeenCalledWith({
+      searchTerm: "target",
+    })
   })
 })

--- a/tests/features/ModelList/ModelList.test.tsx
+++ b/tests/features/ModelList/ModelList.test.tsx
@@ -83,18 +83,31 @@ vi.mock("~/features/ModelList/components/ControlPanel", () => ({
       selectedVerificationResults?: string[]
     }) => number
   }) => (
-    <button
-      type="button"
-      data-testid="control-panel"
-      onClick={() =>
-        getFilteredResultCount?.({
-          searchTerm: "target",
-          selectedVerificationResults: ["pass"],
-        })
-      }
-    >
-      control-panel
-    </button>
+    <div>
+      <button
+        type="button"
+        data-testid="control-panel"
+        onClick={() =>
+          getFilteredResultCount?.({
+            searchTerm: "target",
+            selectedVerificationResults: ["pass"],
+          })
+        }
+      >
+        control-panel
+      </button>
+      <button
+        type="button"
+        data-testid="base-count-control"
+        onClick={() =>
+          getFilteredResultCount?.({
+            searchTerm: "target",
+          })
+        }
+      >
+        base-count-control
+      </button>
+    </div>
   ),
 }))
 
@@ -392,5 +405,26 @@ describe("ModelList", () => {
     expect(getFilteredModels).toHaveBeenCalledWith({
       searchTerm: "target",
     })
+  })
+
+  it("uses the base count for non-verification result estimates", async () => {
+    const user = userEvent.setup()
+    const getFilteredModels = vi.fn(() => [])
+    const getFilteredResultCount = vi.fn(() => 3)
+
+    mockUseModelListData.mockReturnValue({
+      ...createModelListData(),
+      getFilteredModels,
+      getFilteredResultCount,
+    })
+
+    render(<ModelList />)
+
+    await user.click(screen.getByTestId("base-count-control"))
+
+    expect(getFilteredResultCount).toHaveBeenCalledWith({
+      searchTerm: "target",
+    })
+    expect(getFilteredModels).not.toHaveBeenCalled()
   })
 })

--- a/tests/features/ModelList/components/ControlPanel.test.tsx
+++ b/tests/features/ModelList/components/ControlPanel.test.tsx
@@ -377,6 +377,23 @@ describe("ControlPanel", () => {
     ])
   })
 
+  it("keeps verification result filters interactive when the setter is omitted", async () => {
+    const user = userEvent.setup()
+
+    renderControlPanel({
+      setSelectedVerificationResults: undefined,
+    })
+
+    await user.click(screen.getByLabelText("verificationResults.filters.fail"))
+
+    expect(trackProductAnalyticsActionCompletedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: PRODUCT_ANALYTICS_ACTION_IDS.FilterModelList,
+        result: PRODUCT_ANALYTICS_RESULTS.Success,
+      }),
+    )
+  })
+
   it("keeps the search field usable when all top filters are visible", () => {
     renderControlPanel()
 

--- a/tests/features/ModelList/components/ControlPanel.test.tsx
+++ b/tests/features/ModelList/components/ControlPanel.test.tsx
@@ -12,6 +12,10 @@ import {
 } from "~/features/ModelList/modelManagementSources"
 import { MODEL_LIST_SORT_MODES } from "~/features/ModelList/sortModes"
 import {
+  DEFAULT_MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+  MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+} from "~/features/ModelList/verificationResultFilters"
+import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_RESULTS,
 } from "~/services/productAnalytics/events"
@@ -87,7 +91,36 @@ vi.mock("~/components/ui", () => ({
     <div {...props}>{children}</div>
   ),
   CardContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-  CompactMultiSelect: () => <div data-testid="group-filter" />,
+  CompactMultiSelect: ({
+    options,
+    selected,
+    onChange,
+    placeholder,
+  }: {
+    options: Array<{ value: string; label: string }>
+    selected: string[]
+    onChange: (selected: string[]) => void
+    placeholder?: string
+  }) => (
+    <div data-testid={placeholder}>
+      {options.map((option) => (
+        <label key={option.value}>
+          {option.label}
+          <input
+            type="checkbox"
+            checked={selected.includes(option.value)}
+            onChange={(event) => {
+              onChange(
+                event.target.checked
+                  ? [...selected, option.value]
+                  : selected.filter((value) => value !== option.value),
+              )
+            }}
+          />
+        </label>
+      ))}
+    </div>
+  ),
   FormField: ({
     label,
     children,
@@ -183,6 +216,8 @@ function renderControlPanel(
     setSearchTerm: vi.fn(),
     sortMode: MODEL_LIST_SORT_MODES.DEFAULT,
     setSortMode: vi.fn(),
+    selectedVerificationResults: DEFAULT_MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+    setSelectedVerificationResults: vi.fn(),
     selectedBillingMode: MODEL_LIST_BILLING_MODES.TOKEN_BASED,
     setSelectedBillingMode: vi.fn(),
     selectedGroups: ["vip"],
@@ -303,5 +338,24 @@ describe("ControlPanel", () => {
     expect(
       screen.queryByRole("button", { name: "comparison.cta" }),
     ).not.toBeInTheDocument()
+  })
+
+  it("offers latest verification latency sorting and result status filters", async () => {
+    const user = userEvent.setup()
+    const props = renderControlPanel()
+
+    await user.selectOptions(
+      screen.getByLabelText("sortBy"),
+      MODEL_LIST_SORT_MODES.VERIFICATION_LATENCY_ASC,
+    )
+    expect(props.setSortMode).toHaveBeenCalledWith(
+      MODEL_LIST_SORT_MODES.VERIFICATION_LATENCY_ASC,
+    )
+
+    await user.click(screen.getByLabelText("verificationResults.filters.fail"))
+    expect(props.setSelectedVerificationResults).toHaveBeenCalledWith([
+      MODEL_LIST_VERIFICATION_RESULT_FILTERS.PASS,
+      MODEL_LIST_VERIFICATION_RESULT_FILTERS.UNVERIFIED,
+    ])
   })
 })

--- a/tests/features/ModelList/components/ControlPanel.test.tsx
+++ b/tests/features/ModelList/components/ControlPanel.test.tsx
@@ -96,13 +96,15 @@ vi.mock("~/components/ui", () => ({
     selected,
     onChange,
     placeholder,
+    size = "sm",
   }: {
     options: Array<{ value: string; label: string }>
     selected: string[]
     onChange: (selected: string[]) => void
     placeholder?: string
+    size?: string
   }) => (
-    <div data-testid={placeholder}>
+    <div data-size={size} data-testid={placeholder}>
       {options.map((option) => (
         <label key={option.value}>
           {option.label}
@@ -124,8 +126,9 @@ vi.mock("~/components/ui", () => ({
   FormField: ({
     label,
     children,
-  }: React.PropsWithChildren<{ label: string }>) => (
-    <label>
+    className,
+  }: React.PropsWithChildren<{ label: string; className?: string }>) => (
+    <label data-testid={`field-${label}`} className={className}>
       {label}
       {children}
     </label>
@@ -357,5 +360,24 @@ describe("ControlPanel", () => {
       MODEL_LIST_VERIFICATION_RESULT_FILTERS.PASS,
       MODEL_LIST_VERIFICATION_RESULT_FILTERS.UNVERIFIED,
     ])
+  })
+
+  it("keeps the search field usable when all top filters are visible", () => {
+    renderControlPanel()
+
+    expect(screen.getByTestId("model-list-filter-row")).toHaveClass(
+      "lg:flex-wrap",
+    )
+    expect(screen.getByTestId("field-searchModels")).toHaveClass(
+      "min-w-[16rem]",
+    )
+    expect(screen.getByTestId("allGroups")).toHaveAttribute(
+      "data-size",
+      "default",
+    )
+    expect(screen.getByTestId("verificationResults.all")).toHaveAttribute(
+      "data-size",
+      "default",
+    )
   })
 })

--- a/tests/features/ModelList/components/ControlPanel.test.tsx
+++ b/tests/features/ModelList/components/ControlPanel.test.tsx
@@ -343,6 +343,21 @@ describe("ControlPanel", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("keeps verification latency sorting available when pricing is unavailable", () => {
+    renderControlPanel({
+      sourceCapabilities: {
+        ...CAPABILITIES,
+        supportsPricing: false,
+      },
+    })
+
+    const sortSelect = screen.getByLabelText("sortBy")
+    expect(sortSelect).toHaveTextContent("sortOptions.default")
+    expect(sortSelect).toHaveTextContent("sortOptions.verificationLatencyAsc")
+    expect(sortSelect).not.toHaveTextContent("sortOptions.priceAsc")
+    expect(sortSelect).not.toHaveTextContent("sortOptions.priceDesc")
+  })
+
   it("offers latest verification latency sorting and result status filters", async () => {
     const user = userEvent.setup()
     const props = renderControlPanel()

--- a/tests/features/ModelList/verificationResultFilters.test.ts
+++ b/tests/features/ModelList/verificationResultFilters.test.ts
@@ -143,4 +143,60 @@ describe("model list verification result view", () => {
       "gpt-unverified",
     ])
   })
+
+  it("returns no rows when no verification statuses are selected", () => {
+    const result = applyVerificationResultView(
+      [createModelItem("gpt-pass"), createModelItem("gpt-unverified")],
+      {
+        selectedResults: [],
+        shouldSortByLatency: false,
+        verificationSummariesByKey: {},
+      },
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it("keeps original order for equal latency and places null latency last", () => {
+    const alphaSummary = createSummary("gpt-alpha", {
+      status: "pass",
+      latencies: [50],
+    })
+    const betaSummary = createSummary("gpt-beta", {
+      status: "pass",
+      latencies: [50],
+    })
+    const nullLatencySummary = createSummary("gpt-null", {
+      status: "pass",
+      latencies: [],
+    })
+
+    const result = applyVerificationResultView(
+      [
+        createModelItem("gpt-alpha"),
+        createModelItem("gpt-null"),
+        createModelItem("gpt-beta"),
+        createModelItem("gpt-unverified"),
+      ],
+      {
+        selectedResults: [
+          MODEL_LIST_VERIFICATION_RESULT_FILTERS.PASS,
+          MODEL_LIST_VERIFICATION_RESULT_FILTERS.UNVERIFIED,
+        ],
+        shouldSortByLatency: true,
+        verificationSummariesByKey: {
+          [alphaSummary.targetKey]: alphaSummary,
+          [betaSummary.targetKey]: betaSummary,
+          [nullLatencySummary.targetKey]: nullLatencySummary,
+        },
+      },
+    )
+
+    expect(result.map((item) => item.model.model_name)).toEqual([
+      "gpt-alpha",
+      "gpt-beta",
+      "gpt-null",
+      "gpt-unverified",
+    ])
+  })
 })

--- a/tests/features/ModelList/verificationResultFilters.test.ts
+++ b/tests/features/ModelList/verificationResultFilters.test.ts
@@ -37,6 +37,17 @@ function createModelItem(modelName: string) {
   } as any
 }
 
+function createProfileModelItem(modelName: string) {
+  return {
+    ...createModelItem(modelName),
+    source: {
+      kind: "profile",
+      profile: { id: "profile-1", name: "Profile One" },
+      capabilities: {},
+    },
+  } as any
+}
+
 function createSummary(
   modelName: string,
   params: { status: "pass" | "fail"; latencies: number[] },
@@ -155,6 +166,31 @@ describe("model list verification result view", () => {
     )
 
     expect(result).toEqual([])
+  })
+
+  it("treats rows without a model id as unverified", () => {
+    const result = applyVerificationResultView([createModelItem(" ")], {
+      selectedResults: [MODEL_LIST_VERIFICATION_RESULT_FILTERS.UNVERIFIED],
+      shouldSortByLatency: false,
+      verificationSummariesByKey: {},
+    })
+
+    expect(result).toHaveLength(1)
+  })
+
+  it("treats profile rows without a stored summary as unverified", () => {
+    const result = applyVerificationResultView(
+      [createProfileModelItem("profile-model")],
+      {
+        selectedResults: [MODEL_LIST_VERIFICATION_RESULT_FILTERS.UNVERIFIED],
+        shouldSortByLatency: false,
+        verificationSummariesByKey: {},
+      },
+    )
+
+    expect(result.map((item) => item.model.model_name)).toEqual([
+      "profile-model",
+    ])
   })
 
   it("keeps original order for equal latency and places null latency last", () => {

--- a/tests/features/ModelList/verificationResultFilters.test.ts
+++ b/tests/features/ModelList/verificationResultFilters.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  applyVerificationResultView,
+  MODEL_LIST_VERIFICATION_RESULT_FILTERS,
+} from "~/features/ModelList/verificationResultFilters"
+import {
+  createAccountModelVerificationHistoryTarget,
+  serializeVerificationHistoryTarget,
+  type ApiVerificationHistorySummary,
+} from "~/services/verification/verificationResultHistory"
+
+const account = {
+  id: "account-1",
+  name: "Account One",
+  baseUrl: "https://api.example.invalid",
+  siteType: SITE_TYPES.NEW_API,
+} as any
+
+function createModelItem(modelName: string) {
+  return {
+    model: {
+      model_name: modelName,
+      quota_type: 0,
+      model_ratio: 1,
+      completion_ratio: 1,
+      enable_groups: ["default"],
+    },
+    calculatedPrice: {},
+    source: {
+      kind: "account",
+      account,
+      capabilities: {},
+    },
+    groupRatios: {},
+  } as any
+}
+
+function createSummary(
+  modelName: string,
+  params: { status: "pass" | "fail"; latencies: number[] },
+) {
+  const target = createAccountModelVerificationHistoryTarget(
+    account.id,
+    modelName,
+  )
+  if (!target) {
+    throw new Error("Expected account model verification target")
+  }
+
+  return {
+    target,
+    targetKey: serializeVerificationHistoryTarget(target),
+    status: params.status,
+    verifiedAt: 1,
+    apiType: "openai-compatible",
+    probes: params.latencies.map((latencyMs, index) => ({
+      id: index === 0 ? "text-generation" : "models",
+      status: params.status,
+      latencyMs,
+      summary: "",
+    })),
+  } as ApiVerificationHistorySummary
+}
+
+describe("model list verification result view", () => {
+  it("filters rows by selected verification result statuses", () => {
+    const passSummary = createSummary("gpt-pass", {
+      status: "pass",
+      latencies: [120],
+    })
+    const failSummary = createSummary("gpt-fail", {
+      status: "fail",
+      latencies: [80],
+    })
+
+    const result = applyVerificationResultView(
+      [
+        createModelItem("gpt-pass"),
+        createModelItem("gpt-fail"),
+        createModelItem("gpt-unverified"),
+      ],
+      {
+        selectedResults: [
+          MODEL_LIST_VERIFICATION_RESULT_FILTERS.PASS,
+          MODEL_LIST_VERIFICATION_RESULT_FILTERS.UNVERIFIED,
+        ],
+        shouldSortByLatency: false,
+        verificationSummariesByKey: {
+          [passSummary.targetKey]: passSummary,
+          [failSummary.targetKey]: failSummary,
+        },
+      },
+    )
+
+    expect(result.map((item) => item.model.model_name)).toEqual([
+      "gpt-pass",
+      "gpt-unverified",
+    ])
+  })
+
+  it("sorts verified rows by total latest verification latency", () => {
+    const slowSummary = createSummary("gpt-slow", {
+      status: "pass",
+      latencies: [120, 30],
+    })
+    const fastSummary = createSummary("gpt-fast", {
+      status: "pass",
+      latencies: [40],
+    })
+    const failedSummary = createSummary("gpt-failed", {
+      status: "fail",
+      latencies: [70],
+    })
+
+    const result = applyVerificationResultView(
+      [
+        createModelItem("gpt-slow"),
+        createModelItem("gpt-unverified"),
+        createModelItem("gpt-fast"),
+        createModelItem("gpt-failed"),
+      ],
+      {
+        selectedResults: [
+          MODEL_LIST_VERIFICATION_RESULT_FILTERS.PASS,
+          MODEL_LIST_VERIFICATION_RESULT_FILTERS.FAIL,
+          MODEL_LIST_VERIFICATION_RESULT_FILTERS.UNVERIFIED,
+        ],
+        shouldSortByLatency: true,
+        verificationSummariesByKey: {
+          [slowSummary.targetKey]: slowSummary,
+          [fastSummary.targetKey]: fastSummary,
+          [failedSummary.targetKey]: failedSummary,
+        },
+      },
+    )
+
+    expect(result.map((item) => item.model.model_name)).toEqual([
+      "gpt-fast",
+      "gpt-failed",
+      "gpt-slow",
+      "gpt-unverified",
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- add latest verification latency sorting to the model list
- add multi-select verification result filtering for success, failure, and unverified models
- keep the expanded filter toolbar usable by wrapping controls and aligning control heights

Closes #1021

## Test Plan
- pnpm vitest run tests/features/ModelList/verificationResultFilters.test.ts tests/features/ModelList/components/ControlPanel.test.tsx
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added model filtering by verification test results (pass, fail, unverified)
  - Added a new “test latency” sort option (low to high)
  - Verification history summaries now display computed latency when available
  - Batch actions and result counts now reflect the currently displayed (filtered/sorted) models
* **Localization**
  - Added UI text for verification-result filters and latency sorting labels across supported languages
* **Tests**
  - Expanded coverage for verification filtering, latency sorting, and related UI behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->