### PR TITLE
fix(managed-sites): stabilize real-site channel flow

### DIFF
--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test"
+import type { Locator, Page } from "@playwright/test"
 
 import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
@@ -108,8 +108,9 @@ export async function runManagedSiteChannelsCrudScenario<
       baseUrl: "https://upstream.example.invalid/v1",
       model: CRUD_MODEL,
     })
-    await expect(channelRowByName(context.page, channelName)).toBeVisible({
-      timeout: 60_000,
+    await expectManagedSiteChannelVisibleAfterRefresh({
+      page: context.page,
+      channelName,
     })
 
     await context.page
@@ -120,12 +121,11 @@ export async function runManagedSiteChannelsCrudScenario<
     })
     await expectPaginationSummary(context.page, "1", "1", "1")
 
-    await openSingleVisibleChannelRowActions(context.page, channelName)
-    const editAction = context.page.getByTestId(
-      getManagedSiteChannelRowEditActionTestId(channelName),
+    const editAction = await openSingleVisibleChannelRowActions(
+      context.page,
+      channelName,
     )
-    await expect(editAction).toBeVisible({ timeout: 30_000 })
-    await editAction.click()
+    await editAction.click({ timeout: 10_000 })
     await expect(
       context.page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
     ).toBeVisible({ timeout: 60_000 })
@@ -221,14 +221,10 @@ export async function runManagedSiteTokenChannelStatusScenario<
     await expect(
       row.getByTestId(KEY_MANAGEMENT_TEST_IDS.managedSiteStatusBadge),
     ).toBeVisible({ timeout: 90_000 })
-    const importToManagedSiteButton = row.getByTestId(
-      KEY_MANAGEMENT_TEST_IDS.importToManagedSiteButton,
-    )
-    await expect(importToManagedSiteButton).toBeEnabled({ timeout: 60_000 })
-    await importToManagedSiteButton.click()
-    await expect(
-      keyManagementPage.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
-    ).toBeVisible({ timeout: 60_000 })
+    await openManagedSiteImportDialogFromTokenRow({
+      page: keyManagementPage,
+      row,
+    })
     await keyManagementPage
       .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
       .fill(channelName)
@@ -236,24 +232,23 @@ export async function runManagedSiteTokenChannelStatusScenario<
       .getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton)
       .click()
 
