### PR TITLE
refactor(accounts): centralize account api context ownership

### DIFF
--- a/docs/superpowers/plans/2026-06-26-account-api-context-display-data.md
+++ b/docs/superpowers/plans/2026-06-26-account-api-context-display-data.md
@@ -801,7 +801,7 @@ Create `src/services/accounts/utils/legacyAccountAwareRequest.ts`:
 
 ```ts
 import { accountStorage } from "~/services/accounts/accountStorage"
-import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
 import { AuthTypeEnum } from "~/types"
 import { createLogger } from "~/utils/core/logger"
 

--- a/docs/superpowers/plans/2026-06-26-account-api-context-display-data.md
+++ b/docs/superpowers/plans/2026-06-26-account-api-context-display-data.md
@@ -1,0 +1,1361 @@
+# Account API Context Display Data Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move account request-context ownership into `src/services/accounts/**` while preserving existing display-account UI flows and legacy request enrichment behavior.
+
+**Architecture:** Add request-only `AccountApiContext` builders beside the existing display-account capability context in `src/services/accounts/utils/apiServiceRequest.ts`. Move missing-`accountId` compatibility enrichment into an accounts-owned legacy helper, have `apiService/common/utils.ts` delegate to that helper without importing storage, and keep `fetchTodayIncome(...)` as the one documented temporary `apiService/common/index.ts` storage exception for this first slice.
+
+**Tech Stack:** TypeScript, Vitest, WXT extension services, account storage utilities, apiTransport request helpers, pnpm.
+
+**Spec:** `docs/superpowers/specs/2026-06-26-account-api-context-display-data-design.md`
+
+---
+
+## File Structure
+
+Create:
+
+- `src/services/accounts/utils/legacyAccountAwareRequest.ts`
+  - Own the temporary `baseUrl + userId` fallback currently hidden in `apiService/common/utils.ts`.
+  - Import `accountStorage` here, not in `src/services/apiService/common/utils.ts`.
+  - Preserve current warning context and cookie-session fallback behavior.
+- `tests/services/accounts/legacyAccountAwareRequest.test.ts`
+  - Move the account-enrichment behavior tests out of `tests/services/apiService/common/utils.test.ts`.
+
+Modify:
+
+- `src/services/accounts/utils/apiServiceRequest.ts`
+  - Export `DisplayAccountApiSnapshot`, `AccountApiContext`, `DisplayAccountApiCapabilityContext`, and `StoredAccountApiContextError`.
+  - Add `createDisplayAccountRequestContext(account)` for snapshot account contexts.
+  - Add `resolveStoredAccountApiContext(accountId)` for latest persisted account contexts.
+  - Keep `createDisplayAccountApiContext(account)` as the adapter-capability context and implement it through `createDisplayAccountRequestContext(account)`.
+- `tests/services/accounts/apiServiceRequest.test.ts`
+  - Add focused tests for request-only snapshot context, stored context, Sub2API decoration, missing id, and deleted account errors.
+- `src/services/apiService/common/utils.ts`
+  - Remove direct `accountStorage` import.
+  - Delegate compatibility enrichment to `resolveLegacyAccountAwareRequest(...)` before calling transport.
+- `tests/services/apiService/common/utils.test.ts`
+  - Replace storage-enrichment tests with pass-through/delegation tests.
+- `src/services/accounts/defaultTokenLifecycle/requests.ts`
+  - Replace duplicated stored-account request construction with `createAccountApiRequestFromStoredAccount(account).request` after Task 2 introduces that helper.
+- `tests/services/accounts/defaultTokenLifecycle.test.ts`
+  - Keep behavior expectations, updating expected request construction to the new shared helper if needed.
+- `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+  - Replace the local `createAccountApiRequest(...)` implementation with a call to the new shared context builder while preserving abort signal support.
+- `tests/services/accountKeyRepair.test.ts`
+  - Update only if the migrated request shape changes a focused expectation.
+
+Do not modify in this slice:
+
+- `src/types/index.ts`
+  - Do not delete or rename `DisplaySiteData` fields.
+- `src/services/apiService/common/index.ts`
+  - Leave `fetchTodayIncome(...)` storage lookup in place and document it as the remaining temporary exception. Moving that policy is a follow-up slice because it requires a cleaner account-data orchestration boundary.
+- `src/locales/**`
+- telemetry schemas, settings search definitions, or Playwright E2E tests.
+
+---
+
+## Implementation Notes
+
+Preserve these public behaviors:
+
+- `createDisplayAccountApiContext(account)` still returns `adapter`, `keyManagement`, `tokenProvisioning`, and `request`.
+- Display snapshot requests use `account.id` as `request.accountId`.
+- Cookie-auth session values are placed in `request.auth.cookie`; keep top-level `request.cookieAuthSessionCookie` only in the legacy helper for migration compatibility.
+- Sub2API requests still receive `sub2apiAuthSession: accountSub2ApiAuthSession` when the account-site profile allows account API auth-session decoration.
+- `fetchApi(...)` and `fetchApiData(...)` still preserve current missing-`accountId` fallback through the accounts-owned legacy helper during migration.
+- `fetchTodayIncome(...)` remains compatible for now and may still import `accountStorage` through `src/services/apiService/common/index.ts`.
+
+Use these exact names:
+
+```ts
+export type DisplayAccountApiSnapshot = Pick<
+  DisplaySiteData,
+  | "id"
+  | "siteType"
+  | "baseUrl"
+  | "authType"
+  | "userId"
+  | "token"
+  | "cookieAuthSessionCookie"
+>
+
+export interface AccountApiContext {
+  accountId: string
+  siteType: AccountSiteType
+  request: ApiServiceRequest | Sub2ApiAuthSessionRequest
+}
+
+export interface DisplayAccountApiCapabilityContext
+  extends AccountApiContext {
+  adapter: SiteAdapter
+  keyManagement: KeyManagementCapability | undefined
+  tokenProvisioning: TokenProvisioningCapability | undefined
+}
+```
+
+Telemetry decision: none. This is an internal request-context ownership refactor and does not add a user-visible action, state, or funnel.
+
+Settings search decision: none. No settings UI, anchors, search targets, or deep links change.
+
+E2E decision: no new Playwright E2E by default. The risk is deterministic request construction and storage lookup ownership, which is better covered by focused Vitest tests. Add E2E only if a later implementation slice changes cross-entrypoint browser behavior.
+
+---
+
+### Task 1: Add Snapshot Request-Only Context
+
+**Files:**
+
+- Modify: `src/services/accounts/utils/apiServiceRequest.ts`
+- Test: `tests/services/accounts/apiServiceRequest.test.ts`
+
+- [ ] **Step 1: Add failing snapshot-context tests**
+
+Add these imports in `tests/services/accounts/apiServiceRequest.test.ts`:
+
+```ts
+import {
+  canManageDisplayAccountTokens,
+  createDisplayAccountApiContext,
+  createDisplayAccountRequestContext,
+  fetchDisplayAccountTokens,
+  InvalidTokenPayloadError,
+  resolveDisplayAccountTokenForSecret,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Add these tests inside `describe("fetchDisplayAccountTokens", () => { ... })` after the existing `"returns the token array when the API payload is valid"` test:
+
+```ts
+  it("builds a request-only context from a display account snapshot", () => {
+    expect(createDisplayAccountRequestContext(ACCOUNT as any)).toEqual({
+      accountId: "account-1",
+      siteType: "new-api",
+      request: expect.objectContaining(REQUEST),
+    })
+    expect(createDisplayAccountRequestContext(ACCOUNT as any)).not.toHaveProperty(
+      "adapter",
+    )
+    expect(
+      createDisplayAccountRequestContext(ACCOUNT as any).request,
+    ).not.toHaveProperty("cookieAuthSessionCookie")
+  })
+
+  it("keeps cookie-auth sessions in request auth for display snapshots", () => {
+    const context = createDisplayAccountRequestContext({
+      ...ACCOUNT,
+      authType: AuthTypeEnum.Cookie,
+      token: "",
+      cookieAuthSessionCookie: "session=abc",
+    } as any)
+
+    expect(context.request).toEqual(
+      expect.objectContaining({
+        accountId: "account-1",
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.Cookie,
+          cookie: "session=abc",
+        }),
+      }),
+    )
+  })
+
+  it("rejects display account snapshots without a stable id", () => {
+    expect(() =>
+      createDisplayAccountRequestContext({
+        ...ACCOUNT,
+        id: "   ",
+      } as any),
+    ).toThrow("account_api_context_missing_account_id")
+  })
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: FAIL because `createDisplayAccountRequestContext` is not exported.
+
+- [ ] **Step 3: Add request-only types and builder**
+
+In `src/services/accounts/utils/apiServiceRequest.ts`, update imports:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import { shouldDecorateAccountApiRequestWithAuthSession } from "~/services/accounts/accountSiteProfile"
+import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
+import { formatOptionalSkPrefixSiteToken } from "~/services/accountTokens/apiTokenKey"
+import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import type { TokenProvisioningCapability } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import type { Sub2ApiAuthSessionRequest } from "~/services/apiService/sub2api/authSession"
+import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
+import { createLogger } from "~/utils/core/logger"
+```
+
+Add these exports after `InvalidTokenPayloadError`:
+
+```ts
+export class StoredAccountApiContextError extends Error {
+  readonly code:
+    | "MISSING_ACCOUNT_ID"
+    | "ACCOUNT_NOT_FOUND"
+    | "MISSING_BASE_URL"
+    | "MISSING_USER_ID"
+    | "MISSING_CREDENTIAL"
+
+  constructor(
+    code: StoredAccountApiContextError["code"],
+    message: string,
+  ) {
+    super(message)
+    this.name = "StoredAccountApiContextError"
+    this.code = code
+  }
+}
+
+export type DisplayAccountApiSnapshot = Pick<
+  DisplaySiteData,
+  | "id"
+  | "siteType"
+  | "baseUrl"
+  | "authType"
+  | "userId"
+  | "token"
+  | "cookieAuthSessionCookie"
+>
+
+export interface AccountApiContext {
+  accountId: string
+  siteType: AccountSiteType
+  request: ApiServiceRequest | Sub2ApiAuthSessionRequest
+}
+
+export interface DisplayAccountApiCapabilityContext
+  extends AccountApiContext {
+  adapter: SiteAdapter
+  keyManagement: KeyManagementCapability | undefined
+  tokenProvisioning: TokenProvisioningCapability | undefined
+}
+```
+
+Replace the existing `buildApiRequestFromDisplayAccount(...)` signature with:
+
+```ts
+const buildApiRequestFromDisplayAccount = (
+  account: DisplayAccountApiSnapshot,
+): ApiServiceRequest => ({
+  baseUrl: account.baseUrl,
+  accountId: account.id,
+  auth: {
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  },
+})
+```
+
+Add this exported function before `createDisplayAccountApiContext(...)`:
+
+```ts
+export const createDisplayAccountRequestContext = (
+  account: DisplayAccountApiSnapshot,
+): AccountApiContext => {
+  if (!hasNonEmptyString(account.id)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_ACCOUNT_ID",
+      "account_api_context_missing_account_id",
+    )
+  }
+
+  return {
+    accountId: account.id,
+    siteType: account.siteType,
+    request: withDisplayAccountAuthSession(
+      account,
+      buildApiRequestFromDisplayAccount(account),
+    ),
+  }
+}
+```
+
+Replace `createDisplayAccountApiContext(...)` with:
+
+```ts
+export const createDisplayAccountApiContext = (
+  account: DisplayAccountApiSnapshot,
+): DisplayAccountApiCapabilityContext => {
+  const adapter = getSiteAdapter(account.siteType)
+  const context = createDisplayAccountRequestContext(account)
+
+  return {
+    ...context,
+    adapter,
+    keyManagement: adapter.keyManagement,
+    tokenProvisioning: adapter.tokenProvisioning,
+  }
+}
+```
+
+Update `fetchDisplayAccountTokens(...)` and `resolveDisplayAccountTokenForSecret(...)` parameter types from the inline `Pick<DisplaySiteData, ...>` shape to `DisplayAccountApiSnapshot`.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/utils/apiServiceRequest.ts tests/services/accounts/apiServiceRequest.test.ts
+git commit -m "refactor(accounts): add display account request context"
+```
+
+Expected: commit succeeds. If pre-commit rewrites files, inspect `git status --porcelain` and `git diff --cached` before retrying.
+
+---
+
+### Task 2: Add Stored Account API Context
+
+**Files:**
+
+- Modify: `src/services/accounts/utils/apiServiceRequest.ts`
+- Test: `tests/services/accounts/apiServiceRequest.test.ts`
+
+- [ ] **Step 1: Add failing stored-context tests**
+
+Add this hoisted mock block near the existing mocks in `tests/services/accounts/apiServiceRequest.test.ts`:
+
+```ts
+const { mockGetAccountById } = vi.hoisted(() => ({
+  mockGetAccountById: vi.fn(),
+}))
+```
+
+Add this mock after the existing `sub2apiAuthSession` mock:
+
+```ts
+vi.mock("~/services/accounts/accountStorage", () => ({
+  accountStorage: {
+    getAccountById: mockGetAccountById,
+  },
+}))
+```
+
+Update the import from `~/services/accounts/utils/apiServiceRequest`:
+
+```ts
+import {
+  canManageDisplayAccountTokens,
+  createDisplayAccountApiContext,
+  createDisplayAccountRequestContext,
+  fetchDisplayAccountTokens,
+  InvalidTokenPayloadError,
+  resolveDisplayAccountTokenForSecret,
+  resolveStoredAccountApiContext,
+  StoredAccountApiContextError,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Add this helper after `REQUEST`:
+
+```ts
+const buildStoredAccount = (overrides: Record<string, unknown> = {}) => ({
+  id: "account-1",
+  site_name: "Example",
+  site_url: "https://example.com",
+  site_type: "new-api",
+  authType: AuthTypeEnum.AccessToken,
+  account_info: {
+    id: "1",
+    username: "Ada",
+    access_token: "token",
+  },
+  cookieAuth: undefined,
+  ...overrides,
+})
+```
+
+In the existing `beforeEach`, add:
+
+```ts
+    mockGetAccountById.mockReset()
+```
+
+Add these tests after the snapshot-context tests:
+
+```ts
+  it("resolves stored account context from the latest persisted account", async () => {
+    mockGetAccountById.mockResolvedValueOnce(
+      buildStoredAccount({
+        account_info: {
+          id: "stored-user",
+          username: "Latest",
+          access_token: "stored-token",
+        },
+      }),
+    )
+
+    await expect(resolveStoredAccountApiContext("account-1")).resolves.toEqual({
+      accountId: "account-1",
+      siteType: "new-api",
+      request: expect.objectContaining({
+        baseUrl: "https://example.com",
+        accountId: "account-1",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "stored-user",
+          accessToken: "stored-token",
+          cookie: undefined,
+        },
+      }),
+    })
+    expect(mockGetAccountById).toHaveBeenCalledWith("account-1")
+  })
+
+  it("preserves stored cookie-auth session in request auth", async () => {
+    mockGetAccountById.mockResolvedValueOnce(
+      buildStoredAccount({
+        authType: AuthTypeEnum.Cookie,
+        account_info: {
+          id: "stored-user",
+          username: "Latest",
+          access_token: "",
+        },
+        cookieAuth: {
+          sessionCookie: "session=stored",
+        },
+      }),
+    )
+
+    const context = await resolveStoredAccountApiContext("account-1")
+
+    expect(context.request).toEqual(
+      expect.objectContaining({
+        accountId: "account-1",
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.Cookie,
+          userId: "stored-user",
+          accessToken: "",
+          cookie: "session=stored",
+        }),
+      }),
+    )
+    expect(context.request).not.toHaveProperty("cookieAuthSessionCookie")
+  })
+
+  it("decorates stored Sub2API contexts with the account auth session port", async () => {
+    mockGetAccountById.mockResolvedValueOnce(
+      buildStoredAccount({
+        site_type: SITE_TYPES.SUB2API,
+      }),
+    )
+
+    const context = await resolveStoredAccountApiContext("account-1")
+
+    expect(context.siteType).toBe(SITE_TYPES.SUB2API)
+    expect(context.request).toEqual(
+      expect.objectContaining({
+        sub2apiAuthSession: accountSub2ApiAuthSession,
+      }),
+    )
+  })
+
+  it("throws a stable error when the stored account id is blank", async () => {
+    await expect(resolveStoredAccountApiContext("   ")).rejects.toMatchObject({
+      name: "StoredAccountApiContextError",
+      code: "MISSING_ACCOUNT_ID",
+      message: "account_api_context_missing_account_id",
+    })
+    expect(mockGetAccountById).not.toHaveBeenCalled()
+  })
+
+  it("throws a stable error when the stored account no longer exists", async () => {
+    mockGetAccountById.mockResolvedValueOnce(null)
+
+    await expect(resolveStoredAccountApiContext("missing")).rejects.toMatchObject({
+      name: "StoredAccountApiContextError",
+      code: "ACCOUNT_NOT_FOUND",
+      message: "account_api_context_account_not_found",
+    })
+  })
+
+  it("exposes StoredAccountApiContextError for caller recovery checks", () => {
+    expect(
+      new StoredAccountApiContextError(
+        "MISSING_CREDENTIAL",
+        "account_api_context_missing_credential",
+      ),
+    ).toMatchObject({
+      name: "StoredAccountApiContextError",
+      code: "MISSING_CREDENTIAL",
+      message: "account_api_context_missing_credential",
+    })
+  })
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: FAIL because `resolveStoredAccountApiContext` is not exported.
+
+- [ ] **Step 3: Add stored-account context builder**
+
+In `src/services/accounts/utils/apiServiceRequest.ts`, add imports:
+
+```ts
+import { accountStorage } from "~/services/accounts/accountStorage"
+import type { SiteAccount } from "~/types"
+```
+
+Add this type and helper after `buildApiRequestFromDisplayAccount(...)`:
+
+```ts
+type StoredAccountApiRequestSource = Pick<
+  SiteAccount,
+  "id" | "site_url" | "site_type" | "authType" | "account_info" | "cookieAuth"
+>
+
+export const createAccountApiRequestFromStoredAccount = (
+  account: StoredAccountApiRequestSource,
+): AccountApiContext => {
+  if (!hasNonEmptyString(account.id)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_ACCOUNT_ID",
+      "account_api_context_missing_account_id",
+    )
+  }
+
+  if (!hasNonEmptyString(account.site_url)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_BASE_URL",
+      "account_api_context_missing_base_url",
+    )
+  }
+
+  if (!hasNonEmptyString(account.account_info?.id)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_USER_ID",
+      "account_api_context_missing_user_id",
+    )
+  }
+
+  const accessToken = account.account_info?.access_token ?? ""
+  const cookie = account.cookieAuth?.sessionCookie
+
+  if (account.authType === AuthTypeEnum.AccessToken && !hasNonEmptyString(accessToken)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_CREDENTIAL",
+      "account_api_context_missing_credential",
+    )
+  }
+
+  if (
+    account.authType === AuthTypeEnum.Cookie &&
+    !hasNonEmptyString(accessToken) &&
+    !hasNonEmptyString(cookie)
+  ) {
+    throw new StoredAccountApiContextError(
+      "MISSING_CREDENTIAL",
+      "account_api_context_missing_credential",
+    )
+  }
+
+  const request: ApiServiceRequest = {
+    baseUrl: account.site_url,
+    accountId: account.id,
+    auth: {
+      authType: account.authType,
+      userId: account.account_info.id,
+      accessToken,
+      cookie,
+    },
+  }
+
+  return {
+    accountId: account.id,
+    siteType: account.site_type,
+    request: withDisplayAccountAuthSession(
+      { siteType: account.site_type },
+      request,
+    ),
+  }
+}
+```
+
+Add this exported function after `createAccountApiRequestFromStoredAccount(...)`:
+
+```ts
+export async function resolveStoredAccountApiContext(
+  accountId: string,
+): Promise<AccountApiContext> {
+  if (!hasNonEmptyString(accountId)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_ACCOUNT_ID",
+      "account_api_context_missing_account_id",
+    )
+  }
+
+  const account = await accountStorage.getAccountById(accountId)
+
+  if (!account) {
+    throw new StoredAccountApiContextError(
+      "ACCOUNT_NOT_FOUND",
+      "account_api_context_account_not_found",
+    )
+  }
+
+  return createAccountApiRequestFromStoredAccount(account)
+}
+```
+
+Format the long `if` conditions manually or let the repo hook run Prettier.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/apiServiceRequest.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/utils/apiServiceRequest.ts tests/services/accounts/apiServiceRequest.test.ts
+git commit -m "refactor(accounts): resolve stored account api context"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Move Legacy Missing-AccountId Enrichment To Accounts
+
+**Files:**
+
+- Create: `src/services/accounts/utils/legacyAccountAwareRequest.ts`
+- Create: `tests/services/accounts/legacyAccountAwareRequest.test.ts`
+- Modify: `src/services/apiService/common/utils.ts`
+- Test: `tests/services/apiService/common/utils.test.ts`
+
+- [ ] **Step 1: Add legacy-helper tests in the accounts module**
+
+Create `tests/services/accounts/legacyAccountAwareRequest.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { resolveLegacyAccountAwareRequest } from "~/services/accounts/utils/legacyAccountAwareRequest"
+import { AuthTypeEnum } from "~/types"
+
+const { mockGetAccountByBaseUrlAndUserId } = vi.hoisted(() => ({
+  mockGetAccountByBaseUrlAndUserId: vi.fn(),
+}))
+
+vi.mock("~/services/accounts/accountStorage", () => ({
+  accountStorage: {
+    getAccountByBaseUrlAndUserId: mockGetAccountByBaseUrlAndUserId,
+  },
+}))
+
+describe("resolveLegacyAccountAwareRequest", () => {
+  beforeEach(() => {
+    mockGetAccountByBaseUrlAndUserId.mockReset()
+  })
+
+  it("enriches account metadata when accountId is absent", async () => {
+    mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce({
+      id: "account-1",
+      cookieAuth: {
+        sessionCookie: "session=stored",
+      },
+    })
+
+    await expect(
+      resolveLegacyAccountAwareRequest(
+        {
+          baseUrl: "https://example.com",
+          auth: {
+            authType: AuthTypeEnum.Cookie,
+            userId: "123",
+          },
+        },
+        { endpoint: "/api/test" },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        accountId: "account-1",
+        cookieAuthSessionCookie: "session=stored",
+      }),
+    )
+
+    expect(mockGetAccountByBaseUrlAndUserId).toHaveBeenCalledWith(
+      "https://example.com",
+      "123",
+    )
+  })
+
+  it("preserves caller-provided legacy session cookie when enriching metadata", async () => {
+    mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce({
+      id: "account-1",
+      cookieAuth: {
+        sessionCookie: "session=stored",
+      },
+    })
+
+    await expect(
+      resolveLegacyAccountAwareRequest(
+        {
+          baseUrl: "https://example.com",
+          cookieAuthSessionCookie: "session=fresh",
+          auth: {
+            authType: AuthTypeEnum.Cookie,
+            userId: "123",
+          },
+        },
+        { endpoint: "/api/test" },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        accountId: "account-1",
+        cookieAuthSessionCookie: "session=fresh",
+      }),
+    )
+  })
+
+  it("returns the original request when lookup misses", async () => {
+    const request = {
+      baseUrl: "https://example.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "123",
+      },
+    }
+
+    mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce(null)
+
+    await expect(
+      resolveLegacyAccountAwareRequest(request, { endpoint: "/api/test" }),
+    ).resolves.toBe(request)
+  })
+
+  it("does not query storage when accountId is already present", async () => {
+    const request = {
+      baseUrl: "https://example.com",
+      accountId: "account-1",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "123",
+      },
+    }
+
+    await expect(
+      resolveLegacyAccountAwareRequest(request, { endpoint: "/api/test" }),
+    ).resolves.toBe(request)
+    expect(mockGetAccountByBaseUrlAndUserId).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run the new helper test and verify it fails**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/legacyAccountAwareRequest.test.ts
+```
+
+Expected: FAIL because `src/services/accounts/utils/legacyAccountAwareRequest.ts` does not exist.
+
+- [ ] **Step 3: Implement the accounts-owned legacy helper**
+
+Create `src/services/accounts/utils/legacyAccountAwareRequest.ts`:
+
+```ts
+import { accountStorage } from "~/services/accounts/accountStorage"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import { AuthTypeEnum } from "~/types"
+import { createLogger } from "~/utils/core/logger"
+
+const logger = createLogger("LegacyAccountAwareRequest")
+
+/**
+ * Temporary migration helper for legacy callers that still build requests
+ * without stable account identity. New account API flows should use
+ * createDisplayAccountRequestContext or resolveStoredAccountApiContext instead.
+ */
+export async function resolveLegacyAccountAwareRequest(
+  request: ApiServiceRequest,
+  context: { endpoint?: string } = {},
+): Promise<ApiServiceRequest> {
+  if (request.accountId) return request
+
+  const userId = request.auth?.userId
+
+  logger.warn("fetchApi called without accountId in request", {
+    baseUrl: request.baseUrl,
+    userId,
+    endpoint: context.endpoint,
+    authType: request.auth?.authType ?? AuthTypeEnum.None,
+    hasAccessToken: Boolean(request.auth?.accessToken),
+    hasCookie: Boolean(request.auth?.cookie),
+  })
+
+  const accountInfo = await accountStorage.getAccountByBaseUrlAndUserId(
+    request.baseUrl,
+    userId,
+  )
+
+  if (!accountInfo) return request
+
+  return {
+    ...request,
+    accountId: accountInfo.id,
+    cookieAuthSessionCookie:
+      request.cookieAuthSessionCookie ?? accountInfo.cookieAuth?.sessionCookie,
+  }
+}
+```
+
+- [ ] **Step 4: Run the legacy helper test and verify it passes**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/legacyAccountAwareRequest.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Update common utils tests to assert delegation, not storage**
+
+In `tests/services/apiService/common/utils.test.ts`, remove the `mockGetAccountByBaseUrlAndUserId` hoist and the `vi.mock("~/services/accounts/accountStorage", ...)` block.
+
+Add this hoist:
+
+```ts
+const { mockResolveLegacyAccountAwareRequest } = vi.hoisted(() => ({
+  mockResolveLegacyAccountAwareRequest: vi.fn(),
+}))
+```
+
+Add this mock:
+
+```ts
+vi.mock("~/services/accounts/utils/legacyAccountAwareRequest", () => ({
+  resolveLegacyAccountAwareRequest: mockResolveLegacyAccountAwareRequest,
+}))
+```
+
+In `beforeEach`, add:
+
+```ts
+    mockResolveLegacyAccountAwareRequest.mockReset()
+    mockResolveLegacyAccountAwareRequest.mockImplementation(
+      async (request) => request,
+    )
+```
+
+Replace the four existing `fetchApiData` enrichment tests with these two tests:
+
+```ts
+    it("delegates account-aware compatibility resolution before transport", async () => {
+      const request = {
+        baseUrl: "https://example.com",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: "123",
+        },
+      }
+      const enrichedRequest = {
+        ...request,
+        accountId: "account-1",
+        cookieAuthSessionCookie: "session=stored",
+      }
+      mockResolveLegacyAccountAwareRequest.mockResolvedValueOnce(enrichedRequest)
+      mockFetchApiData.mockResolvedValueOnce({ ok: true })
+
+      await expect(
+        fetchApiData(request, { endpoint: "/api/test" }),
+      ).resolves.toEqual({ ok: true })
+
+      expect(mockResolveLegacyAccountAwareRequest).toHaveBeenCalledWith(
+        request,
+        { endpoint: "/api/test" },
+      )
+      expect(mockFetchApiData).toHaveBeenCalledWith(enrichedRequest, {
+        endpoint: "/api/test",
+      })
+    })
+
+    it("passes through the original request when compatibility resolution is a no-op", async () => {
+      const request = {
+        baseUrl: "https://example.com",
+        accountId: "account-1",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: "123",
+        },
+      }
+      const options = { endpoint: "/api/test" }
+      mockFetchApiData.mockResolvedValueOnce({ ok: true })
+
+      await expect(fetchApiData(request, options)).resolves.toEqual({
+        ok: true,
+      })
+
+      expect(mockResolveLegacyAccountAwareRequest).toHaveBeenCalledWith(
+        request,
+        options,
+      )
+      expect(mockFetchApiData).toHaveBeenCalledWith(request, options)
+    })
+```
+
+- [ ] **Step 6: Run common utils test and verify it fails before code change**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/apiService/common/utils.test.ts
+```
+
+Expected: FAIL because `apiService/common/utils.ts` still imports `accountStorage` and does not call `resolveLegacyAccountAwareRequest`.
+
+- [ ] **Step 7: Update common utils to delegate to the accounts helper**
+
+In `src/services/apiService/common/utils.ts`, remove these imports:
+
+```ts
+import { accountStorage } from "~/services/accounts/accountStorage"
+import { AuthTypeEnum } from "~/types"
+import { createLogger } from "~/utils/core/logger"
+```
+
+Add:
+
+```ts
+import { resolveLegacyAccountAwareRequest } from "~/services/accounts/utils/legacyAccountAwareRequest"
+```
+
+Delete:
+
+```ts
+const logger = createLogger("ApiServiceCommonUtils")
+
+const resolveAccountAwareRequest = async (
+  request: ApiServiceRequest,
+  endpoint: string,
+): Promise<ApiServiceRequest> => {
+  ...
+}
+```
+
+Update `fetchApiData(...)`:
+
+```ts
+export async function fetchApiData<T>(
+  request: ApiServiceRequest,
+  options: FetchApiOptions,
+): Promise<T> {
+  return await transportFetchApiData(
+    await resolveLegacyAccountAwareRequest(request, {
+      endpoint: options.endpoint,
+    }),
+    options,
+  )
+}
+```
+
+Update `fetchApi(...)`:
+
+```ts
+export async function fetchApi<T>(
+  request: ApiServiceRequest,
+  options: FetchApiOptions,
+  _normalResponseType?: boolean,
+): Promise<T | ApiResponse<T>> {
+  return await transportFetchApi(
+    await resolveLegacyAccountAwareRequest(request, {
+      endpoint: options.endpoint,
+    }),
+    options,
+    _normalResponseType as true,
+  )
+}
+```
+
+- [ ] **Step 8: Run focused tests and verify they pass**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/legacyAccountAwareRequest.test.ts tests/services/apiService/common/utils.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run ownership check for common utils**
+
+Run:
+
+```powershell
+rg "accountStorage" src/services/apiService/common/utils.ts
+```
+
+Expected: no matches.
+
+Run:
+
+```powershell
+rg "resolveAccountAwareRequest" src/services/apiService/common src/services/accounts
+```
+
+Expected: no matches.
+
+Run:
+
+```powershell
+rg "resolveLegacyAccountAwareRequest" src/services/accounts src/services/apiService/common tests/services
+```
+
+Expected: matches only in the new helper, its test, `src/services/apiService/common/utils.ts`, and `tests/services/apiService/common/utils.test.ts`.
+
+- [ ] **Step 10: Commit Task 3**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/utils/legacyAccountAwareRequest.ts tests/services/accounts/legacyAccountAwareRequest.test.ts src/services/apiService/common/utils.ts tests/services/apiService/common/utils.test.ts
+git commit -m "refactor(accounts): own legacy api request enrichment"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Migrate Local Request Builders To The Shared Context Seam
+
+**Files:**
+
+- Modify: `src/services/accounts/defaultTokenLifecycle/requests.ts`
+- Modify: `tests/services/accounts/defaultTokenLifecycle.test.ts`
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+- Test: `tests/services/accounts/defaultTokenLifecycle.test.ts`
+- Test: `tests/services/accountKeyRepair.test.ts`
+
+- [ ] **Step 1: Update default-token request expectation to shared helper**
+
+In `tests/services/accounts/defaultTokenLifecycle.test.ts`, keep the existing import from `~/services/accounts/defaultTokenLifecycle` unchanged and add this import:
+
+```ts
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Replace the expectation:
+
+```ts
+    expect(createTokenMock).toHaveBeenCalledWith(
+      createStoredAccountTokenRequest(buildStoredAccount(displayAccount)),
+      generateDefaultTokenRequest(),
+    )
+```
+
+with:
+
+```ts
+    expect(createTokenMock).toHaveBeenCalledWith(
+      createAccountApiRequestFromStoredAccount(
+        buildStoredAccount(displayAccount),
+      ).request,
+      generateDefaultTokenRequest(),
+    )
+```
+
+- [ ] **Step 2: Run default-token test and verify behavior is still green before implementation cleanup**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/defaultTokenLifecycle.test.ts
+```
+
+Expected: PASS or FAIL only on import/type wiring. This step verifies the expected request shape is unchanged before replacing the implementation.
+
+- [ ] **Step 3: Replace stored-token request implementation with shared builder**
+
+In `src/services/accounts/defaultTokenLifecycle/requests.ts`, add:
+
+```ts
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Replace `createStoredAccountTokenRequest(...)` with:
+
+```ts
+/**
+ * Creates an adapter request DTO from a stored account record.
+ */
+export function createStoredAccountTokenRequest(
+  account: SiteAccount,
+): ApiServiceRequest {
+  return createAccountApiRequestFromStoredAccount(account).request
+}
+```
+
+- [ ] **Step 4: Replace group coverage local request builder**
+
+In `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`, add:
+
+```ts
+import { createDisplayAccountRequestContext } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Replace the body of local `createAccountApiRequest(...)` with:
+
+```ts
+function createAccountApiRequest(
+  account: SiteAccount,
+  displaySiteData: DisplaySiteData,
+  abortSignal?: AbortSignal,
+): ApiServiceRequest {
+  const snapshot = {
+    ...displaySiteData,
+    id: displaySiteData.id || account.id,
+    baseUrl: displaySiteData.baseUrl || account.site_url,
+  }
+  const { request } = createDisplayAccountRequestContext(snapshot)
+
+  return abortSignal ? { ...request, abortSignal } : request
+}
+```
+
+Do not change surrounding key-management or token-provisioning logic.
+
+- [ ] **Step 5: Run focused tests for migrated request builders**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/defaultTokenLifecycle.test.ts tests/services/accountKeyRepair.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Search for duplicated account request construction in touched account modules**
+
+Run:
+
+```powershell
+rg "cookie: displaySiteData\\.cookieAuthSessionCookie|account_info\\.access_token|accountId: displaySiteData\\.id \\|\\| account\\.id" src/services/accounts
+```
+
+Expected: no matches in `src/services/accounts/defaultTokenLifecycle/requests.ts` or `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`. Other matches may remain in unrelated account modules and should be reported as follow-up unless they are part of this task.
+
+- [ ] **Step 7: Commit Task 4**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/defaultTokenLifecycle/requests.ts tests/services/accounts/defaultTokenLifecycle.test.ts src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+git commit -m "refactor(accounts): reuse account api context builders"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Document The Remaining Income Exception And Run Migration Gates
+
+**Files:**
+
+- Modify: `src/services/apiService/common/index.ts`
+- Test: `tests/services/apiService/common/accountData.test.ts`
+
+- [ ] **Step 1: Add explicit temporary exception comment to common income code**
+
+In `src/services/apiService/common/index.ts`, keep the `accountStorage` import and add this comment immediately above it:
+
+```ts
+// Temporary exception during account API context migration:
+// fetchTodayIncome still owns exchange-rate lookup until account-data refresh
+// orchestration moves that policy into src/services/accounts/**.
+import { accountStorage } from "~/services/accounts/accountStorage"
+```
+
+If import-order tooling moves the comment away from the import, place the same comment immediately above `fetchTodayIncome(...)` instead:
+
+```ts
+// Temporary exception during account API context migration:
+// this helper still owns exchange-rate lookup until account-data refresh
+// orchestration moves that policy into src/services/accounts/**.
+export async function fetchTodayIncome(
+```
+
+- [ ] **Step 2: Keep current income tests unchanged and verify the exception behavior**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/apiService/common/accountData.test.ts
+```
+
+Expected: PASS, including these existing behaviors:
+
+- `fetchTodayIncome uses the account exchange rate and parses quota fallbacks`
+- `fetchTodayIncome falls back to lookup by baseUrl and userId when accountId is absent`
+
+- [ ] **Step 3: Run all account/request focused tests**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/apiServiceRequest.test.ts tests/services/accounts/legacyAccountAwareRequest.test.ts tests/services/apiService/common/utils.test.ts tests/services/apiService/common/accountData.test.ts tests/services/accounts/defaultTokenLifecycle.test.ts tests/services/accountKeyRepair.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run ownership and migration checks**
+
+Run:
+
+```powershell
+rg "accountStorage" src/services/apiService/common
+```
+
+Expected: one remaining match in `src/services/apiService/common/index.ts` for the documented `fetchTodayIncome(...)` exception, and no match in `src/services/apiService/common/utils.ts`.
+
+Run:
+
+```powershell
+rg "getAccountByBaseUrlAndUserId" src/services/apiService src/services/apiAdapters
+```
+
+Expected: no matches in `src/services/apiService/common/utils.ts`. A match in `src/services/apiService/common/index.ts` is allowed only for the documented `fetchTodayIncome(...)` exception.
+
+Run:
+
+```powershell
+rg "DisplaySiteData" src/services/apiService src/services/apiAdapters src/services/apiTransport
+```
+
+Expected: no new `DisplaySiteData` references from this branch. Existing unrelated matches should be inspected and reported, not rewritten in this slice.
+
+Run:
+
+```powershell
+rg "accountId\\?:" src/types/index.ts src/services src/features
+```
+
+Expected: existing `DisplaySiteData.accountId?: string` may remain. No new optional account-id fields should appear in new account request-context code.
+
+Run:
+
+```powershell
+rg "createDisplayAccountRequestContext|createDisplayAccountApiContext|resolveStoredAccountApiContext|resolveLegacyAccountAwareRequest" src tests
+```
+
+Expected: new request-only consumers use `createDisplayAccountRequestContext(...)` or `resolveStoredAccountApiContext(...)`; existing capability consumers may still use `createDisplayAccountApiContext(...)`; only compatibility code uses `resolveLegacyAccountAwareRequest(...)`.
+
+- [ ] **Step 5: Run staged validation**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/utils/apiServiceRequest.ts src/services/accounts/utils/legacyAccountAwareRequest.ts src/services/apiService/common/utils.ts src/services/apiService/common/index.ts src/services/accounts/defaultTokenLifecycle/requests.ts src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts tests/services/accounts/apiServiceRequest.test.ts tests/services/accounts/legacyAccountAwareRequest.test.ts tests/services/apiService/common/utils.test.ts tests/services/apiService/common/accountData.test.ts tests/services/accounts/defaultTokenLifecycle.test.ts
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+If `tests/services/accountKeyRepair.test.ts` was modified, include it in the `git add` command before `validate:staged`.
+
+- [ ] **Step 6: Run push-level validation because shared exports and request wiring changed**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Inspect final diff**
+
+Run:
+
+```powershell
+git diff --cached --stat
+git diff --cached -- src/services/accounts/utils/apiServiceRequest.ts src/services/accounts/utils/legacyAccountAwareRequest.ts src/services/apiService/common/utils.ts src/services/apiService/common/index.ts
+```
+
+Expected:
+
+- `src/services/apiService/common/utils.ts` no longer imports `accountStorage`.
+- `src/services/accounts/utils/legacyAccountAwareRequest.ts` is the only new owner of compatibility missing-`accountId` enrichment.
+- `fetchTodayIncome(...)` is explicitly marked as the remaining temporary storage exception.
+- No tokens, cookies, raw account identifiers beyond test placeholders, or real service secrets are added.
+
+- [ ] **Step 8: Commit Task 5**
+
+Run:
+
+```powershell
+git commit -m "refactor(accounts): clarify account api context ownership"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Follow-Up Work Not In This Slice
+
+- Move `fetchTodayIncome(...)` exchange-rate lookup and persisted-account selection out of `src/services/apiService/common/index.ts` into an accounts-owned account-data refresh orchestration helper.
+- Delete `resolveLegacyAccountAwareRequest(...)` after all callers pass `accountId` or an explicit account context.
+- Stop reading `DisplaySiteData.accountId`; use `DisplaySiteData.id` as the account id.
+- Narrow more deep service parameters from full `DisplaySiteData` to `DisplayAccountApiSnapshot`, `AccountApiContext`, or `accountId`.
+- Consider renaming `DisplaySiteData` only after service/protocol consumers no longer treat it as a general account object.
+
+---
+
+## Final Handoff Checklist
+
+- [ ] Focused Vitest commands from Task 5 passed.
+- [ ] `pnpm run validate:staged` passed.
+- [ ] `pnpm run validate:push` passed.
+- [ ] `rg "accountStorage" src/services/apiService/common` shows only the documented `fetchTodayIncome(...)` exception.
+- [ ] Telemetry decision reported: none.
+- [ ] Settings search decision reported: none.
+- [ ] E2E decision reported: no new E2E; focused Vitest is the right layer for this slice.
+- [ ] Maintainability decision reported: request-building logic centralized in accounts-owned context builders; income policy intentionally left as a documented follow-up because moving it would broaden account-data refresh orchestration.

