### PR TITLE
fix(analytics): capture background events directly

### DIFF
--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -31,6 +31,7 @@ import {
 } from "~/types"
 import type { LogLevel } from "~/types/logging"
 import type { ThemeMode } from "~/types/theme"
+import { isExtensionBackground } from "~/utils/browser"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("ProductAnalyticsEvents")
@@ -1274,6 +1275,26 @@ export async function trackProductAnalyticsEvent<
       eventName,
       properties,
     } satisfies ProductAnalyticsTrackRequest<TEventName>
+
+    if (isExtensionBackground()) {
+      void import("~/services/productAnalytics/runtime")
+        .then(({ handleProductAnalyticsMessage }) =>
+          handleProductAnalyticsMessage(
+            ProductAnalyticsMessageTypes.TrackEvent,
+            request as ProductAnalyticsTrackRequestDiscriminated,
+          ),
+        )
+        .then((response) => {
+          if (response.success === false) {
+            logger.warn("Product analytics event dispatch was rejected")
+          }
+        })
+        .catch((error) => {
+          logger.warn("Product analytics event dispatch failed", error)
+        })
+      return true
+    }
+
     void Promise.resolve(
       sendProductAnalyticsMessage(
         ProductAnalyticsMessageTypes.TrackEvent,

--- a/src/utils/browser/extensionPageUrls.ts
+++ b/src/utils/browser/extensionPageUrls.ts
@@ -1,0 +1,4 @@
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { getExtensionURL } from "~/utils/browser/browserApi"
+
+export const OPTIONS_PAGE_URL = getExtensionURL(OPTIONS_PAGE_PATH)

--- a/src/utils/browser/index.ts
+++ b/src/utils/browser/index.ts
@@ -1,5 +1,4 @@
 import {
-  OPTIONS_PAGE_PATH,
   POPUP_PAGE_PATH,
   SIDEPANEL_PAGE_PATH,
 } from "~/constants/extensionPages"
@@ -14,8 +13,6 @@ import {
 
 export { detectBrowserFamily } from "./userAgent"
 
-export const OPTIONS_PAGE_URL = getExtensionURL(OPTIONS_PAGE_PATH)
-
 export type ExtensionStoreId = "chrome" | "edge" | "firefox"
 export { getDeviceTypeInfo, isDesktopDevice, isMobileDevice, isTabletDevice }
 
@@ -29,7 +26,6 @@ export function isFirefoxByUA(): boolean {
     navigator.userAgent.indexOf(" Gecko/") !== -1
   )
 }
-
 /**
  * Checks whether the current extension runtime is Firefox.
  * Relies on the moz-extension protocol prefix exposed by WebExtensions.
@@ -109,7 +105,6 @@ export function isExtensionPopup() {
     return false
   }
 }
-
 /**
  * Determines if the current page is loaded inside the extension side panel.
  * @returns True when sidepanel.html is detected in the URL path.

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -38,11 +38,11 @@ import type {
   TempWindowTurnstileFetchParams,
 } from "~/types/tempWindowFetch"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
+import { OPTIONS_PAGE_URL } from "~/utils/browser/extensionPageUrls"
 import {
   isExtensionBackground,
   isExtensionPopup,
   isExtensionSidePanel,
-  OPTIONS_PAGE_URL,
 } from "~/utils/browser/index"
 import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
 import { safeRandomUUID } from "~/utils/core/identifier"

--- a/src/utils/navigation/index.ts
+++ b/src/utils/navigation/index.ts
@@ -7,7 +7,7 @@ import {
   SITE_ROUTE_KINDS,
 } from "~/services/accounts/utils/siteRouteResolver"
 import type { DisplaySiteData } from "~/types"
-import { isExtensionPopup, OPTIONS_PAGE_URL } from "~/utils/browser"
+import { isExtensionPopup } from "~/utils/browser"
 import {
   openSidePanel as _openSidePanel,
   createTab as createTabApi,
@@ -18,6 +18,7 @@ import {
   queryTabs as queryTabsApi,
   updateTab as updateTabApi,
 } from "~/utils/browser/browserApi"
+import { OPTIONS_PAGE_URL } from "~/utils/browser/extensionPageUrls"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import {

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -102,10 +102,13 @@ vi.mock("~/utils/browser/protectionBypass", () => ({
 }))
 
 vi.mock("~/utils/browser/index", () => ({
-  OPTIONS_PAGE_URL: "chrome-extension://test/options.html",
   isExtensionBackground: vi.fn(() => false),
   isExtensionPopup: vi.fn(() => false),
   isExtensionSidePanel: vi.fn(() => false),
+}))
+
+vi.mock("~/utils/browser/extensionPageUrls", () => ({
+  OPTIONS_PAGE_URL: "chrome-extension://test/options.html",
 }))
 
 const BASE_URL = "https://example.com/base/"

--- a/tests/services/productAnalytics/events.test.ts
+++ b/tests/services/productAnalytics/events.test.ts
@@ -20,6 +20,7 @@ import {
   trackProductAnalyticsEvent,
 } from "~/services/productAnalytics/events"
 import { ProductAnalyticsMessageTypes } from "~/services/productAnalytics/messaging"
+import { setLoggingPreferences } from "~/utils/core/logger"
 
 const {
   handleProductAnalyticsMessageMock,
@@ -49,6 +50,7 @@ vi.mock("~/services/productAnalytics/runtime", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
+  setLoggingPreferences({ consoleEnabled: false, level: "debug" })
   isExtensionBackgroundMock.mockReturnValue(false)
   handleProductAnalyticsMessageMock.mockResolvedValue({ success: true })
   sendProductAnalyticsMessageMock.mockResolvedValue({ success: true })
@@ -419,6 +421,75 @@ describe("trackProductAnalyticsEvent", () => {
       )
     })
     expect(sendProductAnalyticsMessageMock).not.toHaveBeenCalled()
+  })
+
+  it("does not block when direct background analytics capture is rejected", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      setLoggingPreferences({ consoleEnabled: true, level: "debug" })
+      isExtensionBackgroundMock.mockReturnValue(true)
+      handleProductAnalyticsMessageMock.mockResolvedValue({ success: false })
+
+      await expect(
+        trackProductAnalyticsEvent(
+          PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+          {
+            feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteModelSync,
+            action_id:
+              PRODUCT_ANALYTICS_ACTION_IDS.ScheduledManagedSiteModelSync,
+            entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+            result: "success",
+            source_kind: PRODUCT_ANALYTICS_SOURCE_KINDS.Auto,
+          },
+        ),
+      ).resolves.toBe(true)
+
+      await vi.waitFor(() => {
+        expect(warnSpy).toHaveBeenCalledWith(
+          "[Background][ProductAnalyticsEvents] Product analytics event dispatch was rejected",
+        )
+      })
+      expect(sendProductAnalyticsMessageMock).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it("does not block when direct background analytics capture fails asynchronously", async () => {
+    const error = new Error("analytics unavailable")
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      setLoggingPreferences({ consoleEnabled: true, level: "debug" })
+      isExtensionBackgroundMock.mockReturnValue(true)
+      handleProductAnalyticsMessageMock.mockRejectedValue(error)
+
+      await expect(
+        trackProductAnalyticsEvent(
+          PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+          {
+            feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteModelSync,
+            action_id:
+              PRODUCT_ANALYTICS_ACTION_IDS.ScheduledManagedSiteModelSync,
+            entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+            result: "success",
+            source_kind: PRODUCT_ANALYTICS_SOURCE_KINDS.Auto,
+          },
+        ),
+      ).resolves.toBe(true)
+
+      await vi.waitFor(() => {
+        expect(warnSpy).toHaveBeenCalledWith(
+          "[Background][ProductAnalyticsEvents] Product analytics event dispatch failed",
+          expect.objectContaining({
+            message: "analytics unavailable",
+            name: "Error",
+          }),
+        )
+      })
+      expect(sendProductAnalyticsMessageMock).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it("does not wait for an in-flight background analytics response", async () => {

--- a/tests/services/productAnalytics/events.test.ts
+++ b/tests/services/productAnalytics/events.test.ts
@@ -21,8 +21,19 @@ import {
 } from "~/services/productAnalytics/events"
 import { ProductAnalyticsMessageTypes } from "~/services/productAnalytics/messaging"
 
-const { sendProductAnalyticsMessageMock } = vi.hoisted(() => ({
+const {
+  handleProductAnalyticsMessageMock,
+  isExtensionBackgroundMock,
+  sendProductAnalyticsMessageMock,
+} = vi.hoisted(() => ({
+  handleProductAnalyticsMessageMock: vi.fn(),
+  isExtensionBackgroundMock: vi.fn(),
   sendProductAnalyticsMessageMock: vi.fn(),
+}))
+
+vi.mock("~/utils/browser", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/utils/browser")>()),
+  isExtensionBackground: isExtensionBackgroundMock,
 }))
 
 vi.mock("~/services/productAnalytics/messaging", async (importOriginal) => ({
@@ -32,8 +43,14 @@ vi.mock("~/services/productAnalytics/messaging", async (importOriginal) => ({
   sendProductAnalyticsMessage: sendProductAnalyticsMessageMock,
 }))
 
+vi.mock("~/services/productAnalytics/runtime", () => ({
+  handleProductAnalyticsMessage: handleProductAnalyticsMessageMock,
+}))
+
 beforeEach(() => {
   vi.clearAllMocks()
+  isExtensionBackgroundMock.mockReturnValue(false)
+  handleProductAnalyticsMessageMock.mockResolvedValue({ success: true })
   sendProductAnalyticsMessageMock.mockResolvedValue({ success: true })
 })
 
@@ -367,6 +384,41 @@ describe("trackProductAnalyticsEvent", () => {
         },
       },
     )
+  })
+
+  it("captures directly through the product analytics runtime in background contexts", async () => {
+    isExtensionBackgroundMock.mockReturnValue(true)
+
+    await expect(
+      trackProductAnalyticsEvent(
+        PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+        {
+          feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteModelSync,
+          action_id: PRODUCT_ANALYTICS_ACTION_IDS.ScheduledManagedSiteModelSync,
+          entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+          result: "success",
+          source_kind: PRODUCT_ANALYTICS_SOURCE_KINDS.Auto,
+        },
+      ),
+    ).resolves.toBe(true)
+
+    await vi.waitFor(() => {
+      expect(handleProductAnalyticsMessageMock).toHaveBeenCalledWith(
+        ProductAnalyticsMessageTypes.TrackEvent,
+        {
+          eventName: PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
+          properties: {
+            feature_id: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteModelSync,
+            action_id:
+              PRODUCT_ANALYTICS_ACTION_IDS.ScheduledManagedSiteModelSync,
+            entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+            result: "success",
+            source_kind: PRODUCT_ANALYTICS_SOURCE_KINDS.Auto,
+          },
+        },
+      )
+    })
+    expect(sendProductAnalyticsMessageMock).not.toHaveBeenCalled()
   })
 
   it("does not wait for an in-flight background analytics response", async () => {

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -52,6 +52,9 @@ const OPTIONS_PAGE_URL = "http://localhost:3000/options.html"
 
 vi.mock("~/utils/browser", () => ({
   isExtensionPopup: vi.fn().mockReturnValue(false),
+}))
+
+vi.mock("~/utils/browser/extensionPageUrls", () => ({
   OPTIONS_PAGE_URL: "http://localhost:3000/options.html",
 }))
 

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -67,10 +67,13 @@ vi.mock("~/services/preferences/userPreferences", () => ({
 }))
 
 vi.mock("~/utils/browser/index", () => ({
-  OPTIONS_PAGE_URL: "chrome-extension://test/options.html",
   isExtensionBackground: mocks.isExtensionBackgroundMock,
   isExtensionPopup: mocks.isExtensionPopupMock,
   isExtensionSidePanel: mocks.isExtensionSidePanelMock,
+}))
+
+vi.mock("~/utils/browser/extensionPageUrls", () => ({
+  OPTIONS_PAGE_URL: "chrome-extension://test/options.html",
 }))
 
 vi.mock("~/utils/browser/protectionBypass", () => ({


### PR DESCRIPTION
## Summary
- Route product analytics tracking directly through the analytics runtime when already running in the extension background context.
- Preserve the existing runtime message path for popup/options/content/sidepanel entrypoints.
- Add coverage for scheduled managed-site model sync analytics from background contexts.

## Diagnosis
- PostHog data showed background direct-captured events such as settings snapshots and shield bypass summaries exist.
- `feature_action_completed` had no `entrypoint=background` rows, and scheduled managed-site model sync action rows were absent.
- The likely failure path was background code sending a runtime message instead of using the local analytics runtime directly.

## Test Plan
- [x] `pnpm vitest run tests/services/productAnalytics/events.test.ts`
- [x] `pnpm vitest run tests/services/productAnalytics/events.test.ts tests/services/productAnalytics/runtime.test.ts tests/services/productAnalytics/actions.test.ts tests/services/modelSync/scheduler.lifecycle.test.ts tests/services/autoCheckin/scheduler.test.ts`
- [x] `pnpm compile`
- [x] `git diff --check`
- [x] `pnpm run validate:staged`
- [x] `pnpm run validate:push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced product analytics event tracking for extension background execution, using direct runtime handling with best-effort delivery and warning logs on failures.
  * Upgraded browser/extension context detection (Firefox/Edge heuristics) and more reliable identification of extension UI surfaces (side panel and background).
  * Updated options page URL resolution and import wiring across navigation and temp window fetching for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->