### PR TITLE
refactor(ui): standardize compact multiselect sizing

### DIFF
--- a/src/components/ChannelFiltersEditor.tsx
+++ b/src/components/ChannelFiltersEditor.tsx
@@ -264,6 +264,7 @@ export default function ChannelFiltersEditor(props: ChannelFiltersEditorProps) {
                         <CompactMultiSelect
                           options={probeOptions}
                           selected={filter.probeIds}
+                          size="default"
                           disabled={!probeRulesSupported}
                           onChange={(value) =>
                             onFieldChange(filter.id, "probeIds", value)

--- a/src/components/ClaudeCodeRouterImportDialog.tsx
+++ b/src/components/ClaudeCodeRouterImportDialog.tsx
@@ -291,6 +291,7 @@ export function ClaudeCodeRouterImportDialog(
             options={upstreamModelOptions}
             selected={selectedModels}
             onChange={setSelectedModels}
+            size="default"
             placeholder={
               isLoadingModels
                 ? t("common:status.loading")

--- a/src/components/KiloCodeExportDialog.tsx
+++ b/src/components/KiloCodeExportDialog.tsx
@@ -957,6 +957,7 @@ export function KiloCodeExportDialog({
                     [siteId]: values,
                   }))
                 }}
+                size="default"
                 placeholder={t("ui:dialog.kiloCode.placeholders.selectTokens")}
                 clearable
               />
@@ -1161,6 +1162,7 @@ export function KiloCodeExportDialog({
             options={siteOptions}
             selected={selectedSiteIds}
             onChange={setSelectedSiteIds}
+            size="default"
             placeholder={t("ui:dialog.kiloCode.placeholders.selectSites")}
             clearable
           />

--- a/src/components/dialogs/ChannelDialog/components/ChannelDialog.tsx
+++ b/src/components/dialogs/ChannelDialog/components/ChannelDialog.tsx
@@ -692,6 +692,7 @@ export function ChannelDialog({
             options={availableModels}
             selected={formData.models}
             onChange={(models) => updateField("models", models)}
+            size="default"
             placeholder={
               isLoadingModels
                 ? t("channelDialog:fields.models.loading")
@@ -713,6 +714,7 @@ export function ChannelDialog({
               options={availableGroups}
               selected={formData.groups}
               onChange={(groups) => updateField("groups", groups)}
+              size="default"
               placeholder={
                 isLoadingGroups
                   ? t("channelDialog:fields.groups.loading")

--- a/src/components/ui/CompactMultiSelect.tsx
+++ b/src/components/ui/CompactMultiSelect.tsx
@@ -82,7 +82,7 @@ export interface CompactMultiSelectProps
   searchPlaceholder?: string
   emptyMessage?: string
   /**
-   * Trigger button size. Defaults to "sm" to keep the control compact.
+   * Trigger button size. Defaults to "default" to match regular form controls.
    */
   size?: React.ComponentProps<typeof Button>["size"]
   /**
@@ -114,7 +114,7 @@ export function CompactMultiSelect({
   maxDisplayValues = 2,
   searchPlaceholder,
   emptyMessage,
-  size = "sm",
+  size = "default",
   bulkActionsMinOptions = 0,
   className,
   ...buttonProps

--- a/src/features/BasicSettings/components/tabs/ManagedSite/ModelRedirectSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/ModelRedirectSettings.tsx
@@ -156,6 +156,7 @@ export default function ModelRedirectSettings() {
                   onChange={(standardModels) =>
                     handleUpdate({ standardModels })
                   }
+                  size="default"
                   placeholder={t("standardModelsPlaceholder")}
                   disabled={isUpdating}
                   allowCustom

--- a/src/features/BasicSettings/components/tabs/ManagedSite/managedSiteModelSyncSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/managedSiteModelSyncSettings.tsx
@@ -739,6 +739,7 @@ export default function ManagedSiteModelSyncSettings() {
                 allowCustom
                 options={channelUpstreamModelOptions}
                 selected={preferences.allowedModels}
+                size="default"
                 placeholder={t(
                   "managedSiteModelSync:settings.allowedModelsPlaceholder",
                 )}

--- a/src/features/KeyManagement/components/AddTokenDialog/TokenForm/ModelLimits.tsx
+++ b/src/features/KeyManagement/components/AddTokenDialog/TokenForm/ModelLimits.tsx
@@ -63,6 +63,7 @@ export function ModelLimits({
             }))}
             selected={modelLimits}
             onChange={handleModelLimitsChange}
+            size="default"
             placeholder={t("dialog.selectModels")}
             label={t("dialog.availableModels")}
           />

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
@@ -754,6 +754,7 @@ export function ManagedSiteTokenBatchExportDialog({
                               onChange={(models) =>
                                 handleItemModelsChange(item, models)
                               }
+                              size="default"
                               placeholder={t(
                                 "channelDialog:fields.models.placeholder",
                               )}

--- a/src/features/ModelList/components/AllAccountsGroupFilterMenu.tsx
+++ b/src/features/ModelList/components/AllAccountsGroupFilterMenu.tsx
@@ -267,6 +267,7 @@ export function AllAccountsGroupFilterMenu({
                       onChange={(values) =>
                         handleAccountSelectionChange(accountId, values)
                       }
+                      size="sm"
                       displayMode="summary"
                       placeholder={t(
                         selectedGroups.length === 0

--- a/tests/components/CompactMultiSelect.test.tsx
+++ b/tests/components/CompactMultiSelect.test.tsx
@@ -571,4 +571,17 @@ describe("CompactMultiSelect", () => {
       getBoundingClientRectSpy.mockRestore()
     }
   })
+
+  it("defaults the summary trigger to regular button height", async () => {
+    renderCompact(
+      <CompactMultiSelect
+        displayMode="summary"
+        options={[{ value: "alpha", label: "Alpha" }]}
+        selected={[]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole("combobox")).toHaveClass("h-9")
+  })
 })


### PR DESCRIPTION
## Summary
- Default CompactMultiSelect to the regular form-control size so new summary-mode usages align with Input and SearchableSelect by default.
- Keep dense account-group filtering explicitly compact with size="sm" while form-like rows use the default size.
- Add a focused regression test for the summary trigger's default height.

## Test Plan
- pnpm vitest --run tests/components/CompactMultiSelect.test.tsx tests/features/ModelList/components/ControlPanel.test.tsx tests/components/ChannelFiltersEditor.test.tsx tests/entrypoints/options/ManagedSiteModelSyncSettings.test.tsx
- pnpm run validate:staged
- pnpm run validate:push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated several multi-select controls to use consistent default sizing across dialogs, settings, and filters.
  * Adjusted one account filter menu to use a smaller compact size for better fit.
  * Improved the summary view styling for multi-selects so the trigger displays at the expected height.

* **Tests**
  * Added coverage for the summary display styling of the compact multi-select component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->