### PR TITLE
feat(key-management): verify account token APIs

### DIFF
--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -509,9 +509,7 @@ function TokenActionButtons({
       })
       showResultToast({
         success: false,
-        message: t("messages:errors.operation.failed", {
-          error: getErrorMessage(error),
-        }),
+        message: t("keyManagement:messages.verifyApiFailed"),
       })
     }
   }
@@ -546,9 +544,7 @@ function TokenActionButtons({
       })
       showResultToast({
         success: false,
-        message: t("messages:errors.operation.failed", {
-          error: getErrorMessage(error),
-        }),
+        message: t("keyManagement:messages.verifyCliSupportFailed"),
       })
     }
   }

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -1,7 +1,9 @@
 import {
   ArrowPathIcon,
+  CommandLineIcon,
   PencilIcon,
   TrashIcon,
+  WrenchScrewdriverIcon,
 } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
 import { Copy } from "lucide-react"
@@ -12,6 +14,7 @@ import { useTranslation } from "react-i18next"
 import { ClaudeCodeRouterImportDialog } from "~/components/ClaudeCodeRouterImportDialog"
 import { CliProxyExportDialog } from "~/components/CliProxyExportDialog"
 import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
+import { VerifyCliSupportDialog } from "~/components/dialogs/VerifyCliSupportDialog"
 import { CCSwitchIcon } from "~/components/icons/CCSwitchIcon"
 import { CherryIcon } from "~/components/icons/CherryIcon"
 import { ClaudeCodeRouterIcon } from "~/components/icons/ClaudeCodeRouterIcon"
@@ -40,6 +43,7 @@ import {
   WorkflowTransitionButton,
 } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { VerifyApiCredentialProfileDialog } from "~/features/ApiCredentialProfiles/components/VerifyApiCredentialProfileDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { buildApiCredentialProfileName } from "~/features/KeyManagement/utils/apiCredentialProfileName"
 import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
@@ -70,6 +74,7 @@ import {
 } from "~/services/verification/aiApiVerification"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { AccountToken, DisplaySiteData } from "~/types"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { showResultToast } from "~/utils/core/toastHelpers"
