### PR TITLE
fix(site-detection): probe sub2api auth endpoint

### DIFF
--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -6,6 +6,7 @@ import {
 } from "~/services/accountSiteOnboarding/registry"
 import { ApiError } from "~/services/apiService/common/errors"
 import { fetchApi, fetchApiData } from "~/services/apiService/common/utils"
+import { SUB2API_AUTH_ME_ENDPOINT } from "~/services/apiService/sub2api/type"
 import { AuthTypeEnum } from "~/types"
 import {
   canUseTempWindowFetch,
@@ -112,9 +113,11 @@ function detectAccountSiteTypeFromApiErrorMessage(
 
 /**
  * Probes the /api/user/self endpoint using cookie auth and infers the site
- * type from upstream auth error messages when title detection fails.
+ * type from One/New API-family auth error messages when title detection fails.
  */
-async function getAccountSiteUserIdType(url: string): Promise<AccountSiteType> {
+async function detectNewApiFamilySiteTypeFromCompatAuthError(
+  url: string,
+): Promise<AccountSiteType> {
   try {
     await fetchApiData<unknown>(
       {
@@ -134,6 +137,48 @@ async function getAccountSiteUserIdType(url: string): Promise<AccountSiteType> {
     }
     throw error
   }
+  return SITE_TYPES.UNKNOWN
+}
+
+/**
+ * Returns whether a parsed response body is a plain JSON object.
+ */
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Probe Sub2API's JWT identity endpoint without opening a browser context.
+ *
+ * Source: https://github.com/Wei-Shaw/sub2api
+ * `/api/v1/auth/me` is protected by JWT middleware; without Authorization,
+ * upstream returns a JSON object with a string `code`. The endpoint-shape signal
+ * is enough to identify white-label Sub2API deployments in the current adapter
+ * set without relying on the visible page title.
+ */
+async function detectSub2ApiFromAuthEndpoint(
+  url: string,
+): Promise<AccountSiteType> {
+  try {
+    const response = await fetch(new URL(SUB2API_AUTH_ME_ENDPOINT, url), {
+      method: "GET",
+      cache: "no-store",
+      credentials: "omit",
+    })
+
+    const contentType = response.headers.get("content-type") || ""
+    if (!/\bjson\b/i.test(contentType)) {
+      return SITE_TYPES.UNKNOWN
+    }
+
+    const responseBody = (await response.json()) as unknown
+    if (isJsonObject(responseBody) && typeof responseBody.code === "string") {
+      return SITE_TYPES.SUB2API
+    }
+  } catch (error) {
+    logger.debug("Sub2API auth endpoint probe failed", { url, error })
+  }
+
   return SITE_TYPES.UNKNOWN
 }
 
@@ -170,5 +215,10 @@ export const getAccountSiteType = async (
     }
   }
 
-  return await getAccountSiteUserIdType(url)
+  const sub2ApiSiteType = await detectSub2ApiFromAuthEndpoint(url)
+  if (sub2ApiSiteType !== SITE_TYPES.UNKNOWN) {
+    return sub2ApiSiteType
+  }
+
+  return await detectNewApiFamilySiteTypeFromCompatAuthError(url)
 }

--- a/tests/services/detectSiteType.fallback.test.ts
+++ b/tests/services/detectSiteType.fallback.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { ApiError } from "~/services/apiService/common/errors"
@@ -41,12 +41,25 @@ vi.mock("~/utils/core/logger", () => ({
 describe("detectSiteType temp-context fallbacks", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: "not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    )
     mocks.canUseTempWindowFetch.mockResolvedValue(false)
     mocks.tempWindowFetch.mockResolvedValue({ success: false })
     mocks.fetchApi.mockResolvedValue(
       "<html><title>Fallback Title</title></html>",
     )
     mocks.fetchApiData.mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it("uses the temp-window HTML title when that fetch succeeds", async () => {

--- a/tests/services/detectSiteType.test.ts
+++ b/tests/services/detectSiteType.test.ts
@@ -365,6 +365,35 @@ describe("detectSiteType", () => {
         )
       })
 
+      it("falls through to New API-family detection when the Sub2API auth endpoint probe fails", async () => {
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse(
+              "<html><title>White Label Dashboard</title></html>",
+              {
+                headers: { "Content-Type": "text/html" },
+              },
+            )
+          }),
+          http.get("https://example.com/api/v1/auth/me", () => {
+            return HttpResponse.error()
+          }),
+          http.get("https://example.com/api/user/self", () => {
+            return HttpResponse.json(
+              {
+                success: false,
+                message: "Unauthorized, New-Api-User header not provided",
+              },
+              { status: 401 },
+            )
+          }),
+        )
+
+        await expect(getAccountSiteType("https://example.com")).resolves.toBe(
+          SITE_TYPES.NEW_API,
+        )
+      })
+
       it("should fallback to API detection when title doesn't match", async () => {
         const mockHTML = "<html><title>Unknown Site</title></html>"
         const mockApiResponse = {

--- a/tests/services/detectSiteType.test.ts
+++ b/tests/services/detectSiteType.test.ts
@@ -22,6 +22,11 @@ vi.mock("~/utils/browser/tempWindowFetch", async (importOriginal) => {
 describe("detectSiteType", () => {
   beforeEach(() => {
     server.resetHandlers()
+    server.use(
+      http.get("https://example.com/api/v1/auth/me", () => {
+        return HttpResponse.json({ message: "not found" }, { status: 404 })
+      }),
+    )
   })
 
   describe("fetchSiteOriginalTitle", () => {
@@ -263,6 +268,12 @@ describe("detectSiteType", () => {
                 { status: 400 },
               )
             }),
+            http.get("https://example.com/api/v1/auth/me", () => {
+              return HttpResponse.json(
+                { message: "not found" },
+                { status: 404 },
+              )
+            }),
           )
 
           await expect(getAccountSiteType("https://example.com")).resolves.toBe(
@@ -287,6 +298,73 @@ describe("detectSiteType", () => {
     })
 
     describe("Fallback to API detection", () => {
+      it("detects Sub2API from its unauthenticated auth endpoint JSON code", async () => {
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse(
+              "<html><title>White Label Dashboard</title></html>",
+              {
+                headers: { "Content-Type": "text/html" },
+              },
+            )
+          }),
+          http.get("https://example.com/api/v1/auth/me", () => {
+            return HttpResponse.json(
+              {
+                code: "UNAUTHORIZED",
+                message: "Authorization header is required",
+              },
+              { status: 401 },
+            )
+          }),
+          http.get("https://example.com/api/user/self", () => {
+            return HttpResponse.json(
+              {
+                success: false,
+                message: "error: completely unmatched identifier",
+              },
+              { status: 400 },
+            )
+          }),
+        )
+
+        await expect(getAccountSiteType("https://example.com")).resolves.toBe(
+          SITE_TYPES.SUB2API,
+        )
+      })
+
+      it("does not detect Sub2API when the auth endpoint returns non-JSON fallback content", async () => {
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse(
+              "<html><title>White Label Dashboard</title></html>",
+              {
+                headers: { "Content-Type": "text/html" },
+              },
+            )
+          }),
+          http.get("https://example.com/api/v1/auth/me", () => {
+            return new HttpResponse("<html><title>App</title></html>", {
+              status: 200,
+              headers: { "Content-Type": "text/html" },
+            })
+          }),
+          http.get("https://example.com/api/user/self", () => {
+            return HttpResponse.json(
+              {
+                success: false,
+                message: "error: completely unmatched identifier",
+              },
+              { status: 400 },
+            )
+          }),
+        )
+
+        await expect(getAccountSiteType("https://example.com")).resolves.toBe(
+          SITE_TYPES.UNKNOWN,
+        )
+      })
+
       it("should fallback to API detection when title doesn't match", async () => {
         const mockHTML = "<html><title>Unknown Site</title></html>"
         const mockApiResponse = {


### PR DESCRIPTION
## Summary

- Detect white-label Sub2API deployments by probing `/api/v1/auth/me` for a JSON envelope with a string `code`
- Keep title/domain detection first, then Sub2API endpoint-shape probe, then the renamed New API-family `/api/user/self` fallback
- Add coverage for Sub2API endpoint detection and non-JSON fallback behavior

## Validation

- `pnpm vitest run tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts`
- `pnpm compile`
- `pnpm run validate:staged`
- pre-push hook: `pnpm compile && pnpm knip`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced site detection by adding an identity-endpoint probe to recognize an additional account type from authentication responses.
* **Bug Fixes**
  * Reduced misclassification by prioritizing the identity check and handling non-JSON and error responses more reliably before falling back to existing API-based detection.
* **Tests**
  * Expanded fallback scenarios and standardized auth endpoint stubbing to prevent side effects, including added cleanup for global fetch mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->