### PR TITLE
feat(settings): open options page from toolbar action

### DIFF
--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -32,10 +32,12 @@ import {
 } from "~/services/preferences/messaging"
 import {
   DEFAULT_PREFERENCES,
+  TOOLBAR_ACTION_CLICK_BEHAVIORS,
   userPreferences,
   type RedemptionAssistPreferences,
   type TempWindowFallbackPreferences,
   type TempWindowFallbackReminderPreferences,
+  type ToolbarActionClickBehavior,
   type UserPreferences,
   type WebAiApiCheckPreferences,
 } from "~/services/preferences/userPreferences"
@@ -249,7 +251,7 @@ interface UserPreferencesContextType {
   refreshInterval: number
   minRefreshInterval: number
   refreshOnOpen: boolean
-  actionClickBehavior: "popup" | "sidepanel"
+  actionClickBehavior: ToolbarActionClickBehavior
   openChangelogOnUpdate: boolean
   autoProvisionKeyOnAccountAdd: boolean
   autoFillCurrentSiteUrlOnAccountAdd: boolean
@@ -303,7 +305,7 @@ interface UserPreferencesContextType {
   updateMinRefreshInterval: (interval: number) => Promise<boolean>
   updateRefreshOnOpen: (enabled: boolean) => Promise<boolean>
   updateActionClickBehavior: (
-    behavior: "popup" | "sidepanel",
+    behavior: ToolbarActionClickBehavior,
   ) => Promise<boolean>
   updateOpenChangelogOnUpdate: (enabled: boolean) => Promise<boolean>
   updateAutoProvisionKeyOnAccountAdd: (enabled: boolean) => Promise<boolean>
@@ -584,7 +586,7 @@ export const UserPreferencesProvider = ({
   }, [])
 
   const updateActionClickBehavior = useCallback(
-    async (behavior: "popup" | "sidepanel") => {
+    async (behavior: ToolbarActionClickBehavior) => {
       const success = await userPreferences.savePreferences({
         actionClickBehavior: behavior,
       })
@@ -2044,7 +2046,8 @@ export const UserPreferencesProvider = ({
     refreshOnOpen:
       preferences?.accountAutoRefresh?.refreshOnOpen ??
       DEFAULT_ACCOUNT_AUTO_REFRESH.refreshOnOpen,
-    actionClickBehavior: preferences?.actionClickBehavior ?? "popup",
+    actionClickBehavior:
+      preferences?.actionClickBehavior ?? TOOLBAR_ACTION_CLICK_BEHAVIORS.Popup,
     openChangelogOnUpdate:
       preferences?.openChangelogOnUpdate ??
       DEFAULT_PREFERENCES.openChangelogOnUpdate ??

--- a/src/entrypoints/background/actionClickBehavior.ts
+++ b/src/entrypoints/background/actionClickBehavior.ts
@@ -1,4 +1,8 @@
 import { POPUP_PAGE_PATH } from "~/constants/extensionPages"
+import {
+  TOOLBAR_ACTION_CLICK_BEHAVIORS,
+  type ToolbarActionClickBehavior,
+} from "~/services/preferences/userPreferences"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -17,9 +21,7 @@ import {
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
-import { openSidePanelWithFallback } from "~/utils/navigation"
-
-type ActionClickBehavior = "popup" | "sidepanel"
+import { openOptionsPage, openSidePanelWithFallback } from "~/utils/navigation"
 
 /**
  * Unified logger scoped to toolbar action click behavior wiring.
@@ -32,7 +34,7 @@ const logger = createLogger("ActionClickBehavior")
  * Forwarding the clicked tab lets Chromium keep the sidePanel.open call inside
  * the original user gesture.
  */
-const handleActionClick = async (tab: browser.tabs.Tab) => {
+const handleOpenSidePanelActionClick = async (tab: browser.tabs.Tab) => {
   const tracker = startProductAnalyticsAction({
     featureId: PRODUCT_ANALYTICS_FEATURE_IDS.SidepanelNavigation,
     actionId: PRODUCT_ANALYTICS_ACTION_IDS.OpenSidepanelFromToolbarAction,
@@ -51,34 +53,64 @@ const handleActionClick = async (tab: browser.tabs.Tab) => {
   }
 }
 
+const handleOpenOptionsActionClick = async () => {
+  await openOptionsPage()
+}
+
+const resolveToolbarActionClickBehavior = (
+  behavior: ToolbarActionClickBehavior,
+  sidePanelSupported: boolean,
+): ToolbarActionClickBehavior => {
+  if (behavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.Options) {
+    return TOOLBAR_ACTION_CLICK_BEHAVIORS.Options
+  }
+
+  if (
+    behavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel &&
+    sidePanelSupported
+  ) {
+    return TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel
+  }
+
+  return TOOLBAR_ACTION_CLICK_BEHAVIORS.Popup
+}
+
 /**
  * Apply toolbar click behavior at runtime.
  * - "popup": restores the popup.html UI and removes side-panel click listeners.
  * - "sidepanel": disables the popup so onClicked fires and opens the shared
  *   side-panel-or-settings fallback path.
+ * - "options": disables the popup so onClicked opens the standard options page.
  */
 export async function applyActionClickBehavior(
-  behavior: ActionClickBehavior,
+  behavior: ToolbarActionClickBehavior,
 ): Promise<void> {
   const sidePanelSupport = getSidePanelSupport()
-  const effectiveBehavior: ActionClickBehavior =
-    behavior === "sidepanel" && sidePanelSupport.supported
-      ? "sidepanel"
-      : "popup"
-  const isSidePanel = effectiveBehavior === "sidepanel"
+  const effectiveBehavior = resolveToolbarActionClickBehavior(
+    behavior,
+    sidePanelSupport.supported,
+  )
+  const isSidePanel =
+    effectiveBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel
+  const isOptions = effectiveBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.Options
 
   // 清理旧的点击监听
-  removeActionClickListener(handleActionClick)
+  removeActionClickListener(handleOpenSidePanelActionClick)
+  removeActionClickListener(handleOpenOptionsActionClick)
 
   await disableNativeSidePanelActionClick()
 
   try {
-    await setActionPopup(isSidePanel ? "" : POPUP_PAGE_PATH)
+    await setActionPopup(isSidePanel || isOptions ? "" : POPUP_PAGE_PATH)
   } catch (error) {
     logger.warn(`action.setPopup not available:\n${getErrorMessage(error)}`)
   }
 
   if (isSidePanel) {
-    addActionClickListener(handleActionClick)
+    addActionClickListener(handleOpenSidePanelActionClick)
+  }
+
+  if (isOptions) {
+    addActionClickListener(handleOpenOptionsActionClick)
   }
 }

--- a/src/features/BasicSettings/components/tabs/General/ActionClickBehaviorSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/ActionClickBehaviorSettings.tsx
@@ -5,12 +5,16 @@ import { ResponsiveToggleGroup } from "~/components/ResponsiveButtonGroup"
 import { SettingSection } from "~/components/SettingSection"
 import { Card, CardItem, CardList } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import {
+  TOOLBAR_ACTION_CLICK_BEHAVIORS,
+  type ToolbarActionClickBehavior,
+} from "~/services/preferences/userPreferences"
 import { getSidePanelSupport } from "~/utils/browser/browserApi"
 import { showResultToast, showUpdateToast } from "~/utils/core/toastHelpers"
 
 /**
- * Lets users choose what the toolbar icon does (popup vs side panel), while
- * reflecting runtime support and fallback messaging for unsupported devices.
+ * Lets users choose what the toolbar icon does, while reflecting runtime
+ * support and fallback messaging for unsupported side-panel devices.
  */
 export default function ActionClickBehaviorSettings() {
   const { t } = useTranslation("settings")
@@ -19,7 +23,7 @@ export default function ActionClickBehaviorSettings() {
   const sidePanelSupport = getSidePanelSupport()
   const sidePanelSupported = sidePanelSupport.supported
 
-  const handleChange = async (behavior: "popup" | "sidepanel") => {
+  const handleChange = async (behavior: ToolbarActionClickBehavior) => {
     if (behavior === actionClickBehavior) return
     const success = await updateActionClickBehavior(behavior)
     if (!success) {
@@ -27,7 +31,10 @@ export default function ActionClickBehaviorSettings() {
       return
     }
 
-    if (behavior === "sidepanel" && !sidePanelSupported) {
+    if (
+      behavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel &&
+      !sidePanelSupported
+    ) {
       showResultToast(true, t("actionClick.sidepanelFallbackToast"))
       return
     }
@@ -61,14 +68,19 @@ export default function ActionClickBehaviorSettings() {
                 onValueChange={handleChange}
                 options={[
                   {
-                    value: "popup",
+                    value: TOOLBAR_ACTION_CLICK_BEHAVIORS.Popup,
                     label: t("actionClick.popupLabel"),
                     ariaLabel: t("actionClick.popupTitle"),
                   },
                   {
-                    value: "sidepanel",
+                    value: TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel,
                     label: t("actionClick.sidepanelLabel"),
                     ariaLabel: t("actionClick.sidepanelTitle"),
+                  },
+                  {
+                    value: TOOLBAR_ACTION_CLICK_BEHAVIORS.Options,
+                    label: t("actionClick.optionsLabel"),
+                    ariaLabel: t("actionClick.optionsTitle"),
                   },
                 ]}
               />

--- a/src/features/BasicSettings/components/tabs/General/General.search.ts
+++ b/src/features/BasicSettings/components/tabs/General/General.search.ts
@@ -180,7 +180,14 @@ export const generalSearchControls: OptionsSearchItemDefinition[] = [
         "settings:tabs.general",
         "settings:actionClick.title",
       ],
-      keywords: ["popup", "sidepanel", "toolbar", "icon"],
+      keywords: [
+        "popup",
+        "sidepanel",
+        "options",
+        "settings",
+        "toolbar",
+        "icon",
+      ],
     },
   ),
   buildControlDefinition(

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -5,16 +5,18 @@
     "title": "Account Management"
   },
   "actionClick": {
-    "actionIconClickDesc": "Choose open behavior when extension icon is clicked",
-    "actionIconClickTitle": "Opens when extension icon is clicked",
-    "description": "Choose what happens when you click the extension icon.",
+    "actionIconClickDesc": "Choose whether toolbar clicks open the popup, side panel, or full options page.",
+    "actionIconClickTitle": "Default destination",
+    "description": "Set what opens when you click the extension icon in the browser toolbar.",
+    "optionsLabel": "Options page",
+    "optionsTitle": "Open full options page",
     "popupLabel": "Popup",
     "popupTitle": "Open popup",
-    "sidepanelFallbackToast": "Side panel preference saved. This device will fall back to opening the popup.",
+    "sidepanelFallbackToast": "Side panel preference saved. This browser does not support side panels, so toolbar clicks will open the popup.",
     "sidepanelLabel": "Side panel",
     "sidepanelTitle": "Open side panel",
-    "sidepanelUnsupportedHelper": "Side panel is not supported on this device. Toolbar icon clicks will fall back to opening the popup.",
-    "title": "Toolbar icon behavior"
+    "sidepanelUnsupportedHelper": "This browser does not support side panels; side panel selections will fall back to the popup.",
+    "title": "Extension icon click"
   },
   "appearanceLanguage": {
     "language": "Language",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -5,16 +5,18 @@
     "title": "アカウント管理"
   },
   "actionClick": {
-    "actionIconClickDesc": "拡張機能アイコンをクリックしたときの開き方を選択します",
-    "actionIconClickTitle": "拡張機能アイコンをクリックしたときの動作",
-    "description": "拡張機能アイコンをクリックしたときの挙動を選択します。",
+    "actionIconClickDesc": "ツールバーアイコンのクリックで、ポップアップ、サイドパネル、または完全なオプションページのどれを開くか選択します。",
+    "actionIconClickTitle": "既定の表示先",
+    "description": "ブラウザーのツールバーにある拡張機能アイコンをクリックしたときの開き方を設定します。",
+    "optionsLabel": "オプションページ",
+    "optionsTitle": "完全なオプションページを開く",
     "popupLabel": "ポップアップ",
     "popupTitle": "ポップアップを開く",
-    "sidepanelFallbackToast": "サイドパネル設定を保存しました。この端末ではポップアップ表示にフォールバックします。",
+    "sidepanelFallbackToast": "サイドパネル設定を保存しました。このブラウザーではサイドパネルを利用できないため、クリック時はポップアップ表示にフォールバックします。",
     "sidepanelLabel": "サイドパネル",
     "sidepanelTitle": "サイドパネルを開く",
-    "sidepanelUnsupportedHelper": "この端末ではサイドパネルを利用できません。ツールバーアイコンをクリックするとポップアップ表示にフォールバックします。",
-    "title": "ツールバーアイコンの動作"
+    "sidepanelUnsupportedHelper": "このブラウザーではサイドパネルを利用できません。サイドパネルを選択するとポップアップ表示にフォールバックします。",
+    "title": "拡張機能アイコンのクリック"
   },
   "appearanceLanguage": {
     "language": "言語",

--- a/src/locales/vi/settings.json
+++ b/src/locales/vi/settings.json
@@ -5,16 +5,18 @@
     "title": "Quản lý tài khoản"
   },
   "actionClick": {
-    "actionIconClickDesc": "Chọn hành vi mở khi bấm vào biểu tượng tiện ích: popup hoặc thanh bên.",
-    "actionIconClickTitle": "Mở khi bấm biểu tượng tiện ích",
-    "description": "Chọn hành vi khi bấm vào biểu tượng tiện ích.",
+    "actionIconClickDesc": "Chọn thao tác bấm biểu tượng trên thanh công cụ sẽ mở popup, thanh bên hay toàn bộ trang tùy chọn.",
+    "actionIconClickTitle": "Đích mở mặc định",
+    "description": "Thiết lập nội dung mở ra khi bấm biểu tượng tiện ích trên thanh công cụ của trình duyệt.",
+    "optionsLabel": "Trang tùy chọn",
+    "optionsTitle": "Mở toàn bộ trang tùy chọn",
     "popupLabel": "Popup",
     "popupTitle": "Mở popup",
-    "sidepanelFallbackToast": "Đã lưu tùy chọn thanh bên. Thiết bị này không hỗ trợ thanh bên, sẽ chuyển về mở popup.",
+    "sidepanelFallbackToast": "Đã lưu tùy chọn thanh bên. Trình duyệt này không hỗ trợ thanh bên, nên thao tác bấm sẽ mở popup.",
     "sidepanelLabel": "Thanh bên",
     "sidepanelTitle": "Mở thanh bên",
-    "sidepanelUnsupportedHelper": "Thiết bị hiện tại không hỗ trợ thanh bên. Bấm biểu tượng trên thanh công cụ sẽ chuyển về mở popup.",
-    "title": "Hành vi biểu tượng thanh công cụ"
+    "sidepanelUnsupportedHelper": "Trình duyệt này không hỗ trợ thanh bên; lựa chọn thanh bên sẽ tự động chuyển về popup.",
+    "title": "Bấm biểu tượng tiện ích"
   },
   "appearanceLanguage": {
     "language": "Ngôn ngữ",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -5,16 +5,18 @@
     "title": "账号管理"
   },
   "actionClick": {
-    "actionIconClickDesc": "选择扩展图标时的打开行为，弹出窗口或侧边栏。",
-    "actionIconClickTitle": "点击扩展图标时打开",
-    "description": "选择点击扩展图标时的行为。",
+    "actionIconClickDesc": "选择点击工具栏图标后打开弹窗、侧边栏或完整选项页。",
+    "actionIconClickTitle": "默认打开内容",
+    "description": "设置浏览器工具栏中扩展图标的打开方式。",
+    "optionsLabel": "选项页",
+    "optionsTitle": "打开完整选项页",
     "popupLabel": "弹窗",
     "popupTitle": "打开弹出窗口",
-    "sidepanelFallbackToast": "已保存侧边栏偏好设置。本设备不支持侧边栏，将回退为打开弹窗。",
+    "sidepanelFallbackToast": "已保存侧边栏偏好设置。当前浏览器不支持侧边栏，点击时会回退到弹窗。",
     "sidepanelLabel": "侧边栏",
     "sidepanelTitle": "打开侧边栏",
-    "sidepanelUnsupportedHelper": "当前设备不支持侧边栏。点击工具栏图标将回退为打开弹窗。",
-    "title": "工具栏图标行为"
+    "sidepanelUnsupportedHelper": "当前浏览器不支持侧边栏；选择侧边栏时会自动回退到弹窗。",
+    "title": "点击扩展图标"
   },
   "appearanceLanguage": {
     "language": "语言",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -5,16 +5,18 @@
     "title": "帳號管理"
   },
   "actionClick": {
-    "actionIconClickDesc": "選擇擴充套件圖示時的開啟行為，彈出視窗或側邊欄。",
-    "actionIconClickTitle": "點擊擴充套件圖示時開啟",
-    "description": "選擇點擊擴充套件圖示時的行為。",
+    "actionIconClickDesc": "選擇點擊工具列圖示後開啟彈窗、側邊欄或完整選項頁。",
+    "actionIconClickTitle": "預設開啟內容",
+    "description": "設定瀏覽器工具列中擴充套件圖示的開啟方式。",
+    "optionsLabel": "選項頁",
+    "optionsTitle": "開啟完整選項頁",
     "popupLabel": "彈窗",
     "popupTitle": "開啟彈出視窗",
-    "sidepanelFallbackToast": "已儲存側邊欄偏好設定。本裝置不支援側邊欄，將回退為開啟彈窗。",
+    "sidepanelFallbackToast": "已儲存側邊欄偏好設定。目前瀏覽器不支援側邊欄，點擊時會回退到彈窗。",
     "sidepanelLabel": "側邊欄",
     "sidepanelTitle": "開啟側邊欄",
-    "sidepanelUnsupportedHelper": "當前裝置不支援側邊欄。點擊工具欄圖示將回退為開啟彈窗。",
-    "title": "工具欄圖示行為"
+    "sidepanelUnsupportedHelper": "目前瀏覽器不支援側邊欄；選擇側邊欄時會自動回退到彈窗。",
+    "title": "點擊擴充套件圖示"
   },
   "appearanceLanguage": {
     "language": "語言",

--- a/src/services/preferences/messaging.ts
+++ b/src/services/preferences/messaging.ts
@@ -1,3 +1,4 @@
+import type { ToolbarActionClickBehavior } from "~/services/preferences/userPreferences"
 import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
@@ -8,7 +9,7 @@ export const PreferencesMessageTypes = {
 } as const
 
 export interface PreferencesUpdateActionClickBehaviorRequest {
-  behavior: "popup" | "sidepanel"
+  behavior: ToolbarActionClickBehavior
 }
 
 interface PreferencesProtocolMap {

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -121,6 +121,15 @@ export interface TempWindowFallbackReminderPreferences {
   dismissed: boolean
 }
 
+export const TOOLBAR_ACTION_CLICK_BEHAVIORS = {
+  Popup: "popup",
+  SidePanel: "sidepanel",
+  Options: "options",
+} as const
+
+export type ToolbarActionClickBehavior =
+  (typeof TOOLBAR_ACTION_CLICK_BEHAVIORS)[keyof typeof TOOLBAR_ACTION_CLICK_BEHAVIORS]
+
 export interface RedemptionAssistUrlWhitelistPreferences {
   /**
    * When enabled, redemption assist will only run on URLs matching the whitelist.
@@ -202,8 +211,9 @@ export interface UserPreferences {
    * Controls what happens when the toolbar icon is clicked.
    * - popup: open extension popup (default)
    * - sidepanel: open side panel (if supported)
+   * - options: open the standard options page
    */
-  actionClickBehavior?: "popup" | "sidepanel"
+  actionClickBehavior?: ToolbarActionClickBehavior
   /**
    * language preference
    */
@@ -508,7 +518,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   showTodayCashflow: true,
   sortField: DATA_TYPE_BALANCE, // 与 UI_CONSTANTS.SORT.DEFAULT_FIELD 保持一致
   sortOrder: "desc", // 与 UI_CONSTANTS.SORT.DEFAULT_ORDER 保持一致
-  actionClickBehavior: "popup",
+  actionClickBehavior: TOOLBAR_ACTION_CLICK_BEHAVIORS.Popup,
   openChangelogOnUpdate: true,
   autoProvisionKeyOnAccountAdd: false, // 默认关闭，避免添加账号时无意创建密钥
   autoFillCurrentSiteUrlOnAccountAdd: false,

--- a/src/services/productAnalytics/events.ts
+++ b/src/services/productAnalytics/events.ts
@@ -882,6 +882,7 @@ export type ProductAnalyticsManagedSiteType =
 export const PRODUCT_ANALYTICS_TOOLBAR_ACTION_CLICK_BEHAVIORS = {
   Popup: "popup",
   Sidepanel: "sidepanel",
+  Options: "options",
 } as const
 
 export type ProductAnalyticsToolbarActionClickBehavior =

--- a/src/services/productAnalytics/settings.ts
+++ b/src/services/productAnalytics/settings.ts
@@ -2,6 +2,7 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   DEFAULT_PREFERENCES,
+  TOOLBAR_ACTION_CLICK_BEHAVIORS,
   type RedemptionAssistPreferences,
   type TempWindowFallbackPreferences,
   type TempWindowFallbackReminderPreferences,
@@ -106,7 +107,12 @@ function getTempWindowMode(
 function getActionClickBehavior(
   behavior: UserPreferences["actionClickBehavior"] | undefined,
 ) {
-  return behavior === "sidepanel" ? "sidepanel" : "popup"
+  if (behavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.Options) {
+    return TOOLBAR_ACTION_CLICK_BEHAVIORS.Options
+  }
+  return behavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel
+    ? TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel
+    : TOOLBAR_ACTION_CLICK_BEHAVIORS.Popup
 }
 
 function getSortingPriorityPreferences(

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -1249,6 +1249,13 @@ export function reloadRuntime(): void {
   }
 }
 
+/**
+ * Opens the extension's standard options page through the browser runtime API.
+ */
+export async function openRuntimeOptionsPage(): Promise<void> {
+  await browser.runtime.openOptionsPage()
+}
+
 export type RuntimeUpdateCheckStatus =
   | "throttled"
   | "no_update"

--- a/src/utils/navigation/index.ts
+++ b/src/utils/navigation/index.ts
@@ -15,6 +15,7 @@ import {
   focusTab,
   getExtensionURL,
   hasWindowsAPI,
+  openRuntimeOptionsPage,
   queryTabs as queryTabsApi,
   updateTab as updateTabApi,
 } from "~/utils/browser/browserApi"
@@ -794,6 +795,11 @@ export const openBookmarkManagerWithSearch = withPopupClose((search: string) =>
  * applicable, so the user ends up in the options page only.
  */
 export const openSettingsPage = withPopupClose(_openSettingsPage)
+
+/**
+ * Open the extension's standard options page and close the popup if applicable.
+ */
+export const openOptionsPage = withPopupClose(openRuntimeOptionsPage)
 
 /**
  * Open the optional-permissions onboarding flow for manual review/debugging.

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -835,6 +835,23 @@ describe("UserPreferencesContext", () => {
     )
   })
 
+  it("persists options-page toolbar action behavior through the provider", async () => {
+    const context = await renderProvider()
+
+    await act(async () => {
+      await context.updateActionClickBehavior("options")
+    })
+
+    expect(mockedUserPreferences.savePreferences).toHaveBeenCalledWith({
+      actionClickBehavior: "options",
+    })
+    expect((latestContext as any)?.actionClickBehavior).toBe("options")
+    expect(mockedSendPreferencesMessage).toHaveBeenCalledWith(
+      "preferences:updateActionClickBehavior",
+      { behavior: "options" },
+    )
+  })
+
   it("persists active tab changes through both tab update helpers", async () => {
     const preferences = clonePreferences()
     preferences.activeTab = DATA_TYPE_BALANCE

--- a/tests/entrypoints/background/actionClickBehavior.test.ts
+++ b/tests/entrypoints/background/actionClickBehavior.test.ts
@@ -17,6 +17,7 @@ describe("background applyActionClickBehavior", () => {
   let disableNativeSidePanelActionClick: ReturnType<typeof vi.fn>
   let getSidePanelSupport: ReturnType<typeof vi.fn>
   let openSidePanelWithFallback: ReturnType<typeof vi.fn>
+  let openOptionsPage: ReturnType<typeof vi.fn>
   let startProductAnalyticsAction: ReturnType<typeof vi.fn>
   let trackerComplete: ReturnType<typeof vi.fn>
 
@@ -27,6 +28,7 @@ describe("background applyActionClickBehavior", () => {
     disableNativeSidePanelActionClick = vi.fn().mockResolvedValue(undefined)
     getSidePanelSupport = vi.fn()
     openSidePanelWithFallback = vi.fn().mockResolvedValue(undefined)
+    openOptionsPage = vi.fn().mockResolvedValue(undefined)
     trackerComplete = vi.fn().mockResolvedValue(undefined)
     startProductAnalyticsAction = vi.fn().mockReturnValue({
       complete: trackerComplete,
@@ -44,6 +46,7 @@ describe("background applyActionClickBehavior", () => {
 
     vi.doMock("~/utils/navigation", () => ({
       openSidePanelWithFallback,
+      openOptionsPage,
     }))
 
     vi.doMock("~/services/productAnalytics/actions", () => ({
@@ -72,7 +75,7 @@ describe("background applyActionClickBehavior", () => {
 
     await applyActionClickBehavior("sidepanel")
 
-    expect(removeActionClickListener).toHaveBeenCalledTimes(1)
+    expect(removeActionClickListener).toHaveBeenCalledTimes(2)
     expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
     expect(setActionPopup).toHaveBeenCalledWith(POPUP_PAGE_PATH)
     expect(addActionClickListener).not.toHaveBeenCalled()
@@ -90,7 +93,7 @@ describe("background applyActionClickBehavior", () => {
 
     await applyActionClickBehavior("sidepanel")
 
-    expect(removeActionClickListener).toHaveBeenCalledTimes(1)
+    expect(removeActionClickListener).toHaveBeenCalledTimes(2)
     expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
     expect(setActionPopup).toHaveBeenCalledWith("")
     expect(addActionClickListener).toHaveBeenCalledTimes(1)
@@ -108,10 +111,50 @@ describe("background applyActionClickBehavior", () => {
 
     await applyActionClickBehavior("sidepanel")
 
-    expect(removeActionClickListener).toHaveBeenCalledTimes(1)
+    expect(removeActionClickListener).toHaveBeenCalledTimes(2)
     expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
     expect(setActionPopup).toHaveBeenCalledWith("")
     expect(addActionClickListener).toHaveBeenCalledTimes(1)
+  })
+
+  it("installs options-page wiring when options behavior is selected", async () => {
+    getSidePanelSupport.mockReturnValue({
+      supported: false,
+      kind: "unsupported",
+      reason: "missing",
+    })
+
+    const { applyActionClickBehavior } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+
+    await applyActionClickBehavior("options")
+
+    expect(removeActionClickListener).toHaveBeenCalledTimes(2)
+    expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
+    expect(setActionPopup).toHaveBeenCalledWith("")
+    expect(addActionClickListener).toHaveBeenCalledTimes(1)
+  })
+
+  it("routes options-page toolbar clicks through the standard options opener", async () => {
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+
+    const { applyActionClickBehavior } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+
+    await applyActionClickBehavior("options")
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    expect(typeof clickHandler).toBe("function")
+
+    await clickHandler?.({ id: 123, windowId: 456 } as browser.tabs.Tab)
+
+    expect(openOptionsPage).toHaveBeenCalledTimes(1)
+    expect(openSidePanelWithFallback).not.toHaveBeenCalled()
   })
 
   it("routes action clicks through the shared side-panel fallback helper", async () => {

--- a/tests/entrypoints/options/ActionClickBehaviorSettings.test.tsx
+++ b/tests/entrypoints/options/ActionClickBehaviorSettings.test.tsx
@@ -107,6 +107,37 @@ describe("ActionClickBehaviorSettings (side panel fallback)", () => {
     expect(vi.mocked(showUpdateToast)).not.toHaveBeenCalled()
   })
 
+  it("persists options page selection and shows the standard update toast", async () => {
+    vi.mocked(getSidePanelSupport).mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    } satisfies SidePanelSupport)
+
+    const updateActionClickBehavior = vi.fn().mockResolvedValue(true)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      actionClickBehavior: "popup",
+      updateActionClickBehavior,
+    } as unknown as ReturnType<typeof useUserPreferencesContext>)
+
+    renderSubject()
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "settings:actionClick.optionsTitle",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(updateActionClickBehavior).toHaveBeenCalledWith("options")
+    })
+
+    expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
+      true,
+      "settings:actionClick.title",
+    )
+    expect(vi.mocked(showResultToast)).not.toHaveBeenCalled()
+  })
+
   it("lets action behavior options wrap inside narrow settings cards", async () => {
     vi.mocked(getSidePanelSupport).mockReturnValue({
       supported: true,

--- a/tests/features/BasicSettings/General.search.test.ts
+++ b/tests/features/BasicSettings/General.search.test.ts
@@ -64,4 +64,14 @@ describe("general settings search definitions", () => {
       SETTINGS_ANCHORS.SITE_ANNOUNCEMENT_NOTIFICATIONS_PAGE,
     ])
   })
+
+  it("lets users find the toolbar click behavior by options-page keywords", () => {
+    const actionClickControl = generalSearchControls.find(
+      (control) => control.id === "control:action-click",
+    )
+
+    expect(actionClickControl?.keywords).toEqual(
+      expect.arrayContaining(["options", "settings"]),
+    )
+  })
 })

--- a/tests/services/productAnalytics/privacy.test.ts
+++ b/tests/services/productAnalytics/privacy.test.ts
@@ -586,6 +586,19 @@ describe("product analytics privacy filtering", () => {
     })
   })
 
+  it("keeps options-page toolbar behavior values", () => {
+    const sanitized = sanitizeProductAnalyticsEvent(
+      PRODUCT_ANALYTICS_EVENTS.SettingsSnapshotCaptured,
+      {
+        toolbar_action_click_behavior: "options",
+      },
+    )
+
+    expect(sanitized).toEqual({
+      toolbar_action_click_behavior: "options",
+    })
+  })
+
   it("keeps WebDAV settings snapshot fields and strips configured secrets", () => {
     const sanitized = sanitizeProductAnalyticsEvent(
       PRODUCT_ANALYTICS_EVENTS.SettingChanged,

--- a/tests/services/productAnalytics/settings.test.ts
+++ b/tests/services/productAnalytics/settings.test.ts
@@ -496,6 +496,33 @@ describe("settings product analytics snapshots", () => {
     expect(JSON.stringify(snapshot)).not.toContain("https://")
   })
 
+  it("preserves options-page toolbar behavior in settings snapshots", () => {
+    const preferences = createPreferences({
+      actionClickBehavior: "options",
+    })
+
+    const [appSnapshot] = buildSettingsSnapshotEvents(
+      preferences,
+      PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      { actionClickBehavior: "options" },
+    )
+    const aggregateSnapshot = buildAggregateSettingsSnapshotEvent(
+      preferences,
+      PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+    )
+
+    expect(appSnapshot).toEqual(
+      expect.objectContaining({
+        toolbar_action_click_behavior: "options",
+      }),
+    )
+    expect(aggregateSnapshot).toEqual(
+      expect.objectContaining({
+        toolbar_action_click_behavior: "options",
+      }),
+    )
+  })
+
   it("reports cleared display sort as none in settings snapshots", () => {
     const preferences = createPreferences({ sortField: null })
 

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -53,6 +53,7 @@ import {
   onTabRemoved,
   onTabUpdated,
   onWindowRemoved,
+  openRuntimeOptionsPage,
   PERMISSION_OPERATION_FAILURE_REASONS,
   reloadRuntime,
   reloadTab,
@@ -1335,6 +1336,15 @@ describe("browserApi window and manifest helpers", () => {
     })
 
     expect(() => reloadRuntime()).not.toThrow()
+  })
+
+  it("opens the standard runtime options page", async () => {
+    const openOptionsPage = vi.fn().mockResolvedValue(undefined)
+    ;(globalThis as any).browser.runtime.openOptionsPage = openOptionsPage
+
+    await openRuntimeOptionsPage()
+
+    expect(openOptionsPage).toHaveBeenCalledTimes(1)
   })
 
   it("normalizes promise-based runtime update checks", async () => {

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -708,6 +708,18 @@ describe("navigation utilities", () => {
     expect(mockedCreateTab).not.toHaveBeenCalled()
   })
 
+  it("openOptionsPage should close the popup after opening the standard options page", async () => {
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {})
+    mockedIsExtensionPopup.mockReturnValue(true)
+
+    await openOptionsPage()
+
+    expect(openRuntimeOptionsPageApi).toHaveBeenCalledTimes(1)
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+
+    closeSpy.mockRestore()
+  })
+
   it("opens account, bookmark, settings, and managed-site wrappers with the expected targets", async () => {
     await openFullAccountManagerPage()
     await openAccountManagerWithSearch("alpha")

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -7,6 +7,7 @@ import {
   focusTab as focusTabApi,
   getExtensionURL,
   hasWindowsAPI,
+  openRuntimeOptionsPage as openRuntimeOptionsPageApi,
   openSidePanel as openSidePanelApi,
 } from "~/utils/browser/browserApi"
 import {
@@ -35,6 +36,7 @@ import {
   openManagedSiteModelSyncPage,
   openModelsPage,
   openMultiplePages,
+  openOptionsPage,
   openOrFocusOptionsPage,
   openPermissionsOnboardingPage,
   openRedeemPage,
@@ -66,6 +68,7 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   const focusTab = vi.fn()
   const getExtensionURL = vi.fn((path: string) => `ext://${path}`)
   const hasWindowsAPI = vi.fn(() => false)
+  const openRuntimeOptionsPage = vi.fn()
   const openSidePanel = vi.fn()
 
   return {
@@ -75,6 +78,7 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
     focusTab,
     getExtensionURL,
     hasWindowsAPI,
+    openRuntimeOptionsPage,
     openSidePanel,
   }
 })
@@ -695,6 +699,13 @@ describe("navigation utilities", () => {
     )
 
     querySpy.mockRestore()
+  })
+
+  it("openOptionsPage should use the browser's standard options page opener", async () => {
+    await openOptionsPage()
+
+    expect(openRuntimeOptionsPageApi).toHaveBeenCalledTimes(1)
+    expect(mockedCreateTab).not.toHaveBeenCalled()
   })
 
   it("opens account, bookmark, settings, and managed-site wrappers with the expected targets", async () => {


### PR DESCRIPTION
Fixes #1057

## Summary
- Add an Options page choice to the toolbar icon click behavior setting.
- Route the new choice through the browser's standard options-page opener instead of the Basic Settings deep link.
- Centralize toolbar action behavior values and keep settings search, localized copy, and settings snapshot analytics aligned.

## Validation
- `pnpm vitest run tests/utils/navigation.test.ts tests/entrypoints/background/actionClickBehavior.test.ts tests/entrypoints/options/ActionClickBehaviorSettings.test.tsx tests/features/BasicSettings/General.search.test.ts tests/services/productAnalytics/privacy.test.ts tests/contexts/UserPreferencesContext.test.tsx tests/services/productAnalytics/settings.test.ts tests/utils/browserApi.test.ts`
- `pnpm run i18n:extract:ci`
- `pnpm compile`
- `pnpm run validate:staged`
- pre-push hook: `pnpm run validate:push`

## Notes
- Telemetry decision: reuse the existing toolbar action behavior settings snapshot field; no new action event added.
- E2E decision: covered with background wiring, navigation, provider, UI, search, and analytics unit/component tests because this change does not require a real browser-only workflow beyond the mocked WebExtension APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Options** choice for extension icon click behavior.
  * Click behavior can now route to **options**, **popup**, or **side panel** (when supported).

* **Bug Fixes**
  * Improved handling so unsupported **side panel** environments fall back to a supported destination.
  * Updated settings copy to clarify click destinations and browser support.

* **Tests**
  * Expanded tests for options routing, persistence of the selected behavior, analytics preservation, and updated navigation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->