### PR TITLE
feat(verification): support aborting model verification flows

### DIFF
--- a/e2e/managedSiteCoreFlows.spec.ts
+++ b/e2e/managedSiteCoreFlows.spec.ts
@@ -876,7 +876,7 @@ test("loads managed-site channels, deep-links into manual model sync, and runs a
     page.getByRole("tab", { name: "Execution History" }),
   ).toBeVisible()
   await expect(
-    page.getByRole("cell", { name: "Production OpenAI" }),
+    page.getByRole("button", { name: "Manage channel: Production OpenAI" }),
   ).toBeVisible()
   await expect(page.getByText("Successful")).toBeVisible()
 
@@ -946,7 +946,7 @@ test("applies model redirect mapping during selected managed-site model sync thr
     page.getByRole("tab", { name: "Execution History" }),
   ).toBeVisible()
   await expect(
-    page.getByRole("cell", { name: "Redirect OpenAI" }),
+    page.getByRole("button", { name: "Manage channel: Redirect OpenAI" }),
   ).toBeVisible()
   await expect(page.getByText("Successful")).toBeVisible()
 

--- a/e2e/managedSiteCoreFlows.spec.ts
+++ b/e2e/managedSiteCoreFlows.spec.ts
@@ -876,7 +876,7 @@ test("loads managed-site channels, deep-links into manual model sync, and runs a
     page.getByRole("tab", { name: "Execution History" }),
   ).toBeVisible()
   await expect(
-    page.getByRole("button", { name: "Manage channel: Production OpenAI" }),
+    page.getByRole("cell", { name: "Production OpenAI" }),
   ).toBeVisible()
   await expect(page.getByText("Successful")).toBeVisible()
 
@@ -946,7 +946,7 @@ test("applies model redirect mapping during selected managed-site model sync thr
     page.getByRole("tab", { name: "Execution History" }),
   ).toBeVisible()
   await expect(
-    page.getByRole("button", { name: "Manage channel: Redirect OpenAI" }),
+    page.getByRole("cell", { name: "Redirect OpenAI" }),
   ).toBeVisible()
   await expect(page.getByText("Successful")).toBeVisible()
 

--- a/src/components/ThemeAwareToaster.tsx
+++ b/src/components/ThemeAwareToaster.tsx
@@ -2,6 +2,7 @@ import { XMarkIcon } from "@heroicons/react/24/outline"
 import type { CSSProperties } from "react"
 import { createPortal } from "react-dom"
 import toast, { ToastBar, Toaster } from "react-hot-toast"
+import { useTranslation } from "react-i18next"
 
 import { getThemeAwareToastStyles } from "~/components/toast/themeAwareToastStyles"
 import { useToasterPortalHost } from "~/components/toast/ToasterPortal"