@@ -271,8 +276,35 @@ function TokenActionButtons({
   const [isClaudeCodeRouterOpen, setIsClaudeCodeRouterOpen] = useState(false)
   const [isCliProxyDialogOpen, setIsCliProxyDialogOpen] = useState(false)
   const [isKiloCodeDialogOpen, setIsKiloCodeDialogOpen] = useState(false)
+  const [verifyingProfile, setVerifyingProfile] =
+    useState<ApiCredentialProfile | null>(null)
+  const [cliVerifyingProfile, setCliVerifyingProfile] =
+    useState<ApiCredentialProfile | null>(null)
 
   const managedSiteLabel = getManagedSiteLabel(t, managedSiteType)
+  const apiType: ApiVerificationApiType = API_TYPES.OPENAI_COMPATIBLE
+
+  const buildTransientProfile = (resolvedToken: AccountToken) => {
+    const now = Date.now()
+    return {
+      id: `account-token:${account.id}:${token.id}`,
+      name: buildApiCredentialProfileName({
+        accountName: account.name,
+        fallbackAccountName: token.accountName,
+        tokenName: token.name,
+      }),
+      apiType,
+      baseUrl: normalizeAccountSiteUrlForManagedChannel({
+        siteType: account.siteType,
+        url: account.baseUrl,
+      }),
+      apiKey: resolvedToken.key,
+      tagIds: account.tagIds ?? [],
+      notes: "",
+      createdAt: now,
+      updatedAt: now,
+    } satisfies ApiCredentialProfile
+  }
 
   const handleImportToManagedSite = async () => {
     const tracker = startProductAnalyticsAction({
@@ -385,7 +417,6 @@ function TokenActionButtons({
       surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRowActions,
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
     })
-    const apiType: ApiVerificationApiType = API_TYPES.OPENAI_COMPATIBLE
     const profileName = buildApiCredentialProfileName({
       accountName: account.name,
       fallbackAccountName: token.accountName,
@@ -448,6 +479,80 @@ function TokenActionButtons({
     }
   }
 
+  const handleVerifyApi = async () => {
+    const tracker = startProductAnalyticsAction({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.VerifyAccountTokenApi,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRowActions,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    })
+    let resolvedToken = token
+
+    try {
+      resolvedToken = await resolveDisplayAccountTokenForSecret(account, token)
+      setVerifyingProfile(buildTransientProfile(resolvedToken))
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
+    } catch (error) {
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      })
+      logger.error("Failed to open token API verification", {
+        message: toSanitizedErrorSummary(
+          error,
+          [
+            token.key,
+            resolvedToken.key,
+            account.token,
+            account.cookieAuthSessionCookie,
+          ].filter(Boolean) as string[],
+        ),
+      })
+      showResultToast({
+        success: false,
+        message: t("messages:errors.operation.failed", {
+          error: getErrorMessage(error),
+        }),
+      })
+    }
+  }
+
+  const handleVerifyCliSupport = async () => {
+    const tracker = startProductAnalyticsAction({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.VerifyAccountTokenCliSupport,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRowActions,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    })
+    let resolvedToken = token
+
+    try {
+      resolvedToken = await resolveDisplayAccountTokenForSecret(account, token)
+      setCliVerifyingProfile(buildTransientProfile(resolvedToken))
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
+    } catch (error) {
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      })
+      logger.error("Failed to open token CLI support verification", {
+        message: toSanitizedErrorSummary(
+          error,
+          [
+            token.key,
+            resolvedToken.key,
+            account.token,
+            account.cookieAuthSessionCookie,
+          ].filter(Boolean) as string[],
+        ),
+      })
+      showResultToast({
+        success: false,
+        message: t("messages:errors.operation.failed", {
+          error: getErrorMessage(error),
+        }),
+      })
+    }
+  }
+
   return (
     <div
       data-testid={KEY_MANAGEMENT_TEST_IDS.tokenRowActions}
@@ -473,6 +578,18 @@ function TokenActionButtons({
         account={account}
         token={token}
       />
+      <VerifyApiCredentialProfileDialog
+        isOpen={Boolean(verifyingProfile)}
+        onClose={() => setVerifyingProfile(null)}
+        profile={verifyingProfile}
+      />
+      {cliVerifyingProfile ? (
+        <VerifyCliSupportDialog
+          isOpen={true}
+          onClose={() => setCliVerifyingProfile(null)}
+          profile={cliVerifyingProfile}
+        />
+      ) : null}
       <IconButton
         aria-label={t("common:actions.copyKey")}
         size="sm"
@@ -493,6 +610,24 @@ function TokenActionButtons({
           <ApiCredentialLibraryIcon className="dark:text-dark-text-tertiary h-4 w-4 text-gray-500" />
         </IconButton>
       </Tooltip>
+      <IconButton
+        aria-label={t("keyManagement:actions.verifyApi")}
+        size="sm"
+        variant="ghost"
+        data-testid={KEY_MANAGEMENT_TEST_IDS.verifyTokenApiButton}
+        onClick={() => void handleVerifyApi()}
+      >
+        <WrenchScrewdriverIcon className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+      </IconButton>
+      <IconButton
+        aria-label={t("keyManagement:actions.verifyCliSupport")}
+        size="sm"
+        variant="ghost"
+        data-testid={KEY_MANAGEMENT_TEST_IDS.verifyTokenCliSupportButton}
+        onClick={() => void handleVerifyCliSupport()}
+      >
+        <CommandLineIcon className="h-4 w-4 text-sky-600 dark:text-sky-400" />
+      </IconButton>
       <IconButton
         aria-label={t("actions.useInCherry")}
         size="sm"

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -3,6 +3,8 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   emptyStateAddTokenButton: "key-management-empty-state-add-token-button",
   addTokenDialog: "key-management-add-token-dialog",
   saveToApiProfilesButton: "key-management-save-to-api-profiles-button",
+  verifyTokenApiButton: "key-management-verify-token-api-button",
+  verifyTokenCliSupportButton: "key-management-verify-token-cli-support-button",
   batchSaveToApiProfilesButton:
     "key-management-batch-save-to-api-profiles-button",
   tokenRowActions: "key-management-token-row-actions",

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -263,7 +263,9 @@
     "loadFailed": "Failed to load key list",
     "revealFailed": "Failed to reveal key",
     "savedToApiProfiles": "Saved {{name}} to API credential library",
-    "saveToApiProfilesFailed": "Failed to save to API credential library"
+    "saveToApiProfilesFailed": "Failed to save to API credential library",
+    "verifyApiFailed": "Failed to open API verification",
+    "verifyCliSupportFailed": "Failed to open CLI compatibility verification"
   },
   "noKeys": "No key data yet",
   "noMatchingKeys": "No matching keys found",

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -24,7 +24,9 @@
     "saveToApiProfiles": "Save to API credential library",
     "saveToApiProfilesHint": "Save this key to the API credential library for quick copying, verification, and export.",
     "showKey": "Show Key",
-    "useInCherry": "Use in Cherry Studio"
+    "useInCherry": "Use in Cherry Studio",
+    "verifyApi": "Verify API",
+    "verifyCliSupport": "Verify CLI Support"
   },
   "allAccounts": "All accounts",
   "allAccountsFailed_one": "{{count}} failed",

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -257,7 +257,9 @@
     "loadFailed": "キー一覧の読み込みに失敗しました",
     "revealFailed": "キーの表示に失敗しました",
     "savedToApiProfiles": "{{name}} を API 認証情報庫に保存しました",
-    "saveToApiProfilesFailed": "API 認証情報庫への保存に失敗しました"
+    "saveToApiProfilesFailed": "API 認証情報庫への保存に失敗しました",
+    "verifyApiFailed": "API 検証を開けませんでした",
+    "verifyCliSupportFailed": "CLI 互換性検証を開けませんでした"
   },
   "noKeys": "まだキーデータがありません",
   "noMatchingKeys": "一致するキーが見つかりません",

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -23,7 +23,9 @@
     "saveToApiProfiles": "API 認証情報庫に保存",
     "saveToApiProfilesHint": "このキーを API 認証情報庫に保存し、コピー、検証、エクスポートに再利用できます。",
     "showKey": "キーを表示",
-    "useInCherry": "Cherry Studio で使う"
+    "useInCherry": "Cherry Studio で使う",
+    "verifyApi": "API を検証",
+    "verifyCliSupport": "CLI 対応を検証"
   },
   "allAccounts": "すべてのアカウント",
   "allAccountsFailed_other": "{{count}} 件失敗",

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -257,7 +257,9 @@
     "loadFailed": "Tải danh sách khóa thất bại",
     "revealFailed": "Hiển thị khóa thất bại",
     "savedToApiProfiles": "Đã lưu {{name}} vào Hồ sơ API",
-    "saveToApiProfilesFailed": "Lưu vào Hồ sơ API thất bại"
+    "saveToApiProfilesFailed": "Lưu vào Hồ sơ API thất bại",
+    "verifyApiFailed": "Không thể mở xác minh API",
+    "verifyCliSupportFailed": "Không thể mở xác minh tính tương thích CLI"
   },
   "noKeys": "Chưa có dữ liệu khóa",
   "noMatchingKeys": "Không tìm thấy khóa khớp",

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -23,7 +23,9 @@
     "saveToApiProfiles": "Lưu vào Hồ sơ API",
     "saveToApiProfilesHint": "Lưu khóa này vào thư viện thông tin xác thực API để sao chép, xác minh và xuất nhanh.",
     "showKey": "Hiển thị khóa",
-    "useInCherry": "Sử dụng trong Cherry Studio"
+    "useInCherry": "Sử dụng trong Cherry Studio",
+    "verifyApi": "Xác minh API",
+    "verifyCliSupport": "Xác minh tính tương thích CLI"
   },
   "allAccounts": "Tất cả tài khoản",
   "allAccountsFailed_other": "{{count}} thất bại",

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -257,7 +257,9 @@
     "loadFailed": "加载密钥列表失败",
     "revealFailed": "显示密钥失败",
     "savedToApiProfiles": "已保存 {{name}} 到 API 凭据库",
-    "saveToApiProfilesFailed": "保存到 API 凭据库失败"
+    "saveToApiProfilesFailed": "保存到 API 凭据库失败",
+    "verifyApiFailed": "打开接口验证失败",
+    "verifyCliSupportFailed": "打开 CLI 兼容性验证失败"
   },
   "noKeys": "暂无密钥数据",
   "noMatchingKeys": "没有找到匹配的密钥",

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -23,7 +23,9 @@
     "saveToApiProfiles": "保存到 API 凭据库",
     "saveToApiProfilesHint": "将此密钥保存到 API 凭据库，用于快速复制、验证和导出。",
     "showKey": "显示密钥",
-    "useInCherry": "在 Cherry Studio 中使用"
+    "useInCherry": "在 Cherry Studio 中使用",
+    "verifyApi": "验证接口",
+    "verifyCliSupport": "验证 CLI 兼容性"
   },
   "allAccounts": "所有账号",
   "allAccountsFailed": "{{count}} 个失败",

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -257,7 +257,9 @@
     "loadFailed": "載入金鑰列表失敗",
     "revealFailed": "顯示金鑰失敗",
     "savedToApiProfiles": "已儲存 {{name}} 到 API 憑據庫",
