### PR TITLE
fix(account): reflect post-save refresh updates

### DIFF
--- a/src/constants/runtimeActions.ts
+++ b/src/constants/runtimeActions.ts
@@ -9,6 +9,7 @@
  */
 export const RuntimeActionPrefixes = {
   AccountDialog: "accountDialog:",
+  AccountRefresh: "accountRefresh:",
   ApiCheck: "apiCheck:",
   AutoCheckin: "autoCheckin:",
   AutoCheckinPretrigger: "autoCheckinPretrigger:",
@@ -42,6 +43,11 @@ export const RuntimeActionIds = {
   AccountDialogImportCookieAuthSessionCookie: composeRuntimeAction(
     RuntimeActionPrefixes.AccountDialog,
     "importCookieAuthSessionCookie",
+  ),
+
+  AccountRefreshCompleted: composeRuntimeAction(
+    RuntimeActionPrefixes.AccountRefresh,
+    "completed",
   ),
 
   ApiCheckContextMenuTrigger: composeRuntimeAction(

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -302,6 +302,7 @@ interface AihubmixPostSaveKeyPromptState {
  * @param props.prefill Optional add-mode sponsor prefill.
  * @param props.isOpen Whether the dialog is currently open.
  * @param props.onClose Handler invoked when dialog closes.
+ * @param props.onPostSaveAccountRefresh Optional handler invoked after deferred account refresh completes.
  * @param props.onSuccess Optional handler invoked after successful save.
  * @returns Aggregated state, setters, and handlers powering the dialog UI.
  */

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -112,6 +112,7 @@ import {
   getActiveTabs,
   getAllTabs,
   getBrowserApiCapabilities,
+  isMessageReceiverUnavailableError,
   onTabActivated,
   onTabUpdated,
   sendRuntimeMessage,
@@ -167,13 +168,51 @@ const logger = createLogger("AccountDialogHook")
 /**
  * Refreshes saved account data without keeping the account dialog save flow open.
  */
-function schedulePostSaveAccountRefresh(accountId: string) {
-  void accountStorage.refreshAccount(accountId, true).catch((error) => {
-    logger.warn("Post-save deferred account refresh failed", {
-      accountId,
-      error: getErrorMessage(error),
+function schedulePostSaveAccountRefresh(
+  accountId: string,
+  onPostSaveAccountRefresh?: (accountIds: string[]) => Promise<void>,
+) {
+  void accountStorage
+    .refreshAccount(accountId, true)
+    .then(async (result) => {
+      if (!result?.refreshed) {
+        return
+      }
+
+      if (onPostSaveAccountRefresh) {
+        await onPostSaveAccountRefresh([accountId])
+      }
+
+      try {
+        await sendRuntimeMessage(
+          {
+            action: RuntimeActionIds.AccountRefreshCompleted,
+            updatedAccountIds: [accountId],
+          },
+          { maxAttempts: 1 },
+        )
+      } catch (error) {
+        const errorMessage = getErrorMessage(error)
+        if (isMessageReceiverUnavailableError(error)) {
+          logger.debug("Post-save account refresh notification ignored", {
+            accountId,
+            error: errorMessage,
+          })
+          return
+        }
+
+        logger.warn("Post-save account refresh notification failed", {
+          accountId,
+          error: errorMessage,
+        })
+      }
     })
-  })
+    .catch((error) => {
+      logger.warn("Post-save deferred account refresh failed", {
+        accountId,
+        error: getErrorMessage(error),
+      })
+    })
 }
 
 interface CookieAuthPermissionState {
@@ -238,6 +277,7 @@ interface UseAccountDialogProps {
   prefill?: AddAccountPrefill | null
   isOpen: boolean
   onClose: () => void
+  onPostSaveAccountRefresh?: (accountIds: string[]) => Promise<void>
   onSuccess?: (data: any) => void
 }
 
@@ -271,6 +311,7 @@ export function useAccountDialog({
   prefill,
   isOpen,
   onClose,
+  onPostSaveAccountRefresh,
   onSuccess,
 }: UseAccountDialogProps) {
   const { t } = useTranslation(["accountDialog", "settings", "messages"])
@@ -1935,7 +1976,7 @@ export function useAccountDialog({
           : null
 
       if (savedAccountId) {
-        schedulePostSaveAccountRefresh(savedAccountId)
+        schedulePostSaveAccountRefresh(savedAccountId, onPostSaveAccountRefresh)
       }
 
       const feedbackMessage =

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -83,6 +83,7 @@ export default function AccountDialog({
     createTag,
     renameTag,
     deleteTag,
+    reloadAccountsById,
   } = useAccountDataContext()
   const { openEditAccount } = useDialogStateContext()
 
@@ -94,6 +95,7 @@ export default function AccountDialog({
     mode,
     account,
     prefill,
+    onPostSaveAccountRefresh: reloadAccountsById,
     onSuccess,
   })
 

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -180,6 +180,7 @@ interface AccountDataContextType {
   unpinAccount: (id: string) => Promise<boolean>
   togglePinAccount: (id: string) => Promise<boolean>
   loadAccountData: () => Promise<void>
+  reloadAccountsById: (accountIds: string[]) => Promise<void>
   handleRefresh: (force?: boolean) => Promise<{
     success: number
     failed: number
@@ -846,9 +847,8 @@ export const AccountDataProvider = ({
     void checkCurrentTab()
   }, [accounts, checkCurrentTab, hasLoadedAccountData])
 
-  // 监听后台自动刷新的更新通知
-  useEffect(() => {
-    const reloadAccountsById = async (accountIds: string[]) => {
+  const reloadAccountsById = useCallback(
+    async (accountIds: string[]) => {
       const uniqueIds = Array.from(
         new Set(
           accountIds.filter(
@@ -959,8 +959,17 @@ export const AccountDataProvider = ({
         )
         await loadAccountData()
       }
-    }
+    },
+    [
+      buildDisplayDataWithBalanceHistory,
+      estimatedTodayIncomeEnabled,
+      loadAccountData,
+      tagStore,
+    ],
+  )
 
+  // 监听后台自动刷新的更新通知
+  useEffect(() => {
     return onRuntimeMessage((message: any) => {
       if (
         message.type === "AUTO_REFRESH_UPDATE" &&
@@ -974,19 +983,17 @@ export const AccountDataProvider = ({
         loadAccountData()
       }
 
-      if (message?.action === RuntimeActionIds.AutoCheckinRunCompleted) {
+      if (
+        message?.action === RuntimeActionIds.AutoCheckinRunCompleted ||
+        message?.action === RuntimeActionIds.AccountRefreshCompleted
+      ) {
         const updatedAccountIds = Array.isArray(message.updatedAccountIds)
           ? message.updatedAccountIds
           : []
         void reloadAccountsById(updatedAccountIds)
       }
     })
-  }, [
-    buildDisplayDataWithBalanceHistory,
-    estimatedTodayIncomeEnabled,
-    loadAccountData,
-    tagStore,
-  ])
+  }, [loadAccountData, reloadAccountsById])
 
   const handleSort = useCallback(
     (field: SortField) => {
@@ -1373,6 +1380,7 @@ export const AccountDataProvider = ({
       unpinAccount,
       togglePinAccount,
       loadAccountData,
+      reloadAccountsById,
       handleRefresh,
       handleRefreshDisabledAccounts,
       handleSort,
@@ -1413,6 +1421,7 @@ export const AccountDataProvider = ({
       unpinAccount,
       togglePinAccount,
       loadAccountData,
+      reloadAccountsById,
       handleRefresh,
       handleRefreshDisabledAccounts,
       handleSort,

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -905,14 +905,26 @@ export const AccountDataProvider = ({
         setAccounts(mergedAccounts)
         const balanceHistoryStore = await dailyBalanceHistoryStorage.getStore()
         const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
+        const latestActiveReloadedAccounts = activeReloadedAccounts.filter(
+          (account) =>
+            targetedReloadGenerationByAccountIdRef.current[account.id] ===
+            reloadGeneration,
+        )
+        if (latestActiveReloadedAccounts.length === 0) {
+          return
+        }
+
+        const latestReloadedById = Object.fromEntries(
+          latestActiveReloadedAccounts.map((account) => [account.id, account]),
+        )
         const latestAccounts = accountsRef.current
         const latestKnownIds = new Set(
           latestAccounts.map((account) => account.id),
         )
         const latestMergedAccounts = latestAccounts.map(
-          (account) => reloadedById[account.id] ?? account,
+          (account) => latestReloadedById[account.id] ?? account,
         )
-        for (const account of activeReloadedAccounts) {
+        for (const account of latestActiveReloadedAccounts) {
           if (!latestKnownIds.has(account.id)) {
             latestMergedAccounts.push(account)
           }
@@ -941,7 +953,7 @@ export const AccountDataProvider = ({
             currentDayKey: todayKey,
           }),
         )
-        for (const account of activeReloadedAccounts) {
+        for (const account of latestActiveReloadedAccounts) {
           if (
             targetedReloadGenerationByAccountIdRef.current[account.id] ===
             reloadGeneration

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -1958,6 +1958,52 @@ describe("AccountDataContext refresh orchestration", () => {
 
     expect(initialLoadCalls).toBeGreaterThan(0)
   })
+
+  it("reloads a saved account into display data after a post-save refresh notification", async () => {
+    mockGetAllAccounts.mockResolvedValue([
+      { id: "saved-account-id", name: "before", last_sync_time: 0 },
+    ])
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData).toEqual([
+        expect.objectContaining({
+          id: "saved-account-id",
+          name: "before",
+          last_sync_time: 0,
+        }),
+      ])
+    })
+
+    mockGetAccountById.mockResolvedValueOnce({
+      id: "saved-account-id",
+      name: "after",
+      last_sync_time: 1_710_123_456_789,
+    })
+
+    const listener = (globalThis as any).__accountDataContextRuntimeListener as
+      | ((message: any) => void)
+      | undefined
+    expect(listener).toBeTypeOf("function")
+
+    await act(async () => {
+      listener!({
+        action: RuntimeActionIds.AccountRefreshCompleted,
+        updatedAccountIds: ["saved-account-id"],
+      })
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData).toEqual([
+        expect.objectContaining({
+          id: "saved-account-id",
+          name: "after",
+          last_sync_time: 1_710_123_456_789,
+        }),
+      ])
+    })
+  })
 })
 
 describe("AccountDataContext sorting behavior", () => {

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -2004,6 +2004,85 @@ describe("AccountDataContext refresh orchestration", () => {
       ])
     })
   })
+
+  it("does not let an older targeted reload overwrite a newer reload after balance history loads", async () => {
+    mockGetAllAccounts.mockResolvedValue([
+      { id: "saved-account-id", name: "before", last_sync_time: 0 },
+    ])
+    const olderBalanceHistoryLoad = createDeferred<{
+      schemaVersion: number
+      snapshotsByAccountId: Record<string, never>
+    }>()
+    const balanceHistoryStore = {
+      schemaVersion: DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION,
+      snapshotsByAccountId: {},
+    }
+    mockGetDailyBalanceHistoryStore.mockResolvedValue(balanceHistoryStore)
+
+    const getLatestCtx = await renderAccountDataProvider()
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData).toEqual([
+        expect.objectContaining({
+          id: "saved-account-id",
+          name: "before",
+          last_sync_time: 0,
+        }),
+      ])
+    })
+
+    mockGetDailyBalanceHistoryStore.mockReset()
+    mockGetDailyBalanceHistoryStore
+      .mockReturnValueOnce(olderBalanceHistoryLoad.promise)
+      .mockResolvedValueOnce(balanceHistoryStore)
+
+    mockGetAccountById
+      .mockResolvedValueOnce({
+        id: "saved-account-id",
+        name: "older",
+        last_sync_time: 1,
+      })
+      .mockResolvedValueOnce({
+        id: "saved-account-id",
+        name: "newer",
+        last_sync_time: 2,
+      })
+
+    const olderReload = getLatestCtx().reloadAccountsById(["saved-account-id"])
+
+    await waitFor(() => {
+      expect(mockGetDailyBalanceHistoryStore).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      await getLatestCtx().reloadAccountsById(["saved-account-id"])
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData).toEqual([
+        expect.objectContaining({
+          id: "saved-account-id",
+          name: "newer",
+          last_sync_time: 2,
+        }),
+      ])
+    })
+
+    await act(async () => {
+      olderBalanceHistoryLoad.resolve(balanceHistoryStore)
+      await olderReload
+    })
+
+    await waitFor(() => {
+      expect(getLatestCtx().displayData).toEqual([
+        expect.objectContaining({
+          id: "saved-account-id",
+          name: "newer",
+          last_sync_time: 2,
+        }),
+      ])
+    })
+  })
 })
 
 describe("AccountDataContext sorting behavior", () => {

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -499,6 +499,125 @@ describe("useAccountDialog save and auto-config flows", () => {
     })
   })
 
+  it("skips post-save refresh notification when saved data is unchanged", async () => {
+    const onPostSaveAccountRefresh = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(accountStorage, "refreshAccount").mockResolvedValue({
+      account: buildSiteAccount({ id: "saved-account-id" }),
+      refreshed: false,
+    })
+
+    const { result } = renderAddHook({ onPostSaveAccountRefresh })
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await fillStandardAddAccountDraft(result)
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    await waitFor(() => {
+      expect(accountStorage.refreshAccount).toHaveBeenCalledWith(
+        "saved-account-id",
+        true,
+      )
+    })
+    expect(onPostSaveAccountRefresh).not.toHaveBeenCalled()
+    expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
+  })
+
+  it("ignores unavailable receivers during post-save refresh notification", async () => {
+    const onPostSaveAccountRefresh = vi.fn().mockResolvedValue(undefined)
+    const receiverUnavailableError = new Error(
+      "Could not establish connection. Receiving end does not exist.",
+    )
+    mockSendRuntimeMessage.mockRejectedValueOnce(receiverUnavailableError)
+
+    const { result } = renderAddHook({ onPostSaveAccountRefresh })
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await fillStandardAddAccountDraft(result)
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    await waitFor(() => {
+      expect(onPostSaveAccountRefresh).toHaveBeenCalledWith([
+        "saved-account-id",
+      ])
+      expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+        {
+          action: RuntimeActionIds.AccountRefreshCompleted,
+          updatedAccountIds: ["saved-account-id"],
+        },
+        { maxAttempts: 1 },
+      )
+    })
+  })
+
+  it("continues after post-save refresh notification failures", async () => {
+    const onPostSaveAccountRefresh = vi.fn().mockResolvedValue(undefined)
+    mockSendRuntimeMessage.mockRejectedValueOnce(new Error("runtime failed"))
+
+    const { result } = renderAddHook({ onPostSaveAccountRefresh })
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await fillStandardAddAccountDraft(result)
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    await waitFor(() => {
+      expect(onPostSaveAccountRefresh).toHaveBeenCalledWith([
+        "saved-account-id",
+      ])
+      expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+        {
+          action: RuntimeActionIds.AccountRefreshCompleted,
+          updatedAccountIds: ["saved-account-id"],
+        },
+        { maxAttempts: 1 },
+      )
+    })
+  })
+
+  it("logs post-save refresh failures without reopening the save flow", async () => {
+    const refreshError = new Error("refresh failed")
+    vi.spyOn(accountStorage, "refreshAccount").mockRejectedValueOnce(
+      refreshError,
+    )
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await fillStandardAddAccountDraft(result)
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    await waitFor(() => {
+      expect(accountStorage.refreshAccount).toHaveBeenCalledWith(
+        "saved-account-id",
+        true,
+      )
+    })
+    expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
+  })
+
   it("does not persist Sub2API refresh-token auth until the mode is explicitly enabled", async () => {
     const { result } = renderAddHook()
 

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -3,6 +3,7 @@ import toast from "react-hot-toast"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { DIALOG_MODES } from "~/constants/dialogModes"
+import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import { useAccountDialog } from "~/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog"
 import {
@@ -47,6 +48,7 @@ const {
   mockOpenDefaultTokenQuickCreateDialogForAccount,
   mockGetManagedSiteConfig,
   mockOpenSettingsTab,
+  mockSendRuntimeMessage,
   mockStartProductAnalyticsAction,
   mockCompleteProductAnalyticsAction,
 } = vi.hoisted(() => ({
@@ -59,6 +61,7 @@ const {
   mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
   mockGetManagedSiteConfig: vi.fn(),
   mockOpenSettingsTab: vi.fn().mockResolvedValue(undefined),
+  mockSendRuntimeMessage: vi.fn().mockResolvedValue(undefined),
   mockStartProductAnalyticsAction: vi.fn(),
   mockCompleteProductAnalyticsAction: vi.fn(),
 }))
@@ -144,7 +147,7 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
     getAllTabs: vi.fn(async () => []),
     onTabActivated: vi.fn(() => () => {}),
     onTabUpdated: vi.fn(() => () => {}),
-    sendRuntimeMessage: vi.fn(),
+    sendRuntimeMessage: mockSendRuntimeMessage,
   }
 })
 
@@ -196,12 +199,16 @@ describe("useAccountDialog save and auto-config flows", () => {
     })
   })
 
-  const renderAddHook = (options?: { onSuccess?: ReturnType<typeof vi.fn> }) =>
+  const renderAddHook = (options?: {
+    onPostSaveAccountRefresh?: ReturnType<typeof vi.fn>
+    onSuccess?: ReturnType<typeof vi.fn>
+  }) =>
     renderHook(() =>
       useAccountDialog({
         mode: DIALOG_MODES.ADD,
         isOpen: true,
         onClose: vi.fn(),
+        onPostSaveAccountRefresh: options?.onPostSaveAccountRefresh,
         onSuccess: options?.onSuccess ?? vi.fn(),
       }),
     )
@@ -456,6 +463,39 @@ describe("useAccountDialog save and auto-config flows", () => {
     )
     await waitFor(() => {
       expect(refreshSpy).toHaveBeenCalledWith("saved-account-id", true)
+    })
+  })
+
+  it("notifies open account-management surfaces after a deferred post-save refresh updates data", async () => {
+    const onPostSaveAccountRefresh = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(accountStorage, "refreshAccount").mockResolvedValue({
+      account: buildSiteAccount({ id: "saved-account-id" }),
+      refreshed: true,
+    })
+
+    const { result } = renderAddHook({ onPostSaveAccountRefresh })
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await fillStandardAddAccountDraft(result)
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    await waitFor(() => {
+      expect(onPostSaveAccountRefresh).toHaveBeenCalledWith([
+        "saved-account-id",
+      ])
+      expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+        {
+          action: RuntimeActionIds.AccountRefreshCompleted,
+          updatedAccountIds: ["saved-account-id"],
+        },
+        { maxAttempts: 1 },
+      )
     })
   })
 

--- a/tests/utils/runtimeActions.test.ts
+++ b/tests/utils/runtimeActions.test.ts
@@ -78,6 +78,9 @@ describe("runtimeActions registry and helpers", () => {
     expect(RuntimeActionIds.OpenFeedbackBugReport).toBe(
       "feedback:openBugReport",
     )
+    expect(RuntimeActionIds.AccountRefreshCompleted).toBe(
+      "accountRefresh:completed",
+    )
     expect(RuntimeActionIds.BalanceHistoryDebugSeedEstimateSnapshots).toBe(
       "balanceHistory:debugSeedEstimateSnapshots",
     )


### PR DESCRIPTION
## Summary
- add an account-refresh runtime action for post-save deferred refresh completion
- reload refreshed account rows directly in the initiating Account Management UI
- keep other open extension surfaces synchronized through the runtime notification

## Test Plan
- pnpm vitest --run tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
- pnpm vitest --run tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
- pnpm vitest --run tests/utils/runtimeActions.test.ts
- pnpm tsc --noEmit
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account details now automatically refresh after saving, updating the relevant account entries and keeping the list and balances in sync.

* **Bug Fixes**
  * Improved refresh reliability with targeted updates and safer handling of overlapping refresh requests and refresh completion notifications.

* **Tests**
  * Added and expanded automated tests to verify post-save refresh behavior, runtime completion messaging, and concurrency/race outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->