@@ -28,6 +29,7 @@ export const ThemeAwareToaster = ({
 }: ThemeAwareToasterProps) => {
   const { resolvedTheme } = useTheme()
   const portalHost = useToasterPortalHost()
+  const { t: translate } = useTranslation("common")
 
   const toaster = (
     <Toaster
@@ -62,15 +64,19 @@ export const ThemeAwareToaster = ({
         },
       }}
     >
-      {(t) => (
-        <ToastBar toast={t}>
+      {(toastInstance) => (
+        <ToastBar toast={toastInstance}>
           {({ icon, message }) => {
             return (
               <>
                 {icon}
                 {message}
-                {t.type !== "loading" && (
-                  <button onClick={() => toast.dismiss(t.id)}>
+                {toastInstance.type !== "loading" && (
+                  <button
+                    type="button"
+                    aria-label={translate("actions.close")}
+                    onClick={() => toast.dismiss(toastInstance.id)}
+                  >
                     <XMarkIcon className="h-4 w-4" />
                   </button>
                 )}

--- a/src/components/ThemeAwareToaster.tsx
+++ b/src/components/ThemeAwareToaster.tsx
@@ -5,7 +5,6 @@ import toast, { ToastBar, Toaster } from "react-hot-toast"
 
 import { getThemeAwareToastStyles } from "~/components/toast/themeAwareToastStyles"
 import { useToasterPortalHost } from "~/components/toast/ToasterPortal"
-import { IconButton } from "~/components/ui"
 import { useTheme } from "~/contexts/ThemeContext"
 
 interface ThemeAwareToasterProps {
@@ -71,15 +70,9 @@ export const ThemeAwareToaster = ({
                 {icon}
                 {message}
                 {t.type !== "loading" && (
-                  <IconButton
-                    type="button"
-                    aria-label="Close notification"
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => toast.dismiss(t.id)}
-                  >
+                  <button onClick={() => toast.dismiss(t.id)}>
                     <XMarkIcon className="h-4 w-4" />
-                  </IconButton>
+                  </button>
                 )}
               </>
             )

--- a/src/components/dialogs/VerifyApiDialog/index.tsx
+++ b/src/components/dialogs/VerifyApiDialog/index.tsx
@@ -275,7 +275,20 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
         selectedToken,
         { abortSignal },
       )
-      if (abortSignal?.aborted || shouldStopRef.current) return null
+      if (abortSignal?.aborted || shouldStopRef.current) {
+        replaceProbes(
+          probesRef.current.map((probe) =>
+            probe.definition.id === probeId
+              ? {
+                  ...probe,
+                  isRunning: false,
+                  result: buildStoppedProbeResult(probeId),
+                }
+              : probe,
+          ),
+        )
+        return null
+      }
       const result = await runApiVerificationProbe({
         baseUrl: account.baseUrl,
         apiKey: resolvedToken.key,

--- a/src/components/dialogs/VerifyApiDialog/index.tsx
+++ b/src/components/dialogs/VerifyApiDialog/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { ProbeStatusBadge } from "~/components/dialogs/VerifyApiDialog/ProbeStatusBadge"
@@ -71,6 +71,32 @@ import { formatLatency, safeJsonStringify } from "./utils"
 const logger = createLogger("VerifyApiDialog")
 
 /**
+ * Detects user-initiated cancellation across DOM and service-layer aborts.
+ */
+function isAbortError(error: unknown, abortSignal?: AbortSignal) {
+  return (
+    abortSignal?.aborted ||
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  )
+}
+
+/**
+ * Builds a synthetic result so interrupted probes render as stopped, not failed.
+ */
+function buildStoppedProbeResult(
+  probeId: ApiVerificationProbeId,
+): ApiVerificationProbeResult {
+  return {
+    id: probeId,
+    status: "unsupported",
+    latencyMs: 0,
+    summary: "Stopped",
+    summaryKey: "verifyDialog.summaries.stopped",
+  }
+}
+
+/**
  * Modal dialog that runs API verification for a selected account token + model.
  */
 export function VerifyApiDialog(props: VerifyApiDialogProps) {
@@ -92,6 +118,11 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
     API_TYPES.OPENAI_COMPATIBLE,
   )
   const [modelId, setModelId] = useState<string>(initialModelId?.trim() ?? "")
+  const shouldStopRef = useRef(false)
+  const suiteAbortControllerRef = useRef<AbortController | null>(null)
+  const probeAbortControllersRef = useRef(
+    new Map<ApiVerificationProbeId, AbortController>(),
+  )
   const historyTarget = useMemo(() => {
     const trimmedModelId = initialModelId?.trim()
     return trimmedModelId
@@ -223,7 +254,11 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
     }
   }
 
-  const runProbe = async (probeId: ApiVerificationProbeId) => {
+  const runProbe = async (
+    probeId: ApiVerificationProbeId,
+    abortSignal?: AbortSignal,
+  ) => {
+    if (abortSignal?.aborted || shouldStopRef.current) return null
     if (!selectedToken || !selectedTokenIsCompatible) return null
     let resolvedToken = selectedToken
 
@@ -238,7 +273,9 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
       resolvedToken = await resolveDisplayAccountTokenForSecret(
         account,
         selectedToken,
+        { abortSignal },
       )
+      if (abortSignal?.aborted || shouldStopRef.current) return null
       const result = await runApiVerificationProbe({
         baseUrl: account.baseUrl,
         apiKey: resolvedToken.key,
@@ -251,7 +288,23 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
           models: resolvedToken.models,
         },
         probeId,
+        abortSignal,
       })
+
+      if (abortSignal?.aborted || shouldStopRef.current) {
+        replaceProbes(
+          probesRef.current.map((probe) =>
+            probe.definition.id === probeId
+              ? {
+                  ...probe,
+                  isRunning: false,
+                  result: buildStoppedProbeResult(probeId),
+                }
+              : probe,
+          ),
+        )
+        return null
+      }
 
       const nextProbes = probesRef.current.map((probe) =>
         probe.definition.id === probeId
@@ -266,6 +319,21 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
       )
       return result
     } catch (error) {
+      if (isAbortError(error, abortSignal) || shouldStopRef.current) {
+        replaceProbes(
+          probesRef.current.map((probe) =>
+            probe.definition.id === probeId
+              ? {
+                  ...probe,
+                  isRunning: false,
+                  result: buildStoppedProbeResult(probeId),
+                }
+              : probe,
+          ),
+        )
+        return null
+      }
+
       const sanitizedMessage = toSanitizedErrorSummary(
         error,
         [
@@ -319,6 +387,9 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
   const runAll = async () => {
     if (!canRunAll) return
 
+    shouldStopRef.current = false
+    const abortController = new AbortController()
+    suiteAbortControllerRef.current = abortController
     const tracker = startProductAnalyticsAction(analyticsContext)
     let successCount = 0
     let failureCount = 0
@@ -330,10 +401,11 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
       // Run sequentially so each probe updates independently (and can be retried individually).
       const ordered = getApiVerificationProbeDefinitions(apiType)
       for (const probe of ordered) {
+        if (shouldStopRef.current || abortController.signal.aborted) break
         if (probe.requiresModelId && !modelId.trim() && !tokenModelHint)
           continue
 
-        const result = await runProbe(probe.id)
+        const result = await runProbe(probe.id, abortController.signal)
         if (!result) continue
         if (result.status === "pass") {
           hasExecutedProbe = true
@@ -344,6 +416,27 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
           failedProbeResult ??= result
         }
       }
+      if (shouldStopRef.current || abortController.signal.aborted) {
+        replaceProbes(
+          probesRef.current.map((probe) =>
+            probe.result
+              ? { ...probe, isRunning: false }
+              : {
+                  ...probe,
+                  isRunning: false,
+                  result: buildStoppedProbeResult(probe.definition.id),
+                },
+          ),
+        )
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Cancelled, {
+          insights: {
+            successCount,
+            failureCount,
+          },
+        })
+        return
+      }
+
       const completionResult =
         failureCount > 0
           ? PRODUCT_ANALYTICS_RESULTS.Failure
@@ -380,8 +473,16 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
         },
       })
     } finally {
+      if (suiteAbortControllerRef.current === abortController) {
+        suiteAbortControllerRef.current = null
+      }
       setIsRunning(false)
     }
+  }
+
+  const stopRun = () => {
+    shouldStopRef.current = true
+    suiteAbortControllerRef.current?.abort()
   }
 
   useEffect(() => {
@@ -389,6 +490,11 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
 
     let cancelled = false
     const trimmedModelId = initialModelId?.trim() ?? ""
+    shouldStopRef.current = false
+    suiteAbortControllerRef.current?.abort()
+    suiteAbortControllerRef.current = null
+    probeAbortControllersRef.current.forEach((controller) => controller.abort())
+    probeAbortControllersRef.current.clear()
     setTokens([])
     setSelectedTokenId("")
     setModelId(trimmedModelId)
@@ -452,12 +558,12 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
           {t("verifyDialog.actions.close")}
         </Button>
         <Button
-          variant="success"
-          onClick={runAll}
-          disabled={isRunning || isLoadingTokens || !canRunAll}
+          variant={isRunning ? "destructive" : "success"}
+          onClick={isRunning ? stopRun : runAll}
+          disabled={!isRunning && (isLoadingTokens || !canRunAll)}
         >
           {isRunning
-            ? t("verifyDialog.actions.running")
+            ? t("verifyDialog.actions.stop")
             : t("verifyDialog.actions.run")}
         </Button>
       </div>
@@ -595,6 +701,28 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
               probe.definition.requiresModelId &&
               !modelId.trim() &&
               !tokenModelHint
+            const stopProbe = () => {
+              probeAbortControllersRef.current.get(probe.definition.id)?.abort()
+            }
+            const runSingleProbe = () => {
+              const abortController = new AbortController()
+              probeAbortControllersRef.current.set(
+                probe.definition.id,
+                abortController,
+              )
+              shouldStopRef.current = false
+              void runProbe(
+                probe.definition.id,
+                abortController.signal,
+              ).finally(() => {
+                if (
+                  probeAbortControllersRef.current.get(probe.definition.id) ===
+                  abortController
+                ) {
+                  probeAbortControllersRef.current.delete(probe.definition.id)
+                }
+              })
+            }
 
             const resultSummary = isDisabledForModel
               ? t("verifyDialog.requiresModelId")
@@ -648,19 +776,29 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
 
                   <Button
                     size="sm"
-                    variant="secondary"
-                    onClick={() => runProbe(probe.definition.id)}
+                    variant={probe.isRunning ? "destructive" : "secondary"}
+                    onClick={probe.isRunning ? stopProbe : runSingleProbe}
+                    aria-label={
+                      probe.isRunning
+                        ? t("verifyDialog.actions.stopProbe", {
+                            probe: getApiVerificationProbeLabel(
+                              t,
+                              probe.definition.id,
+                            ),
+                          })
+                        : undefined
+                    }
                     disabled={
                       isRunning ||
                       isLoadingTokens ||
-                      probe.isRunning ||
-                      !selectedToken ||
-                      !selectedTokenIsCompatible ||
-                      isDisabledForModel
+                      (!probe.isRunning &&
+                        (!selectedToken ||
+                          !selectedTokenIsCompatible ||
+                          isDisabledForModel))
                     }
                   >
                     {probe.isRunning
-                      ? t("verifyDialog.actions.running")
+                      ? t("verifyDialog.actions.stop")
                       : probe.attempts > 0
                         ? t("verifyDialog.actions.retry")
                         : t("verifyDialog.actions.runOne")}

--- a/src/components/dialogs/VerifyCliSupportDialog/index.tsx
+++ b/src/components/dialogs/VerifyCliSupportDialog/index.tsx
@@ -62,6 +62,17 @@ import { formatLatency, safeJsonStringify } from "./utils"
 const logger = createLogger("VerifyCliSupportDialog")
 
 /**
+ * Detects user-initiated cancellation across DOM and service-layer aborts.
+ */
+function isAbortError(error: unknown, abortSignal?: AbortSignal) {
+  return (
+    abortSignal?.aborted ||
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  )
+}
+
+/**
  * Build the initial UI state for all tool rows.
  */
 function buildInitialToolState(): ToolItemState[] {
@@ -71,6 +82,20 @@ function buildInitialToolState(): ToolItemState[] {
     attempts: 0,
     result: null,
   }))
+}
+
+/**
+ * Builds a synthetic result so interrupted tool checks render as stopped, not failed.
+ */
+function buildStoppedToolResult(toolId: (typeof CLI_TOOL_IDS)[number]) {
+  return {
+    id: toolId,
+    probeId: "tool-calling" as const,
+    status: "unsupported" as const,
+    latencyMs: 0,
+    summary: "Stopped",
+    summaryKey: "verifyDialog.summaries.stopped",
+  }
 }
 
 /**
@@ -115,6 +140,12 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
   const [isLoadingModels, setIsLoadingModels] = useState(false)
   const [fetchModelsError, setFetchModelsError] = useState<string | null>(null)
   const [tools, setTools] = useState<ToolItemState[]>([])
+  const shouldStopRef = useRef(false)
+  const activeAbortControllerRef = useRef<AbortController | null>(null)
+  const toolAbortControllersRef = useRef(
+    new Map<(typeof CLI_TOOL_IDS)[number], AbortController>(),
+  )
+  const fetchModelsAbortControllerRef = useRef<AbortController | null>(null)
   const fetchModelsRequestIdRef = useRef(0)
 
   const selectedToken = tokens.find(
@@ -213,6 +244,9 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
     }
 
     const requestId = (fetchModelsRequestIdRef.current += 1)
+    fetchModelsAbortControllerRef.current?.abort()
+    const abortController = new AbortController()
+    fetchModelsAbortControllerRef.current = abortController
     setFetchModelsError(null)
     setIsLoadingModels(true)
 
@@ -222,12 +256,20 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
           apiType: profile.apiType,
           baseUrl: profile.baseUrl,
           apiKey: profile.apiKey,
+          abortSignal: abortController.signal,
         }),
       )
 
       if (fetchModelsRequestIdRef.current !== requestId) return
       setProfileModelOptions(normalized)
     } catch (error) {
+      if (
+        abortController.signal.aborted ||
+        fetchModelsRequestIdRef.current !== requestId
+      ) {
+        return
+      }
+
       const message =
         toSanitizedErrorSummary(error, [profile.apiKey, profile.baseUrl]) ||
         t("verifyDialog.modelsFetchFailed")
@@ -238,6 +280,9 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
       setProfileModelOptions([])
       setFetchModelsError(message)
     } finally {
+      if (fetchModelsAbortControllerRef.current === abortController) {
+        fetchModelsAbortControllerRef.current = null
+      }
       if (fetchModelsRequestIdRef.current === requestId) {
         setIsLoadingModels(false)
       }
@@ -246,7 +291,9 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
 
   const runTool = async (
     toolId: (typeof CLI_TOOL_IDS)[number],
+    abortSignal?: AbortSignal,
   ): Promise<CliSupportResult | null> => {
+    if (abortSignal?.aborted || shouldStopRef.current) return null
     if (isProfileSource && !activeApiKey) return null
     const sourceAccount = account
     const accountToken = selectedToken
@@ -273,7 +320,9 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
         const resolvedToken = await resolveDisplayAccountTokenForSecret(
           sourceAccount,
           accountToken,
+          { abortSignal },
         )
+        if (abortSignal?.aborted || shouldStopRef.current) return null
         resolvedApiKey = resolvedToken.key
         if (accountToken.key) {
           secretsToRedact.add(accountToken.key)
@@ -290,7 +339,23 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
         baseUrl: sourceBaseUrl,
         apiKey: resolvedApiKey,
         modelId: resolvedModelId,
+        abortSignal,
       })
+
+      if (abortSignal?.aborted || shouldStopRef.current) {
+        setTools((prev) =>
+          prev.map((t) =>
+            t.toolId === toolId
+              ? {
+                  ...t,
+                  isRunning: false,
+                  result: buildStoppedToolResult(toolId),
+                }
+              : t,
+          ),
+        )
+        return null
+      }
 
       setTools((prev) =>
         prev.map((t) =>
@@ -299,6 +364,21 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
       )
       return result
     } catch (error) {
+      if (isAbortError(error, abortSignal) || shouldStopRef.current) {
+        setTools((prev) =>
+          prev.map((t) =>
+            t.toolId === toolId
+              ? {
+                  ...t,
+                  isRunning: false,
+                  result: buildStoppedToolResult(toolId),
+                }
+              : t,
+          ),
+        )
+        return null
+      }
+
       const finishedAt = Date.now()
       const sanitizedMessage = toSanitizedErrorSummary(
         error,
@@ -372,6 +452,9 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
 
   const runAll = async () => {
     if (!hasRunnableSource) return
+    shouldStopRef.current = false
+    const abortController = new AbortController()
+    activeAbortControllerRef.current = abortController
     const tracker = startProductAnalyticsAction(analyticsContext)
     let successCount = 0
     let failureCount = 0
@@ -383,7 +466,8 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
     try {
       // Run sequentially so each tool updates independently (and can be retried individually).
       for (const toolId of CLI_TOOL_IDS) {
-        const result = await runTool(toolId)
+        if (shouldStopRef.current || abortController.signal.aborted) break
+        const result = await runTool(toolId, abortController.signal)
         if (!result) continue
         if (result.status === "pass") {
           hasExecutedTool = true
@@ -394,6 +478,27 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
           failedToolResult ??= result
         }
       }
+      if (shouldStopRef.current || abortController.signal.aborted) {
+        setTools((prev) =>
+          prev.map((tool) =>
+            tool.result
+              ? { ...tool, isRunning: false }
+              : {
+                  ...tool,
+                  isRunning: false,
+                  result: buildStoppedToolResult(tool.toolId),
+                },
+          ),
+        )
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Cancelled, {
+          insights: {
+            successCount,
+            failureCount,
+          },
+        })
+        return
+      }
+
       const completionResult =
         failureCount > 0
           ? PRODUCT_ANALYTICS_RESULTS.Failure
@@ -430,11 +535,26 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
         },
       })
     } finally {
+      if (activeAbortControllerRef.current === abortController) {
+        activeAbortControllerRef.current = null
+      }
       setIsRunning(false)
     }
   }
 
+  const stopRun = () => {
+    shouldStopRef.current = true
+    activeAbortControllerRef.current?.abort()
+  }
+
   useEffect(() => {
+    shouldStopRef.current = false
+    activeAbortControllerRef.current?.abort()
+    activeAbortControllerRef.current = null
+    toolAbortControllersRef.current.forEach((controller) => controller.abort())
+    toolAbortControllersRef.current.clear()
+    fetchModelsAbortControllerRef.current?.abort()
+    fetchModelsAbortControllerRef.current = null
     if (!isOpen) return
     setTools(buildInitialToolState())
     setProfileModelOptions([])
@@ -459,12 +579,12 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
         {t("verifyDialog.actions.close")}
       </Button>
       <Button
-        variant="success"
-        onClick={runAll}
-        disabled={isRunning || isLoadingTokens || !canRunAll}
+        variant={isRunning ? "destructive" : "success"}
+        onClick={isRunning ? stopRun : runAll}
+        disabled={!isRunning && (isLoadingTokens || !canRunAll)}
       >
         {isRunning
-          ? t("verifyDialog.actions.running")
+          ? t("verifyDialog.actions.stop")
           : t("verifyDialog.actions.run")}
       </Button>
     </div>
@@ -573,6 +693,22 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
           {tools.map((tool) => {
             const result = tool.result
             const isDisabledForModel = !resolvedModelId.trim()
+            const stopTool = () => {
+              toolAbortControllersRef.current.get(tool.toolId)?.abort()
+            }
+            const runSingleTool = () => {
+              const abortController = new AbortController()
+              toolAbortControllersRef.current.set(tool.toolId, abortController)
+              shouldStopRef.current = false
+              void runTool(tool.toolId, abortController.signal).finally(() => {
+                if (
+                  toolAbortControllersRef.current.get(tool.toolId) ===
+                  abortController
+                ) {
+                  toolAbortControllersRef.current.delete(tool.toolId)
+                }
+              })
+            }
 
             const resultSummary = isDisabledForModel
               ? t("verifyDialog.requiresModelId")
@@ -620,18 +756,24 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
 
                   <Button
                     size="sm"
-                    variant="secondary"
-                    onClick={() => runTool(tool.toolId)}
+                    variant={tool.isRunning ? "destructive" : "secondary"}
+                    onClick={tool.isRunning ? stopTool : runSingleTool}
+                    aria-label={
+                      tool.isRunning
+                        ? t("verifyDialog.actions.stopTool", {
+                            tool: getCliSupportToolLabel(t, tool.toolId),
+                          })
+                        : undefined
+                    }
                     disabled={
                       isRunning ||
                       isLoadingTokens ||
-                      tool.isRunning ||
-                      !hasRunnableSource ||
-                      isDisabledForModel
+                      (!tool.isRunning &&
+                        (!hasRunnableSource || isDisabledForModel))
                     }
                   >
                     {tool.isRunning
-                      ? t("verifyDialog.actions.running")
+                      ? t("verifyDialog.actions.stop")
                       : tool.attempts > 0
                         ? t("verifyDialog.actions.retry")
                         : t("verifyDialog.actions.runOne")}

--- a/src/components/dialogs/VerifyCliSupportDialog/index.tsx
+++ b/src/components/dialogs/VerifyCliSupportDialog/index.tsx
@@ -322,7 +322,20 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
           accountToken,
           { abortSignal },
         )
-        if (abortSignal?.aborted || shouldStopRef.current) return null
+        if (abortSignal?.aborted || shouldStopRef.current) {
+          setTools((prev) =>
+            prev.map((t) =>
+              t.toolId === toolId
+                ? {
+                    ...t,
+                    isRunning: false,
+                    result: buildStoppedToolResult(toolId),
+                  }
+                : t,
+            ),
+          )
+          return null
+        }
         resolvedApiKey = resolvedToken.key
         if (accountToken.key) {
           secretsToRedact.add(accountToken.key)

--- a/src/components/toast/WarningToast.tsx
+++ b/src/components/toast/WarningToast.tsx
@@ -2,7 +2,6 @@ import { XMarkIcon } from "@heroicons/react/24/outline"
 import { useState } from "react"
 import toast, { ToastBar, type Toast } from "react-hot-toast"
 
-import { Button, IconButton } from "~/components/ui"
 import { useTheme } from "~/contexts/ThemeContext"
 
 import { getThemeAwareToastStyles } from "./themeAwareToastStyles"
@@ -62,27 +61,23 @@ export function WarningToast({
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <div className="min-w-0">{renderedMessage}</div>
             {action ? (
-              <Button
+              <button
                 type="button"
                 onClick={handleActionClick}
                 disabled={isActionPending}
-                variant="link"
-                size="sm"
-                className="h-auto w-fit p-0"
+                className="w-fit text-sm font-medium text-blue-600 transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60 dark:text-blue-400"
               >
                 {action.label}
-              </Button>
+              </button>
             ) : null}
           </div>
-          <IconButton
+          <button
             type="button"
             aria-label="Close notification"
-            variant="ghost"
-            size="xs"
             onClick={() => toast.dismiss(toastInstance.id)}
           >
             <XMarkIcon className="h-4 w-4" />
-          </IconButton>
+          </button>
         </>
       )}
     </ToastBar>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -64,25 +64,17 @@ SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
-    container?: React.ComponentProps<typeof SelectPrimitive.Portal>["container"]
     position?: "item-aligned" | "popper"
   }
 >(
   (
-    {
-      className,
-      children,
-      container,
-      position = "popper",
-      align = "center",
-      ...props
-    },
+    { className, children, position = "popper", align = "center", ...props },
     ref,
   ) => {
     const floatingLayerClass = useFloatingLayerClass()
 
     return (
-      <SelectPrimitive.Portal container={container}>
+      <SelectPrimitive.Portal>
         <SelectPrimitive.Content
           ref={ref}
           data-slot="select-content"

--- a/src/entrypoints/content/redemptionAssist/components/RedemptionPromptToast.tsx
+++ b/src/entrypoints/content/redemptionAssist/components/RedemptionPromptToast.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -8,7 +8,6 @@ import {
   Card,
   CardContent,
   CardHeader,
-  Checkbox,
   Heading3,
   Link,
 } from "~/components/ui"
@@ -70,6 +69,14 @@ export const RedemptionPromptToast: React.FC<RedemptionPromptToastProps> = ({
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Content,
     },
   })
+
+  const selectAllRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    const el = selectAllRef.current
+    if (!el) return
+    el.indeterminate = someSelected
+  }, [someSelected])
 
   const handleCancel = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -144,10 +151,12 @@ export const RedemptionPromptToast: React.FC<RedemptionPromptToastProps> = ({
           <Body>{message}</Body>
           {codes.length > 1 && (
             <div className="mt-2 flex items-center gap-2">
-              <Checkbox
-                aria-label={t("redemptionAssist:messages.selectAll")}
-                checked={someSelected ? "indeterminate" : allSelected}
-                onCheckedChange={handleToggleAll}
+              <input
+                ref={selectAllRef}
+                type="checkbox"
+                className="h-3 w-3"
+                checked={allSelected}
+                onChange={handleToggleAll}
               />
               <span className="text-foreground text-xs">
                 {t("redemptionAssist:messages.selectAll")}
@@ -157,19 +166,18 @@ export const RedemptionPromptToast: React.FC<RedemptionPromptToastProps> = ({
           {codes.length > 0 && (
             <div className="mt-2 max-h-44 space-y-1 overflow-y-auto pr-1">
               {codes.map(({ code, preview }) => (
-                <div
+                <label
                   key={code}
                   className="border-border/60 hover:bg-muted/70 flex cursor-pointer items-center gap-2 rounded-md border px-2 py-1.5 text-xs"
-                  onClick={() => toggleCode(code)}
                 >
-                  <Checkbox
-                    aria-label={preview}
+                  <input
+                    type="checkbox"
+                    className="h-3 w-3"
                     checked={selected.has(code)}
-                    onCheckedChange={() => toggleCode(code)}
-                    onClick={(event) => event.stopPropagation()}
+                    onChange={() => toggleCode(code)}
                   />
                   <code className="text-foreground font-mono">{preview}</code>
-                </div>
+                </label>
               ))}
             </div>
           )}

--- a/src/entrypoints/content/redemptionAssist/components/RedemptionPromptToast.tsx
+++ b/src/entrypoints/content/redemptionAssist/components/RedemptionPromptToast.tsx
@@ -150,7 +150,7 @@ export const RedemptionPromptToast: React.FC<RedemptionPromptToastProps> = ({
         <CardContent padding="sm">
           <Body>{message}</Body>
           {codes.length > 1 && (
-            <div className="mt-2 flex items-center gap-2">
+            <label className="mt-2 flex items-center gap-2">
               <input
                 ref={selectAllRef}
                 type="checkbox"
@@ -161,7 +161,7 @@ export const RedemptionPromptToast: React.FC<RedemptionPromptToastProps> = ({
               <span className="text-foreground text-xs">
                 {t("redemptionAssist:messages.selectAll")}
               </span>
-            </div>
+            </label>
           )}
           {codes.length > 0 && (
             <div className="mt-2 max-h-44 space-y-1 overflow-y-auto pr-1">

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckBaseUrlHistoryPicker.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckBaseUrlHistoryPicker.tsx
@@ -1,7 +1,7 @@
 import { ClockIcon, TrashIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
 
-import { Button, IconButton } from "~/components/ui"
+import { IconButton } from "~/components/ui"
 import {
   Popover,
   PopoverContent,
@@ -74,10 +74,8 @@ export function ApiCheckBaseUrlHistoryPicker({
               role="listitem"
               className="group flex min-w-0 items-center gap-1 rounded-sm"
             >
-              <Button
+              <button
                 type="button"
-                variant="ghost"
-                size="sm"
                 className={cn(
                   "focus:bg-accent focus:text-accent-foreground flex min-w-0 flex-1 rounded-sm px-2 py-1.5 text-left text-sm outline-none",
                   suggestion.baseUrl === selectedBaseUrl
@@ -88,7 +86,7 @@ export function ApiCheckBaseUrlHistoryPicker({
                 onClick={() => onSelect(suggestion.baseUrl)}
               >
                 <span className="truncate">{suggestion.baseUrl}</span>
-              </Button>
+              </button>
               <IconButton
                 type="button"
                 aria-label={`${t("webAiApiCheck:modal.history.remove")}: ${

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckCandidateButtons.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckCandidateButtons.tsx
@@ -1,6 +1,5 @@
 import type { TFunction } from "i18next"
 
-import { Button } from "~/components/ui"
 import { cn } from "~/lib/utils"
 import type { ApiCheckCandidate } from "~/services/verification/webAiApiCheck/extractCredentials"
 
@@ -46,11 +45,9 @@ export function ApiCheckCandidateButtons({
             : candidate.value
 
         return (
-          <Button
+          <button
             key={`${kind}-${candidate.value}`}
             type="button"
-            variant="ghost"
-            size="sm"
             data-testid={`${
               kind === "apiKey"
                 ? WEB_AI_API_CHECK_TEST_IDS.apiKeyCandidatePrefix
@@ -66,7 +63,7 @@ export function ApiCheckCandidateButtons({
             onClick={() => onSelect(candidate.value)}
           >
             {label}
-          </Button>
+          </button>
         )
       })}
     </div>

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
@@ -12,13 +12,10 @@ import {
   Input,
   Notice,
   SearchableSelect,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Textarea,
 } from "~/components/ui"
+import { inputVariants } from "~/components/ui/input"
+import { cn } from "~/lib/utils"
 import type { ApiVerificationApiType } from "~/services/verification/aiApiVerification"
 
 import { WEB_AI_API_CHECK_TEST_IDS } from "../testIds"
@@ -205,26 +202,23 @@ export function ApiCheckModal({ t, view, actions, refs }: ApiCheckModalProps) {
                   >
                     {t("webAiApiCheck:modal.fields.apiType")}
                   </label>
-                  <Select
+                  <select
+                    id="api-check-api-type"
+                    className={cn(inputVariants({}), "dark:bg-input/30 h-9")}
                     value={view.apiType}
-                    onValueChange={(value) =>
-                      actions.setApiType(value as ApiVerificationApiType)
+                    onChange={(e) =>
+                      actions.setApiType(
+                        e.target.value as ApiVerificationApiType,
+                      )
                     }
                     disabled={view.isRunningAll}
                   >
-                    <SelectTrigger id="api-check-api-type">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent
-                      container={view.popoverPortalContainer ?? undefined}
-                    >
-                      {view.apiTypeOptions.map((opt) => (
-                        <SelectItem key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    {view.apiTypeOptions.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
                 </div>
 
                 <div className="space-y-1.5">

--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast/headless"
 import { useTranslation } from "react-i18next"
 
-import { Button } from "~/components/ui"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import {
   resolveProductAnalyticsErrorCategoryFromError,
@@ -403,14 +402,12 @@ export function useApiCheckModalViewModel() {
                   name: typeof response.name === "string" ? response.name : "",
                 })}
               </span>
-              <Button
+              <button
                 type="button"
-                variant="default"
-                size="sm"
                 data-testid={
                   WEB_AI_API_CHECK_TEST_IDS.openApiProfilesToastButton
                 }
-                className="h-auto shrink-0 rounded-md px-2 py-1 text-xs"
+                className="shrink-0 rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
                 onClick={() => {
                   void sendRuntimeMessage({
                     action: RuntimeActionIds.OpenSettingsApiCredentialProfiles,
@@ -419,7 +416,7 @@ export function useApiCheckModalViewModel() {
                 }}
               >
                 {t("webAiApiCheck:modal.actions.openApiProfiles")}
-              </Button>
+              </button>
             </div>
           ),
           { duration: 8000 },

--- a/src/entrypoints/options/components/Header.tsx
+++ b/src/entrypoints/options/components/Header.tsx
@@ -145,11 +145,9 @@ function Header({
 
             {/* 插件图标和名称 */}
             <div className="tap-highlight-transparent flex min-w-0 touch-manipulation items-center space-x-2 sm:space-x-3">
-              <IconButton
+              <button
                 type="button"
                 onClick={onTitleClick}
-                variant="ghost"
-                size="none"
                 className="tap-highlight-transparent touch-manipulation rounded-lg focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                 aria-label={t("app.name")}
               >
@@ -158,7 +156,7 @@ function Header({
                   alt={t("app.name")}
                   className="h-7.5 w-7.5 rounded-lg shadow-sm sm:h-8.5 sm:w-8.5"
                 />
-              </IconButton>
+              </button>
               {!showMobileExpandedSearch ? (
                 <div className="min-w-0">
                   <div className="flex min-w-0 flex-col gap-0.5">

--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -281,17 +281,15 @@ export default function SiteInfoInput(props: SiteInfoInputProps) {
               </Tooltip>
             </div>
 
-            <Button
+            <button
               type="button"
-              variant="link"
-              size="sm"
               onClick={onUseCurrentTab}
-              className="h-auto p-0 text-blue-800 disabled:cursor-not-allowed disabled:text-gray-400 dark:text-blue-200 dark:disabled:text-gray-600"
+              className="flex items-center font-medium text-blue-800 disabled:cursor-not-allowed disabled:text-gray-400 dark:text-blue-200 dark:disabled:text-gray-600"
               disabled={!currentTabUrl}
-              leftIcon={<GlobeAltIcon className="h-3 w-3" />}
             >
+              <GlobeAltIcon className="mr-1 h-3 w-3" />
               <span>{t("siteInfo.useCurrent")}</span>
-            </Button>
+            </button>
           </div>
         )}
       </div>

--- a/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
+++ b/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
@@ -515,16 +515,14 @@ export function TagPicker({
             >
               <span className="max-w-40 truncate">{tag.name}</span>
               {!disabled && (
-                <IconButton
+                <button
                   type="button"
-                  variant="ghost"
-                  size="none"
                   className="ml-1 rounded-sm opacity-70 hover:opacity-100"
                   onClick={() => removeTag(tag.id)}
                   aria-label={t("form.tagsRemove", { name: tag.name })}
                 >
                   <XMarkIcon className="h-3 w-3" />
-                </IconButton>
+                </button>
               )}
             </Badge>
           ))}

--- a/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
+++ b/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
@@ -520,6 +520,7 @@ export function TagPicker({
                   className="ml-1 rounded-sm opacity-70 hover:opacity-100"
                   onClick={() => removeTag(tag.id)}
                   aria-label={t("form.tagsRemove", { name: tag.name })}
+                  disabled={isWorking}
                 >
                   <XMarkIcon className="h-3 w-3" />
                 </button>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -20,14 +20,7 @@ import { ClaudeCodeRouterIcon } from "~/components/icons/ClaudeCodeRouterIcon"
 import { CliProxyIcon } from "~/components/icons/CliProxyIcon"
 import { KiloCodeIcon } from "~/components/icons/KiloCodeIcon"
 import { ManagedSiteIcon } from "~/components/icons/ManagedSiteIcon"
-import {
-  Badge,
-  Button,
-  Card,
-  CardContent,
-  Heading6,
-  IconButton,
-} from "~/components/ui"
+import { Badge, Card, CardContent, Heading6, IconButton } from "~/components/ui"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -342,11 +335,9 @@ export function ApiCredentialProfileListItem({
                         </Badge>
                       ) : null}
                     </div>
-                    <Button
+                    <button
                       type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="dark:text-dark-text-tertiary dark:hover:text-dark-text-primary h-auto shrink-0 gap-1 px-1 py-0 text-[11px] text-gray-500 transition-colors hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      className="dark:text-dark-text-tertiary dark:hover:text-dark-text-primary inline-flex shrink-0 items-center gap-1 text-[11px] text-gray-500 transition-colors hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
                       onClick={handleRefreshTelemetry}
                       disabled={isTelemetryRefreshing}
                       aria-label={t(
@@ -361,7 +352,7 @@ export function ApiCredentialProfileListItem({
                       {isTelemetryRefreshing
                         ? t("apiCredentialProfiles:telemetry.refreshing")
                         : t("apiCredentialProfiles:telemetry.actions.refresh")}
-                    </Button>
+                    </button>
                   </div>
 
                   <div className="grid flex-1 auto-rows-max grid-cols-[repeat(auto-fit,minmax(7rem,1fr))] content-evenly gap-2 text-xs sm:grid-cols-4">

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next"
 
 import { ApiCredentialLibraryIcon } from "~/components/icons/productIcons"
 import {
-  Button,
   EmptyState,
   Input,
   Notice,
@@ -400,15 +399,13 @@ export function ApiCredentialProfilesListView({
               description={
                 <span>
                   {t("apiCredentialProfiles:empty.keyManagementImportHint")}{" "}
-                  <Button
+                  <button
                     type="button"
-                    variant="link"
-                    size="sm"
-                    className="inline h-auto p-0 align-baseline text-blue-700 dark:text-blue-200"
+                    className="font-medium text-blue-700 underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-blue-200"
                     onClick={handleOpenKeyManagement}
                   >
                     {t("apiCredentialProfiles:empty.keyManagementLink")}
-                  </Button>
+                  </button>
                 </span>
               }
             />

--- a/src/features/ApiCredentialProfiles/components/VerifyApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/VerifyApiCredentialProfileDialog.tsx
@@ -198,6 +198,7 @@ export function VerifyApiCredentialProfileDialog({
 
   const apiTypeRef = useRef(apiType)
   const fetchModelsRequestIdRef = useRef(0)
+  const fetchModelsAbortControllerRef = useRef<AbortController | null>(null)
   const pendingHistoryContextKeyRef = useRef<string | null>(null)
   const lastLoadedHistoryContextKeyRef = useRef<string | null>(null)
   const trimmedModelId = modelId.trim()
@@ -289,6 +290,9 @@ export function VerifyApiCredentialProfileDialog({
       if (!profile) return
 
       const requestId = (fetchModelsRequestIdRef.current += 1)
+      fetchModelsAbortControllerRef.current?.abort()
+      const abortController = new AbortController()
+      fetchModelsAbortControllerRef.current = abortController
       setFetchModelsError(null)
       setIsFetchingModels(true)
 
@@ -298,6 +302,7 @@ export function VerifyApiCredentialProfileDialog({
             apiType: nextApiType,
             baseUrl: profile.baseUrl,
             apiKey: profile.apiKey,
+            abortSignal: abortController.signal,
           }),
         )
 
@@ -320,6 +325,13 @@ export function VerifyApiCredentialProfileDialog({
           })
         }
       } catch (error) {
+        if (
+          abortController.signal.aborted ||
+          fetchModelsRequestIdRef.current !== requestId
+        ) {
+          return
+        }
+
         const message =
           toSanitizedErrorSummary(error, [profile.apiKey, profile.baseUrl]) ||
           t("apiCredentialProfiles:verify.modelsFetchFailed")
@@ -330,6 +342,9 @@ export function VerifyApiCredentialProfileDialog({
 
         setFetchModelsError(message)
       } finally {
+        if (fetchModelsAbortControllerRef.current === abortController) {
+          fetchModelsAbortControllerRef.current = null
+        }
         if (fetchModelsRequestIdRef.current === requestId) {
           setIsFetchingModels(false)
         }
@@ -340,6 +355,8 @@ export function VerifyApiCredentialProfileDialog({
 
   useEffect(() => {
     if (!isOpen || !profile) {
+      fetchModelsAbortControllerRef.current?.abort()
+      fetchModelsAbortControllerRef.current = null
       pendingHistoryContextKeyRef.current = null
       lastLoadedHistoryContextKeyRef.current = null
       return

--- a/src/features/AutoCheckin/components/FilterBar.tsx
+++ b/src/features/AutoCheckin/components/FilterBar.tsx
@@ -7,7 +7,7 @@ import {
 import { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Input } from "~/components/ui"
+import { Input } from "~/components/ui"
 import { trackProductAnalyticsActionCompleted } from "~/services/productAnalytics/actions"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -147,10 +147,7 @@ export default function FilterBar({
     icon: ReactNode,
     count?: number,
   ) => (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
+    <button
       onClick={() => {
         onStatusChange(value)
         trackFilterSelection(PRODUCT_ANALYTICS_MODE_IDS.StatusFilter, value)
@@ -174,7 +171,7 @@ export default function FilterBar({
           {count}
         </span>
       )}
-    </Button>
+    </button>
   )
 
   return (

--- a/src/features/AutoCheckin/components/FilterBar.tsx
+++ b/src/features/AutoCheckin/components/FilterBar.tsx
@@ -148,6 +148,8 @@ export default function FilterBar({
     count?: number,
   ) => (
     <button
+      type="button"
+      aria-pressed={status === value}
       onClick={() => {
         onStatusChange(value)
         trackFilterSelection(PRODUCT_ANALYTICS_MODE_IDS.StatusFilter, value)

--- a/src/features/BalanceHistory/BalanceHistory.tsx
+++ b/src/features/BalanceHistory/BalanceHistory.tsx
@@ -1348,11 +1348,9 @@ export default function BalanceHistory() {
                       <div className="min-w-0 space-y-1">
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
-                            <Button
+                            <button
                               type="button"
-                              variant="ghost"
-                              size="sm"
-                              className={`${ANIMATIONS.transition.base} h-auto min-w-0 gap-1 px-1 py-0.5 text-sm font-medium`}
+                              className={`${ANIMATIONS.transition.base} dark:hover:bg-dark-bg-tertiary inline-flex min-w-0 items-center gap-1 rounded-md px-1 py-0.5 text-sm font-medium hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
                             >
                               <span className="min-w-0 truncate">
                                 {t("breakdown.title")}:{" "}
@@ -1362,7 +1360,7 @@ export default function BalanceHistory() {
                                 )}
                               </span>
                               <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
-                            </Button>
+                            </button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="start" className="w-44">
                             <DropdownMenuRadioGroup
@@ -1475,11 +1473,9 @@ export default function BalanceHistory() {
                         <div className="flex min-w-0 items-center gap-2">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button
+                              <button
                                 type="button"
-                                variant="ghost"
-                                size="sm"
-                                className={`${ANIMATIONS.transition.base} h-auto min-w-0 gap-1 px-1 py-0.5 text-sm font-medium`}
+                                className={`${ANIMATIONS.transition.base} dark:hover:bg-dark-bg-tertiary inline-flex min-w-0 items-center gap-1 rounded-md px-1 py-0.5 text-sm font-medium hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
                               >
                                 <span className="min-w-0 truncate">
                                   {t("trend.title")}:{" "}
@@ -1489,7 +1485,7 @@ export default function BalanceHistory() {
                                   )}
                                 </span>
                                 <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
-                              </Button>
+                              </button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="start" className="w-44">
                               <DropdownMenuRadioGroup
@@ -1523,11 +1519,9 @@ export default function BalanceHistory() {
 
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button
+                              <button
                                 type="button"
-                                variant="ghost"
-                                size="sm"
-                                className={`${ANIMATIONS.transition.base} h-auto min-w-0 gap-1 px-1 py-0.5 text-sm font-medium`}
+                                className={`${ANIMATIONS.transition.base} dark:hover:bg-dark-bg-tertiary inline-flex min-w-0 items-center gap-1 rounded-md px-1 py-0.5 text-sm font-medium hover:bg-gray-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
                               >
                                 <span className="min-w-0 truncate">
                                   {t("trend.controls.scope")}:{" "}
@@ -1537,7 +1531,7 @@ export default function BalanceHistory() {
                                   )}
                                 </span>
                                 <ChevronDown className="h-4 w-4 shrink-0 opacity-70" />
-                              </Button>
+                              </button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="start" className="w-40">
                               <DropdownMenuRadioGroup

--- a/src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx
+++ b/src/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.tsx
@@ -12,7 +12,6 @@ import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import AccountLinkButton from "~/components/AccountLinkButton"
-import { Button } from "~/components/ui"
 import {
   Table,
   TableBody,
@@ -210,11 +209,9 @@ export default function BalanceHistoryAccountSummaryTable({
               {headerGroup.headers.map((header) => (
                 <TableHead key={header.id} style={{ width: header.getSize() }}>
                   {header.isPlaceholder ? null : header.column.getCanSort() ? (
-                    <Button
+                    <button
                       type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-auto w-full justify-start gap-2 p-0"
+                      className="flex w-full items-center gap-2"
                       onClick={header.column.getToggleSortingHandler()}
                     >
                       {flexRender(
@@ -227,7 +224,7 @@ export default function BalanceHistoryAccountSummaryTable({
                       {header.column.getIsSorted() === "desc" && (
                         <ChevronDown className="h-3.5 w-3.5 opacity-60" />
                       )}
-                    </Button>
+                    </button>
                   ) : (
                     flexRender(
                       header.column.columnDef.header,

--- a/src/features/KeyManagement/components/RepairMissingKeysResultsPanel.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysResultsPanel.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
+import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
 import { ShieldCheck, TriangleAlert } from "lucide-react"
 import type { Dispatch, SetStateAction } from "react"
@@ -170,8 +170,18 @@ export function RepairMissingKeysResultsPanel({
               value={searchTerm}
               onChange={(event) => onSearchTermChange(event.target.value)}
               leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
-              onClear={() => onSearchTermChange("")}
-              clearButtonLabel={t("common:actions.clear")}
+              rightIcon={
+                searchTerm ? (
+                  <button
+                    type="button"
+                    onClick={() => onSearchTermChange("")}
+                    className="dark:hover:bg-dark-bg-tertiary rounded p-1 hover:bg-gray-100"
+                    aria-label={t("common:actions.clear")}
+                  >
+                    <XMarkIcon className="h-4 w-4" />
+                  </button>
+                ) : null
+              }
               containerClassName="w-full"
             />
           </div>

--- a/src/features/KeyManagement/components/RepairMissingKeysResultsPanel.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysResultsPanel.tsx
@@ -1,7 +1,7 @@
 import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
 import { ShieldCheck, TriangleAlert } from "lucide-react"
-import type { Dispatch, SetStateAction } from "react"
+import { useRef, type Dispatch, type SetStateAction } from "react"
 
 import {
   Badge,
@@ -77,6 +77,8 @@ export function RepairMissingKeysResultsPanel({
   onSelectedInvalidTokenKeysChange,
   t,
 }: RepairMissingKeysResultsPanelProps) {
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+
   return (
     <>
       <ResponsiveToggleGroup
@@ -161,6 +163,7 @@ export function RepairMissingKeysResultsPanel({
               {t("keyManagement:repairMissingKeys.searchLabel")}
             </Label>
             <Input
+              ref={searchInputRef}
               id="repair-missing-keys-search"
               type="text"
               placeholder={t(
@@ -174,7 +177,10 @@ export function RepairMissingKeysResultsPanel({
                 searchTerm ? (
                   <button
                     type="button"
-                    onClick={() => onSearchTermChange("")}
+                    onClick={() => {
+                      onSearchTermChange("")
+                      searchInputRef.current?.focus()
+                    }}
                     className="dark:hover:bg-dark-bg-tertiary rounded p-1 hover:bg-gray-100"
                     aria-label={t("common:actions.clear")}
                   >

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -444,18 +444,17 @@ function TokenActionButtons({
                 name: profile.name,
               })}
             </span>
-            <Button
+            <button
               type="button"
               data-testid={KEY_MANAGEMENT_TEST_IDS.openApiProfilesToastButton}
-              size="sm"
-              className="h-7 shrink-0 px-2 text-xs"
+              className="shrink-0 rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
               onClick={() => {
                 openApiCredentialProfilesPage()
                 toast.dismiss(toastInstance.id)
               }}
             >
               {t("keyManagement:actions.openApiProfiles")}
-            </Button>
+            </button>
           </div>
         ),
         { duration: 8000 },

--- a/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.tsx
+++ b/src/features/KeyManagement/utils/apiCredentialProfileSaveAction.tsx
@@ -1,7 +1,6 @@
 import type { TFunction } from "i18next"
 import toast from "react-hot-toast"
 
-import { Button } from "~/components/ui"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { buildApiCredentialProfileName } from "~/features/KeyManagement/utils/apiCredentialProfileName"
 import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
@@ -167,18 +166,17 @@ export async function saveApiTokensToApiCredentialProfiles({
           <span className="min-w-0 truncate">
             {t("keyManagement:messages.batchSavedToApiProfiles")}
           </span>
-          <Button
+          <button
             type="button"
             data-testid={KEY_MANAGEMENT_TEST_IDS.openApiProfilesToastButton}
-            size="sm"
-            className="h-7 shrink-0 px-2 text-xs"
+            className="shrink-0 rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
             onClick={() => {
               openApiCredentialProfilesPage()
               toast.dismiss(toastInstance.id)
             }}
           >
             {t("keyManagement:actions.openApiProfiles")}
-          </Button>
+          </button>
         </div>
       ),
       {

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -23,6 +23,7 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronUp,
+  CircleX,
   Columns3,
   Filter,
   Layers,
@@ -1281,10 +1282,19 @@ export default function ManagedSiteChannels({
                 value={searchValue}
                 onChange={(event) => handleSearchChange(event.target.value)}
                 placeholder={t("toolbar.searchPlaceholder")}
-                leftIcon={<ListFilter className="h-4 w-4" />}
-                onClear={() => handleSearchChange("")}
-                clearButtonLabel={t("toolbar.clearSearch")}
+                className="ps-9"
               />
+              <ListFilter className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+              {searchValue && (
+                <button
+                  type="button"
+                  aria-label={t("toolbar.clearSearch")}
+                  className="text-muted-foreground/80 absolute top-1/2 right-2 -translate-y-1/2"
+                  onClick={() => handleSearchChange("")}
+                >
+                  <CircleX className="h-4 w-4" />
+                </button>
+              )}
             </div>
 
             <div className="grid grid-cols-2 gap-2 md:flex md:flex-1 md:items-center md:gap-2">
@@ -1494,11 +1504,9 @@ export default function ManagedSiteChannels({
                           style={{ width: header.getSize() }}
                         >
                           {header.isPlaceholder ? null : header.column.getCanSort() ? (
-                            <Button
+                            <button
                               type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="h-auto w-full justify-start gap-2 p-0"
+                              className="flex w-full items-center gap-2"
                               onClick={header.column.getToggleSortingHandler()}
                             >
                               {flexRender(
@@ -1511,7 +1519,7 @@ export default function ManagedSiteChannels({
                               {header.column.getIsSorted() === "desc" && (
                                 <ChevronDown className="h-3.5 w-3.5 opacity-60" />
                               )}
-                            </Button>
+                            </button>
                           ) : (
                             flexRender(
                               header.column.columnDef.header,

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -38,6 +38,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from "react"
 import toast from "react-hot-toast"
@@ -271,6 +272,7 @@ export default function ManagedSiteChannels({
   const [migrationChannels, setMigrationChannels] = useState<ChannelRow[]>([])
   const [isMigrationDialogOpen, setIsMigrationDialogOpen] = useState(false)
   const [isMigrationMode, setIsMigrationMode] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
   const verification = useNewApiManagedVerification()
   const { openNewApiManagedVerification } = verification
 
@@ -1279,6 +1281,7 @@ export default function ManagedSiteChannels({
           <div className="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-center">
             <div className="relative w-full md:max-w-sm">
               <Input
+                ref={searchInputRef}
                 value={searchValue}
                 onChange={(event) => handleSearchChange(event.target.value)}
                 placeholder={t("toolbar.searchPlaceholder")}
@@ -1290,7 +1293,10 @@ export default function ManagedSiteChannels({
                   type="button"
                   aria-label={t("toolbar.clearSearch")}
                   className="text-muted-foreground/80 absolute top-1/2 right-2 -translate-y-1/2"
-                  onClick={() => handleSearchChange("")}
+                  onClick={() => {
+                    handleSearchChange("")
+                    searchInputRef.current?.focus()
+                  }}
                 >
                   <CircleX className="h-4 w-4" />
                 </button>

--- a/src/features/ManagedSiteModelSync/components/FilterBar.tsx
+++ b/src/features/ManagedSiteModelSync/components/FilterBar.tsx
@@ -47,6 +47,8 @@ export default function FilterBar({
     count?: number,
   ) => (
     <button
+      type="button"
+      aria-pressed={status === value}
       onClick={() => onStatusChange(value)}
       className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
         status === value

--- a/src/features/ManagedSiteModelSync/components/FilterBar.tsx
+++ b/src/features/ManagedSiteModelSync/components/FilterBar.tsx
@@ -7,7 +7,7 @@ import {
 import { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Button, Input } from "~/components/ui"
+import { Input } from "~/components/ui"
 import { ExecutionStatistics } from "~/types/managedSiteModelSync"
 
 export type FilterStatus = "all" | "success" | "failed"
@@ -46,10 +46,7 @@ export default function FilterBar({
     icon: ReactNode,
     count?: number,
   ) => (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
+    <button
       onClick={() => onStatusChange(value)}
       className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
         status === value
@@ -70,7 +67,7 @@ export default function FilterBar({
           {count}
         </span>
       )}
-    </Button>
+    </button>
   )
 
   return (

--- a/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
+++ b/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
@@ -4,10 +4,11 @@ import {
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline"
 import dayjs from "dayjs"
+import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 
 import ManagedSiteChannelLinkButton from "~/components/ManagedSiteChannelLinkButton"
-import { Badge, Button, Card, Checkbox } from "~/components/ui"
+import { Badge, Button, Card } from "~/components/ui"
 import type { ExecutionItemResult } from "~/types/managedSiteModelSync"
 
 interface ResultsTableProps {
@@ -53,12 +54,20 @@ export default function ResultsTable({
 
   const allSelected = items.length > 0 && selectedIds.size === items.length
   const someSelected = selectedIds.size > 0 && !allSelected
+  const selectAllRef = useRef<HTMLInputElement | null>(null)
   const columns = {
     status: visibleColumns?.status ?? true,
     message: visibleColumns?.message ?? true,
     attempts: visibleColumns?.attempts ?? true,
     finishedAt: visibleColumns?.finishedAt ?? true,
   }
+
+  useEffect(() => {
+    const element = selectAllRef.current
+    if (!element) return
+
+    element.indeterminate = someSelected
+  }, [someSelected])
 
   return (
     <Card padding="none">
@@ -67,10 +76,12 @@ export default function ResultsTable({
           <thead className="border-b border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800">
             <tr>
               <th className="px-4 py-3 text-left">
-                <Checkbox
-                  checked={someSelected ? "indeterminate" : allSelected}
-                  onCheckedChange={(checked) => onSelectAll(checked === true)}
-                  aria-label={t("execution.table.selectAll")}
+                <input
+                  ref={selectAllRef}
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={(e) => onSelectAll(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                 />
               </th>
               {columns.status && (
@@ -114,14 +125,13 @@ export default function ResultsTable({
                   className="group hover:bg-gray-50 dark:hover:bg-gray-800"
                 >
                   <td className="px-4 py-3">
-                    <Checkbox
+                    <input
+                      type="checkbox"
                       checked={selectedIds.has(item.channelId)}
-                      onCheckedChange={(checked) =>
-                        onSelectItem(item.channelId, checked === true)
+                      onChange={(e) =>
+                        onSelectItem(item.channelId, e.target.checked)
                       }
-                      aria-label={t("execution.table.selectChannel", {
-                        channelName: item.channelName,
-                      })}
+                      className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                     />
                   </td>
                   {columns.status && (

--- a/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
+++ b/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
@@ -79,6 +79,7 @@ export default function ResultsTable({
                 <input
                   ref={selectAllRef}
                   type="checkbox"
+                  aria-label={t("execution.table.selectAllChannels")}
                   checked={allSelected}
                   onChange={(e) => onSelectAll(e.target.checked)}
                   className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
@@ -127,6 +128,9 @@ export default function ResultsTable({
                   <td className="px-4 py-3">
                     <input
                       type="checkbox"
+                      aria-label={t("execution.table.selectChannel", {
+                        name: item.channelName,
+                      })}
                       checked={selectedIds.has(item.channelId)}
                       onChange={(e) =>
                         onSelectItem(item.channelId, e.target.checked)

--- a/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
+++ b/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
@@ -455,7 +455,17 @@ export function BatchVerifyModelsDialog({
   )
 
   const getResolvedToken = useCallback(
-    (item: AccountBatchVerifyModelItem, token: ApiToken): Promise<ApiToken> => {
+    (
+      item: AccountBatchVerifyModelItem,
+      token: ApiToken,
+      abortSignal?: AbortSignal,
+    ): Promise<ApiToken> => {
+      if (abortSignal) {
+        return resolveDisplayAccountTokenForSecret(item.source.account, token, {
+          abortSignal,
+        })
+      }
+
       const cacheKey = `${item.source.account.id}:${token.id}`
       const cached = resolvedTokenCacheRef.current.get(cacheKey)
       if (cached) return cached
@@ -548,7 +558,11 @@ export function BatchVerifyModelsDialog({
                   return null
                 }
 
-                const resolvedToken = await getResolvedToken(item, token)
+                const resolvedToken = await getResolvedToken(
+                  item,
+                  token,
+                  abortSignal,
+                )
                 if (isStopped()) return null
 
                 return {

--- a/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
+++ b/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
@@ -460,22 +460,42 @@ export function BatchVerifyModelsDialog({
       token: ApiToken,
       abortSignal?: AbortSignal,
     ): Promise<ApiToken> => {
-      if (abortSignal) {
-        return resolveDisplayAccountTokenForSecret(item.source.account, token, {
-          abortSignal,
-        })
-      }
-
       const cacheKey = `${item.source.account.id}:${token.id}`
       const cached = resolvedTokenCacheRef.current.get(cacheKey)
-      if (cached) return cached
+      const promise =
+        cached ??
+        resolveDisplayAccountTokenForSecret(item.source.account, token, {
+          abortSignal,
+        })
+      if (!cached) {
+        const cachedPromise = promise.catch((error) => {
+          resolvedTokenCacheRef.current.delete(cacheKey)
+          throw error
+        })
+        cachedPromise.catch(() => {})
+        resolvedTokenCacheRef.current.set(cacheKey, cachedPromise)
+      }
 
-      const promise = resolveDisplayAccountTokenForSecret(
-        item.source.account,
-        token,
-      )
-      resolvedTokenCacheRef.current.set(cacheKey, promise)
-      return promise
+      if (!abortSignal || !cached) return promise
+      if (abortSignal.aborted) {
+        return Promise.reject(
+          abortSignal.reason ?? new DOMException("Aborted", "AbortError"),
+        )
+      }
+
+      return Promise.race([
+        promise,
+        new Promise<ApiToken>((_resolve, reject) => {
+          abortSignal.addEventListener(
+            "abort",
+            () =>
+              reject(
+                abortSignal.reason ?? new DOMException("Aborted", "AbortError"),
+              ),
+            { once: true },
+          )
+        }),
+      ])
     },
     [],
   )

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -406,10 +406,12 @@ function createModelPricingCacheKey(
 /** Builds the adapter pricing request from a display account. */
 function createDisplayAccountModelPricingRequest(
   account: DisplaySiteData,
+  abortSignal?: AbortSignal,
 ): ModelPricingRequest {
   return {
     baseUrl: account.baseUrl,
     accountId: account.id,
+    abortSignal,
     auth: {
       authType: account.authType,
       userId: account.userId,
@@ -453,6 +455,7 @@ async function mapWithConcurrency<T, R>(
 async function loadTokenScopedCatalogPricingContext(params: {
   account: DisplaySiteData
   token: ApiToken
+  abortSignal?: AbortSignal
 }): Promise<SettledContextResult> {
   try {
     const pricing = await loadAccountTokenFallbackPricingResponse(params)
@@ -479,6 +482,7 @@ async function loadTokenScopedCatalogPricingContext(params: {
 /** Loads token-scoped catalog fallbacks for every account token in comparison mode. */
 async function fetchTokenScopedCatalogPricingContexts(
   account: DisplaySiteData,
+  abortSignal?: AbortSignal,
 ): Promise<AccountPricingQueryResult> {
   const tokens = (await fetchDisplayAccountTokens(account)).filter(
     (token) => token.status === 1,
@@ -490,7 +494,8 @@ async function fetchTokenScopedCatalogPricingContexts(
   const settledResults = await mapWithConcurrency(
     tokens,
     TOKEN_SCOPED_CATALOG_CONCURRENCY,
-    (token) => loadTokenScopedCatalogPricingContext({ account, token }),
+    (token) =>
+      loadTokenScopedCatalogPricingContext({ account, token, abortSignal }),
   )
   const contexts = settledResults.flatMap((result) =>
     result.context ? [result.context] : [],
@@ -586,10 +591,13 @@ function useSingleAccountModelData(params: {
         : undefined,
     [safeDisplayData, selectedSource],
   )
+  const fallbackCatalogAbortControllerRef = useRef<AbortController | null>(null)
 
   const resetFallbackState = useCallback(() => {
     fallbackTokensRequestIdRef.current += 1
     fallbackCatalogRequestIdRef.current += 1
+    fallbackCatalogAbortControllerRef.current?.abort()
+    fallbackCatalogAbortControllerRef.current = null
     setFallbackStateScopeKey(MODEL_LIST_QUERY_SCOPE_VALUES.NONE)
     setFallbackPricingData(null)
     setFallbackTokens([])
@@ -712,7 +720,7 @@ function useSingleAccountModelData(params: {
     staleTime: MODEL_PRICING_CACHE_TTL_MS,
     refetchOnWindowFocus: false,
     retry: shouldRetryModelPricingQuery,
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       if (!currentAccount) {
         throw new Error("No account selected")
       }
@@ -732,7 +740,7 @@ function useSingleAccountModelData(params: {
       directLoadCacheHitRef.current = false
 
       const data = await readiness.modelPricing.fetchPricing(
-        createDisplayAccountModelPricingRequest(currentAccount),
+        createDisplayAccountModelPricingRequest(currentAccount, signal),
       )
 
       if (!Array.isArray(data.data)) {
@@ -831,6 +839,9 @@ function useSingleAccountModelData(params: {
     if (!currentAccount || !selectedFallbackToken) return
     const requestScopeKey = currentAccountScopeKey
     const requestId = ++fallbackCatalogRequestIdRef.current
+    fallbackCatalogAbortControllerRef.current?.abort()
+    const abortController = new AbortController()
+    fallbackCatalogAbortControllerRef.current = abortController
 
     setFallbackStateScopeKey(requestScopeKey)
     setIsLoadingFallbackCatalog(true)
@@ -840,6 +851,7 @@ function useSingleAccountModelData(params: {
       const pricing = await loadAccountTokenFallbackPricingResponse({
         account: currentAccount,
         token: selectedFallbackToken,
+        abortSignal: abortController.signal,
       })
 
       if (!isActiveFallbackCatalogRequest(requestScopeKey, requestId)) {
@@ -859,6 +871,13 @@ function useSingleAccountModelData(params: {
         modelCount: getPricingModelCount(pricing),
       })
     } catch (error) {
+      if (
+        abortController.signal.aborted ||
+        !isActiveFallbackCatalogRequest(requestScopeKey, requestId)
+      ) {
+        return
+      }
+
       if (!isActiveFallbackCatalogRequest(requestScopeKey, requestId)) {
         return
       }
@@ -882,6 +901,9 @@ function useSingleAccountModelData(params: {
         fallbackUsed: true,
       })
     } finally {
+      if (fallbackCatalogAbortControllerRef.current === abortController) {
+        fallbackCatalogAbortControllerRef.current = null
+      }
       if (isActiveFallbackCatalogRequest(requestScopeKey, requestId)) {
         setIsLoadingFallbackCatalog(false)
       }
@@ -1191,13 +1213,13 @@ function useAllAccountsModelData(
       staleTime: MODEL_PRICING_CACHE_TTL_MS,
       refetchOnWindowFocus: false,
       retry: shouldRetryModelPricingQuery,
-      queryFn: async () => {
+      queryFn: async ({ signal }) => {
         const readiness = resolveModelListAccountSourceReadiness(account)
         if (
           readiness.route ===
           MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog
         ) {
-          return fetchTokenScopedCatalogPricingContexts(account)
+          return fetchTokenScopedCatalogPricingContexts(account, signal)
         }
 
         if (
@@ -1223,7 +1245,7 @@ function useAllAccountsModelData(
         }
 
         const data = await readiness.modelPricing.fetchPricing(
-          createDisplayAccountModelPricingRequest(account),
+          createDisplayAccountModelPricingRequest(account, signal),
         )
 
         if (!Array.isArray(data.data)) {
@@ -1444,7 +1466,7 @@ function useProfileModelData(
     staleTime: MODEL_PRICING_CACHE_TTL_MS,
     refetchOnWindowFocus: false,
     retry: 1,
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       if (!currentProfile) {
         throw new Error("No profile selected")
       }
@@ -1453,6 +1475,7 @@ function useProfileModelData(
         apiType: currentProfile.apiType,
         baseUrl: currentProfile.baseUrl,
         apiKey: currentProfile.apiKey,
+        abortSignal: signal,
       })
 
       return buildApiCredentialProfilePricingResponse(modelIds)

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -897,10 +897,6 @@ function useSingleAccountModelData(params: {
         return
       }
 
-      if (!isActiveFallbackCatalogRequest(requestScopeKey, requestId)) {
-        return
-      }
-
       const errorMessage = getErrorMessage(error)
       const sanitizedMessage =
         errorMessage && errorMessage !== ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -60,7 +60,10 @@ import {
   type ProductAnalyticsSourceKind,
 } from "~/services/productAnalytics/events"
 import { buildModelListDiagnostics } from "~/services/productAnalytics/modelListDiagnostics"
-import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
+import {
+  isAbortError,
+  toSanitizedErrorSummary,
+} from "~/services/verification/aiApiVerification/utils"
 import type { ApiToken, DisplaySiteData } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
 
@@ -433,6 +436,7 @@ async function mapWithConcurrency<T, R>(
   items: T[],
   concurrency: number,
   mapper: (item: T) => Promise<R>,
+  abortSignal?: AbortSignal,
 ) {
   const results = new Array<R>(items.length)
   let nextIndex = 0
@@ -441,6 +445,9 @@ async function mapWithConcurrency<T, R>(
   await Promise.all(
     Array.from({ length: workerCount }, async () => {
       while (nextIndex < items.length) {
+        if (abortSignal?.aborted) {
+          throw abortSignal.reason ?? new DOMException("Aborted", "AbortError")
+        }
         const currentIndex = nextIndex
         nextIndex += 1
         results[currentIndex] = await mapper(items[currentIndex])
@@ -475,6 +482,10 @@ async function loadTokenScopedCatalogPricingContext(params: {
       },
     }
   } catch (error) {
+    if (isAbortError(error, params.abortSignal)) {
+      throw error
+    }
+
     return { error }
   }
 }
@@ -484,9 +495,16 @@ async function fetchTokenScopedCatalogPricingContexts(
   account: DisplaySiteData,
   abortSignal?: AbortSignal,
 ): Promise<AccountPricingQueryResult> {
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason ?? new DOMException("Aborted", "AbortError")
+  }
+
   const tokens = (await fetchDisplayAccountTokens(account)).filter(
     (token) => token.status === 1,
   )
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason ?? new DOMException("Aborted", "AbortError")
+  }
   if (tokens.length === 0) {
     throw createUnsupportedModelPricingError()
   }
@@ -496,6 +514,7 @@ async function fetchTokenScopedCatalogPricingContexts(
     TOKEN_SCOPED_CATALOG_CONCURRENCY,
     (token) =>
       loadTokenScopedCatalogPricingContext({ account, token, abortSignal }),
+    abortSignal,
   )
   const contexts = settledResults.flatMap((result) =>
     result.context ? [result.context] : [],
@@ -915,6 +934,13 @@ function useSingleAccountModelData(params: {
     selectedFallbackToken,
     t,
   ])
+
+  useEffect(() => {
+    return () => {
+      fallbackCatalogAbortControllerRef.current?.abort()
+      fallbackCatalogAbortControllerRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     if (

--- a/src/features/ShareSnapshots/components/ShareSnapshotCaptionToast.tsx
+++ b/src/features/ShareSnapshots/components/ShareSnapshotCaptionToast.tsx
@@ -5,7 +5,6 @@
  */
 import { useEffect, useRef, useState } from "react"
 
-import { Button, Textarea } from "~/components/ui"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
@@ -64,10 +63,10 @@ export const ShareSnapshotCaptionToast = ({
       <div className="dark:text-dark-text-secondary mb-2 text-xs text-gray-500">
         {hint}
       </div>
-      <Textarea
+      <textarea
         readOnly
         value={caption}
-        className="mb-3 h-28 resize-none text-xs"
+        className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary dark:text-dark-text-primary mb-3 h-28 w-full resize-none rounded-md border border-gray-200 bg-gray-50 p-2 text-xs text-gray-900 focus:outline-none"
       />
       {copyError ? (
         <div className="mb-2 text-xs text-red-600 dark:text-red-400">
@@ -75,17 +74,21 @@ export const ShareSnapshotCaptionToast = ({
         </div>
       ) : null}
       <div className="flex items-center justify-end gap-2">
-        <Button
+        <button
           type="button"
-          size="sm"
+          className="dark:bg-dark-bg-tertiary dark:text-dark-text-primary rounded-md bg-gray-900 px-3 py-1.5 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
           onClick={handleCopy}
           disabled={isCopying}
         >
           {copyLabel}
-        </Button>
-        <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+        </button>
+        <button
+          type="button"
+          className="dark:text-dark-text-secondary rounded-md px-3 py-1.5 text-xs text-gray-600"
+          onClick={onClose}
+        >
           {closeLabel}
-        </Button>
+        </button>
       </div>
     </div>
   )

--- a/src/features/SiteAnnouncements/SiteAnnouncements.tsx
+++ b/src/features/SiteAnnouncements/SiteAnnouncements.tsx
@@ -442,15 +442,13 @@ export default function SiteAnnouncementsPage({
                 </span>{" "}
               </>
             )}
-            <Button
+            <button
               type="button"
-              variant="link"
-              size="sm"
               className={textLinkClassName}
               onClick={handleOpenPollingSettings}
             >
               {t("description.pollingSettingsLink")}
-            </Button>
+            </button>
           </>
         }
         className="mb-5"
@@ -552,15 +550,13 @@ export default function SiteAnnouncementsPage({
                 isPollingDisabled ? (
                   <>
                     <span>{t("empty.descriptionWhenPollingDisabled")}</span>{" "}
-                    <Button
+                    <button
                       type="button"
-                      variant="link"
-                      size="sm"
                       className={textLinkClassName}
                       onClick={handleOpenPollingSettings}
                     >
                       {t("empty.pollingSettingsLink")}
-                    </Button>
+                    </button>
                   </>
                 ) : (
                   t("empty.description")

--- a/src/locales/en/aiApiVerification.json
+++ b/src/locales/en/aiApiVerification.json
@@ -6,7 +6,9 @@
       "retry": "Retry",
       "run": "Run",
       "running": "Running...",
-      "runOne": "Run"
+      "runOne": "Run",
+      "stop": "Stop",
+      "stopProbe": "Stop {{probe}}"
     },
     "apiTypes": {
       "anthropic": "Anthropic",
@@ -68,6 +70,7 @@
       "noModelIdProvidedToRunProbes": "No model id provided to run probes.",
       "noModelsReturned": "No models returned.",
       "noToolCallDetected": "No tool call detected (model may not support tools).",
+      "stopped": "Stopped by user.",
       "structuredOutputInvalid": "Invalid output.",
       "structuredOutputSucceeded": "Structured output succeeded.",
       "textGenerationSucceeded": "Text generation succeeded.",

--- a/src/locales/en/cliSupportVerification.json
+++ b/src/locales/en/cliSupportVerification.json
@@ -4,8 +4,9 @@
       "close": "Close",
       "retry": "Retry",
       "run": "Run simulation",
-      "running": "Running...",
-      "runOne": "Run"
+      "runOne": "Run",
+      "stop": "Stop",
+      "stopTool": "Stop {{tool}}"
     },
     "details": {
       "input": "Input",
@@ -40,6 +41,7 @@
       "networkError": "Network error / blocked request",
       "noModelIdProvided": "No model id available",
       "noToolCallDetected": "No tool call detected (tool calling may not be supported)",
+      "stopped": "Stopped by user.",
       "supported": "Supported",
       "supportedStreaming": "Supported (streaming)",
       "toolCallSucceeded": "Tool call succeeded.",

--- a/src/locales/en/managedSiteModelSync.json
+++ b/src/locales/en/managedSiteModelSync.json
@@ -73,6 +73,8 @@
       "finishedAt": "Finished At",
       "manageChannel": "Manage channel",
       "message": "Message",
+      "selectAllChannels": "Select all channels",
+      "selectChannel": "Select channel {{name}}",
       "status": "Status",
       "syncChannel": "Sync"
     },

--- a/src/locales/en/managedSiteModelSync.json
+++ b/src/locales/en/managedSiteModelSync.json
@@ -73,8 +73,6 @@
       "finishedAt": "Finished At",
       "manageChannel": "Manage channel",
       "message": "Message",
-      "selectAll": "Select all channels",
-      "selectChannel": "Select channel {{channelName}}",
       "status": "Status",
       "syncChannel": "Sync"
     },

--- a/src/locales/ja/aiApiVerification.json
+++ b/src/locales/ja/aiApiVerification.json
@@ -6,7 +6,9 @@
       "retry": "再試行",
       "run": "実行",
       "running": "実行中...",
-      "runOne": "実行"
+      "runOne": "実行",
+      "stop": "停止",
+      "stopProbe": "{{probe}} を停止"
     },
     "apiTypes": {
       "anthropic": "Anthropic",
@@ -67,6 +69,7 @@
       "noModelIdProvidedToRunProbes": "プローブを実行するためのモデル ID が指定されていません。",
       "noModelsReturned": "モデルが返されませんでした。",
       "noToolCallDetected": "ツール呼び出しが検出されませんでした（モデルがツールに対応していない可能性があります）。",
+      "stopped": "ユーザーが停止しました。",
       "structuredOutputInvalid": "出力が不正です。",
       "structuredOutputSucceeded": "構造化出力に成功しました。",
       "textGenerationSucceeded": "テキスト生成に成功しました。",

--- a/src/locales/ja/cliSupportVerification.json
+++ b/src/locales/ja/cliSupportVerification.json
@@ -4,8 +4,9 @@
       "close": "閉じる",
       "retry": "再試行",
       "run": "シミュレーションを実行",
-      "running": "実行中...",
-      "runOne": "実行"
+      "runOne": "実行",
+      "stop": "停止",
+      "stopTool": "{{tool}} を停止"
     },
     "details": {
       "input": "入力",
@@ -40,6 +41,7 @@
       "networkError": "ネットワークエラー / リクエストがブロックされました",
       "noModelIdProvided": "利用可能なモデル ID がありません",
       "noToolCallDetected": "ツール呼び出しが検出されませんでした（ツール呼び出し未対応の可能性があります）",
+      "stopped": "ユーザーが停止しました。",
       "supported": "対応",
       "supportedStreaming": "対応（ストリーミング）",
       "toolCallSucceeded": "ツール呼び出しに成功しました。",

--- a/src/locales/ja/managedSiteModelSync.json
+++ b/src/locales/ja/managedSiteModelSync.json
@@ -70,6 +70,8 @@
       "finishedAt": "完了時刻",
       "manageChannel": "チャネルを管理",
       "message": "メッセージ",
+      "selectAllChannels": "すべてのチャネルを選択",
+      "selectChannel": "チャネル {{name}} を選択",
       "status": "状態",
       "syncChannel": "同期"
     },

--- a/src/locales/ja/managedSiteModelSync.json
+++ b/src/locales/ja/managedSiteModelSync.json
@@ -70,8 +70,6 @@
       "finishedAt": "完了時刻",
       "manageChannel": "チャネルを管理",
       "message": "メッセージ",
-      "selectAll": "すべてのチャネルを選択",
-      "selectChannel": "チャネル {{channelName}} を選択",
       "status": "状態",
       "syncChannel": "同期"
     },

--- a/src/locales/vi/aiApiVerification.json
+++ b/src/locales/vi/aiApiVerification.json
@@ -6,7 +6,9 @@
       "retry": "Thử lại",
       "run": "Bắt đầu xác minh",
       "running": "Đang chạy...",
-      "runOne": "Chạy"
+      "runOne": "Chạy",
+      "stop": "Dừng",
+      "stopProbe": "Dừng {{probe}}"
     },
     "apiTypes": {
       "anthropic": "Anthropic",
@@ -66,6 +68,7 @@
       "noModelIdProvidedToRunProbes": "Chưa cung cấp ID mô hình, không thể chạy thăm dò.",
       "noModelsReturned": "Không trả về mô hình nào.",
       "noToolCallDetected": "Không phát hiện thấy lệnh gọi công cụ (mô hình có thể không hỗ trợ công cụ).",
+      "stopped": "Đã dừng bởi người dùng.",
       "structuredOutputInvalid": "Nội dung đầu ra không hợp lệ.",
       "structuredOutputSucceeded": "Đầu ra có cấu trúc thành công.",
       "textGenerationSucceeded": "Tạo văn bản thành công.",

--- a/src/locales/vi/cliSupportVerification.json
+++ b/src/locales/vi/cliSupportVerification.json
@@ -4,8 +4,9 @@
       "close": "Đóng",
       "retry": "Thử lại",
       "run": "Bắt đầu xác thực",
-      "running": "Đang chạy...",
-      "runOne": "Chạy"
+      "runOne": "Chạy",
+      "stop": "Dừng",
+      "stopTool": "Dừng {{tool}}"
     },
     "details": {
       "input": "Đầu vào",
@@ -40,6 +41,7 @@
       "networkError": "Lỗi mạng / Yêu cầu bị chặn",
       "noModelIdProvided": "Không có ID mô hình khả dụng",
       "noToolCallDetected": "Không phát hiện gọi công cụ (có thể không hỗ trợ tool/function calling)",
+      "stopped": "Đã dừng bởi người dùng.",
       "supported": "Hỗ trợ",
       "supportedStreaming": "Hỗ trợ (truyền phát)",
       "toolCallSucceeded": "Gọi công cụ thành công.",

--- a/src/locales/vi/managedSiteModelSync.json
+++ b/src/locales/vi/managedSiteModelSync.json
@@ -70,6 +70,8 @@
       "finishedAt": "Thời gian hoàn thành",
       "manageChannel": "Quản lý kênh",
       "message": "Thông báo lỗi",
+      "selectAllChannels": "Chọn tất cả các kênh",
+      "selectChannel": "Chọn kênh {{name}}",
       "status": "Trạng thái",
       "syncChannel": "Đồng bộ hóa kênh này"
     },

--- a/src/locales/vi/managedSiteModelSync.json
+++ b/src/locales/vi/managedSiteModelSync.json
@@ -70,8 +70,6 @@
       "finishedAt": "Thời gian hoàn thành",
       "manageChannel": "Quản lý kênh",
       "message": "Thông báo lỗi",
-      "selectAll": "Chọn tất cả kênh",
-      "selectChannel": "Chọn kênh {{channelName}}",
       "status": "Trạng thái",
       "syncChannel": "Đồng bộ hóa kênh này"
     },

--- a/src/locales/zh-CN/aiApiVerification.json
+++ b/src/locales/zh-CN/aiApiVerification.json
@@ -6,7 +6,9 @@
       "retry": "重试",
       "run": "开始验证",
       "running": "运行中...",
-      "runOne": "运行"
+      "runOne": "运行",
+      "stop": "停止",
+      "stopProbe": "停止 {{probe}}"
     },
     "apiTypes": {
       "anthropic": "Anthropic",
@@ -66,6 +68,7 @@
       "noModelIdProvidedToRunProbes": "未提供模型 ID，无法运行探测。",
       "noModelsReturned": "未返回任何模型。",
       "noToolCallDetected": "未检测到工具调用（模型可能不支持工具）。",
+      "stopped": "已停止。",
       "structuredOutputInvalid": "输出内容无效。",
       "structuredOutputSucceeded": "结构化输出成功。",
       "textGenerationSucceeded": "文本生成成功。",

--- a/src/locales/zh-CN/cliSupportVerification.json
+++ b/src/locales/zh-CN/cliSupportVerification.json
@@ -4,8 +4,9 @@
       "close": "关闭",
       "retry": "重试",
       "run": "开始验证",
-      "running": "运行中...",
-      "runOne": "运行"
+      "runOne": "运行",
+      "stop": "停止",
+      "stopTool": "停止 {{tool}}"
     },
     "details": {
       "input": "输入",
@@ -40,6 +41,7 @@
       "networkError": "网络错误 / 请求被阻止",
       "noModelIdProvided": "没有可用的模型 ID",
       "noToolCallDetected": "未检测到工具调用（可能不支持 tool/function calling）",
+      "stopped": "已停止。",
       "supported": "支持",
       "supportedStreaming": "支持（流式）",
       "toolCallSucceeded": "工具调用成功。",

--- a/src/locales/zh-CN/managedSiteModelSync.json
+++ b/src/locales/zh-CN/managedSiteModelSync.json
@@ -70,6 +70,8 @@
       "finishedAt": "完成时间",
       "manageChannel": "管理渠道",
       "message": "错误信息",
+      "selectAllChannels": "选择所有渠道",
+      "selectChannel": "选择渠道 {{name}}",
       "status": "状态",
       "syncChannel": "同步此渠道"
     },

--- a/src/locales/zh-CN/managedSiteModelSync.json
+++ b/src/locales/zh-CN/managedSiteModelSync.json
@@ -70,8 +70,6 @@
       "finishedAt": "完成时间",
       "manageChannel": "管理渠道",
       "message": "错误信息",
-      "selectAll": "选择全部渠道",
-      "selectChannel": "选择渠道 {{channelName}}",
       "status": "状态",
       "syncChannel": "同步此渠道"
     },

--- a/src/locales/zh-TW/aiApiVerification.json
+++ b/src/locales/zh-TW/aiApiVerification.json
@@ -6,7 +6,9 @@
       "retry": "重試",
       "run": "開始驗證",
       "running": "執行中...",
-      "runOne": "執行"
+      "runOne": "執行",
+      "stop": "停止",
+      "stopProbe": "停止 {{probe}}"
     },
     "apiTypes": {
       "anthropic": "Anthropic",
@@ -66,6 +68,7 @@
       "noModelIdProvidedToRunProbes": "未提供模型 ID，無法執行探測。",
       "noModelsReturned": "未返回任何模型。",
       "noToolCallDetected": "未檢測到工具呼叫（模型可能不支援工具）。",
+      "stopped": "已停止。",
       "structuredOutputInvalid": "輸出內容無效。",
       "structuredOutputSucceeded": "結構化輸出成功。",
       "textGenerationSucceeded": "文字生成成功。",

--- a/src/locales/zh-TW/cliSupportVerification.json
+++ b/src/locales/zh-TW/cliSupportVerification.json
@@ -4,8 +4,9 @@
       "close": "關閉",
       "retry": "重試",
       "run": "開始驗證",
-      "running": "執行中...",
-      "runOne": "執行"
+      "runOne": "執行",
+      "stop": "停止",
+      "stopTool": "停止 {{tool}}"
     },
     "details": {
       "input": "輸入",
@@ -40,6 +41,7 @@
       "networkError": "網路錯誤 / 請求被阻止",
       "noModelIdProvided": "沒有可用的模型 ID",
       "noToolCallDetected": "未檢測到工具呼叫（可能不支援 tool/function calling）",
+      "stopped": "已停止。",
       "supported": "支援",
       "supportedStreaming": "支援（流式）",
       "toolCallSucceeded": "工具呼叫成功。",

--- a/src/locales/zh-TW/managedSiteModelSync.json
+++ b/src/locales/zh-TW/managedSiteModelSync.json
@@ -70,8 +70,6 @@
       "finishedAt": "完成時間",
       "manageChannel": "管理渠道",
       "message": "錯誤資訊",
-      "selectAll": "選擇全部渠道",
-      "selectChannel": "選擇渠道 {{channelName}}",
       "status": "狀態",
       "syncChannel": "同步此渠道"
     },

--- a/src/locales/zh-TW/managedSiteModelSync.json
+++ b/src/locales/zh-TW/managedSiteModelSync.json
@@ -70,6 +70,8 @@
       "finishedAt": "完成時間",
       "manageChannel": "管理渠道",
       "message": "錯誤資訊",
+      "selectAllChannels": "選擇所有渠道",
+      "selectChannel": "選擇渠道 {{name}}",
       "status": "狀態",
       "syncChannel": "同步此渠道"
     },

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -132,6 +132,10 @@ export const createDisplayAccountApiContext = (
   }
 }
 
+export interface ResolveDisplayAccountTokenForSecretOptions {
+  abortSignal?: AbortSignal
+}
+
 /**
  * Fetches the current token inventory for a display account.
  */
@@ -190,12 +194,16 @@ export async function resolveDisplayAccountTokenForSecret<
     | "cookieAuthSessionCookie"
   >,
   token: TToken,
+  options: ResolveDisplayAccountTokenForSecretOptions = {},
 ): Promise<TToken> {
   const { keyManagement, request } = createDisplayAccountApiContext(account)
+  const resolutionRequest = options.abortSignal
+    ? { ...request, abortSignal: options.abortSignal }
+    : request
   const resolvedKey = await requireDisplayAccountKeyManagement(
     account,
     keyManagement,
-  ).resolveTokenKey({ request, token })
+  ).resolveTokenKey({ request: resolutionRequest, token })
   return formatOptionalSkPrefixSiteToken(
     resolvedKey === token.key ? token : { ...token, key: resolvedKey },
     account.siteType,

--- a/src/services/apiCredentialProfiles/modelCatalog.ts
+++ b/src/services/apiCredentialProfiles/modelCatalog.ts
@@ -15,6 +15,7 @@ type FetchApiCredentialModelCatalogParams = {
   apiType: ApiVerificationApiType
   baseUrl: string
   apiKey: string
+  abortSignal?: AbortSignal
 }
 
 /**
@@ -30,6 +31,7 @@ export async function fetchApiCredentialModelIds(
     return fetchOpenAICompatibleModelIds({
       baseUrl: params.baseUrl,
       apiKey: params.apiKey,
+      abortSignal: params.abortSignal,
     })
   }
 
@@ -37,6 +39,7 @@ export async function fetchApiCredentialModelIds(
     return fetchAnthropicModelIds({
       baseUrl: params.baseUrl,
       apiKey: params.apiKey,
+      abortSignal: params.abortSignal,
     })
   }
 
@@ -44,6 +47,7 @@ export async function fetchApiCredentialModelIds(
     return fetchGoogleModelIds({
       baseUrl: params.baseUrl,
       apiKey: params.apiKey,
+      abortSignal: params.abortSignal,
     })
   }
 

--- a/src/services/apiCredentialProfiles/modelCatalog.ts
+++ b/src/services/apiCredentialProfiles/modelCatalog.ts
@@ -11,7 +11,7 @@ import {
   type ApiVerificationApiType,
 } from "~/services/verification/aiApiVerification"
 
-type FetchApiCredentialModelCatalogParams = {
+interface FetchApiCredentialModelCatalogParams {
   apiType: ApiVerificationApiType
   baseUrl: string
   apiKey: string

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -1447,6 +1447,7 @@ export async function fetchSub2ApiRuntimeModels(
     const response = await fetch(endpointUrl, {
       method: "GET",
       cache: "no-store",
+      signal: request.abortSignal,
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },

--- a/src/services/modelList/accountSources/sub2apiEstimates.ts
+++ b/src/services/modelList/accountSources/sub2apiEstimates.ts
@@ -64,6 +64,7 @@ interface LoadSub2ApiEstimatedPricingResponseParams {
   resolvedKey: string
   runtimeModelIds: string[]
   fallbackResponse: PricingResponse
+  abortSignal?: AbortSignal
 }
 
 const toTrimmedString = (value: unknown): string =>
@@ -347,9 +348,11 @@ const hasSub2ApiDashboardAuth = (account: Sub2ApiEstimateAccount): boolean => {
 
 const createSub2ApiDashboardRequest = (
   account: Sub2ApiEstimateAccount,
+  abortSignal?: AbortSignal,
 ): ApiServiceRequest => ({
   baseUrl: account.baseUrl,
   accountId: account.id,
+  abortSignal,
   auth: {
     authType: AuthTypeEnum.AccessToken,
     userId: account.userId,
@@ -366,10 +369,13 @@ export const loadSub2ApiEstimatedPricingResponse = async (
   }
 
   try {
-    const dashboardRequest = createSub2ApiDashboardRequest(params.account)
+    const dashboardRequest = createSub2ApiDashboardRequest(
+      params.account,
+      params.abortSignal,
+    )
     const [dashboardEstimateData, priceTable] = await Promise.all([
       loadSub2ApiDashboardEstimateData(dashboardRequest),
-      loadModelPriceTable(),
+      loadModelPriceTable(params.abortSignal),
     ])
     const { groups, groupRates, accountTokens } = dashboardEstimateData
     const group = resolveSub2ApiKeyGroupForPriceEstimation({

--- a/src/services/modelList/accountSources/sub2apiEstimates.ts
+++ b/src/services/modelList/accountSources/sub2apiEstimates.ts
@@ -19,6 +19,7 @@ import {
   loadModelPriceTable,
   type ModelPriceTable,
 } from "~/services/modelPricing/modelPriceTable"
+import { isAbortError } from "~/services/verification/aiApiVerification/utils"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 
 interface Sub2ApiGroupLike {
@@ -391,7 +392,11 @@ export const loadSub2ApiEstimatedPricingResponse = async (
       groupRates,
       priceTable,
     })
-  } catch {
+  } catch (error) {
+    if (isAbortError(error, params.abortSignal)) {
+      throw error
+    }
+
     return buildSub2ApiRuntimePricingResponse(
       params.runtimeModelIds,
       MODEL_UNAVAILABLE_PRICE_REASONS.PRICING_SOURCE_UNAVAILABLE,

--- a/src/services/modelList/accountSources/tokenScopedFallback.ts
+++ b/src/services/modelList/accountSources/tokenScopedFallback.ts
@@ -171,6 +171,10 @@ export async function loadAccountTokenFallbackPricingResponse(
         abortSignal: params.abortSignal,
       })
     } catch (error) {
+      if (isAbortError(error, params.abortSignal)) {
+        throw error
+      }
+
       if (declaredModelIds.length === 0) {
         throw error
       }

--- a/src/services/modelList/accountSources/tokenScopedFallback.ts
+++ b/src/services/modelList/accountSources/tokenScopedFallback.ts
@@ -36,6 +36,7 @@ interface LoadAccountTokenFallbackPricingParams {
     | "cookieAuthSessionCookie"
   >
   token: ApiToken
+  abortSignal?: AbortSignal
 }
 
 export const ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED =
@@ -63,9 +64,11 @@ const createAccountModelPricingRequest = (
 const createRuntimeCatalogRequest = (
   account: LoadAccountTokenFallbackPricingParams["account"],
   apiKey: string,
+  abortSignal?: AbortSignal,
 ): ModelCatalogRequest => ({
   baseUrl: account.baseUrl,
   accountId: account.id,
+  abortSignal,
   auth: {
     authType: AuthTypeEnum.AccessToken,
     apiKey,
@@ -104,10 +107,15 @@ export async function loadAccountTokenFallbackPricingResponse(
       throw createMissingModelPricingCapabilityError(params.account.siteType)
     }
 
-    const resolvedToken = await resolveDisplayAccountTokenForSecret(
-      params.account,
-      params.token,
-    )
+    const resolvedToken = params.abortSignal
+      ? await resolveDisplayAccountTokenForSecret(
+          params.account,
+          params.token,
+          {
+            abortSignal: params.abortSignal,
+          },
+        )
+      : await resolveDisplayAccountTokenForSecret(params.account, params.token)
     resolvedTokenKey = resolvedToken.key
 
     if (
@@ -115,7 +123,11 @@ export async function loadAccountTokenFallbackPricingResponse(
       MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog
     ) {
       const runtimeModelIds = await readiness.modelCatalog.fetchModels(
-        createRuntimeCatalogRequest(params.account, resolvedToken.key),
+        createRuntimeCatalogRequest(
+          params.account,
+          resolvedToken.key,
+          params.abortSignal,
+        ),
       )
       const modelOnlyResponse =
         buildSub2ApiRuntimePricingResponse(runtimeModelIds)
@@ -130,6 +142,7 @@ export async function loadAccountTokenFallbackPricingResponse(
           resolvedKey: resolvedToken.key,
           runtimeModelIds,
           fallbackResponse: modelOnlyResponse,
+          abortSignal: params.abortSignal,
         })
       }
 
@@ -150,6 +163,7 @@ export async function loadAccountTokenFallbackPricingResponse(
         apiType: API_TYPES.OPENAI_COMPATIBLE,
         baseUrl: params.account.baseUrl,
         apiKey: resolvedToken.key,
+        abortSignal: params.abortSignal,
       })
     } catch (error) {
       if (declaredModelIds.length === 0) {

--- a/src/services/modelList/accountSources/tokenScopedFallback.ts
+++ b/src/services/modelList/accountSources/tokenScopedFallback.ts
@@ -20,7 +20,10 @@ import {
   loadSub2ApiEstimatedPricingResponse,
 } from "~/services/modelList/accountSources/sub2apiEstimates"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
-import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
+import {
+  isAbortError,
+  toSanitizedErrorSummary,
+} from "~/services/verification/aiApiVerification/utils"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { parseDelimitedList } from "~/utils/core/string"
 
@@ -50,9 +53,11 @@ const createMissingModelPricingCapabilityError = (siteType: string) =>
 
 const createAccountModelPricingRequest = (
   account: LoadAccountTokenFallbackPricingParams["account"],
+  abortSignal?: AbortSignal,
 ): ModelPricingRequest => ({
   baseUrl: account.baseUrl,
   accountId: account.id,
+  abortSignal,
   auth: {
     authType: account.authType,
     userId: account.userId,
@@ -93,7 +98,7 @@ export async function loadAccountTokenFallbackPricingResponse(
         ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile
     ) {
       return await readiness.modelPricing.fetchPricing(
-        createAccountModelPricingRequest(params.account),
+        createAccountModelPricingRequest(params.account, params.abortSignal),
       )
     }
 
@@ -176,6 +181,10 @@ export async function loadAccountTokenFallbackPricingResponse(
       ...upstreamModelIds,
     ])
   } catch (error) {
+    if (isAbortError(error, params.abortSignal)) {
+      throw error
+    }
+
     const sanitizedMessage = toSanitizedErrorSummary(error, [
       params.account.baseUrl,
       params.account.token,

--- a/src/services/modelPricing/modelPriceTable.ts
+++ b/src/services/modelPricing/modelPriceTable.ts
@@ -82,14 +82,50 @@ const normalizeLiteLlmPriceTable = (payload: unknown): ModelPriceTable => {
   }
 }
 
+const composeAbortSignals = (
+  timeoutController: AbortController,
+  abortSignal?: AbortSignal,
+) => {
+  if (!abortSignal) {
+    return {
+      signal: timeoutController.signal,
+      cleanup: () => {},
+    }
+  }
+
+  if (typeof AbortSignal.any === "function") {
+    return {
+      signal: AbortSignal.any([abortSignal, timeoutController.signal]),
+      cleanup: () => {},
+    }
+  }
+
+  const relayAbort = () => {
+    timeoutController.abort(abortSignal.reason)
+  }
+  if (abortSignal.aborted) {
+    relayAbort()
+  } else {
+    abortSignal.addEventListener("abort", relayAbort, { once: true })
+  }
+
+  return {
+    signal: timeoutController.signal,
+    cleanup: () => abortSignal.removeEventListener("abort", relayAbort),
+  }
+}
+
 /**
  * Loads the official-price snapshot used by optional catalog estimation.
  *
  * Source: LiteLLM model_prices_and_context_window.json. Values are USD per
  * token and are normalized to this app's USD-per-1M-token display units.
  */
-export async function loadModelPriceTable(): Promise<ModelPriceTable> {
+export async function loadModelPriceTable(
+  abortSignal?: AbortSignal,
+): Promise<ModelPriceTable> {
   const controller = new AbortController()
+  const composedSignal = composeAbortSignals(controller, abortSignal)
   const timeoutId = setTimeout(
     () => controller.abort(),
     MODEL_PRICE_TABLE_FETCH_TIMEOUT_MS,
@@ -98,7 +134,7 @@ export async function loadModelPriceTable(): Promise<ModelPriceTable> {
 
   try {
     response = await fetch(LITELLM_MODEL_PRICE_TABLE_URL, {
-      signal: controller.signal,
+      signal: composedSignal.signal,
     })
   } catch (error) {
     if (controller.signal.aborted) {
@@ -109,6 +145,7 @@ export async function loadModelPriceTable(): Promise<ModelPriceTable> {
 
     throw new Error("Failed to load LiteLLM price table", { cause: error })
   } finally {
+    composedSignal.cleanup()
     clearTimeout(timeoutId)
   }
 

--- a/src/services/modelPricing/modelPriceTable.ts
+++ b/src/services/modelPricing/modelPriceTable.ts
@@ -1,3 +1,5 @@
+import { isAbortError as isSharedAbortError } from "~/services/verification/aiApiVerification/utils"
+
 export type ModelPriceTableEntry = {
   input?: number | string | null
   output?: number | string | null
@@ -115,6 +117,9 @@ const composeAbortSignals = (
   }
 }
 
+const isCallerAbortError = (error: unknown, abortSignal?: AbortSignal) =>
+  Boolean(abortSignal?.aborted && isSharedAbortError(error, abortSignal))
+
 /**
  * Loads the official-price snapshot used by optional catalog estimation.
  *
@@ -137,6 +142,10 @@ export async function loadModelPriceTable(
       signal: composedSignal.signal,
     })
   } catch (error) {
+    if (isCallerAbortError(error, abortSignal)) {
+      throw error
+    }
+
     if (controller.signal.aborted) {
       throw new Error("Timed out loading LiteLLM price table", {
         cause: error,

--- a/src/services/verification/aiApiVerification/i18n.ts
+++ b/src/services/verification/aiApiVerification/i18n.ts
@@ -94,6 +94,11 @@ export function translateApiVerificationSummary(
         "aiApiVerification:verifyDialog.summaries.noToolCallDetected",
         summaryParams,
       )
+    case "verifyDialog.summaries.stopped":
+      return t(
+        "aiApiVerification:verifyDialog.summaries.stopped",
+        summaryParams,
+      )
     case "verifyDialog.summaries.toolCallSucceeded":
       return t(
         "aiApiVerification:verifyDialog.summaries.toolCallSucceeded",

--- a/src/services/verification/cliSupportVerification/cliSupportVerificationService.ts
+++ b/src/services/verification/cliSupportVerification/cliSupportVerificationService.ts
@@ -17,6 +17,7 @@ type RunCliSupportSimulationParams = {
    * Callers (UI/CLI) should pass an explicit `modelId` to keep verification deterministic.
    */
   modelId?: string
+  abortSignal?: AbortSignal
 }
 
 /**
@@ -38,6 +39,7 @@ export async function runCliSupportTool(
     baseUrl: params.baseUrl,
     apiKey: params.apiKey,
     modelId: params.modelId,
+    abortSignal: params.abortSignal,
   })
 }
 
@@ -59,6 +61,7 @@ export async function runCliSupportSimulation(
         baseUrl: params.baseUrl,
         apiKey: params.apiKey,
         modelId: params.modelId,
+        abortSignal: params.abortSignal,
       }),
     )
   }

--- a/src/services/verification/cliSupportVerification/i18n.ts
+++ b/src/services/verification/cliSupportVerification/i18n.ts
@@ -47,6 +47,11 @@ export function translateCliSupportSummary(
         "cliSupportVerification:verifyDialog.summaries.noToolCallDetected",
         summaryParams,
       )
+    case "verifyDialog.summaries.stopped":
+      return t(
+        "cliSupportVerification:verifyDialog.summaries.stopped",
+        summaryParams,
+      )
     case "verifyDialog.summaries.toolCallSucceeded":
       return t(
         "cliSupportVerification:verifyDialog.summaries.toolCallSucceeded",

--- a/src/services/verification/cliSupportVerification/registry.ts
+++ b/src/services/verification/cliSupportVerification/registry.ts
@@ -10,6 +10,7 @@ type CliToolRunnerParams = {
   baseUrl: string
   apiKey: string
   modelId?: string
+  abortSignal?: AbortSignal
 }
 
 type CliToolRegistryEntry = {
@@ -62,6 +63,7 @@ const cliSupportToolRegistry: Record<CliToolId, CliToolRegistryEntry> = {
         apiKey: params.apiKey,
         apiType: CLI_TOOL_CONFIG.claude.apiType,
         modelId: params.modelId,
+        abortSignal: params.abortSignal,
         endpointPath: CLI_TOOL_CONFIG.claude.endpointPath,
       })
     },
@@ -74,6 +76,7 @@ const cliSupportToolRegistry: Record<CliToolId, CliToolRegistryEntry> = {
         apiKey: params.apiKey,
         apiType: CLI_TOOL_CONFIG.codex.apiType,
         modelId: params.modelId,
+        abortSignal: params.abortSignal,
         endpointPath: CLI_TOOL_CONFIG.codex.endpointPath,
       })
     },
@@ -86,6 +89,7 @@ const cliSupportToolRegistry: Record<CliToolId, CliToolRegistryEntry> = {
         apiKey: params.apiKey,
         apiType: CLI_TOOL_CONFIG.gemini.apiType,
         modelId: params.modelId,
+        abortSignal: params.abortSignal,
         endpointPath: CLI_TOOL_CONFIG.gemini.endpointPath,
       })
     },

--- a/src/services/verification/cliSupportVerification/runners/toolCalling.ts
+++ b/src/services/verification/cliSupportVerification/runners/toolCalling.ts
@@ -3,7 +3,7 @@ import { runApiVerificationProbe } from "~/services/verification/aiApiVerificati
 
 import type { CliSupportResult, CliSupportStatus, CliToolId } from "../types"
 
-type RunCliToolCallingSimulationParams = {
+interface RunCliToolCallingSimulationParams {
   toolId: CliToolId
   baseUrl: string
   apiKey: string

--- a/src/services/verification/cliSupportVerification/runners/toolCalling.ts
+++ b/src/services/verification/cliSupportVerification/runners/toolCalling.ts
@@ -9,6 +9,7 @@ type RunCliToolCallingSimulationParams = {
   apiKey: string
   apiType: ApiVerificationApiType
   modelId?: string
+  abortSignal?: AbortSignal
   /**
    * Documented endpoint template for UI display.
    *
@@ -35,6 +36,7 @@ export async function runCliToolCallingSimulation(
     apiType: params.apiType,
     modelId: params.modelId,
     probeId: "tool-calling",
+    abortSignal: params.abortSignal,
   })
 
   const status: CliSupportStatus = probeResult.status

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -1867,12 +1867,10 @@ describe("ApiCheckModalHost", () => {
 
     expect(await within(probeCard).findByText("OpenAI result")).toBeVisible()
 
-    await user.click(
-      screen.getByRole("combobox", {
-        name: "webAiApiCheck:modal.fields.apiType",
-      }),
+    await user.selectOptions(
+      screen.getByDisplayValue("OpenAI-compatible"),
+      "anthropic",
     )
-    await user.click(await screen.findByRole("option", { name: "Anthropic" }))
 
     await waitFor(() => {
       expectTypedApiCheckMessage(WebAiApiCheckMessageTypes.FetchModels, {

--- a/tests/components/FloatingLayerPrimitives.test.tsx
+++ b/tests/components/FloatingLayerPrimitives.test.tsx
@@ -53,29 +53,6 @@ function ModalSelectHarness() {
 }
 
 /**
- * Minimal select host for custom portal container assertions.
- */
-function SelectWithContainerHarness({
-  portalContainer,
-}: {
-  portalContainer: HTMLElement
-}) {
-  return (
-    <div>
-      <Select defaultValue="alpha">
-        <SelectTrigger aria-label="Select with container" className="w-48">
-          <SelectValue placeholder="Choose a value" />
-        </SelectTrigger>
-        <SelectContent container={portalContainer}>
-          <SelectItem value="alpha">Alpha</SelectItem>
-          <SelectItem value="beta">Beta</SelectItem>
-        </SelectContent>
-      </Select>
-    </div>
-  )
-}
-
-/**
  * Minimal Radix dialog host for dropdown-layer assertions.
  */
 function DialogDropdownHarness() {
@@ -156,26 +133,6 @@ describe("floating layer primitives inside dialogs", () => {
     expect(content).toBeInTheDocument()
     expect(content).toHaveClass(Z_INDEX.modalFloating)
     expect(content).not.toHaveClass(Z_INDEX.floating)
-  })
-
-  it("renders select content inside a custom portal container", async () => {
-    const user = userEvent.setup()
-    const portalContainer = document.createElement("div")
-    document.body.append(portalContainer)
-
-    try {
-      render(<SelectWithContainerHarness portalContainer={portalContainer} />)
-
-      await user.click(
-        await screen.findByRole("combobox", { name: "Select with container" }),
-      )
-
-      const option = await screen.findByRole("option", { name: "Beta" })
-
-      expect(portalContainer).toContainElement(option)
-    } finally {
-      portalContainer.remove()
-    }
   })
 
   it("uses the modal-contained layer for dropdown menus inside DialogContent", async () => {

--- a/tests/components/ThemeAwareToaster.test.tsx
+++ b/tests/components/ThemeAwareToaster.test.tsx
@@ -115,7 +115,12 @@ describe("ThemeAwareToaster", () => {
     expect(screen.getByTestId("toast-icon")).toBeInTheDocument()
     expect(screen.getByTestId("toast-message")).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole("button"))
+    const dismissButton = screen.getByRole("button", {
+      name: "common:actions.close",
+    })
+    expect(dismissButton).toHaveAttribute("type", "button")
+
+    fireEvent.click(dismissButton)
 
     expect(dismissMock).toHaveBeenCalledWith("toast-1")
   })

--- a/tests/components/VerifyApiDialog.test.tsx
+++ b/tests/components/VerifyApiDialog.test.tsx
@@ -997,6 +997,87 @@ describe("VerifyApiDialog", () => {
     expect(mockRunApiVerificationProbe).not.toHaveBeenCalled()
   })
 
+  it("marks a single probe stopped when its request rejects after cancellation", async () => {
+    let receivedSignal: AbortSignal | undefined
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      {
+        id: 1,
+        user_id: 1,
+        key: "secret",
+        status: 1,
+        name: "token-1",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: 0,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ])
+    mockRunApiVerificationProbe.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise((_resolve, reject) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    render(
+      <VerifyApiDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{
+          id: "a1",
+          name: "Account",
+          username: "u",
+          balance: { USD: 0, CNY: 0 },
+          todayConsumption: { USD: 0, CNY: 0 },
+          todayIncome: { USD: 0, CNY: 0 },
+          todayTokens: { upload: 0, download: 0 },
+          health: { status: "healthy" as any },
+          siteType: SITE_TYPES.NEW_API,
+          baseUrl: "https://example.com",
+          token: "t",
+          userId: "1",
+          authType: "access_token" as any,
+          checkIn: { enableDetection: false } as any,
+        }}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    const probeCard = await screen.findByTestId("verify-probe-text-generation")
+    const runButton = within(probeCard).getByRole("button", {
+      name: "aiApiVerification:verifyDialog.actions.runOne",
+    })
+    await waitFor(() => expect(runButton).toBeEnabled())
+    fireEvent.click(runButton)
+
+    const stopButton = await within(probeCard).findByRole("button", {
+      name: "aiApiVerification:verifyDialog.actions.stopProbe",
+    })
+    fireEvent.click(stopButton)
+
+    await waitFor(() => {
+      expect(receivedSignal?.aborted).toBe(true)
+    })
+    expect(
+      await within(probeCard).findByText(
+        "aiApiVerification:verifyDialog.summaries.stopped",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(probeCard).getByRole("button", {
+        name: "aiApiVerification:verifyDialog.actions.retry",
+      }),
+    ).toBeInTheDocument()
+  })
+
   it("completes run-all analytics as failure when any probe fails", async () => {
     mockGetApiVerificationProbeDefinitions.mockReturnValue([
       { id: "models", requiresModelId: false },

--- a/tests/components/VerifyApiDialog.test.tsx
+++ b/tests/components/VerifyApiDialog.test.tsx
@@ -921,10 +921,10 @@ describe("VerifyApiDialog", () => {
         receivedSignal = request.abortSignal
         if (!request.abortSignal) return Promise.resolve(token.key)
 
-        return new Promise<string>((_resolve, reject) => {
+        return new Promise<string>((resolve) => {
           request.abortSignal?.addEventListener(
             "abort",
-            () => reject(new DOMException("Aborted", "AbortError")),
+            () => resolve(token.key),
             { once: true },
           )
         })
@@ -986,6 +986,13 @@ describe("VerifyApiDialog", () => {
 
     await waitFor(() => {
       expect(receivedSignal?.aborted).toBe(true)
+    })
+    await waitFor(() => {
+      expect(
+        within(screen.getByTestId("verify-probe-models")).getByRole("button", {
+          name: "aiApiVerification:verifyDialog.actions.retry",
+        }),
+      ).toBeInTheDocument()
     })
     expect(mockRunApiVerificationProbe).not.toHaveBeenCalled()
   })

--- a/tests/components/VerifyApiDialog.test.tsx
+++ b/tests/components/VerifyApiDialog.test.tsx
@@ -27,6 +27,7 @@ import {
 } from "~~/tests/test-utils/render"
 
 const mockFetchAccountTokens = vi.fn()
+const mockResolveTokenKey = vi.fn()
 const mockStartProductAnalyticsAction = vi.fn()
 const mockCompleteProductAnalyticsAction = vi.fn()
 
@@ -39,8 +40,7 @@ vi.mock("~/services/apiAdapters/registry", () => ({
     keyManagement: {
       fetchTokens: (...args: any[]) => mockFetchAccountTokens(...args),
       createToken: vi.fn(),
-      resolveTokenKey: async ({ token }: { token: { key: string } }) =>
-        token.key,
+      resolveTokenKey: (...args: any[]) => mockResolveTokenKey(...args),
       deleteToken: vi.fn(),
       fetchUserGroups: vi.fn(),
       fetchAvailableModels: vi.fn(),
@@ -85,6 +85,10 @@ describe("VerifyApiDialog", () => {
   beforeEach(async () => {
     // Prevent cross-test leakage from `mockResolvedValueOnce` and call counts.
     mockFetchAccountTokens.mockReset()
+    mockResolveTokenKey.mockReset()
+    mockResolveTokenKey.mockImplementation(
+      async ({ token }: { token: { key: string } }) => token.key,
+    )
     mockRunApiVerificationProbe.mockReset()
     mockGetApiVerificationProbeDefinitions.mockReset()
     mockStartProductAnalyticsAction.mockReset()
@@ -791,6 +795,199 @@ describe("VerifyApiDialog", () => {
       surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsModelListRowActions,
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
     })
+  })
+
+  it("stops a running verification suite and aborts the active probe", async () => {
+    let receivedSignal: AbortSignal | undefined
+    mockGetApiVerificationProbeDefinitions.mockReturnValue([
+      { id: "models", requiresModelId: false },
+      { id: "text-generation", requiresModelId: true },
+    ])
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      {
+        id: 1,
+        user_id: 1,
+        key: "secret",
+        status: 1,
+        name: "token-1",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: 0,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ])
+    mockRunApiVerificationProbe.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise((resolve) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () =>
+              resolve({
+                id: "models",
+                status: "fail",
+                latencyMs: 1,
+                summary: "Stopped late",
+              }),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    render(
+      <VerifyApiDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{
+          id: "a1",
+          name: "Account",
+          username: "u",
+          balance: { USD: 0, CNY: 0 },
+          todayConsumption: { USD: 0, CNY: 0 },
+          todayIncome: { USD: 0, CNY: 0 },
+          todayTokens: { upload: 0, download: 0 },
+          health: { status: "healthy" as any },
+          siteType: SITE_TYPES.NEW_API,
+          baseUrl: "https://example.com",
+          token: "t",
+          userId: "1",
+          authType: "access_token" as any,
+          checkIn: { enableDetection: false } as any,
+        }}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    const runAllButton = await screen.findByRole("button", {
+      name: "aiApiVerification:verifyDialog.actions.run",
+    })
+    await waitFor(() => expect(runAllButton).toBeEnabled())
+    fireEvent.click(runAllButton)
+
+    const stopButton = await screen.findByRole("button", {
+      name: "aiApiVerification:verifyDialog.actions.stop",
+    })
+    fireEvent.click(stopButton)
+
+    await waitFor(() => {
+      expect(receivedSignal?.aborted).toBe(true)
+    })
+    await waitFor(() => {
+      expect(mockRunApiVerificationProbe).toHaveBeenCalledTimes(1)
+      expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Cancelled,
+        {
+          insights: {
+            successCount: 0,
+            failureCount: 0,
+          },
+        },
+      )
+    })
+  })
+
+  it("stops while resolving the full token key before starting a probe", async () => {
+    let receivedSignal: AbortSignal | undefined
+    mockGetApiVerificationProbeDefinitions.mockReturnValue([
+      { id: "models", requiresModelId: false },
+      { id: "text-generation", requiresModelId: true },
+    ])
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      {
+        id: 1,
+        user_id: 1,
+        key: "masked-secret",
+        status: 1,
+        name: "token-1",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: 0,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ])
+    mockResolveTokenKey.mockImplementationOnce(
+      ({
+        request,
+        token,
+      }: {
+        request: { abortSignal?: AbortSignal }
+        token: { key: string }
+      }) => {
+        receivedSignal = request.abortSignal
+        if (!request.abortSignal) return Promise.resolve(token.key)
+
+        return new Promise<string>((_resolve, reject) => {
+          request.abortSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          )
+        })
+      },
+    )
+    mockRunApiVerificationProbe.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) =>
+        new Promise((resolve) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () =>
+              resolve({
+                id: "models",
+                status: "fail",
+                latencyMs: 1,
+                summary: "Stopped late",
+              }),
+            { once: true },
+          )
+        }),
+    )
+
+    render(
+      <VerifyApiDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{
+          id: "a1",
+          name: "Account",
+          username: "u",
+          balance: { USD: 0, CNY: 0 },
+          todayConsumption: { USD: 0, CNY: 0 },
+          todayIncome: { USD: 0, CNY: 0 },
+          todayTokens: { upload: 0, download: 0 },
+          health: { status: "healthy" as any },
+          siteType: SITE_TYPES.NEW_API,
+          baseUrl: "https://example.com",
+          token: "t",
+          userId: "1",
+          authType: "access_token" as any,
+          checkIn: { enableDetection: false } as any,
+        }}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    const runAllButton = await screen.findByRole("button", {
+      name: "aiApiVerification:verifyDialog.actions.run",
+    })
+    await waitFor(() => expect(runAllButton).toBeEnabled())
+    fireEvent.click(runAllButton)
+
+    await waitFor(() => expect(mockResolveTokenKey).toHaveBeenCalledTimes(1))
+
+    const stopButton = await screen.findByRole("button", {
+      name: "aiApiVerification:verifyDialog.actions.stop",
+    })
+    fireEvent.click(stopButton)
+
+    await waitFor(() => {
+      expect(receivedSignal?.aborted).toBe(true)
+    })
+    expect(mockRunApiVerificationProbe).not.toHaveBeenCalled()
   })
 
   it("completes run-all analytics as failure when any probe fails", async () => {

--- a/tests/components/VerifyCliSupportDialog.test.tsx
+++ b/tests/components/VerifyCliSupportDialog.test.tsx
@@ -278,6 +278,71 @@ describe("VerifyCliSupportDialog", () => {
     expect(receivedSignal?.aborted).toBe(true)
   })
 
+  it("ignores aborted profile model-fetch rejections when the dialog closes", async () => {
+    let receivedSignal: AbortSignal | undefined
+    mockFetchApiCredentialModelIds.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise<string[]>((_resolve, reject) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    const { rerender } = render(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={{
+          id: "p1",
+          name: "Profile",
+          apiType: "openai-compatible" as any,
+          baseUrl: "https://example.com",
+          apiKey: "profile-secret",
+          tagIds: [],
+          notes: "",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        initialModelId=""
+      />,
+    )
+
+    await waitFor(() => expect(receivedSignal).toBeDefined())
+
+    await act(async () => {
+      rerender(
+        <VerifyCliSupportDialog
+          isOpen={false}
+          onClose={() => {}}
+          profile={{
+            id: "p1",
+            name: "Profile",
+            apiType: "openai-compatible" as any,
+            baseUrl: "https://example.com",
+            apiKey: "profile-secret",
+            tagIds: [],
+            notes: "",
+            createdAt: 1,
+            updatedAt: 1,
+          }}
+          initialModelId=""
+        />,
+      )
+    })
+
+    expect(receivedSignal?.aborted).toBe(true)
+    expect(
+      screen.queryByText(
+        "cliSupportVerification:verifyDialog.modelsFetchFailed",
+      ),
+    ).not.toBeInTheDocument()
+  })
+
   it("renders tool items and a single model input before running", async () => {
     mockFetchAccountTokens.mockResolvedValueOnce([
       {
@@ -913,6 +978,67 @@ describe("VerifyCliSupportDialog", () => {
       ).toBeInTheDocument()
     })
     expect(mockRunCliSupportTool).not.toHaveBeenCalled()
+  })
+
+  it("marks a single CLI tool stopped when its request rejects after cancellation", async () => {
+    let receivedSignal: AbortSignal | undefined
+    mockRunCliSupportTool.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise((_resolve, reject) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    render(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={{
+          id: "p1",
+          name: "Profile",
+          apiType: "openai-compatible" as any,
+          baseUrl: "https://example.com",
+          apiKey: "profile-secret",
+          tagIds: [],
+          notes: "",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    const toolCard = await screen.findByTestId(getCliToolCardTestId("claude"))
+    const runButton = within(toolCard).getByRole("button", {
+      name: "cliSupportVerification:verifyDialog.actions.runOne",
+    })
+    await waitFor(() => expect(runButton).toBeEnabled())
+    fireEvent.click(runButton)
+
+    const stopButton = await within(toolCard).findByRole("button", {
+      name: "cliSupportVerification:verifyDialog.actions.stopTool",
+    })
+    fireEvent.click(stopButton)
+
+    await waitFor(() => {
+      expect(receivedSignal?.aborted).toBe(true)
+    })
+    expect(
+      await within(toolCard).findByText(
+        "cliSupportVerification:verifyDialog.summaries.stopped",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(toolCard).getByRole("button", {
+        name: "cliSupportVerification:verifyDialog.actions.retry",
+      }),
+    ).toBeInTheDocument()
   })
 
   it("shows the profile model fetch error when loading stored profile models fails", async () => {

--- a/tests/components/VerifyCliSupportDialog.test.tsx
+++ b/tests/components/VerifyCliSupportDialog.test.tsx
@@ -1468,6 +1468,9 @@ describe("VerifyCliSupportDialog", () => {
     const stopButton = await screen.findByRole("button", {
       name: "cliSupportVerification:verifyDialog.actions.stop",
     })
+    await waitFor(() => {
+      expect(receivedSignal).toBeDefined()
+    })
     fireEvent.click(stopButton)
 
     await waitFor(() => {

--- a/tests/components/VerifyCliSupportDialog.test.tsx
+++ b/tests/components/VerifyCliSupportDialog.test.tsx
@@ -12,6 +12,7 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/events"
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -159,12 +160,14 @@ describe("VerifyCliSupportDialog", () => {
     fireEvent.click(runButton)
 
     await waitFor(() => {
-      expect(mockRunCliSupportTool).toHaveBeenCalledWith({
-        toolId: "claude",
-        baseUrl: "https://example.com",
-        apiKey: "profile-secret",
-        modelId: "gpt-test",
-      })
+      expect(mockRunCliSupportTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolId: "claude",
+          baseUrl: "https://example.com",
+          apiKey: "profile-secret",
+          modelId: "gpt-test",
+        }),
+      )
     })
 
     expect(mockFetchAccountTokens).not.toHaveBeenCalled()
@@ -196,11 +199,14 @@ describe("VerifyCliSupportDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockFetchApiCredentialModelIds).toHaveBeenCalledWith({
-        apiType: "openai-compatible",
-        baseUrl: "https://example.com",
-        apiKey: "profile-secret",
-      })
+      expect(mockFetchApiCredentialModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiType: "openai-compatible",
+          baseUrl: "https://example.com",
+          apiKey: "profile-secret",
+          abortSignal: expect.any(AbortSignal),
+        }),
+      )
     })
 
     const modelPicker = screen.getByRole("combobox", {
@@ -210,6 +216,66 @@ describe("VerifyCliSupportDialog", () => {
     fireEvent.click(await screen.findByRole("option", { name: "gpt-4o-mini" }))
 
     expect(modelPicker).toHaveTextContent("gpt-4o-mini")
+  })
+
+  it("aborts an in-flight profile model fetch when the dialog closes", async () => {
+    let receivedSignal: AbortSignal | undefined
+    mockFetchApiCredentialModelIds.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise<string[]>((resolve) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () => resolve(["late-model"]),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    const { rerender } = render(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={{
+          id: "p1",
+          name: "Profile",
+          apiType: "openai-compatible" as any,
+          baseUrl: "https://example.com",
+          apiKey: "profile-secret",
+          tagIds: [],
+          notes: "",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        initialModelId=""
+      />,
+    )
+
+    await waitFor(() => expect(receivedSignal).toBeDefined())
+
+    await act(async () => {
+      rerender(
+        <VerifyCliSupportDialog
+          isOpen={false}
+          onClose={() => {}}
+          profile={{
+            id: "p1",
+            name: "Profile",
+            apiType: "openai-compatible" as any,
+            baseUrl: "https://example.com",
+            apiKey: "profile-secret",
+            tagIds: [],
+            notes: "",
+            createdAt: 1,
+            updatedAt: 1,
+          }}
+          initialModelId=""
+        />,
+      )
+    })
+
+    expect(receivedSignal?.aborted).toBe(true)
   })
 
   it("renders tool items and a single model input before running", async () => {
@@ -367,12 +433,14 @@ describe("VerifyCliSupportDialog", () => {
 
     await waitFor(() => {
       expect(mockRunCliSupportTool).toHaveBeenCalledTimes(1)
-      expect(mockRunCliSupportTool).toHaveBeenCalledWith({
-        toolId: "claude",
-        baseUrl: "https://example.com",
-        apiKey: "secret",
-        modelId: "gpt-test",
-      })
+      expect(mockRunCliSupportTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolId: "claude",
+          baseUrl: "https://example.com",
+          apiKey: "secret",
+          modelId: "gpt-test",
+        }),
+      )
     })
 
     expect(
@@ -593,12 +661,14 @@ describe("VerifyCliSupportDialog", () => {
     fireEvent.click(runButton)
 
     await waitFor(() => {
-      expect(mockRunCliSupportTool).toHaveBeenCalledWith({
-        toolId: "codex",
-        baseUrl: "https://example.com",
-        apiKey: "disabled-secret",
-        modelId: "claude-3-5-sonnet",
-      })
+      expect(mockRunCliSupportTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolId: "codex",
+          baseUrl: "https://example.com",
+          apiKey: "disabled-secret",
+          modelId: "claude-3-5-sonnet",
+        }),
+      )
     })
   })
 
@@ -729,13 +799,98 @@ describe("VerifyCliSupportDialog", () => {
 
     await waitFor(() => {
       expect(mockResolveDisplayAccountTokenForSecret).toHaveBeenCalledTimes(1)
-      expect(mockRunCliSupportTool).toHaveBeenCalledWith({
-        toolId: "claude",
-        baseUrl: "https://example.com",
-        apiKey: "resolved-secret",
-        modelId: "gpt-test",
-      })
+      expect(mockRunCliSupportTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolId: "claude",
+          baseUrl: "https://example.com",
+          apiKey: "resolved-secret",
+          modelId: "gpt-test",
+        }),
+      )
     })
+  })
+
+  it("stops account-mode verification while resolving the full token key", async () => {
+    let receivedSignal: AbortSignal | undefined
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      {
+        id: 1,
+        user_id: 1,
+        key: "",
+        status: 1,
+        name: "token-1",
+        models: "",
+        model_limits: "",
+        created_time: 0,
+        accessed_time: 0,
+        expired_time: 0,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+      },
+    ])
+    mockResolveDisplayAccountTokenForSecret.mockImplementationOnce(
+      (_account, _token, options?: { abortSignal?: AbortSignal }) => {
+        receivedSignal = options?.abortSignal
+        if (!receivedSignal) {
+          return Promise.reject(new Error("missing abort signal"))
+        }
+
+        return new Promise((_resolve, reject) => {
+          receivedSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    render(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{
+          id: "a1",
+          name: "Account",
+          username: "u",
+          balance: { USD: 0, CNY: 0 },
+          todayConsumption: { USD: 0, CNY: 0 },
+          todayIncome: { USD: 0, CNY: 0 },
+          todayTokens: { upload: 0, download: 0 },
+          health: { status: "healthy" as any },
+          siteType: SITE_TYPES.NEW_API,
+          baseUrl: "https://example.com",
+          token: "t",
+          userId: "1",
+          authType: "access_token" as any,
+          checkIn: { enableDetection: false } as any,
+        }}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    const toolCard = await screen.findByTestId(getCliToolCardTestId("claude"))
+    const runButton = within(toolCard).getByRole("button", {
+      name: "cliSupportVerification:verifyDialog.actions.runOne",
+    })
+
+    await waitFor(() => expect(runButton).toBeEnabled())
+    fireEvent.click(runButton)
+
+    await waitFor(() =>
+      expect(mockResolveDisplayAccountTokenForSecret).toHaveBeenCalledTimes(1),
+    )
+
+    const stopButton = within(toolCard).getByRole("button", {
+      name: "cliSupportVerification:verifyDialog.actions.stopTool",
+    })
+    fireEvent.click(stopButton)
+
+    await waitFor(() => {
+      expect(receivedSignal?.aborted).toBe(true)
+    })
+    expect(mockRunCliSupportTool).not.toHaveBeenCalled()
   })
 
   it("shows the profile model fetch error when loading stored profile models fails", async () => {
@@ -1113,6 +1268,81 @@ describe("VerifyCliSupportDialog", () => {
         mockRunCliSupportTool.mock.calls.map((call) => call[0].toolId),
       ).toEqual(["claude", "codex", "gemini"])
     })
+  })
+
+  it("stops a running CLI support simulation and aborts the active request", async () => {
+    let receivedSignal: AbortSignal | undefined
+    mockRunCliSupportTool.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise((resolve) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () =>
+              resolve({
+                id: "claude",
+                probeId: "tool-calling",
+                status: "fail",
+                latencyMs: 1,
+                summary: "Stopped late",
+              }),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    render(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={{
+          id: "p1",
+          name: "Profile",
+          apiType: "openai-compatible" as any,
+          baseUrl: "https://example.com",
+          apiKey: "profile-secret",
+          tagIds: [],
+          notes: "",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "cliSupportVerification:verifyDialog.actions.run",
+      }),
+    )
+
+    const stopButton = await screen.findByRole("button", {
+      name: "cliSupportVerification:verifyDialog.actions.stop",
+    })
+    fireEvent.click(stopButton)
+
+    await waitFor(() => {
+      expect(receivedSignal?.aborted).toBe(true)
+    })
+    await waitFor(() => {
+      expect(mockRunCliSupportTool).toHaveBeenCalledTimes(1)
+      expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Cancelled,
+        {
+          insights: {
+            successCount: 0,
+            failureCount: 0,
+          },
+        },
+      )
+    })
+
+    expect(
+      await screen.findAllByText(
+        "cliSupportVerification:verifyDialog.summaries.stopped",
+      ),
+    ).toHaveLength(3)
   })
 
   it("completes run-all analytics as success when all CLI tools pass", async () => {

--- a/tests/components/VerifyCliSupportDialog.test.tsx
+++ b/tests/components/VerifyCliSupportDialog.test.tsx
@@ -836,10 +836,25 @@ describe("VerifyCliSupportDialog", () => {
           return Promise.reject(new Error("missing abort signal"))
         }
 
-        return new Promise((_resolve, reject) => {
+        return new Promise((resolve) => {
           receivedSignal?.addEventListener(
             "abort",
-            () => reject(new DOMException("Aborted", "AbortError")),
+            () =>
+              resolve({
+                id: 1,
+                user_id: 1,
+                key: "resolved-secret",
+                status: 1,
+                name: "token-1",
+                models: "",
+                model_limits: "",
+                created_time: 0,
+                accessed_time: 0,
+                expired_time: 0,
+                remain_quota: 0,
+                unlimited_quota: true,
+                used_quota: 0,
+              }),
             { once: true },
           )
         })
@@ -889,6 +904,13 @@ describe("VerifyCliSupportDialog", () => {
 
     await waitFor(() => {
       expect(receivedSignal?.aborted).toBe(true)
+    })
+    await waitFor(() => {
+      expect(
+        within(toolCard).getByRole("button", {
+          name: "cliSupportVerification:verifyDialog.actions.retry",
+        }),
+      ).toBeInTheDocument()
     })
     expect(mockRunCliSupportTool).not.toHaveBeenCalled()
   })

--- a/tests/entrypoints/content/RedemptionPromptToast.test.tsx
+++ b/tests/entrypoints/content/RedemptionPromptToast.test.tsx
@@ -71,26 +71,6 @@ vi.mock("~/components/ui", () => ({
   Caption: ({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   ),
-  Checkbox: ({
-    "aria-label": ariaLabel,
-    checked,
-    onClick,
-    onCheckedChange,
-  }: {
-    "aria-label"?: string
-    checked?: boolean | "indeterminate"
-    onClick?: (event: React.MouseEvent<HTMLInputElement>) => void
-    onCheckedChange?: (checked: boolean | "indeterminate") => void
-  }) => (
-    <input
-      type="checkbox"
-      aria-label={ariaLabel}
-      checked={checked === true}
-      data-indeterminate={checked === "indeterminate" ? "true" : undefined}
-      onClick={onClick}
-      onChange={(event) => onCheckedChange?.(event.target.checked)}
-    />
-  ),
   Card: ({ children }: { children: React.ReactNode }) => (
     <section>{children}</section>
   ),
@@ -163,20 +143,7 @@ describe("RedemptionPromptToast", () => {
 
     await waitFor(() => {
       expect(selectAllCheckbox).not.toBeChecked()
-      expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true")
-    })
-
-    fireEvent.click(screen.getByText("ABCD***1"))
-
-    await waitFor(() => {
-      expect(selectAllCheckbox).toBeChecked()
-    })
-
-    fireEvent.click(screen.getByText("ABCD***1"))
-
-    await waitFor(() => {
-      expect(selectAllCheckbox).not.toBeChecked()
-      expect(selectAllCheckbox).toHaveAttribute("data-indeterminate", "true")
+      expect((selectAllCheckbox as HTMLInputElement).indeterminate).toBe(true)
     })
 
     fireEvent.click(codeTwoCheckbox)

--- a/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
+++ b/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
@@ -619,6 +619,9 @@ describe("AutoCheckin account actions", () => {
       expect(openButton).toBeDisabled()
     })
 
+    await waitFor(() => {
+      expect(rejectOpen).toBeDefined()
+    })
     rejectOpen?.(new Error("popup blocked"))
 
     await waitFor(() => {

--- a/tests/entrypoints/options/pages/ApiCredentialProfiles/VerifyApiCredentialProfileDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ApiCredentialProfiles/VerifyApiCredentialProfileDialog.test.tsx
@@ -356,6 +356,9 @@ describe("VerifyApiCredentialProfileDialog", () => {
         expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
       )
     })
+    expect(
+      screen.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.verifyModelId),
+    ).not.toHaveTextContent("late-model")
   })
 
   it("redacts secrets when the initial model fetch fails", async () => {

--- a/tests/entrypoints/options/pages/ApiCredentialProfiles/VerifyApiCredentialProfileDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ApiCredentialProfiles/VerifyApiCredentialProfileDialog.test.tsx
@@ -296,10 +296,13 @@ describe("VerifyApiCredentialProfileDialog", () => {
     )
 
     await waitFor(() =>
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
-        baseUrl: "https://example.com",
-        apiKey: "sk-test",
-      }),
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://example.com",
+          apiKey: "sk-test",
+          abortSignal: expect.any(AbortSignal),
+        }),
+      ),
     )
     expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(1)
 
@@ -307,6 +310,51 @@ describe("VerifyApiCredentialProfileDialog", () => {
       expect(
         screen.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.verifyModelId),
       ).toHaveTextContent("gpt-4o-mini")
+    })
+  })
+
+  it("aborts the in-flight model fetch when switching API types", async () => {
+    const user = userEvent.setup()
+    let receivedSignal: AbortSignal | undefined
+    mockFetchOpenAICompatibleModelIds.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise<string[]>((resolve) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () => resolve(["late-model"]),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    render(
+      <VerifyApiCredentialProfileDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={{
+          id: "p-1",
+          name: "Profile",
+          apiType: API_TYPES.OPENAI_COMPATIBLE,
+          baseUrl: "https://example.com",
+          apiKey: "sk-test",
+          tagIds: [],
+          notes: "",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+      />,
+    )
+
+    await waitFor(() => expect(receivedSignal).toBeDefined())
+    await selectApiTypeOption(user)
+
+    expect(receivedSignal?.aborted).toBe(true)
+    await waitFor(() => {
+      expect(mockFetchAnthropicModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+      )
     })
   })
 
@@ -558,10 +606,13 @@ describe("VerifyApiCredentialProfileDialog", () => {
     )
 
     await waitFor(() =>
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
-        baseUrl: "https://example.com",
-        apiKey: "sk-test",
-      }),
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://example.com",
+          apiKey: "sk-test",
+          abortSignal: expect.any(AbortSignal),
+        }),
+      ),
     )
 
     await selectApiTypeOption(user)
@@ -580,10 +631,13 @@ describe("VerifyApiCredentialProfileDialog", () => {
     ).toBeInTheDocument()
 
     await waitFor(() =>
-      expect(mockFetchAnthropicModelIds).toHaveBeenCalledWith({
-        baseUrl: "https://example.com",
-        apiKey: "sk-test",
-      }),
+      expect(mockFetchAnthropicModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://example.com",
+          apiKey: "sk-test",
+          abortSignal: expect.any(AbortSignal),
+        }),
+      ),
     )
 
     const modelsProbeCard = await screen.findByTestId(
@@ -1196,10 +1250,13 @@ describe("VerifyApiCredentialProfileDialog", () => {
     )
 
     await waitFor(() =>
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
-        baseUrl: "https://example.com",
-        apiKey: "sk-test",
-      }),
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://example.com",
+          apiKey: "sk-test",
+          abortSignal: expect.any(AbortSignal),
+        }),
+      ),
     )
 
     await user.click(

--- a/tests/entrypoints/options/pages/ApiCredentialProfiles/VerifyApiCredentialProfileDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ApiCredentialProfiles/VerifyApiCredentialProfileDialog.test.tsx
@@ -361,6 +361,52 @@ describe("VerifyApiCredentialProfileDialog", () => {
     ).not.toHaveTextContent("late-model")
   })
 
+  it("ignores aborted model-fetch rejections when switching API types", async () => {
+    const user = userEvent.setup()
+    let receivedSignal: AbortSignal | undefined
+    mockFetchOpenAICompatibleModelIds.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise<string[]>((_resolve, reject) => {
+          abortSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    render(
+      <VerifyApiCredentialProfileDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={{
+          id: "p-1",
+          name: "Profile",
+          apiType: API_TYPES.OPENAI_COMPATIBLE,
+          baseUrl: "https://example.com",
+          apiKey: "sk-test",
+          tagIds: [],
+          notes: "",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+      />,
+    )
+
+    await waitFor(() => expect(receivedSignal).toBeDefined())
+    await selectApiTypeOption(user)
+
+    expect(receivedSignal?.aborted).toBe(true)
+    await waitFor(() => {
+      expect(mockFetchAnthropicModelIds).toHaveBeenCalled()
+    })
+    expect(
+      screen.queryByText("apiCredentialProfiles:verify.modelsFetchFailed"),
+    ).not.toBeInTheDocument()
+  })
+
   it("redacts secrets when the initial model fetch fails", async () => {
     mockFetchOpenAICompatibleModelIds.mockRejectedValueOnce(
       new Error("401 https://example.com sk-test invalid"),

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -527,6 +527,19 @@ describe("ManagedSiteChannels", () => {
     )
 
     expect(names).toEqual(["Gamma", "Beta", "Alpha"])
+
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "managedSiteChannels:table.columns.id",
+      }),
+    )
+
+    const ascendingRows = Array.from(container.querySelectorAll("tbody tr"))
+    const ascendingNames = ascendingRows.map((row) =>
+      row.querySelector("td:nth-child(3) .font-medium")?.textContent?.trim(),
+    )
+
+    expect(ascendingNames).toEqual(["Alpha", "Beta", "Gamma"])
   })
 
   it("reloads the channel list when the managed site type changes", async () => {

--- a/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
+++ b/tests/entrypoints/options/pages/ManagedSiteChannels/ManagedSiteChannels.test.tsx
@@ -510,9 +510,7 @@ describe("ManagedSiteChannels", () => {
     })
   })
 
-  it("sorts channels by id descending by default and toggles direction from the shared header button", async () => {
-    const user = userEvent.setup()
-
+  it("sorts channels by id descending by default", async () => {
     mockChannels([
       { id: 1, name: "Alpha", base_url: "https://alpha.example" },
       { id: 3, name: "Gamma", base_url: "https://gamma.example" },
@@ -529,26 +527,6 @@ describe("ManagedSiteChannels", () => {
     )
 
     expect(names).toEqual(["Gamma", "Beta", "Alpha"])
-
-    await user.click(
-      screen.getByRole("button", {
-        name: "managedSiteChannels:table.columns.id",
-      }),
-    )
-
-    const ascendingRows = Array.from(container.querySelectorAll("tbody tr"))
-    const ascendingNames = ascendingRows.map((row) =>
-      row.querySelector("td:nth-child(3) .font-medium")?.textContent?.trim(),
-    )
-
-    expect(ascendingNames).toEqual(["Alpha", "Beta", "Gamma"])
-    expect(
-      screen
-        .getByRole("button", {
-          name: "managedSiteChannels:table.columns.id",
-        })
-        .querySelector("svg"),
-    ).toBeInTheDocument()
   })
 
   it("reloads the channel list when the managed site type changes", async () => {
@@ -1053,23 +1031,14 @@ describe("ManagedSiteChannels", () => {
   it("clears the search input from the dedicated clear button", async () => {
     const user = userEvent.setup()
 
-    mockChannels([
-      { id: 1, name: "Alpha", base_url: "https://alpha.example" },
-      { id: 2, name: "Beta", base_url: "https://beta.example" },
-    ])
+    mockChannels([{ id: 1, name: "Alpha", base_url: "https://example.com" }])
 
     render(<ManagedSiteChannels routeParams={{ search: "Alpha" }} />)
 
     await waitForRowText("Alpha")
-    expect(screen.queryByText("Beta")).not.toBeInTheDocument()
 
     const input = screen.getByRole("textbox") as HTMLInputElement
     expect(input.value).toBe("Alpha")
-    expect(
-      screen.getByRole("button", {
-        name: "managedSiteChannels:toolbar.clearSearch",
-      }),
-    ).toBeInTheDocument()
 
     await user.click(
       screen.getByRole("button", {
@@ -1084,13 +1053,6 @@ describe("ManagedSiteChannels", () => {
         {},
       )
     })
-    expect(screen.getByText("Alpha")).toBeInTheDocument()
-    expect(screen.getByText("Beta")).toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", {
-        name: "managedSiteChannels:toolbar.clearSearch",
-      }),
-    ).not.toBeInTheDocument()
   })
 
   it("filters rows by status from the toolbar and shows the active filter count", async () => {

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -737,10 +737,13 @@ describe("useModelData all-accounts loading", () => {
       { timeout: 3000 },
     )
 
-    expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith({
-      account,
-      token: tokens[0],
-    })
+    expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account,
+        token: tokens[0],
+        abortSignal: expect.any(AbortSignal),
+      }),
+    )
     expect(fetchPricing).not.toHaveBeenCalled()
     expect(result.current.loadErrorMessage).toBeNull()
     expect(result.current.pricingContexts).toEqual([
@@ -1626,6 +1629,53 @@ describe("useModelData all-accounts loading", () => {
     })
   })
 
+  it("passes React Query abort signals to profile catalog model fetches", async () => {
+    let receivedSignal: AbortSignal | undefined
+    mockFetchApiCredentialModelIds.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise<string[]>((resolve) => {
+          abortSignal?.addEventListener("abort", () => resolve([]), {
+            once: true,
+          })
+        })
+      },
+    )
+
+    const profileSource = createProfileSource({
+      id: "profile-cancel",
+      name: "Cancelable Profile",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://profile.example.com",
+      apiKey: "sk-secret",
+      tagIds: [],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 2,
+    })
+
+    const initialProps: { source: ModelManagementSource | null } = {
+      source: profileSource,
+    }
+    const { rerender } = renderHook(
+      ({ source }: { source: ModelManagementSource | null }) =>
+        useModelData({
+          selectedSource: source,
+          accounts: [],
+        }),
+      {
+        initialProps,
+        wrapper: createWrapper(),
+      },
+    )
+
+    await waitFor(() => expect(receivedSignal).toBeDefined())
+
+    rerender({ source: null })
+
+    expect(receivedSignal?.aborted).toBe(true)
+  })
+
   it("tracks fallback catalog success and failure with sanitized source kind", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
@@ -2033,13 +2083,16 @@ describe("useModelData all-accounts loading", () => {
       ).toBe("runtime-model")
     })
     expect(fetchPricing).not.toHaveBeenCalled()
-    expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith({
-      account,
-      token: expect.objectContaining({
-        id: 10,
-        name: "Runtime Key",
+    expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account,
+        token: expect.objectContaining({
+          id: 10,
+          name: "Runtime Key",
+        }),
+        abortSignal: expect.any(AbortSignal),
       }),
-    })
+    )
   })
 
   it("loads Sub2API selected-key fallback runtime models without enabling common pricing", async () => {
@@ -2161,10 +2214,13 @@ describe("useModelData all-accounts loading", () => {
     })
 
     await waitFor(() => {
-      expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith({
-        account,
-        token: fallbackTokens[1],
-      })
+      expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account,
+          token: fallbackTokens[1],
+          abortSignal: expect.any(AbortSignal),
+        }),
+      )
       expect(result.current.accountFallback?.isActive).toBe(true)
     })
     expect(result.current.pricingData).toEqual(
@@ -2336,10 +2392,13 @@ describe("useModelData all-accounts loading", () => {
       () => {
         expect(
           mockLoadAccountTokenFallbackPricingResponse,
-        ).toHaveBeenCalledWith({
-          account,
-          token: fallbackToken,
-        })
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            account,
+            token: fallbackToken,
+            abortSignal: expect.any(AbortSignal),
+          }),
+        )
       },
       { timeout: 3000 },
     )
@@ -2449,10 +2508,13 @@ describe("useModelData all-accounts loading", () => {
     })
     expect(
       mockLoadAccountTokenFallbackPricingResponse,
-    ).toHaveBeenLastCalledWith({
-      account,
-      token: fallbackToken,
-    })
+    ).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        account,
+        token: fallbackToken,
+        abortSignal: expect.any(AbortSignal),
+      }),
+    )
     expect(fetchPricing).not.toHaveBeenCalled()
   })
 
@@ -2589,11 +2651,14 @@ describe("useModelData all-accounts loading", () => {
     )
 
     await waitFor(() =>
-      expect(mockFetchApiCredentialModelIds).toHaveBeenCalledWith({
-        apiType: API_TYPES.OPENAI_COMPATIBLE,
-        baseUrl: "https://profile.example.com",
-        apiKey: "sk-secret",
-      }),
+      expect(mockFetchApiCredentialModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiType: API_TYPES.OPENAI_COMPATIBLE,
+          baseUrl: "https://profile.example.com",
+          apiKey: "sk-secret",
+          abortSignal: expect.any(AbortSignal),
+        }),
+      ),
     )
 
     await waitFor(() =>
@@ -2755,10 +2820,13 @@ describe("useModelData all-accounts loading", () => {
     })
 
     await waitFor(() => {
-      expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith({
-        account,
-        token: fallbackTokens[1],
-      })
+      expect(mockLoadAccountTokenFallbackPricingResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account,
+          token: fallbackTokens[1],
+          abortSignal: expect.any(AbortSignal),
+        }),
+      )
     })
 
     await waitFor(() => {

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -3045,6 +3045,74 @@ describe("useModelData all-accounts loading", () => {
     })
   })
 
+  it("aborts manual fallback catalog loading when the hook unmounts", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+
+    const fetchPricing = vi.fn().mockRejectedValue(new Error("boom"))
+    vi.mocked(getSiteAdapter).mockReturnValue(
+      createMockSiteAdapter(fetchPricing),
+    )
+
+    const fallbackToken = {
+      id: 42,
+      user_id: 31,
+      key: "sk-fallback",
+      status: 1,
+      name: "Fallback key",
+      created_time: 0,
+      accessed_time: 0,
+      expired_time: -1,
+      remain_quota: 0,
+      unlimited_quota: true,
+      used_quota: 0,
+    }
+    let receivedSignal: AbortSignal | undefined
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce([fallbackToken])
+    mockLoadAccountTokenFallbackPricingResponse.mockImplementationOnce(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        receivedSignal = abortSignal
+        return new Promise(() => {})
+      },
+    )
+
+    const account = createDisplayAccount({
+      id: "unmount-fallback-account",
+      baseUrl: "https://unmount-fallback.example.com",
+      userId: "31",
+    })
+
+    const { result, unmount } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAccountSource(account),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.current.accountFallback?.isAvailable).toBe(true)
+    })
+
+    await act(async () => {
+      await result.current.accountFallback?.loadTokens()
+    })
+
+    await waitFor(() => {
+      expect(result.current.accountFallback?.tokens).toHaveLength(1)
+    })
+
+    act(() => {
+      void result.current.accountFallback?.loadCatalog()
+    })
+
+    await waitFor(() => expect(receivedSignal).toBeDefined())
+    unmount()
+
+    expect(receivedSignal?.aborted).toBe(true)
+  })
+
   it("shows the fallback key-load error when token payload normalization fails", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()

--- a/tests/features/AccountManagement/components/TagPicker.test.tsx
+++ b/tests/features/AccountManagement/components/TagPicker.test.tsx
@@ -257,6 +257,45 @@ describe("TagPicker", () => {
     })
   })
 
+  it("disables selected tag removal while a tag action is pending", async () => {
+    const user = userEvent.setup()
+    const onCreateTag = vi.fn(() => new Promise<Tag>(() => {}))
+
+    render(
+      <TagPicker
+        tags={[{ id: "t1", name: "Work", createdAt: 1, updatedAt: 1 }]}
+        selectedTagIds={["t1"]}
+        onSelectedTagIdsChange={vi.fn()}
+        onCreateTag={onCreateTag}
+        onRenameTag={vi.fn()}
+        onDeleteTag={vi.fn()}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "accountDialog:form.tagsSelectedCount",
+      }),
+    )
+    await user.type(
+      await screen.findByPlaceholderText(
+        "accountDialog:form.tagsSearchPlaceholder",
+      ),
+      "NewTag",
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "accountDialog:form.tagsCreate",
+      }),
+    )
+
+    expect(
+      screen.getByRole("button", {
+        name: "accountDialog:form.tagsRemove",
+      }),
+    ).toBeDisabled()
+  })
+
   it("wraps ArrowUp to the last filtered tag when create is available", async () => {
     const user = userEvent.setup()
 

--- a/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
+++ b/tests/features/ApiCredentialProfiles/ApiCredentialProfilesListView.test.tsx
@@ -33,13 +33,6 @@ vi.mock("~/hooks/useMediaQuery", () => ({
 }))
 
 vi.mock("~/components/ui", () => ({
-  Button: ({ children, leftIcon, rightIcon, ...props }: any) => (
-    <button {...props}>
-      {leftIcon}
-      {children}
-      {rightIcon}
-    </button>
-  ),
   Input: ({
     clearButtonLabel,
     leftIcon: _leftIcon,

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
@@ -84,13 +84,6 @@ vi.mock("~/components/ui", async () => {
 
   return {
     Badge: ({ children }: any) => <span>{children}</span>,
-    Button: ({ children, leftIcon, rightIcon, ...props }: any) => (
-      <button type="button" {...props}>
-        {leftIcon}
-        {children}
-        {rightIcon}
-      </button>
-    ),
     Card: ({ children }: any) => <div>{children}</div>,
     CardContent: ({ children }: any) => <div>{children}</div>,
     Heading6: ({ children }: any) => <h6>{children}</h6>,

--- a/tests/features/AutoCheckin/components/FilterBar.test.tsx
+++ b/tests/features/AutoCheckin/components/FilterBar.test.tsx
@@ -109,6 +109,31 @@ describe("AutoCheckin FilterBar", () => {
     })
   })
 
+  it("exposes status filter pressed state", () => {
+    rtlRender(
+      <I18nextProvider i18n={testI18n}>
+        <FilterBar
+          accountResults={[]}
+          status={FILTER_STATUS.SKIPPED}
+          keyword=""
+          onStatusChange={vi.fn()}
+          onKeywordChange={vi.fn()}
+        />
+      </I18nextProvider>,
+    )
+
+    expect(
+      screen.getByRole("button", {
+        name: /autoCheckin:execution\.filters\.all/i,
+      }),
+    ).toHaveAttribute("aria-pressed", "false")
+    expect(
+      screen.getByRole("button", {
+        name: /autoCheckin:execution\.filters\.skipped/i,
+      }),
+    ).toHaveAttribute("aria-pressed", "true")
+  })
+
   it("tracks keyword clearing without exposing the raw keyword", () => {
     const onKeywordChange = vi.fn()
 

--- a/tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
+++ b/tests/features/BalanceHistory/components/BalanceHistoryAccountSummaryTable.test.tsx
@@ -223,13 +223,6 @@ describe("BalanceHistoryAccountSummaryTable", () => {
     )
 
     expect(getAccountOrder()).toEqual(["Zulu", "Alpha", "Mike"])
-    expect(
-      screen
-        .getByRole("button", {
-          name: "balanceHistory:table.columns.startBalance",
-        })
-        .querySelector("svg"),
-    ).toBeInTheDocument()
 
     await user.click(
       screen.getByRole("button", {
@@ -238,13 +231,6 @@ describe("BalanceHistoryAccountSummaryTable", () => {
     )
 
     expect(getAccountOrder()).toEqual(["Mike", "Alpha", "Zulu"])
-    expect(
-      screen
-        .getByRole("button", {
-          name: "balanceHistory:table.columns.startBalance",
-        })
-        .querySelector("svg"),
-    ).toBeInTheDocument()
   })
 
   it("sorts snapshot coverage using zero for rows without total days while preserving the displayed counts", async () => {

--- a/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
@@ -218,9 +218,6 @@ describe("RepairMissingKeysResultsPanel", () => {
       name: "keyManagement:repairMissingKeys.searchLabel",
     })
     expect(searchInput).toHaveValue("Example")
-    expect(
-      screen.getByRole("button", { name: "common:actions.clear" }),
-    ).toBeInTheDocument()
 
     await user.type(searchInput, " 1")
     expect(onSearchTermChange).toHaveBeenLastCalledWith("Example 1")
@@ -230,9 +227,6 @@ describe("RepairMissingKeysResultsPanel", () => {
     )
     expect(onSearchTermChange).toHaveBeenLastCalledWith("")
     expect(searchInput).toHaveValue("")
-    expect(
-      screen.queryByRole("button", { name: "common:actions.clear" }),
-    ).not.toBeInTheDocument()
   })
 
   it("routes invalid-key view selection and delete actions", async () => {

--- a/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysResultsPanel.test.tsx
@@ -227,6 +227,7 @@ describe("RepairMissingKeysResultsPanel", () => {
     )
     expect(onSearchTermChange).toHaveBeenLastCalledWith("")
     expect(searchInput).toHaveValue("")
+    expect(searchInput).toHaveFocus()
   })
 
   it("routes invalid-key view selection and delete actions", async () => {

--- a/tests/features/ManagedSiteModelSync/components.test.tsx
+++ b/tests/features/ManagedSiteModelSync/components.test.tsx
@@ -328,11 +328,12 @@ describe("ManagedSiteModelSync components", () => {
       />,
     )
 
-    const [selectAllCheckbox, firstRowCheckbox] =
-      screen.getAllByRole("checkbox")
+    const [selectAllCheckbox, firstRowCheckbox] = screen.getAllByRole(
+      "checkbox",
+    ) as HTMLInputElement[]
 
     expect(selectAllCheckbox).not.toBeChecked()
-    expect(selectAllCheckbox).toHaveAttribute("aria-checked", "mixed")
+    expect(selectAllCheckbox.indeterminate).toBe(true)
 
     fireEvent.click(selectAllCheckbox)
     fireEvent.click(firstRowCheckbox)

--- a/tests/features/ManagedSiteModelSync/components.test.tsx
+++ b/tests/features/ManagedSiteModelSync/components.test.tsx
@@ -3,6 +3,7 @@ import {
   render as rtlRender,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { I18nextProvider } from "react-i18next"
@@ -294,6 +295,36 @@ describe("ManagedSiteModelSync components", () => {
     expect(onKeywordChange).toHaveBeenCalledWith("")
   })
 
+  it("exposes status filter pressed state", () => {
+    render(
+      <FilterBar
+        status="failed"
+        statistics={{
+          total: 3,
+          successCount: 2,
+          failureCount: 1,
+          durationMs: 1000,
+          startedAt: 0,
+          endedAt: 1000,
+        }}
+        keyword=""
+        onStatusChange={vi.fn()}
+        onKeywordChange={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole("button", {
+        name: /managedSiteModelSync:execution.filters.all/,
+      }),
+    ).toHaveAttribute("aria-pressed", "false")
+    expect(
+      screen.getByRole("button", {
+        name: /managedSiteModelSync:execution.filters.failed/,
+      }),
+    ).toHaveAttribute("aria-pressed", "true")
+  })
+
   it("renders results and empty states across branches", async () => {
     const onSelectAll = vi.fn()
     const onSelectItem = vi.fn()
@@ -328,9 +359,13 @@ describe("ManagedSiteModelSync components", () => {
       />,
     )
 
-    const [selectAllCheckbox, firstRowCheckbox] = screen.getAllByRole(
-      "checkbox",
-    ) as HTMLInputElement[]
+    const selectAllCheckbox = screen.getByRole("checkbox", {
+      name: "managedSiteModelSync:execution.table.selectAllChannels",
+    }) as HTMLInputElement
+    const alphaRow = screen.getByRole("row", { name: /Alpha#11/ })
+    const firstRowCheckbox = within(alphaRow).getByRole("checkbox", {
+      name: "managedSiteModelSync:execution.table.selectChannel",
+    }) as HTMLInputElement
 
     expect(selectAllCheckbox).not.toBeChecked()
     expect(selectAllCheckbox.indeterminate).toBe(true)

--- a/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
+++ b/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
@@ -600,6 +600,70 @@ describe("BatchVerifyModelsDialog", () => {
     expect(mockUpsertLatestSummary).not.toHaveBeenCalled()
   })
 
+  it("aborts token secret resolution when the batch is stopped before probes start", async () => {
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce([
+      {
+        id: 1,
+        name: "default-token",
+        key: "masked",
+        status: 1,
+        group: "default",
+        model_limits_enabled: false,
+        model_limits: "",
+        models: "",
+      },
+    ])
+
+    let receivedSignal: AbortSignal | undefined
+    mockResolveDisplayAccountTokenForSecret.mockImplementationOnce(
+      (_account, _token, options?: { abortSignal?: AbortSignal }) => {
+        receivedSignal = options?.abortSignal
+        if (!receivedSignal) {
+          return Promise.reject(new Error("missing abort signal"))
+        }
+
+        return new Promise((_resolve, reject) => {
+          receivedSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    renderDialog([
+      {
+        key: "account:acc-1:model:gpt-4o",
+        modelId: "gpt-4o",
+        enableGroups: ["default"],
+        source: { kind: "account", account },
+      },
+    ])
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "modelList:batchVerify.actions.start",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockResolveDisplayAccountTokenForSecret).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "modelList:batchVerify.actions.stop",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(receivedSignal?.aborted).toBe(true)
+    })
+    expect(mockRunApiVerificationProbe).not.toHaveBeenCalled()
+    expect(mockUpsertLatestSummary).not.toHaveBeenCalled()
+  })
+
   it("completes batch verification analytics as success when selected probes pass", async () => {
     mockFetchDisplayAccountTokens.mockResolvedValueOnce([
       {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -225,6 +225,24 @@ describe("fetchDisplayAccountTokens", () => {
     })
   })
 
+  it("passes abort signals to token secret resolution requests", async () => {
+    const token = { id: 1, key: "sk-masked", status: 1, name: "Masked" }
+    const abortController = new AbortController()
+    resolveTokenKey.mockResolvedValue("sk-real")
+
+    await resolveDisplayAccountTokenForSecret(ACCOUNT as any, token as any, {
+      abortSignal: abortController.signal,
+    })
+
+    expect(resolveTokenKey).toHaveBeenCalledWith({
+      request: expect.objectContaining({
+        ...REQUEST,
+        abortSignal: abortController.signal,
+      }),
+      token,
+    })
+  })
+
   it("returns a transient sk-prefixed secret for optional-prefix compatible account types", async () => {
     const token = { id: 1, key: "plain-secret", status: 1, name: "Plain" }
     resolveTokenKey.mockResolvedValue("plain-secret")

--- a/tests/services/apiCredentialProfiles/modelCatalog.test.ts
+++ b/tests/services/apiCredentialProfiles/modelCatalog.test.ts
@@ -74,6 +74,42 @@ describe("modelCatalog", () => {
     ).resolves.toEqual(["gemini-2.5-pro"])
   })
 
+  it("passes abort signals to provider-specific model-id fetchers", async () => {
+    const abortController = new AbortController()
+    fetchOpenAICompatibleModelIdsMock.mockResolvedValueOnce(["gpt-4o"])
+    fetchAnthropicModelIdsMock.mockResolvedValueOnce(["claude-3-7-sonnet"])
+    fetchGoogleModelIdsMock.mockResolvedValueOnce(["gemini-2.5-pro"])
+
+    await fetchApiCredentialModelIds({
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://proxy.example.com",
+      apiKey: "proxy-key",
+      abortSignal: abortController.signal,
+    })
+    await fetchApiCredentialModelIds({
+      apiType: API_TYPES.ANTHROPIC,
+      baseUrl: "https://anthropic.example.com",
+      apiKey: "anthropic-key",
+      abortSignal: abortController.signal,
+    })
+    await fetchApiCredentialModelIds({
+      apiType: API_TYPES.GOOGLE,
+      baseUrl: "https://google.example.com",
+      apiKey: "google-key",
+      abortSignal: abortController.signal,
+    })
+
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    )
+    expect(fetchAnthropicModelIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    )
+    expect(fetchGoogleModelIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    )
+  })
+
   it("throws for unsupported profile api types", async () => {
     await expect(
       fetchApiCredentialModelIds({

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -1802,6 +1802,7 @@ describe("apiService sub2api exported operations", () => {
       }) as ApiServiceAccountRequest
 
     it("fetches OpenAI-style runtime models with bearer API-key auth", async () => {
+      const abortController = new AbortController()
       const fetchMock = vi.fn().mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -1821,7 +1822,9 @@ describe("apiService sub2api exported operations", () => {
       vi.stubGlobal("fetch", fetchMock as any)
 
       await expect(
-        fetchSub2ApiRuntimeModels(createRuntimeRequest()),
+        fetchSub2ApiRuntimeModels(
+          createRuntimeRequest({ abortSignal: abortController.signal }),
+        ),
       ).resolves.toEqual(["example-runtime-model"])
 
       expect(fetchMock).toHaveBeenCalledWith(
@@ -1829,6 +1832,7 @@ describe("apiService sub2api exported operations", () => {
         expect.objectContaining({
           method: "GET",
           cache: "no-store",
+          signal: abortController.signal,
           headers: expect.objectContaining({
             Authorization: "Bearer runtime-api-key",
           }),

--- a/tests/services/cliSupportToolCallingRunner.test.ts
+++ b/tests/services/cliSupportToolCallingRunner.test.ts
@@ -96,4 +96,37 @@ describe("cliSupport tool-calling runner", () => {
       output: undefined,
     })
   })
+
+  it("passes abort signals through to the shared API verification probe", async () => {
+    mocks.runApiVerificationProbe.mockResolvedValueOnce({
+      id: "tool-calling",
+      status: "pass",
+      latencyMs: 4,
+      summary: "Supported",
+      input: {},
+      output: {},
+    })
+
+    const { runCliToolCallingSimulation } = await import(
+      "~/services/verification/cliSupportVerification/runners/toolCalling"
+    )
+    const abortController = new AbortController()
+
+    await runCliToolCallingSimulation({
+      toolId: "claude",
+      apiType: "anthropic",
+      baseUrl: "https://example.com",
+      apiKey: "sk-secret",
+      modelId: "claude-test",
+      endpointPath: "/v1/messages",
+      abortSignal: abortController.signal,
+    })
+
+    expect(mocks.runApiVerificationProbe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        probeId: "tool-calling",
+        abortSignal: abortController.signal,
+      }),
+    )
+  })
 })

--- a/tests/services/modelList/accountSources/tokenScopedFallback.test.ts
+++ b/tests/services/modelList/accountSources/tokenScopedFallback.test.ts
@@ -183,11 +183,13 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
       },
     })
 
-    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith({
-      apiType: "openai-compatible",
-      baseUrl: "https://example.com",
-      apiKey: "sk-real-secret",
-    })
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiType: "openai-compatible",
+        baseUrl: "https://example.com",
+        apiKey: "sk-real-secret",
+      }),
+    )
     expect(getSiteAdapterMock).toHaveBeenCalledWith("new-api")
     expect(result.data.map((item) => item.model_name)).toEqual([
       "gpt-4o-mini",
@@ -231,11 +233,13 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
       expect.objectContaining({ siteType: SITE_TYPES.NEW_API }),
       expect.objectContaining({ key: "sk-compatible-masked" }),
     )
-    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith({
-      apiType: "openai-compatible",
-      baseUrl: "https://example.com",
-      apiKey: "sk-selected-token-secret",
-    })
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiType: "openai-compatible",
+        baseUrl: "https://example.com",
+        apiKey: "sk-selected-token-secret",
+      }),
+    )
     expect(result.data.map((item) => item.model_name)).toEqual([
       "selected-token-model",
     ])
@@ -371,11 +375,13 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     })
 
     expect(resolveDisplayAccountTokenForSecretMock).toHaveBeenCalled()
-    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith({
-      apiType: "openai-compatible",
-      baseUrl: "https://compatible.example.invalid",
-      apiKey: "sk-real-secret",
-    })
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiType: "openai-compatible",
+        baseUrl: "https://compatible.example.invalid",
+        apiKey: "sk-real-secret",
+      }),
+    )
     expect(fetchSub2ApiRuntimeModelsMock).not.toHaveBeenCalled()
     expect(result.data.map((item) => item.model_name)).toEqual([
       "gpt-compatible",
@@ -417,25 +423,29 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
       }),
     )
     expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.SUB2API)
-    expect(fetchSub2ApiRuntimeModelsMock).toHaveBeenCalledWith({
-      baseUrl: "https://sub2api.example.invalid",
-      accountId: "account-1",
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        apiKey: "sk-real-sub2api-secret",
-      },
-    })
+    expect(fetchSub2ApiRuntimeModelsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://sub2api.example.invalid",
+        accountId: "account-1",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          apiKey: "sk-real-sub2api-secret",
+        },
+      }),
+    )
     expect(fetchOpenAICompatibleModelIdsMock).not.toHaveBeenCalled()
-    expect(fetchSub2ApiAvailableGroupsMock).toHaveBeenCalledWith({
-      baseUrl: "https://sub2api.example.invalid",
-      accountId: "account-1",
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        userId: "1",
-        accessToken: "account-token",
-        cookie: undefined,
-      },
-    })
+    expect(fetchSub2ApiAvailableGroupsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://sub2api.example.invalid",
+        accountId: "account-1",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "account-token",
+          cookie: undefined,
+        },
+      }),
+    )
     expect(result.model_list_source).toEqual({
       kind: MODEL_LIST_SOURCE_KINDS.SUB2API_RUNTIME_KEY,
       provider: SITE_TYPES.SUB2API,
@@ -453,6 +463,68 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
         },
       }),
     ])
+  })
+
+  it("passes abort signals through token-scoped catalog fallback requests", async () => {
+    const abortController = new AbortController()
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
+      ...TOKEN,
+      key: "sk-real-secret",
+      models: "",
+    })
+    fetchOpenAICompatibleModelIdsMock.mockResolvedValueOnce(["gpt-compatible"])
+
+    await loadAccountTokenFallbackPricingResponse({
+      account: ACCOUNT,
+      token: TOKEN,
+      abortSignal: abortController.signal,
+    })
+
+    expect(resolveDisplayAccountTokenForSecretMock).toHaveBeenLastCalledWith(
+      ACCOUNT,
+      TOKEN,
+      { abortSignal: abortController.signal },
+    )
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    )
+
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
+      ...TOKEN,
+      key: "sk-real-sub2api-secret",
+    })
+    fetchSub2ApiRuntimeModelsMock.mockResolvedValueOnce([
+      "example-runtime-model",
+    ])
+    fetchSub2ApiAvailableGroupsMock.mockResolvedValueOnce([])
+    fetchSub2ApiGroupRatesMock.mockResolvedValueOnce({})
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+
+    await loadAccountTokenFallbackPricingResponse({
+      account: {
+        ...ACCOUNT,
+        siteType: SITE_TYPES.SUB2API,
+        baseUrl: "https://sub2api.example.invalid",
+      },
+      token: TOKEN,
+      abortSignal: abortController.signal,
+    })
+
+    expect(resolveDisplayAccountTokenForSecretMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        siteType: SITE_TYPES.SUB2API,
+        baseUrl: "https://sub2api.example.invalid",
+      }),
+      TOKEN,
+      { abortSignal: abortController.signal },
+    )
+    expect(fetchSub2ApiRuntimeModelsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    )
+    expect(fetchSub2ApiAvailableGroupsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    )
+    expect(loadModelPriceTableMock).toHaveBeenCalledWith(abortController.signal)
   })
 
   it("adds estimated Sub2API prices when dashboard group and price-table data are available", async () => {

--- a/tests/services/modelList/accountSources/tokenScopedFallback.test.ts
+++ b/tests/services/modelList/accountSources/tokenScopedFallback.test.ts
@@ -740,6 +740,65 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     expect(message.length).toBeGreaterThan(0)
   })
 
+  it("passes abort signals through direct pricing fallback requests", async () => {
+    const abortController = new AbortController()
+    const fetchPricingMock = vi.fn().mockResolvedValue({
+      data: [],
+      group_ratio: {},
+      success: true,
+      usable_group: {},
+    })
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.AIHUBMIX,
+      modelPricing: {
+        fetchPricing: fetchPricingMock,
+      },
+    })
+
+    await loadAccountTokenFallbackPricingResponse({
+      account: {
+        ...ACCOUNT,
+        siteType: SITE_TYPES.AIHUBMIX,
+      },
+      token: {
+        ...TOKEN,
+        models: "",
+      },
+      abortSignal: abortController.signal,
+    })
+
+    expect(fetchPricingMock).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    )
+  })
+
+  it("preserves caller aborts from direct pricing fallback requests", async () => {
+    const abortController = new AbortController()
+    abortController.abort(new DOMException("Aborted", "AbortError"))
+    const abortError = new DOMException("Aborted", "AbortError")
+    const fetchPricingMock = vi.fn().mockRejectedValueOnce(abortError)
+    getSiteAdapterMock.mockReturnValueOnce({
+      siteType: SITE_TYPES.AIHUBMIX,
+      modelPricing: {
+        fetchPricing: fetchPricingMock,
+      },
+    })
+
+    await expect(
+      loadAccountTokenFallbackPricingResponse({
+        account: {
+          ...ACCOUNT,
+          siteType: SITE_TYPES.AIHUBMIX,
+        },
+        token: {
+          ...TOKEN,
+          models: "",
+        },
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toBe(abortError)
+  })
+
   it("preserves structured fallback load failure metadata for analytics", async () => {
     resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
       ...TOKEN,
@@ -803,5 +862,37 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
       message: "API Key 所属分组已删除",
       cause: groupDeletedError,
     })
+  })
+
+  it("preserves caller aborts during Sub2API dashboard price estimation", async () => {
+    const abortController = new AbortController()
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
+      ...TOKEN,
+      key: "sk-real-sub2api-secret",
+    })
+    fetchSub2ApiRuntimeModelsMock.mockResolvedValueOnce([
+      "example-runtime-model",
+    ])
+    const abortError = new DOMException("Aborted", "AbortError")
+    fetchSub2ApiAvailableGroupsMock.mockImplementationOnce(() => {
+      abortController.abort(abortError)
+      return Promise.reject(abortError)
+    })
+    loadModelPriceTableMock.mockRejectedValueOnce(abortError)
+
+    await expect(
+      loadAccountTokenFallbackPricingResponse({
+        account: {
+          ...ACCOUNT,
+          siteType: SITE_TYPES.SUB2API,
+          baseUrl: "https://sub2api.example.invalid",
+        },
+        token: {
+          ...TOKEN,
+          key: "sk-masked-sub2api",
+        },
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toBe(abortError)
   })
 })

--- a/tests/services/modelList/accountSources/tokenScopedFallback.test.ts
+++ b/tests/services/modelList/accountSources/tokenScopedFallback.test.ts
@@ -266,6 +266,31 @@ describe("loadAccountTokenFallbackPricingResponse", () => {
     expect(result.data.map((item) => item.model_name)).toEqual(["gpt-4o-mini"])
   })
 
+  it("preserves caller aborts from upstream model lookup even when declared models exist", async () => {
+    const abortController = new AbortController()
+    const abortError = new DOMException("Aborted", "AbortError")
+    resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
+      ...TOKEN,
+      key: "sk-real-secret",
+      models: "gpt-4o-mini",
+    })
+    fetchOpenAICompatibleModelIdsMock.mockImplementationOnce(() => {
+      abortController.abort(abortError)
+      return Promise.reject(abortError)
+    })
+
+    await expect(
+      loadAccountTokenFallbackPricingResponse({
+        account: ACCOUNT,
+        token: {
+          ...TOKEN,
+          models: "gpt-4o-mini",
+        },
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toBe(abortError)
+  })
+
   it("loads AIHubMix account-key fallback models without revealing masked keys", async () => {
     const aihubmixPricing: PricingResponse = {
       success: true,

--- a/tests/services/modelPricing/modelPriceTable.test.ts
+++ b/tests/services/modelPricing/modelPriceTable.test.ts
@@ -99,4 +99,31 @@ describe("loadModelPriceTable", () => {
     expect(abortSignal?.aborted).toBe(true)
     await loadingExpectation
   })
+
+  it("aborts LiteLLM price-table requests when the caller signal aborts", async () => {
+    const abortController = new AbortController()
+    let abortSignal: AbortSignal | undefined
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        abortSignal = init?.signal ?? undefined
+
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted", "AbortError"))
+          })
+        })
+      }),
+    )
+
+    const loading = loadModelPriceTable(abortController.signal)
+    const loadingExpectation = expect(loading).rejects.toThrow(
+      "Failed to load LiteLLM price table",
+    )
+
+    abortController.abort()
+
+    expect(abortSignal?.aborted).toBe(true)
+    await loadingExpectation
+  })
 })

--- a/tests/services/modelPricing/modelPriceTable.test.ts
+++ b/tests/services/modelPricing/modelPriceTable.test.ts
@@ -117,9 +117,9 @@ describe("loadModelPriceTable", () => {
     )
 
     const loading = loadModelPriceTable(abortController.signal)
-    const loadingExpectation = expect(loading).rejects.toThrow(
-      "Failed to load LiteLLM price table",
-    )
+    const loadingExpectation = expect(loading).rejects.toMatchObject({
+      name: "AbortError",
+    })
 
     abortController.abort()
 

--- a/tests/services/modelPricing/modelPriceTable.test.ts
+++ b/tests/services/modelPricing/modelPriceTable.test.ts
@@ -165,4 +165,41 @@ describe("loadModelPriceTable", () => {
       })
     }
   })
+
+  it("relays an already-aborted caller signal when AbortSignal.any is unavailable", async () => {
+    const originalAny = AbortSignal.any
+    const callerAbortController = new AbortController()
+    const abortError = new DOMException("Already stopped", "AbortError")
+    callerAbortController.abort(abortError)
+    let fetchSignal: AbortSignal | undefined
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        fetchSignal = init?.signal ?? undefined
+        return Promise.reject(
+          new DOMException("The operation was aborted", "AbortError"),
+        )
+      }),
+    )
+    Object.defineProperty(AbortSignal, "any", {
+      configurable: true,
+      value: undefined,
+    })
+
+    try {
+      await expect(
+        loadModelPriceTable(callerAbortController.signal),
+      ).rejects.toMatchObject({
+        name: "AbortError",
+      })
+
+      expect(fetchSignal?.aborted).toBe(true)
+      expect(fetchSignal?.reason).toBe(abortError)
+    } finally {
+      Object.defineProperty(AbortSignal, "any", {
+        configurable: true,
+        value: originalAny,
+      })
+    }
+  })
 })

--- a/tests/services/modelPricing/modelPriceTable.test.ts
+++ b/tests/services/modelPricing/modelPriceTable.test.ts
@@ -126,4 +126,43 @@ describe("loadModelPriceTable", () => {
     expect(abortSignal?.aborted).toBe(true)
     await loadingExpectation
   })
+
+  it("uses the timeout controller when AbortSignal.any is unavailable", async () => {
+    const originalAny = AbortSignal.any
+    const callerAbortController = new AbortController()
+    let fetchSignal: AbortSignal | undefined
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        fetchSignal = init?.signal ?? undefined
+
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted", "AbortError"))
+          })
+        })
+      }),
+    )
+    Object.defineProperty(AbortSignal, "any", {
+      configurable: true,
+      value: undefined,
+    })
+
+    try {
+      const loading = loadModelPriceTable(callerAbortController.signal)
+      const loadingExpectation = expect(loading).rejects.toMatchObject({
+        name: "AbortError",
+      })
+
+      callerAbortController.abort()
+
+      expect(fetchSignal?.aborted).toBe(true)
+      await loadingExpectation
+    } finally {
+      Object.defineProperty(AbortSignal, "any", {
+        configurable: true,
+        value: originalAny,
+      })
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Add abort propagation for API verification, CLI support verification, batch model verification, and model-list catalog loading.
- Pass abort signals through model catalog, price table, Sub2API runtime, and token secret resolution requests.
- Preserve stopped-state UX/analytics and add focused cancellation coverage for pre-probe and in-flight request phases.

## Test Plan
- pnpm vitest run tests/services/accounts/apiServiceRequest.test.ts tests/components/VerifyApiDialog.test.tsx tests/components/VerifyCliSupportDialog.test.tsx tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx tests/services/modelList/accountSources/tokenScopedFallback.test.ts
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stop/cancel controls to AI API and CLI verification dialogs, including per-probe/tool stopping.
  * Verification now displays a localized **Stopped** outcome when interrupted.
* **Bug Fixes**
  * Improved cancellation handling across verification, token/model fetching, and pricing flows to stop work cleanly and avoid incorrect failure/analytics states.
* **Accessibility / UI**
  * Toast close/dismiss and many interactive controls now use native HTML elements for more consistent accessibility.
  * Refined selection (indeterminate) and pressed-state feedback; updated localized close labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->