### PR TITLE
refactor(api-adapters): detach new api key management

### DIFF
--- a/docs/superpowers/plans/2026-06-28-new-api-family-key-management-detach.md
+++ b/docs/superpowers/plans/2026-06-28-new-api-family-key-management-detach.md
@@ -1,0 +1,909 @@
+# New API Family Key Management Detach Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detach `apiAdapters/newApi/keyManagement.ts` from the legacy `getApiService(...)` facade by routing New API-family key-management operations through explicit `newApiFamily` implementation helpers.
+
+**Architecture:** Add a capability-sized `src/services/apiService/newApiFamily/keyManagement.ts` Module that owns New API-family default behavior plus capability-local overrides. The New API-family Adapter composes that Module into `KeyManagementCapability`; legacy `getApiService(...)` behavior remains intact for old callers.
+
+**Tech Stack:** TypeScript, existing `apiAdapters`, existing `apiService/common` and site override helpers, Vitest, `pnpm run validate:staged`, `pnpm compile`, `pnpm run validate:push`.
+
+**Spec:** `docs/superpowers/specs/2026-06-28-new-api-family-adapter-detach-design.md`
+
+---
+
+## File Structure
+
+Create:
+
+- `src/services/apiService/newApiFamily/keyManagement.ts`
+  - Exposes capability-sized New API-family key-management helpers.
+  - Wraps common-compatible defaults.
+  - Applies capability-local overrides for OneHub-family token inventory/model/group behavior and WONG token-secret resolution.
+- `src/services/apiService/newApiFamily/index.ts`
+  - Barrel for the New API-family implementation Module. Export only `keyManagement` in this slice.
+
+Modify:
+
+- `src/services/apiAdapters/newApi/keyManagement.ts`
+  - Replace `getApiService(siteType)` calls with direct imports from `~/services/apiService/newApiFamily/keyManagement`.
+- `tests/services/apiAdapters/keyManagement.test.ts`
+  - Change the New API-family adapter test to mock `~/services/apiService/newApiFamily/keyManagement` instead of `~/services/apiService`.
+  - Keep Sub2API and AIHubMix backend-helper tests unchanged except for any mock cleanup required by import ordering.
+- `tests/services/apiService/index.test.ts`
+  - Keep current legacy facade expectations. Add no new coverage unless implementation accidentally changes old behavior.
+- `tests/services/apiService/common/tokenApi.test.ts`
+  - Keep common token behavior covered. Add no new test unless the implementation moves common code.
+- `tests/services/apiService/oneHub/index.test.ts`
+  - Keep OneHub direct helper behavior covered. Add no new test unless override imports move.
+- `tests/services/apiService/wong/index.test.ts`
+  - Keep WONG token-secret method behavior covered. Add no new test unless override imports move.
+
+Do not modify:
+
+- `src/services/apiService/index.ts`
+  - The legacy dynamic facade remains in place for old callers.
+- `src/services/apiService/common/index.ts`
+  - Do not move helper implementations in this slice.
+- `src/services/apiService/oneHub/index.ts`
+  - Reuse its existing key-management helpers for OneHub/DoneHub overrides.
+- `src/services/apiService/wong/index.ts`
+  - Reuse its existing WONG `resolveApiTokenKey(...)` override.
+- Sub2API and AIHubMix adapters or backend helpers.
+- Managed-site providers, model pricing, redemption, account bootstrap/data/refresh, locale files, telemetry files, settings search, Playwright tests, or new site-type definitions.
+
+---
+
+### Task 1: Add New API-Family Key-Management Implementation Module
+
+**Files:**
+
+- Create: `src/services/apiService/newApiFamily/keyManagement.ts`
+- Create: `src/services/apiService/newApiFamily/index.ts`
+- Test: `tests/services/apiService/newApiFamily/keyManagement.test.ts`
+
+- [ ] **Step 1: Write failing New API-family implementation tests**
+
+Create `tests/services/apiService/newApiFamily/keyManagement.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
+  fetchAccountTokens,
+  fetchUserGroups,
+  resolveApiTokenKey,
+  updateApiToken,
+} from "~/services/apiService/newApiFamily/keyManagement"
+import { AuthTypeEnum, type ApiToken } from "~/types"
+
+const {
+  commonCreateApiToken,
+  commonDeleteApiToken,
+  commonFetchAccountAvailableModels,
+  commonFetchAccountTokens,
+  commonFetchUserGroups,
+  commonResolveApiTokenKey,
+  commonUpdateApiToken,
+  oneHubFetchAccountAvailableModels,
+  oneHubFetchAccountTokens,
+  oneHubFetchUserGroups,
+  wongResolveApiTokenKey,
+} = vi.hoisted(() => ({
+  commonCreateApiToken: vi.fn(),
+  commonDeleteApiToken: vi.fn(),
+  commonFetchAccountAvailableModels: vi.fn(),
+  commonFetchAccountTokens: vi.fn(),
+  commonFetchUserGroups: vi.fn(),
+  commonResolveApiTokenKey: vi.fn(),
+  commonUpdateApiToken: vi.fn(),
+  oneHubFetchAccountAvailableModels: vi.fn(),
+  oneHubFetchAccountTokens: vi.fn(),
+  oneHubFetchUserGroups: vi.fn(),
+  wongResolveApiTokenKey: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/common", () => ({
+  createApiToken: commonCreateApiToken,
+  deleteApiToken: commonDeleteApiToken,
+  fetchAccountAvailableModels: commonFetchAccountAvailableModels,
+  fetchAccountTokens: commonFetchAccountTokens,
+  fetchUserGroups: commonFetchUserGroups,
+  resolveApiTokenKey: commonResolveApiTokenKey,
+  updateApiToken: commonUpdateApiToken,
+}))
+
+vi.mock("~/services/apiService/oneHub", () => ({
+  fetchAccountAvailableModels: oneHubFetchAccountAvailableModels,
+  fetchAccountTokens: oneHubFetchAccountTokens,
+  fetchUserGroups: oneHubFetchUserGroups,
+}))
+
+vi.mock("~/services/apiService/wong", () => ({
+  resolveApiTokenKey: wongResolveApiTokenKey,
+}))
+
+const request = {
+  baseUrl: "https://api.example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "user-1",
+    accessToken: "access-token",
+  },
+}
+
+const token = {
+  id: 123,
+  key: "sk-abcd************wxyz",
+  name: "Example token",
+} as ApiToken
+
+const tokenData = {
+  name: "Example token",
+  remain_quota: 500000,
+  expired_time: -1,
+  unlimited_quota: false,
+  model_limits_enabled: false,
+  model_limits: "",
+  allow_ips: "",
+  group: "",
+}
+
+describe("newApiFamily keyManagement implementation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("uses common-compatible helpers by default", async () => {
+    const tokens = [token]
+    const groups = {
+      default: { desc: "Default", ratio: 1 },
+    }
+    const models = ["gpt-4o-mini"]
+
+    commonFetchAccountTokens.mockResolvedValueOnce(tokens)
+    commonCreateApiToken.mockResolvedValueOnce(true)
+    commonUpdateApiToken.mockResolvedValueOnce(true)
+    commonResolveApiTokenKey.mockResolvedValueOnce("sk-real")
+    commonDeleteApiToken.mockResolvedValueOnce(true)
+    commonFetchUserGroups.mockResolvedValueOnce(groups)
+    commonFetchAccountAvailableModels.mockResolvedValueOnce(models)
+
+    await expect(
+      fetchAccountTokens(request, {
+        siteType: SITE_TYPES.NEW_API,
+        page: 2,
+        size: 25,
+      }),
+    ).resolves.toBe(tokens)
+    await expect(
+      createApiToken(request, {
+        siteType: SITE_TYPES.NEW_API,
+        tokenData,
+      }),
+    ).resolves.toBe(true)
+    await expect(
+      updateApiToken(request, {
+        siteType: SITE_TYPES.NEW_API,
+        tokenId: token.id,
+        tokenData,
+      }),
+    ).resolves.toBe(true)
+    await expect(
+      resolveApiTokenKey(request, {
+        siteType: SITE_TYPES.NEW_API,
+        token,
+      }),
+    ).resolves.toBe("sk-real")
+    await expect(
+      deleteApiToken(request, {
+        siteType: SITE_TYPES.NEW_API,
+        tokenId: token.id,
+      }),
+    ).resolves.toBe(true)
+    await expect(
+      fetchUserGroups(request, { siteType: SITE_TYPES.NEW_API }),
+    ).resolves.toBe(groups)
+    await expect(
+      fetchAccountAvailableModels(request, {
+        siteType: SITE_TYPES.NEW_API,
+      }),
+    ).resolves.toBe(models)
+
+    expect(commonFetchAccountTokens).toHaveBeenCalledWith(request, 2, 25)
+    expect(commonCreateApiToken).toHaveBeenCalledWith(request, tokenData)
+    expect(commonUpdateApiToken).toHaveBeenCalledWith(
+      request,
+      token.id,
+      tokenData,
+    )
+    expect(commonResolveApiTokenKey).toHaveBeenCalledWith(request, token)
+    expect(commonDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+    expect(commonFetchUserGroups).toHaveBeenCalledWith(request)
+    expect(commonFetchAccountAvailableModels).toHaveBeenCalledWith(request)
+  })
+
+  it("uses OneHub-family helpers for token list, groups, and available models", async () => {
+    const tokens = [token]
+    const groups = {
+      onehub: { desc: "OneHub", ratio: 1.5 },
+    }
+    const models = ["onehub-model"]
+
+    oneHubFetchAccountTokens.mockResolvedValueOnce(tokens)
+    oneHubFetchUserGroups.mockResolvedValueOnce(groups)
+    oneHubFetchAccountAvailableModels.mockResolvedValueOnce(models)
+
+    await expect(
+      fetchAccountTokens(request, {
+        siteType: SITE_TYPES.DONE_HUB,
+        page: 4,
+        size: 10,
+      }),
+    ).resolves.toBe(tokens)
+    await expect(
+      fetchUserGroups(request, { siteType: SITE_TYPES.DONE_HUB }),
+    ).resolves.toBe(groups)
+    await expect(
+      fetchAccountAvailableModels(request, {
+        siteType: SITE_TYPES.DONE_HUB,
+      }),
+    ).resolves.toBe(models)
+
+    expect(oneHubFetchAccountTokens).toHaveBeenCalledWith(request, 4, 10)
+    expect(oneHubFetchUserGroups).toHaveBeenCalledWith(request)
+    expect(oneHubFetchAccountAvailableModels).toHaveBeenCalledWith(request)
+    expect(commonFetchAccountTokens).not.toHaveBeenCalled()
+    expect(commonFetchUserGroups).not.toHaveBeenCalled()
+    expect(commonFetchAccountAvailableModels).not.toHaveBeenCalled()
+  })
+
+  it("uses WONG token-secret resolution while keeping other operations common-compatible", async () => {
+    wongResolveApiTokenKey.mockResolvedValueOnce("sk-wong-secret")
+    commonFetchAccountTokens.mockResolvedValueOnce([token])
+
+    await expect(
+      resolveApiTokenKey(request, {
+        siteType: SITE_TYPES.WONG_GONGYI,
+        token,
+      }),
+    ).resolves.toBe("sk-wong-secret")
+    await expect(
+      fetchAccountTokens(request, {
+        siteType: SITE_TYPES.WONG_GONGYI,
+      }),
+    ).resolves.toEqual([token])
+
+    expect(wongResolveApiTokenKey).toHaveBeenCalledWith(request, token)
+    expect(commonResolveApiTokenKey).not.toHaveBeenCalled()
+    expect(commonFetchAccountTokens).toHaveBeenCalledWith(request, 0, 100)
+  })
+})
+```
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/newApiFamily/keyManagement.test.ts
+```
+
+Expected: FAIL with a missing module error for `~/services/apiService/newApiFamily/keyManagement`.
+
+- [ ] **Step 3: Add the New API-family key-management implementation**
+
+Create `src/services/apiService/newApiFamily/keyManagement.ts`:
+
+```ts
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import * as commonKeyManagement from "~/services/apiService/common"
+import * as oneHubKeyManagement from "~/services/apiService/oneHub"
+import * as wongKeyManagement from "~/services/apiService/wong"
+import type {
+  ApiServiceRequest,
+  CreateTokenRequest,
+  CreateTokenResult,
+  UserGroupInfo,
+} from "~/services/apiService/common/type"
+import type { ApiToken } from "~/types"
+
+type PaginationOptions = {
+  page?: number
+  size?: number
+}
+
+type NewApiFamilySiteOptions = {
+  siteType: AccountSiteType
+}
+
+type KeyManagementImplementation = {
+  fetchAccountTokens(
+    request: ApiServiceRequest,
+    page?: number,
+    size?: number,
+  ): Promise<ApiToken[]>
+  createApiToken(
+    request: ApiServiceRequest,
+    tokenData: CreateTokenRequest,
+  ): Promise<CreateTokenResult>
+  updateApiToken(
+    request: ApiServiceRequest,
+    tokenId: number,
+    tokenData: CreateTokenRequest,
+  ): Promise<boolean | void>
+  resolveApiTokenKey(
+    request: ApiServiceRequest,
+    token: Pick<ApiToken, "id" | "key">,
+  ): Promise<string>
+  deleteApiToken(
+    request: ApiServiceRequest,
+    tokenId: number,
+  ): Promise<boolean | void>
+  fetchUserGroups(
+    request: ApiServiceRequest,
+  ): Promise<Record<string, UserGroupInfo>>
+  fetchAccountAvailableModels(request: ApiServiceRequest): Promise<string[]>
+}
+
+const defaultKeyManagementImplementation: KeyManagementImplementation = {
+  fetchAccountTokens: commonKeyManagement.fetchAccountTokens,
+  createApiToken: commonKeyManagement.createApiToken,
+  updateApiToken: commonKeyManagement.updateApiToken,
+  resolveApiTokenKey: commonKeyManagement.resolveApiTokenKey,
+  deleteApiToken: commonKeyManagement.deleteApiToken,
+  fetchUserGroups: commonKeyManagement.fetchUserGroups,
+  fetchAccountAvailableModels: commonKeyManagement.fetchAccountAvailableModels,
+}
+
+const oneHubKeyManagementOverrides: Partial<KeyManagementImplementation> = {
+  fetchAccountTokens: oneHubKeyManagement.fetchAccountTokens,
+  fetchUserGroups: oneHubKeyManagement.fetchUserGroups,
+  fetchAccountAvailableModels: oneHubKeyManagement.fetchAccountAvailableModels,
+}
+
+const keyManagementOverrides: Partial<
+  Record<AccountSiteType, Partial<KeyManagementImplementation>>
+> = {
+  [SITE_TYPES.ONE_HUB]: oneHubKeyManagementOverrides,
+  [SITE_TYPES.DONE_HUB]: oneHubKeyManagementOverrides,
+  [SITE_TYPES.WONG_GONGYI]: {
+    resolveApiTokenKey: wongKeyManagement.resolveApiTokenKey,
+  },
+}
+
+function getKeyManagementImplementation(
+  siteType: AccountSiteType,
+): KeyManagementImplementation {
+  return {
+    ...defaultKeyManagementImplementation,
+    ...keyManagementOverrides[siteType],
+  }
+}
+
+export async function fetchAccountTokens(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & PaginationOptions,
+): Promise<ApiToken[]> {
+  const implementation = getKeyManagementImplementation(options.siteType)
+  return implementation.fetchAccountTokens(
+    request,
+    options.page ?? 0,
+    options.size ?? 100,
+  )
+}
+
+export async function createApiToken(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & { tokenData: CreateTokenRequest },
+): Promise<CreateTokenResult> {
+  const implementation = getKeyManagementImplementation(options.siteType)
+  return implementation.createApiToken(request, options.tokenData)
+}
+
+export async function updateApiToken(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & {
+    tokenId: number
+    tokenData: CreateTokenRequest
+  },
+): Promise<boolean | void> {
+  const implementation = getKeyManagementImplementation(options.siteType)
+  return implementation.updateApiToken(
+    request,
+    options.tokenId,
+    options.tokenData,
+  )
+}
+
+export async function resolveApiTokenKey(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & {
+    token: Pick<ApiToken, "id" | "key">
+  },
+): Promise<string> {
+  const implementation = getKeyManagementImplementation(options.siteType)
+  return implementation.resolveApiTokenKey(request, options.token)
+}
+
+export async function deleteApiToken(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & { tokenId: number },
+): Promise<boolean | void> {
+  const implementation = getKeyManagementImplementation(options.siteType)
+  return implementation.deleteApiToken(request, options.tokenId)
+}
+
+export async function fetchUserGroups(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions,
+): Promise<Record<string, UserGroupInfo>> {
+  const implementation = getKeyManagementImplementation(options.siteType)
+  return implementation.fetchUserGroups(request)
+}
+
+export async function fetchAccountAvailableModels(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions,
+): Promise<string[]> {
+  const implementation = getKeyManagementImplementation(options.siteType)
+  return implementation.fetchAccountAvailableModels(request)
+}
+```
+
+- [ ] **Step 4: Add the New API-family barrel**
+
+Create `src/services/apiService/newApiFamily/index.ts`:
+
+```ts
+export * as keyManagement from "./keyManagement"
+```
+
+- [ ] **Step 5: Run the new implementation test**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/newApiFamily/keyManagement.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the implementation Module**
+
+Run:
+
+```powershell
+git add src/services/apiService/newApiFamily/keyManagement.ts src/services/apiService/newApiFamily/index.ts tests/services/apiService/newApiFamily/keyManagement.test.ts
+git commit -m "refactor(api-service): add new api key management implementation"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 2: Rewire New API Adapter Key Management
+
+**Files:**
+
+- Modify: `src/services/apiAdapters/newApi/keyManagement.ts`
+- Modify: `tests/services/apiAdapters/keyManagement.test.ts`
+
+- [ ] **Step 1: Update adapter tests to mock the New API-family implementation Module**
+
+In `tests/services/apiAdapters/keyManagement.test.ts`, remove `mockGetApiService` from the hoisted object.
+
+Replace the current `~/services/apiService` mock:
+
+```ts
+vi.mock("~/services/apiService", () => ({
+  getApiService: mockGetApiService,
+}))
+```
+
+with a mock for the New API-family implementation Module:
+
+```ts
+vi.mock("~/services/apiService/newApiFamily/keyManagement", () => ({
+  createApiToken: mockCreateApiToken,
+  deleteApiToken: mockDeleteApiToken,
+  fetchAccountAvailableModels: mockFetchAccountAvailableModels,
+  fetchAccountTokens: mockFetchAccountTokens,
+  fetchUserGroups: mockFetchUserGroups,
+  resolveApiTokenKey: mockResolveApiTokenKey,
+  updateApiToken: mockUpdateApiToken,
+}))
+```
+
+In `beforeEach`, remove the `mockGetApiService.mockReturnValue(...)` setup.
+
+In `"delegates New API-family key operations through the site-specific apiService"`, rename the test to:
+
+```ts
+it("delegates New API-family key operations through the New API-family implementation", async () => {
+```
+
+Remove:
+
+```ts
+expect(mockGetApiService).not.toHaveBeenCalled()
+```
+
+Replace the final `mockGetApiService.mock.calls` assertion with assertions that every implementation call receives the `siteType` option:
+
+```ts
+expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, {
+  siteType: SITE_TYPES.ONE_HUB,
+  page: 2,
+  size: 25,
+})
+expect(mockCreateApiToken).toHaveBeenCalledWith(request, {
+  siteType: SITE_TYPES.ONE_HUB,
+  tokenData,
+})
+expect(mockUpdateApiToken).toHaveBeenCalledWith(request, {
+  siteType: SITE_TYPES.ONE_HUB,
+  tokenId: token.id,
+  tokenData,
+})
+expect(mockResolveApiTokenKey).toHaveBeenCalledWith(request, {
+  siteType: SITE_TYPES.ONE_HUB,
+  token,
+})
+expect(mockDeleteApiToken).toHaveBeenCalledWith(request, {
+  siteType: SITE_TYPES.ONE_HUB,
+  tokenId: token.id,
+})
+expect(mockFetchUserGroups).toHaveBeenCalledWith(request, {
+  siteType: SITE_TYPES.ONE_HUB,
+})
+expect(mockFetchAccountAvailableModels).toHaveBeenCalledWith(request, {
+  siteType: SITE_TYPES.ONE_HUB,
+})
+```
+
+In `"propagates New API-family key lifecycle errors from the site-specific apiService"`, rename the test to:
+
+```ts
+it("propagates New API-family key lifecycle errors from the implementation Module", async () => {
+```
+
+Replace:
+
+```ts
+expect(mockDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+```
+
+with:
+
+```ts
+expect(mockDeleteApiToken).toHaveBeenCalledWith(request, {
+  siteType: SITE_TYPES.ONE_HUB,
+  tokenId: token.id,
+})
+```
+
+- [ ] **Step 2: Run adapter key-management tests and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts
+```
+
+Expected: FAIL because `src/services/apiAdapters/newApi/keyManagement.ts` still imports `getApiService(...)` and calls old argument shapes.
+
+- [ ] **Step 3: Rewire the New API adapter implementation**
+
+Modify `src/services/apiAdapters/newApi/keyManagement.ts`.
+
+Replace:
+
+```ts
+import { getApiService } from "~/services/apiService"
+```
+
+with:
+
+```ts
+import {
+  createApiToken,
+  deleteApiToken,
+  fetchAccountAvailableModels,
+  fetchAccountTokens,
+  fetchUserGroups,
+  resolveApiTokenKey,
+  updateApiToken,
+} from "~/services/apiService/newApiFamily/keyManagement"
+```
+
+Replace the `return` object in `createNewApiKeyManagement(...)` with:
+
+```ts
+  return {
+    fetchTokens: (request, options) =>
+      fetchAccountTokens(request, {
+        siteType,
+        page: options?.page,
+        size: options?.size,
+      }),
+    createToken: (request, tokenData) =>
+      createApiToken(request, { siteType, tokenData }),
+    updateToken: ({ request, tokenId, tokenData }) =>
+      updateApiToken(request, { siteType, tokenId, tokenData }),
+    resolveTokenKey: ({ request, token }) =>
+      resolveApiTokenKey(request, { siteType, token }),
+    deleteToken: ({ request, tokenId }) =>
+      deleteApiToken(request, { siteType, tokenId }),
+    fetchAvailableModels: (request) =>
+      fetchAccountAvailableModels(request, { siteType }),
+    userGroups: {
+      fetch: (request) => fetchUserGroups(request, { siteType }),
+    },
+  }
+```
+
+- [ ] **Step 4: Run adapter key-management tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run registry tests to catch capability shape regressions**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the adapter rewire**
+
+Run:
+
+```powershell
+git add src/services/apiAdapters/newApi/keyManagement.ts tests/services/apiAdapters/keyManagement.test.ts
+git commit -m "refactor(api-adapters): detach new api key management"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+---
+
+### Task 3: Preserve Legacy Facade Behavior
+
+**Files:**
+
+- Test: `tests/services/apiService/index.test.ts`
+- Test: `tests/services/apiService/common/tokenApi.test.ts`
+- Test: `tests/services/apiService/oneHub/index.test.ts`
+- Test: `tests/services/apiService/wong/index.test.ts`
+
+- [ ] **Step 1: Run existing legacy facade and helper tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/index.test.ts tests/services/apiService/common/tokenApi.test.ts tests/services/apiService/oneHub/index.test.ts tests/services/apiService/wong/index.test.ts
+```
+
+Expected: PASS. These tests prove the legacy `getApiService(...)` facade and the direct backend helpers still behave as before.
+
+- [ ] **Step 2: Add a legacy regression test only if Step 1 exposes a gap**
+
+If Step 1 fails because existing tests do not cover one of these still-supported legacy calls:
+
+- `getApiService(SITE_TYPES.ONE_HUB).fetchAccountTokens(...)`
+- `getApiService(SITE_TYPES.WONG_GONGYI).resolveApiTokenKey(...)`
+- `getApiService(SITE_TYPES.NEW_API).fetchUserGroups(...)`
+
+then add the missing assertion to `tests/services/apiService/index.test.ts` using the existing hoisted mocks. For example, for common user groups, add `commonFetchUserGroups` to the hoisted mocks and common mock:
+
+```ts
+const {
+  commonFetchUserGroups,
+} = vi.hoisted(() => ({
+  commonFetchUserGroups: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/common", () => ({
+  fetchUserGroups: commonFetchUserGroups,
+}))
+```
+
+Then add:
+
+```ts
+it("should route common user groups through the legacy facade", async () => {
+  commonFetchUserGroups.mockResolvedValue({ default: { desc: "Default", ratio: 1 } })
+
+  const request = {
+    baseUrl: "https://example.invalid",
+    auth: { authType: "access_token", userId: "1", accessToken: "token" },
+  }
+
+  await (getApiService(SITE_TYPES.NEW_API).fetchUserGroups as any)(request)
+
+  expect(commonFetchUserGroups).toHaveBeenCalledWith(request)
+})
+```
+
+Do not add this test if existing coverage is already sufficient and Step 1 passes.
+
+- [ ] **Step 3: Run legacy tests again if Step 2 changed tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/index.test.ts tests/services/apiService/common/tokenApi.test.ts tests/services/apiService/oneHub/index.test.ts tests/services/apiService/wong/index.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit only if Step 2 changed tests**
+
+If Step 2 added or changed tests, run:
+
+```powershell
+git add tests/services/apiService/index.test.ts
+git commit -m "test(api-service): preserve key management facade behavior"
+```
+
+Expected: commit succeeds after the repo hook runs `validate:staged`.
+
+Skip this commit if Step 2 made no changes.
+
+---
+
+### Task 4: Final Validation And Scope Audit
+
+**Files:**
+
+- Review all task-scoped files changed in Tasks 1-3.
+
+- [ ] **Step 1: Assert the New API adapter no longer imports the legacy facade**
+
+Run:
+
+```powershell
+rg -n "getApiService|~/services/apiService\"|~/services/apiService'" src/services/apiAdapters/newApi/keyManagement.ts
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Run focused implementation and adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/newApiFamily/keyManagement.test.ts tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run legacy facade and backend helper tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/index.test.ts tests/services/apiService/common/tokenApi.test.ts tests/services/apiService/oneHub/index.test.ts tests/services/apiService/wong/index.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run TypeScript compile**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run staged validation**
+
+If there are uncommitted task-scoped changes, stage only those files:
+
+```powershell
+git status --short
+git add src/services/apiService/newApiFamily/keyManagement.ts src/services/apiService/newApiFamily/index.ts src/services/apiAdapters/newApi/keyManagement.ts tests/services/apiService/newApiFamily/keyManagement.test.ts tests/services/apiAdapters/keyManagement.test.ts tests/services/apiService/index.test.ts
+pnpm run validate:staged
+```
+
+Expected: PASS. Existing unrelated untracked files may remain untracked and must not be staged.
+
+If all prior task commits succeeded and there are no uncommitted task files, run:
+
+```powershell
+git status --short
+```
+
+Expected: only unrelated pre-existing untracked files remain.
+
+- [ ] **Step 6: Run push gate before publishing**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. This gate is required before pushing or opening a PR because this slice adds a new shared service Module and changes import graph wiring.
+
+- [ ] **Step 7: Inspect final diff scope**
+
+If tasks were committed individually, run:
+
+```powershell
+git show --stat --oneline HEAD~3..HEAD
+git diff --name-status HEAD~3..HEAD
+```
+
+Expected changed files are limited to:
+
+```text
+src/services/apiService/newApiFamily/keyManagement.ts
+src/services/apiService/newApiFamily/index.ts
+src/services/apiAdapters/newApi/keyManagement.ts
+tests/services/apiService/newApiFamily/keyManagement.test.ts
+tests/services/apiAdapters/keyManagement.test.ts
+tests/services/apiService/index.test.ts
+```
+
+`tests/services/apiService/index.test.ts` should appear only if Task 3 added missing legacy coverage.
+
+- [ ] **Step 8: Report execution notes**
+
+Before handing off, report:
+
+```text
+Focused tests:
+- pnpm vitest run tests/services/apiService/newApiFamily/keyManagement.test.ts tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts
+- pnpm vitest run tests/services/apiService/index.test.ts tests/services/apiService/common/tokenApi.test.ts tests/services/apiService/oneHub/index.test.ts tests/services/apiService/wong/index.test.ts
+
+Validation:
+- pnpm compile
+- pnpm run validate:staged
+- pnpm run validate:push
+
+Telemetry decision:
+- none; this is internal service routing with no new user action, setting, background flow, or analytics field.
+
+Settings search decision:
+- none; no settings UI, route, anchor, or search definition changes.
+
+E2E decision:
+- no Playwright E2E; the risk is service Module routing and Adapter delegation, covered by Vitest.
+```
+
+---
+
+## Out Of Scope
+
+- Do not modify `src/services/apiService/index.ts`.
+- Do not migrate account bootstrap, account data, account refresh, model pricing, redemption, site notice, or token provisioning.
+- Do not rename `common` to `newApiFamily`.
+- Do not move common helper implementations out of `src/services/apiService/common/index.ts`.
+- Do not modify OneHub or WONG backend helper behavior.
+- Do not migrate Sub2API or AIHubMix key-management adapters.
+- Do not touch managed-site provider/channel CRUD, model sync, locale files, telemetry schemas, settings search files, Playwright tests, or new site-type definitions.
+- Do not add import guards or dependency tooling in this slice.
+
+## Self-Review
+
+- Spec coverage: Task 1 creates the `newApiFamily/keyManagement` Implementation Module and capability-local override map. Task 2 rewires `apiAdapters/newApi/keyManagement.ts` away from `getApiService(...)`. Task 3 preserves legacy facade behavior. Task 4 covers focused tests, compile, staged validation, push validation, scope audit, telemetry, settings search, and E2E decision.
+- Scope control: The plan does not touch other adapter capabilities, managed-site flows, `apiService/index.ts`, `common` rename, locale files, telemetry, settings search, or Playwright tests.
+- Type consistency: The plan consistently uses `KeyManagementCapability.fetchTokens(request, options)`, `createToken(request, tokenData)`, `updateToken({ request, tokenId, tokenData })`, `resolveTokenKey({ request, token })`, `deleteToken({ request, tokenId })`, `userGroups.fetch(request)`, and `fetchAvailableModels(request)`.
+- Compatibility: Legacy `getApiService(...)` remains intact. New API-family Adapter calls pass `siteType` explicitly to the implementation Module, avoiding hidden argument inspection inside the Adapter.

