### PR TITLE
feat(web-ai-api-check): persist pre-save verification history

### DIFF
--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
@@ -17,6 +17,12 @@ import {
   type ApiVerificationApiType,
   type ApiVerificationProbeId,
 } from "~/services/verification/aiApiVerification"
+import {
+  createProfileModelVerificationHistoryTarget,
+  createProfileVerificationHistoryTarget,
+  createVerificationHistorySummary,
+  verificationResultHistoryStorage,
+} from "~/services/verification/verificationResultHistory"
 import type { WebAiApiCheckBaseUrlSuggestion } from "~/services/verification/webAiApiCheck/baseUrlHistory"
 import { extractApiCheckCredentialsFromText } from "~/services/verification/webAiApiCheck/extractCredentials"
 import {
@@ -25,6 +31,7 @@ import {
 } from "~/services/verification/webAiApiCheck/messaging"
 import type { Tag } from "~/types"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
+import { createLogger } from "~/utils/core/logger"
 
 import {
   API_CHECK_MODAL_CLOSE_REASONS,
@@ -45,6 +52,8 @@ import { useApiCheckBaseUrlHistory } from "./useApiCheckBaseUrlHistory"
 import { useApiCheckModalShell } from "./useApiCheckModalShell"
 import { useApiCheckModelDiscovery } from "./useApiCheckModelDiscovery"
 import { useApiCheckProbeRunner } from "./useApiCheckProbeRunner"
+
+const logger = createLogger("ApiCheckModalViewModel")
 
 /**
  * Converts an HTML date input value into a local day-level timestamp.
@@ -248,6 +257,7 @@ export function useApiCheckModalViewModel() {
     stopProbe,
     runAll,
     stopRunAll,
+    getCurrentVerificationResultsSnapshot,
   } = probeRunner
 
   const canClose = !isRunningAll && !isAnyProbeRunning
@@ -453,6 +463,38 @@ export function useApiCheckModalViewModel() {
 
   const canSaveProfile = !!baseUrl.trim() && !!apiKey.trim() && !isSavingProfile
 
+  const persistPreSaveVerificationHistory = useCallback(
+    async (profileId: string) => {
+      const snapshot = getCurrentVerificationResultsSnapshot()
+      if (!snapshot) return
+
+      const target = snapshot.modelId
+        ? createProfileModelVerificationHistoryTarget(
+            profileId,
+            snapshot.modelId,
+          )
+        : createProfileVerificationHistoryTarget(profileId)
+      if (!target) return
+
+      const summary = createVerificationHistorySummary({
+        target,
+        apiType: snapshot.apiType,
+        results: snapshot.results,
+        preferredModelId: snapshot.modelId,
+      })
+      if (!summary) return
+
+      try {
+        await verificationResultHistoryStorage.upsertLatestSummary(summary)
+      } catch (error) {
+        logger.error("Failed to persist pre-save verification history", {
+          error,
+        })
+      }
+    },
+    [getCurrentVerificationResultsSnapshot],
+  )
+
   const handleSaveProfile = async () => {
     const tracker = startProductAnalyticsAction({
       ...contentApiCheckAnalyticsScope,
@@ -493,6 +535,8 @@ export function useApiCheckModalViewModel() {
       )
 
       if (response?.success) {
+        await persistPreSaveVerificationHistory(response.profileId)
+
         toast.success(
           (toastInstance) => (
             <div className="flex min-w-0 items-center gap-2">

--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckProbeRunner.ts
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckProbeRunner.ts
@@ -56,6 +56,14 @@ type RunProbeOptions = {
   shouldIgnoreResult?: () => boolean
 }
 
+type VerificationResultsSnapshot = {
+  apiType: ApiVerificationApiType
+  baseUrl: string
+  apiKey: string
+  modelId?: string
+  results: ApiVerificationProbeResult[]
+}
+
 /**
  * Build the initial probe UI state for the selected API type.
  */
@@ -81,6 +89,34 @@ function markProbeNotRunning(
   return probes.map((probe) =>
     probe.id === probeId ? { ...probe, isRunning: false } : probe,
   )
+}
+
+/**
+ * Extract completed probe results from the current UI state.
+ */
+function extractProbeResults(
+  probes: ProbeItemState[],
+): ApiVerificationProbeResult[] {
+  return probes
+    .map((probe) => probe.result)
+    .filter((result): result is ApiVerificationProbeResult => result !== null)
+}
+
+/**
+ * Serializes the credential context represented by a probe run.
+ */
+function createVerificationContextKey(params: {
+  apiType: ApiVerificationApiType
+  baseUrl: string
+  apiKey: string
+  modelId: string
+}) {
+  return [
+    params.apiType,
+    params.baseUrl.trim(),
+    params.apiKey.trim(),
+    params.modelId.trim(),
+  ].join("\n")
 }
 
 /**
@@ -136,6 +172,7 @@ export function useApiCheckProbeRunner({
   )
   const cancelledProbeRunIdsRef = useRef(new Set<string>())
   const activeRunAllProbeIdRef = useRef<ApiVerificationProbeId | null>(null)
+  const verifiedContextKeyRef = useRef<string | null>(null)
 
   const probeDefinitions = useMemo(
     () => getApiVerificationProbeDefinitions(apiType),
@@ -152,7 +189,48 @@ export function useApiCheckProbeRunner({
   const resetProbeState = useCallback((nextApiType: ApiVerificationApiType) => {
     setProbes(buildProbeState(nextApiType))
     setTestStoppedMessage(null)
+    verifiedContextKeyRef.current = null
   }, [])
+
+  const updateProbeResult = useCallback(
+    (probeId: ApiVerificationProbeId, result: ApiVerificationProbeResult) => {
+      verifiedContextKeyRef.current = createVerificationContextKey({
+        apiType,
+        baseUrl,
+        apiKey,
+        modelId,
+      })
+      setProbes((prev) =>
+        prev.map((probe) =>
+          probe.id === probeId ? { ...probe, isRunning: false, result } : probe,
+        ),
+      )
+    },
+    [apiKey, apiType, baseUrl, modelId],
+  )
+
+  const getCurrentVerificationResultsSnapshot =
+    useCallback((): VerificationResultsSnapshot | null => {
+      const currentContextKey = createVerificationContextKey({
+        apiType,
+        baseUrl,
+        apiKey,
+        modelId,
+      })
+      if (verifiedContextKeyRef.current !== currentContextKey) return null
+
+      const results = extractProbeResults(probes)
+      if (results.length === 0) return null
+
+      const trimmedModelId = modelId.trim()
+      return {
+        apiType,
+        baseUrl: baseUrl.trim(),
+        apiKey: apiKey.trim(),
+        ...(trimmedModelId ? { modelId: trimmedModelId } : {}),
+        results,
+      }
+    }, [apiKey, apiType, baseUrl, modelId, probes])
 
   const runProbe = useCallback(
     async (
@@ -261,13 +339,7 @@ export function useApiCheckProbeRunner({
             )
             return null
           }
-          setProbes((prev) =>
-            prev.map((probe) =>
-              probe.id === probeId
-                ? { ...probe, isRunning: false, result }
-                : probe,
-            ),
-          )
+          updateProbeResult(probeId, result)
           const analyticsResult = getProbeAnalyticsResult(result)
           tracker?.complete(analyticsResult, {
             ...(analyticsResult === PRODUCT_ANALYTICS_RESULTS.Failure
@@ -312,13 +384,7 @@ export function useApiCheckProbeRunner({
           return null
         }
 
-        setProbes((prev) =>
-          prev.map((probe) =>
-            probe.id === probeId
-              ? { ...probe, isRunning: false, result: fallback }
-              : probe,
-          ),
-        )
+        updateProbeResult(probeId, fallback)
         tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
           errorCategory:
             failedResponse?.errorCategory ??
@@ -353,17 +419,7 @@ export function useApiCheckProbeRunner({
           )
           return null
         }
-        setProbes((prev) =>
-          prev.map((probe) =>
-            probe.id === probeId
-              ? {
-                  ...probe,
-                  isRunning: false,
-                  result: fallback,
-                }
-              : probe,
-          ),
-        )
+        updateProbeResult(probeId, fallback)
         tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
           errorCategory,
           insights: buildApiCheckAnalyticsInsights(apiType, trigger, {
@@ -391,6 +447,7 @@ export function useApiCheckProbeRunner({
       setValidationError,
       t,
       trigger,
+      updateProbeResult,
     ],
   )
 
@@ -596,6 +653,7 @@ export function useApiCheckProbeRunner({
     testStoppedMessage,
     hasAnyResult,
     isAnyProbeRunning,
+    getCurrentVerificationResultsSnapshot,
     resetProbeState,
     runProbe: (probeId: ApiVerificationProbeId) => {
       void runProbe(probeId)

--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckProbeRunner.ts
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckProbeRunner.ts
@@ -56,7 +56,7 @@ type RunProbeOptions = {
   shouldIgnoreResult?: () => boolean
 }
 
-type VerificationResultsSnapshot = {
+interface VerificationResultsSnapshot {
   apiType: ApiVerificationApiType
   baseUrl: string
   apiKey: string
@@ -94,10 +94,13 @@ function markProbeNotRunning(
 /**
  * Extract completed probe results from the current UI state.
  */
-function extractProbeResults(
+function extractProbeResultsForContext(
   probes: ProbeItemState[],
+  resultContextKeys: ReadonlyMap<ApiVerificationProbeId, string>,
+  contextKey: string,
 ): ApiVerificationProbeResult[] {
   return probes
+    .filter((probe) => resultContextKeys.get(probe.id) === contextKey)
     .map((probe) => probe.result)
     .filter((result): result is ApiVerificationProbeResult => result !== null)
 }
@@ -172,7 +175,9 @@ export function useApiCheckProbeRunner({
   )
   const cancelledProbeRunIdsRef = useRef(new Set<string>())
   const activeRunAllProbeIdRef = useRef<ApiVerificationProbeId | null>(null)
-  const verifiedContextKeyRef = useRef<string | null>(null)
+  const probeResultContextKeysRef = useRef(
+    new Map<ApiVerificationProbeId, string>(),
+  )
 
   const probeDefinitions = useMemo(
     () => getApiVerificationProbeDefinitions(apiType),
@@ -189,17 +194,20 @@ export function useApiCheckProbeRunner({
   const resetProbeState = useCallback((nextApiType: ApiVerificationApiType) => {
     setProbes(buildProbeState(nextApiType))
     setTestStoppedMessage(null)
-    verifiedContextKeyRef.current = null
+    probeResultContextKeysRef.current.clear()
   }, [])
 
   const updateProbeResult = useCallback(
     (probeId: ApiVerificationProbeId, result: ApiVerificationProbeResult) => {
-      verifiedContextKeyRef.current = createVerificationContextKey({
-        apiType,
-        baseUrl,
-        apiKey,
-        modelId,
-      })
+      probeResultContextKeysRef.current.set(
+        probeId,
+        createVerificationContextKey({
+          apiType,
+          baseUrl,
+          apiKey,
+          modelId,
+        }),
+      )
       setProbes((prev) =>
         prev.map((probe) =>
           probe.id === probeId ? { ...probe, isRunning: false, result } : probe,
@@ -217,9 +225,12 @@ export function useApiCheckProbeRunner({
         apiKey,
         modelId,
       })
-      if (verifiedContextKeyRef.current !== currentContextKey) return null
 
-      const results = extractProbeResults(probes)
+      const results = extractProbeResultsForContext(
+        probes,
+        probeResultContextKeysRef.current,
+        currentContextKey,
+      )
       if (results.length === 0) return null
 
       const trimmedModelId = modelId.trim()

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -3438,6 +3438,111 @@ describe("ApiCheckModalHost", () => {
     expect(upsertVerificationHistorySummaryMock).not.toHaveBeenCalled()
   })
 
+  it("does not persist mixed-context pre-save probe results after a later probe matches changed credentials", async () => {
+    const user = userEvent.setup()
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: ["gpt-test-model"] }
+        }
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          return {
+            success: true,
+            result: {
+              id: message.probeId,
+              status: "pass",
+              latencyMs: 12,
+              summary:
+                message.probeId === "models"
+                  ? "Original models OK"
+                  : "Changed text generation OK",
+            },
+          }
+        }
+        if (type === WebAiApiCheckMessageTypes.SaveProfile) {
+          return {
+            success: true,
+            profileId: "p-changed",
+            name: "proxy.example.com",
+            apiType: message.apiType,
+            baseUrl: "https://proxy.example.com/api",
+          }
+        }
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    await user.click(
+      await screen.findByPlaceholderText("https://example.com/api"),
+    )
+    await user.paste("https://proxy.example.com/api")
+    const apiKeyInput = await screen.findByPlaceholderText("sk-...")
+    await user.click(apiKeyInput)
+    await user.paste("sk-test-original-fixture")
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(WEB_AI_API_CHECK_TEST_IDS.modelId),
+      ).toHaveTextContent("gpt-test-model")
+    })
+
+    const modelsProbeCard = await screen.findByTestId(
+      getWebAiApiCheckProbeTestId("models"),
+    )
+    await user.click(
+      within(modelsProbeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.runOne",
+      }),
+    )
+    expect(
+      await within(modelsProbeCard).findByText("Original models OK"),
+    ).toBeVisible()
+
+    await user.clear(apiKeyInput)
+    await user.paste("sk-test-changed-fixture")
+
+    await waitFor(() => {
+      expectTypedApiCheckMessage(WebAiApiCheckMessageTypes.FetchModels, {
+        apiType: "openai-compatible",
+        baseUrl: "https://proxy.example.com/api",
+        apiKey: "sk-test-changed-fixture",
+      })
+    })
+
+    const textGenerationProbeCard = await screen.findByTestId(
+      getWebAiApiCheckProbeTestId("text-generation"),
+    )
+    await user.click(
+      within(textGenerationProbeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.runOne",
+      }),
+    )
+    expect(
+      await within(textGenerationProbeCard).findByText(
+        "Changed text generation OK",
+      ),
+    ).toBeVisible()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.actions.saveToProfiles",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(upsertVerificationHistorySummaryMock).toHaveBeenCalled()
+    })
+    const [[summary]] = upsertVerificationHistorySummaryMock.mock.calls
+    expect(summary.probes).toEqual([
+      expect.objectContaining({
+        id: "text-generation",
+        summary: "Changed text generation OK",
+      }),
+    ])
+  })
+
   it("saves profile metadata entered in the API check modal", async () => {
     const user = userEvent.setup()
     vi.mocked(sendWebAiApiCheckMessage).mockImplementation(

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -50,10 +50,12 @@ const {
   startProductAnalyticsActionMock,
   completeProductAnalyticsActionMock,
   updateWebAiApiCheckMock,
+  upsertVerificationHistorySummaryMock,
 } = vi.hoisted(() => ({
   startProductAnalyticsActionMock: vi.fn(),
   completeProductAnalyticsActionMock: vi.fn(),
   updateWebAiApiCheckMock: vi.fn(),
+  upsertVerificationHistorySummaryMock: vi.fn(),
 }))
 
 function createDeferred<T>() {
@@ -121,6 +123,23 @@ vi.mock(
   },
 )
 
+vi.mock(
+  "~/services/verification/verificationResultHistory",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/verification/verificationResultHistory")
+      >()
+    return {
+      ...actual,
+      verificationResultHistoryStorage: {
+        ...actual.verificationResultHistoryStorage,
+        upsertLatestSummary: upsertVerificationHistorySummaryMock,
+      },
+    }
+  },
+)
+
 describe("ApiCheckModalHost", () => {
   const expectAnalyticsCallsToExcludeSensitiveValues = (
     values: readonly string[],
@@ -160,6 +179,10 @@ describe("ApiCheckModalHost", () => {
     })
     updateWebAiApiCheckMock.mockReset()
     updateWebAiApiCheckMock.mockResolvedValue(true)
+    upsertVerificationHistorySummaryMock.mockReset()
+    upsertVerificationHistorySummaryMock.mockImplementation(
+      async (summary) => summary,
+    )
     vi.mocked(sendRuntimeMessage).mockReset()
     vi.mocked(sendRuntimeMessage).mockResolvedValue({ success: false })
     vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
@@ -3240,6 +3263,179 @@ describe("ApiCheckModalHost", () => {
         },
       },
     )
+  })
+
+  it("persists completed pre-save probe results as profile verification history after saving", async () => {
+    const user = userEvent.setup()
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: ["gpt-test-model"] }
+        }
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          return {
+            success: true,
+            result: {
+              id: message.probeId,
+              status: "pass",
+              latencyMs: 12,
+              summary: "Text generation OK",
+              summaryKey: "verifyDialog.summaries.textGenerationSucceeded",
+              summaryParams: { model: "gpt-test-model" },
+            },
+          }
+        }
+        if (type === WebAiApiCheckMessageTypes.SaveProfile) {
+          return {
+            success: true,
+            profileId: "p-verified",
+            name: "proxy.example.com",
+            apiType: message.apiType,
+            baseUrl: "https://proxy.example.com/api",
+          }
+        }
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    await user.click(
+      await screen.findByPlaceholderText("https://example.com/api"),
+    )
+    await user.paste("https://proxy.example.com/api")
+    await user.click(await screen.findByPlaceholderText("sk-..."))
+    await user.paste("sk-test-secret-fixture")
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(WEB_AI_API_CHECK_TEST_IDS.modelId),
+      ).toHaveTextContent("gpt-test-model")
+    })
+
+    const probeCard = await screen.findByTestId(
+      getWebAiApiCheckProbeTestId("text-generation"),
+    )
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.runOne",
+      }),
+    )
+    expect(
+      await within(probeCard).findByText(
+        "aiApiVerification:verifyDialog.summaries.textGenerationSucceeded",
+      ),
+    ).toBeVisible()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.actions.saveToProfiles",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(upsertVerificationHistorySummaryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: {
+            kind: "profile-model",
+            profileId: "p-verified",
+            modelId: "gpt-test-model",
+          },
+          targetKey: "profile:p-verified:model:gpt-test-model",
+          status: "pass",
+          apiType: "openai-compatible",
+          resolvedModelId: "gpt-test-model",
+          probes: [
+            expect.objectContaining({
+              id: "text-generation",
+              status: "pass",
+              latencyMs: 12,
+              summary: "Text generation OK",
+              summaryKey: "verifyDialog.summaries.textGenerationSucceeded",
+              summaryParams: { model: "gpt-test-model" },
+            }),
+          ],
+        }),
+      )
+    })
+  })
+
+  it("does not persist stale pre-save probe results after credentials change", async () => {
+    const user = userEvent.setup()
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any, message: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: ["gpt-test-model"] }
+        }
+        if (type === WebAiApiCheckMessageTypes.RunProbe) {
+          return {
+            success: true,
+            result: {
+              id: message.probeId,
+              status: "pass",
+              latencyMs: 12,
+              summary: "Text generation OK",
+            },
+          }
+        }
+        if (type === WebAiApiCheckMessageTypes.SaveProfile) {
+          return {
+            success: true,
+            profileId: "p-changed",
+            name: "proxy.example.com",
+            apiType: message.apiType,
+            baseUrl: "https://proxy.example.com/api",
+          }
+        }
+        return { success: false }
+      },
+    )
+
+    await openModal()
+
+    await user.click(
+      await screen.findByPlaceholderText("https://example.com/api"),
+    )
+    await user.paste("https://proxy.example.com/api")
+    const apiKeyInput = await screen.findByPlaceholderText("sk-...")
+    await user.click(apiKeyInput)
+    await user.paste("sk-test-original-fixture")
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(WEB_AI_API_CHECK_TEST_IDS.modelId),
+      ).toHaveTextContent("gpt-test-model")
+    })
+
+    const probeCard = await screen.findByTestId(
+      getWebAiApiCheckProbeTestId("text-generation"),
+    )
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "webAiApiCheck:modal.actions.runOne",
+      }),
+    )
+    expect(
+      await within(probeCard).findByText("Text generation OK"),
+    ).toBeVisible()
+
+    await user.clear(apiKeyInput)
+    await user.paste("sk-test-changed-fixture")
+    await user.click(
+      await screen.findByRole("button", {
+        name: "webAiApiCheck:modal.actions.saveToProfiles",
+      }),
+    )
+
+    await waitFor(() => {
+      expectTypedApiCheckMessage(WebAiApiCheckMessageTypes.SaveProfile, {
+        apiType: "openai-compatible",
+        baseUrl: "https://proxy.example.com/api",
+        apiKey: "sk-test-changed-fixture",
+        pageUrl: "https://example.com",
+      })
+    })
+    expect(upsertVerificationHistorySummaryMock).not.toHaveBeenCalled()
   })
 
   it("saves profile metadata entered in the API check modal", async () => {


### PR DESCRIPTION
## Summary
- Persist completed Web AI API Check probe results as API credential verification history after the profile is saved.
- Bind the migrated history to the returned profile id, using profile-model history when a model is selected.
- Skip migration when credentials changed after testing so stale pre-save results are not attached to a new profile.

## Issue
Refs #1025

This implements the clarified behavior that pre-save testing should have the same visible result as saving first and then testing the credential profile.

## Validation
- pnpm vitest run tests/components/ApiCheckModalHost.test.tsx -t "persists completed pre-save probe results"
- pnpm vitest run tests/components/ApiCheckModalHost.test.tsx -t "pre-save probe results"
- pnpm vitest run tests/components/ApiCheckModalHost.test.tsx
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push
- pre-push validate:push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saved API verification results are now preserved in profile history when credentials are saved, including the relevant probe summaries for later review.

* **Bug Fixes**
  * Improved matching so only results from the latest, corresponding credential context are persisted (avoids saving stale checks after edits).

* **Tests**
  * Added coverage to confirm verification-history persistence behavior across successful saves and credential-change scenarios, and to validate the persisted payload details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->