-    "saveToApiProfilesFailed": "儲存到 API 憑據庫失敗"
+    "saveToApiProfilesFailed": "儲存到 API 憑據庫失敗",
+    "verifyApiFailed": "開啟介面驗證失敗",
+    "verifyCliSupportFailed": "開啟 CLI 相容性驗證失敗"
   },
   "noKeys": "暫無金鑰資料",
   "noMatchingKeys": "沒有找到匹配的金鑰",

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -23,7 +23,9 @@
     "saveToApiProfiles": "儲存到 API 憑據庫",
     "saveToApiProfilesHint": "將此金鑰儲存到 API 憑據庫，用於快速複製、驗證與匯出。",
     "showKey": "顯示金鑰",
-    "useInCherry": "在 Cherry Studio 中使用"
+    "useInCherry": "在 Cherry Studio 中使用",
+    "verifyApi": "驗證介面",
+    "verifyCliSupport": "驗證 CLI 相容性"
   },
   "allAccounts": "所有帳號",
   "allAccountsFailed_other": "{{count}} 個失敗",

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -566,6 +566,8 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
   ViewManagedSiteChannel: "view_managed_site_channel",
   VerifyApiCredential: "verify_api_credential",
   VerifyApiCredentialCliSupport: "verify_api_credential_cli_support",
