### PR TITLE
refactor(ui): use primitives for native controls

### DIFF
--- a/e2e/managedSiteCoreFlows.spec.ts
+++ b/e2e/managedSiteCoreFlows.spec.ts
@@ -876,7 +876,7 @@ test("loads managed-site channels, deep-links into manual model sync, and runs a
     page.getByRole("tab", { name: "Execution History" }),
   ).toBeVisible()
   await expect(
-    page.getByRole("cell", { name: "Production OpenAI" }),
+    page.getByRole("button", { name: "Manage channel: Production OpenAI" }),
   ).toBeVisible()
   await expect(page.getByText("Successful")).toBeVisible()
 
@@ -946,7 +946,7 @@ test("applies model redirect mapping during selected managed-site model sync thr
     page.getByRole("tab", { name: "Execution History" }),
   ).toBeVisible()
   await expect(
-    page.getByRole("cell", { name: "Redirect OpenAI" }),
+    page.getByRole("button", { name: "Manage channel: Redirect OpenAI" }),
   ).toBeVisible()
   await expect(page.getByText("Successful")).toBeVisible()
 

--- a/src/components/ThemeAwareToaster.tsx
+++ b/src/components/ThemeAwareToaster.tsx
@@ -5,6 +5,7 @@ import toast, { ToastBar, Toaster } from "react-hot-toast"
 
 import { getThemeAwareToastStyles } from "~/components/toast/themeAwareToastStyles"
 import { useToasterPortalHost } from "~/components/toast/ToasterPortal"
