### PR TITLE
fix(key-management): allow cancelling key repair checks

### DIFF
--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -51,13 +51,20 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
   const [openingSub2ApiAccountId, setOpeningSub2ApiAccountId] = useState<
     string | null
   >(null)
-  const { error, handleStartAudit, isStarting, progress, setProgress } =
-    useRepairMissingKeysJob({
-      accounts,
-      isOpen,
-      startOnOpen,
-      t,
-    })
+  const {
+    error,
+    handleCancelAudit,
+    handleStartAudit,
+    isCancelling,
+    isStarting,
+    progress,
+    setProgress,
+  } = useRepairMissingKeysJob({
+    accounts,
+    isOpen,
+    startOnOpen,
+    t,
+  })
 
   const disabledAccountIds = useMemo(() => {
     return new Set(
@@ -220,6 +227,14 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
               >
                 {t("common:status.failed")}
               </Badge>
+            ) : progress?.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled ? (
+              <Badge
+                variant="warning"
+                size="sm"
+                className="shrink-0 border-transparent"
+              >
+                {t("common:status.cancelled")}
+              </Badge>
             ) : progress?.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Completed ? (
               <Badge
                 variant={progress.summary.failed > 0 ? "warning" : "success"}
@@ -283,7 +298,9 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
         <div className="space-y-4">
           <RepairMissingKeysProgressCard
             progress={progress}
+            isCancelling={isCancelling}
             isStarting={isStarting}
+            onCancelAudit={() => void handleCancelAudit()}
             onStartAudit={() => void handleStartAudit()}
             t={t}
           />

--- a/src/features/KeyManagement/components/RepairMissingKeysProgressCard.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysProgressCard.tsx
@@ -11,7 +11,9 @@ import {
 
 interface RepairMissingKeysProgressCardProps {
   progress: AccountKeyRepairProgress
+  isCancelling: boolean
   isStarting: boolean
+  onCancelAudit: () => void
   onStartAudit: () => void
   t: TFunction
 }
@@ -21,7 +23,9 @@ interface RepairMissingKeysProgressCardProps {
  */
 export function RepairMissingKeysProgressCard({
   progress,
+  isCancelling,
   isStarting,
+  onCancelAudit,
   onStartAudit,
   t,
 }: RepairMissingKeysProgressCardProps) {
@@ -47,7 +51,18 @@ export function RepairMissingKeysProgressCard({
               <span>
                 {processedTotal}/{eligibleTotal} ({progressPercent}%)
               </span>
-              {progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Running ? (
+              {progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Running ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onCancelAudit}
+                  disabled={isCancelling}
+                  loading={isCancelling}
+                >
+                  {t("keyManagement:repairMissingKeys.actions.cancel")}
+                </Button>
+              ) : (
                 <Button
                   type="button"
                   variant="outline"
@@ -58,7 +73,7 @@ export function RepairMissingKeysProgressCard({
                 >
                   {t("keyManagement:repairMissingKeys.actions.rerun")}
                 </Button>
-              ) : null}
+              )}
             </div>
           </div>
           <div

--- a/src/features/KeyManagement/components/repairMissingKeysDialogHelpers.ts
+++ b/src/features/KeyManagement/components/repairMissingKeysDialogHelpers.ts
@@ -168,6 +168,9 @@ export function getRepairProgressBarColor(progress: AccountKeyRepairProgress) {
   if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
     return "bg-red-600 dark:bg-red-500"
   }
+  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled) {
+    return "bg-amber-600 dark:bg-amber-500"
+  }
   if (
     progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Completed &&
     progress.summary.failed > 0

--- a/src/features/KeyManagement/components/useRepairMissingKeysJob.ts
+++ b/src/features/KeyManagement/components/useRepairMissingKeysJob.ts
@@ -132,6 +132,14 @@ export function useRepairMissingKeysJob({
 
   isDialogOpenRef.current = isOpen
 
+  const invalidatePendingStart = useCallback(() => {
+    startRequestIdRef.current += 1
+    startInFlightRef.current = false
+    if (isDialogOpenRef.current) {
+      setIsStarting(false)
+    }
+  }, [])
+
   const handleStartAudit = useCallback(async () => {
     if (startInFlightRef.current) {
       return
@@ -202,6 +210,7 @@ export function useRepairMissingKeysJob({
     }
 
     cancelInFlightRef.current = true
+    invalidatePendingStart()
     setIsCancelling(true)
     setError("")
     try {
@@ -237,7 +246,7 @@ export function useRepairMissingKeysJob({
         setIsCancelling(false)
       }
     }
-  }, [t])
+  }, [invalidatePendingStart, t])
 
   useEffect(() => {
     isDialogOpenRef.current = isOpen
@@ -252,10 +261,9 @@ export function useRepairMissingKeysJob({
   useEffect(() => {
     return () => {
       isDialogOpenRef.current = false
-      startRequestIdRef.current += 1
-      startInFlightRef.current = false
+      invalidatePendingStart()
     }
-  }, [])
+  }, [invalidatePendingStart])
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/features/KeyManagement/components/useRepairMissingKeysJob.ts
+++ b/src/features/KeyManagement/components/useRepairMissingKeysJob.ts
@@ -87,6 +87,9 @@ function getRepairProgressStatusKind(progress: AccountKeyRepairProgress) {
  * Maps terminal repair progress into the product analytics result enum.
  */
 function getRepairProgressResult(progress: AccountKeyRepairProgress) {
+  if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled) {
+    return PRODUCT_ANALYTICS_RESULTS.Cancelled
+  }
   if (progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Failed) {
     return PRODUCT_ANALYTICS_RESULTS.Failure
   }
@@ -117,8 +120,10 @@ export function useRepairMissingKeysJob({
   )
   const [error, setError] = useState<string>("")
   const [isStarting, setIsStarting] = useState(false)
+  const [isCancelling, setIsCancelling] = useState(false)
   const startedAnalyticsJobIdRef = useRef<string | null>(null)
   const completedAnalyticsJobIdRef = useRef<string | null>(null)
+  const cancelInFlightRef = useRef(false)
   const progressRef = useRef<AccountKeyRepairProgress | null>(null)
   const accountsRef = useRef(accounts)
   const isDialogOpenRef = useRef(isOpen)
@@ -191,12 +196,56 @@ export function useRepairMissingKeysJob({
     }
   }, [t])
 
+  const handleCancelAudit = useCallback(async () => {
+    if (cancelInFlightRef.current) {
+      return
+    }
+
+    cancelInFlightRef.current = true
+    setIsCancelling(true)
+    setError("")
+    try {
+      const response = await sendAccountKeyRepairMessage(
+        AccountKeyRepairMessageTypes.Cancel,
+      )
+      if (response?.success && response.data) {
+        completedAnalyticsJobIdRef.current = response.data.jobId
+        void trackProductAnalyticsActionCompleted({
+          ...repairMissingKeysAnalyticsContext,
+          result: getRepairProgressResult(response.data),
+          insights: {
+            ...getRepairProgressInsightCounts(response.data),
+            statusKind: getRepairProgressStatusKind(response.data),
+          },
+        })
+        if (isDialogOpenRef.current) {
+          setProgress(response.data)
+        }
+        return
+      }
+
+      if (isDialogOpenRef.current) {
+        setError(t("keyManagement:repairMissingKeys.messages.cancelFailed"))
+      }
+    } catch {
+      if (isDialogOpenRef.current) {
+        setError(t("keyManagement:repairMissingKeys.messages.cancelFailed"))
+      }
+    } finally {
+      cancelInFlightRef.current = false
+      if (isDialogOpenRef.current) {
+        setIsCancelling(false)
+      }
+    }
+  }, [t])
+
   useEffect(() => {
     isDialogOpenRef.current = isOpen
     if (isOpen) {
       setIsStarting(startInFlightRef.current)
     } else {
       setIsStarting(false)
+      setIsCancelling(false)
     }
   }, [isOpen])
 
@@ -275,7 +324,8 @@ export function useRepairMissingKeysJob({
     if (!progress) return
     if (
       progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Completed &&
-      progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Failed
+      progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Failed &&
+      progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled
     ) {
       return
     }
@@ -299,7 +349,9 @@ export function useRepairMissingKeysJob({
 
   return {
     error,
+    handleCancelAudit,
     handleStartAudit,
+    isCancelling,
     isStarting,
     progress,
     setProgress,

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -40,6 +40,7 @@
     "translationDescription": "If you are using automatic translation, turn it off for this page or switch to the language you need in extension settings."
   },
   "status": {
+    "cancelled": "Cancelled",
     "configurationRequired": "Configuration required",
     "creating": "Creating...",
     "disabled": "Disabled",

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -284,6 +284,7 @@
   "repairMissingKeys": {
     "action": "Key check",
     "actions": {
+      "cancel": "Cancel check",
       "rerun": "Check again",
       "start": "Start check and fill gaps"
     },
@@ -317,6 +318,7 @@
       "selectedCount_other": "{{count}} invalid keys selected"
     },
     "messages": {
+      "cancelFailed": "Failed to cancel repair job",
       "loadFailed": "Failed to load repair progress",
       "startFailed": "Failed to start repair job"
     },
@@ -330,7 +332,7 @@
     "progressLabel": "Progress",
     "remoteWriteNotice": "This action may create new keys on the corresponding sites. It will not automatically delete any keys.",
     "resultsTitle": "Results",
-    "runningNote": "This job runs in the background. Closing this dialog will not cancel it.",
+    "runningNote": "This job runs in the background. You can close this dialog and check later, or cancel it from the progress card.",
     "searchLabel": "Search",
     "searchPlaceholder": "Search account, origin, or site type...",
     "skipReasons": {

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -40,6 +40,7 @@
     "translationDescription": "ブラウザーの自動翻訳を使用している場合は、このページの自動翻訳をオフにするか、拡張機能の設定で必要な言語に切り替えてください。"
   },
   "status": {
+    "cancelled": "キャンセル済み",
     "configurationRequired": "設定が必要です",
     "creating": "作成中...",
     "disabled": "無効",

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -278,6 +278,7 @@
   "repairMissingKeys": {
     "action": "キーをチェック",
     "actions": {
+      "cancel": "チェックをキャンセル",
       "rerun": "再チェック",
       "start": "チェックして不足分を補完"
     },
@@ -307,6 +308,7 @@
       "selectedCount_other": "{{count}} 件の例外キーを選択中"
     },
     "messages": {
+      "cancelFailed": "修復ジョブをキャンセルできませんでした",
       "loadFailed": "修復進捗の読み込みに失敗しました",
       "startFailed": "修復ジョブの開始に失敗しました"
     },
@@ -320,7 +322,7 @@
     "progressLabel": "進捗",
     "remoteWriteNotice": "この操作により、対応するサイトで新しいキーが作成される場合があります。キーが自動的に削除されることはありません。",
     "resultsTitle": "結果",
-    "runningNote": "このジョブはバックグラウンドで実行されます。このダイアログを閉じてもキャンセルされません。",
+    "runningNote": "このジョブはバックグラウンドで実行されます。このダイアログを閉じて後で確認するか、進捗カードからキャンセルできます。",
     "searchLabel": "検索",
     "searchPlaceholder": "アカウント、origin、またはサイト種別で検索...",
     "skipReasons": {

--- a/src/locales/vi/common.json
+++ b/src/locales/vi/common.json
@@ -40,6 +40,7 @@
     "translationDescription": "Nếu bạn đang dùng tính năng tự động dịch của trình duyệt, hãy tắt tự động dịch cho trang này hoặc chuyển sang ngôn ngữ bạn cần trong cài đặt tiện ích."
   },
   "status": {
+    "cancelled": "Đã hủy",
     "configurationRequired": "Yêu cầu cấu hình",
     "creating": "Đang tạo...",
     "disabled": "Đã vô hiệu hóa",

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -278,6 +278,7 @@
   "repairMissingKeys": {
     "action": "Kiểm tra khóa",
     "actions": {
+      "cancel": "Hủy kiểm tra",
       "rerun": "Kiểm tra lại",
       "start": "Bắt đầu kiểm tra và bổ sung"
     },
@@ -307,6 +308,7 @@
       "selectedCount_other": "Đã chọn {{count}} khóa bất thường"
     },
     "messages": {
+      "cancelFailed": "Hủy tác vụ sửa chữa thất bại",
       "loadFailed": "Tải tiến trình sửa chữa thất bại",
       "startFailed": "Bắt đầu tác vụ sửa chữa thất bại"
     },
@@ -320,7 +322,7 @@
     "progressLabel": "Tiến trình",
     "remoteWriteNotice": "Thao tác này có thể tạo khóa mới trên các trang web tương ứng; sẽ không tự động xóa bất kỳ khóa nào.",
     "resultsTitle": "Kết quả",
-    "runningNote": "Tác vụ đang chạy trong nền, việc đóng hộp thoại này sẽ không hủy tác vụ.",
+    "runningNote": "Tác vụ đang chạy trong nền. Bạn có thể đóng hộp thoại này để kiểm tra sau hoặc hủy trong thẻ tiến trình.",
     "searchLabel": "Tìm kiếm",
     "searchPlaceholder": "Tìm kiếm tài khoản, tên miền hoặc loại trang web...",
     "skipReasons": {

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -40,6 +40,7 @@
     "translationDescription": "如果你正在使用浏览器自动翻译，请关闭此页面的自动翻译，或在扩展设置中切换到需要的语言。"
   },
   "status": {
+    "cancelled": "已取消",
     "configurationRequired": "缺少配置",
     "creating": "创建中...",
     "disabled": "已禁用",

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -278,6 +278,7 @@
   "repairMissingKeys": {
     "action": "密钥检查",
     "actions": {
+      "cancel": "取消检查",
       "rerun": "重新检查",
       "start": "开始检查并补齐"
     },
@@ -307,6 +308,7 @@
       "selectedCount": "已选择 {{count}} 个异常密钥"
     },
     "messages": {
+      "cancelFailed": "取消检查任务失败",
       "loadFailed": "加载修复进度失败",
       "startFailed": "启动修复任务失败"
     },
@@ -320,7 +322,7 @@
     "progressLabel": "进度",
     "remoteWriteNotice": "此操作可能会在对应网站创建新密钥；不会自动删除任何密钥。",
     "resultsTitle": "结果",
-    "runningNote": "任务在后台运行，关闭此对话框不会取消任务。",
+    "runningNote": "任务在后台运行；可关闭此对话框稍后查看，或在进度卡片中取消任务。",
     "searchLabel": "搜索",
     "searchPlaceholder": "搜索账号、域名或站点类型...",
     "skipReasons": {

--- a/src/locales/zh-TW/common.json
+++ b/src/locales/zh-TW/common.json
@@ -40,6 +40,7 @@
     "translationDescription": "如果你正在使用瀏覽器自動翻譯，請關閉此頁面的自動翻譯，或在擴充功能設定中切換到需要的語言。"
   },
   "status": {
+    "cancelled": "已取消",
     "configurationRequired": "缺少配置",
     "creating": "建立中...",
     "disabled": "已禁用",

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -278,6 +278,7 @@
   "repairMissingKeys": {
     "action": "金鑰檢查",
     "actions": {
+      "cancel": "取消檢查",
       "rerun": "重新檢查",
       "start": "開始檢查並補齊"
     },
@@ -307,6 +308,7 @@
       "selectedCount_other": "已選擇 {{count}} 個異常金鑰"
     },
     "messages": {
+      "cancelFailed": "取消檢查任務失敗",
       "loadFailed": "載入修復進度失敗",
       "startFailed": "啟動修復任務失敗"
     },
@@ -320,7 +322,7 @@
     "progressLabel": "進度",
     "remoteWriteNotice": "此操作可能會在對應網站建立新金鑰；不會自動刪除任何金鑰。",
     "resultsTitle": "結果",
-    "runningNote": "任務在後臺執行，關閉此對話方塊不會取消任務。",
+    "runningNote": "任務在後台執行；可關閉此對話框稍後查看，或在進度卡片中取消任務。",
     "searchLabel": "搜尋",
     "searchPlaceholder": "搜尋帳號、域名或站點型別...",
     "skipReasons": {

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -68,12 +68,14 @@ export function buildGroupDefaultTokenRequest(
 function createAccountApiRequest(
   account: SiteAccount,
   displaySiteData: DisplaySiteData,
+  abortSignal?: AbortSignal,
 ): ApiServiceRequest {
   const accountId = displaySiteData.id || account.id
 
   return {
     baseUrl: displaySiteData.baseUrl || account.site_url,
     accountId,
+    abortSignal,
     auth: {
       authType: displaySiteData.authType,
       userId: displaySiteData.userId,
@@ -91,8 +93,10 @@ export async function ensureAccountKeysForAvailableGroups(params: {
   displaySiteData: DisplaySiteData
   accountName: string
   siteUrlOrigin: string
+  abortSignal?: AbortSignal
 }): Promise<AccountKeyCoverageResult> {
-  const { account, displaySiteData, accountName, siteUrlOrigin } = params
+  const { account, displaySiteData, accountName, siteUrlOrigin, abortSignal } =
+    params
   const adapter = getSiteAdapter(displaySiteData.siteType)
   const keyManagement = requireDisplayAccountKeyManagement(
     displaySiteData,
@@ -102,7 +106,7 @@ export async function ensureAccountKeysForAvailableGroups(params: {
     displaySiteData,
     adapter.tokenProvisioning,
   )
-  const request = createAccountApiRequest(account, displaySiteData)
+  const request = createAccountApiRequest(account, displaySiteData, abortSignal)
   const accountId = displaySiteData.id || account.id
 
   const tokens = await keyManagement.fetchTokens(request)

--- a/src/services/accounts/accountKeyAutoProvisioning/index.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/index.ts
@@ -5,6 +5,7 @@ export {
 } from "./ensureDefaultToken"
 export {
   accountKeyRepairRunner,
+  cancelAccountKeyRepair,
   getAccountKeyRepairProgress,
   setupAccountKeyRepairMessagingListeners,
   startAccountKeyRepair,

--- a/src/services/accounts/accountKeyAutoProvisioning/messaging.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/messaging.ts
@@ -9,12 +9,14 @@ import type {
 
 export const AccountKeyRepairMessageTypes = {
   Start: "accountKeyRepair:start",
+  Cancel: "accountKeyRepair:cancel",
   GetProgress: "accountKeyRepair:getProgress",
   DeleteInvalidTokens: "accountKeyRepair:deleteInvalidTokens",
 } as const
 
 interface AccountKeyRepairProtocolMap {
   [AccountKeyRepairMessageTypes.Start](): RuntimeMessageResponse<AccountKeyRepairProgress>
+  [AccountKeyRepairMessageTypes.Cancel](): RuntimeMessageResponse<AccountKeyRepairProgress>
   [AccountKeyRepairMessageTypes.GetProgress](): RuntimeMessageResponse<AccountKeyRepairProgress>
   [AccountKeyRepairMessageTypes.DeleteInvalidTokens](
     request: AccountKeyRepairDeleteInvalidTokensRequest,

--- a/src/services/accounts/accountKeyAutoProvisioning/perOriginQueue.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/perOriginQueue.ts
@@ -8,9 +8,10 @@
 export async function runPerKeySequential<T>(params: {
   items: T[]
   getKey: (item: T) => string
+  shouldContinue?: () => boolean
   worker: (item: T) => Promise<void>
 }): Promise<void> {
-  const { items, getKey, worker } = params
+  const { items, getKey, shouldContinue, worker } = params
 
   const groups = new Map<string, T[]>()
   for (const item of items) {
@@ -26,6 +27,9 @@ export async function runPerKeySequential<T>(params: {
   await Promise.all(
     Array.from(groups.values()).map(async (group) => {
       for (const item of group) {
+        if (shouldContinue && !shouldContinue()) {
+          return
+        }
         await worker(item)
       }
     }),

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -108,6 +108,7 @@ class AccountKeyRepairRunner {
   private storage: Storage
   private currentProgress: AccountKeyRepairProgress | null = null
   private currentRun: Promise<void> | null = null
+  private currentAbortController: AbortController | null = null
   private progressQueue: Promise<void> = Promise.resolve()
 
   constructor() {
@@ -136,6 +137,7 @@ class AccountKeyRepairRunner {
       return await this.getProgress()
     }
 
+    const abortController = new AbortController()
     const now = Date.now()
     const progress: AccountKeyRepairProgress = {
       jobId: safeRandomUUID("accountKeyRepair"),
@@ -158,18 +160,71 @@ class AccountKeyRepairRunner {
     }
 
     this.currentProgress = progress
+    this.currentAbortController = abortController
     await this.persistAndNotify()
 
-    this.currentRun = this.run(progress.jobId).finally(() => {
-      this.currentRun = null
-    })
+    const runPromise = this.run(progress.jobId, abortController.signal).finally(
+      () => {
+        if (this.currentAbortController === abortController) {
+          this.currentAbortController = null
+        }
+        if (this.currentRun === runPromise) {
+          this.currentRun = null
+        }
+      },
+    )
+    this.currentRun = runPromise
 
     return progress
   }
 
-  private async run(jobId: string): Promise<void> {
+  async cancel(): Promise<{
+    success: true
+    data: AccountKeyRepairProgress
+  }> {
+    const progress = await this.getProgress()
+
+    if (progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Running) {
+      return { success: true as const, data: progress }
+    }
+
+    this.currentAbortController?.abort()
+    this.currentAbortController = null
+    this.currentRun = null
+    await this.queueProgressUpdate((prev) =>
+      prev.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Running
+        ? {
+            ...prev,
+            state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+            finishedAt: Date.now(),
+          }
+        : prev,
+    )
+
+    return {
+      success: true as const,
+      data: this.currentProgress ?? progress,
+    }
+  }
+
+  private isCurrentJobCancelled(jobId: string, abortSignal: AbortSignal) {
+    return (
+      abortSignal.aborted ||
+      (this.currentProgress?.jobId === jobId &&
+        this.currentProgress?.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled)
+    )
+  }
+
+  private async run(jobId: string, abortSignal: AbortSignal): Promise<void> {
     try {
+      if (this.isCurrentJobCancelled(jobId, abortSignal)) {
+        return
+      }
+
       const allAccounts = await accountStorage.getAllAccounts()
+      if (this.isCurrentJobCancelled(jobId, abortSignal)) {
+        return
+      }
       const enabledAccounts = allAccounts.filter(
         (account) => account.disabled !== true,
       )
@@ -191,6 +246,10 @@ class AccountKeyRepairRunner {
       await this.persistAndNotify()
 
       for (const account of enabledAccounts) {
+        if (this.isCurrentJobCancelled(jobId, abortSignal)) {
+          return
+        }
+
         const skipReason = getSkipReason(account)
         if (skipReason) {
           await this.recordResult({
@@ -221,14 +280,20 @@ class AccountKeyRepairRunner {
       await runPerKeySequential({
         items: eligibleAccounts,
         getKey: (account) => getOriginKey(account.site_url),
+        shouldContinue: () => !this.isCurrentJobCancelled(jobId, abortSignal),
         worker: async (account) => {
           await this.processEligibleAccount(
             account,
             displaySiteDataById.get(account.id)?.name ?? account.site_name,
             displaySiteDataById,
+            abortSignal,
           )
         },
       })
+
+      if (this.isCurrentJobCancelled(jobId, abortSignal)) {
+        return
+      }
 
       this.updateProgress((prev) => ({
         ...prev,
@@ -237,6 +302,10 @@ class AccountKeyRepairRunner {
       }))
       await this.persistAndNotify()
     } catch (error) {
+      if (this.isCurrentJobCancelled(jobId, abortSignal)) {
+        return
+      }
+
       logger.error("Repair run failed", error)
       this.updateProgress((prev) => ({
         ...prev,
@@ -253,6 +322,9 @@ class AccountKeyRepairRunner {
           currentJobId: current.jobId,
         })
       }
+      if (this.currentAbortController?.signal === abortSignal) {
+        this.currentAbortController = null
+      }
     }
   }
 
@@ -260,9 +332,14 @@ class AccountKeyRepairRunner {
     account: SiteAccount,
     accountName: string,
     displaySiteDataById: ReadonlyMap<string, DisplaySiteData>,
+    abortSignal: AbortSignal,
   ): Promise<void> {
     const originKey = getOriginKey(account.site_url)
     try {
+      if (abortSignal.aborted) {
+        return
+      }
+
       const displaySiteData: DisplaySiteData =
         displaySiteDataById.get(account.id) ??
         accountStorage.convertToDisplayData(account)
@@ -296,7 +373,12 @@ class AccountKeyRepairRunner {
         displaySiteData,
         accountName: resolvedAccountName,
         siteUrlOrigin: originKey,
+        abortSignal,
       })
+
+      if (abortSignal.aborted) {
+        return
+      }
 
       await this.recordResult({
         accountId: account.id,
@@ -317,6 +399,10 @@ class AccountKeyRepairRunner {
         finishedAt: Date.now(),
       })
     } catch (error) {
+      if (abortSignal.aborted) {
+        return
+      }
+
       await this.recordResult({
         accountId: account.id,
         accountName,
@@ -498,6 +584,13 @@ export async function getAccountKeyRepairProgress() {
 }
 
 /**
+ * Cancel the active background repair job, if one is running.
+ */
+export async function cancelAccountKeyRepair() {
+  return await accountKeyRepairRunner.cancel()
+}
+
+/**
  * Delete selected invalid account tokens and update the current repair progress.
  */
 export async function deleteInvalidAccountTokens(
@@ -575,6 +668,13 @@ export function setupAccountKeyRepairMessagingListeners() {
     onAccountKeyRepairMessage(AccountKeyRepairMessageTypes.Start, async () => {
       try {
         return await startAccountKeyRepair()
+      } catch (error) {
+        return toAccountKeyRepairFailure(error)
+      }
+    }),
+    onAccountKeyRepairMessage(AccountKeyRepairMessageTypes.Cancel, async () => {
+      try {
+        return await cancelAccountKeyRepair()
       } catch (error) {
         return toAccountKeyRepairFailure(error)
       }

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -161,19 +161,19 @@ class AccountKeyRepairRunner {
 
     this.currentProgress = progress
     this.currentAbortController = abortController
-    await this.persistAndNotify()
-
-    const runPromise = this.run(progress.jobId, abortController.signal).finally(
-      () => {
+    const initialPersist = this.persistAndNotify()
+    const runPromise = initialPersist
+      .then(() => this.run(progress.jobId, abortController.signal))
+      .finally(() => {
         if (this.currentAbortController === abortController) {
           this.currentAbortController = null
         }
         if (this.currentRun === runPromise) {
           this.currentRun = null
         }
-      },
-    )
+      })
     this.currentRun = runPromise
+    await initialPersist
 
     return progress
   }
@@ -190,7 +190,6 @@ class AccountKeyRepairRunner {
 
     this.currentAbortController?.abort()
     this.currentAbortController = null
-    this.currentRun = null
     await this.queueProgressUpdate((prev) =>
       prev.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Running
         ? {

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -164,6 +164,9 @@ class AccountKeyRepairRunner {
     const initialPersist = this.persistAndNotify()
     const runPromise = initialPersist
       .then(() => this.run(progress.jobId, abortController.signal))
+      .catch((error) => {
+        logger.error("Repair run failed to start", error)
+      })
       .finally(() => {
         if (this.currentAbortController === abortController) {
           this.currentAbortController = null

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -532,7 +532,10 @@ const _fetchApi = async <T>(
     cookie: request.auth?.cookie,
   }
 
-  const fetchOptions = await createAuthRequest(resolvedAuth, options.options)
+  const fetchOptions = await createAuthRequest(resolvedAuth, {
+    ...options.options,
+    signal: options.options?.signal ?? request.abortSignal,
+  })
 
   await enforceLogRequestRateLimit({ baseUrl, endpoint: options.endpoint })
 

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -84,6 +84,7 @@ export interface ApiTransportRequest {
   baseUrl: string
   data?: Record<string, any>
   accountId?: string
+  abortSignal?: AbortSignal
   cookieAuthSessionCookie?: string
   fetchContext?: ApiTransportFetchContext
   /** Skip the generic per-site limiter when the caller already applies a narrower limiter. */

--- a/src/types/accountKeyAutoProvisioning.ts
+++ b/src/types/accountKeyAutoProvisioning.ts
@@ -3,6 +3,7 @@ import type { AccountSiteType } from "~/constants/siteType"
 export const ACCOUNT_KEY_REPAIR_JOB_STATES = {
   Idle: "idle",
   Running: "running",
+  Cancelled: "cancelled",
   Completed: "completed",
   Failed: "failed",
 } as const

--- a/tests/features/KeyManagement/components/RepairMissingKeysProgressCard.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysProgressCard.test.tsx
@@ -38,8 +38,10 @@ function renderCard(
   return render(
     <RepairMissingKeysProgressCard
       progress={buildProgress()}
+      isCancelling={false}
       isStarting={false}
       onStartAudit={vi.fn()}
+      onCancelAudit={vi.fn()}
       t={t}
       {...props}
     />,
@@ -77,8 +79,10 @@ describe("RepairMissingKeysProgressCard", () => {
         progress={buildProgress({
           state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
         })}
+        isCancelling={false}
         isStarting={false}
         onStartAudit={onStartAudit}
+        onCancelAudit={vi.fn()}
         t={t}
       />,
     )
@@ -96,8 +100,10 @@ describe("RepairMissingKeysProgressCard", () => {
         progress={buildProgress({
           state: ACCOUNT_KEY_REPAIR_JOB_STATES.Failed,
         })}
+        isCancelling={false}
         isStarting={true}
         onStartAudit={onStartAudit}
+        onCancelAudit={vi.fn()}
         t={t}
       />,
     )
@@ -107,6 +113,21 @@ describe("RepairMissingKeysProgressCard", () => {
         name: /keyManagement:repairMissingKeys\.actions\.rerun/,
       }),
     ).toBeDisabled()
+  })
+
+  it("shows a cancel action while running", async () => {
+    const user = userEvent.setup()
+    const onCancelAudit = vi.fn()
+
+    renderCard({ onCancelAudit })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:repairMissingKeys.actions.cancel",
+      }),
+    )
+
+    expect(onCancelAudit).toHaveBeenCalledTimes(1)
   })
 
   it("renders state-derived processed totals and outcome counts", () => {

--- a/tests/features/KeyManagement/components/useRepairMissingKeysJob.test.tsx
+++ b/tests/features/KeyManagement/components/useRepairMissingKeysJob.test.tsx
@@ -25,6 +25,7 @@ import { renderHook } from "~~/tests/test-utils/render"
 vi.mock("~/services/accounts/accountKeyAutoProvisioning/messaging", () => ({
   AccountKeyRepairMessageTypes: {
     Start: "accountKeyRepair:start",
+    Cancel: "accountKeyRepair:cancel",
     GetProgress: "accountKeyRepair:getProgress",
     DeleteInvalidTokens: "accountKeyRepair:deleteInvalidTokens",
   },
@@ -291,5 +292,120 @@ describe("useRepairMissingKeysJob", () => {
     expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledWith(
       AccountKeyRepairMessageTypes.Start,
     )
+  })
+
+  it("sends a cancel request and stores the cancelled progress", async () => {
+    const runningProgress = buildProgress({ jobId: "running-job" })
+    const cancelledProgress = buildProgress({
+      jobId: "running-job",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+      finishedAt: 123,
+    })
+    sendAccountKeyRepairMessageMock.mockImplementation(async (type) => {
+      if (type === AccountKeyRepairMessageTypes.Cancel) {
+        return {
+          success: true,
+          data: cancelledProgress,
+        }
+      }
+
+      return {
+        success: true,
+        data: runningProgress,
+      }
+    })
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.progress).toEqual(runningProgress)
+    })
+
+    await act(async () => {
+      await result.current.handleCancelAudit()
+    })
+
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.Cancel,
+    )
+    expect(result.current.progress).toEqual(cancelledProgress)
+    expect(result.current.error).toBe("")
+    expect(trackProductAnalyticsActionCompletedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: PRODUCT_ANALYTICS_RESULTS.Cancelled,
+        insights: expect.objectContaining({
+          itemCount: 2,
+          selectedCount: 1,
+          successCount: 1,
+          failureCount: 0,
+          statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Healthy,
+        }),
+      }),
+    )
+  })
+
+  it("deduplicates concurrent cancel requests", async () => {
+    let resolveCancel:
+      | ((value: { success: true; data: AccountKeyRepairProgress }) => void)
+      | undefined
+    const runningProgress = buildProgress({ jobId: "running-job" })
+    const cancelledProgress = buildProgress({
+      jobId: "running-job",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+      finishedAt: 123,
+    })
+    sendAccountKeyRepairMessageMock.mockImplementation((type) => {
+      if (type === AccountKeyRepairMessageTypes.Cancel) {
+        return new Promise((resolve) => {
+          resolveCancel = resolve
+        })
+      }
+
+      return Promise.resolve({
+        success: true,
+        data: runningProgress,
+      })
+    })
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.progress).toEqual(runningProgress)
+    })
+
+    await act(async () => {
+      const firstCancel = result.current.handleCancelAudit()
+      const secondCancel = result.current.handleCancelAudit()
+
+      resolveCancel?.({
+        success: true,
+        data: cancelledProgress,
+      })
+
+      await Promise.all([firstCancel, secondCancel])
+    })
+
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledTimes(2)
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.GetProgress,
+    )
+    expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledWith(
+      AccountKeyRepairMessageTypes.Cancel,
+    )
+    expect(trackProductAnalyticsActionCompletedMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/features/KeyManagement/components/useRepairMissingKeysJob.test.tsx
+++ b/tests/features/KeyManagement/components/useRepairMissingKeysJob.test.tsx
@@ -351,6 +351,142 @@ describe("useRepairMissingKeysJob", () => {
     )
   })
 
+  it("keeps cancelled progress when an older start response settles after cancel", async () => {
+    let resolveStart:
+      | ((value: { success: true; data: AccountKeyRepairProgress }) => void)
+      | undefined
+    const runningProgress = buildProgress({ jobId: "running-job" })
+    const startedProgress = buildProgress({ jobId: "started-job" })
+    const cancelledProgress = buildProgress({
+      jobId: "running-job",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+      finishedAt: 123,
+    })
+    sendAccountKeyRepairMessageMock.mockImplementation((type) => {
+      if (type === AccountKeyRepairMessageTypes.Start) {
+        return new Promise((resolve) => {
+          resolveStart = resolve
+        })
+      }
+
+      if (type === AccountKeyRepairMessageTypes.Cancel) {
+        return Promise.resolve({
+          success: true,
+          data: cancelledProgress,
+        })
+      }
+
+      return Promise.resolve({
+        success: true,
+        data: runningProgress,
+      })
+    })
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.progress).toEqual(runningProgress)
+    })
+
+    await act(async () => {
+      const startPromise = result.current.handleStartAudit()
+      await result.current.handleCancelAudit()
+
+      resolveStart?.({
+        success: true,
+        data: startedProgress,
+      })
+
+      await startPromise
+    })
+
+    expect(result.current.progress).toEqual(cancelledProgress)
+    expect(result.current.isStarting).toBe(false)
+    expect(result.current.isCancelling).toBe(false)
+  })
+
+  it("shows the cancel failure message when cancelling returns an unsuccessful response", async () => {
+    const runningProgress = buildProgress({ jobId: "running-job" })
+    sendAccountKeyRepairMessageMock.mockImplementation((type) => {
+      if (type === AccountKeyRepairMessageTypes.Cancel) {
+        return Promise.resolve({
+          success: false,
+          error: "cancel failed",
+        })
+      }
+
+      return Promise.resolve({
+        success: true,
+        data: runningProgress,
+      })
+    })
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.progress).toEqual(runningProgress)
+    })
+
+    await act(async () => {
+      await result.current.handleCancelAudit()
+    })
+
+    expect(result.current.error).toBe(
+      "keyManagement:repairMissingKeys.messages.cancelFailed",
+    )
+    expect(result.current.isCancelling).toBe(false)
+  })
+
+  it("shows the cancel failure message when cancelling rejects", async () => {
+    const runningProgress = buildProgress({ jobId: "running-job" })
+    sendAccountKeyRepairMessageMock.mockImplementation((type) => {
+      if (type === AccountKeyRepairMessageTypes.Cancel) {
+        return Promise.reject(new Error("network down"))
+      }
+
+      return Promise.resolve({
+        success: true,
+        data: runningProgress,
+      })
+    })
+
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.progress).toEqual(runningProgress)
+    })
+
+    await act(async () => {
+      await result.current.handleCancelAudit()
+    })
+
+    expect(result.current.error).toBe(
+      "keyManagement:repairMissingKeys.messages.cancelFailed",
+    )
+    expect(result.current.isCancelling).toBe(false)
+  })
+
   it("deduplicates concurrent cancel requests", async () => {
     let resolveCancel:
       | ((value: { success: true; data: AccountKeyRepairProgress }) => void)

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -90,12 +90,13 @@ const displaySiteData = buildDisplaySiteData({
   token: "access-token",
 })
 
-const runCoverage = () =>
+const runCoverage = (abortSignal?: AbortSignal) =>
   ensureAccountKeysForAvailableGroups({
     account,
     displaySiteData,
     accountName: "Relay Account",
     siteUrlOrigin: "https://relay.example.com",
+    abortSignal,
   })
 
 describe("ensureAccountKeysForAvailableGroups", () => {
@@ -170,6 +171,34 @@ describe("ensureAccountKeysForAvailableGroups", () => {
         }),
       }),
       buildGroupDefaultTokenRequest("vip"),
+    )
+  })
+
+  it("passes the abort signal into token, group, and creation requests", async () => {
+    const abortController = new AbortController()
+    mocks.fetchAccountTokens.mockResolvedValue([])
+    mocks.fetchUserGroups.mockResolvedValue({
+      default: { desc: "Default", ratio: 1 },
+    })
+    mocks.createApiToken.mockResolvedValue(true)
+
+    await runCoverage(abortController.signal)
+
+    expect(mocks.fetchAccountTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal: abortController.signal,
+      }),
+    )
+    expect(mocks.fetchUserGroups).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal: abortController.signal,
+      }),
+    )
+    expect(mocks.createApiToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal: abortController.signal,
+      }),
+      buildGroupDefaultTokenRequest("default"),
     )
   })
 

--- a/tests/services/accountKeyRepair.rateLimiting.test.ts
+++ b/tests/services/accountKeyRepair.rateLimiting.test.ts
@@ -65,4 +65,32 @@ describe("accountKeyRepair rate limiting", () => {
 
     await runPromise
   })
+
+  it("does not start later queued items once continuation is cancelled", async () => {
+    const started: string[] = []
+    const first = createDeferred()
+    let shouldContinue = true
+
+    const runPromise = runPerKeySequential({
+      items: [
+        { id: "a1", origin: "https://a.example.com" },
+        { id: "a2", origin: "https://a.example.com" },
+      ],
+      getKey: (item) => item.origin,
+      shouldContinue: () => shouldContinue,
+      worker: async (item) => {
+        started.push(item.id)
+        await first.promise
+      },
+    })
+
+    await flushPromises()
+    expect(started).toEqual(["a1"])
+
+    shouldContinue = false
+    first.resolve()
+
+    await runPromise
+    expect(started).toEqual(["a1"])
+  })
 })

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -10,6 +10,7 @@ import {
   ACCOUNT_KEY_REPAIR_JOB_STATES,
   ACCOUNT_KEY_REPAIR_OUTCOMES,
   ACCOUNT_KEY_REPAIR_SKIP_REASONS,
+  type AccountKeyRepairProgress,
 } from "~/types/accountKeyAutoProvisioning"
 import {
   buildDisplaySiteData,
@@ -28,7 +29,6 @@ const mocks = vi.hoisted(() => {
     }
 
     async set(key: string, value: unknown) {
-      storageMap.set(key, value)
       if (shouldBlockNextStorageSet) {
         shouldBlockNextStorageSet = false
         await new Promise<void>((resolve) => {
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => {
         shouldRejectNextStorageSet = false
         throw new Error("storage write failed")
       }
+      storageMap.set(key, value)
     }
   }
 
@@ -1657,6 +1658,78 @@ describe("accountKeyRepair", () => {
     expect(mocks.sendRuntimeMessage).not.toHaveBeenCalled()
   })
 
+  it("does not mark completed progress as cancelled when the queued cancel update sees a non-running state", async () => {
+    let releaseQueue: (() => void) | undefined
+    const blockedQueue = new Promise<void>((resolve) => {
+      releaseQueue = resolve
+    })
+    const runningProgress = {
+      jobId: "queued-cancel",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+      startedAt: 100,
+      updatedAt: 100,
+      totals: {
+        enabledAccounts: 1,
+        eligibleAccounts: 1,
+        processedAccounts: 0,
+        processedEligibleAccounts: 0,
+      },
+      summary: {
+        created: 0,
+        alreadyHad: 0,
+        skipped: 0,
+        failed: 0,
+      },
+      results: [],
+    }
+    const completedProgress = {
+      ...runningProgress,
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+      finishedAt: 200,
+      updatedAt: 200,
+      totals: {
+        ...runningProgress.totals,
+        processedAccounts: 1,
+        processedEligibleAccounts: 1,
+      },
+      summary: {
+        ...runningProgress.summary,
+        alreadyHad: 1,
+      },
+    }
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+    const controlledRunner = accountKeyRepairRunner as unknown as {
+      currentProgress: AccountKeyRepairProgress
+      progressQueue: Promise<void>
+    }
+
+    controlledRunner.currentProgress = runningProgress
+    controlledRunner.progressQueue = blockedQueue
+
+    const cancelPromise = accountKeyRepairRunner.cancel()
+    await vi.waitFor(() => {
+      expect(controlledRunner.progressQueue).not.toBe(blockedQueue)
+    })
+
+    controlledRunner.currentProgress = completedProgress
+    releaseQueue?.()
+
+    await expect(cancelPromise).resolves.toEqual({
+      success: true,
+      data: {
+        ...completedProgress,
+        updatedAt: expect.any(Number),
+      },
+    })
+    await expect(accountKeyRepairRunner.getProgress()).resolves.toEqual({
+      ...completedProgress,
+      updatedAt: expect.any(Number),
+    })
+  })
+
   it("keeps the cancelled run reserved until it unwinds", async () => {
     const firstAccount = buildSiteAccount({
       id: "first-run",
@@ -1824,6 +1897,9 @@ describe("accountKeyRepair", () => {
       },
     })
 
+    mocks.safeRandomUUID
+      .mockReturnValueOnce("job-failed-start")
+      .mockReturnValueOnce("job-restarted")
     mocks.rejectNextStorageSet()
     mocks.getAllAccounts.mockResolvedValue([account])
 
@@ -1833,13 +1909,13 @@ describe("accountKeyRepair", () => {
 
     const failedStart = accountKeyRepairRunner.start()
     await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
-      jobId: "job-123",
+      jobId: "job-failed-start",
       state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
     })
 
     await expect(failedStart).rejects.toThrow("storage write failed")
     await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
-      jobId: "job-123",
+      jobId: "job-restarted",
       state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
     })
     expect(mocks.getAllAccounts).toHaveBeenCalledTimes(1)

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import { TOKEN_PROVISIONING_REPAIR_POLICY_KINDS } from "~/services/apiAdapters/contracts/tokenProvisioning"
-import { AuthTypeEnum } from "~/types"
+import { AuthTypeEnum, type DisplaySiteData, type SiteAccount } from "~/types"
 import {
   ACCOUNT_KEY_REPAIR_ERRORS,
   ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => {
   const storageMap = new Map<string, unknown>()
   const pendingStorageSets: Array<() => void> = []
   let shouldBlockNextStorageSet = false
+  let shouldRejectNextStorageSet = false
 
   class StorageMock {
     async get(key: string) {
@@ -34,6 +35,10 @@ const mocks = vi.hoisted(() => {
           pendingStorageSets.push(resolve)
         })
       }
+      if (shouldRejectNextStorageSet) {
+        shouldRejectNextStorageSet = false
+        throw new Error("storage write failed")
+      }
     }
   }
 
@@ -42,6 +47,9 @@ const mocks = vi.hoisted(() => {
     pendingStorageSets,
     blockNextStorageSet: () => {
       shouldBlockNextStorageSet = true
+    },
+    rejectNextStorageSet: () => {
+      shouldRejectNextStorageSet = true
     },
     resolveNextStorageSet: () => {
       pendingStorageSets.shift()?.()
@@ -1345,6 +1353,220 @@ describe("accountKeyRepair", () => {
     expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(1)
   })
 
+  it("does not load accounts when cancelled before the queued run starts", async () => {
+    const account = buildSiteAccount({
+      id: "queued-start",
+      site_type: "new-api",
+      site_url: "https://queued-start.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "queued-start-token",
+        username: "queued-start",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+
+    mocks.blockNextStorageSet()
+    mocks.getAllAccounts.mockResolvedValue([account])
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    const startPromise = accountKeyRepairRunner.start()
+    await vi.waitFor(() => {
+      expect(mocks.pendingStorageSets).toHaveLength(1)
+    })
+
+    await expect(accountKeyRepairRunner.cancel()).resolves.toEqual({
+      success: true,
+      data: expect.objectContaining({
+        jobId: "job-123",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+      }),
+    })
+
+    mocks.resolveNextStorageSet()
+    await expect(startPromise).resolves.toMatchObject({
+      jobId: "job-123",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    })
+    await vi.waitFor(async () => {
+      await expect(accountKeyRepairRunner.getProgress()).resolves.toMatchObject(
+        {
+          jobId: "job-123",
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+        },
+      )
+    })
+    expect(mocks.getAllAccounts).not.toHaveBeenCalled()
+  })
+
+  it("stops after account loading when cancellation arrives before account scanning", async () => {
+    const account = buildSiteAccount({
+      id: "cancel-after-load",
+      site_type: "new-api",
+      site_url: "https://loaded.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "loaded-token",
+        username: "cancel-after-load",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    let resolveAccounts: ((accounts: SiteAccount[]) => void) | undefined
+
+    mocks.getAllAccounts.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveAccounts = resolve
+        }),
+    )
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await accountKeyRepairRunner.start()
+    await vi.waitFor(() => {
+      expect(mocks.getAllAccounts).toHaveBeenCalledTimes(1)
+    })
+
+    await accountKeyRepairRunner.cancel()
+    resolveAccounts?.([account])
+
+    await vi.waitFor(async () => {
+      await expect(accountKeyRepairRunner.getProgress()).resolves.toMatchObject(
+        {
+          jobId: "job-123",
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+          results: [],
+        },
+      )
+    })
+    expect(mocks.convertToDisplayData).not.toHaveBeenCalled()
+    expect(mocks.ensureAccountKeysForAvailableGroups).not.toHaveBeenCalled()
+  })
+
+  it("keeps cancelled progress when account loading rejects after cancellation", async () => {
+    let rejectAccounts: ((error: Error) => void) | undefined
+
+    mocks.getAllAccounts.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectAccounts = reject
+        }),
+    )
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await accountKeyRepairRunner.start()
+    await vi.waitFor(() => {
+      expect(mocks.getAllAccounts).toHaveBeenCalledTimes(1)
+    })
+
+    await accountKeyRepairRunner.cancel()
+    rejectAccounts?.(new Error("load failed after cancel"))
+
+    await vi.waitFor(async () => {
+      await expect(accountKeyRepairRunner.getProgress()).resolves.toMatchObject(
+        {
+          jobId: "job-123",
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+          results: [],
+        },
+      )
+    })
+    const progress = await accountKeyRepairRunner.getProgress()
+    expect(progress).not.toHaveProperty("lastError")
+  })
+
+  it("stops account scanning when cancellation arrives after enabled-account persistence", async () => {
+    const account = buildSiteAccount({
+      id: "cancel-during-scan",
+      site_type: "new-api",
+      site_url: "https://scan.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "scan-token",
+        username: "cancel-during-scan",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    let resolveAccounts: ((accounts: SiteAccount[]) => void) | undefined
+
+    mocks.getAllAccounts.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveAccounts = resolve
+        }),
+    )
+    mocks.convertToDisplayData.mockReturnValue([
+      buildDisplaySiteData({
+        id: account.id,
+        name: "Cancel During Scan",
+        baseUrl: account.site_url,
+        siteType: SITE_TYPES.NEW_API,
+        authType: AuthTypeEnum.AccessToken,
+        userId: "301",
+        token: "scan-token",
+      }),
+    ])
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await accountKeyRepairRunner.start()
+    mocks.blockNextStorageSet()
+    resolveAccounts?.([account])
+
+    await vi.waitFor(() => {
+      expect(mocks.pendingStorageSets).toHaveLength(1)
+    })
+    await accountKeyRepairRunner.cancel()
+    mocks.resolveNextStorageSet()
+
+    await vi.waitFor(async () => {
+      await expect(accountKeyRepairRunner.getProgress()).resolves.toMatchObject(
+        {
+          jobId: "job-123",
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+          totals: expect.objectContaining({
+            enabledAccounts: 1,
+            processedAccounts: 0,
+            processedEligibleAccounts: 0,
+          }),
+          results: [],
+        },
+      )
+    })
+    expect(mocks.ensureAccountKeysForAvailableGroups).not.toHaveBeenCalled()
+  })
+
   it("cancels a stored running job when no in-memory run exists", async () => {
     mocks.storageMap.set("accountKeyRepair_progress", {
       jobId: "stale-running",
@@ -1399,6 +1621,40 @@ describe("accountKeyRepair", () => {
       },
       { maxAttempts: 1 },
     )
+  })
+
+  it("does not rewrite stored progress when cancelling a non-running job", async () => {
+    const completedProgress = {
+      jobId: "finished-run",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+      startedAt: 100,
+      finishedAt: 200,
+      updatedAt: 200,
+      totals: {
+        enabledAccounts: 1,
+        eligibleAccounts: 1,
+        processedAccounts: 1,
+        processedEligibleAccounts: 1,
+      },
+      summary: {
+        created: 0,
+        alreadyHad: 1,
+        skipped: 0,
+        failed: 0,
+      },
+      results: [],
+    }
+    mocks.storageMap.set("accountKeyRepair_progress", completedProgress)
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await expect(accountKeyRepairRunner.cancel()).resolves.toEqual({
+      success: true,
+      data: completedProgress,
+    })
+    expect(mocks.sendRuntimeMessage).not.toHaveBeenCalled()
   })
 
   it("keeps the cancelled run reserved until it unwinds", async () => {
@@ -1544,6 +1800,47 @@ describe("accountKeyRepair", () => {
     await vi.waitFor(async () => {
       const progress = await accountKeyRepairRunner.getProgress()
       expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
+    })
+    expect(mocks.getAllAccounts).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the run reserved until failed initial persistence unwinds", async () => {
+    const account = buildSiteAccount({
+      id: "persistence-fails",
+      site_type: "new-api",
+      site_url: "https://persist.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "persist-token",
+        username: "persistence-fails",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+
+    mocks.rejectNextStorageSet()
+    mocks.getAllAccounts.mockResolvedValue([account])
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    const failedStart = accountKeyRepairRunner.start()
+    await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
+      jobId: "job-123",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    })
+
+    await expect(failedStart).rejects.toThrow("storage write failed")
+    await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
+      jobId: "job-123",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
     })
     expect(mocks.getAllAccounts).toHaveBeenCalledTimes(1)
   })
@@ -1702,6 +1999,125 @@ describe("accountKeyRepair", () => {
         }),
       })
     })
+  })
+
+  it("does not record a failed result when account repair rejects after cancellation", async () => {
+    const account = buildSiteAccount({
+      id: "reject-after-cancel",
+      site_type: "new-api",
+      site_url: "https://reject.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "reject-token",
+        username: "reject-after-cancel",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const displayAccount = buildDisplaySiteData({
+      id: account.id,
+      name: "Reject After Cancel",
+      baseUrl: account.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "301",
+      token: "reject-token",
+    })
+    let rejectRepair: ((error: Error) => void) | undefined
+
+    mocks.getAllAccounts.mockResolvedValue([account])
+    mocks.convertToDisplayData.mockReturnValue([displayAccount])
+    mocks.ensureAccountKeysForAvailableGroups.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectRepair = reject
+        }),
+    )
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await accountKeyRepairRunner.start()
+    await vi.waitFor(() => {
+      expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(1)
+    })
+
+    await accountKeyRepairRunner.cancel()
+    rejectRepair?.(new Error("repair failed after cancel"))
+
+    await vi.waitFor(async () => {
+      await expect(accountKeyRepairRunner.getProgress()).resolves.toMatchObject(
+        {
+          jobId: "job-123",
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+          results: [],
+          summary: expect.objectContaining({
+            failed: 0,
+          }),
+        },
+      )
+    })
+  })
+
+  it("skips account processing when entered with an already aborted signal", async () => {
+    const account = buildSiteAccount({
+      id: "pre-aborted",
+      site_type: "new-api",
+      site_url: "https://aborted.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "aborted-token",
+        username: "pre-aborted",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const displayAccount = buildDisplaySiteData({
+      id: account.id,
+      name: "Pre Aborted",
+      baseUrl: account.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "301",
+      token: "aborted-token",
+    })
+    const abortController = new AbortController()
+    abortController.abort()
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await (
+      accountKeyRepairRunner as unknown as {
+        processEligibleAccount(
+          account: SiteAccount,
+          accountName: string,
+          displaySiteDataById: ReadonlyMap<string, DisplaySiteData>,
+          abortSignal: AbortSignal,
+        ): Promise<void>
+      }
+    ).processEligibleAccount(
+      account,
+      "Pre Aborted",
+      new Map([[account.id, displayAccount]]),
+      abortController.signal,
+    )
+
+    expect(mocks.ensureAccountKeysForAvailableGroups).not.toHaveBeenCalled()
   })
 
   it("marks the repair job as failed when loading accounts throws", async () => {

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -18,6 +18,8 @@ import {
 
 const mocks = vi.hoisted(() => {
   const storageMap = new Map<string, unknown>()
+  const pendingStorageSets: Array<() => void> = []
+  let shouldBlockNextStorageSet = false
 
   class StorageMock {
     async get(key: string) {
@@ -26,11 +28,24 @@ const mocks = vi.hoisted(() => {
 
     async set(key: string, value: unknown) {
       storageMap.set(key, value)
+      if (shouldBlockNextStorageSet) {
+        shouldBlockNextStorageSet = false
+        await new Promise<void>((resolve) => {
+          pendingStorageSets.push(resolve)
+        })
+      }
     }
   }
 
   return {
     storageMap,
+    pendingStorageSets,
+    blockNextStorageSet: () => {
+      shouldBlockNextStorageSet = true
+    },
+    resolveNextStorageSet: () => {
+      pendingStorageSets.shift()?.()
+    },
     StorageMock,
     getAllAccounts: vi.fn(),
     convertToDisplayData: vi.fn(),
@@ -107,6 +122,14 @@ describe("accountKeyRepair", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    mocks.pendingStorageSets.splice(0)
+    mocks.getAllAccounts.mockReset()
+    mocks.convertToDisplayData.mockReset()
+    mocks.ensureAccountKeysForAvailableGroups.mockReset()
+    mocks.deleteInvalidAccountToken.mockReset()
+    mocks.sendRuntimeMessage.mockReset()
+    mocks.safeRandomUUID.mockReset()
+    mocks.safeRandomUUID.mockImplementation(() => "job-123")
     mocks.storageMap.clear()
   })
 
@@ -1378,7 +1401,154 @@ describe("accountKeyRepair", () => {
     )
   })
 
-  it("keeps a restarted run active while the cancelled run unwinds", async () => {
+  it("keeps the cancelled run reserved until it unwinds", async () => {
+    const firstAccount = buildSiteAccount({
+      id: "first-run",
+      site_type: "new-api",
+      site_url: "https://first.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "first-token",
+        username: "first-run",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const firstRunDisplay = buildDisplaySiteData({
+      id: firstAccount.id,
+      name: "First Run",
+      baseUrl: firstAccount.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "301",
+      token: "first-token",
+    })
+    let firstAbortSignal: AbortSignal | undefined
+
+    mocks.safeRandomUUID.mockReturnValueOnce("job-first")
+    mocks.getAllAccounts.mockResolvedValueOnce([firstAccount])
+    mocks.convertToDisplayData.mockReturnValueOnce([firstRunDisplay])
+    mocks.ensureAccountKeysForAvailableGroups.mockImplementationOnce(
+      async ({ abortSignal }) => {
+        firstAbortSignal = abortSignal
+        await vi.waitFor(() => {
+          expect(abortSignal?.aborted).toBe(true)
+        })
+        return {
+          created: false,
+          availableGroups: [],
+          coveredGroups: [],
+          createdGroups: [],
+          missingGroups: [],
+          invalidTokens: [],
+        }
+      },
+    )
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await accountKeyRepairRunner.start()
+    await vi.waitFor(() => {
+      expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(1)
+    })
+
+    await accountKeyRepairRunner.cancel()
+    expect(firstAbortSignal?.aborted).toBe(true)
+
+    await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
+      jobId: "job-first",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+    })
+    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(1)
+
+    await vi.waitFor(async () => {
+      const progress = await accountKeyRepairRunner.getProgress()
+      expect(progress).toMatchObject({
+        jobId: "job-first",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+      })
+    })
+  })
+
+  it("reserves a starting run before its first progress persistence finishes", async () => {
+    const account = buildSiteAccount({
+      id: "reserved-run",
+      site_type: "new-api",
+      site_url: "https://reserved.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "reserved-token",
+        username: "reserved-run",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const displayAccount = buildDisplaySiteData({
+      id: account.id,
+      name: "Reserved Run",
+      baseUrl: account.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "301",
+      token: "reserved-token",
+    })
+
+    mocks.blockNextStorageSet()
+    mocks.getAllAccounts.mockResolvedValue([account])
+    mocks.convertToDisplayData.mockReturnValue([displayAccount])
+    mocks.ensureAccountKeysForAvailableGroups.mockResolvedValue({
+      created: false,
+      availableGroups: [],
+      coveredGroups: [],
+      createdGroups: [],
+      missingGroups: [],
+      invalidTokens: [],
+    })
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    const firstStart = accountKeyRepairRunner.start()
+
+    await vi.waitFor(() => {
+      expect(mocks.pendingStorageSets).toHaveLength(1)
+    })
+    await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
+      jobId: "job-123",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    })
+    expect(mocks.getAllAccounts).not.toHaveBeenCalled()
+
+    mocks.resolveNextStorageSet()
+
+    await expect(firstStart).resolves.toMatchObject({
+      jobId: "job-123",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    })
+
+    await vi.waitFor(async () => {
+      const progress = await accountKeyRepairRunner.getProgress()
+      expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
+    })
+    expect(mocks.getAllAccounts).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not let a cancelled run update a restarted job", async () => {
     const firstAccount = buildSiteAccount({
       id: "first-run",
       site_type: "new-api",
@@ -1433,7 +1603,16 @@ describe("accountKeyRepair", () => {
       userId: "302",
       token: "second-token",
     })
-    let firstAbortSignal: AbortSignal | undefined
+    let resolveFirstRun:
+      | ((value: {
+          created: boolean
+          availableGroups: string[]
+          coveredGroups: string[]
+          createdGroups: string[]
+          missingGroups: string[]
+          invalidTokens: []
+        }) => void)
+      | undefined
     let resolveSecondRun:
       | ((value: {
           created: boolean
@@ -1455,20 +1634,12 @@ describe("accountKeyRepair", () => {
       .mockReturnValueOnce([firstRunDisplay])
       .mockReturnValueOnce([secondRunDisplay])
     mocks.ensureAccountKeysForAvailableGroups
-      .mockImplementationOnce(async ({ abortSignal }) => {
-        firstAbortSignal = abortSignal
-        await vi.waitFor(() => {
-          expect(abortSignal?.aborted).toBe(true)
-        })
-        return {
-          created: false,
-          availableGroups: [],
-          coveredGroups: [],
-          createdGroups: [],
-          missingGroups: [],
-          invalidTokens: [],
-        }
-      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRun = resolve
+          }),
+      )
       .mockImplementationOnce(
         () =>
           new Promise((resolve) => {
@@ -1486,22 +1657,31 @@ describe("accountKeyRepair", () => {
     })
 
     await accountKeyRepairRunner.cancel()
-    expect(firstAbortSignal?.aborted).toBe(true)
 
-    await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
-      jobId: "job-second",
-      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    resolveFirstRun?.({
+      created: false,
+      availableGroups: [],
+      coveredGroups: [],
+      createdGroups: [],
+      missingGroups: [],
+      invalidTokens: [],
+    })
+
+    await vi.waitFor(async () => {
+      const progress = await accountKeyRepairRunner.getProgress()
+      expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled)
+    })
+
+    await vi.waitFor(async () => {
+      await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
+        jobId: "job-second",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+      })
     })
 
     await vi.waitFor(() => {
       expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(2)
     })
-
-    await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
-      jobId: "job-second",
-      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
-    })
-    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(2)
 
     resolveSecondRun?.({
       created: false,
@@ -1517,6 +1697,9 @@ describe("accountKeyRepair", () => {
       expect(progress).toMatchObject({
         jobId: "job-second",
         state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+        summary: expect.objectContaining({
+          alreadyHad: 1,
+        }),
       })
     })
   })

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -1132,6 +1132,7 @@ describe("accountKeyRepair", () => {
       }),
       accountName: "Cookie Fallback",
       siteUrlOrigin: "https://cookie.example.com",
+      abortSignal: expect.any(AbortSignal),
     })
   })
 
@@ -1208,6 +1209,318 @@ describe("accountKeyRepair", () => {
     })
   })
 
+  it("cancels an in-flight repair job and does not start later queued accounts", async () => {
+    const firstAccount = buildSiteAccount({
+      id: "queued-1",
+      site_type: "new-api",
+      site_url: "https://shared.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "first-token",
+        username: "queued-1",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const secondAccount = buildSiteAccount({
+      id: "queued-2",
+      site_type: "new-api",
+      site_url: "https://shared.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "302",
+        access_token: "second-token",
+        username: "queued-2",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    let capturedSignal: AbortSignal | undefined
+
+    mocks.getAllAccounts.mockResolvedValue([firstAccount, secondAccount])
+    mocks.convertToDisplayData.mockReturnValue([
+      buildDisplaySiteData({
+        id: firstAccount.id,
+        name: "Queued Account 1",
+        baseUrl: firstAccount.site_url,
+        siteType: SITE_TYPES.NEW_API,
+        authType: AuthTypeEnum.AccessToken,
+        userId: "301",
+        token: "first-token",
+      }),
+      buildDisplaySiteData({
+        id: secondAccount.id,
+        name: "Queued Account 2",
+        baseUrl: secondAccount.site_url,
+        siteType: SITE_TYPES.NEW_API,
+        authType: AuthTypeEnum.AccessToken,
+        userId: "302",
+        token: "second-token",
+      }),
+    ])
+    mocks.ensureAccountKeysForAvailableGroups.mockImplementation(
+      async ({ abortSignal }) => {
+        capturedSignal = abortSignal
+        await vi.waitFor(() => {
+          expect(abortSignal?.aborted).toBe(true)
+        })
+        return {
+          created: false,
+          availableGroups: [],
+          coveredGroups: [],
+          createdGroups: [],
+          missingGroups: [],
+          invalidTokens: [],
+        }
+      },
+    )
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await accountKeyRepairRunner.start()
+
+    await vi.waitFor(() => {
+      expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(1)
+    })
+
+    await expect(accountKeyRepairRunner.cancel()).resolves.toEqual({
+      success: true,
+      data: expect.objectContaining({
+        jobId: "job-123",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+      }),
+    })
+
+    expect(capturedSignal?.aborted).toBe(true)
+
+    await vi.waitFor(async () => {
+      const progress = await accountKeyRepairRunner.getProgress()
+      expect(progress.state).toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled)
+    })
+
+    const progress = await accountKeyRepairRunner.getProgress()
+    expect(progress.totals).toMatchObject({
+      enabledAccounts: 2,
+      eligibleAccounts: 2,
+      processedAccounts: 0,
+      processedEligibleAccounts: 0,
+    })
+    expect(progress.results).toEqual([])
+    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(1)
+  })
+
+  it("cancels a stored running job when no in-memory run exists", async () => {
+    mocks.storageMap.set("accountKeyRepair_progress", {
+      jobId: "stale-running",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+      startedAt: 100,
+      updatedAt: 100,
+      totals: {
+        enabledAccounts: 220,
+        eligibleAccounts: 220,
+        processedAccounts: 219,
+        processedEligibleAccounts: 219,
+      },
+      summary: {
+        created: 0,
+        alreadyHad: 219,
+        skipped: 0,
+        failed: 0,
+      },
+      results: [],
+    })
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await expect(accountKeyRepairRunner.cancel()).resolves.toEqual({
+      success: true,
+      data: expect.objectContaining({
+        jobId: "stale-running",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+        finishedAt: expect.any(Number),
+      }),
+    })
+
+    await expect(accountKeyRepairRunner.getProgress()).resolves.toMatchObject({
+      jobId: "stale-running",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+      totals: {
+        enabledAccounts: 220,
+        eligibleAccounts: 220,
+        processedAccounts: 219,
+        processedEligibleAccounts: 219,
+      },
+    })
+    expect(mocks.sendRuntimeMessage).toHaveBeenLastCalledWith(
+      {
+        type: RuntimeMessageTypes.AccountKeyRepairProgress,
+        payload: expect.objectContaining({
+          jobId: "stale-running",
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+        }),
+      },
+      { maxAttempts: 1 },
+    )
+  })
+
+  it("keeps a restarted run active while the cancelled run unwinds", async () => {
+    const firstAccount = buildSiteAccount({
+      id: "first-run",
+      site_type: "new-api",
+      site_url: "https://first.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "301",
+        access_token: "first-token",
+        username: "first-run",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const secondAccount = buildSiteAccount({
+      id: "second-run",
+      site_type: "new-api",
+      site_url: "https://second.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      disabled: false,
+      account_info: {
+        id: "302",
+        access_token: "second-token",
+        username: "second-run",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const firstRunDisplay = buildDisplaySiteData({
+      id: firstAccount.id,
+      name: "First Run",
+      baseUrl: firstAccount.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "301",
+      token: "first-token",
+    })
+    const secondRunDisplay = buildDisplaySiteData({
+      id: secondAccount.id,
+      name: "Second Run",
+      baseUrl: secondAccount.site_url,
+      siteType: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.AccessToken,
+      userId: "302",
+      token: "second-token",
+    })
+    let firstAbortSignal: AbortSignal | undefined
+    let resolveSecondRun:
+      | ((value: {
+          created: boolean
+          availableGroups: string[]
+          coveredGroups: string[]
+          createdGroups: string[]
+          missingGroups: string[]
+          invalidTokens: []
+        }) => void)
+      | undefined
+
+    mocks.safeRandomUUID
+      .mockReturnValueOnce("job-first")
+      .mockReturnValueOnce("job-second")
+    mocks.getAllAccounts
+      .mockResolvedValueOnce([firstAccount])
+      .mockResolvedValueOnce([secondAccount])
+    mocks.convertToDisplayData
+      .mockReturnValueOnce([firstRunDisplay])
+      .mockReturnValueOnce([secondRunDisplay])
+    mocks.ensureAccountKeysForAvailableGroups
+      .mockImplementationOnce(async ({ abortSignal }) => {
+        firstAbortSignal = abortSignal
+        await vi.waitFor(() => {
+          expect(abortSignal?.aborted).toBe(true)
+        })
+        return {
+          created: false,
+          availableGroups: [],
+          coveredGroups: [],
+          createdGroups: [],
+          missingGroups: [],
+          invalidTokens: [],
+        }
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecondRun = resolve
+          }),
+      )
+
+    const { accountKeyRepairRunner } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+
+    await accountKeyRepairRunner.start()
+    await vi.waitFor(() => {
+      expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(1)
+    })
+
+    await accountKeyRepairRunner.cancel()
+    expect(firstAbortSignal?.aborted).toBe(true)
+
+    await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
+      jobId: "job-second",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    })
+
+    await vi.waitFor(() => {
+      expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(2)
+    })
+
+    await expect(accountKeyRepairRunner.start()).resolves.toMatchObject({
+      jobId: "job-second",
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    })
+    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(2)
+
+    resolveSecondRun?.({
+      created: false,
+      availableGroups: ["default"],
+      coveredGroups: ["default"],
+      createdGroups: [],
+      missingGroups: [],
+      invalidTokens: [],
+    })
+
+    await vi.waitFor(async () => {
+      const progress = await accountKeyRepairRunner.getProgress()
+      expect(progress).toMatchObject({
+        jobId: "job-second",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+      })
+    })
+  })
+
   it("marks the repair job as failed when loading accounts throws", async () => {
     mocks.getAllAccounts.mockRejectedValueOnce(new Error("boom"))
 
@@ -1233,13 +1546,15 @@ describe("accountKeyRepair", () => {
     })
   })
 
-  it("exposes typed operation helpers for start and get-progress", async () => {
+  it("exposes typed operation helpers for start, get-progress, and cancel", async () => {
     mocks.getAllAccounts.mockResolvedValue([])
     mocks.convertToDisplayData.mockReturnValue([])
 
-    const { getAccountKeyRepairProgress, startAccountKeyRepair } = await import(
-      "~/services/accounts/accountKeyAutoProvisioning/repair"
-    )
+    const {
+      cancelAccountKeyRepair,
+      getAccountKeyRepairProgress,
+      startAccountKeyRepair,
+    } = await import("~/services/accounts/accountKeyAutoProvisioning/repair")
 
     await expect(startAccountKeyRepair()).resolves.toEqual({
       success: true,
@@ -1253,6 +1568,14 @@ describe("accountKeyRepair", () => {
       success: true,
       data: expect.objectContaining({
         jobId: "job-123",
+      }),
+    })
+
+    await expect(cancelAccountKeyRepair()).resolves.toEqual({
+      success: true,
+      data: expect.objectContaining({
+        jobId: "job-123",
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
       }),
     })
 

--- a/tests/services/runtimeTypedMessagingSetup.test.ts
+++ b/tests/services/runtimeTypedMessagingSetup.test.ts
@@ -350,6 +350,7 @@ describe("typed runtime messaging setup", () => {
       () => ({
         AccountKeyRepairMessageTypes: {
           Start: "accountKeyRepair:start",
+          Cancel: "accountKeyRepair:cancel",
           GetProgress: "accountKeyRepair:getProgress",
           DeleteInvalidTokens: "accountKeyRepair:deleteInvalidTokens",
         },
@@ -376,12 +377,21 @@ describe("typed runtime messaging setup", () => {
     repair.setupAccountKeyRepairMessagingListeners()
     repair.setupAccountKeyRepairMessagingListeners()
 
-    expect(onAccountKeyRepairMessage).toHaveBeenCalledTimes(3)
+    expect(onAccountKeyRepairMessage).toHaveBeenCalledTimes(4)
     const getProgressHandler = onAccountKeyRepairMessage.mock.calls.find(
       ([type]) => type === "accountKeyRepair:getProgress",
     )?.[1]
     expect(getProgressHandler).toBeTypeOf("function")
     await expect(getProgressHandler!()).resolves.toEqual({
+      success: false,
+      error: "repair failed",
+    })
+
+    const cancelHandler = getRegisteredHandler(
+      onAccountKeyRepairMessage,
+      "accountKeyRepair:cancel",
+    )
+    await expect(cancelHandler()).resolves.toEqual({
       success: false,
       error: "repair failed",
     })


### PR DESCRIPTION
## Summary
- add cancellable account key repair jobs and propagate abort signals into API transport
- expose a typed cancel message and cancel action in the Key Management repair progress UI
- terminalize stale persisted running jobs and cover cancel/restart races with focused tests

## Test Plan
- pnpm vitest run tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts tests/services/accountKeyRepair.rateLimiting.test.ts tests/features/KeyManagement/components/useRepairMissingKeysJob.test.tsx tests/features/KeyManagement/components/RepairMissingKeysProgressCard.test.tsx tests/features/KeyManagement/components/repairMissingKeysDialogHelpers.test.ts tests/services/runtimeTypedMessagingSetup.test.ts
- pnpm compile
- pnpm run i18n:extract:ci
- pnpm run validate:staged
- pnpm run validate:push

Related issue #1038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of release notes

* **New Features**
  * Added the ability to cancel an in-progress key repair check from the progress card.
  * Introduced a “cancelled” job state with updated status/progress visuals.

* **Bug Fixes**
  * Improved cancellation behavior to reliably halt further background processing and preserve the final cancelled result.
  * Updated cancellation flows and tracking to handle cancellation accurately.

* **Documentation / Localization**
  * Updated dialog and progress copy to clarify cancellation behavior and timing.
  * Added translated labels and error messaging for cancelled states and cancel failures across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->