### PR TITLE
refactor(accounts): own income exchange rate context

### DIFF
--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -668,6 +668,7 @@ export async function validateAndSaveAccount(
     siteType: normalizedSiteType,
     url,
   })
+  const resolvedExchangeRate = resolveExchangeRate(exchangeRate)
   const normalizedTagIds = normalizeTagIdsInput(tagIds)
 
   if (options.deferDataRefresh === true) {
@@ -687,7 +688,7 @@ export async function validateAndSaveAccount(
           ? { sessionCookie: sessionCookieHeader.trim() }
           : undefined,
       sub2apiAuth: normalizedSub2ApiAuth,
-      exchange_rate: resolveExchangeRate(exchangeRate),
+      exchange_rate: resolvedExchangeRate,
       notes,
       manualBalanceUsd: normalizedManualBalanceUsd,
       tagIds: normalizedTagIds,
@@ -757,6 +758,7 @@ export async function validateAndSaveAccount(
         baseUrl: requestBaseUrl,
         checkIn: checkInConfig,
         accountId: undefined, // New account, no ID yet
+        exchangeRate: resolvedExchangeRate,
         includeTodayCashflow,
         auth: {
           authType,
@@ -791,7 +793,7 @@ export async function validateAndSaveAccount(
           ? { sessionCookie: sessionCookieHeader.trim() }
           : undefined,
       sub2apiAuth: normalizedSub2ApiAuth,
-      exchange_rate: resolveExchangeRate(exchangeRate), // 使用用户输入的汇率
+      exchange_rate: resolvedExchangeRate, // 使用用户输入的汇率
       notes,
       manualBalanceUsd: normalizedManualBalanceUsd,
       tagIds: normalizedTagIds,
@@ -850,7 +852,7 @@ export async function validateAndSaveAccount(
           ? { sessionCookie: sessionCookieHeader.trim() }
           : undefined,
       sub2apiAuth: normalizedSub2ApiAuth,
-      exchange_rate: resolveExchangeRate(exchangeRate),
+      exchange_rate: resolvedExchangeRate,
       notes,
       manualBalanceUsd: normalizedManualBalanceUsd,
       tagIds: normalizedTagIds,
@@ -990,6 +992,7 @@ export async function validateAndUpdateAccount(
     siteType: normalizedSiteType,
     url,
   })
+  const resolvedExchangeRate = resolveExchangeRate(exchangeRate)
   const normalizedTagIds = normalizeTagIdsInput(tagIds)
 
   if (options.deferDataRefresh === true) {
@@ -1005,7 +1008,7 @@ export async function validateAndUpdateAccount(
           ? { sessionCookie: sessionCookieHeader.trim() }
           : undefined,
       sub2apiAuth: normalizedSub2ApiAuth,
-      exchange_rate: resolveExchangeRate(exchangeRate),
+      exchange_rate: resolvedExchangeRate,
       notes: notes,
       manualBalanceUsd: normalizedManualBalanceUsd,
       tagIds: normalizedTagIds,
@@ -1064,6 +1067,7 @@ export async function validateAndUpdateAccount(
       baseUrl: requestBaseUrl,
       checkIn: checkInConfig,
       accountId,
+      exchangeRate: resolvedExchangeRate,
       includeTodayCashflow,
       auth: {
         authType,
@@ -1090,7 +1094,7 @@ export async function validateAndUpdateAccount(
           ? { sessionCookie: sessionCookieHeader.trim() }
           : undefined,
       sub2apiAuth: normalizedSub2ApiAuth,
-      exchange_rate: resolveExchangeRate(exchangeRate), // 使用用户输入的汇率
+      exchange_rate: resolvedExchangeRate, // 使用用户输入的汇率
       notes: notes,
       manualBalanceUsd: normalizedManualBalanceUsd,
       tagIds: normalizedTagIds,
@@ -1149,7 +1153,7 @@ export async function validateAndUpdateAccount(
           ? { sessionCookie: sessionCookieHeader.trim() }
           : undefined,
       sub2apiAuth: normalizedSub2ApiAuth,
-      exchange_rate: resolveExchangeRate(exchangeRate),
+      exchange_rate: resolvedExchangeRate,
       notes: notes,
       manualBalanceUsd: normalizedManualBalanceUsd,
       tagIds: normalizedTagIds,

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -1119,6 +1119,7 @@ class AccountStorageService {
             baseUrl,
             accountId: account.id,
             checkIn: checkInForRefresh,
+            exchangeRate: account.exchange_rate,
             auth,
             includeTodayCashflow,
           })

--- a/src/services/apiService/common/index.ts
+++ b/src/services/apiService/common/index.ts
@@ -1,6 +1,5 @@
 import { UI_CONSTANTS } from "~/constants/ui"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
-import { accountStorage } from "~/services/accounts/accountStorage"
 import { normalizeApiTokenKey } from "~/services/accountTokens/apiTokenKey"
 import { REQUEST_CONFIG } from "~/services/apiService/common/constant"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
@@ -891,9 +890,6 @@ export async function fetchTodayUsage(
  * @param queryConfig Optional override for non-standard log pagination APIs.
  * @returns Total income amount for today.
  */
-// Temporary exception during account API context migration:
-// this helper still owns exchange-rate lookup until account-data refresh
-// orchestration moves that policy into src/services/accounts/**.
 export async function fetchTodayIncome(
   request: ApiServiceAccountRequest,
   queryConfig?: TodayLogQueryConfig,
@@ -902,19 +898,11 @@ export async function fetchTodayIncome(
     return { today_income: 0 }
   }
 
-  const { baseUrl } = request
-  const { userId } = request.auth
-  let exchangeRate: number = UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
-
-  const account = request.accountId
-    ? await accountStorage.getAccountById(request.accountId)
-    : userId === undefined
-      ? null
-      : await accountStorage.getAccountByBaseUrlAndUserId(baseUrl, userId)
-
-  if (account?.exchange_rate) {
-    exchangeRate = account.exchange_rate
-  }
+  const exchangeRate =
+    typeof request.exchangeRate === "number" &&
+    Number.isFinite(request.exchangeRate)
+      ? request.exchangeRate
+      : UI_CONSTANTS.EXCHANGE_RATE.DEFAULT
   const incomeAggregator = (
     accumulator: number,
     items: LogResponseData["items"],

--- a/src/services/apiService/common/type.ts
+++ b/src/services/apiService/common/type.ts
@@ -396,6 +396,14 @@ export interface AuthTypeFetchParams extends AuthFetchParams {
 export type ApiServiceAccountRequest = ApiServiceRequest & {
   checkIn: CheckInConfig
   /**
+   * Account-owned exchange rate (CNY per USD) used when parsing recharge/system
+   * log text into quota units.
+   *
+   * The API service layer consumes this value but does not resolve it from
+   * account storage.
+   */
+  exchangeRate?: number
+  /**
    * Whether account refresh should include fetching "today cashflow" statistics
    * (today consumption/income plus token/request counts).
    *

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -146,6 +146,7 @@ describe("accountOperations validateAndSaveAccount", () => {
       baseUrl: "https://cookie.example.com/console",
       checkIn: CHECK_IN_DISABLED,
       accountId: undefined,
+      exchangeRate: 7,
       includeTodayCashflow: false,
       auth: {
         authType: AuthTypeEnum.Cookie,

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -1957,6 +1957,7 @@ describe("accountStorage core behaviors", () => {
       id: "income-sync",
       site_url: "https://income.example.com",
       site_type: "one-api",
+      exchange_rate: 8.5,
       checkIn: { enableDetection: true },
     })
     seedStorage([account])
@@ -1985,6 +1986,12 @@ describe("accountStorage core behaviors", () => {
 
     await accountStorage.refreshAccount("income-sync", true)
 
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "income-sync",
+        exchangeRate: 8.5,
+      }),
+    )
     const updatedAccount = await accountStorage.getAccountById("income-sync")
     expect(updatedAccount?.account_info.today_income).toBe(123_456)
   })

--- a/tests/services/apiService/common/accountData.test.ts
+++ b/tests/services/apiService/common/accountData.test.ts
@@ -571,8 +571,7 @@ describe("apiService common account-data helpers", () => {
     expect(mockGetAccountById).not.toHaveBeenCalled()
   })
 
-  it("fetchTodayIncome uses the account exchange rate and parses quota fallbacks", async () => {
-    mockGetAccountById.mockResolvedValueOnce({ exchange_rate: 9 })
+  it("fetchTodayIncome uses the request exchange rate and parses quota fallbacks", async () => {
     mockExtractAmount.mockReturnValueOnce({ amount: 3 })
     mockFetchApiData
       .mockResolvedValueOnce({
@@ -588,18 +587,20 @@ describe("apiService common account-data helpers", () => {
       fetchTodayIncome({
         ...baseRequest,
         accountId: "account-1",
+        exchangeRate: 9,
       } as any),
     ).resolves.toEqual({ today_income: 375 })
 
-    expect(mockGetAccountById).toHaveBeenCalledWith("account-1")
+    expect(mockGetAccountById).not.toHaveBeenCalled()
+    expect(mockGetAccountByBaseUrlAndUserId).not.toHaveBeenCalled()
     expect(mockExtractAmount).toHaveBeenCalledWith("recharge 3 USD", 9)
   })
 
-  it("fetchTodayIncome falls back to lookup by baseUrl and userId when accountId is absent", async () => {
-    mockGetAccountByBaseUrlAndUserId.mockResolvedValueOnce({ exchange_rate: 8 })
+  it("fetchTodayIncome uses the default exchange rate when the request has no exchange rate", async () => {
+    mockExtractAmount.mockReturnValueOnce({ amount: 2 })
     mockFetchApiData
       .mockResolvedValueOnce({
-        items: [{ quota: 20 }],
+        items: [{ content: "recharge 2 USD" }],
         total: 1,
       })
       .mockResolvedValueOnce({
@@ -608,12 +609,11 @@ describe("apiService common account-data helpers", () => {
       })
 
     await expect(fetchTodayIncome(baseRequest as any)).resolves.toEqual({
-      today_income: 20,
+      today_income: 200,
     })
-    expect(mockGetAccountByBaseUrlAndUserId).toHaveBeenCalledWith(
-      baseRequest.baseUrl,
-      "7",
-    )
+    expect(mockGetAccountById).not.toHaveBeenCalled()
+    expect(mockGetAccountByBaseUrlAndUserId).not.toHaveBeenCalled()
+    expect(mockExtractAmount).toHaveBeenCalledWith("recharge 2 USD", 7)
   })
 
   it("fetchTodayIncome supports overridden log query params and response fields", async () => {


### PR DESCRIPTION
## Summary
- pass account-owned exchange rates through account refresh and validation requests
- remove the remaining accountStorage lookup from common fetchTodayIncome
- update focused tests so income parsing uses request/default exchange-rate context

## Validation
- pnpm vitest --run tests/services/apiService/common/accountData.test.ts
- pnpm vitest --run tests/services/accountStorage.test.ts
- pnpm vitest --run tests/services/apiAdapters/accountData.test.ts tests/services/apiAdapters/newApi/accountRefresh.test.ts tests/services/apiAdapters/sub2api/accountRefresh.test.ts tests/services/apiAdapters/aihubmix/accountRefresh.test.ts
- pnpm vitest --run tests/services/apiService/sub2api/index.test.ts tests/services/apiService/doneHub/channelApi.test.ts tests/services/apiService/aihubmix/index.test.ts tests/services/apiService/anyrouter.index.test.ts tests/services/apiService/wong/index.test.ts tests/services/apiService/veloera/channelApi.test.ts
- pnpm run validate:staged
- pnpm run validate:push

## Notes
- E2E not added: this is service/account-layer context plumbing covered by focused Vitest tests.
- Telemetry unchanged: no user-visible behavior or analytics surface changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exchange-rate consistency across account save, update, and refresh flows.
  * Today’s income/quota parsing now uses an exchange rate supplied with the request, falling back to a default when absent.
  * Refresh operations now retain and pass along the account’s stored exchange rate for more accurate today’s income totals.

* **Tests**
  * Updated and extended tests to validate the new request-based exchange-rate behavior and the default fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->