### PR TITLE
fix(api-credentials): export profile credentials without account context

### DIFF
--- a/src/components/CCSwitchExportDialog.tsx
+++ b/src/components/CCSwitchExportDialog.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui"
-import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
 import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
 import {
   CCSWITCH_APPS,
@@ -160,7 +160,7 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
       void (async () => {
         try {
           setIsLoadingModels(true)
-          const resolvedToken = await resolveDisplayAccountTokenForSecret(
+          const resolvedToken = await resolveExportTokenForSecret(
             account,
             token,
           )
@@ -211,10 +211,7 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
       )
 
       try {
-        const resolvedToken = await resolveDisplayAccountTokenForSecret(
-          account,
-          token,
-        )
+        const resolvedToken = await resolveExportTokenForSecret(account, token)
         const opened = openInCCSwitch({
           account,
           token: resolvedToken,

--- a/src/components/ClaudeCodeRouterImportDialog.tsx
+++ b/src/components/ClaudeCodeRouterImportDialog.tsx
@@ -9,7 +9,7 @@ import {
   Input,
   Modal,
 } from "~/components/ui"
-import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
 import { fetchOpenAICompatibleModels } from "~/services/aiApi/openaiCompatible"
 import { importToClaudeCodeRouter } from "~/services/integrations/claudeCodeRouterService"
 import {
@@ -131,7 +131,7 @@ export function ClaudeCodeRouterImportDialog(
       void (async () => {
         try {
           setIsLoadingModels(true)
-          const resolvedToken = await resolveDisplayAccountTokenForSecret(
+          const resolvedToken = await resolveExportTokenForSecret(
             account,
             token,
           )
@@ -188,10 +188,7 @@ export function ClaudeCodeRouterImportDialog(
 
       try {
         setIsSubmitting(true)
-        const resolvedToken = await resolveDisplayAccountTokenForSecret(
-          account,
-          token,
-        )
+        const resolvedToken = await resolveExportTokenForSecret(account, token)
         const result = await importToClaudeCodeRouter({
           account,
           token: resolvedToken,

--- a/src/components/CliProxyExportDialog.tsx
+++ b/src/components/CliProxyExportDialog.tsx
@@ -14,7 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui"
-import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
 import { fetchAnthropicModelIds } from "~/services/aiApi/anthropic"
 import { fetchGoogleModelIds } from "~/services/aiApi/google"
 import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
@@ -288,10 +288,7 @@ export function CliProxyExportDialog(props: CliProxyExportDialogProps) {
           providerType,
           baseUrl: resolvedProviderBaseUrl,
           apiKey: (
-            await resolveDisplayAccountTokenForSecret(
-              modelSuggestionsAccount,
-              token,
-            )
+            await resolveExportTokenForSecret(modelSuggestionsAccount, token)
           ).key,
         })
 
@@ -369,10 +366,7 @@ export function CliProxyExportDialog(props: CliProxyExportDialogProps) {
 
       try {
         setIsSubmitting(true)
-        const resolvedToken = await resolveDisplayAccountTokenForSecret(
-          account,
-          token,
-        )
+        const resolvedToken = await resolveExportTokenForSecret(account, token)
 
         const normalizedModels = models
           .map((item) => {

--- a/src/components/KiloCodeExportDialog.tsx
+++ b/src/components/KiloCodeExportDialog.tsx
@@ -30,8 +30,8 @@ import { compareAccountDisplayNames } from "~/services/accounts/utils/accountDis
 import {
   createDisplayAccountApiContext,
   requireDisplayAccountKeyManagement,
-  resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
 import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
 import {
   buildKiloCodeApiConfigs,
@@ -360,10 +360,7 @@ export function KiloCodeExportDialog({
       }))
 
       try {
-        const resolvedToken = await resolveDisplayAccountTokenForSecret(
-          site,
-          token,
-        )
+        const resolvedToken = await resolveExportTokenForSecret(site, token)
         const modelIds = await fetchOpenAICompatibleModelIds({
           baseUrl: stripTrailingOpenAIV1(site.baseUrl),
           apiKey: resolvedToken.key,
@@ -654,10 +651,7 @@ export function KiloCodeExportDialog({
         )
         if (!token) continue
 
-        const resolvedToken = await resolveDisplayAccountTokenForSecret(
-          site,
-          token,
-        )
+        const resolvedToken = await resolveExportTokenForSecret(site, token)
         const tokenSelectionKey = getTokenSelectionKey(siteId, token.id)
 
         selections.push({

--- a/src/features/KeyManagement/components/BatchCliProxyExportDialog.tsx
+++ b/src/features/KeyManagement/components/BatchCliProxyExportDialog.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui"
-import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
 import {
   buildDefaultCliProxyProviderBaseUrl,
   CLI_PROXY_PROVIDER_TYPES,
@@ -235,7 +235,7 @@ export function BatchCliProxyExportDialog({
       }))
 
       try {
-        const resolvedToken = await resolveDisplayAccountTokenForSecret(
+        const resolvedToken = await resolveExportTokenForSecret(
           item.account,
           item.token,
         )

--- a/src/services/accounts/utils/exportTokenSecret.ts
+++ b/src/services/accounts/utils/exportTokenSecret.ts
@@ -1,0 +1,26 @@
+import {
+  formatOptionalSkPrefixSiteToken,
+  hasUsableApiTokenKey,
+} from "~/services/accountTokens/apiTokenKey"
+import type { ApiToken } from "~/types"
+
+import {
+  resolveDisplayAccountTokenForSecret,
+  type DisplayAccountApiSnapshot,
+  type ResolveDisplayAccountTokenForSecretOptions,
+} from "./apiServiceRequest"
+
+/**
+ * Resolves an export token only when the selected token key is not already a usable secret.
+ */
+export async function resolveExportTokenForSecret<TToken extends ApiToken>(
+  account: DisplayAccountApiSnapshot,
+  token: TToken,
+  options: ResolveDisplayAccountTokenForSecretOptions = {},
+): Promise<TToken> {
+  if (hasUsableApiTokenKey(token.key)) {
+    return formatOptionalSkPrefixSiteToken(token, account.siteType)
+  }
+
+  return resolveDisplayAccountTokenForSecret(account, token, options)
+}

--- a/tests/components/CCSwitchExportDialog.test.tsx
+++ b/tests/components/CCSwitchExportDialog.test.tsx
@@ -509,7 +509,7 @@ describe("CCSwitchExportDialog", () => {
       id: "profile-1",
       name: "Profile Provider",
       apiType: "openai-compatible",
-      baseUrl: "https://profile.example.com/v1",
+      baseUrl: "https://profile.example.com",
       apiKey: "sk-profile",
       tagIds: [],
       notes: "profile note",

--- a/tests/components/CCSwitchExportDialog.test.tsx
+++ b/tests/components/CCSwitchExportDialog.test.tsx
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { CCSwitchExportDialog } from "~/components/CCSwitchExportDialog"
 import {
+  createExportAccount,
+  createExportToken,
+} from "~/features/ApiCredentialProfiles/utils/exportShims"
+import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_ERROR_CATEGORIES,
@@ -10,6 +14,7 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const mockFetchOpenAICompatibleModelIds = vi.fn()
@@ -498,12 +503,66 @@ describe("CCSwitchExportDialog", () => {
     })
   })
 
+  it("exports profile-backed credentials without requiring account API context", async () => {
+    const user = userEvent.setup()
+    const profile: ApiCredentialProfile = {
+      id: "profile-1",
+      name: "Profile Provider",
+      apiType: "openai-compatible",
+      baseUrl: "https://profile.example.com/v1",
+      apiKey: "sk-profile",
+      tagIds: [],
+      notes: "profile note",
+      createdAt: 1,
+      updatedAt: 2,
+    }
+    mockResolveDisplayAccountTokenForSecret.mockRejectedValue(
+      new Error("account_api_context_missing_user_id"),
+    )
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o"])
+
+    render(
+      <CCSwitchExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={createExportAccount(profile)}
+        token={createExportToken(profile)}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
+        baseUrl: "https://profile.example.com",
+        apiKey: "sk-profile",
+      })
+    })
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.ccswitch.actions.export",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockOpenInCCSwitch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({
+            id: "api-credential-profile:profile-1",
+            userId: "",
+          }),
+          token: expect.objectContaining({ key: "sk-profile" }),
+        }),
+      )
+    })
+    expect(mockResolveDisplayAccountTokenForSecret).not.toHaveBeenCalled()
+  })
+
   it("tracks thrown CC Switch submissions as unknown failures", async () => {
     const user = userEvent.setup()
     mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
-    mockResolveDisplayAccountTokenForSecret
-      .mockResolvedValueOnce({ id: "tok", key: "sk-test" })
-      .mockRejectedValueOnce(new Error("secret unavailable"))
+    mockResolveDisplayAccountTokenForSecret.mockRejectedValue(
+      new Error("secret unavailable"),
+    )
 
     render(
       <CCSwitchExportDialog
@@ -512,7 +571,7 @@ describe("CCSwitchExportDialog", () => {
         account={
           { id: "acc", name: "Example", baseUrl: "https://x.test/v1" } as any
         }
-        token={{ id: "tok", key: "sk-test" } as any}
+        token={{ id: "tok", key: "sk-abcd************wxyz" } as any}
       />,
     )
 

--- a/tests/components/ClaudeCodeRouterImportDialog.test.tsx
+++ b/tests/components/ClaudeCodeRouterImportDialog.test.tsx
@@ -541,7 +541,7 @@ describe("ClaudeCodeRouterImportDialog", () => {
       id: "profile-1",
       name: "Profile Provider",
       apiType: "openai-compatible",
-      baseUrl: "https://profile.example.com/v1",
+      baseUrl: "https://profile.example.com",
       apiKey: "sk-profile",
       tagIds: [],
       notes: "",
@@ -565,7 +565,7 @@ describe("ClaudeCodeRouterImportDialog", () => {
 
     await waitFor(() => {
       expect(mockFetchOpenAICompatibleModels).toHaveBeenCalledWith({
-        baseUrl: "https://profile.example.com/v1",
+        baseUrl: "https://profile.example.com",
         apiKey: "sk-profile",
       })
     })

--- a/tests/components/ClaudeCodeRouterImportDialog.test.tsx
+++ b/tests/components/ClaudeCodeRouterImportDialog.test.tsx
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ClaudeCodeRouterImportDialog } from "~/components/ClaudeCodeRouterImportDialog"
 import {
+  createExportAccount,
+  createExportToken,
+} from "~/features/ApiCredentialProfiles/utils/exportShims"
+import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_ERROR_CATEGORIES,
@@ -11,6 +15,7 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import {
   buildApiToken,
   buildDisplaySiteData,
@@ -528,5 +533,58 @@ describe("ClaudeCodeRouterImportDialog", () => {
         entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
       })
     })
+  })
+
+  it("imports profile-backed credentials without requiring account API context", async () => {
+    const user = userEvent.setup()
+    const profile: ApiCredentialProfile = {
+      id: "profile-1",
+      name: "Profile Provider",
+      apiType: "openai-compatible",
+      baseUrl: "https://profile.example.com/v1",
+      apiKey: "sk-profile",
+      tagIds: [],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 2,
+    }
+    mockResolveDisplayAccountTokenForSecret.mockRejectedValue(
+      new Error("account_api_context_missing_user_id"),
+    )
+    mockFetchOpenAICompatibleModels.mockResolvedValueOnce([{ id: "gpt-4o" }])
+
+    render(
+      <ClaudeCodeRouterImportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={createExportAccount(profile)}
+        token={createExportToken(profile)}
+        routerBaseUrl="https://router.example.com"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModels).toHaveBeenCalledWith({
+        baseUrl: "https://profile.example.com/v1",
+        apiKey: "sk-profile",
+      })
+    })
+
+    await user.click(
+      await screen.findByRole("button", { name: "common:actions.import" }),
+    )
+
+    await waitFor(() => {
+      expect(mockImportToClaudeCodeRouter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({
+            id: "api-credential-profile:profile-1",
+            userId: "",
+          }),
+          token: expect.objectContaining({ key: "sk-profile" }),
+        }),
+      )
+    })
+    expect(mockResolveDisplayAccountTokenForSecret).not.toHaveBeenCalled()
   })
 })

--- a/tests/components/CliProxyExportDialog.test.tsx
+++ b/tests/components/CliProxyExportDialog.test.tsx
@@ -3,6 +3,10 @@ import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { CliProxyExportDialog } from "~/components/CliProxyExportDialog"
+import {
+  createExportAccount,
+  createExportToken,
+} from "~/features/ApiCredentialProfiles/utils/exportShims"
 import { CLI_PROXY_PROVIDER_TYPES } from "~/services/integrations/cliProxyProviderTypes"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -13,6 +17,7 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import {
   buildApiToken,
   buildDisplaySiteData,
@@ -632,6 +637,58 @@ describe("CliProxyExportDialog", () => {
         entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
       })
     })
+  })
+
+  it("exports profile-backed credentials without requiring account API context", async () => {
+    const user = userEvent.setup()
+    const profile: ApiCredentialProfile = {
+      id: "profile-1",
+      name: "Profile Provider",
+      apiType: "openai-compatible",
+      baseUrl: "https://profile.example.com/v1",
+      apiKey: "sk-profile",
+      tagIds: [],
+      notes: "",
+      createdAt: 1,
+      updatedAt: 2,
+    }
+    mockResolveDisplayAccountTokenForSecret.mockRejectedValue(
+      new Error("account_api_context_missing_user_id"),
+    )
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o"])
+
+    render(
+      <CliProxyExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={createExportAccount(profile)}
+        token={createExportToken(profile)}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
+        baseUrl: "https://profile.example.com",
+        apiKey: "sk-profile",
+      })
+    })
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.import" }),
+    )
+
+    await waitFor(() => {
+      expect(mockImportToCliProxy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({
+            id: "api-credential-profile:profile-1",
+            userId: "",
+          }),
+          token: expect.objectContaining({ key: "sk-profile" }),
+        }),
+      )
+    })
+    expect(mockResolveDisplayAccountTokenForSecret).not.toHaveBeenCalled()
   })
 
   it("tracks thrown CLI Proxy submissions as unknown failures", async () => {

--- a/tests/components/CliProxyExportDialog.test.tsx
+++ b/tests/components/CliProxyExportDialog.test.tsx
@@ -645,7 +645,7 @@ describe("CliProxyExportDialog", () => {
       id: "profile-1",
       name: "Profile Provider",
       apiType: "openai-compatible",
-      baseUrl: "https://profile.example.com/v1",
+      baseUrl: "https://profile.example.com",
       apiKey: "sk-profile",
       tagIds: [],
       notes: "",

--- a/tests/features/KeyManagement/components/BatchCliProxyExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/BatchCliProxyExportDialog.test.tsx
@@ -63,14 +63,14 @@ describe("BatchCliProxyExportDialog", () => {
     accountId: account.id,
     accountName: account.name,
     name: "Token 1",
-    key: "masked-1",
+    key: "sk-token-1************masked",
   })
   const token2 = createToken({
     id: 2,
     accountId: account.id,
     accountName: account.name,
     name: "Token 2",
-    key: "masked-2",
+    key: "sk-token-2************masked",
   })
 
   beforeEach(() => {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -13,6 +13,7 @@ import {
   resolveStoredAccountApiContext,
   StoredAccountApiContextError,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import { AuthTypeEnum } from "~/types"
 
@@ -618,6 +619,49 @@ describe("fetchDisplayAccountTokens", () => {
     )
 
     expect(result).toBe(token)
+  })
+
+  it("uses an already usable export token without resolving the account context", async () => {
+    const token = { id: 1, key: "plain-secret", status: 1, name: "Plain" }
+
+    const result = await resolveExportTokenForSecret(
+      { ...ACCOUNT, siteType: "Veloera" } as any,
+      token as any,
+    )
+
+    expect(result).toEqual({
+      id: 1,
+      key: "sk-plain-secret",
+      status: 1,
+      name: "Plain",
+    })
+    expect(resolveTokenKey).not.toHaveBeenCalled()
+  })
+
+  it("resolves export tokens when the current key is masked", async () => {
+    const token = {
+      id: 1,
+      key: "sk-abcd************wxyz",
+      status: 1,
+      name: "Masked",
+    }
+    resolveTokenKey.mockResolvedValue("sk-real")
+
+    const result = await resolveExportTokenForSecret(
+      ACCOUNT as any,
+      token as any,
+    )
+
+    expect(result).toEqual({
+      id: 1,
+      key: "sk-real",
+      status: 1,
+      name: "Masked",
+    })
+    expect(resolveTokenKey).toHaveBeenCalledWith({
+      request: expect.objectContaining(REQUEST),
+      token,
+    })
   })
 
   it("throws when adapter key management is not implemented", async () => {


### PR DESCRIPTION
## Summary
- Add a shared export-token helper that uses already-usable token keys directly and only resolves masked or empty keys through account context.
- Apply the helper to profile/account export flows for CCSwitch, Claude Code Router, CLI Proxy, Kilo Code, and batch CLI Proxy.
- Add regressions for API credential profile exports that must not require account API context.

Fixes #1104

## Validation
- pnpm vitest --run tests/services/accounts/apiServiceRequest.test.ts tests/components/CCSwitchExportDialog.test.tsx tests/components/ClaudeCodeRouterImportDialog.test.tsx tests/components/CliProxyExportDialog.test.tsx tests/components/KiloCodeExportDialog.test.tsx tests/features/KeyManagement/components/BatchCliProxyExportDialog.test.tsx
- pnpm run validate:staged
- pnpm compile
- pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export/import dialogs’ token handling by using dedicated export-token resolution, including masked secrets and profile-backed credentials during model lookup and submission.
  * Batch export flows now resolve export tokens more consistently, reducing failures when account API context isn’t available.
* **Tests**
  * Expanded coverage for profile-backed export/import scenarios and masked-token resolution to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->