--- a/docs/superpowers/specs/2026-06-26-account-api-context-display-data-design.md
+++ b/docs/superpowers/specs/2026-06-26-account-api-context-display-data-design.md
@@ -1,0 +1,573 @@
+# Account API Context And Display Data Ownership Design
+
+Date: 2026-06-26
+
+## Purpose
+
+Move account request enrichment out of legacy `apiService/common` and make the
+account data layers explicit.
+
+The current behavior works, but the ownership is confusing:
+
+- `DisplaySiteData` is named like a display-only DTO, while it also carries
+  account operation fields such as `baseUrl`, `token`, `userId`, `authType`,
+  and `cookieAuthSessionCookie`.
+- `apiService/common` silently looks up `accountStorage` when a request is
+  missing `accountId`, then fills `accountId` and cookie-auth session data.
+- Some workflows need the latest persisted `SiteAccount`, while immediate UI
+  actions already have a current display-account snapshot.
+
+This spec keeps behavior compatible while establishing a clearer seam:
+account-owned code prepares account API context; adapter/protocol code consumes
+prepared requests and does not query storage.
+
+## Current Context
+
+Current relevant modules:
+
+- `src/types/index.ts`
+  - `SiteAccount` is the persisted canonical account shape.
+  - `DisplaySiteData` is produced from `SiteAccount` for UI use, but includes
+    operation fields needed by account actions.
+- `src/services/accounts/accountStorage.ts`
+  - owns `SiteAccount` persistence and normalization;
+  - exposes `convertToDisplayData(...)`, `resolveDisplayData(...)`, and
+    `getDisplayDataById(...)`;
+  - currently maps `cookieAuth.sessionCookie` to
+    `DisplaySiteData.cookieAuthSessionCookie`.
+- `src/services/accounts/utils/apiServiceRequest.ts`
+  - already contains `createDisplayAccountApiContext(...)`;
+  - builds `ApiServiceRequest` from `DisplaySiteData`-like input;
+  - adds account-site session decoration such as Sub2API auth session when the
+    account-site profile requires it.
+- `src/services/apiTransport/type.ts`
+  - defines `ApiServiceRequest` / `ApiTransportRequest`;
+  - includes `accountId`, auth config, `cookieAuthSessionCookie`, and
+    fetch-context fields.
+- `src/services/apiService/common/utils.ts`
+  - imports `accountStorage`;
+  - `resolveAccountAwareRequest(...)` searches by `baseUrl` and `userId` when
+    `accountId` is absent;
+  - `fetchApi(...)` and `fetchApiData(...)` call that resolver before transport.
+- `src/services/apiService/common/index.ts`
+  - imports `accountStorage` and `UI_CONSTANTS`;
+  - `fetchTodayIncome(...)` uses persisted account data to choose exchange-rate
+    conversion.
+
+## Problem
+
+The current seam makes account identity and request enrichment implicit.
+
+Friction:
+
+1. `apiService/common` looks like a protocol Module, but it also owns account
+   persistence fallback. That means adapter-readiness can still depend on
+   hidden storage behavior rather than explicit Site Adapter Capability inputs.
+2. Looking up by `baseUrl + userId` is weaker than using stable `accountId`.
+   It is useful only as migration compatibility for existing callers that do
+   not yet carry account identity. New account API flows should always enter
+   through `accountId` or a display snapshot whose `id` is present.
+3. `DisplaySiteData` has become a UI account snapshot, not a pure display DTO.
+   That is acceptable for current UI workflows, but dangerous if service and
+   protocol Modules keep accepting it as a general account object.
+4. Some workflows should re-read the latest `SiteAccount` by id, while others
+   can safely use a just-loaded UI snapshot. The current layering does not make
+   that choice explicit.
+5. `DisplaySiteData.id` already is the stable account id, while
+   `DisplaySiteData.accountId?: string` duplicates identity and invites
+   inconsistent callers.
+
+Deletion test: if `resolveAccountAwareRequest(...)` disappeared from
+`apiService/common`, the missing behavior should reappear once in an
+accounts-owned request-context Module, not across every adapter or feature.
+
+## Goals
+
+- Remove account-storage lookup from `apiService/common` request helpers.
+- Create an accounts-owned request-context Interface for account API calls.
+- Treat `SiteAccount` as canonical persisted account data.
+- Treat `DisplaySiteData` as a UI account snapshot, not as a deep service
+  Interface.
+- Preserve immediate UI flows that can build a request from a current
+  `DisplaySiteData` snapshot without unnecessary storage reads.
+- Require stable `accountId` in every new Account API context. Long-lived
+  workflows, background work, retries, repairs, scheduled jobs, and any flow
+  that only needs identity should store and pass `accountId`, not
+  `baseUrl + userId`.
+- Keep legacy `baseUrl + userId` lookup as a narrow compatibility path only
+  when preserving current behavior requires it.
+- Keep existing cookie-auth session behavior.
+- Establish a gradual path for reducing `DisplaySiteData` as a catch-all type.
+
+## Non-Goals
+
+- Do not immediately delete operation fields from `DisplaySiteData`.
+- Do not rename `DisplaySiteData` in the first implementation slice.
+- Do not force every UI click to re-query `accountStorage`.
+- Do not change persisted `SiteAccount` schema.
+- Do not change account detection, account import, or account save behavior.
+- Do not change adapter protocol behavior except for making request enrichment
+  explicit.
+- Do not add telemetry, settings search entries, or Playwright E2E tests by
+  default.
+- Do not remove legacy `baseUrl + userId` compatibility until all callers are
+  migrated to explicit account context or proven not to need it.
+
+## Vocabulary
+
+Use these terms in implementation and follow-up specs:
+
+- **SiteAccount**: canonical persisted account record.
+- **Display account snapshot**: the existing `DisplaySiteData` read model
+  produced for UI lists, dialogs, filtering, and immediate user actions.
+- **Account API context**: prepared account-operation data used by adapters and
+  protocol helpers. It includes stable account identity and an
+  `ApiServiceRequest`.
+- **Account API capability context**: the existing display-account context that
+  resolves the site adapter capabilities together with the prepared request.
+- **Stored account context**: an Account API context resolved from
+  `accountId` by reading the latest `SiteAccount`.
+- **Snapshot account context**: an Account API context built from a current
+  display account snapshot without another storage read.
+
+## Approaches Considered
+
+### Approach A: Make `DisplaySiteData` Pure Display Immediately
+
+This would remove `token`, `userId`, `authType`, and
+`cookieAuthSessionCookie` from `DisplaySiteData` and force operation callers to
+resolve `SiteAccount` separately.
+
+This has clean naming, but it is too broad for the next slice. Many UI flows
+use `DisplaySiteData` for immediate actions, and changing all of them at once
+would create a high-risk migration with little short-term user benefit.
+
+This should not be the first step.
+
+### Approach B: Keep `DisplaySiteData` As The Main Account Interface
+
+This keeps implementation cheap, but it codifies the current problem. New
+service Modules would keep accepting a wide UI snapshot and would continue to
+learn too much about UI-derived account data.
+
+This should not be the next step.
+
+### Approach C: Add An Account API Context Seam And Gradually Narrow
+`DisplaySiteData`
+
+This is the recommended path.
+
+Keep `DisplaySiteData` fields stable for existing UI behavior, but stop passing
+the whole type into new service/protocol seams. Introduce accounts-owned
+context builders that turn either `accountId` or a display account snapshot
+into a prepared Account API context.
+
+This creates Locality for account request policy, keeps UI flows ergonomic, and
+lets later slices reduce `DisplaySiteData` safely. The request-context seam
+should sit below the existing capability context so current token-management
+callers do not need a broad migration merely to keep using adapter
+capabilities.
+
+## Design
+
+### 1. Define Account API Context In The Accounts Module
+
+Create or extend an accounts-owned Module, likely
+`src/services/accounts/utils/apiServiceRequest.ts`.
+
+Add a request-only Interface that makes the source explicit:
+
+```ts
+export interface AccountApiContext {
+  accountId: string
+  siteType: AccountSiteType
+  request: ApiServiceRequest
+}
+
+export async function resolveStoredAccountApiContext(
+  accountId: string,
+): Promise<AccountApiContext>
+
+export function createDisplayAccountRequestContext(
+  account: DisplayAccountApiSnapshot,
+): AccountApiContext
+```
+
+`DisplayAccountApiSnapshot` should be a narrow structural type, not the full
+`DisplaySiteData` Interface:
+
+```ts
+export type DisplayAccountApiSnapshot = Pick<
+  DisplaySiteData,
+  | "id"
+  | "siteType"
+  | "baseUrl"
+  | "authType"
+  | "userId"
+  | "token"
+  | "cookieAuthSessionCookie"
+>
+```
+
+This lets current UI callers pass `DisplaySiteData` structurally while making
+new service APIs depend only on the fields they actually need.
+
+The existing `createDisplayAccountApiContext(...)` should stay as the
+capability context unless a later migration explicitly renames it:
+
+```ts
+export interface DisplayAccountApiCapabilityContext {
+  adapter: SiteAdapter
+  keyManagement: KeyManagementCapability | undefined
+  tokenProvisioning: TokenProvisioningCapability | undefined
+  request: ApiServiceRequest
+}
+```
+
+It should call `createDisplayAccountRequestContext(...)` internally and then
+attach `adapter`, `keyManagement`, and `tokenProvisioning`. This preserves
+current callers that destructure capabilities while giving new account-owned
+workflows a smaller request-only seam.
+
+### 2. Resolve Stored Account Context By Stable Account Id
+
+`resolveStoredAccountApiContext(accountId)` should:
+
+1. reject a missing or blank `accountId`;
+2. read the latest `SiteAccount` from `accountStorage`;
+3. normalize it through existing storage normalization;
+4. build `ApiServiceRequest` from canonical account fields;
+5. set `request.accountId` from the stored account id;
+6. apply account-site profile request decoration, such as Sub2API auth session;
+7. include the same cookie-auth session value currently added by
+   `DisplaySiteData.cookieAuthSessionCookie`;
+8. throw a typed or clearly named error if the account no longer exists or is
+   not usable for account API requests.
+
+The stored path and snapshot path should share the same request builder after
+their input data is normalized. New request contexts should place the session
+cookie in `request.auth.cookie`, matching the current display-account builder.
+Top-level `request.cookieAuthSessionCookie` should be kept only where needed to
+preserve legacy prepared requests during migration.
+
+The stored path must not fall back to `baseUrl + userId` lookup. Its contract is
+stable account identity in, latest stored account context out. Any origin
+matching behavior needed to preserve old callers belongs only in the legacy
+compatibility helper described below.
+
+Use this path for:
+
+- background refresh;
+- scheduled jobs;
+- retries;
+- repair flows;
+- post-save workflows;
+- long-running flows;
+- flows that already carry only `accountId`.
+
+### 3. Build Snapshot Account Context Without A Storage Read
+
+`createDisplayAccountRequestContext(account)` should build the snapshot request
+without querying `accountStorage`. `createDisplayAccountApiContext(account)`
+should remain available for callers that need adapter capabilities, and it also
+must not query `accountStorage`.
+
+The snapshot path should treat `account.id` as required and write it to
+`request.accountId`. A snapshot without an id is not a valid Account API context
+and should fail before reaching adapter or transport code.
+
+Use this path for immediate UI operations when the UI already has a current
+display account snapshot:
+
+- opening token dialogs;
+- copying a key from the current account row;
+- starting a Model List account-key dialog;
+- opening managed-site channel dialog from a visible account action.
+
+The snapshot path is not canonical. It is a convenience for current UI state.
+Any follow-up retry, background task, or persisted job should store the
+`accountId` and resolve a stored context later.
+
+### 4. Move Legacy Request Enrichment Out Of `apiService/common`
+
+Remove `accountStorage` import from `src/services/apiService/common/utils.ts`.
+
+`fetchApi(...)` and `fetchApiData(...)` should call transport with the request
+they receive. They should not:
+
+- look up accounts;
+- infer account identity by `baseUrl + userId`;
+- fill `accountId`;
+- fill `cookieAuthSessionCookie`.
+
+During migration, if hidden lookup must remain for compatibility, move it to an
+accounts-owned compatibility helper such as:
+
+```ts
+export async function resolveLegacyAccountAwareRequest(
+  request: ApiServiceRequest,
+  context?: { endpoint?: string },
+): Promise<ApiServiceRequest>
+```
+
+That helper may use `baseUrl + userId`, including the existing profile-origin
+matching behavior, but it should be documented as legacy and should live under
+`src/services/accounts/**`, not under `apiService/common`. Keep endpoint/log
+context available so warnings for missing `accountId` remain diagnosable during
+migration.
+
+New call sites should not use the legacy helper. Delete it only after current
+callers are migrated to explicit Account API context or an `rg`/test pass proves
+they never need account-owned request enrichment.
+
+### 5. Treat `fetchTodayIncome(...)` As Account-Owned Policy
+
+`fetchTodayIncome(...)` currently needs persisted account exchange-rate data.
+That logic should not stay hidden inside a generic common protocol Module.
+
+Preferred direction:
+
+- keep the backend request itself in the protocol adapter;
+- move exchange-rate selection and persisted-account lookup to an
+  accounts-owned refresh/income orchestration helper;
+- pass the chosen exchange rate into the parser or result-normalization helper.
+
+If this is too large for the first implementation slice, keep it as an explicit
+second task after request enrichment moves out of `common/utils.ts`.
+
+The first implementation plan must make this boundary explicit. If
+`fetchTodayIncome(...)` is not moved in the first slice, then
+`apiService/common/index.ts` remains a documented temporary exception to the
+broader "no account storage in protocol/common" direction. Do not claim the
+whole `apiService/common` package is storage-free until this exception is
+removed.
+
+### 6. Clarify `DisplaySiteData` Ownership Without Immediate Field Deletion
+
+Short-term rules:
+
+- Do not add new non-display or protocol fields to `DisplaySiteData`.
+- Do not introduce new deep service Interfaces that accept full
+  `DisplaySiteData`.
+- New account-operation helpers should accept `accountId`,
+  `AccountApiContext`, or a narrow `Pick<DisplaySiteData, ...>`.
+- Treat `DisplaySiteData.id` as the account id.
+- Do not use `DisplaySiteData.accountId` for new code. It duplicates `id` and
+  should be considered migration debt.
+
+The existing operation fields may remain for now:
+
+- `baseUrl`
+- `token`
+- `userId`
+- `authType`
+- `cookieAuthSessionCookie`
+- `siteType`
+
+They are operation snapshot fields, not proof that `DisplaySiteData` is the
+canonical account model.
+
+### 7. Gradual Evolution Direction For `DisplaySiteData`
+
+After the Account API context seam is in place, evolve in small steps:
+
+1. Replace deep `DisplaySiteData` parameters with narrow structural types.
+2. Replace long-lived workflow inputs with `accountId`.
+3. Replace repeated request-building code with `AccountApiContext` builders.
+4. Stop reading `DisplaySiteData.accountId`; use `id`.
+5. Consider a type alias or rename when consumers are narrower:
+   - `DisplayAccountSnapshot`;
+   - `AccountViewData`;
+   - `AccountListItemData`.
+6. Only then consider deleting operation fields from the display read model, if
+   enough call sites no longer need them.
+
+This keeps the migration progressive rather than making one broad UI type
+rewrite.
+
+## Data Flow
+
+### Immediate UI Operation
+
+```text
+Account list state
+  -> DisplaySiteData snapshot
+  -> createDisplayAccountRequestContext(snapshot)
+     or createDisplayAccountApiContext(snapshot) when adapter capabilities are needed
+  -> Site Adapter Capability / apiService protocol
+  -> transport
+```
+
+No storage read is required in this path.
+
+### Background Or Long-Lived Operation
+
+```text
+Stored job / retry / scheduler
+  -> accountId
+  -> resolveStoredAccountApiContext(accountId)
+  -> latest SiteAccount from accountStorage
+  -> AccountApiContext
+  -> Site Adapter Capability / apiService protocol
+  -> transport
+```
+
+This path intentionally re-reads storage.
+
+### Legacy Compatibility Path
+
+```text
+Legacy caller without accountId
+  -> accounts-owned resolveLegacyAccountAwareRequest(...)
+  -> baseUrl + userId lookup
+  -> prepared ApiServiceRequest
+  -> apiService protocol
+```
+
+This path should shrink over time and should not be used by new code.
+
+## Error Handling
+
+`resolveStoredAccountApiContext(accountId)` should fail explicitly when:
+
+- the account id is missing;
+- the account no longer exists;
+- the account has no usable base URL;
+- the account has no usable account identity;
+- the account auth type requires credentials that are absent.
+
+Errors should be stable enough for callers to map to user-facing recovery
+messages, but they must not include tokens, cookies, or raw backend messages.
+
+Snapshot context creation may keep current behavior at first, but follow-up
+work should consider the same validation rules currently used by
+`canManageDisplayAccountTokens(...)`.
+
+## Testing Strategy
+
+Add focused tests for the accounts-owned context Module:
+
+- `createDisplayAccountApiContext(...)` builds the same request shape from a
+  display account snapshot as today;
+- `createDisplayAccountRequestContext(...)` returns the request-only context,
+  while `createDisplayAccountApiContext(...)` preserves the existing adapter
+  capability context shape;
+- cookie-auth session data from the snapshot is preserved;
+- Sub2API auth session decoration still applies when the profile requires it;
+- `resolveStoredAccountApiContext(accountId)` reads the latest stored account;
+- stored context uses canonical `SiteAccount` fields, not stale display data;
+- missing account id or deleted account returns a stable error;
+- legacy `baseUrl + userId` compatibility, if retained, lives under accounts
+  helpers and preserves current cookie-session fallback.
+- existing `apiService/common/utils.ts` missing-`accountId` tests are either
+  moved to the accounts-owned legacy helper or deleted only after all relevant
+  callers are migrated to explicit account context.
+
+Update protocol tests:
+
+- `apiService/common/utils.ts` no longer mocks or imports `accountStorage`;
+- `fetchApi(...)` and `fetchApiData(...)` pass prepared requests through
+  unchanged.
+
+Update impacted feature/service tests only where their input seam changes:
+
+- immediate UI paths can still build request context from display snapshots;
+- background/repair/refresh paths resolve by `accountId`.
+
+Focused validation should start with affected tests around
+`accounts/utils/apiServiceRequest`, `apiService/common/utils`, and the first
+migrated callers. Run `pnpm run validate:staged` before committing an
+implementation slice.
+
+Run `pnpm run validate:push` before publishing a slice that changes shared
+exports, adapter contracts, or account request wiring.
+
+## Telemetry Decision
+
+Telemetry decision: none.
+
+This is an internal ownership and request-context refactor. It does not add a
+new user action or observable product state.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, anchors, or deep links change.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E by default.
+
+The primary risk is request-context construction and storage lookup ownership,
+which is better covered by focused unit tests. Add E2E only if an
+implementation slice changes cross-entrypoint browser behavior or extension
+runtime transport behavior.
+
+## Rollout
+
+1. Add `AccountApiContext`, `DisplayAccountApiSnapshot`, and request-only
+   builders under `src/services/accounts/utils/apiServiceRequest.ts`.
+2. Keep `createDisplayAccountApiContext(...)` as the capability context and
+   have it call the request-only builder internally.
+3. Add `resolveStoredAccountApiContext(accountId)` and focused tests.
+4. Move legacy missing-`accountId` enrichment from `apiService/common/utils.ts`
+   into an accounts-owned compatibility helper, or delete it if all current
+   callers are migrated in the same slice.
+5. Update `apiService/common/utils.ts` to stop importing `accountStorage`.
+6. Migrate the first narrow caller group to explicit request-context builders
+   where they do not need adapter capabilities; leave capability consumers on
+   `createDisplayAccountApiContext(...)` until a later targeted migration.
+7. Decide the `fetchTodayIncome(...)` boundary in the first implementation
+   plan: either move exchange-rate/account lookup out of generic
+   `apiService/common` in the same slice, or document
+   `src/services/apiService/common/index.ts` as the remaining temporary
+   `accountStorage` exception.
+8. Add lint/ownership checks or `rg` review commands in the plan so
+   `apiService/common` does not regain `accountStorage` imports.
+9. Gradually replace deep `DisplaySiteData` parameters with `accountId`,
+   `AccountApiContext`, or narrow snapshot types.
+10. Consider renaming or splitting `DisplaySiteData` only after consumers no
+   longer treat it as a general service object.
+
+## Migration Checks
+
+Use these checks during implementation:
+
+```powershell
+rg "accountStorage" src/services/apiService/common
+rg "getAccountByBaseUrlAndUserId" src/services/apiService src/services/apiAdapters
+rg "DisplaySiteData" src/services/apiService src/services/apiAdapters src/services/apiTransport
+rg "accountId\\?:" src/types/index.ts src/services src/features
+rg "createDisplayAccountRequestContext|createDisplayAccountApiContext|resolveStoredAccountApiContext|resolveLegacyAccountAwareRequest" src tests
+```
+
+Expected direction:
+
+- no `accountStorage` imports in `apiService/common/utils.ts`;
+- no `accountStorage` imports in the rest of `apiService/common` once the
+  `fetchTodayIncome(...)` exception is moved;
+- no new full-`DisplaySiteData` parameters in protocol or adapter Modules;
+- new account operations choose either stored context by `accountId` or snapshot
+  context by narrow display-account fields;
+- capability consumers may keep using `createDisplayAccountApiContext(...)`,
+  but request-only consumers should prefer `AccountApiContext`;
+- `DisplaySiteData.accountId` is not used by new code;
+- legacy `baseUrl + userId` lookup is isolated, logged with enough request
+  context to diagnose, and shrinking.
+
+## Follow-Up, Not In Scope For The First Slice
+
+- Rename `DisplaySiteData` to a more honest account snapshot/read-model name.
+- Delete operation fields from `DisplaySiteData`.
+- Remove legacy `baseUrl + userId` account lookup after all callers carry
+  explicit identity.
+- Move `fetchTodayIncome(...)` exchange-rate policy if it is not included in
+  the first implementation slice.
+- Add static ownership enforcement for protocol Modules if repeated drift
+  appears.
+
+The intended seam split is: storage owns canonical `SiteAccount`; accounts
+application code builds Account API context; UI consumes display account
+snapshots; adapters and protocol Modules consume prepared requests without
+querying account storage.