+  VerifyAccountTokenApi: "verify_account_token_api",
+  VerifyAccountTokenCliSupport: "verify_account_token_cli_support",
   VerifyWebDavConnection: "verify_webdav_connection",
   VerifyModelApi: "verify_model_api",
   VerifyModelCliSupport: "verify_model_cli_support",

--- a/tests/features/KeyManagement/components/TokenHeader.analytics.test.tsx
+++ b/tests/features/KeyManagement/components/TokenHeader.analytics.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event"
-import type { ReactNode } from "react"
+import { act, type ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
@@ -344,6 +344,21 @@ describe("TokenHeader analytics", () => {
         }),
       )
     })
+    const openedDialogProps = verifyDialogRenderMock.mock.calls.find(
+      ([props]) => (props as { isOpen?: boolean }).isOpen === true,
+    )?.[0] as { onClose: () => void }
+
+    act(() => {
+      openedDialogProps.onClose()
+    })
+
+    await waitFor(() => {
+      expect(verifyDialogRenderMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isOpen: false,
+        }),
+      )
+    })
   })
 
   it("tracks token API verification open as sanitized unknown failure when secret resolution fails", async () => {
@@ -372,9 +387,15 @@ describe("TokenHeader analytics", () => {
       )
       expect(showResultToastMock).toHaveBeenCalledWith({
         success: false,
-        message: "messages:errors.operation.failed",
+        message: "keyManagement:messages.verifyApiFailed",
       })
     })
+    expect(JSON.stringify(showResultToastMock.mock.calls)).not.toContain(
+      "sk-sensitive",
+    )
+    expect(JSON.stringify(showResultToastMock.mock.calls)).not.toContain(
+      "verification exposed",
+    )
     expect(
       JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
     ).not.toContain("sk-sensitive")
@@ -437,6 +458,13 @@ describe("TokenHeader analytics", () => {
         PRODUCT_ANALYTICS_RESULTS.Success,
       )
     })
