### PR TITLE
feat(account): show site type in account rows

### DIFF
--- a/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
+++ b/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
@@ -517,14 +517,18 @@ export default function SiteInfo({
                 {t("list.site.disabled")}
               </Badge>
             )}
-            <Badge
-              variant="outline"
-              size="sm"
-              className="max-w-[10rem] shrink-0 truncate border-sky-200/80 bg-sky-50/70 whitespace-nowrap text-sky-700 dark:border-sky-700/50 dark:bg-sky-900/20 dark:text-sky-200"
-              title={`${siteTypeLabel}: ${site.siteType}`}
+            <Tooltip
+              content={`${siteTypeLabel}: ${site.siteType}`}
+              position="top"
             >
-              {site.siteType}
-            </Badge>
+              <Badge
+                variant="outline"
+                size="sm"
+                className="max-w-[10rem] shrink-0 truncate border-sky-200/80 bg-sky-50/70 whitespace-nowrap text-sky-700 dark:border-sky-700/50 dark:bg-sky-900/20 dark:text-sky-200"
+              >
+                {site.siteType}
+              </Badge>
+            </Tooltip>
           </div>
 
           <div className="flex min-w-0 items-center gap-1.5 sm:gap-2">

--- a/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
+++ b/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
@@ -132,6 +132,7 @@ export default function SiteInfo({
   const customCheckInUrl = site.checkIn?.customCheckIn?.url
   const customRedeemUrl = site.checkIn?.customCheckIn?.redeemUrl
   const createdAtLabel = t("account:list.header.createdAt")
+  const siteTypeLabel = t("list.site.siteType")
   const createdAtText = formatLocaleDateTime(
     site.created_at,
     t("common:labels.notAvailable"),
@@ -491,19 +492,40 @@ export default function SiteInfo({
       </div>
 
       <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center">
-          {detectedAccountIdSet.has(site.id) && (
-            <Tooltip content={t("list.site.currentSiteExists")} position="top">
-              <Badge variant="warning" size="sm" className="whitespace-nowrap">
-                {t("list.site.currentSite")}
+        <div className="flex flex-wrap items-center gap-x-1 gap-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+            {detectedAccountIdSet.has(site.id) && (
+              <Tooltip
+                content={t("list.site.currentSiteExists")}
+                position="top"
+              >
+                <Badge
+                  variant="warning"
+                  size="sm"
+                  className="whitespace-nowrap"
+                >
+                  {t("list.site.currentSite")}
+                </Badge>
+              </Tooltip>
+            )}
+            {isAccountDisabled && (
+              <Badge
+                variant="secondary"
+                size="sm"
+                className="whitespace-nowrap"
+              >
+                {t("list.site.disabled")}
               </Badge>
-            </Tooltip>
-          )}
-          {isAccountDisabled && (
-            <Badge variant="secondary" size="sm" className="whitespace-nowrap">
-              {t("list.site.disabled")}
+            )}
+            <Badge
+              variant="outline"
+              size="sm"
+              className="max-w-[10rem] shrink-0 truncate border-sky-200/80 bg-sky-50/70 whitespace-nowrap text-sky-700 dark:border-sky-700/50 dark:bg-sky-900/20 dark:text-sky-200"
+              title={`${siteTypeLabel}: ${site.siteType}`}
+            >
+              {site.siteType}
             </Badge>
-          )}
+          </div>
 
           <div className="flex min-w-0 items-center gap-1.5 sm:gap-2">
             {/* Keep the site URL clickable even when the account is disabled so users can still open the provider site. */}

--- a/src/locales/en/account.json
+++ b/src/locales/en/account.json
@@ -150,6 +150,7 @@
       "notCheckedInToday": "Not checked in today, click to go",
       "reason": "Reason",
       "refreshHealthStatus": "Click to refresh health status",
+      "siteType": "Site type",
       "status": "Status",
       "unknown": "Unknown"
     },

--- a/src/locales/ja/account.json
+++ b/src/locales/ja/account.json
@@ -141,6 +141,7 @@
       "notCheckedInToday": "本日は未チェックイン、クリックして移動",
       "reason": "理由",
       "refreshHealthStatus": "クリックして健全性を更新",
+      "siteType": "サイトタイプ",
       "status": "状態",
       "unknown": "不明"
     },

--- a/src/locales/vi/account.json
+++ b/src/locales/vi/account.json
@@ -141,6 +141,7 @@
       "notCheckedInToday": "Hôm nay chưa điểm danh, nhấp vào tôi để điểm danh",
       "reason": "Lý do",
       "refreshHealthStatus": "Nhấp để làm mới trạng thái sức khỏe",
+      "siteType": "Loại trang",
       "status": "Trạng thái",
       "unknown": "Không rõ"
     },

