### PR TITLE
fix(options): preserve search input home end keys

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -95,6 +95,7 @@ function CommandInput({
   className,
   onClear,
   clearButtonLabel = "Clear",
+  onKeyDown,
   ...props
 }: CommandInputProps) {
   const inputRef = React.useRef<HTMLInputElement>(null)
@@ -115,6 +116,12 @@ function CommandInput({
           "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
+        onKeyDown={(event) => {
+          onKeyDown?.(event)
+          if (!event.defaultPrevented && ["Home", "End"].includes(event.key)) {
+            event.stopPropagation()
+          }
+        }}
         {...props}
       />
       {showClearButton && (

--- a/tests/entrypoints/options/OptionsSearchDialog.test.tsx
+++ b/tests/entrypoints/options/OptionsSearchDialog.test.tsx
@@ -121,6 +121,28 @@ describe("OptionsSearchDialog", () => {
     expect(input).toHaveValue("")
   })
 
+  it("lets Home and End move the caret while editing the search query", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <OptionsSearchDialog
+        open
+        onOpenChange={vi.fn()}
+        onPageNavigate={vi.fn()}
+        context={baseContext}
+      />,
+    )
+
+    await screen.findByRole("dialog")
+    const input = screen.getByRole("combobox")
+
+    await user.type(input, "middle")
+    await user.keyboard("{Home}start ")
+    await user.keyboard("{End} end")
+
+    expect(input).toHaveValue("start middle end")
+  })
+
   it("closes through dialog dismissal and resets the query", async () => {
     const user = userEvent.setup()
     const onOpenChange = vi.fn()


### PR DESCRIPTION
Fixes #1054.

Preserve native Home/End caret movement in the shared command input so the options search box and other command-based search inputs no longer route those keys to cmdk navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling in the command/search input so Home and End keys behave correctly while editing, avoiding unintended navigation.
  * Preserved normal text editing behavior by respecting default browser handling when those keys are already intercepted.

* **Tests**
  * Added coverage for Home/End cursor movement in the search dialog to verify the expected input behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->