--- a/docs/superpowers/specs/2026-06-26-account-api-context-display-data-design.md
+++ b/docs/superpowers/specs/2026-06-26-account-api-context-display-data-design.md
@@ -181,7 +181,7 @@ Add a request-only Interface that makes the source explicit:
 export interface AccountApiContext {
   accountId: string
   siteType: AccountSiteType
-  request: ApiServiceRequest
+  request: ApiServiceRequest | Sub2ApiAuthSessionRequest
 }
 
 export async function resolveStoredAccountApiContext(
@@ -220,7 +220,7 @@ export interface DisplayAccountApiCapabilityContext {
   adapter: SiteAdapter
   keyManagement: KeyManagementCapability | undefined
   tokenProvisioning: TokenProvisioningCapability | undefined
-  request: ApiServiceRequest
+  request: ApiServiceRequest | Sub2ApiAuthSessionRequest
 }
 ```
 
@@ -236,17 +236,19 @@ workflows a smaller request-only seam.
 1. reject a missing or blank `accountId`;
 2. read the latest `SiteAccount` from `accountStorage`;
 3. normalize it through existing storage normalization;
-4. build `ApiServiceRequest` from canonical account fields;
+4. build `ApiServiceRequest` from canonical stored-account fields;
 5. set `request.accountId` from the stored account id;
 6. apply account-site profile request decoration, such as Sub2API auth session;
-7. include the same cookie-auth session value currently added by
-   `DisplaySiteData.cookieAuthSessionCookie`;
+7. copy the stored cookie-auth session from
+   `SiteAccount.cookieAuth.sessionCookie` into `request.auth.cookie`;
 8. throw a typed or clearly named error if the account no longer exists or is
    not usable for account API requests.
 
 The stored path and snapshot path should share the same request builder after
 their input data is normalized. New request contexts should place the session
-cookie in `request.auth.cookie`, matching the current display-account builder.
+cookie in `request.auth.cookie`: stored-account contexts read it from
+`SiteAccount.cookieAuth.sessionCookie`, while display snapshot contexts read it
+from `DisplaySiteData.cookieAuthSessionCookie`.
 Top-level `request.cookieAuthSessionCookie` should be kept only where needed to
 preserve legacy prepared requests during migration.
 

--- a/e2e/accountManagementCommonFlows.spec.ts
+++ b/e2e/accountManagementCommonFlows.spec.ts
@@ -93,7 +93,9 @@ function getAccountRow(page: Page, accountName: string) {
 }
 
 async function getAccountButtonY(page: Page, accountName: string) {
-  const accountButton = page.getByRole("button", { name: accountName }).first()
+  const accountButton = getAccountRow(page, accountName)
+    .getByRole("button", { name: accountName })
+    .first()
   await expect(accountButton).toBeVisible()
 
   let accountButtonY: number | undefined

--- a/e2e/accountManagementCommonFlows.spec.ts
+++ b/e2e/accountManagementCommonFlows.spec.ts
@@ -93,16 +93,27 @@ function getAccountRow(page: Page, accountName: string) {
 }
 
 async function getAccountButtonY(page: Page, accountName: string) {
-  const box = await page
-    .getByRole("button", { name: accountName })
-    .first()
-    .boundingBox()
+  const accountButton = page.getByRole("button", { name: accountName }).first()
+  await expect(accountButton).toBeVisible()
 
-  if (!box) {
+  let accountButtonY: number | undefined
+  await expect
+    .poll(
+      async () => {
+        accountButtonY = (await accountButton.boundingBox())?.y
+        return accountButtonY
+      },
+      {
+        message: `resolve account row position for ${accountName}`,
+      },
+    )
+    .not.toBeUndefined()
+
+  if (accountButtonY === undefined) {
     throw new Error(`Could not resolve account row for ${accountName}`)
   }
 
-  return box.y
+  return accountButtonY
 }
 
 async function openAccountActionsMenu(page: Page, accountName: string) {

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -91,6 +91,17 @@ export function useCopyKeyDialog(
 
   const fetchTokens = useCallback(async () => {
     if (!account) return
+    if (!canCreateDefaultKey) {
+      setTokens([])
+      setError(null)
+      setCreateError(null)
+      setOneTimeToken(null)
+      clearDefaultTokenCreateAllowedGroups()
+      setCopiedTokenId(null)
+      setExpandedTokens(new Set())
+      setIsLoading(false)
+      return
+    }
 
     setIsLoading(true)
     setError(null)
@@ -115,7 +126,7 @@ export function useCopyKeyDialog(
     } finally {
       setIsLoading(false)
     }
-  }, [account, clearDefaultTokenCreateAllowedGroups, t])
+  }, [account, canCreateDefaultKey, clearDefaultTokenCreateAllowedGroups, t])
 
   useEffect(() => {
     if (isOpen && account) {

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -72,6 +72,7 @@ export function useCopyKeyDialog(
   const copiedTokenResetTimeoutRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null)
+  const fetchRequestIdRef = useRef(0)
 
   const canCreateDefaultKey = useMemo(
     () => canManageDisplayAccountTokens(account),
@@ -92,6 +93,7 @@ export function useCopyKeyDialog(
   const fetchTokens = useCallback(async () => {
     if (!account) return
     if (!canCreateDefaultKey) {
+      fetchRequestIdRef.current += 1
       setTokens([])
       setError(null)
       setCreateError(null)
@@ -103,6 +105,7 @@ export function useCopyKeyDialog(
       return
     }
 
+    const requestId = (fetchRequestIdRef.current += 1)
     setIsLoading(true)
     setError(null)
     setCreateError(null)
@@ -110,8 +113,10 @@ export function useCopyKeyDialog(
 
     try {
       const tokensResponse = await fetchDisplayAccountTokens(account)
+      if (fetchRequestIdRef.current !== requestId) return
       setTokens(tokensResponse)
     } catch (error) {
+      if (fetchRequestIdRef.current !== requestId) return
       logger.error("Failed to load key list", {
         error,
         accountId: account.id,
@@ -124,7 +129,9 @@ export function useCopyKeyDialog(
       )
       setError(t("ui:dialog.copyKey.loadFailed", { error: errorMessage }))
     } finally {
-      setIsLoading(false)
+      if (fetchRequestIdRef.current === requestId) {
+        setIsLoading(false)
+      }
     }
   }, [account, canCreateDefaultKey, clearDefaultTokenCreateAllowedGroups, t])
 

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -72,6 +72,7 @@ export function useCopyKeyDialog(
   const copiedTokenResetTimeoutRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null)
+  // Incremented to invalidate slower token inventory requests after account eligibility changes.
   const fetchRequestIdRef = useRef(0)
 
   const canCreateDefaultKey = useMemo(

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -61,6 +61,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
   const [isCreating, setIsCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const [oneTimeToken, setOneTimeToken] = useState<ApiToken | null>(null)
+  const fetchRequestIdRef = useRef(0)
 
   const canCreateToken = useMemo(
     () => canManageDisplayAccountTokens(account),
@@ -80,6 +81,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
   const fetchTokens = useCallback(async () => {
     if (!account) return false
     if (!canCreateToken) {
+      fetchRequestIdRef.current += 1
       setTokens([])
       setSelectedTokenId(null)
       setError(null)
@@ -89,15 +91,18 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
       return false
     }
 
+    const requestId = (fetchRequestIdRef.current += 1)
     setIsLoading(true)
     setError(null)
     setCreateError(null)
 
     try {
       const fetchedTokens = await fetchDisplayAccountTokens(account)
+      if (fetchRequestIdRef.current !== requestId) return false
       setTokens(fetchedTokens)
       return true
     } catch (error) {
+      if (fetchRequestIdRef.current !== requestId) return false
       const errorMessage =
         error instanceof InvalidTokenPayloadError
           ? t("messages:errors.unknown")
@@ -119,7 +124,9 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
       setError(t("modelList:keyDialog.loadFailed", { error: errorMessage }))
       return false
     } finally {
-      setIsLoading(false)
+      if (fetchRequestIdRef.current === requestId) {
+        setIsLoading(false)
+      }
     }
   }, [account, canCreateToken, t])
 

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -79,6 +79,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
 
   const fetchTokens = useCallback(async () => {
     if (!account) return false
+    if (!canCreateToken) return false
 
     setIsLoading(true)
     setError(null)
@@ -112,7 +113,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
     } finally {
       setIsLoading(false)
     }
-  }, [account, t])
+  }, [account, canCreateToken, t])
 
   const modelContext = useMemo(
     () => ({ id: modelId, enableGroups: modelEnableGroups }),

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -79,7 +79,15 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
 
   const fetchTokens = useCallback(async () => {
     if (!account) return false
-    if (!canCreateToken) return false
+    if (!canCreateToken) {
+      setTokens([])
+      setSelectedTokenId(null)
+      setError(null)
+      setCreateError(null)
+      setOneTimeToken(null)
+      setIsLoading(false)
+      return false
+    }
 
     setIsLoading(true)
     setError(null)

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -61,6 +61,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
   const [isCreating, setIsCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const [oneTimeToken, setOneTimeToken] = useState<ApiToken | null>(null)
+  // Incremented to invalidate slower token inventory requests after account eligibility changes.
   const fetchRequestIdRef = useRef(0)
 
   const canCreateToken = useMemo(

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -5,6 +5,7 @@ import {
   resolveDefaultTokenLifecycleDecisionFromCapabilities,
 } from "~/services/accounts/defaultTokenLifecycle"
 import {
+  createAccountApiRequestFromStoredAccount,
   requireDisplayAccountKeyManagement,
   requireDisplayAccountTokenProvisioning,
 } from "~/services/accounts/utils/apiServiceRequest"
@@ -16,7 +17,6 @@ import {
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
-import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
 import {
   ACCOUNT_KEY_REPAIR_INVALID_TOKEN_REASONS,
@@ -98,32 +98,6 @@ function buildTokenUpdateRequest(
 }
 
 /**
- * Builds the normalized API-service request for account key audit calls.
- *
- * This helper accepts the stored account too so repair fallback paths can still
- * build a request when display data is missing URL/id fields.
- */
-function createAccountApiRequest(
-  account: SiteAccount,
-  displaySiteData: DisplaySiteData,
-  abortSignal?: AbortSignal,
-): ApiServiceRequest {
-  const accountId = displaySiteData.id || account.id
-
-  return {
-    baseUrl: displaySiteData.baseUrl || account.site_url,
-    accountId,
-    abortSignal,
-    auth: {
-      authType: displaySiteData.authType,
-      userId: displaySiteData.userId,
-      accessToken: displaySiteData.token,
-      cookie: displaySiteData.cookieAuthSessionCookie,
-    },
-  }
-}
-
-/**
  * Ensures one account has API keys for every currently available user group.
  */
 export async function ensureAccountKeysForAvailableGroups(params: {
@@ -145,7 +119,10 @@ export async function ensureAccountKeysForAvailableGroups(params: {
     displaySiteData,
     adapter.tokenProvisioning,
   )
-  const request = createAccountApiRequest(account, displaySiteData, abortSignal)
+  const accountContext = createAccountApiRequestFromStoredAccount(account)
+  const request = abortSignal
+    ? { ...accountContext.request, abortSignal }
+    : accountContext.request
   const accountId = displaySiteData.id || account.id
 
   const tokens = await keyManagement.fetchTokens(request)
@@ -328,7 +305,7 @@ export async function deleteInvalidAccountToken(params: {
     displaySiteData,
     getSiteAdapter(displaySiteData.siteType).keyManagement,
   )
-  const request = createAccountApiRequest(account, displaySiteData)
+  const { request } = createAccountApiRequestFromStoredAccount(account)
   await keyManagement.deleteToken({
     request,
     tokenId: token.tokenId,

--- a/src/services/accounts/defaultTokenLifecycle/lifecycle.ts
+++ b/src/services/accounts/defaultTokenLifecycle/lifecycle.ts
@@ -1,4 +1,5 @@
 import {
+  createAccountApiRequestFromStoredAccount,
   createDisplayAccountApiContext,
   requireDisplayAccountKeyManagement,
   requireDisplayAccountTokenProvisioning,
@@ -27,7 +28,6 @@ import {
   type DefaultTokenLifecycleResult,
 } from "./contracts"
 import {
-  createStoredAccountTokenRequest,
   generateDefaultTokenRequest,
   normalizeDefaultTokenRequestName,
 } from "./requests"
@@ -454,7 +454,7 @@ export async function ensureDefaultTokenLifecycle(params: {
     workflow,
     keyManagement,
     tokenProvisioning,
-    createRequest: createStoredAccountTokenRequest(account),
+    createRequest: createAccountApiRequestFromStoredAccount(account).request,
     inventoryRequest: context.request,
     decision,
     existingTokenIds,

--- a/src/services/accounts/defaultTokenLifecycle/requests.ts
+++ b/src/services/accounts/defaultTokenLifecycle/requests.ts
@@ -1,6 +1,4 @@
 import type { CreateTokenRequest } from "~/services/apiService/common/type"
-import type { ApiServiceRequest } from "~/services/apiTransport/type"
-import type { SiteAccount } from "~/types"
 
 export const DEFAULT_AUTO_PROVISION_TOKEN_NAME = "user group (auto)"
 export const DEFAULT_USER_GROUP_NAME = "default"
@@ -37,7 +35,6 @@ export function generateDefaultTokenRequest(): CreateTokenRequest {
     group: "",
   }
 }
-
 /**
  * Builds the default auto-provision token payload for one user group.
  */
@@ -72,23 +69,5 @@ export function normalizeDefaultTokenRequestName(
         ? groupDefaultTokenData.name
         : tokenData.name,
     group: normalizedGroup,
-  }
-}
-
-/**
- * Creates an adapter request DTO from a stored account record.
- */
-export function createStoredAccountTokenRequest(
-  account: SiteAccount,
-): ApiServiceRequest {
-  return {
-    baseUrl: account.site_url,
-    accountId: account.id,
-    auth: {
-      authType: account.authType,
-      userId: account.account_info.id,
-      accessToken: account.account_info.access_token,
-      cookie: account.cookieAuth?.sessionCookie,
-    },
   }
 }

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -1,12 +1,20 @@
+import type { AccountSiteType } from "~/constants/siteType"
 import { shouldDecorateAccountApiRequestWithAuthSession } from "~/services/accounts/accountSiteProfile"
+import { accountStorage } from "~/services/accounts/accountStorage"
 import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
 import { formatOptionalSkPrefixSiteToken } from "~/services/accountTokens/apiTokenKey"
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
 import type { TokenProvisioningCapability } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import type { ApiServiceRequest } from "~/services/apiService/common/type"
 import type { Sub2ApiAuthSessionRequest } from "~/services/apiService/sub2api/authSession"
-import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
+import {
+  AuthTypeEnum,
+  type ApiToken,
+  type DisplaySiteData,
+  type SiteAccount,
+} from "~/types"
 import { createLogger } from "~/utils/core/logger"
 
 const hasNonEmptyString = (value: unknown): value is string =>
@@ -66,19 +74,49 @@ export class InvalidTokenPayloadError extends Error {
   }
 }
 
+export class StoredAccountApiContextError extends Error {
+  readonly code:
+    | "MISSING_ACCOUNT_ID"
+    | "ACCOUNT_NOT_FOUND"
+    | "MISSING_BASE_URL"
+    | "MISSING_USER_ID"
+    | "MISSING_CREDENTIAL"
+
+  constructor(code: StoredAccountApiContextError["code"], message: string) {
+    super(message)
+    this.name = "StoredAccountApiContextError"
+    this.code = code
+  }
+}
+
+export type DisplayAccountApiSnapshot = Pick<
+  DisplaySiteData,
+  | "id"
+  | "siteType"
+  | "baseUrl"
+  | "authType"
+  | "userId"
+  | "token"
+  | "cookieAuthSessionCookie"
+>
+
+export interface AccountApiContext {
+  accountId: string
+  siteType: AccountSiteType
+  request: ApiServiceRequest | Sub2ApiAuthSessionRequest
+}
+
+export interface DisplayAccountApiCapabilityContext extends AccountApiContext {
+  adapter: SiteAdapter
+  keyManagement: KeyManagementCapability | undefined
+  tokenProvisioning: TokenProvisioningCapability | undefined
+}
+
 /**
  * Build the shared ApiService request DTO used by account-scoped UI flows.
  */
 const buildApiRequestFromDisplayAccount = (
-  account: Pick<
-    DisplaySiteData,
-    | "baseUrl"
-    | "id"
-    | "authType"
-    | "userId"
-    | "token"
-    | "cookieAuthSessionCookie"
-  >,
+  account: DisplayAccountApiSnapshot,
 ): ApiServiceRequest => ({
   baseUrl: account.baseUrl,
   accountId: account.id,
@@ -89,6 +127,105 @@ const buildApiRequestFromDisplayAccount = (
     cookie: account.cookieAuthSessionCookie,
   },
 })
+
+type StoredAccountApiRequestSource = Pick<
+  SiteAccount,
+  "id" | "site_url" | "site_type" | "authType" | "account_info" | "cookieAuth"
+>
+
+export const createAccountApiRequestFromStoredAccount = (
+  account: StoredAccountApiRequestSource,
+): AccountApiContext => {
+  if (!hasNonEmptyString(account.id)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_ACCOUNT_ID",
+      "account_api_context_missing_account_id",
+    )
+  }
+
+  if (!hasNonEmptyString(account.site_url)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_BASE_URL",
+      "account_api_context_missing_base_url",
+    )
+  }
+
+  if (!hasNonEmptyString(account.account_info?.id)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_USER_ID",
+      "account_api_context_missing_user_id",
+    )
+  }
+
+  const accessToken = account.account_info?.access_token ?? ""
+  const cookie = account.cookieAuth?.sessionCookie
+
+  if (
+    account.authType === AuthTypeEnum.AccessToken &&
+    !hasNonEmptyString(accessToken)
+  ) {
+    throw new StoredAccountApiContextError(
+      "MISSING_CREDENTIAL",
+      "account_api_context_missing_credential",
+    )
+  }
+
+  if (
+    account.authType === AuthTypeEnum.Cookie &&
+    !hasNonEmptyString(accessToken) &&
+    !hasNonEmptyString(cookie)
+  ) {
+    throw new StoredAccountApiContextError(
+      "MISSING_CREDENTIAL",
+      "account_api_context_missing_credential",
+    )
+  }
+
+  const request: ApiServiceRequest = {
+    baseUrl: account.site_url,
+    accountId: account.id,
+    auth: {
+      authType: account.authType,
+      userId: account.account_info.id,
+      accessToken,
+      cookie,
+    },
+  }
+
+  return {
+    accountId: account.id,
+    siteType: account.site_type,
+    request: withDisplayAccountAuthSession(
+      { siteType: account.site_type },
+      request,
+    ),
+  }
+}
+
+/**
+ * Resolve the latest stored account and build its account API request context.
+ */
+export async function resolveStoredAccountApiContext(
+  accountId: string,
+): Promise<AccountApiContext> {
+  if (!hasNonEmptyString(accountId)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_ACCOUNT_ID",
+      "account_api_context_missing_account_id",
+    )
+  }
+
+  const account = await accountStorage.getAccountById(accountId)
+
+  if (!account) {
+    throw new StoredAccountApiContextError(
+      "ACCOUNT_NOT_FOUND",
+      "account_api_context_account_not_found",
+    )
+  }
+
+  return createAccountApiRequestFromStoredAccount(account)
+}
 
 const withDisplayAccountAuthSession = (
   account: Pick<DisplaySiteData, "siteType">,
@@ -105,30 +242,42 @@ const withDisplayAccountAuthSession = (
 }
 
 /**
- * Resolve the site adapter and request DTO for a display account.
+ * Build the request DTO for a display account snapshot.
  */
-export const createDisplayAccountApiContext = (
-  account: Pick<
-    DisplaySiteData,
-    | "siteType"
-    | "baseUrl"
-    | "id"
-    | "authType"
-    | "userId"
-    | "token"
-    | "cookieAuthSessionCookie"
-  >,
-) => {
-  const adapter = getSiteAdapter(account.siteType)
+export const createDisplayAccountRequestContext = (
+  account: DisplayAccountApiSnapshot,
+): AccountApiContext => {
+  if (!hasNonEmptyString(account.id)) {
+    throw new StoredAccountApiContextError(
+      "MISSING_ACCOUNT_ID",
+      "account_api_context_missing_account_id",
+    )
+  }
 
   return {
-    adapter,
-    keyManagement: adapter.keyManagement,
-    tokenProvisioning: adapter.tokenProvisioning,
+    accountId: account.id,
+    siteType: account.siteType,
     request: withDisplayAccountAuthSession(
       account,
       buildApiRequestFromDisplayAccount(account),
     ),
+  }
+}
+
+/**
+ * Resolve the site adapter and request DTO for a display account.
+ */
+export const createDisplayAccountApiContext = (
+  account: DisplayAccountApiSnapshot,
+): DisplayAccountApiCapabilityContext => {
+  const adapter = getSiteAdapter(account.siteType)
+  const context = createDisplayAccountRequestContext(account)
+
+  return {
+    ...context,
+    adapter,
+    keyManagement: adapter.keyManagement,
+    tokenProvisioning: adapter.tokenProvisioning,
   }
 }
 
@@ -140,16 +289,7 @@ export interface ResolveDisplayAccountTokenForSecretOptions {
  * Fetches the current token inventory for a display account.
  */
 export async function fetchDisplayAccountTokens(
-  account: Pick<
-    DisplaySiteData,
-    | "siteType"
-    | "baseUrl"
-    | "id"
-    | "authType"
-    | "userId"
-    | "token"
-    | "cookieAuthSessionCookie"
-  >,
+  account: DisplayAccountApiSnapshot,
 ): Promise<ApiToken[]> {
   const { keyManagement, request } = createDisplayAccountApiContext(account)
   const tokensResponse = await requireDisplayAccountKeyManagement(
@@ -183,16 +323,7 @@ export async function fetchDisplayAccountTokens(
 export async function resolveDisplayAccountTokenForSecret<
   TToken extends ApiToken,
 >(
-  account: Pick<
-    DisplaySiteData,
-    | "siteType"
-    | "baseUrl"
-    | "id"
-    | "authType"
-    | "userId"
-    | "token"
-    | "cookieAuthSessionCookie"
-  >,
+  account: DisplayAccountApiSnapshot,
   token: TToken,
   options: ResolveDisplayAccountTokenForSecretOptions = {},
 ): Promise<TToken> {

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -89,16 +89,15 @@ export class StoredAccountApiContextError extends Error {
   }
 }
 
-export type DisplayAccountApiSnapshot = Pick<
-  DisplaySiteData,
-  | "id"
-  | "siteType"
-  | "baseUrl"
-  | "authType"
-  | "userId"
-  | "token"
-  | "cookieAuthSessionCookie"
->
+export interface DisplayAccountApiSnapshot {
+  id: DisplaySiteData["id"]
+  siteType: DisplaySiteData["siteType"]
+  baseUrl: DisplaySiteData["baseUrl"]
+  authType: DisplaySiteData["authType"]
+  userId: DisplaySiteData["userId"]
+  token: DisplaySiteData["token"]
+  cookieAuthSessionCookie?: DisplaySiteData["cookieAuthSessionCookie"]
+}
 
 export interface AccountApiContext {
   accountId: string
@@ -112,57 +111,57 @@ export interface DisplayAccountApiCapabilityContext extends AccountApiContext {
   tokenProvisioning: TokenProvisioningCapability | undefined
 }
 
-/**
- * Build the shared ApiService request DTO used by account-scoped UI flows.
- */
-const buildApiRequestFromDisplayAccount = (
-  account: DisplayAccountApiSnapshot,
-): ApiServiceRequest => ({
-  baseUrl: account.baseUrl,
-  accountId: account.id,
-  auth: {
-    authType: account.authType,
-    userId: account.userId,
-    accessToken: account.token,
-    cookie: account.cookieAuthSessionCookie,
-  },
-})
+interface StoredAccountApiRequestSource {
+  id: SiteAccount["id"]
+  site_url: SiteAccount["site_url"]
+  site_type: SiteAccount["site_type"]
+  authType: SiteAccount["authType"]
+  account_info: SiteAccount["account_info"]
+  cookieAuth?: SiteAccount["cookieAuth"]
+}
 
-type StoredAccountApiRequestSource = Pick<
-  SiteAccount,
-  "id" | "site_url" | "site_type" | "authType" | "account_info" | "cookieAuth"
->
+interface AccountApiRequestSource {
+  id: unknown
+  siteUrl: unknown
+  siteType: AccountSiteType
+  authType: AuthTypeEnum
+  userId: unknown
+  accessToken: unknown
+  cookie: unknown
+}
 
-export const createAccountApiRequestFromStoredAccount = (
-  account: StoredAccountApiRequestSource,
+const createAccountApiContextFromSource = (
+  source: AccountApiRequestSource,
 ): AccountApiContext => {
-  if (!hasNonEmptyString(account.id)) {
+  if (!hasNonEmptyString(source.id)) {
     throw new StoredAccountApiContextError(
       "MISSING_ACCOUNT_ID",
       "account_api_context_missing_account_id",
     )
   }
 
-  if (!hasNonEmptyString(account.site_url)) {
+  if (!hasNonEmptyString(source.siteUrl)) {
     throw new StoredAccountApiContextError(
       "MISSING_BASE_URL",
       "account_api_context_missing_base_url",
     )
   }
 
-  if (!hasNonEmptyString(account.account_info?.id)) {
+  if (!hasNonEmptyString(source.userId)) {
     throw new StoredAccountApiContextError(
       "MISSING_USER_ID",
       "account_api_context_missing_user_id",
     )
   }
 
-  const accessToken = account.account_info?.access_token ?? ""
-  const cookie = account.cookieAuth?.sessionCookie
+  const accessToken =
+    typeof source.accessToken === "string" ? source.accessToken : ""
+  const cookie = typeof source.cookie === "string" ? source.cookie : undefined
 
   if (
-    account.authType === AuthTypeEnum.AccessToken &&
-    !hasNonEmptyString(accessToken)
+    source.authType === AuthTypeEnum.None ||
+    (source.authType === AuthTypeEnum.AccessToken &&
+      !hasNonEmptyString(accessToken))
   ) {
     throw new StoredAccountApiContextError(
       "MISSING_CREDENTIAL",
@@ -171,7 +170,7 @@ export const createAccountApiRequestFromStoredAccount = (
   }
 
   if (
-    account.authType === AuthTypeEnum.Cookie &&
+    source.authType === AuthTypeEnum.Cookie &&
     !hasNonEmptyString(accessToken) &&
     !hasNonEmptyString(cookie)
   ) {
@@ -182,25 +181,38 @@ export const createAccountApiRequestFromStoredAccount = (
   }
 
   const request: ApiServiceRequest = {
-    baseUrl: account.site_url,
-    accountId: account.id,
+    baseUrl: source.siteUrl,
+    accountId: source.id,
     auth: {
-      authType: account.authType,
-      userId: account.account_info.id,
+      authType: source.authType,
+      userId: source.userId,
       accessToken,
       cookie,
     },
   }
 
   return {
-    accountId: account.id,
-    siteType: account.site_type,
+    accountId: source.id,
+    siteType: source.siteType,
     request: withDisplayAccountAuthSession(
-      { siteType: account.site_type },
+      { siteType: source.siteType },
       request,
     ),
   }
 }
+
+export const createAccountApiRequestFromStoredAccount = (
+  account: StoredAccountApiRequestSource,
+): AccountApiContext =>
+  createAccountApiContextFromSource({
+    id: account.id,
+    siteUrl: account.site_url,
+    siteType: account.site_type,
+    authType: account.authType,
+    userId: account.account_info?.id,
+    accessToken: account.account_info?.access_token ?? "",
+    cookie: account.cookieAuth?.sessionCookie,
+  })
 
 /**
  * Resolve the latest stored account and build its account API request context.
@@ -246,23 +258,16 @@ const withDisplayAccountAuthSession = (
  */
 export const createDisplayAccountRequestContext = (
   account: DisplayAccountApiSnapshot,
-): AccountApiContext => {
-  if (!hasNonEmptyString(account.id)) {
-    throw new StoredAccountApiContextError(
-      "MISSING_ACCOUNT_ID",
-      "account_api_context_missing_account_id",
-    )
-  }
-
-  return {
-    accountId: account.id,
+): AccountApiContext =>
+  createAccountApiContextFromSource({
+    id: account.id,
+    siteUrl: account.baseUrl,
     siteType: account.siteType,
-    request: withDisplayAccountAuthSession(
-      account,
-      buildApiRequestFromDisplayAccount(account),
-    ),
-  }
-}
+    authType: account.authType,
+    userId: account.userId,
+    accessToken: account.token,
+    cookie: account.cookieAuthSessionCookie,
+  })
 
 /**
  * Resolve the site adapter and request DTO for a display account.

--- a/src/services/accounts/utils/legacyAccountAwareRequest.ts
+++ b/src/services/accounts/utils/legacyAccountAwareRequest.ts
@@ -1,0 +1,43 @@
+import { accountStorage } from "~/services/accounts/accountStorage"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import { AuthTypeEnum } from "~/types"
+import { createLogger } from "~/utils/core/logger"
+
+const logger = createLogger("LegacyAccountAwareRequest")
+
+/**
+ * Temporary migration helper for legacy callers that still build requests
+ * without stable account identity. New account API flows should use
+ * createDisplayAccountRequestContext or resolveStoredAccountApiContext instead.
+ */
+export async function resolveLegacyAccountAwareRequest(
+  request: ApiServiceRequest,
+  context: { endpoint?: string } = {},
+): Promise<ApiServiceRequest> {
+  if (request.accountId) return request
+
+  const userId = request.auth?.userId
+
+  logger.warn("fetchApi called without accountId in request", {
+    baseUrl: request.baseUrl,
+    userId,
+    endpoint: context.endpoint,
+    authType: request.auth?.authType ?? AuthTypeEnum.None,
+    hasAccessToken: Boolean(request.auth?.accessToken),
+    hasCookie: Boolean(request.auth?.cookie),
+  })
+
+  const accountInfo = await accountStorage.getAccountByBaseUrlAndUserId(
+    request.baseUrl,
+    userId,
+  )
+
+  if (!accountInfo) return request
+
+  return {
+    ...request,
+    accountId: accountInfo.id,
+    cookieAuthSessionCookie:
+      request.cookieAuthSessionCookie ?? accountInfo.cookieAuth?.sessionCookie,
+  }
+}

--- a/src/services/accounts/utils/legacyAccountAwareRequest.ts
+++ b/src/services/accounts/utils/legacyAccountAwareRequest.ts
@@ -27,6 +27,8 @@ export async function resolveLegacyAccountAwareRequest(
     hasCookie: Boolean(request.auth?.cookie),
   })
 
+  if (!userId) return request
+
   const accountInfo = await accountStorage.getAccountByBaseUrlAndUserId(
     request.baseUrl,
     userId,

--- a/src/services/apiService/common/index.ts
+++ b/src/services/apiService/common/index.ts
@@ -891,6 +891,9 @@ export async function fetchTodayUsage(
  * @param queryConfig Optional override for non-standard log pagination APIs.
  * @returns Total income amount for today.
  */
+// Temporary exception during account API context migration:
+// this helper still owns exchange-rate lookup until account-data refresh
+// orchestration moves that policy into src/services/accounts/**.
 export async function fetchTodayIncome(
   request: ApiServiceAccountRequest,
   queryConfig?: TodayLogQueryConfig,

--- a/src/services/apiService/common/utils.ts
+++ b/src/services/apiService/common/utils.ts
@@ -1,4 +1,4 @@
-import { accountStorage } from "~/services/accounts/accountStorage"
+import { resolveLegacyAccountAwareRequest } from "~/services/accounts/utils/legacyAccountAwareRequest"
 import type {
   ApiResponse,
   FetchApiOptions,
@@ -12,44 +12,8 @@ import {
   fetchApiData as transportFetchApiData,
 } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
-import { AuthTypeEnum } from "~/types"
-import { createLogger } from "~/utils/core/logger"
 
 export { extractDataFromApiResponseBody, isHttpUrl }
-
-const logger = createLogger("ApiServiceCommonUtils")
-
-const resolveAccountAwareRequest = async (
-  request: ApiServiceRequest,
-  endpoint: string,
-): Promise<ApiServiceRequest> => {
-  if (request.accountId) return request
-
-  const userId = request.auth?.userId
-
-  logger.warn("fetchApi called without accountId in request", {
-    baseUrl: request.baseUrl,
-    userId,
-    endpoint,
-    authType: request.auth?.authType ?? AuthTypeEnum.None,
-    hasAccessToken: Boolean(request.auth?.accessToken),
-    hasCookie: Boolean(request.auth?.cookie),
-  })
-
-  const accountInfo = await accountStorage.getAccountByBaseUrlAndUserId(
-    request.baseUrl,
-    userId,
-  )
-
-  if (!accountInfo) return request
-
-  return {
-    ...request,
-    accountId: accountInfo.id,
-    cookieAuthSessionCookie:
-      request.cookieAuthSessionCookie ?? accountInfo.cookieAuth?.sessionCookie,
-  }
-}
 
 /**
  * Fetch account-site API data after applying account-aware fallback metadata.
@@ -62,7 +26,9 @@ export async function fetchApiData<T>(
   options: FetchApiOptions,
 ): Promise<T> {
   return await transportFetchApiData(
-    await resolveAccountAwareRequest(request, options.endpoint),
+    await resolveLegacyAccountAwareRequest(request, {
+      endpoint: options.endpoint,
+    }),
     options,
   )
 }
@@ -90,7 +56,9 @@ export async function fetchApi<T>(
   _normalResponseType?: boolean,
 ): Promise<T | ApiResponse<T>> {
   return await transportFetchApi(
-    await resolveAccountAwareRequest(request, options.endpoint),
+    await resolveLegacyAccountAwareRequest(request, {
+      endpoint: options.endpoint,
+    }),
     options,
     _normalResponseType as true,
   )

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -906,6 +906,42 @@ describe("ModelKeyDialog", () => {
     expect(fetchAccountTokensMock).not.toHaveBeenCalled()
   })
 
+  it("clears loaded token state when the selected account becomes ineligible", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+
+    const { rerender } = render(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={ACCOUNT}
+        modelId="gpt-4"
+        modelEnableGroups={["default"]}
+      />,
+    )
+
+    expect(
+      await screen.findByRole("button", { name: "common:actions.copyKey" }),
+    ).toBeInTheDocument()
+
+    rerender(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{ ...ACCOUNT, authType: AuthTypeEnum.None, token: "" }}
+        modelId="gpt-4"
+        modelEnableGroups={["default"]}
+      />,
+    )
+
+    expect(
+      await screen.findByText("modelList:keyDialog.ineligible.missingAuth"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "common:actions.copyKey" }),
+    ).not.toBeInTheDocument()
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
   it("uses the unknown fallback when token inventory payload is invalid", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce(null)
 

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "~/services/productAnalytics/events"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { AuthTypeEnum } from "~/types"
-import { render, screen, waitFor } from "~~/tests/test-utils/render"
+import { act, render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
   fetchAccountTokensMock,
@@ -157,6 +157,17 @@ function mockTimeoutsAsMicrotasks() {
 
       return originalSetTimeout(callback, delay)
     })
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+
+  return { promise, resolve, reject }
 }
 
 describe("ModelKeyDialog", () => {
@@ -936,6 +947,47 @@ describe("ModelKeyDialog", () => {
     expect(
       await screen.findByText("modelList:keyDialog.ineligible.missingAuth"),
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "common:actions.copyKey" }),
+    ).not.toBeInTheDocument()
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores stale token fetch completions after the selected account becomes ineligible", async () => {
+    const pendingTokens = createDeferred<(typeof TOKEN)[]>()
+    fetchAccountTokensMock.mockReturnValueOnce(pendingTokens.promise)
+
+    const { rerender } = render(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={ACCOUNT}
+        modelId="gpt-4"
+        modelEnableGroups={["default"]}
+      />,
+    )
+
+    await screen.findByText("modelList:keyDialog.loading")
+
+    rerender(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{ ...ACCOUNT, authType: AuthTypeEnum.None, token: "" }}
+        modelId="gpt-4"
+        modelEnableGroups={["default"]}
+      />,
+    )
+
+    expect(
+      await screen.findByText("modelList:keyDialog.ineligible.missingAuth"),
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      pendingTokens.resolve([TOKEN])
+      await pendingTokens.promise
+    })
+
     expect(
       screen.queryByRole("button", { name: "common:actions.copyKey" }),
     ).not.toBeInTheDocument()

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -882,7 +882,7 @@ describe("ModelKeyDialog", () => {
     expect(
       await screen.findByText("modelList:keyDialog.ineligible.missingAuth"),
     ).toBeInTheDocument()
-    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+    expect(fetchAccountTokensMock).not.toHaveBeenCalled()
   })
 
   it("explains missing credentials when token management credentials are incomplete", async () => {
@@ -903,7 +903,7 @@ describe("ModelKeyDialog", () => {
         "modelList:keyDialog.ineligible.missingCredentials",
       ),
     ).toBeInTheDocument()
-    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+    expect(fetchAccountTokensMock).not.toHaveBeenCalled()
   })
 
   it("uses the unknown fallback when token inventory payload is invalid", async () => {

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -28,7 +28,7 @@ import {
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { AuthTypeEnum } from "~/types"
 import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
-import { render, screen, waitFor } from "~~/tests/test-utils/render"
+import { act, render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
   fetchAccountTokensMock,
@@ -244,6 +244,17 @@ const TOKEN = {
   model_limits: "",
   group: "",
 } as any
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+
+  return { promise, resolve, reject }
+}
 
 describe("CopyKeyDialog", () => {
   beforeEach(() => {
@@ -631,6 +642,39 @@ describe("CopyKeyDialog", () => {
         name: "ui:dialog.copyKey.createKey",
       }),
     ).toBeDisabled()
+    expect(screen.queryByText("default")).not.toBeInTheDocument()
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores stale token fetch completions after the selected account loses manageable credentials", async () => {
+    const pendingTokens = createDeferred<(typeof TOKEN)[]>()
+    fetchAccountTokensMock.mockReturnValueOnce(pendingTokens.promise)
+
+    const { rerender } = render(
+      <CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />,
+    )
+
+    await screen.findByText("ui:dialog.copyKey.loading")
+
+    rerender(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{ ...ACCOUNT, token: "", cookieAuthSessionCookie: "" }}
+      />,
+    )
+
+    expect(
+      await screen.findByRole("button", {
+        name: "ui:dialog.copyKey.createKey",
+      }),
+    ).toBeDisabled()
+
+    await act(async () => {
+      pendingTokens.resolve([TOKEN])
+      await pendingTokens.promise
+    })
+
     expect(screen.queryByText("default")).not.toBeInTheDocument()
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
   })

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -592,8 +592,6 @@ describe("CopyKeyDialog", () => {
   })
 
   it("does not start token creation for accounts without manageable credentials", async () => {
-    fetchAccountTokensMock.mockResolvedValueOnce([])
-
     render(
       <CopyKeyDialog
         isOpen={true}
@@ -607,7 +605,34 @@ describe("CopyKeyDialog", () => {
         name: "ui:dialog.copyKey.createKey",
       }),
     ).toBeDisabled()
+    expect(fetchAccountTokensMock).not.toHaveBeenCalled()
     expect(createApiTokenMock).not.toHaveBeenCalled()
+  })
+
+  it("clears loaded tokens when the selected account loses manageable credentials", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+
+    const { rerender } = render(
+      <CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />,
+    )
+
+    expect(await screen.findByText("default")).toBeInTheDocument()
+
+    rerender(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{ ...ACCOUNT, token: "", cookieAuthSessionCookie: "" }}
+      />,
+    )
+
+    expect(
+      await screen.findByRole("button", {
+        name: "ui:dialog.copyKey.createKey",
+      }),
+    ).toBeDisabled()
+    expect(screen.queryByText("default")).not.toBeInTheDocument()
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
   })
 
   it("opens a generic constrained Add Token dialog when default token policy requires selection", async () => {

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -2450,6 +2450,8 @@ describe("useAccountDialog save and auto-config flows", () => {
       apiServiceRequest,
       "createDisplayAccountApiContext",
     ).mockReturnValue({
+      accountId: savedDisplayData.id,
+      siteType: SITE_TYPES.SUB2API,
       adapter: {
         siteType: SITE_TYPES.SUB2API,
         keyManagement: {
@@ -2559,6 +2561,8 @@ describe("useAccountDialog save and auto-config flows", () => {
       apiServiceRequest,
       "createDisplayAccountApiContext",
     ).mockReturnValue({
+      accountId: savedDisplayData.id,
+      siteType: SITE_TYPES.SUB2API,
       adapter: {
         siteType: SITE_TYPES.SUB2API,
         keyManagement: {
@@ -2661,6 +2665,8 @@ describe("useAccountDialog save and auto-config flows", () => {
       apiServiceRequest,
       "createDisplayAccountApiContext",
     ).mockReturnValue({
+      accountId: savedDisplayData.id,
+      siteType: SITE_TYPES.SUB2API,
       adapter: {
         siteType: SITE_TYPES.SUB2API,
         keyManagement: {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -4,13 +4,21 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
 import {
   canManageDisplayAccountTokens,
+  createAccountApiRequestFromStoredAccount,
   createDisplayAccountApiContext,
+  createDisplayAccountRequestContext,
   fetchDisplayAccountTokens,
   InvalidTokenPayloadError,
   resolveDisplayAccountTokenForSecret,
+  resolveStoredAccountApiContext,
+  StoredAccountApiContextError,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import { AuthTypeEnum } from "~/types"
+
+const { mockGetAccountById } = vi.hoisted(() => ({
+  mockGetAccountById: vi.fn(),
+}))
 
 vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteAdapter: vi.fn(),
@@ -20,6 +28,12 @@ vi.mock("~/services/accounts/sub2apiAuthSession", () => ({
   accountSub2ApiAuthSession: {
     getLatestAuth: vi.fn(),
     persistAuthUpdate: vi.fn(),
+  },
+}))
+
+vi.mock("~/services/accounts/accountStorage", () => ({
+  accountStorage: {
+    getAccountById: mockGetAccountById,
   },
 }))
 
@@ -43,6 +57,21 @@ const REQUEST = {
     cookie: "",
   },
 }
+
+const buildStoredAccount = (overrides: Record<string, unknown> = {}) => ({
+  id: "account-1",
+  site_name: "Example",
+  site_url: "https://example.com",
+  site_type: "new-api",
+  authType: AuthTypeEnum.AccessToken,
+  account_info: {
+    id: "1",
+    username: "Ada",
+    access_token: "token",
+  },
+  cookieAuth: undefined,
+  ...overrides,
+})
 
 describe("fetchDisplayAccountTokens", () => {
   let fetchTokens: ReturnType<typeof vi.fn>
@@ -104,6 +133,7 @@ describe("fetchDisplayAccountTokens", () => {
 
     vi.mocked(getSiteAdapter).mockReset()
     vi.mocked(getSiteAdapter).mockReturnValue(adapter as any)
+    mockGetAccountById.mockReset()
   })
 
   it("returns the token array when the API payload is valid", async () => {
@@ -113,12 +143,14 @@ describe("fetchDisplayAccountTokens", () => {
 
     expect(result).toEqual([{ id: 1, key: "sk-test", status: 1 }])
     expect(fetchTokens).toHaveBeenCalledWith(expect.objectContaining(REQUEST))
-    expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual({
-      adapter,
-      keyManagement,
-      tokenProvisioning,
-      request: expect.objectContaining(REQUEST),
-    })
+    expect(createDisplayAccountApiContext(ACCOUNT as any)).toEqual(
+      expect.objectContaining({
+        adapter,
+        keyManagement,
+        tokenProvisioning,
+        request: expect.objectContaining(REQUEST),
+      }),
+    )
     expect(createDisplayAccountApiContext(ACCOUNT as any)).not.toHaveProperty(
       "service",
     )
@@ -129,6 +161,252 @@ describe("fetchDisplayAccountTokens", () => {
         }),
       }),
     )
+  })
+
+  it("builds a request-only context from a display account snapshot", () => {
+    expect(createDisplayAccountRequestContext(ACCOUNT as any)).toEqual({
+      accountId: "account-1",
+      siteType: "new-api",
+      request: expect.objectContaining(REQUEST),
+    })
+    expect(
+      createDisplayAccountRequestContext(ACCOUNT as any),
+    ).not.toHaveProperty("adapter")
+    expect(
+      createDisplayAccountRequestContext(ACCOUNT as any).request,
+    ).not.toHaveProperty("cookieAuthSessionCookie")
+  })
+
+  it("keeps cookie-auth sessions in request auth for display snapshots", () => {
+    const context = createDisplayAccountRequestContext({
+      ...ACCOUNT,
+      authType: AuthTypeEnum.Cookie,
+      token: "",
+      cookieAuthSessionCookie: "session=abc",
+    } as any)
+
+    expect(context.request).toEqual(
+      expect.objectContaining({
+        accountId: "account-1",
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.Cookie,
+          cookie: "session=abc",
+        }),
+      }),
+    )
+  })
+
+  it("rejects display account snapshots without a stable id", () => {
+    expect(() =>
+      createDisplayAccountRequestContext({
+        ...ACCOUNT,
+        id: "   ",
+      } as any),
+    ).toThrow("account_api_context_missing_account_id")
+  })
+
+  it("resolves stored account context from the latest persisted account", async () => {
+    mockGetAccountById.mockResolvedValueOnce(
+      buildStoredAccount({
+        account_info: {
+          id: "stored-user",
+          username: "Latest",
+          access_token: "stored-token",
+        },
+      }),
+    )
+
+    await expect(resolveStoredAccountApiContext("account-1")).resolves.toEqual({
+      accountId: "account-1",
+      siteType: "new-api",
+      request: expect.objectContaining({
+        baseUrl: "https://example.com",
+        accountId: "account-1",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "stored-user",
+          accessToken: "stored-token",
+          cookie: undefined,
+        },
+      }),
+    })
+    expect(mockGetAccountById).toHaveBeenCalledWith("account-1")
+  })
+
+  it("preserves stored cookie-auth session in request auth", async () => {
+    mockGetAccountById.mockResolvedValueOnce(
+      buildStoredAccount({
+        authType: AuthTypeEnum.Cookie,
+        account_info: {
+          id: "stored-user",
+          username: "Latest",
+          access_token: "",
+        },
+        cookieAuth: {
+          sessionCookie: "session=stored",
+        },
+      }),
+    )
+
+    const context = await resolveStoredAccountApiContext("account-1")
+
+    expect(context.request).toEqual(
+      expect.objectContaining({
+        accountId: "account-1",
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.Cookie,
+          userId: "stored-user",
+          accessToken: "",
+          cookie: "session=stored",
+        }),
+      }),
+    )
+    expect(context.request).not.toHaveProperty("cookieAuthSessionCookie")
+  })
+
+  it("decorates stored Sub2API contexts with the account auth session port", async () => {
+    mockGetAccountById.mockResolvedValueOnce(
+      buildStoredAccount({
+        site_type: SITE_TYPES.SUB2API,
+      }),
+    )
+
+    const context = await resolveStoredAccountApiContext("account-1")
+
+    expect(context.siteType).toBe(SITE_TYPES.SUB2API)
+    expect(context.request).toEqual(
+      expect.objectContaining({
+        sub2apiAuthSession: accountSub2ApiAuthSession,
+      }),
+    )
+  })
+
+  it("throws a stable error when the stored account id is blank", async () => {
+    await expect(resolveStoredAccountApiContext("   ")).rejects.toMatchObject({
+      name: "StoredAccountApiContextError",
+      code: "MISSING_ACCOUNT_ID",
+      message: "account_api_context_missing_account_id",
+    })
+    expect(mockGetAccountById).not.toHaveBeenCalled()
+  })
+
+  it("throws a stable error when the stored account no longer exists", async () => {
+    mockGetAccountById.mockResolvedValueOnce(null)
+
+    await expect(
+      resolveStoredAccountApiContext("missing"),
+    ).rejects.toMatchObject({
+      name: "StoredAccountApiContextError",
+      code: "ACCOUNT_NOT_FOUND",
+      message: "account_api_context_account_not_found",
+    })
+  })
+
+  it("throws a stable error when a stored account has a blank id", () => {
+    expect(() =>
+      createAccountApiRequestFromStoredAccount(
+        buildStoredAccount({
+          id: "   ",
+        }) as any,
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        name: "StoredAccountApiContextError",
+        code: "MISSING_ACCOUNT_ID",
+        message: "account_api_context_missing_account_id",
+      }),
+    )
+  })
+
+  it("throws a stable error when a stored account has a blank base URL", () => {
+    expect(() =>
+      createAccountApiRequestFromStoredAccount(
+        buildStoredAccount({
+          site_url: "   ",
+        }) as any,
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        name: "StoredAccountApiContextError",
+        code: "MISSING_BASE_URL",
+        message: "account_api_context_missing_base_url",
+      }),
+    )
+  })
+
+  it("throws a stable error when a stored account has a blank user id", () => {
+    expect(() =>
+      createAccountApiRequestFromStoredAccount(
+        buildStoredAccount({
+          account_info: {
+            id: "   ",
+            username: "Ada",
+            access_token: "token",
+          },
+        }) as any,
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        name: "StoredAccountApiContextError",
+        code: "MISSING_USER_ID",
+        message: "account_api_context_missing_user_id",
+      }),
+    )
+  })
+
+  it("throws a stable error when an access-token stored account has a blank credential", () => {
+    expect(() =>
+      createAccountApiRequestFromStoredAccount(
+        buildStoredAccount({
+          account_info: {
+            id: "1",
+            username: "Ada",
+            access_token: "   ",
+          },
+        }) as any,
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        name: "StoredAccountApiContextError",
+        code: "MISSING_CREDENTIAL",
+        message: "account_api_context_missing_credential",
+      }),
+    )
+  })
+
+  it("throws a stable error when a cookie stored account has no credential", () => {
+    expect(() =>
+      createAccountApiRequestFromStoredAccount(
+        buildStoredAccount({
+          authType: AuthTypeEnum.Cookie,
+          account_info: {
+            id: "1",
+            username: "Ada",
+            access_token: "   ",
+          },
+          cookieAuth: undefined,
+        }) as any,
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        name: "StoredAccountApiContextError",
+        code: "MISSING_CREDENTIAL",
+        message: "account_api_context_missing_credential",
+      }),
+    )
+  })
+
+  it("exposes StoredAccountApiContextError for caller recovery checks", () => {
+    expect(
+      new StoredAccountApiContextError(
+        "MISSING_CREDENTIAL",
+        "account_api_context_missing_credential",
+      ),
+    ).toMatchObject({
+      name: "StoredAccountApiContextError",
+      code: "MISSING_CREDENTIAL",
+      message: "account_api_context_missing_credential",
+    })
   })
 
   it("keeps non-Sub2API account-scoped requests transport-only", async () => {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -205,6 +205,53 @@ describe("fetchDisplayAccountTokens", () => {
     ).toThrow("account_api_context_missing_account_id")
   })
 
+  it.each([
+    [
+      "base URL",
+      { baseUrl: "   " },
+      "MISSING_BASE_URL",
+      "account_api_context_missing_base_url",
+    ],
+    [
+      "user id",
+      { userId: "   " },
+      "MISSING_USER_ID",
+      "account_api_context_missing_user_id",
+    ],
+    [
+      "access-token credential",
+      { token: "   " },
+      "MISSING_CREDENTIAL",
+      "account_api_context_missing_credential",
+    ],
+    [
+      "cookie credential",
+      {
+        authType: AuthTypeEnum.Cookie,
+        token: "   ",
+        cookieAuthSessionCookie: "   ",
+      },
+      "MISSING_CREDENTIAL",
+      "account_api_context_missing_credential",
+    ],
+  ])(
+    "rejects display account snapshots with a blank %s",
+    (_label, overrides, code, message) => {
+      expect(() =>
+        createDisplayAccountRequestContext({
+          ...ACCOUNT,
+          ...overrides,
+        } as any),
+      ).toThrow(
+        expect.objectContaining({
+          name: "StoredAccountApiContextError",
+          code,
+          message,
+        }),
+      )
+    },
+  )
+
   it("resolves stored account context from the latest persisted account", async () => {
     mockGetAccountById.mockResolvedValueOnce(
       buildStoredAccount({
@@ -385,6 +432,22 @@ describe("fetchDisplayAccountTokens", () => {
             access_token: "   ",
           },
           cookieAuth: undefined,
+        }) as any,
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        name: "StoredAccountApiContextError",
+        code: "MISSING_CREDENTIAL",
+        message: "account_api_context_missing_credential",
+      }),
+    )
+  })
+
+  it("throws a stable error when a stored account has no supported auth type", () => {
+    expect(() =>
+      createAccountApiRequestFromStoredAccount(
+        buildStoredAccount({
+          authType: AuthTypeEnum.None,
         }) as any,
       ),
     ).toThrow(

--- a/tests/services/accounts/defaultTokenLifecycle.test.ts
+++ b/tests/services/accounts/defaultTokenLifecycle.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   createDefaultTokenFromDecision,
-  createStoredAccountTokenRequest,
   DEFAULT_TOKEN_INVENTORY_STATE_KINDS,
   DEFAULT_TOKEN_LIFECYCLE_BLOCK_REASONS,
   DEFAULT_TOKEN_LIFECYCLE_ERRORS,
@@ -14,6 +13,7 @@ import {
   resolveDefaultTokenLifecycleDecision,
   selectSingleNewApiTokenByIdDiff,
 } from "~/services/accounts/defaultTokenLifecycle"
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
 import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
 import {
@@ -564,7 +564,9 @@ describe("ensureDefaultTokenLifecycle", () => {
 
     expect(resolveDefaultTokenCreationMock).toHaveBeenCalledTimes(1)
     expect(createTokenMock).toHaveBeenCalledWith(
-      createStoredAccountTokenRequest(buildStoredAccount(displayAccount)),
+      createAccountApiRequestFromStoredAccount(
+        buildStoredAccount(displayAccount),
+      ).request,
       generateDefaultTokenRequest(),
     )
   })

--- a/tests/services/accounts/legacyAccountAwareRequest.test.ts
+++ b/tests/services/accounts/legacyAccountAwareRequest.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { resolveLegacyAccountAwareRequest } from "~/services/accounts/utils/legacyAccountAwareRequest"
+import { AuthTypeEnum } from "~/types"
+
+const { mockGetAccountByBaseUrlAndUserId } = vi.hoisted(() => ({
+  mockGetAccountByBaseUrlAndUserId: vi.fn(),
+}))
+
+vi.mock("~/services/accounts/accountStorage", () => ({
+  accountStorage: {
+    getAccountByBaseUrlAndUserId: mockGetAccountByBaseUrlAndUserId,
+  },
+}))
+
+describe("resolveLegacyAccountAwareRequest", () => {
+  beforeEach(() => {
+    mockGetAccountByBaseUrlAndUserId.mockReset()
+  })
+
+  it("enriches account metadata when accountId is absent", async () => {
+    mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce({
+      id: "account-1",
+      cookieAuth: {
+        sessionCookie: "session=stored",
+      },
+    })
+
+    await expect(
+      resolveLegacyAccountAwareRequest(
+        {
+          baseUrl: "https://example.com",
+          auth: {
+            authType: AuthTypeEnum.Cookie,
+            userId: "123",
+          },
+        },
+        { endpoint: "/api/test" },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        accountId: "account-1",
+        cookieAuthSessionCookie: "session=stored",
+      }),
+    )
+
+    expect(mockGetAccountByBaseUrlAndUserId).toHaveBeenCalledWith(
+      "https://example.com",
+      "123",
+    )
+  })
+
+  it("preserves caller-provided legacy session cookie when enriching metadata", async () => {
+    mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce({
+      id: "account-1",
+      cookieAuth: {
+        sessionCookie: "session=stored",
+      },
+    })
+
+    await expect(
+      resolveLegacyAccountAwareRequest(
+        {
+          baseUrl: "https://example.com",
+          cookieAuthSessionCookie: "session=fresh",
+          auth: {
+            authType: AuthTypeEnum.Cookie,
+            userId: "123",
+          },
+        },
+        { endpoint: "/api/test" },
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        accountId: "account-1",
+        cookieAuthSessionCookie: "session=fresh",
+      }),
+    )
+  })
+
+  it("returns the original request when lookup misses", async () => {
+    const request = {
+      baseUrl: "https://example.com",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "123",
+      },
+    }
+
+    mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce(null)
+
+    await expect(
+      resolveLegacyAccountAwareRequest(request, { endpoint: "/api/test" }),
+    ).resolves.toBe(request)
+  })
+
+  it("does not query storage when accountId is already present", async () => {
+    const request = {
+      baseUrl: "https://example.com",
+      accountId: "account-1",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "123",
+      },
+    }
+
+    await expect(
+      resolveLegacyAccountAwareRequest(request, { endpoint: "/api/test" }),
+    ).resolves.toBe(request)
+    expect(mockGetAccountByBaseUrlAndUserId).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/accounts/legacyAccountAwareRequest.test.ts
+++ b/tests/services/accounts/legacyAccountAwareRequest.test.ts
@@ -94,6 +94,21 @@ describe("resolveLegacyAccountAwareRequest", () => {
     ).resolves.toBe(request)
   })
 
+  it("does not query storage when auth user id is missing", async () => {
+    const request = {
+      baseUrl: "https://example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "token",
+      },
+    }
+
+    await expect(
+      resolveLegacyAccountAwareRequest(request, { endpoint: "/api/test" }),
+    ).resolves.toBe(request)
+    expect(mockGetAccountByBaseUrlAndUserId).not.toHaveBeenCalled()
+  })
+
   it("does not query storage when accountId is already present", async () => {
     const request = {
       baseUrl: "https://example.com",

--- a/tests/services/apiService/common/utils.test.ts
+++ b/tests/services/apiService/common/utils.test.ts
@@ -4,17 +4,19 @@ import type { LogItem } from "~/services/apiService/common/type"
 import {
   aggregateUsageData,
   extractAmount,
+  fetchApi,
   fetchApiData,
   getTodayTimestampRange,
 } from "~/services/apiService/common/utils"
 import { AuthTypeEnum } from "~/types"
 
-const { mockFetchApiData } = vi.hoisted(() => ({
+const { mockFetchApi, mockFetchApiData } = vi.hoisted(() => ({
+  mockFetchApi: vi.fn(),
   mockFetchApiData: vi.fn(),
 }))
 
-const { mockGetAccountByBaseUrlAndUserId } = vi.hoisted(() => ({
-  mockGetAccountByBaseUrlAndUserId: vi.fn(),
+const { mockResolveLegacyAccountAwareRequest } = vi.hoisted(() => ({
+  mockResolveLegacyAccountAwareRequest: vi.fn(),
 }))
 
 vi.mock("~/services/apiTransport/request", async (importOriginal) => {
@@ -22,90 +24,26 @@ vi.mock("~/services/apiTransport/request", async (importOriginal) => {
     await importOriginal<typeof import("~/services/apiTransport/request")>()
   return {
     ...actual,
+    fetchApi: mockFetchApi,
     fetchApiData: mockFetchApiData,
   }
 })
 
-vi.mock("~/services/accounts/accountStorage", () => ({
-  accountStorage: {
-    getAccountByBaseUrlAndUserId: mockGetAccountByBaseUrlAndUserId,
-  },
+vi.mock("~/services/accounts/utils/legacyAccountAwareRequest", () => ({
+  resolveLegacyAccountAwareRequest: mockResolveLegacyAccountAwareRequest,
 }))
 
 describe("API Service Common Utils", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockResolveLegacyAccountAwareRequest.mockReset()
+    mockResolveLegacyAccountAwareRequest.mockImplementation(
+      async (request) => request,
+    )
   })
 
   describe("fetchApiData", () => {
-    it("enriches account metadata before delegating to transport when accountId is absent", async () => {
-      mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce({
-        id: "account-1",
-        cookieAuth: {
-          sessionCookie: "session=stored",
-        },
-      })
-      mockFetchApiData.mockResolvedValueOnce({ ok: true })
-
-      await expect(
-        fetchApiData(
-          {
-            baseUrl: "https://example.com",
-            auth: {
-              authType: AuthTypeEnum.Cookie,
-              userId: "123",
-            },
-          },
-          { endpoint: "/api/test" },
-        ),
-      ).resolves.toEqual({ ok: true })
-
-      expect(mockGetAccountByBaseUrlAndUserId).toHaveBeenCalledWith(
-        "https://example.com",
-        "123",
-      )
-      expect(mockFetchApiData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accountId: "account-1",
-          cookieAuthSessionCookie: "session=stored",
-        }),
-        { endpoint: "/api/test" },
-      )
-    })
-
-    it("preserves a caller-provided session cookie when enriching account metadata", async () => {
-      mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce({
-        id: "account-1",
-        cookieAuth: {
-          sessionCookie: "session=stored",
-        },
-      })
-      mockFetchApiData.mockResolvedValueOnce({ ok: true })
-
-      await expect(
-        fetchApiData(
-          {
-            baseUrl: "https://example.com",
-            cookieAuthSessionCookie: "session=fresh",
-            auth: {
-              authType: AuthTypeEnum.Cookie,
-              userId: "123",
-            },
-          },
-          { endpoint: "/api/test" },
-        ),
-      ).resolves.toEqual({ ok: true })
-
-      expect(mockFetchApiData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accountId: "account-1",
-          cookieAuthSessionCookie: "session=fresh",
-        }),
-        { endpoint: "/api/test" },
-      )
-    })
-
-    it("delegates the original request unchanged when account lookup misses", async () => {
+    it("delegates account-aware compatibility resolution before transport", async () => {
       const request = {
         baseUrl: "https://example.com",
         auth: {
@@ -113,44 +51,84 @@ describe("API Service Common Utils", () => {
           userId: "123",
         },
       }
+      const enrichedRequest = {
+        ...request,
+        accountId: "account-1",
+        cookieAuthSessionCookie: "session=stored",
+      }
+      mockResolveLegacyAccountAwareRequest.mockResolvedValueOnce(
+        enrichedRequest,
+      )
+      mockFetchApiData.mockResolvedValueOnce({ ok: true })
+
+      await expect(
+        fetchApiData(request, { endpoint: "/api/test" }),
+      ).resolves.toEqual({ ok: true })
+
+      expect(mockResolveLegacyAccountAwareRequest).toHaveBeenCalledWith(
+        request,
+        { endpoint: "/api/test" },
+      )
+      expect(mockFetchApiData).toHaveBeenCalledWith(enrichedRequest, {
+        endpoint: "/api/test",
+      })
+    })
+
+    it("passes through the original request when compatibility resolution is a no-op", async () => {
+      const request = {
+        baseUrl: "https://example.com",
+        accountId: "account-1",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: "123",
+        },
+      }
       const options = { endpoint: "/api/test" }
-      mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce(undefined)
       mockFetchApiData.mockResolvedValueOnce({ ok: true })
 
       await expect(fetchApiData(request, options)).resolves.toEqual({
         ok: true,
       })
 
-      expect(mockGetAccountByBaseUrlAndUserId).toHaveBeenCalledWith(
-        "https://example.com",
-        "123",
+      expect(mockResolveLegacyAccountAwareRequest).toHaveBeenCalledWith(
+        request,
+        options,
       )
       expect(mockFetchApiData).toHaveBeenCalledWith(request, options)
     })
+  })
 
-    it("does not look up account metadata when accountId is already present", async () => {
-      mockFetchApiData.mockResolvedValueOnce({ ok: true })
+  describe("fetchApi", () => {
+    it("delegates account-aware compatibility resolution before transport", async () => {
+      const request = {
+        baseUrl: "https://example.com",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: "123",
+        },
+      }
+      const enrichedRequest = {
+        ...request,
+        accountId: "account-1",
+        cookieAuthSessionCookie: "session=stored",
+      }
+      mockResolveLegacyAccountAwareRequest.mockResolvedValueOnce(
+        enrichedRequest,
+      )
+      mockFetchApi.mockResolvedValueOnce({ ok: true })
 
       await expect(
-        fetchApiData(
-          {
-            baseUrl: "https://example.com",
-            accountId: "account-1",
-            auth: {
-              authType: AuthTypeEnum.Cookie,
-              userId: "123",
-            },
-          },
-          { endpoint: "/api/test" },
-        ),
+        fetchApi(request, { endpoint: "/api/test" }, true),
       ).resolves.toEqual({ ok: true })
 
-      expect(mockGetAccountByBaseUrlAndUserId).not.toHaveBeenCalled()
-      expect(mockFetchApiData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accountId: "account-1",
-        }),
+      expect(mockResolveLegacyAccountAwareRequest).toHaveBeenCalledWith(
+        request,
         { endpoint: "/api/test" },
+      )
+      expect(mockFetchApi).toHaveBeenCalledWith(
+        enrichedRequest,
+        { endpoint: "/api/test" },
+        true,
       )
     })
   })


### PR DESCRIPTION
## Summary
- centralize display and stored account API request context construction under account utilities
- move legacy missing-accountId request enrichment out of common API utils into an account-owned helper
- update default token lifecycle and account key group coverage to use stored/display account context builders

## Validation
- pnpm vitest --run tests/services/accounts/defaultTokenLifecycle.test.ts
- pnpm vitest --run tests/services/accountKeyGroupCoverage.test.ts
- pnpm vitest --run tests/services/accountKeyRepair.test.ts
- pnpm run validate:staged
- pnpm run validate:push
- git push pre-push validate:push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized account API request-context building from stored accounts and UI display snapshots, including automatic legacy compatibility when `accountId` is missing.
* **Bug Fixes**
  * Added stricter, stable validation for account context creation/resolution.
  * Preserved cookie session behavior during enrichment and ensured account-scoped requests are constructed consistently across features.
  * Prevented stale or unauthorized token loading; token dialogs now clear immediately when permissions become ineligible.
* **Documentation**
  * Added a migration plan and design spec for account API context ownership.
* **Tests**
  * Expanded unit tests and updated UI/e2e coverage for the new context behavior and legacy fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->