### PR TITLE
fix(onboarding): group permission intro separately

### DIFF
--- a/src/features/OptionsOverview/components/dialogs/PermissionOnboardingDialog.tsx
+++ b/src/features/OptionsOverview/components/dialogs/PermissionOnboardingDialog.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next"
 import { LanguageSwitcher } from "~/components/LanguageSwitcher"
 import { Modal } from "~/components/ui"
 import { Alert, AlertDescription } from "~/components/ui/Alert"
-import { Badge } from "~/components/ui/badge"
 import { Button } from "~/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/Card"
 import { BodySmall, Heading3, Link } from "~/components/ui/Typography"
@@ -214,25 +213,23 @@ export function PermissionOnboardingDialog({
           </Alert>
         )}
 
-        <Card padding="none" className="overflow-hidden">
+        <Card
+          padding="none"
+          className="overflow-hidden"
+          data-testid={
+            OPTIONS_OVERVIEW_TEST_IDS.permissionOnboardingIntroSection
+          }
+        >
           <CardHeader bordered padding="sm">
             <CardTitle className="flex items-center gap-2 text-base font-semibold">
-              <Sparkles className="h-5 w-5" />
-              {t("permissionsOnboarding.permissionListTitle")}
+              <Sparkles className="h-5 w-5 text-amber-500" />
+              {t("permissionsOnboarding.openSourceBadge")}
             </CardTitle>
             <BodySmall className="dark:text-dark-text-secondary mt-1 text-gray-500">
-              {t("permissionsOnboarding.permissionListDescription")}
+              {t("permissionsOnboarding.intro")}
             </BodySmall>
           </CardHeader>
-          <CardContent padding="sm" spacing="sm" className="space-y-4">
-            <div className="flex flex-wrap items-center gap-3">
-              <Badge variant="info">
-                {t("permissionsOnboarding.openSourceBadge")}
-              </Badge>
-              <BodySmall className="dark:text-dark-text-secondary text-gray-500">
-                {t("permissionsOnboarding.intro")}
-              </BodySmall>
-            </div>
+          <CardContent padding="sm" spacing="sm" className="space-y-3">
             <BodySmall className="dark:text-dark-text-secondary text-gray-500">
               {t("permissionsOnboarding.analyticsDisclosure")}
             </BodySmall>
@@ -258,6 +255,24 @@ export function PermissionOnboardingDialog({
               </AlertDescription>
             </Alert>
           </CardContent>
+        </Card>
+
+        <Card
+          padding="none"
+          className="overflow-hidden"
+          data-testid={
+            OPTIONS_OVERVIEW_TEST_IDS.permissionOnboardingPermissionsSection
+          }
+        >
+          <CardHeader bordered padding="sm">
+            <CardTitle className="flex items-center gap-2 text-base font-semibold">
+              <Sparkles className="h-5 w-5 text-emerald-500" />
+              {t("permissionsOnboarding.permissionListTitle")}
+            </CardTitle>
+            <BodySmall className="dark:text-dark-text-secondary mt-1 text-gray-500">
+              {t("permissionsOnboarding.permissionListDescription")}
+            </BodySmall>
+          </CardHeader>
           <CardContent padding="none" spacing="none">
             <PermissionList
               items={permissionItems.map((permission) => ({

--- a/src/features/OptionsOverview/testIds.ts
+++ b/src/features/OptionsOverview/testIds.ts
@@ -6,4 +6,7 @@ export const OPTIONS_OVERVIEW_TEST_IDS = {
   recentUsage: "options-overview-recent-usage",
   actionCenter: "options-overview-action-center",
   permissionOnboardingDialog: "permission-onboarding-dialog",
+  permissionOnboardingIntroSection: "permission-onboarding-intro-section",
+  permissionOnboardingPermissionsSection:
+    "permission-onboarding-permissions-section",
 } as const

--- a/tests/features/OptionsOverview/PermissionOnboardingDialog.languageSelection.test.tsx
+++ b/tests/features/OptionsOverview/PermissionOnboardingDialog.languageSelection.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { SupportedUiLanguage } from "~/constants/i18n"
 import GeneralTab from "~/features/BasicSettings/components/tabs/General/GeneralTab"
 import { PermissionOnboardingDialog } from "~/features/OptionsOverview/components/dialogs/PermissionOnboardingDialog"
+import { OPTIONS_OVERVIEW_TEST_IDS } from "~/features/OptionsOverview/testIds"
 import enSettings from "~/locales/en/settings.json"
 import jaSettings from "~/locales/ja/settings.json"
 import zhCnSettings from "~/locales/zh-CN/settings.json"
@@ -991,5 +992,46 @@ describe("PermissionOnboardingDialog language selection", () => {
     expect(
       screen.getByText(i18n.t("permissionsOnboarding.analyticsDisclosure")),
     ).toHaveClass("text-gray-500")
+  })
+
+  it("separates introduction copy from the permissions section and keeps permission guidance adjacent to the list", async () => {
+    const i18n = await createSettingsI18n("en")
+
+    renderWithI18n(<PermissionOnboardingDialog open onClose={vi.fn()} />, i18n)
+
+    const introSection = await screen.findByTestId(
+      OPTIONS_OVERVIEW_TEST_IDS.permissionOnboardingIntroSection,
+    )
+    const permissionsSection = screen.getByTestId(
+      OPTIONS_OVERVIEW_TEST_IDS.permissionOnboardingPermissionsSection,
+    )
+
+    expect(
+      within(introSection).getByText(i18n.t("permissionsOnboarding.intro")),
+    ).toBeInTheDocument()
+    expect(
+      within(introSection).queryByText(
+        i18n.t("permissionsOnboarding.permissionListDescription"),
+      ),
+    ).not.toBeInTheDocument()
+
+    expect(
+      within(permissionsSection).getByText(
+        i18n.t("permissionsOnboarding.permissionListTitle"),
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(permissionsSection).getByText(
+        i18n.t("permissionsOnboarding.permissionListDescription"),
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(permissionsSection).getByText(
+        i18n.t("permissions.items.cookies.title"),
+      ),
+    ).toBeInTheDocument()
+
+    const order = introSection.compareDocumentPosition(permissionsSection)
+    expect(order & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- Split the permissions onboarding intro and permissions list into separate sections.
- Keep permission guidance adjacent to the permission rows and add stable section test ids.
- Add a component regression test for the new onboarding section structure.

## Validation
- pnpm vitest run tests/features/OptionsOverview/PermissionOnboardingDialog.languageSelection.test.tsx
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the permission onboarding dialog layout so the intro message and permissions list now appear in separate, clearer sections.
  * Updated section styling and headings for a more consistent presentation.

* **Tests**
  * Added coverage to verify the intro content and permissions details are shown in the correct sections and order.
  * Added dedicated page anchors to support more reliable UI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->