### PR TITLE
feat(web-ai-api-check): allow cancelling availability tests and show API keys by default

### DIFF
--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
@@ -202,7 +202,7 @@ export function ApiCheckModalHost() {
   const [apiKey, setApiKey] = useState("")
   const [extractionMetadata, setExtractionMetadata] =
     useState<ApiCheckOpenModalDetail["extraction"]>(undefined)
-  const [apiKeyVisible, setApiKeyVisible] = useState(false)
+  const [apiKeyVisible, setApiKeyVisible] = useState(true)
   const [apiType, setApiType] = useState<ApiVerificationApiType>(
     API_TYPES.OPENAI_COMPATIBLE,
   )
@@ -389,7 +389,7 @@ export function ApiCheckModalHost() {
       setBaseUrl(nextBaseUrl)
       setApiKey(nextApiKey)
 
-      setApiKeyVisible(false)
+      setApiKeyVisible(true)
       setModelId("")
       setModelIds([])
       setFetchModelsError(null)

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
@@ -789,7 +789,11 @@ export function ApiCheckModalHost() {
           cancelledProbeRunIdsRef.current.has(runId) ||
           options.shouldIgnoreResult?.()
         ) {
-          setProbes((prev) => markProbeNotRunning(prev, probeId))
+          setProbes((prev) =>
+            activeProbeRunIdsRef.current.get(probeId) === runId
+              ? markProbeNotRunning(prev, probeId)
+              : prev,
+          )
           return null
         }
         setProbes((prev) =>
@@ -834,7 +838,11 @@ export function ApiCheckModalHost() {
         cancelledProbeRunIdsRef.current.has(runId) ||
         options.shouldIgnoreResult?.()
       ) {
-        setProbes((prev) => markProbeNotRunning(prev, probeId))
+        setProbes((prev) =>
+          activeProbeRunIdsRef.current.get(probeId) === runId
+            ? markProbeNotRunning(prev, probeId)
+            : prev,
+        )
         return null
       }
 
@@ -871,7 +879,11 @@ export function ApiCheckModalHost() {
         cancelledProbeRunIdsRef.current.has(runId) ||
         options.shouldIgnoreResult?.()
       ) {
-        setProbes((prev) => markProbeNotRunning(prev, probeId))
+        setProbes((prev) =>
+          activeProbeRunIdsRef.current.get(probeId) === runId
+            ? markProbeNotRunning(prev, probeId)
+            : prev,
+        )
         return null
       }
       setProbes((prev) =>
@@ -993,7 +1005,7 @@ export function ApiCheckModalHost() {
           (result) => result.status === "fail",
         ).length
         const skippedCount = Math.max(
-          probeDefinitions.length - results.length,
+          probeDefinitions.length - successCount - failureCount,
           0,
         )
 

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost.tsx
@@ -15,6 +15,7 @@ import {
   Button,
   IconButton,
   Input,
+  Notice,
   SearchableSelect,
   Textarea,
 } from "~/components/ui"
@@ -30,6 +31,7 @@ import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FAILURE_REASONS,
   PRODUCT_ANALYTICS_FEATURE_IDS,
   PRODUCT_ANALYTICS_MODE_IDS,
   PRODUCT_ANALYTICS_RESULTS,
@@ -59,6 +61,7 @@ import {
 } from "~/services/verification/webAiApiCheck/messaging"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { isTestMode } from "~/utils/core/environment"
+import { safeRandomUUID } from "~/utils/core/identifier"
 
 import {
   API_CHECK_OPEN_MODAL_EVENT,
@@ -169,6 +172,18 @@ function buildProbeState(apiType: ApiVerificationApiType): ProbeItemState[] {
 }
 
 /**
+ * Clear the running flag when a late probe result should no longer update UI data.
+ */
+function markProbeNotRunning(
+  probes: ProbeItemState[],
+  probeId: ApiVerificationProbeId,
+): ProbeItemState[] {
+  return probes.map((probe) =>
+    probe.id === probeId ? { ...probe, isRunning: false } : probe,
+  )
+}
+
+/**
  * Always-mounted modal host rendered inside the content-script Shadow DOM root.
  *
  * The host listens for CustomEvents to open/close, so the rest of the content
@@ -232,9 +247,23 @@ export function ApiCheckModalHost() {
     buildProbeState(API_TYPES.OPENAI_COMPATIBLE),
   )
   const [isRunningAll, setIsRunningAll] = useState(false)
+  const [isStoppingRunAll, setIsStoppingRunAll] = useState(false)
+  const [testStoppedMessage, setTestStoppedMessage] = useState<string | null>(
+    null,
+  )
   const [isSavingProfile, setIsSavingProfile] = useState(false)
   const [validationError, setValidationError] = useState<string | null>(null)
   const hasInitializedApiTypeRef = useRef(false)
+  const shouldStopRunAllRef = useRef(false)
+  const activeProbeRunIdsRef = useRef(new Map<ApiVerificationProbeId, string>())
+  const activeProbeTrackersRef = useRef(
+    new Map<
+      ApiVerificationProbeId,
+      ReturnType<typeof startProductAnalyticsAction>
+    >(),
+  )
+  const cancelledProbeRunIdsRef = useRef(new Set<string>())
+  const activeRunAllProbeIdRef = useRef<ApiVerificationProbeId | null>(null)
 
   const probeDefinitions = useMemo(
     () => getApiVerificationProbeDefinitions(apiType),
@@ -257,6 +286,7 @@ export function ApiCheckModalHost() {
 
   const resetProbeState = (nextApiType: ApiVerificationApiType) => {
     setProbes(buildProbeState(nextApiType))
+    setTestStoppedMessage(null)
   }
 
   useEffect(() => {
@@ -692,7 +722,11 @@ export function ApiCheckModalHost() {
 
   const runProbe = async (
     probeId: ApiVerificationProbeId,
-    options: { trackIndividual?: boolean } = {},
+    options: {
+      trackIndividual?: boolean
+      runId?: string
+      shouldIgnoreResult?: () => boolean
+    } = {},
   ): Promise<ApiCheckProbeResultWithAnalyticsCategory | null> => {
     const shouldTrack = options.trackIndividual !== false
     const tracker = shouldTrack
@@ -730,10 +764,16 @@ export function ApiCheckModalHost() {
       ),
     )
 
+    const runId = options.runId ?? safeRandomUUID(`web-ai-api-check-${probeId}`)
     try {
+      activeProbeRunIdsRef.current.set(probeId, runId)
+      if (tracker) {
+        activeProbeTrackersRef.current.set(probeId, tracker)
+      }
       const response = await sendWebAiApiCheckMessage(
         WebAiApiCheckMessageTypes.RunProbe,
         {
+          runId,
           apiType,
           baseUrl: trimmedBaseUrl,
           apiKey: trimmedApiKey,
@@ -745,6 +785,13 @@ export function ApiCheckModalHost() {
       if (response.success && response.result) {
         const result =
           response.result as ApiCheckProbeResultWithAnalyticsCategory
+        if (
+          cancelledProbeRunIdsRef.current.has(runId) ||
+          options.shouldIgnoreResult?.()
+        ) {
+          setProbes((prev) => markProbeNotRunning(prev, probeId))
+          return null
+        }
         setProbes((prev) =>
           prev.map((probe) =>
             probe.id === probeId
@@ -783,6 +830,14 @@ export function ApiCheckModalHost() {
         },
       }
 
+      if (
+        cancelledProbeRunIdsRef.current.has(runId) ||
+        options.shouldIgnoreResult?.()
+      ) {
+        setProbes((prev) => markProbeNotRunning(prev, probeId))
+        return null
+      }
+
       setProbes((prev) =>
         prev.map((probe) =>
           probe.id === probeId
@@ -812,6 +867,13 @@ export function ApiCheckModalHost() {
           baseUrl: trimmedBaseUrl,
         },
       }
+      if (
+        cancelledProbeRunIdsRef.current.has(runId) ||
+        options.shouldIgnoreResult?.()
+      ) {
+        setProbes((prev) => markProbeNotRunning(prev, probeId))
+        return null
+      }
       setProbes((prev) =>
         prev.map((probe) =>
           probe.id === probeId
@@ -830,6 +892,53 @@ export function ApiCheckModalHost() {
         }),
       })
       return fallback
+    } finally {
+      if (activeProbeRunIdsRef.current.get(probeId) === runId) {
+        activeProbeRunIdsRef.current.delete(probeId)
+      }
+      if (activeProbeTrackersRef.current.get(probeId) === tracker) {
+        activeProbeTrackersRef.current.delete(probeId)
+      }
+      cancelledProbeRunIdsRef.current.delete(runId)
+    }
+  }
+
+  const stopProbe = (probeId: ApiVerificationProbeId) => {
+    const activeRunId = activeProbeRunIdsRef.current.get(probeId)
+    if (!activeRunId) return
+
+    void sendWebAiApiCheckMessage(WebAiApiCheckMessageTypes.CancelRunProbe, {
+      runId: activeRunId,
+    }).catch(() => {})
+    cancelledProbeRunIdsRef.current.add(activeRunId)
+
+    activeProbeTrackersRef.current
+      .get(probeId)
+      ?.complete(PRODUCT_ANALYTICS_RESULTS.Cancelled, {
+        insights: buildApiCheckAnalyticsInsights(apiType, trigger, {
+          mode: PRODUCT_ANALYTICS_MODE_IDS.Single,
+          failureReason: PRODUCT_ANALYTICS_FAILURE_REASONS.CancelledByUser,
+        }),
+      })
+    activeProbeTrackersRef.current.delete(probeId)
+
+    setProbes((prev) => markProbeNotRunning(prev, probeId))
+  }
+
+  const stopRunAll = () => {
+    if (shouldStopRunAllRef.current) return
+    shouldStopRunAllRef.current = true
+    setIsStoppingRunAll(true)
+    setTestStoppedMessage(t("webAiApiCheck:modal.messages.stoppingTest"))
+
+    const activeRunAllProbeId = activeRunAllProbeIdRef.current
+    const activeRunId = activeRunAllProbeId
+      ? activeProbeRunIdsRef.current.get(activeRunAllProbeId)
+      : undefined
+    if (activeRunId) {
+      void sendWebAiApiCheckMessage(WebAiApiCheckMessageTypes.CancelRunProbe, {
+        runId: activeRunId,
+      }).catch(() => {})
     }
   }
 
@@ -856,14 +965,57 @@ export function ApiCheckModalHost() {
       return
     }
 
+    shouldStopRunAllRef.current = false
+    setIsStoppingRunAll(false)
+    setTestStoppedMessage(null)
     setIsRunningAll(true)
     const results: ApiCheckProbeResultWithAnalyticsCategory[] = []
     try {
       for (const def of probeDefinitions) {
+        if (shouldStopRunAllRef.current) break
         // Run sequentially so the UI updates progressively and we avoid bursty network traffic.
-        const result = await runProbe(def.id, { trackIndividual: false })
-        if (result) results.push(result)
+        const runId = safeRandomUUID(`web-ai-api-check-${def.id}`)
+        activeRunAllProbeIdRef.current = def.id
+        const result = await runProbe(def.id, {
+          trackIndividual: false,
+          runId,
+          shouldIgnoreResult: () => shouldStopRunAllRef.current,
+        })
+        if (!shouldStopRunAllRef.current && result) results.push(result)
+        if (shouldStopRunAllRef.current) break
       }
+
+      if (shouldStopRunAllRef.current) {
+        const successCount = results.filter(
+          (result) => result.status === "pass",
+        ).length
+        const failureCount = results.filter(
+          (result) => result.status === "fail",
+        ).length
+        const skippedCount = Math.max(
+          probeDefinitions.length - results.length,
+          0,
+        )
+
+        setProbes((prev) =>
+          prev.map((probe) =>
+            probe.isRunning ? { ...probe, isRunning: false } : probe,
+          ),
+        )
+        setTestStoppedMessage(t("webAiApiCheck:modal.messages.testStopped"))
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Cancelled, {
+          insights: buildApiCheckAnalyticsInsights(apiType, trigger, {
+            mode: PRODUCT_ANALYTICS_MODE_IDS.All,
+            itemCount: probeDefinitions.length,
+            successCount,
+            failureCount,
+            skippedCount,
+            failureReason: PRODUCT_ANALYTICS_FAILURE_REASONS.CancelledByUser,
+          }),
+        })
+        return
+      }
+
       const successCount = results.filter(
         (result) => result.status === "pass",
       ).length
@@ -901,10 +1053,12 @@ export function ApiCheckModalHost() {
       })
     } finally {
       setIsRunningAll(false)
+      setIsStoppingRunAll(false)
+      shouldStopRunAllRef.current = false
+      activeRunAllProbeIdRef.current = null
     }
   }
 
-  // Users may want to persist credentials first, then verify later.
   const canSaveProfile = !!baseUrl.trim() && !!apiKey.trim() && !isSavingProfile
 
   const handleSaveProfile = async () => {
@@ -992,7 +1146,6 @@ export function ApiCheckModalHost() {
       setIsSavingProfile(false)
     }
   }
-
   const apiTypeOptions = useMemo(
     () => [
       { value: API_TYPES.OPENAI_COMPATIBLE, label: "OpenAI-compatible" },
@@ -1017,8 +1170,12 @@ export function ApiCheckModalHost() {
       />
       <div
         ref={backdropRef}
+        data-testid={WEB_AI_API_CHECK_TEST_IDS.backdrop}
         className="pointer-events-auto absolute inset-0 bg-black/40"
-        onClick={close}
+        onClick={() => {
+          if (isRunningAll || isAnyProbeRunning) return
+          close()
+        }}
       />
 
       <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-3">
@@ -1185,13 +1342,17 @@ export function ApiCheckModalHost() {
 
                 <Button
                   type="button"
-                  onClick={runAll}
+                  variant={isRunningAll ? "outline" : "default"}
+                  onClick={isRunningAll ? stopRunAll : runAll}
                   disabled={
-                    isRunningAll || isFetchingModels || isAnyProbeRunning
+                    isStoppingRunAll ||
+                    (!isRunningAll && (isFetchingModels || isAnyProbeRunning))
                   }
                 >
                   {isRunningAll
-                    ? t("webAiApiCheck:modal.actions.testing")
+                    ? isStoppingRunAll
+                      ? t("webAiApiCheck:modal.actions.stopping")
+                      : t("webAiApiCheck:modal.actions.stopTest")
                     : t("webAiApiCheck:modal.actions.test")}
                 </Button>
 
@@ -1212,6 +1373,10 @@ export function ApiCheckModalHost() {
                 <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-200">
                   {fetchModelsError}
                 </div>
+              ) : null}
+
+              {testStoppedMessage ? (
+                <Notice tone="warning" description={testStoppedMessage} />
               ) : null}
 
               <div className="space-y-2">
@@ -1258,13 +1423,20 @@ export function ApiCheckModalHost() {
                           type="button"
                           size="sm"
                           variant="secondary"
-                          onClick={() => runProbe(probe.id)}
+                          onClick={() =>
+                            probe.isRunning
+                              ? stopProbe(probe.id)
+                              : runProbe(probe.id)
+                          }
                           disabled={
-                            isRunningAll || isFetchingModels || probe.isRunning
+                            isRunningAll ||
+                            (!probe.isRunning && isFetchingModels)
                           }
                         >
                           {probe.isRunning
-                            ? t("webAiApiCheck:modal.actions.running")
+                            ? isRunningAll
+                              ? t("webAiApiCheck:modal.actions.running")
+                              : t("webAiApiCheck:modal.actions.stopTest")
                             : probe.attempts > 0
                               ? t("webAiApiCheck:modal.actions.retry")
                               : t("webAiApiCheck:modal.actions.runOne")}

--- a/src/entrypoints/content/webAiApiCheck/testIds.ts
+++ b/src/entrypoints/content/webAiApiCheck/testIds.ts
@@ -1,6 +1,7 @@
 import type { ApiVerificationProbeId } from "~/services/verification/aiApiVerification"
 
 export const WEB_AI_API_CHECK_TEST_IDS = {
+  backdrop: "api-check-backdrop",
   modal: "api-check-modal",
   modelId: "api-check-model-id",
   baseUrlCandidatePrefix: "web-ai-api-check-base-url-candidate",

--- a/src/locales/en/webAiApiCheck.json
+++ b/src/locales/en/webAiApiCheck.json
@@ -24,8 +24,9 @@
       "saveToProfiles": "Save to API credential library",
       "saving": "Saving…",
       "showKey": "Show key",
-      "test": "Test",
-      "testing": "Testing…"
+      "stopping": "Stopping…",
+      "stopTest": "Stop test",
+      "test": "Test"
     },
     "candidates": {
       "apiKey": "Candidate key {{index}}"
@@ -46,7 +47,9 @@
       "saveWithoutTest": "Tip: you can save once base URL + API key are provided (no need to test or fetch models first). Testing is optional and only helps verify availability."
     },
     "messages": {
-      "savedToProfiles": "Saved {{name}} to API credential library."
+      "savedToProfiles": "Saved {{name}} to API credential library.",
+      "stoppingTest": "Stopping the test. The current request will be interrupted as soon as possible.",
+      "testStopped": "Test stopped. Completed results were kept, and items that had not started will not continue."
     },
     "privacyHint": "API Keys will be considered sensitive information: hidden by default, and nothing is stored unless you choose to save to API credential library.",
     "probes": {

--- a/src/locales/ja/webAiApiCheck.json
+++ b/src/locales/ja/webAiApiCheck.json
@@ -24,8 +24,9 @@
       "saveToProfiles": "API 認証情報庫に保存",
       "saving": "保存中…",
       "showKey": "キーを表示",
-      "test": "テスト",
-      "testing": "テスト中…"
+      "stopping": "停止中…",
+      "stopTest": "テストを停止",
+      "test": "テスト"
     },
     "candidates": {
       "apiKey": "候補 Key {{index}}"
@@ -46,7 +47,9 @@
       "saveWithoutTest": "ヒント: Base URL と API キーが入力されていれば、その時点で保存できます（先にテストやモデル取得を行う必要はありません）。テストは任意で、可用性確認の補助にすぎません。"
     },
     "messages": {
-      "savedToProfiles": "{{name}} を API 認証情報庫に保存しました。"
+      "savedToProfiles": "{{name}} を API 認証情報庫に保存しました。",
+      "stoppingTest": "テストを停止しています。現在のリクエストは可能な限り早く中断されます。",
+      "testStopped": "テストを停止しました。完了済みの結果は保持され、未開始の項目は続行されません。"
     },
     "privacyHint": "API キーは機密情報として扱われます。既定では非表示で、API 認証情報庫に保存する操作を行わない限り、何も保存されません。",
     "probes": {

--- a/src/locales/vi/webAiApiCheck.json
+++ b/src/locales/vi/webAiApiCheck.json
@@ -24,8 +24,9 @@
       "saveToProfiles": "Lưu vào API Profiles",
       "saving": "Đang lưu...",
       "showKey": "Hiện Key",
-      "test": "Kiểm tra",
-      "testing": "Đang kiểm tra..."
+      "stopping": "Đang dừng...",
+      "stopTest": "Dừng kiểm tra",
+      "test": "Kiểm tra"
     },
     "candidates": {
       "apiKey": "Key ứng viên {{index}}"
@@ -46,7 +47,9 @@
       "saveWithoutTest": "Mẹo: Chỉ cần điền Base URL và API Key là có thể lưu vào API Profiles (không cần kiểm tra hoặc lấy danh sách mô hình trước). Kiểm tra chỉ được sử dụng để xác minh khả năng khả dụng."
     },
     "messages": {
-      "savedToProfiles": "Đã lưu {{name}} vào API Profiles"
+      "savedToProfiles": "Đã lưu {{name}} vào API Profiles",
+      "stoppingTest": "Đang dừng kiểm tra. Yêu cầu hiện tại sẽ được ngắt sớm nhất có thể.",
+      "testStopped": "Đã dừng kiểm tra. Các kết quả đã hoàn tất được giữ lại, và các mục chưa bắt đầu sẽ không chạy tiếp."
     },
     "privacyHint": "API Key được coi là thông tin nhạy cảm: mặc định bị ẩn và trừ khi bạn chủ động lưu vào API Profiles, sẽ không có bất kỳ dữ liệu nào được lưu trữ liên tục.",
     "probes": {

--- a/src/locales/zh-CN/webAiApiCheck.json
+++ b/src/locales/zh-CN/webAiApiCheck.json
@@ -24,8 +24,9 @@
       "saveToProfiles": "保存到 API 凭据库",
       "saving": "保存中…",
       "showKey": "显示 Key",
-      "test": "测试",
-      "testing": "测试中…"
+      "stopping": "正在停止…",
+      "stopTest": "停止测试",
+      "test": "测试"
     },
     "candidates": {
       "apiKey": "候选 Key {{index}}"
@@ -46,7 +47,9 @@
       "saveWithoutTest": "提示：只要填写 Base URL 与 API Key 就能保存到 API 凭据库（无需先测试或获取模型列表）。测试仅用于验证可用性。"
     },
     "messages": {
-      "savedToProfiles": "已保存 {{name}} 到 API 凭据库"
+      "savedToProfiles": "已保存 {{name}} 到 API 凭据库",
+      "stoppingTest": "正在停止测试，当前请求会尽快中断。",
+      "testStopped": "测试已停止，已完成的结果已保留，未开始的项目不会继续运行。"
     },
     "privacyHint": "API Key 会被视为敏感信息：默认隐藏，且除非你主动保存到 API 凭据库，否则不会持久化保存任何数据。",
     "probes": {

--- a/src/locales/zh-TW/webAiApiCheck.json
+++ b/src/locales/zh-TW/webAiApiCheck.json
@@ -24,8 +24,9 @@
       "saveToProfiles": "儲存到 API 憑據庫",
       "saving": "儲存中…",
       "showKey": "顯示 Key",
-      "test": "測試",
-      "testing": "測試中…"
+      "stopping": "正在停止…",
+      "stopTest": "停止測試",
+      "test": "測試"
     },
     "candidates": {
       "apiKey": "候選 Key {{index}}"
@@ -46,7 +47,9 @@
       "saveWithoutTest": "提示：只要填寫 Base URL 與 API Key 就能儲存到 API 憑據庫（無需先測試或獲取模型列表）。測試僅用於驗證可用性。"
     },
     "messages": {
-      "savedToProfiles": "已儲存 {{name}} 到 API 憑據庫"
+      "savedToProfiles": "已儲存 {{name}} 到 API 憑據庫",
+      "stoppingTest": "正在停止測試，目前請求會盡快中斷。",
+      "testStopped": "測試已停止，已完成的結果已保留，未開始的項目不會繼續執行。"
     },
     "privacyHint": "API Key 會被視為敏感資訊：預設隱藏，且除非你主動儲存到 API 憑據庫，否則不會持久化儲存任何資料。",
     "probes": {

--- a/src/services/verification/webAiApiCheck/background.ts
+++ b/src/services/verification/webAiApiCheck/background.ts
@@ -339,19 +339,26 @@ export async function resolveWebAiApiCheckRunProbeMessage(
 export async function resolveWebAiApiCheckCancelRunProbeMessage(
   request: ApiCheckCancelRunProbeRequest,
 ): Promise<ApiCheckCancelRunProbeResponse> {
-  const runId = request.runId.trim()
-  if (!runId) {
+  try {
+    const runId = typeof request.runId === "string" ? request.runId.trim() : ""
+    if (!runId) {
+      return { success: true, cancelled: false }
+    }
+
+    const abortController = activeProbeAbortControllers.get(runId)
+    if (!abortController) {
+      return { success: true, cancelled: false }
+    }
+
+    abortController.abort()
+    activeProbeAbortControllers.delete(runId)
+    return { success: true, cancelled: true }
+  } catch (error) {
+    logger.error("ApiCheck cancel message handling failed", {
+      message: toSanitizedErrorSummary(error, []),
+    })
     return { success: true, cancelled: false }
   }
-
-  const abortController = activeProbeAbortControllers.get(runId)
-  if (!abortController) {
-    return { success: true, cancelled: false }
-  }
-
-  abortController.abort()
-  activeProbeAbortControllers.delete(runId)
-  return { success: true, cancelled: true }
 }
 
 /**

--- a/src/services/verification/webAiApiCheck/background.ts
+++ b/src/services/verification/webAiApiCheck/background.ts
@@ -17,9 +17,8 @@ import {
   type ApiVerificationProbeResult,
 } from "~/services/verification/aiApiVerification"
 import {
-  inferHttpStatus,
+  buildSafeProbeFailureDiagnostics,
   inferStructuredHttpStatus,
-  summaryKeyFromHttpStatus,
   toSanitizedErrorSummary,
 } from "~/services/verification/aiApiVerification/utils"
 import {
@@ -32,6 +31,8 @@ import { isUrlAllowedByRegexList } from "~/utils/core/urlWhitelist"
 
 import { onWebAiApiCheckMessage, WebAiApiCheckMessageTypes } from "./messaging"
 import type {
+  ApiCheckCancelRunProbeRequest,
+  ApiCheckCancelRunProbeResponse,
   ApiCheckFetchModelsRequest,
   ApiCheckFetchModelsResponse,
   ApiCheckRunProbeRequest,
@@ -46,6 +47,8 @@ import type {
  * Unified logger scoped to Web AI API Check background handlers.
  */
 const logger = createLogger("WebAiApiCheck")
+
+const activeProbeAbortControllers = new Map<string, AbortController>()
 
 /**
  * Read Web AI API Check preferences with safe defaults.
@@ -257,7 +260,7 @@ export async function resolveWebAiApiCheckRunProbeMessage(
   request: ApiCheckRunProbeRequest,
 ): Promise<ApiCheckRunProbeResponse> {
   try {
-    const { apiType, baseUrl, apiKey, modelId, probeId } = request
+    const { runId, apiType, baseUrl, apiKey, modelId, probeId } = request
 
     if (!apiType || !baseUrl?.trim() || !apiKey?.trim() || !probeId) {
       return {
@@ -277,27 +280,31 @@ export async function resolveWebAiApiCheckRunProbeMessage(
     }
 
     try {
+      const abortController = runId ? new AbortController() : undefined
+      if (runId && abortController) {
+        activeProbeAbortControllers.set(runId, abortController)
+      }
+
       const result = await runApiVerificationProbe({
         baseUrl: normalizedBaseUrl,
         apiKey,
         apiType,
         modelId: modelId?.trim() || undefined,
         probeId: probeId as ApiVerificationProbeId,
+        abortSignal: abortController?.signal,
       })
 
       return { success: true, result }
     } catch (error) {
       const message = toSanitizedErrorSummary(error, [apiKey])
-      const status = inferHttpStatus(error, message)
-      const analyticsStatus = inferStructuredHttpStatus(error)
-      const summaryKey = summaryKeyFromHttpStatus(status)
+      const diagnostics = buildSafeProbeFailureDiagnostics(error, message)
 
       logger.error("Probe execution failed", {
         apiType,
         probeId,
         baseUrl: normalizedBaseUrl,
         message,
-        status,
+        status: diagnostics.summaryParams?.status,
       })
 
       const result: ApiVerificationProbeResult = {
@@ -305,19 +312,18 @@ export async function resolveWebAiApiCheckRunProbeMessage(
         status: "fail",
         latencyMs: 0,
         summary: message,
-        summaryKey,
-        summaryParams: summaryKey ? { status } : undefined,
+        ...diagnostics,
         input: {
           apiType,
           baseUrl: normalizedBaseUrl,
         },
-        output:
-          typeof analyticsStatus === "number"
-            ? { inferredHttpStatus: analyticsStatus }
-            : undefined,
       }
 
       return { success: true, result }
+    } finally {
+      if (runId) {
+        activeProbeAbortControllers.delete(runId)
+      }
     }
   } catch (error) {
     logger.error("ApiCheck message handling failed", {
@@ -325,6 +331,27 @@ export async function resolveWebAiApiCheckRunProbeMessage(
     })
     return toGenericFailureResponse()
   }
+}
+
+/**
+ * Abort a single in-flight API verification probe.
+ */
+export async function resolveWebAiApiCheckCancelRunProbeMessage(
+  request: ApiCheckCancelRunProbeRequest,
+): Promise<ApiCheckCancelRunProbeResponse> {
+  const runId = request.runId.trim()
+  if (!runId) {
+    return { success: true, cancelled: false }
+  }
+
+  const abortController = activeProbeAbortControllers.get(runId)
+  if (!abortController) {
+    return { success: true, cancelled: false }
+  }
+
+  abortController.abort()
+  activeProbeAbortControllers.delete(runId)
+  return { success: true, cancelled: true }
 }
 
 /**
@@ -418,6 +445,10 @@ export function setupWebAiApiCheckMessagingListeners() {
     onWebAiApiCheckMessage(
       WebAiApiCheckMessageTypes.RunProbe,
       async ({ data }) => resolveWebAiApiCheckRunProbeMessage(data),
+    ),
+    onWebAiApiCheckMessage(
+      WebAiApiCheckMessageTypes.CancelRunProbe,
+      async ({ data }) => resolveWebAiApiCheckCancelRunProbeMessage(data),
     ),
     onWebAiApiCheckMessage(
       WebAiApiCheckMessageTypes.SaveProfile,

--- a/src/services/verification/webAiApiCheck/messaging.ts
+++ b/src/services/verification/webAiApiCheck/messaging.ts
@@ -5,6 +5,8 @@ import {
 import { createLogger } from "~/utils/core/logger"
 
 import type {
+  ApiCheckCancelRunProbeRequest,
+  ApiCheckCancelRunProbeResponse,
   ApiCheckFetchModelsRequest,
   ApiCheckFetchModelsResponse,
   ApiCheckRunProbeRequest,
@@ -19,6 +21,7 @@ export const WebAiApiCheckMessageTypes = {
   ShouldPrompt: "webAiApiCheck:shouldPrompt",
   FetchModels: "webAiApiCheck:fetchModels",
   RunProbe: "webAiApiCheck:runProbe",
+  CancelRunProbe: "webAiApiCheck:cancelRunProbe",
   SaveProfile: "webAiApiCheck:saveProfile",
 } as const
 
@@ -49,6 +52,9 @@ interface WebAiApiCheckProtocolMap {
   [WebAiApiCheckMessageTypes.RunProbe](
     data: ApiCheckRunProbeRequest,
   ): ApiCheckRunProbeResponse
+  [WebAiApiCheckMessageTypes.CancelRunProbe](
+    data: ApiCheckCancelRunProbeRequest,
+  ): ApiCheckCancelRunProbeResponse
   [WebAiApiCheckMessageTypes.SaveProfile](
     data: ApiCheckSaveProfileRequest,
   ): ApiCheckSaveProfileResponse

--- a/src/services/verification/webAiApiCheck/types.ts
+++ b/src/services/verification/webAiApiCheck/types.ts
@@ -62,6 +62,7 @@ export type ApiCheckFetchModelsResponse =
  * The returned result must never include secrets (apiKey), and error summaries must be sanitized.
  */
 export type ApiCheckRunProbeRequest = {
+  runId?: string
   apiType: ApiVerificationApiType
   baseUrl: string
   apiKey: string
@@ -82,6 +83,22 @@ export type ApiCheckRunProbeResponse =
       error?: string
       errorCategory?: ProductAnalyticsErrorCategory
     }
+
+/**
+ * Runtime data from content -> background to abort one in-flight probe.
+ */
+export type ApiCheckCancelRunProbeRequest = {
+  runId: string
+}
+
+/**
+ * Runtime response for {@link ApiCheckCancelRunProbeRequest}.
+ */
+export type ApiCheckCancelRunProbeResponse = {
+  success: true
+  cancelled: boolean
+}
+
 /**
  * Runtime data from content → background to persist the current credentials
  * as an API credential profile.

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -1556,6 +1556,115 @@ describe("ApiCheckModalHost", () => {
     ).toBeInTheDocument()
   })
 
+  it("keeps a retried probe running when the stopped run resolves late", async () => {
+    const user = userEvent.setup()
+    const firstProbeDeferred = createDeferred<ApiCheckRunProbeResponse>()
+    const secondProbeDeferred = createDeferred<ApiCheckRunProbeResponse>()
+    const runProbeMessages: Array<Record<string, unknown>> = []
+
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.CancelRunProbe) {
+          return { success: true, cancelled: true }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          runProbeMessages.push(message)
+          return runProbeMessages.length === 1
+            ? await firstProbeDeferred.promise
+            : await secondProbeDeferred.promise
+        }
+
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    const baseUrlInput = await screen.findByPlaceholderText(
+      "https://example.com/api",
+    )
+    const apiKeyInput = await screen.findByPlaceholderText("sk-...")
+
+    await user.click(baseUrlInput)
+    await user.paste("https://proxy.example.com/api")
+    await user.click(apiKeyInput)
+    await user.paste("sk-test-secret-fixture")
+
+    const probeCard = await screen.findByTestId(
+      getWebAiApiCheckProbeTestId("text-generation"),
+    )
+
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.runOne",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(runProbeMessages).toHaveLength(1)
+    })
+
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.stopTest",
+      }),
+    )
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.retry",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(runProbeMessages).toHaveLength(2)
+      expect(
+        within(probeCard).getByRole("button", {
+          name: "webAiApiCheck:modal.actions.stopTest",
+        }),
+      ).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      firstProbeDeferred.resolve({
+        success: true,
+        result: {
+          id: "text-generation",
+          status: "fail",
+          latencyMs: 0,
+          summary: "Cancelled first run",
+        },
+      })
+    })
+
+    expect(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.stopTest",
+      }),
+    ).toBeInTheDocument()
+    expect(
+      within(probeCard).queryByText("Cancelled first run"),
+    ).not.toBeInTheDocument()
+
+    await act(async () => {
+      secondProbeDeferred.resolve({
+        success: true,
+        result: {
+          id: "text-generation",
+          status: "pass",
+          latencyMs: 1,
+          summary: "Retry OK",
+        },
+      })
+    })
+
+    expect(await within(probeCard).findByText("Retry OK")).toBeInTheDocument()
+  })
+
   it("maps structured probe HTTP status to an auth analytics failure", async () => {
     const user = userEvent.setup()
     vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
@@ -1860,6 +1969,102 @@ describe("ApiCheckModalHost", () => {
             successCount: 1,
             failureCount: 0,
             skippedCount: 4,
+            failureReason: PRODUCT_ANALYTICS_FAILURE_REASONS.CancelledByUser,
+          },
+        },
+      )
+    })
+  })
+
+  it("counts completed unsupported probes as skipped when the API probe suite is stopped", async () => {
+    const user = userEvent.setup()
+    const secondProbeDeferred = createDeferred<ApiCheckRunProbeResponse>()
+    const runProbeMessages: Array<Record<string, unknown>> = []
+
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.CancelRunProbe) {
+          return { success: true, cancelled: true }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          runProbeMessages.push(message)
+          if (message.probeId === "models") {
+            return {
+              success: true,
+              result: {
+                id: "models",
+                status: "unsupported",
+                latencyMs: 1,
+                summary: "Models are unsupported",
+              },
+            }
+          }
+          if (message.probeId === "text-generation") {
+            return await secondProbeDeferred.promise
+          }
+
+          return {
+            success: true,
+            result: {
+              id: message.probeId as ApiVerificationProbeId,
+              status: "pass",
+              latencyMs: 1,
+              summary: "Should not run",
+            },
+          }
+        }
+
+        return { success: false }
+      },
+    )
+
+    await startManualProbeSuite(user)
+
+    await waitFor(() => {
+      expect(runProbeMessages.map((message) => message.probeId)).toEqual([
+        "models",
+        "text-generation",
+      ])
+    })
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.actions.stopTest",
+      }),
+    )
+
+    await act(async () => {
+      secondProbeDeferred.resolve({
+        success: true,
+        result: {
+          id: "text-generation",
+          status: "fail",
+          latencyMs: 0,
+          summary: "Cancelled by user",
+        },
+      })
+    })
+
+    expect(
+      await screen.findByText("webAiApiCheck:modal.messages.testStopped"),
+    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Cancelled,
+        {
+          insights: {
+            sourceKind: PRODUCT_ANALYTICS_SOURCE_KINDS.Manual,
+            apiType: "openai-compatible",
+            mode: PRODUCT_ANALYTICS_MODE_IDS.All,
+            itemCount: 5,
+            successCount: 0,
+            failureCount: 0,
+            skippedCount: 5,
             failureReason: PRODUCT_ANALYTICS_FAILURE_REASONS.CancelledByUser,
           },
         },

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -55,10 +55,12 @@ const {
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>((promiseResolve) => {
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
     resolve = promiseResolve
+    reject = promiseReject
   })
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 vi.mock("~/services/productAnalytics/actions", () => ({
@@ -1665,6 +1667,137 @@ describe("ApiCheckModalHost", () => {
     expect(await within(probeCard).findByText("Retry OK")).toBeInTheDocument()
   })
 
+  it("ignores a stopped probe failure response and cancel transport errors", async () => {
+    const user = userEvent.setup()
+    const probeDeferred = createDeferred<ApiCheckRunProbeResponse>()
+
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.CancelRunProbe) {
+          throw new Error("cancel transport failed")
+        }
+
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          return await probeDeferred.promise
+        }
+
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    const baseUrlInput = await screen.findByPlaceholderText(
+      "https://example.com/api",
+    )
+    const apiKeyInput = await screen.findByPlaceholderText("sk-...")
+
+    await user.click(baseUrlInput)
+    await user.paste("https://proxy.example.com/api")
+    await user.click(apiKeyInput)
+    await user.paste("sk-test-secret-fixture")
+
+    const probeCard = await screen.findByTestId(
+      getWebAiApiCheckProbeTestId("text-generation"),
+    )
+
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.runOne",
+      }),
+    )
+    await user.click(
+      await within(probeCard).findByRole("button", {
+        name: "webAiApiCheck:modal.actions.stopTest",
+      }),
+    )
+
+    await act(async () => {
+      probeDeferred.resolve({
+        success: false,
+        error: "Should not show",
+      })
+    })
+
+    expect(
+      within(probeCard).queryByText("Should not show"),
+    ).not.toBeInTheDocument()
+    expect(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.retry",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("ignores a stopped probe rejected request", async () => {
+    const user = userEvent.setup()
+    const probeDeferred = createDeferred<ApiCheckRunProbeResponse>()
+
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.CancelRunProbe) {
+          return { success: true, cancelled: true }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          return await probeDeferred.promise
+        }
+
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    const baseUrlInput = await screen.findByPlaceholderText(
+      "https://example.com/api",
+    )
+    const apiKeyInput = await screen.findByPlaceholderText("sk-...")
+
+    await user.click(baseUrlInput)
+    await user.paste("https://proxy.example.com/api")
+    await user.click(apiKeyInput)
+    await user.paste("sk-test-secret-fixture")
+
+    const probeCard = await screen.findByTestId(
+      getWebAiApiCheckProbeTestId("text-generation"),
+    )
+
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.runOne",
+      }),
+    )
+    await user.click(
+      await within(probeCard).findByRole("button", {
+        name: "webAiApiCheck:modal.actions.stopTest",
+      }),
+    )
+
+    await act(async () => {
+      probeDeferred.reject(new Error("probe transport failed"))
+    })
+
+    expect(
+      within(probeCard).queryByText(
+        "webAiApiCheck:modal.errors.runProbeFailed",
+      ),
+    ).not.toBeInTheDocument()
+    expect(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.retry",
+      }),
+    ).toBeInTheDocument()
+  })
+
   it("maps structured probe HTTP status to an auth analytics failure", async () => {
     const user = userEvent.setup()
     vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
@@ -2134,6 +2267,18 @@ describe("ApiCheckModalHost", () => {
         screen.getByText("webAiApiCheck:modal.actions.test"),
       ).toBeInTheDocument()
     })
+  })
+
+  it("closes the modal when the backdrop is clicked while probes are idle", async () => {
+    await openModal()
+
+    fireEvent.click(
+      await screen.findByTestId(WEB_AI_API_CHECK_TEST_IDS.backdrop),
+    )
+
+    expect(
+      screen.queryByTestId(WEB_AI_API_CHECK_TEST_IDS.modal),
+    ).not.toBeInTheDocument()
   })
 
   it("falls back to the local probe error when the background probe call throws", async () => {

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -227,6 +227,25 @@ describe("ApiCheckModalHost", () => {
     expect(apiKeyInput.value).toBe("")
   })
 
+  it("shows the extracted API key by default", async () => {
+    await openModal({
+      sourceText:
+        "Base URL: https://proxy.example.com/api\nAPI Key: sk-test-visible-fixture",
+    })
+
+    const apiKeyInput = (await screen.findByPlaceholderText(
+      "sk-...",
+    )) as HTMLInputElement
+
+    expect(apiKeyInput.value).toBe("sk-test-visible-fixture")
+    expect(apiKeyInput).toHaveAttribute("type", "text")
+    expect(
+      screen.getByRole("button", {
+        name: "webAiApiCheck:modal.actions.hideKey",
+      }),
+    ).toBeInTheDocument()
+  })
+
   it("tracks modal open with safe credential presence insights", async () => {
     const sourceText =
       "Base URL: https://proxy.example.com/api\nAPI Key: sk-test-open-fixture"

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -34,10 +34,12 @@ import {
   PRODUCT_ANALYTICS_SOURCE_KINDS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
+import type { ApiVerificationProbeId } from "~/services/verification/aiApiVerification"
 import {
   sendWebAiApiCheckMessage,
   WebAiApiCheckMessageTypes,
 } from "~/services/verification/webAiApiCheck/messaging"
+import type { ApiCheckRunProbeResponse } from "~/services/verification/webAiApiCheck/types"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { render } from "~~/tests/test-utils/render"
 
@@ -50,6 +52,14 @@ const {
   completeProductAnalyticsActionMock: vi.fn(),
   updateWebAiApiCheckMock: vi.fn(),
 }))
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
 
 vi.mock("~/services/productAnalytics/actions", () => ({
   resolveProductAnalyticsErrorCategoryFromError: (error: unknown) =>
@@ -92,15 +102,19 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
-vi.mock("~/services/verification/webAiApiCheck/messaging", () => ({
-  WebAiApiCheckMessageTypes: {
-    ShouldPrompt: "webAiApiCheck:shouldPrompt",
-    FetchModels: "webAiApiCheck:fetchModels",
-    RunProbe: "webAiApiCheck:runProbe",
-    SaveProfile: "webAiApiCheck:saveProfile",
+vi.mock(
+  "~/services/verification/webAiApiCheck/messaging",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/verification/webAiApiCheck/messaging")
+      >()
+    return {
+      ...actual,
+      sendWebAiApiCheckMessage: vi.fn(),
+    }
   },
-  sendWebAiApiCheckMessage: vi.fn(),
-}))
+)
 
 describe("ApiCheckModalHost", () => {
   const expectAnalyticsCallsToExcludeSensitiveValues = (
@@ -175,6 +189,25 @@ describe("ApiCheckModalHost", () => {
     await act(async () => {
       dispatchOpenApiCheckModal({ ...defaultDetail, ...detailOverrides })
     })
+  }
+
+  const startManualProbeSuite = async (
+    user: ReturnType<typeof userEvent.setup>,
+  ) => {
+    await openModal()
+
+    const baseUrlInput = await screen.findByPlaceholderText(
+      "https://example.com/api",
+    )
+    const apiKeyInput = await screen.findByPlaceholderText("sk-...")
+
+    await user.click(baseUrlInput)
+    await user.paste("https://proxy.example.com/api")
+    await user.click(apiKeyInput)
+    await user.paste("sk-test-secret-fixture")
+    await user.click(
+      await screen.findByText("webAiApiCheck:modal.actions.test"),
+    )
   }
 
   it("opens with empty inputs for manual trigger without selection", async () => {
@@ -1398,6 +1431,112 @@ describe("ApiCheckModalHost", () => {
     )
   })
 
+  it("stops an individual running API probe and ignores its late result", async () => {
+    const user = userEvent.setup()
+    const probeDeferred = createDeferred<ApiCheckRunProbeResponse>()
+    const runProbeMessages: Array<Record<string, unknown>> = []
+
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.CancelRunProbe) {
+          return { success: true, cancelled: true }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          runProbeMessages.push(message)
+          return await probeDeferred.promise
+        }
+
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    const baseUrlInput = await screen.findByPlaceholderText(
+      "https://example.com/api",
+    )
+    const apiKeyInput = await screen.findByPlaceholderText("sk-...")
+
+    await user.click(baseUrlInput)
+    await user.paste("https://proxy.example.com/api")
+    await user.click(apiKeyInput)
+    await user.paste("sk-test-secret-fixture")
+
+    const probeCard = await screen.findByTestId(
+      getWebAiApiCheckProbeTestId("text-generation"),
+    )
+
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.runOne",
+      }),
+    )
+
+    const activeRunId = await waitFor(() => {
+      expect(runProbeMessages).toEqual([
+        expect.objectContaining({
+          probeId: "text-generation",
+          runId: expect.any(String),
+        }),
+      ])
+      return runProbeMessages[0].runId as string
+    })
+
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.stopTest",
+      }),
+    )
+
+    expect(sendWebAiApiCheckMessage).toHaveBeenCalledWith(
+      WebAiApiCheckMessageTypes.CancelRunProbe,
+      { runId: activeRunId },
+    )
+    expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.WebAiApiCheck,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.RunApiCredentialProbe,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.ContentApiCheckModal,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Content,
+    })
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Cancelled,
+      {
+        insights: {
+          sourceKind: PRODUCT_ANALYTICS_SOURCE_KINDS.Manual,
+          apiType: "openai-compatible",
+          mode: PRODUCT_ANALYTICS_MODE_IDS.Single,
+          failureReason: PRODUCT_ANALYTICS_FAILURE_REASONS.CancelledByUser,
+        },
+      },
+    )
+
+    await act(async () => {
+      probeDeferred.resolve({
+        success: true,
+        result: {
+          id: "text-generation",
+          status: "fail",
+          latencyMs: 0,
+          summary: "Cancelled by user",
+        },
+      })
+    })
+
+    expect(
+      within(probeCard).queryByText("Cancelled by user"),
+    ).not.toBeInTheDocument()
+    expect(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.retry",
+      }),
+    ).toBeInTheDocument()
+  })
+
   it("maps structured probe HTTP status to an auth analytics failure", async () => {
     const user = userEvent.setup()
     vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
@@ -1606,6 +1745,171 @@ describe("ApiCheckModalHost", () => {
         },
       },
     )
+  })
+
+  it("stops the running API probe suite, cancels the active background run, and keeps queued probes idle", async () => {
+    const user = userEvent.setup()
+    const firstProbeDeferred = createDeferred<ApiCheckRunProbeResponse>()
+    const runProbeMessages: Array<Record<string, unknown>> = []
+
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.CancelRunProbe) {
+          return { success: true, cancelled: true }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          runProbeMessages.push(message)
+          const probeId = message.probeId as ApiVerificationProbeId
+          if (message.probeId === "text-generation") {
+            return await firstProbeDeferred.promise
+          }
+
+          return {
+            success: true,
+            result: {
+              id: probeId,
+              status: "pass",
+              latencyMs: 1,
+              summary: "Should not run",
+            },
+          }
+        }
+
+        return { success: false }
+      },
+    )
+
+    await startManualProbeSuite(user)
+
+    const activeRunId = await waitFor(() => {
+      const activeProbeMessage = runProbeMessages.find(
+        (message) => message.probeId === "text-generation",
+      )
+      expect(activeProbeMessage).toEqual(
+        expect.objectContaining({
+          probeId: "text-generation",
+          runId: expect.any(String),
+        }),
+      )
+      return activeProbeMessage!.runId as string
+    })
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.actions.stopTest",
+      }),
+    )
+
+    expect(sendWebAiApiCheckMessage).toHaveBeenCalledWith(
+      WebAiApiCheckMessageTypes.CancelRunProbe,
+      { runId: activeRunId },
+    )
+    firstProbeDeferred.resolve({
+      success: true,
+      result: {
+        id: "text-generation",
+        status: "fail",
+        latencyMs: 0,
+        summary: "Cancelled by user",
+      },
+    })
+
+    expect(
+      await screen.findByText("webAiApiCheck:modal.messages.testStopped"),
+    ).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(runProbeMessages).toHaveLength(2)
+    })
+    expect(
+      await screen.findByText("webAiApiCheck:modal.actions.test"),
+    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Cancelled,
+        {
+          insights: {
+            sourceKind: PRODUCT_ANALYTICS_SOURCE_KINDS.Manual,
+            apiType: "openai-compatible",
+            mode: PRODUCT_ANALYTICS_MODE_IDS.All,
+            itemCount: 5,
+            successCount: 1,
+            failureCount: 0,
+            skippedCount: 4,
+            failureReason: PRODUCT_ANALYTICS_FAILURE_REASONS.CancelledByUser,
+          },
+        },
+      )
+    })
+  })
+
+  it("keeps the modal open when the backdrop is clicked while the API probe suite is running", async () => {
+    const user = userEvent.setup()
+    const firstProbeDeferred = createDeferred<ApiCheckRunProbeResponse>()
+
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          if (message.probeId === "text-generation") {
+            return await firstProbeDeferred.promise
+          }
+
+          return {
+            success: true,
+            result: {
+              id: message.probeId as ApiVerificationProbeId,
+              status: "pass",
+              latencyMs: 1,
+              summary: "Probe OK",
+            },
+          }
+        }
+
+        return { success: false }
+      },
+    )
+
+    await startManualProbeSuite(user)
+    await screen.findByRole("button", {
+      name: "webAiApiCheck:modal.actions.stopTest",
+    })
+
+    fireEvent.click(screen.getByTestId(WEB_AI_API_CHECK_TEST_IDS.backdrop))
+
+    expect(
+      screen.getByTestId(WEB_AI_API_CHECK_TEST_IDS.modal),
+    ).toBeInTheDocument()
+    expect(sendWebAiApiCheckMessage).not.toHaveBeenCalledWith(
+      WebAiApiCheckMessageTypes.CancelRunProbe,
+      expect.anything(),
+    )
+
+    await act(async () => {
+      firstProbeDeferred.resolve({
+        success: true,
+        result: {
+          id: "text-generation",
+          status: "pass",
+          latencyMs: 1,
+          summary: "Probe OK",
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("webAiApiCheck:modal.actions.test"),
+      ).toBeInTheDocument()
+    })
   })
 
   it("falls back to the local probe error when the background probe call throws", async () => {

--- a/tests/services/productAnalytics/events.test.ts
+++ b/tests/services/productAnalytics/events.test.ts
@@ -155,6 +155,8 @@ describe("product analytics event enums", () => {
       SelectApiCredentialProfileExportDestination:
         "select_api_credential_profile_export_destination",
       SnapshotApiCredentialProfiles: "snapshot_api_credential_profiles",
+      RunApiCredentialProbe: "run_api_credential_probe",
+      RunApiCredentialProbeSuite: "run_api_credential_probe_suite",
     })
   })
 

--- a/tests/services/webAiApiCheck/background.test.ts
+++ b/tests/services/webAiApiCheck/background.test.ts
@@ -4,6 +4,12 @@ import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
 import { PRODUCT_ANALYTICS_ERROR_CATEGORIES } from "~/services/productAnalytics/events"
 import type { ApiVerificationProbeResult } from "~/services/verification/aiApiVerification"
 
+const { onWebAiApiCheckMessageMock } = vi.hoisted(() => ({
+  onWebAiApiCheckMessageMock: vi.fn(
+    (_type: string, _handler: (...args: any[]) => unknown) => vi.fn(),
+  ),
+}))
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void
   const promise = new Promise<T>((promiseResolve) => {
@@ -22,6 +28,16 @@ vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
     userPreferences: {
       getPreferences: vi.fn(),
     },
+  }
+})
+
+vi.mock("~/services/verification/webAiApiCheck/messaging", async () => {
+  const actual = await vi.importActual<
+    typeof import("~/services/verification/webAiApiCheck/messaging")
+  >("~/services/verification/webAiApiCheck/messaging")
+  return {
+    ...actual,
+    onWebAiApiCheckMessage: onWebAiApiCheckMessageMock,
   }
 })
 
@@ -557,6 +573,20 @@ describe("webAiApiCheck background handlers", () => {
     expect(secondCancelResponse).toEqual({ success: true, cancelled: false })
   })
 
+  it("cancelRunProbe rejects malformed run ids without throwing", async () => {
+    vi.resetModules()
+
+    const background = await import(
+      "~/services/verification/webAiApiCheck/background"
+    )
+
+    await expect(
+      background.resolveWebAiApiCheckCancelRunProbeMessage({
+        runId: undefined,
+      } as any),
+    ).resolves.toEqual({ success: true, cancelled: false })
+  })
+
   it("runProbe sanitizes apiKey when probe execution throws", async () => {
     vi.resetModules()
     const { runApiVerificationProbe } = await import(
@@ -825,5 +855,31 @@ describe("webAiApiCheck background handlers", () => {
       success: false,
       error: "Failed to handle request",
     })
+  })
+
+  it("registers the cancel-run-probe background message handler", async () => {
+    vi.resetModules()
+    onWebAiApiCheckMessageMock.mockClear()
+
+    const background = await import(
+      "~/services/verification/webAiApiCheck/background"
+    )
+    const { WebAiApiCheckMessageTypes } = await import(
+      "~/services/verification/webAiApiCheck/messaging"
+    )
+
+    background.setupWebAiApiCheckMessagingListeners()
+    background.setupWebAiApiCheckMessagingListeners()
+
+    expect(onWebAiApiCheckMessageMock).toHaveBeenCalledTimes(5)
+    expect(
+      onWebAiApiCheckMessageMock.mock.calls.map((call) => call[0]),
+    ).toEqual([
+      WebAiApiCheckMessageTypes.ShouldPrompt,
+      WebAiApiCheckMessageTypes.FetchModels,
+      WebAiApiCheckMessageTypes.RunProbe,
+      WebAiApiCheckMessageTypes.CancelRunProbe,
+      WebAiApiCheckMessageTypes.SaveProfile,
+    ])
   })
 })

--- a/tests/services/webAiApiCheck/background.test.ts
+++ b/tests/services/webAiApiCheck/background.test.ts
@@ -4,11 +4,20 @@ import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
 import { PRODUCT_ANALYTICS_ERROR_CATEGORIES } from "~/services/productAnalytics/events"
 import type { ApiVerificationProbeResult } from "~/services/verification/aiApiVerification"
 
-const { onWebAiApiCheckMessageMock } = vi.hoisted(() => ({
-  onWebAiApiCheckMessageMock: vi.fn(
-    (_type: string, _handler: (...args: any[]) => unknown) => vi.fn(),
-  ),
-}))
+const { onWebAiApiCheckMessageMock, webAiApiCheckMessageHandlers } = vi.hoisted(
+  () => ({
+    webAiApiCheckMessageHandlers: new Map<
+      string,
+      (payload: { data: any }) => unknown
+    >(),
+    onWebAiApiCheckMessageMock: vi.fn(
+      (type: string, handler: (payload: { data: any }) => unknown) => {
+        webAiApiCheckMessageHandlers.set(type, handler)
+        return vi.fn()
+      },
+    ),
+  }),
+)
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void
@@ -587,6 +596,65 @@ describe("webAiApiCheck background handlers", () => {
     ).resolves.toEqual({ success: true, cancelled: false })
   })
 
+  it("cancelRunProbe returns a safe response when abort throws", async () => {
+    vi.resetModules()
+    let receivedSignal: AbortSignal | undefined
+    const probeDeferred = createDeferred<ApiVerificationProbeResult>()
+
+    const { runApiVerificationProbe } = await import(
+      "~/services/verification/aiApiVerification"
+    )
+    vi.mocked(runApiVerificationProbe).mockImplementation(
+      async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return await probeDeferred.promise
+      },
+    )
+
+    const background = await import(
+      "~/services/verification/webAiApiCheck/background"
+    )
+
+    const probePromise = background.resolveWebAiApiCheckRunProbeMessage({
+      runId: "web-ai-api-check-run-throws",
+      apiType: "openai-compatible",
+      baseUrl: "https://proxy.example.com/api/v1",
+      apiKey: "sk-test-secret-fixture",
+      modelId: "gpt-4o-mini",
+      probeId: "text-generation",
+    })
+
+    await vi.waitFor(() => {
+      expect(receivedSignal).toBeInstanceOf(AbortSignal)
+    })
+
+    const abortSpy = vi
+      .spyOn(AbortController.prototype, "abort")
+      .mockImplementation(() => {
+        throw new Error("abort failed")
+      })
+
+    await expect(
+      background.resolveWebAiApiCheckCancelRunProbeMessage({
+        runId: "web-ai-api-check-run-throws",
+      }),
+    ).resolves.toEqual({ success: true, cancelled: false })
+
+    abortSpy.mockRestore()
+
+    probeDeferred.resolve({
+      id: "text-generation",
+      status: "fail",
+      latencyMs: 0,
+      summary: "Cancelled by user",
+      input: {
+        apiType: "openai-compatible",
+        baseUrl: "https://proxy.example.com/api",
+      },
+    })
+    await probePromise
+  })
+
   it("runProbe sanitizes apiKey when probe execution throws", async () => {
     vi.resetModules()
     const { runApiVerificationProbe } = await import(
@@ -881,5 +949,13 @@ describe("webAiApiCheck background handlers", () => {
       WebAiApiCheckMessageTypes.CancelRunProbe,
       WebAiApiCheckMessageTypes.SaveProfile,
     ])
+
+    const cancelHandler = webAiApiCheckMessageHandlers.get(
+      WebAiApiCheckMessageTypes.CancelRunProbe,
+    )
+    expect(cancelHandler).toEqual(expect.any(Function))
+    await expect(
+      cancelHandler?.({ data: { runId: "missing-run" } }),
+    ).resolves.toEqual({ success: true, cancelled: false })
   })
 })

--- a/tests/services/webAiApiCheck/background.test.ts
+++ b/tests/services/webAiApiCheck/background.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it, vi } from "vitest"
 
 import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
 import { PRODUCT_ANALYTICS_ERROR_CATEGORIES } from "~/services/productAnalytics/events"
+import type { ApiVerificationProbeResult } from "~/services/verification/aiApiVerification"
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
 
 vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
   const actual =
@@ -465,6 +474,7 @@ describe("webAiApiCheck background handlers", () => {
       baseUrl: "https://proxy.example.com/api",
       modelId: undefined,
       probeId: "text-generation",
+      abortSignal: undefined,
     })
     expect(response).toEqual({
       success: true,
@@ -479,6 +489,72 @@ describe("webAiApiCheck background handlers", () => {
         },
       },
     })
+  })
+
+  it("runProbe can be cancelled by run id while the probe is in flight", async () => {
+    vi.resetModules()
+    let receivedSignal: AbortSignal | undefined
+    const probeDeferred = createDeferred<ApiVerificationProbeResult>()
+
+    const { runApiVerificationProbe } = await import(
+      "~/services/verification/aiApiVerification"
+    )
+    vi.mocked(runApiVerificationProbe).mockImplementation(
+      async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return await probeDeferred.promise
+      },
+    )
+
+    const background = await import(
+      "~/services/verification/webAiApiCheck/background"
+    )
+
+    const probePromise = background.resolveWebAiApiCheckRunProbeMessage({
+      runId: "web-ai-api-check-run-1",
+      apiType: "openai-compatible",
+      baseUrl: "https://proxy.example.com/api/v1",
+      apiKey: "sk-test-secret-fixture",
+      modelId: "gpt-4o-mini",
+      probeId: "text-generation",
+    })
+
+    await vi.waitFor(() => {
+      expect(receivedSignal).toBeInstanceOf(AbortSignal)
+    })
+
+    const cancelResponse =
+      await background.resolveWebAiApiCheckCancelRunProbeMessage({
+        runId: "web-ai-api-check-run-1",
+      })
+
+    expect(cancelResponse).toEqual({ success: true, cancelled: true })
+    expect(receivedSignal?.aborted).toBe(true)
+
+    probeDeferred.resolve({
+      id: "text-generation",
+      status: "fail",
+      latencyMs: 0,
+      summary: "Cancelled by user",
+      input: {
+        apiType: "openai-compatible",
+        baseUrl: "https://proxy.example.com/api",
+      },
+    })
+    await expect(probePromise).resolves.toMatchObject({
+      success: true,
+      result: {
+        id: "text-generation",
+        status: "fail",
+        summary: "Cancelled by user",
+      },
+    })
+
+    const secondCancelResponse =
+      await background.resolveWebAiApiCheckCancelRunProbeMessage({
+        runId: "web-ai-api-check-run-1",
+      })
+    expect(secondCancelResponse).toEqual({ success: true, cancelled: false })
   })
 
   it("runProbe sanitizes apiKey when probe execution throws", async () => {


### PR DESCRIPTION
## Summary
- Add cancellable API availability checks for both full test suites and individual probes, including late-result suppression and user-facing stop states.
- Report interrupted probe runs as cancelled results on the existing run analytics actions instead of separate stop actions.
- Show extracted API keys by default while preserving the hide/reveal control.

## Issue
Refs #1025

This addresses the interruption and default key visibility parts of the broader issue; the remaining suggestions need separate product decisions.

## Test Plan
- pnpm vitest run tests/components/ApiCheckModalHost.test.tsx tests/services/webAiApiCheck/background.test.ts tests/services/productAnalytics/events.test.ts
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable stopping for individual API credential tests and the full suite while runs are in progress.
  * Introduced consistent stop/cancel behavior so late results don’t affect the UI or recorded outcomes.
* **UI/Behavior**
  * Backdrop clicks only close the modal when no tests are running.
  * Added/updated “Stop test” controls and enhanced primary run/stop button behavior.
  * API key visibility now starts enabled when the modal opens.
* **Localization**
  * Updated stop-related labels and status messages (“Stopping…”, “Stop test”, “Test stopped…”) across supported languages.
* **Tests**
  * Expanded coverage for cancellation/stop flows, including late-result and edge-case handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->