--- a/src/locales/zh-CN/account.json
+++ b/src/locales/zh-CN/account.json
@@ -141,6 +141,7 @@
       "notCheckedInToday": "今日未签到，点我去签到",
       "reason": "原因",
       "refreshHealthStatus": "点击刷新健康状态",
+      "siteType": "站点类型",
       "status": "状态",
       "unknown": "未知"
     },

--- a/src/locales/zh-TW/account.json
+++ b/src/locales/zh-TW/account.json
@@ -141,6 +141,7 @@
       "notCheckedInToday": "今日未簽到，點我去簽到",
       "reason": "原因",
       "refreshHealthStatus": "點擊重新整理健康狀態",
+      "siteType": "站點類型",
       "status": "狀態",
       "unknown": "未知"
     },

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -164,6 +164,12 @@ describe("SiteInfo", () => {
     )
   })
 
+  it("shows the raw site type in the account row", () => {
+    render(<SiteInfo site={buildSite({ siteType: SITE_TYPES.SUB2API })} />)
+
+    expect(screen.getByText(SITE_TYPES.SUB2API)).toBeVisible()
+  })
+
   it("renders a formatted created-time row", () => {
     const createdAt = new Date(2026, 0, 2, 3, 4, 5).getTime()
     const expected = formatLocaleDateTime(

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -68,6 +68,21 @@ vi.mock("react-hot-toast", () => ({
   },
 }))
 
+vi.mock("~/components/Tooltip", () => ({
+  default: ({
+    children,
+    content,
+  }: {
+    children: ReactNode
+    content: ReactNode
+  }) => (
+    <div data-tooltip-content={typeof content === "string" ? content : ""}>
+      {children}
+      {typeof content === "string" ? null : content}
+    </div>
+  ),
+}))
+
 vi.mock("~/features/AccountManagement/hooks/AccountDataContext", () => ({
   useAccountDataContext: () => ({
     detectedAccount: null,
@@ -167,7 +182,13 @@ describe("SiteInfo", () => {
   it("shows the raw site type in the account row", () => {
     render(<SiteInfo site={buildSite({ siteType: SITE_TYPES.SUB2API })} />)
 
-    expect(screen.getByText(SITE_TYPES.SUB2API)).toBeVisible()
+    const siteTypeBadge = screen.getByText(SITE_TYPES.SUB2API)
+
+    expect(siteTypeBadge).toBeVisible()
+    expect(siteTypeBadge.parentElement).toHaveAttribute(
+      "data-tooltip-content",
+      `account:list.site.siteType: ${SITE_TYPES.SUB2API}`,
+    )
   })
 
   it("renders a formatted created-time row", () => {


### PR DESCRIPTION
## Summary
- show each account row's raw site type as a compact metadata badge
- keep the badge visually distinct from status badges while preserving normal text rhythm
- add the site-type label across app locales

Closes #1091

## Validation
- pnpm vitest run tests/features/AccountManagement/components/SiteInfo.test.tsx
- pnpm run i18n:extract:ci
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “site type” badge to the account list, including a tooltip for the badge label and value.
  * Introduced new “site type” translations across supported languages.
* **Refactor**
  * Updated the badges layout in the site info row for more consistent wrapping and alignment.
* **Tests**
  * Extended component tests to verify the site type value and tooltip content render correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->