### PR TITLE
test: clear react act warnings

### DIFF
--- a/tests/entrypoints/options/BalanceHistory.test.tsx
+++ b/tests/entrypoints/options/BalanceHistory.test.tsx
@@ -8,6 +8,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import BalanceHistory from "~/entrypoints/options/pages/BalanceHistory"
+import { BALANCE_HISTORY_TEST_IDS } from "~/features/BalanceHistory/testIds"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import {
   getDayKeyFromUnixSeconds,
@@ -27,7 +28,13 @@ import { BalanceHistoryMessageTypes } from "~/services/runtimeMessaging/messageT
 import { tagStorage } from "~/services/tags/tagStorage"
 import { DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION } from "~/types/dailyBalanceHistory"
 import { openSettingsTab, pushWithinOptionsPage } from "~/utils/navigation"
-import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "~~/tests/test-utils/render"
 
 const getMetricDropdownButtonName = (
   section: "breakdown" | "trend",
@@ -1051,6 +1058,15 @@ describe("BalanceHistory options page", () => {
       render(<BalanceHistory />)
 
       expect(await screen.findByText(PAGE_TITLE)).toBeInTheDocument()
+      const accountSummary = await screen.findByTestId(
+        BALANCE_HISTORY_TEST_IDS.accountSummary,
+      )
+      expect(
+        await within(accountSummary).findByText("Site A"),
+      ).toBeInTheDocument()
+      expect(
+        await within(accountSummary).findByText("$10.00"),
+      ).toBeInTheDocument()
 
       const user = userEvent.setup()
       await user.click(
@@ -1075,6 +1091,9 @@ describe("BalanceHistory options page", () => {
       expect(updateCurrencyType).toHaveBeenCalledWith("CNY")
       expect(screen.getByLabelText(START_DAY_LABEL)).toHaveValue("2026-02-01")
       expect(screen.getByLabelText(END_DAY_LABEL)).toHaveValue("2026-02-07")
+      expect(
+        await within(accountSummary).findByText("Site A"),
+      ).toBeInTheDocument()
     } finally {
       dateNowSpy.mockRestore()
     }

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -1480,11 +1480,9 @@ describe("useKeyManagement enabled account filtering", () => {
       expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1),
     )
 
-    await expect(
-      act(async () => {
-        await result.current.refreshManagedSiteTokenStatuses()
-      }),
-    ).resolves.toBeUndefined()
+    await act(async () => {
+      await result.current.refreshManagedSiteTokenStatuses()
+    })
 
     await waitFor(() =>
       expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(2),

--- a/tests/entrypoints/options/pages/ModelList/ModelItem.profileActions.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelItem.profileActions.test.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import ModelItem from "~/features/ModelList/components/ModelItem"
@@ -30,6 +31,21 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   return {
     ...actual,
     createTab: mockCreateTab,
+  }
+})
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+
+  return {
+    ...actual,
+    UserPreferencesProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useUserPreferencesContext: () => ({
+      themeMode: "light",
+      updateThemeMode: vi.fn().mockResolvedValue(undefined),
+    }),
   }
 })
 
@@ -606,6 +622,12 @@ describe("ModelItem profile actions", () => {
       authType: AuthTypeEnum.AccessToken,
       checkIn: { enableDetection: false },
     })
+    const catalogFallbackSource = {
+      ...accountSource,
+      capabilities: toAihubmixCatalogFallbackCapabilities(
+        accountSource.capabilities,
+      ),
+    }
 
     render(
       <ModelItem
@@ -632,10 +654,8 @@ describe("ModelItem profile actions", () => {
         effectiveGroup="default"
         selectedGroups={["default"]}
         availableGroups={["default"]}
-        source={accountSource}
-        displayCapabilities={toAihubmixCatalogFallbackCapabilities(
-          accountSource.capabilities,
-        )}
+        source={catalogFallbackSource}
+        displayCapabilities={catalogFallbackSource.capabilities}
         onVerifyModel={() => {}}
         onVerifyCliSupport={() => {}}
         onOpenModelKeyDialog={() => {}}

--- a/tests/entrypoints/popup/HeaderSection.test.tsx
+++ b/tests/entrypoints/popup/HeaderSection.test.tsx
@@ -114,6 +114,10 @@ vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
   }),
 }))
 
+vi.mock("~/features/ProductAnnouncements/ProductAnnouncementButton", () => ({
+  ProductAnnouncementButton: () => null,
+}))
+
 vi.mock("~/services/productAnalytics/actions", () => ({
   startProductAnalyticsAction: (...args: unknown[]) =>
     startProductAnalyticsActionMock(...args),

--- a/tests/test-utils/render.test.tsx
+++ b/tests/test-utils/render.test.tsx
@@ -14,6 +14,16 @@ vi.mock("~/services/updates/runtime", () => ({
 }))
 
 describe("test render utilities", () => {
+  it("does not request release update status by default", async () => {
+    const { result } = renderHook(() => "ok")
+
+    await waitFor(() => {
+      expect(result.current).toBe("ok")
+    })
+    expect(requestReleaseUpdateStatusMock).not.toHaveBeenCalled()
+    expect(requestReleaseUpdateCheckNowMock).not.toHaveBeenCalled()
+  })
+
   it("supports renderHook with withReleaseUpdateStatusProvider false", async () => {
     const { result } = renderHook(() => "ok", {
       withReleaseUpdateStatusProvider: false,

--- a/tests/test-utils/render.tsx
+++ b/tests/test-utils/render.tsx
@@ -27,7 +27,7 @@ function IdentityProvider({ children }: { children: ReactNode }) {
 
 const AppProviders = ({
   children,
-  withReleaseUpdateStatusProvider = true,
+  withReleaseUpdateStatusProvider = false,
   withUserPreferencesProvider = true,
   withThemeProvider = true,
 }: AppProvidersProps) => {
@@ -83,7 +83,7 @@ function normalizeProviderOptions<T extends ProviderToggleOptions>(
   remainingOptions: Omit<T, keyof ProviderToggleOptions>
 } {
   const {
-    withReleaseUpdateStatusProvider = true,
+    withReleaseUpdateStatusProvider = false,
     withUserPreferencesProvider = true,
     withThemeProvider = true,
     ...remainingOptions


### PR DESCRIPTION
## Summary
- disable the release update status provider by default in test render utilities
- wait for async UI state in Balance History tests
- isolate popup header and ModelItem tests from unrelated async providers/hooks
- simplify the Key Management act assertion pattern

## Validation
- pnpm run validate:staged
- pnpm vitest --run --reporter=dot
- remote Test workflow: https://github.com/qixing-jk/all-api-hub/actions/runs/28226406449
- CI unit logs: ci_unit_act_matches=0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of options-page behavior around account summary display, currency/date controls, and managed-site status updates.
  * Stabilized model and header-related UI coverage so theme and announcement-related behaviors render consistently.
  * Updated shared rendering defaults so unnecessary release-check behavior is no longer enabled in tests unless explicitly requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->