--- a/docs/superpowers/plans/2026-06-28-new-api-family-key-management-detach.md
+++ b/docs/superpowers/plans/2026-06-28-new-api-family-key-management-detach.md
@@ -70,15 +70,7 @@ Create `tests/services/apiService/newApiFamily/keyManagement.test.ts`:
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
-import {
-  createApiToken,
-  deleteApiToken,
-  fetchAccountAvailableModels,
-  fetchAccountTokens,
-  fetchUserGroups,
-  resolveApiTokenKey,
-  updateApiToken,
-} from "~/services/apiService/newApiFamily/keyManagement"
+import { createKeyManagementImplementation } from "~/services/apiService/newApiFamily/keyManagement"
 import { AuthTypeEnum, type ApiToken } from "~/types"
 
 const {
@@ -160,6 +152,7 @@ describe("newApiFamily keyManagement implementation", () => {
   })
 
   it("uses common-compatible helpers by default", async () => {
+    const keyManagement = createKeyManagementImplementation(SITE_TYPES.NEW_API)
     const tokens = [token]
     const groups = {
       default: { desc: "Default", ratio: 1 },
@@ -175,44 +168,23 @@ describe("newApiFamily keyManagement implementation", () => {
     commonFetchAccountAvailableModels.mockResolvedValueOnce(models)
 
     await expect(
-      fetchAccountTokens(request, {
-        siteType: SITE_TYPES.NEW_API,
-        page: 2,
-        size: 25,
-      }),
+      keyManagement.fetchAccountTokens(request, 2, 25),
     ).resolves.toBe(tokens)
     await expect(
-      createApiToken(request, {
-        siteType: SITE_TYPES.NEW_API,
-        tokenData,
-      }),
+      keyManagement.createApiToken(request, tokenData),
     ).resolves.toBe(true)
     await expect(
-      updateApiToken(request, {
-        siteType: SITE_TYPES.NEW_API,
-        tokenId: token.id,
-        tokenData,
-      }),
+      keyManagement.updateApiToken(request, token.id, tokenData),
     ).resolves.toBe(true)
     await expect(
-      resolveApiTokenKey(request, {
-        siteType: SITE_TYPES.NEW_API,
-        token,
-      }),
+      keyManagement.resolveApiTokenKey(request, token),
     ).resolves.toBe("sk-real")
     await expect(
-      deleteApiToken(request, {
-        siteType: SITE_TYPES.NEW_API,
-        tokenId: token.id,
-      }),
+      keyManagement.deleteApiToken(request, token.id),
     ).resolves.toBe(true)
+    await expect(keyManagement.fetchUserGroups(request)).resolves.toBe(groups)
     await expect(
-      fetchUserGroups(request, { siteType: SITE_TYPES.NEW_API }),
-    ).resolves.toBe(groups)
-    await expect(
-      fetchAccountAvailableModels(request, {
-        siteType: SITE_TYPES.NEW_API,
-      }),
+      keyManagement.fetchAccountAvailableModels(request),
     ).resolves.toBe(models)
 
     expect(commonFetchAccountTokens).toHaveBeenCalledWith(request, 2, 25)
@@ -229,6 +201,7 @@ describe("newApiFamily keyManagement implementation", () => {
   })
 
   it("uses OneHub-family helpers for token list, groups, and available models", async () => {
+    const keyManagement = createKeyManagementImplementation(SITE_TYPES.DONE_HUB)
     const tokens = [token]
     const groups = {
       onehub: { desc: "OneHub", ratio: 1.5 },
@@ -240,19 +213,13 @@ describe("newApiFamily keyManagement implementation", () => {
     oneHubFetchAccountAvailableModels.mockResolvedValueOnce(models)
 
     await expect(
-      fetchAccountTokens(request, {
-        siteType: SITE_TYPES.DONE_HUB,
-        page: 4,
-        size: 10,
-      }),
+      keyManagement.fetchAccountTokens(request, 4, 10),
     ).resolves.toBe(tokens)
     await expect(
-      fetchUserGroups(request, { siteType: SITE_TYPES.DONE_HUB }),
+      keyManagement.fetchUserGroups(request),
     ).resolves.toBe(groups)
     await expect(
-      fetchAccountAvailableModels(request, {
-        siteType: SITE_TYPES.DONE_HUB,
-      }),
+      keyManagement.fetchAccountAvailableModels(request),
     ).resolves.toBe(models)
 
     expect(oneHubFetchAccountTokens).toHaveBeenCalledWith(request, 4, 10)
@@ -264,20 +231,19 @@ describe("newApiFamily keyManagement implementation", () => {
   })
 
   it("uses WONG token-secret resolution while keeping other operations common-compatible", async () => {
+    const keyManagement = createKeyManagementImplementation(
+      SITE_TYPES.WONG_GONGYI,
+    )
+
     wongResolveApiTokenKey.mockResolvedValueOnce("sk-wong-secret")
     commonFetchAccountTokens.mockResolvedValueOnce([token])
 
     await expect(
-      resolveApiTokenKey(request, {
-        siteType: SITE_TYPES.WONG_GONGYI,
-        token,
-      }),
+      keyManagement.resolveApiTokenKey(request, token),
     ).resolves.toBe("sk-wong-secret")
-    await expect(
-      fetchAccountTokens(request, {
-        siteType: SITE_TYPES.WONG_GONGYI,
-      }),
-    ).resolves.toEqual([token])
+    await expect(keyManagement.fetchAccountTokens(request)).resolves.toEqual([
+      token,
+    ])
 
     expect(wongResolveApiTokenKey).toHaveBeenCalledWith(request, token)
     expect(commonResolveApiTokenKey).not.toHaveBeenCalled()
@@ -312,15 +278,6 @@ import type {
   UserGroupInfo,
 } from "~/services/apiService/common/type"
 import type { ApiToken } from "~/types"
-
-type PaginationOptions = {
-  page?: number
-  size?: number
-}
-
-type NewApiFamilySiteOptions = {
-  siteType: AccountSiteType
-}
 
 type KeyManagementImplementation = {
   fetchAccountTokens(
@@ -377,82 +334,33 @@ const keyManagementOverrides: Partial<
   },
 }
 
-function getKeyManagementImplementation(
+const getKeyManagementImplementation = (
+  siteType: AccountSiteType,
+): KeyManagementImplementation => ({
+  ...defaultKeyManagementImplementation,
+  ...keyManagementOverrides[siteType],
+})
+
+export function createKeyManagementImplementation(
   siteType: AccountSiteType,
 ): KeyManagementImplementation {
+  const implementation = getKeyManagementImplementation(siteType)
+
   return {
-    ...defaultKeyManagementImplementation,
-    ...keyManagementOverrides[siteType],
+    fetchAccountTokens: (request, page, size) =>
+      implementation.fetchAccountTokens(request, page ?? 0, size ?? 100),
+    createApiToken: (request, tokenData) =>
+      implementation.createApiToken(request, tokenData),
+    updateApiToken: (request, tokenId, tokenData) =>
+      implementation.updateApiToken(request, tokenId, tokenData),
+    resolveApiTokenKey: (request, token) =>
+      implementation.resolveApiTokenKey(request, token),
+    deleteApiToken: (request, tokenId) =>
+      implementation.deleteApiToken(request, tokenId),
+    fetchUserGroups: (request) => implementation.fetchUserGroups(request),
+    fetchAccountAvailableModels: (request) =>
+      implementation.fetchAccountAvailableModels(request),
   }
-}
-
-export async function fetchAccountTokens(
-  request: ApiServiceRequest,
-  options: NewApiFamilySiteOptions & PaginationOptions,
-): Promise<ApiToken[]> {
-  const implementation = getKeyManagementImplementation(options.siteType)
-  return implementation.fetchAccountTokens(
-    request,
-    options.page ?? 0,
-    options.size ?? 100,
-  )
-}
-
-export async function createApiToken(
-  request: ApiServiceRequest,
-  options: NewApiFamilySiteOptions & { tokenData: CreateTokenRequest },
-): Promise<CreateTokenResult> {
-  const implementation = getKeyManagementImplementation(options.siteType)
-  return implementation.createApiToken(request, options.tokenData)
-}
-
-export async function updateApiToken(
-  request: ApiServiceRequest,
-  options: NewApiFamilySiteOptions & {
-    tokenId: number
-    tokenData: CreateTokenRequest
-  },
-): Promise<boolean | void> {
-  const implementation = getKeyManagementImplementation(options.siteType)
-  return implementation.updateApiToken(
-    request,
-    options.tokenId,
-    options.tokenData,
-  )
-}
-
-export async function resolveApiTokenKey(
-  request: ApiServiceRequest,
-  options: NewApiFamilySiteOptions & {
-    token: Pick<ApiToken, "id" | "key">
-  },
-): Promise<string> {
-  const implementation = getKeyManagementImplementation(options.siteType)
-  return implementation.resolveApiTokenKey(request, options.token)
-}
-
-export async function deleteApiToken(
-  request: ApiServiceRequest,
-  options: NewApiFamilySiteOptions & { tokenId: number },
-): Promise<boolean | void> {
-  const implementation = getKeyManagementImplementation(options.siteType)
-  return implementation.deleteApiToken(request, options.tokenId)
-}
-
-export async function fetchUserGroups(
-  request: ApiServiceRequest,
-  options: NewApiFamilySiteOptions,
-): Promise<Record<string, UserGroupInfo>> {
-  const implementation = getKeyManagementImplementation(options.siteType)
-  return implementation.fetchUserGroups(request)
-}
-
-export async function fetchAccountAvailableModels(
-  request: ApiServiceRequest,
-  options: NewApiFamilySiteOptions,
-): Promise<string[]> {
-  const implementation = getKeyManagementImplementation(options.siteType)
-  return implementation.fetchAccountAvailableModels(request)
 }
 ```
 
@@ -506,10 +414,20 @@ vi.mock("~/services/apiService", () => ({
 }))
 ```
 
-with a mock for the New API-family implementation Module:
+with a mock for the New API-family implementation Module factory:
 
 ```ts
-vi.mock("~/services/apiService/newApiFamily/keyManagement", () => ({
+vi.mock("~/services/apiService/newApiFamily", () => ({
+  keyManagement: {
+    createKeyManagementImplementation: mockCreateKeyManagementImplementation,
+  },
+}))
+```
+
+In `beforeEach`, replace the `mockGetApiService.mockReturnValue(...)` setup with:
+
+```ts
+mockCreateKeyManagementImplementation.mockReturnValue({
   createApiToken: mockCreateApiToken,
   deleteApiToken: mockDeleteApiToken,
   fetchAccountAvailableModels: mockFetchAccountAvailableModels,
@@ -517,10 +435,8 @@ vi.mock("~/services/apiService/newApiFamily/keyManagement", () => ({
   fetchUserGroups: mockFetchUserGroups,
   resolveApiTokenKey: mockResolveApiTokenKey,
   updateApiToken: mockUpdateApiToken,
-}))
+})
 ```
-
-In `beforeEach`, remove the `mockGetApiService.mockReturnValue(...)` setup.
 
 In `"delegates New API-family key operations through the site-specific apiService"`, rename the test to:
 
@@ -534,37 +450,23 @@ Remove:
 expect(mockGetApiService).not.toHaveBeenCalled()
 ```
 
-Replace the final `mockGetApiService.mock.calls` assertion with assertions that every implementation call receives the `siteType` option:
+Replace the final `mockGetApiService.mock.calls` assertion with assertions that the implementation factory receives `siteType` once and all operations call the bound implementation:
 
 ```ts
-expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, {
-  siteType: SITE_TYPES.ONE_HUB,
-  page: 2,
-  size: 25,
-})
-expect(mockCreateApiToken).toHaveBeenCalledWith(request, {
-  siteType: SITE_TYPES.ONE_HUB,
+expect(mockCreateKeyManagementImplementation).toHaveBeenCalledWith(
+  SITE_TYPES.ONE_HUB,
+)
+expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, 2, 25)
+expect(mockCreateApiToken).toHaveBeenCalledWith(request, tokenData)
+expect(mockUpdateApiToken).toHaveBeenCalledWith(
+  request,
+  token.id,
   tokenData,
-})
-expect(mockUpdateApiToken).toHaveBeenCalledWith(request, {
-  siteType: SITE_TYPES.ONE_HUB,
-  tokenId: token.id,
-  tokenData,
-})
-expect(mockResolveApiTokenKey).toHaveBeenCalledWith(request, {
-  siteType: SITE_TYPES.ONE_HUB,
-  token,
-})
-expect(mockDeleteApiToken).toHaveBeenCalledWith(request, {
-  siteType: SITE_TYPES.ONE_HUB,
-  tokenId: token.id,
-})
-expect(mockFetchUserGroups).toHaveBeenCalledWith(request, {
-  siteType: SITE_TYPES.ONE_HUB,
-})
-expect(mockFetchAccountAvailableModels).toHaveBeenCalledWith(request, {
-  siteType: SITE_TYPES.ONE_HUB,
-})
+)
+expect(mockResolveApiTokenKey).toHaveBeenCalledWith(request, token)
+expect(mockDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+expect(mockFetchUserGroups).toHaveBeenCalledWith(request)
+expect(mockFetchAccountAvailableModels).toHaveBeenCalledWith(request)
 ```
 
 In `"propagates New API-family key lifecycle errors from the site-specific apiService"`, rename the test to:
@@ -579,14 +481,7 @@ Replace:
 expect(mockDeleteApiToken).toHaveBeenCalledWith(request, token.id)
 ```
 
-with:
-
-```ts
-expect(mockDeleteApiToken).toHaveBeenCalledWith(request, {
-  siteType: SITE_TYPES.ONE_HUB,
-  tokenId: token.id,
-})
-```
+with the same assertion, because the bound implementation receives only the business arguments after `siteType` is selected by the factory.
 
 - [ ] **Step 2: Run adapter key-management tests and verify the expected failure**
 
@@ -596,7 +491,7 @@ Run:
 pnpm vitest run tests/services/apiAdapters/keyManagement.test.ts
 ```
 
-Expected: FAIL because `src/services/apiAdapters/newApi/keyManagement.ts` still imports `getApiService(...)` and calls old argument shapes.
+Expected: FAIL because `src/services/apiAdapters/newApi/keyManagement.ts` still imports `getApiService(...)` instead of creating a bound New API-family key-management implementation.
 
 - [ ] **Step 3: Rewire the New API adapter implementation**
 
@@ -611,15 +506,14 @@ import { getApiService } from "~/services/apiService"
 with:
 
 ```ts
-import {
-  createApiToken,
-  deleteApiToken,
-  fetchAccountAvailableModels,
-  fetchAccountTokens,
-  fetchUserGroups,
-  resolveApiTokenKey,
-  updateApiToken,
-} from "~/services/apiService/newApiFamily/keyManagement"
+import { keyManagement } from "~/services/apiService/newApiFamily"
+```
+
+Create the bound implementation at the start of `createNewApiKeyManagement(...)`:
+
+```ts
+const implementation =
+  keyManagement.createKeyManagementImplementation(siteType)
 ```
 
 Replace the `return` object in `createNewApiKeyManagement(...)` with:
@@ -627,23 +521,19 @@ Replace the `return` object in `createNewApiKeyManagement(...)` with:
 ```ts
   return {
     fetchTokens: (request, options) =>
-      fetchAccountTokens(request, {
-        siteType,
-        page: options?.page,
-        size: options?.size,
-      }),
+      implementation.fetchAccountTokens(request, options?.page, options?.size),
     createToken: (request, tokenData) =>
-      createApiToken(request, { siteType, tokenData }),
+      implementation.createApiToken(request, tokenData),
     updateToken: ({ request, tokenId, tokenData }) =>
-      updateApiToken(request, { siteType, tokenId, tokenData }),
+      implementation.updateApiToken(request, tokenId, tokenData),
     resolveTokenKey: ({ request, token }) =>
-      resolveApiTokenKey(request, { siteType, token }),
+      implementation.resolveApiTokenKey(request, token),
     deleteToken: ({ request, tokenId }) =>
-      deleteApiToken(request, { siteType, tokenId }),
+      implementation.deleteApiToken(request, tokenId),
     fetchAvailableModels: (request) =>
-      fetchAccountAvailableModels(request, { siteType }),
+      implementation.fetchAccountAvailableModels(request),
     userGroups: {
-      fetch: (request) => fetchUserGroups(request, { siteType }),
+      fetch: (request) => implementation.fetchUserGroups(request),
     },
   }
 ```
@@ -777,7 +667,8 @@ Skip this commit if Step 2 made no changes.
 Run:
 
 ```powershell
-rg -n "getApiService|~/services/apiService\"|~/services/apiService'" src/services/apiAdapters/newApi/keyManagement.ts
+rg -n "getApiService" src/services/apiAdapters/newApi/keyManagement.ts
+rg -nF 'from "~/services/apiService"' src/services/apiAdapters/newApi/keyManagement.ts
 ```
 
 Expected: no output.

--- a/docs/superpowers/specs/2026-06-28-new-api-family-adapter-detach-design.md
+++ b/docs/superpowers/specs/2026-06-28-new-api-family-adapter-detach-design.md
@@ -1,0 +1,552 @@
+# New API Family Adapter Detach Design
+
+Date: 2026-06-28
+
+## Purpose
+
+Make the existing account-site Adapter Seam real all the way down for the New
+API family by removing `apiAdapters/newApi/*` dependency on the legacy
+`getApiService(...)` dynamic facade.
+
+The current architecture already exposes account-site behavior through
+`getSiteAdapter(siteType)` and capability objects. The remaining friction is
+that many New API-family Adapter Implementations still call back into
+`getApiService(siteType)`, which keeps `src/services/apiService/index.ts` as
+the effective routing center for migrated capabilities.
+
+This spec defines the target shape and migration slices. It is a docs-only
+design artifact and does not implement the refactor.
+
+## Current Context
+
+`src/services/apiAdapters/` now owns the intended account-site capability Seam:
+
+- `contracts/siteAdapter.ts` declares optional capabilities such as
+  `accountBootstrap`, `accountData`, `accountRefresh`, `keyManagement`,
+  `modelPricing`, `redemption`, `siteNotice`, `siteAnnouncements`,
+  `modelCatalog`, and `tokenProvisioning`.
+- `registry.ts` resolves Adapter Family metadata from
+  `accountSiteDefinitions` and returns New API-family, Sub2API, AIHubMix, or
+  unsupported Adapters.
+- Feature/domain Modules already consume `getSiteAdapter(siteType)` for many
+  migrated account-site flows.
+
+However, the New API-family Adapter Implementations still route through the old
+flat compatibility Module:
+
+```text
+feature/domain Module
+  -> getSiteAdapter(siteType)
+    -> apiAdapters/newApi/keyManagement
+      -> getApiService(siteType)
+        -> apiService/index dynamic wrapper
+          -> commonAPI or site override Module
+```
+
+Examples include:
+
+- `src/services/apiAdapters/newApi/accountBootstrap.ts`
+- `src/services/apiAdapters/newApi/accountData.ts`
+- `src/services/apiAdapters/newApi/accountRefresh.ts`
+- `src/services/apiAdapters/newApi/keyManagement.ts`
+- `src/services/apiAdapters/newApi/modelPricing.ts`
+- `src/services/apiAdapters/newApi/redemption.ts`
+
+This is acceptable as migration glue, but it should not be the final shape.
+
+## Problem
+
+The current Module split creates a shallow loop:
+
+1. The public account-site Interface says callers should use
+   `SiteAdapter` capability objects.
+2. New API-family capability Implementations immediately call back into
+   `getApiService(...)`.
+3. `getApiService(...)` dynamically enumerates `commonAPI`, applies override
+   Modules, and exposes a broad flat Interface.
+4. The codebase still has pressure to add new New API-family capability helpers
+   to `common` and rely on the dynamic wrapper to make them available.
+
+The result is that `apiAdapters` has the right external Interface, but
+`apiService/index.ts` remains the deep implementation dependency for migrated
+capabilities.
+
+Deletion test: if `getApiService(...)` were removed from
+`apiAdapters/newApi/*` today, the New API-family adapter implementation details
+would have to be reconstructed capability by capability. That means the current
+adapter Modules are not yet deep enough; they are wrappers over another broad
+Interface.
+
+## Goals
+
+- Make `apiAdapters/newApi/*` depend on explicit New API-family Implementation
+  Modules instead of `getApiService(...)`.
+- Clarify that the old `common` Module means One API / New API-compatible
+  backend implementation, not universal project-wide behavior.
+- Keep `getSiteAdapter(siteType)` as the primary Seam for migrated
+  account-site capabilities.
+- Keep `apiService/index.ts` as a legacy compatibility facade for unmigrated
+  callers.
+- Preserve existing site override behavior for New API-family Account Site
+  Types such as Veloera, DoneHub, OneHub, AnyRouter, WONG, and V-API where the
+  current implementation intentionally varies.
+- Migrate capability groups incrementally, with tests proving each group no
+  longer depends on the legacy facade.
+- Avoid broad behavior changes, locale changes, telemetry changes, or
+  managed-site reshaping.
+
+## Non-Goals
+
+- Do not delete `src/services/apiService/index.ts` in this refactor.
+- Do not move managed-site/channel-management flows into `apiAdapters` merely
+  because some provider Implementations still use `getApiService(...)`.
+- Do not migrate every function in `src/services/apiService/common/index.ts` at
+  once.
+- Do not rename persisted `siteType` values or public constants.
+- Do not redesign Sub2API or AIHubMix Adapters in this slice unless a shared
+  contract needs a compile fix.
+- Do not change request payloads, auth decoration, token secret recovery,
+  pricing math, redemption copy, announcement behavior, check-in behavior, or
+  managed-site channel behavior.
+- Do not broaden `SiteAdapter` with speculative capabilities.
+- Do not add a dependency or generated artifact.
+
+## Target Shape
+
+The desired dependency direction:
+
+```text
+feature/domain Module
+  -> getSiteAdapter(siteType)
+    -> apiAdapters/newApi/keyManagement
+      -> newApiFamily/keyManagement Implementation
+```
+
+Legacy callers may still use:
+
+```text
+legacy caller
+  -> getApiService(siteType)
+    -> compatibility facade
+      -> New API-family Implementation or getSiteAdapter(siteType)
+```
+
+The long-term Module layout should be close to:
+
+```text
+src/services/apiAdapters/
+  contracts/
+  registry.ts
+  newApi/
+    index.ts
+    accountBootstrap.ts
+    accountData.ts
+    accountRefresh.ts
+    keyManagement.ts
+    modelPricing.ts
+    redemption.ts
+    siteNotice.ts
+    tokenProvisioning.ts
+  sub2api/
+  aihubmix/
+
+src/services/apiService/
+  newApiFamily/
+    accountBootstrap.ts
+    accountData.ts
+    accountRefresh.ts
+    keyManagement.ts
+    modelPricing.ts
+    redemption.ts
+    siteNotice.ts
+    tokenProvisioning.ts
+    index.ts
+  common/
+    index.ts
+  index.ts
+```
+
+`newApiFamily` is the explicit backend-family Implementation. It can initially
+wrap or re-export existing `common` helpers while the file split is in
+progress, but the important rule is that `apiAdapters/newApi/*` imports from
+`newApiFamily`, not from `getApiService(...)`.
+
+`common` may remain during the transition as the old helper location. Once
+enough helpers move, it can either be renamed to `newApiFamily` or reduced to a
+compatibility barrel. The rename should happen only when import churn is small
+enough to review safely.
+
+## Interface Ownership
+
+`SiteAdapter` remains the caller-facing Interface for migrated account-site
+capabilities.
+
+`newApiFamily` should not expose one giant flat Interface. It should expose
+capability-sized Implementation functions that match real backend behavior:
+
+```ts
+// src/services/apiService/newApiFamily/keyManagement.ts
+export async function fetchAccountTokens(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & PaginationOptions = {},
+): Promise<ApiToken[]>
+
+export async function createApiToken(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & { tokenData: TokenCreateData },
+): Promise<ApiResponse<ApiToken>>
+
+export async function updateApiToken(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & {
+    tokenId: number | string
+    tokenData: TokenUpdateData
+  },
+): Promise<ApiResponse<ApiToken>>
+
+export async function resolveApiTokenKey(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & { token: ApiToken },
+): Promise<string>
+
+export async function deleteApiToken(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions & { tokenId: number | string },
+): Promise<ApiResponse<unknown>>
+
+export async function fetchUserGroups(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions = {},
+): Promise<UserGroup[]>
+
+export async function fetchAccountAvailableModels(
+  request: ApiServiceRequest,
+  options: NewApiFamilySiteOptions = {},
+): Promise<string[]>
+```
+
+The New API-family Adapter composes those functions into the capability
+Interface:
+
+```ts
+// src/services/apiAdapters/newApi/keyManagement.ts
+export function createNewApiKeyManagement(
+  siteType: AccountSiteType,
+): KeyManagementCapability {
+  return {
+    fetchTokens: (request, options) =>
+      fetchAccountTokens(request, {
+        siteType,
+        page: options?.page,
+        size: options?.size,
+      }),
+    createToken: (request, tokenData) =>
+      createApiToken(request, { siteType, tokenData }),
+    updateToken: ({ request, tokenId, tokenData }) =>
+      updateApiToken(request, { siteType, tokenId, tokenData }),
+    resolveTokenKey: ({ request, token }) =>
+      resolveApiTokenKey(request, { siteType, token }),
+    deleteToken: ({ request, tokenId }) =>
+      deleteApiToken(request, { siteType, tokenId }),
+    fetchAvailableModels: (request) =>
+      fetchAccountAvailableModels(request, { siteType }),
+    userGroups: {
+      fetch: (request) => fetchUserGroups(request, { siteType }),
+    },
+  }
+}
+```
+
+The exact function signatures should be chosen per slice to minimize churn, but
+they must make the site override decision explicit. Passing `siteType` as an
+options field is preferred over hidden argument inspection.
+
+## Override Strategy
+
+The hard part is preserving existing override behavior without keeping the
+dynamic facade in the Adapter Implementation.
+
+Use this rule:
+
+- New API-family default behavior lives in `newApiFamily/*`.
+- Site-specific deviations are represented by explicit implementation maps or
+  small override functions inside `newApiFamily/*`.
+- The map is capability-local, not a single project-wide dynamic wrapper.
+
+Example shape:
+
+```ts
+type KeyManagementImplementation = {
+  fetchAccountTokens: typeof fetchAccountTokens
+  createApiToken: typeof createApiToken
+  updateApiToken: typeof updateApiToken
+  resolveApiTokenKey: typeof resolveApiTokenKey
+  deleteApiToken: typeof deleteApiToken
+  fetchUserGroups: typeof fetchUserGroups
+  fetchAccountAvailableModels: typeof fetchAccountAvailableModels
+}
+
+const keyManagementOverrides: Partial<
+  Record<AccountSiteType, Partial<KeyManagementImplementation>>
+> = {
+  [SITE_TYPES.VELOERA]: {
+    resolveApiTokenKey: resolveVeloeraApiTokenKey,
+  },
+}
+
+export function getNewApiFamilyKeyManagementImplementation(
+  siteType: AccountSiteType,
+): KeyManagementImplementation {
+  return {
+    ...defaultKeyManagementImplementation,
+    ...keyManagementOverrides[siteType],
+  }
+}
+```
+
+This preserves Locality: key-management differences live in the key-management
+Implementation Module instead of being discovered by enumerating every export
+from `commonAPI`.
+
+Do not introduce a universal replacement for `siteOverrideMap` during this
+refactor. That would recreate the same shallow Interface under a new filename.
+
+## Migration Slices
+
+### Slice 1: Key Management
+
+Files:
+
+- Modify `src/services/apiAdapters/newApi/keyManagement.ts`
+- Create `src/services/apiService/newApiFamily/keyManagement.ts`
+- Optionally create `src/services/apiService/newApiFamily/index.ts`
+- Test `tests/services/apiAdapters/newApi/keyManagement.test.ts` or extend the
+  nearest existing adapter registry/capability tests
+- Adjust `tests/services/apiService/index.test.ts` only for compatibility
+  assertions affected by extracted imports
+
+Why first:
+
+- It is a high-value Account Site Type capability.
+- Existing memory and implementation history show New API-family key management
+  currently delegates through `getApiService(siteType)`.
+- It has visible override risk: token inventory, token creation, user groups,
+  token secret resolution, and available models must preserve site-specific
+  behavior.
+
+Done when:
+
+- `apiAdapters/newApi/keyManagement.ts` has no import from
+  `~/services/apiService`.
+- Tests prove the Adapter calls the New API-family Implementation with the
+  intended `siteType`.
+- Existing `getApiService(siteType).fetchAccountTokens(...)` behavior remains
+  compatible for legacy callers.
+
+### Slice 2: Account Bootstrap, Data, And Refresh
+
+Files:
+
+- Modify `src/services/apiAdapters/newApi/accountBootstrap.ts`
+- Modify `src/services/apiAdapters/newApi/accountData.ts`
+- Modify `src/services/apiAdapters/newApi/accountRefresh.ts`
+- Create or extend:
+  - `src/services/apiService/newApiFamily/accountBootstrap.ts`
+  - `src/services/apiService/newApiFamily/accountData.ts`
+  - `src/services/apiService/newApiFamily/accountRefresh.ts`
+- Update focused tests for auto-detect, site-name, account operations, or
+  adapter capability behavior as needed
+
+Why second:
+
+- These capabilities are account onboarding/readiness paths and need careful
+  preservation of request construction and check-in support behavior.
+- They are smaller than key management but touch important setup flows.
+
+Done when:
+
+- The three New API-family Adapter files no longer call `getApiService(...)`.
+- Auto-detect and account save/update flows still consume `getSiteAdapter`.
+- Tests prove missing capability behavior and successful New API-family
+  delegation.
+
+### Slice 3: Model Pricing And Redemption
+
+Files:
+
+- Modify `src/services/apiAdapters/newApi/modelPricing.ts`
+- Modify `src/services/apiAdapters/newApi/redemption.ts`
+- Create or extend:
+  - `src/services/apiService/newApiFamily/modelPricing.ts`
+  - `src/services/apiService/newApiFamily/redemption.ts`
+- Update model-list and redemption tests if the mocked seam changes
+
+Why third:
+
+- Product-level unsupported states are already handled through adapter
+  capabilities.
+- The main risk is preserving pricing response shape, cache ordering, credited
+  amount handling, and localized failure behavior.
+
+Done when:
+
+- The Adapter files no longer import `getApiService`.
+- Model List still checks capability support before fetch/cache paths.
+- Redemption still returns the existing localized failure result for missing
+  capability.
+
+### Slice 4: Site Notice And Token Provisioning
+
+Files:
+
+- Modify `src/services/apiAdapters/newApi/siteNotice.ts`
+- Modify `src/services/apiAdapters/newApi/tokenProvisioning.ts`
+- Create or extend:
+  - `src/services/apiService/newApiFamily/siteNotice.ts`
+  - `src/services/apiService/newApiFamily/tokenProvisioning.ts`
+- Update announcement and token-provisioning tests if imports move
+
+Why fourth:
+
+- `siteNotice` already imports `common` directly, so it is closer to the target
+  shape and can move after riskier facade calls are gone.
+- `tokenProvisioning` is policy-adjacent; keep the backend facts in the Adapter
+  and product policy in the account lifecycle Modules.
+
+Done when:
+
+- New API-family Adapter files consistently import from `newApiFamily/*`.
+- `common` no longer owns the primary import path for migrated Adapter
+  Implementations.
+
+### Slice 5: Compatibility Facade Reduction
+
+Files:
+
+- Modify `src/services/apiService/index.ts`
+- Modify `src/services/apiService/common/index.ts` only when moved exports are
+  already covered by `newApiFamily`
+- Update `tests/services/apiService/index.test.ts`
+- Run `pnpm knip` through `pnpm run validate:push`
+
+Why last:
+
+- The dynamic facade still protects legacy callers.
+- Reducing it before Adapter Implementations move would create noisy churn and
+  raise regression risk.
+
+Done when:
+
+- `apiService/index.ts` is documented as a legacy compatibility facade.
+- It does not need new capability additions for migrated account-site behavior.
+- Any stale `ApiServiceCapabilities` fields or unused exported types are
+  removed only after searches prove no real consumer remains.
+
+## Testing Strategy
+
+Each migration slice should include focused tests at the real Interface:
+
+- Adapter tests should mock the New API-family Implementation Module, not
+  `~/services/apiService`.
+- Legacy compatibility tests should remain in `tests/services/apiService` and
+  prove old `getApiService(...)` calls still work.
+- Feature/domain tests should keep using `getSiteAdapter(...)` or existing
+  product Modules.
+- Do not rewrite broad test fixtures just to remove old mocks. Keep legacy mocks
+  alive until the specific flow has moved.
+
+Useful assertions:
+
+- New API-family Adapter calls pass the intended `siteType` into the
+  implementation.
+- Capability absence remains represented by `undefined` on `SiteAdapter`.
+- Strict override behavior for Sub2API and AIHubMix remains unchanged in
+  `apiService/index.ts`.
+- Existing request payload fields remain unchanged:
+  - `baseUrl`
+  - `accountId`
+  - `auth.authType`
+  - `auth.userId`
+  - `auth.accessToken`
+  - `auth.cookie`
+  - any feature-specific auth-session decoration
+
+E2E decision: no Playwright E2E by default. The risk is service Module routing
+and capability delegation, which is better covered by focused Vitest tests.
+Add E2E only if a slice changes browser-extension runtime behavior,
+cross-entrypoint messaging, storage, notifications, or real UI workflow
+semantics.
+
+## Validation Plan
+
+For each implementation slice, run the focused tests for touched behavior.
+
+Expected focused commands by slice:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/registry.test.ts tests/services/apiService/index.test.ts
+```
+
+Add slice-specific suites:
+
+```powershell
+pnpm vitest run tests/services/accountOperations.test.ts
+pnpm vitest run tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+pnpm vitest run tests/services/redeemService.test.ts
+pnpm vitest run tests/services/siteAnnouncements/providers.test.ts
+```
+
+Use exact existing filenames after checking current tests; do not invent a test
+path when a focused suite already covers the behavior.
+
+Commit gate:
+
+```powershell
+pnpm run validate:staged
+```
+
+Push/PR gate for this refactor family:
+
+```powershell
+pnpm compile
+pnpm run validate:push
+```
+
+`validate:push` is appropriate here because the work changes shared TypeScript
+service contracts, import graph wiring, and likely `knip` export reachability.
+
+## Commit Boundaries
+
+Use one commit per migration slice:
+
+1. `refactor(api-adapters): detach new api key management`
+2. `refactor(api-adapters): detach new api account reads`
+3. `refactor(api-adapters): detach new api pricing and redemption`
+4. `refactor(api-adapters): route new api notice and provisioning`
+5. `refactor(api-service): reduce legacy facade surface`
+
+Do not mix compatibility facade reduction into earlier commits unless the
+earlier slice cannot compile without a tiny compatibility shim.
+
+## Diff Inspection Checklist
+
+Before handoff for each slice, inspect the diff for:
+
+- no new `getApiService(...)` import in `src/services/apiAdapters/newApi/**`
+- no direct feature/domain import of backend-specific implementation files
+- no broad `siteOverrideMap` clone under a new name
+- no Sub2API or AIHubMix behavior change unless explicitly in the slice
+- no managed-site migration
+- no locale, telemetry, E2E, or UI copy drift
+- no stale comments saying `common` is universal
+
+## Follow-Up, Not In Scope For This Spec
+
+- Rename `common` to `newApiFamily` after imports have moved far enough that
+  the diff is reviewable.
+- Move shared request/result types out of `apiService/common/type` only when
+  the ownership is clear and the churn is justified.
+- Normalize `SiteAnnouncementsCapability` away from Sub2API-specific data if a
+  second account-scoped announcement backend appears.
+- Decide whether AIHubMix should expose `family` metadata on its Adapter for
+  consistency/debuggability.

--- a/src/services/apiAdapters/newApi/keyManagement.ts
+++ b/src/services/apiAdapters/newApi/keyManagement.ts
@@ -1,6 +1,6 @@
 import type { AccountSiteType } from "~/constants/siteType"
 import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
-import { getApiService } from "~/services/apiService"
+import { keyManagement } from "~/services/apiService/newApiFamily"
 
 /**
  * Create key-management operations bound to the New API-family site type.
@@ -8,25 +8,24 @@ import { getApiService } from "~/services/apiService"
 export function createNewApiKeyManagement(
   siteType: AccountSiteType,
 ): KeyManagementCapability {
+  const implementation =
+    keyManagement.createKeyManagementImplementation(siteType)
+
   return {
     fetchTokens: (request, options) =>
-      getApiService(siteType).fetchAccountTokens(
-        request,
-        options?.page,
-        options?.size,
-      ),
+      implementation.fetchAccountTokens(request, options?.page, options?.size),
     createToken: (request, tokenData) =>
-      getApiService(siteType).createApiToken(request, tokenData),
+      implementation.createApiToken(request, tokenData),
     updateToken: ({ request, tokenId, tokenData }) =>
-      getApiService(siteType).updateApiToken(request, tokenId, tokenData),
+      implementation.updateApiToken(request, tokenId, tokenData),
     resolveTokenKey: ({ request, token }) =>
-      getApiService(siteType).resolveApiTokenKey(request, token),
+      implementation.resolveApiTokenKey(request, token),
     deleteToken: ({ request, tokenId }) =>
-      getApiService(siteType).deleteApiToken(request, tokenId),
+      implementation.deleteApiToken(request, tokenId),
     fetchAvailableModels: (request) =>
-      getApiService(siteType).fetchAccountAvailableModels(request),
+      implementation.fetchAccountAvailableModels(request),
     userGroups: {
-      fetch: (request) => getApiService(siteType).fetchUserGroups(request),
+      fetch: (request) => implementation.fetchUserGroups(request),
     },
   }
 }

--- a/src/services/apiService/newApiFamily/index.ts
+++ b/src/services/apiService/newApiFamily/index.ts
@@ -1,0 +1,1 @@
+export * as keyManagement from "./keyManagement"

--- a/src/services/apiService/newApiFamily/keyManagement.ts
+++ b/src/services/apiService/newApiFamily/keyManagement.ts
@@ -1,0 +1,98 @@
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import * as commonKeyManagement from "~/services/apiService/common"
+import type {
+  ApiServiceRequest,
+  CreateTokenRequest,
+  CreateTokenResult,
+  UserGroupInfo,
+} from "~/services/apiService/common/type"
+import * as oneHubKeyManagement from "~/services/apiService/oneHub"
+import * as wongKeyManagement from "~/services/apiService/wong"
+import type { ApiToken } from "~/types"
+
+interface KeyManagementImplementation {
+  fetchAccountTokens: (
+    request: ApiServiceRequest,
+    page?: number,
+    size?: number,
+  ) => Promise<ApiToken[]>
+  createApiToken: (
+    request: ApiServiceRequest,
+    tokenData: CreateTokenRequest,
+  ) => Promise<CreateTokenResult>
+  updateApiToken: (
+    request: ApiServiceRequest,
+    tokenId: number,
+    tokenData: CreateTokenRequest,
+  ) => Promise<boolean | void>
+  resolveApiTokenKey: (
+    request: ApiServiceRequest,
+    token: Pick<ApiToken, "id" | "key">,
+  ) => Promise<string>
+  deleteApiToken: (
+    request: ApiServiceRequest,
+    tokenId: number,
+  ) => Promise<boolean | void>
+  fetchUserGroups: (
+    request: ApiServiceRequest,
+  ) => Promise<Record<string, UserGroupInfo>>
+  fetchAccountAvailableModels: (request: ApiServiceRequest) => Promise<string[]>
+}
+
+const defaultKeyManagementImplementation: KeyManagementImplementation = {
+  fetchAccountTokens: commonKeyManagement.fetchAccountTokens,
+  createApiToken: commonKeyManagement.createApiToken,
+  updateApiToken: commonKeyManagement.updateApiToken,
+  resolveApiTokenKey: commonKeyManagement.resolveApiTokenKey,
+  deleteApiToken: commonKeyManagement.deleteApiToken,
+  fetchUserGroups: commonKeyManagement.fetchUserGroups,
+  fetchAccountAvailableModels: commonKeyManagement.fetchAccountAvailableModels,
+}
+
+const oneHubKeyManagementOverrides: Partial<KeyManagementImplementation> = {
+  fetchAccountTokens: oneHubKeyManagement.fetchAccountTokens,
+  fetchUserGroups: oneHubKeyManagement.fetchUserGroups,
+  fetchAccountAvailableModels: oneHubKeyManagement.fetchAccountAvailableModels,
+}
+
+const keyManagementOverrides: Partial<
+  Record<AccountSiteType, Partial<KeyManagementImplementation>>
+> = {
+  [SITE_TYPES.ONE_HUB]: oneHubKeyManagementOverrides,
+  [SITE_TYPES.DONE_HUB]: oneHubKeyManagementOverrides,
+  [SITE_TYPES.WONG_GONGYI]: {
+    resolveApiTokenKey: wongKeyManagement.resolveApiTokenKey,
+  },
+}
+
+const getKeyManagementImplementation = (
+  siteType: AccountSiteType,
+): KeyManagementImplementation => ({
+  ...defaultKeyManagementImplementation,
+  ...keyManagementOverrides[siteType],
+})
+
+/**
+ * Create key-management operations bound to a New API-family site type.
+ */
+export function createKeyManagementImplementation(
+  siteType: AccountSiteType,
+): KeyManagementImplementation {
+  const implementation = getKeyManagementImplementation(siteType)
+
+  return {
+    fetchAccountTokens: (request, page, size) =>
+      implementation.fetchAccountTokens(request, page ?? 0, size ?? 100),
+    createApiToken: (request, tokenData) =>
+      implementation.createApiToken(request, tokenData),
+    updateApiToken: (request, tokenId, tokenData) =>
+      implementation.updateApiToken(request, tokenId, tokenData),
+    resolveApiTokenKey: (request, token) =>
+      implementation.resolveApiTokenKey(request, token),
+    deleteApiToken: (request, tokenId) =>
+      implementation.deleteApiToken(request, tokenId),
+    fetchUserGroups: (request) => implementation.fetchUserGroups(request),
+    fetchAccountAvailableModels: (request) =>
+      implementation.fetchAccountAvailableModels(request),
+  }
+}

--- a/src/services/apiService/oneHub/index.ts
+++ b/src/services/apiService/oneHub/index.ts
@@ -2,6 +2,7 @@ import { normalizeApiTokenKey } from "~/services/accountTokens/apiTokenKey"
 import type {
   ApiServiceRequest,
   PricingResponse,
+  UserGroupInfo,
 } from "~/services/apiService/common/type"
 import { fetchApiData } from "~/services/apiService/common/utils"
 import {
@@ -10,7 +11,6 @@ import {
 } from "~/services/apiService/oneHub/transform"
 import type {
   OneHubModelPricing,
-  OneHubUserGroupInfo,
   OneHubUserGroupMap,
   OneHubUserGroupsResponse,
   PaginatedTokenDate,
@@ -101,7 +101,7 @@ export const fetchAccountTokens = async (
  */
 export const fetchUserGroups = async (
   request: ApiServiceRequest,
-): Promise<Record<string, OneHubUserGroupInfo>> => {
+): Promise<Record<string, UserGroupInfo>> => {
   try {
     const response = await fetchApiData<OneHubUserGroupsResponse["data"]>(
       request,

--- a/src/services/apiService/oneHub/transform.ts
+++ b/src/services/apiService/oneHub/transform.ts
@@ -1,6 +1,7 @@
 import type {
   ModelPricing,
   PricingResponse,
+  UserGroupInfo,
 } from "~/services/apiService/common/type"
 import type {
   OneHubModelPricing,
@@ -63,8 +64,8 @@ export function transformModelPricing(
  */
 export function transformUserGroup(
   input: OneHubUserGroupsResponse["data"],
-): OneHubUserGroupsResponse["data"] {
-  const result: Record<string, any> = {}
+): Record<string, UserGroupInfo> {
+  const result: Record<string, UserGroupInfo> = {}
 
   // 转换已有的分组
   for (const key in input) {

--- a/tests/entrypoints/options/pages/ModelList/ModelListModelKeyFlow.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListModelKeyFlow.test.tsx
@@ -30,15 +30,19 @@ vi.mock("react-hot-toast", () => ({
   },
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: () => ({
-    fetchAccountTokens: (...args: any[]) => fetchAccountTokensMock(...args),
-    createApiToken: (...args: any[]) => createApiTokenMock(...args),
-    fetchAccountAvailableModels: (...args: any[]) =>
-      fetchAccountAvailableModelsMock(...args),
-    fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
-    updateApiToken: vi.fn(async () => true),
-  }),
+vi.mock("~/services/apiService/newApiFamily", () => ({
+  keyManagement: {
+    createKeyManagementImplementation: () => ({
+      fetchAccountTokens: (...args: any[]) => fetchAccountTokensMock(...args),
+      createApiToken: (...args: any[]) => createApiTokenMock(...args),
+      updateApiToken: vi.fn(async () => true),
+      resolveApiTokenKey: vi.fn(),
+      deleteApiToken: vi.fn(),
+      fetchAccountAvailableModels: (...args: any[]) =>
+        fetchAccountAvailableModelsMock(...args),
+      fetchUserGroups: (...args: any[]) => fetchUserGroupsMock(...args),
+    }),
+  },
 }))
 
 vi.mock("~/services/models/utils/modelProviders", async (importOriginal) => {

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -13,12 +13,12 @@ const {
   mockAihubmixFetchAccountTokens,
   mockAihubmixResolveApiTokenKey,
   mockAihubmixUpdateApiToken,
+  mockCreateKeyManagementImplementation,
   mockCreateApiToken,
   mockDeleteApiToken,
   mockFetchAccountAvailableModels,
   mockFetchAccountTokens,
   mockFetchUserGroups,
-  mockGetApiService,
   mockResolveApiTokenKey,
   mockSub2ApiCreateApiToken,
   mockSub2ApiDeleteApiToken,
@@ -35,12 +35,12 @@ const {
   mockAihubmixFetchAccountTokens: vi.fn(),
   mockAihubmixResolveApiTokenKey: vi.fn(),
   mockAihubmixUpdateApiToken: vi.fn(),
+  mockCreateKeyManagementImplementation: vi.fn(),
   mockCreateApiToken: vi.fn(),
   mockDeleteApiToken: vi.fn(),
   mockFetchAccountAvailableModels: vi.fn(),
   mockFetchAccountTokens: vi.fn(),
   mockFetchUserGroups: vi.fn(),
-  mockGetApiService: vi.fn(),
   mockResolveApiTokenKey: vi.fn(),
   mockSub2ApiCreateApiToken: vi.fn(),
   mockSub2ApiDeleteApiToken: vi.fn(),
@@ -52,8 +52,10 @@ const {
   mockUpdateApiToken: vi.fn(),
 }))
 
-vi.mock("~/services/apiService", () => ({
-  getApiService: mockGetApiService,
+vi.mock("~/services/apiService/newApiFamily", () => ({
+  keyManagement: {
+    createKeyManagementImplementation: mockCreateKeyManagementImplementation,
+  },
 }))
 
 vi.mock("~/services/apiService/sub2api", () => ({
@@ -110,7 +112,7 @@ const availableModels = ["gpt-4o-mini", "claude-3-haiku"]
 describe("apiAdapter keyManagement", () => {
   beforeEach(() => {
     vi.resetAllMocks()
-    mockGetApiService.mockReturnValue({
+    mockCreateKeyManagementImplementation.mockReturnValue({
       createApiToken: mockCreateApiToken,
       deleteApiToken: mockDeleteApiToken,
       fetchAccountAvailableModels: mockFetchAccountAvailableModels,
@@ -121,7 +123,7 @@ describe("apiAdapter keyManagement", () => {
     })
   })
 
-  it("delegates New API-family key operations through the site-specific apiService", async () => {
+  it("delegates New API-family key operations through the New API-family implementation", async () => {
     const expectedTokens = [token]
     mockFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
     mockCreateApiToken.mockResolvedValueOnce(true)
@@ -132,8 +134,6 @@ describe("apiAdapter keyManagement", () => {
     mockFetchAccountAvailableModels.mockResolvedValueOnce(availableModels)
 
     const keyManagement = createNewApiKeyManagement(SITE_TYPES.ONE_HUB)
-
-    expect(mockGetApiService).not.toHaveBeenCalled()
 
     await expect(
       keyManagement.fetchTokens(request, { page: 2, size: 25 }),
@@ -161,15 +161,9 @@ describe("apiAdapter keyManagement", () => {
       availableModels,
     )
 
-    expect(mockGetApiService.mock.calls).toEqual([
-      [SITE_TYPES.ONE_HUB],
-      [SITE_TYPES.ONE_HUB],
-      [SITE_TYPES.ONE_HUB],
-      [SITE_TYPES.ONE_HUB],
-      [SITE_TYPES.ONE_HUB],
-      [SITE_TYPES.ONE_HUB],
-      [SITE_TYPES.ONE_HUB],
-    ])
+    expect(mockCreateKeyManagementImplementation).toHaveBeenCalledWith(
+      SITE_TYPES.ONE_HUB,
+    )
     expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, 2, 25)
     expect(mockCreateApiToken).toHaveBeenCalledWith(request, tokenData)
     expect(mockUpdateApiToken).toHaveBeenCalledWith(
@@ -183,7 +177,7 @@ describe("apiAdapter keyManagement", () => {
     expect(mockFetchAccountAvailableModels).toHaveBeenCalledWith(request)
   })
 
-  it("propagates New API-family key lifecycle errors from the site-specific apiService", async () => {
+  it("propagates New API-family key lifecycle errors from the implementation Module", async () => {
     const error = new Error("delete failed")
     mockDeleteApiToken.mockRejectedValueOnce(error)
 

--- a/tests/services/apiService/newApiFamily/keyManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/keyManagement.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { createKeyManagementImplementation } from "~/services/apiService/newApiFamily/keyManagement"
+import { AuthTypeEnum, type ApiToken } from "~/types"
+
+const {
+  commonCreateApiToken,
+  commonDeleteApiToken,
+  commonFetchAccountAvailableModels,
+  commonFetchAccountTokens,
+  commonFetchUserGroups,
+  commonResolveApiTokenKey,
+  commonUpdateApiToken,
+  oneHubFetchAccountAvailableModels,
+  oneHubFetchAccountTokens,
+  oneHubFetchUserGroups,
+  wongResolveApiTokenKey,
+} = vi.hoisted(() => ({
+  commonCreateApiToken: vi.fn(),
+  commonDeleteApiToken: vi.fn(),
+  commonFetchAccountAvailableModels: vi.fn(),
+  commonFetchAccountTokens: vi.fn(),
+  commonFetchUserGroups: vi.fn(),
+  commonResolveApiTokenKey: vi.fn(),
+  commonUpdateApiToken: vi.fn(),
+  oneHubFetchAccountAvailableModels: vi.fn(),
+  oneHubFetchAccountTokens: vi.fn(),
+  oneHubFetchUserGroups: vi.fn(),
+  wongResolveApiTokenKey: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/common", () => ({
+  createApiToken: commonCreateApiToken,
+  deleteApiToken: commonDeleteApiToken,
+  fetchAccountAvailableModels: commonFetchAccountAvailableModels,
+  fetchAccountTokens: commonFetchAccountTokens,
+  fetchUserGroups: commonFetchUserGroups,
+  resolveApiTokenKey: commonResolveApiTokenKey,
+  updateApiToken: commonUpdateApiToken,
+}))
+
+vi.mock("~/services/apiService/oneHub", () => ({
+  fetchAccountAvailableModels: oneHubFetchAccountAvailableModels,
+  fetchAccountTokens: oneHubFetchAccountTokens,
+  fetchUserGroups: oneHubFetchUserGroups,
+}))
+
+vi.mock("~/services/apiService/wong", () => ({
+  resolveApiTokenKey: wongResolveApiTokenKey,
+}))
+
+describe("newApiFamily keyManagement", () => {
+  const request = {
+    baseUrl: "https://api.example.invalid",
+    accountId: "account-1",
+    auth: {
+      authType: AuthTypeEnum.AccessToken,
+      accessToken: "access-token",
+      userId: "user-1",
+    },
+  }
+
+  const token: ApiToken = {
+    id: 123,
+    user_id: 1,
+    key: "sk-abcd************wxyz",
+    status: 1,
+    name: "Example token",
+    created_time: 0,
+    accessed_time: 0,
+    expired_time: -1,
+    remain_quota: 500000,
+    unlimited_quota: false,
+    model_limits_enabled: false,
+    model_limits: "",
+    allow_ips: "",
+    used_quota: 0,
+    group: "",
+  }
+  const tokenKeyReference: Pick<ApiToken, "id" | "key"> = {
+    id: token.id,
+    key: token.key,
+  }
+
+  const tokenData = {
+    name: "Example token",
+    remain_quota: 500000,
+    expired_time: -1,
+    unlimited_quota: false,
+    model_limits_enabled: false,
+    model_limits: "",
+    allow_ips: "",
+    group: "",
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("uses common-compatible key-management helpers by default for New API", async () => {
+    const keyManagement = createKeyManagementImplementation(SITE_TYPES.NEW_API)
+
+    commonFetchAccountTokens.mockResolvedValue([token])
+    commonCreateApiToken.mockResolvedValue(true)
+    commonUpdateApiToken.mockResolvedValue(true)
+    commonResolveApiTokenKey.mockResolvedValue("sk-resolved")
+    commonDeleteApiToken.mockResolvedValue(true)
+    commonFetchUserGroups.mockResolvedValue({ default: { desc: "", ratio: 1 } })
+    commonFetchAccountAvailableModels.mockResolvedValue(["gpt-4o"])
+
+    await expect(
+      keyManagement.fetchAccountTokens(request, 2, 25),
+    ).resolves.toEqual([token])
+    await expect(
+      keyManagement.createApiToken(request, tokenData),
+    ).resolves.toBe(true)
+    await expect(
+      keyManagement.updateApiToken(request, token.id, tokenData),
+    ).resolves.toBe(true)
+    await expect(
+      keyManagement.resolveApiTokenKey(request, tokenKeyReference),
+    ).resolves.toBe("sk-resolved")
+    await expect(keyManagement.deleteApiToken(request, token.id)).resolves.toBe(
+      true,
+    )
+    await expect(keyManagement.fetchUserGroups(request)).resolves.toEqual({
+      default: { desc: "", ratio: 1 },
+    })
+    await expect(
+      keyManagement.fetchAccountAvailableModels(request),
+    ).resolves.toEqual(["gpt-4o"])
+
+    expect(commonFetchAccountTokens).toHaveBeenCalledWith(request, 2, 25)
+    expect(commonCreateApiToken).toHaveBeenCalledWith(request, tokenData)
+    expect(commonUpdateApiToken).toHaveBeenCalledWith(
+      request,
+      token.id,
+      tokenData,
+    )
+    expect(commonResolveApiTokenKey).toHaveBeenCalledWith(
+      request,
+      tokenKeyReference,
+    )
+    expect(commonDeleteApiToken).toHaveBeenCalledWith(request, token.id)
+    expect(commonFetchUserGroups).toHaveBeenCalledWith(request)
+    expect(commonFetchAccountAvailableModels).toHaveBeenCalledWith(request)
+  })
+
+  it.each([SITE_TYPES.ONE_HUB, SITE_TYPES.DONE_HUB])(
+    "uses OneHub-family helpers for %s token list, groups, and models",
+    async (siteType) => {
+      const keyManagement = createKeyManagementImplementation(siteType)
+
+      oneHubFetchAccountTokens.mockResolvedValue([token])
+      oneHubFetchUserGroups.mockResolvedValue({
+        default: { desc: "", ratio: 1 },
+      })
+      oneHubFetchAccountAvailableModels.mockResolvedValue(["gpt-4o"])
+
+      await expect(
+        keyManagement.fetchAccountTokens(request, 4, 10),
+      ).resolves.toEqual([token])
+      await expect(keyManagement.fetchUserGroups(request)).resolves.toEqual({
+        default: { desc: "", ratio: 1 },
+      })
+      await expect(
+        keyManagement.fetchAccountAvailableModels(request),
+      ).resolves.toEqual(["gpt-4o"])
+
+      expect(oneHubFetchAccountTokens).toHaveBeenCalledWith(request, 4, 10)
+      expect(oneHubFetchUserGroups).toHaveBeenCalledWith(request)
+      expect(oneHubFetchAccountAvailableModels).toHaveBeenCalledWith(request)
+      expect(commonFetchAccountTokens).not.toHaveBeenCalled()
+      expect(commonFetchUserGroups).not.toHaveBeenCalled()
+      expect(commonFetchAccountAvailableModels).not.toHaveBeenCalled()
+    },
+  )
+
+  it("uses the Wong key resolver while keeping token listing common-compatible", async () => {
+    const keyManagement = createKeyManagementImplementation(
+      SITE_TYPES.WONG_GONGYI,
+    )
+
+    wongResolveApiTokenKey.mockResolvedValue("sk-wong-resolved")
+    commonFetchAccountTokens.mockResolvedValue([token])
+
+    await expect(
+      keyManagement.resolveApiTokenKey(request, tokenKeyReference),
+    ).resolves.toBe("sk-wong-resolved")
+    await expect(keyManagement.fetchAccountTokens(request)).resolves.toEqual([
+      token,
+    ])
+
+    expect(wongResolveApiTokenKey).toHaveBeenCalledWith(
+      request,
+      tokenKeyReference,
+    )
+    expect(commonResolveApiTokenKey).not.toHaveBeenCalled()
+    expect(commonFetchAccountTokens).toHaveBeenCalledWith(request, 0, 100)
+    expect(oneHubFetchAccountTokens).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Add a New API-family key-management implementation module with capability-local overrides.
- Rewire the New API adapter key-management capability away from the legacy `getApiService` facade.
- Keep legacy facade behavior intact and align OneHub user-group typing with its normalized runtime shape.

## Test Plan
- `pnpm vitest run tests/services/apiService/newApiFamily/keyManagement.test.ts tests/services/apiAdapters/keyManagement.test.ts tests/services/apiAdapters/registry.test.ts`
- `pnpm vitest run tests/services/apiService/index.test.ts tests/services/apiService/common/tokenApi.test.ts tests/services/apiService/oneHub/index.test.ts tests/services/apiService/wong/index.test.ts`
- `pnpm compile`
- `pnpm run validate:push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved New API key-management behavior so site types route to the correct token, user-group, model-list, and API token key-resolution flows.
  * Ensured the adapter now delegates through the New API-family implementation while preserving legacy-compatible behavior.
* **Documentation**
  * Added specs covering the New API adapter transition design and validation/checklist steps.
* **Tests**
  * Added targeted coverage for New API-family key management and updated adapter/page tests to validate the new delegation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->