### PR TITLE
fix: address Sub2API repair layout and content fetch signals

### DIFF
--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -74,6 +74,7 @@ import {
   removeTempWindowCookieRule,
 } from "~/utils/browser/dnrCookieInjector"
 import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
+import { normalizeRequestInitForMessage } from "~/utils/browser/requestInitMessage"
 import { resolveAuthTypeEnum } from "~/utils/core/authType"
 import { getErrorMessage } from "~/utils/core/error"
 import { safeRandomUUID } from "~/utils/core/identifier"
@@ -1124,7 +1125,7 @@ export async function handleTempWindowFetch(
       action: RuntimeActionIds.ContentPerformTempWindowFetch,
       requestId: tempRequestId,
       fetchUrl,
-      fetchOptions: effectiveFetchOptions,
+      fetchOptions: normalizeRequestInitForMessage(effectiveFetchOptions),
       responseType,
     })
 
@@ -1540,7 +1541,7 @@ export async function handleTempWindowTurnstileFetch(
       action: RuntimeActionIds.ContentPerformTempWindowFetch,
       requestId: tempRequestId,
       fetchUrl: fetchUrlWithToken,
-      fetchOptions: effectiveFetchOptions,
+      fetchOptions: normalizeRequestInitForMessage(effectiveFetchOptions),
       responseType,
     })) as TempWindowFetch | undefined
 

--- a/src/entrypoints/content/messageHandlers/utils/tempFetchUtils.ts
+++ b/src/entrypoints/content/messageHandlers/utils/tempFetchUtils.ts
@@ -19,6 +19,10 @@ export function normalizeFetchOptions(options: RequestInit = {}): RequestInit {
     normalized.headers = sanitizeHeaders(options.headers)
   }
 
+  if (normalized.signal && !(normalized.signal instanceof AbortSignal)) {
+    delete normalized.signal
+  }
+
   return normalized
 }
 

--- a/src/entrypoints/content/messageHandlers/utils/tempFetchUtils.ts
+++ b/src/entrypoints/content/messageHandlers/utils/tempFetchUtils.ts
@@ -19,6 +19,7 @@ export function normalizeFetchOptions(options: RequestInit = {}): RequestInit {
     normalized.headers = sanitizeHeaders(options.headers)
   }
 
+  // Message-cloned signals lose the native AbortSignal prototype.
   if (normalized.signal && !(normalized.signal instanceof AbortSignal)) {
     delete normalized.signal
   }