+    const openedDialogProps = verifyCliDialogRenderMock.mock.calls.find(
+      ([props]) => (props as { isOpen?: boolean }).isOpen === true,
+    )?.[0] as { onClose: () => void }
+
+    act(() => {
+      openedDialogProps.onClose()
+    })
     expect(
       JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
     ).not.toContain(resolvedSecret)
@@ -468,9 +496,15 @@ describe("TokenHeader analytics", () => {
       )
       expect(showResultToastMock).toHaveBeenCalledWith({
         success: false,
-        message: "messages:errors.operation.failed",
+        message: "keyManagement:messages.verifyCliSupportFailed",
       })
     })
+    expect(JSON.stringify(showResultToastMock.mock.calls)).not.toContain(
+      "sk-sensitive-cli",
+    )
+    expect(JSON.stringify(showResultToastMock.mock.calls)).not.toContain(
+      "cli verification exposed",
+    )
     expect(
       JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
     ).not.toContain("sk-sensitive-cli")

--- a/tests/features/KeyManagement/components/TokenHeader.analytics.test.tsx
+++ b/tests/features/KeyManagement/components/TokenHeader.analytics.test.tsx
@@ -2,6 +2,11 @@ import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import {
+  AIHUBMIX_API_ORIGIN,
+  AIHUBMIX_WEB_ORIGIN,
+  SITE_TYPES,
+} from "~/constants/siteType"
 import { TokenHeader } from "~/features/KeyManagement/components/TokenListItem/TokenHeader"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import {
@@ -31,6 +36,8 @@ const {
   resolveDisplayAccountTokenForSecretMock,
   showResultToastMock,
   startProductAnalyticsActionMock,
+  verifyCliDialogRenderMock,
+  verifyDialogRenderMock,
 } = vi.hoisted(() => ({
   completeProductAnalyticsActionMock: vi.fn(),
   createProfileMock: vi.fn(),
@@ -39,6 +46,8 @@ const {
   resolveDisplayAccountTokenForSecretMock: vi.fn(),
   showResultToastMock: vi.fn(),
   startProductAnalyticsActionMock: vi.fn(),
+  verifyCliDialogRenderMock: vi.fn(),
+  verifyDialogRenderMock: vi.fn(),
 }))
 
 vi.mock("~/components/dialogs/ChannelDialog", () => ({
@@ -67,6 +76,23 @@ vi.mock("~/components/ClaudeCodeRouterImportDialog", () => ({
 vi.mock("~/components/CliProxyExportDialog", () => ({
   CliProxyExportDialog: () => null,
 }))
+
+vi.mock("~/components/dialogs/VerifyCliSupportDialog", () => ({
+  VerifyCliSupportDialog: (props: unknown) => {
+    verifyCliDialogRenderMock(props)
+    return null
+  },
+}))
+
+vi.mock(
+  "~/features/ApiCredentialProfiles/components/VerifyApiCredentialProfileDialog",
+  () => ({
+    VerifyApiCredentialProfileDialog: (props: unknown) => {
+      verifyDialogRenderMock(props)
+      return null
+    },
+  }),
+)
 
 vi.mock("~/services/accounts/utils/apiServiceRequest", () => ({
   resolveDisplayAccountTokenForSecret: (...args: unknown[]) =>
@@ -146,6 +172,8 @@ describe("TokenHeader analytics", () => {
     resolveDisplayAccountTokenForSecretMock.mockReset()
     showResultToastMock.mockReset()
     startProductAnalyticsActionMock.mockReset()
+    verifyCliDialogRenderMock.mockReset()
+    verifyDialogRenderMock.mockReset()
     startProductAnalyticsActionMock.mockReturnValue({
       complete: completeProductAnalyticsActionMock,
     })
@@ -235,6 +263,220 @@ describe("TokenHeader analytics", () => {
     expect(
       JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
     ).not.toContain("secret resolution exposed")
+  })
+
+  it("tracks opening token API verification without exposing the resolved secret", async () => {
+    const resolvedSecret = "sk-sensitive-verify"
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce(
+      createToken({ id: 1, key: resolvedSecret }),
+    )
+
+    const user = userEvent.setup()
+    renderTokenHeader()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.verifyApi",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(resolveDisplayAccountTokenForSecretMock).toHaveBeenCalledTimes(1)
+      expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
+        featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+        actionId: PRODUCT_ANALYTICS_ACTION_IDS.VerifyAccountTokenApi,
+        surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRowActions,
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      })
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Success,
+      )
+    })
+    expect(
+      JSON.stringify(startProductAnalyticsActionMock.mock.calls),
+    ).not.toContain("sk-sensitive")
+    expect(
+      JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
+    ).not.toContain(resolvedSecret)
+  })
+
+  it("opens token API verification with a transient normalized profile", async () => {
+    const resolvedSecret = "sk-aihubmix-resolved"
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce(
+      createToken({ id: 8, key: resolvedSecret }),
+    )
+
+    const user = userEvent.setup()
+    renderTokenHeader({
+      account: createAccount({
+        id: "aihubmix-account",
+        name: "AIHubMix Account",
+        siteType: SITE_TYPES.AIHUBMIX,
+        baseUrl: AIHUBMIX_WEB_ORIGIN,
+        tagIds: ["tag-a"],
+      }),
+      token: createToken({
+        id: 8,
+        name: "Model Key",
+        accountId: "aihubmix-account",
+        accountName: "AIHubMix Account",
+        key: "masked-key",
+      }),
+    })
+
+    await user.click(
+      screen.getByTestId(KEY_MANAGEMENT_TEST_IDS.verifyTokenApiButton),
+    )
+
+    await waitFor(() => {
+      expect(verifyDialogRenderMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isOpen: true,
+          profile: expect.objectContaining({
+            id: "account-token:aihubmix-account:8",
+            name: "AIHubMix Account - Model Key",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: AIHUBMIX_API_ORIGIN,
+            apiKey: resolvedSecret,
+            tagIds: ["tag-a"],
+            notes: "",
+          }),
+        }),
+      )
+    })
+  })
+
+  it("tracks token API verification open as sanitized unknown failure when secret resolution fails", async () => {
+    resolveDisplayAccountTokenForSecretMock.mockRejectedValueOnce(
+      new Error("verification exposed sk-sensitive-verify"),
+    )
+
+    const user = userEvent.setup()
+    renderTokenHeader()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.verifyApi",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(verifyDialogRenderMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          isOpen: true,
+        }),
+      )
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Failure,
+        { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },
+      )
+      expect(showResultToastMock).toHaveBeenCalledWith({
+        success: false,
+        message: "messages:errors.operation.failed",
+      })
+    })
+    expect(
+      JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
+    ).not.toContain("sk-sensitive")
+    expect(
+      JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
+    ).not.toContain("verification exposed")
+  })
+
+  it("opens token CLI support verification with a transient normalized profile", async () => {
+    const resolvedSecret = "sk-cli-resolved"
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce(
+      createToken({ id: 9, key: resolvedSecret }),
+    )
+
+    const user = userEvent.setup()
+    renderTokenHeader({
+      account: createAccount({
+        id: "cli-account",
+        name: "CLI Account",
+        baseUrl: "https://cli.example/v1",
+        tagIds: ["tag-cli"],
+      }),
+      token: createToken({
+        id: 9,
+        name: "CLI Key",
+        accountId: "cli-account",
+        accountName: "CLI Account",
+        key: "masked-key",
+      }),
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.verifyCliSupport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(verifyCliDialogRenderMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isOpen: true,
+          profile: expect.objectContaining({
+            id: "account-token:cli-account:9",
+            name: "CLI Account - CLI Key",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://cli.example/v1",
+            apiKey: resolvedSecret,
+            tagIds: ["tag-cli"],
+            notes: "",
+          }),
+        }),
+      )
+      expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
+        featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+        actionId: PRODUCT_ANALYTICS_ACTION_IDS.VerifyAccountTokenCliSupport,
+        surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRowActions,
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      })
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Success,
+      )
+    })
+    expect(
+      JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
+    ).not.toContain(resolvedSecret)
+  })
+
+  it("tracks token CLI support verification open as sanitized unknown failure when secret resolution fails", async () => {
+    resolveDisplayAccountTokenForSecretMock.mockRejectedValueOnce(
+      new Error("cli verification exposed sk-sensitive-cli"),
+    )
+
+    const user = userEvent.setup()
+    renderTokenHeader()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.verifyCliSupport",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(verifyCliDialogRenderMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          isOpen: true,
+        }),
+      )
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Failure,
+        { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },
+      )
+      expect(showResultToastMock).toHaveBeenCalledWith({
+        success: false,
+        message: "messages:errors.operation.failed",
+      })
+    })
+    expect(
+      JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
+    ).not.toContain("sk-sensitive-cli")
+    expect(
+      JSON.stringify(completeProductAnalyticsActionMock.mock.calls),
+    ).not.toContain("cli verification exposed")
   })
 
   it("tracks managed-site token verification retry as sanitized success after callback completion", async () => {

--- a/tests/services/productAnalytics/events.test.ts
+++ b/tests/services/productAnalytics/events.test.ts
@@ -130,6 +130,8 @@ describe("product analytics event enums", () => {
         "save_account_token_to_api_credential_profile",
       SaveAccountTokensToApiCredentialProfiles:
         "save_account_tokens_to_api_credential_profiles",
+      VerifyAccountTokenApi: "verify_account_token_api",
+      VerifyAccountTokenCliSupport: "verify_account_token_cli_support",
       RefreshManagedSiteTokenStatus: "refresh_managed_site_token_status",
       RetryManagedSiteTokenVerification:
         "retry_managed_site_token_verification",

--- a/tests/services/productAnalytics/privacy.test.ts
+++ b/tests/services/productAnalytics/privacy.test.ts
@@ -343,6 +343,18 @@ describe("product analytics privacy filtering", () => {
       errorCategory: undefined,
     },
     {
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.VerifyAccountTokenApi,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRowActions,
+      result: PRODUCT_ANALYTICS_RESULTS.Success,
+      errorCategory: undefined,
+    },
+    {
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.VerifyAccountTokenCliSupport,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementRowActions,
+      result: PRODUCT_ANALYTICS_RESULTS.Success,
+      errorCategory: undefined,
+    },
+    {
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.RefreshManagedSiteTokenStatus,
       surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementHeader,
       result: PRODUCT_ANALYTICS_RESULTS.Success,


### PR DESCRIPTION
## Summary
- add API connectivity and CLI compatibility verification actions to account token rows in Key Management
- build transient API credential profiles from resolved account token secrets for verification only
- add key-management analytics actions, privacy coverage, test ids, and localized labels

## Validation
- pnpm exec vitest --run tests/features/KeyManagement/components/TokenHeader.analytics.test.tsx tests/entrypoints/options/pages/KeyManagement/TokenHeader.saveToApiProfiles.test.tsx tests/services/productAnalytics/events.test.ts tests/services/productAnalytics/privacy.test.ts
- pnpm exec tsc --noEmit
- pnpm run i18n:extract:ci
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token verification actions for API and CLI support, including new token header buttons and verification dialogs.
  * Added localized UI labels and error messages for the new verification actions across supported languages.
* **Tests**
  * Expanded analytics and privacy coverage for token verification flows (success, failure, and sensitive-data handling).
* **Chores**
  * Added new product analytics action identifiers for the API and CLI verification actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->