### PR TITLE
fix(accounts): use group-aware default token names

### DIFF
--- a/src/components/KiloCodeExportDialog.tsx
+++ b/src/components/KiloCodeExportDialog.tsx
@@ -19,8 +19,8 @@ import {
   type CompactMultiSelectOption,
 } from "~/components/ui"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
+import { buildDefaultTokenCreatePrefill } from "~/features/KeyManagement/components/AddTokenDialog/defaultTokenCreatePrefill"
 import { useAccountData } from "~/hooks/useAccountData"
-import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
   ensureAccountApiToken,
   resolveDefaultTokenQuickCreateResolution,
@@ -815,15 +815,9 @@ export function KiloCodeExportDialog({
   const defaultTokenQuickCreateSite = defaultTokenCreateContext
     ? displayById.get(defaultTokenCreateContext.siteId)
     : undefined
-  const defaultTokenQuickCreatePrefill =
-    defaultTokenCreateContext &&
-    defaultTokenCreateContext.allowedGroups.length > 0
-      ? {
-          modelId: "",
-          defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-          allowedGroups: defaultTokenCreateContext.allowedGroups,
-        }
-      : undefined
+  const defaultTokenQuickCreatePrefill = buildDefaultTokenCreatePrefill(
+    defaultTokenCreateContext?.allowedGroups,
+  )
 
   const renderSiteCard = (site: DisplaySiteData) => {
     const siteId = site.id

--- a/src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
+++ b/src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
@@ -1,9 +1,6 @@
 import { useChannelDialogContext } from "~/components/dialogs/ChannelDialog/context/ChannelDialogContext"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
-import {
-  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-  resolvePreferredDefaultUserGroup,
-} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import { buildDefaultTokenCreatePrefill } from "~/features/KeyManagement/components/AddTokenDialog/defaultTokenCreatePrefill"
 
 import { ChannelDialog } from "./ChannelDialog"
 
@@ -20,18 +17,11 @@ export function ChannelDialogContainer() {
     handleDefaultTokenQuickCreateSuccess,
   } = useChannelDialogContext()
 
-  const defaultTokenQuickCreatePrefill =
-    defaultTokenQuickCreateDialog.account &&
-    defaultTokenQuickCreateDialog.allowedGroups.length > 0
-      ? {
-          modelId: "",
-          defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-          group: resolvePreferredDefaultUserGroup(
-            defaultTokenQuickCreateDialog.allowedGroups,
-          ),
-          allowedGroups: defaultTokenQuickCreateDialog.allowedGroups,
-        }
-      : undefined
+  const defaultTokenQuickCreatePrefill = defaultTokenQuickCreateDialog.account
+    ? buildDefaultTokenCreatePrefill(
+        defaultTokenQuickCreateDialog.allowedGroups,
+      )
+    : undefined
 
   return (
     <>

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -14,12 +14,9 @@ import type { AddAccountPrefill } from "~/features/AccountManagement/sponsors/ty
 import { useSponsorRecommendations } from "~/features/AccountManagement/sponsors/useSponsorRecommendations"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
+import { buildDefaultTokenCreatePrefill } from "~/features/KeyManagement/components/AddTokenDialog/defaultTokenCreatePrefill"
 import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
 import { buildOneTimeApiKeyProfileSaveAction } from "~/features/KeyManagement/utils/apiCredentialProfileSaveAction"
-import {
-  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-  resolvePreferredDefaultUserGroup,
-} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import type { DisplaySiteData } from "~/types"
 import { createLogger } from "~/utils/core/logger"
 import {
@@ -171,18 +168,9 @@ export default function AccountDialog({
           ...addModeSiteInfoProps,
         }
 
-  const postSaveSub2ApiCreatePrefill =
-    state.postSaveSub2ApiAllowedGroups &&
-    state.postSaveSub2ApiAllowedGroups.length > 0
-      ? {
-          modelId: "",
-          defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-          group: resolvePreferredDefaultUserGroup(
-            state.postSaveSub2ApiAllowedGroups,
-          ),
-          allowedGroups: state.postSaveSub2ApiAllowedGroups,
-        }
-      : undefined
+  const postSaveSub2ApiCreatePrefill = buildDefaultTokenCreatePrefill(
+    state.postSaveSub2ApiAllowedGroups,
+  )
   const postSaveSub2ApiDialogSessionId =
     typeof state.postSaveSub2ApiDialogSessionId === "number"
       ? state.postSaveSub2ApiDialogSessionId

--- a/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
@@ -5,9 +5,9 @@ import { CCSwitchExportDialog } from "~/components/CCSwitchExportDialog"
 import { Modal } from "~/components/ui"
 import { useCopyKeyDialog } from "~/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
+import { buildDefaultTokenCreatePrefill } from "~/features/KeyManagement/components/AddTokenDialog/defaultTokenCreatePrefill"
 import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
 import { buildOneTimeApiKeyProfileSaveAction } from "~/features/KeyManagement/utils/apiCredentialProfileSaveAction"
-import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import type { ApiToken, DisplaySiteData } from "~/types"
 import { createLogger } from "~/utils/core/logger"
 
@@ -114,15 +114,9 @@ export default function CopyKeyDialog({
     setIsAddTokenDialogOpen(true)
   }, [account, defaultTokenCreateAllowedGroups, isOpen])
 
-  const defaultTokenQuickCreatePrefill =
-    defaultTokenCreateAllowedGroups &&
-    defaultTokenCreateAllowedGroups.length > 0
-      ? {
-          modelId: "",
-          defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-          allowedGroups: defaultTokenCreateAllowedGroups,
-        }
-      : undefined
+  const defaultTokenQuickCreatePrefill = buildDefaultTokenCreatePrefill(
+    defaultTokenCreateAllowedGroups,
+  )
 
   const handleOpenCCSwitchDialog = (
     token: ApiToken,

--- a/src/features/KeyManagement/components/AddTokenDialog/defaultTokenCreatePrefill.ts
+++ b/src/features/KeyManagement/components/AddTokenDialog/defaultTokenCreatePrefill.ts
@@ -1,0 +1,30 @@
+import {
+  buildGroupDefaultTokenRequest,
+  resolvePreferredDefaultUserGroup,
+} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+
+export interface DefaultTokenCreatePrefill {
+  modelId: string
+  defaultName: string
+  group: string
+  allowedGroups: string[]
+}
+
+/**
+ * Builds the AddTokenDialog prefill for constrained default-token creation.
+ */
+export function buildDefaultTokenCreatePrefill(
+  allowedGroups: readonly string[] | null | undefined,
+): DefaultTokenCreatePrefill | undefined {
+  if (!allowedGroups || allowedGroups.length === 0) return undefined
+
+  const group = resolvePreferredDefaultUserGroup(allowedGroups)
+  const tokenRequest = buildGroupDefaultTokenRequest(group)
+
+  return {
+    modelId: "",
+    defaultName: tokenRequest.name,
+    group: tokenRequest.group,
+    allowedGroups: [...allowedGroups],
+  }
+}

--- a/src/features/KeyManagement/components/AddTokenDialog/index.tsx
+++ b/src/features/KeyManagement/components/AddTokenDialog/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next"
 import { Alert } from "~/components/ui"
 import { Modal } from "~/components/ui/Dialog/Modal"
 import { UI_CONSTANTS } from "~/constants/ui"
+import { normalizeDefaultTokenRequestName } from "~/services/accounts/defaultTokenLifecycle"
 import {
   createDisplayAccountApiContext,
   requireDisplayAccountKeyManagement,
@@ -165,7 +166,7 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
     )
     setIsSubmitting(true)
     try {
-      const tokenData: CreateTokenRequest = {
+      const rawTokenData: CreateTokenRequest = {
         name: formData.name.trim(),
         remain_quota: formData.unlimitedQuota
           ? -1
@@ -182,6 +183,9 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
         allow_ips: formData.allowIps.trim() || "",
         group: formData.group,
       }
+      const tokenData = isEditMode
+        ? rawTokenData
+        : normalizeDefaultTokenRequestName(rawTokenData)
       const { keyManagement, request } =
         createDisplayAccountApiContext(currentAccount)
 

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -3,7 +3,7 @@ import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { shouldShowOneTimeKeyDialogForCreatedToken } from "~/features/KeyManagement/utils"
-import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import { buildGroupDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
   canManageDisplayAccountTokens,
   createDisplayAccountApiContext,
@@ -334,8 +334,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
       try {
         const { keyManagement, request } =
           createDisplayAccountApiContext(account)
-        const tokenRequest = generateDefaultTokenRequest()
-        tokenRequest.group = normalizedGroup
+        const tokenRequest = buildGroupDefaultTokenRequest(normalizedGroup)
         const created = await requireDisplayAccountKeyManagement(
           account,
           keyManagement,

--- a/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
@@ -15,6 +15,7 @@ import { t } from "~/utils/i18n/core"
 export {
   DEFAULT_AUTO_PROVISION_TOKEN_NAME,
   DEFAULT_USER_GROUP_NAME,
+  buildGroupDefaultTokenRequest,
   generateDefaultTokenRequest,
   resolvePreferredDefaultUserGroup,
 } from "~/services/accounts/defaultTokenLifecycle"

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -15,7 +15,6 @@ import {
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
-import type { CreateTokenRequest } from "~/services/apiService/common/type"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { DisplaySiteData, SiteAccount } from "~/types"
 import {
@@ -26,8 +25,7 @@ import {
 import { t } from "~/utils/i18n/core"
 
 import {
-  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-  DEFAULT_USER_GROUP_NAME,
+  buildGroupDefaultTokenRequest,
   generateDefaultTokenRequest,
 } from "./ensureDefaultToken"
 
@@ -42,22 +40,6 @@ interface AccountKeyCoverageResult {
 
 const normalizeGroupName = (value: unknown) =>
   typeof value === "string" ? value.trim() : ""
-
-/**
- * Builds the default auto-provision token payload for one user group.
- */
-export function buildGroupDefaultTokenRequest(
-  group: string,
-): CreateTokenRequest {
-  return {
-    ...generateDefaultTokenRequest(),
-    name:
-      group && group !== DEFAULT_USER_GROUP_NAME
-        ? `${group} group (auto)`
-        : DEFAULT_AUTO_PROVISION_TOKEN_NAME,
-    group,
-  }
-}
 
 /**
  * Builds the normalized API-service request for account key audit calls.

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -31,6 +31,7 @@ import {
   DefaultTokenLifecyclePolicyBlockedError,
   ensureDefaultTokenLifecycle,
   generateDefaultTokenRequest,
+  normalizeDefaultTokenRequestName,
   resolveDefaultTokenLifecycleDecision,
 } from "~/services/accounts/defaultTokenLifecycle"
 import {
@@ -513,7 +514,7 @@ export async function resolveDefaultTokenQuickCreateResolution(
   if (decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create) {
     return {
       kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
-      tokenData: decision.tokenData,
+      tokenData: normalizeDefaultTokenRequestName(decision.tokenData),
     }
   }
 

--- a/src/services/accounts/defaultTokenLifecycle/lifecycle.ts
+++ b/src/services/accounts/defaultTokenLifecycle/lifecycle.ts
@@ -29,6 +29,7 @@ import {
 import {
   createStoredAccountTokenRequest,
   generateDefaultTokenRequest,
+  normalizeDefaultTokenRequestName,
 } from "./requests"
 
 const isApiTokenWithValidId = (value: unknown): value is ApiToken =>
@@ -254,13 +255,11 @@ export async function createDefaultTokenFromDecision(params: {
     decision,
     existingTokenIds,
   } = params
+  const tokenData = normalizeDefaultTokenRequestName(decision.tokenData)
 
   let createResult: Awaited<ReturnType<KeyManagementCapability["createToken"]>>
   try {
-    createResult = await keyManagement.createToken(
-      createRequest,
-      decision.tokenData,
-    )
+    createResult = await keyManagement.createToken(createRequest, tokenData)
   } catch (error) {
     return blockCreatedToken({
       reason: DEFAULT_TOKEN_LIFECYCLE_BLOCK_REASONS.CreateTokenFailed,

--- a/src/services/accounts/defaultTokenLifecycle/requests.ts
+++ b/src/services/accounts/defaultTokenLifecycle/requests.ts
@@ -39,6 +39,43 @@ export function generateDefaultTokenRequest(): CreateTokenRequest {
 }
 
 /**
+ * Builds the default auto-provision token payload for one user group.
+ */
+export function buildGroupDefaultTokenRequest(
+  group: string,
+): CreateTokenRequest {
+  const normalizedGroup = group.trim()
+
+  return {
+    ...generateDefaultTokenRequest(),
+    name:
+      normalizedGroup && normalizedGroup !== DEFAULT_USER_GROUP_NAME
+        ? `${normalizedGroup} group (auto)`
+        : DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+    group: normalizedGroup,
+  }
+}
+
+/**
+ * Applies the group-aware default name only to auto-generated default-token names.
+ */
+export function normalizeDefaultTokenRequestName(
+  tokenData: CreateTokenRequest,
+): CreateTokenRequest {
+  const normalizedGroup = tokenData.group.trim()
+  const groupDefaultTokenData = buildGroupDefaultTokenRequest(normalizedGroup)
+
+  return {
+    ...tokenData,
+    name:
+      tokenData.name === DEFAULT_AUTO_PROVISION_TOKEN_NAME
+        ? groupDefaultTokenData.name
+        : tokenData.name,
+    group: normalizedGroup,
+  }
+}
+
+/**
  * Creates an adapter request DTO from a stored account record.
  */
 export function createStoredAccountTokenRequest(

--- a/tests/components/KiloCodeExportDialog.test.tsx
+++ b/tests/components/KiloCodeExportDialog.test.tsx
@@ -890,9 +890,9 @@ describe("KiloCodeExportDialog", () => {
     expect(latestDialogProps?.createPrefill).toMatchObject({
       modelId: "",
       defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+      group: "default",
       allowedGroups: ["default", "vip"],
     })
-    expect(latestDialogProps?.createPrefill).not.toHaveProperty("group")
 
     await user.click(
       await screen.findByRole("button", { name: "mock-add-token-close" }),

--- a/tests/components/dialogs/ChannelDialog/ChannelDialogContainer.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/ChannelDialogContainer.test.tsx
@@ -6,7 +6,6 @@ import {
   ChannelDialogProvider,
   useChannelDialogContext,
 } from "~/components/dialogs/ChannelDialog"
-import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
@@ -89,7 +88,7 @@ describe("ChannelDialogContainer", () => {
           isOpen: true,
           createPrefill: {
             modelId: "",
-            defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+            defaultName: "vip group (auto)",
             group: "vip",
             allowedGroups: ["vip"],
           },

--- a/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
@@ -5,6 +5,7 @@ import { Z_INDEX } from "~/components/ui"
 import { SITE_TYPES } from "~/constants/siteType"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
+import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/defaultTokenLifecycle"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
@@ -1328,6 +1329,58 @@ describe("AddTokenDialog prefill", () => {
 
     expect(createApiTokenMock.mock.calls[0]?.[1]).toMatchObject({
       group: "level3",
+    })
+  })
+
+  it("normalizes the default auto token name when create prefill changes to a non-default group", async () => {
+    fetchAccountAvailableModelsMock.mockResolvedValueOnce(["gpt-4"])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { desc: "default", ratio: 1 },
+      vip: { desc: "VIP", ratio: 2 },
+    })
+    createApiTokenMock.mockResolvedValueOnce(true)
+
+    const user = userEvent.setup()
+
+    render(
+      <AddTokenDialog
+        isOpen={true}
+        onClose={() => {}}
+        availableAccounts={[ACCOUNT]}
+        preSelectedAccountId={ACCOUNT.id}
+        createPrefill={{
+          modelId: "gpt-4",
+          defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+          group: "default",
+          allowedGroups: ["default", "vip"],
+        }}
+      />,
+    )
+
+    await screen.findByLabelText(/keyManagement:dialog\.tokenName/)
+
+    const groupField = screen
+      .getByText("keyManagement:dialog.groupLabel")
+      .closest("div")
+    expect(groupField).toBeTruthy()
+
+    const groupTrigger = within(groupField as HTMLElement).getByRole("combobox")
+    await user.click(groupTrigger)
+    await user.click(
+      await screen.findByText("vip - VIP (keyManagement:dialog.groupRate 2)"),
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
+    )
+
+    await waitFor(() => {
+      expect(createApiTokenMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(createApiTokenMock.mock.calls[0]?.[1]).toMatchObject({
+      name: "vip group (auto)",
+      group: "vip",
     })
   })
 

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
@@ -65,7 +65,7 @@ describe("ModelKeyDialog sub2api support", () => {
   it("allows creating a compatible key for sub2api accounts", async () => {
     fetchAccountTokensMock
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([TOKEN])
+      .mockResolvedValueOnce([buildSub2ApiToken({ group: "vip" })])
     adapterCreateTokenMock.mockResolvedValueOnce(true)
 
     const user = userEvent.setup()
@@ -76,7 +76,7 @@ describe("ModelKeyDialog sub2api support", () => {
         onClose={() => {}}
         account={ACCOUNT}
         modelId="gpt-4"
-        modelEnableGroups={["default"]}
+        modelEnableGroups={["vip"]}
       />,
     )
 
@@ -89,7 +89,8 @@ describe("ModelKeyDialog sub2api support", () => {
     await waitFor(() => {
       expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
       expect(adapterCreateTokenMock.mock.calls[0]?.[1]).toMatchObject({
-        group: "default",
+        name: "vip group (auto)",
+        group: "vip",
         model_limits_enabled: false,
         model_limits: "",
       })

--- a/tests/features/AccountManagement/components/AccountDialog.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialog.test.tsx
@@ -877,7 +877,7 @@ describe("AccountDialog", () => {
     ).toHaveTextContent(
       JSON.stringify({
         modelId: "",
-        defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        defaultName: "vip group (auto)",
         group: "vip",
         allowedGroups: ["vip", "paid"],
       }),

--- a/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx
@@ -186,7 +186,10 @@ describe("CopyKeyDialog sub2api support", () => {
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
       expect(createApiTokenMock).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ group: "vip" }),
+        expect.objectContaining({
+          name: "vip group (auto)",
+          group: "vip",
+        }),
       )
     })
   })
@@ -303,19 +306,11 @@ describe("CopyKeyDialog sub2api support", () => {
       name: "keyManagement:dialog.createToken",
     })
 
-    const groupTrigger = screen
-      .getAllByRole("combobox")
-      .find((element) =>
-        element.textContent?.includes("keyManagement:dialog.groupLabel"),
-      )
-    expect(groupTrigger).toBeTruthy()
-
-    await user.click(groupTrigger as HTMLElement)
-    await user.click(
-      await screen.findByText(
-        "default - Default (keyManagement:dialog.groupRate 1)",
-      ),
-    )
+    expect(
+      screen.getByRole("textbox", {
+        name: "keyManagement:dialog.tokenName *",
+      }),
+    ).toHaveValue("user group (auto)")
 
     await user.click(
       await screen.findByRole("button", {

--- a/tests/features/KeyManagement/components/defaultTokenCreatePrefill.test.ts
+++ b/tests/features/KeyManagement/components/defaultTokenCreatePrefill.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { buildDefaultTokenCreatePrefill } from "~/features/KeyManagement/components/AddTokenDialog/defaultTokenCreatePrefill"
+import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+
+describe("buildDefaultTokenCreatePrefill", () => {
+  it("keeps the default token name when the default group is available", () => {
+    expect(buildDefaultTokenCreatePrefill(["vip", "default"])).toEqual({
+      modelId: "",
+      defaultName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+      group: "default",
+      allowedGroups: ["vip", "default"],
+    })
+  })
+
+  it("uses the selected non-default group in the token name", () => {
+    expect(buildDefaultTokenCreatePrefill(["vip", "paid"])).toEqual({
+      modelId: "",
+      defaultName: "vip group (auto)",
+      group: "vip",
+      allowedGroups: ["vip", "paid"],
+    })
+  })
+
+  it("returns undefined without selectable groups", () => {
+    expect(buildDefaultTokenCreatePrefill([])).toBeUndefined()
+    expect(buildDefaultTokenCreatePrefill(undefined)).toBeUndefined()
+  })
+})

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  buildGroupDefaultTokenRequest,
   DEFAULT_AUTO_PROVISION_TOKEN_NAME,
   generateDefaultTokenRequest,
 } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
-  buildGroupDefaultTokenRequest,
   deleteInvalidAccountToken,
   ensureAccountKeysForAvailableGroups,
 } from "~/services/accounts/accountKeyAutoProvisioning/groupCoverage"

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  buildGroupDefaultTokenRequest,
   DEFAULT_AUTO_PROVISION_TOKEN_NAME,
   ensureDefaultApiTokenForAccount,
   generateDefaultTokenRequest,
@@ -500,6 +501,36 @@ describe("accountOperations Sub2API token creation guards", () => {
     })
   })
 
+  it("normalizes ready default quick-create token names for non-default groups", async () => {
+    const { resolveDefaultTokenQuickCreateResolution } = await import(
+      "~/services/accounts/accountOperations"
+    )
+
+    resolveDefaultTokenCreationMock
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+        tokenData: { ...generateDefaultTokenRequest(), group: "vip" },
+        oneTimeSecret: false,
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+      })
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      vip: { desc: "VIP", ratio: 2 },
+    })
+
+    await expect(
+      resolveDefaultTokenQuickCreateResolution(DISPLAY_ACCOUNT),
+    ).resolves.toMatchObject({
+      kind: TOKEN_QUICK_CREATE_RESOLUTION_KINDS.Ready,
+      tokenData: {
+        name: "vip group (auto)",
+        group: "vip",
+      },
+    })
+  })
+
   it("rejects quick-create resolution when Sub2API group inventory is missing", async () => {
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
       kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
@@ -657,6 +688,19 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
       model_limits_enabled: false,
       model_limits: "",
       group: "",
+    })
+  })
+
+  it("builds group-aware default token payload names", () => {
+    expect(buildGroupDefaultTokenRequest("default")).toEqual({
+      ...generateDefaultTokenRequest(),
+      name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+      group: "default",
+    })
+    expect(buildGroupDefaultTokenRequest("vip")).toEqual({
+      ...generateDefaultTokenRequest(),
+      name: "vip group (auto)",
+      group: "vip",
     })
   })
 

--- a/tests/services/accounts/defaultTokenLifecycle.test.ts
+++ b/tests/services/accounts/defaultTokenLifecycle.test.ts
@@ -362,6 +362,42 @@ describe("defaultTokenLifecycle decision and create helpers", () => {
     expect(keyManagement.fetchTokens).not.toHaveBeenCalled()
   })
 
+  it("names auto-provisioned tokens after the selected non-default group before creation", async () => {
+    const createdToken = buildToken({ id: 22, key: "sk-created" })
+    const keyManagement = {
+      createToken: vi.fn().mockResolvedValueOnce(createdToken),
+      fetchTokens: vi.fn(),
+    } as unknown as KeyManagementCapability
+    const tokenProvisioning = {
+      classifyCreatedToken: vi.fn(() => ({
+        kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+        token: createdToken,
+        oneTimeSecret: false,
+      })),
+    } as unknown as TokenProvisioningCapability
+
+    await createDefaultTokenFromDecision({
+      workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+      keyManagement,
+      tokenProvisioning,
+      createRequest: buildRequest(),
+      inventoryRequest: buildRequest(),
+      decision: createDecision({
+        ...generateDefaultTokenRequest(),
+        group: "vip",
+      }),
+      existingTokenIds: [],
+    })
+
+    expect(keyManagement.createToken).toHaveBeenCalledWith(
+      buildRequest(),
+      expect.objectContaining({
+        name: "vip group (auto)",
+        group: "vip",
+      }),
+    )
+  })
+
   it("refetches inventory and selects one new token when policy asks for inventory recovery", async () => {
     const createdToken = buildToken({ id: 22, key: "sk-created" })
     const keyManagement = {


### PR DESCRIPTION
## Summary
- centralize group-aware default token names for auto-created account keys
- normalize quick-create Ready payloads and AddTokenDialog create submissions so non-default groups use matching names
- cover CopyKeyDialog, AddTokenDialog, ModelKeyDialog, account repair/group coverage, and lifecycle paths with focused regressions

## Validation
- pnpm vitest run tests/services/accountOperations.ensureAccountApiToken.test.ts tests/features/AccountManagement/components/CopyKeyDialog.sub2api.test.tsx tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
- pnpm vitest run tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/components/dialogs/ChannelDialog/ChannelDialogContainer.test.tsx tests/components/KiloCodeExportDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick-create token flows now prefill the selected group and use group-aware token names, including non-default groups.
  * Default token creation now consistently carries the chosen group through the dialog and account workflows.

* **Bug Fixes**
  * Improved token name handling so created tokens are normalized correctly when the selected group changes.
  * Made token creation behave more consistently across account, channel, key copy, and model key dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->