+import { IconButton } from "~/components/ui"
 import { useTheme } from "~/contexts/ThemeContext"
 
 interface ThemeAwareToasterProps {
@@ -70,9 +71,15 @@ export const ThemeAwareToaster = ({
                 {icon}
                 {message}
                 {t.type !== "loading" && (
-                  <button onClick={() => toast.dismiss(t.id)}>
+                  <IconButton
+                    type="button"
+                    aria-label="Close notification"
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => toast.dismiss(t.id)}
+                  >
                     <XMarkIcon className="h-4 w-4" />
-                  </button>
+                  </IconButton>
                 )}
               </>
             )

--- a/src/components/toast/WarningToast.tsx
+++ b/src/components/toast/WarningToast.tsx
@@ -2,6 +2,7 @@ import { XMarkIcon } from "@heroicons/react/24/outline"
 import { useState } from "react"
 import toast, { ToastBar, type Toast } from "react-hot-toast"
 
+import { Button, IconButton } from "~/components/ui"
 import { useTheme } from "~/contexts/ThemeContext"
 
 import { getThemeAwareToastStyles } from "./themeAwareToastStyles"
@@ -61,23 +62,27 @@ export function WarningToast({
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <div className="min-w-0">{renderedMessage}</div>
             {action ? (
-              <button
+              <Button
                 type="button"
                 onClick={handleActionClick}
                 disabled={isActionPending}
-                className="w-fit text-sm font-medium text-blue-600 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60 dark:text-blue-400"
+                variant="link"
+                size="sm"
+                className="h-auto w-fit p-0"
               >
                 {action.label}
-              </button>
+              </Button>
             ) : null}
           </div>
-          <button
+          <IconButton
             type="button"
             aria-label="Close notification"
+            variant="ghost"
+            size="xs"
             onClick={() => toast.dismiss(toastInstance.id)}
           >
             <XMarkIcon className="h-4 w-4" />
-          </button>
+          </IconButton>
         </>
       )}
     </ToastBar>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -64,17 +64,25 @@ SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+    container?: React.ComponentProps<typeof SelectPrimitive.Portal>["container"]
     position?: "item-aligned" | "popper"
   }
 >(
   (
-    { className, children, position = "popper", align = "center", ...props },
+    {
+      className,
+      children,
+      container,
+      position = "popper",
+      align = "center",
+      ...props
+    },
     ref,
   ) => {
     const floatingLayerClass = useFloatingLayerClass()
 
     return (
-      <SelectPrimitive.Portal>
+      <SelectPrimitive.Portal container={container}>
         <SelectPrimitive.Content
           ref={ref}
           data-slot="select-content"

--- a/src/entrypoints/content/redemptionAssist/components/RedemptionPromptToast.tsx
+++ b/src/entrypoints/content/redemptionAssist/components/RedemptionPromptToast.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react"
+import React, { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -8,6 +8,7 @@ import {
   Card,
   CardContent,
   CardHeader,
+  Checkbox,
   Heading3,
   Link,
 } from "~/components/ui"
@@ -69,14 +70,6 @@ export const RedemptionPromptToast: React.FC<RedemptionPromptToastProps> = ({
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Content,
     },
   })
-
-  const selectAllRef = useRef<HTMLInputElement | null>(null)
-
-  useEffect(() => {
-    const el = selectAllRef.current
-    if (!el) return
-    el.indeterminate = someSelected
-  }, [someSelected])
 
   const handleCancel = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -151,12 +144,10 @@ export const RedemptionPromptToast: React.FC<RedemptionPromptToastProps> = ({
           <Body>{message}</Body>
           {codes.length > 1 && (
             <div className="mt-2 flex items-center gap-2">
-              <input
-                ref={selectAllRef}
-                type="checkbox"
-                className="h-3 w-3"
-                checked={allSelected}
-                onChange={handleToggleAll}
+              <Checkbox
+                aria-label={t("redemptionAssist:messages.selectAll")}
+                checked={someSelected ? "indeterminate" : allSelected}
+                onCheckedChange={handleToggleAll}
               />
               <span className="text-foreground text-xs">
                 {t("redemptionAssist:messages.selectAll")}
@@ -166,18 +157,19 @@ export const RedemptionPromptToast: React.FC<RedemptionPromptToastProps> = ({
           {codes.length > 0 && (
             <div className="mt-2 max-h-44 space-y-1 overflow-y-auto pr-1">
               {codes.map(({ code, preview }) => (
-                <label
+                <div
                   key={code}
                   className="border-border/60 hover:bg-muted/70 flex cursor-pointer items-center gap-2 rounded-md border px-2 py-1.5 text-xs"
+                  onClick={() => toggleCode(code)}
                 >
-                  <input
-                    type="checkbox"
-                    className="h-3 w-3"
+                  <Checkbox
+                    aria-label={preview}
                     checked={selected.has(code)}
-                    onChange={() => toggleCode(code)}
+                    onCheckedChange={() => toggleCode(code)}
+                    onClick={(event) => event.stopPropagation()}
                   />
                   <code className="text-foreground font-mono">{preview}</code>
-                </label>
+                </div>
               ))}
             </div>
           )}

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckBaseUrlHistoryPicker.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckBaseUrlHistoryPicker.tsx
@@ -1,7 +1,7 @@
 import { ClockIcon, TrashIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
 
-import { IconButton } from "~/components/ui"
+import { Button, IconButton } from "~/components/ui"
 import {
   Popover,
   PopoverContent,
@@ -74,8 +74,10 @@ export function ApiCheckBaseUrlHistoryPicker({
               role="listitem"
               className="group flex min-w-0 items-center gap-1 rounded-sm"
             >
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="sm"
                 className={cn(
                   "focus:bg-accent focus:text-accent-foreground flex min-w-0 flex-1 rounded-sm px-2 py-1.5 text-left text-sm outline-none",
                   suggestion.baseUrl === selectedBaseUrl
@@ -86,7 +88,7 @@ export function ApiCheckBaseUrlHistoryPicker({
                 onClick={() => onSelect(suggestion.baseUrl)}
               >
                 <span className="truncate">{suggestion.baseUrl}</span>
-              </button>
+              </Button>
               <IconButton
                 type="button"
                 aria-label={`${t("webAiApiCheck:modal.history.remove")}: ${

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckCandidateButtons.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckCandidateButtons.tsx
@@ -1,5 +1,6 @@
 import type { TFunction } from "i18next"
 
+import { Button } from "~/components/ui"
 import { cn } from "~/lib/utils"
 import type { ApiCheckCandidate } from "~/services/verification/webAiApiCheck/extractCredentials"
 
@@ -45,9 +46,11 @@ export function ApiCheckCandidateButtons({
             : candidate.value
 
         return (
-          <button
+          <Button
             key={`${kind}-${candidate.value}`}
             type="button"
+            variant="ghost"
+            size="sm"
             data-testid={`${
               kind === "apiKey"
                 ? WEB_AI_API_CHECK_TEST_IDS.apiKeyCandidatePrefix
@@ -63,7 +66,7 @@ export function ApiCheckCandidateButtons({
             onClick={() => onSelect(candidate.value)}
           >
             {label}
-          </button>
+          </Button>
         )
       })}
     </div>

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
@@ -12,10 +12,13 @@ import {
   Input,
   Notice,
   SearchableSelect,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Textarea,
 } from "~/components/ui"
-import { inputVariants } from "~/components/ui/input"
-import { cn } from "~/lib/utils"
 import type { ApiVerificationApiType } from "~/services/verification/aiApiVerification"
 
 import { WEB_AI_API_CHECK_TEST_IDS } from "../testIds"
@@ -202,23 +205,26 @@ export function ApiCheckModal({ t, view, actions, refs }: ApiCheckModalProps) {
                   >
                     {t("webAiApiCheck:modal.fields.apiType")}
                   </label>
-                  <select
-                    id="api-check-api-type"
-                    className={cn(inputVariants({}), "dark:bg-input/30 h-9")}
+                  <Select
                     value={view.apiType}
-                    onChange={(e) =>
-                      actions.setApiType(
-                        e.target.value as ApiVerificationApiType,
-                      )
+                    onValueChange={(value) =>
+                      actions.setApiType(value as ApiVerificationApiType)
                     }
                     disabled={view.isRunningAll}
                   >
-                    {view.apiTypeOptions.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
+                    <SelectTrigger id="api-check-api-type">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent
+                      container={view.popoverPortalContainer ?? undefined}
+                    >
+                      {view.apiTypeOptions.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
 
                 <div className="space-y-1.5">

--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast/headless"
 import { useTranslation } from "react-i18next"
 
+import { Button } from "~/components/ui"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import {
   resolveProductAnalyticsErrorCategoryFromError,
@@ -402,12 +403,14 @@ export function useApiCheckModalViewModel() {
                   name: typeof response.name === "string" ? response.name : "",
                 })}
               </span>
-              <button
+              <Button
                 type="button"
+                variant="default"
+                size="sm"
                 data-testid={
                   WEB_AI_API_CHECK_TEST_IDS.openApiProfilesToastButton
                 }
-                className="shrink-0 rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                className="h-auto shrink-0 rounded-md px-2 py-1 text-xs"
                 onClick={() => {
                   void sendRuntimeMessage({
                     action: RuntimeActionIds.OpenSettingsApiCredentialProfiles,
@@ -416,7 +419,7 @@ export function useApiCheckModalViewModel() {
                 }}
               >
                 {t("webAiApiCheck:modal.actions.openApiProfiles")}
-              </button>
+              </Button>
             </div>
           ),
           { duration: 8000 },

--- a/src/entrypoints/options/components/Header.tsx
+++ b/src/entrypoints/options/components/Header.tsx
@@ -145,9 +145,11 @@ function Header({
 
             {/* 插件图标和名称 */}
             <div className="tap-highlight-transparent flex min-w-0 touch-manipulation items-center space-x-2 sm:space-x-3">
-              <button
+              <IconButton
                 type="button"
                 onClick={onTitleClick}
+                variant="ghost"
+                size="none"
                 className="tap-highlight-transparent touch-manipulation rounded-lg focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                 aria-label={t("app.name")}
               >
@@ -156,7 +158,7 @@ function Header({
                   alt={t("app.name")}
                   className="h-7.5 w-7.5 rounded-lg shadow-sm sm:h-8.5 sm:w-8.5"
                 />
-              </button>
+              </IconButton>
               {!showMobileExpandedSearch ? (
                 <div className="min-w-0">
                   <div className="flex min-w-0 flex-col gap-0.5">

--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -273,15 +273,17 @@ export default function SiteInfoInput(props: SiteInfoInputProps) {
               </Tooltip>
             </div>
 
-            <button
+            <Button
               type="button"
+              variant="link"
+              size="sm"
               onClick={onUseCurrentTab}
-              className="flex items-center font-medium text-blue-800 disabled:cursor-not-allowed disabled:text-gray-400 dark:text-blue-200 dark:disabled:text-gray-600"
+              className="h-auto p-0 text-blue-800 disabled:cursor-not-allowed disabled:text-gray-400 dark:text-blue-200 dark:disabled:text-gray-600"
               disabled={!currentTabUrl}
+              leftIcon={<GlobeAltIcon className="h-3 w-3" />}
             >
-              <GlobeAltIcon className="mr-1 h-3 w-3" />
               <span>{t("siteInfo.useCurrent")}</span>
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
+++ b/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
@@ -515,14 +515,16 @@ export function TagPicker({
             >
               <span className="max-w-40 truncate">{tag.name}</span>
               {!disabled && (
-                <button
+                <IconButton
                   type="button"
+                  variant="ghost"
+                  size="none"
                   className="ml-1 rounded-sm opacity-70 hover:opacity-100"
                   onClick={() => removeTag(tag.id)}
                   aria-label={t("form.tagsRemove", { name: tag.name })}
                 >
                   <XMarkIcon className="h-3 w-3" />
-                </button>
+                </IconButton>
               )}
             </Badge>
           ))}

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -20,7 +20,14 @@ import { ClaudeCodeRouterIcon } from "~/components/icons/ClaudeCodeRouterIcon"
 import { CliProxyIcon } from "~/components/icons/CliProxyIcon"
 import { KiloCodeIcon } from "~/components/icons/KiloCodeIcon"
 import { ManagedSiteIcon } from "~/components/icons/ManagedSiteIcon"
-import { Badge, Card, CardContent, Heading6, IconButton } from "~/components/ui"
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Heading6,
+  IconButton,
+} from "~/components/ui"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -335,9 +342,11 @@ export function ApiCredentialProfileListItem({
                         </Badge>
                       ) : null}
                     </div>
-                    <button
+                    <Button
                       type="button"
-                      className="dark:text-dark-text-tertiary dark:hover:text-dark-text-primary inline-flex shrink-0 items-center gap-1 text-[11px] text-gray-500 transition-colors hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      variant="ghost"
+                      size="sm"
+                      className="dark:text-dark-text-tertiary dark:hover:text-dark-text-primary h-auto shrink-0 gap-1 px-1 py-0 text-[11px] text-gray-500 transition-colors hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
                       onClick={handleRefreshTelemetry}
                       disabled={isTelemetryRefreshing}
                       aria-label={t(
@@ -352,7 +361,7 @@ export function ApiCredentialProfileListItem({
                       {isTelemetryRefreshing
                         ? t("apiCredentialProfiles:telemetry.refreshing")
                         : t("apiCredentialProfiles:telemetry.actions.refresh")}
-                    </button>
+                    </Button>
                   </div>
 
                   <div className="grid flex-1 auto-rows-max grid-cols-[repeat(auto-fit,minmax(7rem,1fr))] content-evenly gap-2 text-xs sm:grid-cols-4">

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { ApiCredentialLibraryIcon } from "~/components/icons/productIcons"
 import {
+  Button,
   EmptyState,
   Input,
   Notice,
@@ -399,13 +400,15 @@ export function ApiCredentialProfilesListView({
               description={
                 <span>
                   {t("apiCredentialProfiles:empty.keyManagementImportHint")}{" "}
-                  <button
+                  <Button
                     type="button"
-                    className="font-medium text-blue-700 underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-blue-200"
+                    variant="link"
+                    size="sm"
+                    className="inline h-auto p-0 align-baseline text-blue-700 dark:text-blue-200"
                     onClick={handleOpenKeyManagement}
                   >
                     {t("apiCredentialProfiles:empty.keyManagementLink")}
-                  </button>
+                  </Button>
                 </span>
               }
             />

--- a/src/features/AutoCheckin/components/FilterBar.tsx
+++ b/src/features/AutoCheckin/components/FilterBar.tsx
@@ -7,7 +7,7 @@ import {
 import { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Input } from "~/components/ui"
+import { Button, Input } from "~/components/ui"
 import { trackProductAnalyticsActionCompleted } from "~/services/productAnalytics/actions"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -147,7 +147,10 @@ export default function FilterBar({
     icon: ReactNode,
     count?: number,
   ) => (
-    <button
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
       onClick={() => {
         onStatusChange(value)
         trackFilterSelection(PRODUCT_ANALYTICS_MODE_IDS.StatusFilter, value)
@@ -171,7 +174,7 @@ export default function FilterBar({
           {count}
         </span>
       )}
-    </button>
+    </Button>
   )
 
   return (

--- a/src/features/BalanceHistory/BalanceHistory.tsx
+++ b/src/features/BalanceHistory/BalanceHistory.tsx
@@ -1348,9 +1348,11 @@ export default function BalanceHistory() {
                       <div className="min-w-0 space-y-1">
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
-                            <button
+                            <Button
                               type="button"
-                              className={`${ANIMATIONS.transition.base} dark:hover:bg-dark-bg-tertiary inline-flex min-w-0 items-center gap-1 rounded-md px-1 py-0.5 text-sm font-medium hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
+                              variant="ghost"
+                              size="sm"
+                              className={`${ANIMATIONS.transition.base} h-auto min-w-0 gap-1 px-1 py-0.5 text-sm font-medium`}
                             >
                               <span className="min-w-0 truncate">
                                 {t("breakdown.title")}:{" "}
@@ -1360,7 +1362,7 @@ export default function BalanceHistory() {
                                 )}
                               </span>
                               <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
-                            </button>
+                            </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="start" className="w-44">
                             <DropdownMenuRadioGroup
@@ -1473,9 +1475,11 @@ export default function BalanceHistory() {
                         <div className="flex min-w-0 items-center gap-2">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <button
+                              <Button
                                 type="button"
-                                className={`${ANIMATIONS.transition.base} dark:hover:bg-dark-bg-tertiary inline-flex min-w-0 items-center gap-1 rounded-md px-1 py-0.5 text-sm font-medium hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
+                                variant="ghost"
+                                size="sm"
+                                className={`${ANIMATIONS.transition.base} h-auto min-w-0 gap-1 px-1 py-0.5 text-sm font-medium`}
                               >
                                 <span className="min-w-0 truncate">
                                   {t("trend.title")}:{" "}
@@ -1485,7 +1489,7 @@ export default function BalanceHistory() {
                                   )}
                                 </span>
                                 <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
-                              </button>
+                              </Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="start" className="w-44">
                               <DropdownMenuRadioGroup
@@ -1519,9 +1523,11 @@ export default function BalanceHistory() {
 
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <button
+                              <Button
                                 type="button"
-                                className={`${ANIMATIONS.transition.base} dark:hover:bg-dark-bg-tertiary inline-flex min-w-0 items-center gap-1 rounded-md px-1 py-0.5 text-sm font-medium hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
+                                variant="ghost"
+                                size="sm"
+                                className={`${ANIMATIONS.transition.base} h-auto min-w-0 gap-1 px-1 py-0.5 text-sm font-medium`}
                               >
                                 <span className="min-w-0 truncate">
                                   {t("trend.controls.scope")}:{" "}
@@ -1531,7 +1537,7 @@ export default function BalanceHistory() {
                                   )}
                                 </span>
                                 <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
-                              </button>
+                              </Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="start" className="w-40">
                               <DropdownMenuRadioGroup

--- a/src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx
+++ b/src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx
@@ -12,6 +12,7 @@ import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import AccountLinkButton from "~/components/AccountLinkButton"
+import { Button } from "~/components/ui"
 import {
   Table,
   TableBody,
@@ -209,9 +210,11 @@ export default function BalanceHistoryAccountSummaryTable({
               {headerGroup.headers.map((header) => (
                 <TableHead key={header.id} style={{ width: header.getSize() }}>
                   {header.isPlaceholder ? null : header.column.getCanSort() ? (
-                    <button
+                    <Button
                       type="button"
-                      className="flex w-full items-center gap-2"
+                      variant="ghost"
+                      size="sm"
+                      className="h-auto w-full justify-start gap-2 p-0"
                       onClick={header.column.getToggleSortingHandler()}
                     >
                       {flexRender(
@@ -224,7 +227,7 @@ export default function BalanceHistoryAccountSummaryTable({
                       {header.column.getIsSorted() === "desc" && (
                         <ChevronDown className="h-3.5 w-3.5 opacity-60" />
                       )}
-                    </button>
+                    </Button>
                   ) : (
                     flexRender(
                       header.column.columnDef.header,

--- a/src/features/KeyManagement/components/RepairMissingKeysResultsPanel.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysResultsPanel.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
 import { ShieldCheck, TriangleAlert } from "lucide-react"
 import type { Dispatch, SetStateAction } from "react"
@@ -170,18 +170,8 @@ export function RepairMissingKeysResultsPanel({
               value={searchTerm}
               onChange={(event) => onSearchTermChange(event.target.value)}
               leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
-              rightIcon={
-                searchTerm ? (
-                  <button
-                    type="button"
-                    onClick={() => onSearchTermChange("")}
-                    className="dark:hover:bg-dark-bg-tertiary rounded p-1 hover:bg-gray-100"
-                    aria-label={t("common:actions.clear")}
-                  >
-                    <XMarkIcon className="h-4 w-4" />
-                  </button>
-                ) : null
-              }
+              onClear={() => onSearchTermChange("")}
+              clearButtonLabel={t("common:actions.clear")}
               containerClassName="w-full"
             />
           </div>

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -444,17 +444,18 @@ function TokenActionButtons({
                 name: profile.name,
               })}
             </span>
-            <button
+            <Button
               type="button"
               data-testid={KEY_MANAGEMENT_TEST_IDS.openApiProfilesToastButton}
-              className="shrink-0 rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+              size="sm"
+              className="h-7 shrink-0 px-2 text-xs"
               onClick={() => {
                 openApiCredentialProfilesPage()
                 toast.dismiss(toastInstance.id)
               }}
             >
               {t("keyManagement:actions.openApiProfiles")}
-            </button>
+            </Button>
           </div>
         ),
         { duration: 8000 },

--- a/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.tsx
+++ b/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.tsx
@@ -1,6 +1,7 @@
 import type { TFunction } from "i18next"
 import toast from "react-hot-toast"
 
+import { Button } from "~/components/ui"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { buildApiCredentialProfileName } from "~/features/KeyManagement/utils/apiCredentialProfileName"
 import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
@@ -166,17 +167,18 @@ export async function saveApiTokensToApiCredentialProfiles({
           <span className="min-w-0 truncate">
             {t("keyManagement:messages.batchSavedToApiProfiles")}
           </span>
-          <button
+          <Button
             type="button"
             data-testid={KEY_MANAGEMENT_TEST_IDS.openApiProfilesToastButton}
-            className="shrink-0 rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+            size="sm"
+            className="h-7 shrink-0 px-2 text-xs"
             onClick={() => {
               openApiCredentialProfilesPage()
               toast.dismiss(toastInstance.id)
             }}
           >
             {t("keyManagement:actions.openApiProfiles")}
-          </button>
+          </Button>
         </div>
       ),
       {

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -23,7 +23,6 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronUp,
-  CircleX,
   Columns3,
   Filter,
   Layers,
@@ -1282,19 +1281,10 @@ export default function ManagedSiteChannels({
                 value={searchValue}
                 onChange={(event) => handleSearchChange(event.target.value)}
                 placeholder={t("toolbar.searchPlaceholder")}
-                className="ps-9"
+                leftIcon={<ListFilter className="h-4 w-4" />}
+                onClear={() => handleSearchChange("")}
+                clearButtonLabel={t("toolbar.clearSearch")}
               />
-              <ListFilter className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-              {searchValue && (
-                <button
-                  type="button"
-                  aria-label={t("toolbar.clearSearch")}
-                  className="text-muted-foreground/80 absolute top-1/2 right-2 -translate-y-1/2"
-                  onClick={() => handleSearchChange("")}
-                >
-                  <CircleX className="h-4 w-4" />
-                </button>
-              )}
             </div>
 
             <div className="grid grid-cols-2 gap-2 md:flex md:flex-1 md:items-center md:gap-2">
@@ -1504,9 +1494,11 @@ export default function ManagedSiteChannels({
                           style={{ width: header.getSize() }}
                         >
                           {header.isPlaceholder ? null : header.column.getCanSort() ? (
-                            <button
+                            <Button
                               type="button"
-                              className="flex w-full items-center gap-2"
+                              variant="ghost"
+                              size="sm"
+                              className="h-auto w-full justify-start gap-2 p-0"
                               onClick={header.column.getToggleSortingHandler()}
                             >
                               {flexRender(
@@ -1519,7 +1511,7 @@ export default function ManagedSiteChannels({
                               {header.column.getIsSorted() === "desc" && (
                                 <ChevronDown className="h-3.5 w-3.5 opacity-60" />
                               )}
-                            </button>
+                            </Button>
                           ) : (
                             flexRender(
                               header.column.columnDef.header,

--- a/src/features/ManagedSiteModelSync/components/FilterBar.tsx
+++ b/src/features/ManagedSiteModelSync/components/FilterBar.tsx
@@ -7,7 +7,7 @@ import {
 import { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Input } from "~/components/ui"
+import { Button, Input } from "~/components/ui"
 import { ExecutionStatistics } from "~/types/managedSiteModelSync"
 
 export type FilterStatus = "all" | "success" | "failed"
@@ -46,7 +46,10 @@ export default function FilterBar({
     icon: ReactNode,
     count?: number,
   ) => (
-    <button
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
       onClick={() => onStatusChange(value)}
       className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
         status === value
@@ -67,7 +70,7 @@ export default function FilterBar({
           {count}
         </span>
       )}
-    </button>
+    </Button>
   )
 
   return (

--- a/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
+++ b/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
@@ -4,11 +4,10 @@ import {
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline"
 import dayjs from "dayjs"
-import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 
 import ManagedSiteChannelLinkButton from "~/components/ManagedSiteChannelLinkButton"
-import { Badge, Button, Card } from "~/components/ui"
+import { Badge, Button, Card, Checkbox } from "~/components/ui"
 import type { ExecutionItemResult } from "~/types/managedSiteModelSync"
 
 interface ResultsTableProps {
@@ -54,20 +53,12 @@ export default function ResultsTable({
 
   const allSelected = items.length > 0 && selectedIds.size === items.length
   const someSelected = selectedIds.size > 0 && !allSelected
-  const selectAllRef = useRef<HTMLInputElement | null>(null)
   const columns = {
     status: visibleColumns?.status ?? true,
     message: visibleColumns?.message ?? true,
     attempts: visibleColumns?.attempts ?? true,
     finishedAt: visibleColumns?.finishedAt ?? true,
   }
-
-  useEffect(() => {
-    const element = selectAllRef.current
-    if (!element) return
-
-    element.indeterminate = someSelected
-  }, [someSelected])
 
   return (
     <Card padding="none">
@@ -76,12 +67,10 @@ export default function ResultsTable({
           <thead className="border-b border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800">
             <tr>
               <th className="px-4 py-3 text-left">
-                <input
-                  ref={selectAllRef}
-                  type="checkbox"
-                  checked={allSelected}
-                  onChange={(e) => onSelectAll(e.target.checked)}
-                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                <Checkbox
+                  checked={someSelected ? "indeterminate" : allSelected}
+                  onCheckedChange={(checked) => onSelectAll(checked === true)}
+                  aria-label={t("execution.table.selectAll")}
                 />
               </th>
               {columns.status && (
@@ -125,13 +114,14 @@ export default function ResultsTable({
                   className="group hover:bg-gray-50 dark:hover:bg-gray-800"
                 >
                   <td className="px-4 py-3">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={selectedIds.has(item.channelId)}
-                      onChange={(e) =>
-                        onSelectItem(item.channelId, e.target.checked)
+                      onCheckedChange={(checked) =>
+                        onSelectItem(item.channelId, checked === true)
                       }
-                      className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                      aria-label={t("execution.table.selectChannel", {
+                        channelName: item.channelName,
+                      })}
                     />
                   </td>
                   {columns.status && (

--- a/src/features/ShareSnapshots/components/ShareSnapshotCaptionToast.tsx
+++ b/src/features/ShareSnapshots/components/ShareSnapshotCaptionToast.tsx
@@ -5,6 +5,7 @@
  */
 import { useEffect, useRef, useState } from "react"
 
+import { Button, Textarea } from "~/components/ui"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
@@ -63,10 +64,10 @@ export const ShareSnapshotCaptionToast = ({
       <div className="dark:text-dark-text-secondary mb-2 text-xs text-gray-500">
         {hint}
       </div>
-      <textarea
+      <Textarea
         readOnly
         value={caption}
-        className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary dark:text-dark-text-primary mb-3 h-28 w-full resize-none rounded-md border border-gray-200 bg-gray-50 p-2 text-xs text-gray-900 focus:outline-none"
+        className="mb-3 h-28 resize-none text-xs"
       />
       {copyError ? (
         <div className="mb-2 text-xs text-red-600 dark:text-red-400">
@@ -74,21 +75,17 @@ export const ShareSnapshotCaptionToast = ({
         </div>
       ) : null}
       <div className="flex items-center justify-end gap-2">
-        <button
+        <Button
           type="button"
-          className="dark:bg-dark-bg-tertiary dark:text-dark-text-primary rounded-md bg-gray-900 px-3 py-1.5 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
+          size="sm"
           onClick={handleCopy}
           disabled={isCopying}
         >
           {copyLabel}
-        </button>
-        <button
-          type="button"
-          className="dark:text-dark-text-secondary rounded-md px-3 py-1.5 text-xs text-gray-600"
-          onClick={onClose}
-        >
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onClose}>
           {closeLabel}
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/src/features/SiteAnnouncements/SiteAnnouncements.tsx
+++ b/src/features/SiteAnnouncements/SiteAnnouncements.tsx
@@ -442,13 +442,15 @@ export default function SiteAnnouncementsPage({
                 </span>{" "}
               </>
             )}
-            <button
+            <Button
               type="button"
+              variant="link"
+              size="sm"
               className={textLinkClassName}
               onClick={handleOpenPollingSettings}
             >
               {t("description.pollingSettingsLink")}
-            </button>
+            </Button>
           </>
         }
         className="mb-5"
@@ -550,13 +552,15 @@ export default function SiteAnnouncementsPage({
                 isPollingDisabled ? (
                   <>
                     <span>{t("empty.descriptionWhenPollingDisabled")}</span>{" "}
-                    <button
+                    <Button
                       type="button"
+                      variant="link"
+                      size="sm"
                       className={textLinkClassName}
                       onClick={handleOpenPollingSettings}
                     >
                       {t("empty.pollingSettingsLink")}
-                    </button>
+                    </Button>
                   </>
                 ) : (
                   t("empty.description")

--- a/src/locales/en/managedSiteModelSync.json
+++ b/src/locales/en/managedSiteModelSync.json
@@ -73,6 +73,8 @@
       "finishedAt": "Finished At",
       "manageChannel": "Manage channel",
       "message": "Message",
+      "selectAll": "Select all channels",
+      "selectChannel": "Select channel {{channelName}}",
       "status": "Status",
       "syncChannel": "Sync"
     },

--- a/src/locales/ja/managedSiteModelSync.json
+++ b/src/locales/ja/managedSiteModelSync.json
@@ -70,6 +70,8 @@
       "finishedAt": "完了時刻",
       "manageChannel": "チャネルを管理",
       "message": "メッセージ",
+      "selectAll": "すべてのチャネルを選択",
+      "selectChannel": "チャネル {{channelName}} を選択",
       "status": "状態",
       "syncChannel": "同期"
     },

--- a/src/locales/vi/managedSiteModelSync.json
+++ b/src/locales/vi/managedSiteModelSync.json
@@ -70,6 +70,8 @@
       "finishedAt": "Thời gian hoàn thành",
       "manageChannel": "Quản lý kênh",
       "message": "Thông báo lỗi",
+      "selectAll": "Chọn tất cả kênh",
+      "selectChannel": "Chọn kênh {{channelName}}",
       "status": "Trạng thái",
       "syncChannel": "Đồng bộ hóa kênh này"
     },

--- a/src/locales/zh-CN/managedSiteModelSync.json
+++ b/src/locales/zh-CN/managedSiteModelSync.json
@@ -70,6 +70,8 @@
       "finishedAt": "完成时间",
       "manageChannel": "管理渠道",
       "message": "错误信息",
+      "selectAll": "选择全部渠道",
+      "selectChannel": "选择渠道 {{channelName}}",
       "status": "状态",
       "syncChannel": "同步此渠道"
     },

--- a/src/locales/zh-TW/managedSiteModelSync.json
+++ b/src/locales/zh-TW/managedSiteModelSync.json
@@ -70,6 +70,8 @@
       "finishedAt": "完成時間",
       "manageChannel": "管理渠道",
       "message": "錯誤資訊",
+      "selectAll": "選擇全部渠道",
+      "selectChannel": "選擇渠道 {{channelName}}",
       "status": "狀態",
       "syncChannel": "同步此渠道"
     },

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -1867,10 +1867,12 @@ describe("ApiCheckModalHost", () => {
 
     expect(await within(probeCard).findByText("OpenAI result")).toBeVisible()
 
-    await user.selectOptions(
-      screen.getByDisplayValue("OpenAI-compatible"),
-      "anthropic",
+    await user.click(
+      screen.getByRole("combobox", {
+        name: "webAiApiCheck:modal.fields.apiType",
+      }),
     )
+    await user.click(await screen.findByRole("option", { name: "Anthropic" }))
 
     await waitFor(() => {
       expectTypedApiCheckMessage(WebAiApiCheckMessageTypes.FetchModels, {

--- a/tests/components/FloatingLayerPrimitives.test.tsx
+++ b/tests/components/FloatingLayerPrimitives.test.tsx
@@ -53,6 +53,29 @@ function ModalSelectHarness() {
 }
 
 /**
+ * Minimal select host for custom portal container assertions.
+ */
+function SelectWithContainerHarness({
+  portalContainer,
+}: {
+  portalContainer: HTMLElement
+}) {
+  return (
+    <div>
+      <Select defaultValue="alpha">
+        <SelectTrigger aria-label="Select with container" className="w-48">
+          <SelectValue placeholder="Choose a value" />
+        </SelectTrigger>
+        <SelectContent container={portalContainer}>
+          <SelectItem value="alpha">Alpha</SelectItem>
+          <SelectItem value="beta">Beta</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+/**
  * Minimal Radix dialog host for dropdown-layer assertions.
  */
 function DialogDropdownHarness() {
@@ -133,6 +156,26 @@ describe("floating layer primitives inside dialogs", () => {
     expect(content).toBeInTheDocument()
     expect(content).toHaveClass(Z_INDEX.modalFloating)
     expect(content).not.toHaveClass(Z_INDEX.floating)
+  })
+
+  it("renders select content inside a custom portal container", async () => {
+    const user = userEvent.setup()
+    const portalContainer = document.createElement("div")
+    document.body.append(portalContainer)
+
+    try {
+      render(<SelectWithContainerHarness portalContainer={portalContainer} />)
+
+      await user.click(
+        await screen.findByRole("combobox", { name: "Select with container" }),
+      )
+
+      const option = await screen.findByRole("option", { name: "Beta" })
+
+      expect(portalContainer).toContainElement(option)
+    } finally {
+      portalContainer.remove()
+    }
   })
 
   it("uses the modal-contained layer for dropdown menus inside DialogContent", async () => {

--- a/tests/entrypoints/content/RedemptionPromptToast.test.tsx
+++ b/tests/entrypoints/content/RedemptionPromptToast.test.tsx
@@ -71,6 +71,26 @@ vi.mock("~/components/ui", () => ({
   Caption: ({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   ),
+  Checkbox: ({
+    "aria-label": ariaLabel,
+    checked,
+    onClick,
+    onCheckedChange,
+  }: {
+    "aria-label"?: string
+    checked?: boolean | "indeterminate"
+    onClick?: (event: React.MouseEvent<HTMLInputElement>) => void
+    onCheckedChange?: (checked: boolean | "indeterminate") => void
+  }) => (
+    <input
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked === true}
+      data-indeterminate={checked === "indeterminate" ? "true" : undefined}
+      onClick={onClick}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+    />
+  ),
   Card: ({ children }: { children: React.ReactNode }) => (
     <section>{children}</section>
   ),
@@ -143,7 +163,7 @@ describe("RedemptionPromptToast", () => {
 
     await waitFor(() => {
       expect(selectAllCheckbox).not.toBeChecked()
-      expect((selectAllCheckbox as HTMLInputElement).indeterminate).toBe(true)
+      expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true")
     })
 
     fireEvent.click(codeTwoCheckbox)

--- a/tests/entrypoints/content/RedemptionPromptToast.test.tsx
+++ b/tests/entrypoints/content/RedemptionPromptToast.test.tsx
@@ -166,6 +166,19 @@ describe("RedemptionPromptToast", () => {
       expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true")
     })
 
+    fireEvent.click(screen.getByText("ABCD***1"))
+
+    await waitFor(() => {
+      expect(selectAllCheckbox).toBeChecked()
+    })
+
+    fireEvent.click(screen.getByText("ABCD***1"))
+
+    await waitFor(() => {
+      expect(selectAllCheckbox).not.toBeChecked()
+      expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true")
+    })
+
     fireEvent.click(codeTwoCheckbox)
 
     expect(autoRedeemButton).toBeDisabled()

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -510,7 +510,9 @@ describe("ManagedSiteChannels", () => {
     })
   })
 
-  it("sorts channels by id descending by default", async () => {
+  it("sorts channels by id descending by default and toggles direction from the shared header button", async () => {
+    const user = userEvent.setup()
+
     mockChannels([
       { id: 1, name: "Alpha", base_url: "https://alpha.example" },
       { id: 3, name: "Gamma", base_url: "https://gamma.example" },
@@ -527,6 +529,26 @@ describe("ManagedSiteChannels", () => {
     )
 
     expect(names).toEqual(["Gamma", "Beta", "Alpha"])
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "managedSiteChannels:table.columns.id",
+      }),
+    )
+
+    const ascendingRows = Array.from(container.querySelectorAll("tbody tr"))
+    const ascendingNames = ascendingRows.map((row) =>
+      row.querySelector("td:nth-child(3) .font-medium")?.textContent?.trim(),
+    )
+
+    expect(ascendingNames).toEqual(["Alpha", "Beta", "Gamma"])
+    expect(
+      screen
+        .getByRole("button", {
+          name: "managedSiteChannels:table.columns.id",
+        })
+        .querySelector("svg"),
+    ).toBeInTheDocument()
   })
 
   it("reloads the channel list when the managed site type changes", async () => {
@@ -1031,14 +1053,23 @@ describe("ManagedSiteChannels", () => {
   it("clears the search input from the dedicated clear button", async () => {
     const user = userEvent.setup()
 
-    mockChannels([{ id: 1, name: "Alpha", base_url: "https://example.com" }])
+    mockChannels([
+      { id: 1, name: "Alpha", base_url: "https://alpha.example" },
+      { id: 2, name: "Beta", base_url: "https://beta.example" },
+    ])
 
     render(<ManagedSiteChannels routeParams={{ search: "Alpha" }} />)
 
     await waitForRowText("Alpha")
+    expect(screen.queryByText("Beta")).not.toBeInTheDocument()
 
     const input = screen.getByRole("textbox") as HTMLInputElement
     expect(input.value).toBe("Alpha")
+    expect(
+      screen.getByRole("button", {
+        name: "managedSiteChannels:toolbar.clearSearch",
+      }),
+    ).toBeInTheDocument()
 
     await user.click(
       screen.getByRole("button", {
@@ -1053,6 +1084,12 @@ describe("ManagedSiteChannels", () => {
         {},
       )
     })
+    expect(screen.getByText("Alpha")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "managedSiteChannels:toolbar.clearSearch",
+      }),
+    ).not.toBeInTheDocument()
   })
 
   it("filters rows by status from the toolbar and shows the active filter count", async () => {

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -1085,6 +1085,7 @@ describe("ManagedSiteChannels", () => {
       )
     })
     expect(screen.getByText("Alpha")).toBeInTheDocument()
+    expect(screen.getByText("Beta")).toBeInTheDocument()
     expect(
       screen.queryByRole("button", {
         name: "managedSiteChannels:toolbar.clearSearch",

--- a/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
+++ b/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
@@ -33,6 +33,13 @@ vi.mock("~/hooks/useMediaQuery", () => ({
 }))
 
 vi.mock("~/components/ui", () => ({
+  Button: ({ children, leftIcon, rightIcon, ...props }: any) => (
+    <button {...props}>
+      {leftIcon}
+      {children}
+      {rightIcon}
+    </button>
+  ),
   Input: ({
     clearButtonLabel,
     leftIcon: _leftIcon,

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
@@ -84,6 +84,13 @@ vi.mock("~/components/ui", async () => {
 
   return {
     Badge: ({ children }: any) => <span>{children}</span>,
+    Button: ({ children, leftIcon, rightIcon, ...props }: any) => (
+      <button type="button" {...props}>
+        {leftIcon}
+        {children}
+        {rightIcon}
+      </button>
+    ),
     Card: ({ children }: any) => <div>{children}</div>,
     CardContent: ({ children }: any) => <div>{children}</div>,
     Heading6: ({ children }: any) => <h6>{children}</h6>,

--- a/tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
+++ b/tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
@@ -223,6 +223,13 @@ describe("BalanceHistoryAccountSummaryTable", () => {
     )
 
     expect(getAccountOrder()).toEqual(["Zulu", "Alpha", "Mike"])
+    expect(
+      screen
+        .getByRole("button", {
+          name: "balanceHistory:table.columns.startBalance",
+        })
+        .querySelector("svg"),
+    ).toBeInTheDocument()
 
     await user.click(
       screen.getByRole("button", {

--- a/tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
+++ b/tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
@@ -238,6 +238,13 @@ describe("BalanceHistoryAccountSummaryTable", () => {
     )
 
     expect(getAccountOrder()).toEqual(["Mike", "Alpha", "Zulu"])
+    expect(
+      screen
+        .getByRole("button", {
+          name: "balanceHistory:table.columns.startBalance",
+        })
+        .querySelector("svg"),
+    ).toBeInTheDocument()
   })
 
   it("sorts snapshot coverage using zero for rows without total days while preserving the displayed counts", async () => {

--- a/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
@@ -218,6 +218,9 @@ describe("RepairMissingKeysResultsPanel", () => {
       name: "keyManagement:repairMissingKeys.searchLabel",
     })
     expect(searchInput).toHaveValue("Example")
+    expect(
+      screen.getByRole("button", { name: "common:actions.clear" }),
+    ).toBeInTheDocument()
 
     await user.type(searchInput, " 1")
     expect(onSearchTermChange).toHaveBeenLastCalledWith("Example 1")
@@ -227,6 +230,9 @@ describe("RepairMissingKeysResultsPanel", () => {
     )
     expect(onSearchTermChange).toHaveBeenLastCalledWith("")
     expect(searchInput).toHaveValue("")
+    expect(
+      screen.queryByRole("button", { name: "common:actions.clear" }),
+    ).not.toBeInTheDocument()
   })
 
   it("routes invalid-key view selection and delete actions", async () => {

--- a/tests/features/ManagedSiteModelSync/components.test.tsx
+++ b/tests/features/ManagedSiteModelSync/components.test.tsx
@@ -328,12 +328,11 @@ describe("ManagedSiteModelSync components", () => {
       />,
     )
 
-    const [selectAllCheckbox, firstRowCheckbox] = screen.getAllByRole(
-      "checkbox",
-    ) as HTMLInputElement[]
+    const [selectAllCheckbox, firstRowCheckbox] =
+      screen.getAllByRole("checkbox")
 
     expect(selectAllCheckbox).not.toBeChecked()
-    expect(selectAllCheckbox.indeterminate).toBe(true)
+    expect(selectAllCheckbox).toHaveAttribute("aria-checked", "mixed")
 
     fireEvent.click(selectAllCheckbox)
     fireEvent.click(firstRowCheckbox)


### PR DESCRIPTION
## Summary
- Replace unnecessary raw native controls with existing UI primitives across content scripts, options pages, toasts, filters, and tables
- Add portal-container support for Select content in content-script modal usage
- Keep native controls where they remain semantically appropriate or need a dedicated design pass, such as file inputs, radio inputs, hidden measurement buttons, and bespoke navigation/metric controls

## Validation
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for rendering Select dropdown content into a caller-provided container.
  * Added new localized labels for “select all” and “select channel” actions.
* **Bug Fixes**
  * Improved UI consistency and accessibility by migrating many native controls to shared Button/IconButton/Checkbox/Textarea/Select components (including toast close/copy and clearer search/input behaviors).
  * Updated selection logic to reliably support mixed/indeterminate states via standardized checkbox/aria behavior.
* **Tests**
  * Updated and expanded unit, integration, and e2e tests to reflect the new controls and selection/portal interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->