### PR TITLE
ci(e2e): rename workflow and enable two workers

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,4 +1,4 @@
-name: E2E Smoke
+name: E2E
 
 on:
   push:
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   e2e-smoke:
-    name: E2E smoke (${{ matrix.name }})
+    name: E2E (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-e2e') }}
@@ -103,6 +103,7 @@ jobs:
         timeout-minutes: ${{ matrix.timeout_minutes }}
         env:
           AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
+          AAH_E2E_WORKERS: "2"
           AAH_SKIP_E2E_BUILD: "1"
         run: pnpm run e2e:${{ matrix.e2e_type }}
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,12 +5,13 @@ import { loadPlaywrightEnvFiles } from "./e2e/utils/playwrightEnv"
 loadPlaywrightEnvFiles()
 
 const isCI = !!process.env.CI
-const localWorkerCount = Number(process.env.AAH_E2E_WORKERS ?? 4)
-const workers = isCI
-  ? 1
-  : Number.isFinite(localWorkerCount)
-    ? localWorkerCount
-    : 4
+const configuredWorkerCount = Number(process.env.AAH_E2E_WORKERS)
+const workers =
+  Number.isInteger(configuredWorkerCount) && configuredWorkerCount > 0
+    ? configuredWorkerCount
+    : isCI
+      ? 1
+      : 4
 
 export default defineConfig({
   testDir: "./e2e",


### PR DESCRIPTION
## Summary
- Rename the E2E workflow/job display labels from smoke to E2E to match that the default leg runs the full E2E suite.
- Allow AAH_E2E_WORKERS to override the CI Playwright worker default while keeping the fallback at 1 in CI and 4 locally.
- Run the default E2E leg with 2 workers in CI; the extension fixture uses isolated temp persistent profiles per worker.

## Test Plan
- pnpm exec prettier --check .github/workflows/e2e-smoke.yml playwright.config.ts
- pnpm run validate:staged
- pnpm compile
- AAH_E2E_WORKERS=2 pnpm run e2e:default -- --list
- AAH_E2E_WORKERS=2 AAH_SKIP_E2E_BUILD=1 pnpm exec playwright test e2e/smoke.spec.ts e2e/optionsOverviewDefaultRoute.spec.ts --project=chromium --reporter=list
- AAH_E2E_WORKERS=2 AAH_SKIP_E2E_BUILD=1 pnpm exec playwright test e2e/popupQuickActions.spec.ts e2e/basicSettingsCommonFlows.spec.ts --project=chromium --reporter=list
- workflow_dispatch on ci/e2e-worker-concurrency: https://github.com/qixing-jk/all-api-hub/actions/runs/28084751687

## CI Timing Check
- Branch E2E (default): 120 passed / 9 skipped, job 6m10s, test step 4m31s.
- Branch E2E (dnr-required): 2 passed / 1 skipped, job 1m56s, test step 33s.
- Recent main default comparison: test step 7m42s in run 28079168374 and 7m29s in run 28059218621.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated E2E smoke test runs to use a clearer run label and a fixed worker count in CI.
  * Improved test worker handling so configured values are only applied when valid, with safer defaults in CI and local runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->