### PR TITLE
refactor(account-session): centralize browser session reads

### DIFF
--- a/docs/superpowers/plans/2026-06-27-account-browser-session-capability.md
+++ b/docs/superpowers/plans/2026-06-27-account-browser-session-capability.md
@@ -771,21 +771,22 @@ type Sub2ApiResyncedToken = {
 const hasUsableAccessToken = (session: AccountBrowserSession): boolean =>
   typeof session.accessToken === "string" && session.accessToken.trim().length > 0
 
+const SUB2API_RESYNC_SOURCE_BY_BROWSER_SESSION_SOURCE = {
+  [ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB]:
+    ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+  [ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB]:
+    ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+  [ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW]:
+    ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+} as const satisfies Record<
+  AccountBrowserSession["source"],
+  Sub2ApiResyncedToken["source"]
+>
+
 const mapResyncSource = (
   source: AccountBrowserSession["source"],
-): Sub2ApiResyncedToken["source"] => {
-  switch (source) {
-    case ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB:
-    case ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB:
-      return ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
-    case ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW:
-      return ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
-    default: {
-      const exhaustive: never = source
-      return exhaustive
-    }
-  }
-}
+): Sub2ApiResyncedToken["source"] =>
+  SUB2API_RESYNC_SOURCE_BY_BROWSER_SESSION_SOURCE[source]
 
 /**
  * Re-sync Sub2API JWT from browser-session state.

--- a/docs/superpowers/plans/2026-06-27-account-browser-session-capability.md
+++ b/docs/superpowers/plans/2026-06-27-account-browser-session-capability.md
@@ -1,0 +1,1548 @@
+# Account Browser Session Capability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize account-site browser-session reads so Sub2API session import, token re-sync, active-tab account matching, and auto-detect current-tab reads consume one normalized Module instead of duplicating runtime-message orchestration.
+
+**Architecture:** Add `src/services/accountBrowserSession/` as the browser-context orchestration seam. It wraps existing `sendTabMessage`, `getAllTabs`, and `sendRuntimeMessage` calls, while keeping page-local `localStorage` extraction inside the existing `ContentSessionExtractor` path. Then migrate callers one by one without changing runtime action names, background handlers, saved account shape, user-facing copy, or existing `SiteAdapter` API capabilities.
+
+**Tech Stack:** TypeScript, WXT browser helpers, Vitest, Testing Library, existing WebExtension fake-browser test setup.
+
+---
+
+## File Structure
+
+- Create `src/services/accountBrowserSession/types.ts`
+  - Owns normalized browser-session result types and input option types.
+- Create `src/services/accountBrowserSession/sessionReader.ts`
+  - Owns tab selection, runtime-message calls, normalization, predicates, and temp-window fallback.
+- Create `src/services/accountBrowserSession/index.ts`
+  - Barrel export for callers.
+- Create `tests/services/accountBrowserSession/sessionReader.test.ts`
+  - Focused TDD coverage for normalization and fallback ordering.
+- Modify `src/services/apiService/sub2api/tokenResync.ts`
+  - Replace duplicated same-origin tab scan/temp-window fallback with the new Module.
+- Modify `tests/services/apiService/sub2api/tokenResync.test.ts`
+  - Preserve public behavior while depending on the new Module shape.
+- Modify `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+  - Replace Sub2API session import tab scan/temp-window fallback with the new Module.
+- Modify `tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx`
+  - Preserve existing UI behavior and reduce direct assertions on browser-message internals where they are now covered by service tests.
+- Modify `src/features/AccountManagement/hooks/AccountDataContext.tsx`
+  - Replace active-tab user verification direct message construction with the new Module.
+- Modify `tests/features/AccountManagement/hooks/AccountDataContext.test.tsx`
+  - Preserve active-tab account matching behavior.
+- Modify `src/services/siteDetection/autoDetectService.ts`
+  - Replace current-tab direct content-session message construction with the new Module while keeping API fallback and analytics behavior.
+- Modify `tests/services/autoDetectService.test.ts`
+  - Preserve current-tab, API fallback, and content-script-unavailable behavior.
+
+---
+
+## Task 1: Add The Account Browser-Session Module
+
+**Files:**
+
+- Create: `src/services/accountBrowserSession/types.ts`
+- Create: `src/services/accountBrowserSession/sessionReader.ts`
+- Create: `src/services/accountBrowserSession/index.ts`
+- Create: `tests/services/accountBrowserSession/sessionReader.test.ts`
+
+- [ ] **Step 1: Write failing tests for tab read normalization and failure handling**
+
+Create `tests/services/accountBrowserSession/sessionReader.test.ts` with these initial tests:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  readAccountBrowserSessionFromTab,
+  readAccountBrowserSessionFromExistingTabs,
+  resolveAccountBrowserSession,
+} from "~/services/accountBrowserSession"
+
+const {
+  mockGetAllTabs,
+  mockGetBrowserApiCapabilities,
+  mockSendRuntimeMessage,
+  mockSendTabMessage,
+} = vi.hoisted(() => ({
+  mockGetAllTabs: vi.fn(),
+  mockGetBrowserApiCapabilities: vi.fn(),
+  mockSendRuntimeMessage: vi.fn(),
+  mockSendTabMessage: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/browserApi", () => ({
+  getAllTabs: mockGetAllTabs,
+  getBrowserApiCapabilities: mockGetBrowserApiCapabilities,
+  sendRuntimeMessage: mockSendRuntimeMessage,
+  sendTabMessage: mockSendTabMessage,
+}))
+
+describe("account browser-session reader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetBrowserApiCapabilities.mockReturnValue({
+      hasWindows: true,
+      hasTabs: true,
+      hasBackgroundMessaging: true,
+    })
+  })
+
+  it("reads and normalizes a successful tab content-session response", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: 42,
+        user: { username: " tab-user " },
+        accessToken: " jwt-from-tab ",
+        siteTypeHint: SITE_TYPES.SUB2API,
+        sub2apiAuth: {
+          refreshToken: " refresh-token ",
+          tokenExpiresAt: 123456,
+        },
+      },
+    })
+
+    const session = await readAccountBrowserSessionFromTab({
+      tabId: 12,
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      source: "current_tab",
+      fetchContext: {
+        kind: "current_tab",
+        tabId: 12,
+        origin: "https://sub2.example.com",
+        incognito: true,
+        cookieStoreId: "firefox-container-1",
+      },
+    })
+
+    expect(session).toEqual({
+      source: "current_tab",
+      siteType: SITE_TYPES.SUB2API,
+      userId: "42",
+      user: { username: " tab-user " },
+      accessToken: "jwt-from-tab",
+      siteTypeHint: SITE_TYPES.SUB2API,
+      sub2apiAuth: {
+        refreshToken: "refresh-token",
+        tokenExpiresAt: 123456,
+      },
+      fetchContext: {
+        kind: "current_tab",
+        tabId: 12,
+        origin: "https://sub2.example.com",
+        incognito: true,
+        cookieStoreId: "firefox-container-1",
+      },
+    })
+    expect(mockSendTabMessage).toHaveBeenCalledWith(12, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+    })
+  })
+
+  it("returns null for failed or unusable tab responses", async () => {
+    mockSendTabMessage
+      .mockResolvedValueOnce({ success: false })
+      .mockResolvedValueOnce({ success: true, data: { userId: "   " } })
+      .mockRejectedValueOnce(new Error("receiver missing"))
+
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 1,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: "current_tab",
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 1,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: "current_tab",
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 1,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: "current_tab",
+      }),
+    ).resolves.toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts
+```
+
+Expected: fail because `~/services/accountBrowserSession` does not exist.
+
+- [ ] **Step 3: Implement the public types**
+
+Create `src/services/accountBrowserSession/types.ts`:
+
+```ts
+import type { AccountSiteType } from "~/constants/siteType"
+import type { Sub2ApiAuthConfig } from "~/types"
+
+export type AccountBrowserSessionSource =
+  | "current_tab"
+  | "existing_tab"
+  | "temp_window"
+
+export type AccountBrowserSessionFetchContext = {
+  kind: "current_tab" | "browser_context"
+  tabId?: number
+  origin?: string
+  incognito?: boolean
+  cookieStoreId?: string
+}
+
+export type AccountBrowserSession = {
+  source: AccountBrowserSessionSource
+  siteType: AccountSiteType
+  siteTypeHint?: AccountSiteType
+  userId: string
+  user: Record<string, unknown>
+  accessToken?: string
+  sub2apiAuth?: Sub2ApiAuthConfig
+  fetchContext?: AccountBrowserSessionFetchContext
+}
+
+export type AccountBrowserSessionPredicate = (
+  session: AccountBrowserSession,
+) => boolean
+
+export type ReadAccountBrowserSessionFromTabOptions = {
+  tabId: number
+  baseUrl: string
+  siteType: AccountSiteType
+  source: Extract<AccountBrowserSessionSource, "current_tab" | "existing_tab">
+  fetchContext?: AccountBrowserSessionFetchContext
+}
+
+export type ReadAccountBrowserSessionFromExistingTabsOptions = {
+  baseUrl: string
+  siteType: AccountSiteType
+  isUsableSession?: AccountBrowserSessionPredicate
+}
+
+export type ResolveAccountBrowserSessionOptions = {
+  baseUrl: string
+  siteType: AccountSiteType
+  currentTab?: {
+    tabId: number
+    incognito?: boolean
+    cookieStoreId?: string
+  }
+  useExistingTabs?: boolean
+  useTempWindow?: boolean
+  suppressMinimize?: boolean
+  requestIdPrefix?: string
+  isUsableSession?: AccountBrowserSessionPredicate
+}
+```
+
+- [ ] **Step 4: Implement tab reading and normalization**
+
+Create `src/services/accountBrowserSession/sessionReader.ts`:
+
+```ts
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { isAccountSiteType } from "~/constants/siteType"
+import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
+import {
+  getAllTabs,
+  getBrowserApiCapabilities,
+  sendRuntimeMessage,
+  sendTabMessage,
+} from "~/utils/browser/browserApi"
+import { createLogger } from "~/utils/core/logger"
+import { tryParseOrigin } from "~/utils/core/urlParsing"
+
+import type {
+  AccountBrowserSession,
+  AccountBrowserSessionFetchContext,
+  ReadAccountBrowserSessionFromExistingTabsOptions,
+  ReadAccountBrowserSessionFromTabOptions,
+  ResolveAccountBrowserSessionOptions,
+} from "./types"
+
+const logger = createLogger("AccountBrowserSession")
+
+const hasNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+const normalizeOptionalString = (value: unknown): string | undefined =>
+  hasNonEmptyString(value) ? value.trim() : undefined
+
+const normalizeSub2ApiAuth = (
+  value: unknown,
+): AccountBrowserSession["sub2apiAuth"] => {
+  if (!value || typeof value !== "object") return undefined
+
+  const refreshToken = normalizeOptionalString(
+    (value as { refreshToken?: unknown }).refreshToken,
+  )
+  if (!refreshToken) return undefined
+
+  const tokenExpiresAt = (value as { tokenExpiresAt?: unknown }).tokenExpiresAt
+
+  return {
+    refreshToken,
+    ...(typeof tokenExpiresAt === "number" && Number.isFinite(tokenExpiresAt)
+      ? { tokenExpiresAt }
+      : {}),
+  }
+}
+
+const normalizeSessionData = (
+  data: unknown,
+  options: {
+    source: AccountBrowserSession["source"]
+    siteType: AccountBrowserSession["siteType"]
+    fetchContext?: AccountBrowserSessionFetchContext
+  },
+): AccountBrowserSession | null => {
+  if (!data || typeof data !== "object") return null
+
+  const payload = data as {
+    userId?: unknown
+    user?: unknown
+    accessToken?: unknown
+    siteTypeHint?: unknown
+    siteType?: unknown
+    sub2apiAuth?: unknown
+    fetchContext?: AccountBrowserSessionFetchContext
+  }
+
+  const userId = normalizeAccountIdentity(payload.userId)
+  if (!userId) return null
+
+  const user =
+    payload.user && typeof payload.user === "object" && !Array.isArray(payload.user)
+      ? (payload.user as Record<string, unknown>)
+      : { id: userId, username: userId }
+  const accessToken = normalizeOptionalString(payload.accessToken)
+  const siteTypeHint = isAccountSiteType(payload.siteTypeHint)
+    ? payload.siteTypeHint
+    : isAccountSiteType(payload.siteType)
+      ? payload.siteType
+      : undefined
+  const sub2apiAuth = normalizeSub2ApiAuth(payload.sub2apiAuth)
+  const fetchContext = options.fetchContext ?? payload.fetchContext
+
+  return {
+    source: options.source,
+    siteType: options.siteType,
+    ...(siteTypeHint ? { siteTypeHint } : {}),
+    userId,
+    user,
+    ...(accessToken ? { accessToken } : {}),
+    ...(sub2apiAuth ? { sub2apiAuth } : {}),
+    ...(fetchContext ? { fetchContext } : {}),
+  }
+}
+
+export async function readAccountBrowserSessionFromTab(
+  options: ReadAccountBrowserSessionFromTabOptions,
+): Promise<AccountBrowserSession | null> {
+  try {
+    const response = await sendTabMessage(options.tabId, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: options.baseUrl,
+      siteType: options.siteType,
+    })
+
+    if (!response?.success || !response.data) return null
+
+    return normalizeSessionData(response.data, {
+      source: options.source,
+      siteType: options.siteType,
+      fetchContext: options.fetchContext,
+    })
+  } catch (error) {
+    logger.debug("Failed to read account browser session from tab", {
+      tabId: options.tabId,
+      siteType: options.siteType,
+      error,
+    })
+    return null
+  }
+}
+
+const getSameOriginTabs = async (baseUrl: string) => {
+  const origin = tryParseOrigin(baseUrl)
+  if (!origin) return []
+  if (!getBrowserApiCapabilities().hasTabs) return []
+
+  const tabs = await getAllTabs().catch(() => [])
+  return tabs
+    .filter((tab) => {
+      if (!tab?.id || !tab.url) return false
+      return tryParseOrigin(tab.url) === origin
+    })
+    .sort((a, b) => Number(Boolean(b.active)) - Number(Boolean(a.active)))
+}
+
+export async function readAccountBrowserSessionFromExistingTabs(
+  options: ReadAccountBrowserSessionFromExistingTabsOptions,
+): Promise<AccountBrowserSession | null> {
+  const tabs = await getSameOriginTabs(options.baseUrl)
+
+  for (const tab of tabs) {
+    const tabId = tab.id
+    if (typeof tabId !== "number") continue
+
+    const session = await readAccountBrowserSessionFromTab({
+      tabId,
+      baseUrl: options.baseUrl,
+      siteType: options.siteType,
+      source: "existing_tab",
+    })
+
+    if (session && (!options.isUsableSession || options.isUsableSession(session))) {
+      return session
+    }
+  }
+
+  return null
+}
+
+const readAccountBrowserSessionFromTempWindow = async (
+  options: ResolveAccountBrowserSessionOptions,
+): Promise<AccountBrowserSession | null> => {
+  try {
+    const response = await sendRuntimeMessage({
+      action: RuntimeActionIds.AutoDetectSite,
+      url: options.baseUrl,
+      requestId: `${options.requestIdPrefix ?? "account-browser-session"}-${Date.now()}`,
+      ...(options.suppressMinimize ? { suppressMinimize: true } : {}),
+      ...(options.currentTab?.incognito === true ? { useIncognito: true } : {}),
+      ...(options.currentTab?.cookieStoreId
+        ? { cookieStoreId: options.currentTab.cookieStoreId }
+        : {}),
+    })
+
+    if (!response?.success || !response.data) return null
+
+    return normalizeSessionData(response.data, {
+      source: "temp_window",
+      siteType: options.siteType,
+    })
+  } catch (error) {
+    logger.debug("Failed to read account browser session from temp window", {
+      siteType: options.siteType,
+      error,
+    })
+    return null
+  }
+}
+
+export async function resolveAccountBrowserSession(
+  options: ResolveAccountBrowserSessionOptions,
+): Promise<AccountBrowserSession | null> {
+  const isUsable = options.isUsableSession ?? (() => true)
+
+  if (options.currentTab) {
+    const origin = tryParseOrigin(options.baseUrl)
+    const session = await readAccountBrowserSessionFromTab({
+      tabId: options.currentTab.tabId,
+      baseUrl: options.baseUrl,
+      siteType: options.siteType,
+      source: "current_tab",
+      fetchContext: {
+        kind: "current_tab",
+        tabId: options.currentTab.tabId,
+        ...(origin ? { origin } : {}),
+        ...(options.currentTab.incognito === true ? { incognito: true } : {}),
+        ...(options.currentTab.cookieStoreId
+          ? { cookieStoreId: options.currentTab.cookieStoreId }
+          : {}),
+      },
+    })
+    if (session && isUsable(session)) return session
+  }
+
+  if (options.useExistingTabs) {
+    const session = await readAccountBrowserSessionFromExistingTabs({
+      baseUrl: options.baseUrl,
+      siteType: options.siteType,
+      isUsableSession: isUsable,
+    })
+    if (session) return session
+  }
+
+  if (options.useTempWindow) {
+    const session = await readAccountBrowserSessionFromTempWindow(options)
+    if (session && isUsable(session)) return session
+  }
+
+  return null
+}
+```
+
+- [ ] **Step 5: Add the barrel export**
+
+Create `src/services/accountBrowserSession/index.ts`:
+
+```ts
+export * from "./sessionReader"
+export * from "./types"
+```
+
+- [ ] **Step 6: Run tests to verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Add fallback-order and predicate tests**
+
+Append these tests inside the same `describe` block:
+
+```ts
+  it("filters same-origin tabs, tries the active tab first, and honors the usability predicate", async () => {
+    mockGetAllTabs.mockResolvedValueOnce([
+      { id: 1, url: "https://other.example.com/dashboard", active: true },
+      { id: 2, url: "https://sub2.example.com/settings", active: false },
+      { id: 3, url: "https://sub2.example.com/console", active: true },
+    ])
+    mockSendTabMessage
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId: "1",
+          user: { username: "without-refresh" },
+          accessToken: "token-1",
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId: "2",
+          user: { username: "with-refresh" },
+          accessToken: "token-2",
+          sub2apiAuth: { refreshToken: "refresh-2" },
+        },
+      })
+
+    const session = await readAccountBrowserSessionFromExistingTabs({
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      isUsableSession: (candidate) =>
+        Boolean(candidate.sub2apiAuth?.refreshToken),
+    })
+
+    expect(session?.userId).toBe("2")
+    expect(session?.source).toBe("existing_tab")
+    expect(mockSendTabMessage).toHaveBeenNthCalledWith(1, 3, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+    })
+    expect(mockSendTabMessage).toHaveBeenNthCalledWith(2, 2, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+    })
+  })
+
+  it("falls back to temp-window auto-detect when existing tabs are unusable", async () => {
+    mockGetAllTabs.mockResolvedValueOnce([
+      { id: 10, url: "https://sub2.example.com/dashboard", active: true },
+    ])
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "10",
+        user: { username: "tab-user" },
+        accessToken: "tab-token",
+      },
+    })
+    mockSendRuntimeMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "11",
+        user: { username: "temp-user" },
+        accessToken: "temp-token",
+        sub2apiAuth: { refreshToken: "temp-refresh" },
+      },
+    })
+
+    const session = await resolveAccountBrowserSession({
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      useExistingTabs: true,
+      useTempWindow: true,
+      requestIdPrefix: "test-session",
+      isUsableSession: (candidate) =>
+        Boolean(candidate.sub2apiAuth?.refreshToken),
+    })
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        source: "temp_window",
+        userId: "11",
+        accessToken: "temp-token",
+        sub2apiAuth: { refreshToken: "temp-refresh" },
+      }),
+    )
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.AutoDetectSite,
+        url: "https://sub2.example.com",
+        requestId: expect.stringMatching(/^test-session-/),
+      }),
+    )
+  })
+```
+
+- [ ] **Step 8: Run tests to verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit Task 1**
+
+Run:
+
+```powershell
+git add src/services/accountBrowserSession tests/services/accountBrowserSession
+git commit -m "feat(account-session): add browser session reader"
+```
+
+Expected: commit succeeds after the staged validation hook.
+
+---
+
+## Task 2: Migrate Sub2API Token Re-Sync
+
+**Files:**
+
+- Modify: `src/services/apiService/sub2api/tokenResync.ts`
+- Modify: `tests/services/apiService/sub2api/tokenResync.test.ts`
+- Read: `src/services/accountBrowserSession/sessionReader.ts`
+
+- [ ] **Step 1: Write failing mock-seam tests**
+
+Replace the browser API mock in `tests/services/apiService/sub2api/tokenResync.test.ts` with an account browser-session mock:
+
+```ts
+const { mockResolveAccountBrowserSession } = vi.hoisted(() => ({
+  mockResolveAccountBrowserSession: vi.fn(),
+}))
+
+vi.mock("~/services/accountBrowserSession", () => ({
+  resolveAccountBrowserSession: mockResolveAccountBrowserSession,
+}))
+```
+
+Keep imports of `RuntimeActionIds` only if another assertion still needs it; otherwise remove it.
+
+Rewrite the behavior tests to assert the public contract and the new dependency:
+
+```ts
+it("returns an existing-tab token from the browser-session reader", async () => {
+  mockResolveAccountBrowserSession.mockResolvedValueOnce({
+    source: "existing_tab",
+    siteType: "sub2api",
+    userId: "42",
+    user: { username: "tab-user" },
+    accessToken: " token-from-tab ",
+  })
+
+  await expect(
+    resyncSub2ApiAuthToken("https://sub2.example.com"),
+  ).resolves.toEqual({
+    accessToken: "token-from-tab",
+    source: "existing_tab",
+  })
+  expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+    expect.objectContaining({
+      baseUrl: "https://sub2.example.com",
+      siteType: "sub2api",
+      useExistingTabs: true,
+      useTempWindow: true,
+      requestIdPrefix: "sub2api-token-resync",
+      isUsableSession: expect.any(Function),
+    }),
+  )
+})
+
+it("maps current-tab source to the existing public existing-tab source", async () => {
+  mockResolveAccountBrowserSession.mockResolvedValueOnce({
+    source: "current_tab",
+    siteType: "sub2api",
+    userId: "42",
+    user: { username: "tab-user" },
+    accessToken: "current-tab-token",
+  })
+
+  await expect(
+    resyncSub2ApiAuthToken("https://sub2.example.com"),
+  ).resolves.toEqual({
+    accessToken: "current-tab-token",
+    source: "existing_tab",
+  })
+})
+
+it("returns a temp-window token from the browser-session reader", async () => {
+  mockResolveAccountBrowserSession.mockResolvedValueOnce({
+    source: "temp_window",
+    siteType: "sub2api",
+    userId: "7",
+    user: { username: "temp-user" },
+    accessToken: " temp-window-token ",
+  })
+
+  await expect(
+    resyncSub2ApiAuthToken("https://sub2.example.com"),
+  ).resolves.toEqual({
+    accessToken: "temp-window-token",
+    source: "temp_window",
+  })
+})
+
+it("returns null when the browser-session reader finds no usable token", async () => {
+  mockResolveAccountBrowserSession.mockResolvedValueOnce(null)
+
+  await expect(
+    resyncSub2ApiAuthToken("https://sub2.example.com"),
+  ).resolves.toBeNull()
+})
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/sub2api/tokenResync.test.ts
+```
+
+Expected: fail because `tokenResync.ts` still uses direct browser helper imports and does not call `resolveAccountBrowserSession`.
+
+- [ ] **Step 3: Replace `tokenResync.ts` implementation**
+
+Replace the direct browser orchestration in `src/services/apiService/sub2api/tokenResync.ts` with:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  resolveAccountBrowserSession,
+  type AccountBrowserSession,
+} from "~/services/accountBrowserSession"
+
+type Sub2ApiResyncedToken = {
+  accessToken: string
+  source: "existing_tab" | "temp_window"
+}
+
+const hasUsableAccessToken = (session: AccountBrowserSession): boolean =>
+  typeof session.accessToken === "string" && session.accessToken.trim().length > 0
+
+const mapResyncSource = (
+  source: AccountBrowserSession["source"],
+): Sub2ApiResyncedToken["source"] =>
+  source === "temp_window" ? "temp_window" : "existing_tab"
+
+/**
+ * Re-sync Sub2API JWT from browser-session state.
+ *
+ * Strategy:
+ * 1) Prefer an already-open same-origin tab through the browser-session reader.
+ * 2) Fall back to the temp-window auto-detect context.
+ */
+export async function resyncSub2ApiAuthToken(
+  baseUrl: string,
+): Promise<Sub2ApiResyncedToken | null> {
+  const session = await resolveAccountBrowserSession({
+    baseUrl,
+    siteType: SITE_TYPES.SUB2API,
+    useExistingTabs: true,
+    useTempWindow: true,
+    requestIdPrefix: "sub2api-token-resync",
+    isUsableSession: hasUsableAccessToken,
+  })
+
+  const accessToken = session?.accessToken?.trim()
+  if (!session || !accessToken) return null
+
+  return {
+    accessToken,
+    source: mapResyncSource(session.source),
+  }
+}
+```
+
+- [ ] **Step 4: Run focused tests to verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts tests/services/apiService/sub2api/tokenResync.test.ts
+```
+
+Expected: both suites pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```powershell
+git add src/services/apiService/sub2api/tokenResync.ts tests/services/apiService/sub2api/tokenResync.test.ts
+git commit -m "refactor(sub2api): use browser session reader for token resync"
+```
+
+Expected: commit succeeds after the staged validation hook.
+
+---
+
+## Task 3: Migrate Sub2API Session Import In Account Dialog
+
+**Files:**
+
+- Modify: `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+- Modify: `tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx`
+- Read: `src/services/accountBrowserSession/sessionReader.ts`
+
+- [ ] **Step 1: Add a failing test that mocks the new Module instead of browser APIs**
+
+At the top of `tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx`, add a hoisted mock:
+
+```ts
+const {
+  mockOpenWithAccount,
+  mockOpenDefaultTokenQuickCreateDialogForAccount,
+  mockResolveAccountBrowserSession,
+  mockToastError,
+  mockToastSuccess,
+} = vi.hoisted(() => ({
+  mockOpenWithAccount: vi.fn(),
+  mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
+  mockResolveAccountBrowserSession: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastSuccess: vi.fn(),
+}))
+
+vi.mock("~/services/accountBrowserSession", () => ({
+  resolveAccountBrowserSession: mockResolveAccountBrowserSession,
+}))
+```
+
+If the file already has a `vi.hoisted` block for dialog/toast mocks, merge this into that existing block instead of creating a second block with duplicate names.
+
+In `beforeEach`, reset the new mock:
+
+```ts
+mockResolveAccountBrowserSession.mockResolvedValue(null)
+```
+
+Add this test near the existing Sub2API import tests:
+
+```ts
+it("imports Sub2API session data through the browser-session reader", async () => {
+  mockResolveAccountBrowserSession.mockResolvedValueOnce({
+    source: "existing_tab",
+    siteType: SITE_TYPES.SUB2API,
+    userId: "42",
+    user: { username: "tab-user" },
+    accessToken: "jwt-from-reader",
+    sub2apiAuth: {
+      refreshToken: "refresh-from-reader",
+      tokenExpiresAt: 123456,
+    },
+  })
+
+  const { result } = renderHook(() =>
+    useAccountDialog({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    }),
+  )
+
+  await waitFor(() => {
+    expect(result.current.state).toBeTruthy()
+  })
+
+  await act(async () => {
+    result.current.setters.setUrl("https://sub2.example.com")
+    result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+  })
+
+  await act(async () => {
+    await result.current.handlers.handleImportSub2apiSession()
+  })
+
+  expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+    expect.objectContaining({
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      useExistingTabs: true,
+      useTempWindow: true,
+      requestIdPrefix: "account-dialog-sub2api-import",
+      isUsableSession: expect.any(Function),
+    }),
+  )
+  expect(result.current.state.sub2apiRefreshToken).toBe("refresh-from-reader")
+  expect(result.current.state.sub2apiTokenExpiresAt).toBe(123456)
+  expect(result.current.state.accessToken).toBe("jwt-from-reader")
+  expect(result.current.state.userId).toBe("42")
+  expect(result.current.state.username).toBe("tab-user")
+  expect(mockToastSuccess).toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run the account-dialog suite to verify RED**
+
+Run:
+
+```powershell
+pnpm vitest run tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+```
+
+Expected: fail because `handleImportSub2apiSession` still scans tabs and calls runtime messages directly.
+
+- [ ] **Step 3: Migrate `handleImportSub2apiSession`**
+
+In `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`:
+
+Remove unused imports after the migration:
+
+```ts
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import {
+  getAllTabs,
+  getBrowserApiCapabilities,
+  sendRuntimeMessage,
+  sendTabMessage,
+} from "~/utils/browser/browserApi"
+import { tryParseOrigin } from "~/utils/core/urlParsing"
+```
+
+Add this import:
+
+```ts
+import {
+  resolveAccountBrowserSession,
+  type AccountBrowserSession,
+} from "~/services/accountBrowserSession"
+```
+
+Replace the browser-scanning body inside `handleImportSub2apiSession` with:
+
+```ts
+      const baseUrl = url.trim()
+      const hasUsableSub2apiRefreshToken = (
+        value: AccountBrowserSession | null,
+      ): value is AccountBrowserSession =>
+        typeof value?.sub2apiAuth?.refreshToken === "string" &&
+        value.sub2apiAuth.refreshToken.trim().length > 0
+
+      const imported = await resolveAccountBrowserSession({
+        baseUrl,
+        siteType: SITE_TYPES.SUB2API,
+        useExistingTabs: true,
+        useTempWindow: true,
+        requestIdPrefix: "account-dialog-sub2api-import",
+        isUsableSession: hasUsableSub2apiRefreshToken,
+      })
+
+      const refreshToken = imported?.sub2apiAuth?.refreshToken?.trim() ?? ""
+```
+
+Keep the existing draft update logic, but read fields from `imported`:
+
+```ts
+      const tokenExpiresAtRaw = imported?.sub2apiAuth?.tokenExpiresAt
+      const importedAccessToken = imported?.accessToken?.trim() ?? ""
+      const importedUserId = normalizeAccountIdentity(imported?.userId) ?? ""
+      const importedUsername =
+        typeof imported?.user?.username === "string"
+          ? imported.user.username.trim()
+          : ""
+```
+
+- [ ] **Step 4: Update existing tests that asserted direct browser API calls**
+
+For tests in `useAccountDialog.sub2apiConstraints.test.tsx` that currently set up `getAllTabs`, `globalThis.browser.tabs.sendMessage`, or `sendRuntimeMessage` solely for Sub2API session import, either:
+
+- convert them to mock `mockResolveAccountBrowserSession` results, or
+- delete the direct browser-message assertion when the behavior is already covered by `tests/services/accountBrowserSession/sessionReader.test.ts`.
+
+Preserve these user-visible assertions:
+
+- session import fills refresh token, expiry, access token, user id, and username
+- missing refresh token keeps draft fields empty and shows `mockToastError`
+- successful import shows `mockToastSuccess`
+
+Use this missing-session test shape:
+
+```ts
+it("shows the existing missing-session feedback when the reader cannot provide a refresh token", async () => {
+  mockResolveAccountBrowserSession.mockResolvedValueOnce(null)
+
+  const { result } = renderHook(() =>
+    useAccountDialog({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    }),
+  )
+
+  await waitFor(() => {
+    expect(result.current.state).toBeTruthy()
+  })
+
+  await act(async () => {
+    result.current.setters.setUrl("https://sub2.example.com")
+    result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+  })
+
+  await act(async () => {
+    await result.current.handlers.handleImportSub2apiSession()
+  })
+
+  expect(result.current.state.sub2apiRefreshToken).toBe("")
+  expect(result.current.state.accessToken).toBe("")
+  expect(result.current.state.userId).toBe("")
+  expect(mockToastError).toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 5: Run focused tests to verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+```
+
+Expected: both suites pass.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```powershell
+git add src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+git commit -m "refactor(account-dialog): use browser session reader for sub2api import"
+```
+
+Expected: commit succeeds after the staged validation hook.
+
+---
+
+## Task 4: Migrate Active-Tab Account Matching
+
+**Files:**
+
+- Modify: `src/features/AccountManagement/hooks/AccountDataContext.tsx`
+- Modify: `tests/features/AccountManagement/hooks/AccountDataContext.test.tsx`
+- Read: `src/services/accountBrowserSession/sessionReader.ts`
+
+- [ ] **Step 1: Add a failing test/mock seam for AccountDataContext**
+
+In `tests/features/AccountManagement/hooks/AccountDataContext.test.tsx`, add a hoisted mock:
+
+```ts
+const {
+  mockReadAccountBrowserSessionFromTab,
+  // keep existing hoisted mocks in this file
+} = vi.hoisted(() => ({
+  mockReadAccountBrowserSessionFromTab: vi.fn(),
+  // keep existing mock initializers
+}))
+
+vi.mock("~/services/accountBrowserSession", () => ({
+  readAccountBrowserSessionFromTab: mockReadAccountBrowserSessionFromTab,
+}))
+```
+
+Merge this with the file's existing `vi.hoisted` block. Do not create duplicate `const` declarations.
+
+Set the default in `beforeEach`:
+
+```ts
+mockReadAccountBrowserSessionFromTab.mockResolvedValue(null)
+```
+
+Update the existing test `"matches the active tab user to the correct same-origin account"` so the browser-session mock returns the current tab user:
+
+```ts
+mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+  source: "current_tab",
+  siteType: "new-api",
+  userId: "42",
+  user: { id: "42", username: "42" },
+  fetchContext: {
+    kind: "current_tab",
+    tabId: 7,
+    origin: "https://api.example.com",
+  },
+})
+```
+
+Replace the final `globalThis.browser.tabs.sendMessage` assertion with:
+
+```ts
+expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledWith({
+  tabId: 7,
+  baseUrl: "https://api.example.com",
+  siteType: "new-api",
+  source: "current_tab",
+  fetchContext: {
+    kind: "current_tab",
+    tabId: 7,
+    origin: "https://api.example.com",
+  },
+})
+```
+
+- [ ] **Step 2: Run the suite to verify RED**
+
+Run:
+
+```powershell
+pnpm vitest run tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+```
+
+Expected: fail because `AccountDataContext` still calls `sendTabMessage` directly.
+
+- [ ] **Step 3: Migrate `AccountDataContext` active-tab read**
+
+In `src/features/AccountManagement/hooks/AccountDataContext.tsx`, remove these imports if they become unused:
+
+```ts
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { sendTabMessage } from "~/utils/browser/browserApi"
+```
+
+Keep the other browser helper imports.
+
+Add:
+
+```ts
+import { readAccountBrowserSessionFromTab } from "~/services/accountBrowserSession"
+```
+
+Replace the direct `sendTabMessage` block with:
+
+```ts
+          const session = await readAccountBrowserSessionFromTab({
+            tabId,
+            baseUrl: parsedUrl.origin,
+            siteType: siteTypeForUserRead,
+            source: "current_tab",
+            fetchContext: {
+              kind: "current_tab",
+              tabId,
+              origin: parsedUrl.origin,
+            },
+          })
+
+          verifiedUserId = normalizeAccountIdentity(session?.userId)
+          verifiedUser =
+            session?.user ??
+            (verifiedUserId
+              ? { id: verifiedUserId, username: verifiedUserId }
+              : null)
+```
+
+Preserve the existing cache assignment and error handling structure.
+
+- [ ] **Step 4: Run focused tests to verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+```
+
+Expected: both suites pass.
+
+- [ ] **Step 5: Commit Task 4**
+
+Run:
+
+```powershell
+git add src/features/AccountManagement/hooks/AccountDataContext.tsx tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+git commit -m "refactor(account-data): use browser session reader for active tab matching"
+```
+
+Expected: commit succeeds after the staged validation hook.
+
+---
+
+## Task 5: Migrate Auto-Detect Current-Tab Read
+
+**Files:**
+
+- Modify: `src/services/siteDetection/autoDetectService.ts`
+- Modify: `tests/services/autoDetectService.test.ts`
+- Read: `src/services/accountBrowserSession/sessionReader.ts`
+
+- [ ] **Step 1: Add a failing mock-seam test**
+
+In `tests/services/autoDetectService.test.ts`, add a hoisted mock:
+
+```ts
+const {
+  mockFetchUserInfo,
+  mockGetActiveOrAllTabs,
+  mockGetActiveTabs,
+  mockGetAccountSiteType,
+  mockGetSiteAdapter,
+  mockIsMessageReceiverUnavailableError,
+  mockReadAccountBrowserSessionFromTab,
+  mockSendRuntimeMessage,
+} = vi.hoisted(() => ({
+  mockFetchUserInfo: vi.fn(),
+  mockGetActiveOrAllTabs: vi.fn(),
+  mockGetActiveTabs: vi.fn(),
+  mockGetAccountSiteType: vi.fn(),
+  mockGetSiteAdapter: vi.fn(),
+  mockIsMessageReceiverUnavailableError: vi.fn(),
+  mockReadAccountBrowserSessionFromTab: vi.fn(),
+  mockSendRuntimeMessage: vi.fn(),
+}))
+
+vi.mock("~/services/accountBrowserSession", () => ({
+  readAccountBrowserSessionFromTab: mockReadAccountBrowserSessionFromTab,
+}))
+```
+
+Merge this with the existing hoisted block instead of duplicating it.
+
+Set default:
+
+```ts
+mockReadAccountBrowserSessionFromTab.mockResolvedValue(null)
+```
+
+Add this test near current-tab tests:
+
+```ts
+it("uses the browser-session reader for current-tab auto-detect before API fallback", async () => {
+  mockGetAccountSiteType.mockResolvedValueOnce(SITE_TYPES.SUB2API)
+  mockGetActiveOrAllTabs.mockResolvedValue([
+    {
+      id: 201,
+      active: true,
+      url: "https://sub2.example.com/dashboard",
+    },
+  ])
+  mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+    source: "current_tab",
+    siteType: SITE_TYPES.SUB2API,
+    siteTypeHint: SITE_TYPES.SUB2API,
+    userId: "42",
+    user: { username: "tab-user" },
+    accessToken: "jwt-from-tab",
+    sub2apiAuth: { refreshToken: "refresh-from-tab" },
+    fetchContext: {
+      kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+      tabId: 201,
+      origin: "https://sub2.example.com",
+    },
+  })
+
+  const result = await autoDetectSmart("https://sub2.example.com/console")
+
+  expect(result.success).toBe(true)
+  expect(result.data).toEqual(
+    expect.objectContaining({
+      userId: "42",
+      accessToken: "jwt-from-tab",
+      sub2apiAuth: { refreshToken: "refresh-from-tab" },
+      siteType: SITE_TYPES.SUB2API,
+    }),
+  )
+  expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledWith({
+    tabId: 201,
+    baseUrl: "https://sub2.example.com/console",
+    siteType: SITE_TYPES.SUB2API,
+    source: "current_tab",
+    fetchContext: {
+      kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+      tabId: 201,
+      origin: "https://sub2.example.com",
+    },
+  })
+  expect(mockFetchUserInfo).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run auto-detect suite to verify RED**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/autoDetectService.test.ts
+```
+
+Expected: fail because `autoDetectService.ts` still calls `sendTabMessage` directly.
+
+- [ ] **Step 3: Migrate current-tab content-session read**
+
+In `src/services/siteDetection/autoDetectService.ts`, remove `sendTabMessage` from the browser helper import if it becomes unused.
+
+Add:
+
+```ts
+import { readAccountBrowserSessionFromTab } from "~/services/accountBrowserSession"
+```
+
+In `getUserDataFromCurrentTab(...)`, replace the direct `sendTabMessage` call with:
+
+```ts
+      const session = await readAccountBrowserSessionFromTab({
+        tabId,
+        baseUrl: url,
+        siteType,
+        source: "current_tab",
+        fetchContext,
+      })
+
+      if (session) {
+        return {
+          userData: {
+            userId: session.userId,
+            user: session.user,
+            accessToken: session.accessToken,
+            sub2apiAuth: session.sub2apiAuth,
+            siteTypeHint: normalizeSiteTypeHint(session.siteTypeHint),
+            fetchContext,
+          },
+          contentScriptUnavailable,
+          strategy: AUTO_DETECT_STRATEGIES.CurrentTab,
+          fetchContext,
+        }
+      }
+```
+
+Because the new helper returns `null` for both failed responses and thrown content-message errors, preserve reload-hint behavior by catching receiver-unavailable errors inside the helper only for caller paths that need it is not possible. For this task, keep reload-hint behavior by allowing `readAccountBrowserSessionFromTab` to accept an optional `onError?: (error: unknown) => void` callback:
+
+Extend `ReadAccountBrowserSessionFromTabOptions` in `types.ts`:
+
+```ts
+  onError?: (error: unknown) => void
+```
+
+In `readAccountBrowserSessionFromTab(...)` catch block:
+
+```ts
+    options.onError?.(error)
+```
+
+Then call it from auto-detect:
+
+```ts
+        onError(error) {
+          contentScriptUnavailable = isMessageReceiverUnavailableError(error)
+
+          if (contentScriptUnavailable) {
+            logger.warn("当前标签页 content script 不可用，尝试 API 降级", {
+              url,
+              tabId,
+              fetchContext: summarizeApiServiceFetchContext(fetchContext),
+              error: getErrorMessage(error),
+            })
+          } else {
+            logger.warn("从当前标签页获取用户数据失败", {
+              url,
+              tabId,
+              fetchContext: summarizeApiServiceFetchContext(fetchContext),
+              error: getErrorMessage(error),
+            })
+          }
+        },
+```
+
+- [ ] **Step 4: Add or adjust `onError` test coverage in the browser-session suite**
+
+In `tests/services/accountBrowserSession/sessionReader.test.ts`, add:
+
+```ts
+  it("notifies callers about tab read errors without throwing", async () => {
+    const onError = vi.fn()
+    const error = new Error("receiver missing")
+    mockSendTabMessage.mockRejectedValueOnce(error)
+
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 1,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: "current_tab",
+        onError,
+      }),
+    ).resolves.toBeNull()
+    expect(onError).toHaveBeenCalledWith(error)
+  })
+```
+
+- [ ] **Step 5: Run focused tests to verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts tests/services/autoDetectService.test.ts
+```
+
+Expected: both suites pass.
+
+- [ ] **Step 6: Run all migrated focused suites together**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts tests/services/apiService/sub2api/tokenResync.test.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx tests/features/AccountManagement/hooks/AccountDataContext.test.tsx tests/services/autoDetectService.test.ts
+```
+
+Expected: all suites pass.
+
+- [ ] **Step 7: Commit Task 5**
+
+Run:
+
+```powershell
+git add src/services/accountBrowserSession src/services/siteDetection/autoDetectService.ts tests/services/accountBrowserSession/sessionReader.test.ts tests/services/autoDetectService.test.ts
+git commit -m "refactor(autodetect): use browser session reader for current tab"
+```
+
+Expected: commit succeeds after the staged validation hook.
+
+---
+
+## Task 6: Final Validation And Cleanup
+
+**Files:**
+
+- Inspect all task-scoped files from Tasks 1-5.
+- Do not touch unrelated untracked root handoff files.
+
+- [ ] **Step 1: Search for remaining direct session-read duplication**
+
+Run:
+
+```powershell
+rg -n "ContentGetUserFromLocalStorage|AutoDetectSite|getAllTabs\\(|sendTabMessage\\(" src/services/apiService/sub2api/tokenResync.ts src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts src/features/AccountManagement/hooks/AccountDataContext.tsx src/services/siteDetection/autoDetectService.ts
+```
+
+Expected:
+
+- `tokenResync.ts`: no direct `ContentGetUserFromLocalStorage`, `AutoDetectSite`, `getAllTabs`, or `sendTabMessage`.
+- `useAccountDialog.ts`: no direct Sub2API session-import use of those browser APIs.
+- `AccountDataContext.tsx`: may still import/use tab event helpers, but not direct `ContentGetUserFromLocalStorage`.
+- `autoDetectService.ts`: no direct `ContentGetUserFromLocalStorage`; `AutoDetectSite` may remain for background/temp-window auto-detect outside the new Module.
+
+- [ ] **Step 2: Run focused migrated suites**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts tests/services/apiService/sub2api/tokenResync.test.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx tests/features/AccountManagement/hooks/AccountDataContext.test.tsx tests/services/autoDetectService.test.ts
+```
+
+Expected: all suites pass.
+
+- [ ] **Step 3: Run related validation for changed source files**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/accountBrowserSession/sessionReader.ts src/services/apiService/sub2api/tokenResync.ts src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts src/features/AccountManagement/hooks/AccountDataContext.tsx src/services/siteDetection/autoDetectService.ts
+```
+
+Expected: related tests pass. If this command is unsupported by the local Vitest setup, record the exact error and use the focused suites from Step 2 plus `pnpm compile`.
+
+- [ ] **Step 4: Run type validation**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: TypeScript compile passes.
+
+- [ ] **Step 5: Stage only task-scoped implementation files**
+
+Run:
+
+```powershell
+git add src/services/accountBrowserSession tests/services/accountBrowserSession src/services/apiService/sub2api/tokenResync.ts tests/services/apiService/sub2api/tokenResync.test.ts src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx src/features/AccountManagement/hooks/AccountDataContext.tsx tests/features/AccountManagement/hooks/AccountDataContext.test.tsx src/services/siteDetection/autoDetectService.ts tests/services/autoDetectService.test.ts
+```
+
+Expected: only task-scoped files are staged.
+
+- [ ] **Step 6: Run commit gate**
+
+Run:
+
+```powershell
+pnpm run validate:staged
+```
+
+Expected: staged validation passes.
+
+- [ ] **Step 7: Inspect final diff**
+
+Run:
+
+```powershell
+git diff --cached --stat
+git diff --cached -- src/services/accountBrowserSession src/services/apiService/sub2api/tokenResync.ts src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts src/features/AccountManagement/hooks/AccountDataContext.tsx src/services/siteDetection/autoDetectService.ts
+```
+
+Expected: no unrelated files, debug code, stale comments, or duplicate browser-session orchestration.
+
+- [ ] **Step 8: Commit final cleanup if needed**
+
+If all implementation work was committed task-by-task, skip this step.
+
+If Task 6 produced staged fixes, run:
+
+```powershell
+git commit -m "refactor(account-session): centralize browser session reads"
+```
+
+Expected: commit succeeds after the staged validation hook.
+
+- [ ] **Step 9: Run push gate because shared service code changed**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: compile, knip, and repo push validation pass.

--- a/docs/superpowers/plans/2026-06-27-account-browser-session-capability.md
+++ b/docs/superpowers/plans/2026-06-27-account-browser-session-capability.md
@@ -111,9 +111,9 @@ describe("account browser-session reader", () => {
       tabId: 12,
       baseUrl: "https://sub2.example.com",
       siteType: SITE_TYPES.SUB2API,
-      source: "current_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
       fetchContext: {
-        kind: "current_tab",
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
         tabId: 12,
         origin: "https://sub2.example.com",
         incognito: true,
@@ -122,7 +122,7 @@ describe("account browser-session reader", () => {
     })
 
     expect(session).toEqual({
-      source: "current_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
       siteType: SITE_TYPES.SUB2API,
       userId: "42",
       user: { username: " tab-user " },
@@ -133,7 +133,7 @@ describe("account browser-session reader", () => {
         tokenExpiresAt: 123456,
       },
       fetchContext: {
-        kind: "current_tab",
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
         tabId: 12,
         origin: "https://sub2.example.com",
         incognito: true,
@@ -158,7 +158,7 @@ describe("account browser-session reader", () => {
         tabId: 1,
         baseUrl: "https://sub2.example.com",
         siteType: SITE_TYPES.SUB2API,
-        source: "current_tab",
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
       }),
     ).resolves.toBeNull()
     await expect(
@@ -166,7 +166,7 @@ describe("account browser-session reader", () => {
         tabId: 1,
         baseUrl: "https://sub2.example.com",
         siteType: SITE_TYPES.SUB2API,
-        source: "current_tab",
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
       }),
     ).resolves.toBeNull()
     await expect(
@@ -174,7 +174,7 @@ describe("account browser-session reader", () => {
         tabId: 1,
         baseUrl: "https://sub2.example.com",
         siteType: SITE_TYPES.SUB2API,
-        source: "current_tab",
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
       }),
     ).resolves.toBeNull()
   })
@@ -197,20 +197,19 @@ Create `src/services/accountBrowserSession/types.ts`:
 
 ```ts
 import type { AccountSiteType } from "~/constants/siteType"
