### PR TITLE
refactor(api-service): propagate account API context explicitly

### DIFF
--- a/docs/superpowers/plans/2026-06-27-account-api-context-propagation.md
+++ b/docs/superpowers/plans/2026-06-27-account-api-context-propagation.md
@@ -1342,6 +1342,8 @@ Use the stored account site type for adapter and capability lookup:
   )
 ```
 
+Before changing adapter or capability lookup, verify this site type source against the current in-repo contracts in `src/constants/siteType.ts`, `src/services/siteDetection/detectSiteType.ts`, and `src/services/apiService/index.ts`. This keeps the repair workflow aligned with the saved account type instead of a display snapshot or a guessed compatible family.
+
 Narrow display-data usage to metadata:
 
 ```ts

--- a/docs/superpowers/plans/2026-06-27-account-api-context-propagation.md
+++ b/docs/superpowers/plans/2026-06-27-account-api-context-propagation.md
@@ -112,6 +112,8 @@ vi.mock("~/services/accounts/accountStorage", () => ({
 Add this test under `describe("siteAnnouncementScheduler", () => { ... })`:
 
 ```ts
+  import { SITE_TYPES } from "~/constants/siteType"
+
   it("uses the stored-account API context for provider requests", async () => {
     providerFetchMock.mockResolvedValue({
       providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Sub2Api,
@@ -121,7 +123,7 @@ Add this test under `describe("siteAnnouncementScheduler", () => { ... })`:
     })
     const account = createAccount({
       id: "sub-1",
-      site_type: "sub2api",
+      site_type: SITE_TYPES.SUB2API,
       site_url: "https://sub.example.com",
       authType: AuthTypeEnum.Cookie,
       account_info: {
@@ -159,6 +161,19 @@ Add this test under `describe("siteAnnouncementScheduler", () => { ... })`:
           }),
           sub2apiAuthSession: expect.any(Object),
         }),
+      }),
+    )
+    const providerRequest = providerFetchMock.mock.calls[0]?.[0]
+    await expect(
+      providerRequest.apiRequest.sub2apiAuthSession.getLatestAuth("sub-1"),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        accessToken: "stored-access-token",
+        userId: "stored-user",
+        sub2apiAuth: {
+          refreshToken: "stored-refresh-token",
+          tokenExpiresAt: 123456,
+        },
       }),
     )
   })
@@ -228,11 +243,11 @@ Change:
 to:
 
 ```ts
-  const apiRequest = createAccountApiRequestFromStoredAccount(account)
-    .request as ApiServiceRequest
+  const apiRequest = createAccountApiRequestFromStoredAccount(account).request
 ```
 
-The cast is acceptable only if TypeScript cannot infer the `Sub2ApiAuthSessionRequest` extension as assignable to `ApiServiceRequest`; do not keep the cast if `tsc` accepts the expression without it.
+Do not add a cast here; the context builder return type should stay assignable
+to the downstream request type without masking type drift.
 
 - [ ] **Step 5: Replace manual request construction in redemption**
 

--- a/docs/superpowers/plans/2026-06-27-account-api-context-propagation.md
+++ b/docs/superpowers/plans/2026-06-27-account-api-context-propagation.md
@@ -1,0 +1,1776 @@
+# Account API Context Propagation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Propagate prepared Account API context from the highest reliable workflow boundary so downstream protocol, adapter, and common service code no longer relies on hidden account-storage lookup.
+
+**Architecture:** Keep the existing accounts-owned context builders as the source of truth: immediate UI actions build from a display account snapshot, long-lived work resolves by stable `accountId`, and account-owned flows that already hold `SiteAccount` build directly from that stored account. First replace hand-built stored-account requests in scheduler/background services, then move token lifecycle and repair orchestration to pass prepared `AccountApiContext`/`ApiServiceRequest` downward, and only then shrink `resolveLegacyAccountAwareRequest(...)` to an explicit compatibility path.
+
+**Tech Stack:** TypeScript, Vitest, WXT extension services, account API context builders, site adapter capabilities, pnpm.
+
+**Spec:** `docs/superpowers/specs/2026-06-26-account-api-context-display-data-design.md`
+
+---
+
+## File Structure
+
+Already exists and should be reused:
+
+- `src/services/accounts/utils/apiServiceRequest.ts`
+  - Exports `DisplayAccountApiSnapshot`, `AccountApiContext`, `DisplayAccountApiCapabilityContext`, `createDisplayAccountRequestContext(...)`, `createDisplayAccountApiContext(...)`, `createAccountApiRequestFromStoredAccount(...)`, and `resolveStoredAccountApiContext(...)`.
+  - Do not add another request-context module unless this file becomes too large for the focused changes below.
+- `src/services/accounts/utils/legacyAccountAwareRequest.ts`
+  - Keep as the legacy `baseUrl + userId` compatibility helper.
+
+Modify in the implementation slice:
+
+- `src/services/accounts/defaultTokenLifecycle/lifecycle.ts`
+  - Add prepared-context entry points for token lifecycle work.
+  - Keep display-snapshot wrappers for immediate UI compatibility.
+- `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+  - Make post-save automation accept/pass `accountId` or already-prepared stored context at the workflow boundary.
+  - Keep the old display-snapshot inventory wrapper only as a compatibility wrapper.
+- `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+  - Let background auto-provision use `SiteAccount`/stored account context directly instead of requiring `DisplaySiteData`.
+- `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+  - Keep the existing `SiteAccount` request source and stop using `DisplaySiteData` for request construction.
+- `src/services/accounts/accountKeyAutoProvisioning/repair.ts`
+  - Treat repair as a background workflow: pass account ids/stored accounts through the runner and only use display data for names/results.
+- `src/services/accounts/accountOperations.ts`
+  - Update `autoProvisionKeyOnAccountAdd(...)` to use stored-account context where the workflow has already crossed a tick/storage boundary.
+  - Keep shared UI/managed-site `ensureAccountApiToken(...)` as a display-snapshot compatibility wrapper until its callers are audited.
+  - Keep quick-create resolution as a display-snapshot UI path.
+- `src/services/siteAnnouncements/scheduler.ts`
+  - Replace private `createApiRequestFromAccount(...)` with `createAccountApiRequestFromStoredAccount(account).request`.
+  - Keep scheduler inputs as `accountIds`; resolve stored accounts once at the scheduler/manual-check boundary.
+- `src/services/history/usageHistory/sync.ts`
+  - Replace private `buildApiRequestForAccount(...)` with `createAccountApiRequestFromStoredAccount(account).request`.
+- `src/services/redemption/redeemService.ts`
+  - Use `createAccountApiRequestFromStoredAccount(account).request` for redemption requests after resolving `accountId` to `SiteAccount`.
+- `src/services/apiService/common/utils.ts`
+  - After the migrated account-owned workflows no longer depend on fallback, convert `fetchApi(...)` and `fetchApiData(...)` to transport pass-through.
+  - Leave `resolveLegacyAccountAwareRequest(...)` callable only from explicit compatibility tests/helpers.
+
+Focused tests to update:
+
+- `tests/services/accounts/apiServiceRequest.test.ts`
+- `tests/services/accounts/defaultTokenLifecycle.test.ts`
+- `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+- `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+- `tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts`
+- `tests/services/accountKeyRepair.test.ts`
+- `tests/services/accountKeyGroupCoverage.test.ts`
+- `tests/services/siteAnnouncements/scheduler.test.ts`
+- `tests/services/usageHistory/sync.test.ts`
+- `tests/services/redeemService.test.ts`
+- `tests/services/apiService/common/utils.test.ts`
+- `tests/services/accounts/legacyAccountAwareRequest.test.ts`
+
+Do not modify:
+
+- `src/types/index.ts`
+  - Do not rename or delete `DisplaySiteData` fields in this slice.
+- `src/services/apiAdapters/**`
+  - Adapter capabilities already accept prepared `ApiServiceRequest`; do not widen them to `DisplaySiteData`.
+- `src/services/apiTransport/**`
+  - Transport should remain unaware of account storage and display snapshots.
+- `src/services/apiService/common/index.ts` account-data behavior unless a migrated caller test proves it still depends on hidden fallback.
+- App locale files, settings search definitions, telemetry schemas, or Playwright E2E tests.
+
+Telemetry decision: none. This is internal request-context propagation with no new user action, setting, or visible state.
+
+Settings search decision: none. No settings UI, anchors, search targets, or deep links change.
+
+E2E decision: no new Playwright E2E. The primary risk is request-source selection and storage lookup ownership; focused Vitest tests are the right layer.
+
+---
+
+### Task 1: Replace Stored-Account Request Builders
+
+**Files:**
+
+- Modify: `src/services/siteAnnouncements/scheduler.ts`
+- Modify: `src/services/history/usageHistory/sync.ts`
+- Modify: `src/services/redemption/redeemService.ts`
+- Test: `tests/services/siteAnnouncements/scheduler.test.ts`
+- Test: `tests/services/usageHistory/sync.test.ts`
+- Test: `tests/services/redeemService.test.ts`
+
+- [ ] **Step 1: Add a failing scheduler test for stored context decoration**
+
+In `tests/services/siteAnnouncements/scheduler.test.ts`, update the account-storage mock so no display account lookup is needed:
+
+```ts
+vi.mock("~/services/accounts/accountStorage", () => ({
+  accountStorage: {
+    getEnabledAccounts: getEnabledAccountsMock,
+    getAccountById: getAccountByIdMock,
+  },
+}))
+```
+
+Add this test under `describe("siteAnnouncementScheduler", () => { ... })`:
+
+```ts
+  it("uses the stored-account API context for provider requests", async () => {
+    providerFetchMock.mockResolvedValue({
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Sub2Api,
+      siteKey: "sub2api:sub-1:https://sub.example.com",
+      status: "success",
+      announcements: [],
+    })
+    const account = createAccount({
+      id: "sub-1",
+      site_type: "sub2api",
+      site_url: "https://sub.example.com",
+      authType: AuthTypeEnum.Cookie,
+      account_info: {
+        id: "stored-user",
+        access_token: "stored-access-token",
+        username: "stored-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+      cookieAuth: { sessionCookie: "stored-session-cookie" },
+      sub2apiAuth: {
+        refreshToken: "stored-refresh-token",
+        tokenExpiresAt: 123456,
+      },
+    })
+    getEnabledAccountsMock.mockResolvedValue([account])
+
+    const response = await resolveSiteAnnouncementsCheckNowMessage({})
+
+    expect(response).toMatchObject({ success: true })
+    expect(providerFetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiRequest: expect.objectContaining({
+          baseUrl: "https://sub.example.com",
+          accountId: "sub-1",
+          auth: expect.objectContaining({
+            authType: AuthTypeEnum.Cookie,
+            userId: "stored-user",
+            accessToken: "stored-access-token",
+            cookie: "stored-session-cookie",
+          }),
+          sub2apiAuthSession: expect.any(Object),
+        }),
+      }),
+    )
+  })
+```
+
+- [ ] **Step 2: Run the scheduler test and verify it fails**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/siteAnnouncements/scheduler.test.ts
+```
+
+Expected: FAIL because `scheduler.ts` still manually builds the request and does not attach the Sub2API auth-session port from the stored context builder.
+
+- [ ] **Step 3: Replace manual request construction in site announcements**
+
+In `src/services/siteAnnouncements/scheduler.ts`, remove:
+
+```ts
+import type { ApiServiceRequest } from "~/services/apiService/common/type"
+```
+
+Add:
+
+```ts
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Delete the private `createApiRequestFromAccount(...)` helper.
+
+Change `createProviderRequest(...)`:
+
+```ts
+function createProviderRequest(
+  account: SiteAccount,
+  provider: SiteAnnouncementProvider,
+): SiteAnnouncementProviderRequest {
+  return {
+    accountId: account.id,
+    siteName: account.site_name,
+    siteType: account.site_type,
+    baseUrl: account.site_url,
+    providerId: provider.id,
+    apiRequest: createAccountApiRequestFromStoredAccount(account).request,
+  }
+}
+```
+
+- [ ] **Step 4: Replace manual request construction in usage-history sync**
+
+In `src/services/history/usageHistory/sync.ts`, remove `type ApiServiceRequest` from the common type import and add:
+
+```ts
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+```
+
+Delete the private `buildApiRequestForAccount(...)` helper.
+
+Change:
+
+```ts
+  const apiRequest = buildApiRequestForAccount(account)
+```
+
+to:
+
+```ts
+  const apiRequest = createAccountApiRequestFromStoredAccount(account)
+    .request as ApiServiceRequest
+```
+
+The cast is acceptable only if TypeScript cannot infer the `Sub2ApiAuthSessionRequest` extension as assignable to `ApiServiceRequest`; do not keep the cast if `tsc` accepts the expression without it.
+
+- [ ] **Step 5: Replace manual request construction in redemption**
+
+In `src/services/redemption/redeemService.ts`, add:
+
+```ts
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Change:
+
+```ts
+      const creditedAmount = await redemption.redeem({
+        request: {
+          baseUrl: account.site_url,
+          accountId,
+          auth: {
+            authType: account.authType,
+            userId: account.account_info.id,
+            accessToken: account.account_info.access_token,
+            cookie: account.cookieAuth?.sessionCookie,
+          },
+        },
+        code,
+      })
+```
+
+to:
+
+```ts
+      const creditedAmount = await redemption.redeem({
+        request: createAccountApiRequestFromStoredAccount(account).request,
+        code,
+      })
+```
+
+- [ ] **Step 6: Run focused tests and related checks**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/siteAnnouncements/scheduler.test.ts
+pnpm vitest --run tests/services/usageHistory/sync.test.ts tests/services/redeemService.test.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/siteAnnouncements/scheduler.ts src/services/history/usageHistory/sync.ts src/services/redemption/redeemService.ts tests/services/siteAnnouncements/scheduler.test.ts tests/services/usageHistory/sync.test.ts tests/services/redeemService.test.ts
+git commit -m "refactor(accounts): reuse stored api request context"
+```
+
+Expected: commit succeeds. If hooks modify files, inspect `git status --porcelain` and `git diff --cached` before retrying.
+
+---
+
+### Task 2: Add Prepared Token Lifecycle APIs
+
+**Files:**
+
+- Modify: `src/services/accounts/defaultTokenLifecycle/lifecycle.ts`
+- Test: `tests/services/accounts/defaultTokenLifecycle.test.ts`
+
+- [ ] **Step 1: Add failing tests for request-source ownership**
+
+In `tests/services/accounts/defaultTokenLifecycle.test.ts`, update the import from `~/services/accounts/defaultTokenLifecycle`:
+
+```ts
+import {
+  buildGroupDefaultTokenRequest,
+  createDefaultTokenFromDecision,
+  DEFAULT_TOKEN_INVENTORY_STATE_KINDS,
+  DEFAULT_TOKEN_LIFECYCLE_BLOCK_REASONS,
+  DEFAULT_TOKEN_LIFECYCLE_ERRORS,
+  DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS,
+  ensureDefaultTokenLifecycle,
+  ensureDefaultTokenLifecycleWithContext,
+  generateDefaultTokenRequest,
+  inspectDefaultTokenInventory,
+  inspectDefaultTokenInventoryWithContext,
+  resolveDefaultTokenLifecycleDecision,
+  resolveDefaultTokenLifecycleDecisionWithContext,
+  selectSingleNewApiTokenByIdDiff,
+} from "~/services/accounts/defaultTokenLifecycle"
+```
+
+Add this type import:
+
+```ts
+import type { AccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Add this helper next to `buildRequest()`:
+
+```ts
+const buildPreparedContext = (
+  request: ApiServiceRequest = buildRequest(),
+): AccountApiContext => ({
+  accountId: request.accountId ?? "account-id",
+  siteType: SITE_TYPES.NEW_API,
+  request,
+})
+```
+
+Add these tests under `describe("defaultTokenLifecycle inventory helpers", () => { ... })`:
+
+```ts
+  it("inspects inventory from a prepared request context", async () => {
+    const request = buildRequest()
+    const existingToken = buildToken({ id: 12, key: "sk-prepared" })
+    fetchAccountTokensMock.mockResolvedValueOnce([existingToken])
+    isInventoryTokenUsableMock.mockReturnValueOnce(true)
+
+    await expect(
+      inspectDefaultTokenInventoryWithContext({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        context: buildPreparedContext(request),
+      }),
+    ).resolves.toEqual({
+      kind: DEFAULT_TOKEN_INVENTORY_STATE_KINDS.Present,
+      token: existingToken,
+      existingTokenIds: [12],
+      hasUsableSecret: true,
+    })
+
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(fetchAccountTokensMock).toHaveBeenCalledWith(request)
+  })
+```
+
+Add this test under `describe("defaultTokenLifecycle decision and create helpers", () => { ... })`:
+
+```ts
+  it("resolves creation decisions from a prepared request context", async () => {
+    const resolveDefaultTokenCreationMock = vi
+      .fn()
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+        tokenData: buildGroupDefaultTokenRequest("vip"),
+        oneTimeSecret: false,
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+      })
+    const fetchUserGroupsMock = vi.fn().mockResolvedValueOnce({
+      vip: { desc: "VIP", ratio: 2 },
+    })
+
+    getSiteAdapterMock.mockReturnValueOnce({
+      keyManagement: {
+        fetchTokens: vi.fn(),
+        createToken: vi.fn(),
+        updateToken: vi.fn(),
+        resolveTokenKey: vi.fn(),
+        deleteToken: vi.fn(),
+        fetchAvailableModels: vi.fn(),
+        userGroups: { fetch: fetchUserGroupsMock },
+      },
+      tokenProvisioning: {
+        isInventoryTokenUsable: vi.fn(),
+        resolveDefaultTokenCreation: resolveDefaultTokenCreationMock,
+        classifyCreatedToken: vi.fn(),
+        getRepairPolicy: vi.fn(),
+      },
+    })
+
+    await expect(
+      resolveDefaultTokenLifecycleDecisionWithContext({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        context: buildPreparedContext(),
+      }),
+    ).resolves.toMatchObject({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+      tokenData: expect.objectContaining({ group: "vip" }),
+    })
+
+    expect(fetchUserGroupsMock).toHaveBeenCalledWith(buildRequest())
+  })
+```
+
+Add this test under `describe("ensureDefaultTokenLifecycle", () => { ... })`:
+
+```ts
+  it("uses the prepared stored request for both inventory and token creation", async () => {
+    const request = {
+      baseUrl: "https://stored.example.invalid",
+      accountId: "stored-account-id",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "stored-user-id",
+        accessToken: "stored-access-token",
+        cookie: "stored-session-cookie",
+      },
+    }
+    const createdToken = buildToken({ id: 17, key: "sk-created" })
+    const createTokenMock = vi.fn().mockResolvedValueOnce(createdToken)
+    const resolveDefaultTokenCreationMock = vi.fn(() => ({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+      tokenData: generateDefaultTokenRequest(),
+      oneTimeSecret: false,
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
+    }))
+
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    getSiteAdapterMock.mockReturnValueOnce({
+      keyManagement: {
+        fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+        createToken: createTokenMock,
+        updateToken: vi.fn(),
+        resolveTokenKey: vi.fn(),
+        deleteToken: vi.fn(),
+        fetchAvailableModels: vi.fn(),
+      },
+      tokenProvisioning: {
+        isInventoryTokenUsable: vi.fn(),
+        resolveDefaultTokenCreation: resolveDefaultTokenCreationMock,
+        classifyCreatedToken: vi.fn(() => ({
+          kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+          token: createdToken,
+          oneTimeSecret: false,
+        })),
+        getRepairPolicy: vi.fn(),
+      },
+    })
+
+    await expect(
+      ensureDefaultTokenLifecycleWithContext({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        context: buildPreparedContext(request),
+      }),
+    ).resolves.toEqual({
+      kind: DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: false,
+      existingTokenIds: [],
+    })
+
+    expect(fetchAccountTokensMock).toHaveBeenCalledWith(request)
+    expect(createTokenMock).toHaveBeenCalledWith(
+      request,
+      generateDefaultTokenRequest(),
+    )
+  })
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/defaultTokenLifecycle.test.ts
+```
+
+Expected: FAIL because `inspectDefaultTokenInventoryWithContext(...)`, `resolveDefaultTokenLifecycleDecisionWithContext(...)`, and `ensureDefaultTokenLifecycleWithContext(...)` are not exported.
+
+- [ ] **Step 3: Add prepared-context lifecycle APIs**
+
+In `src/services/accounts/defaultTokenLifecycle/lifecycle.ts`, update the imports:
+
+```ts
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
+import {
+  createAccountApiRequestFromStoredAccount,
+  createDisplayAccountApiContext,
+  requireDisplayAccountKeyManagement,
+  requireDisplayAccountTokenProvisioning,
+  type AccountApiContext,
+} from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Add this helper below `MissingUserGroupsCapabilityError`:
+
+```ts
+const requireTokenLifecycleCapabilities = (context: AccountApiContext) => {
+  const adapter = getSiteAdapter(context.siteType)
+
+  return {
+    keyManagement: requireDisplayAccountKeyManagement(
+      { siteType: context.siteType },
+      adapter.keyManagement,
+    ),
+    tokenProvisioning: requireDisplayAccountTokenProvisioning(
+      { siteType: context.siteType },
+      adapter.tokenProvisioning,
+    ),
+  }
+}
+```
+
+Add the prepared inventory API above the existing `inspectDefaultTokenInventory(...)` wrapper:
+
+```ts
+/**
+ * Fetches the current default-token inventory from an already prepared context.
+ */
+export async function inspectDefaultTokenInventoryWithContext(params: {
+  workflow: TokenProvisioningWorkflow
+  context: AccountApiContext
+}): Promise<DefaultTokenInventoryState> {
+  const { keyManagement, tokenProvisioning } =
+    requireTokenLifecycleCapabilities(params.context)
+
+  return inspectDefaultTokenInventoryWithCapabilities({
+    workflow: params.workflow,
+    keyManagement,
+    tokenProvisioning,
+    request: params.context.request,
+  })
+}
+```
+
+Change `inspectDefaultTokenInventory(...)` to delegate through the display-snapshot builder:
+
+```ts
+export async function inspectDefaultTokenInventory(params: {
+  workflow: TokenProvisioningWorkflow
+  displaySiteData: DisplaySiteData
+}): Promise<DefaultTokenInventoryState> {
+  return inspectDefaultTokenInventoryWithContext({
+    workflow: params.workflow,
+    context: createDisplayAccountApiContext(params.displaySiteData),
+  })
+}
+```
+
+Add the prepared decision API above the existing `resolveDefaultTokenLifecycleDecision(...)` wrapper:
+
+```ts
+/**
+ * Resolves lifecycle-level default-token creation policy from a prepared context.
+ */
+export async function resolveDefaultTokenLifecycleDecisionWithContext(params: {
+  workflow: TokenProvisioningWorkflow
+  context: AccountApiContext
+  defaultTokenData?: ResolveDefaultTokenCreationRequest["defaultTokenData"]
+  explicitGroup?: string
+  missingUserGroupsMessage?: string
+}): Promise<DefaultTokenCreationDecision> {
+  const { keyManagement, tokenProvisioning } =
+    requireTokenLifecycleCapabilities(params.context)
+
+  return resolveDefaultTokenCreationWithUserGroups({
+    keyManagement,
+    tokenProvisioning,
+    request: params.context.request,
+    decisionRequest: {
+      workflow: params.workflow,
+      defaultTokenData:
+        params.defaultTokenData ?? generateDefaultTokenRequest(),
+      explicitGroup: params.explicitGroup,
+    },
+    missingUserGroupsMessage: params.missingUserGroupsMessage,
+  })
+}
+```
+
+Change `resolveDefaultTokenLifecycleDecision(...)` to delegate:
+
+```ts
+export async function resolveDefaultTokenLifecycleDecision(params: {
+  workflow: TokenProvisioningWorkflow
+  displaySiteData: DisplaySiteData
+  defaultTokenData?: ResolveDefaultTokenCreationRequest["defaultTokenData"]
+  explicitGroup?: string
+  missingUserGroupsMessage?: string
+}): Promise<DefaultTokenCreationDecision> {
+  return resolveDefaultTokenLifecycleDecisionWithContext({
+    workflow: params.workflow,
+    context: createDisplayAccountApiContext(params.displaySiteData),
+    defaultTokenData: params.defaultTokenData,
+    explicitGroup: params.explicitGroup,
+    missingUserGroupsMessage: params.missingUserGroupsMessage,
+  })
+}
+```
+
+Add the prepared ensure API above the existing `ensureDefaultTokenLifecycle(...)` wrapper:
+
+```ts
+/**
+ * Ensures a default token exists using an already prepared request context.
+ */
+export async function ensureDefaultTokenLifecycleWithContext(params: {
+  workflow: TokenProvisioningWorkflow
+  context: AccountApiContext
+  createContext?: AccountApiContext
+  defaultTokenData?: ResolveDefaultTokenCreationRequest["defaultTokenData"]
+  explicitGroup?: string
+  inspectInventory?: boolean
+}): Promise<DefaultTokenLifecycleResult> {
+  const { workflow, context } = params
+
+  if (workflow === TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection) {
+    throw new Error(
+      DEFAULT_TOKEN_LIFECYCLE_ERRORS.QuickCreateSelectionIsDecisionOnly,
+    )
+  }
+
+  let existingTokenIds: number[] = []
+  const { keyManagement, tokenProvisioning } =
+    requireTokenLifecycleCapabilities(context)
+
+  if (params.inspectInventory !== false) {
+    const inventoryState = await inspectDefaultTokenInventoryWithCapabilities({
+      workflow,
+      keyManagement,
+      tokenProvisioning,
+      request: context.request,
+    })
+    existingTokenIds = inventoryState.existingTokenIds
+
+    if (
+      inventoryState.kind === DEFAULT_TOKEN_INVENTORY_STATE_KINDS.Present &&
+      inventoryState.hasUsableSecret
+    ) {
+      return {
+        kind: DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS.Ready,
+        token: inventoryState.token,
+        created: false,
+        existingTokenIds,
+      }
+    }
+  }
+
+  let decision: DefaultTokenCreationDecision
+  try {
+    decision = await resolveDefaultTokenCreationWithUserGroups({
+      keyManagement,
+      tokenProvisioning,
+      request: context.request,
+      decisionRequest: {
+        workflow,
+        defaultTokenData:
+          params.defaultTokenData ?? generateDefaultTokenRequest(),
+        explicitGroup: params.explicitGroup,
+      },
+    })
+  } catch (error) {
+    if (!(error instanceof MissingUserGroupsCapabilityError)) {
+      throw error
+    }
+
+    return {
+      kind: DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS.Blocked,
+      reason: DEFAULT_TOKEN_LIFECYCLE_BLOCK_REASONS.MissingUserGroups,
+      existingTokenIds,
+      cause: error,
+    }
+  }
+
+  if (
+    decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired
+  ) {
+    return {
+      kind: DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS.SelectionRequired,
+      allowedGroups: decision.allowedGroups,
+      existingTokenIds,
+    }
+  }
+
+  if (decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked) {
+    return {
+      kind: DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS.Blocked,
+      reason: decision.reason,
+      existingTokenIds,
+    }
+  }
+
+  if (decision.kind === DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups) {
+    return {
+      kind: DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS.Blocked,
+      reason: DEFAULT_TOKEN_LIFECYCLE_BLOCK_REASONS.MissingUserGroups,
+      existingTokenIds,
+    }
+  }
+
+  if (
+    params.inspectInventory === false &&
+    decision.recoverCreatedToken ===
+      TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch &&
+    existingTokenIds.length === 0
+  ) {
+    existingTokenIds = getTokenIds(
+      sanitizeApiTokens(await keyManagement.fetchTokens(context.request)),
+    )
+  }
+
+  return await createDefaultTokenFromDecision({
+    workflow,
+    keyManagement,
+    tokenProvisioning,
+    createRequest: (params.createContext ?? context).request,
+    inventoryRequest: context.request,
+    decision,
+    existingTokenIds,
+  })
+}
+```
+
+Change `ensureDefaultTokenLifecycle(...)` to be a compatibility wrapper. It should preserve current behavior for mixed display/stored callers by passing display context as inventory context and stored context as create context:
+
+```ts
+export async function ensureDefaultTokenLifecycle(params: {
+  workflow: TokenProvisioningWorkflow
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+  defaultTokenData?: ResolveDefaultTokenCreationRequest["defaultTokenData"]
+  explicitGroup?: string
+  inspectInventory?: boolean
+}): Promise<DefaultTokenLifecycleResult> {
+  return ensureDefaultTokenLifecycleWithContext({
+    workflow: params.workflow,
+    context: createDisplayAccountApiContext(params.displaySiteData),
+    createContext: createAccountApiRequestFromStoredAccount(params.account),
+    defaultTokenData: params.defaultTokenData,
+    explicitGroup: params.explicitGroup,
+    inspectInventory: params.inspectInventory,
+  })
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/defaultTokenLifecycle.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/defaultTokenLifecycle/lifecycle.ts tests/services/accounts/defaultTokenLifecycle.test.ts
+git commit -m "refactor(accounts): add prepared token lifecycle contexts"
+```
+
+Expected: commit succeeds. If hooks modify files, inspect `git status --porcelain` and `git diff --cached` before retrying.
+
+---
+
+### Task 3: Move Post-Save And Background Ensure To Stored Context
+
+**Files:**
+
+- Modify: `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`
+- Modify: `src/services/accounts/accountOperations.ts`
+- Test: `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`
+- Test: `tests/services/accountOperations.ensureAccountApiToken.test.ts`
+- Test: `tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts`
+
+- [ ] **Step 1: Add failing tests for stored-context workflow behavior**
+
+In `tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts`, keep the default-token lifecycle import focused on helpers that the test file calls directly:
+
+```ts
+import {
+  DEFAULT_TOKEN_INVENTORY_STATE_KINDS,
+  inspectDefaultTokenInventory,
+  selectSingleNewApiTokenByIdDiff,
+} from "~/services/accounts/defaultTokenLifecycle"
+```
+
+Update the post-save workflow import to include the stored-account entry point:
+
+```ts
+import {
+  ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES,
+  ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
+  ensureAccountTokenForPostSaveWorkflow,
+  ensureAccountTokenForPostSaveWorkflowFromStoredAccount,
+  inspectAccountTokenInventory,
+} from "~/services/accounts/accountPostSaveWorkflow"
+```
+
+Add this test under `describe("ensureAccountTokenForPostSaveWorkflow", () => { ... })`:
+
+```ts
+  it("can run post-save automation from the stored account context without display request fields", async () => {
+    const account = buildSiteAccount({
+      id: "stored-account-id",
+      site_name: "Stored Account",
+      site_url: "https://stored.example.invalid",
+      site_type: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.Cookie,
+      cookieAuth: { sessionCookie: "stored-session-cookie" },
+      account_info: {
+        id: "stored-user-id",
+        access_token: "stored-access-token",
+        username: "stored-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const createdToken = buildToken({ id: 88, key: "sk-created" })
+
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+      token: createdToken,
+      oneTimeSecret: false,
+    })
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflowFromStoredAccount({
+        account,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: false,
+    })
+
+    const expectedStoredRequest = {
+      baseUrl: "https://stored.example.invalid",
+      accountId: "stored-account-id",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "stored-user-id",
+        accessToken: "stored-access-token",
+        cookie: "stored-session-cookie",
+      },
+    }
+
+    expect(fetchAccountTokensMock).toHaveBeenCalledWith(expectedStoredRequest)
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expectedStoredRequest,
+      expect.objectContaining({ name: DEFAULT_AUTO_PROVISION_TOKEN_NAME }),
+    )
+  })
+```
+
+Keep a compatibility assertion for the old display-shaped wrapper so immediate Account Dialog call sites are not broken in this slice:
+
+```ts
+  it("keeps the post-save display wrapper as a compatibility path", async () => {
+    const displayAccount = buildDisplayAccount()
+    const account = buildStoredAccount(displayAccount)
+    const existingToken = buildToken({ id: 5, key: "sk-ready" })
+    fetchAccountTokensMock.mockResolvedValueOnce([existingToken])
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toMatchObject({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: existingToken,
+      created: false,
+    })
+  })
+```
+
+In `tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts`, replace the existing test named `"shows failure feedback when saved account display data is invalid for auto-provision"` with a stored-account expectation:
+
+```ts
+  it("does not require saved display request fields for background auto-provision", async () => {
+    const invalidDisplaySiteData: Partial<DisplaySiteData> = {
+      id: "invalid-display-account",
+      name: "Invalid Display",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://api.example.com",
+      authType: AuthTypeEnum.AccessToken,
+      userId: "1",
+      token: "",
+      cookieAuthSessionCookie: "",
+    }
+    vi.spyOn(accountStorage, "getDisplayDataById").mockResolvedValueOnce(
+      invalidDisplaySiteData as DisplaySiteData,
+    )
+
+    const result = await validateAndSaveAccount(
+      "https://api.example.com",
+      "Test Site",
+      "tester",
+      "test-token",
+      "1",
+      "7.0",
+      "",
+      [],
+      CHECK_IN_DISABLED,
+      "unknown",
+      AuthTypeEnum.AccessToken,
+      "",
+    )
+
+    expect(result.success).toBe(true)
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({
+          id: expect.any(String),
+          site_url: "https://api.example.com",
+          account_info: expect.objectContaining({
+            id: "1",
+            access_token: "test-token",
+          }),
+        }),
+      }),
+    )
+    expect(toastSuccessMock).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+```
+
+In the existing `"uses the disambiguated account label for the auto-provision flow"` test, update the final expectation because `ensureDefaultApiTokenForAccount(...)` no longer receives display data:
+
+```ts
+    expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledWith({
+      account: expect.objectContaining({
+        site_name: "Test Site",
+        account_info: expect.objectContaining({
+          username: "tester-2",
+        }),
+      }),
+    })
+```
+
+In `tests/services/accountOperations.ensureAccountApiToken.test.ts`, update every `ensureDefaultApiTokenForAccount({ account, displaySiteData })` call to pass only the stored account:
+
+```ts
+await expect(
+  ensureDefaultApiTokenForAccount({
+    account: SITE_ACCOUNT,
+  }),
+).resolves.toEqual({ token, created: false })
+```
+
+For the existing test named `"uses display account fields for inventory reads and stored account fields for token creation"`, replace the expectation with stored-account request fields for both inventory and creation:
+
+```ts
+    expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
+      1,
+      expectedStoredRequest,
+    )
+    expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
+      2,
+      expectedStoredRequest,
+    )
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expectedStoredRequest,
+      expect.objectContaining({
+        name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+        group: "",
+      }),
+    )
+```
+
+Do not change tests that call `ensureAccountApiToken(...)`; those continue to prove the shared UI/managed-site compatibility wrapper behavior. Moving that wrapper to stored-only context requires the caller audit in the next step.
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts
+```
+
+Expected: FAIL because post-save/background auto-provision still uses display-snapshot request fields for inventory reads. `tests/services/accountOperations.ensureAccountApiToken.test.ts` should continue to pass and protects the shared UI compatibility wrapper.
+
+- [ ] **Step 3: Update post-save and background ensure helpers to pass stored context**
+
+In `src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts`, import the prepared lifecycle helper and stored-account context builder:
+
+```ts
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
+```
+
+Update the lifecycle import:
+
+```ts
+import {
+  DEFAULT_TOKEN_LIFECYCLE_BLOCK_REASONS,
+  DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS,
+  ensureDefaultTokenLifecycleWithContext,
+  inspectDefaultTokenInventory,
+  selectSingleNewApiTokenByIdDiff,
+} from "~/services/accounts/defaultTokenLifecycle"
+```
+
+Add a stored-account entry point and keep `ensureAccountTokenForPostSaveWorkflow(...)` as a compatibility wrapper:
+
+```ts
+export async function ensureAccountTokenForPostSaveWorkflowFromStoredAccount(params: {
+  account: SiteAccount
+}): Promise<EnsureAccountTokenResult> {
+  const storedContext = createAccountApiRequestFromStoredAccount(params.account)
+  const result = await ensureDefaultTokenLifecycleWithContext({
+    workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+    context: storedContext,
+    createContext: storedContext,
+  })
+```
+
+Move the current result mapping into this stored-account function unchanged.
+
+Then change the old wrapper so existing display-shaped callers keep compiling while the request source is stored:
+
+```ts
+export function ensureAccountTokenForPostSaveWorkflow(params: {
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+}): Promise<EnsureAccountTokenResult> {
+  return ensureAccountTokenForPostSaveWorkflowFromStoredAccount({
+    account: params.account,
+  })
+}
+```
+
+In `src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts`, import `createAccountApiRequestFromStoredAccount` and `ensureDefaultTokenLifecycleWithContext`, then change `ensureDefaultApiTokenForAccount(...)` so display data is no longer a request source:
+
+```ts
+export async function ensureDefaultApiTokenForAccount(params: {
+  account: SiteAccount
+}): Promise<{ token: ApiToken; created: boolean }> {
+  const { account } = params
+  const storedContext = createAccountApiRequestFromStoredAccount(account)
+  const result = await ensureDefaultTokenLifecycleWithContext({
+    workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
+    context: storedContext,
+    createContext: storedContext,
+  })
+```
+
+Leave the result/error mapping unchanged.
+
+Do not change `ensureAccountApiToken(...)` in `src/services/accounts/accountOperations.ts` in this task. It is used by immediate UI and managed-site flows such as `ChannelDialog`, `KiloCodeExportDialog`, and managed-site providers. Keep it on `ensureDefaultTokenLifecycle(...)` until those callers are classified.
+
+Add this audit command to the task notes and leave each caller untouched:
+
+```powershell
+rg "ensureAccountApiToken\\(" src/components src/services/managedSites src/features
+```
+
+Expected callers remain classified as shared UI/managed-site compatibility paths, not background/cross-tick accountId-only work.
+
+Do not change `resolveDefaultTokenQuickCreateResolution(...)`: it is an immediate UI decision path and should keep `DisplaySiteData`.
+
+- [ ] **Step 4: Remove unnecessary display-data fetches from auto-provision after add**
+
+In `src/services/accounts/accountOperations.ts`, keep the stored account validation in `autoProvisionKeyOnAccountAdd(...)` and stop reading display data solely to build API requests.
+
+Replace this block:
+
+```ts
+    const displaySiteData =
+      (await accountStorage.getDisplayDataById(accountId)) ??
+      accountStorage.convertToDisplayData(account)
+    const hasToken =
+      typeof displaySiteData?.token === "string" &&
+      displaySiteData.token.trim().length > 0
+    const hasCookie =
+      typeof displaySiteData?.cookieAuthSessionCookie === "string" &&
+      displaySiteData.cookieAuthSessionCookie.trim().length > 0
+
+    if (
+      typeof displaySiteData?.id !== "string" ||
+      displaySiteData.id.trim().length === 0 ||
+      typeof displaySiteData?.baseUrl !== "string" ||
+      displaySiteData.baseUrl.trim().length === 0 ||
+      typeof displaySiteData?.siteType !== "string" ||
+      displaySiteData.siteType.trim().length === 0 ||
+      displaySiteData.authType === AuthTypeEnum.None ||
+      typeof displaySiteData.userId !== "string" ||
+      displaySiteData.userId.trim().length === 0 ||
+      (displaySiteData.authType === AuthTypeEnum.AccessToken && !hasToken) ||
+      (displaySiteData.authType === AuthTypeEnum.Cookie &&
+        !hasToken &&
+        !hasCookie)
+    ) {
+      throw new Error(ACCOUNT_KEY_REPAIR_ERRORS.InvalidDisplaySiteData)
+    }
+
+    const { created } = await ensureDefaultApiTokenForAccount({ account })
+```
+
+with:
+
+```ts
+    const { created } = await ensureDefaultApiTokenForAccount({ account })
+```
+
+The background helper no longer accepts `displaySiteData`; the request must come from `account`.
+
+Update success toast account names to use `account.site_name`:
+
+```ts
+          accountName: account.site_name,
+```
+
+- [ ] **Step 5: Run focused tests and update expectations that intentionally changed**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
+```
+
+Expected: PASS after updating test expectations from display request to stored request for post-save/background ensure while preserving shared `ensureAccountApiToken(...)` compatibility behavior.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountOperations.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
+git commit -m "refactor(accounts): resolve background token context once"
+```
+
+Expected: commit succeeds. If hooks modify files, inspect `git status --porcelain` and `git diff --cached` before retrying.
+
+---
+
+### Task 4: Route Repair Workflows Through Stored Account Requests
+
+**Files:**
+
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`
+- Modify: `src/services/accounts/accountKeyAutoProvisioning/repair.ts`
+- Test: `tests/services/accountKeyGroupCoverage.test.ts`
+- Test: `tests/services/accountKeyRepair.test.ts`
+
+- [ ] **Step 1: Add failing tests for repair request source**
+
+In `tests/services/accountKeyGroupCoverage.test.ts`, add this regression test so a stale display snapshot cannot affect remote token requests or adapter selection:
+
+```ts
+  it("uses stored account context for group coverage token APIs and adapter lookup", async () => {
+    const account = buildSiteAccount({
+      id: "stored-account-id",
+      site_url: "https://stored.example.invalid",
+      site_type: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.Cookie,
+      cookieAuth: { sessionCookie: "stored-session-cookie" },
+      account_info: {
+        id: "stored-user-id",
+        access_token: "stored-access-token",
+        username: "stored-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const displaySiteData = buildDisplaySiteData({
+      id: "display-account-id",
+      baseUrl: "https://display.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+      authType: AuthTypeEnum.Cookie,
+      userId: "display-user-id",
+      token: "display-access-token",
+      cookieAuthSessionCookie: "display-session-cookie",
+    })
+
+    mocks.fetchAccountTokens.mockResolvedValueOnce([])
+    mocks.fetchUserGroups.mockResolvedValueOnce({
+      default: { desc: "Default", ratio: 1 },
+    })
+    mocks.createApiToken.mockResolvedValueOnce({ id: 1, key: "sk-created" })
+    mocks.classifyCreatedToken.mockReturnValueOnce({
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+      token: { id: 1, key: "sk-created" },
+      oneTimeSecret: false,
+    })
+
+    await ensureAccountKeysForAvailableGroups({
+      account,
+      displaySiteData,
+      accountName: "Stored Account",
+      siteUrlOrigin: "https://stored.example.invalid",
+    })
+
+    const expectedStoredRequest = {
+      baseUrl: "https://stored.example.invalid",
+      accountId: "stored-account-id",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "stored-user-id",
+        accessToken: "stored-access-token",
+        cookie: "stored-session-cookie",
+      },
+    }
+
+    const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
+    expect(getSiteAdapter).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(mocks.fetchAccountTokens).toHaveBeenCalledWith(expectedStoredRequest)
+    expect(mocks.fetchUserGroups).toHaveBeenCalledWith(expectedStoredRequest)
+    expect(mocks.createApiToken).toHaveBeenCalledWith(
+      expectedStoredRequest,
+      expect.any(Object),
+    )
+  })
+```
+
+In `tests/services/accountKeyRepair.test.ts`, update the runner expectation in `"records skipped, created, and failed outcomes during a repair run"` so invalid display data is not treated as a request-construction failure for an otherwise valid stored account. The expected summary should become:
+
+```ts
+    mocks.ensureAccountKeysForAvailableGroups
+      .mockResolvedValueOnce({
+        created: true,
+        availableGroups: [],
+        coveredGroups: [],
+        createdGroups: [""],
+        missingGroups: [],
+        invalidTokens: [],
+      })
+      .mockResolvedValueOnce({
+        created: true,
+        availableGroups: [],
+        coveredGroups: [],
+        createdGroups: [""],
+        missingGroups: [],
+        invalidTokens: [],
+      })
+
+    expect(progress.totals).toMatchObject({
+      enabledAccounts: 4,
+      eligibleAccounts: 2,
+      processedAccounts: 2,
+      processedEligibleAccounts: 2,
+    })
+    expect(progress.summary).toEqual({
+      created: 2,
+      alreadyHad: 0,
+      skipped: 2,
+      failed: 0,
+      availableGroups: 0,
+      coveredGroups: 0,
+      createdKeys: 2,
+      renamedKeys: 0,
+      renameFailed: 0,
+      invalidKeys: 0,
+      deletedKeys: 0,
+      deleteFailed: 0,
+    })
+```
+
+Also expect `mocks.ensureAccountKeysForAvailableGroups` to be called twice.
+
+- [ ] **Step 2: Run focused tests and verify failures**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts
+```
+
+Expected: the repair-runner test fails until repair stops treating display-account request fields as required for background work. The group-coverage test is regression coverage and should pass once the implementation uses `account.site_type` for adapter lookup and the stored-account request for token APIs.
+
+- [ ] **Step 3: Keep display data in group coverage as metadata only**
+
+In `src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts`, `ensureAccountKeysForAvailableGroups(...)` already builds `request` from `createAccountApiRequestFromStoredAccount(account)`. Keep that behavior.
+
+Use the stored account site type for adapter and capability lookup:
+
+```ts
+  const adapter = getSiteAdapter(account.site_type)
+  const capabilitySite = { siteType: account.site_type }
+  const keyManagement = requireDisplayAccountKeyManagement(
+    capabilitySite,
+    adapter.keyManagement,
+  )
+  const tokenProvisioning = requireDisplayAccountTokenProvisioning(
+    capabilitySite,
+    adapter.tokenProvisioning,
+  )
+```
+
+Narrow display-data usage to metadata:
+
+```ts
+  const accountId = account.id
+```
+
+For result `siteType`, prefer `account.site_type`:
+
+```ts
+      siteType: account.site_type,
+```
+
+In `deleteInvalidAccountToken(...)`, also use `account.site_type` for adapter/capability lookup:
+
+```ts
+  const adapter = getSiteAdapter(account.site_type)
+  const keyManagement = requireDisplayAccountKeyManagement(
+    { siteType: account.site_type },
+    adapter.keyManagement,
+  )
+```
+
+Do not replace `request` construction with display snapshot data, and do not use `displaySiteData.siteType` for adapter selection.
+
+- [ ] **Step 4: Stop validating display request fields in the repair runner**
+
+In `src/services/accounts/accountKeyAutoProvisioning/repair.ts`, inside `processEligibleAccount(...)`, replace the block that checks `displaySiteData.id`, `baseUrl`, `siteType`, `userId`, `token`, and `cookieAuthSessionCookie`.
+
+Keep only stored-account request validation by constructing the request in the group coverage helper. The runner should do this:
+
+```ts
+      const displaySiteData: DisplaySiteData =
+        displaySiteDataById.get(account.id) ??
+        accountStorage.convertToDisplayData(account)
+      const resolvedAccountName = displaySiteData.name || accountName
+
+      const result = await ensureAccountKeysForAvailableGroups({
+        account,
+        displaySiteData,
+        accountName: resolvedAccountName,
+        siteUrlOrigin: originKey,
+        abortSignal,
+        renameAutoTemplateTokens: options.renameAutoTemplateTokens,
+      })
+```
+
+If `createAccountApiRequestFromStoredAccount(account)` later throws `StoredAccountApiContextError`, let the existing catch record a failed result with the stable error message. Do not convert it to `ACCOUNT_KEY_REPAIR_ERRORS.InvalidDisplaySiteData`.
+
+- [ ] **Step 5: Run focused tests and verify pass**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts src/services/accounts/accountKeyAutoProvisioning/repair.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/accountKeyRepair.test.ts
+git commit -m "refactor(accounts): keep repair requests account-owned"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Preserve Immediate UI Snapshot Paths
+
+**Files:**
+
+- Modify only if tests need expectation updates:
+  - `tests/features/AccountManagement/components/CopyKeyDialog.test.tsx`
+  - `tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx`
+  - `tests/components/VerifyCliSupportDialog.test.tsx`
+  - `tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx`
+- No production change expected unless an earlier task accidentally migrated UI paths.
+
+- [ ] **Step 1: Verify immediate UI call sites still use display snapshot context**
+
+Run:
+
+```powershell
+rg "createDisplayAccountApiContext\\(|createDisplayAccountRequestContext\\(" src/features src/components
+```
+
+Expected call sites include immediate user actions such as:
+
+```text
+src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+src/components/dialogs/VerifyApiDialog/index.tsx
+src/components/dialogs/VerifyCliSupportDialog/index.tsx
+src/features/KeyManagement/hooks/useKeyManagement.ts
+src/features/TokenProvisioning/components/AddTokenDialog/index.tsx
+src/features/TokenProvisioning/components/AddTokenDialog/hooks/useTokenData.ts
+```
+
+Do not convert these to `resolveStoredAccountApiContext(...)` in this plan. They are immediate UI operations using the currently visible account snapshot.
+
+- [ ] **Step 2: Verify quick-create resolution remains display-snapshot based**
+
+Run:
+
+```powershell
+rg "resolveDefaultTokenQuickCreateResolution\\(" src/features src/components src/services/accounts
+```
+
+Expected: immediate UI selection flows still pass `DisplaySiteData`. This is intentional because quick-create group selection reflects the visible account state.
+
+- [ ] **Step 3: Run existing UI-focused tests that cover snapshot paths**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/components/VerifyCliSupportDialog.test.tsx tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+```
+
+Expected: PASS. If a path fails because a UI flow was converted to stored lookup, revert that production change and keep the UI snapshot path.
+
+- [ ] **Step 4: Commit only if tests or production code changed**
+
+If no files changed, skip this step.
+
+If test expectations needed correction, run:
+
+```powershell
+git status --porcelain
+git add tests/features/AccountManagement/components/CopyKeyDialog.test.tsx tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx tests/components/VerifyCliSupportDialog.test.tsx tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+git commit -m "test(accounts): preserve display snapshot api actions"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 6: Shrink Common Fetch Legacy Fallback To Explicit Compatibility
+
+**Files:**
+
+- Modify: `src/services/apiService/common/utils.ts`
+- Test: `tests/services/apiService/common/utils.test.ts`
+- Test: `tests/services/accounts/legacyAccountAwareRequest.test.ts`
+
+- [ ] **Step 1: Add failing tests that common fetch no longer resolves legacy context**
+
+In `tests/services/apiService/common/utils.test.ts`, remove the hoisted `mockResolveLegacyAccountAwareRequest`, the `vi.mock("~/services/accounts/utils/legacyAccountAwareRequest", ...)` block, and the `beforeEach` reset/setup for that mock.
+
+Then change the expectations for `fetchApiData(...)` and `fetchApi(...)` so they call transport with the original request.
+
+Replace the `fetchApiData` compatibility-resolution test with:
+
+```ts
+    it("passes requests directly to transport without account-aware lookup", async () => {
+      const request = {
+        baseUrl: "https://example.invalid",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "token",
+          userId: "123",
+        },
+      }
+      const options = { endpoint: "/api/test" }
+      mockFetchApiData.mockResolvedValueOnce({ ok: true })
+
+      await expect(fetchApiData(request, options)).resolves.toEqual({
+        ok: true,
+      })
+
+      expect(mockFetchApiData).toHaveBeenCalledWith(request, options)
+    })
+```
+
+Replace the `fetchApi` compatibility-resolution test with:
+
+```ts
+    it("passes response requests directly to transport without account-aware lookup", async () => {
+      const request = {
+        baseUrl: "https://example.invalid",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "token",
+          userId: "123",
+        },
+      }
+      const options = { endpoint: "/api/test" }
+      mockFetchApi.mockResolvedValueOnce({ success: true, data: { ok: true } })
+
+      await expect(fetchApi(request, options, true)).resolves.toEqual({
+        success: true,
+        data: { ok: true },
+      })
+
+      expect(mockFetchApi).toHaveBeenCalledWith(request, options, true)
+    })
+```
+
+Keep `tests/services/accounts/legacyAccountAwareRequest.test.ts` unchanged; it owns legacy lookup behavior.
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/apiService/common/utils.test.ts tests/services/accounts/legacyAccountAwareRequest.test.ts
+```
+
+Expected: FAIL because `fetchApi(...)` and `fetchApiData(...)` still call `resolveLegacyAccountAwareRequest(...)`.
+
+- [ ] **Step 3: Remove default legacy lookup from common fetch wrappers**
+
+In `src/services/apiService/common/utils.ts`, remove:
+
+```ts
+import { resolveLegacyAccountAwareRequest } from "~/services/accounts/utils/legacyAccountAwareRequest"
+```
+
+Change `fetchApiData(...)`:
+
+```ts
+export async function fetchApiData<T>(
+  request: ApiServiceRequest,
+  options: FetchApiOptions,
+): Promise<T> {
+  return await transportFetchApiData(request, options)
+}
+```
+
+Keep the existing `fetchApi(...)` overload declarations and change only the implementation:
+
+```ts
+export function fetchApi<T>(
+  request: ApiServiceRequest,
+  options: FetchApiOptions,
+  _normalResponseType: true,
+): Promise<T>
+export function fetchApi<T>(
+  request: ApiServiceRequest,
+  options: FetchApiOptions,
+  _normalResponseType?: false,
+): Promise<ApiResponse<T>>
+export async function fetchApi<T>(
+  request: ApiServiceRequest,
+  options: FetchApiOptions,
+  _normalResponseType?: boolean,
+): Promise<T | ApiResponse<T>> {
+  return await transportFetchApi(
+    request,
+    options,
+    _normalResponseType as true,
+  )
+}
+```
+
+Do not delete `src/services/accounts/utils/legacyAccountAwareRequest.ts`.
+
+- [ ] **Step 4: Run focused common and migrated workflow tests**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/apiService/common/utils.test.ts tests/services/accounts/legacyAccountAwareRequest.test.ts tests/services/accounts/apiServiceRequest.test.ts tests/services/accounts/defaultTokenLifecycle.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts tests/services/accountKeyRepair.test.ts tests/services/accountKeyGroupCoverage.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run fetch-caller audit and migration gates**
+
+Before accepting the removal of default common-fetch fallback, enumerate the remaining common fetch wrapper callers:
+
+```powershell
+rg "fetchApi(Data)?\\(" src/services src/features src/components
+rg "baseUrl: .*auth:|auth: \\{" src/services src/features src/components
+```
+
+Classify every account-site request builder touched by the output as one of:
+
+- Prepared account context: carries `accountId` or is built from `createDisplayAccountRequestContext(...)`, `createDisplayAccountApiContext(...)`, `resolveStoredAccountApiContext(...)`, or `createAccountApiRequestFromStoredAccount(account)`.
+- Public/no-account request: endpoint does not need account-owned session/cookie enrichment.
+- Managed-session synthetic request: intentionally not a stored account.
+- Explicit legacy compatibility path: must call `resolveLegacyAccountAwareRequest(...)` directly from an accounts-owned boundary.
+
+If any account-owned caller still depends on `baseUrl + userId` enrichment without `accountId`, fix that caller before removing fallback from `common/utils.ts`.
+
+Run:
+
+```powershell
+rg "resolveLegacyAccountAwareRequest" src tests
+rg "accountStorage" src/services/apiService/common
+rg "getAccountByBaseUrlAndUserId" src/services/apiService src/services/apiAdapters src/services/apiTransport
+rg "DisplaySiteData" src/services/apiService src/services/apiAdapters src/services/apiTransport
+```
+
+Expected:
+
+- `resolveLegacyAccountAwareRequest` appears only in:
+  - `src/services/accounts/utils/legacyAccountAwareRequest.ts`
+  - `tests/services/accounts/legacyAccountAwareRequest.test.ts`
+  - optionally comments in migration docs/plans.
+- `accountStorage` has no matches in `src/services/apiService/common`.
+- `getAccountByBaseUrlAndUserId` has no matches in `src/services/apiService`, `src/services/apiAdapters`, or `src/services/apiTransport`.
+- `DisplaySiteData` has no new matches in protocol, adapter, or transport modules. Existing unrelated matches should be reported, not rewritten.
+
+- [ ] **Step 6: Commit Task 6**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/apiService/common/utils.ts tests/services/apiService/common/utils.test.ts tests/services/accounts/legacyAccountAwareRequest.test.ts
+git commit -m "refactor(api-service): make common fetch context-explicit"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 7: Final Validation And Handoff
+
+**Files:**
+
+- No production changes expected.
+- Optional updates only for test expectation cleanup from previous tasks.
+
+- [ ] **Step 1: Run related Vitest coverage for migrated account workflows**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/accounts/apiServiceRequest.test.ts tests/services/accounts/defaultTokenLifecycle.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts tests/services/accountKeyRepair.test.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/siteAnnouncements/scheduler.test.ts tests/services/usageHistory/sync.test.ts tests/services/redeemService.test.ts tests/services/apiService/common/utils.test.ts tests/services/accounts/legacyAccountAwareRequest.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run API-service account-data backend tests as regression coverage**
+
+Run:
+
+```powershell
+pnpm vitest --run tests/services/apiService/common/accountData.test.ts tests/services/apiService/anyrouter.index.test.ts tests/services/apiService/wong/index.test.ts tests/services/apiService/veloera/channelApi.test.ts tests/services/apiService/doneHub/channelApi.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiService/aihubmix/index.test.ts
+```
+
+Expected: PASS. These ensure removing common fetch fallback did not break prepared requests in account-data adapters.
+
+- [ ] **Step 3: Run ownership gates**
+
+Run:
+
+```powershell
+rg "accountStorage" src/services/apiService src/services/apiAdapters src/services/apiTransport
+rg "getAccountByBaseUrlAndUserId" src/services/apiService src/services/apiAdapters src/services/apiTransport
+rg "resolveLegacyAccountAwareRequest" src tests
+rg "fetchApi(Data)?\\(" src/services src/features src/components
+rg "createDisplayAccountApiContext\\(|createDisplayAccountRequestContext\\(" src/services/accounts src/features src/components
+rg "resolveStoredAccountApiContext\\(|createAccountApiRequestFromStoredAccount\\(" src/services/accounts src/features src/components
+```
+
+Expected:
+
+- No storage lookup from `apiService`, `apiAdapters`, or `apiTransport`.
+- Legacy resolver remains accounts-owned and test-owned only.
+- Remaining common fetch wrapper callers are classified as prepared account context, public/no-account request, managed-session synthetic request, or explicit legacy compatibility path.
+- Immediate UI files still use display snapshot context.
+- AccountId-only background/retry/repair/cross-tick boundaries use `resolveStoredAccountApiContext(accountId)`; account-owned flows that already hold `SiteAccount` use `createAccountApiRequestFromStoredAccount(account)`.
+
+- [ ] **Step 4: Run staged validation**
+
+Run:
+
+```powershell
+git status --porcelain
+git add src/services/accounts/defaultTokenLifecycle/lifecycle.ts src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts src/services/accounts/accountKeyAutoProvisioning/repair.ts src/services/accounts/accountOperations.ts src/services/siteAnnouncements/scheduler.ts src/services/history/usageHistory/sync.ts src/services/redemption/redeemService.ts src/services/apiService/common/utils.ts tests/services/accounts/apiServiceRequest.test.ts tests/services/accounts/defaultTokenLifecycle.test.ts tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts tests/services/accountOperations.ensureAccountApiToken.test.ts tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts tests/services/accountKeyRepair.test.ts tests/services/accountKeyGroupCoverage.test.ts tests/services/siteAnnouncements/scheduler.test.ts tests/services/usageHistory/sync.test.ts tests/services/redeemService.test.ts tests/services/apiService/common/utils.test.ts tests/services/accounts/legacyAccountAwareRequest.test.ts
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run push-level validation**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. This implementation changes shared request-context wiring and common fetch behavior, so `compile` and `knip` coverage from the push gate are required.
+
+- [ ] **Step 6: Inspect final diff**
+
+Run:
+
+```powershell
+git diff --stat 08f047d4ab519b5108ab7391648f0c10c1ba6bf2..HEAD
+git diff 08f047d4ab519b5108ab7391648f0c10c1ba6bf2..HEAD -- src/services/siteAnnouncements/scheduler.ts src/services/history/usageHistory/sync.ts src/services/redemption/redeemService.ts src/services/accounts/defaultTokenLifecycle/lifecycle.ts src/services/accounts/accountOperations.ts src/services/apiService/common/utils.ts
+```
+
+Expected:
+
+- Token lifecycle exposes prepared-context APIs and keeps display wrappers for immediate UI compatibility.
+- Stored-account scheduler/background services reuse `createAccountApiRequestFromStoredAccount(account)` instead of hand-building account API requests.
+- Post-save/background helpers use stored account context for inventory and creation; shared `ensureAccountApiToken(...)` remains a display-snapshot compatibility wrapper pending caller audit.
+- Repair request construction is account-owned; display data is metadata only.
+- Common fetch wrappers call transport directly.
+- `resolveLegacyAccountAwareRequest(...)` is still present but no longer the default path.
+- No secrets, tokens, cookies, private endpoints, or real service-specific test data were added.
+
+- [ ] **Step 7: Commit final validation-only adjustments if needed**
+
+If Task 7 required no file changes, skip this step.
+
+If a final validation command exposed a task-scoped cleanup that belongs to an earlier task, return to that task's commit step and include the exact files changed there. Do not create a generic validation commit with ambiguous scope.
+
+Expected: the final history remains a sequence of task-scoped commits, or this step is skipped because validation required no additional file changes.
+
+---
+
+## Follow-Up Work Not In This Slice
+
+- Convert post-save workflow entry points in `AccountDialog` to store/pass `accountId` when they are truly cross-tick jobs rather than same-tick save continuations.
+- Migrate shared `ensureAccountApiToken(...)` after classifying `ChannelDialog`, `KiloCodeExportDialog`, and managed-site provider callers as immediate UI snapshot, account-owned stored account, or explicit compatibility paths.
+- Decide whether account-data refresh should gain explicit prepared fetch wrappers after common fetch fallback is removed. Do this only if a real caller still lacks `accountId`.
+- Delete `resolveLegacyAccountAwareRequest(...)` after every remaining caller either passes explicit context or is proven not to need account-owned request enrichment.
+- Consider a small static ownership check if storage lookup starts reappearing in protocol or adapter modules.
+
+---
+
+## Final Handoff Checklist
+
+- [ ] Focused Vitest commands from Tasks 1-7 passed.
+- [ ] `pnpm run validate:staged` passed.
+- [ ] `pnpm run validate:push` passed.
+- [ ] Immediate UI operations use `createDisplayAccountApiContext(...)` or `createDisplayAccountRequestContext(...)` from display snapshots.
+- [ ] AccountId-only background/retry/repair/cross-tick boundaries use `resolveStoredAccountApiContext(accountId)`.
+- [ ] Account-owned flows that already hold `SiteAccount` use `createAccountApiRequestFromStoredAccount(account)`.
+- [ ] Protocol, adapter, common service, and transport modules do not accept full `DisplaySiteData` as an Account API request source.
+- [ ] `src/services/apiService/common` does not import `accountStorage`.
+- [ ] `resolveLegacyAccountAwareRequest(...)` remains accounts-owned and is not called by common fetch wrappers.
+- [ ] Telemetry decision reported: none.
+- [ ] Settings search decision reported: none.
+- [ ] E2E decision reported: no new E2E; focused Vitest is the right layer.
+- [ ] Maintainability decision reported: reused existing accounts-owned context builders; no new parallel context abstraction added; legacy lookup intentionally left as a compatibility helper until the remaining surface is proven migrated.

--- a/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken.ts
@@ -2,14 +2,15 @@ import {
   DEFAULT_TOKEN_LIFECYCLE_BLOCK_REASONS,
   DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS,
   DefaultTokenLifecyclePolicyBlockedError,
-  ensureDefaultTokenLifecycle,
+  ensureDefaultTokenLifecycleWithContext,
 } from "~/services/accounts/defaultTokenLifecycle"
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
 import {
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_ERRORS,
   TOKEN_PROVISIONING_WORKFLOWS,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
-import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
+import type { ApiToken, SiteAccount } from "~/types"
 import { t } from "~/utils/i18n/core"
 
 export {
@@ -28,13 +29,13 @@ export {
  */
 export async function ensureDefaultApiTokenForAccount(params: {
   account: SiteAccount
-  displaySiteData: DisplaySiteData
 }): Promise<{ token: ApiToken; created: boolean }> {
-  const { account, displaySiteData } = params
-  const result = await ensureDefaultTokenLifecycle({
+  const { account } = params
+  const storedContext = createAccountApiRequestFromStoredAccount(account)
+  const result = await ensureDefaultTokenLifecycleWithContext({
     workflow: TOKEN_PROVISIONING_WORKFLOWS.BackgroundAutoProvision,
-    account,
-    displaySiteData,
+    context: storedContext,
+    createContext: storedContext,
   })
 
   if (

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -108,22 +108,22 @@ export async function ensureAccountKeysForAvailableGroups(params: {
   abortSignal?: AbortSignal
   renameAutoTemplateTokens?: boolean
 }): Promise<AccountKeyCoverageResult> {
-  const { account, displaySiteData, accountName, siteUrlOrigin, abortSignal } =
-    params
-  const adapter = getSiteAdapter(displaySiteData.siteType)
+  const { account, accountName, siteUrlOrigin, abortSignal } = params
+  const adapter = getSiteAdapter(account.site_type)
+  const capabilitySite = { siteType: account.site_type }
   const keyManagement = requireDisplayAccountKeyManagement(
-    displaySiteData,
+    capabilitySite,
     adapter.keyManagement,
   )
   const tokenProvisioning = requireDisplayAccountTokenProvisioning(
-    displaySiteData,
+    capabilitySite,
     adapter.tokenProvisioning,
   )
   const accountContext = createAccountApiRequestFromStoredAccount(account)
   const request = abortSignal
     ? { ...accountContext.request, abortSignal }
     : accountContext.request
-  const accountId = displaySiteData.id || account.id
+  const accountId = account.id
 
   const tokens = await keyManagement.fetchTokens(request)
   const groupsData = keyManagement.userGroups
@@ -253,7 +253,7 @@ export async function ensureAccountKeysForAvailableGroups(params: {
     invalidTokens.push({
       accountId,
       accountName,
-      siteType: displaySiteData.siteType,
+      siteType: account.site_type,
       siteUrlOrigin,
       tokenId: token.id,
       tokenName: token.name,
@@ -300,10 +300,11 @@ export async function deleteInvalidAccountToken(params: {
   account: SiteAccount
   displaySiteData: DisplaySiteData
 }): Promise<AccountKeyRepairDeleteInvalidTokensResult["deleted"][number]> {
-  const { token, account, displaySiteData } = params
+  const { token, account } = params
+  const adapter = getSiteAdapter(account.site_type)
   const keyManagement = requireDisplayAccountKeyManagement(
-    displaySiteData,
-    getSiteAdapter(displaySiteData.siteType).keyManagement,
+    { siteType: account.site_type },
+    adapter.keyManagement,
   )
   const { request } = createAccountApiRequestFromStoredAccount(account)
   await keyManagement.deleteToken({

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -377,29 +377,6 @@ class AccountKeyRepairRunner {
         displaySiteDataById.get(account.id) ??
         accountStorage.convertToDisplayData(account)
       const resolvedAccountName = displaySiteData.name || accountName
-      const hasToken =
-        typeof displaySiteData?.token === "string" &&
-        displaySiteData.token.trim().length > 0
-      const hasCookie =
-        typeof displaySiteData?.cookieAuthSessionCookie === "string" &&
-        displaySiteData.cookieAuthSessionCookie.trim().length > 0
-      if (
-        typeof displaySiteData?.id !== "string" ||
-        displaySiteData.id.trim().length === 0 ||
-        typeof displaySiteData?.baseUrl !== "string" ||
-        displaySiteData.baseUrl.trim().length === 0 ||
-        typeof displaySiteData?.siteType !== "string" ||
-        displaySiteData.siteType.trim().length === 0 ||
-        displaySiteData.authType === AuthTypeEnum.None ||
-        typeof displaySiteData.userId !== "string" ||
-        displaySiteData.userId.trim().length === 0 ||
-        (displaySiteData.authType === AuthTypeEnum.AccessToken && !hasToken) ||
-        (displaySiteData.authType === AuthTypeEnum.Cookie &&
-          !hasToken &&
-          !hasCookie)
-      ) {
-        throw new Error(ACCOUNT_KEY_REPAIR_ERRORS.InvalidDisplaySiteData)
-      }
 
       const result = await ensureAccountKeysForAvailableGroups({
         account,

--- a/src/services/accounts/accountOperations.ts
+++ b/src/services/accounts/accountOperations.ts
@@ -72,7 +72,6 @@ import {
   type SiteAccount,
   type Sub2ApiAuthConfig,
 } from "~/types"
-import { ACCOUNT_KEY_REPAIR_ERRORS } from "~/types/accountKeyAutoProvisioning"
 import type {
   AccountSaveResponse,
   AccountValidationResponse,
@@ -1301,49 +1300,18 @@ async function autoProvisionKeyOnAccountAdd(
       return
     }
 
-    const displaySiteData =
-      (await accountStorage.getDisplayDataById(accountId)) ??
-      accountStorage.convertToDisplayData(account)
-    const hasToken =
-      typeof displaySiteData?.token === "string" &&
-      displaySiteData.token.trim().length > 0
-    const hasCookie =
-      typeof displaySiteData?.cookieAuthSessionCookie === "string" &&
-      displaySiteData.cookieAuthSessionCookie.trim().length > 0
-
-    if (
-      typeof displaySiteData?.id !== "string" ||
-      displaySiteData.id.trim().length === 0 ||
-      typeof displaySiteData?.baseUrl !== "string" ||
-      displaySiteData.baseUrl.trim().length === 0 ||
-      typeof displaySiteData?.siteType !== "string" ||
-      displaySiteData.siteType.trim().length === 0 ||
-      displaySiteData.authType === AuthTypeEnum.None ||
-      typeof displaySiteData.userId !== "string" ||
-      displaySiteData.userId.trim().length === 0 ||
-      (displaySiteData.authType === AuthTypeEnum.AccessToken && !hasToken) ||
-      (displaySiteData.authType === AuthTypeEnum.Cookie &&
-        !hasToken &&
-        !hasCookie)
-    ) {
-      throw new Error(ACCOUNT_KEY_REPAIR_ERRORS.InvalidDisplaySiteData)
-    }
-
-    const { created } = await ensureDefaultApiTokenForAccount({
-      account,
-      displaySiteData,
-    })
+    const { created } = await ensureDefaultApiTokenForAccount({ account })
 
     if (created) {
       toast.success(
         t("messages:accountOperations.autoProvisionCreated", {
-          accountName: displaySiteData.name || account.site_name,
+          accountName: account.site_name,
         }),
       )
     } else {
       showWarningToast(
         t("messages:accountOperations.autoProvisionAlreadyHad", {
-          accountName: displaySiteData.name || account.site_name,
+          accountName: account.site_name,
         }),
       )
     }

--- a/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
+++ b/src/services/accounts/accountPostSaveWorkflow/ensureAccountToken.ts
@@ -1,10 +1,11 @@
 import {
   DEFAULT_TOKEN_LIFECYCLE_BLOCK_REASONS,
   DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS,
-  ensureDefaultTokenLifecycle,
+  ensureDefaultTokenLifecycleWithContext,
   inspectDefaultTokenInventory,
   selectSingleNewApiTokenByIdDiff,
 } from "~/services/accounts/defaultTokenLifecycle"
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
 import {
   TOKEN_PROVISIONING_BLOCK_REASONS,
   TOKEN_PROVISIONING_WORKFLOWS,
@@ -36,14 +37,14 @@ export function inspectAccountTokenInventory(params: {
 /**
  * Ensures a saved account has a token that can be used by post-save automation.
  */
-export async function ensureAccountTokenForPostSaveWorkflow(params: {
+export async function ensureAccountTokenForPostSaveWorkflowFromStoredAccount(params: {
   account: SiteAccount
-  displaySiteData: DisplaySiteData
 }): Promise<EnsureAccountTokenResult> {
-  const result = await ensureDefaultTokenLifecycle({
+  const storedContext = createAccountApiRequestFromStoredAccount(params.account)
+  const result = await ensureDefaultTokenLifecycleWithContext({
     workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
-    account: params.account,
-    displaySiteData: params.displaySiteData,
+    context: storedContext,
+    createContext: storedContext,
   })
 
   if (result.kind === DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS.Ready) {
@@ -99,4 +100,17 @@ export async function ensureAccountTokenForPostSaveWorkflow(params: {
     code: ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES.TokenCreationFailed,
     message: t("messages:accountOperations.createTokenFailed"),
   }
+}
+
+/**
+ * Preserves the post-save display-shaped call contract while request context
+ * comes from the saved account record.
+ */
+export function ensureAccountTokenForPostSaveWorkflow(params: {
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+}): Promise<EnsureAccountTokenResult> {
+  return ensureAccountTokenForPostSaveWorkflowFromStoredAccount({
+    account: params.account,
+  })
 }

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -1092,6 +1092,8 @@ class AccountStorageService {
         try {
           const support = await accountRefresh.fetchCheckInSupport({
             baseUrl,
+            accountId: account.id,
+            cookieAuthSessionCookie: account.cookieAuth?.sessionCookie,
             auth,
           })
 

--- a/src/services/accounts/defaultTokenLifecycle/lifecycle.ts
+++ b/src/services/accounts/defaultTokenLifecycle/lifecycle.ts
@@ -3,6 +3,8 @@ import {
   createDisplayAccountApiContext,
   requireDisplayAccountKeyManagement,
   requireDisplayAccountTokenProvisioning,
+  type AccountApiContext,
+  type DisplayAccountApiCapabilityContext,
 } from "~/services/accounts/utils/apiServiceRequest"
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
 import {
@@ -15,6 +17,7 @@ import {
   type TokenProvisioningCapability,
   type TokenProvisioningWorkflow,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
 
@@ -47,6 +50,39 @@ class MissingUserGroupsCapabilityError extends Error {
   constructor(message: string) {
     super(message)
     this.name = "MissingUserGroupsCapabilityError"
+  }
+}
+
+const isDisplayAccountApiCapabilityContext = (
+  context: AccountApiContext,
+): context is DisplayAccountApiCapabilityContext =>
+  "keyManagement" in context && "tokenProvisioning" in context
+
+const requireTokenLifecycleCapabilities = (context: AccountApiContext) => {
+  if (isDisplayAccountApiCapabilityContext(context)) {
+    return {
+      keyManagement: requireDisplayAccountKeyManagement(
+        { siteType: context.siteType },
+        context.keyManagement,
+      ),
+      tokenProvisioning: requireDisplayAccountTokenProvisioning(
+        { siteType: context.siteType },
+        context.tokenProvisioning,
+      ),
+    }
+  }
+
+  const adapter = getSiteAdapter(context.siteType)
+
+  return {
+    keyManagement: requireDisplayAccountKeyManagement(
+      { siteType: context.siteType },
+      adapter.keyManagement,
+    ),
+    tokenProvisioning: requireDisplayAccountTokenProvisioning(
+      { siteType: context.siteType },
+      adapter.tokenProvisioning,
+    ),
   }
 }
 
@@ -97,28 +133,33 @@ const inspectDefaultTokenInventoryWithCapabilities = async (params: {
 }
 
 /**
- * Fetches the current default-token inventory and evaluates policy usability.
+ * Fetches the current default-token inventory from an already prepared context.
+ */
+export async function inspectDefaultTokenInventoryWithContext(params: {
+  workflow: TokenProvisioningWorkflow
+  context: AccountApiContext
+}): Promise<DefaultTokenInventoryState> {
+  const { keyManagement, tokenProvisioning } =
+    requireTokenLifecycleCapabilities(params.context)
+
+  return inspectDefaultTokenInventoryWithCapabilities({
+    workflow: params.workflow,
+    keyManagement,
+    tokenProvisioning,
+    request: params.context.request,
+  })
+}
+
+/**
+ * Fetches the current default-token inventory for a display account snapshot.
  */
 export async function inspectDefaultTokenInventory(params: {
   workflow: TokenProvisioningWorkflow
   displaySiteData: DisplaySiteData
 }): Promise<DefaultTokenInventoryState> {
-  const { workflow, displaySiteData } = params
-  const context = createDisplayAccountApiContext(displaySiteData)
-  const keyManagement = requireDisplayAccountKeyManagement(
-    displaySiteData,
-    context.keyManagement,
-  )
-  const tokenProvisioning = requireDisplayAccountTokenProvisioning(
-    displaySiteData,
-    context.tokenProvisioning,
-  )
-
-  return inspectDefaultTokenInventoryWithCapabilities({
-    workflow,
-    keyManagement,
-    tokenProvisioning,
-    request: context.request,
+  return inspectDefaultTokenInventoryWithContext({
+    workflow: params.workflow,
+    context: createDisplayAccountApiContext(params.displaySiteData),
   })
 }
 
@@ -156,7 +197,34 @@ async function resolveDefaultTokenCreationWithUserGroups(params: {
 }
 
 /**
- * Resolves the lifecycle-level default-token creation decision for a display account.
+ * Resolves lifecycle-level default-token creation policy from a prepared context.
+ */
+export async function resolveDefaultTokenLifecycleDecisionWithContext(params: {
+  workflow: TokenProvisioningWorkflow
+  context: AccountApiContext
+  defaultTokenData?: ResolveDefaultTokenCreationRequest["defaultTokenData"]
+  explicitGroup?: string
+  missingUserGroupsMessage?: string
+}): Promise<DefaultTokenCreationDecision> {
+  const { keyManagement, tokenProvisioning } =
+    requireTokenLifecycleCapabilities(params.context)
+
+  return resolveDefaultTokenCreationWithUserGroups({
+    keyManagement,
+    tokenProvisioning,
+    request: params.context.request,
+    decisionRequest: {
+      workflow: params.workflow,
+      defaultTokenData:
+        params.defaultTokenData ?? generateDefaultTokenRequest(),
+      explicitGroup: params.explicitGroup,
+    },
+    missingUserGroupsMessage: params.missingUserGroupsMessage,
+  })
+}
+
+/**
+ * Resolves lifecycle-level default-token creation policy for a display account.
  */
 export async function resolveDefaultTokenLifecycleDecision(params: {
   workflow: TokenProvisioningWorkflow
@@ -165,26 +233,11 @@ export async function resolveDefaultTokenLifecycleDecision(params: {
   explicitGroup?: string
   missingUserGroupsMessage?: string
 }): Promise<DefaultTokenCreationDecision> {
-  const context = createDisplayAccountApiContext(params.displaySiteData)
-  const keyManagement = requireDisplayAccountKeyManagement(
-    params.displaySiteData,
-    context.keyManagement,
-  )
-  const tokenProvisioning = requireDisplayAccountTokenProvisioning(
-    params.displaySiteData,
-    context.tokenProvisioning,
-  )
-
-  return resolveDefaultTokenCreationWithUserGroups({
-    keyManagement,
-    tokenProvisioning,
-    request: context.request,
-    decisionRequest: {
-      workflow: params.workflow,
-      defaultTokenData:
-        params.defaultTokenData ?? generateDefaultTokenRequest(),
-      explicitGroup: params.explicitGroup,
-    },
+  return resolveDefaultTokenLifecycleDecisionWithContext({
+    workflow: params.workflow,
+    context: createDisplayAccountApiContext(params.displaySiteData),
+    defaultTokenData: params.defaultTokenData,
+    explicitGroup: params.explicitGroup,
     missingUserGroupsMessage: params.missingUserGroupsMessage,
   })
 }
@@ -335,17 +388,17 @@ export async function createDefaultTokenFromDecision(params: {
 }
 
 /**
- * Ensures a default token exists and is usable for workflows that can create one.
+ * Ensures a default token exists using an already prepared request context.
  */
-export async function ensureDefaultTokenLifecycle(params: {
+export async function ensureDefaultTokenLifecycleWithContext(params: {
   workflow: TokenProvisioningWorkflow
-  account: SiteAccount
-  displaySiteData: DisplaySiteData
+  context: AccountApiContext
+  createContext?: AccountApiContext
   defaultTokenData?: ResolveDefaultTokenCreationRequest["defaultTokenData"]
   explicitGroup?: string
   inspectInventory?: boolean
 }): Promise<DefaultTokenLifecycleResult> {
-  const { workflow, account, displaySiteData } = params
+  const { workflow, context } = params
 
   if (workflow === TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection) {
     throw new Error(
@@ -354,16 +407,8 @@ export async function ensureDefaultTokenLifecycle(params: {
   }
 
   let existingTokenIds: number[] = []
-
-  const context = createDisplayAccountApiContext(displaySiteData)
-  const keyManagement = requireDisplayAccountKeyManagement(
-    displaySiteData,
-    context.keyManagement,
-  )
-  const tokenProvisioning = requireDisplayAccountTokenProvisioning(
-    displaySiteData,
-    context.tokenProvisioning,
-  )
+  const { keyManagement, tokenProvisioning } =
+    requireTokenLifecycleCapabilities(context)
 
   if (params.inspectInventory !== false) {
     const inventoryState = await inspectDefaultTokenInventoryWithCapabilities({
@@ -454,11 +499,38 @@ export async function ensureDefaultTokenLifecycle(params: {
     workflow,
     keyManagement,
     tokenProvisioning,
-    createRequest: createAccountApiRequestFromStoredAccount(account).request,
+    createRequest: (params.createContext ?? context).request,
     inventoryRequest: context.request,
     decision,
     existingTokenIds,
   })
 
   return createResult
+}
+
+/**
+ * Ensures a default token exists for display/stored account compatibility callers.
+ */
+export async function ensureDefaultTokenLifecycle(params: {
+  workflow: TokenProvisioningWorkflow
+  account: SiteAccount
+  displaySiteData: DisplaySiteData
+  defaultTokenData?: ResolveDefaultTokenCreationRequest["defaultTokenData"]
+  explicitGroup?: string
+  inspectInventory?: boolean
+}): Promise<DefaultTokenLifecycleResult> {
+  if (params.workflow === TOKEN_PROVISIONING_WORKFLOWS.QuickCreateSelection) {
+    throw new Error(
+      DEFAULT_TOKEN_LIFECYCLE_ERRORS.QuickCreateSelectionIsDecisionOnly,
+    )
+  }
+
+  return ensureDefaultTokenLifecycleWithContext({
+    workflow: params.workflow,
+    context: createDisplayAccountApiContext(params.displaySiteData),
+    createContext: createAccountApiRequestFromStoredAccount(params.account),
+    defaultTokenData: params.defaultTokenData,
+    explicitGroup: params.explicitGroup,
+    inspectInventory: params.inspectInventory,
+  })
 }

--- a/src/services/accounts/defaultTokenLifecycle/lifecycle.ts
+++ b/src/services/accounts/defaultTokenLifecycle/lifecycle.ts
@@ -58,32 +58,33 @@ const isDisplayAccountApiCapabilityContext = (
 ): context is DisplayAccountApiCapabilityContext =>
   "keyManagement" in context && "tokenProvisioning" in context
 
+const requireTokenLifecycleCapabilityPair = (params: {
+  siteType: AccountApiContext["siteType"]
+  keyManagement: KeyManagementCapability | undefined
+  tokenProvisioning: TokenProvisioningCapability | undefined
+}) => ({
+  keyManagement: requireDisplayAccountKeyManagement(
+    { siteType: params.siteType },
+    params.keyManagement,
+  ),
+  tokenProvisioning: requireDisplayAccountTokenProvisioning(
+    { siteType: params.siteType },
+    params.tokenProvisioning,
+  ),
+})
+
 const requireTokenLifecycleCapabilities = (context: AccountApiContext) => {
   if (isDisplayAccountApiCapabilityContext(context)) {
-    return {
-      keyManagement: requireDisplayAccountKeyManagement(
-        { siteType: context.siteType },
-        context.keyManagement,
-      ),
-      tokenProvisioning: requireDisplayAccountTokenProvisioning(
-        { siteType: context.siteType },
-        context.tokenProvisioning,
-      ),
-    }
+    return requireTokenLifecycleCapabilityPair(context)
   }
 
   const adapter = getSiteAdapter(context.siteType)
 
-  return {
-    keyManagement: requireDisplayAccountKeyManagement(
-      { siteType: context.siteType },
-      adapter.keyManagement,
-    ),
-    tokenProvisioning: requireDisplayAccountTokenProvisioning(
-      { siteType: context.siteType },
-      adapter.tokenProvisioning,
-    ),
-  }
+  return requireTokenLifecycleCapabilityPair({
+    siteType: context.siteType,
+    keyManagement: adapter.keyManagement,
+    tokenProvisioning: adapter.tokenProvisioning,
+  })
 }
 
 /**

--- a/src/services/apiAdapters/contracts/accountRefresh.ts
+++ b/src/services/apiAdapters/contracts/accountRefresh.ts
@@ -4,10 +4,10 @@ import type {
   RefreshAccountResult,
 } from "~/services/apiService/common/type"
 
-export type AccountRefreshSupportRequest = {
-  baseUrl: string
-  auth: ApiServiceRequest["auth"]
-}
+export type AccountRefreshSupportRequest = Pick<
+  ApiServiceRequest,
+  "baseUrl" | "auth" | "accountId" | "cookieAuthSessionCookie"
+>
 
 export type AccountRefreshRequest = ApiServiceAccountRequest
 

--- a/src/services/apiService/anyrouter/index.ts
+++ b/src/services/apiService/anyrouter/index.ts
@@ -48,6 +48,9 @@ export async function fetchCheckInStatus(
 
     const checkInData = await anyrouterProvider.checkIn({
       site_url: request.baseUrl,
+      id: request.accountId,
+      cookieAuthSessionCookie:
+        request.cookieAuthSessionCookie ?? request.auth.cookie,
       account_info: { id: numericUserId },
     })
     return checkInData.status !== CHECKIN_RESULT_STATUS.ALREADY_CHECKED

--- a/src/services/apiService/common/utils.ts
+++ b/src/services/apiService/common/utils.ts
@@ -1,4 +1,3 @@
-import { resolveLegacyAccountAwareRequest } from "~/services/accounts/utils/legacyAccountAwareRequest"
 import type {
   ApiResponse,
   FetchApiOptions,
@@ -16,7 +15,7 @@ import type { ApiServiceRequest } from "~/services/apiTransport/type"
 export { extractDataFromApiResponseBody, isHttpUrl }
 
 /**
- * Fetch account-site API data after applying account-aware fallback metadata.
+ * Fetch account-site API data.
  * @param request Account-site request DTO.
  * @param options Fetch options.
  * @returns Extracted response data.
@@ -25,16 +24,11 @@ export async function fetchApiData<T>(
   request: ApiServiceRequest,
   options: FetchApiOptions,
 ): Promise<T> {
-  return await transportFetchApiData(
-    await resolveLegacyAccountAwareRequest(request, {
-      endpoint: options.endpoint,
-    }),
-    options,
-  )
+  return await transportFetchApiData(request, options)
 }
 
 /**
- * Fetch account-site API responses after applying account-aware fallback metadata.
+ * Fetch account-site API responses.
  * @param request Account-site request DTO.
  * @param options Fetch options.
  * @param _normalResponseType Whether to unwrap normal response envelopes.
@@ -55,13 +49,7 @@ export async function fetchApi<T>(
   options: FetchApiOptions,
   _normalResponseType?: boolean,
 ): Promise<T | ApiResponse<T>> {
-  return await transportFetchApi(
-    await resolveLegacyAccountAwareRequest(request, {
-      endpoint: options.endpoint,
-    }),
-    options,
-    _normalResponseType as true,
-  )
+  return await transportFetchApi(request, options, _normalResponseType as true)
 }
 
 /**

--- a/src/services/checkin/autoCheckin/providers/anyrouter.ts
+++ b/src/services/checkin/autoCheckin/providers/anyrouter.ts
@@ -13,11 +13,17 @@ import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
 import type { AutoCheckinProvider } from "./index"
 
 export type AnyrouterCheckInParams = {
+  id?: string
   site_url: string
+  cookieAuthSessionCookie?: string
   account_info: {
     id: number
   }
 }
+
+const isSiteAccount = (
+  account: SiteAccount | AnyrouterCheckInParams,
+): account is SiteAccount => "site_type" in account
 
 /**
  * AnyRouter returns an empty message string when the user has already checked in.
@@ -36,6 +42,9 @@ const checkinAnyRouter = async (
   account: SiteAccount | AnyrouterCheckInParams,
 ): Promise<AutoCheckinProviderResult> => {
   const { site_url, account_info } = account
+  const cookieAuthSessionCookie = isSiteAccount(account)
+    ? account.cookieAuth?.sessionCookie
+    : account.cookieAuthSessionCookie
 
   try {
     const response = await fetchApi<{
@@ -46,6 +55,8 @@ const checkinAnyRouter = async (
     }>(
       {
         baseUrl: site_url,
+        ...(account.id ? { accountId: account.id } : {}),
+        ...(cookieAuthSessionCookie ? { cookieAuthSessionCookie } : {}),
         auth: {
           authType: AuthTypeEnum.Cookie,
           userId: account_info.id,

--- a/src/services/checkin/autoCheckin/providers/newApi.ts
+++ b/src/services/checkin/autoCheckin/providers/newApi.ts
@@ -264,6 +264,8 @@ async function fetchCheckedInTodayStatus(
     const checkInData = await fetchApiData<CheckInStatus>(
       {
         baseUrl: account.site_url,
+        accountId: account.id,
+        cookieAuthSessionCookie: account.cookieAuth?.sessionCookie,
         auth: {
           authType: getEffectiveAuthType(account),
           userId: account.account_info.id,
@@ -773,6 +775,8 @@ async function performCheckin(
   return await fetchApi<CheckinRecord>(
     {
       baseUrl: site_url,
+      accountId: account.id,
+      cookieAuthSessionCookie: account.cookieAuth?.sessionCookie,
       auth: {
         authType: getEffectiveAuthType(account),
         userId: account_info.id,

--- a/src/services/checkin/autoCheckin/providers/veloera.ts
+++ b/src/services/checkin/autoCheckin/providers/veloera.ts
@@ -36,6 +36,8 @@ async function checkinVeloera(account: SiteAccount): Promise<CheckinResult> {
     const response = await fetchApi<unknown>(
       {
         baseUrl: site_url,
+        accountId: account.id,
+        cookieAuthSessionCookie: account.cookieAuth?.sessionCookie,
         auth: {
           authType,
           userId: account_info.id,

--- a/src/services/checkin/autoCheckin/providers/wong.ts
+++ b/src/services/checkin/autoCheckin/providers/wong.ts
@@ -46,6 +46,8 @@ async function performCheckin(
   return await fetchApi<WongCheckinStatusData | undefined>(
     {
       baseUrl: site_url,
+      accountId: account.id,
+      cookieAuthSessionCookie: account.cookieAuth?.sessionCookie,
       auth: {
         authType: getEffectiveAuthType(account),
         userId: account_info.id,

--- a/src/services/history/usageHistory/sync.ts
+++ b/src/services/history/usageHistory/sync.ts
@@ -1,15 +1,15 @@
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
 import { REQUEST_CONFIG } from "~/services/apiService/common/constant"
 import { ApiError } from "~/services/apiService/common/errors"
 import {
   LogType,
-  type ApiServiceRequest,
   type LogItem,
   type LogResponseData,
 } from "~/services/apiService/common/type"
 import { fetchApiData } from "~/services/apiService/common/utils"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { userPreferences } from "~/services/preferences/userPreferences"
-import type { SiteAccount } from "~/types"
 import {
   DEFAULT_USAGE_HISTORY_PREFERENCES,
   USAGE_HISTORY_SCHEDULE_MODE,
@@ -48,22 +48,6 @@ function getUsageHistoryPreferences(
   preferences: Awaited<ReturnType<typeof userPreferences.getPreferences>>,
 ): UsageHistoryPreferences {
   return preferences.usageHistory ?? DEFAULT_USAGE_HISTORY_PREFERENCES
-}
-
-/**
- * Build an ApiServiceRequest DTO from a stored account record.
- */
-function buildApiRequestForAccount(account: SiteAccount): ApiServiceRequest {
-  return {
-    baseUrl: account.site_url,
-    accountId: account.id,
-    auth: {
-      authType: account.authType,
-      userId: account.account_info.id,
-      accessToken: account.account_info.access_token,
-      cookie: account.cookieAuth?.sessionCookie,
-    },
-  }
 }
 
 /**
@@ -208,7 +192,7 @@ export async function syncUsageHistoryForAccount(params: {
     }
   }
 
-  const apiRequest = buildApiRequestForAccount(account)
+  const apiRequest = createAccountApiRequestFromStoredAccount(account).request
   // Defensive: preferences may be corrupted or come from untyped sources; avoid NaN propagation.
   const retentionDaysRaw = Number(config.retentionDays)
   const retentionDays = Number.isFinite(retentionDaysRaw)

--- a/src/services/redemption/redeemService.ts
+++ b/src/services/redemption/redeemService.ts
@@ -1,5 +1,6 @@
 import { UI_CONSTANTS } from "~/constants/ui"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import type { DisplaySiteData } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
@@ -53,16 +54,7 @@ class RedeemService {
       }
 
       const creditedAmount = await redemption.redeem({
-        request: {
-          baseUrl: account.site_url,
-          accountId,
-          auth: {
-            authType: account.authType,
-            userId: account.account_info.id,
-            accessToken: account.account_info.access_token,
-            cookie: account.cookieAuth?.sessionCookie,
-          },
-        },
+        request: createAccountApiRequestFromStoredAccount(account).request,
         code,
       })
 

--- a/src/services/siteAnnouncements/scheduler.ts
+++ b/src/services/siteAnnouncements/scheduler.ts
@@ -1,6 +1,6 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import { accountStorage } from "~/services/accounts/accountStorage"
-import type { ApiServiceRequest } from "~/services/apiService/common/type"
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { SiteAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import { createRuntimeMessageFailure } from "~/services/runtimeMessaging/result"
@@ -59,24 +59,6 @@ function clampIntervalMinutes(value: unknown): number {
 }
 
 /**
- * Builds the API request object from a stored account record.
- */
-function createApiRequestFromAccount(account: SiteAccount): ApiServiceRequest {
-  return {
-    baseUrl: account.site_url,
-    accountId: account.id,
-    auth: {
-      authType: account.authType,
-      userId: account.account_info?.id,
-      accessToken: account.account_info?.access_token,
-      cookie: account.cookieAuth?.sessionCookie,
-      refreshToken: account.sub2apiAuth?.refreshToken,
-      tokenExpiresAt: account.sub2apiAuth?.tokenExpiresAt,
-    },
-  }
-}
-
-/**
  * Creates the provider request context for a specific account.
  */
 function createProviderRequest(
@@ -89,7 +71,7 @@ function createProviderRequest(
     siteType: account.site_type,
     baseUrl: account.site_url,
     providerId: provider.id,
-    apiRequest: createApiRequestFromAccount(account),
+    apiRequest: createAccountApiRequestFromStoredAccount(account).request,
   }
 }
 

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -179,6 +179,74 @@ describe("ensureAccountKeysForAvailableGroups", () => {
     )
   })
 
+  it("uses stored account context for group coverage token APIs and adapter lookup", async () => {
+    const account = buildSiteAccount({
+      id: "stored-account-id",
+      site_url: "https://stored.example.invalid",
+      site_type: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.Cookie,
+      cookieAuth: { sessionCookie: "stored-session-cookie" },
+      account_info: {
+        id: "stored-user-id",
+        access_token: "stored-access-token",
+        username: "stored-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const displaySiteData = buildDisplaySiteData({
+      id: "display-account-id",
+      baseUrl: "https://display.example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+      authType: AuthTypeEnum.Cookie,
+      userId: "display-user-id",
+      token: "display-access-token",
+      cookieAuthSessionCookie: "display-session-cookie",
+    })
+
+    mocks.fetchAccountTokens.mockResolvedValueOnce([])
+    mocks.fetchUserGroups.mockResolvedValueOnce({
+      default: { desc: "Default", ratio: 1 },
+    })
+    mocks.createApiToken.mockResolvedValueOnce({ id: 1, key: "sk-created" })
+    mocks.classifyCreatedToken.mockReturnValueOnce({
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+      token: { id: 1, key: "sk-created" },
+      oneTimeSecret: false,
+    })
+
+    await ensureAccountKeysForAvailableGroups({
+      account,
+      displaySiteData,
+      accountName: "Stored Account",
+      siteUrlOrigin: "https://stored.example.invalid",
+    })
+
+    const expectedStoredRequest = {
+      baseUrl: "https://stored.example.invalid",
+      accountId: "stored-account-id",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "stored-user-id",
+        accessToken: "stored-access-token",
+        cookie: "stored-session-cookie",
+      },
+    }
+
+    const { getSiteAdapter } = await import("~/services/apiAdapters/registry")
+    expect(getSiteAdapter).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(mocks.fetchAccountTokens).toHaveBeenCalledWith(expectedStoredRequest)
+    expect(mocks.fetchUserGroups).toHaveBeenCalledWith(expectedStoredRequest)
+    expect(mocks.createApiToken).toHaveBeenCalledWith(
+      expectedStoredRequest,
+      expect.any(Object),
+    )
+  })
+
   it("renames only auto-template token names to match their current group", async () => {
     mocks.fetchAccountTokens.mockResolvedValue([
       buildApiToken({

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -300,14 +300,23 @@ describe("accountKeyRepair", () => {
         cookieAuthSessionCookie: "",
       }),
     ])
-    mocks.ensureAccountKeysForAvailableGroups.mockResolvedValueOnce({
-      created: true,
-      availableGroups: [],
-      coveredGroups: [],
-      createdGroups: [""],
-      missingGroups: [],
-      invalidTokens: [],
-    })
+    mocks.ensureAccountKeysForAvailableGroups
+      .mockResolvedValueOnce({
+        created: true,
+        availableGroups: [],
+        coveredGroups: [],
+        createdGroups: [""],
+        missingGroups: [],
+        invalidTokens: [],
+      })
+      .mockResolvedValueOnce({
+        created: true,
+        availableGroups: [],
+        coveredGroups: [],
+        createdGroups: [""],
+        missingGroups: [],
+        invalidTokens: [],
+      })
     mocks.sendRuntimeMessage.mockResolvedValue(undefined)
 
     const { accountKeyRepairRunner } = await import(
@@ -333,13 +342,13 @@ describe("accountKeyRepair", () => {
       processedEligibleAccounts: 2,
     })
     expect(progress.summary).toEqual({
-      created: 1,
+      created: 2,
       alreadyHad: 0,
       skipped: 2,
-      failed: 1,
+      failed: 0,
       availableGroups: 0,
       coveredGroups: 0,
-      createdKeys: 1,
+      createdKeys: 2,
       renamedKeys: 0,
       renameFailed: 0,
       invalidKeys: 0,
@@ -367,13 +376,12 @@ describe("accountKeyRepair", () => {
         }),
         expect.objectContaining({
           accountId: "bad-cookie-1",
-          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Failed,
-          errorMessage: ACCOUNT_KEY_REPAIR_ERRORS.InvalidDisplaySiteData,
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
           siteUrlOrigin: "https://cookie.example.com",
         }),
       ]),
     )
-    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(1)
+    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(2)
     expect(mocks.sendRuntimeMessage).toHaveBeenCalledWith(
       {
         type: RuntimeMessageTypes.AccountKeyRepairProgress,

--- a/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
+++ b/tests/services/accountOperations.autoProvisionKeyOnAccountAdd.test.ts
@@ -252,13 +252,14 @@ describe("accountOperations auto-provision key on add", () => {
     expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledTimes(1)
     expect(toastSuccessMock).toHaveBeenCalledTimes(1)
     expect(toastCustomMock).not.toHaveBeenCalled()
-    expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        displaySiteData: expect.objectContaining({
-          name: "Test Site · tester-2",
+    expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledWith({
+      account: expect.objectContaining({
+        site_name: "Test Site",
+        account_info: expect.objectContaining({
+          username: "tester-2",
         }),
       }),
-    )
+    })
   })
 
   it("defaults to disabling auto-provision when preferences read fails", async () => {
@@ -409,9 +410,7 @@ describe("accountOperations auto-provision key on add", () => {
     expect(toastErrorMock).toHaveBeenCalledTimes(1)
   })
 
-  it("shows failure feedback when saved account display data is invalid for auto-provision", async () => {
-    // Intentionally omit required DisplaySiteData fields to exercise the
-    // defensive validation branch used when storage returns malformed data.
+  it("does not require saved display request fields for background auto-provision", async () => {
     const invalidDisplaySiteData: Partial<DisplaySiteData> = {
       id: "invalid-display-account",
       name: "Invalid Display",
@@ -446,8 +445,19 @@ describe("accountOperations auto-provision key on add", () => {
     await flushPromises()
     await flushPromises()
 
-    expect(ensureDefaultApiTokenForAccountMock).not.toHaveBeenCalled()
-    expect(toastSuccessMock).not.toHaveBeenCalled()
-    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+    expect(ensureDefaultApiTokenForAccountMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({
+          id: expect.any(String),
+          site_url: "https://api.example.com",
+          account_info: expect.objectContaining({
+            id: "1",
+            access_token: "test-token",
+          }),
+        }),
+      }),
+    )
+    expect(toastSuccessMock).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/accountOperations.ensureAccountApiToken.test.ts
+++ b/tests/services/accountOperations.ensureAccountApiToken.test.ts
@@ -247,7 +247,6 @@ describe("accountOperations Sub2API token creation guards", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: SITE_ACCOUNT,
-        displaySiteData: DISPLAY_ACCOUNT,
       }),
     ).rejects.toThrow("messages:tokenProvisioning.createRequiresGroup")
 
@@ -274,7 +273,6 @@ describe("accountOperations Sub2API token creation guards", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: SITE_ACCOUNT,
-        displaySiteData: DISPLAY_ACCOUNT,
       }),
     ).rejects.toThrow("messages:tokenProvisioning.createRequiresGroup")
 
@@ -288,7 +286,6 @@ describe("accountOperations Sub2API token creation guards", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: SITE_ACCOUNT,
-        displaySiteData: DISPLAY_ACCOUNT,
       }),
     ).resolves.toEqual({ token, created: false })
 
@@ -716,7 +713,6 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: siteAccount as any,
-        displaySiteData: displayAccount as any,
       }),
     ).resolves.toEqual({ token: createdToken, created: true })
 
@@ -732,16 +728,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     )
   })
 
-  it("uses display account fields for inventory reads and stored account fields for token creation", async () => {
-    const displayAccount = {
-      id: "display-account-id",
-      siteType: SITE_TYPES.NEW_API,
-      baseUrl: "https://display.example.invalid",
-      authType: AuthTypeEnum.Cookie,
-      userId: "display-user-id",
-      token: "display-access-token",
-      cookieAuthSessionCookie: "display-session-cookie",
-    }
+  it("uses stored account fields for inventory reads and token creation", async () => {
     const siteAccount = buildSiteAccount({
       id: "stored-account-id",
       site_type: SITE_TYPES.NEW_API,
@@ -770,41 +757,31 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: siteAccount,
-        displaySiteData: displayAccount as any,
       }),
     ).resolves.toEqual({ token: createdToken, created: true })
 
-    const expectedDisplayRequest = {
-      baseUrl: "https://display.example.invalid",
-      accountId: "display-account-id",
+    const expectedStoredRequest = {
+      baseUrl: "https://stored.example.invalid",
+      accountId: "stored-account-id",
       auth: {
         authType: AuthTypeEnum.Cookie,
-        userId: "display-user-id",
-        accessToken: "display-access-token",
-        cookie: "display-session-cookie",
+        userId: "stored-user-id",
+        accessToken: "stored-access-token",
+        cookie: "stored-session-cookie",
       },
     }
 
     expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
     expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
       1,
-      expectedDisplayRequest,
+      expectedStoredRequest,
     )
     expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
       2,
-      expectedDisplayRequest,
+      expectedStoredRequest,
     )
     expect(createApiTokenMock).toHaveBeenCalledWith(
-      {
-        baseUrl: "https://stored.example.invalid",
-        accountId: "stored-account-id",
-        auth: {
-          authType: AuthTypeEnum.Cookie,
-          userId: "stored-user-id",
-          accessToken: "stored-access-token",
-          cookie: "stored-session-cookie",
-        },
-      },
+      expectedStoredRequest,
       expect.objectContaining({
         name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
         group: "",
@@ -834,7 +811,6 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: siteAccount as any,
-        displaySiteData: displayAccount as any,
       }),
     ).resolves.toEqual({ token: createdToken, created: true })
 
@@ -842,7 +818,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
   })
 
   it("blocks implicit AIHubMix default-token creation because the key must be shown once", async () => {
-    const { displayAccount, siteAccount } = createAIHubMixAccounts()
+    const { siteAccount } = createAIHubMixAccounts()
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
@@ -853,7 +829,6 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: siteAccount as any,
-        displaySiteData: displayAccount as any,
       }),
     ).rejects.toThrow("messages:aihubmix.createRequiresOneTimeKeyDialog")
 
@@ -1067,7 +1042,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
   })
 
   it("blocks background token ensure when created token secret cannot be recovered", async () => {
-    const { displayAccount, siteAccount } = createAIHubMixAccounts()
+    const { siteAccount } = createAIHubMixAccounts()
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
@@ -1085,13 +1060,12 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: siteAccount as any,
-        displaySiteData: displayAccount as any,
       }),
     ).rejects.toThrow("messages:aihubmix.createRequiresOneTimeKeyDialog")
   })
 
   it("preserves the fallback policy reason for unsupported background auto-provision", async () => {
-    const { displayAccount, siteAccount } = createNonSub2ApiAccounts()
+    const { siteAccount } = createNonSub2ApiAccounts()
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenCreationMock.mockReturnValueOnce({
@@ -1102,7 +1076,6 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: siteAccount as any,
-        displaySiteData: displayAccount as any,
       }),
     ).rejects.toMatchObject({
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupRequired,
@@ -1110,7 +1083,7 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
   })
 
   it("fails when default token creation reports false", async () => {
-    const { displayAccount, siteAccount } = createNonSub2ApiAccounts()
+    const { siteAccount } = createNonSub2ApiAccounts()
 
     fetchAccountTokensMock.mockResolvedValueOnce([])
     createApiTokenMock.mockResolvedValueOnce(false)
@@ -1118,13 +1091,12 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: siteAccount as any,
-        displaySiteData: displayAccount as any,
       }),
     ).rejects.toThrow(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
   })
 
   it("fails when the token inventory is still empty after a successful create", async () => {
-    const { displayAccount, siteAccount } = createNonSub2ApiAccounts()
+    const { siteAccount } = createNonSub2ApiAccounts()
 
     fetchAccountTokensMock.mockResolvedValueOnce([]).mockResolvedValueOnce([])
     createApiTokenMock.mockResolvedValueOnce(true)
@@ -1132,7 +1104,6 @@ describe("ensureDefaultApiTokenForAccount non-Sub2API branches", () => {
     await expect(
       ensureDefaultApiTokenForAccount({
         account: siteAccount as any,
-        displaySiteData: displayAccount as any,
       }),
     ).rejects.toThrow(TOKEN_PROVISIONING_ERRORS.TokenNotFound)
   })

--- a/tests/services/accountOperations.validateAndSaveAccount.test.ts
+++ b/tests/services/accountOperations.validateAndSaveAccount.test.ts
@@ -1069,10 +1069,8 @@ describe("accountOperations validateAndSaveAccount", () => {
       expect.objectContaining({
         account: expect.objectContaining({
           site_name: "Example",
-        }),
-        displaySiteData: expect.objectContaining({
-          name: "Example",
-          baseUrl: "https://api.example.com",
+          site_url: "https://api.example.com",
+          site_type: SITE_TYPES.NEW_API,
         }),
       }),
     )

--- a/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
+++ b/tests/services/accountPostSaveWorkflow.ensureAccountToken.test.ts
@@ -9,6 +9,7 @@ import {
   ACCOUNT_POST_SAVE_WORKFLOW_ERROR_CODES,
   ENSURE_ACCOUNT_TOKEN_RESULT_KINDS,
   ensureAccountTokenForPostSaveWorkflow,
+  ensureAccountTokenForPostSaveWorkflowFromStoredAccount,
   inspectAccountTokenInventory,
 } from "~/services/accounts/accountPostSaveWorkflow"
 import {
@@ -265,6 +266,83 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     expect(createApiTokenMock).not.toHaveBeenCalled()
   })
 
+  it("can run post-save automation from the stored account context without display request fields", async () => {
+    const account = buildSiteAccount({
+      id: "stored-account-id",
+      site_name: "Stored Account",
+      site_url: "https://stored.example.invalid",
+      site_type: SITE_TYPES.NEW_API,
+      authType: AuthTypeEnum.Cookie,
+      cookieAuth: { sessionCookie: "stored-session-cookie" },
+      account_info: {
+        id: "stored-user-id",
+        access_token: "stored-access-token",
+        username: "stored-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    const createdToken = buildToken({ id: 88, key: "sk-created" })
+
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    createApiTokenMock.mockResolvedValueOnce(createdToken)
+    classifyCreatedTokenMock.mockReturnValueOnce({
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+      token: createdToken,
+      oneTimeSecret: false,
+    })
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflowFromStoredAccount({
+        account,
+      }),
+    ).resolves.toEqual({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: false,
+    })
+
+    const expectedStoredRequest = {
+      baseUrl: "https://stored.example.invalid",
+      accountId: "stored-account-id",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "stored-user-id",
+        accessToken: "stored-access-token",
+        cookie: "stored-session-cookie",
+      },
+    }
+
+    expect(fetchAccountTokensMock).toHaveBeenCalledWith(expectedStoredRequest)
+    expect(createApiTokenMock).toHaveBeenCalledWith(
+      expectedStoredRequest,
+      expect.objectContaining({ name: DEFAULT_AUTO_PROVISION_TOKEN_NAME }),
+    )
+  })
+
+  it("keeps the post-save display wrapper as a compatibility path", async () => {
+    const displayAccount = buildDisplayAccount()
+    const account = buildStoredAccount(displayAccount)
+    const existingToken = buildToken({ id: 5, key: "sk-ready" })
+    fetchAccountTokensMock.mockResolvedValueOnce([existingToken])
+
+    await expect(
+      ensureAccountTokenForPostSaveWorkflow({
+        account,
+        displaySiteData: displayAccount,
+      }),
+    ).resolves.toMatchObject({
+      kind: ENSURE_ACCOUNT_TOKEN_RESULT_KINDS.Ready,
+      token: existingToken,
+      created: false,
+    })
+  })
+
   it("reports an existing AIHubMix masked inventory token as present but not usable as a secret", async () => {
     const displayAccount = buildDisplayAccount({
       siteType: SITE_TYPES.AIHUBMIX,
@@ -359,7 +437,7 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
   })
 
-  it("uses display account fields for inventory reads and stored account fields for token creation", async () => {
+  it("uses stored account fields for post-save inventory reads and token creation", async () => {
     const displayAccount = buildDisplayAccount({
       id: "display-account-id",
       baseUrl: "https://display.example.invalid",
@@ -406,37 +484,28 @@ describe("ensureAccountTokenForPostSaveWorkflow", () => {
       oneTimeSecret: false,
     })
 
-    const expectedDisplayRequest = {
-      baseUrl: "https://display.example.invalid",
-      accountId: "display-account-id",
+    const expectedStoredRequest = {
+      baseUrl: "https://stored.example.invalid",
+      accountId: "stored-account-id",
       auth: {
         authType: AuthTypeEnum.Cookie,
-        userId: "display-user-id",
-        accessToken: "display-access-token",
-        cookie: "display-session-cookie",
+        userId: "stored-user-id",
+        accessToken: "stored-access-token",
+        cookie: "stored-session-cookie",
       },
     }
 
     expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
     expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
       1,
-      expectedDisplayRequest,
+      expectedStoredRequest,
     )
     expect(fetchAccountTokensMock).toHaveBeenNthCalledWith(
       2,
-      expectedDisplayRequest,
+      expectedStoredRequest,
     )
     expect(createApiTokenMock).toHaveBeenCalledWith(
-      {
-        baseUrl: "https://stored.example.invalid",
-        accountId: "stored-account-id",
-        auth: {
-          authType: AuthTypeEnum.Cookie,
-          userId: "stored-user-id",
-          accessToken: "stored-access-token",
-          cookie: "stored-session-cookie",
-        },
-      },
+      expectedStoredRequest,
       expect.objectContaining({
         name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
         group: "",

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -1657,6 +1657,7 @@ describe("accountStorage core behaviors", () => {
       id: "needs-detect",
       site_url: "https://foo.example.com",
       site_type: "unknown",
+      cookieAuth: { sessionCookie: "stored-session-cookie" },
       checkIn: {} as any,
     })
     seedStorage([account])
@@ -1673,14 +1674,19 @@ describe("accountStorage core behaviors", () => {
     )
     expect(mockGetSiteAdapter).toHaveBeenCalledWith("one-api")
     expect(mockGetSiteAdapter).not.toHaveBeenCalledWith(SITE_TYPES.UNKNOWN)
-    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
-      baseUrl: "https://foo.example.com",
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        userId: "1",
-        accessToken: "token",
-      },
-    })
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://foo.example.com",
+        accountId: "needs-detect",
+        cookieAuthSessionCookie: "stored-session-cookie",
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "token",
+          cookie: "stored-session-cookie",
+        }),
+      }),
+    )
     expect(updatedAccount?.site_type).toBe("one-api")
     expect(updatedAccount?.checkIn?.enableDetection).toBe(true)
   })
@@ -1727,17 +1733,17 @@ describe("accountStorage core behaviors", () => {
       },
     )
 
-    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
-      baseUrl: "https://revive.example.com",
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        userId: "1",
-        accessToken: "token",
-        cookie: undefined,
-        refreshToken: undefined,
-        tokenExpiresAt: undefined,
-      },
-    })
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://revive.example.com",
+        accountId: "disabled-revive",
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "token",
+        }),
+      }),
+    )
     expect(mockRefreshAccountData).toHaveBeenCalledTimes(1)
     expect(result).toEqual(
       expect.objectContaining({
@@ -1837,14 +1843,17 @@ describe("accountStorage core behaviors", () => {
 
     expect(mockGetAccountSiteType).not.toHaveBeenCalled()
     expect(mockGetSiteAdapter).toHaveBeenCalledWith("one-api")
-    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith({
-      baseUrl: "https://bar.example.com",
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        userId: "1",
-        accessToken: "token",
-      },
-    })
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://bar.example.com",
+        accountId: "known-site",
+        auth: expect.objectContaining({
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "token",
+        }),
+      }),
+    )
     const updatedAccount = await accountStorage.getAccountById("known-site")
     expect(updatedAccount?.site_type).toBe("one-api")
     expect(updatedAccount?.checkIn?.enableDetection).toBe(false)

--- a/tests/services/accounts/defaultTokenLifecycle.test.ts
+++ b/tests/services/accounts/defaultTokenLifecycle.test.ts
@@ -2,18 +2,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  buildGroupDefaultTokenRequest,
   createDefaultTokenFromDecision,
   DEFAULT_TOKEN_INVENTORY_STATE_KINDS,
   DEFAULT_TOKEN_LIFECYCLE_BLOCK_REASONS,
   DEFAULT_TOKEN_LIFECYCLE_ERRORS,
   DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS,
   ensureDefaultTokenLifecycle,
+  ensureDefaultTokenLifecycleWithContext,
   generateDefaultTokenRequest,
   inspectDefaultTokenInventory,
+  inspectDefaultTokenInventoryWithContext,
   resolveDefaultTokenLifecycleDecision,
+  resolveDefaultTokenLifecycleDecisionWithContext,
   selectSingleNewApiTokenByIdDiff,
 } from "~/services/accounts/defaultTokenLifecycle"
 import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
+import type { AccountApiContext } from "~/services/accounts/utils/apiServiceRequest"
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
 import type { SiteAdapter } from "~/services/apiAdapters/contracts/siteAdapter"
 import {
@@ -136,6 +141,14 @@ const buildRequest = (): ApiServiceRequest => ({
   },
 })
 
+const buildPreparedContext = (
+  request: ApiServiceRequest = buildRequest(),
+): AccountApiContext => ({
+  accountId: request.accountId ?? "account-id",
+  siteType: SITE_TYPES.NEW_API,
+  request,
+})
+
 const createDecision = (
   tokenData = generateDefaultTokenRequest(),
 ): Extract<
@@ -200,6 +213,28 @@ describe("defaultTokenLifecycle inventory helpers", () => {
       kind: DEFAULT_TOKEN_INVENTORY_STATE_KINDS.Missing,
       existingTokenIds: [],
     })
+  })
+
+  it("inspects inventory from a prepared request context", async () => {
+    const request = buildRequest()
+    const existingToken = buildToken({ id: 12, key: "sk-prepared" })
+    fetchAccountTokensMock.mockResolvedValueOnce([existingToken])
+    isInventoryTokenUsableMock.mockReturnValueOnce(true)
+
+    await expect(
+      inspectDefaultTokenInventoryWithContext({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        context: buildPreparedContext(request),
+      }),
+    ).resolves.toEqual({
+      kind: DEFAULT_TOKEN_INVENTORY_STATE_KINDS.Present,
+      token: existingToken,
+      existingTokenIds: [12],
+      hasUsableSecret: true,
+    })
+
+    expect(getSiteAdapterMock).toHaveBeenCalledWith(SITE_TYPES.NEW_API)
+    expect(fetchAccountTokensMock).toHaveBeenCalledWith(request)
   })
 
   it("reports the latest valid inventory token and policy usability", async () => {
@@ -296,6 +331,53 @@ describe("defaultTokenLifecycle decision and create helpers", () => {
         },
       }),
     )
+  })
+
+  it("resolves creation decisions from a prepared request context", async () => {
+    const resolveDefaultTokenCreationMock = vi
+      .fn()
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+      })
+      .mockReturnValueOnce({
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+        tokenData: buildGroupDefaultTokenRequest("vip"),
+        oneTimeSecret: false,
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+      })
+    const fetchUserGroupsMock = vi.fn().mockResolvedValueOnce({
+      vip: { desc: "VIP", ratio: 2 },
+    })
+
+    getSiteAdapterMock.mockReturnValueOnce({
+      keyManagement: {
+        fetchTokens: vi.fn(),
+        createToken: vi.fn(),
+        updateToken: vi.fn(),
+        resolveTokenKey: vi.fn(),
+        deleteToken: vi.fn(),
+        fetchAvailableModels: vi.fn(),
+        userGroups: { fetch: fetchUserGroupsMock },
+      },
+      tokenProvisioning: {
+        isInventoryTokenUsable: vi.fn(),
+        resolveDefaultTokenCreation: resolveDefaultTokenCreationMock,
+        classifyCreatedToken: vi.fn(),
+        getRepairPolicy: vi.fn(),
+      },
+    })
+
+    await expect(
+      resolveDefaultTokenLifecycleDecisionWithContext({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        context: buildPreparedContext(),
+      }),
+    ).resolves.toMatchObject({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+      tokenData: expect.objectContaining({ group: "vip" }),
+    })
+
+    expect(fetchUserGroupsMock).toHaveBeenCalledWith(buildRequest())
   })
 
   it("throws the provided missing-user-groups message when group lookup is unavailable", async () => {
@@ -506,6 +588,68 @@ describe("ensureDefaultTokenLifecycle", () => {
       created: false,
       existingTokenIds: [5],
     })
+  })
+
+  it("uses the prepared stored request for both inventory and token creation", async () => {
+    const request = {
+      baseUrl: "https://stored.example.invalid",
+      accountId: "stored-account-id",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "stored-user-id",
+        accessToken: "stored-access-token",
+        cookie: "stored-session-cookie",
+      },
+    }
+    const createdToken = buildToken({ id: 17, key: "sk-created" })
+    const createTokenMock = vi.fn().mockResolvedValueOnce(createdToken)
+    const resolveDefaultTokenCreationMock = vi.fn(() => ({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+      tokenData: generateDefaultTokenRequest(),
+      oneTimeSecret: false,
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.CreatedResponseFirst,
+    }))
+
+    fetchAccountTokensMock.mockResolvedValueOnce([])
+    getSiteAdapterMock.mockReturnValueOnce({
+      keyManagement: {
+        fetchTokens: (...args: unknown[]) => fetchAccountTokensMock(...args),
+        createToken: createTokenMock,
+        updateToken: vi.fn(),
+        resolveTokenKey: vi.fn(),
+        deleteToken: vi.fn(),
+        fetchAvailableModels: vi.fn(),
+      },
+      tokenProvisioning: {
+        isInventoryTokenUsable: vi.fn(),
+        resolveDefaultTokenCreation: resolveDefaultTokenCreationMock,
+        classifyCreatedToken: vi.fn(() => ({
+          kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Usable,
+          token: createdToken,
+          oneTimeSecret: false,
+        })),
+        getRepairPolicy: vi.fn(),
+      },
+    })
+
+    await expect(
+      ensureDefaultTokenLifecycleWithContext({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.PostSaveAutomation,
+        context: buildPreparedContext(request),
+      }),
+    ).resolves.toEqual({
+      kind: DEFAULT_TOKEN_LIFECYCLE_RESULT_KINDS.Created,
+      token: createdToken,
+      created: true,
+      oneTimeSecret: false,
+      existingTokenIds: [],
+    })
+
+    expect(fetchAccountTokensMock).toHaveBeenCalledWith(request)
+    expect(createTokenMock).toHaveBeenCalledWith(
+      request,
+      generateDefaultTokenRequest(),
+    )
   })
 
   it("continues to policy creation when the existing inventory token is unusable", async () => {

--- a/tests/services/apiService/anyrouter.index.test.ts
+++ b/tests/services/apiService/anyrouter.index.test.ts
@@ -110,6 +110,28 @@ describe("AnyRouter API service", () => {
 
     expect(mockCheckIn).toHaveBeenCalledWith({
       site_url: "https://anyrouter.example.com",
+      id: undefined,
+      account_info: { id: 42 },
+    })
+  })
+
+  it("passes request account identity to the AnyRouter check-in provider", async () => {
+    mockCheckIn.mockResolvedValueOnce({
+      status: CHECKIN_RESULT_STATUS.SUCCESS,
+    })
+
+    await expect(
+      fetchCheckInStatus({
+        ...baseRequest,
+        accountId: "stored-account-id",
+        cookieAuthSessionCookie: "stored-session-cookie",
+      }),
+    ).resolves.toBe(true)
+
+    expect(mockCheckIn).toHaveBeenCalledWith({
+      site_url: "https://anyrouter.example.com",
+      id: "stored-account-id",
+      cookieAuthSessionCookie: "stored-session-cookie",
       account_info: { id: 42 },
     })
   })
@@ -128,10 +150,12 @@ describe("AnyRouter API service", () => {
 
     expect(mockCheckIn).toHaveBeenNthCalledWith(1, {
       site_url: "https://anyrouter.example.com",
+      id: undefined,
       account_info: { id: 42 },
     })
     expect(mockCheckIn).toHaveBeenNthCalledWith(2, {
       site_url: "https://anyrouter.example.com",
+      id: undefined,
       account_info: { id: 42 },
     })
   })

--- a/tests/services/apiService/common/utils.test.ts
+++ b/tests/services/apiService/common/utils.test.ts
@@ -15,10 +15,6 @@ const { mockFetchApi, mockFetchApiData } = vi.hoisted(() => ({
   mockFetchApiData: vi.fn(),
 }))
 
-const { mockResolveLegacyAccountAwareRequest } = vi.hoisted(() => ({
-  mockResolveLegacyAccountAwareRequest: vi.fn(),
-}))
-
 vi.mock("~/services/apiTransport/request", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("~/services/apiTransport/request")>()
@@ -29,57 +25,18 @@ vi.mock("~/services/apiTransport/request", async (importOriginal) => {
   }
 })
 
-vi.mock("~/services/accounts/utils/legacyAccountAwareRequest", () => ({
-  resolveLegacyAccountAwareRequest: mockResolveLegacyAccountAwareRequest,
-}))
-
 describe("API Service Common Utils", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockResolveLegacyAccountAwareRequest.mockReset()
-    mockResolveLegacyAccountAwareRequest.mockImplementation(
-      async (request) => request,
-    )
   })
 
   describe("fetchApiData", () => {
-    it("delegates account-aware compatibility resolution before transport", async () => {
+    it("passes requests directly to transport without account-aware lookup", async () => {
       const request = {
-        baseUrl: "https://example.com",
+        baseUrl: "https://example.invalid",
         auth: {
-          authType: AuthTypeEnum.Cookie,
-          userId: "123",
-        },
-      }
-      const enrichedRequest = {
-        ...request,
-        accountId: "account-1",
-        cookieAuthSessionCookie: "session=stored",
-      }
-      mockResolveLegacyAccountAwareRequest.mockResolvedValueOnce(
-        enrichedRequest,
-      )
-      mockFetchApiData.mockResolvedValueOnce({ ok: true })
-
-      await expect(
-        fetchApiData(request, { endpoint: "/api/test" }),
-      ).resolves.toEqual({ ok: true })
-
-      expect(mockResolveLegacyAccountAwareRequest).toHaveBeenCalledWith(
-        request,
-        { endpoint: "/api/test" },
-      )
-      expect(mockFetchApiData).toHaveBeenCalledWith(enrichedRequest, {
-        endpoint: "/api/test",
-      })
-    })
-
-    it("passes through the original request when compatibility resolution is a no-op", async () => {
-      const request = {
-        baseUrl: "https://example.com",
-        accountId: "account-1",
-        auth: {
-          authType: AuthTypeEnum.Cookie,
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "token",
           userId: "123",
         },
       }
@@ -90,46 +47,29 @@ describe("API Service Common Utils", () => {
         ok: true,
       })
 
-      expect(mockResolveLegacyAccountAwareRequest).toHaveBeenCalledWith(
-        request,
-        options,
-      )
       expect(mockFetchApiData).toHaveBeenCalledWith(request, options)
     })
   })
 
   describe("fetchApi", () => {
-    it("delegates account-aware compatibility resolution before transport", async () => {
+    it("passes response requests directly to transport without account-aware lookup", async () => {
       const request = {
-        baseUrl: "https://example.com",
+        baseUrl: "https://example.invalid",
         auth: {
-          authType: AuthTypeEnum.Cookie,
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "token",
           userId: "123",
         },
       }
-      const enrichedRequest = {
-        ...request,
-        accountId: "account-1",
-        cookieAuthSessionCookie: "session=stored",
-      }
-      mockResolveLegacyAccountAwareRequest.mockResolvedValueOnce(
-        enrichedRequest,
-      )
-      mockFetchApi.mockResolvedValueOnce({ ok: true })
+      const options = { endpoint: "/api/test" }
+      mockFetchApi.mockResolvedValueOnce({ success: true, data: { ok: true } })
 
-      await expect(
-        fetchApi(request, { endpoint: "/api/test" }, true),
-      ).resolves.toEqual({ ok: true })
+      await expect(fetchApi(request, options, true)).resolves.toEqual({
+        success: true,
+        data: { ok: true },
+      })
 
-      expect(mockResolveLegacyAccountAwareRequest).toHaveBeenCalledWith(
-        request,
-        { endpoint: "/api/test" },
-      )
-      expect(mockFetchApi).toHaveBeenCalledWith(
-        enrichedRequest,
-        { endpoint: "/api/test" },
-        true,
-      )
+      expect(mockFetchApi).toHaveBeenCalledWith(request, options, true)
     })
   })
 

--- a/tests/services/autoCheckin/providers/anyrouter.test.ts
+++ b/tests/services/autoCheckin/providers/anyrouter.test.ts
@@ -74,6 +74,9 @@ describe("anyrouterProvider", () => {
 
       const result = await anyrouterProvider.checkIn(mockAccount)
       expect(result.status).toBe("success")
+      expect(mockedFetchApi.mock.calls[0]?.[0]).toMatchObject({
+        accountId: "test-id",
+      })
     })
 
     it("returns success for English success messages", async () => {

--- a/tests/services/autoCheckin/providers/anyrouter.test.ts
+++ b/tests/services/autoCheckin/providers/anyrouter.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
-import { anyrouterProvider } from "~/services/checkin/autoCheckin/providers/anyrouter"
+import {
+  anyrouterProvider,
+  type AnyrouterCheckInParams,
+} from "~/services/checkin/autoCheckin/providers/anyrouter"
 import { AuthTypeEnum, SiteHealthStatus, type SiteAccount } from "~/types"
 
 vi.mock("~/services/apiService/common/utils", () => ({
@@ -76,6 +79,43 @@ describe("anyrouterProvider", () => {
       expect(result.status).toBe("success")
       expect(mockedFetchApi.mock.calls[0]?.[0]).toMatchObject({
         accountId: "test-id",
+      })
+    })
+
+    it("passes lightweight AnyRouter account context to fetchApi", async () => {
+      const { fetchApi } = await import("~/services/apiService/common/utils")
+      const mockedFetchApi = vi.mocked(
+        fetchApi as unknown as (...args: any[]) => Promise<any>,
+      )
+      mockedFetchApi.mockResolvedValueOnce({
+        code: 1,
+        ret: 1,
+        success: true,
+        message: "Success",
+      })
+
+      const account: AnyrouterCheckInParams = {
+        id: "stored-account-id",
+        site_url: "https://anyrouter.top",
+        cookieAuthSessionCookie: "session=stored-cookie",
+        account_info: {
+          id: 12345,
+        },
+      }
+
+      const result = await anyrouterProvider.checkIn(account)
+
+      const latestRequest =
+        mockedFetchApi.mock.calls[mockedFetchApi.mock.calls.length - 1]?.[0]
+      expect(result.status).toBe("success")
+      expect(latestRequest).toMatchObject({
+        baseUrl: "https://anyrouter.top",
+        accountId: "stored-account-id",
+        cookieAuthSessionCookie: "session=stored-cookie",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+          userId: 12345,
+        },
       })
     })
 

--- a/tests/services/autoCheckin/providers/newApi.test.ts
+++ b/tests/services/autoCheckin/providers/newApi.test.ts
@@ -165,6 +165,12 @@ describe("newApiProvider", () => {
           reason: "clicked",
         }),
       })
+      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+        accountId: "test-id",
+      })
+      expect(vi.mocked(fetchApiData).mock.calls[0]?.[0]).toMatchObject({
+        accountId: "test-id",
+      })
       expect(tempWindowTriggerCheckinPageAction).toHaveBeenCalledWith(
         expect.objectContaining({
           originUrl: "https://test.com",

--- a/tests/services/autoCheckin/providers/veloera.test.ts
+++ b/tests/services/autoCheckin/providers/veloera.test.ts
@@ -90,6 +90,9 @@ describe("veloeraProvider", () => {
         messageKey: "autoCheckin:providerFallback.checkinSuccessful",
         data: { quota_awarded: 2 },
       })
+      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+        accountId: "test-id",
+      })
     })
 
     it("returns success on successful check-in", async () => {

--- a/tests/services/autoCheckin/providers/wong.test.ts
+++ b/tests/services/autoCheckin/providers/wong.test.ts
@@ -93,6 +93,9 @@ describe("wongGongyiProvider", () => {
 
       const result = await wongGongyiProvider.checkIn(mockAccount)
       expect(result.status).toBe("already_checked")
+      expect(mockedFetchApi.mock.calls[0]?.[0]).toMatchObject({
+        accountId: "test-id",
+      })
       expect(result.messageKey).toBe(
         "autoCheckin:providerFallback.alreadyCheckedToday",
       )

--- a/tests/services/siteAnnouncements/scheduler.test.ts
+++ b/tests/services/siteAnnouncements/scheduler.test.ts
@@ -614,6 +614,57 @@ describe("siteAnnouncementScheduler", () => {
     }
   })
 
+  it("uses the stored-account API context for provider requests", async () => {
+    providerFetchMock.mockResolvedValue({
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Sub2Api,
+      siteKey: "sub2api:sub-1:https://sub.example.com",
+      status: "success",
+      announcements: [],
+    })
+    const account = createAccount({
+      id: "sub-1",
+      site_type: "sub2api",
+      site_url: "https://sub.example.com",
+      authType: AuthTypeEnum.Cookie,
+      account_info: {
+        id: "stored-user",
+        access_token: "stored-access-token",
+        username: "stored-user",
+        quota: 0,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+      cookieAuth: { sessionCookie: "stored-session-cookie" },
+      sub2apiAuth: {
+        refreshToken: "stored-refresh-token",
+        tokenExpiresAt: 123456,
+      },
+    })
+    getEnabledAccountsMock.mockResolvedValue([account])
+
+    const response = await resolveSiteAnnouncementsCheckNowMessage({})
+
+    expect(response).toMatchObject({ success: true })
+    expect(providerFetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiRequest: expect.objectContaining({
+          baseUrl: "https://sub.example.com",
+          accountId: "sub-1",
+          auth: expect.objectContaining({
+            authType: AuthTypeEnum.Cookie,
+            userId: "stored-user",
+            accessToken: "stored-access-token",
+            cookie: "stored-session-cookie",
+          }),
+          sub2apiAuthSession: expect.any(Object),
+        }),
+      }),
+    )
+  })
+
   it("dedupes common site checks but keeps Sub2API account-scoped checks", async () => {
     providerFetchMock.mockImplementation((request) =>
       Promise.resolve({

--- a/tests/services/siteAnnouncements/scheduler.test.ts
+++ b/tests/services/siteAnnouncements/scheduler.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Storage } from "@plasmohq/storage"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import { SiteAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import {
@@ -623,7 +624,7 @@ describe("siteAnnouncementScheduler", () => {
     })
     const account = createAccount({
       id: "sub-1",
-      site_type: "sub2api",
+      site_type: SITE_TYPES.SUB2API,
       site_url: "https://sub.example.com",
       authType: AuthTypeEnum.Cookie,
       account_info: {
@@ -644,6 +645,9 @@ describe("siteAnnouncementScheduler", () => {
       },
     })
     getEnabledAccountsMock.mockResolvedValue([account])
+    getAccountByIdMock.mockImplementation(async (id: string) =>
+      id === account.id ? account : null,
+    )
 
     const response = await resolveSiteAnnouncementsCheckNowMessage({})
 
@@ -661,6 +665,19 @@ describe("siteAnnouncementScheduler", () => {
           }),
           sub2apiAuthSession: expect.any(Object),
         }),
+      }),
+    )
+    const providerRequest = providerFetchMock.mock.calls[0]?.[0]
+    await expect(
+      providerRequest.apiRequest.sub2apiAuthSession.getLatestAuth("sub-1"),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        accessToken: "stored-access-token",
+        userId: "stored-user",
+        sub2apiAuth: {
+          refreshToken: "stored-refresh-token",
+          tokenExpiresAt: 123456,
+        },
       }),
     )
   })
@@ -682,12 +699,12 @@ describe("siteAnnouncementScheduler", () => {
       createAccount({ id: "common-2" }),
       createAccount({
         id: "sub-1",
-        site_type: "sub2api",
+        site_type: SITE_TYPES.SUB2API,
         site_url: "https://sub.example.com",
       }),
       createAccount({
         id: "sub-2",
-        site_type: "sub2api",
+        site_type: SITE_TYPES.SUB2API,
         site_url: "https://sub.example.com",
       }),
     ])
@@ -842,7 +859,7 @@ describe("siteAnnouncementScheduler", () => {
     })
     const account = createAccount({
       id: "sub-1",
-      site_type: "sub2api",
+      site_type: SITE_TYPES.SUB2API,
       site_url: "https://sub.example.com",
     })
     getEnabledAccountsMock.mockResolvedValue([account])


### PR DESCRIPTION
## Summary

- replace implicit legacy account-aware fetch fallback with explicit account API request context propagation
- route account-owned workflows through stored/display account request builders
- preserve account id, cookie auth session, Sub2API auth session, fetch context, and abort signals across token lifecycle, auto-checkin, refresh, redemption, usage history, and site announcements
- add focused coverage for migrated account and provider paths

## Validation

- pnpm run validate:staged
- pnpm run validate:push
- pnpm e2e:real-site
- sub-agent review: Lagrange, Kuhn, and resumed Ampere reported no findings for actual functional impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account-related background and automation flows now consistently use stored account request context for token provisioning, repairs/group coverage, post-save automation, check-ins, redemption, usage sync, and site announcements.
  * Check-in/refresh API requests now include stronger account identifiers and session-cookie details when available.
* **Bug Fixes**
  * Improved reliability of token auto-provisioning and repair by removing dependence on incomplete display details.
  * Reduced chance of mismatched API requests caused by missing/inconsistent account metadata.
* **Documentation**
  * Added/updated a staged migration plan for context propagation across background services.
* **Tests**
  * Updated and extended test coverage for the new context-based request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->