### PR TITLE
feat(api-credentials): add expiration metadata

### DIFF
--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -68,6 +68,7 @@ type SaveProfileInput = {
   apiKey: string
   tagIds: string[]
   notes: string
+  expiresAt?: number | null
   telemetryConfig?: ApiCredentialTelemetryConfig
 }
 
@@ -110,6 +111,46 @@ function normalizeTelemetryMode(
 }
 
 /**
+ * Converts a timestamp into the value shape expected by an HTML date input.
+ */
+function formatDateInputValue(timestamp: number | undefined): string {
+  if (!timestamp || timestamp <= 0) return ""
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return ""
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * Converts a date input value into a local day-level timestamp.
+ */
+function parseDateInputValue(value: string): number | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const [yearRaw, monthRaw, dayRaw] = trimmed.split("-")
+  const year = Number(yearRaw)
+  const month = Number(monthRaw)
+  const day = Number(dayRaw)
+  if (!year || !month || !day) return null
+
+  const date = new Date(year, month - 1, day)
+  if (
+    Number.isNaN(date.getTime()) ||
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null
+  }
+
+  return date.getTime()
+}
+
+/**
  * Add/edit modal for API credential profiles.
  */
 export function ApiCredentialProfileDialog({
@@ -140,6 +181,7 @@ export function ApiCredentialProfileDialog({
   const [apiKey, setApiKey] = useState("")
   const [tagIds, setTagIds] = useState<string[]>([])
   const [notes, setNotes] = useState("")
+  const [expiresAtInput, setExpiresAtInput] = useState("")
   const [telemetryMode, setTelemetryMode] =
     useState<ApiCredentialTelemetryCapabilityMode>(
       DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode,
@@ -162,6 +204,7 @@ export function ApiCredentialProfileDialog({
   const baseUrlInputId = "api-credential-profile-baseUrl"
   const apiKeyInputId = "api-credential-profile-apiKey"
   const notesInputId = "api-credential-profile-notes"
+  const expiresAtInputId = "api-credential-profile-expiresAt"
   const telemetryModeInputId = "api-credential-profile-telemetry-mode"
   const customEndpointInputId =
     "api-credential-profile-telemetry-custom-endpoint"
@@ -178,6 +221,7 @@ export function ApiCredentialProfileDialog({
       setApiKey(profile.apiKey ?? "")
       setTagIds(profile.tagIds ?? [])
       setNotes(profile.notes ?? "")
+      setExpiresAtInput(formatDateInputValue(profile.expiresAt))
       setTelemetryMode(normalizeTelemetryMode(profile.telemetryConfig?.mode))
       setCustomEndpoint(profile.telemetryConfig?.customEndpoint?.endpoint ?? "")
       setCustomJsonPaths(
@@ -192,6 +236,7 @@ export function ApiCredentialProfileDialog({
     setApiKey("")
     setTagIds([])
     setNotes("")
+    setExpiresAtInput("")
     setTelemetryMode(DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode)
     setCustomEndpoint("")
     setCustomJsonPaths({})
@@ -373,6 +418,7 @@ export function ApiCredentialProfileDialog({
         apiKey: apiKey.trim(),
         tagIds,
         notes: notes.trim(),
+        expiresAt: parseDateInputValue(expiresAtInput),
         telemetryConfig: buildTelemetryConfig(),
       })
 
@@ -583,6 +629,20 @@ export function ApiCredentialProfileDialog({
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               placeholder={t("apiCredentialProfiles:dialog.placeholders.notes")}
+              disabled={isSaving}
+            />
+          </FormField>
+
+          <FormField
+            label={t("apiCredentialProfiles:dialog.fields.expiresAt")}
+            description={t("apiCredentialProfiles:dialog.hints.expiresAt")}
+            htmlFor={expiresAtInputId}
+          >
+            <Input
+              id={expiresAtInputId}
+              type="date"
+              value={expiresAtInput}
+              onChange={(e) => setExpiresAtInput(e.target.value)}
               disabled={isSaving}
             />
           </FormField>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -150,6 +150,32 @@ function getHealthStatusLabel(
   return t("account:healthStatus.unknown")
 }
 
+/**
+ * Formats the optional profile expiration as a calendar date.
+ */
+function formatProfileExpiration(
+  timestamp: number | undefined,
+  fallback: string,
+): string {
+  if (!timestamp || timestamp <= 0) return fallback
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return fallback
+
+  try {
+    return date.toLocaleDateString()
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * Converts a timestamp to the start of its local calendar day for expiry checks.
+ */
+function getStartOfLocalDay(timestamp: number): number {
+  const date = new Date(timestamp)
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+}
+
 const optionsEntrypoint = PRODUCT_ANALYTICS_ENTRYPOINTS.Options
 const rowActionsSurface =
   PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesRowActions
@@ -200,6 +226,26 @@ export function ApiCredentialProfileListItem({
   ]
     .filter(Boolean)
     .join(": ")
+  const notAvailableLabel = t("common:labels.notAvailable")
+  const expiresAt = profile.expiresAt
+  const expirationDate = formatProfileExpiration(expiresAt, notAvailableLabel)
+  const hasExpiration =
+    expiresAt !== undefined &&
+    expiresAt > 0 &&
+    expirationDate !== notAvailableLabel
+  const isExpired =
+    expiresAt !== undefined &&
+    hasExpiration &&
+    getStartOfLocalDay(expiresAt) < getStartOfLocalDay(Date.now())
+  const expirationStatusLabel = hasExpiration
+    ? isExpired
+      ? t("apiCredentialProfiles:list.expirationStatus.expired", {
+          date: expirationDate,
+        })
+      : t("apiCredentialProfiles:list.expirationStatus.active", {
+          date: expirationDate,
+        })
+    : t("apiCredentialProfiles:list.expirationStatus.none")
 
   return (
     <ProductAnalyticsScope
@@ -221,6 +267,13 @@ export function ApiCredentialProfileListItem({
                   className="max-w-full truncate"
                 >
                   {getApiVerificationApiTypeLabel(t, profile.apiType)}
+                </Badge>
+                <Badge
+                  variant={isExpired ? "danger" : "outline"}
+                  size="sm"
+                  className="max-w-full truncate"
+                >
+                  {expirationStatusLabel}
                 </Badge>
                 {tagNames.map((tag) => (
                   <Badge
@@ -316,6 +369,17 @@ export function ApiCredentialProfileListItem({
                     summary={verificationSummary}
                     className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:gap-2"
                   />
+                </div>
+
+                <div className="dark:text-dark-text-tertiary flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-500">
+                  <span>
+                    {t("apiCredentialProfiles:list.createdAt")}:{" "}
+                    {formatLocaleDateTime(profile.createdAt, notAvailableLabel)}
+                  </span>
+                  <span>
+                    {t("apiCredentialProfiles:list.updatedAt")}:{" "}
+                    {formatLocaleDateTime(profile.updatedAt, notAvailableLabel)}
+                  </span>
                 </div>
 
                 <div className="dark:bg-dark-bg-tertiary/60 flex flex-1 flex-col rounded-lg border border-gray-100 bg-gray-50 p-2 sm:p-3 dark:border-gray-800">

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles.ts
@@ -23,6 +23,7 @@ type CreateProfileInput = {
   apiKey: string
   tagIds?: string[]
   notes?: string
+  expiresAt?: number | null
   telemetryConfig?: ApiCredentialTelemetryConfig
 }
 

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
@@ -67,6 +67,7 @@ type SaveApiCredentialProfileInput = {
   apiKey: string
   tagIds: string[]
   notes: string
+  expiresAt?: number | null
   telemetryConfig?: ApiCredentialTelemetryConfig
 }
 
@@ -413,6 +414,7 @@ export function useApiCredentialProfilesController() {
             apiKey: input.apiKey,
             tagIds: input.tagIds,
             notes: input.notes,
+            expiresAt: input.expiresAt,
             telemetryConfig: input.telemetryConfig,
           })
         } else {
@@ -423,6 +425,7 @@ export function useApiCredentialProfilesController() {
             apiKey: input.apiKey,
             tagIds: input.tagIds,
             notes: input.notes,
+            expiresAt: input.expiresAt,
             telemetryConfig: input.telemetryConfig,
           })
         }

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -40,6 +40,7 @@
     "fields": {
       "apiKey": "API key",
       "baseUrl": "Base URL",
+      "expiresAt": "Expiration date",
       "name": "Name",
       "notes": "Notes",
       "tags": "Tags",
@@ -49,6 +50,7 @@
     "hints": {
       "apiKeyCreateUrl": "Create an API key in the provider console first, then return here to paste and save it.",
       "baseUrlNormalized": "Will be saved as: {{baseUrl}}",
+      "expiresAt": "Optional. Record when this key is expected to stop working.",
       "tags": "Optional. Shared with accounts and bookmarks.",
       "telemetryEndpoint": "Only read-only GET paths under the profile base URL origin are allowed. Use a path such as /usage or a same-origin URL.",
       "telemetryJsonPaths": "Enter dot-separated paths in the response JSON. At least one path is required. Empty metrics remain not provided.",
@@ -101,7 +103,14 @@
   },
   "list": {
     "apiKey": "API key",
-    "baseUrl": "Base URL"
+    "baseUrl": "Base URL",
+    "createdAt": "Added",
+    "expirationStatus": {
+      "active": "Expires {{date}}",
+      "expired": "Expired {{date}}",
+      "none": "No expiration"
+    },
+    "updatedAt": "Updated"
   },
   "messages": {
     "apiKeyCopied": "API key copied",

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -40,6 +40,7 @@
     "fields": {
       "apiKey": "API キー",
       "baseUrl": "Base URL",
+      "expiresAt": "有効期限日",
       "name": "名前",
       "notes": "メモ",
       "tags": "タグ",
@@ -49,6 +50,7 @@
     "hints": {
       "apiKeyCreateUrl": "先にプロバイダーのコンソールで API Key を作成し、ここに戻って貼り付けて保存してください。",
       "baseUrlNormalized": "保存時の値: {{baseUrl}}",
+      "expiresAt": "任意。このキーが使えなくなる見込みの日付を記録します。",
       "tags": "任意です。アカウントやブックマークと共有されます。",
       "telemetryEndpoint": "プロファイルの Base URL と同一オリジンの読み取り専用 GET パスのみ許可されます。/usage のようなパス、または同一オリジン URL を使用してください。",
       "telemetryJsonPaths": "レスポンス JSON 内のドット区切りパスを入力してください。少なくとも 1 つ必要です。空欄の指標は未提供のままになります。",
@@ -101,7 +103,14 @@
   },
   "list": {
     "apiKey": "API キー",
-    "baseUrl": "Base URL"
+    "baseUrl": "Base URL",
+    "createdAt": "追加日時",
+    "expirationStatus": {
+      "active": "{{date}} まで有効",
+      "expired": "期限切れ {{date}}",
+      "none": "有効期限なし"
+    },
+    "updatedAt": "更新日時"
   },
   "messages": {
     "apiKeyCopied": "API キーをコピーしました",

--- a/src/locales/vi/apiCredentialProfiles.json
+++ b/src/locales/vi/apiCredentialProfiles.json
@@ -40,6 +40,7 @@
     "fields": {
       "apiKey": "Mã khóa",
       "baseUrl": "Base URL",
+      "expiresAt": "Ngày hết hạn",
       "name": "Tên",
       "notes": "Ghi chú",
       "tags": "Thẻ",
@@ -49,6 +50,7 @@
     "hints": {
       "apiKeyCreateUrl": "Tạo API Key trong bảng điều khiển của nhà cung cấp trước, rồi quay lại đây để dán và lưu.",
       "baseUrlNormalized": "Sau khi lưu sẽ được chuẩn hóa thành: {{baseUrl}}",
+      "expiresAt": "Tùy chọn. Ghi lại ngày mã khóa dự kiến ngừng hoạt động.",
       "tags": "Tùy chọn. Dùng chung các thẻ toàn cục với tài khoản/dấu trang.",
       "telemetryEndpoint": "Chỉ cho phép các địa chỉ GET chỉ đọc có cùng nguồn gốc với profile Base URL, có thể sử dụng /usage hoặc URL cùng nguồn gốc đầy đủ.",
       "telemetryJsonPaths": "Điền đường dẫn trường được phân tách bằng dấu chấm trong JSON phản hồi, điền ít nhất một đường dẫn. Các số liệu không được điền sẽ ở trạng thái không được cung cấp.",
@@ -101,7 +103,14 @@
   },
   "list": {
     "apiKey": "Mã khóa",
-    "baseUrl": "Base URL"
+    "baseUrl": "Base URL",
+    "createdAt": "Đã thêm",
+    "expirationStatus": {
+      "active": "Hết hạn {{date}}",
+      "expired": "Đã hết hạn {{date}}",
+      "none": "Không có ngày hết hạn"
+    },
+    "updatedAt": "Đã cập nhật"
   },
   "messages": {
     "apiKeyCopied": "Đã sao chép mã khóa",

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -40,6 +40,7 @@
     "fields": {
       "apiKey": "密钥",
       "baseUrl": "Base URL",
+      "expiresAt": "到期日",
       "name": "名称",
       "notes": "备注",
       "tags": "标签",
@@ -49,6 +50,7 @@
     "hints": {
       "apiKeyCreateUrl": "可先在服务商控制台创建 API Key，完成后回到这里粘贴保存。",
       "baseUrlNormalized": "保存后将规范化为：{{baseUrl}}",
+      "expiresAt": "可选。用于记录这枚密钥预计失效的日期。",
       "tags": "可选。与账号/书签共用全局标签。",
       "telemetryEndpoint": "仅允许 profile Base URL 同源下的只读 GET 地址，可使用 /usage 或完整同源 URL。",
       "telemetryJsonPaths": "填写响应 JSON 中的点分隔字段路径，至少填写一个。未填写的指标会保持未提供。",
@@ -101,7 +103,14 @@
   },
   "list": {
     "apiKey": "密钥",
-    "baseUrl": "Base URL"
+    "baseUrl": "Base URL",
+    "createdAt": "添加时间",
+    "expirationStatus": {
+      "active": "{{date}} 到期",
+      "expired": "已过期 {{date}}",
+      "none": "未设置到期"
+    },
+    "updatedAt": "修改时间"
   },
   "messages": {
     "apiKeyCopied": "已复制密钥",

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -40,6 +40,7 @@
     "fields": {
       "apiKey": "金鑰",
       "baseUrl": "Base URL",
+      "expiresAt": "到期日",
       "name": "名稱",
       "notes": "備註",
       "tags": "標籤",
@@ -49,6 +50,7 @@
     "hints": {
       "apiKeyCreateUrl": "可先在服務商控制台建立 API Key，完成後回到這裡貼上並儲存。",
       "baseUrlNormalized": "儲存後將規範化為：{{baseUrl}}",
+      "expiresAt": "可選。用於記錄這枚金鑰預計失效的日期。",
       "tags": "可選。與帳號/書籤共用全域性標籤。",
       "telemetryEndpoint": "僅允許 profile Base URL 同源下的唯讀 GET 地址，可使用 /usage 或完整同源 URL。",
       "telemetryJsonPaths": "填寫回應 JSON 中的點分隔欄位路徑，至少填寫一個。未填寫的指標會保持未提供。",
@@ -101,7 +103,14 @@
   },
   "list": {
     "apiKey": "金鑰",
-    "baseUrl": "Base URL"
+    "baseUrl": "Base URL",
+    "createdAt": "新增時間",
+    "expirationStatus": {
+      "active": "{{date}} 到期",
+      "expired": "已過期 {{date}}",
+      "none": "未設定到期"
+    },
+    "updatedAt": "修改時間"
   },
   "messages": {
     "apiKeyCopied": "已複製金鑰",

--- a/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
+++ b/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
@@ -43,6 +43,7 @@ type ApiCredentialProfileCreateInput = {
   apiKey: string
   tagIds?: string[]
   notes?: string
+  expiresAt?: number | null
   telemetryConfig?: Partial<ApiCredentialTelemetryConfig>
 }
 
@@ -119,6 +120,15 @@ function coerceFiniteNumber(raw: unknown): number | undefined {
     if (Number.isFinite(parsed)) return parsed
   }
   return undefined
+}
+
+/**
+ * Coerces an optional user-maintained expiration timestamp.
+ */
+function coerceOptionalTimestamp(raw: unknown): number | undefined {
+  const value = coerceFiniteNumber(raw)
+  if (value === undefined || value <= 0) return undefined
+  return Math.round(value)
 }
 
 /**
@@ -477,6 +487,7 @@ export function coerceApiCredentialProfilesConfig(
       typeof candidate.updatedAt === "number" ? candidate.updatedAt : createdAt
     const notes = typeof candidate.notes === "string" ? candidate.notes : ""
     const tagIds = normalizeTagIdList(candidate.tagIds)
+    const expiresAt = coerceOptionalTimestamp(candidate.expiresAt)
 
     if (!apiKey || !baseUrl) {
       // Skip obviously invalid rows; they are not actionable in UI.
@@ -491,6 +502,7 @@ export function coerceApiCredentialProfilesConfig(
       apiKey,
       tagIds,
       notes: notes.trim(),
+      ...(expiresAt !== undefined ? { expiresAt } : {}),
       telemetryConfig: coerceApiCredentialTelemetryConfig(
         candidate.telemetryConfig,
         { baseUrl },
@@ -661,6 +673,7 @@ class ApiCredentialProfilesStorageService {
     }
 
     const now = Date.now()
+    const expiresAt = coerceOptionalTimestamp(input.expiresAt)
     const nextProfile: ApiCredentialProfile = {
       id: safeRandomUUID("api-profile"),
       name: normalizedName,
@@ -669,6 +682,7 @@ class ApiCredentialProfilesStorageService {
       apiKey: normalizedKey,
       tagIds: normalizeTagIdList(input.tagIds),
       notes: typeof input.notes === "string" ? input.notes.trim() : "",
+      ...(expiresAt !== undefined ? { expiresAt } : {}),
       telemetryConfig: coerceApiCredentialTelemetryConfig(
         input.telemetryConfig,
         { baseUrl: normalizedBaseUrl },
@@ -752,9 +766,15 @@ class ApiCredentialProfilesStorageService {
         updates.telemetryConfig !== undefined ||
         nextApiType !== current.apiType ||
         nextBaseUrl !== current.baseUrl
+      const nextExpiresAt =
+        updates.expiresAt !== undefined
+          ? coerceOptionalTimestamp(updates.expiresAt)
+          : current.expiresAt
+      const { expiresAt: _currentExpiresAt, ...currentWithoutExpiresAt } =
+        current
 
       const next: ApiCredentialProfile = {
-        ...current,
+        ...currentWithoutExpiresAt,
         name: nextName,
         apiType: nextApiType,
         baseUrl: nextBaseUrl,
@@ -767,6 +787,7 @@ class ApiCredentialProfilesStorageService {
           typeof updates.notes === "string"
             ? updates.notes.trim()
             : current.notes,
+        ...(nextExpiresAt !== undefined ? { expiresAt: nextExpiresAt } : {}),
         telemetryConfig: shouldReCoerceTelemetryConfig
           ? coerceApiCredentialTelemetryConfig(
               updates.telemetryConfig !== undefined

--- a/src/types/apiCredentialProfiles.ts
+++ b/src/types/apiCredentialProfiles.ts
@@ -115,6 +115,11 @@ export type ApiCredentialProfile = {
    */
   tagIds: string[]
   notes: string
+  /**
+   * Optional user-maintained credential expiration date, stored as a local
+   * day-level timestamp from the API credential library form.
+   */
+  expiresAt?: number
   telemetryConfig?: ApiCredentialTelemetryConfig
   telemetrySnapshot?: ApiCredentialTelemetrySnapshot
   createdAt: number

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
@@ -189,6 +189,12 @@ describe("ApiCredentialProfileDialog", () => {
         target: { value: "sk-auto" },
       },
     )
+    fireEvent.change(
+      screen.getByLabelText("apiCredentialProfiles:dialog.fields.expiresAt"),
+      {
+        target: { value: "2026-07-31" },
+      },
+    )
 
     fireEvent.click(screen.getByRole("button", { name: "common:actions.save" }))
 
@@ -206,6 +212,7 @@ describe("ApiCredentialProfileDialog", () => {
         apiKey: "sk-auto",
         tagIds: [],
         notes: "",
+        expiresAt: new Date(2026, 6, 31).getTime(),
         telemetryConfig: {
           mode: "auto",
         },
@@ -338,6 +345,7 @@ describe("ApiCredentialProfileDialog", () => {
   it("replays stored telemetry config when editing an existing profile", () => {
     renderDialog({
       profile: buildProfile({
+        expiresAt: new Date(2026, 6, 31).getTime(),
         telemetryConfig: {
           mode: "customReadOnlyEndpoint",
           customEndpoint: {
@@ -352,6 +360,9 @@ describe("ApiCredentialProfileDialog", () => {
     })
 
     expect(screen.getByDisplayValue("Profile")).toHaveValue("Profile")
+    expect(
+      screen.getByLabelText("apiCredentialProfiles:dialog.fields.expiresAt"),
+    ).toHaveValue("2026-07-31")
     expect(
       screen.getByLabelText(
         "apiCredentialProfiles:dialog.fields.telemetryPreset",

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ApiCredentialProfileListItem } from "~/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
@@ -18,7 +18,7 @@ vi.mock("react-i18next", async (importOriginal) => {
   return {
     ...actual,
     useTranslation: () => ({
-      t: (key: string, options?: { count?: number }) => {
+      t: (key: string, options?: { count?: number; date?: string }) => {
         if (key === "common:quota.unlimited") return "Unlimited"
         if (key === "apiCredentialProfiles:telemetry.notProvided") {
           return "Not provided"
@@ -34,6 +34,12 @@ vi.mock("react-i18next", async (importOriginal) => {
         }
         if (key === "apiCredentialProfiles:telemetry.refreshing") {
           return "Refreshing telemetry"
+        }
+        if (key === "apiCredentialProfiles:list.expirationStatus.active") {
+          return `apiCredentialProfiles:list.expirationStatus.active ${options?.date}`
+        }
+        if (key === "apiCredentialProfiles:list.expirationStatus.expired") {
+          return `apiCredentialProfiles:list.expirationStatus.expired ${options?.date}`
         }
         return key
       },
@@ -198,6 +204,10 @@ function renderListItem(
 }
 
 describe("ApiCredentialProfileListItem", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -283,6 +293,84 @@ describe("ApiCredentialProfileListItem", () => {
         API_CREDENTIAL_PROFILES_TEST_IDS.telemetryTodayRequests,
       ),
     ).toHaveTextContent("Not provided")
+  })
+
+  it("shows expiration as a status badge and keeps audit timestamps separate", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 6, 30, 12).getTime())
+
+    const expiresAt = new Date(2026, 6, 31).getTime()
+    const createdAt = new Date(2026, 5, 1, 8, 30).getTime()
+    const updatedAt = new Date(2026, 5, 15, 9, 45).getTime()
+
+    renderListItem(
+      buildProfile({
+        expiresAt,
+        createdAt,
+        updatedAt,
+      }),
+    )
+
+    expect(
+      screen.getByText(
+        `apiCredentialProfiles:list.expirationStatus.active ${new Date(
+          expiresAt,
+        ).toLocaleDateString()}`,
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(/apiCredentialProfiles:list.expiresAt:/),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/apiCredentialProfiles:list.createdAt:/),
+    ).toHaveTextContent(new Date(createdAt).toLocaleDateString())
+    expect(
+      screen.getByText(/apiCredentialProfiles:list.updatedAt:/),
+    ).toHaveTextContent(new Date(updatedAt).toLocaleDateString())
+  })
+
+  it("distinguishes expired credentials from credentials without an expiration date", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 6, 30, 12).getTime())
+
+    const expiredAt = new Date(2026, 6, 29).getTime()
+
+    const { rerender } = renderListItem(buildProfile({ expiresAt: expiredAt }))
+
+    expect(
+      screen.getByText(
+        `apiCredentialProfiles:list.expirationStatus.expired ${new Date(
+          expiredAt,
+        ).toLocaleDateString()}`,
+      ),
+    ).toBeInTheDocument()
+
+    rerender(
+      <ApiCredentialProfileListItem
+        profile={buildProfile({ expiresAt: undefined })}
+        verificationSummary={null}
+        tagNames={[]}
+        visibleKeys={new Set()}
+        toggleKeyVisibility={vi.fn()}
+        onCopyBaseUrl={vi.fn()}
+        onCopyApiKey={vi.fn()}
+        onCopyBundle={vi.fn()}
+        onOpenModelManagement={vi.fn()}
+        onVerify={vi.fn()}
+        onVerifyCliSupport={vi.fn()}
+        onRefreshTelemetry={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onExport={vi.fn()}
+        isTelemetryRefreshing={false}
+        managedSiteType="new-api"
+        managedSiteLabel="New API"
+      />,
+    )
+
+    expect(
+      screen.getByText("apiCredentialProfiles:list.expirationStatus.none"),
+    ).toBeInTheDocument()
   })
 
   it("explicitly marks missing balance from a successful usage source as not provided", () => {

--- a/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
+++ b/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
@@ -221,6 +221,7 @@ describe("useApiCredentialProfilesController", () => {
         apiKey: "sk-custom",
         tagIds: [],
         notes: "",
+        expiresAt: 1796083200000,
         telemetryConfig: {
           mode: "customReadOnlyEndpoint",
           customEndpoint: {
@@ -235,6 +236,7 @@ describe("useApiCredentialProfilesController", () => {
 
     expect(createProfileMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        expiresAt: 1796083200000,
         telemetryConfig: {
           mode: "customReadOnlyEndpoint",
           customEndpoint: {

--- a/tests/services/apiCredentialProfilesStorage.more.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.more.test.ts
@@ -110,6 +110,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
             name: " ",
             tagIds: [" t1 ", "t1", ""],
             notes: " note ",
+            expiresAt: "1796083200000",
             createdAt: 100,
             updatedAt: 200,
           },
@@ -134,6 +135,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
         name: "https://example.com",
         tagIds: ["t1"],
         notes: "note",
+        expiresAt: 1796083200000,
         createdAt: 100,
         updatedAt: 200,
       }),
@@ -155,6 +157,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
             apiKey: " sk-anthropic ",
             name: 42,
             notes: null,
+            expiresAt: "not-a-date",
             createdAt: "bad",
             updatedAt: "bad",
             tagIds: [" team-a ", 7, "team-a", "team-b"],
@@ -179,6 +182,11 @@ describe("apiCredentialProfilesStorage additional flows", () => {
         tagIds: ["team-a", "team-b"],
       }),
     ])
+    expect(coerced.profiles[0]).toEqual(
+      expect.not.objectContaining({
+        expiresAt: expect.anything(),
+      }),
+    )
   })
 
   it("merges incoming configs using identity de-dupe and refreshes lastUpdated", () => {
@@ -739,6 +747,46 @@ describe("apiCredentialProfilesStorage additional flows", () => {
         telemetryConfig: {
           mode: "customReadOnlyEndpoint",
         },
+      }),
+    )
+  })
+
+  it("updates and clears profile expiration without changing createdAt", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Expiring profile",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://expiring.example.com",
+      apiKey: "sk-expiring",
+      expiresAt: new Date(2026, 5, 30).getTime(),
+    })
+
+    vi.setSystemTime(new Date("2026-04-01T00:00:00.000Z"))
+
+    const updated = await apiCredentialProfilesStorage.updateProfile(
+      profile.id,
+      {
+        expiresAt: new Date(2026, 6, 31).getTime(),
+      },
+    )
+
+    expect(updated).toEqual(
+      expect.objectContaining({
+        createdAt: profile.createdAt,
+        expiresAt: new Date(2026, 6, 31).getTime(),
+        updatedAt: Date.now(),
+      }),
+    )
+
+    const cleared = await apiCredentialProfilesStorage.updateProfile(
+      profile.id,
+      {
+        expiresAt: null,
+      },
+    )
+
+    expect(cleared).toEqual(
+      expect.not.objectContaining({
+        expiresAt: expect.anything(),
       }),
     )
   })

--- a/tests/services/apiCredentialProfilesStorage.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.test.ts
@@ -37,6 +37,7 @@ describe("apiCredentialProfilesStorage", () => {
   })
 
   it("normalizes baseUrl, trims apiKey, and sanitizes tag ids", async () => {
+    const expiresAt = new Date(2026, 6, 31).getTime()
     const created = await apiCredentialProfilesStorage.createProfile({
       name: "Test Profile",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
@@ -44,12 +45,14 @@ describe("apiCredentialProfilesStorage", () => {
       apiKey: "  sk-test  ",
       tagIds: [" t1 ", "t1", "", "t2"],
       notes: "  hello  ",
+      expiresAt,
     })
 
     expect(created.baseUrl).toBe("https://example.com/api")
     expect(created.apiKey).toBe("sk-test")
     expect(created.tagIds).toEqual(["t1", "t2"])
     expect(created.notes).toBe("hello")
+    expect(created.expiresAt).toBe(expiresAt)
   })
 
   it("de-dupes identical profiles on create (identity: apiType+baseUrl+apiKey)", async () => {

--- a/tests/test-utils/factories.ts
+++ b/tests/test-utils/factories.ts
@@ -271,6 +271,7 @@ export function buildApiCredentialProfile(
     apiKey: buildApiKey(),
     tagIds: [],
     notes: "",
+    expiresAt: undefined,
     createdAt: 1700000000000,
     updatedAt: 1700000000000,
   }


### PR DESCRIPTION
## Related issue context

Related to #1025. This PR covers the API Credential Profiles side of expiration metadata and created/updated timestamp display only; it does not complete the whole issue.

## Summary
- Add optional expiration metadata to API credential profiles and preserve it through storage/controller flows.
- Show credential expiration as a status badge with distinct active, expired, and no-expiration states.
- Sync API credential expiration copy across supported app locales.

## Test Plan
- pnpm vitest run tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
- pnpm run i18n:extract:ci
- pnpm run validate:staged
- pnpm run validate:push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional expiration date for API credential profiles.
  * Profile forms now let you set or clear an expiration date.
  * Profile cards now show expiration status, plus created/updated timestamps.

* **Bug Fixes**
  * Expiration dates are now saved, loaded, and displayed consistently.
  * Invalid or missing expiration values are handled safely.

* **Documentation**
  * Updated multilingual labels and hints for the new expiration fields and status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