--- a/src/features/KeyManagement/components/RepairAccountCoverageList.tsx
+++ b/src/features/KeyManagement/components/RepairAccountCoverageList.tsx
@@ -91,7 +91,7 @@ export function RepairAccountCoverageList({
             key={`${result.accountId}-${result.finishedAt}`}
             className="px-4 py-3"
           >
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
               <div className="min-w-0 space-y-1">
                 <div className="flex min-w-0 items-center gap-2">
                   <div className="truncate text-sm font-medium">
@@ -110,42 +110,53 @@ export function RepairAccountCoverageList({
                   {result.siteUrlOrigin}
                 </div>
               </div>
-              <Badge
-                variant={badgeVariant}
-                size="sm"
-                className="shrink-0 border-transparent"
-              >
-                {outcomeLabel}
-              </Badge>
-            </div>
 
-            {canCreateSub2ApiKey ? (
-              <div className="mt-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => onOpenSub2ApiTokenDialog(result.accountId)}
-                  disabled={openingSub2ApiAccountId === result.accountId}
-                  loading={openingSub2ApiAccountId === result.accountId}
+              <div className="flex flex-col gap-2 sm:items-end">
+                <div
+                  className={[
+                    "flex w-full flex-col gap-2 sm:w-auto sm:items-end",
+                    canCreateSub2ApiKey ? "sm:min-w-72" : "",
+                  ].join(" ")}
                 >
-                  {t("keyManagement:dialog.createToken")}
-                </Button>
-              </div>
-            ) : null}
+                  <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+                    {details ? (
+                      <div
+                        className={[
+                          "max-w-full text-xs leading-5 sm:max-w-56 sm:text-right",
+                          result.outcome === ACCOUNT_KEY_REPAIR_OUTCOMES.Failed
+                            ? "text-red-700 dark:text-red-300"
+                            : "dark:text-dark-text-secondary text-gray-500",
+                        ].join(" ")}
+                      >
+                        {details}
+                      </div>
+                    ) : null}
 
-            {details ? (
-              <div
-                className={[
-                  "mt-2 text-xs",
-                  result.outcome === ACCOUNT_KEY_REPAIR_OUTCOMES.Failed
-                    ? "text-red-700 dark:text-red-300"
-                    : "dark:text-dark-text-secondary text-gray-500",
-                ].join(" ")}
-              >
-                {details}
+                    <Badge
+                      variant={badgeVariant}
+                      size="sm"
+                      className="w-fit shrink-0 border-transparent"
+                    >
+                      {outcomeLabel}
+                    </Badge>
+                  </div>
+
+                  {canCreateSub2ApiKey ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onOpenSub2ApiTokenDialog(result.accountId)}
+                      disabled={openingSub2ApiAccountId === result.accountId}
+                      loading={openingSub2ApiAccountId === result.accountId}
+                      className="w-full sm:w-auto"
+                    >
+                      {t("keyManagement:dialog.createToken")}
+                    </Button>
+                  ) : null}
+                </div>
               </div>
-            ) : null}
+            </div>
 
             {result.availableGroups ? (
               <div className="mt-2 flex flex-wrap gap-2 text-xs">

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog.tsx
@@ -291,6 +291,7 @@ export function RepairMissingKeysDialog(props: RepairMissingKeysDialogProps) {
       isOpen={isOpen}
       onClose={onClose}
       size="lg"
+      panelClassName="sm:max-w-3xl"
       header={
         <div className="space-y-1 pr-10">
           <div className="flex flex-wrap items-center gap-2">

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -251,9 +251,12 @@ function normalizeHeaderInit(
  * Normalizes request options before crossing an extension message boundary.
  */
 function normalizeRequestInitForMessage(options: RequestInit): RequestInit {
+  const normalizedOptions = { ...options }
+  delete normalizedOptions.signal
+
   return {
-    ...options,
-    headers: normalizeHeaderInit(options.headers),
+    ...normalizedOptions,
+    headers: normalizeHeaderInit(normalizedOptions.headers),
   }
 }
 

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -30,6 +30,10 @@ import {
   COOKIE_AUTH_HEADER_NAME,
   COOKIE_SESSION_OVERRIDE_HEADER_NAME,
 } from "~/utils/browser/cookieHelper"
+import {
+  normalizeHeaderInit,
+  normalizeRequestInitForMessage,
+} from "~/utils/browser/requestInitMessage"
 import { executeWithTempWindowFallback } from "~/utils/browser/tempWindowFetch"
 import { isTestMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
@@ -207,56 +211,6 @@ const createBaseRequest = (
     },
     credentials,
     ...requestOptions,
-  }
-}
-
-/**
- * Converts supported header inputs into a structured-clone-safe object.
- */
-function normalizeHeaderInit(
-  headers: HeadersInit | undefined,
-): Record<string, string> {
-  if (!headers) return {}
-
-  if (headers instanceof Headers) {
-    const result: Record<string, string> = {}
-    headers.forEach((value, key) => {
-      result[key] = value
-    })
-    return result
-  }
-
-  if (Array.isArray(headers)) {
-    return headers.reduce(
-      (acc, [key, value]) => {
-        acc[key] = value
-        return acc
-      },
-      {} as Record<string, string>,
-    )
-  }
-
-  return Object.entries(headers).reduce(
-    (acc, [key, value]) => {
-      if (value != null) {
-        acc[key] = String(value)
-      }
-      return acc
-    },
-    {} as Record<string, string>,
-  )
-}
-
-/**
- * Normalizes request options before crossing an extension message boundary.
- */
-function normalizeRequestInitForMessage(options: RequestInit): RequestInit {
-  const normalizedOptions = { ...options }
-  delete normalizedOptions.signal
-
-  return {
-    ...normalizedOptions,
-    headers: normalizeHeaderInit(normalizedOptions.headers),
   }
 }
 

--- a/src/utils/browser/requestInitMessage.ts
+++ b/src/utils/browser/requestInitMessage.ts
@@ -1,0 +1,55 @@
+/**
+ * Converts supported header inputs into a structured-clone-safe object.
+ */
+export function normalizeHeaderInit(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
+  if (!headers) return {}
+
+  if (headers instanceof Headers) {
+    const result: Record<string, string> = {}
+    headers.forEach((value, key) => {
+      result[key] = value
+    })
+    return result
+  }
+
+  if (Array.isArray(headers)) {
+    return headers.reduce(
+      (acc, [key, value]) => {
+        acc[key] = value
+        return acc
+      },
+      {} as Record<string, string>,
+    )
+  }
+
+  return Object.entries(headers).reduce(
+    (acc, [key, value]) => {
+      if (value != null) {
+        acc[key] = String(value)
+      }
+      return acc
+    },
+    {} as Record<string, string>,
+  )
+}
+
+/**
+ * Builds a message-safe RequestInit copy for extension message payloads.
+ * AbortSignal cannot reliably cross extension message boundaries; true
+ * cross-context cancellation must use a separate request-id cancel protocol.
+ */
+export function normalizeRequestInitForMessage(
+  options: RequestInit,
+): RequestInit {
+  const normalizedOptions: RequestInit = { ...options }
+
+  delete normalizedOptions.signal
+
+  if (options.headers) {
+    normalizedOptions.headers = normalizeHeaderInit(options.headers)
+  }
+
+  return normalizedOptions
+}

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -41,13 +41,14 @@ import type {
   TempWindowTurnstileFetchParams,
 } from "~/types/tempWindowFetch"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
+import { OPTIONS_PAGE_URL } from "~/utils/browser/extensionPageUrls"
 import {
   isExtensionBackground,
   isExtensionPopup,
   isExtensionSidePanel,
 } from "~/utils/browser/index"
-import { OPTIONS_PAGE_URL } from "~/utils/browser/extensionPageUrls"
 import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
+import { normalizeRequestInitForMessage } from "~/utils/browser/requestInitMessage"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 
@@ -243,6 +244,9 @@ export async function tempWindowFetch(
 
   const payload: TempWindowFetchParams = {
     ...params,
+    ...(params.fetchOptions
+      ? { fetchOptions: normalizeRequestInitForMessage(params.fetchOptions) }
+      : {}),
     suppressMinimize,
   }
 
@@ -289,6 +293,9 @@ export async function tempWindowTurnstileFetch(
 
   const payload: TempWindowTurnstileFetchParams = {
     ...params,
+    ...(params.fetchOptions
+      ? { fetchOptions: normalizeRequestInitForMessage(params.fetchOptions) }
+      : {}),
     suppressMinimize,
   }
 

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -2272,6 +2272,49 @@ describe("tempWindowPool window fallback", () => {
     expect(fetchCalls.at(-1)?.[0]).toBe(709)
   })
 
+  it("omits abort signals from content temp fetch messages", async () => {
+    tempContextMode = "tab"
+    createTabMock.mockResolvedValueOnce({ id: 605 })
+    const abortController = new AbortController()
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleTempWindowFetch(
+      {
+        originUrl: "https://example.com",
+        fetchUrl: "https://example.com/api/models",
+        fetchOptions: {
+          method: "POST",
+          signal: abortController.signal,
+        },
+        requestId: "req-signal",
+      },
+      sendResponse,
+    )
+    await vi.advanceTimersByTimeAsync(1000)
+    await request
+
+    const fetchCall = sendMessageMock.mock.calls.find(
+      ([, message]) =>
+        message.action === RuntimeActionIds.ContentPerformTempWindowFetch,
+    )
+
+    expect(fetchCall?.[1].fetchOptions).toEqual({
+      method: "POST",
+    })
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        success: true,
+        message: "",
+        data: "ok",
+      },
+    })
+  })
+
   it("injects a WAF cookie rule for token-auth temp fetches and removes it afterward", async () => {
     tempContextMode = "tab"
     createTabMock.mockResolvedValueOnce({ id: 606 })

--- a/tests/entrypoints/content/messageHandlers/utils/tempFetchUtils.test.ts
+++ b/tests/entrypoints/content/messageHandlers/utils/tempFetchUtils.test.ts
@@ -98,6 +98,20 @@ describe("tempFetchUtils", () => {
     })
   })
 
+  it("drops message-cloned fetch signals before content-side fetch", async () => {
+    const { normalizeFetchOptions } = await import(
+      "~/entrypoints/content/messageHandlers/utils/tempFetchUtils"
+    )
+
+    const normalized = normalizeFetchOptions({
+      method: "GET",
+      signal: { aborted: false } as unknown as AbortSignal,
+    })
+
+    expect(normalized).toEqual({ method: "GET" })
+    expect(normalized).not.toHaveProperty("signal")
+  })
+
   it("parses arrayBuffer and blob responses into serializable payloads", async () => {
     const { parseResponseData } = await import(
       "~/entrypoints/content/messageHandlers/utils/tempFetchUtils"

--- a/tests/entrypoints/content/messageHandlers/utils/tempFetchUtils.test.ts
+++ b/tests/entrypoints/content/messageHandlers/utils/tempFetchUtils.test.ts
@@ -112,6 +112,20 @@ describe("tempFetchUtils", () => {
     expect(normalized).not.toHaveProperty("signal")
   })
 
+  it("preserves native fetch signals during normalization", async () => {
+    const { normalizeFetchOptions } = await import(
+      "~/entrypoints/content/messageHandlers/utils/tempFetchUtils"
+    )
+
+    const abortController = new AbortController()
+    const normalized = normalizeFetchOptions({
+      method: "GET",
+      signal: abortController.signal,
+    })
+
+    expect(normalized.signal).toBe(abortController.signal)
+  })
+
   it("parses arrayBuffer and blob responses into serializable payloads", async () => {
     const { parseResponseData } = await import(
       "~/entrypoints/content/messageHandlers/utils/tempFetchUtils"

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -403,6 +403,46 @@ describe("apiTransport request helpers", () => {
     )
   })
 
+  it("omits abort signals from current-tab content fetch messages", async () => {
+    const abortController = new AbortController()
+    mockSendTabMessageWithRetry.mockResolvedValueOnce({
+      success: true,
+      status: 200,
+      data: {
+        success: true,
+        data: { ok: true },
+        message: "ok",
+      },
+    })
+
+    await expect(
+      fetchApiData<{ ok: boolean }>(
+        {
+          baseUrl: BASE_URL,
+          auth: {
+            authType: AuthTypeEnum.Cookie,
+            cookie: "session=abc123",
+            userId: "123",
+          },
+          abortSignal: abortController.signal,
+          fetchContext: {
+            kind: API_TRANSPORT_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+            tabId: 456,
+            origin: "https://example.com",
+          },
+        },
+        { endpoint: ENDPOINT },
+      ),
+    ).resolves.toEqual({ ok: true })
+
+    expect(mockSendTabMessageWithRetry).toHaveBeenCalledTimes(1)
+    expect(mockSendTabMessageWithRetry.mock.calls[0][1].fetchOptions).toEqual(
+      expect.not.objectContaining({
+        signal: expect.anything(),
+      }),
+    )
+  })
+
   it("normalizes Headers objects before sending current-tab content fetch", async () => {
     mockSendTabMessageWithRetry.mockResolvedValueOnce({
       success: true,

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -273,6 +273,25 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
     )
   })
 
+  it("omits fetch options from tempWindowFetch runtime messages when none are provided", async () => {
+    mocks.sendRuntimeMessageMock.mockResolvedValue({
+      success: true,
+      data: "ok",
+    })
+
+    await tempWindowFetch({
+      originUrl: "https://example.com",
+      fetchUrl: "https://example.com/api/models",
+    })
+
+    expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith({
+      action: RuntimeActionIds.TempWindowFetch,
+      originUrl: "https://example.com",
+      fetchUrl: "https://example.com/api/models",
+      suppressMinimize: false,
+    })
+  })
+
   it("routes tempWindowTurnstileFetch through runtime messaging and keeps explicit suppression overrides", async () => {
     setWindowHref("chrome-extension://test/popup.html")
     mocks.isExtensionPopupMock.mockReturnValue(true)
@@ -329,6 +348,28 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
         fetchOptions: { method: "POST" },
       }),
     )
+  })
+
+  it("omits fetch options from tempWindowTurnstileFetch runtime messages when none are provided", async () => {
+    mocks.sendRuntimeMessageMock.mockResolvedValue({
+      success: true,
+      data: "token",
+      turnstile: { status: "token_obtained", hasTurnstile: true },
+    })
+
+    await tempWindowTurnstileFetch({
+      originUrl: "https://example.com",
+      pageUrl: "https://example.com/checkin",
+      fetchUrl: "https://example.com/api/checkin",
+    })
+
+    expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith({
+      action: RuntimeActionIds.TempWindowTurnstileFetch,
+      originUrl: "https://example.com",
+      pageUrl: "https://example.com/checkin",
+      fetchUrl: "https://example.com/api/checkin",
+      suppressMinimize: false,
+    })
   })
 
   it("routes tempWindowTriggerCheckinPageAction through runtime messaging", async () => {

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -249,6 +249,30 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
     })
   })
 
+  it("omits abort signals from tempWindowFetch runtime messages", async () => {
+    const abortController = new AbortController()
+    mocks.sendRuntimeMessageMock.mockResolvedValue({
+      success: true,
+      data: "ok",
+    })
+
+    await tempWindowFetch({
+      originUrl: "https://example.com",
+      fetchUrl: "https://example.com/api/models",
+      fetchOptions: {
+        method: "POST",
+        signal: abortController.signal,
+      },
+    })
+
+    expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.TempWindowFetch,
+        fetchOptions: { method: "POST" },
+      }),
+    )
+  })
+
   it("routes tempWindowTurnstileFetch through runtime messaging and keeps explicit suppression overrides", async () => {
     setWindowHref("chrome-extension://test/popup.html")
     mocks.isExtensionPopupMock.mockReturnValue(true)
@@ -279,6 +303,32 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       fetchOptions: { method: "POST" },
       suppressMinimize: false,
     })
+  })
+
+  it("omits abort signals from tempWindowTurnstileFetch runtime messages", async () => {
+    const abortController = new AbortController()
+    mocks.sendRuntimeMessageMock.mockResolvedValue({
+      success: true,
+      data: "token",
+      turnstile: { status: "token_obtained", hasTurnstile: true },
+    })
+
+    await tempWindowTurnstileFetch({
+      originUrl: "https://example.com",
+      pageUrl: "https://example.com/checkin",
+      fetchUrl: "https://example.com/api/checkin",
+      fetchOptions: {
+        method: "POST",
+        signal: abortController.signal,
+      },
+    })
+
+    expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.TempWindowTurnstileFetch,
+        fetchOptions: { method: "POST" },
+      }),
+    )
   })
 
   it("routes tempWindowTriggerCheckinPageAction through runtime messaging", async () => {


### PR DESCRIPTION
## Summary
- align the Sub2API manual repair action with the account repair outcome row layout
- widen the repair dialog panel so account actions and status details have room to wrap cleanly
- omit abort signals before current-tab content fetch requests cross extension message boundaries

## Test Plan
- pnpm exec vitest run tests/entrypoints/content/messageHandlers/utils/tempFetchUtils.test.ts tests/services/apiTransport/request.test.ts
- pnpm run validate:push
- git push pre-push validation: pnpm run validate:push

## Notes
- `pnpm exec vitest related --run ...` was attempted first, but it expanded into a broad related set and hit the 120s command timeout before reporting assertion failures; focused tests and the repo push gate passed afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-context request option handling by normalizing headers and omitting non-native, message-cloned signal-like values while preserving native abort signals.
  * Ensured temp-window and content-tab fetch flows omit forwarded abort signals from transmitted fetch options.
* **UI Improvements**
  * Updated Repair account coverage list layout to a more responsive, grid-based structure.
  * Adjusted the missing-keys dialog width on small screens for improved readability.
* **Tests**
  * Added/extended unit tests to verify signal normalization and that message payloads exclude `signal`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->