### PR TITLE
ci: shard unit test coverage workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,16 +92,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: "pnpm"
@@ -122,7 +122,7 @@ jobs:
           --shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}
 
       - name: Upload Vitest blob report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: vitest-blob-report-${{ matrix.shard.index }}
@@ -137,16 +137,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: "pnpm"
@@ -156,7 +158,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Download Vitest blob reports
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: .vitest-reports
           pattern: vitest-blob-report-*
@@ -170,21 +172,21 @@ jobs:
           --outputFile.junit=test-report.junit.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
           files: test-report.junit.xml
 
       - name: Upload test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: test-report
@@ -192,7 +194,7 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: coverage-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,14 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - index: 1
+            total: 2
+          - index: 2
+            total: 2
 
     steps:
       - name: Checkout code
@@ -102,13 +110,70 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Run tests with coverage
-        run: pnpm exec vitest --run --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
+      - name: Run test shard with coverage
+        run: >
+          pnpm exec vitest --run --coverage
+          --coverage.thresholds.statements=0
+          --coverage.thresholds.branches=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.lines=0
+          --reporter=default
+          --reporter=blob
+          --shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}
+
+      - name: Upload Vitest blob report
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: vitest-blob-report-${{ matrix.shard.index }}
+          path: .vitest-reports/*.json
+          include-hidden-files: true
+          retention-days: 1
+
+  unit-tests-merge:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    if: ${{ !cancelled() }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Download Vitest blob reports
+        uses: actions/download-artifact@v7
+        with:
+          path: .vitest-reports
+          pattern: vitest-blob-report-*
+          merge-multiple: true
+
+      - name: Merge test and coverage reports
+        run: >
+          pnpm exec vitest --merge-reports=.vitest-reports --coverage
+          --reporter=default
+          --reporter=junit
+          --outputFile.junit=test-report.junit.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -116,6 +181,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
+          files: test-report.junit.xml
 
       - name: Upload test report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- split the Test workflow unit test job into two parallel Vitest shards
- upload Vitest blob reports per shard and merge them in a follow-up job
- keep the final coverage threshold, Codecov coverage upload, test-result upload, and artifacts in the merge job

## Validation
- local: parsed .github/workflows/test.yml with yaml
- local: verified Vitest blob shard and merge command shape on a small test subset
- local: pnpm run validate:staged
- local pre-push: pnpm compile && pnpm knip
- remote workflow_dispatch: https://github.com/qixing-jk/all-api-hub/actions/runs/28080301278 succeeded

## Notes
- shard jobs disable coverage thresholds so they only collect partial coverage
- unit-tests-merge keeps the repo coverage threshold from vitest.config.ts and should be the required unit-test gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the test workflow to execute automated unit tests in parallel shards for faster feedback.
  * Added a follow-up merge step that combines shard results into a single JUnit and coverage report.
  * Improved the reliability and completeness of CI test reporting and coverage uploads by using shard-scoped artifacts and consolidated outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->