### PR TITLE
fix(account): disable AIHubMix built-in check-in

### DIFF
--- a/src/services/accountSiteDefinitions/definitions.ts
+++ b/src/services/accountSiteDefinitions/definitions.ts
@@ -203,7 +203,7 @@ const ACCOUNT_SITE_DEFINITIONS = [
         defaultAuthType: ACCOUNT_SITE_AUTH_TYPES.AccessToken,
         defaultAuthHostnames: [],
         supportsCookieAuth: false,
-        supportsBuiltInCheckInDetection: true,
+        supportsBuiltInCheckInDetection: false,
       },
       createdToken: {
         secretHandling:

--- a/tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts
+++ b/tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts
@@ -150,6 +150,7 @@ describe("Account Dialog site policy", () => {
       SITE_TYPES.AIHUBMIX,
     )
     expect(aihubmixPolicy.allowCookieAuthSession).toBe(false)
+    expect(aihubmixPolicy.allowBuiltInCheckInDetection).toBe(false)
     expect(aihubmixPolicy.allowSub2ApiRefreshTokenState).toBe(false)
     expect(aihubmixPolicy.deferSuccessForOneTimeKeyPostSaveFlow).toBe(true)
 
@@ -211,7 +212,8 @@ describe("Account Dialog site policy", () => {
 
     expect(normalized.authType).toBe(AuthTypeEnum.AccessToken)
     expect(normalized.cookieAuthSessionCookie).toBe("")
-    expect(normalized.checkIn.enableDetection).toBe(true)
+    expect(normalized.checkIn.enableDetection).toBe(false)
+    expect(normalized.checkIn.autoCheckInEnabled).toBe(false)
     expect(normalized.sub2apiUseRefreshToken).toBe(false)
     expect(normalized.sub2apiRefreshToken).toBe("")
     expect(normalized.sub2apiTokenExpiresAt).toBeNull()

--- a/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialogForm.test.tsx
@@ -720,4 +720,29 @@ describe("AccountDialog AccountForm", () => {
       autoCheckInEnabled: true,
     })
   })
+
+  it("does not show built-in auto check-in controls for AIHubMix accounts", async () => {
+    const props = createProps()
+    props.draft.siteType = SITE_TYPES.AIHUBMIX
+    props.draft.checkIn = createCheckIn({
+      enableDetection: true,
+      autoCheckInEnabled: true,
+    })
+
+    render(<AccountForm {...withSitePolicy(props)} />)
+
+    expect(
+      await screen.findByText("accountDialog:form.checkInStatusUnsupported", {
+        exact: false,
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("accountDialog:form.checkInStatusDesc"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("switch", {
+        name: "accountDialog:form.autoCheckInEnabled",
+      }),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/tests/services/accountSiteDefinitions/registry.test.ts
+++ b/tests/services/accountSiteDefinitions/registry.test.ts
@@ -453,7 +453,7 @@ describe("account site definition registry", () => {
         defaultAuthType: AuthTypeEnum.AccessToken,
         defaultAuthHostnames: [],
         supportsCookieAuth: false,
-        supportsBuiltInCheckInDetection: true,
+        supportsBuiltInCheckInDetection: false,
       },
       createdToken: {
         secretHandling:

--- a/tests/services/accounts/accountSiteProfile.test.ts
+++ b/tests/services/accounts/accountSiteProfile.test.ts
@@ -156,7 +156,7 @@ describe("accountSiteProfile", () => {
     )
     expect(profile.auth.allowedAuthTypes).toEqual([AuthTypeEnum.AccessToken])
     expect(profile.auth.supportsCookieAuth).toBe(false)
-    expect(profile.auth.supportsBuiltInCheckInDetection).toBe(true)
+    expect(profile.auth.supportsBuiltInCheckInDetection).toBe(false)
     expect(profile.modelList.displayCapabilitiesSource).toBe(
       ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile,
     )


### PR DESCRIPTION
## Summary
- mark AIHubMix as not supporting built-in check-in detection in the account site profile
- keep AIHubMix account-dialog drafts normalized with built-in check-in disabled
- cover the account form so AIHubMix does not show the built-in auto check-in control

## Validation
- pnpm exec vitest run tests/features/AccountManagement/components/AccountDialog/sitePolicy.test.ts
- pnpm exec vitest run tests/features/AccountManagement/components/AccountDialogForm.test.tsx
- pnpm run validate:staged
- pre-push hook: pnpm compile && pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AIHubMix account experience so built-in check-in detection is no longer treated as supported.
  * Updated account policy and draft normalization so AIHubMix has built-in check-in detection and auto check-in disabled.
  * Improved the account dialog UI to hide unsupported auto check-in controls and display the correct unsupported-status messaging.
* **Tests**
  * Updated and added coverage for AIHubMix check-in detection and auto check-in behavior in account dialog and account profile scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->