-    await expect(
-      row.getByTestId(KEY_MANAGEMENT_TEST_IDS.managedSiteStatusBadge),
-    ).toHaveText("Added", { timeout: 90_000 })
-    await expect(
-      row.getByTestId(KEY_MANAGEMENT_TEST_IDS.managedSiteChannelLinkButton),
-    ).toBeVisible({ timeout: 60_000 })
-    await keyManagementPage.goto(
-      channelsUrl(context.extensionId, { search: channelName }),
-    )
-    await waitForExtensionRoot(keyManagementPage)
-    await expect(channelRowByName(keyManagementPage, channelName)).toBeVisible({
-      timeout: 60_000,
+    await expectManagedSiteImportStatusAfterChannelCreate(row)
+    await openManagedSiteChannelsAndExpectRow({
+      page: keyManagementPage,
+      extensionId: context.extensionId,
+      channelName,
     })
     await expectPaginationSummary(keyManagementPage, "1", "1", "1")
 
     return { skipped: false as const }
   } finally {
     if (createdTokenName) {
+      keyManagementPage = await openKeyManagementForAccount({
+        page: keyManagementPage,
+        extensionId: context.extensionId,
+        accountId: context.sourceAccount.accountId,
+        openFromAccountRow: false,
+      })
       await deleteTokenFromKeyManagementPage({
         page: keyManagementPage,
         token: createdTokenName,
@@ -270,6 +265,87 @@ export async function runManagedSiteTokenChannelStatusScenario<
       prefix: context.cleanupPrefix ?? context.runPrefix,
     })
   }
+}
+
+async function openManagedSiteImportDialogFromTokenRow(params: {
+  page: Page
+  row: Locator
+}) {
+  await expect(async () => {
+    const importToManagedSiteButton = params.row.getByTestId(
+      KEY_MANAGEMENT_TEST_IDS.importToManagedSiteButton,
+    )
+
+    await expect(importToManagedSiteButton).toBeEnabled({ timeout: 20_000 })
+    await importToManagedSiteButton.click()
+    await expect(
+      params.page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
+    ).toBeVisible({ timeout: 30_000 })
+  }).toPass({
+    intervals: [1_000, 3_000, 5_000],
+    timeout: 90_000,
+  })
+}
+
+async function openManagedSiteChannelsAndExpectRow(params: {
+  page: Page
+  extensionId: string
+  channelName: string
+}) {
+  await params.page.goto(
+    channelsUrl(params.extensionId, { search: params.channelName }),
+  )
+  await waitForExtensionRoot(params.page)
+  await expectManagedSiteChannelVisibleAfterRefresh({
+    page: params.page,
+    channelName: params.channelName,
+  })
+}
+
+async function expectManagedSiteChannelVisibleAfterRefresh(params: {
+  page: Page
+  channelName: string
+}) {
+  await expect(async () => {
+    const row = channelRowByName(params.page, params.channelName)
+    if ((await row.count()) > 0) {
+      await expect(row).toBeVisible({ timeout: 10_000 })
+      return
+    }
+
+    const refreshButton = params.page.getByTestId(
+      MANAGED_SITE_CHANNELS_TEST_IDS.refreshButton,
+    )
+    await expect(refreshButton).toBeEnabled({ timeout: 10_000 })
+    await refreshButton.click()
+    await expect(row).toBeVisible({ timeout: 20_000 })
+  }).toPass({
+    intervals: [1_000, 3_000, 5_000],
+    timeout: 90_000,
+  })
+}
+
+async function expectManagedSiteImportStatusAfterChannelCreate(row: Locator) {
+  const statusBadge = row.getByTestId(
+    KEY_MANAGEMENT_TEST_IDS.managedSiteStatusBadge,
+  )
+
+  await expect(statusBadge).toHaveText(/^(Added|Cannot fully verify)$/u, {
+    timeout: 90_000,
+  })
+
+  const statusText = (await statusBadge.textContent())?.trim()
+
+  if (statusText === "Added") {
+    await expect(
+      row.getByTestId(KEY_MANAGEMENT_TEST_IDS.managedSiteChannelLinkButton),
+    ).toBeVisible({ timeout: 60_000 })
+    return
+  }
+
+  await expect(
+    row.getByTestId(KEY_MANAGEMENT_TEST_IDS.managedSiteVerificationRetryButton),
+  ).toBeVisible({ timeout: 60_000 })
 }
 
 async function cleanupKeyManagementTokensByPrefix(params: {
@@ -356,11 +432,25 @@ async function fillModelInput(page: Page, model: string) {
 }
 
 async function openSingleVisibleChannelRowActions(page: Page, rowText: string) {
-  const row = channelRowByName(page, rowText)
-  await expect(row).toBeVisible({ timeout: 60_000 })
-  await row
-    .getByTestId(getManagedSiteChannelRowActionsButtonTestId(rowText))
-    .click()
+  const editAction = page.getByTestId(
+    getManagedSiteChannelRowEditActionTestId(rowText),
+  )
+
+  await expect(async () => {
+    const row = channelRowByName(page, rowText)
+    await expect(row).toBeVisible({ timeout: 10_000 })
+    const actionsButton = row.getByTestId(
+      getManagedSiteChannelRowActionsButtonTestId(rowText),
+    )
+    await expect(actionsButton).toBeEnabled({ timeout: 10_000 })
+    await actionsButton.click({ timeout: 10_000 })
+    await expect(editAction).toBeVisible({ timeout: 10_000 })
+  }).toPass({
+    intervals: [1_000, 3_000, 5_000],
+    timeout: 60_000,
+  })
+
+  return editAction
 }
 
 export function buildManagedSiteE2ePrefix(params: {

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -326,26 +326,23 @@ async function expectManagedSiteChannelVisibleAfterRefresh(params: {
 }
 
 async function expectManagedSiteImportStatusAfterChannelCreate(row: Locator) {
-  const statusBadge = row.getByTestId(
-    KEY_MANAGEMENT_TEST_IDS.managedSiteStatusBadge,
+  const channelLinkButton = row.getByTestId(
+    KEY_MANAGEMENT_TEST_IDS.managedSiteChannelLinkButton,
+  )
+  const verificationRetryButton = row.getByTestId(
+    KEY_MANAGEMENT_TEST_IDS.managedSiteVerificationRetryButton,
   )
 
-  await expect(statusBadge).toHaveText(/^(Added|Cannot fully verify)$/u, {
+  await expect(async () => {
+    if (await channelLinkButton.isVisible()) {
+      return
+    }
+
+    await expect(verificationRetryButton).toBeVisible({ timeout: 10_000 })
+  }).toPass({
+    intervals: [1_000, 3_000, 5_000],
     timeout: 90_000,
   })
-
-  const statusText = (await statusBadge.textContent())?.trim()
-
-  if (statusText === "Added") {
-    await expect(
-      row.getByTestId(KEY_MANAGEMENT_TEST_IDS.managedSiteChannelLinkButton),
-    ).toBeVisible({ timeout: 60_000 })
-    return
-  }
-
-  await expect(
-    row.getByTestId(KEY_MANAGEMENT_TEST_IDS.managedSiteVerificationRetryButton),
-  ).toBeVisible({ timeout: 60_000 })
 }
 
 async function cleanupKeyManagementTokensByPrefix(params: {
@@ -439,6 +436,10 @@ async function openSingleVisibleChannelRowActions(page: Page, rowText: string) {
   await expect(async () => {
     const row = channelRowByName(page, rowText)
     await expect(row).toBeVisible({ timeout: 10_000 })
+    if (await editAction.isVisible()) {
+      return
+    }
+
     const actionsButton = row.getByTestId(
       getManagedSiteChannelRowActionsButtonTestId(rowText),
     )

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -925,6 +925,9 @@ export function TokenHeader({
                 size="sm"
                 variant="outline"
                 className="h-auto px-2 py-0.5 text-xs"
+                data-testid={
+                  KEY_MANAGEMENT_TEST_IDS.managedSiteVerificationRetryButton
+                }
                 onClick={handleManagedSiteVerificationRetryClick}
               >
                 {t("managedSiteStatus.actions.verifyNow")}

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -11,6 +11,8 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   importToManagedSiteButton: "key-management-import-to-managed-site-button",
   managedSiteChannelLinkButton:
     "key-management-managed-site-channel-link-button",
+  managedSiteVerificationRetryButton:
+    "key-management-managed-site-verification-retry-button",
   openSelectedAccountModelsButton:
     "key-management-open-selected-account-models-button",
   titleActions: "key-management-title-actions",

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -1274,6 +1274,7 @@ export default function ManagedSiteChannels({
                 <>
                   <Button
                     variant="outline"
+                    data-testid={MANAGED_SITE_CHANNELS_TEST_IDS.refreshButton}
                     onClick={() =>
                       void refreshChannels({
                         featureId:

--- a/src/features/ManagedSiteChannels/testIds.ts
+++ b/src/features/ManagedSiteChannels/testIds.ts
@@ -1,5 +1,6 @@
 export const MANAGED_SITE_CHANNELS_TEST_IDS = {
   addChannelButton: "managed-site-channels-add-channel-button",
+  refreshButton: "managed-site-channels-refresh-button",
   searchInput: "managed-site-channels-search-input",
   paginationSummary: "managed-site-channels-pagination-summary",
   deleteChannelConfirmButton: "managed-site-channels-delete-confirm-button",

--- a/src/services/apiService/axonHub/index.ts
+++ b/src/services/apiService/axonHub/index.ts
@@ -686,12 +686,12 @@ export async function createChannel(
     const { status, ...input } = channelData.channel
     const created = await createAxonHubChannel(config, input)
     const finalChannel = { ...created }
+    invalidateChannelListCache(config)
     if (status === CHANNEL_STATUS.Enable) {
       const axonHubStatus = toAxonHubStatus(status)
       await updateAxonHubChannelStatus(config, created.id, axonHubStatus)
       finalChannel.status = axonHubStatus
     }
-    invalidateChannelListCache(config)
 
     return {
       success: true,
@@ -721,13 +721,13 @@ export async function updateChannel(
     const graphqlId = await resolveAxonHubGraphqlIdForMutation(config, id)
     const updated = await updateAxonHubChannel(config, graphqlId, input)
     const finalChannel = { ...updated }
+    invalidateChannelListCache(config)
 
     if (status !== undefined) {
       const axonHubStatus = toAxonHubStatus(status)
       await updateAxonHubChannelStatus(config, graphqlId, axonHubStatus)
       finalChannel.status = axonHubStatus
     }
-    invalidateChannelListCache(config)
 
     return {
       success: true,

--- a/src/services/apiService/axonHub/index.ts
+++ b/src/services/apiService/axonHub/index.ts
@@ -691,6 +691,7 @@ export async function createChannel(
       await updateAxonHubChannelStatus(config, created.id, axonHubStatus)
       finalChannel.status = axonHubStatus
     }
+    invalidateChannelListCache(config)
 
     return {
       success: true,
@@ -726,6 +727,7 @@ export async function updateChannel(
       await updateAxonHubChannelStatus(config, graphqlId, axonHubStatus)
       finalChannel.status = axonHubStatus
     }
+    invalidateChannelListCache(config)
 
     return {
       success: true,
@@ -755,6 +757,9 @@ export async function deleteChannel(
       config,
       await resolveAxonHubGraphqlIdForMutation(config, channelId),
     )
+    if (deleted) {
+      invalidateChannelListCache(config)
+    }
 
     return {
       success: deleted,

--- a/src/services/managedSites/providers/octopus.ts
+++ b/src/services/managedSites/providers/octopus.ts
@@ -257,7 +257,7 @@ export async function createChannel(
     const result = await octopusApi.createChannel(config, request)
     return {
       success: result.success,
-      data: result.data,
+      data: result.data ? octopusChannelToManagedSite(result.data) : null,
       message: result.message || "success",
     }
   } catch (error) {
@@ -297,7 +297,7 @@ export async function updateChannel(
 
     return {
       success: result.success,
-      data: result.data,
+      data: result.data ? octopusChannelToManagedSite(result.data) : null,
       message: result.message || "success",
     }
   } catch (error) {

--- a/tests/services/apiService/axonHub/index.test.ts
+++ b/tests/services/apiService/axonHub/index.test.ts
@@ -44,6 +44,38 @@ const buildRequest = (): ApiServiceRequest => ({
   },
 })
 
+type AxonHubGraphqlRoute = {
+  matches: (query: string) => boolean
+  respond: () => Response
+}
+
+function matchesGraphqlOperation(operationName: string) {
+  return (query: string) => query.includes(operationName)
+}
+
+function useAxonHubGraphqlRoutes(params: {
+  token: string
+  routes: AxonHubGraphqlRoute[]
+}) {
+  server.use(
+    http.post(AUTH_URL, () => HttpResponse.json({ token: params.token })),
+    http.post(GRAPHQL_URL, async ({ request }) => {
+      const body = (await request.json()) as { query?: string }
+      const query = body.query ?? ""
+      const route = params.routes.find((candidate) => candidate.matches(query))
+
+      if (route) {
+        return route.respond()
+      }
+
+      return HttpResponse.json(
+        { errors: [{ message: "Unexpected GraphQL operation" }] },
+        { status: 500 },
+      )
+    }),
+  )
+}
+
 describe("AxonHub API service", () => {
   beforeEach(() => {
     __resetCachesForTesting()
@@ -796,60 +828,56 @@ describe("AxonHub API service", () => {
   it("invalidates cached channel lists when create succeeds but status update fails", async () => {
     let listHits = 0
 
-    server.use(
-      http.post(AUTH_URL, () =>
-        HttpResponse.json({ token: "partial-create-cache" }),
-      ),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as { query?: string }
-
-        if (body.query?.includes("query QueryChannels")) {
-          listHits += 1
-          return HttpResponse.json({
-            data: {
-              queryChannels: {
-                edges: [],
-                pageInfo: { hasNextPage: false, endCursor: null },
-                totalCount: 0,
+    useAxonHubGraphqlRoutes({
+      token: "partial-create-cache",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query QueryChannels"),
+          respond: () => {
+            listHits += 1
+            return HttpResponse.json({
+              data: {
+                queryChannels: {
+                  edges: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  totalCount: 0,
+                },
               },
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation CreateChannel")) {
-          return HttpResponse.json({
-            data: {
-              createChannel: {
-                id: "13",
-                type: "openai",
-                baseURL: "https://created.example.com/v1",
-                name: "Created Channel",
-                status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                credentials: { apiKeys: ["sk-created"] },
-                supportedModels: ["gpt-4.1"],
-                manualModels: ["gpt-4.1"],
-                defaultTestModel: "gpt-4.1",
-                settings: { modelMappings: [] },
-                orderingWeight: 5,
-                remark: null,
+            })
+          },
+        },
+        {
+          matches: matchesGraphqlOperation("mutation CreateChannel"),
+          respond: () =>
+            HttpResponse.json({
+              data: {
+                createChannel: {
+                  id: "13",
+                  type: "openai",
+                  baseURL: "https://created.example.com/v1",
+                  name: "Created Channel",
+                  status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+                  credentials: { apiKeys: ["sk-created"] },
+                  supportedModels: ["gpt-4.1"],
+                  manualModels: ["gpt-4.1"],
+                  defaultTestModel: "gpt-4.1",
+                  settings: { modelMappings: [] },
+                  orderingWeight: 5,
+                  remark: null,
+                },
               },
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation UpdateChannelStatus")) {
-          return HttpResponse.json(
-            { errors: [{ message: "status exploded" }] },
-            { status: 500 },
-          )
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
+            }),
+        },
+        {
+          matches: matchesGraphqlOperation("mutation UpdateChannelStatus"),
+          respond: () =>
+            HttpResponse.json(
+              { errors: [{ message: "status exploded" }] },
+              { status: 500 },
+            ),
+        },
+      ],
+    })
 
     await listChannels(config)
     await listChannels(config)
@@ -900,73 +928,69 @@ describe("AxonHub API service", () => {
     }).id
     let listHits = 0
 
-    server.use(
-      http.post(AUTH_URL, () =>
-        HttpResponse.json({ token: "partial-update-cache" }),
-      ),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as { query?: string }
-
-        if (body.query?.includes("query QueryChannels")) {
-          listHits += 1
-          return HttpResponse.json({
-            data: {
-              queryChannels: {
-                edges: [
-                  {
-                    node: {
-                      id: graphqlId,
-                      type: "openai",
-                      baseURL: "https://updated.example.com/v1",
-                      name: "Updated Channel",
-                      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                      credentials: { apiKey: "sk-updated" },
-                      supportedModels: ["gpt-4.1"],
-                      manualModels: [],
+    useAxonHubGraphqlRoutes({
+      token: "partial-update-cache",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query QueryChannels"),
+          respond: () => {
+            listHits += 1
+            return HttpResponse.json({
+              data: {
+                queryChannels: {
+                  edges: [
+                    {
+                      node: {
+                        id: graphqlId,
+                        type: "openai",
+                        baseURL: "https://updated.example.com/v1",
+                        name: "Updated Channel",
+                        status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+                        credentials: { apiKey: "sk-updated" },
+                        supportedModels: ["gpt-4.1"],
+                        manualModels: [],
+                      },
                     },
-                  },
-                ],
-                pageInfo: { hasNextPage: false, endCursor: null },
-                totalCount: 1,
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  totalCount: 1,
+                },
               },
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation UpdateChannel(")) {
-          return HttpResponse.json({
-            data: {
-              updateChannel: {
-                id: graphqlId,
-                type: "openai",
-                baseURL: "https://updated.example.com/v1",
-                name: "Updated Channel",
-                status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                credentials: { apiKeys: ["sk-updated"] },
-                supportedModels: ["gpt-4.1"],
-                manualModels: ["gpt-4.1"],
-                defaultTestModel: "gpt-4.1",
-                settings: { modelMappings: [] },
-                orderingWeight: 5,
-                remark: null,
+            })
+          },
+        },
+        {
+          matches: matchesGraphqlOperation("mutation UpdateChannel("),
+          respond: () =>
+            HttpResponse.json({
+              data: {
+                updateChannel: {
+                  id: graphqlId,
+                  type: "openai",
+                  baseURL: "https://updated.example.com/v1",
+                  name: "Updated Channel",
+                  status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+                  credentials: { apiKeys: ["sk-updated"] },
+                  supportedModels: ["gpt-4.1"],
+                  manualModels: ["gpt-4.1"],
+                  defaultTestModel: "gpt-4.1",
+                  settings: { modelMappings: [] },
+                  orderingWeight: 5,
+                  remark: null,
+                },
               },
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation UpdateChannelStatus")) {
-          return HttpResponse.json(
-            { errors: [{ message: "status exploded" }] },
-            { status: 500 },
-          )
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
+            }),
+        },
+        {
+          matches: matchesGraphqlOperation("mutation UpdateChannelStatus"),
+          respond: () =>
+            HttpResponse.json(
+              { errors: [{ message: "status exploded" }] },
+              { status: 500 },
+            ),
+        },
+      ],
+    })
 
     await listChannels(config)
     await listChannels(config)

--- a/tests/services/apiService/axonHub/index.test.ts
+++ b/tests/services/apiService/axonHub/index.test.ts
@@ -720,6 +720,79 @@ describe("AxonHub API service", () => {
     })
   })
 
+  it("invalidates cached channel lists after adapter mutations", async () => {
+    let listHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () => HttpResponse.json({ token: "mutation-cache" })),
+      http.post(GRAPHQL_URL, async ({ request }) => {
+        const body = (await request.json()) as { query?: string }
+
+        if (body.query?.includes("query QueryChannels")) {
+          listHits += 1
+          return HttpResponse.json({
+            data: {
+              queryChannels: {
+                edges: [],
+                pageInfo: { hasNextPage: false, endCursor: null },
+                totalCount: 0,
+              },
+            },
+          })
+        }
+
+        if (body.query?.includes("mutation CreateChannel")) {
+          return HttpResponse.json({
+            data: {
+              createChannel: {
+                id: "13",
+                type: "openai",
+                baseURL: "https://created.example.com/v1",
+                name: "Created Channel",
+                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+                credentials: { apiKeys: ["sk-created"] },
+                supportedModels: ["gpt-4.1"],
+                manualModels: ["gpt-4.1"],
+                defaultTestModel: "gpt-4.1",
+                settings: { modelMappings: [] },
+                orderingWeight: 5,
+                remark: null,
+              },
+            },
+          })
+        }
+
+        return HttpResponse.json(
+          { errors: [{ message: "Unexpected GraphQL operation" }] },
+          { status: 500 },
+        )
+      }),
+    )
+
+    await listChannels(config)
+    await listChannels(config)
+    expect(listHits).toBe(1)
+
+    await expect(
+      createChannelAdapter(buildRequest(), {
+        channel: {
+          type: "openai",
+          name: "Created Channel",
+          baseURL: "https://created.example.com/v1",
+          credentials: { apiKeys: ["sk-created"] },
+          supportedModels: ["gpt-4.1"],
+          manualModels: ["gpt-4.1"],
+          defaultTestModel: "gpt-4.1",
+          settings: {},
+          orderingWeight: 5,
+        },
+      }),
+    ).resolves.toMatchObject({ success: true })
+
+    await listChannels(config)
+    expect(listHits).toBe(2)
+  })
+
   it("updates status zero through the adapter wrapper and returns a failure message when delete returns false", async () => {
     const graphqlId = "gid://axonhub/Channel/7"
     const rowId = axonHubChannelToManagedSite({

--- a/tests/services/apiService/axonHub/index.test.ts
+++ b/tests/services/apiService/axonHub/index.test.ts
@@ -793,6 +793,208 @@ describe("AxonHub API service", () => {
     expect(listHits).toBe(2)
   })
 
+  it("invalidates cached channel lists when create succeeds but status update fails", async () => {
+    let listHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ token: "partial-create-cache" }),
+      ),
+      http.post(GRAPHQL_URL, async ({ request }) => {
+        const body = (await request.json()) as { query?: string }
+
+        if (body.query?.includes("query QueryChannels")) {
+          listHits += 1
+          return HttpResponse.json({
+            data: {
+              queryChannels: {
+                edges: [],
+                pageInfo: { hasNextPage: false, endCursor: null },
+                totalCount: 0,
+              },
+            },
+          })
+        }
+
+        if (body.query?.includes("mutation CreateChannel")) {
+          return HttpResponse.json({
+            data: {
+              createChannel: {
+                id: "13",
+                type: "openai",
+                baseURL: "https://created.example.com/v1",
+                name: "Created Channel",
+                status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+                credentials: { apiKeys: ["sk-created"] },
+                supportedModels: ["gpt-4.1"],
+                manualModels: ["gpt-4.1"],
+                defaultTestModel: "gpt-4.1",
+                settings: { modelMappings: [] },
+                orderingWeight: 5,
+                remark: null,
+              },
+            },
+          })
+        }
+
+        if (body.query?.includes("mutation UpdateChannelStatus")) {
+          return HttpResponse.json(
+            { errors: [{ message: "status exploded" }] },
+            { status: 500 },
+          )
+        }
+
+        return HttpResponse.json(
+          { errors: [{ message: "Unexpected GraphQL operation" }] },
+          { status: 500 },
+        )
+      }),
+    )
+
+    await listChannels(config)
+    await listChannels(config)
+    expect(listHits).toBe(1)
+
+    await expect(
+      createChannelAdapter(buildRequest(), {
+        channel: {
+          type: "openai",
+          name: "Created Channel",
+          baseURL: "https://created.example.com/v1",
+          credentials: { apiKeys: ["sk-created"] },
+          supportedModels: ["gpt-4.1"],
+          manualModels: ["gpt-4.1"],
+          defaultTestModel: "gpt-4.1",
+          settings: {},
+          orderingWeight: 5,
+          status: CHANNEL_STATUS.Enable,
+        },
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      message: "status exploded",
+    })
+
+    await listChannels(config)
+    expect(listHits).toBe(2)
+  })
+
+  it("invalidates cached channel lists when update succeeds but status update fails", async () => {
+    const graphqlId = "gid://axonhub/Channel/13"
+    const rowId = axonHubChannelToManagedSite({
+      id: graphqlId,
+      createdAt: null,
+      updatedAt: null,
+      type: "openai",
+      baseURL: "https://updated.example.com/v1",
+      name: "Updated Channel",
+      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+      credentials: { apiKey: "sk-updated" },
+      supportedModels: ["gpt-4.1"],
+      manualModels: [],
+      defaultTestModel: null,
+      settings: {},
+      orderingWeight: 0,
+      remark: null,
+      errorMessage: null,
+    }).id
+    let listHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ token: "partial-update-cache" }),
+      ),
+      http.post(GRAPHQL_URL, async ({ request }) => {
+        const body = (await request.json()) as { query?: string }
+
+        if (body.query?.includes("query QueryChannels")) {
+          listHits += 1
+          return HttpResponse.json({
+            data: {
+              queryChannels: {
+                edges: [
+                  {
+                    node: {
+                      id: graphqlId,
+                      type: "openai",
+                      baseURL: "https://updated.example.com/v1",
+                      name: "Updated Channel",
+                      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+                      credentials: { apiKey: "sk-updated" },
+                      supportedModels: ["gpt-4.1"],
+                      manualModels: [],
+                    },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+                totalCount: 1,
+              },
+            },
+          })
+        }
+
+        if (body.query?.includes("mutation UpdateChannel(")) {
+          return HttpResponse.json({
+            data: {
+              updateChannel: {
+                id: graphqlId,
+                type: "openai",
+                baseURL: "https://updated.example.com/v1",
+                name: "Updated Channel",
+                status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+                credentials: { apiKeys: ["sk-updated"] },
+                supportedModels: ["gpt-4.1"],
+                manualModels: ["gpt-4.1"],
+                defaultTestModel: "gpt-4.1",
+                settings: { modelMappings: [] },
+                orderingWeight: 5,
+                remark: null,
+              },
+            },
+          })
+        }
+
+        if (body.query?.includes("mutation UpdateChannelStatus")) {
+          return HttpResponse.json(
+            { errors: [{ message: "status exploded" }] },
+            { status: 500 },
+          )
+        }
+
+        return HttpResponse.json(
+          { errors: [{ message: "Unexpected GraphQL operation" }] },
+          { status: 500 },
+        )
+      }),
+    )
+
+    await listChannels(config)
+    await listChannels(config)
+    expect(listHits).toBe(1)
+
+    await expect(
+      updateChannelAdapter(buildRequest(), {
+        id: rowId,
+        type: "openai",
+        name: "Updated Channel",
+        baseURL: "https://updated.example.com/v1",
+        credentials: { apiKeys: ["sk-updated"] },
+        supportedModels: ["gpt-4.1"],
+        manualModels: ["gpt-4.1"],
+        defaultTestModel: "gpt-4.1",
+        settings: {},
+        orderingWeight: 5,
+        status: CHANNEL_STATUS.Enable,
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      message: "status exploded",
+    })
+
+    await listChannels(config)
+    expect(listHits).toBe(2)
+  })
+
   it("updates status zero through the adapter wrapper and returns a failure message when delete returns false", async () => {
     const graphqlId = "gid://axonhub/Channel/7"
     const rowId = axonHubChannelToManagedSite({

--- a/tests/services/octopusService/octopusService.more.test.ts
+++ b/tests/services/octopusService/octopusService.more.test.ts
@@ -42,6 +42,19 @@ const passedOctopusConfig = {
   password: "passed-octo-pass",
 }
 
+const octopusChannelFixture: OctopusChannel = {
+  id: 1,
+  name: " Octopus Channel ",
+  type: OctopusOutboundType.Gemini,
+  enabled: true,
+  base_urls: [{ url: "https://proxy.example.com/v1" }],
+  keys: [{ enabled: true, channel_key: "octo-key" }],
+  model: "gemini-2.5-pro",
+  proxy: false,
+  auto_sync: true,
+  auto_group: OctopusAutoGroupType.None,
+}
+
 vi.mock("~/services/preferences/userPreferences", () => ({
   userPreferences: {
     getPreferences: mockGetPreferences,
@@ -83,12 +96,17 @@ describe("octopus additional flows", () => {
     })
     mockCreateChannelApi.mockResolvedValue({
       success: true,
-      data: { id: 1 },
+      data: octopusChannelFixture,
       message: "created",
     })
     mockUpdateChannelApi.mockResolvedValue({
       success: true,
-      data: { id: 1 },
+      data: {
+        ...octopusChannelFixture,
+        name: "Updated Octopus Channel",
+        enabled: false,
+        model: "claude-3.7-sonnet",
+      },
       message: "updated",
     })
     mockDeleteChannelApi.mockResolvedValue({
@@ -158,6 +176,17 @@ describe("octopus additional flows", () => {
     } as any)
 
     expect(created.success).toBe(true)
+    expect(created.data).toMatchObject({
+      id: 1,
+      name: " Octopus Channel ",
+      base_url: "https://proxy.example.com/v1",
+      key: "octo-key",
+      models: "gemini-2.5-pro",
+      status: 1,
+      priority: 0,
+      weight: 0,
+      group: "",
+    })
     expect(mockCreateChannelApi).toHaveBeenCalledWith(
       {
         baseUrl: "https://passed-octopus.example.com",
@@ -186,6 +215,15 @@ describe("octopus additional flows", () => {
     } as any)
 
     expect(updated.success).toBe(true)
+    expect(updated.data).toMatchObject({
+      id: 1,
+      name: "Updated Octopus Channel",
+      models: "claude-3.7-sonnet",
+      status: 2,
+      priority: 0,
+      weight: 0,
+      group: "",
+    })
     expect(mockUpdateChannelApi).toHaveBeenCalledWith(
       {
         baseUrl: "https://passed-octopus.example.com",


### PR DESCRIPTION
## Summary
- Accept New API token imports that require a follow-up verification step instead of forcing an immediately verified channel link.
- Return table-ready Octopus channel mutation results and invalidate AxonHub channel-list cache after mutations.
- Harden the managed-site real-site E2E flow with bounded refresh/action retries and cleanup from Key Management.

## Validation
- `pnpm run validate:push`
- Commit hooks: `pnpm run validate:staged` for both final commits
- Real-site managed-site E2E single-target checks passed for New API, Veloera, DoneHub, Octopus, AxonHub, and Claude Code Hub during local verification
- Full managed-site sweep passed through New API, Veloera, DoneHub, Octopus, and AxonHub; Claude Code Hub hit one extension service-worker startup flake, then passed on single-target rerun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of managed site channel list updates after create, update, delete, and refresh actions.
  * Strengthened token-to-managed-site import and verification retry flows to avoid stale or missed status.
  * Enhanced end-to-end sequencing and retry/wait behavior for channel row actions and post-action UI confirmation.
* **New Features**
  * Added a **Refresh** action to the Managed Site Channels page.
  * Improved support for managed-site verification retry, including clearer “Verify now” interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->