### PR TITLE
fix(model-sync): guide disabled auto sync setup

### DIFF
--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -1311,6 +1311,11 @@ export default function ManagedSiteModelSync({
               intervalMs={intervalMs}
               nextScheduledAt={nextScheduledAt}
               lastRunAt={lastExecution?.statistics?.endedAt ?? null}
+              configureAutoSyncAnalyticsAction={{
+                ...actionBarAnalyticsScope,
+                actionId:
+                  PRODUCT_ANALYTICS_ACTION_IDS.OpenManagedSiteModelSyncSettings,
+              }}
               onConfigureAutoSync={() => {
                 void openSettingsTab("managedSite", {
                   preserveHistory: true,

--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -10,6 +10,7 @@ import ManagedSiteTypeSwitcher from "~/components/ManagedSiteTypeSwitcher"
 import { OptionsPageSettingsTitleAction } from "~/components/OptionsPageSettingsTitleAction"
 import { PageHeader } from "~/components/PageHeader"
 import { Button, EmptyState, Input } from "~/components/ui"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { hasValidManagedSiteConfig } from "~/services/managedSites/managedSiteService"
 import {
@@ -50,6 +51,7 @@ import type {
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 import { showWarningToast } from "~/utils/core/toastHelpers"
+import { openSettingsTab } from "~/utils/navigation"
 
 import ActionBar from "./components/ActionBar"
 import EmptyResults from "./components/EmptyResults"
@@ -1309,6 +1311,12 @@ export default function ManagedSiteModelSync({
               intervalMs={intervalMs}
               nextScheduledAt={nextScheduledAt}
               lastRunAt={lastExecution?.statistics?.endedAt ?? null}
+              onConfigureAutoSync={() => {
+                void openSettingsTab("managedSite", {
+                  preserveHistory: true,
+                  anchor: SETTINGS_ANCHORS.MANAGED_SITE_MODEL_SYNC,
+                })
+              }}
             />
           </div>
 

--- a/src/features/ManagedSiteModelSync/components/OverviewCard.tsx
+++ b/src/features/ManagedSiteModelSync/components/OverviewCard.tsx
@@ -1,7 +1,7 @@
 import type { TFunction } from "i18next"
 import { useTranslation } from "react-i18next"
 
-import { Card, CardContent } from "~/components/ui"
+import { Button, Card, CardContent } from "~/components/ui"
 import { formatFullTime } from "~/utils/core/formatters"
 
 interface OverviewCardProps {
@@ -9,6 +9,7 @@ interface OverviewCardProps {
   intervalMs?: number
   nextScheduledAt?: string | number | null
   lastRunAt?: number | string | null
+  onConfigureAutoSync?: () => void
 }
 
 /**
@@ -49,7 +50,13 @@ const formatIsoOrFallback = (
  * Shows current scheduler state (enabled, next scheduled run) even when no execution history exists.
  */
 export default function OverviewCard(props: OverviewCardProps) {
-  const { enabled, intervalMs, nextScheduledAt, lastRunAt } = props
+  const {
+    enabled,
+    intervalMs,
+    nextScheduledAt,
+    lastRunAt,
+    onConfigureAutoSync,
+  } = props
   const { t } = useTranslation("managedSiteModelSync")
 
   return (
@@ -99,6 +106,22 @@ export default function OverviewCard(props: OverviewCardProps) {
             </div>
           </div>
         </div>
+
+        {!enabled && onConfigureAutoSync ? (
+          <div className="flex flex-col gap-3 rounded-md border border-gray-200 bg-gray-50 p-3 sm:flex-row sm:items-center sm:justify-between dark:border-gray-700 dark:bg-gray-800/60">
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              {t("execution.overview.disabledHint")}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onConfigureAutoSync}
+            >
+              {t("execution.overview.enableAutoSync")}
+            </Button>
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   )

--- a/src/features/ManagedSiteModelSync/components/OverviewCard.tsx
+++ b/src/features/ManagedSiteModelSync/components/OverviewCard.tsx
@@ -2,6 +2,7 @@ import type { TFunction } from "i18next"
 import { useTranslation } from "react-i18next"
 
 import { Button, Card, CardContent } from "~/components/ui"
+import type { ProductAnalyticsScopedActionConfig } from "~/services/productAnalytics/actionConfig"
 import { formatFullTime } from "~/utils/core/formatters"
 
 interface OverviewCardProps {
@@ -10,6 +11,7 @@ interface OverviewCardProps {
   nextScheduledAt?: string | number | null
   lastRunAt?: number | string | null
   onConfigureAutoSync?: () => void
+  configureAutoSyncAnalyticsAction?: ProductAnalyticsScopedActionConfig
 }
 
 /**
@@ -56,6 +58,7 @@ export default function OverviewCard(props: OverviewCardProps) {
     nextScheduledAt,
     lastRunAt,
     onConfigureAutoSync,
+    configureAutoSyncAnalyticsAction,
   } = props
   const { t } = useTranslation("managedSiteModelSync")
 
@@ -116,6 +119,7 @@ export default function OverviewCard(props: OverviewCardProps) {
               type="button"
               variant="outline"
               size="sm"
+              analyticsAction={configureAutoSyncAnalyticsAction}
               onClick={onConfigureAutoSync}
             >
               {t("execution.overview.enableAutoSync")}

--- a/src/locales/en/managedSiteModelSync.json
+++ b/src/locales/en/managedSiteModelSync.json
@@ -37,6 +37,8 @@
     "overview": {
       "autoSync": "Auto-sync",
       "disabled": "Disabled",
+      "disabledHint": "Model lists only sync when you run them manually. Enable auto-sync to let the extension run on schedule.",
+      "enableAutoSync": "Enable Auto-Sync",
       "enabled": "Enabled",
       "everyHours_one": "Every {{count}}h",
       "everyHours_other": "Every {{count}}h",

--- a/src/locales/ja/managedSiteModelSync.json
+++ b/src/locales/ja/managedSiteModelSync.json
@@ -36,6 +36,8 @@
     "overview": {
       "autoSync": "自動同期",
       "disabled": "無効",
+      "disabledHint": "現在、モデル一覧は手動実行時のみ同期されます。自動同期を有効にすると、拡張機能が設定した間隔で実行します。",
+      "enableAutoSync": "自動同期を有効化",
       "enabled": "有効",
       "everyHours_other": "{{count}} 時間ごと",
       "everyMinutes_other": "{{count}} 分ごと",

--- a/src/locales/vi/managedSiteModelSync.json
+++ b/src/locales/vi/managedSiteModelSync.json
@@ -36,6 +36,8 @@
     "overview": {
       "autoSync": "Tự động đồng bộ hóa",
       "disabled": "Đã tắt",
+      "disabledHint": "Danh sách mô hình hiện chỉ đồng bộ hóa khi bạn chạy thủ công. Bật tự động đồng bộ hóa để tiện ích chạy theo lịch.",
+      "enableAutoSync": "Bật tự động đồng bộ hóa",
       "enabled": "Đã bật",
       "everyHours_other": "Mỗi {{count}} giờ",
       "everyMinutes_other": "Mỗi {{count}} phút",

--- a/src/locales/zh-CN/managedSiteModelSync.json
+++ b/src/locales/zh-CN/managedSiteModelSync.json
@@ -36,6 +36,8 @@
     "overview": {
       "autoSync": "自动同步",
       "disabled": "已禁用",
+      "disabledHint": "当前只会在你手动执行时同步模型列表。启用自动同步后，扩展会按设定间隔自动运行。",
+      "enableAutoSync": "启用自动同步",
       "enabled": "已启用",
       "everyHours": "每 {{count}} 小时",
       "everyMinutes": "每 {{count}} 分钟",

--- a/src/locales/zh-TW/managedSiteModelSync.json
+++ b/src/locales/zh-TW/managedSiteModelSync.json
@@ -36,6 +36,8 @@
     "overview": {
       "autoSync": "自動同步",
       "disabled": "已禁用",
+      "disabledHint": "目前只會在你手動執行時同步模型列表。啟用自動同步後，擴充套件會按照設定間隔自動執行。",
+      "enableAutoSync": "啟用自動同步",
       "enabled": "已啟用",
       "everyHours_other": "每 {{count}} 小時",
       "everyMinutes_other": "每 {{count}} 分鐘",

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -444,6 +444,7 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
   OpenManagedSiteChannelModelSync: "open_managed_site_channel_model_sync",
   OpenManagedSiteModelSyncConfigRequired:
     "open_managed_site_model_sync_config_required",
+  OpenManagedSiteModelSyncSettings: "open_managed_site_model_sync_settings",
   OpenModelKeyDialog: "open_model_key_dialog",
   OpenModelManagement: "open_model_management",
   OpenOptionsOverviewTarget: "open_options_overview_target",

--- a/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
+++ b/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
@@ -407,11 +407,20 @@ describe("ManagedSiteModelSync page", () => {
       ),
     ).toBeInTheDocument()
 
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "managedSiteModelSync:execution.overview.enableAutoSync",
-      }),
+    const configureButton = screen.getByRole("button", {
+      name: "managedSiteModelSync:execution.overview.enableAutoSync",
+    })
+
+    expect(configureButton).toHaveAttribute(
+      "data-analytics-action",
+      [
+        PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteModelSync,
+        PRODUCT_ANALYTICS_ACTION_IDS.OpenManagedSiteModelSyncSettings,
+        PRODUCT_ANALYTICS_SURFACE_IDS.OptionsManagedSiteModelSyncActionBar,
+        PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      ].join(":"),
     )
+    fireEvent.click(configureButton)
 
     expect(mockOpenSettingsTab).toHaveBeenCalledWith("managedSite", {
       anchor: "managed-site-model-sync",

--- a/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
+++ b/tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
@@ -360,6 +360,65 @@ describe("ManagedSiteModelSync page", () => {
     })
   })
 
+  it("opens managed-site model sync settings from the disabled auto-sync prompt", async () => {
+    mockSendRuntimeMessage.mockImplementation(
+      async (type: string, _data?: any) => {
+        switch (type) {
+          case ModelSyncMessageTypes.GetLastExecution:
+            return {
+              success: true,
+              data: {
+                items: [],
+                statistics: {
+                  total: 0,
+                  successCount: 0,
+                  failureCount: 0,
+                  durationMs: 0,
+                  startedAt: 0,
+                  endedAt: 0,
+                },
+              },
+            }
+          case ModelSyncMessageTypes.GetProgress:
+            return {
+              success: true,
+              data: { isRunning: false, completed: 0, total: 0, failed: 0 },
+            }
+          case ModelSyncMessageTypes.GetNextRun:
+            return { success: true, data: { nextScheduledAt: null } }
+          case ModelSyncMessageTypes.GetPreferences:
+            return {
+              success: true,
+              data: { enableSync: false, intervalMs: 2 * 60 * 60 * 1000 },
+            }
+          case ModelSyncMessageTypes.ListChannels:
+            return { success: true, data: { items: [] } }
+          default:
+            return { success: true }
+        }
+      },
+    )
+
+    render(<ManagedSiteModelSync />)
+
+    expect(
+      await screen.findByText(
+        "managedSiteModelSync:execution.overview.disabledHint",
+      ),
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "managedSiteModelSync:execution.overview.enableAutoSync",
+      }),
+    )
+
+    expect(mockOpenSettingsTab).toHaveBeenCalledWith("managedSite", {
+      anchor: "managed-site-model-sync",
+      preserveHistory: true,
+    })
+  })
+
   it("shows a configuration empty state and skips model-sync loading when managed-site config is missing", async () => {
     mockUseUserPreferencesContext.mockReturnValue({
       preferences: {

--- a/tests/features/ManagedSiteModelSync/components.test.tsx
+++ b/tests/features/ManagedSiteModelSync/components.test.tsx
@@ -15,6 +15,12 @@ import OverviewCard from "~/features/ManagedSiteModelSync/components/OverviewCar
 import ProgressCard from "~/features/ManagedSiteModelSync/components/ProgressCard"
 import ResultsTable from "~/features/ManagedSiteModelSync/components/ResultsTable"
 import StatisticsCard from "~/features/ManagedSiteModelSync/components/StatisticsCard"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+} from "~/services/productAnalytics/events"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
 const { trackStartedMock } = vi.hoisted(() => ({
@@ -151,6 +157,13 @@ describe("ManagedSiteModelSync components", () => {
 
   it("guides users to configure auto-sync when the scheduler is disabled", () => {
     const configureAutoSync = vi.fn()
+    const analyticsAction = {
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteModelSync,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.OpenManagedSiteModelSyncSettings,
+      surfaceId:
+        PRODUCT_ANALYTICS_SURFACE_IDS.OptionsManagedSiteModelSyncActionBar,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    }
 
     render(
       <OverviewCard
@@ -159,6 +172,7 @@ describe("ManagedSiteModelSync components", () => {
         nextScheduledAt={null}
         lastRunAt={null}
         onConfigureAutoSync={configureAutoSync}
+        configureAutoSyncAnalyticsAction={analyticsAction}
       />,
     )
 
@@ -173,6 +187,30 @@ describe("ManagedSiteModelSync components", () => {
     )
 
     expect(configureAutoSync).toHaveBeenCalledTimes(1)
+    expect(trackStartedMock).toHaveBeenCalledWith(analyticsAction)
+  })
+
+  it("hides auto-sync configuration guidance when no configuration callback is provided", () => {
+    render(
+      <OverviewCard
+        enabled={false}
+        intervalMs={24 * 60 * 60 * 1000}
+        nextScheduledAt={null}
+        lastRunAt={null}
+      />,
+    )
+
+    expect(
+      screen.queryByText(
+        "managedSiteModelSync:execution.overview.disabledHint",
+      ),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "managedSiteModelSync:execution.overview.enableAutoSync",
+      }),
+    ).not.toBeInTheDocument()
+    expect(trackStartedMock).not.toHaveBeenCalled()
   })
 
   it("wires action and filter callbacks", () => {

--- a/tests/features/ManagedSiteModelSync/components.test.tsx
+++ b/tests/features/ManagedSiteModelSync/components.test.tsx
@@ -149,6 +149,32 @@ describe("ManagedSiteModelSync components", () => {
     expect(screen.getByText("4.2s")).toBeInTheDocument()
   })
 
+  it("guides users to configure auto-sync when the scheduler is disabled", () => {
+    const configureAutoSync = vi.fn()
+
+    render(
+      <OverviewCard
+        enabled={false}
+        intervalMs={24 * 60 * 60 * 1000}
+        nextScheduledAt={null}
+        lastRunAt={null}
+        onConfigureAutoSync={configureAutoSync}
+      />,
+    )
+
+    expect(
+      screen.getByText("managedSiteModelSync:execution.overview.disabledHint"),
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "managedSiteModelSync:execution.overview.enableAutoSync",
+      }),
+    )
+
+    expect(configureAutoSync).toHaveBeenCalledTimes(1)
+  })
+
   it("wires action and filter callbacks", () => {
     const onRunAll = vi.fn()
     const onRunSelected = vi.fn()

--- a/tests/services/productAnalytics/events.test.ts
+++ b/tests/services/productAnalytics/events.test.ts
@@ -238,6 +238,7 @@ describe("product analytics event enums", () => {
       OpenManagedSiteChannelManagement: "open_managed_site_channel_management",
       OpenManagedSiteModelSyncConfigRequired:
         "open_managed_site_model_sync_config_required",
+      OpenManagedSiteModelSyncSettings: "open_managed_site_model_sync_settings",
       ScheduledManagedSiteModelSync: "scheduled_managed_site_model_sync",
       UpdateManagedSiteModelSyncSettings:
         "update_managed_site_model_sync_settings",


### PR DESCRIPTION
## Summary
- Add disabled auto-sync guidance to the managed-site model sync execution overview.
- Link the prompt to the managed-site model sync settings anchor instead of changing scheduler settings inline.
- Sync the new copy across app locales.

## Test Plan
- pnpm vitest run tests/features/ManagedSiteModelSync/components.test.tsx tests/features/ManagedSiteModelSync/ManagedSiteModelSync.test.tsx
- pnpm run i18n:extract:ci
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “enable auto-sync” action for when auto-sync is disabled, guiding users to the Managed Site Model Sync settings.
  * Updated the auto-sync disabled state to display a helpful hint about manual-only syncing until auto-sync is enabled.
* **Localization**
  * Extended UI copy across English, Japanese, Vietnamese, Simplified Chinese, and Traditional Chinese with new strings for the disabled hint and enable-auto-sync label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->