### PR TITLE
fix(account): expose auth method help tooltip

### DIFF
--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -5,7 +5,7 @@ import {
   KeyIcon,
   PencilIcon,
 } from "@heroicons/react/24/outline"
-import { Cookie } from "lucide-react"
+import { CircleHelp, Cookie } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import Tooltip from "~/components/Tooltip"
@@ -103,6 +103,9 @@ export default function SiteInfoInput(props: SiteInfoInputProps) {
     canUseCookieAuth &&
     props.showAuthTypeSelector === true &&
     props.authType === AuthTypeEnum.Cookie
+  const authTypeHelpText = isAuthTypeLocked
+    ? t("siteInfo.sub2apiAuthOnly")
+    : t("siteInfo.cookieWarning")
 
   const handleEditClick = () => {
     if (detectedAccount && onEditAccount) {
@@ -125,52 +128,57 @@ export default function SiteInfoInput(props: SiteInfoInputProps) {
               data-layout="auth-type-field"
               className="order-1 max-w-full [@container(min-width:28rem)]:order-2"
             >
-              <label className="dark:text-dark-text-secondary mb-1 block text-sm font-medium text-gray-700">
-                {t("siteInfo.authMethod")}
-              </label>
-              <Tooltip
-                wrapperClassName="w-full [@container(min-width:28rem)]:w-auto"
-                content={
-                  isAuthTypeLocked
-                    ? t("siteInfo.sub2apiAuthOnly")
-                    : t("siteInfo.cookieWarning")
-                }
-              >
-                <Select
-                  value={props.authType}
-                  onValueChange={(value) =>
-                    props.onAuthTypeChange(value as AuthTypeEnum)
-                  }
-                  disabled={isAuthTypeLocked}
+              <div className="mb-1 flex items-center gap-1.5">
+                <label className="dark:text-dark-text-secondary text-sm font-medium text-gray-700">
+                  {t("siteInfo.authMethod")}
+                </label>
+                <Tooltip
+                  content={authTypeHelpText}
+                  wrapperClassName="inline-flex"
                 >
-                  <SelectTrigger
-                    className="w-full max-w-full [@container(min-width:28rem)]:w-auto"
-                    aria-label={t("siteInfo.authMethod")}
-                    data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger}
-                    data-auth-type={props.authType}
+                  <button
+                    type="button"
+                    aria-label={authTypeHelpText}
+                    className="dark:text-dark-text-tertiary inline-flex h-4 w-4 items-center justify-center rounded-full text-gray-400 transition-colors hover:text-gray-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:outline-none dark:hover:text-gray-300"
                   >
-                    <SelectValue
-                      placeholder={t("siteInfo.authMethodPlaceholder")}
-                    />
-                  </SelectTrigger>
-                  <SelectContent align="end" className="min-w-48">
-                    <SelectItem value={AuthTypeEnum.AccessToken}>
+                    <CircleHelp className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </Tooltip>
+              </div>
+              <Select
+                value={props.authType}
+                onValueChange={(value) =>
+                  props.onAuthTypeChange(value as AuthTypeEnum)
+                }
+                disabled={isAuthTypeLocked}
+              >
+                <SelectTrigger
+                  className="w-full max-w-full [@container(min-width:28rem)]:w-auto"
+                  aria-label={t("siteInfo.authMethod")}
+                  data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger}
+                  data-auth-type={props.authType}
+                >
+                  <SelectValue
+                    placeholder={t("siteInfo.authMethodPlaceholder")}
+                  />
+                </SelectTrigger>
+                <SelectContent align="end" className="min-w-48">
+                  <SelectItem value={AuthTypeEnum.AccessToken}>
+                    <div className="flex items-center gap-2">
+                      <KeyIcon className="h-4 w-4" />
+                      <span>{t("siteInfo.authType.accessToken")}</span>
+                    </div>
+                  </SelectItem>
+                  {canUseCookieAuth && (
+                    <SelectItem value={AuthTypeEnum.Cookie}>
                       <div className="flex items-center gap-2">
-                        <KeyIcon className="h-4 w-4" />
-                        <span>{t("siteInfo.authType.accessToken")}</span>
+                        <Cookie className="h-4 w-4" />
+                        <span>{t("siteInfo.authType.cookieAuth")}</span>
                       </div>
                     </SelectItem>
-                    {canUseCookieAuth && (
-                      <SelectItem value={AuthTypeEnum.Cookie}>
-                        <div className="flex items-center gap-2">
-                          <Cookie className="h-4 w-4" />
-                          <span>{t("siteInfo.authType.cookieAuth")}</span>
-                        </div>
-                      </SelectItem>
-                    )}
-                  </SelectContent>
-                </Select>
-              </Tooltip>
+                  )}
+                </SelectContent>
+              </Select>
             </div>
             <div
               data-layout="site-url-field"

--- a/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
@@ -92,6 +92,11 @@ describe("AccountDialog SiteInfoInput", () => {
     expect(
       await screen.findByLabelText("accountDialog:siteInfo.authMethod"),
     ).toBeEnabled()
+    expect(
+      screen.getByRole("button", {
+        name: "accountDialog:siteInfo.cookieWarning",
+      }),
+    ).toBeInTheDocument()
 
     await user.click(
       await screen.findByTestId("account-management-auth-type-trigger"),
@@ -249,6 +254,11 @@ describe("AccountDialog SiteInfoInput", () => {
     expect(
       screen.getByLabelText("accountDialog:siteInfo.authMethod"),
     ).toBeDisabled()
+    expect(
+      screen.getByRole("button", {
+        name: "accountDialog:siteInfo.sub2apiAuthOnly",
+      }),
+    ).toBeInTheDocument()
   })
 
   it("shows the current-login warning and forwards edit requests for the detected account", async () => {


### PR DESCRIPTION
## Summary
- Move the auth-method guidance tooltip to an explicit help icon beside the label.
- Keep the selector interaction unchanged while making both normal and locked auth guidance discoverable.
- Cover the normal and Sub2API locked states in the SiteInfoInput tests.

## Test Plan
- pnpm vitest --run tests/features/AccountManagement/components/AccountDialogSiteInfoInput.test.tsx
- pnpm run validate:staged
- pnpm compile
- pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the account site info form to show a dedicated help icon next to the authentication method label.
  * Help text is now clearer and more directly tied to the selected authentication option.

* **Bug Fixes**
  * Improved visibility of auth-related guidance, including cookie-auth warnings and Sub2API-only messaging, in relevant account setup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->