### PR TITLE
fix(model-list): align custom key prefill with group defaults

### DIFF
--- a/e2e/modelToKeyManagementJourney.spec.ts
+++ b/e2e/modelToKeyManagementJourney.spec.ts
@@ -14,12 +14,12 @@ import { getServiceWorker } from "~~/e2e/utils/extensionState"
 const MODEL_KEY_BASE_URL = "https://model-key.example.com"
 const MODEL_KEY_ACCOUNT_ID = "model-key-account"
 const MODEL_ID = "gpt-model-key-mini"
-const CREATED_KEY_NAME = `model ${MODEL_ID}`
+const CREATED_KEY_NAME = "vip group (auto)"
 
 const MODEL_KEY_PRICING: ModelPricing[] = [
   {
     model_name: MODEL_ID,
-    model_description: "E2E model that should produce a scoped key",
+    model_description: "E2E model that should produce a group default key",
     quota_type: 0,
     model_ratio: 1,
     model_price: 0,
@@ -36,7 +36,7 @@ test.beforeEach(async ({ context, page }) => {
   await stubLlmMetadataIndex(context)
 })
 
-test("creates a model-scoped key from Model List and continues in Key Management", async ({
+test("creates a group default key from Model List and continues in Key Management", async ({
   context,
   extensionId,
   page,

--- a/e2e/scenarios/modelToKeyManagement.ts
+++ b/e2e/scenarios/modelToKeyManagement.ts
@@ -164,8 +164,6 @@ export async function runModelToKeyManagementScenario(
   }
 
   await expect(addKeyDialog.locator("#tokenName")).toHaveValue(createdKeyName)
-  await expect(addKeyDialog.getByText("Model Limits")).toBeVisible()
-  await expect(addKeyDialog.getByText(modelId)).toBeVisible()
 
   for (const label of params.expectedAddKeyDialogLabels ?? []) {
     await expect(addKeyDialog.getByText(label)).toBeVisible()

--- a/src/features/ModelList/components/ModelKeyDialog/index.tsx
+++ b/src/features/ModelList/components/ModelKeyDialog/index.tsx
@@ -19,6 +19,10 @@ import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import AddTokenDialog from "~/features/KeyManagement/components/AddTokenDialog"
 import { OneTimeApiKeyDialog } from "~/features/KeyManagement/components/OneTimeApiKeyDialog"
 import { buildOneTimeApiKeyProfileSaveAction } from "~/features/KeyManagement/utils/apiCredentialProfileSaveAction"
+import {
+  buildGroupDefaultTokenRequest,
+  resolvePreferredDefaultUserGroup,
+} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
@@ -49,6 +53,19 @@ const logger = createLogger("ModelKeyDialog")
 function getCompatibleTokenLabel(token: Pick<ApiToken, "name" | "group">) {
   const group = typeof token.group === "string" ? token.group.trim() : ""
   return `${token.name} · ${group || DEFAULT_MODEL_GROUP}`
+}
+
+/**
+ * Resolves the group used when the custom create flow opens its default-key form.
+ */
+function resolveCustomCreateGroup(
+  selectedGroup: string,
+  groupOptions: readonly string[],
+) {
+  const normalizedSelectedGroup = selectedGroup.trim()
+  return (
+    normalizedSelectedGroup || resolvePreferredDefaultUserGroup(groupOptions)
+  )
 }
 
 /**
@@ -163,6 +180,12 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
   const handleOpenKeysPage = () => {
     void openKeysPage(account.id)
   }
+  const customCreateGroup = resolveCustomCreateGroup(
+    createGroup,
+    createGroupOptions,
+  )
+  const customCreateTokenRequest =
+    buildGroupDefaultTokenRequest(customCreateGroup)
   const handleRetryFetchTokens = async () => {
     const tracker = startProductAnalyticsAction({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ModelList,
@@ -479,12 +502,9 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
         availableAccounts={[account]}
         preSelectedAccountId={account.id}
         createPrefill={{
-          modelId,
-          group: createGroup
-            ? createGroup
-            : createGroupOptions.includes(DEFAULT_MODEL_GROUP)
-              ? DEFAULT_MODEL_GROUP
-              : createGroupOptions[0] ?? DEFAULT_MODEL_GROUP,
+          modelId: "",
+          defaultName: customCreateTokenRequest.name,
+          group: customCreateTokenRequest.group,
           allowedGroups: createGroupOptions,
         }}
         onSuccess={handleTokenCreated}

--- a/tests/entrypoints/options/pages/ModelList/ModelListModelKeyFlow.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListModelKeyFlow.test.tsx
@@ -175,7 +175,7 @@ describe("Model List → ModelKeyDialog", () => {
     toastErrorMock.mockReset()
   })
 
-  it("opens dialog and creates a custom key with model limits prefilled", async () => {
+  it("opens dialog and creates a custom group key without model limits prefilled", async () => {
     fetchAccountTokensMock
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([TOKEN])
@@ -201,7 +201,7 @@ describe("Model List → ModelKeyDialog", () => {
 
     expect(
       await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
-    ).toHaveValue("model gpt-4")
+    ).toHaveValue("vip group (auto)")
 
     await user.click(
       screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
@@ -212,8 +212,9 @@ describe("Model List → ModelKeyDialog", () => {
     })
 
     expect(createApiTokenMock.mock.calls[0]?.[1]).toMatchObject({
-      model_limits_enabled: true,
-      model_limits: "gpt-4",
+      name: "vip group (auto)",
+      model_limits_enabled: false,
+      model_limits: "",
       group: "vip",
     })
   })


### PR DESCRIPTION
## Summary
- Align the Model List custom key flow with group default key naming.
- Stop preselecting model limits for the custom create path so it creates a key that can use the model rather than a model-only key.
- Reuse the shared preferred default group rule for the custom create fallback.

## Test Plan
- pnpm exec vitest --run tests/entrypoints/options/pages/ModelList/ModelListModelKeyFlow.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.sub2api.test.tsx tests/entrypoints/options/pages/KeyManagement/AddTokenDialog.prefill.test.tsx
- pnpm exec eslint src/features/ModelList/components/ModelKeyDialog/index.tsx
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom key creation so the selected group resolves more reliably, with a consistent fallback to the preferred default group.
  * Updated the key creation dialog to prefill consistent values for name and group.
  * Fixed an issue where custom group keys could be created with model limits prefilled.
* **Tests**
  * Adjusted model-to-key management coverage to focus on group default keys and updated expectations for token limits behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->