### PR TITLE
feat(web-ai-api-check): add optional save metadata fields

### DIFF
--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
@@ -1,4 +1,4 @@
-import { XMarkIcon } from "@heroicons/react/24/outline"
+import { ChevronDownIcon, XMarkIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
 import type {
   KeyboardEvent as ReactKeyboardEvent,
@@ -8,6 +8,7 @@ import type {
 
 import {
   Button,
+  FormField,
   IconButton,
   Input,
   Notice,
@@ -15,6 +16,12 @@ import {
   Textarea,
 } from "~/components/ui"
 import { inputVariants } from "~/components/ui/input"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "~/components/ui/collapsible"
+import { TagPicker } from "~/features/AccountManagement/components/TagPicker"
 import { cn } from "~/lib/utils"
 import type { ApiVerificationApiType } from "~/services/verification/aiApiVerification"
 
@@ -246,6 +253,92 @@ export function ApiCheckModal({ t, view, actions, refs }: ApiCheckModalProps) {
                   />
                 </div>
               </div>
+
+              <Collapsible
+                open={view.isProfileOptionsOpen}
+                onOpenChange={actions.setIsProfileOptionsOpen}
+                className="border-border/70 bg-muted/20 rounded-md border"
+              >
+                <CollapsibleTrigger
+                  type="button"
+                  aria-label={t(
+                    "webAiApiCheck:modal.optionalProfileFields.title",
+                  )}
+                  className="hover:bg-muted/40 flex w-full items-center justify-between gap-3 rounded-md px-3 py-2 text-left transition-colors"
+                >
+                  <div className="min-w-0">
+                    <div className="text-foreground text-sm font-medium">
+                      {t("webAiApiCheck:modal.optionalProfileFields.title")}
+                    </div>
+                    <div className="text-muted-foreground truncate text-xs">
+                      {t(
+                        view.hasProfileMetadataInput
+                          ? "webAiApiCheck:modal.optionalProfileFields.hasInput"
+                          : "webAiApiCheck:modal.optionalProfileFields.hint",
+                      )}
+                    </div>
+                  </div>
+                  <ChevronDownIcon
+                    className={cn(
+                      "text-muted-foreground h-4 w-4 shrink-0 transition-transform",
+                      view.isProfileOptionsOpen ? "rotate-180" : "rotate-0",
+                    )}
+                  />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="border-border/60 border-t px-3 py-3">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <FormField
+                      label={t("webAiApiCheck:modal.fields.tags")}
+                      description={t("webAiApiCheck:modal.hints.tags")}
+                    >
+                      <TagPicker
+                        tags={view.tags}
+                        selectedTagIds={view.selectedTagIds}
+                        onSelectedTagIdsChange={actions.setSelectedTagIds}
+                        onCreateTag={actions.createTag}
+                        onRenameTag={actions.renameTag}
+                        allowDelete={false}
+                        placeholder={t("webAiApiCheck:modal.placeholders.tags")}
+                        disabled={view.isSavingProfile}
+                        portalContainer={view.popoverPortalContainer}
+                      />
+                    </FormField>
+
+                    <FormField
+                      label={t("webAiApiCheck:modal.fields.expiresAt")}
+                      description={t("webAiApiCheck:modal.hints.expiresAt")}
+                      htmlFor="api-check-expires-at"
+                    >
+                      <Input
+                        id="api-check-expires-at"
+                        type="date"
+                        value={view.expiresAtInput}
+                        onChange={(e) =>
+                          actions.setExpiresAtInput(e.target.value)
+                        }
+                        disabled={view.isSavingProfile}
+                      />
+                    </FormField>
+
+                    <FormField
+                      className="md:col-span-2"
+                      label={t("webAiApiCheck:modal.fields.notes")}
+                      htmlFor="api-check-notes"
+                    >
+                      <Textarea
+                        id="api-check-notes"
+                        value={view.notes}
+                        onChange={(e) => actions.setNotes(e.target.value)}
+                        rows={2}
+                        placeholder={t(
+                          "webAiApiCheck:modal.placeholders.notes",
+                        )}
+                        disabled={view.isSavingProfile}
+                      />
+                    </FormField>
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
 
               {view.validationError ? (
                 <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-200">

--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
@@ -23,6 +23,7 @@ import {
   sendWebAiApiCheckMessage,
   WebAiApiCheckMessageTypes,
 } from "~/services/verification/webAiApiCheck/messaging"
+import type { Tag } from "~/types"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 
 import {
@@ -45,6 +46,32 @@ import { useApiCheckModalShell } from "./useApiCheckModalShell"
 import { useApiCheckModelDiscovery } from "./useApiCheckModelDiscovery"
 import { useApiCheckProbeRunner } from "./useApiCheckProbeRunner"
 
+/**
+ * Converts an HTML date input value into a local day-level timestamp.
+ */
+function parseDateInputValue(value: string): number | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const [yearRaw, monthRaw, dayRaw] = trimmed.split("-")
+  const year = Number(yearRaw)
+  const month = Number(monthRaw)
+  const day = Number(dayRaw)
+  if (!year || !month || !day) return null
+
+  const date = new Date(year, month - 1, day)
+  if (
+    Number.isNaN(date.getTime()) ||
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null
+  }
+
+  return date.getTime()
+}
+
 export interface ApiCheckModalViewModel {
   isOpen: boolean
   sourceText: string
@@ -57,6 +84,12 @@ export interface ApiCheckModalViewModel {
   apiType: ApiVerificationApiType
   modelId: string
   modelIdsOptions: Array<{ value: string; label: string }>
+  tags: Tag[]
+  selectedTagIds: string[]
+  notes: string
+  expiresAtInput: string
+  isProfileOptionsOpen: boolean
+  hasProfileMetadataInput: boolean
   isFetchingModels: boolean
   fetchModelsError: string | null
   popoverPortalContainer: HTMLElement | null
@@ -87,6 +120,12 @@ export interface ApiCheckModalActions {
   setApiKeyVisible: (isVisible: boolean) => void
   setApiType: (apiType: ApiVerificationApiType) => void
   setModelId: (modelId: string) => void
+  setSelectedTagIds: (tagIds: string[]) => void
+  setNotes: (notes: string) => void
+  setExpiresAtInput: (value: string) => void
+  setIsProfileOptionsOpen: (isOpen: boolean) => void
+  createTag: (name: string) => Promise<Tag>
+  renameTag: (tagId: string, name: string) => Promise<Tag>
   fetchModels: () => void
   runProbe: (probeId: ApiVerificationProbeId) => void
   stopProbe: (probeId: ApiVerificationProbeId) => void
@@ -115,6 +154,11 @@ export function useApiCheckModalViewModel() {
   const [apiType, setApiType] = useState<ApiVerificationApiType>(
     API_TYPES.OPENAI_COMPATIBLE,
   )
+  const [tags, setTags] = useState<Tag[]>([])
+  const [selectedTagIds, setSelectedTagIds] = useState<string[]>([])
+  const [notes, setNotes] = useState("")
+  const [expiresAtInput, setExpiresAtInput] = useState("")
+  const [isProfileOptionsOpen, setIsProfileOptionsOpen] = useState(false)
 
   const baseUrlValueRef = useRef("")
 
@@ -211,6 +255,47 @@ export function useApiCheckModalViewModel() {
   const isRunAllActionDisabled =
     isStoppingRunAll ||
     (!isRunningAll && (isFetchingModels || isAnyProbeRunning))
+  const hasProfileMetadataInput =
+    selectedTagIds.length > 0 || !!notes.trim() || !!expiresAtInput.trim()
+
+  const loadTags = useCallback(async () => {
+    const response = await sendWebAiApiCheckMessage(
+      WebAiApiCheckMessageTypes.ListTags,
+      {},
+    )
+    if (response?.success) {
+      setTags(response.tags)
+    }
+  }, [])
+
+  const createTag = useCallback(async (name: string) => {
+    const response = await sendWebAiApiCheckMessage(
+      WebAiApiCheckMessageTypes.CreateTag,
+      { name },
+    )
+    if (!response?.success) {
+      throw new Error(response?.error || "Failed to create tag")
+    }
+    setTags((current) => [
+      ...current.filter((tag) => tag.id !== response.tag.id),
+      response.tag,
+    ])
+    return response.tag
+  }, [])
+
+  const renameTag = useCallback(async (tagId: string, name: string) => {
+    const response = await sendWebAiApiCheckMessage(
+      WebAiApiCheckMessageTypes.RenameTag,
+      { tagId, name },
+    )
+    if (!response?.success) {
+      throw new Error(response?.error || "Failed to rename tag")
+    }
+    setTags((current) =>
+      current.map((tag) => (tag.id === response.tag.id ? response.tag : tag)),
+    )
+    return response.tag
+  }, [])
 
   useEffect(() => {
     if (!hasInitializedApiTypeRef.current) {
@@ -253,6 +338,10 @@ export function useApiCheckModalViewModel() {
       clearHistoryPrefilledFetchKey()
       updateBaseUrl(nextBaseUrl)
       setApiKey(nextApiKey)
+      setSelectedTagIds([])
+      setNotes("")
+      setExpiresAtInput("")
+      setIsProfileOptionsOpen(false)
 
       setApiKeyVisible(true)
       resetModelList({ clearSelection: true })
@@ -284,6 +373,8 @@ export function useApiCheckModalViewModel() {
           )
         },
       })
+
+      void loadTags()
     }
 
     window.addEventListener(API_CHECK_OPEN_MODAL_EVENT, handleOpen as any)
@@ -304,6 +395,7 @@ export function useApiCheckModalViewModel() {
     resetProbeState,
     setHistoryPrefilledFetchKey,
     updateBaseUrl,
+    loadTags,
   ])
 
   const close = () => {
@@ -381,6 +473,9 @@ export function useApiCheckModalViewModel() {
     }
     recordBaseUrlHistory(trimmedBaseUrl)
 
+    const trimmedNotes = notes.trim()
+    const expiresAt = parseDateInputValue(expiresAtInput)
+
     setIsSavingProfile(true)
     try {
       const response = await sendWebAiApiCheckMessage(
@@ -390,6 +485,9 @@ export function useApiCheckModalViewModel() {
           baseUrl: trimmedBaseUrl,
           apiKey: trimmedApiKey,
           pageUrl: pageUrl || window.location.href,
+          ...(selectedTagIds.length > 0 ? { tagIds: selectedTagIds } : {}),
+          ...(trimmedNotes ? { notes: trimmedNotes } : {}),
+          ...(expiresAt !== null ? { expiresAt } : {}),
         },
       )
 
@@ -469,6 +567,12 @@ export function useApiCheckModalViewModel() {
       apiType,
       modelId,
       modelIdsOptions,
+      tags,
+      selectedTagIds,
+      notes,
+      expiresAtInput,
+      isProfileOptionsOpen,
+      hasProfileMetadataInput,
       isFetchingModels,
       fetchModelsError,
       popoverPortalContainer,
@@ -498,6 +602,12 @@ export function useApiCheckModalViewModel() {
       setApiKeyVisible,
       setApiType,
       setModelId,
+      setSelectedTagIds,
+      setNotes,
+      setExpiresAtInput,
+      setIsProfileOptionsOpen,
+      createTag,
+      renameTag,
       fetchModels: fetchModelsManually,
       runProbe: (probeId: ApiVerificationProbeId) => {
         void runProbe(probeId)

--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
@@ -49,7 +49,7 @@ import { useApiCheckProbeRunner } from "./useApiCheckProbeRunner"
 /**
  * Converts an HTML date input value into a local day-level timestamp.
  */
-function parseDateInputValue(value: string): number | null {
+export function parseDateInputValue(value: string): number | null {
   const trimmed = value.trim()
   if (!trimmed) return null
 
@@ -259,6 +259,7 @@ export function useApiCheckModalViewModel() {
     selectedTagIds.length > 0 || !!notes.trim() || !!expiresAtInput.trim()
 
   const loadTags = useCallback(async () => {
+    setTags([])
     const response = await sendWebAiApiCheckMessage(
       WebAiApiCheckMessageTypes.ListTags,
       {},

--- a/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
+++ b/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
@@ -60,15 +60,23 @@ export interface TagPickerProps {
   /**
    * Delete an existing global tag (also removes it from accounts).
    */
-  onDeleteTag: (tagId: string) => Promise<{ updatedAccounts: number }>
+  onDeleteTag?: (tagId: string) => Promise<{ updatedAccounts: number }>
   /**
    * Disable all interactions.
    */
   disabled?: boolean
   /**
+   * Whether to expose global tag deletion from this picker.
+   */
+  allowDelete?: boolean
+  /**
    * Placeholder shown when there are no selected tags.
    */
   placeholder?: string
+  /**
+   * Optional portal container for the tag popover.
+   */
+  portalContainer?: HTMLElement | null
 }
 
 /**
@@ -89,7 +97,9 @@ export function TagPicker({
   onRenameTag,
   onDeleteTag,
   disabled = false,
+  allowDelete = true,
   placeholder,
+  portalContainer,
 }: TagPickerProps) {
   const { t } = useTranslation(["accountDialog", "ui"])
   const pickerId = useId()
@@ -299,7 +309,7 @@ export function TagPicker({
   }
 
   const confirmDelete = async () => {
-    if (!deleteTarget || disabled || isWorking) return
+    if (!deleteTarget || !onDeleteTag || disabled || isWorking) return
     setIsWorking(true)
     setTagActionError(null)
     try {
@@ -340,7 +350,11 @@ export function TagPicker({
             <ChevronDownIcon className="h-4 w-4 opacity-70" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="p-3" align="start">
+        <PopoverContent
+          className="p-3"
+          align="start"
+          container={portalContainer ?? undefined}
+        >
           <div className="space-y-3">
             <Input
               value={query}
@@ -481,19 +495,21 @@ export function TagPicker({
                           >
                             <PencilSquareIcon className="h-4 w-4" />
                           </IconButton>
-                          <IconButton
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => {
-                              setIsOpen(false)
-                              setDeleteTarget(tag)
-                            }}
-                            aria-label={t("form.tagsDelete")}
-                            disabled={disabled || isWorking}
-                          >
-                            <TrashIcon className="h-4 w-4" />
-                          </IconButton>
+                          {allowDelete && onDeleteTag ? (
+                            <IconButton
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => {
+                                setIsOpen(false)
+                                setDeleteTarget(tag)
+                              }}
+                              aria-label={t("form.tagsDelete")}
+                              disabled={disabled || isWorking}
+                            >
+                              <TrashIcon className="h-4 w-4" />
+                            </IconButton>
+                          ) : null}
                         </span>
                       )}
                     </div>

--- a/src/locales/en/webAiApiCheck.json
+++ b/src/locales/en/webAiApiCheck.json
@@ -41,10 +41,15 @@
       "apiKey": "API key",
       "apiType": "API type",
       "baseUrl": "Base URL",
-      "modelId": "Model ID"
+      "expiresAt": "Expiration date",
+      "modelId": "Model ID",
+      "notes": "Notes",
+      "tags": "Tags"
     },
     "hints": {
-      "saveWithoutTest": "Tip: you can save once base URL + API key are provided (no need to test or fetch models first). Testing is optional and only helps verify availability."
+      "expiresAt": "Optional. Record when this key is expected to expire.",
+      "saveWithoutTest": "Tip: you can save once base URL + API key are provided (no need to test or fetch models first). Testing is optional and only helps verify availability.",
+      "tags": "Optional. Shared with the global account and bookmark tags."
     },
     "history": {
       "empty": "No Base URL history yet",
@@ -56,6 +61,15 @@
       "savedToProfiles": "Saved {{name}} to API credential library.",
       "stoppingTest": "Stopping the test. The current request will be interrupted as soon as possible.",
       "testStopped": "Test stopped. Completed results were kept, and items that had not started will not continue."
+    },
+    "optionalProfileFields": {
+      "hasInput": "Optional save details added",
+      "hint": "Tags, notes, and expiration date do not affect test results.",
+      "title": "Save options (optional)"
+    },
+    "placeholders": {
+      "notes": "Optional notes",
+      "tags": "Select tags"
     },
     "privacyHint": "API Keys will be considered sensitive information: hidden by default, and nothing is stored unless you choose to save to API credential library.",
     "probes": {

--- a/src/locales/ja/webAiApiCheck.json
+++ b/src/locales/ja/webAiApiCheck.json
@@ -41,10 +41,15 @@
       "apiKey": "API キー",
       "apiType": "API 種別",
       "baseUrl": "Base URL",
-      "modelId": "モデル ID"
+      "expiresAt": "有効期限",
+      "modelId": "モデル ID",
+      "notes": "メモ",
+      "tags": "タグ"
     },
     "hints": {
-      "saveWithoutTest": "ヒント: Base URL と API キーが入力されていれば、その時点で保存できます（先にテストやモデル取得を行う必要はありません）。テストは任意で、可用性確認の補助にすぎません。"
+      "expiresAt": "任意。このキーの想定失効日を記録します。",
+      "saveWithoutTest": "ヒント: Base URL と API キーが入力されていれば、その時点で保存できます（先にテストやモデル取得を行う必要はありません）。テストは任意で、可用性確認の補助にすぎません。",
+      "tags": "任意。アカウントやブックマークと同じグローバルタグを使用します。"
     },
     "history": {
       "empty": "Base URL の履歴はまだありません",
@@ -56,6 +61,15 @@
       "savedToProfiles": "{{name}} を API 認証情報庫に保存しました。",
       "stoppingTest": "テストを停止しています。現在のリクエストは可能な限り早く中断されます。",
       "testStopped": "テストを停止しました。完了済みの結果は保持され、未開始の項目は続行されません。"
+    },
+    "optionalProfileFields": {
+      "hasInput": "任意の保存情報が入力されています",
+      "hint": "タグ、メモ、有効期限はテスト結果に影響しません。",
+      "title": "保存オプション（任意）"
+    },
+    "placeholders": {
+      "notes": "任意のメモ",
+      "tags": "タグを選択"
     },
     "privacyHint": "API キーは機密情報として扱われます。既定では非表示で、API 認証情報庫に保存する操作を行わない限り、何も保存されません。",
     "probes": {

--- a/src/locales/vi/webAiApiCheck.json
+++ b/src/locales/vi/webAiApiCheck.json
@@ -41,10 +41,15 @@
       "apiKey": "API Key",
       "apiType": "Loại API",
       "baseUrl": "Base URL",
-      "modelId": "Model ID"
+      "expiresAt": "Ngày hết hạn",
+      "modelId": "Model ID",
+      "notes": "Ghi chú",
+      "tags": "Thẻ"
     },
     "hints": {
-      "saveWithoutTest": "Mẹo: Chỉ cần điền Base URL và API Key là có thể lưu vào API Profiles (không cần kiểm tra hoặc lấy danh sách mô hình trước). Kiểm tra chỉ được sử dụng để xác minh khả năng khả dụng."
+      "expiresAt": "Tùy chọn. Ghi lại ngày dự kiến khóa này hết hạn.",
+      "saveWithoutTest": "Mẹo: Chỉ cần điền Base URL và API Key là có thể lưu vào API Profiles (không cần kiểm tra hoặc lấy danh sách mô hình trước). Kiểm tra chỉ được sử dụng để xác minh khả năng khả dụng.",
+      "tags": "Tùy chọn. Dùng chung với thẻ toàn cục của tài khoản và dấu trang."
     },
     "history": {
       "empty": "Chưa có lịch sử Base URL",
@@ -56,6 +61,15 @@
       "savedToProfiles": "Đã lưu {{name}} vào API Profiles",
       "stoppingTest": "Đang dừng kiểm tra. Yêu cầu hiện tại sẽ được ngắt sớm nhất có thể.",
       "testStopped": "Đã dừng kiểm tra. Các kết quả đã hoàn tất được giữ lại, và các mục chưa bắt đầu sẽ không chạy tiếp."
+    },
+    "optionalProfileFields": {
+      "hasInput": "Đã thêm thông tin lưu tùy chọn",
+      "hint": "Thẻ, ghi chú và ngày hết hạn không ảnh hưởng đến kết quả kiểm tra.",
+      "title": "Tùy chọn lưu (không bắt buộc)"
+    },
+    "placeholders": {
+      "notes": "Ghi chú tùy chọn",
+      "tags": "Chọn thẻ"
     },
     "privacyHint": "API Key được coi là thông tin nhạy cảm: mặc định bị ẩn và trừ khi bạn chủ động lưu vào API Profiles, sẽ không có bất kỳ dữ liệu nào được lưu trữ liên tục.",
     "probes": {

--- a/src/locales/zh-CN/webAiApiCheck.json
+++ b/src/locales/zh-CN/webAiApiCheck.json
@@ -41,10 +41,15 @@
       "apiKey": "API Key",
       "apiType": "API 类型",
       "baseUrl": "Base URL",
-      "modelId": "模型 ID"
+      "expiresAt": "到期日",
+      "modelId": "模型 ID",
+      "notes": "备注",
+      "tags": "标签"
     },
     "hints": {
-      "saveWithoutTest": "提示：只要填写 Base URL 与 API Key 就能保存到 API 凭据库（无需先测试或获取模型列表）。测试仅用于验证可用性。"
+      "expiresAt": "可选。用于记录这枚密钥预计失效的日期。",
+      "saveWithoutTest": "提示：只要填写 Base URL 与 API Key 就能保存到 API 凭据库（无需先测试或获取模型列表）。测试仅用于验证可用性。",
+      "tags": "可选。与账号/书签共用全局标签。"
     },
     "history": {
       "empty": "暂无 Base URL 历史",
@@ -56,6 +61,15 @@
       "savedToProfiles": "已保存 {{name}} 到 API 凭据库",
       "stoppingTest": "正在停止测试，当前请求会尽快中断。",
       "testStopped": "测试已停止，已完成的结果已保留，未开始的项目不会继续运行。"
+    },
+    "optionalProfileFields": {
+      "hasInput": "已填写可选保存信息",
+      "hint": "标签、备注和到期日不会影响测试结果。",
+      "title": "保存选项（可选）"
+    },
+    "placeholders": {
+      "notes": "可选备注",
+      "tags": "选择标签"
     },
     "privacyHint": "API Key 会被视为敏感信息：默认隐藏，且除非你主动保存到 API 凭据库，否则不会持久化保存任何数据。",
     "probes": {

--- a/src/locales/zh-TW/webAiApiCheck.json
+++ b/src/locales/zh-TW/webAiApiCheck.json
@@ -41,10 +41,15 @@
       "apiKey": "API Key",
       "apiType": "API 型別",
       "baseUrl": "Base URL",
-      "modelId": "模型 ID"
+      "expiresAt": "到期日",
+      "modelId": "模型 ID",
+      "notes": "備註",
+      "tags": "標籤"
     },
     "hints": {
-      "saveWithoutTest": "提示：只要填寫 Base URL 與 API Key 就能儲存到 API 憑據庫（無需先測試或獲取模型列表）。測試僅用於驗證可用性。"
+      "expiresAt": "可選。用於記錄這枚金鑰預計失效的日期。",
+      "saveWithoutTest": "提示：只要填寫 Base URL 與 API Key 就能儲存到 API 憑據庫（無需先測試或獲取模型列表）。測試僅用於驗證可用性。",
+      "tags": "可選。與帳號/書籤共用全域標籤。"
     },
     "history": {
       "empty": "暫無 Base URL 歷史",
@@ -56,6 +61,15 @@
       "savedToProfiles": "已儲存 {{name}} 到 API 憑據庫",
       "stoppingTest": "正在停止測試，目前請求會盡快中斷。",
       "testStopped": "測試已停止，已完成的結果已保留，未開始的項目不會繼續執行。"
+    },
+    "optionalProfileFields": {
+      "hasInput": "已填寫可選儲存資訊",
+      "hint": "標籤、備註和到期日不會影響測試結果。",
+      "title": "儲存選項（可選）"
+    },
+    "placeholders": {
+      "notes": "可選備註",
+      "tags": "選擇標籤"
     },
     "privacyHint": "API Key 會被視為敏感資訊：預設隱藏，且除非你主動儲存到 API 憑據庫，否則不會持久化儲存任何資料。",
     "probes": {

--- a/src/services/verification/webAiApiCheck/background.ts
+++ b/src/services/verification/webAiApiCheck/background.ts
@@ -9,6 +9,7 @@ import {
 } from "~/services/preferences/userPreferences"
 import { resolveProductAnalyticsErrorCategoryFromError } from "~/services/productAnalytics/actions"
 import { PRODUCT_ANALYTICS_ERROR_CATEGORIES } from "~/services/productAnalytics/events"
+import { tagStorage } from "~/services/tags/tagStorage"
 import {
   API_TYPES,
   runApiVerificationProbe,
@@ -35,14 +36,20 @@ import { onWebAiApiCheckMessage, WebAiApiCheckMessageTypes } from "./messaging"
 import type {
   ApiCheckCancelRunProbeRequest,
   ApiCheckCancelRunProbeResponse,
+  ApiCheckCreateTagRequest,
+  ApiCheckCreateTagResponse,
   ApiCheckFetchModelsRequest,
   ApiCheckFetchModelsResponse,
   ApiCheckGetBaseUrlHistorySuggestionsRequest,
   ApiCheckGetBaseUrlHistorySuggestionsResponse,
+  ApiCheckListTagsRequest,
+  ApiCheckListTagsResponse,
   ApiCheckRecordBaseUrlHistoryRequest,
   ApiCheckRecordBaseUrlHistoryResponse,
   ApiCheckRemoveBaseUrlHistoryRequest,
   ApiCheckRemoveBaseUrlHistoryResponse,
+  ApiCheckRenameTagRequest,
+  ApiCheckRenameTagResponse,
   ApiCheckRunProbeRequest,
   ApiCheckRunProbeResponse,
   ApiCheckSaveProfileRequest,
@@ -252,6 +259,57 @@ export async function resolveWebAiApiCheckRemoveBaseUrlHistoryMessage(
       message: toSanitizedErrorSummary(error, []),
     })
     return { success: true }
+  }
+}
+
+/**
+ * List global tags for the API-check save metadata picker.
+ */
+async function resolveWebAiApiCheckListTagsMessage(
+  _request: ApiCheckListTagsRequest,
+): Promise<ApiCheckListTagsResponse> {
+  try {
+    const tags = await tagStorage.listTags()
+    return { success: true, tags }
+  } catch (error) {
+    logger.error("Failed to list tags for ApiCheck metadata", {
+      message: toSanitizedErrorSummary(error, []),
+    })
+    return { success: false, error: "Failed to list tags" }
+  }
+}
+
+/**
+ * Create a global tag from the API-check save metadata picker.
+ */
+async function resolveWebAiApiCheckCreateTagMessage(
+  request: ApiCheckCreateTagRequest,
+): Promise<ApiCheckCreateTagResponse> {
+  try {
+    const tag = await tagStorage.createTag(request.name)
+    return { success: true, tag }
+  } catch (error) {
+    logger.error("Failed to create tag from ApiCheck metadata", {
+      message: toSanitizedErrorSummary(error, []),
+    })
+    return { success: false, error: toSanitizedErrorSummary(error, []) }
+  }
+}
+
+/**
+ * Rename a global tag from the API-check save metadata picker.
+ */
+async function resolveWebAiApiCheckRenameTagMessage(
+  request: ApiCheckRenameTagRequest,
+): Promise<ApiCheckRenameTagResponse> {
+  try {
+    const tag = await tagStorage.renameTag(request.tagId, request.name)
+    return { success: true, tag }
+  } catch (error) {
+    logger.error("Failed to rename tag from ApiCheck metadata", {
+      message: toSanitizedErrorSummary(error, []),
+    })
+    return { success: false, error: toSanitizedErrorSummary(error, []) }
   }
 }
 
@@ -482,8 +540,11 @@ export async function resolveWebAiApiCheckSaveProfileMessage(
         apiType,
         baseUrl: normalizedBaseUrl,
         apiKey,
-        tagIds: [],
-        notes: "",
+        ...(request.tagIds !== undefined ? { tagIds: request.tagIds } : {}),
+        ...(request.notes !== undefined ? { notes: request.notes } : {}),
+        ...(request.expiresAt !== undefined
+          ? { expiresAt: request.expiresAt }
+          : {}),
       })
 
       return {
@@ -546,6 +607,18 @@ export function setupWebAiApiCheckMessagingListeners() {
     onWebAiApiCheckMessage(
       WebAiApiCheckMessageTypes.RemoveBaseUrlHistory,
       async ({ data }) => resolveWebAiApiCheckRemoveBaseUrlHistoryMessage(data),
+    ),
+    onWebAiApiCheckMessage(
+      WebAiApiCheckMessageTypes.ListTags,
+      async ({ data }) => resolveWebAiApiCheckListTagsMessage(data),
+    ),
+    onWebAiApiCheckMessage(
+      WebAiApiCheckMessageTypes.CreateTag,
+      async ({ data }) => resolveWebAiApiCheckCreateTagMessage(data),
+    ),
+    onWebAiApiCheckMessage(
+      WebAiApiCheckMessageTypes.RenameTag,
+      async ({ data }) => resolveWebAiApiCheckRenameTagMessage(data),
     ),
     onWebAiApiCheckMessage(
       WebAiApiCheckMessageTypes.RunProbe,

--- a/src/services/verification/webAiApiCheck/messaging.ts
+++ b/src/services/verification/webAiApiCheck/messaging.ts
@@ -7,14 +7,20 @@ import { createLogger } from "~/utils/core/logger"
 import type {
   ApiCheckCancelRunProbeRequest,
   ApiCheckCancelRunProbeResponse,
+  ApiCheckCreateTagRequest,
+  ApiCheckCreateTagResponse,
   ApiCheckFetchModelsRequest,
   ApiCheckFetchModelsResponse,
   ApiCheckGetBaseUrlHistorySuggestionsRequest,
   ApiCheckGetBaseUrlHistorySuggestionsResponse,
+  ApiCheckListTagsRequest,
+  ApiCheckListTagsResponse,
   ApiCheckRecordBaseUrlHistoryRequest,
   ApiCheckRecordBaseUrlHistoryResponse,
   ApiCheckRemoveBaseUrlHistoryRequest,
   ApiCheckRemoveBaseUrlHistoryResponse,
+  ApiCheckRenameTagRequest,
+  ApiCheckRenameTagResponse,
   ApiCheckRunProbeRequest,
   ApiCheckRunProbeResponse,
   ApiCheckSaveProfileRequest,
@@ -29,6 +35,9 @@ export const WebAiApiCheckMessageTypes = {
   GetBaseUrlHistorySuggestions: "webAiApiCheck:getBaseUrlHistorySuggestions",
   RecordBaseUrlHistory: "webAiApiCheck:recordBaseUrlHistory",
   RemoveBaseUrlHistory: "webAiApiCheck:removeBaseUrlHistory",
+  ListTags: "webAiApiCheck:listTags",
+  CreateTag: "webAiApiCheck:createTag",
+  RenameTag: "webAiApiCheck:renameTag",
   RunProbe: "webAiApiCheck:runProbe",
   CancelRunProbe: "webAiApiCheck:cancelRunProbe",
   SaveProfile: "webAiApiCheck:saveProfile",
@@ -67,6 +76,15 @@ interface WebAiApiCheckProtocolMap {
   [WebAiApiCheckMessageTypes.RemoveBaseUrlHistory](
     data: ApiCheckRemoveBaseUrlHistoryRequest,
   ): ApiCheckRemoveBaseUrlHistoryResponse
+  [WebAiApiCheckMessageTypes.ListTags](
+    data: ApiCheckListTagsRequest,
+  ): ApiCheckListTagsResponse
+  [WebAiApiCheckMessageTypes.CreateTag](
+    data: ApiCheckCreateTagRequest,
+  ): ApiCheckCreateTagResponse
+  [WebAiApiCheckMessageTypes.RenameTag](
+    data: ApiCheckRenameTagRequest,
+  ): ApiCheckRenameTagResponse
   [WebAiApiCheckMessageTypes.RunProbe](
     data: ApiCheckRunProbeRequest,
   ): ApiCheckRunProbeResponse

--- a/src/services/verification/webAiApiCheck/types.ts
+++ b/src/services/verification/webAiApiCheck/types.ts
@@ -5,6 +5,7 @@ import type {
   ApiVerificationProbeResult,
 } from "~/services/verification/aiApiVerification"
 import type { WebAiApiCheckBaseUrlSuggestion } from "~/services/verification/webAiApiCheck/baseUrlHistory"
+import type { Tag } from "~/types"
 
 /**
  * Runtime data from content → background to decide whether auto-detect can prompt.
@@ -63,6 +64,47 @@ export type ApiCheckRemoveBaseUrlHistoryResponse = {
   success: true
   suggestions?: WebAiApiCheckBaseUrlSuggestion[]
 }
+
+export type ApiCheckListTagsRequest = Record<string, never>
+
+export type ApiCheckListTagsResponse =
+  | {
+      success: true
+      tags: Tag[]
+    }
+  | {
+      success: false
+      error?: string
+    }
+
+export type ApiCheckCreateTagRequest = {
+  name: string
+}
+
+export type ApiCheckCreateTagResponse =
+  | {
+      success: true
+      tag: Tag
+    }
+  | {
+      success: false
+      error?: string
+    }
+
+export type ApiCheckRenameTagRequest = {
+  tagId: string
+  name: string
+}
+
+export type ApiCheckRenameTagResponse =
+  | {
+      success: true
+      tag: Tag
+    }
+  | {
+      success: false
+      error?: string
+    }
 
 /**
  * Runtime data from content → background to fetch upstream model ids.
@@ -147,6 +189,9 @@ export type ApiCheckSaveProfileRequest = {
   apiKey: string
   pageUrl?: string
   name?: string
+  tagIds?: string[]
+  notes?: string
+  expiresAt?: number | null
 }
 
 /**

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { ApiCheckModalHost } from "~/entrypoints/content/webAiApiCheck/components/ApiCheckModalHost"
+import { parseDateInputValue } from "~/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel"
 import {
   API_CHECK_MODAL_CLOSE_REASONS,
   API_CHECK_MODAL_CLOSED_EVENT,
@@ -3343,7 +3344,330 @@ describe("ApiCheckModalHost", () => {
     })
   })
 
-  it("lets users collapse optional save fields after entering metadata", async () => {
+  it("ignores impossible calendar dates when preparing profile metadata", () => {
+    expect(parseDateInputValue("2026-02-31")).toBeNull()
+  })
+
+  it("clears stale global tags before reloading them on modal open", async () => {
+    const user = userEvent.setup()
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any) => {
+        if (type === WebAiApiCheckMessageTypes.ListTags) {
+          return {
+            success: true,
+            tags: [
+              { id: "tag-work", name: "Work", createdAt: 1, updatedAt: 1 },
+            ],
+          }
+        }
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    const optionalSaveFieldsTrigger = await screen.findByRole("button", {
+      name: "webAiApiCheck:modal.optionalProfileFields.title",
+    })
+    await user.click(optionalSaveFieldsTrigger)
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.placeholders.tags",
+      }),
+    )
+    expect(await screen.findByText("Work")).toBeInTheDocument()
+    await user.keyboard("{Escape}")
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "common:actions.close",
+      }),
+    )
+
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any) => {
+        if (type === WebAiApiCheckMessageTypes.ListTags) {
+          return { success: false, error: "Tags unavailable" }
+        }
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+        return { success: false }
+      },
+    )
+
+    await act(async () => {
+      dispatchOpenApiCheckModal({
+        sourceText: "",
+        pageUrl: "https://example.com/next",
+        trigger: "contextMenu",
+      })
+    })
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.optionalProfileFields.title",
+      }),
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.placeholders.tags",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText("Work")).toBeNull()
+    })
+  })
+
+  it("adds created tags to the modal tag picker and selection", async () => {
+    const user = userEvent.setup()
+
+    await openModal()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.optionalProfileFields.title",
+      }),
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.placeholders.tags",
+      }),
+    )
+    await user.type(
+      await screen.findByPlaceholderText(
+        "accountDialog:form.tagsSearchPlaceholder",
+      ),
+      "Created",
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "accountDialog:form.tagsCreate",
+      }),
+    )
+
+    await waitFor(() => {
+      expectTypedApiCheckMessage(WebAiApiCheckMessageTypes.CreateTag, {
+        name: "Created",
+      })
+    })
+    expect(
+      await screen.findByRole("button", {
+        name: "accountDialog:form.tagsSelectedCount",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("shows the local create-tag fallback when the background response has no error", async () => {
+    const user = userEvent.setup()
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any) => {
+        if (type === WebAiApiCheckMessageTypes.ListTags) {
+          return { success: true, tags: [] }
+        }
+        if (type === WebAiApiCheckMessageTypes.CreateTag) {
+          return { success: false }
+        }
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.optionalProfileFields.title",
+      }),
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.placeholders.tags",
+      }),
+    )
+    await user.type(
+      await screen.findByPlaceholderText(
+        "accountDialog:form.tagsSearchPlaceholder",
+      ),
+      "Created",
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "accountDialog:form.tagsCreate",
+      }),
+    )
+
+    expect(
+      await screen.findByRole("alert", {
+        name: "",
+      }),
+    ).toHaveTextContent("accountDialog:messages.operationFailed")
+  })
+
+  it("renames global tags in the modal tag picker", async () => {
+    const user = userEvent.setup()
+
+    await openModal()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.optionalProfileFields.title",
+      }),
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.placeholders.tags",
+      }),
+    )
+    await user.type(
+      await screen.findByPlaceholderText(
+        "accountDialog:form.tagsSearchPlaceholder",
+      ),
+      "Work",
+    )
+    await user.click(
+      await screen.findByLabelText("accountDialog:form.tagsRename"),
+    )
+    const renameInput = (await screen.findAllByDisplayValue("Work")).find(
+      (input) =>
+        input.getAttribute("placeholder") !==
+        "accountDialog:form.tagsSearchPlaceholder",
+    ) as HTMLInputElement
+    await user.clear(renameInput)
+    await user.type(renameInput, "Renamed")
+    await user.click(
+      await screen.findByLabelText("accountDialog:form.tagsRenameSave"),
+    )
+
+    await waitFor(() => {
+      expectTypedApiCheckMessage(WebAiApiCheckMessageTypes.RenameTag, {
+        tagId: "tag-work",
+        name: "Renamed",
+      })
+    })
+    await user.click(
+      await screen.findByRole("button", { name: "common:actions.clear" }),
+    )
+    expect(await screen.findByText("Renamed")).toBeInTheDocument()
+  })
+
+  it("shows the local rename-tag fallback when the background response has no error", async () => {
+    const user = userEvent.setup()
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any) => {
+        if (type === WebAiApiCheckMessageTypes.ListTags) {
+          return {
+            success: true,
+            tags: [
+              { id: "tag-work", name: "Work", createdAt: 1, updatedAt: 1 },
+            ],
+          }
+        }
+        if (type === WebAiApiCheckMessageTypes.RenameTag) {
+          return { success: false }
+        }
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.optionalProfileFields.title",
+      }),
+    )
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.placeholders.tags",
+      }),
+    )
+    await user.click(
+      await screen.findByLabelText("accountDialog:form.tagsRename"),
+    )
+    const renameInput = await screen.findByDisplayValue("Work")
+    await user.clear(renameInput)
+    await user.type(renameInput, "Renamed")
+    await user.click(
+      await screen.findByLabelText("accountDialog:form.tagsRenameSave"),
+    )
+
+    expect(
+      await screen.findByRole("alert", {
+        name: "",
+      }),
+    ).toHaveTextContent("accountDialog:messages.operationFailed")
+  })
+
+  it("omits an invalid profile expiration date when saving metadata", async () => {
+    const user = userEvent.setup()
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.ListTags) {
+          return { success: true, tags: [] }
+        }
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+        if (type === WebAiApiCheckMessageTypes.SaveProfile) {
+          return {
+            success: true,
+            profileId: "p-1",
+            name: "proxy.example.com",
+            apiType: message.apiType,
+            baseUrl: "https://proxy.example.com/api",
+          }
+        }
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    await user.click(
+      await screen.findByPlaceholderText("https://example.com/api"),
+    )
+    await user.paste("https://proxy.example.com/api")
+    await user.click(await screen.findByPlaceholderText("sk-..."))
+    await user.paste("sk-test-secret-fixture")
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.optionalProfileFields.title",
+      }),
+    )
+    fireEvent.change(
+      await screen.findByLabelText("webAiApiCheck:modal.fields.expiresAt"),
+      { target: { value: "2026-02-31" } },
+    )
+
+    const saveButton = await screen.findByRole("button", {
+      name: "webAiApiCheck:modal.actions.saveToProfiles",
+    })
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled()
+    })
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expectTypedApiCheckMessage(WebAiApiCheckMessageTypes.SaveProfile, {
+        apiType: "openai-compatible",
+        baseUrl: "https://proxy.example.com/api",
+        apiKey: "sk-test-secret-fixture",
+        pageUrl: "https://example.com",
+      })
+    })
+  })
+
+  it("lets users collapse optional save fields without losing entered metadata", async () => {
     const user = userEvent.setup()
 
     await openModal()
@@ -3352,6 +3676,18 @@ describe("ApiCheckModalHost", () => {
       name: "webAiApiCheck:modal.optionalProfileFields.title",
     })
     await user.click(optionalSaveFieldsTrigger)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.placeholders.tags",
+      }),
+    )
+    await user.click(await screen.findByText("Work"))
+
+    fireEvent.change(
+      await screen.findByLabelText("webAiApiCheck:modal.fields.expiresAt"),
+      { target: { value: "2026-10-31" } },
+    )
 
     await user.click(
       await screen.findByPlaceholderText(
@@ -3370,6 +3706,18 @@ describe("ApiCheckModalHost", () => {
       screen.queryByPlaceholderText("webAiApiCheck:modal.placeholders.notes"),
     ).toBeNull()
     expect(optionalSaveFieldsTrigger).toHaveAttribute("aria-expanded", "false")
+
+    await user.click(optionalSaveFieldsTrigger)
+
+    expect(await screen.findByText("Work")).toBeInTheDocument()
+    expect(
+      await screen.findByLabelText("webAiApiCheck:modal.fields.expiresAt"),
+    ).toHaveValue("2026-10-31")
+    expect(
+      await screen.findByPlaceholderText(
+        "webAiApiCheck:modal.placeholders.notes",
+      ),
+    ).toHaveValue("Shared by Alice")
   })
 
   it("shows a quick-open button after saving to profiles", async () => {

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -163,6 +163,42 @@ describe("ApiCheckModalHost", () => {
     vi.mocked(sendRuntimeMessage).mockResolvedValue({ success: false })
     vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
       async (type: any) => {
+        if (type === WebAiApiCheckMessageTypes.ListTags) {
+          return {
+            success: true,
+            tags: [
+              { id: "tag-work", name: "Work", createdAt: 1, updatedAt: 1 },
+              {
+                id: "tag-expiring",
+                name: "Expiring",
+                createdAt: 2,
+                updatedAt: 2,
+              },
+            ],
+          }
+        }
+        if (type === WebAiApiCheckMessageTypes.CreateTag) {
+          return {
+            success: true,
+            tag: {
+              id: "tag-created",
+              name: "Created",
+              createdAt: 3,
+              updatedAt: 3,
+            },
+          }
+        }
+        if (type === WebAiApiCheckMessageTypes.RenameTag) {
+          return {
+            success: true,
+            tag: {
+              id: "tag-work",
+              name: "Renamed",
+              createdAt: 1,
+              updatedAt: 4,
+            },
+          }
+        }
         if (type === WebAiApiCheckMessageTypes.FetchModels) {
           return { success: true, modelIds: [] }
         }
@@ -3203,6 +3239,137 @@ describe("ApiCheckModalHost", () => {
         },
       },
     )
+  })
+
+  it("saves profile metadata entered in the API check modal", async () => {
+    const user = userEvent.setup()
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.ListTags) {
+          return {
+            success: true,
+            tags: [
+              { id: "tag-work", name: "Work", createdAt: 1, updatedAt: 1 },
+              {
+                id: "tag-expiring",
+                name: "Expiring",
+                createdAt: 2,
+                updatedAt: 2,
+              },
+            ],
+          }
+        }
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: [] }
+        }
+        if (type === WebAiApiCheckMessageTypes.SaveProfile) {
+          return {
+            success: true,
+            profileId: "p-1",
+            name: "proxy.example.com",
+            apiType: message.apiType,
+            baseUrl: "https://proxy.example.com/api",
+          }
+        }
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    await user.click(
+      await screen.findByPlaceholderText("https://example.com/api"),
+    )
+    await user.paste("https://proxy.example.com/api")
+    await user.click(await screen.findByPlaceholderText("sk-..."))
+    await user.paste("sk-test-secret-fixture")
+
+    expect(
+      screen.queryByRole("button", {
+        name: "webAiApiCheck:modal.optionalProfileFields.title",
+      }),
+    ).not.toBeNull()
+    expect(
+      screen.queryByRole("button", {
+        name: "webAiApiCheck:modal.placeholders.tags",
+      }),
+    ).toBeNull()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.optionalProfileFields.title",
+      }),
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.placeholders.tags",
+      }),
+    )
+    expect(screen.queryByLabelText("accountDialog:form.tagsDelete")).toBeNull()
+    await user.click(await screen.findByText("Work"))
+    await user.click(await screen.findByText("Expiring"))
+
+    await user.click(
+      await screen.findByPlaceholderText(
+        "webAiApiCheck:modal.placeholders.notes",
+      ),
+    )
+    await user.paste("Shared by Alice")
+    fireEvent.change(
+      await screen.findByLabelText("webAiApiCheck:modal.fields.expiresAt"),
+      { target: { value: "2026-10-31" } },
+    )
+
+    const saveButton = await screen.findByRole("button", {
+      name: "webAiApiCheck:modal.actions.saveToProfiles",
+    })
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled()
+    })
+
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expectTypedApiCheckMessage(WebAiApiCheckMessageTypes.SaveProfile, {
+        apiType: "openai-compatible",
+        baseUrl: "https://proxy.example.com/api",
+        apiKey: "sk-test-secret-fixture",
+        pageUrl: "https://example.com",
+        tagIds: ["tag-work", "tag-expiring"],
+        notes: "Shared by Alice",
+        expiresAt: new Date(2026, 9, 31).getTime(),
+      })
+    })
+  })
+
+  it("lets users collapse optional save fields after entering metadata", async () => {
+    const user = userEvent.setup()
+
+    await openModal()
+
+    const optionalSaveFieldsTrigger = await screen.findByRole("button", {
+      name: "webAiApiCheck:modal.optionalProfileFields.title",
+    })
+    await user.click(optionalSaveFieldsTrigger)
+
+    await user.click(
+      await screen.findByPlaceholderText(
+        "webAiApiCheck:modal.placeholders.notes",
+      ),
+    )
+    await user.paste("Shared by Alice")
+
+    expect(
+      screen.getByText("webAiApiCheck:modal.optionalProfileFields.hasInput"),
+    ).toBeInTheDocument()
+
+    await user.click(optionalSaveFieldsTrigger)
+
+    expect(
+      screen.queryByPlaceholderText("webAiApiCheck:modal.placeholders.notes"),
+    ).toBeNull()
+    expect(optionalSaveFieldsTrigger).toHaveAttribute("aria-expanded", "false")
   })
 
   it("shows a quick-open button after saving to profiles", async () => {

--- a/tests/services/webAiApiCheck/background.test.ts
+++ b/tests/services/webAiApiCheck/background.test.ts
@@ -1310,4 +1310,52 @@ describe("webAiApiCheck background handlers", () => {
     expect(tagStorage.createTag).toHaveBeenCalledWith("Created")
     expect(tagStorage.renameTag).toHaveBeenCalledWith("tag-work", "Renamed")
   })
+
+  it("tag message handlers return sanitized errors when tag storage rejects", async () => {
+    vi.resetModules()
+    onWebAiApiCheckMessageMock.mockClear()
+
+    const background = await import(
+      "~/services/verification/webAiApiCheck/background"
+    )
+    const { WebAiApiCheckMessageTypes } = await import(
+      "~/services/verification/webAiApiCheck/messaging"
+    )
+    const { tagStorage } = await import("~/services/tags/tagStorage")
+
+    vi.mocked(tagStorage.listTags).mockRejectedValue(new Error("list failed"))
+    vi.mocked(tagStorage.createTag).mockRejectedValue(
+      new Error("create failed"),
+    )
+    vi.mocked(tagStorage.renameTag).mockRejectedValue(
+      new Error("rename failed"),
+    )
+
+    background.setupWebAiApiCheckMessagingListeners()
+
+    await expect(
+      webAiApiCheckMessageHandlers.get(WebAiApiCheckMessageTypes.ListTags)?.({
+        data: {},
+      }),
+    ).resolves.toEqual({
+      success: false,
+      error: "Failed to list tags",
+    })
+    await expect(
+      webAiApiCheckMessageHandlers.get(WebAiApiCheckMessageTypes.CreateTag)?.({
+        data: { name: "Created" },
+      }),
+    ).resolves.toEqual({
+      success: false,
+      error: "create failed",
+    })
+    await expect(
+      webAiApiCheckMessageHandlers.get(WebAiApiCheckMessageTypes.RenameTag)?.({
+        data: { tagId: "tag-work", name: "Renamed" },
+      }),
+    ).resolves.toEqual({
+      success: false,
+      error: "rename failed",
+    })
+  })
 })

--- a/tests/services/webAiApiCheck/background.test.ts
+++ b/tests/services/webAiApiCheck/background.test.ts
@@ -72,6 +72,14 @@ vi.mock(
   }),
 )
 
+vi.mock("~/services/tags/tagStorage", () => ({
+  tagStorage: {
+    listTags: vi.fn(),
+    createTag: vi.fn(),
+    renameTag: vi.fn(),
+  },
+}))
+
 vi.mock("~/services/verification/aiApiVerification", async (importOriginal) => {
   const actual =
     await importOriginal<
@@ -805,6 +813,9 @@ describe("webAiApiCheck background handlers", () => {
       baseUrl: "https://proxy.example.com/api/v1/chat/completions",
       apiKey: "sk-test-secret-fixture",
       pageUrl: "https://example.com/docs",
+      tagIds: ["tag-work", " tag-work ", "", "tag-expiring"],
+      notes: "  shared by Alice  ",
+      expiresAt: 1790812800000,
     })
 
     expect(apiCredentialProfilesStorage.createProfile).toHaveBeenCalledWith({
@@ -812,8 +823,9 @@ describe("webAiApiCheck background handlers", () => {
       apiType: "openai-compatible",
       baseUrl: "https://proxy.example.com/api",
       apiKey: "sk-test-secret-fixture",
-      tagIds: [],
-      notes: "",
+      tagIds: ["tag-work", " tag-work ", "", "tag-expiring"],
+      notes: "  shared by Alice  ",
+      expiresAt: 1790812800000,
     })
 
     const responsePayload = response as any
@@ -892,8 +904,6 @@ describe("webAiApiCheck background handlers", () => {
       apiType: "openai-compatible",
       baseUrl: "https://proxy.example.com/api",
       apiKey: "sk-test-secret-fixture",
-      tagIds: [],
-      notes: "",
     })
     expect(response).toEqual({
       success: false,
@@ -1228,11 +1238,27 @@ describe("webAiApiCheck background handlers", () => {
     const { WebAiApiCheckMessageTypes } = await import(
       "~/services/verification/webAiApiCheck/messaging"
     )
+    const { tagStorage } = await import("~/services/tags/tagStorage")
 
+    vi.mocked(tagStorage.listTags).mockResolvedValue([
+      { id: "tag-work", name: "Work", createdAt: 1, updatedAt: 1 },
+    ])
+    vi.mocked(tagStorage.createTag).mockResolvedValue({
+      id: "tag-created",
+      name: "Created",
+      createdAt: 2,
+      updatedAt: 2,
+    })
+    vi.mocked(tagStorage.renameTag).mockResolvedValue({
+      id: "tag-work",
+      name: "Renamed",
+      createdAt: 1,
+      updatedAt: 3,
+    })
     background.setupWebAiApiCheckMessagingListeners()
     background.setupWebAiApiCheckMessagingListeners()
 
-    expect(onWebAiApiCheckMessageMock).toHaveBeenCalledTimes(8)
+    expect(onWebAiApiCheckMessageMock).toHaveBeenCalledTimes(11)
     expect(
       onWebAiApiCheckMessageMock.mock.calls.map((call) => call[0]),
     ).toEqual([
@@ -1241,6 +1267,9 @@ describe("webAiApiCheck background handlers", () => {
       WebAiApiCheckMessageTypes.GetBaseUrlHistorySuggestions,
       WebAiApiCheckMessageTypes.RecordBaseUrlHistory,
       WebAiApiCheckMessageTypes.RemoveBaseUrlHistory,
+      WebAiApiCheckMessageTypes.ListTags,
+      WebAiApiCheckMessageTypes.CreateTag,
+      WebAiApiCheckMessageTypes.RenameTag,
       WebAiApiCheckMessageTypes.RunProbe,
       WebAiApiCheckMessageTypes.CancelRunProbe,
       WebAiApiCheckMessageTypes.SaveProfile,
@@ -1253,5 +1282,32 @@ describe("webAiApiCheck background handlers", () => {
     await expect(
       cancelHandler?.({ data: { runId: "missing-run" } }),
     ).resolves.toEqual({ success: true, cancelled: false })
+
+    await expect(
+      webAiApiCheckMessageHandlers.get(WebAiApiCheckMessageTypes.ListTags)?.({
+        data: {},
+      }),
+    ).resolves.toEqual({
+      success: true,
+      tags: [{ id: "tag-work", name: "Work", createdAt: 1, updatedAt: 1 }],
+    })
+    await expect(
+      webAiApiCheckMessageHandlers.get(WebAiApiCheckMessageTypes.CreateTag)?.({
+        data: { name: "Created" },
+      }),
+    ).resolves.toEqual({
+      success: true,
+      tag: { id: "tag-created", name: "Created", createdAt: 2, updatedAt: 2 },
+    })
+    await expect(
+      webAiApiCheckMessageHandlers.get(WebAiApiCheckMessageTypes.RenameTag)?.({
+        data: { tagId: "tag-work", name: "Renamed" },
+      }),
+    ).resolves.toEqual({
+      success: true,
+      tag: { id: "tag-work", name: "Renamed", createdAt: 1, updatedAt: 3 },
+    })
+    expect(tagStorage.createTag).toHaveBeenCalledWith("Created")
+    expect(tagStorage.renameTag).toHaveBeenCalledWith("tag-work", "Renamed")
   })
 })


### PR DESCRIPTION
## Context

This PR implements the optional metadata form slice from #1025 for Web AI API Check.

The issue asks for several improvements to the API test flow. This PR focuses only on the clarified request that users should be able to enter tags, notes, and an expiration date directly in the test modal before saving credentials to API Credential Profiles, without a second save dialog.

## Related work

- #1051 already added API Credential Profiles support for expiration metadata, expiration status display, and created/updated timestamps.
- This PR builds on #1051 by collecting the expiration date, tags, and notes from the Web AI API Check save flow and passing them into the profile storage path.

## Summary

- Adds a collapsed "Save options (optional)" section in the Web AI API Check modal for tags, notes, and expiration date.
- Loads existing global tags and supports creating/renaming tags through typed Web AI API Check background messages.
- Saves entered tag IDs, trimmed notes, and date-only expiration metadata with the created API Credential Profile.
- Keeps the optional section out of the main test path by default, while still allowing users to collapse it again after entering metadata.

## Out of scope

Other #1025 ideas are intentionally left for follow-up work, including pinned/frequent Base URLs, custom key cleanup/deobfuscation rules, and save-time verification history.

## Validation

- pnpm vitest run tests/components/ApiCheckModalHost.test.tsx tests/features/AccountManagement/components/TagPicker.test.tsx tests/services/webAiApiCheck/background.test.ts
- pnpm run i18n:extract:ci
- pnpm compile
- pnpm knip
- pnpm run validate:staged
- pre-push validate:push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “profile fields” section to the API check modal for tags, expiration date, and notes.
  * Enabled creating and renaming tags from within the modal (tag deletion is hidden/disabled there).
* **Bug Fixes**
  * Optional profile metadata is only saved when the user enters meaningful values (including expiration date validation).
* **Tests**
  * Expanded coverage for tag operations, profile save behavior, date handling, and collapsing/expanding the optional section.
* **Documentation**
  * Updated modal labels, hints, and placeholders across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->