+import type { ApiServiceFetchContext } from "~/services/apiService/common/type"
 import type { Sub2ApiAuthConfig } from "~/types"
 
-export type AccountBrowserSessionSource =
-  | "current_tab"
-  | "existing_tab"
-  | "temp_window"
+export const ACCOUNT_BROWSER_SESSION_SOURCES = {
+  CURRENT_TAB: "current_tab",
+  EXISTING_TAB: "existing_tab",
+  TEMP_WINDOW: "temp_window",
+} as const
 
-export type AccountBrowserSessionFetchContext = {
-  kind: "current_tab" | "browser_context"
-  tabId?: number
-  origin?: string
-  incognito?: boolean
-  cookieStoreId?: string
-}
+export type AccountBrowserSessionSource =
+  (typeof ACCOUNT_BROWSER_SESSION_SOURCES)[keyof typeof ACCOUNT_BROWSER_SESSION_SOURCES]
+
+export type AccountBrowserSessionFetchContext = ApiServiceFetchContext
 
 export type AccountBrowserSession = {
   source: AccountBrowserSessionSource
@@ -231,7 +230,11 @@ export type ReadAccountBrowserSessionFromTabOptions = {
   tabId: number
   baseUrl: string
   siteType: AccountSiteType
-  source: Extract<AccountBrowserSessionSource, "current_tab" | "existing_tab">
+  source: Extract<
+    AccountBrowserSessionSource,
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
+  >
   fetchContext?: AccountBrowserSessionFetchContext
 }
 
@@ -412,7 +415,7 @@ export async function readAccountBrowserSessionFromExistingTabs(
       tabId,
       baseUrl: options.baseUrl,
       siteType: options.siteType,
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
 
     if (session && (!options.isUsableSession || options.isUsableSession(session))) {
@@ -441,7 +444,7 @@ const readAccountBrowserSessionFromTempWindow = async (
     if (!response?.success || !response.data) return null
 
     return normalizeSessionData(response.data, {
-      source: "temp_window",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
       siteType: options.siteType,
     })
   } catch (error) {
@@ -464,9 +467,9 @@ export async function resolveAccountBrowserSession(
       tabId: options.currentTab.tabId,
       baseUrl: options.baseUrl,
       siteType: options.siteType,
-      source: "current_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
       fetchContext: {
-        kind: "current_tab",
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
         tabId: options.currentTab.tabId,
         ...(origin ? { origin } : {}),
         ...(options.currentTab.incognito === true ? { incognito: true } : {}),
@@ -553,7 +556,7 @@ Append these tests inside the same `describe` block:
     })
 
     expect(session?.userId).toBe("2")
-    expect(session?.source).toBe("existing_tab")
+    expect(session?.source).toBe(ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB)
     expect(mockSendTabMessage).toHaveBeenNthCalledWith(1, 3, {
       action: RuntimeActionIds.ContentGetUserFromLocalStorage,
       url: "https://sub2.example.com",
@@ -600,7 +603,7 @@ Append these tests inside the same `describe` block:
 
     expect(session).toEqual(
       expect.objectContaining({
-        source: "temp_window",
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
         userId: "11",
         accessToken: "temp-token",
         sub2apiAuth: { refreshToken: "temp-refresh" },
@@ -668,7 +671,7 @@ Rewrite the behavior tests to assert the public contract and the new dependency:
 ```ts
 it("returns an existing-tab token from the browser-session reader", async () => {
   mockResolveAccountBrowserSession.mockResolvedValueOnce({
-    source: "existing_tab",
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     siteType: "sub2api",
     userId: "42",
     user: { username: "tab-user" },
@@ -679,7 +682,7 @@ it("returns an existing-tab token from the browser-session reader", async () => 
     resyncSub2ApiAuthToken("https://sub2.example.com"),
   ).resolves.toEqual({
     accessToken: "token-from-tab",
-    source: "existing_tab",
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
   })
   expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -695,7 +698,7 @@ it("returns an existing-tab token from the browser-session reader", async () => 
 
 it("maps current-tab source to the existing public existing-tab source", async () => {
   mockResolveAccountBrowserSession.mockResolvedValueOnce({
-    source: "current_tab",
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
     siteType: "sub2api",
     userId: "42",
     user: { username: "tab-user" },
@@ -706,13 +709,13 @@ it("maps current-tab source to the existing public existing-tab source", async (
     resyncSub2ApiAuthToken("https://sub2.example.com"),
   ).resolves.toEqual({
     accessToken: "current-tab-token",
-    source: "existing_tab",
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
   })
 })
 
 it("returns a temp-window token from the browser-session reader", async () => {
   mockResolveAccountBrowserSession.mockResolvedValueOnce({
-    source: "temp_window",
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
     siteType: "sub2api",
     userId: "7",
     user: { username: "temp-user" },
@@ -723,7 +726,7 @@ it("returns a temp-window token from the browser-session reader", async () => {
     resyncSub2ApiAuthToken("https://sub2.example.com"),
   ).resolves.toEqual({
     accessToken: "temp-window-token",
-    source: "temp_window",
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
   })
 })
 
@@ -753,13 +756,16 @@ Replace the direct browser orchestration in `src/services/apiService/sub2api/tok
 ```ts
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  ACCOUNT_BROWSER_SESSION_SOURCES,
   resolveAccountBrowserSession,
   type AccountBrowserSession,
 } from "~/services/accountBrowserSession"
 
 type Sub2ApiResyncedToken = {
   accessToken: string
-  source: "existing_tab" | "temp_window"
+  source:
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
 }
 
 const hasUsableAccessToken = (session: AccountBrowserSession): boolean =>
@@ -767,8 +773,19 @@ const hasUsableAccessToken = (session: AccountBrowserSession): boolean =>
 
 const mapResyncSource = (
   source: AccountBrowserSession["source"],
-): Sub2ApiResyncedToken["source"] =>
-  source === "temp_window" ? "temp_window" : "existing_tab"
+): Sub2ApiResyncedToken["source"] => {
+  switch (source) {
+    case ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB:
+    case ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB:
+      return ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
+    case ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW:
+      return ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
+    default: {
+      const exhaustive: never = source
+      return exhaustive
+    }
+  }
+}
 
 /**
  * Re-sync Sub2API JWT from browser-session state.
@@ -867,7 +884,7 @@ Add this test near the existing Sub2API import tests:
 ```ts
 it("imports Sub2API session data through the browser-session reader", async () => {
   mockResolveAccountBrowserSession.mockResolvedValueOnce({
-    source: "existing_tab",
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     siteType: SITE_TYPES.SUB2API,
     userId: "42",
     user: { username: "tab-user" },
@@ -1098,12 +1115,12 @@ Update the existing test `"matches the active tab user to the correct same-origi
 
 ```ts
 mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
-  source: "current_tab",
+  source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
   siteType: "new-api",
   userId: "42",
   user: { id: "42", username: "42" },
   fetchContext: {
-    kind: "current_tab",
+    kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
     tabId: 7,
     origin: "https://api.example.com",
   },
@@ -1117,9 +1134,9 @@ expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledWith({
   tabId: 7,
   baseUrl: "https://api.example.com",
   siteType: "new-api",
-  source: "current_tab",
+  source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
   fetchContext: {
-    kind: "current_tab",
+    kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
     tabId: 7,
     origin: "https://api.example.com",
   },
@@ -1160,20 +1177,16 @@ Replace the direct `sendTabMessage` block with:
             tabId,
             baseUrl: parsedUrl.origin,
             siteType: siteTypeForUserRead,
-            source: "current_tab",
+            source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
             fetchContext: {
-              kind: "current_tab",
+              kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
               tabId,
               origin: parsedUrl.origin,
             },
           })
 
-          verifiedUserId = normalizeAccountIdentity(session?.userId)
-          verifiedUser =
-            session?.user ??
-            (verifiedUserId
-              ? { id: verifiedUserId, username: verifiedUserId }
-              : null)
+          verifiedUserId = session?.userId ?? null
+          verifiedUser = session?.user ?? null
 ```
 
 Preserve the existing cache assignment and error handling structure.
@@ -1260,7 +1273,7 @@ it("uses the browser-session reader for current-tab auto-detect before API fallb
     },
   ])
   mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
-    source: "current_tab",
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
     siteType: SITE_TYPES.SUB2API,
     siteTypeHint: SITE_TYPES.SUB2API,
     userId: "42",
@@ -1289,7 +1302,7 @@ it("uses the browser-session reader for current-tab auto-detect before API fallb
     tabId: 201,
     baseUrl: "https://sub2.example.com/console",
     siteType: SITE_TYPES.SUB2API,
-    source: "current_tab",
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
     fetchContext: {
       kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
       tabId: 201,
@@ -1327,7 +1340,7 @@ In `getUserDataFromCurrentTab(...)`, replace the direct `sendTabMessage` call wi
         tabId,
         baseUrl: url,
         siteType,
-        source: "current_tab",
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
         fetchContext,
       })
 
@@ -1348,18 +1361,28 @@ In `getUserDataFromCurrentTab(...)`, replace the direct `sendTabMessage` call wi
       }
 ```
 
-Because the new helper returns `null` for both failed responses and thrown content-message errors, preserve reload-hint behavior by catching receiver-unavailable errors inside the helper only for caller paths that need it is not possible. For this task, keep reload-hint behavior by allowing `readAccountBrowserSessionFromTab` to accept an optional `onError?: (error: unknown) => void` callback:
+Because the helper returns `null` for both failed responses and thrown content-message errors, preserve reload-hint behavior by passing an `onError` callback with the reader source context into `readAccountBrowserSessionFromTab`.
 
 Extend `ReadAccountBrowserSessionFromTabOptions` in `types.ts`:
 
 ```ts
-  onError?: (error: unknown) => void
+export type AccountBrowserSessionErrorContext = {
+  source: AccountBrowserSessionSource
+}
+
+export type AccountBrowserSessionErrorHandler = (
+  error: unknown,
+  context: AccountBrowserSessionErrorContext,
+) => void
+
+// ...
+  onError?: AccountBrowserSessionErrorHandler
 ```
 
 In `readAccountBrowserSessionFromTab(...)` catch block:
 
 ```ts
-    options.onError?.(error)
+    options.onError?.(error, { source: options.source })
 ```
 
 Then call it from auto-detect:
@@ -1401,11 +1424,13 @@ In `tests/services/accountBrowserSession/sessionReader.test.ts`, add:
         tabId: 1,
         baseUrl: "https://sub2.example.com",
         siteType: SITE_TYPES.SUB2API,
-        source: "current_tab",
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
         onError,
       }),
     ).resolves.toBeNull()
-    expect(onError).toHaveBeenCalledWith(error)
+    expect(onError).toHaveBeenCalledWith(error, {
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+    })
   })
 ```
 

--- a/docs/superpowers/specs/2026-06-27-account-browser-session-capability-design.md
+++ b/docs/superpowers/specs/2026-06-27-account-browser-session-capability-design.md
@@ -147,18 +147,18 @@ src/services/accountBrowserSession/
 The public contract should be small and result-focused:
 
 ```ts
-export type AccountBrowserSessionSource =
-  | "current_tab"
-  | "existing_tab"
-  | "temp_window"
+import type { ApiServiceFetchContext } from "~/services/apiService/common/type"
 
-export type AccountBrowserSessionFetchContext = {
-  kind: "current_tab" | "browser_context"
-  tabId?: number
-  origin?: string
-  incognito?: boolean
-  cookieStoreId?: string
-}
+export const ACCOUNT_BROWSER_SESSION_SOURCES = {
+  CURRENT_TAB: "current_tab",
+  EXISTING_TAB: "existing_tab",
+  TEMP_WINDOW: "temp_window",
+} as const
+
+export type AccountBrowserSessionSource =
+  (typeof ACCOUNT_BROWSER_SESSION_SOURCES)[keyof typeof ACCOUNT_BROWSER_SESSION_SOURCES]
+
+export type AccountBrowserSessionFetchContext = ApiServiceFetchContext
 
 export type AccountBrowserSession = {
   source: AccountBrowserSessionSource
@@ -263,13 +263,15 @@ It should preserve the current public return shape:
 ```ts
 type Sub2ApiResyncedToken = {
   accessToken: string
-  source: "existing_tab" | "temp_window"
+  source:
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
 }
 ```
 
-If the new Module returns `"current_tab"` in this path, map it to
-`"existing_tab"` because token re-sync's public contract only exposes the two
-existing categories.
+If the new Module returns `ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB` in this
+path, map it to `ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB` because token
+re-sync's public contract only exposes the two existing categories.
 
 ### 7. Keep Auto-Detect Fallback Semantics Stable
 

--- a/docs/superpowers/specs/2026-06-27-account-browser-session-capability-design.md
+++ b/docs/superpowers/specs/2026-06-27-account-browser-session-capability-design.md
@@ -1,0 +1,405 @@
+# Account Browser Session Capability Design
+
+Date: 2026-06-27
+
+## Purpose
+
+Move account-site browser-session reads behind a small, site-aware Module so
+product callers no longer duplicate tab scanning, content-script messages, and
+temp-window fallback logic.
+
+This design closes the remaining useful part of
+`sub2api-capability-refactor-handoff.md`: browser-session identity resolution
+and session import. The authenticated API capability work from that handoff has
+already moved into existing Site Adapter Capabilities such as
+`accountBootstrap`, `accountCompletion`, `accountData`, `keyManagement`,
+`tokenProvisioning`, `accountRefresh`, and `modelCatalog`.
+
+## Current Context
+
+Sub2API browser pages persist dashboard session state in `localStorage`:
+
+- `auth_token`
+- `auth_user`
+- `refresh_token`
+- `token_expires_at`
+
+The content-script extraction code already knows how to parse and refresh that
+state through `ContentSessionExtractor` implementations under
+`src/services/accountSiteOnboarding/contentSession/`.
+
+The problem is not extraction inside the page. The remaining duplicated
+product logic is how callers find a usable browser context and ask that context
+for the session:
+
+- `src/services/siteDetection/autoDetectService.ts`
+  - reads the current tab through `RuntimeActionIds.ContentGetUserFromLocalStorage`
+  - falls back to API identity when content-session data is unavailable
+- `src/features/AccountManagement/hooks/AccountDataContext.tsx`
+  - reads the active tab to match the current page user to a saved account
+- `src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts`
+  - scans same-origin tabs, imports Sub2API refresh-token state, and falls back
+    to `RuntimeActionIds.AutoDetectSite`
+- `src/services/apiService/sub2api/tokenResync.ts`
+  - scans same-origin tabs, reads the access token, and falls back to
+    `RuntimeActionIds.AutoDetectSite`
+
+The current shape works, but each caller has to understand too much about the
+browser-message protocol and fallback ordering.
+
+## Problem
+
+The current browser-session Interface is shallow.
+
+Callers that only need "read the browser session for this account site" must
+know:
+
+1. whether the browser has tab access
+2. how to find same-origin tabs
+3. how to prioritize active tabs
+4. which runtime action reads `localStorage`
+5. which runtime action opens a temp-window fallback
+6. how to normalize the returned user id, user object, access token, and
+   Sub2API refresh-token metadata
+7. which missing fields make a result useful for account matching, session
+   import, or token re-sync
+
+Deletion test: if the repeated tab/message/fallback logic is deleted from the
+callers, it should reappear once inside an account browser-session Module, not
+as another scattered helper in each product flow.
+
+## Goals
+
+- Add a focused account browser-session Module that can read account-site
+  browser-session identity from:
+  - a specific current tab
+  - same-origin existing tabs
+  - the existing temp-window auto-detect fallback
+- Preserve current Sub2API behavior:
+  - current-tab user matching
+  - existing-tab-first session import
+  - temp-window fallback for session import
+  - token re-sync access-token recovery
+  - refresh-token and expiry propagation for Sub2API
+  - incognito and Firefox container context propagation where already present
+- Keep `ContentSessionExtractor` as the content/page extraction owner.
+- Keep `SiteAdapter` authenticated API capabilities as they are.
+- Make product callers consume browser-session results instead of raw runtime
+  message protocols.
+- Keep the first implementation focused on Sub2API because it is the only
+  current site type that needs refresh-token browser-session import.
+
+## Non-Goals
+
+- Do not redesign existing `SiteAdapter` capabilities.
+- Do not move API-authenticated identity fetch out of `accountBootstrap`.
+- Do not rewrite Sub2API token refresh protocol logic inside
+  `accountSiteOnboarding/contentSession/sub2api.ts`.
+- Do not change saved account storage shape.
+- Do not add new user-facing copy, locale keys, settings search entries, or
+  product telemetry fields.
+- Do not add Playwright E2E coverage unless implementation exposes a browser
+  runtime gap that lower-level tests cannot cover.
+- Do not generalize this into a cross-backend auth-storage abstraction.
+
+## Approaches Considered
+
+### Approach A: Keep The Current Per-Caller Logic
+
+This avoids churn, but keeps browser-message knowledge spread across UI,
+account detection, and Sub2API protocol recovery. It provides low locality:
+changing fallback order or message shape requires auditing several unrelated
+callers.
+
+### Approach B: Add A Broad `SiteAdapter.browserSession` Capability
+
+This would put browser-session behavior next to authenticated API capabilities.
+It is conceptually clean, but it risks making `SiteAdapter` responsible for
+browser orchestration, content-script messaging, and temp-window behavior. That
+would mix two seams that currently vary for different reasons:
+
+- `SiteAdapter` owns account-site API capabilities.
+- `ContentSessionExtractor` owns page-local session extraction.
+- Browser orchestration owns how extension contexts reach the page.
+
+This approach is too broad for the current need.
+
+### Approach C: Add A Browser-Session Orchestrator Module
+
+Create a service Module that owns browser-context selection and runtime-message
+fallbacks, while delegating page-local extraction to the existing content
+session extractors.
+
+This is the recommended path. It gives product callers a deeper Interface:
+"resolve browser session for this account site" instead of "scan tabs, send
+runtime messages, parse response, then decide if the result is useful."
+
+## Design
+
+### 1. Add Account Browser-Session Types
+
+Create a new service area:
+
+```text
+src/services/accountBrowserSession/
+```
+
+The public contract should be small and result-focused:
+
+```ts
+export type AccountBrowserSessionSource =
+  | "current_tab"
+  | "existing_tab"
+  | "temp_window"
+
+export type AccountBrowserSessionFetchContext = {
+  kind: "current_tab" | "browser_context"
+  tabId?: number
+  origin?: string
+  incognito?: boolean
+  cookieStoreId?: string
+}
+
+export type AccountBrowserSession = {
+  source: AccountBrowserSessionSource
+  siteType: AccountSiteType
+  userId: string
+  user: Record<string, unknown>
+  accessToken?: string
+  sub2apiAuth?: Sub2ApiAuthConfig
+  fetchContext?: AccountBrowserSessionFetchContext
+}
+```
+
+The interface should not expose runtime message response objects. It returns a
+normalized account browser-session result or `null`.
+
+### 2. Provide Three Read Entry Points
+
+The Module should expose three operations:
+
+```ts
+readAccountBrowserSessionFromTab(params)
+readAccountBrowserSessionFromExistingTabs(params)
+resolveAccountBrowserSession(params)
+```
+
+Responsibilities:
+
+- `readAccountBrowserSessionFromTab(...)`
+  - send `RuntimeActionIds.ContentGetUserFromLocalStorage`
+  - normalize successful responses
+  - return `null` for missing, failed, or unusable responses
+  - preserve the current-tab fetch context when provided
+- `readAccountBrowserSessionFromExistingTabs(...)`
+  - parse target origin
+  - check tab capability
+  - list tabs
+  - keep same-origin tabs only
+  - sort active tabs first
+  - call `readAccountBrowserSessionFromTab(...)`
+  - accept an optional predicate such as `isUsableSession`
+- `resolveAccountBrowserSession(...)`
+  - try a specific current tab when supplied
+  - optionally try same-origin existing tabs
+  - optionally call temp-window auto-detect
+  - normalize the temp-window result into the same result shape
+  - accept an optional predicate to choose whether a partial result is enough
+
+### 3. Keep Content Extraction In Account Site Onboarding
+
+Do not duplicate `localStorage` parsing in the new Module.
+
+The content-script handler should continue to use
+`ContentSessionExtractor` implementations. The new Module only orchestrates
+which browser context to ask and how to normalize the answer.
+
+### 4. Migrate Current-Tab Account Matching
+
+`AccountDataContext` should use
+`readAccountBrowserSessionFromTab(...)` for active-tab user matching.
+
+It should keep its current cache and dedupe behavior, but it should no longer
+build the raw `ContentGetUserFromLocalStorage` message itself.
+
+The matching contract remains:
+
+- same-origin accounts are detected first
+- user-level match is attempted only when same-origin accounts exist
+- failed reads do not block site-level detection
+- verified user identity is cached by tab id and URL
+
+### 5. Migrate Sub2API Session Import
+
+`useAccountDialog` should use
+`resolveAccountBrowserSession(...)` with:
+
+- `siteType: SITE_TYPES.SUB2API`
+- existing-tab search enabled
+- temp-window fallback enabled
+- `isUsableSession` requiring `sub2apiAuth.refreshToken`
+
+The UI-specific behavior stays in the hook:
+
+- URL validation
+- analytics result classification
+- toast messages
+- draft updates
+
+The browser-session Module supplies the normalized session only.
+
+### 6. Migrate Sub2API Token Re-Sync
+
+`src/services/apiService/sub2api/tokenResync.ts` should consume
+`resolveAccountBrowserSession(...)` with:
+
+- `siteType: SITE_TYPES.SUB2API`
+- existing-tab search enabled
+- temp-window fallback enabled
+- `isUsableSession` requiring a non-empty `accessToken`
+
+It should preserve the current public return shape:
+
+```ts
+type Sub2ApiResyncedToken = {
+  accessToken: string
+  source: "existing_tab" | "temp_window"
+}
+```
+
+If the new Module returns `"current_tab"` in this path, map it to
+`"existing_tab"` because token re-sync's public contract only exposes the two
+existing categories.
+
+### 7. Keep Auto-Detect Fallback Semantics Stable
+
+`autoDetectService` already has broader detection responsibilities. Do not
+replace the entire service in this slice.
+
+Only route the direct current-tab content-session read through the new Module
+where it reduces message-protocol knowledge. Preserve existing API fallback,
+background fallback, analytics context, and failure-reason behavior.
+
+## Error Handling
+
+- A content-script failure should return `null` from browser-session read
+  helpers, with debug logging where the caller previously logged.
+- A temp-window failure should return `null` unless the existing caller already
+  surfaces an error. UI hooks should continue to own user-visible error copy.
+- Missing `refreshToken` is not an exception for the Module. It is a predicate
+  decision made by the caller.
+- Missing `accessToken` is not an exception for the Module. It is a predicate
+  decision made by the caller.
+- The Module must not log tokens, refresh tokens, cookies, raw URLs beyond
+  existing safe origin/base URL logging patterns, or full response payloads.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This refactor does not introduce a new user action or product state. Existing
+analytics for account auto-detect and Sub2API session import should remain at
+the product caller layer.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No settings UI, route, anchor, or search definition changes.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E by default.
+
+The main risk is service orchestration and fallback ordering, which can be
+covered with focused Vitest tests around browser API mocks. Add Playwright only
+if implementation changes extension runtime routing or temp-window behavior in
+a way existing tests cannot exercise.
+
+## Testing Strategy
+
+Use TDD for each migration slice.
+
+Add focused unit tests for the new browser-session Module:
+
+- reads and normalizes a successful tab content-session response
+- returns `null` when the content-session response fails
+- filters existing tabs by same origin and tries the active tab first
+- falls back from existing tabs to temp-window auto-detect
+- honors an `isUsableSession` predicate so Sub2API import can require a
+  refresh token while token re-sync can require only an access token
+- preserves current-tab fetch-context metadata
+
+Update caller tests:
+
+- `AccountDataContext` keeps user-level active-tab matching behavior while
+  delegating browser-session reads
+- `useAccountDialog` imports Sub2API refresh-token state through the new Module
+  and still shows the existing missing-session feedback when no refresh token
+  is available
+- `tokenResync.ts` returns the same public result shape while delegating
+  browser-session recovery
+- `autoDetectService` preserves current-tab and temp-window fallback behavior
+  after removing direct message-protocol wiring where practical
+
+## Validation Plan
+
+Focused validation:
+
+```powershell
+pnpm vitest run tests/services/accountBrowserSession
+pnpm vitest run tests/services/apiService/sub2api/tokenResync.test.ts
+pnpm vitest run tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+pnpm vitest run tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+pnpm vitest run tests/services/siteDetection/autoDetectService.test.ts
+```
+
+Type validation:
+
+```powershell
+pnpm compile
+```
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+If shared exports, runtime actions, background temp-window routing, or content
+message handlers change, run before pushing:
+
+```powershell
+pnpm run validate:push
+```
+
+If the implementation changes temp-window runtime behavior, also run the
+relevant temp-window suites:
+
+```powershell
+pnpm vitest run tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts tests/entrypoints/background/tempWindowPoolNativeCheckin.test.ts
+```
+
+## Rollout
+
+1. Add the browser-session contract and tests.
+2. Implement the service Module over existing browser API helpers and runtime
+   actions.
+3. Migrate `tokenResync.ts` to prove the access-token recovery use case first.
+4. Migrate Sub2API session import in `useAccountDialog`.
+5. Migrate active-tab user matching in `AccountDataContext`.
+6. Migrate the current-tab read in `autoDetectService` only where it preserves
+   existing detection semantics.
+7. Run focused tests and type validation.
+8. Run `pnpm run validate:staged`, inspect the final diff, and commit.
+9. Run `pnpm run validate:push` before pushing or opening a PR.
+
+## Follow-Up, Not In Scope
+
+- If a second site type needs browser-session import, add its content-session
+  extractor first, then decide whether the browser-session Module needs a
+  capability registry.
+- If several callers need richer source metadata, add it to the normalized
+  result instead of leaking raw runtime responses.
+- If temp-window behavior becomes more general than auto-detect, consider a
+  dedicated temp-window browser-session runtime action in a separate slice.

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -26,6 +26,11 @@ import {
   isAccountAuthType,
   resolveDefaultAccountAuthType,
 } from "~/features/AccountManagement/utils/accountAuthType"
+import {
+  ACCOUNT_BROWSER_SESSION_SOURCES,
+  resolveAccountBrowserSession,
+  type AccountBrowserSession,
+} from "~/services/accountBrowserSession"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import {
   autoDetectAccount,
@@ -110,13 +115,10 @@ import { deepOverride } from "~/utils"
 import { isExtensionPopup } from "~/utils/browser"
 import {
   getActiveTabs,
-  getAllTabs,
-  getBrowserApiCapabilities,
   isMessageReceiverUnavailableError,
   onTabActivated,
   onTabUpdated,
   sendRuntimeMessage,
-  sendTabMessage,
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
@@ -1500,9 +1502,8 @@ export function useAccountDialog({
   /**
    * Import Sub2API dashboard session credentials (including refresh_token) into the form.
    *
-   * Strategy:
-   * 1) Prefer any existing tab with the same origin (least intrusive; supports incognito tabs when allowed).
-   * 2) Fall back to the background temp-window auto-detect flow.
+   * Strategy is centralized in accountBrowserSession so tab lookup, messaging,
+   * temp-window fallback, and normalization stay consistent across import flows.
    */
   const handleImportSub2apiSession = async () => {
     const analyticsAction = startAccountDialogAnalyticsAction(
@@ -1520,70 +1521,38 @@ export function useAccountDialog({
     setIsImportingSub2apiSession(true)
     try {
       const baseUrl = url.trim()
-      const targetOrigin = tryParseOrigin(baseUrl)
 
-      let imported: any | null = null
-      const hasUsableSub2apiRefreshToken = (value: unknown): boolean =>
-        typeof (value as any)?.sub2apiAuth?.refreshToken === "string" &&
-        (value as any).sub2apiAuth.refreshToken.trim().length > 0
+      const hasUsableSub2apiRefreshToken = (
+        value: AccountBrowserSession | null,
+      ): value is AccountBrowserSession =>
+        typeof value?.sub2apiAuth?.refreshToken === "string" &&
+        value.sub2apiAuth.refreshToken.trim().length > 0
+      let importError: unknown
 
-      if (targetOrigin && getBrowserApiCapabilities().hasTabs) {
-        const tabs = await getAllTabs().catch(() => [])
-        const candidates = tabs
-          .filter((tab) => {
-            if (!tab?.id || !tab.url) return false
-            return tryParseOrigin(tab.url) === targetOrigin
-          })
-          .sort((a, b) => Number(Boolean(b.active)) - Number(Boolean(a.active)))
-
-        for (const tab of candidates) {
-          const tabId = tab.id
-          if (typeof tabId !== "number") continue
-
-          try {
-            const response = await sendTabMessage(tabId, {
-              action: RuntimeActionIds.ContentGetUserFromLocalStorage,
-              url: baseUrl,
-              siteType: SITE_TYPES.SUB2API,
-            })
-            if (response?.success && response.data) {
-              imported = response.data
-              if (hasUsableSub2apiRefreshToken(imported)) {
-                break
-              }
-            }
-          } catch {
-            // Ignore and continue to the next candidate.
+      const imported = await resolveAccountBrowserSession({
+        baseUrl,
+        siteType: SITE_TYPES.SUB2API,
+        useExistingTabs: true,
+        useTempWindow: true,
+        requestIdPrefix: "account-dialog-sub2api-import",
+        isUsableSession: hasUsableSub2apiRefreshToken,
+        onError: (error, context) => {
+          if (context.source === ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW) {
+            importError ??= error
           }
-        }
-      }
+        },
+      })
 
-      if (!hasUsableSub2apiRefreshToken(imported)) {
-        const response = await sendRuntimeMessage({
-          action: RuntimeActionIds.AutoDetectSite,
-          url: baseUrl,
-          requestId: `account-dialog-sub2api-import-${Date.now()}`,
-        })
-        if (response?.success && response.data) {
-          imported = response.data
-        }
-      }
-
-      const refreshToken =
-        typeof imported?.sub2apiAuth?.refreshToken === "string"
-          ? imported.sub2apiAuth.refreshToken.trim()
-          : ""
+      const refreshToken = imported?.sub2apiAuth?.refreshToken?.trim() ?? ""
       if (!refreshToken) {
+        if (importError) throw importError
         analyticsAction.complete(PRODUCT_ANALYTICS_RESULTS.Skipped)
         toast.error(t("messages.importSub2apiSessionMissing"))
         return
       }
 
       const tokenExpiresAtRaw = imported?.sub2apiAuth?.tokenExpiresAt
-      const importedAccessToken =
-        typeof imported?.accessToken === "string"
-          ? imported.accessToken.trim()
-          : ""
+      const importedAccessToken = imported?.accessToken?.trim() ?? ""
       const importedUserId = normalizeAccountIdentity(imported?.userId) ?? ""
       const importedUsername =
         typeof imported?.user?.username === "string"

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -30,6 +30,7 @@ import {
   ACCOUNT_BROWSER_SESSION_SOURCES,
   resolveAccountBrowserSession,
   type AccountBrowserSession,
+  type ResolveAccountBrowserSessionOptions,
 } from "~/services/accountBrowserSession"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import {
@@ -159,6 +160,30 @@ function createCurrentTabCookieImportContext(
     ...(typeof tab.cookieStoreId === "string" && tab.cookieStoreId.trim()
       ? { cookieStoreId: tab.cookieStoreId.trim() }
       : {}),
+  }
+}
+
+/**
+ * Reuses the active tab only when it belongs to the target origin and browser profile.
+ */
+function createCurrentTabBrowserSessionContext(
+  context: CurrentTabCookieImportContext | null,
+  targetUrl: string,
+): ResolveAccountBrowserSessionOptions["currentTab"] | undefined {
+  const targetOrigin = tryParseOrigin(targetUrl)
+  if (
+    !context ||
+    !targetOrigin ||
+    targetOrigin !== context.origin ||
+    typeof context.tabId !== "number"
+  ) {
+    return undefined
+  }
+
+  return {
+    tabId: context.tabId,
+    incognito: context.incognito === true,
+    ...(context.cookieStoreId ? { cookieStoreId: context.cookieStoreId } : {}),
   }
 }
 
@@ -1527,11 +1552,16 @@ export function useAccountDialog({
       ): value is AccountBrowserSession =>
         typeof value?.sub2apiAuth?.refreshToken === "string" &&
         value.sub2apiAuth.refreshToken.trim().length > 0
+      const currentTab = createCurrentTabBrowserSessionContext(
+        currentTabCookieImportContextRef.current,
+        baseUrl,
+      )
       let importError: unknown
 
       const imported = await resolveAccountBrowserSession({
         baseUrl,
         siteType: SITE_TYPES.SUB2API,
+        ...(currentTab ? { currentTab } : {}),
         useExistingTabs: true,
         useTempWindow: true,
         requestIdPrefix: "account-dialog-sub2api-import",

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -23,7 +23,6 @@ import {
   ACCOUNT_BROWSER_SESSION_SOURCES,
   readAccountBrowserSessionFromTab,
 } from "~/services/accountBrowserSession"
-import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import {
   doAccountSiteIdentitiesMatch,
   resolveAccountSiteContentSessionHintForOrigin,
@@ -518,12 +517,8 @@ export const AccountDataProvider = ({
             },
           })
 
-          verifiedUserId = normalizeAccountIdentity(session?.userId)
-          verifiedUser =
-            session?.user ??
-            (verifiedUserId
-              ? { id: verifiedUserId, username: verifiedUserId }
-              : null)
+          verifiedUserId = session?.userId ?? null
+          verifiedUser = session?.user ?? null
 
           // Cache verified user identity data by tab+url to prevent duplicate reads.
           currentTabUserCacheRef.current = {

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -19,6 +19,10 @@ import {
 } from "~/constants"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import {
+  ACCOUNT_BROWSER_SESSION_SOURCES,
+  readAccountBrowserSessionFromTab,
+} from "~/services/accountBrowserSession"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import {
   doAccountSiteIdentitiesMatch,
@@ -26,6 +30,7 @@ import {
 } from "~/services/accounts/accountSiteProfile"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { isSameAccountSiteOrigin } from "~/services/accounts/utils/siteUrlNormalization"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
 import { getDayKeyFromUnixSeconds } from "~/services/history/dailyBalanceHistory/dayKeys"
 import { dailyBalanceHistoryStorage } from "~/services/history/dailyBalanceHistory/storage"
 import {
@@ -61,7 +66,6 @@ import {
   onTabActivated,
   onTabRemoved,
   onTabUpdated,
-  sendTabMessage,
 } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 
@@ -502,26 +506,21 @@ export const AccountDataProvider = ({
         }
 
         try {
-          // Ask the content script to read the site's localStorage and return the current userId.
-          const userResponse = await sendTabMessage(tabId, {
-            action: RuntimeActionIds.ContentGetUserFromLocalStorage,
-            url: parsedUrl.origin,
+          const session = await readAccountBrowserSessionFromTab({
+            tabId,
+            baseUrl: parsedUrl.origin,
             siteType: siteTypeForUserRead,
+            source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+            fetchContext: {
+              kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+              tabId,
+              origin: parsedUrl.origin,
+            },
           })
 
-          const userIdRaw = userResponse?.success
-            ? userResponse?.data?.userId
-            : null
-          const userRaw =
-            userResponse?.success &&
-            userResponse?.data?.user &&
-            typeof userResponse.data.user === "object" &&
-            !Array.isArray(userResponse.data.user)
-              ? (userResponse.data.user as Record<string, unknown>)
-              : null
-          verifiedUserId = normalizeAccountIdentity(userIdRaw)
+          verifiedUserId = normalizeAccountIdentity(session?.userId)
           verifiedUser =
-            userRaw ??
+            session?.user ??
             (verifiedUserId
               ? { id: verifiedUserId, username: verifiedUserId }
               : null)

--- a/src/services/accountBrowserSession/index.ts
+++ b/src/services/accountBrowserSession/index.ts
@@ -1,0 +1,2 @@
+export * from "./sessionReader"
+export * from "./types"

--- a/src/services/accountBrowserSession/sessionReader.ts
+++ b/src/services/accountBrowserSession/sessionReader.ts
@@ -1,0 +1,262 @@
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { isAccountSiteType } from "~/constants/siteType"
+import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
+import {
+  getAllTabs,
+  getBrowserApiCapabilities,
+  sendRuntimeMessage,
+  sendTabMessage,
+} from "~/utils/browser/browserApi"
+import { createLogger } from "~/utils/core/logger"
+import { tryParseOrigin } from "~/utils/core/urlParsing"
+
+import type {
+  AccountBrowserSession,
+  AccountBrowserSessionFetchContext,
+  ReadAccountBrowserSessionFromExistingTabsOptions,
+  ReadAccountBrowserSessionFromTabOptions,
+  ResolveAccountBrowserSessionOptions,
+} from "./types"
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "./types"
+
+const logger = createLogger("AccountBrowserSession")
+
+const hasNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+const normalizeOptionalString = (value: unknown): string | undefined =>
+  hasNonEmptyString(value) ? value.trim() : undefined
+
+const normalizeSub2ApiAuth = (
+  value: unknown,
+): AccountBrowserSession["sub2apiAuth"] => {
+  if (!value || typeof value !== "object") return undefined
+
+  const refreshToken = normalizeOptionalString(
+    (value as { refreshToken?: unknown }).refreshToken,
+  )
+  if (!refreshToken) return undefined
+
+  const tokenExpiresAt = (value as { tokenExpiresAt?: unknown }).tokenExpiresAt
+
+  return {
+    refreshToken,
+    ...(typeof tokenExpiresAt === "number" && Number.isFinite(tokenExpiresAt)
+      ? { tokenExpiresAt }
+      : {}),
+  }
+}
+
+const normalizeSessionData = (
+  data: unknown,
+  options: {
+    source: AccountBrowserSession["source"]
+    siteType: AccountBrowserSession["siteType"]
+    fetchContext?: AccountBrowserSessionFetchContext
+  },
+): AccountBrowserSession | null => {
+  if (!data || typeof data !== "object") return null
+
+  const payload = data as {
+    userId?: unknown
+    user?: unknown
+    accessToken?: unknown
+    siteTypeHint?: unknown
+    siteType?: unknown
+    sub2apiAuth?: unknown
+    fetchContext?: AccountBrowserSessionFetchContext
+  }
+
+  const userId = normalizeAccountIdentity(payload.userId)
+  if (!userId) return null
+
+  const user =
+    payload.user &&
+    typeof payload.user === "object" &&
+    !Array.isArray(payload.user)
+      ? (payload.user as Record<string, unknown>)
+      : { id: userId, username: userId }
+  const accessToken = normalizeOptionalString(payload.accessToken)
+  const siteTypeHint = isAccountSiteType(payload.siteTypeHint)
+    ? payload.siteTypeHint
+    : isAccountSiteType(payload.siteType)
+      ? payload.siteType
+      : undefined
+  const sub2apiAuth = normalizeSub2ApiAuth(payload.sub2apiAuth)
+  const fetchContext = options.fetchContext ?? payload.fetchContext
+
+  return {
+    source: options.source,
+    siteType: options.siteType,
+    ...(siteTypeHint ? { siteTypeHint } : {}),
+    userId,
+    user,
+    ...(accessToken ? { accessToken } : {}),
+    ...(sub2apiAuth ? { sub2apiAuth } : {}),
+    ...(fetchContext ? { fetchContext } : {}),
+  }
+}
+
+/**
+ * Reads and normalizes an account browser session from a specific tab.
+ */
+export async function readAccountBrowserSessionFromTab(
+  options: ReadAccountBrowserSessionFromTabOptions,
+): Promise<AccountBrowserSession | null> {
+  try {
+    const response = await sendTabMessage(options.tabId, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: options.baseUrl,
+      siteType: options.siteType,
+    })
+
+    if (!response?.success || !response.data) return null
+
+    return normalizeSessionData(response.data, {
+      source: options.source,
+      siteType: options.siteType,
+      fetchContext: options.fetchContext,
+    })
+  } catch (error) {
+    logger.debug("Failed to read account browser session from tab", {
+      tabId: options.tabId,
+      siteType: options.siteType,
+      error,
+    })
+    options.onError?.(error, { source: options.source })
+    return null
+  }
+}
+
+const getSameOriginTabs = async (baseUrl: string) => {
+  const origin = tryParseOrigin(baseUrl)
+  if (!origin) return []
+  if (!getBrowserApiCapabilities().hasTabs) return []
+
+  const tabs = await getAllTabs().catch(() => [])
+  return tabs
+    .filter((tab) => {
+      if (!tab?.id || !tab.url) return false
+      return tryParseOrigin(tab.url) === origin
+    })
+    .sort((a, b) => Number(Boolean(b.active)) - Number(Boolean(a.active)))
+}
+
+const createCurrentTabFetchContext = (
+  options: ResolveAccountBrowserSessionOptions,
+): AccountBrowserSessionFetchContext | undefined => {
+  if (!options.currentTab) return undefined
+
+  const origin = tryParseOrigin(options.baseUrl)
+  if (!origin) return undefined
+
+  return {
+    kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+    tabId: options.currentTab.tabId,
+    origin,
+    ...(options.currentTab.incognito === true ? { incognito: true } : {}),
+    ...(options.currentTab.cookieStoreId
+      ? { cookieStoreId: options.currentTab.cookieStoreId }
+      : {}),
+  }
+}
+
+/**
+ * Reads account browser sessions from same-origin tabs, preferring active tabs first.
+ */
+export async function readAccountBrowserSessionFromExistingTabs(
+  options: ReadAccountBrowserSessionFromExistingTabsOptions,
+): Promise<AccountBrowserSession | null> {
+  const tabs = await getSameOriginTabs(options.baseUrl)
+
+  for (const tab of tabs) {
+    const tabId = tab.id
+    if (typeof tabId !== "number") continue
+
+    const session = await readAccountBrowserSessionFromTab({
+      tabId,
+      baseUrl: options.baseUrl,
+      siteType: options.siteType,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      onError: options.onError,
+    })
+
+    if (
+      session &&
+      (!options.isUsableSession || options.isUsableSession(session))
+    ) {
+      return session
+    }
+  }
+
+  return null
+}
+
+const readAccountBrowserSessionFromTempWindow = async (
+  options: ResolveAccountBrowserSessionOptions,
+): Promise<AccountBrowserSession | null> => {
+  try {
+    const response = await sendRuntimeMessage({
+      action: RuntimeActionIds.AutoDetectSite,
+      url: options.baseUrl,
+      requestId: `${options.requestIdPrefix ?? "account-browser-session"}-${Date.now()}`,
+      ...(options.suppressMinimize ? { suppressMinimize: true } : {}),
+      ...(options.currentTab?.incognito === true ? { useIncognito: true } : {}),
+    })
+
+    if (!response?.success || !response.data) return null
+
+    return normalizeSessionData(response.data, {
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+      siteType: options.siteType,
+    })
+  } catch (error) {
+    logger.debug("Failed to read account browser session from temp window", {
+      siteType: options.siteType,
+      error,
+    })
+    options.onError?.(error, {
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+    })
+    return null
+  }
+}
+
+/**
+ * Resolves an account browser session across current-tab, existing-tab, and temp-window sources.
+ */
+export async function resolveAccountBrowserSession(
+  options: ResolveAccountBrowserSessionOptions,
+): Promise<AccountBrowserSession | null> {
+  const isUsable = options.isUsableSession ?? (() => true)
+
+  if (options.currentTab) {
+    const session = await readAccountBrowserSessionFromTab({
+      tabId: options.currentTab.tabId,
+      baseUrl: options.baseUrl,
+      siteType: options.siteType,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      fetchContext: createCurrentTabFetchContext(options),
+      onError: options.onError,
+    })
+    if (session && isUsable(session)) return session
+  }
+
+  if (options.useExistingTabs) {
+    const session = await readAccountBrowserSessionFromExistingTabs({
+      baseUrl: options.baseUrl,
+      siteType: options.siteType,
+      isUsableSession: isUsable,
+      onError: options.onError,
+    })
+    if (session) return session
+  }
+
+  if (options.useTempWindow) {
+    const session = await readAccountBrowserSessionFromTempWindow(options)
+    if (session && isUsable(session)) return session
+  }
+
+  return null
+}

--- a/src/services/accountBrowserSession/sessionReader.ts
+++ b/src/services/accountBrowserSession/sessionReader.ts
@@ -48,6 +48,49 @@ const normalizeSub2ApiAuth = (
   }
 }
 
+const normalizeFetchContext = (
+  value: unknown,
+): AccountBrowserSessionFetchContext | undefined => {
+  if (!value || typeof value !== "object") return undefined
+
+  const context = value as {
+    kind?: unknown
+    tabId?: unknown
+    origin?: unknown
+    incognito?: unknown
+    cookieStoreId?: unknown
+  }
+  const browserContext = {
+    ...(context.incognito === true ? { incognito: true } : {}),
+    ...(hasNonEmptyString(context.cookieStoreId)
+      ? { cookieStoreId: context.cookieStoreId.trim() }
+      : {}),
+  }
+
+  if (context.kind === API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT) {
+    return {
+      kind: API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT,
+      ...browserContext,
+    }
+  }
+
+  if (
+    context.kind === API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB &&
+    typeof context.tabId === "number" &&
+    Number.isFinite(context.tabId) &&
+    hasNonEmptyString(context.origin)
+  ) {
+    return {
+      kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+      tabId: context.tabId,
+      origin: context.origin.trim(),
+      ...browserContext,
+    }
+  }
+
+  return undefined
+}
+
 const normalizeSessionData = (
   data: unknown,
   options: {
@@ -65,7 +108,7 @@ const normalizeSessionData = (
     siteTypeHint?: unknown
     siteType?: unknown
     sub2apiAuth?: unknown
-    fetchContext?: AccountBrowserSessionFetchContext
+    fetchContext?: unknown
   }
 
   const userId = normalizeAccountIdentity(payload.userId)
@@ -84,7 +127,8 @@ const normalizeSessionData = (
       ? payload.siteType
       : undefined
   const sub2apiAuth = normalizeSub2ApiAuth(payload.sub2apiAuth)
-  const fetchContext = options.fetchContext ?? payload.fetchContext
+  const fetchContext =
+    options.fetchContext ?? normalizeFetchContext(payload.fetchContext)
 
   return {
     source: options.source,
@@ -129,7 +173,33 @@ export async function readAccountBrowserSessionFromTab(
   }
 }
 
-const getSameOriginTabs = async (baseUrl: string) => {
+const doesTabMatchBrowserContext = (
+  tab: browser.tabs.Tab,
+  browserContext: ReadAccountBrowserSessionFromExistingTabsOptions["browserContext"],
+) => {
+  if (!browserContext) return true
+
+  if (
+    typeof browserContext.incognito === "boolean" &&
+    (tab.incognito === true) !== browserContext.incognito
+  ) {
+    return false
+  }
+
+  if (
+    browserContext.cookieStoreId &&
+    tab.cookieStoreId !== browserContext.cookieStoreId
+  ) {
+    return false
+  }
+
+  return true
+}
+
+const getSameOriginTabs = async (
+  baseUrl: string,
+  browserContext?: ReadAccountBrowserSessionFromExistingTabsOptions["browserContext"],
+) => {
   const origin = tryParseOrigin(baseUrl)
   if (!origin) return []
   if (!getBrowserApiCapabilities().hasTabs) return []
@@ -138,7 +208,10 @@ const getSameOriginTabs = async (baseUrl: string) => {
   return tabs
     .filter((tab) => {
       if (!tab?.id || !tab.url) return false
-      return tryParseOrigin(tab.url) === origin
+      return (
+        tryParseOrigin(tab.url) === origin &&
+        doesTabMatchBrowserContext(tab, browserContext)
+      )
     })
     .sort((a, b) => Number(Boolean(b.active)) - Number(Boolean(a.active)))
 }
@@ -168,7 +241,7 @@ const createCurrentTabFetchContext = (
 export async function readAccountBrowserSessionFromExistingTabs(
   options: ReadAccountBrowserSessionFromExistingTabsOptions,
 ): Promise<AccountBrowserSession | null> {
-  const tabs = await getSameOriginTabs(options.baseUrl)
+  const tabs = await getSameOriginTabs(options.baseUrl, options.browserContext)
 
   for (const tab of tabs) {
     const tabId = tab.id
@@ -179,6 +252,13 @@ export async function readAccountBrowserSessionFromExistingTabs(
       baseUrl: options.baseUrl,
       siteType: options.siteType,
       source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      fetchContext: normalizeFetchContext({
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId,
+        origin: tryParseOrigin(options.baseUrl),
+        ...(tab.incognito === true ? { incognito: true } : {}),
+        ...(tab.cookieStoreId ? { cookieStoreId: tab.cookieStoreId } : {}),
+      }),
       onError: options.onError,
     })
 
@@ -247,6 +327,14 @@ export async function resolveAccountBrowserSession(
     const session = await readAccountBrowserSessionFromExistingTabs({
       baseUrl: options.baseUrl,
       siteType: options.siteType,
+      browserContext: options.currentTab
+        ? {
+            incognito: options.currentTab.incognito === true,
+            ...(options.currentTab.cookieStoreId
+              ? { cookieStoreId: options.currentTab.cookieStoreId }
+              : {}),
+          }
+        : undefined,
       isUsableSession: isUsable,
       onError: options.onError,
     })

--- a/src/services/accountBrowserSession/types.ts
+++ b/src/services/accountBrowserSession/types.ts
@@ -1,0 +1,74 @@
+import type { AccountSiteType } from "~/constants/siteType"
+import type { ApiServiceFetchContext } from "~/services/apiService/common/type"
+import type { Sub2ApiAuthConfig } from "~/types"
+
+export const ACCOUNT_BROWSER_SESSION_SOURCES = {
+  CURRENT_TAB: "current_tab",
+  EXISTING_TAB: "existing_tab",
+  TEMP_WINDOW: "temp_window",
+} as const
+
+export type AccountBrowserSessionSource =
+  (typeof ACCOUNT_BROWSER_SESSION_SOURCES)[keyof typeof ACCOUNT_BROWSER_SESSION_SOURCES]
+
+export type AccountBrowserSessionFetchContext = ApiServiceFetchContext
+
+export type AccountBrowserSession = {
+  source: AccountBrowserSessionSource
+  siteType: AccountSiteType
+  siteTypeHint?: AccountSiteType
+  userId: string
+  user: Record<string, unknown>
+  accessToken?: string
+  sub2apiAuth?: Sub2ApiAuthConfig
+  fetchContext?: AccountBrowserSessionFetchContext
+}
+
+export type AccountBrowserSessionPredicate = (
+  session: AccountBrowserSession,
+) => boolean
+
+export type AccountBrowserSessionErrorContext = {
+  source: AccountBrowserSessionSource
+}
+
+export type AccountBrowserSessionErrorHandler = (
+  error: unknown,
+  context: AccountBrowserSessionErrorContext,
+) => void
+
+export type ReadAccountBrowserSessionFromTabOptions = {
+  tabId: number
+  baseUrl: string
+  siteType: AccountSiteType
+  source: Extract<
+    AccountBrowserSessionSource,
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
+  >
+  fetchContext?: AccountBrowserSessionFetchContext
+  onError?: AccountBrowserSessionErrorHandler
+}
+
+export type ReadAccountBrowserSessionFromExistingTabsOptions = {
+  baseUrl: string
+  siteType: AccountSiteType
+  isUsableSession?: AccountBrowserSessionPredicate
+  onError?: AccountBrowserSessionErrorHandler
+}
+
+export type ResolveAccountBrowserSessionOptions = {
+  baseUrl: string
+  siteType: AccountSiteType
+  currentTab?: {
+    tabId: number
+    incognito?: boolean
+    cookieStoreId?: string
+  }
+  useExistingTabs?: boolean
+  useTempWindow?: boolean
+  suppressMinimize?: boolean
+  requestIdPrefix?: string
+  isUsableSession?: AccountBrowserSessionPredicate
+  onError?: AccountBrowserSessionErrorHandler
+}

--- a/src/services/accountBrowserSession/types.ts
+++ b/src/services/accountBrowserSession/types.ts
@@ -53,6 +53,10 @@ export type ReadAccountBrowserSessionFromTabOptions = {
 export type ReadAccountBrowserSessionFromExistingTabsOptions = {
   baseUrl: string
   siteType: AccountSiteType
+  browserContext?: {
+    incognito?: boolean
+    cookieStoreId?: string
+  }
   isUsableSession?: AccountBrowserSessionPredicate
   onError?: AccountBrowserSessionErrorHandler
 }

--- a/src/services/apiService/sub2api/tokenResync.ts
+++ b/src/services/apiService/sub2api/tokenResync.ts
@@ -16,21 +16,22 @@ const hasUsableAccessToken = (session: AccountBrowserSession): boolean =>
   typeof session.accessToken === "string" &&
   session.accessToken.trim().length > 0
 
+const SUB2API_RESYNC_SOURCE_BY_BROWSER_SESSION_SOURCE = {
+  [ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB]:
+    ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+  [ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB]:
+    ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+  [ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW]:
+    ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+} as const satisfies Record<
+  AccountBrowserSession["source"],
+  Sub2ApiResyncedToken["source"]
+>
+
 const mapResyncSource = (
   source: AccountBrowserSession["source"],
-): Sub2ApiResyncedToken["source"] => {
-  switch (source) {
-    case ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB:
-    case ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB:
-      return ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
-    case ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW:
-      return ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
-    default: {
-      const exhaustive: never = source
-      return exhaustive
-    }
-  }
-}
+): Sub2ApiResyncedToken["source"] =>
+  SUB2API_RESYNC_SOURCE_BY_BROWSER_SESSION_SOURCE[source]
 
 /**
  * Re-sync Sub2API JWT from browser-session state.

--- a/src/services/apiService/sub2api/tokenResync.ts
+++ b/src/services/apiService/sub2api/tokenResync.ts
@@ -18,10 +18,19 @@ const hasUsableAccessToken = (session: AccountBrowserSession): boolean =>
 
 const mapResyncSource = (
   source: AccountBrowserSession["source"],
-): Sub2ApiResyncedToken["source"] =>
-  source === ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
-    ? ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
-    : ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
+): Sub2ApiResyncedToken["source"] => {
+  switch (source) {
+    case ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB:
+    case ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB:
+      return ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
+    case ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW:
+      return ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
+    default: {
+      const exhaustive: never = source
+      return exhaustive
+    }
+  }
+}
 
 /**
  * Re-sync Sub2API JWT from browser-session state.

--- a/src/services/apiService/sub2api/tokenResync.ts
+++ b/src/services/apiService/sub2api/tokenResync.ts
@@ -1,144 +1,52 @@
-import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
-  getAllTabs,
-  getBrowserApiCapabilities,
-  sendRuntimeMessage,
-  sendTabMessage,
-} from "~/utils/browser/browserApi"
-import { createLogger } from "~/utils/core/logger"
-import { tryParseOrigin } from "~/utils/core/urlParsing"
-
-import { getSafeErrorMessage } from "./redaction"
-
-/**
- * Unified logger scoped to Sub2API token re-sync.
- *
- * Sub2API moved to an access-token + refresh-token model. We rely on the
- * Sub2API dashboard localStorage (and our content-script handler) to perform a
- * best-effort refresh when the stored access token is close to expiry.
- *
- * IMPORTANT: Never log JWT values.
- */
-const logger = createLogger("Sub2ApiTokenResync")
+  ACCOUNT_BROWSER_SESSION_SOURCES,
+  resolveAccountBrowserSession,
+  type AccountBrowserSession,
+} from "~/services/accountBrowserSession"
 
 type Sub2ApiResyncedToken = {
   accessToken: string
-  source: "existing_tab" | "temp_window"
+  source:
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
 }
 
-/**
- * Helper: send a message to a tab to read the Sub2API auth state from localStorage.
- *
- * The content script will attempt to read the `auth_token` and respond with the
- * value (if exists) or an error (if any issue occurs, e.g. CORS, missing keys).
- *
- * IMPORTANT: Never log JWT values.
- */
-async function readUserFromTab(tabId: number, baseUrl: string) {
-  try {
-    return await sendTabMessage(tabId, {
-      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
-      url: baseUrl,
-      siteType: SITE_TYPES.SUB2API,
-    })
-  } catch (error) {
-    logger.debug("Failed to read Sub2API auth state from tab", {
-      tabId,
-      error: getSafeErrorMessage(error),
-    })
-    return null
-  }
-}
+const hasUsableAccessToken = (session: AccountBrowserSession): boolean =>
+  typeof session.accessToken === "string" &&
+  session.accessToken.trim().length > 0
+
+const mapResyncSource = (
+  source: AccountBrowserSession["source"],
+): Sub2ApiResyncedToken["source"] =>
+  source === ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
+    ? ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
+    : ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
 
 /**
- * Best-effort: read `auth_token` from an already-open tab with the same origin.
- */
-async function readSub2ApiAuthTokenFromExistingTab(
-  baseUrl: string,
-): Promise<string | null> {
-  const origin = tryParseOrigin(baseUrl)
-  if (!origin) return null
-
-  if (!getBrowserApiCapabilities().hasTabs) return null
-
-  const tabs = await getAllTabs().catch(() => [])
-  const candidates = tabs
-    .filter((tab) => {
-      if (!tab?.id || !tab.url) return false
-      const tabOrigin = tryParseOrigin(tab.url)
-      return tabOrigin === origin
-    })
-    .sort((a, b) => Number(Boolean(b.active)) - Number(Boolean(a.active)))
-
-  for (const tab of candidates) {
-    const tabId = tab.id
-    if (typeof tabId !== "number") continue
-
-    const response = await readUserFromTab(tabId, baseUrl)
-    if (!response?.success) {
-      continue
-    }
-
-    const token = response.data?.accessToken
-    if (typeof token === "string" && token.trim()) {
-      return token.trim()
-    }
-  }
-
-  return null
-}
-
-/**
- * Best-effort: read `auth_token` by opening a temp window context.
- *
- * Reuses the existing auto-detect runtime flow, which already knows how to
- * acquire a temp context and read localStorage in a site page environment.
- */
-async function readSub2ApiAuthTokenFromTempWindow(
-  baseUrl: string,
-): Promise<string | null> {
-  try {
-    const response = await sendRuntimeMessage({
-      action: RuntimeActionIds.AutoDetectSite,
-      url: baseUrl,
-      requestId: `sub2api-token-resync-${Date.now()}`,
-    })
-
-    const token = response?.data?.accessToken
-    if (typeof token === "string" && token.trim()) {
-      return token.trim()
-    }
-
-    return null
-  } catch (error) {
-    logger.warn("Failed to read auth_token via temp window", {
-      baseUrl,
-      error: getSafeErrorMessage(error),
-    })
-    return null
-  }
-}
-
-/**
- * Re-sync Sub2API JWT from localStorage.
+ * Re-sync Sub2API JWT from browser-session state.
  *
  * Strategy:
- * 1) Prefer an already-open tab (least intrusive)
- * 2) Fall back to a temp-window context
+ * 1) Prefer an already-open same-origin tab through the browser-session reader.
+ * 2) Fall back to the temp-window auto-detect context.
  */
 export async function resyncSub2ApiAuthToken(
   baseUrl: string,
 ): Promise<Sub2ApiResyncedToken | null> {
-  const fromTab = await readSub2ApiAuthTokenFromExistingTab(baseUrl)
-  if (fromTab) {
-    return { accessToken: fromTab, source: "existing_tab" }
-  }
+  const session = await resolveAccountBrowserSession({
+    baseUrl,
+    siteType: SITE_TYPES.SUB2API,
+    useExistingTabs: true,
+    useTempWindow: true,
+    requestIdPrefix: "sub2api-token-resync",
+    isUsableSession: hasUsableAccessToken,
+  })
 
-  const fromTempWindow = await readSub2ApiAuthTokenFromTempWindow(baseUrl)
-  if (fromTempWindow) {
-    return { accessToken: fromTempWindow, source: "temp_window" }
-  }
+  const accessToken = session?.accessToken?.trim()
+  if (!session || !accessToken) return null
 
-  return null
+  return {
+    accessToken,
+    source: mapResyncSource(session.source),
+  }
 }

--- a/src/services/siteDetection/autoDetectService.ts
+++ b/src/services/siteDetection/autoDetectService.ts
@@ -21,6 +21,10 @@ import {
   isAccountSiteType,
   type AccountSiteType,
 } from "~/constants/siteType"
+import {
+  ACCOUNT_BROWSER_SESSION_SOURCES,
+  readAccountBrowserSessionFromTab,
+} from "~/services/accountBrowserSession"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import { getSiteAdapter } from "~/services/apiAdapters/registry"
 import {
@@ -34,7 +38,6 @@ import {
   getBrowserApiCapabilities,
   isMessageReceiverUnavailableError,
   sendRuntimeMessage,
-  sendTabMessage,
 } from "~/utils/browser/browserApi"
 import { isExtensionPopup } from "~/utils/browser/index"
 import { getErrorMessage } from "~/utils/core/error"
@@ -500,47 +503,46 @@ async function getUserDataFromCurrentTab(
   })
 
   try {
-    // 通过 content script 获取用户信息
-    try {
-      const userResponse = await sendTabMessage(tabId, {
-        action: RuntimeActionIds.ContentGetUserFromLocalStorage,
-        url: url,
-        siteType,
-      })
+    const session = await readAccountBrowserSessionFromTab({
+      tabId,
+      baseUrl: url,
+      siteType,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      fetchContext,
+      onError(error) {
+        contentScriptUnavailable = isMessageReceiverUnavailableError(error)
 
-      const userId = normalizeAccountIdentity(userResponse?.data?.userId)
-      if (userResponse?.success && userResponse.data && userId) {
-        return {
-          userData: {
-            userId,
-            user: userResponse.data.user,
-            accessToken: userResponse.data.accessToken,
-            sub2apiAuth: userResponse.data.sub2apiAuth,
-            siteTypeHint: normalizeSiteTypeHint(userResponse.data.siteTypeHint),
-            fetchContext,
-          },
-          contentScriptUnavailable,
-          strategy: AUTO_DETECT_STRATEGIES.CurrentTab,
-          fetchContext,
+        if (contentScriptUnavailable) {
+          logger.warn("当前标签页 content script 不可用，尝试 API 降级", {
+            url,
+            tabId,
+            fetchContext: summarizeApiServiceFetchContext(fetchContext),
+            error: getErrorMessage(error),
+          })
+        } else {
+          logger.warn("从当前标签页获取用户数据失败", {
+            url,
+            tabId,
+            fetchContext: summarizeApiServiceFetchContext(fetchContext),
+            error: getErrorMessage(error),
+          })
         }
-      }
-    } catch (error) {
-      contentScriptUnavailable = isMessageReceiverUnavailableError(error)
+      },
+    })
 
-      if (contentScriptUnavailable) {
-        logger.warn("当前标签页 content script 不可用，尝试 API 降级", {
-          url,
-          tabId,
-          fetchContext: summarizeApiServiceFetchContext(fetchContext),
-          error: getErrorMessage(error),
-        })
-      } else {
-        logger.warn("从当前标签页获取用户数据失败", {
-          url,
-          tabId,
-          fetchContext: summarizeApiServiceFetchContext(fetchContext),
-          error: getErrorMessage(error),
-        })
+    if (session) {
+      return {
+        userData: {
+          userId: session.userId,
+          user: session.user,
+          accessToken: session.accessToken,
+          sub2apiAuth: session.sub2apiAuth,
+          siteTypeHint: normalizeSiteTypeHint(session.siteTypeHint),
+          fetchContext,
+        },
+        contentScriptUnavailable,
+        strategy: AUTO_DETECT_STRATEGIES.CurrentTab,
+        fetchContext,
       }
     }
 

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -14,6 +14,8 @@ import {
   AccountDataProvider,
   useAccountDataContext,
 } from "~/features/AccountManagement/hooks/AccountDataContext"
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession/types"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
 import type { SearchResult } from "~/services/search/accountSearch"
 import type { DisplaySiteData } from "~/types"
 import { DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION } from "~/types/dailyBalanceHistory"
@@ -58,6 +60,7 @@ const {
   mockRefreshAllAccounts,
   mockRefreshDisabledAccounts,
   mockToastPromise,
+  mockReadAccountBrowserSessionFromTab,
   mockGetActiveTabs,
   mockGetAllTabs,
   mockSendTabMessage,
@@ -97,6 +100,7 @@ const {
   mockRefreshAllAccounts: vi.fn(),
   mockRefreshDisabledAccounts: vi.fn(),
   mockToastPromise: vi.fn(),
+  mockReadAccountBrowserSessionFromTab: vi.fn(),
   mockGetActiveTabs: vi.fn<() => Promise<browser.tabs.Tab[]>>(async () => []),
   mockGetAllTabs: vi.fn<() => Promise<browser.tabs.Tab[]>>(async () => []),
   mockSendTabMessage: vi.fn(
@@ -239,6 +243,16 @@ vi.mock("~/utils/browser/browserApi", () => ({
   onTabUpdated: mockOnTabUpdated,
 }))
 
+vi.mock("~/services/accountBrowserSession", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/accountBrowserSession")>()
+
+  return {
+    ...actual,
+    readAccountBrowserSessionFromTab: mockReadAccountBrowserSessionFromTab,
+  }
+})
+
 vi.mock("~/services/search/accountSearch", () => ({
   buildAccountSearchIndex: mockBuildAccountSearchIndex,
   searchAccountSearchIndex: mockSearchAccountSearchIndex,
@@ -312,6 +326,7 @@ beforeEach(() => {
     latestSyncTime: 0,
   })
   mockToastPromise.mockImplementation((promise: Promise<any>) => promise)
+  mockReadAccountBrowserSessionFromTab.mockResolvedValue(null)
   mockGetActiveTabs.mockResolvedValue([])
   mockGetAllTabs.mockResolvedValue([])
   mockOnRuntimeMessage.mockImplementation((listener: any) => {
@@ -1524,10 +1539,17 @@ describe("AccountDataContext current tab detection", () => {
     mockGetActiveTabs.mockResolvedValue([
       createBrowserTab({ id: 7, url: "https://api.example.com/settings" }),
     ])
-    vi.mocked(globalThis.browser.tabs.sendMessage).mockResolvedValue({
-      success: true,
-      data: { userId: "42" },
-    } as any)
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: "new-api",
+      userId: "42",
+      user: { id: "42", username: "42" },
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 7,
+        origin: "https://api.example.com",
+      },
+    })
 
     const getLatestCtx = await renderAccountDataProvider()
 
@@ -1538,10 +1560,16 @@ describe("AccountDataContext current tab detection", () => {
       expect(getLatestCtx().detectedAccount?.id).toBe("acc-2")
     })
 
-    expect(globalThis.browser.tabs.sendMessage).toHaveBeenCalledWith(7, {
-      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
-      url: "https://api.example.com",
+    expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledWith({
+      tabId: 7,
+      baseUrl: "https://api.example.com",
       siteType: "new-api",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 7,
+        origin: "https://api.example.com",
+      },
     })
   })
 
@@ -1558,9 +1586,7 @@ describe("AccountDataContext current tab detection", () => {
     mockGetActiveTabs.mockResolvedValue([
       createBrowserTab({ id: 8, url: "https://api.example.com/settings" }),
     ])
-    vi.mocked(globalThis.browser.tabs.sendMessage).mockRejectedValue(
-      new Error("content script unavailable"),
-    )
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce(null)
 
     const getLatestCtx = await renderAccountDataProvider()
 
@@ -1594,7 +1620,7 @@ describe("AccountDataContext current tab detection", () => {
       expect(getLatestCtx().isDetecting).toBe(false)
     })
 
-    expect(globalThis.browser.tabs.sendMessage).not.toHaveBeenCalled()
+    expect(mockReadAccountBrowserSessionFromTab).not.toHaveBeenCalled()
   })
 
   it("clears previously detected hints when the active tab context disappears", async () => {
@@ -1621,10 +1647,12 @@ describe("AccountDataContext current tab detection", () => {
         }
       }
     })
-    vi.mocked(globalThis.browser.tabs.sendMessage).mockResolvedValue({
-      success: true,
-      data: { userId: "7" },
-    } as any)
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: "new-api",
+      userId: "7",
+      user: { id: "7", username: "7" },
+    })
 
     const getLatestCtx = await renderAccountDataProvider()
 
@@ -1649,7 +1677,7 @@ describe("AccountDataContext current tab detection", () => {
       expect(getLatestCtx().isDetecting).toBe(false)
     })
 
-    expect(globalThis.browser.tabs.sendMessage).toHaveBeenCalledTimes(1)
+    expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledTimes(1)
   })
 
   it("rechecks only when the updated tab is still active", async () => {
@@ -1676,10 +1704,12 @@ describe("AccountDataContext current tab detection", () => {
         }
       }
     })
-    vi.mocked(globalThis.browser.tabs.sendMessage).mockResolvedValue({
-      success: true,
-      data: { userId: "7" },
-    } as any)
+    mockReadAccountBrowserSessionFromTab.mockResolvedValue({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: "new-api",
+      userId: "7",
+      user: { id: "7", username: "7" },
+    })
 
     const getLatestCtx = await renderAccountDataProvider()
 
@@ -1695,7 +1725,7 @@ describe("AccountDataContext current tab detection", () => {
       }
     })
 
-    expect(globalThis.browser.tabs.sendMessage).toHaveBeenCalledTimes(1)
+    expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledTimes(1)
 
     await act(async () => {
       for (const listener of updatedListeners) {
@@ -1704,7 +1734,7 @@ describe("AccountDataContext current tab detection", () => {
     })
 
     await waitFor(() => {
-      expect(globalThis.browser.tabs.sendMessage).toHaveBeenCalledTimes(2)
+      expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledTimes(2)
       expect(getLatestCtx().detectedAccount?.id).toBe("acc-1")
     })
   })

--- a/tests/features/AccountManagement/hooks/useAccountDialog.analytics.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.analytics.test.tsx
@@ -1094,6 +1094,59 @@ describe("useAccountDialog analytics", () => {
     expectNoSensitiveAnalyticsFields()
   })
 
+  it("keeps Sub2API import skipped when an existing-tab probe fails before missing temp-window session", async () => {
+    const { getAllTabs, sendRuntimeMessage } = await import(
+      "~/utils/browser/browserApi"
+    )
+    vi.mocked(getAllTabs).mockResolvedValueOnce([
+      {
+        id: 12,
+        url: "https://sub2.example.com/dashboard",
+        active: true,
+      } as browser.tabs.Tab,
+    ])
+    vi.mocked(globalThis.browser.tabs.sendMessage).mockRejectedValueOnce(
+      new Error("receiver missing"),
+    )
+    vi.mocked(sendRuntimeMessage).mockResolvedValueOnce({
+      success: true,
+      data: {
+        accessToken: "private-jwt",
+        userId: "42",
+        user: { username: "private-user" },
+        sub2apiAuth: {
+          refreshToken: " ",
+        },
+      },
+    })
+
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.url).toBe("https://sub2.example.com")
+      expect(result.current.state.siteType).toBe(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleImportSub2apiSession()
+    })
+
+    expectStartedAction(PRODUCT_ANALYTICS_ACTION_IDS.ImportSub2apiSession)
+    expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Skipped,
+    )
+    expectNoSensitiveAnalyticsFields()
+  })
+
   it("tracks Sub2API import runtime errors as failures without raw error text", async () => {
     const { sendRuntimeMessage } = await import("~/utils/browser/browserApi")
     vi.mocked(sendRuntimeMessage).mockRejectedValueOnce(

--- a/tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
@@ -2,9 +2,9 @@ import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { DIALOG_MODES } from "~/constants/dialogModes"
-import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import { useAccountDialog } from "~/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog"
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession/types"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { AuthTypeEnum } from "~/types"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
@@ -12,11 +12,13 @@ import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 const {
   mockOpenWithAccount,
   mockOpenDefaultTokenQuickCreateDialogForAccount,
+  mockResolveAccountBrowserSession,
   mockToastError,
   mockToastSuccess,
 } = vi.hoisted(() => ({
   mockOpenWithAccount: vi.fn(),
   mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
+  mockResolveAccountBrowserSession: vi.fn(),
   mockToastError: vi.fn(),
   mockToastSuccess: vi.fn(),
 }))
@@ -38,6 +40,16 @@ vi.mock("~/components/dialogs/ChannelDialog", () => ({
   }),
 }))
 
+vi.mock("~/services/accountBrowserSession", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/accountBrowserSession")>()
+
+  return {
+    ...actual,
+    resolveAccountBrowserSession: mockResolveAccountBrowserSession,
+  }
+})
+
 vi.mock("~/services/productAnalytics/actions", () => ({
   startProductAnalyticsAction: vi.fn(() => ({
     complete: vi.fn(),
@@ -50,7 +62,6 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   return {
     ...actual,
     getActiveTabs: vi.fn(async () => []),
-    getAllTabs: vi.fn(async () => []),
     onTabActivated: vi.fn(() => () => {}),
     onTabUpdated: vi.fn(() => () => {}),
     sendRuntimeMessage: vi.fn(),
@@ -60,6 +71,7 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
 describe("useAccountDialog Sub2API constraints", () => {
   beforeEach(async () => {
     vi.clearAllMocks()
+    mockResolveAccountBrowserSession.mockResolvedValue(null)
     await accountStorage.clearAllData()
     ;(globalThis.browser.tabs.sendMessage as any) = vi.fn()
   })
@@ -203,108 +215,43 @@ describe("useAccountDialog Sub2API constraints", () => {
     })
   })
 
-  it("prefers importing Sub2API session data from an existing matching tab before falling back to background auto-detect", async () => {
-    const { getAllTabs, sendRuntimeMessage } = await import(
-      "~/utils/browser/browserApi"
-    )
-    vi.mocked(getAllTabs).mockResolvedValue([
-      { id: 10, url: "https://other.example.com", active: false } as any,
-      {
-        id: 11,
-        url: "https://sub2.example.com/dashboard",
-        active: false,
-      } as any,
-      { id: 12, url: "https://sub2.example.com/settings", active: true } as any,
-    ])
-    vi.mocked(globalThis.browser.tabs.sendMessage).mockImplementation(
-      async (tabId: number, message: { action: string; url: string }) => {
-        expect(message.action).toBe(
-          RuntimeActionIds.ContentGetUserFromLocalStorage,
-        )
-        expect(message.url).toBe("https://sub2.example.com")
-        expect(message).toMatchObject({ siteType: "sub2api" })
-
-        if (tabId === 12) {
-          return {
-            success: true,
-            data: {
-              accessToken: "jwt-from-tab",
-              userId: "42",
-              user: { username: "tab-user" },
-              sub2apiAuth: {
-                refreshToken: "refresh-from-tab",
-                tokenExpiresAt: 123456,
-              },
-            },
-          }
-        }
-
-        throw new Error("unexpected tab")
-      },
-    )
-
-    const { result } = renderHook(() =>
-      useAccountDialog({
-        mode: DIALOG_MODES.ADD,
-        isOpen: true,
-        onClose: vi.fn(),
-        onSuccess: vi.fn(),
-      }),
-    )
-
-    await waitFor(() => {
-      expect(result.current.state).toBeTruthy()
-    })
-
-    await act(async () => {
-      result.current.setters.setUrl("https://sub2.example.com")
-      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
-    })
-
-    await waitFor(() => {
-      expect(result.current.state.url).toBe("https://sub2.example.com")
-      expect(result.current.state.siteType).toBe(SITE_TYPES.SUB2API)
-    })
-
-    await act(async () => {
-      await result.current.handlers.handleImportSub2apiSession()
-    })
-
-    expect(result.current.state.sub2apiUseRefreshToken).toBe(false)
-    expect(result.current.state.sub2apiRefreshToken).toBe("refresh-from-tab")
-    expect(result.current.state.sub2apiTokenExpiresAt).toBe(123456)
-    expect(result.current.state.accessToken).toBe("jwt-from-tab")
-    expect(result.current.state.userId).toBe("42")
-    expect(result.current.state.username).toBe("tab-user")
-    expect(mockToastSuccess).toHaveBeenCalled()
-    expect(sendRuntimeMessage).not.toHaveBeenCalled()
-  })
-
-  it("falls back to background auto-detect when no matching tab yields a Sub2API refresh token", async () => {
-    const { getAllTabs, sendRuntimeMessage } = await import(
-      "~/utils/browser/browserApi"
-    )
-    vi.mocked(getAllTabs).mockResolvedValue([
-      {
-        id: 21,
-        url: "https://sub2.example.com/dashboard",
-        active: true,
-      } as any,
-    ])
-    vi.mocked(globalThis.browser.tabs.sendMessage).mockRejectedValue(
-      new Error("content script unavailable"),
-    )
-    vi.mocked(sendRuntimeMessage).mockResolvedValue({
-      success: true,
-      data: {
-        accessToken: "jwt-from-background",
-        userId: "7",
-        user: { username: "bg-user" },
+  it("imports Sub2API session data through the browser-session reader", async () => {
+    mockResolveAccountBrowserSession.mockImplementationOnce(async (options) => {
+      const noRefreshSession = {
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+        siteType: SITE_TYPES.SUB2API,
+        userId: "41",
+        user: { username: "missing-refresh-user" },
+        accessToken: "jwt-without-refresh",
+      }
+      const blankRefreshSession = {
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+        siteType: SITE_TYPES.SUB2API,
+        userId: "41",
+        user: { username: "blank-refresh-user" },
+        accessToken: "jwt-with-blank-refresh",
         sub2apiAuth: {
           refreshToken: "   ",
         },
-      },
-    } as any)
+      }
+      const usableSession = {
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+        siteType: SITE_TYPES.SUB2API,
+        userId: "42",
+        user: { username: "tab-user" },
+        accessToken: "jwt-from-reader",
+        sub2apiAuth: {
+          refreshToken: "refresh-from-reader",
+          tokenExpiresAt: 123456,
+        },
+      }
+
+      expect(options.isUsableSession(noRefreshSession)).toBe(false)
+      expect(options.isUsableSession(blankRefreshSession)).toBe(false)
+      expect(options.isUsableSession(usableSession)).toBe(true)
+
+      return usableSession
+    })
 
     const { result } = renderHook(() =>
       useAccountDialog({
@@ -333,116 +280,72 @@ describe("useAccountDialog Sub2API constraints", () => {
       await result.current.handlers.handleImportSub2apiSession()
     })
 
-    expect(sendRuntimeMessage).toHaveBeenCalledWith(
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        action: RuntimeActionIds.AutoDetectSite,
-        url: "https://sub2.example.com",
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        useExistingTabs: true,
+        useTempWindow: true,
+        requestIdPrefix: "account-dialog-sub2api-import",
+        isUsableSession: expect.any(Function),
       }),
     )
+    expect(result.current.state.sub2apiUseRefreshToken).toBe(false)
+    expect(result.current.state.sub2apiRefreshToken).toBe("refresh-from-reader")
+    expect(result.current.state.sub2apiTokenExpiresAt).toBe(123456)
+    expect(result.current.state.accessToken).toBe("jwt-from-reader")
+    expect(result.current.state.userId).toBe("42")
+    expect(result.current.state.username).toBe("tab-user")
+    expect(mockToastSuccess).toHaveBeenCalled()
+  })
+
+  it("shows missing-session feedback when the browser-session reader finds no usable Sub2API session", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce(null)
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.url).toBe("https://sub2.example.com")
+      expect(result.current.state.siteType).toBe(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleImportSub2apiSession()
+    })
+
     expect(result.current.state.sub2apiRefreshToken).toBe("")
     expect(result.current.state.accessToken).toBe("")
     expect(result.current.state.userId).toBe("")
     expect(mockToastError).toHaveBeenCalled()
   })
 
-  it("continues scanning matching tabs until a Sub2API refresh token is found", async () => {
-    const { getAllTabs, sendRuntimeMessage } = await import(
-      "~/utils/browser/browserApi"
-    )
-    vi.mocked(getAllTabs).mockResolvedValue([
-      {
-        id: 31,
-        url: "https://sub2.example.com/dashboard",
-        active: true,
-      } as any,
-      {
-        id: 32,
-        url: "https://sub2.example.com/settings",
-        active: false,
-      } as any,
-    ])
-    vi.mocked(globalThis.browser.tabs.sendMessage)
-      .mockResolvedValueOnce({
-        success: true,
-        data: {
-          accessToken: "stale-tab-token",
-          userId: "1",
-          user: { username: "stale-user" },
-        },
-      } as any)
-      .mockResolvedValueOnce({
-        success: true,
-        data: {
-          accessToken: "fresh-tab-token",
-          userId: "2",
-          user: { username: "fresh-user" },
-          sub2apiAuth: {
-            refreshToken: "refresh-from-second-tab",
-            tokenExpiresAt: 555666,
-          },
-        },
-      } as any)
-
-    const { result } = renderHook(() =>
-      useAccountDialog({
-        mode: DIALOG_MODES.ADD,
-        isOpen: true,
-        onClose: vi.fn(),
-        onSuccess: vi.fn(),
-      }),
-    )
-
-    await waitFor(() => {
-      expect(result.current.state).toBeTruthy()
-    })
-
-    await act(async () => {
-      result.current.setters.setUrl("https://sub2.example.com")
-      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
-    })
-
-    await act(async () => {
-      await result.current.handlers.handleImportSub2apiSession()
-    })
-
-    expect(globalThis.browser.tabs.sendMessage).toHaveBeenCalledTimes(2)
-    expect(sendRuntimeMessage).not.toHaveBeenCalled()
-    expect(result.current.state.sub2apiRefreshToken).toBe(
-      "refresh-from-second-tab",
-    )
-    expect(result.current.state.sub2apiTokenExpiresAt).toBe(555666)
-    expect(result.current.state.accessToken).toBe("fresh-tab-token")
-    expect(result.current.state.userId).toBe("2")
-    expect(result.current.state.username).toBe("fresh-user")
-    expect(mockToastSuccess).toHaveBeenCalled()
-  })
-
-  it("hydrates Sub2API session fields from the background fallback when tab import cannot provide them", async () => {
-    const { getAllTabs, sendRuntimeMessage } = await import(
-      "~/utils/browser/browserApi"
-    )
-    vi.mocked(getAllTabs).mockResolvedValue([
-      {
-        id: 41,
-        url: "https://sub2.example.com/dashboard",
-        active: true,
-      } as any,
-    ])
-    vi.mocked(globalThis.browser.tabs.sendMessage).mockRejectedValue(
-      new Error("content script unavailable"),
-    )
-    vi.mocked(sendRuntimeMessage).mockResolvedValue({
-      success: true,
-      data: {
-        accessToken: "jwt-from-background",
-        userId: "7",
-        user: { username: "bg-user" },
-        sub2apiAuth: {
-          refreshToken: "refresh-from-background",
-          tokenExpiresAt: 987654,
-        },
+  it("hydrates Sub2API session fields from the browser-session reader temp-window result", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+      siteType: SITE_TYPES.SUB2API,
+      accessToken: "jwt-from-background",
+      userId: "7",
+      user: { username: "bg-user" },
+      sub2apiAuth: {
+        refreshToken: "refresh-from-background",
+        tokenExpiresAt: 987654,
       },
-    } as any)
+    })
 
     const { result } = renderHook(() =>
       useAccountDialog({
@@ -466,12 +369,6 @@ describe("useAccountDialog Sub2API constraints", () => {
       await result.current.handlers.handleImportSub2apiSession()
     })
 
-    expect(sendRuntimeMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: RuntimeActionIds.AutoDetectSite,
-        url: "https://sub2.example.com",
-      }),
-    )
     expect(result.current.state.sub2apiUseRefreshToken).toBe(false)
     expect(result.current.state.sub2apiRefreshToken).toBe(
       "refresh-from-background",
@@ -484,31 +381,17 @@ describe("useAccountDialog Sub2API constraints", () => {
   })
 
   it("keeps existing JWT fields when the imported optional Sub2API values are malformed", async () => {
-    const { getAllTabs, sendRuntimeMessage } = await import(
-      "~/utils/browser/browserApi"
-    )
-    vi.mocked(getAllTabs).mockResolvedValue([
-      {
-        id: 51,
-        url: "https://sub2.example.com/dashboard",
-        active: true,
-      } as any,
-    ])
-    vi.mocked(globalThis.browser.tabs.sendMessage).mockRejectedValue(
-      new Error("content script unavailable"),
-    )
-    vi.mocked(sendRuntimeMessage).mockResolvedValue({
-      success: true,
-      data: {
-        accessToken: "   ",
-        userId: Number.NaN,
-        user: { username: "   " },
-        sub2apiAuth: {
-          refreshToken: "refresh-from-background",
-          tokenExpiresAt: Number.POSITIVE_INFINITY,
-        },
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+      siteType: SITE_TYPES.SUB2API,
+      accessToken: "   ",
+      userId: "",
+      user: { username: "   " },
+      sub2apiAuth: {
+        refreshToken: "refresh-from-background",
+        tokenExpiresAt: Number.POSITIVE_INFINITY,
       },
-    } as any)
+    })
 
     const { result } = renderHook(() =>
       useAccountDialog({
@@ -757,25 +640,18 @@ describe("useAccountDialog Sub2API constraints", () => {
     getAccountByIdSpy.mockRestore()
   })
 
-  it("falls back to background auto-detect when enumerating tabs fails entirely", async () => {
-    const { getAllTabs, sendRuntimeMessage } = await import(
-      "~/utils/browser/browserApi"
-    )
-    vi.mocked(getAllTabs).mockRejectedValue(
-      new Error("tab enumeration unavailable"),
-    )
-    vi.mocked(sendRuntimeMessage).mockResolvedValue({
-      success: true,
-      data: {
-        accessToken: "jwt-from-background",
-        userId: "77",
-        user: { username: "bg-user" },
-        sub2apiAuth: {
-          refreshToken: "refresh-from-background",
-          tokenExpiresAt: 222333,
-        },
+  it("imports a usable Sub2API session even when the browser-session reader handles tab enumeration failures", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+      siteType: SITE_TYPES.SUB2API,
+      accessToken: "jwt-from-background",
+      userId: "77",
+      user: { username: "bg-user" },
+      sub2apiAuth: {
+        refreshToken: "refresh-from-background",
+        tokenExpiresAt: 222333,
       },
-    } as any)
+    })
 
     const { result } = renderHook(() =>
       useAccountDialog({
@@ -799,12 +675,6 @@ describe("useAccountDialog Sub2API constraints", () => {
       await result.current.handlers.handleImportSub2apiSession()
     })
 
-    expect(sendRuntimeMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: RuntimeActionIds.AutoDetectSite,
-        url: "https://sub2.example.com",
-      }),
-    )
     expect(result.current.state.sub2apiRefreshToken).toBe(
       "refresh-from-background",
     )
@@ -815,24 +685,8 @@ describe("useAccountDialog Sub2API constraints", () => {
     expect(mockToastSuccess).toHaveBeenCalled()
   })
 
-  it("surfaces background fallback failures during Sub2API session import and resets the loading state", async () => {
-    const { getAllTabs, sendRuntimeMessage } = await import(
-      "~/utils/browser/browserApi"
-    )
-    vi.mocked(getAllTabs).mockResolvedValue([
-      {
-        id: 31,
-        url: "https://sub2.example.com/dashboard",
-        active: true,
-      } as any,
-    ])
-    vi.mocked(globalThis.browser.tabs.sendMessage).mockRejectedValue(
-      new Error("content script unavailable"),
-    )
-    vi.mocked(sendRuntimeMessage).mockRejectedValue(
-      new Error("background auto-detect failed"),
-    )
-
+  it("shows missing-session feedback when Sub2API session import cannot find a usable session and resets the loading state", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce(null)
     const { result } = renderHook(() =>
       useAccountDialog({
         mode: DIALOG_MODES.ADD,
@@ -855,14 +709,8 @@ describe("useAccountDialog Sub2API constraints", () => {
       await result.current.handlers.handleImportSub2apiSession()
     })
 
-    expect(sendRuntimeMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: RuntimeActionIds.AutoDetectSite,
-        url: "https://sub2.example.com",
-      }),
-    )
     expect(mockToastError).toHaveBeenCalledWith(
-      "accountDialog:messages.operationFailed",
+      "accountDialog:messages.importSub2apiSessionMissing",
     )
     expect(result.current.state.isImportingSub2apiSession).toBe(false)
     expect(result.current.state.sub2apiRefreshToken).toBe("")

--- a/tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
@@ -299,6 +299,66 @@ describe("useAccountDialog Sub2API constraints", () => {
     expect(mockToastSuccess).toHaveBeenCalled()
   })
 
+  it("passes the current private tab context to the Sub2API browser-session import", async () => {
+    const { getActiveTabs } = await import("~/utils/browser/browserApi")
+    vi.mocked(getActiveTabs).mockResolvedValue([
+      {
+        id: 99,
+        url: "https://sub2.example.com/dashboard",
+        incognito: true,
+        cookieStoreId: "firefox-container-1",
+      } as browser.tabs.Tab,
+    ])
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.SUB2API,
+      userId: "42",
+      user: { username: "private-tab-user" },
+      accessToken: "jwt-from-private-tab",
+      sub2apiAuth: {
+        refreshToken: "refresh-from-private-tab",
+      },
+    })
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe(
+        "https://sub2.example.com",
+      )
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleImportSub2apiSession()
+    })
+
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://sub2.example.com",
+        currentTab: {
+          tabId: 99,
+          incognito: true,
+          cookieStoreId: "firefox-container-1",
+        },
+      }),
+    )
+    expect(result.current.state.sub2apiRefreshToken).toBe(
+      "refresh-from-private-tab",
+    )
+  })
+
   it("shows missing-session feedback when the browser-session reader finds no usable Sub2API session", async () => {
     mockResolveAccountBrowserSession.mockResolvedValueOnce(null)
     const { result } = renderHook(() =>

--- a/tests/services/accountBrowserSession/sessionReader.test.ts
+++ b/tests/services/accountBrowserSession/sessionReader.test.ts
@@ -145,6 +145,7 @@ describe("account browser-session reader", () => {
         success: true,
         data: {
           userId: "43",
+          siteType: SITE_TYPES.SUB2API,
           fetchContext: {
             kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
             tabId: "not-a-number",
@@ -183,18 +184,21 @@ describe("account browser-session reader", () => {
       }),
     )
 
-    await expect(
-      readAccountBrowserSessionFromTab({
+    const sessionWithoutTrustedFetchContext =
+      await readAccountBrowserSessionFromTab({
         tabId: 43,
         baseUrl: "https://sub2.example.com",
         siteType: SITE_TYPES.SUB2API,
         source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
-      }),
-    ).resolves.toEqual(
-      expect.not.objectContaining({
-        fetchContext: expect.anything(),
+      })
+
+    expect(sessionWithoutTrustedFetchContext).toEqual(
+      expect.objectContaining({
+        userId: "43",
+        siteTypeHint: SITE_TYPES.SUB2API,
       }),
     )
+    expect(sessionWithoutTrustedFetchContext).not.toHaveProperty("fetchContext")
 
     await expect(
       readAccountBrowserSessionFromTab({
@@ -426,6 +430,55 @@ describe("account browser-session reader", () => {
         useTempWindow: true,
       }),
     ).resolves.toBeNull()
+
+    expect(mockSendRuntimeMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it("passes current-tab browser context without container metadata to fallbacks", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "9",
+        user: { username: "current-user" },
+        accessToken: "current-token",
+      },
+    })
+    mockGetAllTabs.mockResolvedValueOnce([])
+    mockSendRuntimeMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "11",
+        user: { username: "temp-user" },
+        accessToken: "temp-token",
+      },
+    })
+
+    const session = await resolveAccountBrowserSession({
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      currentTab: {
+        tabId: 9,
+        incognito: true,
+      },
+      useExistingTabs: true,
+      useTempWindow: true,
+      isUsableSession: (candidate) =>
+        candidate.source === ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+    })
+
+    expect(session?.source).toBe(ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW)
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.AutoDetectSite,
+        url: "https://sub2.example.com",
+        useIncognito: true,
+      }),
+    )
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        cookieStoreId: expect.any(String),
+      }),
+    )
   })
 
   it("omits current-tab fetch context when the base URL has no parseable origin", async () => {

--- a/tests/services/accountBrowserSession/sessionReader.test.ts
+++ b/tests/services/accountBrowserSession/sessionReader.test.ts
@@ -126,6 +126,94 @@ describe("account browser-session reader", () => {
     ).resolves.toBeNull()
   })
 
+  it("normalizes payload fetch context only when it matches a trusted shape", async () => {
+    mockSendTabMessage
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId: "42",
+          fetchContext: {
+            kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+            tabId: 42,
+            origin: " https://sub2.example.com ",
+            incognito: true,
+            cookieStoreId: " firefox-container-1 ",
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId: "43",
+          fetchContext: {
+            kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+            tabId: "not-a-number",
+            origin: "https://sub2.example.com",
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId: "44",
+          fetchContext: {
+            kind: API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT,
+            incognito: true,
+            cookieStoreId: " firefox-container-2 ",
+          },
+        },
+      })
+
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 42,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        fetchContext: {
+          kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+          tabId: 42,
+          origin: "https://sub2.example.com",
+          incognito: true,
+          cookieStoreId: "firefox-container-1",
+        },
+      }),
+    )
+
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 43,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      }),
+    ).resolves.toEqual(
+      expect.not.objectContaining({
+        fetchContext: expect.anything(),
+      }),
+    )
+
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 44,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        fetchContext: {
+          kind: API_SERVICE_FETCH_CONTEXT_KINDS.BROWSER_CONTEXT,
+          incognito: true,
+          cookieStoreId: "firefox-container-2",
+        },
+      }),
+    )
+  })
+
   it("notifies callers about tab read errors without throwing", async () => {
     const onError = vi.fn()
     const error = new Error("receiver missing")
@@ -186,6 +274,67 @@ describe("account browser-session reader", () => {
       siteType: SITE_TYPES.SUB2API,
     })
     expect(mockSendTabMessage).toHaveBeenNthCalledWith(2, 2, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+    })
+  })
+
+  it("filters existing tabs by browser context before probing local storage", async () => {
+    mockGetAllTabs.mockResolvedValueOnce([
+      {
+        id: 1,
+        url: "https://sub2.example.com/dashboard",
+        active: true,
+        incognito: false,
+      },
+      {
+        id: 2,
+        url: "https://sub2.example.com/settings",
+        active: false,
+        incognito: true,
+        cookieStoreId: "firefox-container-2",
+      },
+      {
+        id: 3,
+        url: "https://sub2.example.com/console",
+        active: false,
+        incognito: true,
+        cookieStoreId: "firefox-container-1",
+      },
+    ])
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "3",
+        user: { username: "container-user" },
+        accessToken: "container-token",
+      },
+    })
+
+    const session = await readAccountBrowserSessionFromExistingTabs({
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      browserContext: {
+        incognito: true,
+        cookieStoreId: "firefox-container-1",
+      },
+    })
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        userId: "3",
+        fetchContext: {
+          kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+          tabId: 3,
+          origin: "https://sub2.example.com",
+          incognito: true,
+          cookieStoreId: "firefox-container-1",
+        },
+      }),
+    )
+    expect(mockSendTabMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendTabMessage).toHaveBeenCalledWith(3, {
       action: RuntimeActionIds.ContentGetUserFromLocalStorage,
       url: "https://sub2.example.com",
       siteType: SITE_TYPES.SUB2API,
@@ -261,6 +410,22 @@ describe("account browser-session reader", () => {
     expect(onError).toHaveBeenCalledWith(error, {
       source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
     })
+  })
+
+  it("returns null when temp-window auto-detect responds without session data", async () => {
+    mockGetAllTabs.mockResolvedValueOnce([])
+    mockSendRuntimeMessage.mockResolvedValueOnce({
+      success: false,
+    })
+
+    await expect(
+      resolveAccountBrowserSession({
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        useExistingTabs: true,
+        useTempWindow: true,
+      }),
+    ).resolves.toBeNull()
   })
 
   it("omits current-tab fetch context when the base URL has no parseable origin", async () => {

--- a/tests/services/accountBrowserSession/sessionReader.test.ts
+++ b/tests/services/accountBrowserSession/sessionReader.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  ACCOUNT_BROWSER_SESSION_SOURCES,
+  readAccountBrowserSessionFromExistingTabs,
+  readAccountBrowserSessionFromTab,
+  resolveAccountBrowserSession,
+} from "~/services/accountBrowserSession"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
+
+const {
+  mockGetAllTabs,
+  mockGetBrowserApiCapabilities,
+  mockSendRuntimeMessage,
+  mockSendTabMessage,
+} = vi.hoisted(() => ({
+  mockGetAllTabs: vi.fn(),
+  mockGetBrowserApiCapabilities: vi.fn(),
+  mockSendRuntimeMessage: vi.fn(),
+  mockSendTabMessage: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/browserApi", () => ({
+  getAllTabs: mockGetAllTabs,
+  getBrowserApiCapabilities: mockGetBrowserApiCapabilities,
+  sendRuntimeMessage: mockSendRuntimeMessage,
+  sendTabMessage: mockSendTabMessage,
+}))
+
+describe("account browser-session reader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetBrowserApiCapabilities.mockReturnValue({
+      hasWindows: true,
+      hasTabs: true,
+      hasBackgroundMessaging: true,
+    })
+  })
+
+  it("reads and normalizes a successful tab content-session response", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: 42,
+        user: { username: " tab-user " },
+        accessToken: " jwt-from-tab ",
+        siteTypeHint: SITE_TYPES.SUB2API,
+        sub2apiAuth: {
+          refreshToken: " refresh-token ",
+          tokenExpiresAt: 123456,
+        },
+      },
+    })
+
+    const session = await readAccountBrowserSessionFromTab({
+      tabId: 12,
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 12,
+        origin: "https://sub2.example.com",
+        incognito: true,
+        cookieStoreId: "firefox-container-1",
+      },
+    })
+
+    expect(session).toEqual({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.SUB2API,
+      userId: "42",
+      user: { username: " tab-user " },
+      accessToken: "jwt-from-tab",
+      siteTypeHint: SITE_TYPES.SUB2API,
+      sub2apiAuth: {
+        refreshToken: "refresh-token",
+        tokenExpiresAt: 123456,
+      },
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 12,
+        origin: "https://sub2.example.com",
+        incognito: true,
+        cookieStoreId: "firefox-container-1",
+      },
+    })
+    expect(mockSendTabMessage).toHaveBeenCalledWith(12, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+    })
+  })
+
+  it("returns null for failed or unusable tab responses", async () => {
+    mockSendTabMessage
+      .mockResolvedValueOnce({ success: false })
+      .mockResolvedValueOnce({ success: true, data: { userId: "   " } })
+      .mockRejectedValueOnce(new Error("receiver missing"))
+
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 1,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 1,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 1,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      }),
+    ).resolves.toBeNull()
+  })
+
+  it("notifies callers about tab read errors without throwing", async () => {
+    const onError = vi.fn()
+    const error = new Error("receiver missing")
+    mockSendTabMessage.mockRejectedValueOnce(error)
+
+    await expect(
+      readAccountBrowserSessionFromTab({
+        tabId: 1,
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+        onError,
+      }),
+    ).resolves.toBeNull()
+
+    expect(onError).toHaveBeenCalledWith(error, {
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+    })
+  })
+
+  it("filters same-origin tabs, tries the active tab first, and honors the usability predicate", async () => {
+    mockGetAllTabs.mockResolvedValueOnce([
+      { id: 1, url: "https://other.example.com/dashboard", active: true },
+      { id: 2, url: "https://sub2.example.com/settings", active: false },
+      { id: 3, url: "https://sub2.example.com/console", active: true },
+    ])
+    mockSendTabMessage
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId: "1",
+          user: { username: "without-refresh" },
+          accessToken: "token-1",
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId: "2",
+          user: { username: "with-refresh" },
+          accessToken: "token-2",
+          sub2apiAuth: { refreshToken: "refresh-2" },
+        },
+      })
+
+    const session = await readAccountBrowserSessionFromExistingTabs({
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      isUsableSession: (candidate) =>
+        Boolean(candidate.sub2apiAuth?.refreshToken),
+    })
+
+    expect(session?.userId).toBe("2")
+    expect(session?.source).toBe(ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB)
+    expect(mockSendTabMessage).toHaveBeenNthCalledWith(1, 3, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+    })
+    expect(mockSendTabMessage).toHaveBeenNthCalledWith(2, 2, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+    })
+  })
+
+  it("falls back to temp-window auto-detect when existing tabs are unusable", async () => {
+    mockGetAllTabs.mockResolvedValueOnce([
+      { id: 10, url: "https://sub2.example.com/dashboard", active: true },
+    ])
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "10",
+        user: { username: "tab-user" },
+        accessToken: "tab-token",
+      },
+    })
+    mockSendRuntimeMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "11",
+        user: { username: "temp-user" },
+        accessToken: "temp-token",
+        sub2apiAuth: { refreshToken: "temp-refresh" },
+      },
+    })
+
+    const session = await resolveAccountBrowserSession({
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      useExistingTabs: true,
+      useTempWindow: true,
+      requestIdPrefix: "test-session",
+      isUsableSession: (candidate) =>
+        Boolean(candidate.sub2apiAuth?.refreshToken),
+    })
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+        userId: "11",
+        accessToken: "temp-token",
+        sub2apiAuth: { refreshToken: "temp-refresh" },
+      }),
+    )
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.AutoDetectSite,
+        url: "https://sub2.example.com",
+        requestId: expect.stringMatching(/^test-session-/),
+      }),
+    )
+  })
+
+  it("notifies callers about temp-window read errors without throwing", async () => {
+    const error = new Error("private backend error")
+    const onError = vi.fn()
+
+    mockGetAllTabs.mockResolvedValueOnce([])
+    mockSendRuntimeMessage.mockRejectedValueOnce(error)
+
+    await expect(
+      resolveAccountBrowserSession({
+        baseUrl: "https://sub2.example.com",
+        siteType: SITE_TYPES.SUB2API,
+        useExistingTabs: true,
+        useTempWindow: true,
+        onError,
+      }),
+    ).resolves.toBeNull()
+
+    expect(onError).toHaveBeenCalledWith(error, {
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+    })
+  })
+
+  it("omits current-tab fetch context when the base URL has no parseable origin", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "12",
+        user: { username: "tab-user" },
+      },
+    })
+
+    const session = await resolveAccountBrowserSession({
+      baseUrl: "not a url",
+      siteType: SITE_TYPES.SUB2API,
+      currentTab: {
+        tabId: 12,
+        incognito: true,
+        cookieStoreId: "firefox-container-1",
+      },
+    })
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+        userId: "12",
+      }),
+    )
+    expect(session?.fetchContext).toBeUndefined()
+  })
+
+  it("passes incognito but not cookie-store metadata to AutoDetectSite temp-window fallback", async () => {
+    mockGetAllTabs.mockResolvedValueOnce([])
+    mockSendRuntimeMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "11",
+        user: { username: "temp-user" },
+        accessToken: "temp-token",
+      },
+    })
+
+    const session = await resolveAccountBrowserSession({
+      baseUrl: "https://sub2.example.com",
+      siteType: SITE_TYPES.SUB2API,
+      currentTab: {
+        tabId: 9,
+        incognito: true,
+        cookieStoreId: "firefox-container-1",
+      },
+      useExistingTabs: true,
+      useTempWindow: true,
+      requestIdPrefix: "container-check",
+      isUsableSession: (candidate) =>
+        candidate.source === ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW &&
+        Boolean(candidate.accessToken),
+    })
+
+    expect(session?.source).toBe(ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW)
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.AutoDetectSite,
+        url: "https://sub2.example.com",
+        useIncognito: true,
+      }),
+    )
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        cookieStoreId: expect.any(String),
+      }),
+    )
+  })
+})

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession/types"
 import { API_ERROR_CODES, ApiError } from "~/services/apiService/common/errors"
 import type {
   ApiServiceAccountRequest,
@@ -573,7 +574,7 @@ describe("apiService sub2api refreshAccountData", () => {
 
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "new-jwt",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
 
     const request = createRequest()
@@ -616,7 +617,7 @@ describe("apiService sub2api refreshAccountData", () => {
 
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "new-jwt",
-      source: "temp_window",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
     })
 
     const result = await refreshAccountData(createRequest())
@@ -896,7 +897,7 @@ describe("apiService sub2api refreshAccountData", () => {
 
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "resynced-jwt",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
 
     const request = createRequest({
@@ -999,7 +1000,7 @@ describe("apiService sub2api refreshAccountData", () => {
 
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "resynced-jwt",
-      source: "temp_window",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
     })
 
     const request = createRequest({
@@ -1324,7 +1325,7 @@ describe("apiService sub2api exported operations", () => {
     vi.stubGlobal("fetch", fetchMock as any)
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "resynced-jwt",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
     vi.mocked(fetchApi).mockResolvedValueOnce({
       code: 0,
@@ -1428,7 +1429,7 @@ describe("apiService sub2api exported operations", () => {
 
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "resynced-jwt",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
 
     vi.mocked(fetchApi)
@@ -1473,7 +1474,7 @@ describe("apiService sub2api exported operations", () => {
   it("getOrCreateAccessToken falls back to browser-session re-sync when no refresh token is available", async () => {
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "resynced-jwt",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
 
     vi.mocked(fetchApi).mockResolvedValueOnce({
@@ -1529,7 +1530,7 @@ describe("apiService sub2api exported operations", () => {
   it("getOrCreateAccessToken converts 401 after re-sync into login-required", async () => {
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "resynced-jwt",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
     vi.mocked(fetchApi).mockRejectedValueOnce(
       new ApiError("still unauthorized", 401, "/api/v1/auth/me"),
@@ -1552,7 +1553,7 @@ describe("apiService sub2api exported operations", () => {
   it("getOrCreateAccessToken preserves non-auth errors after re-sync retry", async () => {
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "resynced-jwt",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
     vi.mocked(fetchApi).mockRejectedValueOnce(new Error("server exploded"))
 
@@ -2082,7 +2083,7 @@ describe("apiService sub2api exported operations", () => {
 
     vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
       accessToken: "resynced-jwt",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
 
     await expect(

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession/types"
 import { ApiError } from "~/services/apiService/common/errors"
 import type {
   ApiServiceRequest,
@@ -742,7 +743,7 @@ describe("apiService sub2api key management service", () => {
     getLatestAuthMock.mockResolvedValue(null)
     resyncSub2ApiAuthTokenMock.mockResolvedValue({
       accessToken: "resynced-jwt",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
 
     fetchApiMock

--- a/tests/services/apiService/sub2api/tokenResync.test.ts
+++ b/tests/services/apiService/sub2api/tokenResync.test.ts
@@ -1,127 +1,133 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession"
 import { resyncSub2ApiAuthToken } from "~/services/apiService/sub2api/tokenResync"
 
-const {
-  mockGetAllTabs,
-  mockGetBrowserApiCapabilities,
-  mockSendRuntimeMessage,
-  mockSendTabMessage,
-} = vi.hoisted(() => ({
-  mockGetAllTabs: vi.fn(),
-  mockGetBrowserApiCapabilities: vi.fn(),
-  mockSendRuntimeMessage: vi.fn(),
-  mockSendTabMessage: vi.fn(),
+const { mockResolveAccountBrowserSession } = vi.hoisted(() => ({
+  mockResolveAccountBrowserSession: vi.fn(),
 }))
 
-vi.mock("~/utils/browser/browserApi", () => ({
-  getAllTabs: mockGetAllTabs,
-  getBrowserApiCapabilities: mockGetBrowserApiCapabilities,
-  sendRuntimeMessage: mockSendRuntimeMessage,
-  sendTabMessage: mockSendTabMessage,
-}))
+vi.mock("~/services/accountBrowserSession", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/accountBrowserSession")>()
+
+  return {
+    ...actual,
+    resolveAccountBrowserSession: mockResolveAccountBrowserSession,
+  }
+})
 
 describe("Sub2API token re-sync", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.unstubAllGlobals()
-    mockGetBrowserApiCapabilities.mockReturnValue({
-      hasWindows: true,
-      hasTabs: true,
-      hasBackgroundMessaging: true,
-    })
-    vi.stubGlobal("browser", {
-      tabs: {
-        query: vi.fn(),
-      },
-    })
   })
 
-  it("skips existing-tab lookup for invalid site URLs and falls back to temp-window recovery", async () => {
-    mockSendRuntimeMessage.mockResolvedValueOnce({})
-
-    await expect(resyncSub2ApiAuthToken("not-a-url")).resolves.toBeNull()
-
-    expect(mockGetAllTabs).not.toHaveBeenCalled()
-    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: RuntimeActionIds.AutoDetectSite,
-        url: "not-a-url",
-      }),
-    )
-  })
-
-  it("prefers same-origin existing tabs and trims the recovered access token", async () => {
-    mockGetAllTabs.mockResolvedValueOnce([
-      { id: 1, url: "https://other.example.com/dashboard", active: false },
-      { id: 2, url: "https://sub2.example.com/settings", active: false },
-      { id: 3, url: "https://sub2.example.com/console", active: true },
-    ])
-
-    mockSendTabMessage
-      .mockResolvedValueOnce({
-        success: true,
-        data: { accessToken: "   " },
-      })
-      .mockResolvedValueOnce({
-        success: true,
-        data: { accessToken: " token-from-tab " },
-      })
+  it("returns an existing-tab token from the browser-session reader", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      siteType: "sub2api",
+      userId: "42",
+      user: { username: "tab-user" },
+      accessToken: " token-from-tab ",
+    })
 
     const result = await resyncSub2ApiAuthToken("https://sub2.example.com")
 
     expect(result).toEqual({
       accessToken: "token-from-tab",
-      source: "existing_tab",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
-    expect(mockSendTabMessage).toHaveBeenNthCalledWith(1, 3, {
-      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
-      url: "https://sub2.example.com",
-      siteType: "sub2api",
-    })
-    expect(mockSendTabMessage).toHaveBeenNthCalledWith(2, 2, {
-      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
-      url: "https://sub2.example.com",
-      siteType: "sub2api",
-    })
-    expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
-  })
-
-  it("falls back to the temp-window runtime flow when no existing tab yields a token", async () => {
-    mockGetAllTabs.mockResolvedValueOnce([
-      { id: 10, url: "https://sub2.example.com/dashboard", active: true },
-    ])
-    mockSendTabMessage.mockResolvedValueOnce({
-      success: false,
-    })
-    mockSendRuntimeMessage.mockResolvedValueOnce({
-      data: { accessToken: " temp-window-token " },
-    })
-
-    const result = await resyncSub2ApiAuthToken("https://sub2.example.com")
-
-    expect(result).toEqual({
-      accessToken: "temp-window-token",
-      source: "temp_window",
-    })
-    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        action: RuntimeActionIds.AutoDetectSite,
-        url: "https://sub2.example.com",
+        baseUrl: "https://sub2.example.com",
+        siteType: "sub2api",
+        useExistingTabs: true,
+        useTempWindow: true,
+        requestIdPrefix: "sub2api-token-resync",
+        isUsableSession: expect.any(Function),
       }),
     )
   })
 
-  it("returns null when both existing-tab and temp-window recovery fail", async () => {
-    mockGetAllTabs.mockResolvedValueOnce([
-      { id: 11, url: "https://sub2.example.com/dashboard", active: true },
-    ])
-    mockSendTabMessage.mockRejectedValueOnce(new Error("receiver missing"))
-    mockSendRuntimeMessage.mockRejectedValueOnce(new Error("window blocked"))
+  it("maps current-tab source to existing public existing-tab source", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: "sub2api",
+      userId: "42",
+      user: { username: "current-user" },
+      accessToken: "current-tab-token",
+    })
+
+    await expect(
+      resyncSub2ApiAuthToken("https://sub2.example.com"),
+    ).resolves.toEqual({
+      accessToken: "current-tab-token",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+  })
+
+  it("returns a temp-window token from the browser-session reader", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+      siteType: "sub2api",
+      userId: "42",
+      user: { username: "temp-user" },
+      accessToken: " temp-window-token ",
+    })
+
+    await expect(
+      resyncSub2ApiAuthToken("https://sub2.example.com"),
+    ).resolves.toEqual({
+      accessToken: "temp-window-token",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+    })
+  })
+
+  it("returns null when the browser-session reader finds no usable token", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce(null)
 
     await expect(
       resyncSub2ApiAuthToken("https://sub2.example.com"),
     ).resolves.toBeNull()
+  })
+
+  it("passes a usability predicate that accepts only non-empty access tokens", async () => {
+    mockResolveAccountBrowserSession.mockImplementationOnce(
+      async ({ isUsableSession }) => {
+        expect(
+          isUsableSession({
+            source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+            siteType: "sub2api",
+            userId: "42",
+            user: { username: "blank-user" },
+            accessToken: "   ",
+          }),
+        ).toBe(false)
+        expect(
+          isUsableSession({
+            source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+            siteType: "sub2api",
+            userId: "42",
+            user: { username: "usable-user" },
+            accessToken: " usable-token ",
+          }),
+        ).toBe(true)
+
+        return {
+          source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+          siteType: "sub2api",
+          userId: "42",
+          user: { username: "usable-user" },
+          accessToken: " usable-token ",
+        }
+      },
+    )
+
+    await expect(
+      resyncSub2ApiAuthToken("https://sub2.example.com"),
+    ).resolves.toEqual({
+      accessToken: "usable-token",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
   })
 })

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -6,6 +6,7 @@ import {
   AUTO_DETECT_STRATEGIES,
 } from "~/constants/autoDetect"
 import { SITE_TYPES } from "~/constants/siteType"
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession/types"
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiService/common/type"
 import { autoDetectSmart } from "~/services/siteDetection/autoDetectService"
 import { AuthTypeEnum } from "~/types"
@@ -17,6 +18,7 @@ const {
   mockGetAccountSiteType,
   mockGetSiteAdapter,
   mockIsMessageReceiverUnavailableError,
+  mockReadAccountBrowserSessionFromTab,
   mockSendRuntimeMessage,
 } = vi.hoisted(() => ({
   mockFetchUserInfo: vi.fn(),
@@ -25,12 +27,23 @@ const {
   mockGetAccountSiteType: vi.fn(),
   mockGetSiteAdapter: vi.fn(),
   mockIsMessageReceiverUnavailableError: vi.fn(),
+  mockReadAccountBrowserSessionFromTab: vi.fn(),
   mockSendRuntimeMessage: vi.fn(),
 }))
 
 vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteAdapter: mockGetSiteAdapter,
 }))
+
+vi.mock("~/services/accountBrowserSession", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/accountBrowserSession")>()
+
+  return {
+    ...actual,
+    readAccountBrowserSessionFromTab: mockReadAccountBrowserSessionFromTab,
+  }
+})
 
 vi.mock("~/services/siteDetection/detectSiteType", () => ({
   getAccountSiteType: mockGetAccountSiteType,
@@ -75,6 +88,7 @@ describe("autoDetectSmart", () => {
     mockGetActiveOrAllTabs.mockResolvedValue([])
     mockGetActiveTabs.mockResolvedValue([])
     mockIsMessageReceiverUnavailableError.mockReturnValue(false)
+    mockReadAccountBrowserSessionFromTab.mockResolvedValue(null)
     mockSendRuntimeMessage.mockResolvedValue(null)
     mockGetSiteAdapter.mockReturnValue({
       accountBootstrap: {
@@ -106,13 +120,17 @@ describe("autoDetectSmart", () => {
       },
     ])
     mockGetActiveTabs.mockResolvedValue([{ id: 1 }])
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: true,
-      data: {
-        userId: "12",
-        user: { id: 12, username: "alice" },
-        accessToken: "current-tab-token",
-        siteTypeHint: SITE_TYPES.VELOERA,
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.NEW_API,
+      siteTypeHint: SITE_TYPES.VELOERA,
+      userId: "12",
+      user: { id: 12, username: "alice" },
+      accessToken: "current-tab-token",
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 1,
+        origin: "https://example.com",
       },
     })
 
@@ -147,11 +165,17 @@ describe("autoDetectSmart", () => {
         cookieStoreId: "1-incognito",
       },
     ])
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: true,
-      data: {
-        userId: "12",
-        user: { id: 12, username: "alice" },
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.NEW_API,
+      userId: "12",
+      user: { id: 12, username: "alice" },
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 101,
+        origin: "https://example.com",
+        incognito: true,
+        cookieStoreId: "1-incognito",
       },
     })
 
@@ -174,10 +198,19 @@ describe("autoDetectSmart", () => {
         },
       },
     })
-    expect(browserAny.tabs.sendMessage).toHaveBeenCalledWith(101, {
-      action: expect.any(String),
-      url: "https://example.com/console",
+    expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledWith({
+      tabId: 101,
+      baseUrl: "https://example.com/console",
       siteType: SITE_TYPES.NEW_API,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 101,
+        origin: "https://example.com",
+        incognito: true,
+        cookieStoreId: "1-incognito",
+      },
+      onError: expect.any(Function),
     })
     expect(mockGetActiveTabs).not.toHaveBeenCalled()
   })
@@ -192,11 +225,17 @@ describe("autoDetectSmart", () => {
         cookieStoreId: "1-incognito",
       },
     ])
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: true,
-      data: {
-        userId: "12",
-        user: { id: 12, username: "alice" },
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.NEW_API,
+      userId: "12",
+      user: { id: 12, username: "alice" },
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 101,
+        origin: "https://example.com",
+        incognito: true,
+        cookieStoreId: "1-incognito",
       },
     })
 
@@ -221,10 +260,6 @@ describe("autoDetectSmart", () => {
         cookieStoreId: "1-incognito",
       },
     ])
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: false,
-      error: "no local storage user",
-    })
     mockFetchUserInfo.mockResolvedValue({
       id: 13,
       username: "api-incognito-user",
@@ -265,6 +300,57 @@ describe("autoDetectSmart", () => {
     })
   })
 
+  it("uses the browser-session reader for current-tab auto-detect before API fallback", async () => {
+    mockGetAccountSiteType.mockResolvedValueOnce(SITE_TYPES.SUB2API)
+    mockGetActiveOrAllTabs.mockResolvedValue([
+      {
+        id: 201,
+        active: true,
+        url: "https://sub2.example.com/dashboard",
+      },
+    ])
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.SUB2API,
+      siteTypeHint: SITE_TYPES.SUB2API,
+      userId: "42",
+      user: { username: "tab-user" },
+      accessToken: "jwt-from-tab",
+      sub2apiAuth: { refreshToken: "refresh-from-tab" },
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 201,
+        origin: "https://sub2.example.com",
+      },
+    })
+
+    const result = await autoDetectSmart("https://sub2.example.com/console")
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        userId: "42",
+        user: { username: "tab-user" },
+        siteType: SITE_TYPES.SUB2API,
+        accessToken: "jwt-from-tab",
+        sub2apiAuth: { refreshToken: "refresh-from-tab" },
+      },
+    })
+    expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledWith({
+      tabId: 201,
+      baseUrl: "https://sub2.example.com/console",
+      siteType: SITE_TYPES.SUB2API,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 201,
+        origin: "https://sub2.example.com",
+      },
+      onError: expect.any(Function),
+    })
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+  })
+
   it("does not report Sub2API API fallback success from cookie-auth user-info calls", async () => {
     mockGetAccountSiteType.mockResolvedValueOnce(SITE_TYPES.SUB2API)
     mockGetActiveOrAllTabs.mockResolvedValue([
@@ -274,10 +360,6 @@ describe("autoDetectSmart", () => {
         url: "https://sub2.example.com/dashboard",
       },
     ])
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: false,
-      error: "no local storage user",
-    })
     mockFetchUserInfo.mockRejectedValue(
       new Error("messages:sub2api.loginRequired"),
     )
@@ -317,10 +399,6 @@ describe("autoDetectSmart", () => {
         url: "https://example.com/home",
       },
     ])
-    browserAny.tabs.sendMessage.mockResolvedValueOnce({
-      success: false,
-      error: "no local storage user",
-    })
 
     const result = await autoDetectSmart("https://example.com/console")
 
@@ -337,8 +415,11 @@ describe("autoDetectSmart", () => {
         url: "https://example.com/dashboard",
       },
     ])
-    browserAny.tabs.sendMessage.mockRejectedValueOnce(
-      new Error("content storage failed"),
+    mockReadAccountBrowserSessionFromTab.mockImplementationOnce(
+      async (options) => {
+        options.onError?.(new Error("content storage failed"))
+        return null
+      },
     )
     mockIsMessageReceiverUnavailableError.mockReturnValue(false)
     mockFetchUserInfo.mockResolvedValueOnce({
@@ -368,8 +449,11 @@ describe("autoDetectSmart", () => {
         url: "https://example.com/dashboard",
       },
     ])
-    browserAny.tabs.sendMessage.mockRejectedValueOnce(
-      new Error("content storage failed"),
+    mockReadAccountBrowserSessionFromTab.mockImplementationOnce(
+      async (options) => {
+        options.onError?.(new Error("content storage failed"))
+        return null
+      },
     )
     mockIsMessageReceiverUnavailableError.mockImplementationOnce(() => {
       throw new Error("classifier failed")
@@ -409,11 +493,15 @@ describe("autoDetectSmart", () => {
       id: 17,
       username: "fallback-after-site-type-failure",
     })
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: true,
-      data: {
-        userId: "16",
-        user: { id: 16, username: "content-user" },
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.NEW_API,
+      userId: "16",
+      user: { id: 16, username: "content-user" },
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 106,
+        origin: "https://example.com",
       },
     })
 
@@ -455,11 +543,15 @@ describe("autoDetectSmart", () => {
         url: "https://other.example.com/home",
       },
     ])
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: true,
-      data: {
-        userId: "12",
-        user: { id: 12, username: "alice" },
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.NEW_API,
+      userId: "12",
+      user: { id: 12, username: "alice" },
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 101,
+        origin: "https://example.com",
       },
     })
 
@@ -473,14 +565,20 @@ describe("autoDetectSmart", () => {
         tabId: 101,
       },
     })
-    expect(browserAny.tabs.sendMessage).toHaveBeenCalledWith(101, {
-      action: expect.any(String),
-      url: "https://example.com/console",
+    expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledWith({
+      tabId: 101,
+      baseUrl: "https://example.com/console",
       siteType: SITE_TYPES.NEW_API,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 101,
+        origin: "https://example.com",
+      },
+      onError: expect.any(Function),
     })
-    expect(browserAny.tabs.sendMessage).not.toHaveBeenCalledWith(
-      202,
-      expect.anything(),
+    expect(mockReadAccountBrowserSessionFromTab).not.toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: 202 }),
     )
     expect(mockGetActiveTabs).not.toHaveBeenCalled()
   })
@@ -495,15 +593,6 @@ describe("autoDetectSmart", () => {
       },
     ])
     mockGetActiveTabs.mockResolvedValue([{ id: 2 }])
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: true,
-      data: {
-        userId: "99",
-        user: { id: 99, username: "wrong-current-tab-user" },
-        accessToken: "wrong-current-tab-token",
-        siteTypeHint: SITE_TYPES.AIHUBMIX,
-      },
-    })
     mockSendRuntimeMessage.mockResolvedValue({
       success: true,
       data: {
@@ -527,7 +616,7 @@ describe("autoDetectSmart", () => {
       },
     })
     expect(result.data).not.toHaveProperty("fetchContext")
-    expect(browserAny.tabs.sendMessage).not.toHaveBeenCalled()
+    expect(mockReadAccountBrowserSessionFromTab).not.toHaveBeenCalled()
     expect(mockSendRuntimeMessage).toHaveBeenCalledWith({
       action: expect.any(String),
       requestId: expect.any(String),
@@ -581,13 +670,17 @@ describe("autoDetectSmart", () => {
       },
     ])
     mockGetActiveTabs.mockResolvedValue([{ id: 2 }])
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: true,
-      data: {
-        userId: "7",
-        user: { id: 7, username: "aihubmix-user" },
-        accessToken: "main-origin-session-token",
-        siteTypeHint: SITE_TYPES.AIHUBMIX,
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.AIHUBMIX,
+      siteTypeHint: SITE_TYPES.AIHUBMIX,
+      userId: "7",
+      user: { id: 7, username: "aihubmix-user" },
+      accessToken: "main-origin-session-token",
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 2,
+        origin: "https://aihubmix.com",
       },
     })
 
@@ -608,10 +701,17 @@ describe("autoDetectSmart", () => {
         },
       },
     })
-    expect(browserAny.tabs.sendMessage).toHaveBeenCalledWith(2, {
-      action: expect.any(String),
-      url: "https://aihubmix.com",
+    expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledWith({
+      tabId: 2,
+      baseUrl: "https://aihubmix.com",
       siteType: SITE_TYPES.AIHUBMIX,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 2,
+        origin: "https://aihubmix.com",
+      },
+      onError: expect.any(Function),
     })
     expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
     expect(mockFetchUserInfo).not.toHaveBeenCalled()
@@ -628,7 +728,12 @@ describe("autoDetectSmart", () => {
       },
     ])
     mockGetActiveTabs.mockResolvedValue([{ id: 1 }])
-    browserAny.tabs.sendMessage.mockRejectedValue(new Error("no receiver"))
+    mockReadAccountBrowserSessionFromTab.mockImplementationOnce(
+      async (options) => {
+        options.onError?.(new Error("no receiver"))
+        return null
+      },
+    )
     mockIsMessageReceiverUnavailableError.mockReturnValue(true)
     mockFetchUserInfo.mockResolvedValue(null)
 
@@ -706,7 +811,7 @@ describe("autoDetectSmart", () => {
         cookieStoreId: "1-incognito",
       },
     })
-    expect(browserAny.tabs.sendMessage).not.toHaveBeenCalled()
+    expect(mockReadAccountBrowserSessionFromTab).not.toHaveBeenCalled()
     expect(mockSendRuntimeMessage).toHaveBeenCalledWith({
       action: expect.any(String),
       requestId: expect.any(String),
@@ -726,10 +831,6 @@ describe("autoDetectSmart", () => {
         cookieStoreId: "1-incognito",
       },
     ])
-    browserAny.tabs.sendMessage.mockResolvedValue({
-      success: false,
-      error: "no local storage user",
-    })
     mockFetchUserInfo.mockResolvedValue(null)
     mockSendRuntimeMessage.mockResolvedValue({
       success: true,
@@ -1083,7 +1184,7 @@ describe("autoDetectSmart", () => {
       user: { id: 32, username: "background-after-current-tab-throw" },
     })
     expect(result.data).not.toHaveProperty("fetchContext")
-    expect(browserAny.tabs.sendMessage).not.toHaveBeenCalled()
+    expect(mockReadAccountBrowserSessionFromTab).not.toHaveBeenCalled()
     expect(mockSendRuntimeMessage).toHaveBeenCalledTimes(1)
   })
 
@@ -1097,7 +1198,12 @@ describe("autoDetectSmart", () => {
         url: "https://example.com/home",
       },
     ])
-    browserAny.tabs.sendMessage.mockRejectedValueOnce(new Error("no receiver"))
+    mockReadAccountBrowserSessionFromTab.mockImplementationOnce(
+      async (options) => {
+        options.onError?.(new Error("no receiver"))
+        return null
+      },
+    )
     mockIsMessageReceiverUnavailableError.mockReturnValue(true)
     mockFetchUserInfo.mockResolvedValue(null)
 
@@ -1129,7 +1235,12 @@ describe("autoDetectSmart", () => {
         cookieStoreId: "private-store",
       },
     ])
-    browserAny.tabs.sendMessage.mockRejectedValueOnce(new Error("no receiver"))
+    mockReadAccountBrowserSessionFromTab.mockImplementationOnce(
+      async (options) => {
+        options.onError?.(new Error("no receiver"))
+        return null
+      },
+    )
     mockIsMessageReceiverUnavailableError.mockReturnValue(true)
     mockFetchUserInfo.mockResolvedValue(null)
 


### PR DESCRIPTION
## Summary
- add a shared account browser-session reader for current-tab, existing-tab, and temp-window session reads
- route Sub2API token re-sync and Account Dialog Sub2API import through the shared reader
- reuse the reader for current-tab auto-detect and AccountData active-tab matching
- document the capability design and implementation plan

## Validation
- pnpm vitest run tests/services/accountBrowserSession/sessionReader.test.ts
- pnpm vitest run tests/services/apiService/sub2api/tokenResync.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiService/sub2api/keyManagement.test.ts
- pnpm vitest run tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.analytics.test.tsx
- pnpm vitest run tests/features/AccountManagement/hooks/AccountDataContext.test.tsx tests/services/autoDetectService.test.ts
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account and session lookup now uses a unified browser-session flow to read current-tab, same-origin existing-tab, and temporary-window session data, returning a consistent normalized result.

* **Bug Fixes**
  * Improved current-tab account verification and auto-detection reliability when tab messaging is unavailable, with clearer fallback behavior.
  * Improved Sub2API session import and access-token resync by applying the same session usability rules across flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->