### PR TITLE
fix(settings): prevent stale preference update failures

### DIFF
--- a/src/components/ManagedSiteTypeSwitcher.tsx
+++ b/src/components/ManagedSiteTypeSwitcher.tsx
@@ -84,8 +84,8 @@ export default function ManagedSiteTypeSwitcher({
     const siteType = value as ManagedSiteType
     if (siteType === managedSiteType) return
 
-    const success = await updateManagedSiteType(siteType)
-    showUpdateToast(success, t("managedSite.siteTypeLabel"))
+    const writeResult = await updateManagedSiteType(siteType)
+    showUpdateToast(writeResult, t("managedSite.siteTypeLabel"))
   }
 
   return (

--- a/src/components/PopupInterruptionHintBanner.tsx
+++ b/src/components/PopupInterruptionHintBanner.tsx
@@ -57,9 +57,9 @@ export default function PopupInterruptionHintBanner({
   const handleUseSidepanel = async () => {
     setIsApplying(true)
     try {
-      const success = await updateActionClickBehavior("sidepanel")
-      if (!success) {
-        showUpdateToast(false, t("popupInterruption.settingName"))
+      const writeResult = await updateActionClickBehavior("sidepanel")
+      if (!writeResult.ok) {
+        showUpdateToast(writeResult, t("popupInterruption.settingName"))
         return
       }
 

--- a/src/components/SettingSection.tsx
+++ b/src/components/SettingSection.tsx
@@ -5,7 +5,9 @@ import { useTranslation } from "react-i18next"
 
 import { BodySmall, Button, Heading3 } from "~/components/ui"
 import { Modal } from "~/components/ui/Dialog/Modal"
+import type { PreferenceWriteResult } from "~/services/preferences/userPreferences"
 import { createLogger } from "~/utils/core/logger"
+import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 
 /**
  * Unified logger scoped to shared settings section UI primitives.
@@ -15,7 +17,7 @@ const logger = createLogger("SettingSection")
 interface SettingSectionProps {
   title: string
   description?: string
-  onReset?: () => Promise<boolean>
+  onReset?: () => Promise<PreferenceWriteResult>
   resetButtonLabel?: string
   children: ReactNode
   id?: string
@@ -48,12 +50,16 @@ export function SettingSection({
 
     try {
       setIsResetting(true)
-      const success = await onReset()
+      const result = await onReset()
 
-      if (success) {
+      if (result.ok) {
         toast.success(t("messages.resetSuccess", { name: title }))
       } else {
-        toast.error(t("messages.resetFailed", { name: title }))
+        toast.error(
+          getPreferenceWriteFailureMessage(result.reason, {
+            fallback: t("messages.resetFailed", { name: title }),
+          }),
+        )
       }
     } catch (error) {
       logger.error("Failed to reset setting section", { title, error })

--- a/src/components/dialogs/UpdateLogDialog/components/UpdateLogDialog.tsx
+++ b/src/components/dialogs/UpdateLogDialog/components/UpdateLogDialog.tsx
@@ -6,6 +6,7 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { createTab } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
+import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { getDocsChangelogUrl } from "~/utils/navigation/docsLinks"
 
 import { UPDATE_LOG_DIALOG_TEST_IDS } from "../testIds"
@@ -75,6 +76,8 @@ export function UpdateLogDialog({
       const result = await updateOpenChangelogOnUpdate(enabled)
       if (result.ok) {
         setAutoOpenOverride(enabled)
+      } else {
+        showUpdateToast(result, t("ui:dialog.updateLog.autoOpenSetting"))
       }
     } catch (error) {
       const logger = createLogger("UpdateLogDialog")

--- a/src/components/dialogs/UpdateLogDialog/components/UpdateLogDialog.tsx
+++ b/src/components/dialogs/UpdateLogDialog/components/UpdateLogDialog.tsx
@@ -72,8 +72,8 @@ export function UpdateLogDialog({
 
     setIsSavingAutoOpen(true)
     try {
-      const success = await updateOpenChangelogOnUpdate(enabled)
-      if (success) {
+      const result = await updateOpenChangelogOnUpdate(enabled)
+      if (result.ok) {
         setAutoOpenOverride(enabled)
       }
     } catch (error) {

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -34,6 +34,7 @@ import {
   DEFAULT_PREFERENCES,
   TOOLBAR_ACTION_CLICK_BEHAVIORS,
   userPreferences,
+  type PreferenceWriteResult,
   type RedemptionAssistPreferences,
   type TempWindowFallbackPreferences,
   type TempWindowFallbackReminderPreferences,
@@ -86,7 +87,6 @@ import {
 } from "~/types/siteAnnouncements"
 import type { SortingPriorityConfig } from "~/types/sorting"
 import {
-  DEFAULT_TASK_NOTIFICATION_PREFERENCES,
   normalizeTaskNotificationPreferences,
   type TaskNotificationPreferences,
 } from "~/types/taskNotifications"
@@ -115,9 +115,11 @@ type RuntimeMutationResponse = {
   data?: unknown
 }
 
-type PreferenceSaveOptions = {
+export type PreferenceSaveOptions = {
   expectedLastUpdated?: number
 }
+
+type PreferenceWritePromise = Promise<PreferenceWriteResult>
 
 const INVALID_RUNTIME_MUTATION_RESPONSE: RuntimeMutationResponse = {
   success: false,
@@ -289,164 +291,166 @@ interface UserPreferencesContextType {
   taskNotifications: TaskNotificationPreferences
   siteAnnouncementNotifications: SiteAnnouncementPreferences
 
-  updateActiveTab: (activeTab: DashboardTabType) => Promise<boolean>
-  updateDefaultTab: (activeTab: DashboardTabType) => Promise<boolean>
-  updateCurrencyType: (currencyType: CurrencyType) => Promise<boolean>
-  updateShowTodayCashflow: (enabled: boolean) => Promise<boolean>
+  updateActiveTab: (activeTab: DashboardTabType) => PreferenceWritePromise
+  updateDefaultTab: (activeTab: DashboardTabType) => PreferenceWritePromise
+  updateCurrencyType: (currencyType: CurrencyType) => PreferenceWritePromise
+  updateShowTodayCashflow: (enabled: boolean) => PreferenceWritePromise
   updateSortConfig: (
     sortField: ActiveSortField,
     sortOrder: SortOrder,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateSortingPriorityConfig: (
     sortingPriority: SortingPriorityConfig,
-  ) => Promise<boolean>
-  updateAutoRefresh: (enabled: boolean) => Promise<boolean>
-  updateRefreshInterval: (interval: number) => Promise<boolean>
-  updateMinRefreshInterval: (interval: number) => Promise<boolean>
-  updateRefreshOnOpen: (enabled: boolean) => Promise<boolean>
+  ) => PreferenceWritePromise
+  updateAutoRefresh: (enabled: boolean) => PreferenceWritePromise
+  updateRefreshInterval: (interval: number) => PreferenceWritePromise
+  updateMinRefreshInterval: (interval: number) => PreferenceWritePromise
+  updateRefreshOnOpen: (enabled: boolean) => PreferenceWritePromise
   updateActionClickBehavior: (
     behavior: ToolbarActionClickBehavior,
-  ) => Promise<boolean>
-  updateOpenChangelogOnUpdate: (enabled: boolean) => Promise<boolean>
-  updateAutoProvisionKeyOnAccountAdd: (enabled: boolean) => Promise<boolean>
+  ) => PreferenceWritePromise
+  updateOpenChangelogOnUpdate: (enabled: boolean) => PreferenceWritePromise
+  updateAutoProvisionKeyOnAccountAdd: (
+    enabled: boolean,
+  ) => PreferenceWritePromise
   updateAutoFillCurrentSiteUrlOnAccountAdd: (
     enabled: boolean,
-  ) => Promise<boolean>
-  updateWarnOnDuplicateAccountAdd: (enabled: boolean) => Promise<boolean>
+  ) => PreferenceWritePromise
+  updateWarnOnDuplicateAccountAdd: (enabled: boolean) => PreferenceWritePromise
   updateNewApiBaseUrl: (
     url: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateNewApiAdminToken: (
     token: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateNewApiUserId: (
     userId: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateNewApiUsername: (
     username: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateNewApiPassword: (
     password: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateNewApiTotpSecret: (
     totpSecret: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateDoneHubBaseUrl: (
     url: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateDoneHubAdminToken: (
     token: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateDoneHubUserId: (
     userId: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateVeloeraBaseUrl: (
     url: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateVeloeraAdminToken: (
     token: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateVeloeraUserId: (
     userId: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateOctopusBaseUrl: (
     url: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateOctopusUsername: (
     username: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateOctopusPassword: (
     password: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateOctopusConfig: (
     updates: Partial<NonNullable<UserPreferences["octopus"]>>,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateAxonHubBaseUrl: (
     url: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateAxonHubEmail: (
     email: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateAxonHubPassword: (
     password: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateAxonHubConfig: (
     updates: Partial<AxonHubConfig>,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateClaudeCodeHubBaseUrl: (
     url: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateClaudeCodeHubAdminToken: (
     token: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateClaudeCodeHubConfig: (
     updates: Partial<ClaudeCodeHubConfig>,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
-  updateManagedSiteType: (siteType: ManagedSiteType) => Promise<boolean>
+  ) => PreferenceWritePromise
+  updateManagedSiteType: (siteType: ManagedSiteType) => PreferenceWritePromise
   updateCliProxyBaseUrl: (
     url: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateCliProxyManagementKey: (
     key: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateClaudeCodeRouterBaseUrl: (
     url: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateClaudeCodeRouterApiKey: (
     key: string,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
-  updateThemeMode: (themeMode: ThemeMode) => Promise<boolean>
-  updateLoggingConsoleEnabled: (enabled: boolean) => Promise<boolean>
-  updateLoggingLevel: (level: LogLevel) => Promise<boolean>
+  ) => PreferenceWritePromise
+  updateThemeMode: (themeMode: ThemeMode) => PreferenceWritePromise
+  updateLoggingConsoleEnabled: (enabled: boolean) => PreferenceWritePromise
+  updateLoggingLevel: (level: LogLevel) => PreferenceWritePromise
   updateAutoCheckin: (
     updates: Partial<AutoCheckinPreferences>,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateBalanceHistory: (
     updates: Partial<BalanceHistoryPreferences>,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateNewApiModelSync: (
     updates: Partial<UserManagedSiteModelSyncConfig>,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateModelRedirect: (
     updates: Partial<ModelRedirectPreferences>,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateRedemptionAssist: (
     updates: Partial<RedemptionAssistPreferences>,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateWebAiApiCheck: (
     updates: DeepPartial<WebAiApiCheckPreferences>,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateWebdavSettings: (
     updates: Partial<WebDAVSettings>,
     options?: PreferenceSaveOptions,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateWebdavAutoSyncSettings: (
     updates: Pick<
       Partial<WebDAVSettings>,
@@ -456,36 +460,36 @@ interface UserPreferencesContextType {
   ) => Promise<RuntimeMutationResponse>
   updateTempWindowFallback: (
     updates: Partial<TempWindowFallbackPreferences>,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateTempWindowFallbackReminder: (
     updates: Partial<TempWindowFallbackReminderPreferences>,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateTaskNotifications: (
     updates: Partial<TaskNotificationPreferences>,
-  ) => Promise<boolean>
+  ) => PreferenceWritePromise
   updateSiteAnnouncementNotifications: (
     updates: Partial<SiteAnnouncementPreferences>,
-  ) => Promise<boolean>
-  resetToDefaults: () => Promise<boolean>
-  resetDisplaySettings: () => Promise<boolean>
-  resetAutoRefreshConfig: () => Promise<boolean>
-  resetNewApiConfig: () => Promise<boolean>
-  resetDoneHubConfig: () => Promise<boolean>
-  resetVeloeraConfig: () => Promise<boolean>
-  resetOctopusConfig: () => Promise<boolean>
-  resetAxonHubConfig: () => Promise<boolean>
-  resetClaudeCodeHubConfig: () => Promise<boolean>
-  resetNewApiModelSyncConfig: () => Promise<boolean>
-  resetCliProxyConfig: () => Promise<boolean>
-  resetClaudeCodeRouterConfig: () => Promise<boolean>
-  resetAutoCheckinConfig: () => Promise<boolean>
-  resetRedemptionAssistConfig: () => Promise<boolean>
-  resetWebAiApiCheckConfig: () => Promise<boolean>
-  resetModelRedirectConfig: () => Promise<boolean>
-  resetWebdavConfig: () => Promise<boolean>
-  resetLoggingSettings: () => Promise<boolean>
-  resetSortingPriorityConfig: () => Promise<boolean>
-  resetTaskNotifications: () => Promise<boolean>
+  ) => Promise<RuntimeMutationResponse>
+  resetToDefaults: () => PreferenceWritePromise
+  resetDisplaySettings: () => PreferenceWritePromise
+  resetAutoRefreshConfig: () => PreferenceWritePromise
+  resetNewApiConfig: () => PreferenceWritePromise
+  resetDoneHubConfig: () => PreferenceWritePromise
+  resetVeloeraConfig: () => PreferenceWritePromise
+  resetOctopusConfig: () => PreferenceWritePromise
+  resetAxonHubConfig: () => PreferenceWritePromise
+  resetClaudeCodeHubConfig: () => PreferenceWritePromise
+  resetNewApiModelSyncConfig: () => PreferenceWritePromise
+  resetCliProxyConfig: () => PreferenceWritePromise
+  resetClaudeCodeRouterConfig: () => PreferenceWritePromise
+  resetAutoCheckinConfig: () => PreferenceWritePromise
+  resetRedemptionAssistConfig: () => PreferenceWritePromise
+  resetWebAiApiCheckConfig: () => PreferenceWritePromise
+  resetModelRedirectConfig: () => PreferenceWritePromise
+  resetWebdavConfig: () => PreferenceWritePromise
+  resetLoggingSettings: () => PreferenceWritePromise
+  resetSortingPriorityConfig: () => PreferenceWritePromise
+  resetTaskNotifications: () => PreferenceWritePromise
   loadPreferences: () => Promise<void>
 }
 
@@ -549,28 +553,38 @@ export const UserPreferencesProvider = ({
     void loadPreferences()
   }, [loadPreferences])
 
+  const applySuccessfulPreferenceWrite = useCallback(
+    (
+      result: PreferenceWriteResult,
+      updates?: DeepPartial<UserPreferences>,
+    ): UserPreferences | null => {
+      if (!result.ok) {
+        return null
+      }
+
+      const nextPreferences = normalizeContextPreferenceSnapshot(
+        result.preferences,
+      )
+      setPreferences(nextPreferences)
+      trackOptionsSettingsSnapshots(nextPreferences, updates)
+      return nextPreferences
+    },
+    [],
+  )
+
   const persistPreferenceUpdates = useCallback(
     async (
       updates: Parameters<typeof userPreferences.savePreferences>[0],
       options?: PreferenceSaveOptions,
     ) => {
-      const savedPreferences = await savePreferencesWithOptions(
-        updates,
-        options,
+      const result = await savePreferencesWithOptions(updates, options)
+      applySuccessfulPreferenceWrite(
+        result,
+        updates as DeepPartial<UserPreferences>,
       )
-      if (savedPreferences) {
-        const nextPreferences =
-          normalizeContextPreferenceSnapshot(savedPreferences)
-        setPreferences(nextPreferences)
-        trackOptionsSettingsSnapshots(
-          nextPreferences,
-          updates as DeepPartial<UserPreferences>,
-        )
-        return true
-      }
-      return false
+      return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   /**
@@ -578,19 +592,19 @@ export const UserPreferencesProvider = ({
    * @param activeTab - Consumption vs balance tab identifier.
    */
   const updateActiveTab = useCallback(async (activeTab: DashboardTabType) => {
-    const success = await userPreferences.updateActiveTab(activeTab)
-    if (success) {
+    const result = await userPreferences.updateActiveTab(activeTab)
+    if (result.ok) {
       setPreferences((prev) => (prev ? { ...prev, activeTab } : null))
     }
-    return success
+    return result
   }, [])
 
   const updateActionClickBehavior = useCallback(
     async (behavior: ToolbarActionClickBehavior) => {
-      const success = await userPreferences.savePreferences({
+      const result = await userPreferences.savePreferences({
         actionClickBehavior: behavior,
       })
-      if (success) {
+      if (result.ok) {
         setPreferences((prev) =>
           prev
             ? {
@@ -607,7 +621,7 @@ export const UserPreferencesProvider = ({
           },
         )
       }
-      return success
+      return result
     },
     [],
   )
@@ -617,13 +631,13 @@ export const UserPreferencesProvider = ({
    * @param enabled - When true, shows the update log on first UI open after update.
    */
   const updateOpenChangelogOnUpdate = useCallback(async (enabled: boolean) => {
-    const success = await userPreferences.updateOpenChangelogOnUpdate(enabled)
-    if (success) {
+    const result = await userPreferences.updateOpenChangelogOnUpdate(enabled)
+    if (result.ok) {
       setPreferences((prev) =>
         prev ? { ...prev, openChangelogOnUpdate: enabled } : prev,
       )
     }
-    return success
+    return result
   }, [])
 
   /**
@@ -633,9 +647,9 @@ export const UserPreferencesProvider = ({
    */
   const updateAutoProvisionKeyOnAccountAdd = useCallback(
     async (enabled: boolean) => {
-      const success =
+      const result =
         await userPreferences.updateAutoProvisionKeyOnAccountAdd(enabled)
-      if (success) {
+      if (result.ok) {
         const updates: Partial<UserPreferences> = {
           autoProvisionKeyOnAccountAdd: enabled,
         }
@@ -645,7 +659,7 @@ export const UserPreferencesProvider = ({
           trackOptionsSettingsSnapshots(next, updates)
         }
       }
-      return success
+      return result
     },
     [preferences],
   )
@@ -657,9 +671,9 @@ export const UserPreferencesProvider = ({
    */
   const updateAutoFillCurrentSiteUrlOnAccountAdd = useCallback(
     async (enabled: boolean) => {
-      const success =
+      const result =
         await userPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd(enabled)
-      if (success) {
+      if (result.ok) {
         const updates: Partial<UserPreferences> = {
           autoFillCurrentSiteUrlOnAccountAdd: enabled,
         }
@@ -669,7 +683,7 @@ export const UserPreferencesProvider = ({
           trackOptionsSettingsSnapshots(next, updates)
         }
       }
-      return success
+      return result
     },
     [preferences],
   )
@@ -680,9 +694,9 @@ export const UserPreferencesProvider = ({
    */
   const updateWarnOnDuplicateAccountAdd = useCallback(
     async (enabled: boolean) => {
-      const success =
+      const result =
         await userPreferences.updateWarnOnDuplicateAccountAdd(enabled)
-      if (success) {
+      if (result.ok) {
         const updates: Partial<UserPreferences> = {
           warnOnDuplicateAccountAdd: enabled,
         }
@@ -692,17 +706,17 @@ export const UserPreferencesProvider = ({
           trackOptionsSettingsSnapshots(next, updates)
         }
       }
-      return success
+      return result
     },
     [preferences],
   )
 
   const resetClaudeCodeRouterConfig = useCallback(async () => {
-    const success = await userPreferences.resetClaudeCodeRouterConfig()
-    if (success) {
+    const result = await userPreferences.resetClaudeCodeRouterConfig()
+    if (result.ok) {
       await loadPreferences()
     }
-    return success
+    return result
   }, [loadPreferences])
 
   /**
@@ -763,10 +777,10 @@ export const UserPreferencesProvider = ({
 
   const updateTempWindowFallbackReminder = useCallback(
     async (updates: Partial<TempWindowFallbackReminderPreferences>) => {
-      const success = await userPreferences.savePreferences({
+      const result = await userPreferences.savePreferences({
         tempWindowFallbackReminder: updates,
       })
-      if (success) {
+      if (result.ok) {
         setPreferences((prev) => {
           if (!prev) return null
           const merged: TempWindowFallbackReminderPreferences = {
@@ -783,25 +797,25 @@ export const UserPreferencesProvider = ({
           }
         })
       }
-      return success
+      return result
     },
     [],
   )
 
   const updateDefaultTab = useCallback(async (activeTab: DashboardTabType) => {
-    const success = await userPreferences.updateActiveTab(activeTab)
-    if (success) {
+    const result = await userPreferences.updateActiveTab(activeTab)
+    if (result.ok) {
       setPreferences((prev) => (prev ? { ...prev, activeTab } : null))
     }
-    return success
+    return result
   }, [])
 
   const updateCurrencyType = useCallback(async (currencyType: CurrencyType) => {
-    const success = await userPreferences.updateCurrencyType(currencyType)
-    if (success) {
+    const result = await userPreferences.updateCurrencyType(currencyType)
+    if (result.ok) {
       setPreferences((prev) => (prev ? { ...prev, currencyType } : null))
     }
-    return success
+    return result
   }, [])
 
   /**
@@ -838,38 +852,38 @@ export const UserPreferencesProvider = ({
           : {}),
       }
 
-      const success = await userPreferences.savePreferences(updates)
-      if (success && preferences) {
+      const result = await userPreferences.savePreferences(updates)
+      if (result.ok && preferences) {
         const next = deepOverride(preferences, updates)
         setPreferences(next)
         trackOptionsSettingsSnapshots(next, updates)
       }
-      return success
+      return result
     },
     [preferences],
   )
 
   const updateSortConfig = useCallback(
     async (sortField: ActiveSortField, sortOrder: SortOrder) => {
-      const success = await userPreferences.updateSortConfig(
+      const result = await userPreferences.updateSortConfig(
         sortField,
         sortOrder,
       )
-      if (success) {
+      if (result.ok) {
         setPreferences((prev) =>
           prev ? { ...prev, sortField, sortOrder } : null,
         )
       }
-      return success
+      return result
     },
     [],
   )
 
   const updateSortingPriorityConfig = useCallback(
     async (sortingPriority: SortingPriorityConfig) => {
-      const success =
+      const result =
         await userPreferences.setSortingPriorityConfig(sortingPriority)
-      if (success) {
+      if (result.ok) {
         setPreferences((prev) =>
           prev
             ? {
@@ -879,82 +893,74 @@ export const UserPreferencesProvider = ({
             : null,
         )
       }
-      return success
+      return result
     },
     [],
   )
 
-  const updateAutoRefresh = useCallback(async (enabled: boolean) => {
-    const updates = {
-      accountAutoRefresh: { enabled: enabled },
-    }
-    const savedPreferences =
-      await userPreferences.savePreferencesWithResult(updates)
-    if (savedPreferences) {
-      const nextPreferences =
-        normalizeContextPreferenceSnapshot(savedPreferences)
-      setPreferences(nextPreferences)
-      trackOptionsSettingsSnapshots(nextPreferences, updates)
-      void sendAutoRefreshMessage(AutoRefreshMessageTypes.UpdateSettings, {
-        settings: updates,
-      })
-    }
-    return savedPreferences !== null
-  }, [])
+  const updateAutoRefresh = useCallback(
+    async (enabled: boolean) => {
+      const updates = {
+        accountAutoRefresh: { enabled: enabled },
+      }
+      const result = await userPreferences.savePreferencesWithResult(updates)
+      if (applySuccessfulPreferenceWrite(result, updates)) {
+        void sendAutoRefreshMessage(AutoRefreshMessageTypes.UpdateSettings, {
+          settings: updates,
+        })
+      }
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
-  const updateRefreshInterval = useCallback(async (interval: number) => {
-    const updates = {
-      accountAutoRefresh: { interval: interval },
-    }
-    const savedPreferences =
-      await userPreferences.savePreferencesWithResult(updates)
-    if (savedPreferences) {
-      const nextPreferences =
-        normalizeContextPreferenceSnapshot(savedPreferences)
-      setPreferences(nextPreferences)
-      trackOptionsSettingsSnapshots(nextPreferences, updates)
-      void sendAutoRefreshMessage(AutoRefreshMessageTypes.UpdateSettings, {
-        settings: updates,
-      })
-    }
-    return savedPreferences !== null
-  }, [])
+  const updateRefreshInterval = useCallback(
+    async (interval: number) => {
+      const updates = {
+        accountAutoRefresh: { interval: interval },
+      }
+      const result = await userPreferences.savePreferencesWithResult(updates)
+      if (applySuccessfulPreferenceWrite(result, updates)) {
+        void sendAutoRefreshMessage(AutoRefreshMessageTypes.UpdateSettings, {
+          settings: updates,
+        })
+      }
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
-  const updateMinRefreshInterval = useCallback(async (minInterval: number) => {
-    const updates = {
-      accountAutoRefresh: { minInterval: minInterval },
-    }
-    const savedPreferences =
-      await userPreferences.savePreferencesWithResult(updates)
-    if (savedPreferences) {
-      const nextPreferences =
-        normalizeContextPreferenceSnapshot(savedPreferences)
-      setPreferences(nextPreferences)
-      trackOptionsSettingsSnapshots(nextPreferences, updates)
-      void sendAutoRefreshMessage(AutoRefreshMessageTypes.UpdateSettings, {
-        settings: updates,
-      })
-    }
-    return savedPreferences !== null
-  }, [])
+  const updateMinRefreshInterval = useCallback(
+    async (minInterval: number) => {
+      const updates = {
+        accountAutoRefresh: { minInterval: minInterval },
+      }
+      const result = await userPreferences.savePreferencesWithResult(updates)
+      if (applySuccessfulPreferenceWrite(result, updates)) {
+        void sendAutoRefreshMessage(AutoRefreshMessageTypes.UpdateSettings, {
+          settings: updates,
+        })
+      }
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
-  const updateRefreshOnOpen = useCallback(async (refreshOnOpen: boolean) => {
-    const updates = {
-      accountAutoRefresh: { refreshOnOpen: refreshOnOpen },
-    }
-    const savedPreferences =
-      await userPreferences.savePreferencesWithResult(updates)
-    if (savedPreferences) {
-      const nextPreferences =
-        normalizeContextPreferenceSnapshot(savedPreferences)
-      setPreferences(nextPreferences)
-      trackOptionsSettingsSnapshots(nextPreferences, updates)
-      void sendAutoRefreshMessage(AutoRefreshMessageTypes.UpdateSettings, {
-        settings: updates,
-      })
-    }
-    return savedPreferences !== null
-  }, [])
+  const updateRefreshOnOpen = useCallback(
+    async (refreshOnOpen: boolean) => {
+      const updates = {
+        accountAutoRefresh: { refreshOnOpen: refreshOnOpen },
+      }
+      const result = await userPreferences.savePreferencesWithResult(updates)
+      if (applySuccessfulPreferenceWrite(result, updates)) {
+        void sendAutoRefreshMessage(AutoRefreshMessageTypes.UpdateSettings, {
+          settings: updates,
+        })
+      }
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
   const updateNewApiBaseUrl = useCallback(
     async (baseUrl: string, options?: PreferenceSaveOptions) => {
@@ -1243,43 +1249,43 @@ export const UserPreferencesProvider = ({
 
   const updateManagedSiteType = useCallback(
     async (siteType: ManagedSiteType) => {
-      const success = await userPreferences.updateManagedSiteType(siteType)
-      if (success) {
+      const result = await userPreferences.updateManagedSiteType(siteType)
+      if (result.ok) {
         setPreferences((prev) =>
           prev ? { ...prev, managedSiteType: siteType } : null,
         )
       }
-      return success
+      return result
     },
     [],
   )
 
   const updateThemeMode = useCallback(async (themeMode: ThemeMode) => {
-    const success = await userPreferences.savePreferences({ themeMode })
-    if (success) {
+    const result = await userPreferences.savePreferences({ themeMode })
+    if (result.ok) {
       setPreferences((prev) => (prev ? { ...prev, themeMode } : null))
     }
-    return success
+    return result
   }, [])
 
   const updateLoggingConsoleEnabled = useCallback(async (enabled: boolean) => {
     const updates = { logging: { consoleEnabled: enabled } }
-    const success = await userPreferences.updateLoggingPreferences({
+    const result = await userPreferences.updateLoggingPreferences({
       consoleEnabled: enabled,
     })
-    if (success) {
+    if (result.ok) {
       setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
     }
-    return success
+    return result
   }, [])
 
   const updateLoggingLevel = useCallback(async (level: LogLevel) => {
     const updates = { logging: { level } }
-    const success = await userPreferences.updateLoggingPreferences({ level })
-    if (success) {
+    const result = await userPreferences.updateLoggingPreferences({ level })
+    if (result.ok) {
       setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
     }
-    return success
+    return result
   }, [])
 
   const updateAutoCheckin = useCallback(
@@ -1287,28 +1293,18 @@ export const UserPreferencesProvider = ({
       const preferenceUpdates = {
         autoCheckin: updates,
       }
-      const savedPreferences =
+      const result =
         await userPreferences.savePreferencesWithResult(preferenceUpdates)
 
-      if (savedPreferences) {
-        const nextPreferences = normalizeContextPreferenceSnapshot({
-          ...savedPreferences,
-          autoCheckin: deepOverride(
-            DEFAULT_PREFERENCES.autoCheckin,
-            savedPreferences.autoCheckin ?? updates,
-          ),
-        })
-        setPreferences(nextPreferences)
-        trackOptionsSettingsSnapshots(nextPreferences, preferenceUpdates)
-
+      if (applySuccessfulPreferenceWrite(result, preferenceUpdates)) {
         // Notify background to update alarm
         void sendAutoCheckinMessage(AutoCheckinMessageTypes.UpdateSettings, {
           settings: updates,
         })
       }
-      return savedPreferences !== null
+      return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateBalanceHistory = useCallback(
@@ -1316,21 +1312,10 @@ export const UserPreferencesProvider = ({
       const preferenceUpdates = {
         balanceHistory: updates,
       }
-      const savedPreferences =
+      const result =
         await userPreferences.savePreferencesWithResult(preferenceUpdates)
 
-      if (savedPreferences) {
-        const nextPreferences = normalizeContextPreferenceSnapshot({
-          ...savedPreferences,
-          balanceHistory: deepOverride(
-            DEFAULT_PREFERENCES.balanceHistory ??
-              DEFAULT_BALANCE_HISTORY_PREFERENCES,
-            savedPreferences.balanceHistory ?? updates,
-          ),
-        })
-        setPreferences(nextPreferences)
-        trackOptionsSettingsSnapshots(nextPreferences, preferenceUpdates)
-
+      if (applySuccessfulPreferenceWrite(result, preferenceUpdates)) {
         void sendBalanceHistoryMessage(
           BalanceHistoryMessageTypes.UpdateSettings,
           {
@@ -1339,9 +1324,9 @@ export const UserPreferencesProvider = ({
         )
       }
 
-      return savedPreferences !== null
+      return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateNewApiModelSync = useCallback(
@@ -1349,28 +1334,18 @@ export const UserPreferencesProvider = ({
       const preferenceUpdates = {
         managedSiteModelSync: updates,
       }
-      const savedPreferences =
+      const result =
         await userPreferences.savePreferencesWithResult(preferenceUpdates)
 
-      if (savedPreferences) {
-        const nextPreferences = normalizeContextPreferenceSnapshot({
-          ...savedPreferences,
-          managedSiteModelSync: deepOverride(
-            DEFAULT_MANAGED_SITE_MODEL_SYNC_CONFIG,
-            savedPreferences.managedSiteModelSync ?? updates,
-          ) as UserManagedSiteModelSyncConfig,
-        })
-        setPreferences(nextPreferences)
-        trackOptionsSettingsSnapshots(nextPreferences, preferenceUpdates)
-
+      if (applySuccessfulPreferenceWrite(result, preferenceUpdates)) {
         // Notify background to update alarm
         void sendModelSyncMessage(ModelSyncMessageTypes.UpdateSettings, {
           settings: updates,
         })
       }
-      return savedPreferences !== null
+      return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateModelRedirect = useCallback(
@@ -1378,22 +1353,12 @@ export const UserPreferencesProvider = ({
       const preferenceUpdates = {
         modelRedirect: updates,
       }
-      const savedPreferences =
+      const result =
         await userPreferences.savePreferencesWithResult(preferenceUpdates)
-      if (savedPreferences) {
-        const nextPreferences = normalizeContextPreferenceSnapshot({
-          ...savedPreferences,
-          modelRedirect: deepOverride(
-            DEFAULT_PREFERENCES.modelRedirect,
-            savedPreferences.modelRedirect ?? updates,
-          ),
-        })
-        setPreferences(nextPreferences)
-        trackOptionsSettingsSnapshots(nextPreferences, preferenceUpdates)
-      }
-      return savedPreferences !== null
+      applySuccessfulPreferenceWrite(result, preferenceUpdates)
+      return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateRedemptionAssist = useCallback(
@@ -1401,21 +1366,10 @@ export const UserPreferencesProvider = ({
       const preferenceUpdates = {
         redemptionAssist: updates,
       }
-      const savedPreferences =
+      const result =
         await userPreferences.savePreferencesWithResult(preferenceUpdates)
 
-      if (savedPreferences) {
-        const nextPreferences = normalizeContextPreferenceSnapshot({
-          ...savedPreferences,
-          redemptionAssist: deepOverride(
-            DEFAULT_PREFERENCES.redemptionAssist ??
-              DEFAULT_REDEMPTION_ASSIST_PREFERENCES,
-            savedPreferences.redemptionAssist ?? updates,
-          ),
-        })
-        setPreferences(nextPreferences)
-        trackOptionsSettingsSnapshots(nextPreferences, preferenceUpdates)
-
+      if (applySuccessfulPreferenceWrite(result, preferenceUpdates)) {
         void sendRedemptionAssistMessage(
           RedemptionAssistMessageTypes.UpdateSettings,
           {
@@ -1434,9 +1388,9 @@ export const UserPreferencesProvider = ({
         }
       }
 
-      return savedPreferences !== null
+      return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateWebAiApiCheck = useCallback(
@@ -1444,21 +1398,10 @@ export const UserPreferencesProvider = ({
       const preferenceUpdates = {
         webAiApiCheck: updates,
       }
-      const savedPreferences =
+      const result =
         await userPreferences.savePreferencesWithResult(preferenceUpdates)
 
-      if (savedPreferences) {
-        const nextPreferences = normalizeContextPreferenceSnapshot({
-          ...savedPreferences,
-          webAiApiCheck: deepOverride(
-            DEFAULT_PREFERENCES.webAiApiCheck ??
-              DEFAULT_WEB_AI_API_CHECK_PREFERENCES,
-            savedPreferences.webAiApiCheck ?? updates,
-          ),
-        })
-        setPreferences(nextPreferences)
-        trackOptionsSettingsSnapshots(nextPreferences, preferenceUpdates)
-
+      if (applySuccessfulPreferenceWrite(result, preferenceUpdates)) {
         const shouldRefreshContextMenus =
           typeof updates.contextMenu?.enabled === "boolean" ||
           typeof updates.enabled === "boolean"
@@ -1470,9 +1413,9 @@ export const UserPreferencesProvider = ({
         }
       }
 
-      return savedPreferences !== null
+      return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateWebdavSettings = useCallback(
@@ -1531,22 +1474,12 @@ export const UserPreferencesProvider = ({
       const preferenceUpdates = {
         tempWindowFallback: updates,
       }
-      const savedPreferences =
+      const result =
         await userPreferences.savePreferencesWithResult(preferenceUpdates)
-      if (savedPreferences) {
-        const nextPreferences = normalizeContextPreferenceSnapshot({
-          ...savedPreferences,
-          tempWindowFallback: deepOverride(
-            DEFAULT_TEMP_WINDOW_FALLBACK_CONFIG,
-            savedPreferences.tempWindowFallback ?? updates,
-          ) as TempWindowFallbackPreferences,
-        })
-        setPreferences(nextPreferences)
-        trackOptionsSettingsSnapshots(nextPreferences, preferenceUpdates)
-      }
-      return savedPreferences !== null
+      applySuccessfulPreferenceWrite(result, preferenceUpdates)
+      return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateTaskNotifications = useCallback(
@@ -1554,24 +1487,12 @@ export const UserPreferencesProvider = ({
       const preferenceUpdates = {
         taskNotifications: updates,
       }
-      const savedPreferences =
+      const result =
         await userPreferences.savePreferencesWithResult(preferenceUpdates)
-      if (savedPreferences) {
-        const nextPreferences = normalizeContextPreferenceSnapshot({
-          ...savedPreferences,
-          taskNotifications: normalizeTaskNotificationPreferences(
-            deepOverride(
-              DEFAULT_TASK_NOTIFICATION_PREFERENCES,
-              savedPreferences.taskNotifications ?? updates,
-            ),
-          ),
-        })
-        setPreferences(nextPreferences)
-        trackOptionsSettingsSnapshots(nextPreferences, preferenceUpdates)
-      }
-      return savedPreferences !== null
+      applySuccessfulPreferenceWrite(result, preferenceUpdates)
+      return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateSiteAnnouncementNotifications = useCallback(
@@ -1616,13 +1537,13 @@ export const UserPreferencesProvider = ({
         }
       }
 
-      return response.success
+      return response
     },
     [preferences],
   )
   const resetToDefaults = useCallback(async () => {
-    const success = await userPreferences.resetToDefaults()
-    if (success) {
+    const result = await userPreferences.resetToDefaults()
+    if (result.ok) {
       await loadPreferences()
 
       // Notify all background services about the reset
@@ -1690,12 +1611,12 @@ export const UserPreferencesProvider = ({
 
       void sendPreferencesMessage(PreferencesMessageTypes.RefreshContextMenus)
     }
-    return success
+    return result
   }, [loadPreferences])
 
   const resetDisplaySettings = useCallback(async () => {
-    const success = await userPreferences.resetDisplaySettings()
-    if (success) {
+    const result = await userPreferences.resetDisplaySettings()
+    if (result.ok) {
       const now = Date.now()
       setPreferences((prev) =>
         prev
@@ -1716,12 +1637,12 @@ export const UserPreferencesProvider = ({
         },
       )
     }
-    return success
+    return result
   }, [])
 
   const resetAutoRefreshConfig = useCallback(async () => {
-    const success = await userPreferences.resetAutoRefreshConfig()
-    if (success) {
+    const result = await userPreferences.resetAutoRefreshConfig()
+    if (result.ok) {
       const defaults = DEFAULT_PREFERENCES.accountAutoRefresh
 
       setPreferences((prev) =>
@@ -1740,72 +1661,72 @@ export const UserPreferencesProvider = ({
         { accountAutoRefresh: defaults },
       )
     }
-    return success
+    return result
   }, [])
 
   const resetNewApiConfig = useCallback(async () => {
-    const success = await userPreferences.resetNewApiConfig()
-    if (success) {
+    const result = await userPreferences.resetNewApiConfig()
+    if (result.ok) {
       await reloadPreferencesAndTrackSnapshots({
         newApi: DEFAULT_PREFERENCES.newApi,
       })
     }
-    return success
+    return result
   }, [reloadPreferencesAndTrackSnapshots])
 
   const resetDoneHubConfig = useCallback(async () => {
-    const success = await userPreferences.resetDoneHubConfig()
-    if (success) {
+    const result = await userPreferences.resetDoneHubConfig()
+    if (result.ok) {
       await reloadPreferencesAndTrackSnapshots({
         doneHub: DEFAULT_PREFERENCES.doneHub,
       })
     }
-    return success
+    return result
   }, [reloadPreferencesAndTrackSnapshots])
 
   const resetVeloeraConfig = useCallback(async () => {
-    const success = await userPreferences.resetVeloeraConfig()
-    if (success) {
+    const result = await userPreferences.resetVeloeraConfig()
+    if (result.ok) {
       await reloadPreferencesAndTrackSnapshots({
         veloera: DEFAULT_PREFERENCES.veloera,
       })
     }
-    return success
+    return result
   }, [reloadPreferencesAndTrackSnapshots])
 
   const resetOctopusConfig = useCallback(async () => {
-    const success = await userPreferences.resetOctopusConfig()
-    if (success) {
+    const result = await userPreferences.resetOctopusConfig()
+    if (result.ok) {
       await reloadPreferencesAndTrackSnapshots({
         octopus: DEFAULT_PREFERENCES.octopus,
       })
     }
-    return success
+    return result
   }, [reloadPreferencesAndTrackSnapshots])
 
   const resetAxonHubConfig = useCallback(async () => {
-    const success = await userPreferences.resetAxonHubConfig()
-    if (success) {
+    const result = await userPreferences.resetAxonHubConfig()
+    if (result.ok) {
       await reloadPreferencesAndTrackSnapshots({
         axonHub: DEFAULT_PREFERENCES.axonHub,
       })
     }
-    return success
+    return result
   }, [reloadPreferencesAndTrackSnapshots])
 
   const resetClaudeCodeHubConfig = useCallback(async () => {
-    const success = await userPreferences.resetClaudeCodeHubConfig()
-    if (success) {
+    const result = await userPreferences.resetClaudeCodeHubConfig()
+    if (result.ok) {
       await reloadPreferencesAndTrackSnapshots({
         claudeCodeHub: DEFAULT_PREFERENCES.claudeCodeHub,
       })
     }
-    return success
+    return result
   }, [reloadPreferencesAndTrackSnapshots])
 
   const resetNewApiModelSyncConfig = useCallback(async () => {
-    const success = await userPreferences.resetNewApiModelSyncConfig()
-    if (success) {
+    const result = await userPreferences.resetNewApiModelSyncConfig()
+    if (result.ok) {
       const defaults = DEFAULT_PREFERENCES.managedSiteModelSync
       setPreferences((prev) =>
         prev
@@ -1825,22 +1746,22 @@ export const UserPreferencesProvider = ({
         { managedSiteModelSync: defaults },
       )
     }
-    return success
+    return result
   }, [])
 
   const resetCliProxyConfig = useCallback(async () => {
-    const success = await userPreferences.resetCliProxyConfig()
-    if (success) {
+    const result = await userPreferences.resetCliProxyConfig()
+    if (result.ok) {
       await reloadPreferencesAndTrackSnapshots({
         cliProxy: DEFAULT_PREFERENCES.cliProxy,
       })
     }
-    return success
+    return result
   }, [reloadPreferencesAndTrackSnapshots])
 
   const resetAutoCheckinConfig = useCallback(async () => {
-    const success = await userPreferences.resetAutoCheckinConfig()
-    if (success) {
+    const result = await userPreferences.resetAutoCheckinConfig()
+    if (result.ok) {
       const defaults = DEFAULT_PREFERENCES.autoCheckin
       setPreferences((prev) =>
         prev
@@ -1860,12 +1781,12 @@ export const UserPreferencesProvider = ({
         { autoCheckin: defaults },
       )
     }
-    return success
+    return result
   }, [])
 
   const resetRedemptionAssistConfig = useCallback(async () => {
-    const success = await userPreferences.resetRedemptionAssist()
-    if (success) {
+    const result = await userPreferences.resetRedemptionAssist()
+    if (result.ok) {
       const defaults = DEFAULT_PREFERENCES.redemptionAssist
       setPreferences((prev) =>
         prev
@@ -1888,12 +1809,12 @@ export const UserPreferencesProvider = ({
         { redemptionAssist: defaults },
       )
     }
-    return success
+    return result
   }, [])
 
   const resetWebAiApiCheckConfig = useCallback(async () => {
-    const success = await userPreferences.resetWebAiApiCheck()
-    if (success) {
+    const result = await userPreferences.resetWebAiApiCheck()
+    if (result.ok) {
       const defaults = DEFAULT_PREFERENCES.webAiApiCheck
       setPreferences((prev) =>
         prev
@@ -1908,12 +1829,12 @@ export const UserPreferencesProvider = ({
         { webAiApiCheck: defaults },
       )
     }
-    return success
+    return result
   }, [])
 
   const resetModelRedirectConfig = useCallback(async () => {
-    const success = await userPreferences.resetModelRedirectConfig()
-    if (success) {
+    const result = await userPreferences.resetModelRedirectConfig()
+    if (result.ok) {
       const defaults = DEFAULT_PREFERENCES.modelRedirect
       setPreferences((prev) =>
         prev
@@ -1928,35 +1849,35 @@ export const UserPreferencesProvider = ({
         { modelRedirect: defaults },
       )
     }
-    return success
+    return result
   }, [])
 
   const resetWebdavConfig = useCallback(async () => {
-    const success = await userPreferences.resetWebdavConfig()
-    if (success) {
+    const result = await userPreferences.resetWebdavConfig()
+    if (result.ok) {
       await reloadPreferencesAndTrackSnapshots({
         webdav: DEFAULT_PREFERENCES.webdav,
       })
     }
-    return success
+    return result
   }, [reloadPreferencesAndTrackSnapshots])
 
   const resetLoggingSettings = useCallback(async () => {
     const defaults = DEFAULT_PREFERENCES.logging
-    const success = await userPreferences.updateLoggingPreferences(defaults)
-    if (success) {
+    const result = await userPreferences.updateLoggingPreferences(defaults)
+    if (result.ok) {
       setPreferences((prev) =>
         prev
           ? deepOverride(prev, { logging: defaults, lastUpdated: Date.now() })
           : prev,
       )
     }
-    return success
+    return result
   }, [])
 
   const resetSortingPriorityConfig = useCallback(async () => {
-    const success = await userPreferences.resetSortingPriorityConfig()
-    if (success) {
+    const result = await userPreferences.resetSortingPriorityConfig()
+    if (result.ok) {
       setPreferences((prev) =>
         prev
           ? {
@@ -1967,12 +1888,12 @@ export const UserPreferencesProvider = ({
           : prev,
       )
     }
-    return success
+    return result
   }, [])
 
   const resetTaskNotifications = useCallback(async () => {
-    const success = await userPreferences.resetTaskNotifications()
-    if (success) {
+    const result = await userPreferences.resetTaskNotifications()
+    if (result.ok) {
       setPreferences((prev) =>
         prev
           ? deepOverride(prev, {
@@ -1988,7 +1909,7 @@ export const UserPreferencesProvider = ({
         { taskNotifications: DEFAULT_PREFERENCES.taskNotifications },
       )
     }
-    return success
+    return result
   }, [])
 
   useEffect(() => {
@@ -2010,8 +1931,8 @@ export const UserPreferencesProvider = ({
     }
 
     void (async () => {
-      const success = await userPreferences.savePreferences(updates)
-      if (success) {
+      const result = await userPreferences.savePreferences(updates)
+      if (result.ok) {
         setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
       }
     })()

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -610,12 +610,14 @@ export const UserPreferencesProvider = ({
           actionClickBehavior: behavior,
         })
       ) {
-        await sendPreferencesMessage(
+        void sendPreferencesMessage(
           PreferencesMessageTypes.UpdateActionClickBehavior,
           {
             behavior,
           },
-        )
+        ).catch((error) => {
+          logger.warn("Failed to notify action click behavior update", error)
+        })
       }
       return result
     },

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -591,29 +591,25 @@ export const UserPreferencesProvider = ({
    * Persist the currently visible balance tab and mirror it in React state.
    * @param activeTab - Consumption vs balance tab identifier.
    */
-  const updateActiveTab = useCallback(async (activeTab: DashboardTabType) => {
-    const result = await userPreferences.updateActiveTab(activeTab)
-    if (result.ok) {
-      setPreferences((prev) => (prev ? { ...prev, activeTab } : null))
-    }
-    return result
-  }, [])
+  const updateActiveTab = useCallback(
+    async (activeTab: DashboardTabType) => {
+      const result = await userPreferences.updateActiveTab(activeTab)
+      applySuccessfulPreferenceWrite(result, { activeTab })
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
   const updateActionClickBehavior = useCallback(
     async (behavior: ToolbarActionClickBehavior) => {
       const result = await userPreferences.savePreferences({
         actionClickBehavior: behavior,
       })
-      if (result.ok) {
-        setPreferences((prev) =>
-          prev
-            ? {
-                ...prev,
-                actionClickBehavior: behavior,
-              }
-            : prev,
-        )
-
+      if (
+        applySuccessfulPreferenceWrite(result, {
+          actionClickBehavior: behavior,
+        })
+      ) {
         await sendPreferencesMessage(
           PreferencesMessageTypes.UpdateActionClickBehavior,
           {
@@ -623,22 +619,21 @@ export const UserPreferencesProvider = ({
       }
       return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   /**
    * Enable/disable automatically showing the inline update log after updates.
    * @param enabled - When true, shows the update log on first UI open after update.
    */
-  const updateOpenChangelogOnUpdate = useCallback(async (enabled: boolean) => {
-    const result = await userPreferences.updateOpenChangelogOnUpdate(enabled)
-    if (result.ok) {
-      setPreferences((prev) =>
-        prev ? { ...prev, openChangelogOnUpdate: enabled } : prev,
-      )
-    }
-    return result
-  }, [])
+  const updateOpenChangelogOnUpdate = useCallback(
+    async (enabled: boolean) => {
+      const result = await userPreferences.updateOpenChangelogOnUpdate(enabled)
+      applySuccessfulPreferenceWrite(result, { openChangelogOnUpdate: enabled })
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
   /**
    * Enable/disable automatically provisioning a default API key (token) after
@@ -649,19 +644,12 @@ export const UserPreferencesProvider = ({
     async (enabled: boolean) => {
       const result =
         await userPreferences.updateAutoProvisionKeyOnAccountAdd(enabled)
-      if (result.ok) {
-        const updates: Partial<UserPreferences> = {
-          autoProvisionKeyOnAccountAdd: enabled,
-        }
-        if (preferences) {
-          const next = { ...preferences, ...updates }
-          setPreferences(next)
-          trackOptionsSettingsSnapshots(next, updates)
-        }
-      }
+      applySuccessfulPreferenceWrite(result, {
+        autoProvisionKeyOnAccountAdd: enabled,
+      })
       return result
     },
-    [preferences],
+    [applySuccessfulPreferenceWrite],
   )
 
   /**
@@ -673,19 +661,12 @@ export const UserPreferencesProvider = ({
     async (enabled: boolean) => {
       const result =
         await userPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd(enabled)
-      if (result.ok) {
-        const updates: Partial<UserPreferences> = {
-          autoFillCurrentSiteUrlOnAccountAdd: enabled,
-        }
-        if (preferences) {
-          const next = { ...preferences, ...updates }
-          setPreferences(next)
-          trackOptionsSettingsSnapshots(next, updates)
-        }
-      }
+      applySuccessfulPreferenceWrite(result, {
+        autoFillCurrentSiteUrlOnAccountAdd: enabled,
+      })
       return result
     },
-    [preferences],
+    [applySuccessfulPreferenceWrite],
   )
 
   /**
@@ -696,19 +677,12 @@ export const UserPreferencesProvider = ({
     async (enabled: boolean) => {
       const result =
         await userPreferences.updateWarnOnDuplicateAccountAdd(enabled)
-      if (result.ok) {
-        const updates: Partial<UserPreferences> = {
-          warnOnDuplicateAccountAdd: enabled,
-        }
-        if (preferences) {
-          const next = { ...preferences, ...updates }
-          setPreferences(next)
-          trackOptionsSettingsSnapshots(next, updates)
-        }
-      }
+      applySuccessfulPreferenceWrite(result, {
+        warnOnDuplicateAccountAdd: enabled,
+      })
       return result
     },
-    [preferences],
+    [applySuccessfulPreferenceWrite],
   )
 
   const resetClaudeCodeRouterConfig = useCallback(async () => {
@@ -777,46 +751,33 @@ export const UserPreferencesProvider = ({
 
   const updateTempWindowFallbackReminder = useCallback(
     async (updates: Partial<TempWindowFallbackReminderPreferences>) => {
-      const result = await userPreferences.savePreferences({
+      const preferenceUpdates = {
         tempWindowFallbackReminder: updates,
-      })
-      if (result.ok) {
-        setPreferences((prev) => {
-          if (!prev) return null
-          const merged: TempWindowFallbackReminderPreferences = {
-            ...(DEFAULT_PREFERENCES.tempWindowFallbackReminder ?? {
-              dismissed: false,
-            }),
-            ...(prev.tempWindowFallbackReminder ?? {}),
-            ...updates,
-          }
-          return {
-            ...prev,
-            tempWindowFallbackReminder: merged,
-            lastUpdated: Date.now(),
-          }
-        })
       }
+      const result = await userPreferences.savePreferences(preferenceUpdates)
+      applySuccessfulPreferenceWrite(result, preferenceUpdates)
       return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
-  const updateDefaultTab = useCallback(async (activeTab: DashboardTabType) => {
-    const result = await userPreferences.updateActiveTab(activeTab)
-    if (result.ok) {
-      setPreferences((prev) => (prev ? { ...prev, activeTab } : null))
-    }
-    return result
-  }, [])
+  const updateDefaultTab = useCallback(
+    async (activeTab: DashboardTabType) => {
+      const result = await userPreferences.updateActiveTab(activeTab)
+      applySuccessfulPreferenceWrite(result, { activeTab })
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
-  const updateCurrencyType = useCallback(async (currencyType: CurrencyType) => {
-    const result = await userPreferences.updateCurrencyType(currencyType)
-    if (result.ok) {
-      setPreferences((prev) => (prev ? { ...prev, currencyType } : null))
-    }
-    return result
-  }, [])
+  const updateCurrencyType = useCallback(
+    async (currencyType: CurrencyType) => {
+      const result = await userPreferences.updateCurrencyType(currencyType)
+      applySuccessfulPreferenceWrite(result, { currencyType })
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
   /**
    * Toggle whether today cashflow statistics are shown and fetched.
@@ -853,14 +814,10 @@ export const UserPreferencesProvider = ({
       }
 
       const result = await userPreferences.savePreferences(updates)
-      if (result.ok && preferences) {
-        const next = deepOverride(preferences, updates)
-        setPreferences(next)
-        trackOptionsSettingsSnapshots(next, updates)
-      }
+      applySuccessfulPreferenceWrite(result, updates)
       return result
     },
-    [preferences],
+    [applySuccessfulPreferenceWrite, preferences],
   )
 
   const updateSortConfig = useCallback(
@@ -869,33 +826,22 @@ export const UserPreferencesProvider = ({
         sortField,
         sortOrder,
       )
-      if (result.ok) {
-        setPreferences((prev) =>
-          prev ? { ...prev, sortField, sortOrder } : null,
-        )
-      }
+      applySuccessfulPreferenceWrite(result, { sortField, sortOrder })
       return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateSortingPriorityConfig = useCallback(
     async (sortingPriority: SortingPriorityConfig) => {
       const result =
         await userPreferences.setSortingPriorityConfig(sortingPriority)
-      if (result.ok) {
-        setPreferences((prev) =>
-          prev
-            ? {
-                ...prev,
-                sortingPriorityConfig: sortingPriority,
-              }
-            : null,
-        )
-      }
+      applySuccessfulPreferenceWrite(result, {
+        sortingPriorityConfig: sortingPriority,
+      })
       return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
   const updateAutoRefresh = useCallback(
@@ -1250,43 +1196,42 @@ export const UserPreferencesProvider = ({
   const updateManagedSiteType = useCallback(
     async (siteType: ManagedSiteType) => {
       const result = await userPreferences.updateManagedSiteType(siteType)
-      if (result.ok) {
-        setPreferences((prev) =>
-          prev ? { ...prev, managedSiteType: siteType } : null,
-        )
-      }
+      applySuccessfulPreferenceWrite(result, { managedSiteType: siteType })
       return result
     },
-    [],
+    [applySuccessfulPreferenceWrite],
   )
 
-  const updateThemeMode = useCallback(async (themeMode: ThemeMode) => {
-    const result = await userPreferences.savePreferences({ themeMode })
-    if (result.ok) {
-      setPreferences((prev) => (prev ? { ...prev, themeMode } : null))
-    }
-    return result
-  }, [])
+  const updateThemeMode = useCallback(
+    async (themeMode: ThemeMode) => {
+      const result = await userPreferences.savePreferences({ themeMode })
+      applySuccessfulPreferenceWrite(result, { themeMode })
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
-  const updateLoggingConsoleEnabled = useCallback(async (enabled: boolean) => {
-    const updates = { logging: { consoleEnabled: enabled } }
-    const result = await userPreferences.updateLoggingPreferences({
-      consoleEnabled: enabled,
-    })
-    if (result.ok) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return result
-  }, [])
+  const updateLoggingConsoleEnabled = useCallback(
+    async (enabled: boolean) => {
+      const updates = { logging: { consoleEnabled: enabled } }
+      const result = await userPreferences.updateLoggingPreferences({
+        consoleEnabled: enabled,
+      })
+      applySuccessfulPreferenceWrite(result, updates)
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
-  const updateLoggingLevel = useCallback(async (level: LogLevel) => {
-    const updates = { logging: { level } }
-    const result = await userPreferences.updateLoggingPreferences({ level })
-    if (result.ok) {
-      setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-    }
-    return result
-  }, [])
+  const updateLoggingLevel = useCallback(
+    async (level: LogLevel) => {
+      const updates = { logging: { level } }
+      const result = await userPreferences.updateLoggingPreferences({ level })
+      applySuccessfulPreferenceWrite(result, updates)
+      return result
+    },
+    [applySuccessfulPreferenceWrite],
+  )
 
   const updateAutoCheckin = useCallback(
     async (updates: Partial<AutoCheckinPreferences>) => {
@@ -1617,52 +1562,29 @@ export const UserPreferencesProvider = ({
   const resetDisplaySettings = useCallback(async () => {
     const result = await userPreferences.resetDisplaySettings()
     if (result.ok) {
-      const now = Date.now()
-      setPreferences((prev) =>
-        prev
-          ? {
-              ...prev,
-              activeTab: DEFAULT_PREFERENCES.activeTab,
-              currencyType: DEFAULT_PREFERENCES.currencyType,
-              lastUpdated: now,
-            }
-          : prev,
-      )
-      trackOptionsSettingsSnapshots(
-        { ...DEFAULT_PREFERENCES, lastUpdated: now },
-        {
-          activeTab: DEFAULT_PREFERENCES.activeTab,
-          currencyType: DEFAULT_PREFERENCES.currencyType,
-          showTodayCashflow: DEFAULT_PREFERENCES.showTodayCashflow,
-        },
-      )
+      applySuccessfulPreferenceWrite(result, {
+        activeTab: DEFAULT_PREFERENCES.activeTab,
+        currencyType: DEFAULT_PREFERENCES.currencyType,
+        showTodayCashflow: DEFAULT_PREFERENCES.showTodayCashflow,
+      })
     }
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   const resetAutoRefreshConfig = useCallback(async () => {
     const result = await userPreferences.resetAutoRefreshConfig()
-    if (result.ok) {
+    if (
+      applySuccessfulPreferenceWrite(result, {
+        accountAutoRefresh: DEFAULT_PREFERENCES.accountAutoRefresh,
+      })
+    ) {
       const defaults = DEFAULT_PREFERENCES.accountAutoRefresh
-
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              accountAutoRefresh: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
       void sendAutoRefreshMessage(AutoRefreshMessageTypes.UpdateSettings, {
         settings: { accountAutoRefresh: defaults },
       })
-      trackOptionsSettingsSnapshots(
-        deepOverride(DEFAULT_PREFERENCES, { accountAutoRefresh: defaults }),
-        { accountAutoRefresh: defaults },
-      )
     }
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   const resetNewApiConfig = useCallback(async () => {
     const result = await userPreferences.resetNewApiConfig()
@@ -1726,28 +1648,20 @@ export const UserPreferencesProvider = ({
 
   const resetNewApiModelSyncConfig = useCallback(async () => {
     const result = await userPreferences.resetNewApiModelSyncConfig()
-    if (result.ok) {
+    if (
+      applySuccessfulPreferenceWrite(result, {
+        managedSiteModelSync: DEFAULT_PREFERENCES.managedSiteModelSync,
+      })
+    ) {
       const defaults = DEFAULT_PREFERENCES.managedSiteModelSync
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              managedSiteModelSync: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
       if (defaults) {
         void sendModelSyncMessage(ModelSyncMessageTypes.UpdateSettings, {
           settings: defaults,
         })
       }
-      trackOptionsSettingsSnapshots(
-        deepOverride(DEFAULT_PREFERENCES, { managedSiteModelSync: defaults }),
-        { managedSiteModelSync: defaults },
-      )
     }
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   const resetCliProxyConfig = useCallback(async () => {
     const result = await userPreferences.resetCliProxyConfig()
@@ -1761,41 +1675,29 @@ export const UserPreferencesProvider = ({
 
   const resetAutoCheckinConfig = useCallback(async () => {
     const result = await userPreferences.resetAutoCheckinConfig()
-    if (result.ok) {
+    if (
+      applySuccessfulPreferenceWrite(result, {
+        autoCheckin: DEFAULT_PREFERENCES.autoCheckin,
+      })
+    ) {
       const defaults = DEFAULT_PREFERENCES.autoCheckin
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              autoCheckin: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
       if (defaults) {
         void sendAutoCheckinMessage(AutoCheckinMessageTypes.UpdateSettings, {
           settings: defaults,
         })
       }
-      trackOptionsSettingsSnapshots(
-        deepOverride(DEFAULT_PREFERENCES, { autoCheckin: defaults }),
-        { autoCheckin: defaults },
-      )
     }
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   const resetRedemptionAssistConfig = useCallback(async () => {
     const result = await userPreferences.resetRedemptionAssist()
-    if (result.ok) {
+    if (
+      applySuccessfulPreferenceWrite(result, {
+        redemptionAssist: DEFAULT_PREFERENCES.redemptionAssist,
+      })
+    ) {
       const defaults = DEFAULT_PREFERENCES.redemptionAssist
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              redemptionAssist: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
       if (defaults) {
         void sendRedemptionAssistMessage(
           RedemptionAssistMessageTypes.UpdateSettings,
@@ -1804,53 +1706,25 @@ export const UserPreferencesProvider = ({
           },
         )
       }
-      trackOptionsSettingsSnapshots(
-        deepOverride(DEFAULT_PREFERENCES, { redemptionAssist: defaults }),
-        { redemptionAssist: defaults },
-      )
     }
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   const resetWebAiApiCheckConfig = useCallback(async () => {
     const result = await userPreferences.resetWebAiApiCheck()
-    if (result.ok) {
-      const defaults = DEFAULT_PREFERENCES.webAiApiCheck
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              webAiApiCheck: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
-      trackOptionsSettingsSnapshots(
-        deepOverride(DEFAULT_PREFERENCES, { webAiApiCheck: defaults }),
-        { webAiApiCheck: defaults },
-      )
-    }
+    applySuccessfulPreferenceWrite(result, {
+      webAiApiCheck: DEFAULT_PREFERENCES.webAiApiCheck,
+    })
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   const resetModelRedirectConfig = useCallback(async () => {
     const result = await userPreferences.resetModelRedirectConfig()
-    if (result.ok) {
-      const defaults = DEFAULT_PREFERENCES.modelRedirect
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              modelRedirect: defaults,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
-      trackOptionsSettingsSnapshots(
-        deepOverride(DEFAULT_PREFERENCES, { modelRedirect: defaults }),
-        { modelRedirect: defaults },
-      )
-    }
+    applySuccessfulPreferenceWrite(result, {
+      modelRedirect: DEFAULT_PREFERENCES.modelRedirect,
+    })
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   const resetWebdavConfig = useCallback(async () => {
     const result = await userPreferences.resetWebdavConfig()
@@ -1865,52 +1739,25 @@ export const UserPreferencesProvider = ({
   const resetLoggingSettings = useCallback(async () => {
     const defaults = DEFAULT_PREFERENCES.logging
     const result = await userPreferences.updateLoggingPreferences(defaults)
-    if (result.ok) {
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, { logging: defaults, lastUpdated: Date.now() })
-          : prev,
-      )
-    }
+    applySuccessfulPreferenceWrite(result, { logging: defaults })
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   const resetSortingPriorityConfig = useCallback(async () => {
     const result = await userPreferences.resetSortingPriorityConfig()
-    if (result.ok) {
-      setPreferences((prev) =>
-        prev
-          ? {
-              ...prev,
-              sortingPriorityConfig: undefined,
-              lastUpdated: Date.now(),
-            }
-          : prev,
-      )
-    }
+    applySuccessfulPreferenceWrite(result, {
+      sortingPriorityConfig: DEFAULT_PREFERENCES.sortingPriorityConfig,
+    })
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   const resetTaskNotifications = useCallback(async () => {
     const result = await userPreferences.resetTaskNotifications()
-    if (result.ok) {
-      setPreferences((prev) =>
-        prev
-          ? deepOverride(prev, {
-              taskNotifications: DEFAULT_PREFERENCES.taskNotifications,
-              lastUpdated: Date.now(),
-            })
-          : prev,
-      )
-      trackOptionsSettingsSnapshots(
-        deepOverride(DEFAULT_PREFERENCES, {
-          taskNotifications: DEFAULT_PREFERENCES.taskNotifications,
-        }),
-        { taskNotifications: DEFAULT_PREFERENCES.taskNotifications },
-      )
-    }
+    applySuccessfulPreferenceWrite(result, {
+      taskNotifications: DEFAULT_PREFERENCES.taskNotifications,
+    })
     return result
-  }, [])
+  }, [applySuccessfulPreferenceWrite])
 
   useEffect(() => {
     if (!preferences) return
@@ -1932,11 +1779,9 @@ export const UserPreferencesProvider = ({
 
     void (async () => {
       const result = await userPreferences.savePreferences(updates)
-      if (result.ok) {
-        setPreferences((prev) => (prev ? deepOverride(prev, updates) : null))
-      }
+      applySuccessfulPreferenceWrite(result, updates)
     })()
-  }, [preferences])
+  }, [applySuccessfulPreferenceWrite, preferences])
 
   if (!preferences) {
     return null

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -767,19 +767,20 @@ export function useAccountDialog({
 
   const handleDuplicateAccountWarningDisableAndContinue =
     useCallback(async () => {
-      let success = false
+      let result: Awaited<
+        ReturnType<typeof updateWarnOnDuplicateAccountAdd>
+      > | null = null
       try {
-        const result = await updateWarnOnDuplicateAccountAdd(false)
-        success = result.ok
+        result = await updateWarnOnDuplicateAccountAdd(false)
       } catch (error) {
         logger.warn("Failed to disable duplicate-account warning preference", {
           error,
         })
       }
 
-      if (!success) {
+      if (!result?.ok) {
         showUpdateToast(
-          false,
+          result ?? false,
           t("settings:duplicateAccountWarningOnAdd.toggleLabel"),
         )
         return

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -769,7 +769,8 @@ export function useAccountDialog({
     useCallback(async () => {
       let success = false
       try {
-        success = await updateWarnOnDuplicateAccountAdd(false)
+        const result = await updateWarnOnDuplicateAccountAdd(false)
+        success = result.ok
       } catch (error) {
         logger.warn("Failed to disable duplicate-account warning preference", {
           error,

--- a/src/features/BasicSettings/components/tabs/AccountManagement/AutoFillCurrentSiteUrlOnAccountAddSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/AutoFillCurrentSiteUrlOnAccountAddSettings.tsx
@@ -18,9 +18,9 @@ export default function AutoFillCurrentSiteUrlOnAccountAddSettings() {
   } = useUserPreferencesContext()
 
   const handleToggle = async (enabled: boolean) => {
-    const success = await updateAutoFillCurrentSiteUrlOnAccountAdd(enabled)
+    const writeResult = await updateAutoFillCurrentSiteUrlOnAccountAdd(enabled)
     showUpdateToast(
-      success,
+      writeResult,
       t("autoFillCurrentSiteUrlOnAccountAdd.toggleLabel"),
     )
   }

--- a/src/features/BasicSettings/components/tabs/AccountManagement/AutoProvisionKeyOnAccountAddSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/AutoProvisionKeyOnAccountAddSettings.tsx
@@ -16,8 +16,8 @@ export default function AutoProvisionKeyOnAccountAddSettings() {
     useUserPreferencesContext()
 
   const handleToggle = async (enabled: boolean) => {
-    const success = await updateAutoProvisionKeyOnAccountAdd(enabled)
-    showUpdateToast(success, t("autoProvisionKeyOnAccountAdd.toggleLabel"))
+    const writeResult = await updateAutoProvisionKeyOnAccountAdd(enabled)
+    showUpdateToast(writeResult, t("autoProvisionKeyOnAccountAdd.toggleLabel"))
   }
 
   return (

--- a/src/features/BasicSettings/components/tabs/AccountManagement/DuplicateAccountWarningOnAddSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/DuplicateAccountWarningOnAddSettings.tsx
@@ -16,8 +16,8 @@ export default function DuplicateAccountWarningOnAddSettings() {
     useUserPreferencesContext()
 
   const handleToggle = async (enabled: boolean) => {
-    const success = await updateWarnOnDuplicateAccountAdd(enabled)
-    showUpdateToast(success, t("duplicateAccountWarningOnAdd.toggleLabel"))
+    const writeResult = await updateWarnOnDuplicateAccountAdd(enabled)
+    showUpdateToast(writeResult, t("duplicateAccountWarningOnAdd.toggleLabel"))
   }
 
   return (

--- a/src/features/BasicSettings/components/tabs/AccountManagement/SortingPrioritySettings/index.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/SortingPrioritySettings/index.tsx
@@ -96,13 +96,13 @@ export default function SortingPrioritySettings() {
 
       // 立即保存
       if (initialConfig) {
-        const success = await updateSortingPriorityConfig({
+        const writeResult = await updateSortingPriorityConfig({
           ...initialConfig,
           criteria: updatedItems,
           lastModified: Date.now(),
         })
-        if (success) {
-          showUpdateToast(success, t("sorting.title"))
+        if (writeResult.ok) {
+          showUpdateToast(writeResult, t("sorting.title"))
         }
       }
     }
@@ -117,13 +117,13 @@ export default function SortingPrioritySettings() {
 
     // 立即保存
     if (initialConfig) {
-      const success = await updateSortingPriorityConfig({
+      const writeResult = await updateSortingPriorityConfig({
         ...initialConfig,
         criteria: updatedItems,
         lastModified: Date.now(),
       })
-      if (success) {
-        showUpdateToast(success, t("sorting.title"))
+      if (writeResult.ok) {
+        showUpdateToast(writeResult, t("sorting.title"))
       }
     }
   }

--- a/src/features/BasicSettings/components/tabs/AccountManagement/SortingPrioritySettings/index.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/SortingPrioritySettings/index.tsx
@@ -72,6 +72,14 @@ export default function SortingPrioritySettings() {
   } = useUserPreferencesContext()
   const [items, setItems] = useState<SortingFieldConfig[]>([])
 
+  const resetItemsFromInitialConfig = () => {
+    setItems(
+      initialConfig?.criteria
+        ? [...initialConfig.criteria].sort((a, b) => a.priority - b.priority)
+        : [],
+    )
+  }
+
   useEffect(() => {
     if (initialConfig?.criteria) {
       // Sort items based on priority for consistent display
@@ -101,8 +109,9 @@ export default function SortingPrioritySettings() {
           criteria: updatedItems,
           lastModified: Date.now(),
         })
-        if (writeResult.ok) {
-          showUpdateToast(writeResult, t("sorting.title"))
+        showUpdateToast(writeResult, t("sorting.title"))
+        if (!writeResult.ok) {
+          resetItemsFromInitialConfig()
         }
       }
     }
@@ -122,8 +131,9 @@ export default function SortingPrioritySettings() {
         criteria: updatedItems,
         lastModified: Date.now(),
       })
-      if (writeResult.ok) {
-        showUpdateToast(writeResult, t("sorting.title"))
+      showUpdateToast(writeResult, t("sorting.title"))
+      if (!writeResult.ok) {
+        resetItemsFromInitialConfig()
       }
     }
   }

--- a/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
+++ b/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
@@ -71,14 +71,14 @@ export default function BalanceHistorySettings() {
     let toastId: string | undefined
     try {
       toastId = toast.loading(t("messages.loading.savingSettings"))
-      const success = await updateBalanceHistory({
+      const writeResult = await updateBalanceHistory({
         enabled,
         endOfDayCapture: { enabled: endOfDayCaptureEnabled },
         estimatedTodayIncome: { enabled: estimatedTodayIncomeEnabled },
         retentionDays: safeRetentionDays,
       })
 
-      if (!success) {
+      if (!writeResult.ok) {
         toast.error(t("settings:messages.saveSettingsFailed"), { id: toastId })
         return
       }

--- a/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
+++ b/src/features/BasicSettings/components/tabs/BalanceHistory/BalanceHistorySettings.tsx
@@ -19,6 +19,7 @@ import { hasAlarmsAPI, sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { isDevelopmentMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
+import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 
 const logger = createLogger("BalanceHistorySettings")
 
@@ -79,7 +80,12 @@ export default function BalanceHistorySettings() {
       })
 
       if (!writeResult.ok) {
-        toast.error(t("settings:messages.saveSettingsFailed"), { id: toastId })
+        toast.error(
+          getPreferenceWriteFailureMessage(writeResult.reason, {
+            fallback: t("settings:messages.saveSettingsFailed"),
+          }),
+          { id: toastId },
+        )
         return
       }
 

--- a/src/features/BasicSettings/components/tabs/CheckinRedeem/AutoCheckinSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/CheckinRedeem/AutoCheckinSettings.tsx
@@ -79,9 +79,9 @@ export default function AutoCheckinSettings() {
   const savePreferences = async (updates: Partial<AutoCheckinPreferences>) => {
     try {
       setIsSaving(true)
-      const success = await updateAutoCheckin(updates)
+      const writeResult = await updateAutoCheckin(updates)
 
-      if (success) {
+      if (writeResult.ok) {
         toast.success(t("autoCheckin:messages.success.settingsSaved"))
       } else {
         toast.error(t("settings:messages.saveSettingsFailed"))
@@ -170,7 +170,7 @@ export default function AutoCheckinSettings() {
       description={t("autoCheckin:description")}
       onReset={async () => {
         const result = await resetAutoCheckinConfig()
-        if (result) {
+        if (result.ok) {
           setIsSaving(false)
         }
         return result

--- a/src/features/BasicSettings/components/tabs/CheckinRedeem/AutoCheckinSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/CheckinRedeem/AutoCheckinSettings.tsx
@@ -27,6 +27,7 @@ import {
   AutoCheckinPreferences,
 } from "~/types/autoCheckin"
 import { createLogger } from "~/utils/core/logger"
+import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 import { pushWithinOptionsPage } from "~/utils/navigation"
 
 /**
@@ -84,7 +85,11 @@ export default function AutoCheckinSettings() {
       if (writeResult.ok) {
         toast.success(t("autoCheckin:messages.success.settingsSaved"))
       } else {
-        toast.error(t("settings:messages.saveSettingsFailed"))
+        toast.error(
+          getPreferenceWriteFailureMessage(writeResult.reason, {
+            fallback: t("settings:messages.saveSettingsFailed"),
+          }),
+        )
       }
     } catch (error) {
       logger.error("Failed to save preferences", error)

--- a/src/features/BasicSettings/components/tabs/CheckinRedeem/RedemptionAssistSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/CheckinRedeem/RedemptionAssistSettings.tsx
@@ -16,6 +16,7 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
+import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 
 /**
  * Unified logger scoped to the Basic Settings redemption assist section.
@@ -62,7 +63,11 @@ export default function RedemptionAssistSettings() {
       if (writeResult.ok) {
         toast.success(t("redemptionAssist:messages.success.settingsSaved"))
       } else {
-        toast.error(t("settings:messages.saveSettingsFailed"))
+        toast.error(
+          getPreferenceWriteFailureMessage(writeResult.reason, {
+            fallback: t("settings:messages.saveSettingsFailed"),
+          }),
+        )
       }
     } catch (error) {
       const msg = getErrorMessage(error)

--- a/src/features/BasicSettings/components/tabs/CheckinRedeem/RedemptionAssistSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/CheckinRedeem/RedemptionAssistSettings.tsx
@@ -57,9 +57,9 @@ export default function RedemptionAssistSettings() {
   ) => {
     try {
       setIsSaving(true)
-      const success = await updateRedemptionAssist(updates)
+      const writeResult = await updateRedemptionAssist(updates)
 
-      if (success) {
+      if (writeResult.ok) {
         toast.success(t("redemptionAssist:messages.success.settingsSaved"))
       } else {
         toast.error(t("settings:messages.saveSettingsFailed"))
@@ -83,7 +83,7 @@ export default function RedemptionAssistSettings() {
       description={t("redemptionAssist:settings.description")}
       onReset={async () => {
         const result = await resetRedemptionAssistConfig()
-        if (result) {
+        if (result.ok) {
           setIsSaving(false)
         }
         return result

--- a/src/features/BasicSettings/components/tabs/ClaudeCodeRouter/ClaudeCodeRouterSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ClaudeCodeRouter/ClaudeCodeRouterSettings.tsx
@@ -5,7 +5,7 @@ import { SettingSection } from "~/components/SettingSection"
 import { Card, CardItem, CardList, Input } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
-import { showUpdateToast } from "~/utils/core/toastHelpers"
+import { runPreferenceUpdateWithToast } from "~/utils/core/toastHelpers"
 
 /**
  * Settings section for configuring Claude Code Router admin API connection.
@@ -42,18 +42,20 @@ export default function ClaudeCodeRouterSettings() {
 
   const handleBaseUrlChange = async (url: string) => {
     if (url === claudeCodeRouterBaseUrl) return
-    const success = await updateClaudeCodeRouterBaseUrl(url, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("settings:claudeCodeRouter.baseUrlLabel"),
+      update: (options) => updateClaudeCodeRouterBaseUrl(url, options),
     })
-    showUpdateToast(success, t("settings:claudeCodeRouter.baseUrlLabel"))
   }
 
   const handleKeyChange = async (key: string) => {
     if (key === claudeCodeRouterApiKey) return
-    const success = await updateClaudeCodeRouterApiKey(key, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("settings:claudeCodeRouter.apiKeyLabel"),
+      update: (options) => updateClaudeCodeRouterApiKey(key, options),
     })
-    showUpdateToast(success, t("settings:claudeCodeRouter.apiKeyLabel"))
   }
 
   return (

--- a/src/features/BasicSettings/components/tabs/CliProxy/CliProxySettings.tsx
+++ b/src/features/BasicSettings/components/tabs/CliProxy/CliProxySettings.tsx
@@ -6,7 +6,10 @@ import { Button, Card, CardItem, CardList, Input, Link } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { verifyCliProxyManagementConnection } from "~/services/integrations/cliProxyService"
-import { showResultToast, showUpdateToast } from "~/utils/core/toastHelpers"
+import {
+  runPreferenceUpdateWithToast,
+  showResultToast,
+} from "~/utils/core/toastHelpers"
 
 const CLI_PROXY_MANAGEMENT_DOC_URL = "https://help.router-for.me/management/api"
 
@@ -77,12 +80,13 @@ export default function CliProxySettings() {
     setLocalConfig((prev) => ({ ...prev, baseUrl: trimmedUrl }))
 
     if (trimmedUrl === cliProxyBaseUrl.trim()) return
-    const success = await updateCliProxyBaseUrl(trimmedUrl, {
+    const writeResult = await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("cliProxy.baseUrlLabel"),
+      update: (options) => updateCliProxyBaseUrl(trimmedUrl, options),
     })
-    showUpdateToast(success, t("cliProxy.baseUrlLabel"))
 
-    if (success && trimmedUrl && localKey.trim()) {
+    if (writeResult.ok && trimmedUrl && localKey.trim()) {
       await runConnectionCheckWithToast({
         baseUrl: trimmedUrl,
         managementKey: localKey,
@@ -95,12 +99,13 @@ export default function CliProxySettings() {
     setLocalConfig((prev) => ({ ...prev, managementKey: trimmedKey }))
 
     if (trimmedKey === cliProxyManagementKey.trim()) return
-    const success = await updateCliProxyManagementKey(trimmedKey, {
+    const writeResult = await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("cliProxy.managementKeyLabel"),
+      update: (options) => updateCliProxyManagementKey(trimmedKey, options),
     })
-    showUpdateToast(success, t("cliProxy.managementKeyLabel"))
 
-    if (success && localBaseUrl.trim() && trimmedKey) {
+    if (writeResult.ok && localBaseUrl.trim() && trimmedKey) {
       await runConnectionCheckWithToast({
         baseUrl: localBaseUrl,
         managementKey: trimmedKey,

--- a/src/features/BasicSettings/components/tabs/General/ActionClickBehaviorSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/ActionClickBehaviorSettings.tsx
@@ -25,9 +25,9 @@ export default function ActionClickBehaviorSettings() {
 
   const handleChange = async (behavior: ToolbarActionClickBehavior) => {
     if (behavior === actionClickBehavior) return
-    const success = await updateActionClickBehavior(behavior)
-    if (!success) {
-      showUpdateToast(false, t("actionClick.title"))
+    const writeResult = await updateActionClickBehavior(behavior)
+    if (!writeResult.ok) {
+      showUpdateToast(writeResult, t("actionClick.title"))
       return
     }
 
@@ -39,7 +39,7 @@ export default function ActionClickBehaviorSettings() {
       return
     }
 
-    showUpdateToast(true, t("actionClick.title"))
+    showUpdateToast(writeResult, t("actionClick.title"))
   }
 
   return (

--- a/src/features/BasicSettings/components/tabs/General/ChangelogOnUpdateSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/ChangelogOnUpdateSettings.tsx
@@ -16,8 +16,8 @@ export default function ChangelogOnUpdateSettings() {
     useUserPreferencesContext()
 
   const handleToggle = async (enabled: boolean) => {
-    const success = await updateOpenChangelogOnUpdate(enabled)
-    showUpdateToast(success, t("changelogOnUpdate.toggleLabel"))
+    const writeResult = await updateOpenChangelogOnUpdate(enabled)
+    showUpdateToast(writeResult, t("changelogOnUpdate.toggleLabel"))
   }
 
   return (

--- a/src/features/BasicSettings/components/tabs/General/DisplaySettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/DisplaySettings.tsx
@@ -30,20 +30,20 @@ export default function DisplaySettings() {
 
   const handleCurrencyChange = async (currency: CurrencyType) => {
     if (currency === currencyType) return
-    const success = await updateCurrencyType(currency)
-    showUpdateToast(success, t("display.currencyUnit"))
+    const writeResult = await updateCurrencyType(currency)
+    showUpdateToast(writeResult, t("display.currencyUnit"))
   }
 
   const handleDefaultTabChange = async (tab: DashboardTabType) => {
     if (!showTodayCashflow && tab === DATA_TYPE_CASHFLOW) return
     if (tab === activeTab) return
-    const success = await updateDefaultTab(tab)
-    showUpdateToast(success, t("display.defaultTab"))
+    const writeResult = await updateDefaultTab(tab)
+    showUpdateToast(writeResult, t("display.defaultTab"))
   }
 
   const handleTodayCashflowToggle = async (enabled: boolean) => {
-    const success = await updateShowTodayCashflow(enabled)
-    showUpdateToast(success, t("display.todayCashflowEnabled"))
+    const writeResult = await updateShowTodayCashflow(enabled)
+    showUpdateToast(writeResult, t("display.todayCashflowEnabled"))
   }
 
   return (

--- a/src/features/BasicSettings/components/tabs/General/LoggingSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/LoggingSettings.tsx
@@ -51,15 +51,15 @@ export default function LoggingSettings() {
   } = useUserPreferencesContext()
 
   const handleConsoleToggle = async (enabled: boolean) => {
-    const success = await updateLoggingConsoleEnabled(enabled)
-    showUpdateToast(success, t("logging.consoleEnabled"))
+    const writeResult = await updateLoggingConsoleEnabled(enabled)
+    showUpdateToast(writeResult, t("logging.consoleEnabled"))
   }
 
   const handleLevelChange = async (level: string) => {
     const nextLevel = level as LogLevel
     if (nextLevel === loggingLevel) return
-    const success = await updateLoggingLevel(nextLevel)
-    showUpdateToast(success, t("logging.minLevel"))
+    const writeResult = await updateLoggingLevel(nextLevel)
+    showUpdateToast(writeResult, t("logging.minLevel"))
   }
 
   return (

--- a/src/features/BasicSettings/components/tabs/General/ResetSettingsSection.tsx
+++ b/src/features/BasicSettings/components/tabs/General/ResetSettingsSection.tsx
@@ -35,8 +35,8 @@ export default function ResetSettingsSection() {
   const handleResetConfirm = async () => {
     setIsResetting(true)
     try {
-      const success = await resetToDefaults()
-      showResetToast(success)
+      const result = await resetToDefaults()
+      showResetToast(result.ok)
     } finally {
       setIsResetting(false)
       setIsConfirmDialogOpen(false)

--- a/src/features/BasicSettings/components/tabs/General/SiteAnnouncementNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/SiteAnnouncementNotificationSettings.tsx
@@ -59,8 +59,8 @@ export default function SiteAnnouncementNotificationSettings() {
   }, [siteAnnouncementNotifications.intervalMinutes])
 
   const handleToggle = async (enabled: boolean) => {
-    const success = await updateSiteAnnouncementNotifications({ enabled })
-    showUpdateToast(success, t("siteAnnouncementNotifications.polling.enable"))
+    const response = await updateSiteAnnouncementNotifications({ enabled })
+    showUpdateToast(response, t("siteAnnouncementNotifications.polling.enable"))
   }
 
   const handleIntervalBlur = async () => {
@@ -75,19 +75,19 @@ export default function SiteAnnouncementNotificationSettings() {
       return
     }
 
-    let success = false
+    let response = { success: false }
     try {
-      success = await updateSiteAnnouncementNotifications({
+      response = await updateSiteAnnouncementNotifications({
         intervalMinutes,
       })
     } catch {
-      success = false
+      response = { success: false }
     }
-    if (!success) {
+    if (!response.success) {
       setIntervalInput(String(siteAnnouncementNotifications.intervalMinutes))
     }
     showUpdateToast(
-      success,
+      response,
       t("siteAnnouncementNotifications.polling.interval"),
     )
   }

--- a/src/features/BasicSettings/components/tabs/ManagedSite/AxonHubSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/AxonHubSettings.tsx
@@ -8,7 +8,11 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { signIn } from "~/services/apiService/axonHub"
 import { getErrorMessage } from "~/utils/core/error"
-import { showUpdateToast } from "~/utils/core/toastHelpers"
+import {
+  createVersionedPreferenceSaveOptions,
+  getPreferenceWriteFailureMessage,
+  runPreferenceUpdateWithToast,
+} from "~/utils/core/toastHelpers"
 
 const isLikelyCorsSetupError = (message: string) =>
   /cors|failed to fetch|network|http 403|forbidden/i.test(message)
@@ -51,27 +55,30 @@ export default function AxonHubSettings() {
   const handleBaseUrlChange = async (url: string) => {
     const trimmedUrl = url.trim()
     if (trimmedUrl === axonHubBaseUrl) return
-    const success = await updateAxonHubBaseUrl(trimmedUrl, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("axonHub.fields.baseUrlLabel"),
+      update: (options) => updateAxonHubBaseUrl(trimmedUrl, options),
     })
-    showUpdateToast(success, t("axonHub.fields.baseUrlLabel"))
   }
 
   const handleEmailChange = async (email: string) => {
     const trimmedEmail = email.trim()
     if (trimmedEmail === axonHubEmail) return
-    const success = await updateAxonHubEmail(trimmedEmail, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("axonHub.fields.emailLabel"),
+      update: (options) => updateAxonHubEmail(trimmedEmail, options),
     })
-    showUpdateToast(success, t("axonHub.fields.emailLabel"))
   }
 
   const handlePasswordChange = async (password: string) => {
     if (password === axonHubPassword) return
-    const success = await updateAxonHubPassword(password, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("axonHub.fields.passwordLabel"),
+      update: (options) => updateAxonHubPassword(password, options),
     })
-    showUpdateToast(success, t("axonHub.fields.passwordLabel"))
   }
 
   const handleValidateConfig = async () => {
@@ -97,22 +104,24 @@ export default function AxonHubSettings() {
         password: localConfig.password,
       })
 
-      const success = await updateAxonHubConfig(
+      const saveResult = await updateAxonHubConfig(
         {
           baseUrl: trimmedUrl,
           email: trimmedEmail,
           password: localConfig.password,
         },
-        {
-          expectedLastUpdated,
-        },
+        createVersionedPreferenceSaveOptions(expectedLastUpdated),
       )
 
-      toast[success ? "success" : "error"](
-        success
-          ? t("axonHub.validation.success")
-          : t("messages.updateFailed", { name: t("axonHub.title") }),
-      )
+      if (saveResult.ok) {
+        toast.success(t("axonHub.validation.success"))
+      } else {
+        toast.error(
+          getPreferenceWriteFailureMessage(saveResult.reason, {
+            fallback: t("messages.updateFailed", { name: t("axonHub.title") }),
+          }),
+        )
+      }
     } catch (error) {
       const errorMessage = getErrorMessage(error)
       toast.error(

--- a/src/features/BasicSettings/components/tabs/ManagedSite/ClaudeCodeHubSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/ClaudeCodeHubSettings.tsx
@@ -8,7 +8,11 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { validateClaudeCodeHubConfig } from "~/services/apiService/claudeCodeHub"
 import { getErrorMessage } from "~/utils/core/error"
-import { showUpdateToast } from "~/utils/core/toastHelpers"
+import {
+  createVersionedPreferenceSaveOptions,
+  getPreferenceWriteFailureMessage,
+  runPreferenceUpdateWithToast,
+} from "~/utils/core/toastHelpers"
 
 /**
  * Renders Claude Code Hub settings fields and a config validation action.
@@ -45,19 +49,21 @@ export default function ClaudeCodeHubSettings() {
   const handleBaseUrlChange = async (url: string) => {
     const trimmedUrl = url.trim()
     if (trimmedUrl === claudeCodeHubBaseUrl) return
-    const success = await updateClaudeCodeHubBaseUrl(trimmedUrl, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("claudeCodeHub.fields.baseUrlLabel"),
+      update: (options) => updateClaudeCodeHubBaseUrl(trimmedUrl, options),
     })
-    showUpdateToast(success, t("claudeCodeHub.fields.baseUrlLabel"))
   }
 
   const handleTokenChange = async (token: string) => {
     const trimmedToken = token.trim()
     if (trimmedToken === claudeCodeHubAdminToken) return
-    const success = await updateClaudeCodeHubAdminToken(trimmedToken, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("claudeCodeHub.fields.adminTokenLabel"),
+      update: (options) => updateClaudeCodeHubAdminToken(trimmedToken, options),
     })
-    showUpdateToast(success, t("claudeCodeHub.fields.adminTokenLabel"))
   }
 
   const handleValidateConfig = async () => {
@@ -82,21 +88,25 @@ export default function ClaudeCodeHubSettings() {
         adminToken,
       })
 
-      const success = await updateClaudeCodeHubConfig(
+      const saveResult = await updateClaudeCodeHubConfig(
         {
           baseUrl: trimmedUrl,
           adminToken,
         },
-        {
-          expectedLastUpdated,
-        },
+        createVersionedPreferenceSaveOptions(expectedLastUpdated),
       )
 
-      toast[success ? "success" : "error"](
-        success
-          ? t("claudeCodeHub.validation.success")
-          : t("messages.updateFailed", { name: t("claudeCodeHub.title") }),
-      )
+      if (saveResult.ok) {
+        toast.success(t("claudeCodeHub.validation.success"))
+      } else {
+        toast.error(
+          getPreferenceWriteFailureMessage(saveResult.reason, {
+            fallback: t("messages.updateFailed", {
+              name: t("claudeCodeHub.title"),
+            }),
+          }),
+        )
+      }
     } catch (error) {
       toast.error(
         t("claudeCodeHub.validation.failed", {

--- a/src/features/BasicSettings/components/tabs/ManagedSite/DoneHubSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/DoneHubSettings.tsx
@@ -14,7 +14,7 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { isManagedSiteAdminUserIdInputValid } from "~/services/managedSites/utils/adminUserId"
 import { createTab } from "~/utils/browser/browserApi"
-import { showUpdateToast } from "~/utils/core/toastHelpers"
+import { runPreferenceUpdateWithToast } from "~/utils/core/toastHelpers"
 import { joinUrl } from "~/utils/core/url"
 
 /**
@@ -57,18 +57,20 @@ export default function DoneHubSettings() {
   const handleBaseUrlChange = async (url: string) => {
     const clean = url.trim()
     if (clean === doneHubBaseUrl) return
-    const success = await updateDoneHubBaseUrl(clean, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("doneHub.fields.baseUrlLabel"),
+      update: (options) => updateDoneHubBaseUrl(clean, options),
     })
-    showUpdateToast(success, t("doneHub.fields.baseUrlLabel"))
   }
 
   const handleAdminTokenChange = async (token: string) => {
     if (token === doneHubAdminToken) return
-    const success = await updateDoneHubAdminToken(token, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("doneHub.fields.adminTokenLabel"),
+      update: (options) => updateDoneHubAdminToken(token, options),
     })
-    showUpdateToast(success, t("doneHub.fields.adminTokenLabel"))
   }
 
   const handleUserIdChange = async (id: string) => {
@@ -77,10 +79,11 @@ export default function DoneHubSettings() {
 
     setLocalConfig((prev) => ({ ...prev, userId: trimmedId }))
     if (trimmedId === doneHubUserId) return
-    const success = await updateDoneHubUserId(trimmedId, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("doneHub.fields.userIdLabel"),
+      update: (options) => updateDoneHubUserId(trimmedId, options),
     })
-    showUpdateToast(success, t("doneHub.fields.userIdLabel"))
   }
 
   const trimmedBaseUrl = localBaseUrl.trim()

--- a/src/features/BasicSettings/components/tabs/ManagedSite/ModelRedirectSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/ModelRedirectSettings.tsx
@@ -70,8 +70,8 @@ export default function ModelRedirectSettings() {
   const handleUpdate = async (updates: Record<string, unknown>) => {
     try {
       setIsUpdating(true)
-      const success = await updateModelRedirect(updates)
-      if (!success) {
+      const writeResult = await updateModelRedirect(updates)
+      if (!writeResult.ok) {
         toast.error(t("messages.updateFailed"))
         return
       }

--- a/src/features/BasicSettings/components/tabs/ManagedSite/ModelRedirectSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/ModelRedirectSettings.tsx
@@ -14,6 +14,7 @@ import { getManagedSiteAdminConfig } from "~/services/managedSites/utils/managed
 import { ModelRedirectService } from "~/services/models/modelRedirect"
 import { ALL_PRESET_STANDARD_MODELS } from "~/types/managedSiteModelRedirect"
 import { createLogger } from "~/utils/core/logger"
+import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 
 import { ClearModelRedirectMappingsDialog } from "../../dialogs/ClearModelRedirectMappingsDialog"
 
@@ -72,7 +73,11 @@ export default function ModelRedirectSettings() {
       setIsUpdating(true)
       const writeResult = await updateModelRedirect(updates)
       if (!writeResult.ok) {
-        toast.error(t("messages.updateFailed"))
+        toast.error(
+          getPreferenceWriteFailureMessage(writeResult.reason, {
+            fallback: t("messages.updateFailed"),
+          }),
+        )
         return
       }
       toast.success(t("messages.updateSuccess"))

--- a/src/features/BasicSettings/components/tabs/ManagedSite/NewApiSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/NewApiSettings.tsx
@@ -21,7 +21,7 @@ import {
 } from "~/services/accounts/utils/siteRouteResolver"
 import { isManagedSiteAdminUserIdInputValid } from "~/services/managedSites/utils/adminUserId"
 import { createTab } from "~/utils/browser/browserApi"
-import { showUpdateToast } from "~/utils/core/toastHelpers"
+import { runPreferenceUpdateWithToast } from "~/utils/core/toastHelpers"
 
 /**
  * Settings panel for configuring New API connection credentials (base URL, admin token, user ID).
@@ -82,18 +82,20 @@ export default function NewApiSettings() {
 
   const handleNewApiBaseUrlChange = async (url: string) => {
     if (url === newApiBaseUrl) return
-    const success = await updateNewApiBaseUrl(url, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("newApi.fields.baseUrlLabel"),
+      update: (options) => updateNewApiBaseUrl(url, options),
     })
-    showUpdateToast(success, t("newApi.fields.baseUrlLabel"))
   }
 
   const handleNewApiAdminTokenChange = async (token: string) => {
     if (token === newApiAdminToken) return
-    const success = await updateNewApiAdminToken(token, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("newApi.fields.adminTokenLabel"),
+      update: (options) => updateNewApiAdminToken(token, options),
     })
-    showUpdateToast(success, t("newApi.fields.adminTokenLabel"))
   }
 
   const handleNewApiUserIdChange = async (id: string) => {
@@ -102,38 +104,42 @@ export default function NewApiSettings() {
 
     setLocalConfig((prev) => ({ ...prev, userId: trimmedId }))
     if (trimmedId === newApiUserId) return
-    const success = await updateNewApiUserId(trimmedId, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("newApi.fields.userIdLabel"),
+      update: (options) => updateNewApiUserId(trimmedId, options),
     })
-    showUpdateToast(success, t("newApi.fields.userIdLabel"))
   }
 
   const handleNewApiUsernameChange = async (username: string) => {
     const trimmedUsername = username.trim()
     setLocalConfig((prev) => ({ ...prev, username: trimmedUsername }))
     if (trimmedUsername === newApiUsername) return
-    const success = await updateNewApiUsername(trimmedUsername, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("newApi.fields.usernameLabel"),
+      update: (options) => updateNewApiUsername(trimmedUsername, options),
     })
-    showUpdateToast(success, t("newApi.fields.usernameLabel"))
   }
 
   const handleNewApiPasswordChange = async (password: string) => {
     if (password === newApiPassword) return
-    const success = await updateNewApiPassword(password, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("newApi.fields.passwordLabel"),
+      update: (options) => updateNewApiPassword(password, options),
     })
-    showUpdateToast(success, t("newApi.fields.passwordLabel"))
   }
 
   const handleNewApiTotpSecretChange = async (totpSecret: string) => {
     const trimmedTotpSecret = totpSecret.trim()
     setLocalConfig((prev) => ({ ...prev, totpSecret: trimmedTotpSecret }))
     if (trimmedTotpSecret === newApiTotpSecret) return
-    const success = await updateNewApiTotpSecret(trimmedTotpSecret, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("newApi.fields.totpSecretLabel"),
+      update: (options) => updateNewApiTotpSecret(trimmedTotpSecret, options),
     })
-    showUpdateToast(success, t("newApi.fields.totpSecretLabel"))
   }
 
   const trimmedBaseUrl = localBaseUrl.trim()

--- a/src/features/BasicSettings/components/tabs/ManagedSite/OctopusSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/OctopusSettings.tsx
@@ -7,7 +7,11 @@ import { Button, Card, CardItem, CardList, Input } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { octopusAuthManager } from "~/services/apiService/octopus/auth"
-import { showUpdateToast } from "~/utils/core/toastHelpers"
+import {
+  createVersionedPreferenceSaveOptions,
+  getPreferenceWriteFailureMessage,
+  runPreferenceUpdateWithToast,
+} from "~/utils/core/toastHelpers"
 
 /**
  * Settings panel for configuring Octopus connection credentials (base URL, username, password).
@@ -49,30 +53,33 @@ export default function OctopusSettings() {
   const localPassword = localConfig.password
 
   const handleBaseUrlChange = async (url: string) => {
-    url = url.trim()
-    if (url === octopusBaseUrl) return
-    const success = await updateOctopusBaseUrl(url, {
+    const trimmedUrl = url.trim()
+    if (trimmedUrl === octopusBaseUrl) return
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("octopus.fields.baseUrlLabel"),
+      update: (options) => updateOctopusBaseUrl(trimmedUrl, options),
     })
-    showUpdateToast(success, t("octopus.fields.baseUrlLabel"))
   }
 
   const handleUsernameChange = async (username: string) => {
-    username = username.trim()
-    if (username === octopusUsername) return
-    const success = await updateOctopusUsername(username, {
+    const trimmedUsername = username.trim()
+    if (trimmedUsername === octopusUsername) return
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("octopus.fields.usernameLabel"),
+      update: (options) => updateOctopusUsername(trimmedUsername, options),
     })
-    showUpdateToast(success, t("octopus.fields.usernameLabel"))
   }
 
   const handlePasswordChange = async (password: string) => {
-    password = password.trim()
-    if (password === octopusPassword) return
-    const success = await updateOctopusPassword(password, {
+    const trimmedPassword = password.trim()
+    if (trimmedPassword === octopusPassword) return
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("octopus.fields.passwordLabel"),
+      update: (options) => updateOctopusPassword(trimmedPassword, options),
     })
-    showUpdateToast(success, t("octopus.fields.passwordLabel"))
   }
 
   const handleValidateConfig = async () => {
@@ -85,7 +92,6 @@ export default function OctopusSettings() {
       return
     }
 
-    // Persist trimmed values to ensure stored inputs match validated values
     setLocalConfig((prev) => ({
       ...prev,
       baseUrl: trimmedUrl,
@@ -102,22 +108,19 @@ export default function OctopusSettings() {
       })
 
       if (result.success) {
-        // Persist validated config to storage
-        const success = await updateOctopusConfig(
+        const saveResult = await updateOctopusConfig(
           {
             baseUrl: trimmedUrl,
             username: trimmedUsername,
             password: trimmedPassword,
           },
-          {
-            expectedLastUpdated,
-          },
+          createVersionedPreferenceSaveOptions(expectedLastUpdated),
         )
 
-        if (success) {
+        if (saveResult.ok) {
           toast.success(t("octopus.validation.success"))
         } else {
-          toast.error(t("settings:messages.updateFailed"))
+          toast.error(getPreferenceWriteFailureMessage(saveResult.reason))
         }
       } else {
         toast.error(result.error || t("octopus.validation.failed"))

--- a/src/features/BasicSettings/components/tabs/ManagedSite/OctopusSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/OctopusSettings.tsx
@@ -120,7 +120,11 @@ export default function OctopusSettings() {
         if (saveResult.ok) {
           toast.success(t("octopus.validation.success"))
         } else {
-          toast.error(getPreferenceWriteFailureMessage(saveResult.reason))
+          toast.error(
+            getPreferenceWriteFailureMessage(saveResult.reason, {
+              fallback: t("octopus.validation.failed"),
+            }),
+          )
         }
       } else {
         toast.error(result.error || t("octopus.validation.failed"))

--- a/src/features/BasicSettings/components/tabs/ManagedSite/VeloeraSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/VeloeraSettings.tsx
@@ -14,7 +14,7 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { isManagedSiteAdminUserIdInputValid } from "~/services/managedSites/utils/adminUserId"
 import { createTab } from "~/utils/browser/browserApi"
-import { showUpdateToast } from "~/utils/core/toastHelpers"
+import { runPreferenceUpdateWithToast } from "~/utils/core/toastHelpers"
 import { joinUrl } from "~/utils/core/url"
 
 /**
@@ -59,10 +59,11 @@ export default function VeloeraSettings() {
     setLocalConfig((prev) => ({ ...prev, baseUrl: trimmedUrl }))
 
     if (trimmedUrl === veloeraBaseUrl.trim()) return
-    const success = await updateVeloeraBaseUrl(trimmedUrl, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("veloera.fields.baseUrlLabel"),
+      update: (options) => updateVeloeraBaseUrl(trimmedUrl, options),
     })
-    showUpdateToast(success, t("veloera.fields.baseUrlLabel"))
   }
 
   const handleVeloeraAdminTokenChange = async (token: string) => {
@@ -70,10 +71,11 @@ export default function VeloeraSettings() {
     setLocalConfig((prev) => ({ ...prev, adminToken: trimmedToken }))
 
     if (trimmedToken === veloeraAdminToken.trim()) return
-    const success = await updateVeloeraAdminToken(trimmedToken, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("veloera.fields.adminTokenLabel"),
+      update: (options) => updateVeloeraAdminToken(trimmedToken, options),
     })
-    showUpdateToast(success, t("veloera.fields.adminTokenLabel"))
   }
 
   const handleVeloeraUserIdChange = async (id: string) => {
@@ -82,10 +84,11 @@ export default function VeloeraSettings() {
 
     setLocalConfig((prev) => ({ ...prev, userId: trimmedId }))
     if (trimmedId === veloeraUserId.trim()) return
-    const success = await updateVeloeraUserId(trimmedId, {
+    await runPreferenceUpdateWithToast({
       expectedLastUpdated,
+      setting: t("veloera.fields.userIdLabel"),
+      update: (options) => updateVeloeraUserId(trimmedId, options),
     })
-    showUpdateToast(success, t("veloera.fields.userIdLabel"))
   }
 
   const trimmedBaseUrl = localBaseUrl.trim()

--- a/src/features/BasicSettings/components/tabs/ManagedSite/managedSiteModelSyncSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/managedSiteModelSyncSettings.tsx
@@ -45,6 +45,7 @@ import type { ManagedSiteModelSyncPreferences } from "~/types/managedSiteModelSy
 import { getErrorMessage } from "~/utils/core/error"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
+import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 import { pushWithinOptionsPage } from "~/utils/navigation"
 
 import { MANAGED_SITE_MODEL_SYNC_CHANNEL_PROCESSING_TIMEOUT_TARGET_ID } from "./managedSiteModelSyncTargetIds"
@@ -265,7 +266,11 @@ export default function ManagedSiteModelSyncSettings() {
 
       if (!writeResult.ok) {
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure)
-        toast.error(t("settings:messages.saveSettingsFailed"))
+        toast.error(
+          getPreferenceWriteFailureMessage(writeResult.reason, {
+            fallback: t("settings:messages.saveSettingsFailed"),
+          }),
+        )
         return false
       } else if (!updates.globalChannelModelFilters) {
         // Avoid double toast when saving from the global filters dialog,

--- a/src/features/BasicSettings/components/tabs/ManagedSite/managedSiteModelSyncSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/managedSiteModelSyncSettings.tsx
@@ -261,9 +261,9 @@ export default function ManagedSiteModelSyncSettings() {
           updates.globalChannelModelFilters
       }
 
-      const success = await updateNewApiModelSync(userPrefsUpdate)
+      const writeResult = await updateNewApiModelSync(userPrefsUpdate)
 
-      if (!success) {
+      if (!writeResult.ok) {
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure)
         toast.error(t("settings:messages.saveSettingsFailed"))
         return false
@@ -482,10 +482,10 @@ export default function ManagedSiteModelSyncSettings() {
         },
       )
 
-      const success = await savePreferences({
+      const saved = await savePreferences({
         globalChannelModelFilters: payload,
       })
-      if (!success) {
+      if (!saved) {
         return
       }
       setGlobalChannelModelFiltersDraft(payload)
@@ -522,11 +522,11 @@ export default function ManagedSiteModelSyncSettings() {
         )
         const result = await resetNewApiModelSyncConfig()
         tracker.complete(
-          result
+          result.ok
             ? PRODUCT_ANALYTICS_RESULTS.Success
             : PRODUCT_ANALYTICS_RESULTS.Failure,
         )
-        if (result) setIsSaving(false)
+        if (result.ok) setIsSaving(false)
         return result
       }}
     >

--- a/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
@@ -258,17 +258,17 @@ export default function TaskNotificationSettings() {
   }, [refreshPermissionStatus])
 
   const handleGlobalToggle = async (enabled: boolean) => {
-    const success = await updateTaskNotifications({ enabled })
-    showUpdateToast(success, t("taskNotifications.enable"))
+    const writeResult = await updateTaskNotifications({ enabled })
+    showUpdateToast(writeResult, t("taskNotifications.enable"))
   }
 
   const handleChannelUpdate = async (
     channels: TaskNotificationChannelPreferences,
     label: string,
   ) => {
-    const success = await updateTaskNotifications({ channels })
-    showUpdateToast(success, label)
-    return success
+    const result = await updateTaskNotifications({ channels })
+    showUpdateToast(result, label)
+    return result.ok
   }
 
   const handleBrowserChannelToggle = async (enabled: boolean) => {
@@ -495,20 +495,20 @@ export default function TaskNotificationSettings() {
     task: TaskNotificationTask,
     enabled: boolean,
   ) => {
-    const success = await updateTaskNotifications({
+    const result = await updateTaskNotifications({
       tasks: {
         ...taskNotifications.tasks,
         [task]: enabled,
       },
     })
-    showUpdateToast(success, t("taskNotifications.tasksLabel"))
+    showUpdateToast(result, t("taskNotifications.tasksLabel"))
   }
 
   const handleSiteAnnouncementToggle = async (enabled: boolean) => {
-    const success = await updateSiteAnnouncementNotifications({
+    const response = await updateSiteAnnouncementNotifications({
       notificationEnabled: enabled,
     })
-    showUpdateToast(success, t("taskNotifications.siteAnnouncements.enable"))
+    showUpdateToast(response, t("taskNotifications.siteAnnouncements.enable"))
   }
 
   const saveChannelDraftBeforeTest = async (

--- a/src/features/BasicSettings/components/tabs/Refresh/RefreshSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Refresh/RefreshSettings.tsx
@@ -43,13 +43,13 @@ export default function RefreshSettings() {
   }, [minRefreshInterval])
 
   const handleAutoRefreshChange = async (value: boolean) => {
-    const success = await updateAutoRefresh(value)
-    showUpdateToast(success, t("refresh.autoRefresh"))
+    const writeResult = await updateAutoRefresh(value)
+    showUpdateToast(writeResult, t("refresh.autoRefresh"))
   }
 
   const handleRefreshOnOpenChange = async (value: boolean) => {
-    const success = await updateRefreshOnOpen(value)
-    showUpdateToast(success, t("refresh.refreshOnOpen"))
+    const writeResult = await updateRefreshOnOpen(value)
+    showUpdateToast(writeResult, t("refresh.refreshOnOpen"))
   }
 
   const handleRefreshIntervalBlur = async () => {
@@ -65,8 +65,8 @@ export default function RefreshSettings() {
     }
     if (value === refreshInterval) return
 
-    const success = await updateRefreshInterval(value)
-    showUpdateToast(success, t("refresh.refreshInterval"))
+    const writeResult = await updateRefreshInterval(value)
+    showUpdateToast(writeResult, t("refresh.refreshInterval"))
   }
 
   const handleMinRefreshIntervalBlur = async () => {
@@ -84,8 +84,8 @@ export default function RefreshSettings() {
     }
     if (value === minRefreshInterval) return
 
-    const success = await updateMinRefreshInterval(value)
-    showUpdateToast(success, t("refresh.minRefreshInterval"))
+    const writeResult = await updateMinRefreshInterval(value)
+    showUpdateToast(writeResult, t("refresh.minRefreshInterval"))
   }
 
   return (

--- a/src/features/BasicSettings/components/tabs/WebAiApiCheck/WebAiApiCheckSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/WebAiApiCheck/WebAiApiCheckSettings.tsx
@@ -18,6 +18,7 @@ import {
   type WebAiApiCheckPreferences,
 } from "~/services/preferences/userPreferences"
 import { createLogger } from "~/utils/core/logger"
+import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 
 import { WEB_AI_API_CHECK_TARGET_IDS } from "./searchTargets"
 
@@ -144,7 +145,11 @@ export default function WebAiApiCheckSettings() {
       if (writeResult.ok) {
         toast.success(t("webAiApiCheck:messages.success.settingsSaved"))
       } else {
-        toast.error(t("settings:messages.saveSettingsFailed"))
+        toast.error(
+          getPreferenceWriteFailureMessage(writeResult.reason, {
+            fallback: t("settings:messages.saveSettingsFailed"),
+          }),
+        )
       }
     } catch (error) {
       logger.error("Failed to save Web AI API Check settings", error)

--- a/src/features/BasicSettings/components/tabs/WebAiApiCheck/WebAiApiCheckSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/WebAiApiCheck/WebAiApiCheckSettings.tsx
@@ -139,9 +139,9 @@ export default function WebAiApiCheckSettings() {
   const saveSettings = async (updates: Partial<WebAiApiCheckPreferences>) => {
     try {
       setIsSaving(true)
-      const success = await updateWebAiApiCheck(updates)
+      const writeResult = await updateWebAiApiCheck(updates)
 
-      if (success) {
+      if (writeResult.ok) {
         toast.success(t("webAiApiCheck:messages.success.settingsSaved"))
       } else {
         toast.error(t("settings:messages.saveSettingsFailed"))
@@ -161,7 +161,7 @@ export default function WebAiApiCheckSettings() {
       description={t("webAiApiCheck:settings.description")}
       onReset={async () => {
         const result = await resetWebAiApiCheckConfig()
-        if (result) setIsSaving(false)
+        if (result.ok) setIsSaving(false)
         return result
       }}
     >

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -70,6 +70,7 @@ import {
   type WebDAVSyncDataSelection,
 } from "~/types/webdav"
 import { createLogger } from "~/utils/core/logger"
+import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 import { applyPreferenceLanguage } from "~/utils/i18n/applyPreferenceLanguage"
 import { t as translate } from "~/utils/i18n/core"
 
@@ -108,6 +109,16 @@ class ExistingWebdavBackupMalformedError extends Error {
     this.name = "ExistingWebdavBackupMalformedError"
     ;(this as Error & { cause?: unknown }).cause = cause
   }
+}
+
+const getPersistWebdavConfigErrorMessage = (error: unknown, t: TFunction) => {
+  if (error instanceof PersistWebdavConfigError && error.preferenceFailure) {
+    return getPreferenceWriteFailureMessage(error.preferenceFailure, {
+      fallback: t("settings:messages.saveSettingsFailed"),
+    })
+  }
+
+  return t("settings:messages.saveSettingsFailed")
 }
 
 class WebdavRebuildConfirmationRequired extends Error {
@@ -260,17 +271,19 @@ export default function WebDAVSettings() {
       return
     }
 
-    let success: boolean
+    let result
     try {
-      success = await updateWebdavSettings(updates, {
+      result = await updateWebdavSettings(updates, {
         expectedLastUpdated:
           options?.expectedLastUpdated ?? preferences.lastUpdated,
       })
     } catch (error) {
       throw new PersistWebdavConfigError(error)
     }
-    if (!success) {
-      throw new PersistWebdavConfigError()
+    if (!result.ok) {
+      throw new PersistWebdavConfigError(undefined, {
+        failure: result.reason,
+      })
     }
   }
 
@@ -291,9 +304,11 @@ export default function WebDAVSettings() {
     } catch (e) {
       logger.error("Failed to save WebDAV settings", e)
       toast.error(
-        t("settings:messages.updateFailed", {
-          name: t("webdav.title"),
-        }),
+        e instanceof PersistWebdavConfigError
+          ? getPersistWebdavConfigErrorMessage(e, t)
+          : t("settings:messages.updateFailed", {
+              name: t("webdav.title"),
+            }),
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
         errorCategory: getWebdavAnalyticsErrorCategory(e),
@@ -323,7 +338,7 @@ export default function WebDAVSettings() {
       logger.error("WebDAV connection test failed", e)
       toast.error(
         e instanceof PersistWebdavConfigError
-          ? t("settings:messages.saveSettingsFailed")
+          ? getPersistWebdavConfigErrorMessage(e, t)
           : e?.message || t("webdav.testFailed"),
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -471,7 +486,7 @@ export default function WebDAVSettings() {
       logger.error("Failed to upload backup to WebDAV", e)
       toast.error(
         e instanceof PersistWebdavConfigError
-          ? t("settings:messages.saveSettingsFailed")
+          ? getPersistWebdavConfigErrorMessage(e, t)
           : e?.message || t("webdav.uploadFailed"),
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -634,7 +649,7 @@ export default function WebDAVSettings() {
       logger.error("Failed to download/import WebDAV backup", e)
       toast.error(
         e instanceof PersistWebdavConfigError
-          ? t("settings:messages.saveSettingsFailed")
+          ? getPersistWebdavConfigErrorMessage(e, t)
           : e?.message || t("importExport:import.downloadImportFailed"),
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -737,7 +752,7 @@ export default function WebDAVSettings() {
           }))
         } catch (error) {
           logger.error("Failed to persist WebDAV decrypt password", error)
-          toast.error(t("settings:messages.saveSettingsFailed"))
+          toast.error(getPersistWebdavConfigErrorMessage(error, t))
           decryptPasswordPersistFailed = true
           decryptPasswordPersistError = error
         }

--- a/src/features/ImportExport/components/webDavAnalytics.ts
+++ b/src/features/ImportExport/components/webDavAnalytics.ts
@@ -1,3 +1,4 @@
+import type { PreferenceWriteFailure } from "~/services/preferences/userPreferences"
 import {
   resolveProductAnalyticsErrorCategoryFromError,
   type ProductAnalyticsActionContext,
@@ -19,9 +20,12 @@ export const webDavSettingsSurface =
  * distinguish save-before-action failures from remote WebDAV execution.
  */
 export class PersistWebdavConfigError extends Error {
-  constructor(cause?: unknown) {
+  readonly preferenceFailure?: PreferenceWriteFailure
+
+  constructor(cause?: unknown, options?: { failure?: PreferenceWriteFailure }) {
     super("Failed to persist WebDAV settings", { cause })
     this.name = "PersistWebdavConfigError"
+    this.preferenceFailure = options?.failure
     ;(this as Error & { cause?: unknown }).cause = cause
   }
 }

--- a/src/features/ImportExport/utils.ts
+++ b/src/features/ImportExport/utils.ts
@@ -49,6 +49,8 @@ export async function importFromBackupObject(
       switch (error.code) {
         case "FORMAT_NOT_CORRECT":
           throw new Error(t("importExport:import.formatNotCorrect"))
+        case "IMPORT_FAILED":
+          throw new Error(t("importExport:import.importFailed"))
         case "NO_IMPORTABLE_DATA":
           throw new Error(t("importExport:import.noImportableData"))
       }

--- a/src/features/ManagedSiteVerification/NewApiManagedVerificationDialog.tsx
+++ b/src/features/ManagedSiteVerification/NewApiManagedVerificationDialog.tsx
@@ -186,22 +186,22 @@ export function NewApiManagedVerificationDialog(
 
     try {
       if (needsBaseUrl && nextBaseUrl !== newApiBaseUrl) {
-        const success = await updateNewApiBaseUrl(nextBaseUrl)
-        if (!success) {
+        const writeResult = await updateNewApiBaseUrl(nextBaseUrl)
+        if (!writeResult.ok) {
           throw new Error(t("dialog.messages.quickConfigSaveFailed"))
         }
       }
 
       if (needsCredentials && nextUsername !== newApiUsername) {
-        const success = await updateNewApiUsername(nextUsername)
-        if (!success) {
+        const writeResult = await updateNewApiUsername(nextUsername)
+        if (!writeResult.ok) {
           throw new Error(t("dialog.messages.quickConfigSaveFailed"))
         }
       }
 
       if (needsCredentials && quickPassword !== newApiPassword) {
-        const success = await updateNewApiPassword(quickPassword)
-        if (!success) {
+        const writeResult = await updateNewApiPassword(quickPassword)
+        if (!writeResult.ok) {
           throw new Error(t("dialog.messages.quickConfigSaveFailed"))
         }
       }

--- a/src/features/ManagedSiteVerification/NewApiManagedVerificationDialog.tsx
+++ b/src/features/ManagedSiteVerification/NewApiManagedVerificationDialog.tsx
@@ -21,6 +21,7 @@ import {
   type OpenNewApiManagedVerificationParams,
 } from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
 import { getErrorMessage } from "~/utils/core/error"
+import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 
 const NEW_API_VERIFICATION_CODE_LENGTH = 6
 
@@ -188,21 +189,33 @@ export function NewApiManagedVerificationDialog(
       if (needsBaseUrl && nextBaseUrl !== newApiBaseUrl) {
         const writeResult = await updateNewApiBaseUrl(nextBaseUrl)
         if (!writeResult.ok) {
-          throw new Error(t("dialog.messages.quickConfigSaveFailed"))
+          throw new Error(
+            getPreferenceWriteFailureMessage(writeResult.reason, {
+              fallback: t("dialog.messages.quickConfigSaveFailed"),
+            }),
+          )
         }
       }
 
       if (needsCredentials && nextUsername !== newApiUsername) {
         const writeResult = await updateNewApiUsername(nextUsername)
         if (!writeResult.ok) {
-          throw new Error(t("dialog.messages.quickConfigSaveFailed"))
+          throw new Error(
+            getPreferenceWriteFailureMessage(writeResult.reason, {
+              fallback: t("dialog.messages.quickConfigSaveFailed"),
+            }),
+          )
         }
       }
 
       if (needsCredentials && quickPassword !== newApiPassword) {
         const writeResult = await updateNewApiPassword(quickPassword)
         if (!writeResult.ok) {
-          throw new Error(t("dialog.messages.quickConfigSaveFailed"))
+          throw new Error(
+            getPreferenceWriteFailureMessage(writeResult.reason, {
+              fallback: t("dialog.messages.quickConfigSaveFailed"),
+            }),
+          )
         }
       }
 

--- a/src/hooks/usePreferenceDraft.ts
+++ b/src/hooks/usePreferenceDraft.ts
@@ -23,6 +23,13 @@ function defaultIsEqual<T>(left: T, right: T) {
 }
 
 /**
+ * Check whether a value can be reconciled field-by-field.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+/**
  * Manage a local settings draft against a persisted preference snapshot.
  *
  * Clean drafts rehydrate automatically from storage refreshes. Dirty drafts keep
@@ -51,8 +58,36 @@ export function usePreferenceDraft<T>({
     if (isEqual(draft, savedValue)) {
       setBaselineValue(savedValue)
       setBaselineVersion(savedVersion)
+      return
     }
-  }, [draft, isDirty, isEqual, savedValue, savedVersion])
+
+    if (savedVersion <= baselineVersion) {
+      return
+    }
+
+    if (!isRecord(savedValue) || !isRecord(baselineValue) || !isRecord(draft)) {
+      return
+    }
+
+    const savedChangesMatchDraft = Object.entries(savedValue).every(
+      ([key, value]) =>
+        defaultIsEqual(value, baselineValue[key]) ||
+        defaultIsEqual(draft[key], value),
+    )
+
+    if (savedChangesMatchDraft) {
+      setBaselineValue(savedValue)
+      setBaselineVersion(savedVersion)
+    }
+  }, [
+    baselineValue,
+    baselineVersion,
+    draft,
+    isDirty,
+    isEqual,
+    savedValue,
+    savedVersion,
+  ])
 
   return {
     draft,

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -309,6 +309,7 @@
       "titleWithCookieInterceptor": "Enable protection bypass for requests"
     },
     "updateLog": {
+      "autoOpenSetting": "Update log auto-open",
       "disableAutoOpen": "Don't show after updates",
       "enableAutoOpen": "Re-enable after updates",
       "loading": "Loading changelog…",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -304,6 +304,7 @@
       "titleWithCookieInterceptor": "リクエスト用の保護回避を有効にする"
     },
     "updateLog": {
+      "autoOpenSetting": "更新ログの自動表示",
       "disableAutoOpen": "更新後に表示しない",
       "enableAutoOpen": "更新後の自動表示を再有効化",
       "loading": "更新ログを読み込み中…",

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -304,6 +304,7 @@
       "titleWithCookieInterceptor": "Bật quy trình vượt khiên để hoàn thành yêu cầu mạng"
     },
     "updateLog": {
+      "autoOpenSetting": "Tự động mở nhật ký cập nhật",
       "disableAutoOpen": "Không tự động mở nữa",
       "enableAutoOpen": "Bật lại tự động mở",
       "loading": "Đang tải nhật ký cập nhật...",

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -304,6 +304,7 @@
       "titleWithCookieInterceptor": "启用过盾流程以完成网络请求"
     },
     "updateLog": {
+      "autoOpenSetting": "更新日志自动打开",
       "disableAutoOpen": "不再自动打开",
       "enableAutoOpen": "重新启用自动打开",
       "loading": "正在加载更新日志…",

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -304,6 +304,7 @@
       "titleWithCookieInterceptor": "啟用過盾流程以完成網路請求"
     },
     "updateLog": {
+      "autoOpenSetting": "更新日誌自動開啟",
       "disableAutoOpen": "不再自動開啟",
       "enableAutoOpen": "重新啟用自動開啟",
       "loading": "正在載入更新日誌…",

--- a/src/services/importExport/importExportService.ts
+++ b/src/services/importExport/importExportService.ts
@@ -235,12 +235,12 @@ async function importV1Backup(
   if (preferencesRequested) {
     const preferencesData = data.preferences || data.data?.preferences
     if (preferencesData) {
-      const success = options?.preserveWebdav
+      const writeResult = options?.preserveWebdav
         ? await userPreferences.importPreferences(preferencesData, {
             preserveWebdav: true,
           })
         : await userPreferences.importPreferences(preferencesData)
-      if (success) {
+      if (writeResult.ok) {
         preferencesImported = true
       } else {
         logger.error("Failed to import user preferences from legacy backup")
@@ -540,12 +540,12 @@ async function importV2Backup(
 
   if (preferencesRequested) {
     const { preferences } = data as BackupFullV2 | BackupPreferencesPartialV2
-    const success = options?.preserveWebdav
+    const writeResult = options?.preserveWebdav
       ? await userPreferences.importPreferences(preferences, {
           preserveWebdav: true,
         })
       : await userPreferences.importPreferences(preferences)
-    if (success) {
+    if (writeResult.ok) {
       preferencesImported = true
     } else {
       logger.error("Failed to import user preferences from V2 backup")

--- a/src/services/importExport/importExportService.ts
+++ b/src/services/importExport/importExportService.ts
@@ -18,7 +18,10 @@ import { createLogger } from "~/utils/core/logger"
  */
 const logger = createLogger("ImportExportService")
 
-type ImportExportErrorCode = "FORMAT_NOT_CORRECT" | "NO_IMPORTABLE_DATA"
+type ImportExportErrorCode =
+  | "FORMAT_NOT_CORRECT"
+  | "IMPORT_FAILED"
+  | "NO_IMPORTABLE_DATA"
 
 export class ImportExportError extends Error {
   readonly code: ImportExportErrorCode
@@ -244,6 +247,7 @@ async function importV1Backup(
         preferencesImported = true
       } else {
         logger.error("Failed to import user preferences from legacy backup")
+        throw new ImportExportError("IMPORT_FAILED")
       }
     }
   }

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -519,6 +519,29 @@ export interface UserPreferences {
   webdavSyncStrategy?: WebDAVSyncStrategy
 }
 
+export type PreferenceWriteConflict = {
+  type: "stale"
+  expectedLastUpdated: number
+  actualLastUpdated: number
+}
+
+export type PreferenceWriteFailure =
+  | PreferenceWriteConflict
+  | {
+      type: "storage-error"
+      error: unknown
+    }
+
+export type PreferenceWriteResult =
+  | {
+      ok: true
+      preferences: UserPreferences
+    }
+  | {
+      ok: false
+      reason: PreferenceWriteFailure
+    }
+
 // Stable template used for field-level defaults.
 // Use `createDefaultPreferences()` when a fresh preference object is required.
 
@@ -683,60 +706,86 @@ class UserPreferencesService {
   }
 
   /**
-   * Save partial user preferences (deep merge) and return the stamped snapshot.
+   * Save partial user preferences (deep merge) and return a typed write result.
    */
   async savePreferencesWithResult(
     preferences: DeepPartial<UserPreferences>,
     options?: {
       expectedLastUpdated?: number
     },
-  ): Promise<UserPreferences | null> {
-    const updatedPreferences = await this.withStorageWriteLock(async () => {
-      const currentPreferences = await this.getPreferences()
-      if (
-        typeof options?.expectedLastUpdated === "number" &&
-        Number.isFinite(options.expectedLastUpdated) &&
-        currentPreferences.lastUpdated !== options.expectedLastUpdated
-      ) {
-        return null
+  ): Promise<PreferenceWriteResult> {
+    try {
+      const writeResult = await this.withStorageWriteLock(async () => {
+        const currentPreferences = await this.getPreferences()
+        if (
+          typeof options?.expectedLastUpdated === "number" &&
+          Number.isFinite(options.expectedLastUpdated) &&
+          currentPreferences.lastUpdated !== options.expectedLastUpdated
+        ) {
+          return {
+            ok: false,
+            reason: {
+              type: "stale",
+              expectedLastUpdated: options.expectedLastUpdated,
+              actualLastUpdated: currentPreferences.lastUpdated,
+            },
+          } satisfies PreferenceWriteResult
+        }
+
+        const timestamp = Date.now()
+        const sharedPreferencesLastUpdated = patchTouchesSharedPreferences(
+          preferences,
+        )
+          ? timestamp
+          : getSharedPreferencesLastUpdated(currentPreferences)
+
+        const nextPreferences = stampPreferencesMetadata(
+          deepOverride(currentPreferences, preferences),
+          {
+            lastUpdated: timestamp,
+            sharedPreferencesLastUpdated,
+          },
+        )
+
+        await this.storage.set(
+          USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
+          nextPreferences,
+        )
+
+        return {
+          ok: true,
+          preferences: nextPreferences,
+        } satisfies PreferenceWriteResult
+      })
+
+      if (!writeResult.ok && writeResult.reason.type === "stale") {
+        logger.debug("跳过过期的偏好设置写入", {
+          expectedLastUpdated: writeResult.reason.expectedLastUpdated,
+          actualLastUpdated: writeResult.reason.actualLastUpdated,
+        })
+        return writeResult
       }
 
-      const timestamp = Date.now()
-      const sharedPreferencesLastUpdated = patchTouchesSharedPreferences(
-        preferences,
-      )
-        ? timestamp
-        : getSharedPreferencesLastUpdated(currentPreferences)
+      if (writeResult.ok) {
+        logger.debug("偏好设置保存成功", {
+          lastUpdated: writeResult.preferences.lastUpdated,
+          sharedPreferencesLastUpdated:
+            writeResult.preferences.sharedPreferencesLastUpdated,
+          preferencesVersion: writeResult.preferences.preferencesVersion,
+        })
+      }
 
-      const nextPreferences = stampPreferencesMetadata(
-        deepOverride(currentPreferences, preferences),
-        {
-          lastUpdated: timestamp,
-          sharedPreferencesLastUpdated,
+      return writeResult
+    } catch (error) {
+      logger.error("保存偏好设置失败", error)
+      return {
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error,
         },
-      )
-
-      await this.storage.set(
-        USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
-        nextPreferences,
-      )
-
-      return nextPreferences
-    })
-    if (!updatedPreferences) {
-      logger.debug("跳过过期的偏好设置写入", {
-        expectedLastUpdated: options?.expectedLastUpdated,
-      })
-      return null
+      }
     }
-
-    logger.debug("偏好设置保存成功", {
-      lastUpdated: updatedPreferences.lastUpdated,
-      sharedPreferencesLastUpdated:
-        updatedPreferences.sharedPreferencesLastUpdated,
-      preferencesVersion: updatedPreferences.preferencesVersion,
-    })
-    return updatedPreferences
   }
 
   /**
@@ -747,23 +796,16 @@ class UserPreferencesService {
     options?: {
       expectedLastUpdated?: number
     },
-  ): Promise<boolean> {
-    try {
-      const updatedPreferences = await this.savePreferencesWithResult(
-        preferences,
-        options,
-      )
-      return updatedPreferences !== null
-    } catch (error) {
-      logger.error("保存偏好设置失败", error)
-      return false
-    }
+  ): Promise<PreferenceWriteResult> {
+    return this.savePreferencesWithResult(preferences, options)
   }
 
   /**
    * Update active tab preference.
    */
-  async updateActiveTab(activeTab: DashboardTabType): Promise<boolean> {
+  async updateActiveTab(
+    activeTab: DashboardTabType,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ activeTab })
   }
 
@@ -771,7 +813,9 @@ class UserPreferencesService {
    * Enable/disable automatically showing the inline update log after updates.
    * @param enabled - When true, shows the update log on first UI open after update.
    */
-  async updateOpenChangelogOnUpdate(enabled: boolean): Promise<boolean> {
+  async updateOpenChangelogOnUpdate(
+    enabled: boolean,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ openChangelogOnUpdate: enabled })
   }
 
@@ -780,7 +824,9 @@ class UserPreferencesService {
    * successfully adding an account.
    * @param enabled - When true, runs token provisioning after account add.
    */
-  async updateAutoProvisionKeyOnAccountAdd(enabled: boolean): Promise<boolean> {
+  async updateAutoProvisionKeyOnAccountAdd(
+    enabled: boolean,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ autoProvisionKeyOnAccountAdd: enabled })
   }
 
@@ -791,7 +837,7 @@ class UserPreferencesService {
    */
   async updateAutoFillCurrentSiteUrlOnAccountAdd(
     enabled: boolean,
-  ): Promise<boolean> {
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ autoFillCurrentSiteUrlOnAccountAdd: enabled })
   }
 
@@ -800,14 +846,18 @@ class UserPreferencesService {
    * @param enabled - When true, adding an account whose site URL already exists
    * prompts for confirmation.
    */
-  async updateWarnOnDuplicateAccountAdd(enabled: boolean): Promise<boolean> {
+  async updateWarnOnDuplicateAccountAdd(
+    enabled: boolean,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ warnOnDuplicateAccountAdd: enabled })
   }
 
   /**
    * Update currency preference.
    */
-  async updateCurrencyType(currencyType: CurrencyType): Promise<boolean> {
+  async updateCurrencyType(
+    currencyType: CurrencyType,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ currencyType })
   }
 
@@ -817,7 +867,9 @@ class UserPreferencesService {
    * When disabled, expensive log pagination requests are skipped and today fields
    * are treated as zero during refresh.
    */
-  async updateShowTodayCashflow(showTodayCashflow: boolean): Promise<boolean> {
+  async updateShowTodayCashflow(
+    showTodayCashflow: boolean,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ showTodayCashflow })
   }
 
@@ -827,14 +879,16 @@ class UserPreferencesService {
   async updateSortConfig(
     sortField: ActiveSortField,
     sortOrder: SortOrder,
-  ): Promise<boolean> {
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ sortField, sortOrder })
   }
 
   /**
    * Toggle health status visibility.
    */
-  async updateShowHealthStatus(showHealthStatus: boolean): Promise<boolean> {
+  async updateShowHealthStatus(
+    showHealthStatus: boolean,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ showHealthStatus })
   }
 
@@ -848,7 +902,7 @@ class UserPreferencesService {
     backupEncryptionEnabled?: boolean
     backupEncryptionPassword?: string
     syncData?: WebDAVSettings["syncData"]
-  }): Promise<boolean> {
+  }): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       webdav: settings,
     })
@@ -861,7 +915,7 @@ class UserPreferencesService {
     autoSync?: boolean
     syncInterval?: number
     syncStrategy?: WebDAVSettings["syncStrategy"]
-  }): Promise<boolean> {
+  }): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       webdav: settings,
     })
@@ -870,26 +924,36 @@ class UserPreferencesService {
   /**
    * Reset all preferences to defaults.
    */
-  async resetToDefaults(): Promise<boolean> {
+  async resetToDefaults(): Promise<PreferenceWriteResult> {
     try {
+      const nextPreferences = createDefaultPreferences()
       await this.withStorageWriteLock(async () => {
         await this.storage.set(
           USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
-          createDefaultPreferences(),
+          nextPreferences,
         )
       })
       logger.info("已重置为默认设置")
-      return true
+      return {
+        ok: true,
+        preferences: nextPreferences,
+      }
     } catch (error) {
       logger.error("重置设置失败", error)
-      return false
+      return {
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error,
+        },
+      }
     }
   }
 
   /**
    * Clear stored preferences (removes key).
    */
-  async clearPreferences(): Promise<boolean> {
+  async clearPreferences(): Promise<PreferenceWriteResult> {
     try {
       await this.withStorageWriteLock(async () => {
         await this.storage.remove(
@@ -897,10 +961,19 @@ class UserPreferencesService {
         )
       })
       logger.info("偏好设置已清空")
-      return true
+      return {
+        ok: true,
+        preferences: createDefaultPreferences(),
+      }
     } catch (error) {
       logger.error("清空偏好设置失败", error)
-      return false
+      return {
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error,
+        },
+      }
     }
   }
 
@@ -925,9 +998,9 @@ class UserPreferencesService {
     options?: {
       preserveWebdav?: boolean
     },
-  ): Promise<boolean> {
+  ): Promise<PreferenceWriteResult> {
     try {
-      await this.withStorageWriteLock(async () => {
+      const importedPreferences = await this.withStorageWriteLock(async () => {
         const migratedPreferences = migrateAndNormalizePreferences(preferences)
 
         const currentPreferences = options?.preserveWebdav
@@ -951,19 +1024,31 @@ class UserPreferencesService {
             : importedAt
           : importedAt
 
+        const nextPreferences = stampPreferencesMetadata(preferencesToStore, {
+          lastUpdated: importedAt,
+          sharedPreferencesLastUpdated,
+        })
+
         await this.storage.set(
           USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
-          stampPreferencesMetadata(preferencesToStore, {
-            lastUpdated: importedAt,
-            sharedPreferencesLastUpdated,
-          }),
+          nextPreferences,
         )
+        return nextPreferences
       })
       logger.info("偏好设置导入成功，已迁移至最新版本")
-      return true
+      return {
+        ok: true,
+        preferences: importedPreferences,
+      }
     } catch (error) {
       logger.error("导入偏好设置失败", error)
-      return false
+      return {
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error,
+        },
+      }
     }
   }
 
@@ -975,12 +1060,12 @@ class UserPreferencesService {
 
   async setSortingPriorityConfig(
     config: SortingPriorityConfig,
-  ): Promise<boolean> {
+  ): Promise<PreferenceWriteResult> {
     config.lastModified = Date.now()
     return this.savePreferences({ sortingPriorityConfig: config })
   }
 
-  async resetSortingPriorityConfig(): Promise<boolean> {
+  async resetSortingPriorityConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       sortingPriorityConfig: createDefaultSortingPriorityConfig(),
     })
@@ -997,7 +1082,7 @@ class UserPreferencesService {
   /**
    * Set language preference.
    */
-  async setLanguage(language: string): Promise<boolean> {
+  async setLanguage(language: string): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       language: normalizeAppLanguage(language) ?? language,
     })
@@ -1016,14 +1101,14 @@ class UserPreferencesService {
    */
   async updateLoggingPreferences(
     updates: Partial<LoggingPreferences>,
-  ): Promise<boolean> {
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({ logging: updates })
   }
 
   /**
    * Reset display settings (currency + active tab).
    */
-  async resetDisplaySettings(): Promise<boolean> {
+  async resetDisplaySettings(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       activeTab: DEFAULT_PREFERENCES.activeTab,
       currencyType: DEFAULT_PREFERENCES.currencyType,
@@ -1034,7 +1119,7 @@ class UserPreferencesService {
   /**
    * Reset auto refresh config.
    */
-  async resetAutoRefreshConfig(): Promise<boolean> {
+  async resetAutoRefreshConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       accountAutoRefresh: DEFAULT_PREFERENCES.accountAutoRefresh,
     })
@@ -1043,7 +1128,7 @@ class UserPreferencesService {
   /**
    * Reset New API config.
    */
-  async resetNewApiConfig(): Promise<boolean> {
+  async resetNewApiConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       newApi: DEFAULT_PREFERENCES.newApi,
     })
@@ -1052,7 +1137,9 @@ class UserPreferencesService {
   /**
    * Update Veloera config.
    */
-  async updateVeloeraConfig(config: Partial<VeloeraConfig>): Promise<boolean> {
+  async updateVeloeraConfig(
+    config: Partial<VeloeraConfig>,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       veloera: config,
     })
@@ -1061,7 +1148,9 @@ class UserPreferencesService {
   /**
    * Update Done Hub config.
    */
-  async updateDoneHubConfig(config: Partial<DoneHubConfig>): Promise<boolean> {
+  async updateDoneHubConfig(
+    config: Partial<DoneHubConfig>,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       doneHub: config,
     })
@@ -1070,7 +1159,7 @@ class UserPreferencesService {
   /**
    * Reset Veloera config.
    */
-  async resetVeloeraConfig(): Promise<boolean> {
+  async resetVeloeraConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       veloera: DEFAULT_PREFERENCES.veloera,
     })
@@ -1079,7 +1168,7 @@ class UserPreferencesService {
   /**
    * Reset Done Hub config.
    */
-  async resetDoneHubConfig(): Promise<boolean> {
+  async resetDoneHubConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       doneHub: DEFAULT_DONE_HUB_CONFIG,
     })
@@ -1088,7 +1177,9 @@ class UserPreferencesService {
   /**
    * Update Octopus config.
    */
-  async updateOctopusConfig(config: Partial<OctopusConfig>): Promise<boolean> {
+  async updateOctopusConfig(
+    config: Partial<OctopusConfig>,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       octopus: config,
     })
@@ -1097,7 +1188,9 @@ class UserPreferencesService {
   /**
    * Update AxonHub config.
    */
-  async updateAxonHubConfig(config: Partial<AxonHubConfig>): Promise<boolean> {
+  async updateAxonHubConfig(
+    config: Partial<AxonHubConfig>,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       axonHub: config,
     })
@@ -1108,7 +1201,7 @@ class UserPreferencesService {
    */
   async updateClaudeCodeHubConfig(
     config: Partial<ClaudeCodeHubConfig>,
-  ): Promise<boolean> {
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       claudeCodeHub: config,
     })
@@ -1117,7 +1210,7 @@ class UserPreferencesService {
   /**
    * Reset Octopus config.
    */
-  async resetOctopusConfig(): Promise<boolean> {
+  async resetOctopusConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       octopus: DEFAULT_PREFERENCES.octopus,
     })
@@ -1126,7 +1219,7 @@ class UserPreferencesService {
   /**
    * Reset AxonHub config.
    */
-  async resetAxonHubConfig(): Promise<boolean> {
+  async resetAxonHubConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       axonHub: DEFAULT_PREFERENCES.axonHub,
     })
@@ -1135,7 +1228,7 @@ class UserPreferencesService {
   /**
    * Reset Claude Code Hub config.
    */
-  async resetClaudeCodeHubConfig(): Promise<boolean> {
+  async resetClaudeCodeHubConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       claudeCodeHub: DEFAULT_PREFERENCES.claudeCodeHub,
     })
@@ -1144,7 +1237,9 @@ class UserPreferencesService {
   /**
    * Update managed site type (new-api, veloera, done-hub, or octopus).
    */
-  async updateManagedSiteType(siteType: ManagedSiteType): Promise<boolean> {
+  async updateManagedSiteType(
+    siteType: ManagedSiteType,
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       managedSiteType: siteType,
     })
@@ -1191,23 +1286,23 @@ class UserPreferencesService {
   /**
    * Reset New API Model Sync config.
    */
-  async resetNewApiModelSyncConfig(): Promise<boolean> {
+  async resetNewApiModelSyncConfig(): Promise<PreferenceWriteResult> {
     return this.resetManagedSiteModelSyncConfig()
   }
 
-  async resetManagedSiteModelSyncConfig(): Promise<boolean> {
+  async resetManagedSiteModelSyncConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       managedSiteModelSync: DEFAULT_PREFERENCES.managedSiteModelSync,
     })
   }
 
-  async resetCliProxyConfig(): Promise<boolean> {
+  async resetCliProxyConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       cliProxy: DEFAULT_PREFERENCES.cliProxy,
     })
   }
 
-  async resetClaudeCodeRouterConfig(): Promise<boolean> {
+  async resetClaudeCodeRouterConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       claudeCodeRouter: DEFAULT_PREFERENCES.claudeCodeRouter,
     })
@@ -1216,7 +1311,7 @@ class UserPreferencesService {
   /**
    * Reset auto check-in config.
    */
-  async resetAutoCheckinConfig(): Promise<boolean> {
+  async resetAutoCheckinConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       autoCheckin: DEFAULT_PREFERENCES.autoCheckin,
     })
@@ -1225,7 +1320,7 @@ class UserPreferencesService {
   /**
    * Reset model redirect config.
    */
-  async resetModelRedirectConfig(): Promise<boolean> {
+  async resetModelRedirectConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       modelRedirect: DEFAULT_PREFERENCES.modelRedirect,
     })
@@ -1234,7 +1329,7 @@ class UserPreferencesService {
   /**
    * Reset redemption assist config.
    */
-  async resetRedemptionAssist(): Promise<boolean> {
+  async resetRedemptionAssist(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       redemptionAssist: DEFAULT_PREFERENCES.redemptionAssist,
     })
@@ -1243,7 +1338,7 @@ class UserPreferencesService {
   /**
    * Reset Web AI API Check config.
    */
-  async resetWebAiApiCheck(): Promise<boolean> {
+  async resetWebAiApiCheck(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       webAiApiCheck: DEFAULT_PREFERENCES.webAiApiCheck,
     })
@@ -1254,7 +1349,7 @@ class UserPreferencesService {
    */
   async updateWebAiApiCheck(
     updates: DeepPartial<WebAiApiCheckPreferences>,
-  ): Promise<boolean> {
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       webAiApiCheck: updates,
     })
@@ -1263,7 +1358,7 @@ class UserPreferencesService {
   /**
    * Reset WebDAV config.
    */
-  async resetWebdavConfig(): Promise<boolean> {
+  async resetWebdavConfig(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       webdav: DEFAULT_PREFERENCES.webdav,
     })
@@ -1274,7 +1369,7 @@ class UserPreferencesService {
    */
   async updateTaskNotifications(
     updates: Partial<TaskNotificationPreferences>,
-  ): Promise<boolean> {
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       taskNotifications: updates,
     })
@@ -1283,7 +1378,7 @@ class UserPreferencesService {
   /**
    * Reset task-notification preferences.
    */
-  async resetTaskNotifications(): Promise<boolean> {
+  async resetTaskNotifications(): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       taskNotifications: DEFAULT_PREFERENCES.taskNotifications,
     })
@@ -1294,7 +1389,7 @@ class UserPreferencesService {
    */
   async updateSiteAnnouncementNotifications(
     updates: Partial<SiteAnnouncementPreferences>,
-  ): Promise<boolean> {
+  ): Promise<PreferenceWriteResult> {
     return this.savePreferences({
       siteAnnouncementNotifications: updates,
     })

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -519,8 +519,16 @@ export interface UserPreferences {
   webdavSyncStrategy?: WebDAVSyncStrategy
 }
 
+export const PREFERENCE_WRITE_FAILURE_TYPES = {
+  Stale: "stale",
+  StorageError: "storage-error",
+} as const
+
+export type PreferenceWriteFailureType =
+  (typeof PREFERENCE_WRITE_FAILURE_TYPES)[keyof typeof PREFERENCE_WRITE_FAILURE_TYPES]
+
 export type PreferenceWriteConflict = {
-  type: "stale"
+  type: typeof PREFERENCE_WRITE_FAILURE_TYPES.Stale
   expectedLastUpdated: number
   actualLastUpdated: number
 }
@@ -528,7 +536,7 @@ export type PreferenceWriteConflict = {
 export type PreferenceWriteFailure =
   | PreferenceWriteConflict
   | {
-      type: "storage-error"
+      type: typeof PREFERENCE_WRITE_FAILURE_TYPES.StorageError
       error: unknown
     }
 
@@ -685,20 +693,24 @@ class UserPreferencesService {
     return withExtensionStorageWriteLock(STORAGE_LOCKS.USER_PREFERENCES, work)
   }
 
+  private async readPreferencesSnapshot(): Promise<UserPreferences> {
+    const storedPreferences = (await this.storage.get(
+      USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
+    )) as UserPreferences | undefined
+    const defaultPreferences = createReadOnlyDefaultPreferences()
+    const preferences = storedPreferences ?? defaultPreferences
+
+    const migratedPreferences = migrateAndNormalizePreferences(preferences)
+
+    return deepOverride(defaultPreferences, migratedPreferences)
+  }
+
   /**
    * Get user preferences (with migration + defaults merged) without mutating storage.
    */
   async getPreferences(): Promise<UserPreferences> {
     try {
-      const storedPreferences = (await this.storage.get(
-        USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
-      )) as UserPreferences | undefined
-      const defaultPreferences = createReadOnlyDefaultPreferences()
-      const preferences = storedPreferences ?? defaultPreferences
-
-      const migratedPreferences = migrateAndNormalizePreferences(preferences)
-
-      return deepOverride(defaultPreferences, migratedPreferences)
+      return await this.readPreferencesSnapshot()
     } catch (error) {
       logger.error("获取用户偏好设置失败", error)
       return createReadOnlyDefaultPreferences()
@@ -716,7 +728,7 @@ class UserPreferencesService {
   ): Promise<PreferenceWriteResult> {
     try {
       const writeResult = await this.withStorageWriteLock(async () => {
-        const currentPreferences = await this.getPreferences()
+        const currentPreferences = await this.readPreferencesSnapshot()
         if (
           typeof options?.expectedLastUpdated === "number" &&
           Number.isFinite(options.expectedLastUpdated) &&
@@ -725,7 +737,7 @@ class UserPreferencesService {
           return {
             ok: false,
             reason: {
-              type: "stale",
+              type: PREFERENCE_WRITE_FAILURE_TYPES.Stale,
               expectedLastUpdated: options.expectedLastUpdated,
               actualLastUpdated: currentPreferences.lastUpdated,
             },
@@ -781,7 +793,7 @@ class UserPreferencesService {
       return {
         ok: false,
         reason: {
-          type: "storage-error",
+          type: PREFERENCE_WRITE_FAILURE_TYPES.StorageError,
           error,
         },
       }
@@ -943,7 +955,7 @@ class UserPreferencesService {
       return {
         ok: false,
         reason: {
-          type: "storage-error",
+          type: PREFERENCE_WRITE_FAILURE_TYPES.StorageError,
           error,
         },
       }
@@ -970,7 +982,7 @@ class UserPreferencesService {
       return {
         ok: false,
         reason: {
-          type: "storage-error",
+          type: PREFERENCE_WRITE_FAILURE_TYPES.StorageError,
           error,
         },
       }
@@ -1004,7 +1016,7 @@ class UserPreferencesService {
         const migratedPreferences = migrateAndNormalizePreferences(preferences)
 
         const currentPreferences = options?.preserveWebdav
-          ? await this.getPreferences()
+          ? await this.readPreferencesSnapshot()
           : null
         const importedAt = Date.now()
 
@@ -1045,7 +1057,7 @@ class UserPreferencesService {
       return {
         ok: false,
         reason: {
-          type: "storage-error",
+          type: PREFERENCE_WRITE_FAILURE_TYPES.StorageError,
           error,
         },
       }

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -1021,7 +1021,11 @@ class WebdavAutoSyncService {
     })
 
     if (!writeResult.ok) {
-      throw new Error("Failed to import WebDAV preferences")
+      throw new Error(
+        writeResult.reason.type === "storage-error"
+          ? getErrorMessage(writeResult.reason.error)
+          : "Failed to import WebDAV preferences",
+      )
     }
   }
 

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -62,6 +62,7 @@ import { withExtensionStorageWriteLock } from "../core/storageWriteLock"
 import { channelConfigStorage } from "../managedSites/channelConfigStorage"
 import {
   userPreferences,
+  type PreferenceWriteFailure,
   type UserPreferences,
 } from "../preferences/userPreferences"
 import { WebdavAutoSyncMessageTypes } from "../runtimeMessaging/messageTypes"
@@ -98,7 +99,7 @@ type UpdateWebdavAutoSyncSettingsResult =
     }
   | {
       ok: false
-      reason: "conflict" | "error"
+      reason: PreferenceWriteFailure
     }
 
 /**
@@ -1015,11 +1016,11 @@ class WebdavAutoSyncService {
   }
 
   private async importPreferencesOrThrow(preferences: UserPreferences) {
-    const imported = await userPreferences.importPreferences(preferences, {
+    const writeResult = await userPreferences.importPreferences(preferences, {
       preserveWebdav: true,
     })
 
-    if (!imported) {
+    if (!writeResult.ok) {
       throw new Error("Failed to import WebDAV preferences")
     }
   }
@@ -1566,16 +1567,16 @@ class WebdavAutoSyncService {
     options?: { expectedLastUpdated?: number },
   ): Promise<UpdateWebdavAutoSyncSettingsResult> {
     try {
-      const savedPreferences = await userPreferences.savePreferencesWithResult(
+      const writeResult = await userPreferences.savePreferencesWithResult(
         {
           webdav: settings,
         },
         options,
       )
-      if (!savedPreferences) {
+      if (!writeResult.ok) {
         return {
           ok: false,
-          reason: "conflict",
+          reason: writeResult.reason,
         }
       }
 
@@ -1583,13 +1584,16 @@ class WebdavAutoSyncService {
       logger.info("设置已更新", settings)
       return {
         ok: true,
-        savedPreferences,
+        savedPreferences: writeResult.preferences,
       }
     } catch (error) {
       logger.error("更新设置失败", error)
       return {
         ok: false,
-        reason: "error",
+        reason: {
+          type: "storage-error",
+          error,
+        },
       }
     }
   }
@@ -1754,7 +1758,7 @@ export async function resolveWebdavAutoSyncUpdateSettingsMessage(
       : {
           success: false,
           error:
-            result.reason === "conflict"
+            result.reason.type === "stale"
               ? t("settings:messages.preferencesChangedExternally")
               : t("settings:messages.saveSettingsFailed"),
         }

--- a/src/utils/core/toastHelpers.ts
+++ b/src/utils/core/toastHelpers.ts
@@ -4,6 +4,11 @@ import toast, { type ToastOptions } from "react-hot-toast"
 import type { WarningToastAction } from "~/components/toast/types"
 import { WarningToast } from "~/components/toast/WarningToast"
 import { WarningToastIcon } from "~/components/toast/WarningToastIcon"
+import type { PreferenceSaveOptions } from "~/contexts/UserPreferencesContext"
+import type {
+  PreferenceWriteFailure,
+  PreferenceWriteResult,
+} from "~/services/preferences/userPreferences"
 import { t } from "~/utils/i18n/core"
 
 type ToastResultObject = {
@@ -68,15 +73,121 @@ export function showResultToast(...args: ToastParams): void {
   }
 }
 
+type GuardedPreferenceUpdate = (
+  options: PreferenceSaveOptions,
+) => Promise<PreferenceWriteResult>
+
+type PreferenceUpdateToastOptions = {
+  expectedLastUpdated: number
+  setting: string
+  update: GuardedPreferenceUpdate
+}
+
+/**
+ * Maps persisted preference write failures to stable local user feedback.
+ */
+export function getPreferenceWriteFailureMessage(
+  failure: PreferenceWriteFailure,
+  options?: {
+    setting?: string
+    fallback?: string
+  },
+): string {
+  if (failure.type === "stale") {
+    return t("settings:messages.preferencesChangedExternally")
+  }
+
+  if (options?.fallback) {
+    return options.fallback
+  }
+
+  return options?.setting
+    ? t("settings:messages.updateFailed", { name: options.setting })
+    : t("messages:toast.error.operationFailedGeneric")
+}
+
+/**
+ * Shows a toast for a structured preference write result.
+ */
+function showPreferenceWriteResultToast(
+  result: PreferenceWriteResult,
+  setting: string,
+): void {
+  const successMsg = t("settings:messages.updateSuccess", { name: setting })
+  if (result.ok) {
+    showResultToast(true, successMsg)
+    return
+  }
+
+  toast.error(getPreferenceWriteFailureMessage(result.reason, { setting }))
+}
+
+const isPreferenceWriteResult = (
+  value: boolean | PreferenceWriteResult | ToastResultObject,
+): value is PreferenceWriteResult =>
+  typeof value === "object" && value !== null && "ok" in value
+
+const isToastResultObject = (
+  value: boolean | PreferenceWriteResult | ToastResultObject,
+): value is ToastResultObject =>
+  typeof value === "object" && value !== null && "success" in value
+
 /**
  * Shows a toast notification for an update operation.
- * @param success - Whether the update was successful.
+ * @param result - Whether the update succeeded, or a structured mutation result.
  * @param setting - The name of the setting that was updated.
  */
-export const showUpdateToast = (success: boolean, setting: string): void => {
+export const showUpdateToast = (
+  result: boolean | PreferenceWriteResult | ToastResultObject,
+  setting: string,
+): void => {
+  if (isPreferenceWriteResult(result)) {
+    showPreferenceWriteResultToast(result, setting)
+    return
+  }
+
   const successMsg = t("settings:messages.updateSuccess", { name: setting })
   const errorMsg = t("settings:messages.updateFailed", { name: setting })
-  showResultToast(success, successMsg, errorMsg)
+
+  if (isToastResultObject(result)) {
+    showResultToast({
+      success: result.success,
+      message: result.message,
+      successFallback: result.successFallback ?? successMsg,
+      errorFallback: result.errorFallback ?? errorMsg,
+    })
+    return
+  }
+
+  showResultToast(result, successMsg, errorMsg)
+}
+
+/**
+ * Runs an optimistic-concurrency preference update and shows result-aware
+ * feedback for stale snapshots and storage failures.
+ */
+export async function runPreferenceUpdateWithToast({
+  expectedLastUpdated,
+  setting,
+  update,
+}: PreferenceUpdateToastOptions): Promise<PreferenceWriteResult> {
+  const result = await update({
+    expectedLastUpdated,
+  })
+
+  showPreferenceWriteResultToast(result, setting)
+  return result
+}
+
+/**
+ * Creates versioned save options for callers that have custom success/error UI.
+ */
+export function createVersionedPreferenceSaveOptions(
+  expectedLastUpdated: number,
+): PreferenceSaveOptions {
+  return {
+    expectedLastUpdated,
+  }
 }
 
 /**

--- a/src/utils/core/toastHelpers.ts
+++ b/src/utils/core/toastHelpers.ts
@@ -9,6 +9,7 @@ import type {
   PreferenceWriteFailure,
   PreferenceWriteResult,
 } from "~/services/preferences/userPreferences"
+import { PREFERENCE_WRITE_FAILURE_TYPES } from "~/services/preferences/userPreferences"
 import { t } from "~/utils/i18n/core"
 
 type ToastResultObject = {
@@ -93,7 +94,7 @@ export function getPreferenceWriteFailureMessage(
     fallback?: string
   },
 ): string {
-  if (failure.type === "stale") {
+  if (failure.type === PREFERENCE_WRITE_FAILURE_TYPES.Stale) {
     return t("settings:messages.preferencesChangedExternally")
   }
 

--- a/tests/components/PopupInterruptionHintBanner.test.tsx
+++ b/tests/components/PopupInterruptionHintBanner.test.tsx
@@ -6,6 +6,7 @@ import {
   clearPopupInterruptionHint,
   POPUP_CRITICAL_FLOWS,
 } from "~/services/popupInterruptionHint"
+import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
 import { openSidePanelPage } from "~/utils/navigation"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
@@ -64,7 +65,10 @@ vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
 describe("PopupInterruptionHintBanner", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUpdateActionClickBehavior.mockResolvedValue(true)
+    mockUpdateActionClickBehavior.mockResolvedValue({
+      ok: true,
+      preferences: DEFAULT_PREFERENCES,
+    })
     mockOpenSidePanelPage.mockResolvedValue(undefined)
     mockClearPopupInterruptionHint.mockResolvedValue(undefined)
   })
@@ -114,7 +118,11 @@ describe("PopupInterruptionHintBanner", () => {
 
   it("keeps the hint visible when saving the sidepanel preference fails", async () => {
     const user = userEvent.setup()
-    mockUpdateActionClickBehavior.mockResolvedValue(false)
+    const writeFailure = {
+      ok: false,
+      reason: { type: "storage-error", error: new Error("save failed") },
+    }
+    mockUpdateActionClickBehavior.mockResolvedValue(writeFailure)
     mockGetPopupInterruptionHint.mockResolvedValue({
       flow: POPUP_CRITICAL_FLOWS.AccountAutoDetect,
       status: "pending",
@@ -133,7 +141,7 @@ describe("PopupInterruptionHintBanner", () => {
     expect(mockClearPopupInterruptionHint).not.toHaveBeenCalled()
     expect(mockOpenSidePanelPage).not.toHaveBeenCalled()
     expect(mockShowUpdateToast).toHaveBeenCalledWith(
-      false,
+      writeFailure,
       "ui:popupInterruption.settingName",
     )
     expect(screen.getByText("ui:popupInterruption.title")).toBeVisible()

--- a/tests/components/UpdateLogDialog.test.tsx
+++ b/tests/components/UpdateLogDialog.test.tsx
@@ -15,10 +15,22 @@ import {
   waitFor,
 } from "~~/tests/test-utils/render"
 
+const { toastErrorMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+}))
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    error: toastErrorMock,
+    success: vi.fn(),
+  },
+}))
+
 describe("UpdateLogDialog", () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
+    toastErrorMock.mockReset()
   })
 
   it("toggles the open-changelog-on-update preference from the dialog", async () => {
@@ -27,7 +39,14 @@ describe("UpdateLogDialog", () => {
 
     const updateSpy = vi
       .spyOn(userPreferences, "updateOpenChangelogOnUpdate")
-      .mockResolvedValue({ ok: true, preferences })
+      .mockImplementation(async (enabled) => ({
+        ok: true,
+        preferences: {
+          ...preferences,
+          openChangelogOnUpdate: enabled,
+          lastUpdated: preferences.lastUpdated + 1,
+        },
+      }))
 
     render(<UpdateLogDialog isOpen onClose={() => {}} version="2.39.0" />)
 
@@ -64,7 +83,7 @@ describe("UpdateLogDialog", () => {
     })
   })
 
-  it("keeps the current auto-open label when saving the toggle fails", async () => {
+  it("keeps the current auto-open label and surfaces feedback when saving the toggle fails", async () => {
     vi.spyOn(userPreferences, "getPreferences").mockResolvedValue(
       buildUserPreferences({ openChangelogOnUpdate: true }),
     )
@@ -93,6 +112,9 @@ describe("UpdateLogDialog", () => {
 
     expect(toggleButton).toHaveTextContent(
       "ui:dialog.updateLog.disableAutoOpen",
+    )
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "settings:messages.updateFailed",
     )
   })
 

--- a/tests/components/UpdateLogDialog.test.tsx
+++ b/tests/components/UpdateLogDialog.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { UpdateLogDialog } from "~/components/dialogs/UpdateLogDialog"
 import { UPDATE_LOG_DIALOG_TEST_IDS } from "~/components/dialogs/UpdateLogDialog/testIds"
+import type { PreferenceWriteResult } from "~/services/preferences/userPreferences"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import * as browserApi from "~/utils/browser/browserApi"
 import * as docsLinks from "~/utils/navigation/docsLinks"
@@ -21,13 +22,12 @@ describe("UpdateLogDialog", () => {
   })
 
   it("toggles the open-changelog-on-update preference from the dialog", async () => {
-    vi.spyOn(userPreferences, "getPreferences").mockResolvedValue(
-      buildUserPreferences({ openChangelogOnUpdate: true }),
-    )
+    const preferences = buildUserPreferences({ openChangelogOnUpdate: true })
+    vi.spyOn(userPreferences, "getPreferences").mockResolvedValue(preferences)
 
     const updateSpy = vi
       .spyOn(userPreferences, "updateOpenChangelogOnUpdate")
-      .mockResolvedValue(true)
+      .mockResolvedValue({ ok: true, preferences })
 
     render(<UpdateLogDialog isOpen onClose={() => {}} version="2.39.0" />)
 
@@ -71,7 +71,13 @@ describe("UpdateLogDialog", () => {
 
     const updateSpy = vi
       .spyOn(userPreferences, "updateOpenChangelogOnUpdate")
-      .mockResolvedValue(false)
+      .mockResolvedValue({
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error: new Error("save failed"),
+        },
+      })
 
     render(<UpdateLogDialog isOpen onClose={() => {}} version="2.39.0" />)
 
@@ -201,7 +207,8 @@ describe("UpdateLogDialog", () => {
       buildUserPreferences({ openChangelogOnUpdate: true }),
     )
 
-    let resolveUpdate: ((value: boolean) => void) | undefined
+    const preferences = buildUserPreferences({ openChangelogOnUpdate: false })
+    let resolveUpdate: ((value: PreferenceWriteResult) => void) | undefined
     const updateSpy = vi
       .spyOn(userPreferences, "updateOpenChangelogOnUpdate")
       .mockImplementation(
@@ -224,7 +231,7 @@ describe("UpdateLogDialog", () => {
     expect(updateSpy).toHaveBeenCalledWith(false)
     expect(toggleButton).toBeDisabled()
 
-    resolveUpdate?.(true)
+    resolveUpdate?.({ ok: true, preferences })
 
     await waitFor(() => {
       expect(toggleButton).not.toBeDisabled()

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -1222,9 +1222,12 @@ describe("UserPreferencesContext", () => {
     expect((latestContext as any)?.preferences.webdav).toEqual(
       expect.objectContaining(DEFAULT_PREFERENCES.webdav),
     )
-    expect((latestContext as any)?.preferences.sortingPriorityConfig).toBe(
-      undefined,
-    )
+    expect(
+      (latestContext as any)?.preferences.sortingPriorityConfig.criteria,
+    ).toEqual(DEFAULT_SORTING_PRIORITY_CONFIG.criteria)
+    expect(
+      (latestContext as any)?.preferences.sortingPriorityConfig.lastModified,
+    ).toEqual(expect.any(Number))
     expect((latestContext as any)?.preferences.taskNotifications).toEqual(
       DEFAULT_PREFERENCES.taskNotifications,
     )

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -877,6 +877,30 @@ describe("UserPreferencesContext", () => {
     )
   })
 
+  it("keeps action behavior writes successful when the runtime notification fails", async () => {
+    const notifyError = new Error("runtime closed")
+    mockedSendPreferencesMessage.mockRejectedValueOnce(notifyError)
+    const context = await renderProvider()
+
+    await act(async () => {
+      await expect(
+        context.updateActionClickBehavior("sidepanel"),
+      ).resolves.toMatchObject({ ok: true })
+    })
+
+    expect((latestContext as any)?.actionClickBehavior).toBe("sidepanel")
+    expect(mockedSendPreferencesMessage).toHaveBeenCalledWith(
+      "preferences:updateActionClickBehavior",
+      { behavior: "sidepanel" },
+    )
+    await waitFor(() => {
+      expect(loggerMocks.warn).toHaveBeenCalledWith(
+        "Failed to notify action click behavior update",
+        notifyError,
+      )
+    })
+  })
+
   it("persists active tab changes through both tab update helpers", async () => {
     const preferences = clonePreferences()
     preferences.activeTab = DATA_TYPE_BALANCE

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -20,6 +20,7 @@ import {
 import {
   DEFAULT_PREFERENCES,
   userPreferences,
+  type PreferenceWriteResult,
   type UserPreferences,
 } from "~/services/preferences/userPreferences"
 import { DEFAULT_SORTING_PRIORITY_CONFIG } from "~/services/preferences/utils/sortingPriority"
@@ -207,6 +208,14 @@ let preferencePersistence = setupMockPreferencePersistence(
   mockedUserPreferences as any,
 )
 
+const preferenceWriteFailure: PreferenceWriteResult = {
+  ok: false,
+  reason: {
+    type: "storage-error",
+    error: new Error("save failed"),
+  },
+}
+
 const createDeferred = <T,>() => {
   let resolve!: (value: T | PromiseLike<T>) => void
   let reject!: (reason?: unknown) => void
@@ -216,6 +225,13 @@ const createDeferred = <T,>() => {
   })
 
   return { promise, resolve, reject }
+}
+
+const expectFailedWrite = (result: PreferenceWriteResult) => {
+  expect(result).toMatchObject({
+    ok: false,
+    reason: { type: "storage-error" },
+  })
 }
 
 const Probe = ({ children }: { children?: ReactNode }) => {
@@ -265,14 +281,17 @@ describe("UserPreferencesContext", () => {
     )
     const applyPersistedUpdate = (
       updates: Partial<UserPreferences> | Record<string, unknown>,
-    ) => {
+    ): PreferenceWriteResult => {
       const nextPreferences = deepOverride(
         preferencePersistence.getPersistedPreferences(),
         updates,
       )
       nextPreferences.lastUpdated += 1
       preferencePersistence.setPersistedPreferences(nextPreferences)
-      return true
+      return {
+        ok: true,
+        preferences: nextPreferences,
+      }
     }
     mockedUserPreferences.updateActiveTab.mockImplementation(
       async (activeTab) => applyPersistedUpdate({ activeTab }),
@@ -313,7 +332,10 @@ describe("UserPreferencesContext", () => {
     mockedUserPreferences.updateTaskNotifications.mockImplementation(
       async (updates) => applyPersistedUpdate({ taskNotifications: updates }),
     )
-    mockedUserPreferences.resetToDefaults.mockResolvedValue(true)
+    mockedUserPreferences.resetToDefaults.mockResolvedValue({
+      ok: true,
+      preferences: clonePreferences(),
+    })
     mockedUserPreferences.resetDisplaySettings.mockImplementation(async () =>
       applyPersistedUpdate({
         activeTab: DEFAULT_PREFERENCES.activeTab,
@@ -402,7 +424,10 @@ describe("UserPreferencesContext", () => {
         webdav: DEFAULT_PREFERENCES.webdav,
       }),
     )
-    mockedUserPreferences.resetSortingPriorityConfig.mockResolvedValue(true)
+    mockedUserPreferences.resetSortingPriorityConfig.mockResolvedValue({
+      ok: true,
+      preferences: clonePreferences(),
+    })
     mockedUserPreferences.resetTaskNotifications.mockImplementation(async () =>
       applyPersistedUpdate({
         taskNotifications: DEFAULT_PREFERENCES.taskNotifications,
@@ -859,7 +884,7 @@ describe("UserPreferencesContext", () => {
     const context = await renderProvider(preferences)
 
     await act(async () => {
-      expect(await context.updateActiveTab(DATA_TYPE_CASHFLOW)).toBe(true)
+      expect((await context.updateActiveTab(DATA_TYPE_CASHFLOW)).ok).toBe(true)
     })
 
     expect(mockedUserPreferences.updateActiveTab).toHaveBeenCalledWith(
@@ -873,7 +898,7 @@ describe("UserPreferencesContext", () => {
     )
 
     await act(async () => {
-      expect(await context.updateDefaultTab(DATA_TYPE_BALANCE)).toBe(true)
+      expect((await context.updateDefaultTab(DATA_TYPE_BALANCE)).ok).toBe(true)
     })
 
     expect(mockedUserPreferences.updateActiveTab).toHaveBeenLastCalledWith(
@@ -912,9 +937,9 @@ describe("UserPreferencesContext", () => {
     updatedConfig.lastModified = 1_700_000_000_000
 
     await act(async () => {
-      expect(await context.updateSortingPriorityConfig(updatedConfig)).toBe(
-        true,
-      )
+      expect(
+        (await context.updateSortingPriorityConfig(updatedConfig)).ok,
+      ).toBe(true)
     })
 
     expect(mockedUserPreferences.setSortingPriorityConfig).toHaveBeenCalledWith(
@@ -1363,92 +1388,104 @@ describe("UserPreferencesContext", () => {
     preferences.themeMode = "system"
     preferences.managedSiteType = SITE_TYPES.VELOERA
 
-    mockedUserPreferences.updateActiveTab.mockResolvedValue(false)
-    mockedUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
-    mockedUserPreferences.updateCurrencyType.mockResolvedValue(false)
-    mockedUserPreferences.updateSortConfig.mockResolvedValue(false)
-    mockedUserPreferences.setSortingPriorityConfig.mockResolvedValue(false)
-    mockedUserPreferences.updateOpenChangelogOnUpdate.mockResolvedValue(false)
+    mockedUserPreferences.updateActiveTab.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.savePreferencesWithResult.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.updateCurrencyType.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.updateSortConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.setSortingPriorityConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.updateOpenChangelogOnUpdate.mockResolvedValue(
+      preferenceWriteFailure,
+    )
     mockedUserPreferences.updateAutoProvisionKeyOnAccountAdd.mockResolvedValue(
-      false,
+      preferenceWriteFailure,
     )
     mockedUserPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd.mockResolvedValue(
-      false,
+      preferenceWriteFailure,
     )
     mockedUserPreferences.updateWarnOnDuplicateAccountAdd.mockResolvedValue(
-      false,
+      preferenceWriteFailure,
     )
-    mockedUserPreferences.updateManagedSiteType.mockResolvedValue(false)
-    mockedUserPreferences.updateLoggingPreferences.mockResolvedValue(false)
+    mockedUserPreferences.updateManagedSiteType.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.updateLoggingPreferences.mockResolvedValue(
+      preferenceWriteFailure,
+    )
 
     const context = await renderProvider(preferences)
 
     await act(async () => {
-      expect(await context.updateActiveTab(DATA_TYPE_CASHFLOW)).toBe(false)
-      expect(await context.updateActionClickBehavior("sidepanel")).toBe(false)
-      expect(await context.updateOpenChangelogOnUpdate(false)).toBe(false)
-      expect(await context.updateAutoProvisionKeyOnAccountAdd(true)).toBe(false)
-      expect(await context.updateAutoFillCurrentSiteUrlOnAccountAdd(true)).toBe(
-        false,
+      expectFailedWrite(await context.updateActiveTab(DATA_TYPE_CASHFLOW))
+      expectFailedWrite(await context.updateActionClickBehavior("sidepanel"))
+      expectFailedWrite(await context.updateOpenChangelogOnUpdate(false))
+      expectFailedWrite(await context.updateAutoProvisionKeyOnAccountAdd(true))
+      expectFailedWrite(
+        await context.updateAutoFillCurrentSiteUrlOnAccountAdd(true),
       )
-      expect(await context.updateWarnOnDuplicateAccountAdd(false)).toBe(false)
-      expect(await context.updateDefaultTab(DATA_TYPE_CASHFLOW)).toBe(false)
-      expect(await context.updateCurrencyType("CNY")).toBe(false)
-      expect(await context.updateShowTodayCashflow(false)).toBe(false)
-      expect(await context.updateSortConfig(DATA_TYPE_INCOME, "asc")).toBe(
-        false,
-      )
-      expect(
+      expectFailedWrite(await context.updateWarnOnDuplicateAccountAdd(false))
+      expectFailedWrite(await context.updateDefaultTab(DATA_TYPE_CASHFLOW))
+      expectFailedWrite(await context.updateCurrencyType("CNY"))
+      expectFailedWrite(await context.updateShowTodayCashflow(false))
+      expectFailedWrite(await context.updateSortConfig(DATA_TYPE_INCOME, "asc"))
+      expectFailedWrite(
         await context.updateSortingPriorityConfig(
           DEFAULT_SORTING_PRIORITY_CONFIG,
         ),
-      ).toBe(false)
-      expect(await context.updateAutoRefresh(true)).toBe(false)
-      expect(await context.updateRefreshInterval(60_000)).toBe(false)
-      expect(await context.updateMinRefreshInterval(15_000)).toBe(false)
-      expect(await context.updateRefreshOnOpen(true)).toBe(false)
-      expect(await context.updateNewApiBaseUrl("https://new-api.example")).toBe(
-        false,
       )
-      expect(
+      expectFailedWrite(await context.updateAutoRefresh(true))
+      expectFailedWrite(await context.updateRefreshInterval(60_000))
+      expectFailedWrite(await context.updateMinRefreshInterval(15_000))
+      expectFailedWrite(await context.updateRefreshOnOpen(true))
+      expectFailedWrite(
+        await context.updateNewApiBaseUrl("https://new-api.example"),
+      )
+      expectFailedWrite(
         await context.updateDoneHubBaseUrl("https://donehub.example"),
-      ).toBe(false)
-      expect(
+      )
+      expectFailedWrite(
         await context.updateVeloeraBaseUrl("https://veloera.example"),
-      ).toBe(false)
-      expect(
+      )
+      expectFailedWrite(
         await context.updateOctopusBaseUrl("https://octopus.example"),
-      ).toBe(false)
-      expect(await context.updateManagedSiteType(SITE_TYPES.VELOERA)).toBe(
-        false,
       )
-      expect(await context.updateThemeMode("dark")).toBe(false)
-      expect(await context.updateLoggingConsoleEnabled(false)).toBe(false)
-      expect(await context.updateLoggingLevel("warn")).toBe(false)
-      expect(await context.updateAutoCheckin({ globalEnabled: false })).toBe(
-        false,
+      expectFailedWrite(await context.updateManagedSiteType(SITE_TYPES.VELOERA))
+      expectFailedWrite(await context.updateThemeMode("dark"))
+      expectFailedWrite(await context.updateLoggingConsoleEnabled(false))
+      expectFailedWrite(await context.updateLoggingLevel("warn"))
+      expectFailedWrite(
+        await context.updateAutoCheckin({ globalEnabled: false }),
       )
-      expect(await context.updateBalanceHistory({ enabled: true })).toBe(false)
-      expect(await context.updateNewApiModelSync({ enabled: true })).toBe(false)
-      expect(await context.updateModelRedirect({ enabled: true })).toBe(false)
-      expect(await context.updateRedemptionAssist({ enabled: false })).toBe(
-        false,
+      expectFailedWrite(await context.updateBalanceHistory({ enabled: true }))
+      expectFailedWrite(await context.updateNewApiModelSync({ enabled: true }))
+      expectFailedWrite(await context.updateModelRedirect({ enabled: true }))
+      expectFailedWrite(
+        await context.updateRedemptionAssist({ enabled: false }),
       )
-      expect(await context.updateWebAiApiCheck({ enabled: false })).toBe(false)
-      expect(await context.updateTempWindowFallback({ enabled: false })).toBe(
-        false,
+      expectFailedWrite(await context.updateWebAiApiCheck({ enabled: false }))
+      expectFailedWrite(
+        await context.updateTempWindowFallback({ enabled: false }),
       )
-      expect(
+      expectFailedWrite(
         await context.updateTempWindowFallbackReminder({ dismissed: true }),
-      ).toBe(false)
-      expect(await context.updateCliProxyBaseUrl("https://cli.example")).toBe(
-        false,
       )
-      expect(await context.updateCliProxyManagementKey("cli-key")).toBe(false)
-      expect(
+      expectFailedWrite(
+        await context.updateCliProxyBaseUrl("https://cli.example"),
+      )
+      expectFailedWrite(await context.updateCliProxyManagementKey("cli-key"))
+      expectFailedWrite(
         await context.updateClaudeCodeRouterBaseUrl("https://ccr.example"),
-      ).toBe(false)
-      expect(await context.updateClaudeCodeRouterApiKey("ccr-key")).toBe(false)
+      )
+      expectFailedWrite(await context.updateClaudeCodeRouterApiKey("ccr-key"))
     })
 
     expect((latestContext as any)?.activeTab).toBe(DATA_TYPE_BALANCE)
@@ -1466,6 +1503,36 @@ describe("UserPreferencesContext", () => {
     expect(mockedSendRedemptionAssistMessage).not.toHaveBeenCalled()
     expect(mockedSendSiteAnnouncementsMessage).not.toHaveBeenCalled()
     expect(mockedSendWebdavAutoSyncMessage).not.toHaveBeenCalled()
+  })
+
+  it("returns a stale preference write result when the saved snapshot is stale", async () => {
+    const preferences = clonePreferences()
+    preferences.lastUpdated = 7
+    mockedUserPreferences.savePreferencesWithResult.mockResolvedValue({
+      ok: false,
+      reason: {
+        type: "stale",
+        expectedLastUpdated: preferences.lastUpdated,
+        actualLastUpdated: preferences.lastUpdated + 1,
+      },
+    })
+
+    const context = await renderProvider(preferences)
+
+    await act(async () => {
+      expect(
+        await context.updateCliProxyBaseUrl("https://cli.example.invalid", {
+          expectedLastUpdated: preferences.lastUpdated,
+        }),
+      ).toEqual({
+        ok: false,
+        reason: {
+          type: "stale",
+          expectedLastUpdated: preferences.lastUpdated,
+          actualLastUpdated: preferences.lastUpdated + 1,
+        },
+      })
+    })
   })
 
   it("keeps stored backend credentials untouched when credential writes fail", async () => {
@@ -1494,43 +1561,43 @@ describe("UserPreferencesContext", () => {
       password: "stored-octopus-password",
     }
 
-    mockedUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
+    mockedUserPreferences.savePreferencesWithResult.mockResolvedValue(
+      preferenceWriteFailure,
+    )
 
     const context = await renderProvider(preferences)
 
     await act(async () => {
-      expect(await context.updateNewApiAdminToken("next-new-api-admin")).toBe(
-        false,
+      expectFailedWrite(
+        await context.updateNewApiAdminToken("next-new-api-admin"),
       )
-      expect(await context.updateNewApiUserId("next-new-api-user-id")).toBe(
-        false,
+      expectFailedWrite(
+        await context.updateNewApiUserId("next-new-api-user-id"),
       )
-      expect(await context.updateNewApiUsername("next-new-api-user")).toBe(
-        false,
+      expectFailedWrite(await context.updateNewApiUsername("next-new-api-user"))
+      expectFailedWrite(
+        await context.updateNewApiPassword("next-new-api-password"),
       )
-      expect(await context.updateNewApiPassword("next-new-api-password")).toBe(
-        false,
+      expectFailedWrite(
+        await context.updateNewApiTotpSecret("next-new-api-totp"),
       )
-      expect(await context.updateNewApiTotpSecret("next-new-api-totp")).toBe(
-        false,
+      expectFailedWrite(
+        await context.updateDoneHubAdminToken("next-donehub-admin"),
       )
-      expect(await context.updateDoneHubAdminToken("next-donehub-admin")).toBe(
-        false,
+      expectFailedWrite(
+        await context.updateDoneHubUserId("next-donehub-user-id"),
       )
-      expect(await context.updateDoneHubUserId("next-donehub-user-id")).toBe(
-        false,
+      expectFailedWrite(
+        await context.updateVeloeraAdminToken("next-veloera-admin"),
       )
-      expect(await context.updateVeloeraAdminToken("next-veloera-admin")).toBe(
-        false,
+      expectFailedWrite(
+        await context.updateVeloeraUserId("next-veloera-user-id"),
       )
-      expect(await context.updateVeloeraUserId("next-veloera-user-id")).toBe(
-        false,
+      expectFailedWrite(
+        await context.updateOctopusUsername("next-octopus-user"),
       )
-      expect(await context.updateOctopusUsername("next-octopus-user")).toBe(
-        false,
-      )
-      expect(await context.updateOctopusPassword("next-octopus-password")).toBe(
-        false,
+      expectFailedWrite(
+        await context.updateOctopusPassword("next-octopus-password"),
       )
     })
 
@@ -1598,48 +1665,86 @@ describe("UserPreferencesContext", () => {
       lastModified: Date.now(),
     }
 
-    mockedUserPreferences.resetToDefaults.mockResolvedValue(false)
-    mockedUserPreferences.resetDisplaySettings.mockResolvedValue(false)
-    mockedUserPreferences.resetAutoRefreshConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetNewApiConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetDoneHubConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetVeloeraConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetOctopusConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetClaudeCodeHubConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetNewApiModelSyncConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetCliProxyConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetClaudeCodeRouterConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetAutoCheckinConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetRedemptionAssist.mockResolvedValue(false)
-    mockedUserPreferences.resetWebAiApiCheck.mockResolvedValue(false)
-    mockedUserPreferences.resetModelRedirectConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetWebdavConfig.mockResolvedValue(false)
-    mockedUserPreferences.updateLoggingPreferences.mockResolvedValue(false)
-    mockedUserPreferences.resetSortingPriorityConfig.mockResolvedValue(false)
-    mockedUserPreferences.resetTaskNotifications.mockResolvedValue(false)
+    mockedUserPreferences.resetToDefaults.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetDisplaySettings.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetAutoRefreshConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetNewApiConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetDoneHubConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetVeloeraConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetOctopusConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetClaudeCodeHubConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetNewApiModelSyncConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetCliProxyConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetClaudeCodeRouterConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetAutoCheckinConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetRedemptionAssist.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetWebAiApiCheck.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetModelRedirectConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetWebdavConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.updateLoggingPreferences.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetSortingPriorityConfig.mockResolvedValue(
+      preferenceWriteFailure,
+    )
+    mockedUserPreferences.resetTaskNotifications.mockResolvedValue(
+      preferenceWriteFailure,
+    )
 
     const context = await renderProvider(preferences)
 
     await act(async () => {
-      expect(await context.resetToDefaults()).toBe(false)
-      expect(await context.resetDisplaySettings()).toBe(false)
-      expect(await context.resetAutoRefreshConfig()).toBe(false)
-      expect(await context.resetNewApiConfig()).toBe(false)
-      expect(await context.resetDoneHubConfig()).toBe(false)
-      expect(await context.resetVeloeraConfig()).toBe(false)
-      expect(await context.resetOctopusConfig()).toBe(false)
-      expect(await context.resetClaudeCodeHubConfig()).toBe(false)
-      expect(await context.resetNewApiModelSyncConfig()).toBe(false)
-      expect(await context.resetCliProxyConfig()).toBe(false)
-      expect(await context.resetClaudeCodeRouterConfig()).toBe(false)
-      expect(await context.resetAutoCheckinConfig()).toBe(false)
-      expect(await context.resetRedemptionAssistConfig()).toBe(false)
-      expect(await context.resetWebAiApiCheckConfig()).toBe(false)
-      expect(await context.resetModelRedirectConfig()).toBe(false)
-      expect(await context.resetWebdavConfig()).toBe(false)
-      expect(await context.resetLoggingSettings()).toBe(false)
-      expect(await context.resetSortingPriorityConfig()).toBe(false)
-      expect(await context.resetTaskNotifications()).toBe(false)
+      expectFailedWrite(await context.resetToDefaults())
+      expectFailedWrite(await context.resetDisplaySettings())
+      expectFailedWrite(await context.resetAutoRefreshConfig())
+      expectFailedWrite(await context.resetNewApiConfig())
+      expectFailedWrite(await context.resetDoneHubConfig())
+      expectFailedWrite(await context.resetVeloeraConfig())
+      expectFailedWrite(await context.resetOctopusConfig())
+      expectFailedWrite(await context.resetClaudeCodeHubConfig())
+      expectFailedWrite(await context.resetNewApiModelSyncConfig())
+      expectFailedWrite(await context.resetCliProxyConfig())
+      expectFailedWrite(await context.resetClaudeCodeRouterConfig())
+      expectFailedWrite(await context.resetAutoCheckinConfig())
+      expectFailedWrite(await context.resetRedemptionAssistConfig())
+      expectFailedWrite(await context.resetWebAiApiCheckConfig())
+      expectFailedWrite(await context.resetModelRedirectConfig())
+      expectFailedWrite(await context.resetWebdavConfig())
+      expectFailedWrite(await context.resetLoggingSettings())
+      expectFailedWrite(await context.resetSortingPriorityConfig())
+      expectFailedWrite(await context.resetTaskNotifications())
     })
 
     expect((latestContext as any)?.preferences).toEqual(preferences)
@@ -2068,7 +2173,10 @@ describe("UserPreferencesContext", () => {
     mockedUserPreferences.getPreferences
       .mockResolvedValueOnce(initialPreferences)
       .mockReturnValueOnce(deferredPreferences.promise)
-    mockedUserPreferences.updateTaskNotifications.mockResolvedValueOnce(true)
+    mockedUserPreferences.updateTaskNotifications.mockResolvedValueOnce({
+      ok: true,
+      preferences: clonePreferences(),
+    })
 
     const context = await renderProvider(initialPreferences)
 
@@ -2084,9 +2192,11 @@ describe("UserPreferencesContext", () => {
 
     await act(async () => {
       expect(
-        await context.updateTaskNotifications({
-          enabled: false,
-        }),
+        (
+          await context.updateTaskNotifications({
+            enabled: false,
+          })
+        ).ok,
       ).toBe(true)
     })
 
@@ -2110,7 +2220,10 @@ describe("UserPreferencesContext", () => {
     mockedUserPreferences.getPreferences
       .mockResolvedValueOnce(initialPreferences)
       .mockReturnValueOnce(deferredPreferences.promise)
-    mockedUserPreferences.resetTaskNotifications.mockResolvedValueOnce(true)
+    mockedUserPreferences.resetTaskNotifications.mockResolvedValueOnce({
+      ok: true,
+      preferences: clonePreferences(),
+    })
 
     const context = await renderProvider(initialPreferences)
 
@@ -2125,7 +2238,7 @@ describe("UserPreferencesContext", () => {
     })
 
     await act(async () => {
-      expect(await context.resetTaskNotifications()).toBe(true)
+      expect((await context.resetTaskNotifications()).ok).toBe(true)
     })
 
     expect((latestContext as any)?.preferences.taskNotifications).toEqual(
@@ -2307,14 +2420,16 @@ describe("UserPreferencesContext", () => {
 
     const context = await renderProvider(preferences)
 
-    let success = true
+    let response: { success: boolean; data?: unknown; error?: string } = {
+      success: true,
+    }
     await act(async () => {
-      success = await context.updateSiteAnnouncementNotifications({
+      response = await context.updateSiteAnnouncementNotifications({
         enabled: false,
       })
     })
 
-    expect(success).toBe(false)
+    expect(response.success).toBe(false)
     expect(mockedSendSiteAnnouncementsMessage).toHaveBeenCalledWith(
       "siteAnnouncements:updatePreferences",
       {

--- a/tests/entrypoints/options/ActionClickBehaviorSettings.test.tsx
+++ b/tests/entrypoints/options/ActionClickBehaviorSettings.test.tsx
@@ -32,6 +32,11 @@ vi.mock("~/utils/core/toastHelpers", () => ({
   showUpdateToast: vi.fn(),
 }))
 
+const preferenceWriteSuccess = () => ({
+  ok: true,
+  preferences: {},
+})
+
 describe("ActionClickBehaviorSettings (side panel fallback)", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -77,7 +82,9 @@ describe("ActionClickBehaviorSettings (side panel fallback)", () => {
     } satisfies SidePanelSupport
     vi.mocked(getSidePanelSupport).mockReturnValue(sidePanelSupport)
 
-    const updateActionClickBehavior = vi.fn().mockResolvedValue(true)
+    const updateActionClickBehavior = vi
+      .fn()
+      .mockResolvedValue(preferenceWriteSuccess())
     const userPreferencesContext = {
       actionClickBehavior: "popup",
       updateActionClickBehavior,
@@ -113,7 +120,9 @@ describe("ActionClickBehaviorSettings (side panel fallback)", () => {
       kind: "chromium-side-panel",
     } satisfies SidePanelSupport)
 
-    const updateActionClickBehavior = vi.fn().mockResolvedValue(true)
+    const updateActionClickBehavior = vi
+      .fn()
+      .mockResolvedValue(preferenceWriteSuccess())
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       actionClickBehavior: "popup",
       updateActionClickBehavior,
@@ -132,7 +141,7 @@ describe("ActionClickBehaviorSettings (side panel fallback)", () => {
     })
 
     expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:actionClick.title",
     )
     expect(vi.mocked(showResultToast)).not.toHaveBeenCalled()

--- a/tests/entrypoints/options/AutoCheckinSettings.test.tsx
+++ b/tests/entrypoints/options/AutoCheckinSettings.test.tsx
@@ -35,6 +35,16 @@ const {
 
 const pushWithinOptionsPageMock = vi.fn()
 
+const preferenceWriteSuccess = () => ({
+  ok: true,
+  preferences: {},
+})
+
+const preferenceWriteFailure = () => ({
+  ok: false,
+  reason: { type: "storage-error", error: new Error("save failed") },
+})
+
 vi.mock("react-hot-toast", () => ({
   default: toastMocks,
 }))
@@ -99,8 +109,8 @@ describe("AutoCheckinSettings", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    updateAutoCheckin.mockResolvedValue(true)
-    resetAutoCheckinConfig.mockResolvedValue(true)
+    updateAutoCheckin.mockResolvedValue(preferenceWriteSuccess())
+    resetAutoCheckinConfig.mockResolvedValue(preferenceWriteSuccess())
     useUserPreferencesContextMock.mockReturnValue({
       preferences: {
         autoCheckin: createPreferences(),
@@ -217,9 +227,9 @@ describe("AutoCheckinSettings", () => {
   })
 
   it("disables schedule mode changes while preferences are saving", async () => {
-    let resolveSave: (value: boolean) => void
+    let resolveSave: (value: ReturnType<typeof preferenceWriteSuccess>) => void
     updateAutoCheckin.mockReturnValueOnce(
-      new Promise<boolean>((resolve) => {
+      new Promise<ReturnType<typeof preferenceWriteSuccess>>((resolve) => {
         resolveSave = resolve
       }),
     )
@@ -248,7 +258,7 @@ describe("AutoCheckinSettings", () => {
     expect(updateAutoCheckin).toHaveBeenCalledTimes(1)
     expect(updateAutoCheckin).toHaveBeenCalledWith({ globalEnabled: false })
 
-    resolveSave!(true)
+    resolveSave!(preferenceWriteSuccess())
 
     await waitFor(() => {
       expect(
@@ -293,7 +303,7 @@ describe("AutoCheckinSettings", () => {
   })
 
   it("reports invalid retry numbers and save failures", async () => {
-    updateAutoCheckin.mockResolvedValue(false)
+    updateAutoCheckin.mockResolvedValue(preferenceWriteFailure())
 
     render(<AutoCheckinSettings />, {
       withUserPreferencesProvider: false,

--- a/tests/entrypoints/options/AxonHubSettings.test.tsx
+++ b/tests/entrypoints/options/AxonHubSettings.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import AxonHubSettings from "~/features/BasicSettings/components/tabs/ManagedSite/AxonHubSettings"
 import { signIn } from "~/services/apiService/axonHub"
+import type { PreferenceWriteResult } from "~/services/preferences/userPreferences"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
 
@@ -84,7 +85,7 @@ vi.mock("~/components/SettingSection", () => ({
   }: {
     children: ReactNode
     description: string
-    onReset?: () => Promise<any>
+    onReset?: () => Promise<PreferenceWriteResult>
     title: string
   }) => (
     <section>

--- a/tests/entrypoints/options/AxonHubSettings.test.tsx
+++ b/tests/entrypoints/options/AxonHubSettings.test.tsx
@@ -14,6 +14,7 @@ const {
   mockUpdateAxonHubEmail,
   mockUpdateAxonHubPassword,
   mockedUseUserPreferencesContext,
+  showUpdateToastMock,
 } = vi.hoisted(() => ({
   mockResetAxonHubConfig: vi.fn(),
   mockUpdateAxonHubBaseUrl: vi.fn(),
@@ -21,6 +22,7 @@ const {
   mockUpdateAxonHubEmail: vi.fn(),
   mockUpdateAxonHubPassword: vi.fn(),
   mockedUseUserPreferencesContext: vi.fn(),
+  showUpdateToastMock: vi.fn(),
 }))
 
 vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
@@ -40,7 +42,30 @@ vi.mock("~/services/apiService/axonHub", () => ({
 }))
 
 vi.mock("~/utils/core/toastHelpers", () => ({
-  showUpdateToast: vi.fn(),
+  createVersionedPreferenceSaveOptions: (expectedLastUpdated: number) => ({
+    expectedLastUpdated,
+  }),
+  runPreferenceUpdateWithToast: async ({
+    expectedLastUpdated,
+    setting,
+    update,
+  }: {
+    expectedLastUpdated: number
+    setting: string
+    update: (options: { expectedLastUpdated: number }) => Promise<any>
+  }) => {
+    const result = await update({ expectedLastUpdated })
+    showUpdateToastMock(result, setting)
+    return result
+  },
+  getPreferenceWriteFailureMessage: (
+    failure: { type: string },
+    options?: { fallback?: string },
+  ) =>
+    failure.type === "stale"
+      ? "settings:messages.preferencesChangedExternally"
+      : options?.fallback ?? "settings:messages.updateFailed",
+  showUpdateToast: showUpdateToastMock,
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -59,7 +84,7 @@ vi.mock("~/components/SettingSection", () => ({
   }: {
     children: ReactNode
     description: string
-    onReset?: () => Promise<boolean>
+    onReset?: () => Promise<any>
     title: string
   }) => (
     <section>
@@ -195,11 +220,11 @@ describe("AxonHubSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockResetAxonHubConfig.mockResolvedValue(true)
-    mockUpdateAxonHubBaseUrl.mockResolvedValue(true)
-    mockUpdateAxonHubConfig.mockResolvedValue(true)
-    mockUpdateAxonHubEmail.mockResolvedValue(true)
-    mockUpdateAxonHubPassword.mockResolvedValue(true)
+    mockResetAxonHubConfig.mockResolvedValue({ ok: true, preferences: {} })
+    mockUpdateAxonHubBaseUrl.mockResolvedValue({ ok: true, preferences: {} })
+    mockUpdateAxonHubConfig.mockResolvedValue({ ok: true, preferences: {} })
+    mockUpdateAxonHubEmail.mockResolvedValue({ ok: true, preferences: {} })
+    mockUpdateAxonHubPassword.mockResolvedValue({ ok: true, preferences: {} })
     mockedSignIn.mockResolvedValue({ accessToken: "token" })
     mockedUseUserPreferencesContext.mockReturnValue(createContextValue())
   })
@@ -229,7 +254,7 @@ describe("AxonHubSettings", () => {
       )
     })
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:axonHub.fields.baseUrlLabel",
     )
 
@@ -321,7 +346,7 @@ describe("AxonHubSettings", () => {
       )
     })
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:axonHub.fields.emailLabel",
     )
   })
@@ -433,7 +458,10 @@ describe("AxonHubSettings", () => {
   })
 
   it("uses the named update-failed toast when validation succeeds but persistence fails", async () => {
-    mockUpdateAxonHubConfig.mockResolvedValue(false)
+    mockUpdateAxonHubConfig.mockResolvedValue({
+      ok: false,
+      reason: { type: "storage-error", error: new Error("save failed") },
+    })
 
     render(<AxonHubSettings />)
 

--- a/tests/entrypoints/options/BalanceHistorySettings.test.tsx
+++ b/tests/entrypoints/options/BalanceHistorySettings.test.tsx
@@ -127,7 +127,7 @@ describe("BalanceHistorySettings", () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        "settings:messages.saveSettingsFailed",
+        "balanceHistory:messages.error.settingsSaveFailed",
         { id: "toast-id" },
       )
     })

--- a/tests/entrypoints/options/BasicSettingsTabs.test.tsx
+++ b/tests/entrypoints/options/BasicSettingsTabs.test.tsx
@@ -56,6 +56,22 @@ vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
 })
 
 vi.mock("~/utils/core/toastHelpers", () => ({
+  createVersionedPreferenceSaveOptions: (expectedLastUpdated: number) => ({
+    expectedLastUpdated,
+  }),
+  runPreferenceUpdateWithToast: async ({
+    expectedLastUpdated,
+    setting,
+    update,
+  }: {
+    expectedLastUpdated: number
+    setting: string
+    update: (options: { expectedLastUpdated: number }) => Promise<any>
+  }) => {
+    const result = await update({ expectedLastUpdated })
+    showUpdateToastMock(result, setting)
+    return result
+  },
   showUpdateToast: (...args: unknown[]) => showUpdateToastMock(...args),
 }))
 
@@ -88,13 +104,21 @@ const createContextValue = (overrides: Record<string, unknown> = {}) => ({
   newApiUsername: "admin",
   newApiPassword: "secret-password",
   newApiTotpSecret: "JBSWY3DPEHPK3PXP",
-  updateNewApiBaseUrl: vi.fn().mockResolvedValue(true),
-  updateNewApiAdminToken: vi.fn().mockResolvedValue(true),
-  updateNewApiUserId: vi.fn().mockResolvedValue(true),
-  updateNewApiUsername: vi.fn().mockResolvedValue(true),
-  updateNewApiPassword: vi.fn().mockResolvedValue(true),
-  updateNewApiTotpSecret: vi.fn().mockResolvedValue(true),
-  resetNewApiConfig: vi.fn().mockResolvedValue(true),
+  updateNewApiBaseUrl: vi.fn().mockResolvedValue({ ok: true, preferences: {} }),
+  updateNewApiAdminToken: vi
+    .fn()
+    .mockResolvedValue({ ok: true, preferences: {} }),
+  updateNewApiUserId: vi.fn().mockResolvedValue({ ok: true, preferences: {} }),
+  updateNewApiUsername: vi
+    .fn()
+    .mockResolvedValue({ ok: true, preferences: {} }),
+  updateNewApiPassword: vi
+    .fn()
+    .mockResolvedValue({ ok: true, preferences: {} }),
+  updateNewApiTotpSecret: vi
+    .fn()
+    .mockResolvedValue({ ok: true, preferences: {} }),
+  resetNewApiConfig: vi.fn().mockResolvedValue({ ok: true, preferences: {} }),
   ...overrides,
 })
 
@@ -257,15 +281,15 @@ describe("BasicSettings tab layout", () => {
 
     expect(adminTokenInput).toHaveAttribute("type", "text")
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:newApi.fields.baseUrlLabel",
     )
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:newApi.fields.adminTokenLabel",
     )
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:newApi.fields.userIdLabel",
     )
   })

--- a/tests/entrypoints/options/ClaudeCodeHubSettings.test.tsx
+++ b/tests/entrypoints/options/ClaudeCodeHubSettings.test.tsx
@@ -8,6 +8,10 @@ import { validateClaudeCodeHubConfig } from "~/services/apiService/claudeCodeHub
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
+const { showUpdateToastMock } = vi.hoisted(() => ({
+  showUpdateToastMock: vi.fn(),
+}))
+
 vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: vi.fn(),
 }))
@@ -17,7 +21,23 @@ vi.mock("~/services/apiService/claudeCodeHub", () => ({
 }))
 
 vi.mock("~/utils/core/toastHelpers", () => ({
-  showUpdateToast: vi.fn(),
+  createVersionedPreferenceSaveOptions: (expectedLastUpdated: number) => ({
+    expectedLastUpdated,
+  }),
+  runPreferenceUpdateWithToast: async ({
+    expectedLastUpdated,
+    setting,
+    update,
+  }: {
+    expectedLastUpdated: number
+    setting: string
+    update: (options: { expectedLastUpdated: number }) => Promise<any>
+  }) => {
+    const result = await update({ expectedLastUpdated })
+    showUpdateToastMock(result, setting)
+    return result
+  },
+  showUpdateToast: showUpdateToastMock,
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -44,15 +64,23 @@ describe("ClaudeCodeHubSettings", () => {
     )
 
   it("trims the base URL before persisting", async () => {
-    const updateClaudeCodeHubBaseUrl = vi.fn().mockResolvedValue(true)
+    const updateClaudeCodeHubBaseUrl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       preferences: { lastUpdated: 1 },
       claudeCodeHubBaseUrl: "https://cch.example.com",
       claudeCodeHubAdminToken: "admin-token",
       updateClaudeCodeHubBaseUrl,
-      updateClaudeCodeHubAdminToken: vi.fn().mockResolvedValue(true),
-      updateClaudeCodeHubConfig: vi.fn().mockResolvedValue(true),
-      resetClaudeCodeHubConfig: vi.fn().mockResolvedValue(true),
+      updateClaudeCodeHubAdminToken: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateClaudeCodeHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetClaudeCodeHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -76,21 +104,29 @@ describe("ClaudeCodeHubSettings", () => {
     })
 
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:claudeCodeHub.fields.baseUrlLabel",
     )
   })
 
   it("trims the admin token before persisting and skips unchanged trimmed values", async () => {
-    const updateClaudeCodeHubAdminToken = vi.fn().mockResolvedValue(true)
+    const updateClaudeCodeHubAdminToken = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       preferences: { lastUpdated: 2 },
       claudeCodeHubBaseUrl: "https://cch.example.com",
       claudeCodeHubAdminToken: "same-token",
-      updateClaudeCodeHubBaseUrl: vi.fn().mockResolvedValue(true),
+      updateClaudeCodeHubBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
       updateClaudeCodeHubAdminToken,
-      updateClaudeCodeHubConfig: vi.fn().mockResolvedValue(true),
-      resetClaudeCodeHubConfig: vi.fn().mockResolvedValue(true),
+      updateClaudeCodeHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetClaudeCodeHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -115,7 +151,7 @@ describe("ClaudeCodeHubSettings", () => {
     expect(updateClaudeCodeHubAdminToken).toHaveBeenCalledTimes(1)
     expect(mockedShowUpdateToast).toHaveBeenCalledTimes(1)
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:claudeCodeHub.fields.adminTokenLabel",
     )
   })
@@ -127,10 +163,18 @@ describe("ClaudeCodeHubSettings", () => {
       preferences: { lastUpdated: 3 },
       claudeCodeHubBaseUrl: "",
       claudeCodeHubAdminToken: "",
-      updateClaudeCodeHubBaseUrl: vi.fn().mockResolvedValue(true),
-      updateClaudeCodeHubAdminToken: vi.fn().mockResolvedValue(true),
-      updateClaudeCodeHubConfig: vi.fn().mockResolvedValue(true),
-      resetClaudeCodeHubConfig: vi.fn().mockResolvedValue(true),
+      updateClaudeCodeHubBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateClaudeCodeHubAdminToken: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateClaudeCodeHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetClaudeCodeHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -168,17 +212,28 @@ describe("ClaudeCodeHubSettings", () => {
 
   it("validates and persists trimmed Claude Code Hub config values", async () => {
     const toast = await import("react-hot-toast")
-    const updateClaudeCodeHubConfig = vi.fn().mockResolvedValue(true)
+    const updateClaudeCodeHubConfig = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
 
-    mockedValidateClaudeCodeHubConfig.mockResolvedValue(true)
+    mockedValidateClaudeCodeHubConfig.mockResolvedValue({
+      ok: true,
+      preferences: {},
+    })
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       preferences: { lastUpdated: 4 },
       claudeCodeHubBaseUrl: "https://cch.example.com",
       claudeCodeHubAdminToken: "admin-token",
-      updateClaudeCodeHubBaseUrl: vi.fn().mockResolvedValue(true),
-      updateClaudeCodeHubAdminToken: vi.fn().mockResolvedValue(true),
+      updateClaudeCodeHubBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateClaudeCodeHubAdminToken: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
       updateClaudeCodeHubConfig,
-      resetClaudeCodeHubConfig: vi.fn().mockResolvedValue(true),
+      resetClaudeCodeHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -237,10 +292,18 @@ describe("ClaudeCodeHubSettings", () => {
       preferences: { lastUpdated: 5 },
       claudeCodeHubBaseUrl: "https://cch.example.com",
       claudeCodeHubAdminToken: "admin-token",
-      updateClaudeCodeHubBaseUrl: vi.fn().mockResolvedValue(true),
-      updateClaudeCodeHubAdminToken: vi.fn().mockResolvedValue(true),
-      updateClaudeCodeHubConfig: vi.fn().mockResolvedValue(true),
-      resetClaudeCodeHubConfig: vi.fn().mockResolvedValue(true),
+      updateClaudeCodeHubBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateClaudeCodeHubAdminToken: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateClaudeCodeHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetClaudeCodeHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()

--- a/tests/entrypoints/options/ClaudeCodeRouterSettings.test.tsx
+++ b/tests/entrypoints/options/ClaudeCodeRouterSettings.test.tsx
@@ -7,12 +7,40 @@ import ClaudeCodeRouterSettings from "~/features/BasicSettings/components/tabs/C
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
+const { showUpdateToastMock, toastErrorMock } = vi.hoisted(() => ({
+  showUpdateToastMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}))
+
 vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: vi.fn(),
 }))
 
 vi.mock("~/utils/core/toastHelpers", () => ({
-  showUpdateToast: vi.fn(),
+  runPreferenceUpdateWithToast: async ({
+    expectedLastUpdated,
+    setting,
+    update,
+  }: {
+    expectedLastUpdated: number
+    setting: string
+    update: (options: { expectedLastUpdated: number }) => Promise<any>
+  }) => {
+    const result = await update({ expectedLastUpdated })
+    if (result?.ok === false && result.reason?.type === "stale") {
+      toastErrorMock("settings:messages.preferencesChangedExternally")
+    } else {
+      showUpdateToastMock(result, setting)
+    }
+    return result
+  },
+  showUpdateToast: showUpdateToastMock,
+}))
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
 }))
 
 describe("ClaudeCodeRouterSettings", () => {
@@ -28,9 +56,15 @@ describe("ClaudeCodeRouterSettings", () => {
       preferences: { lastUpdated: 1 },
       claudeCodeRouterBaseUrl: "http://router.local",
       claudeCodeRouterApiKey: "router-key",
-      updateClaudeCodeRouterBaseUrl: vi.fn().mockResolvedValue(true),
-      updateClaudeCodeRouterApiKey: vi.fn().mockResolvedValue(true),
-      resetClaudeCodeRouterConfig: vi.fn().mockResolvedValue(true),
+      updateClaudeCodeRouterBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateClaudeCodeRouterApiKey: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetClaudeCodeRouterConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
       ...overrides,
     }) as unknown as UserPreferencesContextValue
 
@@ -49,8 +83,12 @@ describe("ClaudeCodeRouterSettings", () => {
   })
 
   it("persists base URL and API key updates with the current preferences version", async () => {
-    const updateClaudeCodeRouterBaseUrl = vi.fn().mockResolvedValue(true)
-    const updateClaudeCodeRouterApiKey = vi.fn().mockResolvedValue(true)
+    const updateClaudeCodeRouterBaseUrl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
+    const updateClaudeCodeRouterApiKey = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue(
       createContextValue({
         updateClaudeCodeRouterBaseUrl,
@@ -77,25 +115,74 @@ describe("ClaudeCodeRouterSettings", () => {
     await waitFor(() => {
       expect(updateClaudeCodeRouterBaseUrl).toHaveBeenCalledWith(
         "http://next-router.local",
-        {
+        expect.objectContaining({
           expectedLastUpdated: 1,
-        },
+        }),
       )
       expect(updateClaudeCodeRouterApiKey).toHaveBeenCalledWith(
         "next-router-key",
-        {
+        expect.objectContaining({
           expectedLastUpdated: 1,
-        },
+        }),
       )
       expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-        true,
+        expect.objectContaining({ ok: true }),
         "settings:claudeCodeRouter.baseUrlLabel",
       )
       expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-        true,
+        expect.objectContaining({ ok: true }),
         "settings:claudeCodeRouter.apiKeyLabel",
       )
     })
+  })
+
+  it("shows stale preference guidance instead of a generic update failure", async () => {
+    const updateClaudeCodeRouterBaseUrl = vi
+      .fn()
+      .mockImplementation(
+        async (
+          _url: string,
+          _options?: { expectedLastUpdated?: number },
+        ): Promise<any> => {
+          return {
+            ok: false,
+            reason: {
+              type: "stale",
+              expectedLastUpdated: 1,
+              actualLastUpdated: 2,
+            },
+          }
+        },
+      )
+    vi.mocked(useUserPreferencesContext).mockReturnValue(
+      createContextValue({
+        updateClaudeCodeRouterBaseUrl,
+      }),
+    )
+
+    renderSubject()
+
+    const baseUrlInput = screen.getByPlaceholderText(
+      "settings:claudeCodeRouter.baseUrlPlaceholder",
+    )
+    fireEvent.change(baseUrlInput, {
+      target: { value: "http://next-router.local" },
+    })
+    fireEvent.blur(baseUrlInput)
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "settings:messages.preferencesChangedExternally",
+      )
+    })
+
+    expect(updateClaudeCodeRouterBaseUrl).toHaveBeenCalledWith(
+      "http://next-router.local",
+      expect.objectContaining({
+        expectedLastUpdated: 1,
+      }),
+    )
+    expect(vi.mocked(showUpdateToast)).not.toHaveBeenCalled()
   })
 
   it("toggles the API key visibility label and input type", () => {

--- a/tests/entrypoints/options/CliProxySettings.test.tsx
+++ b/tests/entrypoints/options/CliProxySettings.test.tsx
@@ -8,6 +8,14 @@ import { verifyCliProxyManagementConnection } from "~/services/integrations/cliP
 import { showResultToast, showUpdateToast } from "~/utils/core/toastHelpers"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
+const { showResultToastMock, showUpdateToastMock, toastErrorMock } = vi.hoisted(
+  () => ({
+    showResultToastMock: vi.fn(),
+    showUpdateToastMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+  }),
+)
+
 vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: vi.fn(),
 }))
@@ -24,8 +32,31 @@ vi.mock("~/services/integrations/cliProxyService", async (importOriginal) => {
 })
 
 vi.mock("~/utils/core/toastHelpers", () => ({
-  showResultToast: vi.fn(),
-  showUpdateToast: vi.fn(),
+  runPreferenceUpdateWithToast: async ({
+    expectedLastUpdated,
+    setting,
+    update,
+  }: {
+    expectedLastUpdated: number
+    setting: string
+    update: (options: { expectedLastUpdated: number }) => Promise<any>
+  }) => {
+    const result = await update({ expectedLastUpdated })
+    if (result?.ok === false && result.reason?.type === "stale") {
+      toastErrorMock("settings:messages.preferencesChangedExternally")
+    } else {
+      showUpdateToastMock(result, setting)
+    }
+    return result
+  },
+  showResultToast: showResultToastMock,
+  showUpdateToast: showUpdateToastMock,
+}))
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
 }))
 
 describe("CliProxySettings", () => {
@@ -36,9 +67,15 @@ describe("CliProxySettings", () => {
       preferences: { lastUpdated: 1 },
       cliProxyBaseUrl: "http://localhost:8317/v0/management",
       cliProxyManagementKey: "secret-key",
-      updateCliProxyBaseUrl: vi.fn().mockResolvedValue(true),
-      updateCliProxyManagementKey: vi.fn().mockResolvedValue(true),
-      resetCliProxyConfig: vi.fn().mockResolvedValue(true),
+      updateCliProxyBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateCliProxyManagementKey: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetCliProxyConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     vi.mocked(verifyCliProxyManagementConnection).mockResolvedValue({
@@ -55,14 +92,20 @@ describe("CliProxySettings", () => {
     )
 
   it("trims the base URL before persisting and re-checks the connection", async () => {
-    const updateCliProxyBaseUrl = vi.fn().mockResolvedValue(true)
+    const updateCliProxyBaseUrl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       preferences: { lastUpdated: 1 },
       cliProxyBaseUrl: "http://localhost:8317/v0/management",
       cliProxyManagementKey: "secret-key",
       updateCliProxyBaseUrl,
-      updateCliProxyManagementKey: vi.fn().mockResolvedValue(true),
-      resetCliProxyConfig: vi.fn().mockResolvedValue(true),
+      updateCliProxyManagementKey: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetCliProxyConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -79,9 +122,9 @@ describe("CliProxySettings", () => {
     await waitFor(() => {
       expect(updateCliProxyBaseUrl).toHaveBeenCalledWith(
         "http://localhost:9000/v0/management",
-        {
+        expect.objectContaining({
           expectedLastUpdated: 1,
-        },
+        }),
       )
     })
 
@@ -93,7 +136,7 @@ describe("CliProxySettings", () => {
     })
 
     expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:cliProxy.baseUrlLabel",
     )
     expect(vi.mocked(showResultToast)).toHaveBeenCalledWith({
@@ -102,8 +145,68 @@ describe("CliProxySettings", () => {
     })
   })
 
+  it("shows stale preference guidance instead of a generic update failure", async () => {
+    const updateCliProxyBaseUrl = vi
+      .fn()
+      .mockImplementation(
+        async (
+          _url: string,
+          _options?: { expectedLastUpdated?: number },
+        ): Promise<any> => {
+          return {
+            ok: false,
+            reason: {
+              type: "stale",
+              expectedLastUpdated: 1,
+              actualLastUpdated: 2,
+            },
+          }
+        },
+      )
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 1 },
+      cliProxyBaseUrl: "http://localhost:8317/v0/management",
+      cliProxyManagementKey: "secret-key",
+      updateCliProxyBaseUrl,
+      updateCliProxyManagementKey: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetCliProxyConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+    } as any)
+
+    renderSubject()
+
+    const input = screen.getByPlaceholderText(
+      "http://localhost:8317/v0/management",
+    )
+
+    fireEvent.change(input, {
+      target: { value: "http://localhost:9000/v0/management" },
+    })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "settings:messages.preferencesChangedExternally",
+      )
+    })
+
+    expect(updateCliProxyBaseUrl).toHaveBeenCalledWith(
+      "http://localhost:9000/v0/management",
+      expect.objectContaining({
+        expectedLastUpdated: 1,
+      }),
+    )
+    expect(vi.mocked(showUpdateToast)).not.toHaveBeenCalled()
+    expect(verifyCliProxyManagementConnection).not.toHaveBeenCalled()
+  })
+
   it("trims the management key before persisting and surfaces the connection-check result", async () => {
-    const updateCliProxyManagementKey = vi.fn().mockResolvedValue(true)
+    const updateCliProxyManagementKey = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(verifyCliProxyManagementConnection).mockResolvedValue({
       success: false,
       message: "messages:toast.error.operationFailedGeneric",
@@ -112,9 +215,13 @@ describe("CliProxySettings", () => {
       preferences: { lastUpdated: 1 },
       cliProxyBaseUrl: "http://localhost:8317/v0/management",
       cliProxyManagementKey: "secret-key",
-      updateCliProxyBaseUrl: vi.fn().mockResolvedValue(true),
+      updateCliProxyBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
       updateCliProxyManagementKey,
-      resetCliProxyConfig: vi.fn().mockResolvedValue(true),
+      resetCliProxyConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -129,9 +236,9 @@ describe("CliProxySettings", () => {
     await waitFor(() => {
       expect(updateCliProxyManagementKey).toHaveBeenCalledWith(
         "next-secret-key",
-        {
+        expect.objectContaining({
           expectedLastUpdated: 1,
-        },
+        }),
       )
     })
 
@@ -143,7 +250,7 @@ describe("CliProxySettings", () => {
     })
 
     expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:cliProxy.managementKeyLabel",
     )
     expect(vi.mocked(showResultToast)).toHaveBeenCalledWith({
@@ -196,15 +303,21 @@ describe("CliProxySettings", () => {
   })
 
   it("refreshes clean draft fields when the saved preferences snapshot changes", async () => {
-    const updateCliProxyBaseUrl = vi.fn().mockResolvedValue(true)
-    const updateCliProxyManagementKey = vi.fn().mockResolvedValue(true)
+    const updateCliProxyBaseUrl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
+    const updateCliProxyManagementKey = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     let contextValue = {
       preferences: { lastUpdated: 1 },
       cliProxyBaseUrl: "http://localhost:8317/v0/management",
       cliProxyManagementKey: "secret-key",
       updateCliProxyBaseUrl,
       updateCliProxyManagementKey,
-      resetCliProxyConfig: vi.fn().mockResolvedValue(true),
+      resetCliProxyConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     }
     vi.mocked(useUserPreferencesContext).mockImplementation(
       () => contextValue as any,
@@ -250,15 +363,15 @@ describe("CliProxySettings", () => {
     await waitFor(() => {
       expect(updateCliProxyBaseUrl).toHaveBeenLastCalledWith(
         "http://localhost:9010/v0/management",
-        {
+        expect.objectContaining({
           expectedLastUpdated: 2,
-        },
+        }),
       )
       expect(updateCliProxyManagementKey).toHaveBeenLastCalledWith(
         "post-refresh-secret",
-        {
+        expect.objectContaining({
           expectedLastUpdated: 2,
-        },
+        }),
       )
     })
   })

--- a/tests/entrypoints/options/ContextMenuVisibilityToggles.test.tsx
+++ b/tests/entrypoints/options/ContextMenuVisibilityToggles.test.tsx
@@ -71,10 +71,13 @@ describe("Context menu visibility toggles", () => {
     const savePreferencesSpy = vi
       .spyOn(userPreferences, "savePreferencesWithResult")
       .mockResolvedValue({
-        ...structuredClone(DEFAULT_PREFERENCES),
-        webAiApiCheck: {
-          ...structuredClone(DEFAULT_PREFERENCES.webAiApiCheck!),
-          contextMenu: { enabled: false },
+        ok: true,
+        preferences: {
+          ...structuredClone(DEFAULT_PREFERENCES),
+          webAiApiCheck: {
+            ...structuredClone(DEFAULT_PREFERENCES.webAiApiCheck!),
+            contextMenu: { enabled: false },
+          },
         },
       } as any)
 
@@ -118,10 +121,13 @@ describe("Context menu visibility toggles", () => {
     const savePreferencesSpy = vi
       .spyOn(userPreferences, "savePreferencesWithResult")
       .mockResolvedValue({
-        ...structuredClone(DEFAULT_PREFERENCES),
-        redemptionAssist: {
-          ...structuredClone(DEFAULT_PREFERENCES.redemptionAssist!),
-          contextMenu: { enabled: false },
+        ok: true,
+        preferences: {
+          ...structuredClone(DEFAULT_PREFERENCES),
+          redemptionAssist: {
+            ...structuredClone(DEFAULT_PREFERENCES.redemptionAssist!),
+            contextMenu: { enabled: false },
+          },
         },
       } as any)
 

--- a/tests/entrypoints/options/DisplaySettings.test.tsx
+++ b/tests/entrypoints/options/DisplaySettings.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { I18nextProvider } from "react-i18next"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { DATA_TYPE_BALANCE, DATA_TYPE_CASHFLOW } from "~/constants"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import DisplaySettings from "~/features/BasicSettings/components/tabs/General/DisplaySettings"
+import { showUpdateToast } from "~/utils/core/toastHelpers"
+import { testI18n } from "~~/tests/test-utils/i18n"
+
+vi.mock("~/contexts/UserPreferencesContext", () => ({
+  useUserPreferencesContext: vi.fn(),
+}))
+
+vi.mock("~/utils/core/toastHelpers", () => ({
+  showUpdateToast: vi.fn(),
+}))
+
+describe("DisplaySettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      activeTab: DATA_TYPE_BALANCE,
+      currencyType: "USD",
+      showTodayCashflow: true,
+      updateCurrencyType: vi.fn().mockResolvedValue({ ok: true }),
+      updateDefaultTab: vi.fn().mockResolvedValue({ ok: true }),
+      updateShowTodayCashflow: vi.fn().mockResolvedValue({ ok: true }),
+      resetDisplaySettings: vi.fn().mockResolvedValue({ ok: true }),
+    } as any)
+  })
+
+  const renderSubject = () =>
+    render(
+      <I18nextProvider i18n={testI18n}>
+        <DisplaySettings />
+      </I18nextProvider>,
+    )
+
+  it("shows result-aware feedback after changing the currency", async () => {
+    const writeResult = { ok: true as const }
+    const updateCurrencyType = vi.fn().mockResolvedValue(writeResult)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      activeTab: DATA_TYPE_BALANCE,
+      currencyType: "USD",
+      showTodayCashflow: true,
+      updateCurrencyType,
+      updateDefaultTab: vi.fn().mockResolvedValue({ ok: true }),
+      updateShowTodayCashflow: vi.fn().mockResolvedValue({ ok: true }),
+      resetDisplaySettings: vi.fn().mockResolvedValue({ ok: true }),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings:display.cny" }),
+    )
+
+    await waitFor(() => {
+      expect(updateCurrencyType).toHaveBeenCalledWith("CNY")
+    })
+    expect(showUpdateToast).toHaveBeenCalledWith(
+      writeResult,
+      "settings:display.currencyUnit",
+    )
+  })
+
+  it("does not save the hidden cashflow tab while today cashflow is disabled", async () => {
+    const updateDefaultTab = vi.fn().mockResolvedValue({ ok: true })
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      activeTab: DATA_TYPE_BALANCE,
+      currencyType: "USD",
+      showTodayCashflow: false,
+      updateCurrencyType: vi.fn().mockResolvedValue({ ok: true }),
+      updateDefaultTab,
+      updateShowTodayCashflow: vi.fn().mockResolvedValue({ ok: true }),
+      resetDisplaySettings: vi.fn().mockResolvedValue({ ok: true }),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "settings:display.todayCashflow",
+      }),
+    )
+
+    expect(updateDefaultTab).not.toHaveBeenCalled()
+    expect(showUpdateToast).not.toHaveBeenCalled()
+  })
+
+  it("shows result-aware feedback after changing the default tab", async () => {
+    const writeResult = { ok: true as const }
+    const updateDefaultTab = vi.fn().mockResolvedValue(writeResult)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      activeTab: DATA_TYPE_BALANCE,
+      currencyType: "USD",
+      showTodayCashflow: true,
+      updateCurrencyType: vi.fn().mockResolvedValue({ ok: true }),
+      updateDefaultTab,
+      updateShowTodayCashflow: vi.fn().mockResolvedValue({ ok: true }),
+      resetDisplaySettings: vi.fn().mockResolvedValue({ ok: true }),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "settings:display.todayCashflow",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(updateDefaultTab).toHaveBeenCalledWith(DATA_TYPE_CASHFLOW)
+    })
+    expect(showUpdateToast).toHaveBeenCalledWith(
+      writeResult,
+      "settings:display.defaultTab",
+    )
+  })
+})

--- a/tests/entrypoints/options/DisplaySettings.test.tsx
+++ b/tests/entrypoints/options/DisplaySettings.test.tsx
@@ -58,11 +58,11 @@ describe("DisplaySettings", () => {
 
     await waitFor(() => {
       expect(updateCurrencyType).toHaveBeenCalledWith("CNY")
+      expect(showUpdateToast).toHaveBeenCalledWith(
+        writeResult,
+        "settings:display.currencyUnit",
+      )
     })
-    expect(showUpdateToast).toHaveBeenCalledWith(
-      writeResult,
-      "settings:display.currencyUnit",
-    )
   })
 
   it("does not save the hidden cashflow tab while today cashflow is disabled", async () => {

--- a/tests/entrypoints/options/DoneHubSettings.test.tsx
+++ b/tests/entrypoints/options/DoneHubSettings.test.tsx
@@ -7,12 +7,29 @@ import DoneHubSettings from "~/features/BasicSettings/components/tabs/ManagedSit
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
+const { showUpdateToastMock } = vi.hoisted(() => ({
+  showUpdateToastMock: vi.fn(),
+}))
+
 vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: vi.fn(),
 }))
 
 vi.mock("~/utils/core/toastHelpers", () => ({
-  showUpdateToast: vi.fn(),
+  runPreferenceUpdateWithToast: async ({
+    expectedLastUpdated,
+    setting,
+    update,
+  }: {
+    expectedLastUpdated: number
+    setting: string
+    update: (options: { expectedLastUpdated: number }) => Promise<any>
+  }) => {
+    const result = await update({ expectedLastUpdated })
+    showUpdateToastMock(result, setting)
+    return result
+  },
+  showUpdateToast: showUpdateToastMock,
 }))
 
 describe("DoneHubSettings", () => {
@@ -28,16 +45,24 @@ describe("DoneHubSettings", () => {
     )
 
   it("trims the base URL before persisting", async () => {
-    const updateDoneHubBaseUrl = vi.fn().mockResolvedValue(true)
+    const updateDoneHubBaseUrl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       preferences: { lastUpdated: 1 },
       doneHubBaseUrl: "https://api.example.com",
       doneHubAdminToken: "",
       doneHubUserId: "",
       updateDoneHubBaseUrl,
-      updateDoneHubAdminToken: vi.fn().mockResolvedValue(true),
-      updateDoneHubUserId: vi.fn().mockResolvedValue(true),
-      resetDoneHubConfig: vi.fn().mockResolvedValue(true),
+      updateDoneHubAdminToken: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateDoneHubUserId: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetDoneHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -62,16 +87,24 @@ describe("DoneHubSettings", () => {
   })
 
   it("skips persisting when the trimmed base URL is unchanged", () => {
-    const updateDoneHubBaseUrl = vi.fn().mockResolvedValue(true)
+    const updateDoneHubBaseUrl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       preferences: { lastUpdated: 1 },
       doneHubBaseUrl: "https://donehub.example.com",
       doneHubAdminToken: "",
       doneHubUserId: "",
       updateDoneHubBaseUrl,
-      updateDoneHubAdminToken: vi.fn().mockResolvedValue(true),
-      updateDoneHubUserId: vi.fn().mockResolvedValue(true),
-      resetDoneHubConfig: vi.fn().mockResolvedValue(true),
+      updateDoneHubAdminToken: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateDoneHubUserId: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetDoneHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -90,16 +123,24 @@ describe("DoneHubSettings", () => {
   })
 
   it("shows an inline error and skips persisting when the admin user ID is not numeric", async () => {
-    const updateDoneHubUserId = vi.fn().mockResolvedValue(true)
+    const updateDoneHubUserId = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       preferences: { lastUpdated: 1 },
       doneHubBaseUrl: "https://donehub.example.com",
       doneHubAdminToken: "",
       doneHubUserId: "100",
-      updateDoneHubBaseUrl: vi.fn().mockResolvedValue(true),
-      updateDoneHubAdminToken: vi.fn().mockResolvedValue(true),
+      updateDoneHubBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateDoneHubAdminToken: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
       updateDoneHubUserId,
-      resetDoneHubConfig: vi.fn().mockResolvedValue(true),
+      resetDoneHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -119,17 +160,25 @@ describe("DoneHubSettings", () => {
   })
 
   it("persists admin token and numeric user ID updates with the current preferences version", async () => {
-    const updateDoneHubAdminToken = vi.fn().mockResolvedValue(true)
-    const updateDoneHubUserId = vi.fn().mockResolvedValue(true)
+    const updateDoneHubAdminToken = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
+    const updateDoneHubUserId = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue({
       preferences: { lastUpdated: 2 },
       doneHubBaseUrl: "https://donehub.example.com",
       doneHubAdminToken: "old-token",
       doneHubUserId: "100",
-      updateDoneHubBaseUrl: vi.fn().mockResolvedValue(true),
+      updateDoneHubBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
       updateDoneHubAdminToken,
       updateDoneHubUserId,
-      resetDoneHubConfig: vi.fn().mockResolvedValue(true),
+      resetDoneHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any)
 
     renderSubject()
@@ -157,11 +206,11 @@ describe("DoneHubSettings", () => {
     })
 
     expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:doneHub.fields.adminTokenLabel",
     )
     expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:doneHub.fields.userIdLabel",
     )
   })
@@ -172,10 +221,18 @@ describe("DoneHubSettings", () => {
       doneHubBaseUrl: "https://donehub.example.com",
       doneHubAdminToken: "same-token",
       doneHubUserId: "100",
-      updateDoneHubBaseUrl: vi.fn().mockResolvedValue(true),
-      updateDoneHubAdminToken: vi.fn().mockResolvedValue(true),
-      updateDoneHubUserId: vi.fn().mockResolvedValue(true),
-      resetDoneHubConfig: vi.fn().mockResolvedValue(true),
+      updateDoneHubBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateDoneHubAdminToken: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateDoneHubUserId: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetDoneHubConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
     } as any
     vi.mocked(useUserPreferencesContext).mockReturnValue(contextValue)
 

--- a/tests/entrypoints/options/LoggingSettings.test.tsx
+++ b/tests/entrypoints/options/LoggingSettings.test.tsx
@@ -51,10 +51,10 @@ describe("LoggingSettings", () => {
 
     await waitFor(() => {
       expect(updateLoggingConsoleEnabled).toHaveBeenCalledWith(false)
+      expect(showUpdateToast).toHaveBeenCalledWith(
+        writeResult,
+        "settings:logging.consoleEnabled",
+      )
     })
-    expect(showUpdateToast).toHaveBeenCalledWith(
-      writeResult,
-      "settings:logging.consoleEnabled",
-    )
   })
 })

--- a/tests/entrypoints/options/LoggingSettings.test.tsx
+++ b/tests/entrypoints/options/LoggingSettings.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { I18nextProvider } from "react-i18next"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import LoggingSettings from "~/features/BasicSettings/components/tabs/General/LoggingSettings"
+import { showUpdateToast } from "~/utils/core/toastHelpers"
+import { testI18n } from "~~/tests/test-utils/i18n"
+
+vi.mock("~/contexts/UserPreferencesContext", () => ({
+  useUserPreferencesContext: vi.fn(),
+}))
+
+vi.mock("~/utils/core/toastHelpers", () => ({
+  showUpdateToast: vi.fn(),
+}))
+
+describe("LoggingSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      loggingConsoleEnabled: true,
+      loggingLevel: "info",
+      resetLoggingSettings: vi.fn().mockResolvedValue({ ok: true }),
+      updateLoggingConsoleEnabled: vi.fn().mockResolvedValue({ ok: true }),
+      updateLoggingLevel: vi.fn().mockResolvedValue({ ok: true }),
+    } as any)
+  })
+
+  const renderSubject = () =>
+    render(
+      <I18nextProvider i18n={testI18n}>
+        <LoggingSettings />
+      </I18nextProvider>,
+    )
+
+  it("shows result-aware feedback after toggling console logging", async () => {
+    const writeResult = { ok: true as const }
+    const updateLoggingConsoleEnabled = vi.fn().mockResolvedValue(writeResult)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      loggingConsoleEnabled: true,
+      loggingLevel: "info",
+      resetLoggingSettings: vi.fn().mockResolvedValue({ ok: true }),
+      updateLoggingConsoleEnabled,
+      updateLoggingLevel: vi.fn().mockResolvedValue({ ok: true }),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(screen.getByRole("switch", { name: "Toggle" }))
+
+    await waitFor(() => {
+      expect(updateLoggingConsoleEnabled).toHaveBeenCalledWith(false)
+    })
+    expect(showUpdateToast).toHaveBeenCalledWith(
+      writeResult,
+      "settings:logging.consoleEnabled",
+    )
+  })
+})

--- a/tests/entrypoints/options/ManagedSiteModelSyncSettings.test.tsx
+++ b/tests/entrypoints/options/ManagedSiteModelSyncSettings.test.tsx
@@ -352,12 +352,22 @@ const createDeferred = <T,>() => {
   return { promise, resolve, reject }
 }
 
+const preferenceWriteSuccess = () => ({
+  ok: true,
+  preferences: {},
+})
+
+const preferenceWriteFailure = () => ({
+  ok: false,
+  reason: { type: "storage-error", error: new Error("save failed") },
+})
+
 describe("ManagedSiteModelSyncSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockUpdateNewApiModelSync.mockResolvedValue(true)
-    mockResetNewApiModelSyncConfig.mockResolvedValue(true)
+    mockUpdateNewApiModelSync.mockResolvedValue(preferenceWriteSuccess())
+    mockResetNewApiModelSyncConfig.mockResolvedValue(preferenceWriteSuccess())
     mockedUseUserPreferencesContext.mockReturnValue(createContextValue())
 
     mockedSendModelSyncMessage.mockResolvedValue({
@@ -713,7 +723,7 @@ describe("ManagedSiteModelSyncSettings", () => {
   })
 
   it("shows a save error when preference updates return false", async () => {
-    mockUpdateNewApiModelSync.mockResolvedValue(false)
+    mockUpdateNewApiModelSync.mockResolvedValue(preferenceWriteFailure())
 
     render(<ManagedSiteModelSyncSettings />)
 
@@ -952,7 +962,7 @@ describe("ManagedSiteModelSyncSettings", () => {
   })
 
   it("keeps the global filters dialog open when saving preferences fails", async () => {
-    mockUpdateNewApiModelSync.mockResolvedValue(false)
+    mockUpdateNewApiModelSync.mockResolvedValue(preferenceWriteFailure())
 
     render(<ManagedSiteModelSyncSettings />)
 
@@ -1278,7 +1288,8 @@ describe("ManagedSiteModelSyncSettings", () => {
   })
 
   it("keeps the dialog open when close is requested during an in-flight save", async () => {
-    const deferredSave = createDeferred<boolean>()
+    const deferredSave =
+      createDeferred<ReturnType<typeof preferenceWriteSuccess>>()
     mockUpdateNewApiModelSync.mockReturnValue(deferredSave.promise)
 
     render(<ManagedSiteModelSyncSettings />)
@@ -1312,7 +1323,7 @@ describe("ManagedSiteModelSyncSettings", () => {
 
     expect(screen.getByRole("dialog")).toBeInTheDocument()
 
-    deferredSave.resolve(true)
+    deferredSave.resolve(preferenceWriteSuccess())
 
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()

--- a/tests/entrypoints/options/ModelRedirectBulkClear.test.tsx
+++ b/tests/entrypoints/options/ModelRedirectBulkClear.test.tsx
@@ -132,10 +132,10 @@ describe("Model redirect bulk clear flow", () => {
 
     await waitFor(() => {
       expect(updateModelRedirect).toHaveBeenCalledWith({ enabled: true })
+      expect(toast.error).toHaveBeenCalledWith(
+        "modelRedirect:messages.updateFailed",
+      )
     })
-    expect(toast.error).toHaveBeenCalledWith(
-      "modelRedirect:messages.updateFailed",
-    )
   })
 
   it("does not clear when confirmation is canceled", async () => {

--- a/tests/entrypoints/options/ModelRedirectBulkClear.test.tsx
+++ b/tests/entrypoints/options/ModelRedirectBulkClear.test.tsx
@@ -106,6 +106,38 @@ describe("Model redirect bulk clear flow", () => {
 
   const renderSubject = () => render(<ModelRedirectSettings />)
 
+  it("shows the preference write failure message when enabling redirects fails", async () => {
+    const updateModelRedirect = vi.fn().mockResolvedValue({
+      ok: false,
+      reason: {
+        type: "storage-error",
+        error: new Error("save failed"),
+      },
+    })
+    mockedUseUserPreferencesContext.mockReturnValue({
+      preferences: {
+        managedSiteType: "new-api",
+        modelRedirect: {
+          enabled: false,
+          standardModels: [],
+        },
+      },
+      updateModelRedirect,
+      resetModelRedirectConfig: vi.fn(),
+    })
+
+    renderSubject()
+
+    fireEvent.click(await screen.findByRole("switch", { name: "Toggle" }))
+
+    await waitFor(() => {
+      expect(updateModelRedirect).toHaveBeenCalledWith({ enabled: true })
+    })
+    expect(toast.error).toHaveBeenCalledWith(
+      "modelRedirect:messages.updateFailed",
+    )
+  })
+
   it("does not clear when confirmation is canceled", async () => {
     renderSubject()
 

--- a/tests/entrypoints/options/OctopusSettings.test.tsx
+++ b/tests/entrypoints/options/OctopusSettings.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import OctopusSettings from "~/features/BasicSettings/components/tabs/ManagedSite/OctopusSettings"
 import { octopusAuthManager } from "~/services/apiService/octopus/auth"
+import type { PreferenceWriteResult } from "~/services/preferences/userPreferences"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
 
@@ -87,7 +88,7 @@ vi.mock("~/components/SettingSection", () => ({
     children: ReactNode
     title: string
     description: string
-    onReset?: () => Promise<any>
+    onReset?: () => Promise<PreferenceWriteResult>
   }) => (
     <section>
       <h2>{title}</h2>

--- a/tests/entrypoints/options/OctopusSettings.test.tsx
+++ b/tests/entrypoints/options/OctopusSettings.test.tsx
@@ -592,7 +592,7 @@ describe("OctopusSettings", () => {
     )
   })
 
-  it("shows the generic update failure when validation passes but persistence is rejected", async () => {
+  it("shows the validation failure fallback when validation passes but persistence is rejected", async () => {
     mockUpdateOctopusConfig.mockResolvedValue({
       ok: false,
       reason: { type: "storage-error", error: new Error("save failed") },
@@ -617,7 +617,9 @@ describe("OctopusSettings", () => {
           expectedLastUpdated: 1,
         },
       )
-      expect(toast.error).toHaveBeenCalledWith("settings:messages.updateFailed")
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings:octopus.validation.failed",
+      )
     })
   })
 })

--- a/tests/entrypoints/options/OctopusSettings.test.tsx
+++ b/tests/entrypoints/options/OctopusSettings.test.tsx
@@ -14,6 +14,7 @@ const {
   mockUpdateOctopusUsername,
   mockUpdateOctopusPassword,
   mockResetOctopusConfig,
+  showUpdateToastMock,
 } = vi.hoisted(() => ({
   mockedUseUserPreferencesContext: vi.fn(),
   mockUpdateOctopusBaseUrl: vi.fn(),
@@ -21,6 +22,7 @@ const {
   mockUpdateOctopusUsername: vi.fn(),
   mockUpdateOctopusPassword: vi.fn(),
   mockResetOctopusConfig: vi.fn(),
+  showUpdateToastMock: vi.fn(),
 }))
 
 vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
@@ -42,7 +44,30 @@ vi.mock("~/services/apiService/octopus/auth", () => ({
 }))
 
 vi.mock("~/utils/core/toastHelpers", () => ({
-  showUpdateToast: vi.fn(),
+  createVersionedPreferenceSaveOptions: (expectedLastUpdated: number) => ({
+    expectedLastUpdated,
+  }),
+  runPreferenceUpdateWithToast: async ({
+    expectedLastUpdated,
+    setting,
+    update,
+  }: {
+    expectedLastUpdated: number
+    setting: string
+    update: (options: { expectedLastUpdated: number }) => Promise<any>
+  }) => {
+    const result = await update({ expectedLastUpdated })
+    showUpdateToastMock(result, setting)
+    return result
+  },
+  getPreferenceWriteFailureMessage: (
+    failure: { type: string },
+    options?: { fallback?: string },
+  ) =>
+    failure.type === "stale"
+      ? "settings:messages.preferencesChangedExternally"
+      : options?.fallback ?? "settings:messages.updateFailed",
+  showUpdateToast: showUpdateToastMock,
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -62,7 +87,7 @@ vi.mock("~/components/SettingSection", () => ({
     children: ReactNode
     title: string
     description: string
-    onReset?: () => Promise<boolean>
+    onReset?: () => Promise<any>
   }) => (
     <section>
       <h2>{title}</h2>
@@ -199,11 +224,11 @@ describe("OctopusSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockUpdateOctopusBaseUrl.mockResolvedValue(true)
-    mockUpdateOctopusConfig.mockResolvedValue(true)
-    mockUpdateOctopusUsername.mockResolvedValue(true)
-    mockUpdateOctopusPassword.mockResolvedValue(true)
-    mockResetOctopusConfig.mockResolvedValue(true)
+    mockUpdateOctopusBaseUrl.mockResolvedValue({ ok: true, preferences: {} })
+    mockUpdateOctopusConfig.mockResolvedValue({ ok: true, preferences: {} })
+    mockUpdateOctopusUsername.mockResolvedValue({ ok: true, preferences: {} })
+    mockUpdateOctopusPassword.mockResolvedValue({ ok: true, preferences: {} })
+    mockResetOctopusConfig.mockResolvedValue({ ok: true, preferences: {} })
     mockedValidateConfig.mockResolvedValue({ success: true })
     mockedUseUserPreferencesContext.mockReturnValue(createContextValue())
   })
@@ -229,7 +254,7 @@ describe("OctopusSettings", () => {
     })
 
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:octopus.fields.baseUrlLabel",
     )
 
@@ -254,7 +279,7 @@ describe("OctopusSettings", () => {
     })
 
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:octopus.fields.passwordLabel",
     )
 
@@ -312,7 +337,10 @@ describe("OctopusSettings", () => {
       preferences: { lastUpdated: 10 },
     })
     mockedUseUserPreferencesContext.mockImplementation(() => contextValue)
-    mockUpdateOctopusBaseUrl.mockResolvedValue(false)
+    mockUpdateOctopusBaseUrl.mockResolvedValue({
+      ok: false,
+      reason: { type: "storage-error", error: new Error("save failed") },
+    })
 
     const { rerender } = render(<OctopusSettings />)
 
@@ -352,7 +380,7 @@ describe("OctopusSettings", () => {
     })
 
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
-      false,
+      expect.objectContaining({ ok: false }),
       "settings:octopus.fields.baseUrlLabel",
     )
   })
@@ -559,13 +587,16 @@ describe("OctopusSettings", () => {
     expect(mockUpdateOctopusBaseUrl).not.toHaveBeenCalled()
     expect(mockUpdateOctopusPassword).not.toHaveBeenCalled()
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:octopus.fields.usernameLabel",
     )
   })
 
   it("shows the generic update failure when validation passes but persistence is rejected", async () => {
-    mockUpdateOctopusConfig.mockResolvedValue(false)
+    mockUpdateOctopusConfig.mockResolvedValue({
+      ok: false,
+      reason: { type: "storage-error", error: new Error("save failed") },
+    })
 
     render(<OctopusSettings />)
 

--- a/tests/entrypoints/options/RefreshSettings.test.tsx
+++ b/tests/entrypoints/options/RefreshSettings.test.tsx
@@ -10,6 +10,7 @@ import {
   ACCOUNT_AUTO_REFRESH_MIN_INTERVAL_MIN_SECONDS,
   DEFAULT_ACCOUNT_AUTO_REFRESH,
 } from "~/types/accountAutoRefresh"
+import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
 vi.mock("~/contexts/UserPreferencesContext", () => ({
@@ -197,5 +198,33 @@ describe("RefreshSettings (min refresh interval)", () => {
       )
     })
     expect(vi.mocked(toast).error).not.toHaveBeenCalled()
+  })
+
+  it("shows result-aware feedback after toggling refresh on open", async () => {
+    const writeResult = { ok: true as const }
+    const updateRefreshOnOpen = vi.fn().mockResolvedValue(writeResult)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      autoRefresh: true,
+      refreshOnOpen: false,
+      refreshInterval: 360,
+      minRefreshInterval: 60,
+      updateAutoRefresh: vi.fn().mockResolvedValue({ ok: true }),
+      updateRefreshOnOpen,
+      updateRefreshInterval: vi.fn().mockResolvedValue({ ok: true }),
+      updateMinRefreshInterval: vi.fn().mockResolvedValue({ ok: true }),
+      resetAutoRefreshConfig: vi.fn().mockResolvedValue({ ok: true }),
+    } as any)
+
+    renderSubject()
+
+    fireEvent.click(screen.getAllByRole("switch", { name: "Toggle" })[1])
+
+    await waitFor(() => {
+      expect(updateRefreshOnOpen).toHaveBeenCalledWith(true)
+    })
+    expect(showUpdateToast).toHaveBeenCalledWith(
+      writeResult,
+      "settings:refresh.refreshOnOpen",
+    )
   })
 })

--- a/tests/entrypoints/options/SortingPrioritySettings.test.tsx
+++ b/tests/entrypoints/options/SortingPrioritySettings.test.tsx
@@ -16,6 +16,16 @@ const {
   mockResetSortingPriorityConfig: vi.fn(),
 }))
 
+const preferenceWriteSuccess = () => ({
+  ok: true,
+  preferences: {},
+})
+
+const preferenceWriteFailure = () => ({
+  ok: false,
+  reason: { type: "storage-error", error: new Error("save failed") },
+})
+
 vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
   const actual =
     (await importOriginal()) as typeof import("~/contexts/UserPreferencesContext")
@@ -154,8 +164,8 @@ describe("SortingPrioritySettings", () => {
       new Date("2026-03-30T07:10:00.000Z").getTime(),
     )
 
-    mockUpdateSortingPriorityConfig.mockResolvedValue(true)
-    mockResetSortingPriorityConfig.mockResolvedValue(true)
+    mockUpdateSortingPriorityConfig.mockResolvedValue(preferenceWriteSuccess())
+    mockResetSortingPriorityConfig.mockResolvedValue(preferenceWriteSuccess())
     mockedUseUserPreferencesContext.mockReturnValue(createContextValue())
   })
 
@@ -241,7 +251,7 @@ describe("SortingPrioritySettings", () => {
     })
 
     expect(mockedShowUpdateToast).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:sorting.title",
     )
     expect(
@@ -259,7 +269,7 @@ describe("SortingPrioritySettings", () => {
   })
 
   it("toggles a criterion and keeps the UI updated even when saving fails", async () => {
-    mockUpdateSortingPriorityConfig.mockResolvedValue(false)
+    mockUpdateSortingPriorityConfig.mockResolvedValue(preferenceWriteFailure())
 
     render(<SortingPrioritySettings />)
 

--- a/tests/entrypoints/options/SortingPrioritySettings.test.tsx
+++ b/tests/entrypoints/options/SortingPrioritySettings.test.tsx
@@ -273,6 +273,29 @@ describe("SortingPrioritySettings", () => {
     expect(mockedShowUpdateToast).not.toHaveBeenCalled()
   })
 
+  it("reports failed reorder saves and restores persisted order", async () => {
+    mockUpdateSortingPriorityConfig.mockResolvedValue(preferenceWriteFailure())
+
+    render(<SortingPrioritySettings />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "reorder-user-before-pinned" }),
+    )
+
+    await waitFor(() => {
+      expect(mockedShowUpdateToast).toHaveBeenCalledWith(
+        expect.objectContaining({ ok: false }),
+        "settings:sorting.title",
+      )
+    })
+    expect(
+      screen.getByTestId(`sorting-item-${SortingCriteriaType.USER_SORT_FIELD}`),
+    ).toHaveTextContent("priority:0")
+    expect(
+      screen.getByTestId(`sorting-item-${SortingCriteriaType.PINNED}`),
+    ).toHaveTextContent("priority:1")
+  })
+
   it("toggles a criterion, reports failed saves, and restores persisted order", async () => {
     mockUpdateSortingPriorityConfig.mockResolvedValue(preferenceWriteFailure())
 

--- a/tests/entrypoints/options/SortingPrioritySettings.test.tsx
+++ b/tests/entrypoints/options/SortingPrioritySettings.test.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import SortingPrioritySettings from "~/features/BasicSettings/components/tabs/AccountManagement/SortingPrioritySettings"
-import { SortingCriteriaType } from "~/types/sorting"
+import {
+  SortingCriteriaType,
+  type SortingPriorityConfig,
+} from "~/types/sorting"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { fireEvent, render, screen, waitFor } from "~~/tests/test-utils/render"
 
@@ -18,7 +21,7 @@ const {
 
 const preferenceWriteSuccess = () => ({
   ok: true,
-  preferences: {},
+  preferences: {} as any,
 })
 
 const preferenceWriteFailure = () => ({
@@ -52,7 +55,7 @@ vi.mock("~/components/SettingSection", () => ({
     children: ReactNode
     title: string
     description: string
-    onReset?: () => Promise<boolean>
+    onReset?: () => Promise<any>
   }) => (
     <section>
       <h2>{title}</h2>
@@ -128,7 +131,9 @@ vi.mock(
 
 const mockedShowUpdateToast = showUpdateToast as ReturnType<typeof vi.fn>
 
-const createConfig = (criteria?: any[]) => ({
+const createConfig = (
+  criteria?: SortingPriorityConfig["criteria"],
+): SortingPriorityConfig => ({
   criteria: criteria ?? [
     {
       id: SortingCriteriaType.PINNED,
@@ -144,7 +149,7 @@ const createConfig = (criteria?: any[]) => ({
       id: "custom-unknown-rule",
       enabled: true,
       priority: 2,
-    },
+    } as any,
   ],
   lastModified: 123,
 })
@@ -268,7 +273,7 @@ describe("SortingPrioritySettings", () => {
     expect(mockedShowUpdateToast).not.toHaveBeenCalled()
   })
 
-  it("toggles a criterion and keeps the UI updated even when saving fails", async () => {
+  it("toggles a criterion, reports failed saves, and restores persisted order", async () => {
     mockUpdateSortingPriorityConfig.mockResolvedValue(preferenceWriteFailure())
 
     render(<SortingPrioritySettings />)
@@ -305,8 +310,11 @@ describe("SortingPrioritySettings", () => {
 
     expect(
       screen.getByTestId(`sorting-item-${SortingCriteriaType.USER_SORT_FIELD}`),
-    ).toHaveTextContent("enabled:true")
-    expect(mockedShowUpdateToast).not.toHaveBeenCalled()
+    ).toHaveTextContent("enabled:false")
+    expect(mockedShowUpdateToast).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false }),
+      "settings:sorting.title",
+    )
   })
 
   it("resets through SettingSection", async () => {

--- a/tests/entrypoints/options/VeloeraSettings.test.tsx
+++ b/tests/entrypoints/options/VeloeraSettings.test.tsx
@@ -7,12 +7,29 @@ import VeloeraSettings from "~/features/BasicSettings/components/tabs/ManagedSit
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
+const { showUpdateToastMock } = vi.hoisted(() => ({
+  showUpdateToastMock: vi.fn(),
+}))
+
 vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: vi.fn(),
 }))
 
 vi.mock("~/utils/core/toastHelpers", () => ({
-  showUpdateToast: vi.fn(),
+  runPreferenceUpdateWithToast: async ({
+    expectedLastUpdated,
+    setting,
+    update,
+  }: {
+    expectedLastUpdated: number
+    setting: string
+    update: (options: { expectedLastUpdated: number }) => Promise<any>
+  }) => {
+    const result = await update({ expectedLastUpdated })
+    showUpdateToastMock(result, setting)
+    return result
+  },
+  showUpdateToast: showUpdateToastMock,
 }))
 
 describe("VeloeraSettings", () => {
@@ -26,10 +43,18 @@ describe("VeloeraSettings", () => {
       veloeraBaseUrl: "https://veloera.example.com",
       veloeraAdminToken: "stored-token",
       veloeraUserId: "200",
-      updateVeloeraBaseUrl: vi.fn().mockResolvedValue(true),
-      updateVeloeraAdminToken: vi.fn().mockResolvedValue(true),
-      updateVeloeraUserId: vi.fn().mockResolvedValue(true),
-      resetVeloeraConfig: vi.fn().mockResolvedValue(true),
+      updateVeloeraBaseUrl: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateVeloeraAdminToken: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      updateVeloeraUserId: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
+      resetVeloeraConfig: vi
+        .fn()
+        .mockResolvedValue({ ok: true, preferences: {} }),
       ...overrides,
     }) as any
 
@@ -41,7 +66,9 @@ describe("VeloeraSettings", () => {
     )
 
   it("shows an inline error and skips persisting when the admin user ID is not numeric", async () => {
-    const updateVeloeraUserId = vi.fn().mockResolvedValue(true)
+    const updateVeloeraUserId = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue(
       createContextValue({
         veloeraAdminToken: "",
@@ -66,8 +93,12 @@ describe("VeloeraSettings", () => {
   })
 
   it("trims the base URL and admin token before persisting", async () => {
-    const updateVeloeraBaseUrl = vi.fn().mockResolvedValue(true)
-    const updateVeloeraAdminToken = vi.fn().mockResolvedValue(true)
+    const updateVeloeraBaseUrl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
+    const updateVeloeraAdminToken = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue(
       createContextValue({
         updateVeloeraBaseUrl,
@@ -101,7 +132,9 @@ describe("VeloeraSettings", () => {
   })
 
   it("skips persisting the admin user ID when only legacy whitespace differs", () => {
-    const updateVeloeraUserId = vi.fn().mockResolvedValue(true)
+    const updateVeloeraUserId = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue(
       createContextValue({
         veloeraUserId: " 200 ",
@@ -126,7 +159,9 @@ describe("VeloeraSettings", () => {
   })
 
   it("trims and persists a changed admin user ID", async () => {
-    const updateVeloeraUserId = vi.fn().mockResolvedValue(true)
+    const updateVeloeraUserId = vi
+      .fn()
+      .mockResolvedValue({ ok: true, preferences: {} })
     vi.mocked(useUserPreferencesContext).mockReturnValue(
       createContextValue({
         updateVeloeraUserId,
@@ -151,7 +186,7 @@ describe("VeloeraSettings", () => {
         expectedLastUpdated: 1,
       })
       expect(vi.mocked(showUpdateToast)).toHaveBeenCalledWith(
-        true,
+        expect.objectContaining({ ok: true }),
         "settings:veloera.fields.userIdLabel",
       )
     })

--- a/tests/features/AccountManagement/hooks/useAccountDialog.duplicateAccountWarning.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.duplicateAccountWarning.test.tsx
@@ -452,7 +452,13 @@ describe("useAccountDialog duplicate account warning", () => {
   it("keeps the duplicate warning open when disabling future warnings fails", async () => {
     const updatePreferenceSpy = vi
       .spyOn(userPreferences, "updateWarnOnDuplicateAccountAdd")
-      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce({
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error: new Error("save failed"),
+        },
+      })
 
     try {
       await accountStorage.addAccount(

--- a/tests/features/BasicSettings/SiteAnnouncementNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/SiteAnnouncementNotificationSettings.test.tsx
@@ -41,7 +41,7 @@ vi.mock("~/utils/navigation", () => ({
 describe("SiteAnnouncementNotificationSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    updateSiteAnnouncementNotificationsMock.mockResolvedValue(true)
+    updateSiteAnnouncementNotificationsMock.mockResolvedValue({ success: true })
   })
 
   it("updates the polling preference through the preferences context", async () => {
@@ -70,13 +70,15 @@ describe("SiteAnnouncementNotificationSettings", () => {
     })
 
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      true,
+      { success: true },
       "settings:siteAnnouncementNotifications.polling.enable",
     )
   })
 
   it("shows failure feedback when the polling preference update fails", async () => {
-    updateSiteAnnouncementNotificationsMock.mockResolvedValue(false)
+    updateSiteAnnouncementNotificationsMock.mockResolvedValue({
+      success: false,
+    })
 
     render(<SiteAnnouncementNotificationSettings />, {
       withUserPreferencesProvider: false,
@@ -104,7 +106,7 @@ describe("SiteAnnouncementNotificationSettings", () => {
     })
 
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      false,
+      { success: false },
       "settings:siteAnnouncementNotifications.polling.enable",
     )
     expect(pollingSwitch).toHaveAttribute("aria-checked", "true")
@@ -147,7 +149,7 @@ describe("SiteAnnouncementNotificationSettings", () => {
     })
 
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      true,
+      { success: true },
       "settings:siteAnnouncementNotifications.polling.interval",
     )
   })
@@ -230,7 +232,9 @@ describe("SiteAnnouncementNotificationSettings", () => {
   })
 
   it("resets the polling interval input when the update fails", async () => {
-    updateSiteAnnouncementNotificationsMock.mockResolvedValue(false)
+    updateSiteAnnouncementNotificationsMock.mockResolvedValue({
+      success: false,
+    })
 
     render(<SiteAnnouncementNotificationSettings />, {
       withUserPreferencesProvider: false,
@@ -251,7 +255,7 @@ describe("SiteAnnouncementNotificationSettings", () => {
     })
 
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      false,
+      { success: false },
       "settings:siteAnnouncementNotifications.polling.interval",
     )
     expect(intervalInput).toHaveValue(360)
@@ -281,7 +285,7 @@ describe("SiteAnnouncementNotificationSettings", () => {
     })
 
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      false,
+      { success: false },
       "settings:siteAnnouncementNotifications.polling.interval",
     )
     expect(intervalInput).toHaveValue(360)

--- a/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
@@ -55,6 +55,19 @@ const {
   updateTaskNotificationsMock: vi.fn(),
 }))
 
+const preferenceWriteSuccess = () => ({
+  ok: true,
+  preferences: {},
+})
+
+const preferenceWriteFailure = () => ({
+  ok: false,
+  reason: {
+    type: "storage-error",
+    error: new Error("save failed"),
+  },
+})
+
 vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: () => ({
     siteAnnouncementNotifications: DEFAULT_SITE_ANNOUNCEMENT_PREFERENCES,
@@ -110,7 +123,7 @@ describe("TaskNotificationSettings", () => {
       DEFAULT_TASK_NOTIFICATION_PREFERENCES,
     )
     updateSiteAnnouncementNotificationsMock.mockResolvedValue(true)
-    updateTaskNotificationsMock.mockResolvedValue(true)
+    updateTaskNotificationsMock.mockResolvedValue(preferenceWriteSuccess())
   })
 
   it("renders permission controls and requests notification permission", async () => {
@@ -1061,7 +1074,7 @@ describe("TaskNotificationSettings", () => {
   })
 
   it("does not send a webhook test notification when saving the draft fails", async () => {
-    updateTaskNotificationsMock.mockResolvedValueOnce(false)
+    updateTaskNotificationsMock.mockResolvedValueOnce(preferenceWriteFailure())
     taskNotificationsMock.current = {
       ...DEFAULT_TASK_NOTIFICATION_PREFERENCES,
       channels: {
@@ -1296,11 +1309,11 @@ describe("TaskNotificationSettings", () => {
       notificationEnabled: false,
     })
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:taskNotifications.enable",
     )
     expect(showUpdateToastMock).toHaveBeenCalledWith(
-      true,
+      expect.objectContaining({ ok: true }),
       "settings:taskNotifications.tasksLabel",
     )
     expect(showUpdateToastMock).toHaveBeenCalledWith(

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -34,6 +34,18 @@ import {
   setupMockPreferencePersistence,
 } from "~~/tests/test-utils/mockPreferencePersistence"
 
+const createStalePreferenceWriteResult = (
+  expectedLastUpdated: number,
+  actualLastUpdated = expectedLastUpdated + 1,
+) => ({
+  ok: false as const,
+  reason: {
+    type: "stale" as const,
+    expectedLastUpdated,
+    actualLastUpdated,
+  },
+})
+
 const {
   mockApplyPreferenceLanguage,
   mockUserPreferences,
@@ -305,7 +317,10 @@ describe("WebDAVSettings", () => {
           preferencePersistence.getPersistedPreferences().lastUpdated !==
             expectedLastUpdated
         ) {
-          return null
+          return createStalePreferenceWriteResult(
+            expectedLastUpdated,
+            preferencePersistence.getPersistedPreferences().lastUpdated,
+          )
         }
 
         return await savePreferencesWithResult?.(updates, options)
@@ -408,7 +423,9 @@ describe("WebDAVSettings", () => {
   })
 
   it("completes WebDAV config save analytics as unknown failure when persistence rejects the update", async () => {
-    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
+    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(
+      createStalePreferenceWriteResult(1, 2),
+    )
 
     render(<WebDAVSettings />)
 
@@ -485,7 +502,9 @@ describe("WebDAVSettings", () => {
   })
 
   it("completes WebDAV connection test analytics as failure when validation fails", async () => {
-    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
+    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(
+      createStalePreferenceWriteResult(1, 2),
+    )
 
     render(<WebDAVSettings />)
 
@@ -1365,8 +1384,10 @@ describe("WebDAVSettings", () => {
     )
   })
 
-  it("surfaces the save failure message when saving the WebDAV config fails", async () => {
-    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
+  it("surfaces stale preference guidance when saving the WebDAV config is rejected by the version guard", async () => {
+    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(
+      createStalePreferenceWriteResult(1, 2),
+    )
 
     render(<WebDAVSettings />)
 
@@ -1379,7 +1400,9 @@ describe("WebDAVSettings", () => {
     )
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("settings:messages.updateFailed")
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings:messages.preferencesChangedExternally",
+      )
     })
     expect(loggerMocks.error).toHaveBeenCalledWith(
       "Failed to save WebDAV settings",
@@ -1387,8 +1410,10 @@ describe("WebDAVSettings", () => {
     )
   })
 
-  it("shows a local save failure when persisting settings before connection test fails", async () => {
-    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
+  it("shows stale preference guidance when persisting settings before connection test is rejected by the version guard", async () => {
+    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(
+      createStalePreferenceWriteResult(1, 2),
+    )
 
     render(<WebDAVSettings />)
 
@@ -1401,14 +1426,16 @@ describe("WebDAVSettings", () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        "settings:messages.saveSettingsFailed",
+        "settings:messages.preferencesChangedExternally",
       )
     })
     expect(mockTestWebdavConnection).not.toHaveBeenCalled()
   })
 
-  it("shows a local save failure when persisting settings before upload fails", async () => {
-    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(null)
+  it("shows stale preference guidance when persisting settings before upload is rejected by the version guard", async () => {
+    mockUserPreferences.savePreferencesWithResult.mockResolvedValue(
+      createStalePreferenceWriteResult(1, 2),
+    )
 
     render(<WebDAVSettings />)
 
@@ -1421,7 +1448,7 @@ describe("WebDAVSettings", () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        "settings:messages.saveSettingsFailed",
+        "settings:messages.preferencesChangedExternally",
       )
     })
     expect(mockUploadBackup).not.toHaveBeenCalled()
@@ -1833,7 +1860,7 @@ describe("WebDAVSettings", () => {
     })
   })
 
-  it("shows both import success and save-settings failure when persisting the decrypt password fails", async () => {
+  it("shows both import success and stale preference guidance when persisting the decrypt password is rejected by the version guard", async () => {
     mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
     mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
       ENCRYPTED_BACKUP_ENVELOPE,
@@ -1843,7 +1870,9 @@ describe("WebDAVSettings", () => {
     mockUserPreferences.savePreferencesWithResult.mockImplementationOnce(
       defaultSavePreferencesWithResult!,
     )
-    mockUserPreferences.savePreferencesWithResult.mockResolvedValueOnce(null)
+    mockUserPreferences.savePreferencesWithResult.mockResolvedValueOnce(
+      createStalePreferenceWriteResult(1, 2),
+    )
 
     render(<WebDAVSettings />)
 
@@ -1876,7 +1905,7 @@ describe("WebDAVSettings", () => {
         "importExport:import.importSuccess",
       )
       expect(toast.error).toHaveBeenCalledWith(
-        "settings:messages.saveSettingsFailed",
+        "settings:messages.preferencesChangedExternally",
       )
       expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
         PRODUCT_ANALYTICS_RESULTS.Failure,

--- a/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
+++ b/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
@@ -229,12 +229,12 @@ describe("NewApiManagedVerificationDialog", () => {
     )
 
     expect(updateNewApiUsernameMock).toHaveBeenCalledWith("admin")
-    expect(updateNewApiPasswordMock).not.toHaveBeenCalled()
-    expect(props.onUpdateRequestConfig).not.toHaveBeenCalled()
-    expect(props.onRetry).not.toHaveBeenCalled()
     expect(
       await screen.findByText("dialog.messages.quickConfigSaveFailed"),
     ).toBeInTheDocument()
+    expect(updateNewApiPasswordMock).not.toHaveBeenCalled()
+    expect(props.onUpdateRequestConfig).not.toHaveBeenCalled()
+    expect(props.onRetry).not.toHaveBeenCalled()
   })
 
   it("shows base-url save failures without retrying verification", async () => {
@@ -270,11 +270,11 @@ describe("NewApiManagedVerificationDialog", () => {
     expect(updateNewApiBaseUrlMock).toHaveBeenCalledWith(
       "https://changed.example",
     )
-    expect(props.onUpdateRequestConfig).not.toHaveBeenCalled()
-    expect(props.onRetry).not.toHaveBeenCalled()
     expect(
       await screen.findByText("dialog.messages.quickConfigSaveFailed"),
     ).toBeInTheDocument()
+    expect(props.onUpdateRequestConfig).not.toHaveBeenCalled()
+    expect(props.onRetry).not.toHaveBeenCalled()
   })
 
   it("shows password save failures without retrying verification", async () => {
@@ -300,11 +300,11 @@ describe("NewApiManagedVerificationDialog", () => {
 
     expect(updateNewApiUsernameMock).toHaveBeenCalledWith("admin")
     expect(updateNewApiPasswordMock).toHaveBeenCalledWith("secret")
-    expect(props.onUpdateRequestConfig).not.toHaveBeenCalled()
-    expect(props.onRetry).not.toHaveBeenCalled()
     expect(
       await screen.findByText("dialog.messages.quickConfigSaveFailed"),
     ).toBeInTheDocument()
+    expect(props.onUpdateRequestConfig).not.toHaveBeenCalled()
+    expect(props.onRetry).not.toHaveBeenCalled()
   })
 
   it("patches stale request config even when storage already has the same values", async () => {

--- a/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
+++ b/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
@@ -19,6 +19,11 @@ let currentNewApiBaseUrl = "https://managed.example"
 let currentNewApiUsername = ""
 let currentNewApiPassword = ""
 
+const preferenceWriteSuccess = () => ({
+  ok: true,
+  preferences: {},
+})
+
 vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: () => ({
     newApiBaseUrl: currentNewApiBaseUrl,
@@ -146,9 +151,9 @@ describe("NewApiManagedVerificationDialog", () => {
     updateNewApiBaseUrlMock.mockReset()
     updateNewApiUsernameMock.mockReset()
     updateNewApiPasswordMock.mockReset()
-    updateNewApiBaseUrlMock.mockResolvedValue(true)
-    updateNewApiUsernameMock.mockResolvedValue(true)
-    updateNewApiPasswordMock.mockResolvedValue(true)
+    updateNewApiBaseUrlMock.mockResolvedValue(preferenceWriteSuccess())
+    updateNewApiUsernameMock.mockResolvedValue(preferenceWriteSuccess())
+    updateNewApiPasswordMock.mockResolvedValue(preferenceWriteSuccess())
   })
 
   it("shows inline quick-config fields when login-assist settings are missing", () => {

--- a/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
+++ b/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
@@ -24,6 +24,14 @@ const preferenceWriteSuccess = () => ({
   preferences: {},
 })
 
+const preferenceWriteFailure = () => ({
+  ok: false,
+  reason: {
+    type: "storage-error",
+    error: new Error("save failed"),
+  },
+})
+
 vi.mock("~/contexts/UserPreferencesContext", () => ({
   useUserPreferencesContext: () => ({
     newApiBaseUrl: currentNewApiBaseUrl,
@@ -197,6 +205,36 @@ describe("NewApiManagedVerificationDialog", () => {
       password: "secret",
     })
     expect(props.onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows quick-config save failures without retrying verification", async () => {
+    const user = userEvent.setup()
+    updateNewApiUsernameMock.mockResolvedValue(preferenceWriteFailure())
+    const props = createProps()
+
+    render(<NewApiManagedVerificationDialog {...props} />)
+
+    await user.type(
+      screen.getByLabelText("settings:newApi.fields.usernameLabel"),
+      "admin",
+    )
+    await user.type(
+      screen.getByLabelText("settings:newApi.fields.passwordLabel"),
+      "secret",
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "dialog.actions.saveAndRetry",
+      }),
+    )
+
+    expect(updateNewApiUsernameMock).toHaveBeenCalledWith("admin")
+    expect(updateNewApiPasswordMock).not.toHaveBeenCalled()
+    expect(props.onUpdateRequestConfig).not.toHaveBeenCalled()
+    expect(props.onRetry).not.toHaveBeenCalled()
+    expect(
+      await screen.findByText("dialog.messages.quickConfigSaveFailed"),
+    ).toBeInTheDocument()
   })
 
   it("patches stale request config even when storage already has the same values", async () => {

--- a/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
+++ b/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
@@ -237,6 +237,76 @@ describe("NewApiManagedVerificationDialog", () => {
     ).toBeInTheDocument()
   })
 
+  it("shows base-url save failures without retrying verification", async () => {
+    const user = userEvent.setup()
+    updateNewApiBaseUrlMock.mockResolvedValue(preferenceWriteFailure())
+    const props = createProps({
+      step: NEW_API_MANAGED_VERIFICATION_STEPS.FAILURE,
+      request: {
+        ...BASE_REQUEST,
+        config: {
+          ...BASE_REQUEST.config,
+          baseUrl: "",
+        },
+      },
+      errorMessage: "newApiManagedVerification:dialog.messages.missingBaseUrl",
+    })
+
+    render(<NewApiManagedVerificationDialog {...props} />)
+
+    await user.clear(
+      screen.getByLabelText("settings:newApi.fields.baseUrlLabel"),
+    )
+    await user.type(
+      screen.getByLabelText("settings:newApi.fields.baseUrlLabel"),
+      "https://changed.example",
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "dialog.actions.saveAndRetry",
+      }),
+    )
+
+    expect(updateNewApiBaseUrlMock).toHaveBeenCalledWith(
+      "https://changed.example",
+    )
+    expect(props.onUpdateRequestConfig).not.toHaveBeenCalled()
+    expect(props.onRetry).not.toHaveBeenCalled()
+    expect(
+      await screen.findByText("dialog.messages.quickConfigSaveFailed"),
+    ).toBeInTheDocument()
+  })
+
+  it("shows password save failures without retrying verification", async () => {
+    const user = userEvent.setup()
+    updateNewApiPasswordMock.mockResolvedValue(preferenceWriteFailure())
+    const props = createProps()
+
+    render(<NewApiManagedVerificationDialog {...props} />)
+
+    await user.type(
+      screen.getByLabelText("settings:newApi.fields.usernameLabel"),
+      "admin",
+    )
+    await user.type(
+      screen.getByLabelText("settings:newApi.fields.passwordLabel"),
+      "secret",
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "dialog.actions.saveAndRetry",
+      }),
+    )
+
+    expect(updateNewApiUsernameMock).toHaveBeenCalledWith("admin")
+    expect(updateNewApiPasswordMock).toHaveBeenCalledWith("secret")
+    expect(props.onUpdateRequestConfig).not.toHaveBeenCalled()
+    expect(props.onRetry).not.toHaveBeenCalled()
+    expect(
+      await screen.findByText("dialog.messages.quickConfigSaveFailed"),
+    ).toBeInTheDocument()
+  })
+
   it("patches stale request config even when storage already has the same values", async () => {
     const user = userEvent.setup()
     currentNewApiUsername = "admin"

--- a/tests/hooks/usePreferenceDraft.test.tsx
+++ b/tests/hooks/usePreferenceDraft.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
+
+describe("usePreferenceDraft", () => {
+  it("advances the expected save version when a dirty draft receives a newer saved snapshot", () => {
+    const initialSavedValue = {
+      baseUrl: "https://old.example.invalid",
+      adminToken: "old-token",
+    }
+    const { result, rerender } = renderHook(
+      ({
+        savedValue,
+        savedVersion,
+      }: {
+        savedValue: typeof initialSavedValue
+        savedVersion: number
+      }) =>
+        usePreferenceDraft({
+          savedValue,
+          savedVersion,
+        }),
+      {
+        initialProps: {
+          savedValue: initialSavedValue,
+          savedVersion: 1,
+        },
+      },
+    )
+
+    act(() => {
+      result.current.setDraft({
+        baseUrl: "https://next.example.invalid",
+        adminToken: "next-token",
+      })
+    })
+
+    expect(result.current.expectedLastUpdated).toBe(1)
+
+    rerender({
+      savedValue: {
+        baseUrl: "https://next.example.invalid",
+        adminToken: "old-token",
+      },
+      savedVersion: 2,
+    })
+
+    expect(result.current.draft).toEqual({
+      baseUrl: "https://next.example.invalid",
+      adminToken: "next-token",
+    })
+    expect(result.current.isDirty).toBe(true)
+    expect(result.current.expectedLastUpdated).toBe(2)
+  })
+
+  it("keeps the original save version when a newer saved snapshot conflicts with the dirty draft", () => {
+    const initialSavedValue = {
+      baseUrl: "https://old.example.invalid",
+      adminToken: "old-token",
+    }
+    const { result, rerender } = renderHook(
+      ({
+        savedValue,
+        savedVersion,
+      }: {
+        savedValue: typeof initialSavedValue
+        savedVersion: number
+      }) =>
+        usePreferenceDraft({
+          savedValue,
+          savedVersion,
+        }),
+      {
+        initialProps: {
+          savedValue: initialSavedValue,
+          savedVersion: 1,
+        },
+      },
+    )
+
+    act(() => {
+      result.current.setDraft({
+        baseUrl: "https://local.example.invalid",
+        adminToken: "old-token",
+      })
+    })
+
+    rerender({
+      savedValue: {
+        baseUrl: "https://remote.example.invalid",
+        adminToken: "old-token",
+      },
+      savedVersion: 2,
+    })
+
+    expect(result.current.draft).toEqual({
+      baseUrl: "https://local.example.invalid",
+      adminToken: "old-token",
+    })
+    expect(result.current.isDirty).toBe(true)
+    expect(result.current.expectedLastUpdated).toBe(1)
+  })
+})

--- a/tests/services/autoRefreshService.test.ts
+++ b/tests/services/autoRefreshService.test.ts
@@ -21,7 +21,10 @@ import {
 } from "~/services/accounts/autoRefreshService"
 import { usageHistoryScheduler } from "~/services/history/usageHistory/scheduler"
 import type { UserPreferences } from "~/services/preferences/userPreferences"
-import { userPreferences } from "~/services/preferences/userPreferences"
+import {
+  DEFAULT_PREFERENCES,
+  userPreferences,
+} from "~/services/preferences/userPreferences"
 import { DEFAULT_ACCOUNT_AUTO_REFRESH } from "~/types/accountAutoRefresh"
 
 const preferenceWriteSuccess = (
@@ -29,9 +32,10 @@ const preferenceWriteSuccess = (
 ) => ({
   ok: true as const,
   preferences: {
+    ...DEFAULT_PREFERENCES,
     accountAutoRefresh: DEFAULT_ACCOUNT_AUTO_REFRESH,
     ...preferences,
-  } as UserPreferences,
+  },
 })
 
 const { mockOnAutoRefreshMessage } = vi.hoisted(() => ({
@@ -52,12 +56,20 @@ vi.mock("~/services/accounts/accountStorage", () => ({
   },
 }))
 
-vi.mock("~/services/preferences/userPreferences", () => ({
-  userPreferences: {
-    getPreferences: vi.fn(),
-    savePreferences: vi.fn(),
-  },
-}))
+vi.mock("~/services/preferences/userPreferences", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/services/preferences/userPreferences")
+    >()
+
+  return {
+    ...actual,
+    userPreferences: {
+      getPreferences: vi.fn(),
+      savePreferences: vi.fn(),
+    },
+  }
+})
 
 vi.mock("~/services/history/usageHistory/scheduler", () => ({
   usageHistoryScheduler: {

--- a/tests/services/autoRefreshService.test.ts
+++ b/tests/services/autoRefreshService.test.ts
@@ -28,7 +28,10 @@ const preferenceWriteSuccess = (
   preferences: Partial<UserPreferences> = {},
 ) => ({
   ok: true as const,
-  preferences: preferences as UserPreferences,
+  preferences: {
+    accountAutoRefresh: DEFAULT_ACCOUNT_AUTO_REFRESH,
+    ...preferences,
+  } as UserPreferences,
 })
 
 const { mockOnAutoRefreshMessage } = vi.hoisted(() => ({

--- a/tests/services/autoRefreshService.test.ts
+++ b/tests/services/autoRefreshService.test.ts
@@ -24,6 +24,13 @@ import type { UserPreferences } from "~/services/preferences/userPreferences"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { DEFAULT_ACCOUNT_AUTO_REFRESH } from "~/types/accountAutoRefresh"
 
+const preferenceWriteSuccess = (
+  preferences: Partial<UserPreferences> = {},
+) => ({
+  ok: true as const,
+  preferences: preferences as UserPreferences,
+})
+
 const { mockOnAutoRefreshMessage } = vi.hoisted(() => ({
   mockOnAutoRefreshMessage: vi.fn(() => vi.fn()),
 }))
@@ -383,7 +390,9 @@ describe("AutoRefreshService", () => {
     it("should save preferences and reconfigure timer", async () => {
       const updates = { accountAutoRefresh: { enabled: false, interval: 600 } }
 
-      vi.mocked(userPreferences.savePreferences).mockResolvedValue(true)
+      vi.mocked(userPreferences.savePreferences).mockResolvedValue(
+        preferenceWriteSuccess(),
+      )
       vi.mocked(userPreferences.getPreferences).mockResolvedValue({
         accountAutoRefresh: {
           ...DEFAULT_ACCOUNT_AUTO_REFRESH,
@@ -587,7 +596,9 @@ describe("auto-refresh typed message resolvers", () => {
   describe("autoRefresh:updateSettings action", () => {
     it("should update settings and send success response", async () => {
       const settings = { accountAutoRefresh: { enabled: false, interval: 600 } }
-      vi.mocked(userPreferences.savePreferences).mockResolvedValue(true)
+      vi.mocked(userPreferences.savePreferences).mockResolvedValue(
+        preferenceWriteSuccess(),
+      )
       vi.mocked(userPreferences.getPreferences).mockResolvedValue({
         accountAutoRefresh: {
           ...DEFAULT_ACCOUNT_AUTO_REFRESH,

--- a/tests/services/runtimeTypedMessagingSetup.test.ts
+++ b/tests/services/runtimeTypedMessagingSetup.test.ts
@@ -430,7 +430,14 @@ describe("typed runtime messaging setup", () => {
         ok: true,
         savedPreferences: { lastUpdated: 3 } as any,
       })
-      .mockResolvedValueOnce({ ok: false, reason: "conflict" } as any)
+      .mockResolvedValueOnce({
+        ok: false,
+        reason: {
+          type: "stale",
+          expectedLastUpdated: 7,
+          actualLastUpdated: 9,
+        },
+      })
     vi.spyOn(service.webdavAutoSyncService, "getStatus")
       .mockReturnValueOnce({
         isRunning: true,

--- a/tests/services/usageHistory/scheduler.test.ts
+++ b/tests/services/usageHistory/scheduler.test.ts
@@ -106,7 +106,13 @@ describe("usageHistoryScheduler", () => {
       ...DEFAULT_PREFERENCES,
       usageHistory: createUsageHistoryConfig(),
     })
-    vi.mocked(userPreferences.savePreferences).mockResolvedValue(true)
+    vi.mocked(userPreferences.savePreferences).mockResolvedValue({
+      ok: true,
+      preferences: {
+        ...DEFAULT_PREFERENCES,
+        usageHistory: createUsageHistoryConfig(),
+      },
+    })
     vi.mocked(hasAlarmsAPI).mockReturnValue(true)
     vi.mocked(getAlarm).mockResolvedValue(undefined)
     vi.mocked(accountStorage.getEnabledAccounts).mockResolvedValue([

--- a/tests/services/userPreferences.autoFillCurrentSiteUrlOnAccountAdd.test.ts
+++ b/tests/services/userPreferences.autoFillCurrentSiteUrlOnAccountAdd.test.ts
@@ -38,9 +38,9 @@ describe("userPreferences autoFillCurrentSiteUrlOnAccountAdd", () => {
       autoFillCurrentSiteUrlOnAccountAdd: false,
     })
 
-    const success =
+    const result =
       await userPreferences.updateAutoFillCurrentSiteUrlOnAccountAdd(true)
-    expect(success).toBe(true)
+    expect(result.ok).toBe(true)
 
     const prefs = await userPreferences.getPreferences()
     expect(prefs.autoFillCurrentSiteUrlOnAccountAdd).toBe(true)

--- a/tests/services/userPreferences.autoProvisionKeyOnAccountAdd.test.ts
+++ b/tests/services/userPreferences.autoProvisionKeyOnAccountAdd.test.ts
@@ -41,9 +41,9 @@ describe("userPreferences autoProvisionKeyOnAccountAdd", () => {
       autoProvisionKeyOnAccountAdd: true,
     })
 
-    const success =
+    const result =
       await userPreferences.updateAutoProvisionKeyOnAccountAdd(false)
-    expect(success).toBe(true)
+    expect(result.ok).toBe(true)
 
     const prefs = await userPreferences.getPreferences()
     expect(prefs.autoProvisionKeyOnAccountAdd).toBe(false)

--- a/tests/services/userPreferences.logging.test.ts
+++ b/tests/services/userPreferences.logging.test.ts
@@ -42,10 +42,10 @@ describe("userPreferences logging preferences", () => {
       logging: { consoleEnabled: true, level: "info" },
     })
 
-    const success = await userPreferences.updateLoggingPreferences({
+    const writeResult = await userPreferences.updateLoggingPreferences({
       level: "error",
     })
-    expect(success).toBe(true)
+    expect(writeResult.ok).toBe(true)
 
     const logging = await userPreferences.getLoggingPreferences()
     expect(logging.consoleEnabled).toBe(true)

--- a/tests/services/userPreferences.managedSiteConfig.test.ts
+++ b/tests/services/userPreferences.managedSiteConfig.test.ts
@@ -7,14 +7,18 @@ import { USER_PREFERENCES_STORAGE_KEYS } from "~/services/core/storageKeys"
 import {
   DEFAULT_PREFERENCES,
   userPreferences,
+  type PreferenceWriteResult,
 } from "~/services/preferences/userPreferences"
 import { DEFAULT_AXON_HUB_CONFIG } from "~/types/axonHubConfig"
 import { DEFAULT_CLAUDE_CODE_HUB_CONFIG } from "~/types/claudeCodeHubConfig"
 import { DEFAULT_DONE_HUB_CONFIG } from "~/types/doneHubConfig"
 import { DEFAULT_OCTOPUS_CONFIG } from "~/types/octopusConfig"
 
-const expectSuccessfulWrite = async (write: Promise<{ ok: boolean }>) => {
-  await expect(write).resolves.toMatchObject({ ok: true })
+const expectSuccessfulWrite = async (write: Promise<PreferenceWriteResult>) => {
+  await expect(write).resolves.toMatchObject({
+    ok: true,
+    preferences: expect.any(Object),
+  })
 }
 
 describe("userPreferences managed-site helpers", () => {

--- a/tests/services/userPreferences.managedSiteConfig.test.ts
+++ b/tests/services/userPreferences.managedSiteConfig.test.ts
@@ -13,6 +13,10 @@ import { DEFAULT_CLAUDE_CODE_HUB_CONFIG } from "~/types/claudeCodeHubConfig"
 import { DEFAULT_DONE_HUB_CONFIG } from "~/types/doneHubConfig"
 import { DEFAULT_OCTOPUS_CONFIG } from "~/types/octopusConfig"
 
+const expectSuccessfulWrite = async (write: Promise<{ ok: boolean }>) => {
+  await expect(write).resolves.toMatchObject({ ok: true })
+}
+
 describe("userPreferences managed-site helpers", () => {
   const storage = new Storage({ area: "local" })
 
@@ -32,14 +36,14 @@ describe("userPreferences managed-site helpers", () => {
       structuredClone(DEFAULT_PREFERENCES),
     )
 
-    expect(
-      await userPreferences.updateManagedSiteType(SITE_TYPES.VELOERA),
-    ).toBe(true)
-    expect(
-      await userPreferences.updateVeloeraConfig({
+    await expectSuccessfulWrite(
+      userPreferences.updateManagedSiteType(SITE_TYPES.VELOERA),
+    )
+    await expectSuccessfulWrite(
+      userPreferences.updateVeloeraConfig({
         baseUrl: "https://veloera.example.com",
       }),
-    ).toBe(true)
+    )
 
     let managedSite = await userPreferences.getManagedSiteConfig()
     expect(managedSite.siteType).toBe(SITE_TYPES.VELOERA)
@@ -49,16 +53,16 @@ describe("userPreferences managed-site helpers", () => {
       }),
     )
 
-    expect(
-      await userPreferences.updateManagedSiteType(SITE_TYPES.DONE_HUB),
-    ).toBe(true)
-    expect(
-      await userPreferences.updateDoneHubConfig({
+    await expectSuccessfulWrite(
+      userPreferences.updateManagedSiteType(SITE_TYPES.DONE_HUB),
+    )
+    await expectSuccessfulWrite(
+      userPreferences.updateDoneHubConfig({
         baseUrl: "https://done.example.com",
         adminToken: "done-token",
         userId: "done-user",
       }),
-    ).toBe(true)
+    )
 
     managedSite = await userPreferences.getManagedSiteConfig()
     expect(managedSite.siteType).toBe(SITE_TYPES.DONE_HUB)
@@ -69,16 +73,16 @@ describe("userPreferences managed-site helpers", () => {
       userId: "done-user",
     })
 
-    expect(
-      await userPreferences.updateManagedSiteType(SITE_TYPES.OCTOPUS),
-    ).toBe(true)
-    expect(
-      await userPreferences.updateOctopusConfig({
+    await expectSuccessfulWrite(
+      userPreferences.updateManagedSiteType(SITE_TYPES.OCTOPUS),
+    )
+    await expectSuccessfulWrite(
+      userPreferences.updateOctopusConfig({
         baseUrl: "https://octopus.example.com",
         username: "octopus-user",
         password: "octopus-pass",
       }),
-    ).toBe(true)
+    )
 
     managedSite = await userPreferences.getManagedSiteConfig()
     expect(managedSite.siteType).toBe(SITE_TYPES.OCTOPUS)
@@ -89,16 +93,16 @@ describe("userPreferences managed-site helpers", () => {
       password: "octopus-pass",
     })
 
-    expect(
-      await userPreferences.updateManagedSiteType(SITE_TYPES.AXON_HUB),
-    ).toBe(true)
-    expect(
-      await userPreferences.updateAxonHubConfig({
+    await expectSuccessfulWrite(
+      userPreferences.updateManagedSiteType(SITE_TYPES.AXON_HUB),
+    )
+    await expectSuccessfulWrite(
+      userPreferences.updateAxonHubConfig({
         baseUrl: "https://axonhub.example.com",
         email: "admin@example.com",
         password: "secret",
       }),
-    ).toBe(true)
+    )
 
     managedSite = await userPreferences.getManagedSiteConfig()
     expect(managedSite.siteType).toBe(SITE_TYPES.AXON_HUB)
@@ -109,15 +113,15 @@ describe("userPreferences managed-site helpers", () => {
       password: "secret",
     })
 
-    expect(
-      await userPreferences.updateManagedSiteType(SITE_TYPES.CLAUDE_CODE_HUB),
-    ).toBe(true)
-    expect(
-      await userPreferences.updateClaudeCodeHubConfig({
+    await expectSuccessfulWrite(
+      userPreferences.updateManagedSiteType(SITE_TYPES.CLAUDE_CODE_HUB),
+    )
+    await expectSuccessfulWrite(
+      userPreferences.updateClaudeCodeHubConfig({
         baseUrl: "https://cch.example.com",
         adminToken: "admin-token",
       }),
-    ).toBe(true)
+    )
 
     managedSite = await userPreferences.getManagedSiteConfig()
     expect(managedSite.siteType).toBe(SITE_TYPES.CLAUDE_CODE_HUB)
@@ -237,11 +241,11 @@ describe("userPreferences managed-site helpers", () => {
       },
     })
 
-    expect(await userPreferences.resetVeloeraConfig()).toBe(true)
-    expect(await userPreferences.resetDoneHubConfig()).toBe(true)
-    expect(await userPreferences.resetOctopusConfig()).toBe(true)
-    expect(await userPreferences.resetAxonHubConfig()).toBe(true)
-    expect(await userPreferences.resetClaudeCodeHubConfig()).toBe(true)
+    await expectSuccessfulWrite(userPreferences.resetVeloeraConfig())
+    await expectSuccessfulWrite(userPreferences.resetDoneHubConfig())
+    await expectSuccessfulWrite(userPreferences.resetOctopusConfig())
+    await expectSuccessfulWrite(userPreferences.resetAxonHubConfig())
+    await expectSuccessfulWrite(userPreferences.resetClaudeCodeHubConfig())
 
     const preferences = await userPreferences.getPreferences()
     expect(preferences.veloera).toEqual(DEFAULT_PREFERENCES.veloera)

--- a/tests/services/userPreferences.openChangelogOnUpdate.test.ts
+++ b/tests/services/userPreferences.openChangelogOnUpdate.test.ts
@@ -73,8 +73,8 @@ describe("userPreferences openChangelogOnUpdate", () => {
       openChangelogOnUpdate: true,
     })
 
-    const success = await userPreferences.updateOpenChangelogOnUpdate(false)
-    expect(success).toBe(true)
+    const writeResult = await userPreferences.updateOpenChangelogOnUpdate(false)
+    expect(writeResult.ok).toBe(true)
 
     const prefs = await userPreferences.getPreferences()
     expect(prefs.openChangelogOnUpdate).toBe(false)
@@ -84,8 +84,8 @@ describe("userPreferences openChangelogOnUpdate", () => {
     const storage = new Storage({ area: "local" })
     await storage.remove(USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES)
 
-    const success = await userPreferences.updateOpenChangelogOnUpdate(false)
-    expect(success).toBe(true)
+    const writeResult = await userPreferences.updateOpenChangelogOnUpdate(false)
+    expect(writeResult.ok).toBe(true)
 
     const storedAfter = (await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,

--- a/tests/services/userPreferences.settingsHelpers.test.ts
+++ b/tests/services/userPreferences.settingsHelpers.test.ts
@@ -7,13 +7,17 @@ import { USER_PREFERENCES_STORAGE_KEYS } from "~/services/core/storageKeys"
 import {
   DEFAULT_PREFERENCES,
   userPreferences,
+  type PreferenceWriteResult,
 } from "~/services/preferences/userPreferences"
 import { AUTO_CHECKIN_SCHEDULE_MODE } from "~/types/autoCheckin"
 import { DEFAULT_TASK_NOTIFICATION_PREFERENCES } from "~/types/taskNotifications"
 import { WEBDAV_SYNC_STRATEGIES } from "~/types/webdav"
 
-const expectSuccessfulWrite = async (write: Promise<{ ok: boolean }>) => {
-  await expect(write).resolves.toMatchObject({ ok: true })
+const expectSuccessfulWrite = async (write: Promise<PreferenceWriteResult>) => {
+  await expect(write).resolves.toMatchObject({
+    ok: true,
+    preferences: expect.any(Object),
+  })
 }
 
 describe("userPreferences settings helpers", () => {

--- a/tests/services/userPreferences.settingsHelpers.test.ts
+++ b/tests/services/userPreferences.settingsHelpers.test.ts
@@ -12,6 +12,10 @@ import { AUTO_CHECKIN_SCHEDULE_MODE } from "~/types/autoCheckin"
 import { DEFAULT_TASK_NOTIFICATION_PREFERENCES } from "~/types/taskNotifications"
 import { WEBDAV_SYNC_STRATEGIES } from "~/types/webdav"
 
+const expectSuccessfulWrite = async (write: Promise<{ ok: boolean }>) => {
+  await expect(write).resolves.toMatchObject({ ok: true })
+}
+
 describe("userPreferences settings helpers", () => {
   const storage = new Storage({ area: "local" })
 
@@ -31,14 +35,16 @@ describe("userPreferences settings helpers", () => {
       structuredClone(DEFAULT_PREFERENCES),
     )
 
-    expect(await userPreferences.updateActiveTab(DATA_TYPE_BALANCE)).toBe(true)
-    expect(await userPreferences.updateCurrencyType("CNY")).toBe(true)
-    expect(await userPreferences.updateShowTodayCashflow(false)).toBe(true)
-    expect(await userPreferences.updateSortConfig("name", "asc")).toBe(true)
-    expect(await userPreferences.updateShowHealthStatus(false)).toBe(true)
-    expect(await userPreferences.setLanguage("ja")).toBe(true)
-    expect(
-      await userPreferences.updateWebdavSettings({
+    await expectSuccessfulWrite(
+      userPreferences.updateActiveTab(DATA_TYPE_BALANCE),
+    )
+    await expectSuccessfulWrite(userPreferences.updateCurrencyType("CNY"))
+    await expectSuccessfulWrite(userPreferences.updateShowTodayCashflow(false))
+    await expectSuccessfulWrite(userPreferences.updateSortConfig("name", "asc"))
+    await expectSuccessfulWrite(userPreferences.updateShowHealthStatus(false))
+    await expectSuccessfulWrite(userPreferences.setLanguage("ja"))
+    await expectSuccessfulWrite(
+      userPreferences.updateWebdavSettings({
         url: "https://dav.example.com",
         username: "alice",
         password: "secret",
@@ -49,14 +55,14 @@ describe("userPreferences settings helpers", () => {
           accounts: false,
         },
       }),
-    ).toBe(true)
-    expect(
-      await userPreferences.updateWebdavAutoSyncSettings({
+    )
+    await expectSuccessfulWrite(
+      userPreferences.updateWebdavAutoSyncSettings({
         autoSync: true,
         syncInterval: 7200,
         syncStrategy: WEBDAV_SYNC_STRATEGIES.DOWNLOAD_ONLY,
       }),
-    ).toBe(true)
+    )
 
     const preferences = await userPreferences.getPreferences()
     const exportedPreferences = await userPreferences.exportPreferences()
@@ -99,15 +105,15 @@ describe("userPreferences settings helpers", () => {
       structuredClone(DEFAULT_PREFERENCES),
     )
 
-    expect(
-      await userPreferences.updateTaskNotifications({
+    await expectSuccessfulWrite(
+      userPreferences.updateTaskNotifications({
         enabled: false,
         tasks: {
           ...DEFAULT_TASK_NOTIFICATION_PREFERENCES.tasks,
           usageHistorySync: false,
         },
       }),
-    ).toBe(true)
+    )
 
     let preferences = await userPreferences.getPreferences()
     expect(preferences.taskNotifications).toEqual({
@@ -119,7 +125,7 @@ describe("userPreferences settings helpers", () => {
       channels: DEFAULT_TASK_NOTIFICATION_PREFERENCES.channels,
     })
 
-    expect(await userPreferences.resetTaskNotifications()).toBe(true)
+    await expectSuccessfulWrite(userPreferences.resetTaskNotifications())
 
     preferences = await userPreferences.getPreferences()
     expect(preferences.taskNotifications).toEqual(
@@ -203,10 +209,10 @@ describe("userPreferences settings helpers", () => {
       },
     })
 
-    expect(await userPreferences.resetDisplaySettings()).toBe(true)
-    expect(await userPreferences.resetAutoRefreshConfig()).toBe(true)
-    expect(await userPreferences.resetNewApiConfig()).toBe(true)
-    expect(await userPreferences.resetNewApiModelSyncConfig()).toBe(true)
+    await expectSuccessfulWrite(userPreferences.resetDisplaySettings())
+    await expectSuccessfulWrite(userPreferences.resetAutoRefreshConfig())
+    await expectSuccessfulWrite(userPreferences.resetNewApiConfig())
+    await expectSuccessfulWrite(userPreferences.resetNewApiModelSyncConfig())
 
     await userPreferences.savePreferences({
       managedSiteModelSync: {
@@ -216,14 +222,16 @@ describe("userPreferences settings helpers", () => {
       },
     })
 
-    expect(await userPreferences.resetManagedSiteModelSyncConfig()).toBe(true)
-    expect(await userPreferences.resetCliProxyConfig()).toBe(true)
-    expect(await userPreferences.resetClaudeCodeRouterConfig()).toBe(true)
-    expect(await userPreferences.resetAutoCheckinConfig()).toBe(true)
-    expect(await userPreferences.resetModelRedirectConfig()).toBe(true)
-    expect(await userPreferences.resetRedemptionAssist()).toBe(true)
-    expect(await userPreferences.resetWebAiApiCheck()).toBe(true)
-    expect(await userPreferences.resetWebdavConfig()).toBe(true)
+    await expectSuccessfulWrite(
+      userPreferences.resetManagedSiteModelSyncConfig(),
+    )
+    await expectSuccessfulWrite(userPreferences.resetCliProxyConfig())
+    await expectSuccessfulWrite(userPreferences.resetClaudeCodeRouterConfig())
+    await expectSuccessfulWrite(userPreferences.resetAutoCheckinConfig())
+    await expectSuccessfulWrite(userPreferences.resetModelRedirectConfig())
+    await expectSuccessfulWrite(userPreferences.resetRedemptionAssist())
+    await expectSuccessfulWrite(userPreferences.resetWebAiApiCheck())
+    await expectSuccessfulWrite(userPreferences.resetWebdavConfig())
 
     const preferences = await userPreferences.getPreferences()
 
@@ -263,7 +271,7 @@ describe("userPreferences settings helpers", () => {
     const resetTimestamp = new Date("2026-03-30T10:00:00.000Z")
     vi.setSystemTime(resetTimestamp)
 
-    expect(await userPreferences.resetToDefaults()).toBe(true)
+    expect((await userPreferences.resetToDefaults()).ok).toBe(true)
 
     const resetPreferences = await userPreferences.getPreferences()
     expect(resetPreferences.activeTab).toBe(DEFAULT_PREFERENCES.activeTab)
@@ -274,7 +282,7 @@ describe("userPreferences settings helpers", () => {
       resetTimestamp.getTime(),
     )
 
-    expect(await userPreferences.clearPreferences()).toBe(true)
+    expect((await userPreferences.clearPreferences()).ok).toBe(true)
 
     const storedAfterClear = await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,

--- a/tests/services/userPreferences.sharedPreferences.test.ts
+++ b/tests/services/userPreferences.sharedPreferences.test.ts
@@ -72,13 +72,13 @@ describe("userPreferences shared preference timestamps", () => {
 
     vi.setSystemTime(localOnlyUpdateTimestamp)
 
-    const success = await userPreferences.savePreferences({
+    const result = await userPreferences.savePreferences({
       accountAutoRefresh: {
         interval: DEFAULT_PREFERENCES.accountAutoRefresh.interval + 60,
       },
     })
 
-    expect(success).toBe(true)
+    expect(result).toMatchObject({ ok: true })
 
     const storedAfter = (await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
@@ -104,13 +104,13 @@ describe("userPreferences shared preference timestamps", () => {
 
     vi.setSystemTime(localOnlyUpdateTimestamp)
 
-    const success = await userPreferences.savePreferences({
+    const result = await userPreferences.savePreferences({
       accountAutoRefresh: {
         enabled: false,
       },
     })
 
-    expect(success).toBe(true)
+    expect(result).toMatchObject({ ok: true })
 
     const storedAfter = (await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
@@ -131,11 +131,11 @@ describe("userPreferences shared preference timestamps", () => {
 
     vi.setSystemTime(sharedUpdateTimestamp)
 
-    const success = await userPreferences.savePreferences({
+    const result = await userPreferences.savePreferences({
       themeMode: "dark",
     })
 
-    expect(success).toBe(true)
+    expect(result).toMatchObject({ ok: true })
 
     const storedAfter = (await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
@@ -156,14 +156,14 @@ describe("userPreferences shared preference timestamps", () => {
 
     vi.setSystemTime(mixedUpdateTimestamp)
 
-    const success = await userPreferences.savePreferences({
+    const result = await userPreferences.savePreferences({
       themeMode: "dark",
       accountAutoRefresh: {
         enabled: false,
       },
     })
 
-    expect(success).toBe(true)
+    expect(result).toMatchObject({ ok: true })
 
     const storedAfter = (await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
@@ -172,7 +172,7 @@ describe("userPreferences shared preference timestamps", () => {
     expect(storedAfter.sharedPreferencesLastUpdated).toBe(mixedUpdateTimestamp)
   })
 
-  it("skips stale guarded saves after a newer write wins", async () => {
+  it("returns a typed stale result for guarded saves after a newer write wins", async () => {
     const initialTimestamp = 6100
     const newerUpdateTimestamp = 6200
     const staleAttemptTimestamp = 6300
@@ -185,14 +185,20 @@ describe("userPreferences shared preference timestamps", () => {
     })
 
     vi.setSystemTime(newerUpdateTimestamp)
-    const newerWriteSuccess = await userPreferences.savePreferences({
+    const newerWriteResult = await userPreferences.savePreferences({
       activeTab: DATA_TYPE_CASHFLOW,
     })
 
-    expect(newerWriteSuccess).toBe(true)
+    expect(newerWriteResult).toMatchObject({
+      ok: true,
+      preferences: {
+        activeTab: DATA_TYPE_CASHFLOW,
+        lastUpdated: newerUpdateTimestamp,
+      },
+    })
 
     vi.setSystemTime(staleAttemptTimestamp)
-    const staleWriteSuccess = await userPreferences.savePreferences(
+    const staleWriteResult = await userPreferences.savePreferences(
       {
         activeTab: DATA_TYPE_BALANCE,
       },
@@ -201,7 +207,14 @@ describe("userPreferences shared preference timestamps", () => {
       },
     )
 
-    expect(staleWriteSuccess).toBe(false)
+    expect(staleWriteResult).toEqual({
+      ok: false,
+      reason: {
+        type: "stale",
+        expectedLastUpdated: initialTimestamp,
+        actualLastUpdated: newerUpdateTimestamp,
+      },
+    })
 
     const storedAfter = (await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
@@ -210,7 +223,7 @@ describe("userPreferences shared preference timestamps", () => {
     expect(storedAfter.activeTab).toBe(DATA_TYPE_CASHFLOW)
   })
 
-  it("rethrows storage failures from savePreferencesWithResult and keeps savePreferences as a safe boolean wrapper", async () => {
+  it("returns typed storage failures from preference writes", async () => {
     await storage.set(USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES, {
       ...DEFAULT_PREFERENCES,
       themeMode: "system",
@@ -223,17 +236,17 @@ describe("userPreferences shared preference timestamps", () => {
       .mockRejectedValue(new Error("save failed"))
 
     try {
-      await expect(
-        userPreferences.savePreferencesWithResult({
-          themeMode: "dark",
-        }),
-      ).rejects.toThrow("save failed")
+      const writeResult = await userPreferences.savePreferences({
+        themeMode: "dark",
+      })
 
-      await expect(
-        userPreferences.savePreferences({
-          themeMode: "dark",
-        }),
-      ).resolves.toBe(false)
+      expect(writeResult).toMatchObject({
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error: expect.any(Error),
+        },
+      })
 
       const storedAfter = (await storage.get(
         USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
@@ -251,14 +264,14 @@ describe("userPreferences shared preference timestamps", () => {
 
     vi.setSystemTime(importedAt)
 
-    const success = await userPreferences.importPreferences({
+    const result = await userPreferences.importPreferences({
       ...DEFAULT_PREFERENCES,
       themeMode: "dark",
       lastUpdated: backupTimestamp,
       sharedPreferencesLastUpdated: backupTimestamp,
     })
 
-    expect(success).toBe(true)
+    expect(result).toMatchObject({ ok: true })
 
     const storedAfter = (await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
@@ -292,7 +305,7 @@ describe("userPreferences shared preference timestamps", () => {
 
     vi.setSystemTime(importedAt)
 
-    const success = await userPreferences.importPreferences(
+    const result = await userPreferences.importPreferences(
       {
         ...DEFAULT_PREFERENCES,
         themeMode: "dark",
@@ -315,7 +328,7 @@ describe("userPreferences shared preference timestamps", () => {
       },
     )
 
-    expect(success).toBe(true)
+    expect(result).toMatchObject({ ok: true })
 
     const storedAfter = (await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,
@@ -348,14 +361,14 @@ describe("userPreferences shared preference timestamps", () => {
     delete legacyImportedPreferences.lastUpdated
     delete legacyImportedPreferences.sharedPreferencesLastUpdated
 
-    const success = await userPreferences.importPreferences(
+    const result = await userPreferences.importPreferences(
       legacyImportedPreferences,
       {
         preserveWebdav: true,
       },
     )
 
-    expect(success).toBe(true)
+    expect(result).toMatchObject({ ok: true })
 
     const storedAfter = (await storage.get(
       USER_PREFERENCES_STORAGE_KEYS.USER_PREFERENCES,

--- a/tests/services/userPreferences.sortingPriority.test.ts
+++ b/tests/services/userPreferences.sortingPriority.test.ts
@@ -34,9 +34,9 @@ describe("userPreferences sortingPriorityConfig", () => {
     })
 
     vi.setSystemTime(new Date("2026-03-30T01:00:05.000Z"))
-    const success = await userPreferences.resetSortingPriorityConfig()
+    const writeResult = await userPreferences.resetSortingPriorityConfig()
 
-    expect(success).toBe(true)
+    expect(writeResult.ok).toBe(true)
 
     const preferences = await userPreferences.getPreferences()
     expect(preferences.sortingPriorityConfig).toEqual({

--- a/tests/services/userPreferences.test.ts
+++ b/tests/services/userPreferences.test.ts
@@ -139,4 +139,30 @@ describe("userPreferences", () => {
       expect(preferences.webAiApiCheck?.enabled).toBe(true)
     })
   })
+
+  describe("write failures", () => {
+    it("returns a storage-error result when a guarded write cannot read the current snapshot", async () => {
+      const storage = (userPreferences as any).storage as {
+        get: ReturnType<typeof vi.fn>
+        set: ReturnType<typeof vi.fn>
+      }
+      const readError = new Error("read failed")
+
+      vi.spyOn(storage, "get").mockRejectedValueOnce(readError)
+      const setSpy = vi.spyOn(storage, "set")
+
+      const result = await userPreferences.savePreferencesWithResult({
+        currencyType: "CNY",
+      })
+
+      expect(result).toEqual({
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error: readError,
+        },
+      })
+      expect(setSpy).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/tests/services/userPreferences.test.ts
+++ b/tests/services/userPreferences.test.ts
@@ -127,7 +127,7 @@ describe("userPreferences", () => {
             enhanced: { enabled: false },
           },
         }),
-      ).resolves.toBe(true)
+      ).resolves.toMatchObject({ ok: true })
 
       const preferences = await userPreferences.getPreferences()
 

--- a/tests/services/userPreferences.test.ts
+++ b/tests/services/userPreferences.test.ts
@@ -7,6 +7,7 @@ import {
   userPreferences,
 } from "~/services/preferences/userPreferences"
 import { DEFAULT_ACCOUNT_AUTO_REFRESH } from "~/types/accountAutoRefresh"
+import { DEFAULT_SITE_ANNOUNCEMENT_PREFERENCES } from "~/types/siteAnnouncements"
 
 describe("userPreferences", () => {
   describe("DEFAULT_PREFERENCES", () => {
@@ -163,6 +164,72 @@ describe("userPreferences", () => {
         },
       })
       expect(setSpy).not.toHaveBeenCalled()
+    })
+
+    it("returns storage-error results for direct reset, clear, and import write failures", async () => {
+      const storage = (userPreferences as any).storage as {
+        set: ReturnType<typeof vi.fn>
+        remove: ReturnType<typeof vi.fn>
+      }
+      const setError = new Error("set failed")
+      const removeError = new Error("remove failed")
+
+      vi.spyOn(storage, "set").mockRejectedValueOnce(setError)
+      await expect(userPreferences.resetToDefaults()).resolves.toEqual({
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error: setError,
+        },
+      })
+
+      vi.spyOn(storage, "remove").mockRejectedValueOnce(removeError)
+      await expect(userPreferences.clearPreferences()).resolves.toEqual({
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error: removeError,
+        },
+      })
+
+      vi.spyOn(storage, "set").mockRejectedValueOnce(setError)
+      await expect(
+        userPreferences.importPreferences({
+          ...DEFAULT_PREFERENCES,
+          themeMode: "dark",
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        reason: {
+          type: "storage-error",
+          error: setError,
+        },
+      })
+    })
+
+    it("uses the shared write path for site announcement notification updates", async () => {
+      const storage = (userPreferences as any).storage as {
+        set: ReturnType<typeof vi.fn>
+      }
+      const setSpy = vi.spyOn(storage, "set")
+
+      await expect(
+        userPreferences.updateSiteAnnouncementNotifications({
+          intervalMinutes:
+            DEFAULT_SITE_ANNOUNCEMENT_PREFERENCES.intervalMinutes + 60,
+        }),
+      ).resolves.toMatchObject({
+        ok: true,
+        preferences: {
+          siteAnnouncementNotifications: {
+            ...DEFAULT_SITE_ANNOUNCEMENT_PREFERENCES,
+            intervalMinutes:
+              DEFAULT_SITE_ANNOUNCEMENT_PREFERENCES.intervalMinutes + 60,
+          },
+        },
+      })
+
+      expect(setSpy).toHaveBeenCalled()
     })
   })
 })

--- a/tests/services/webdavAutoSyncService.lifecycle.test.ts
+++ b/tests/services/webdavAutoSyncService.lifecycle.test.ts
@@ -142,17 +142,26 @@ describe("webdavAutoSyncService lifecycle", () => {
     mocks.savePreferences.mockResolvedValue(true)
     mocks.savePreferencesWithResult.mockImplementation(
       async (updates, options) => {
-        const success = await mocks.savePreferences(updates, options)
-        return success
+        const writeResult = await mocks.savePreferences(updates, options)
+        return writeResult
           ? {
-              lastUpdated: 1,
-              webdav: {
-                autoSync: false,
-                syncInterval: 3600,
-                syncStrategy: "merge",
+              ok: true,
+              preferences: {
+                lastUpdated: 1,
+                webdav: {
+                  autoSync: false,
+                  syncInterval: 3600,
+                  syncStrategy: "merge",
+                },
               },
             }
-          : null
+          : {
+              ok: false,
+              reason: {
+                type: "storage-error",
+                error: new Error("save failed"),
+              },
+            }
       },
     )
   })
@@ -503,7 +512,14 @@ describe("webdavAutoSyncService lifecycle", () => {
       .spyOn(service, "setupAutoSync")
       .mockResolvedValue(undefined)
 
-    mocks.savePreferencesWithResult.mockResolvedValueOnce(null)
+    mocks.savePreferencesWithResult.mockResolvedValueOnce({
+      ok: false,
+      reason: {
+        type: "stale",
+        expectedLastUpdated: 7,
+        actualLastUpdated: 8,
+      },
+    })
 
     await expect(
       service.updateSettings(
@@ -512,7 +528,11 @@ describe("webdavAutoSyncService lifecycle", () => {
       ),
     ).resolves.toEqual({
       ok: false,
-      reason: "conflict",
+      reason: {
+        type: "stale",
+        expectedLastUpdated: 7,
+        actualLastUpdated: 8,
+      },
     })
 
     expect(setupSpy).not.toHaveBeenCalled()
@@ -534,11 +554,18 @@ describe("webdavAutoSyncService lifecycle", () => {
       .spyOn(webdavAutoSyncService, "updateSettings")
       .mockResolvedValueOnce({
         ok: false,
-        reason: "conflict",
+        reason: {
+          type: "stale",
+          expectedLastUpdated: 7,
+          actualLastUpdated: 8,
+        },
       } as any)
       .mockResolvedValueOnce({
         ok: false,
-        reason: "error",
+        reason: {
+          type: "storage-error",
+          error: new Error("save failed"),
+        },
       } as any)
 
     const conflictResponse = await resolveWebdavAutoSyncTestMessage({
@@ -615,9 +642,11 @@ describe("webdavAutoSyncService lifecycle", () => {
 
     await expect(
       service.updateSettings({ autoSync: false, syncInterval: 900 }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       ok: false,
-      reason: "error",
+      reason: {
+        type: "storage-error",
+      },
     })
 
     expect(setupSpy).not.toHaveBeenCalled()

--- a/tests/services/webdavAutoSyncService.test.ts
+++ b/tests/services/webdavAutoSyncService.test.ts
@@ -35,6 +35,19 @@ const mockSavePreferences = vi.fn()
 const mockExportPreferences = vi.fn()
 const mockImportPreferences = vi.fn()
 
+const preferenceWriteSuccess = () => ({
+  ok: true,
+  preferences: {},
+})
+
+const preferenceWriteFailure = () => ({
+  ok: false,
+  reason: {
+    type: "storage-error",
+    error: new Error("Failed to import WebDAV preferences"),
+  },
+})
+
 vi.mock(
   import("~/services/preferences/userPreferences"),
   async (importOriginal) => {
@@ -897,7 +910,7 @@ describe("WebdavAutoSyncService.syncWithWebdav (selective sync)", () => {
     mockChannelConfigImport.mockResolvedValue(undefined)
     mockApiCredentialProfilesImport.mockResolvedValue(undefined)
     mockTagStoreImport.mockResolvedValue(undefined)
-    mockImportPreferences.mockResolvedValue(true)
+    mockImportPreferences.mockResolvedValue(preferenceWriteSuccess())
 
     mockTagStoreExport.mockResolvedValue({ version: 1, tagsById: {} })
     mockExportPreferences.mockResolvedValue({ lastUpdated: 1 } as any)
@@ -1747,7 +1760,7 @@ describe("WebdavAutoSyncService best-effort upload helpers", () => {
       return await accountDeferred.promise
     })
     mockTagStoreImport.mockResolvedValue(undefined)
-    mockImportPreferences.mockResolvedValue(true)
+    mockImportPreferences.mockResolvedValue(preferenceWriteSuccess())
     mockChannelConfigImport.mockResolvedValue(undefined)
     mockApiCredentialProfilesImport.mockResolvedValue(undefined)
 
@@ -1947,7 +1960,7 @@ describe("WebdavAutoSyncService local apply phase", () => {
     mockChannelConfigImport.mockResolvedValue(undefined)
     mockApiCredentialProfilesImport.mockResolvedValue(undefined)
     mockTagStoreImport.mockResolvedValue(undefined)
-    mockImportPreferences.mockResolvedValue(true)
+    mockImportPreferences.mockResolvedValue(preferenceWriteSuccess())
 
     mockAccountStorageExportData.mockResolvedValue({
       accounts: [{ id: "local-account", created_at: 1, updated_at: 10 }],
@@ -2058,7 +2071,7 @@ describe("WebdavAutoSyncService local apply phase", () => {
     })
     mockImportPreferences.mockImplementation(async () => {
       callOrder.push("preferences")
-      return true
+      return preferenceWriteSuccess()
     })
     mockChannelConfigImport.mockImplementation(async () => {
       callOrder.push("channel")
@@ -2098,7 +2111,7 @@ describe("WebdavAutoSyncService local apply phase", () => {
 
     mockAccountStorageImportData.mockResolvedValue({ migratedCount: 0 })
     mockTagStoreImport.mockResolvedValue(undefined)
-    mockImportPreferences.mockResolvedValue(true)
+    mockImportPreferences.mockResolvedValue(preferenceWriteSuccess())
     mockChannelConfigImport.mockRejectedValueOnce(new Error("channel failed"))
 
     await expect(service.syncWithWebdav()).rejects.toThrow("channel failed")
@@ -2126,7 +2139,7 @@ describe("WebdavAutoSyncService local apply phase", () => {
 
     mockAccountStorageImportData.mockResolvedValue({ migratedCount: 0 })
     mockTagStoreImport.mockResolvedValue(undefined)
-    mockImportPreferences.mockResolvedValue(true)
+    mockImportPreferences.mockResolvedValue(preferenceWriteSuccess())
     mockChannelConfigImport.mockResolvedValue(undefined)
     mockApiCredentialProfilesImport.mockRejectedValueOnce(
       new Error("profile import failed"),
@@ -2148,7 +2161,7 @@ describe("WebdavAutoSyncService local apply phase", () => {
 
   it("throws when importing synced preferences fails and rolls account metadata back to empty defaults", async () => {
     const service = createService()
-    mockImportPreferences.mockResolvedValue(false)
+    mockImportPreferences.mockResolvedValue(preferenceWriteFailure())
 
     await expect(
       (service as any).applyLocalSyncResult({

--- a/tests/test-utils/mockPreferencePersistence.ts
+++ b/tests/test-utils/mockPreferencePersistence.ts
@@ -1,10 +1,12 @@
 import { vi } from "vitest"
 
+import { CURRENT_PREFERENCES_VERSION } from "~/services/preferences/migrations/preferencesMigration"
 import {
   DEFAULT_PREFERENCES,
   type PreferenceWriteResult,
   type UserPreferences,
 } from "~/services/preferences/userPreferences"
+import { patchTouchesSharedPreferences } from "~/services/preferences/webdavSharedPreferences"
 import type { DeepPartial } from "~/types/utils"
 import { deepOverride } from "~/utils"
 
@@ -44,11 +46,38 @@ export function setupMockPreferencePersistence(
   })
 
   mocks.getPreferences.mockImplementation(async () => getPersistedPreferences())
-  mocks.savePreferencesWithResult.mockImplementation(async (updates) => {
-    persistedPreferences = deepOverride(persistedPreferences, updates)
-    persistedPreferences.lastUpdated += 1
-    return createSuccessResult()
-  })
+  mocks.savePreferencesWithResult.mockImplementation(
+    async (updates, options) => {
+      if (
+        typeof options?.expectedLastUpdated === "number" &&
+        Number.isFinite(options.expectedLastUpdated) &&
+        persistedPreferences.lastUpdated !== options.expectedLastUpdated
+      ) {
+        return {
+          ok: false,
+          reason: {
+            type: "stale",
+            expectedLastUpdated: options.expectedLastUpdated,
+            actualLastUpdated: persistedPreferences.lastUpdated,
+          },
+        } satisfies PreferenceWriteResult
+      }
+
+      const nextLastUpdated = persistedPreferences.lastUpdated + 1
+      const nextSharedPreferencesLastUpdated = patchTouchesSharedPreferences(
+        updates,
+      )
+        ? nextLastUpdated
+        : persistedPreferences.sharedPreferencesLastUpdated
+
+      persistedPreferences = deepOverride(persistedPreferences, updates)
+      persistedPreferences.lastUpdated = nextLastUpdated
+      persistedPreferences.sharedPreferencesLastUpdated =
+        nextSharedPreferencesLastUpdated
+      persistedPreferences.preferencesVersion = CURRENT_PREFERENCES_VERSION
+      return createSuccessResult()
+    },
+  )
   mocks.savePreferences.mockImplementation(async (updates, options) => {
     return await mocks.savePreferencesWithResult(updates, options)
   })

--- a/tests/test-utils/mockPreferencePersistence.ts
+++ b/tests/test-utils/mockPreferencePersistence.ts
@@ -2,6 +2,7 @@ import { vi } from "vitest"
 
 import {
   DEFAULT_PREFERENCES,
+  type PreferenceWriteResult,
   type UserPreferences,
 } from "~/services/preferences/userPreferences"
 import type { DeepPartial } from "~/types/utils"
@@ -35,18 +36,21 @@ export function setupMockPreferencePersistence(
     persistedPreferences = structuredClone(nextPreferences)
   }
 
+  const createSuccessResult = (
+    preferences = getPersistedPreferences(),
+  ): PreferenceWriteResult => ({
+    ok: true,
+    preferences,
+  })
+
   mocks.getPreferences.mockImplementation(async () => getPersistedPreferences())
   mocks.savePreferencesWithResult.mockImplementation(async (updates) => {
     persistedPreferences = deepOverride(persistedPreferences, updates)
     persistedPreferences.lastUpdated += 1
-    return getPersistedPreferences()
+    return createSuccessResult()
   })
   mocks.savePreferences.mockImplementation(async (updates, options) => {
-    const savedPreferences = await mocks.savePreferencesWithResult(
-      updates,
-      options,
-    )
-    return savedPreferences !== null
+    return await mocks.savePreferencesWithResult(updates, options)
   })
 
   return {

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -525,6 +525,21 @@ describe("importFromBackupObject", () => {
     expect(result.allImported).toBe(true)
   })
 
+  it("throws when legacy preference import cannot be persisted", async () => {
+    mockUserPreferencesImport.mockResolvedValue(preferenceWriteFailure())
+    const payload: RawBackupData = {
+      version: "3.0",
+      timestamp: Date.now(),
+      preferences: {
+        themeMode: "dark",
+      },
+    }
+
+    await expect(importFromBackupObject(payload)).rejects.toThrow(
+      "importExport:import.importFailed",
+    )
+  })
+
   it("preserves webdav config when preserveWebdav option is provided", async () => {
     const backup: BackupPreferencesPartialV2 = {
       version: BACKUP_VERSION,

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -105,6 +105,16 @@ const mockApiCredentialProfilesMergeConfig =
   apiCredentialProfilesStorage.mergeConfig as unknown as ReturnType<
     typeof vi.fn
   >
+
+const preferenceWriteSuccess = () => ({
+  ok: true,
+  preferences: {},
+})
+
+const preferenceWriteFailure = () => ({
+  ok: false,
+  reason: { type: "storage-error", error: new Error("import failed") },
+})
 const mockApiCredentialProfilesExportConfig =
   apiCredentialProfilesStorage.exportConfig as unknown as ReturnType<
     typeof vi.fn
@@ -205,7 +215,7 @@ describe("parseBackupSummary", () => {
 describe("importFromBackupObject", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUserPreferencesImport.mockResolvedValue(true)
+    mockUserPreferencesImport.mockResolvedValue(preferenceWriteSuccess())
     mockEnsureLegacyMigration.mockResolvedValue({
       migratedAccountCount: 0,
       createdTagCount: 0,
@@ -560,7 +570,7 @@ describe("importFromBackupObject", () => {
   })
 
   it("returns partial success when V2 preference import fails but other sections import", async () => {
-    mockUserPreferencesImport.mockResolvedValue(false)
+    mockUserPreferencesImport.mockResolvedValue(preferenceWriteFailure())
 
     const backup: BackupFullV2 = {
       version: BACKUP_VERSION,

--- a/tests/utils/toastHelpers.test.ts
+++ b/tests/utils/toastHelpers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
 
 import {
+  createVersionedPreferenceSaveOptions,
+  getPreferenceWriteFailureMessage,
+  runPreferenceUpdateWithToast,
   showResetToast,
   showResultToast,
   showUpdateToast,
@@ -78,6 +81,166 @@ describe("toastHelpers", () => {
       const toast = (await import("react-hot-toast")).default
       showUpdateToast(false, "Setting")
       expect(toast.error).toHaveBeenCalledWith("settings:messages.updateFailed")
+    })
+
+    it("shows success toast for structured preference writes", async () => {
+      const toast = (await import("react-hot-toast")).default
+      vi.clearAllMocks()
+
+      showUpdateToast({ ok: true, preferences: {} as any }, "Setting")
+
+      expect(toast.success).toHaveBeenCalledWith(
+        "settings:messages.updateSuccess",
+      )
+    })
+
+    it("shows stale-conflict guidance for structured preference write failures", async () => {
+      const toast = (await import("react-hot-toast")).default
+      vi.clearAllMocks()
+
+      showUpdateToast(
+        {
+          ok: false,
+          reason: {
+            type: "stale",
+            expectedLastUpdated: 1,
+            actualLastUpdated: 2,
+          },
+        },
+        "Setting",
+      )
+
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings:messages.preferencesChangedExternally",
+      )
+    })
+
+    it("shows setting-specific failures for structured storage errors", async () => {
+      const toast = (await import("react-hot-toast")).default
+      vi.clearAllMocks()
+
+      showUpdateToast(
+        {
+          ok: false,
+          reason: { type: "storage-error", error: new Error("disk full") },
+        },
+        "Setting",
+      )
+
+      expect(toast.error).toHaveBeenCalledWith("settings:messages.updateFailed")
+    })
+
+    it("uses explicit fallbacks for toast result objects", async () => {
+      const toast = (await import("react-hot-toast")).default
+      vi.clearAllMocks()
+
+      showUpdateToast(
+        {
+          success: true,
+          message: "",
+          successFallback: "Saved locally",
+        },
+        "Setting",
+      )
+
+      expect(toast.success).toHaveBeenCalledWith("Saved locally")
+    })
+  })
+
+  describe("getPreferenceWriteFailureMessage", () => {
+    it("returns stale guidance before local fallbacks", () => {
+      expect(
+        getPreferenceWriteFailureMessage(
+          {
+            type: "stale",
+            expectedLastUpdated: 1,
+            actualLastUpdated: 2,
+          },
+          { fallback: "Local fallback" },
+        ),
+      ).toBe("settings:messages.preferencesChangedExternally")
+    })
+
+    it("returns local fallbacks for non-stale write failures", () => {
+      expect(
+        getPreferenceWriteFailureMessage(
+          { type: "storage-error", error: new Error("disk full") },
+          { fallback: "Local fallback" },
+        ),
+      ).toBe("Local fallback")
+    })
+
+    it("returns setting-specific fallback copy when no local fallback is provided", () => {
+      expect(
+        getPreferenceWriteFailureMessage(
+          { type: "storage-error", error: new Error("disk full") },
+          { setting: "Setting" },
+        ),
+      ).toBe("settings:messages.updateFailed")
+    })
+
+    it("returns the generic operation failure without setting context", () => {
+      expect(
+        getPreferenceWriteFailureMessage({
+          type: "storage-error",
+          error: new Error("disk full"),
+        }),
+      ).toBe("messages:toast.error.operationFailedGeneric")
+    })
+  })
+
+  describe("runPreferenceUpdateWithToast", () => {
+    it("passes versioned options to the updater and returns the write result", async () => {
+      const toast = (await import("react-hot-toast")).default
+      vi.clearAllMocks()
+      const result = { ok: true as const, preferences: {} as any }
+      const update = vi.fn().mockResolvedValue(result)
+
+      await expect(
+        runPreferenceUpdateWithToast({
+          expectedLastUpdated: 42,
+          setting: "Setting",
+          update,
+        }),
+      ).resolves.toBe(result)
+
+      expect(update).toHaveBeenCalledWith({ expectedLastUpdated: 42 })
+      expect(toast.success).toHaveBeenCalledWith(
+        "settings:messages.updateSuccess",
+      )
+    })
+
+    it("surfaces failed write results from the updater", async () => {
+      const toast = (await import("react-hot-toast")).default
+      vi.clearAllMocks()
+      const result = {
+        ok: false as const,
+        reason: {
+          type: "stale" as const,
+          expectedLastUpdated: 1,
+          actualLastUpdated: 2,
+        },
+      }
+
+      await expect(
+        runPreferenceUpdateWithToast({
+          expectedLastUpdated: 42,
+          setting: "Setting",
+          update: vi.fn().mockResolvedValue(result),
+        }),
+      ).resolves.toBe(result)
+
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings:messages.preferencesChangedExternally",
+      )
+    })
+  })
+
+  describe("createVersionedPreferenceSaveOptions", () => {
+    it("creates expected-last-updated save options", () => {
+      expect(createVersionedPreferenceSaveOptions(42)).toEqual({
+        expectedLastUpdated: 42,
+      })
     })
   })
 


### PR DESCRIPTION
## Summary
- centralize preference writes through structured write results
- surface stale-write failures consistently across settings and related UI flows
- keep local fallback messaging for failed updates

## Validation
- pnpm run validate:push
- pre-push hook: pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Update log auto-open” label across supported locales.

* **Bug Fixes**
  * Preference writes/resets now use structured success/failure outcomes, including “changed externally” (stale) handling.
  * Improved error messaging for storage/WebDAV and other preference write failures.
  * Sorting priority and related toggles now restore the previous order/state when a save fails.

* **Refactor**
  * Standardized preference save/update flows with shared versioned-save and toast helpers.

* **Tests**
  * Updated UI/unit tests to assert the new structured result behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->