### PR TITLE
fix(web-ai-api-check): preserve credentials on empty extraction

### DIFF
--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
@@ -449,8 +449,12 @@ export function useApiCheckModalViewModel() {
       candidates: extracted.candidates,
       summary: extracted.summary,
     })
-    updateBaseUrl(extracted.baseUrl ?? "")
-    setApiKey(extracted.apiKey ?? "")
+    if (extracted.baseUrl) {
+      updateBaseUrl(extracted.baseUrl)
+    }
+    if (extracted.apiKey) {
+      setApiKey(extracted.apiKey)
+    }
   }, [isOpen, sourceText, updateBaseUrl])
 
   const handleSelectBaseUrlHistory = useCallback(

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -823,7 +823,7 @@ describe("ApiCheckModalHost", () => {
     ).toBeInTheDocument()
   })
 
-  it("clears active credentials when edited source text no longer contains credentials", async () => {
+  it("preserves active credentials when edited source text has no extraction result", async () => {
     const user = userEvent.setup()
     vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
       async (type: any) => {
@@ -856,14 +856,14 @@ describe("ApiCheckModalHost", () => {
     await user.type(sourceTextInput, "No credentials here")
 
     await waitFor(() => {
-      expect(baseUrlInput.value).toBe("")
-      expect(apiKeyInput.value).toBe("")
+      expect(baseUrlInput.value).toBe("https://proxy.example.com/api")
+      expect(apiKeyInput.value).toBe("sk-test-source-clear-fixture")
     })
     expect(
       screen.getByRole("button", {
         name: "webAiApiCheck:modal.actions.saveToProfiles",
       }),
-    ).toBeDisabled()
+    ).toBeEnabled()
   })
 
   it("tracks modal open with safe credential presence insights", async () => {

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -866,6 +866,49 @@ describe("ApiCheckModalHost", () => {
     ).toBeEnabled()
   })
 
+  it("preserves the other credential when edited source text only extracts one value", async () => {
+    const user = userEvent.setup()
+    vi.mocked(sendWebAiApiCheckMessage).mockImplementation(
+      async (type: any) => {
+        if (type === WebAiApiCheckMessageTypes.FetchModels) {
+          return { success: true, modelIds: ["gpt-4o-mini"] }
+        }
+        return { success: false }
+      },
+    )
+
+    await openModal({
+      sourceText:
+        "Base URL: https://proxy.example.com/api\nAPI Key: sk-test-partial-fixture",
+    })
+
+    const baseUrlInput = (await screen.findByLabelText(
+      "webAiApiCheck:modal.fields.baseUrl",
+    )) as HTMLInputElement
+    const apiKeyInput = screen.getByLabelText(
+      "webAiApiCheck:modal.fields.apiKey",
+    ) as HTMLInputElement
+    const sourceTextInput = screen.getByLabelText(
+      "webAiApiCheck:modal.sourceText.label",
+    )
+
+    expect(baseUrlInput.value).toBe("https://proxy.example.com/api")
+    expect(apiKeyInput.value).toBe("sk-test-partial-fixture")
+
+    await user.clear(sourceTextInput)
+    await user.type(sourceTextInput, "Base URL: https://next.example.com/api")
+
+    await waitFor(() => {
+      expect(baseUrlInput.value).toBe("https://next.example.com/api")
+      expect(apiKeyInput.value).toBe("sk-test-partial-fixture")
+    })
+    expect(
+      screen.getByRole("button", {
+        name: "webAiApiCheck:modal.actions.saveToProfiles",
+      }),
+    ).toBeEnabled()
+  })
+
   it("tracks modal open with safe credential presence insights", async () => {
     const sourceText =
       "Base URL: https://proxy.example.com/api\nAPI Key: sk-test-open-fixture"


### PR DESCRIPTION
## Summary
- Preserve existing Base URL and API Key values when editing the API check source text yields no extracted credentials
- Keep extracted-field updates field-specific so partial extraction updates only the value that was found
- Update the content modal regression test to cover empty extraction preserving existing credentials

## Validation
- pnpm vitest run tests/components/ApiCheckModalHost.test.tsx --testNamePattern "preserves active credentials"
- pnpm vitest run tests/components/ApiCheckModalHost.test.tsx
- pnpm run validate:staged
- pnpm run validate:push
- git push pre-push hook: pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing base URL and API key when the edited source text does not produce any extracted credentials.
  * Prevented credential fields from being cleared unexpectedly during source-text synchronization.
  * Kept the “save to profiles” option available even when no new credentials are extracted, so users can retain and save their current settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->