### PR TITLE
feat(import-export): support append backup imports

### DIFF
--- a/e2e/importExportCommonFlows.spec.ts
+++ b/e2e/importExportCommonFlows.spec.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises"
+import type { Page } from "@playwright/test"
 
 import {
   OPTIONS_PAGE_PATH,
@@ -42,6 +43,20 @@ import {
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
 const CHANNEL_CONFIGS_STORAGE_KEY = "channel_configs"
+
+async function chooseFullReplaceImport(page: Page) {
+  for (const testId of [
+    IMPORT_EXPORT_TEST_IDS.importAccountsReplaceOption,
+    IMPORT_EXPORT_TEST_IDS.importApiCredentialProfilesReplaceOption,
+    IMPORT_EXPORT_TEST_IDS.importPreferencesReplaceOption,
+    IMPORT_EXPORT_TEST_IDS.importChannelConfigsReplaceOption,
+  ]) {
+    const option = page.getByTestId(testId)
+    if ((await option.count()) > 0) {
+      await option.click()
+    }
+  }
+}
 
 async function readStoredAccountConfig(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
@@ -438,6 +453,7 @@ test("round-trips a full backup through export download and file import", async 
     page.getByTestId(IMPORT_EXPORT_TEST_IDS.containsApiCredentialProfiles),
   ).toBeVisible()
 
+  await chooseFullReplaceImport(page)
   await page.getByTestId(IMPORT_EXPORT_TEST_IDS.importBackupButton).click()
 
   await expect
@@ -466,7 +482,7 @@ test("round-trips a full backup through export download and file import", async 
     .toEqual({
       accountIds: ["round-trip-account"],
       bookmarkIds: ["round-trip-bookmark"],
-      profileIds: ["round-trip-old-profile", "round-trip-profile"],
+      profileIds: ["round-trip-profile"],
       channelConfigIds: ["42"],
       channelFilterNames: ["Round Trip Filter"],
       currencyType: "CNY",
@@ -500,10 +516,10 @@ test("round-trips a full backup through export download and file import", async 
   ).toBeVisible()
   await expect(
     page.getByRole("heading", { name: "Round Trip Old Profile" }),
-  ).toBeVisible()
+  ).toHaveCount(0)
 })
 
-test("imports account backup JSON from the preview field and replaces account storage", async ({
+test("imports account backup JSON from the preview field and appends by default", async ({
   context,
   extensionId,
   page,
@@ -551,13 +567,13 @@ test("imports account backup JSON from the preview field and replaces account st
     .poll(async () => {
       const config = await readStoredAccountConfig(serviceWorker)
       return {
-        accountIds: config.accounts.map((account) => account.id),
+        accountIds: config.accounts.map((account) => account.id).sort(),
         pinnedAccountIds: config.pinnedAccountIds,
         orderedAccountIds: config.orderedAccountIds,
       }
     })
     .toEqual({
-      accountIds: ["imported-account"],
+      accountIds: ["imported-account", "old-account"],
       pinnedAccountIds: ["imported-account"],
       orderedAccountIds: ["imported-account"],
     })
@@ -570,7 +586,7 @@ test("imports account backup JSON from the preview field and replaces account st
   await expect(
     page.getByRole("button", { name: "Imported Account" }),
   ).toBeVisible()
-  await expect(page.getByRole("button", { name: "Old Account" })).toHaveCount(0)
+  await expect(page.getByRole("button", { name: "Old Account" })).toBeVisible()
 })
 
 test("imports account backup JSON from a selected file and restores popup accounts", async ({
@@ -665,6 +681,11 @@ test("imports API credential profiles from backup JSON and restores the popup ta
     page.getByTestId(IMPORT_EXPORT_TEST_IDS.containsApiCredentialProfiles),
   ).toBeVisible()
 
+  await page
+    .getByTestId(
+      IMPORT_EXPORT_TEST_IDS.importApiCredentialProfilesReplaceOption,
+    )
+    .click()
   await page.getByTestId(IMPORT_EXPORT_TEST_IDS.importBackupButton).click()
 
   await expect
@@ -748,6 +769,11 @@ test("refreshes an already-open popup API credentials tab after backup import", 
     page.getByTestId(IMPORT_EXPORT_TEST_IDS.containsApiCredentialProfiles),
   ).toBeVisible()
 
+  await page
+    .getByTestId(
+      IMPORT_EXPORT_TEST_IDS.importApiCredentialProfilesReplaceOption,
+    )
+    .click()
   await page.getByTestId(IMPORT_EXPORT_TEST_IDS.importBackupButton).click()
 
   await expect
@@ -851,6 +877,7 @@ test("restores a full backup and keeps common popup workflows available", async 
     page.getByTestId(IMPORT_EXPORT_TEST_IDS.containsApiCredentialProfiles),
   ).toBeVisible()
 
+  await chooseFullReplaceImport(page)
   await page.getByTestId(IMPORT_EXPORT_TEST_IDS.importBackupButton).click()
 
   await expect
@@ -1006,6 +1033,7 @@ test("restores a full backup and keeps the sidepanel model workflow available", 
     page.getByTestId(IMPORT_EXPORT_TEST_IDS.containsApiCredentialProfiles),
   ).toBeVisible()
 
+  await chooseFullReplaceImport(page)
   await page.getByTestId(IMPORT_EXPORT_TEST_IDS.importBackupButton).click()
 
   await expect
@@ -1094,6 +1122,9 @@ test("imports preference backup JSON and applies settings after reload", async (
   await expect(page.getByText("Data format is correct")).toBeVisible()
   await expect(page.getByText("Contains user settings")).toBeVisible()
 
+  await page
+    .getByTestId(IMPORT_EXPORT_TEST_IDS.importPreferencesReplaceOption)
+    .click()
   await page.getByTestId(IMPORT_EXPORT_TEST_IDS.importBackupButton).click()
 
   await expect

--- a/src/features/ImportExport/ImportExport.tsx
+++ b/src/features/ImportExport/ImportExport.tsx
@@ -27,14 +27,14 @@ export default function ImportExport() {
     isExporting,
     setIsExporting,
     isImporting,
+    importPlan,
+    setImportPlan,
     importData,
     setImportData,
     handleFileImport,
     handleImport,
-    validateImportData,
+    validation,
   } = useImportExport()
-
-  const validation = validateImportData()
 
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search)
@@ -86,6 +86,8 @@ export default function ImportExport() {
         <ImportSection
           importData={importData}
           setImportData={setImportData}
+          importPlan={importPlan}
+          setImportPlan={setImportPlan}
           handleFileImport={handleFileImport}
           handleImport={handleImport}
           isImporting={isImporting}

--- a/src/features/ImportExport/ImportExportPage.search.ts
+++ b/src/features/ImportExport/ImportExportPage.search.ts
@@ -5,7 +5,11 @@ import {
 } from "~/entrypoints/options/search/registryHelpers"
 import type { OptionsSearchItemDefinition } from "~/entrypoints/options/search/types"
 
-import { WEBDAV_AUTO_SYNC_TARGET_IDS, WEBDAV_TARGET_IDS } from "./searchTargets"
+import {
+  IMPORT_EXPORT_TARGET_IDS,
+  WEBDAV_AUTO_SYNC_TARGET_IDS,
+  WEBDAV_TARGET_IDS,
+} from "./searchTargets"
 
 export const importExportPageSearchSections: OptionsSearchItemDefinition[] = [
   buildPageSectionDefinition(
@@ -119,6 +123,17 @@ export const importExportPageSearchControls: OptionsSearchItemDefinition[] = [
     {
       descriptionKey: "importExport:import.description",
       keywords: ["import", "restore", "backup"],
+    },
+  ),
+  buildPageControlDefinition(
+    "control:import-content-selection",
+    MENU_ITEM_IDS.IMPORT_EXPORT,
+    IMPORT_EXPORT_TARGET_IDS.importMode,
+    "importExport:import.sections.label",
+    744.55,
+    {
+      descriptionKey: "importExport:import.sections.accounts.description",
+      keywords: ["import", "append", "merge", "overwrite", "restore"],
     },
   ),
   buildPageControlDefinition(

--- a/src/features/ImportExport/ImportExportPage.search.ts
+++ b/src/features/ImportExport/ImportExportPage.search.ts
@@ -132,8 +132,16 @@ export const importExportPageSearchControls: OptionsSearchItemDefinition[] = [
     "importExport:import.sections.label",
     744.55,
     {
-      descriptionKey: "importExport:import.sections.accounts.description",
-      keywords: ["import", "append", "merge", "overwrite", "restore"],
+      descriptionKey: "importExport:import.description",
+      keywords: [
+        "import",
+        "append",
+        "merge",
+        "replace",
+        "skip",
+        "overwrite",
+        "restore",
+      ],
     },
   ),
   buildPageControlDefinition(

--- a/src/features/ImportExport/components/ImportSection.tsx
+++ b/src/features/ImportExport/components/ImportSection.tsx
@@ -17,7 +17,10 @@ import {
   ToggleButton,
 } from "~/components/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
-import { IMPORT_SECTION_STRATEGIES } from "~/services/importExport/importExportService"
+import {
+  IMPORT_SECTION_KEYS,
+  IMPORT_SECTION_STRATEGIES,
+} from "~/services/importExport/importExportService"
 import {
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_FEATURE_IDS,
@@ -74,7 +77,7 @@ const ImportSection = ({
     }>
   }> = [
     {
-      key: "accounts",
+      key: IMPORT_SECTION_KEYS.Accounts,
       visible: Boolean(validation?.hasAccounts),
       title: t("import.sections.accounts.title"),
       description: t("import.sections.accounts.description"),
@@ -94,7 +97,7 @@ const ImportSection = ({
       ],
     },
     {
-      key: "apiCredentialProfiles",
+      key: IMPORT_SECTION_KEYS.ApiCredentialProfiles,
       visible: Boolean(validation?.hasApiCredentialProfiles),
       title: t("import.sections.apiCredentialProfiles.title"),
       description: t("import.sections.apiCredentialProfiles.description"),
@@ -115,7 +118,7 @@ const ImportSection = ({
       ],
     },
     {
-      key: "preferences",
+      key: IMPORT_SECTION_KEYS.Preferences,
       visible: Boolean(validation?.hasPreferences),
       title: t("import.sections.preferences.title"),
       description: t("import.sections.preferences.description"),
@@ -135,7 +138,7 @@ const ImportSection = ({
       ],
     },
     {
-      key: "channelConfigs",
+      key: IMPORT_SECTION_KEYS.ChannelConfigs,
       visible: Boolean(validation?.hasChannelConfigs),
       title: t("import.sections.channelConfigs.title"),
       description: t("import.sections.channelConfigs.description"),

--- a/src/features/ImportExport/components/ImportSection.tsx
+++ b/src/features/ImportExport/components/ImportSection.tsx
@@ -8,22 +8,31 @@ import {
   CardContent,
   CardDescription,
   CardHeader,
+  CardItem,
+  CardList,
   CardTitle,
   FormField,
+  ResponsiveButtonGroup,
   Textarea,
+  ToggleButton,
 } from "~/components/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
+import { IMPORT_SECTION_STRATEGIES } from "~/services/importExport/importExportService"
 import {
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_FEATURE_IDS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
 
+import type { ManualImportPlan } from "../hooks/useImportExport"
+import { IMPORT_EXPORT_TARGET_IDS } from "../searchTargets"
 import { IMPORT_EXPORT_TEST_IDS } from "../testIds"
 
 interface ImportSectionProps {
   importData: string
   setImportData: (data: string) => void
+  importPlan: ManualImportPlan
+  setImportPlan: React.Dispatch<React.SetStateAction<ManualImportPlan>>
   handleFileImport: (event: React.ChangeEvent<HTMLInputElement>) => void
   handleImport: () => void
   isImporting: boolean
@@ -43,12 +52,135 @@ interface ImportSectionProps {
 const ImportSection = ({
   importData,
   setImportData,
+  importPlan,
+  setImportPlan,
   handleFileImport,
   handleImport,
   isImporting,
   validation,
 }: ImportSectionProps) => {
   const { t } = useTranslation("importExport")
+  type ImportStrategy = ManualImportPlan[keyof ManualImportPlan]
+  const importSections: Array<{
+    key: keyof ManualImportPlan
+    visible: boolean
+    title: string
+    description: string
+    strategies: Array<{
+      strategy: ImportStrategy
+      label: string
+      help: string
+      testId: (typeof IMPORT_EXPORT_TEST_IDS)[keyof typeof IMPORT_EXPORT_TEST_IDS]
+    }>
+  }> = [
+    {
+      key: "accounts",
+      visible: Boolean(validation?.hasAccounts),
+      title: t("import.sections.accounts.title"),
+      description: t("import.sections.accounts.description"),
+      strategies: [
+        {
+          strategy: IMPORT_SECTION_STRATEGIES.Merge,
+          label: t("import.sectionStrategy.accounts.merge"),
+          help: t("import.sectionStrategyHelp.accounts.merge"),
+          testId: IMPORT_EXPORT_TEST_IDS.importAccountsMergeOption,
+        },
+        {
+          strategy: IMPORT_SECTION_STRATEGIES.Replace,
+          label: t("import.sectionStrategy.accounts.replace"),
+          help: t("import.sectionStrategyHelp.accounts.replace"),
+          testId: IMPORT_EXPORT_TEST_IDS.importAccountsReplaceOption,
+        },
+      ],
+    },
+    {
+      key: "apiCredentialProfiles",
+      visible: Boolean(validation?.hasApiCredentialProfiles),
+      title: t("import.sections.apiCredentialProfiles.title"),
+      description: t("import.sections.apiCredentialProfiles.description"),
+      strategies: [
+        {
+          strategy: IMPORT_SECTION_STRATEGIES.Merge,
+          label: t("import.sectionStrategy.apiCredentialProfiles.merge"),
+          help: t("import.sectionStrategyHelp.apiCredentialProfiles.merge"),
+          testId: IMPORT_EXPORT_TEST_IDS.importApiCredentialProfilesMergeOption,
+        },
+        {
+          strategy: IMPORT_SECTION_STRATEGIES.Replace,
+          label: t("import.sectionStrategy.apiCredentialProfiles.replace"),
+          help: t("import.sectionStrategyHelp.apiCredentialProfiles.replace"),
+          testId:
+            IMPORT_EXPORT_TEST_IDS.importApiCredentialProfilesReplaceOption,
+        },
+      ],
+    },
+    {
+      key: "preferences",
+      visible: Boolean(validation?.hasPreferences),
+      title: t("import.sections.preferences.title"),
+      description: t("import.sections.preferences.description"),
+      strategies: [
+        {
+          strategy: IMPORT_SECTION_STRATEGIES.Skip,
+          label: t("import.sectionStrategy.preferences.skip"),
+          help: t("import.sectionStrategyHelp.preferences.skip"),
+          testId: IMPORT_EXPORT_TEST_IDS.importPreferencesSkipOption,
+        },
+        {
+          strategy: IMPORT_SECTION_STRATEGIES.Replace,
+          label: t("import.sectionStrategy.preferences.replace"),
+          help: t("import.sectionStrategyHelp.preferences.replace"),
+          testId: IMPORT_EXPORT_TEST_IDS.importPreferencesReplaceOption,
+        },
+      ],
+    },
+    {
+      key: "channelConfigs",
+      visible: Boolean(validation?.hasChannelConfigs),
+      title: t("import.sections.channelConfigs.title"),
+      description: t("import.sections.channelConfigs.description"),
+      strategies: [
+        {
+          strategy: IMPORT_SECTION_STRATEGIES.Skip,
+          label: t("import.sectionStrategy.channelConfigs.skip"),
+          help: t("import.sectionStrategyHelp.channelConfigs.skip"),
+          testId: IMPORT_EXPORT_TEST_IDS.importChannelConfigsSkipOption,
+        },
+        {
+          strategy: IMPORT_SECTION_STRATEGIES.Merge,
+          label: t("import.sectionStrategy.channelConfigs.merge"),
+          help: t("import.sectionStrategyHelp.channelConfigs.merge"),
+          testId: IMPORT_EXPORT_TEST_IDS.importChannelConfigsMergeOption,
+        },
+        {
+          strategy: IMPORT_SECTION_STRATEGIES.Replace,
+          label: t("import.sectionStrategy.channelConfigs.replace"),
+          help: t("import.sectionStrategyHelp.channelConfigs.replace"),
+          testId: IMPORT_EXPORT_TEST_IDS.importChannelConfigsReplaceOption,
+        },
+      ],
+    },
+  ]
+  const visibleImportSections = importSections.filter(
+    (section) => section.visible,
+  )
+  const hasSelectedImportSection = visibleImportSections.some(
+    ({ key }) => importPlan[key] !== IMPORT_SECTION_STRATEGIES.Skip,
+  )
+  const hasReplaceStrategy = visibleImportSections.some(
+    ({ key }) => importPlan[key] === IMPORT_SECTION_STRATEGIES.Replace,
+  )
+
+  const updateImportPlan = (
+    key: keyof ManualImportPlan,
+    strategy: ManualImportPlan[keyof ManualImportPlan],
+  ) => {
+    setImportPlan((plan) => ({
+      ...plan,
+      [key]: strategy,
+    }))
+  }
+
   return (
     <section id="import-section" className="flex h-full">
       <Card padding="none" className="flex flex-1 flex-col">
@@ -93,6 +225,66 @@ const ImportSection = ({
               clearButtonLabel={t("common:actions.clear")}
             />
           </FormField>
+
+          {visibleImportSections.length > 0 && (
+            <div id={IMPORT_EXPORT_TARGET_IDS.importMode}>
+              <FormField label={t("import.sections.label")}>
+                <CardList className="overflow-hidden rounded-md border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900/40">
+                  {visibleImportSections.map(
+                    ({ key, title, description, strategies }) => (
+                      <CardItem
+                        key={key}
+                        padding="sm"
+                        title={title}
+                        description={description}
+                        rightContent={
+                          <ResponsiveButtonGroup
+                            aria-label={title}
+                            className="max-w-full"
+                          >
+                            {strategies.map(
+                              ({ strategy, label, help, testId }) => {
+                                const selected = importPlan[key] === strategy
+                                const helpId = `import-plan-${key}-${strategy}-help`
+
+                                return (
+                                  <span key={strategy} className="contents">
+                                    <ToggleButton
+                                      type="button"
+                                      size="sm"
+                                      isActive={selected}
+                                      title={help}
+                                      aria-label={label}
+                                      aria-describedby={helpId}
+                                      onClick={() =>
+                                        updateImportPlan(key, strategy)
+                                      }
+                                      data-testid={testId}
+                                      className="min-w-fit flex-1 sm:flex-none"
+                                    >
+                                      {label}
+                                    </ToggleButton>
+                                    <span id={helpId} className="sr-only">
+                                      {help}
+                                    </span>
+                                  </span>
+                                )
+                              },
+                            )}
+                          </ResponsiveButtonGroup>
+                        }
+                      />
+                    ),
+                  )}
+                </CardList>
+                {hasReplaceStrategy && (
+                  <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
+                    {t("import.replaceWarning")}
+                  </p>
+                )}
+              </FormField>
+            </div>
+          )}
 
           {/* 数据验证结果 */}
           {validation && (
@@ -143,7 +335,9 @@ const ImportSection = ({
             <Button
               id="import-backup-action"
               onClick={handleImport}
-              disabled={isImporting || !validation?.valid}
+              disabled={
+                isImporting || !validation?.valid || !hasSelectedImportSection
+              }
               loading={isImporting}
               variant="default"
               bleed

--- a/src/features/ImportExport/hooks/useImportExport.ts
+++ b/src/features/ImportExport/hooks/useImportExport.ts
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import {
+  IMPORT_SECTION_KEYS,
   IMPORT_SECTION_STRATEGIES,
   type ImportPlan,
 } from "~/services/importExport/importExportService"
@@ -31,10 +32,10 @@ const logger = createLogger("ImportExportHook")
 export type ManualImportPlan = Required<ImportPlan>
 
 const DEFAULT_IMPORT_PLAN: ManualImportPlan = {
-  accounts: IMPORT_SECTION_STRATEGIES.Skip,
-  apiCredentialProfiles: IMPORT_SECTION_STRATEGIES.Skip,
-  channelConfigs: IMPORT_SECTION_STRATEGIES.Skip,
-  preferences: IMPORT_SECTION_STRATEGIES.Skip,
+  [IMPORT_SECTION_KEYS.Accounts]: IMPORT_SECTION_STRATEGIES.Skip,
+  [IMPORT_SECTION_KEYS.ApiCredentialProfiles]: IMPORT_SECTION_STRATEGIES.Skip,
+  [IMPORT_SECTION_KEYS.ChannelConfigs]: IMPORT_SECTION_STRATEGIES.Skip,
+  [IMPORT_SECTION_KEYS.Preferences]: IMPORT_SECTION_STRATEGIES.Skip,
 }
 
 /**
@@ -47,16 +48,17 @@ function createDefaultImportPlan(summary: {
   hasApiCredentialProfiles?: boolean
 }): ManualImportPlan {
   return {
-    accounts: summary.hasAccounts
+    [IMPORT_SECTION_KEYS.Accounts]: summary.hasAccounts
       ? IMPORT_SECTION_STRATEGIES.Merge
       : IMPORT_SECTION_STRATEGIES.Skip,
-    apiCredentialProfiles: summary.hasApiCredentialProfiles
+    [IMPORT_SECTION_KEYS.ApiCredentialProfiles]:
+      summary.hasApiCredentialProfiles
+        ? IMPORT_SECTION_STRATEGIES.Merge
+        : IMPORT_SECTION_STRATEGIES.Skip,
+    [IMPORT_SECTION_KEYS.ChannelConfigs]: summary.hasChannelConfigs
       ? IMPORT_SECTION_STRATEGIES.Merge
       : IMPORT_SECTION_STRATEGIES.Skip,
-    channelConfigs: summary.hasChannelConfigs
-      ? IMPORT_SECTION_STRATEGIES.Merge
-      : IMPORT_SECTION_STRATEGIES.Skip,
-    preferences: IMPORT_SECTION_STRATEGIES.Skip,
+    [IMPORT_SECTION_KEYS.Preferences]: IMPORT_SECTION_STRATEGIES.Skip,
   }
 }
 

--- a/src/features/ImportExport/hooks/useImportExport.ts
+++ b/src/features/ImportExport/hooks/useImportExport.ts
@@ -1,8 +1,12 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import {
+  IMPORT_SECTION_STRATEGIES,
+  type ImportPlan,
+} from "~/services/importExport/importExportService"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
@@ -24,12 +28,76 @@ import { importFromBackupObject, parseBackupSummary } from "../utils"
  */
 const logger = createLogger("ImportExportHook")
 
+export type ManualImportPlan = Required<ImportPlan>
+
+const DEFAULT_IMPORT_PLAN: ManualImportPlan = {
+  accounts: IMPORT_SECTION_STRATEGIES.Skip,
+  apiCredentialProfiles: IMPORT_SECTION_STRATEGIES.Skip,
+  channelConfigs: IMPORT_SECTION_STRATEGIES.Skip,
+  preferences: IMPORT_SECTION_STRATEGIES.Skip,
+}
+
+/**
+ * Builds the safest initial choices for the data types present in a backup.
+ */
+function createDefaultImportPlan(summary: {
+  hasAccounts?: boolean
+  hasPreferences?: boolean
+  hasChannelConfigs?: boolean
+  hasApiCredentialProfiles?: boolean
+}): ManualImportPlan {
+  return {
+    accounts: summary.hasAccounts
+      ? IMPORT_SECTION_STRATEGIES.Merge
+      : IMPORT_SECTION_STRATEGIES.Skip,
+    apiCredentialProfiles: summary.hasApiCredentialProfiles
+      ? IMPORT_SECTION_STRATEGIES.Merge
+      : IMPORT_SECTION_STRATEGIES.Skip,
+    channelConfigs: summary.hasChannelConfigs
+      ? IMPORT_SECTION_STRATEGIES.Merge
+      : IMPORT_SECTION_STRATEGIES.Skip,
+    preferences: IMPORT_SECTION_STRATEGIES.Skip,
+  }
+}
+
+/**
+ * Parses import text into the UI validation shape, collapsing invalid or broken
+ * summaries into the same non-throwing result.
+ */
+function parseValidBackupSummary(importData: string, unknownLabel: string) {
+  if (!importData.trim()) return null
+
+  try {
+    const summary = parseBackupSummary(importData, unknownLabel)
+    if (!summary || !("valid" in summary) || !summary.valid) {
+      return { valid: false } as const
+    }
+    return summary
+  } catch {
+    return { valid: false } as const
+  }
+}
+
 export const useImportExport = () => {
   const { t } = useTranslation()
   const { loadPreferences } = useUserPreferencesContext()
   const [isExporting, setIsExporting] = useState(false)
   const [isImporting, setIsImporting] = useState(false)
+  const [importPlan, setImportPlan] =
+    useState<ManualImportPlan>(DEFAULT_IMPORT_PLAN)
   const [importData, setImportData] = useState("")
+
+  const validation = useMemo(() => {
+    return parseValidBackupSummary(importData, t("common:labels.unknown"))
+  }, [importData, t])
+
+  const updateImportData = (data: string) => {
+    setImportData(data)
+    const summary = parseValidBackupSummary(data, t("common:labels.unknown"))
+    setImportPlan(
+      summary?.valid ? createDefaultImportPlan(summary) : DEFAULT_IMPORT_PLAN,
+    )
+  }
 
   // 处理文件导入
   const handleFileImport = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -39,7 +107,7 @@ export const useImportExport = () => {
     const reader = new FileReader()
     reader.onload = (e) => {
       const content = e.target?.result as string
-      setImportData(content)
+      updateImportData(content)
     }
     reader.readAsText(file)
   }
@@ -63,16 +131,18 @@ export const useImportExport = () => {
       setIsImporting(true)
 
       const data = JSON.parse(importData)
-      const result = await importFromBackupObject(data)
+      const result = await importFromBackupObject(data, { plan: importPlan })
       const hasImportedSection = Object.values(result.sections ?? {}).some(
         Boolean,
       )
-      if (result.allImported || result.sections?.preferences) {
+      if (result.sections?.preferences) {
         await loadPreferences()
         await applyPreferenceLanguage(await userPreferences.getLanguage())
       }
       if (result.allImported) {
         toast.success(t("importExport:import.importSuccess"))
+      } else if (hasImportedSection) {
+        toast.success(t("importExport:import.importSelectedSuccess"))
       }
       if (result.allImported || hasImportedSection) {
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
@@ -101,29 +171,16 @@ export const useImportExport = () => {
     }
   }
 
-  // 验证导入数据
-  const validateImportData = () => {
-    if (!importData.trim()) return null
-
-    try {
-      const summary = parseBackupSummary(importData, t("common:labels.unknown"))
-      if (!summary || !("valid" in summary) || !summary.valid) {
-        return { valid: false }
-      }
-      return summary
-    } catch {
-      return { valid: false }
-    }
-  }
-
   return {
     isExporting,
     setIsExporting,
     isImporting,
+    importPlan,
+    setImportPlan,
     importData,
-    setImportData,
+    setImportData: updateImportData,
     handleFileImport,
     handleImport,
-    validateImportData,
+    validation,
   }
 }

--- a/src/features/ImportExport/searchTargets.ts
+++ b/src/features/ImportExport/searchTargets.ts
@@ -26,3 +26,7 @@ export const WEBDAV_AUTO_SYNC_TARGET_IDS = {
   saveSettings: "webdav-auto-sync-save-settings",
   syncNow: "webdav-auto-sync-sync-now",
 } as const
+
+export const IMPORT_EXPORT_TARGET_IDS = {
+  importMode: "import-mode",
+} as const

--- a/src/features/ImportExport/testIds.ts
+++ b/src/features/ImportExport/testIds.ts
@@ -5,6 +5,21 @@ export const IMPORT_EXPORT_TEST_IDS = {
   exportAccountDataButton: "import-export-export-account-data-button",
   exportUserSettingsButton: "import-export-export-user-settings-button",
   importBackupButton: "import-export-import-backup-button",
+  importAccountsMergeOption: "import-export-import-accounts-merge-option",
+  importAccountsReplaceOption: "import-export-import-accounts-replace-option",
+  importApiCredentialProfilesMergeOption:
+    "import-export-import-api-credential-profiles-merge-option",
+  importApiCredentialProfilesReplaceOption:
+    "import-export-import-api-credential-profiles-replace-option",
+  importPreferencesSkipOption: "import-export-import-preferences-skip-option",
+  importPreferencesReplaceOption:
+    "import-export-import-preferences-replace-option",
+  importChannelConfigsSkipOption:
+    "import-export-import-channel-configs-skip-option",
+  importChannelConfigsMergeOption:
+    "import-export-import-channel-configs-merge-option",
+  importChannelConfigsReplaceOption:
+    "import-export-import-channel-configs-replace-option",
   webdavUploadBackupButton: "import-export-webdav-upload-backup-button",
   webdavDownloadImportButton: "import-export-webdav-download-import-button",
 } as const

--- a/src/locales/en/importExport.json
+++ b/src/locales/en/importExport.json
@@ -28,16 +28,75 @@
     "formatError": "Data format error, please check JSON format",
     "formatNotCorrect": "Data format not correct",
     "importFailed": "Import failed: {{error}}",
+    "importSelectedSuccess": "Selected content imported successfully",
     "importSuccess": "Data imported successfully",
     "noImportableData": "No importable data found",
     "pasteJsonData": "Paste JSON data or import via the file selector above...",
+    "replaceWarning": "Some data on this device will be replaced. Export a backup first if needed.",
+    "sections": {
+      "accounts": {
+        "description": "Includes accounts, bookmarks, and tags.",
+        "title": "Accounts and bookmarks"
+      },
+      "apiCredentialProfiles": {
+        "description": "Includes saved API URLs, keys, and notes.",
+        "title": "API credential library"
+      },
+      "channelConfigs": {
+        "description": "Includes channel rules such as model filters.",
+        "title": "Channel configuration"
+      },
+      "label": "Choose what to import",
+      "preferences": {
+        "description": "Includes theme, language, click behavior, and other preferences.",
+        "title": "User settings"
+      }
+    },
+    "sectionStrategy": {
+      "accounts": {
+        "merge": "Add",
+        "replace": "Replace"
+      },
+      "apiCredentialProfiles": {
+        "merge": "Add",
+        "replace": "Replace"
+      },
+      "channelConfigs": {
+        "merge": "Add",
+        "replace": "Replace",
+        "skip": "Skip"
+      },
+      "preferences": {
+        "replace": "Replace",
+        "skip": "Skip"
+      }
+    },
+    "sectionStrategyHelp": {
+      "accounts": {
+        "merge": "Useful when bringing accounts from another computer; existing accounts and bookmarks stay here.",
+        "replace": "Your current accounts and bookmarks will match the backup list."
+      },
+      "apiCredentialProfiles": {
+        "merge": "Add API credentials from the backup; existing credentials stay here.",
+        "replace": "Your current API credential library will match the backup."
+      },
+      "channelConfigs": {
+        "merge": "Add or update rules by channel; newer backup rules will apply.",
+        "replace": "Your current channel configuration will match the backup.",
+        "skip": "Keep the current channel rules."
+      },
+      "preferences": {
+        "replace": "Replace this device's current settings with the backup settings.",
+        "skip": "Keep this device's current theme, language, and habits."
+      }
+    },
     "selectBackupFile": "Select backup file",
     "selectFileImport": "Please select file or input data to import",
     "title": "Import Data"
   },
   "notice": {
     "importantNotice": "Important Notice",
-    "importWarning1": "Imported data will overwrite existing data of the same type, please operate with caution",
+    "importWarning1": "Before importing, choose per data type whether to add, replace, or skip it. Accounts/API credentials are added by default, while current settings are kept",
     "importWarning2": "It is recommended to export current data for backup before importing",
     "importWarning3": "Only supports JSON format files exported by this extension",
     "importWarning4": "Imported data may contain sensitive information (account tokens and API keys). Keep backups secure and only import from trusted sources"

--- a/src/locales/ja/importExport.json
+++ b/src/locales/ja/importExport.json
@@ -28,16 +28,75 @@
     "formatError": "データ形式エラーです。JSON 形式を確認してください",
     "formatNotCorrect": "データ形式が正しくありません",
     "importFailed": "インポートに失敗しました: {{error}}",
+    "importSelectedSuccess": "選択した内容をインポートしました",
     "importSuccess": "データを正常にインポートしました",
     "noImportableData": "インポート可能なデータが見つかりません",
     "pasteJsonData": "JSON データを貼り付けるか、上のファイル選択からインポートしてください...",
+    "replaceWarning": "この端末上の一部データが置き換えられます。必要に応じて先にバックアップをエクスポートしてください。",
+    "sections": {
+      "accounts": {
+        "description": "アカウント、ブックマーク、タグを含みます。",
+        "title": "アカウントとブックマーク"
+      },
+      "apiCredentialProfiles": {
+        "description": "保存済みの API URL、キー、関連メモを含みます。",
+        "title": "API 認証情報庫"
+      },
+      "channelConfigs": {
+        "description": "モデルフィルターなどのチャネルルールを含みます。",
+        "title": "チャネル設定"
+      },
+      "label": "インポートする内容を選択",
+      "preferences": {
+        "description": "テーマ、言語、クリック動作などの設定を含みます。",
+        "title": "ユーザー設定"
+      }
+    },
+    "sectionStrategy": {
+      "accounts": {
+        "merge": "追加",
+        "replace": "置き換え"
+      },
+      "apiCredentialProfiles": {
+        "merge": "追加",
+        "replace": "置き換え"
+      },
+      "channelConfigs": {
+        "merge": "追加",
+        "replace": "置き換え",
+        "skip": "しない"
+      },
+      "preferences": {
+        "replace": "置き換え",
+        "skip": "しない"
+      }
+    },
+    "sectionStrategyHelp": {
+      "accounts": {
+        "merge": "別の端末からアカウントを持ち込む場合に便利です。現在のアカウントとブックマークは残ります。",
+        "replace": "現在のアカウントとブックマークはバックアップ内の一覧になります。"
+      },
+      "apiCredentialProfiles": {
+        "merge": "バックアップ内の API 認証情報を追加します。既存の認証情報は残ります。",
+        "replace": "現在の API 認証情報庫はバックアップ内の内容になります。"
+      },
+      "channelConfigs": {
+        "merge": "チャネルごとにルールを追加または更新し、新しいバックアップ側のルールが反映されます。",
+        "replace": "現在のチャネル設定はバックアップ内の内容になります。",
+        "skip": "現在のチャネルルールを保持します。"
+      },
+      "preferences": {
+        "replace": "バックアップ内の設定で、この端末の現在の設定を置き換えます。",
+        "skip": "この端末の現在のテーマ、言語、操作習慣を保持します。"
+      }
+    },
     "selectBackupFile": "バックアップファイルを選択",
     "selectFileImport": "インポートするファイルを選択するか、データを入力してください",
     "title": "データをインポート"
   },
   "notice": {
     "importantNotice": "重要なお知らせ",
-    "importWarning1": "インポートしたデータは同種の既存データを上書きします。慎重に操作してください",
+    "importWarning1": "インポート前にデータの種類ごとに追加、置き換え、またはインポートしないを選べます。既定ではアカウント/API 認証情報を追加し、現在の設定は保持します",
     "importWarning2": "インポート前に現在のデータをバックアップとしてエクスポートすることを推奨します",
     "importWarning3": "この拡張機能からエクスポートされた JSON 形式ファイルのみをサポートします",
     "importWarning4": "インポートデータには機密情報（アカウントトークンや API キー）が含まれる場合があります。バックアップは安全に保管し、信頼できるソースからのみインポートしてください"

--- a/src/locales/vi/importExport.json
+++ b/src/locales/vi/importExport.json
@@ -28,16 +28,75 @@
     "formatError": "Lỗi định dạng dữ liệu, vui lòng kiểm tra định dạng JSON",
     "formatNotCorrect": "Định dạng dữ liệu không chính xác",
     "importFailed": "Nhập thất bại: {{error}}",
+    "importSelectedSuccess": "Đã nhập nội dung đã chọn",
     "importSuccess": "Nhập dữ liệu thành công",
     "noImportableData": "Không tìm thấy dữ liệu có thể nhập",
     "pasteJsonData": "Dán dữ liệu JSON hoặc nhập qua bộ chọn tệp ở trên...",
+    "replaceWarning": "Một số dữ liệu trên thiết bị này sẽ bị thay thế. Hãy xuất bản sao lưu trước nếu cần.",
+    "sections": {
+      "accounts": {
+        "description": "Bao gồm tài khoản, dấu trang và thẻ.",
+        "title": "Tài khoản và dấu trang"
+      },
+      "apiCredentialProfiles": {
+        "description": "Bao gồm URL API, khóa và ghi chú đã lưu.",
+        "title": "Thư viện thông tin xác thực API"
+      },
+      "channelConfigs": {
+        "description": "Bao gồm các quy tắc kênh như bộ lọc mô hình.",
+        "title": "Cấu hình kênh"
+      },
+      "label": "Chọn nội dung cần nhập",
+      "preferences": {
+        "description": "Bao gồm chủ đề, ngôn ngữ, hành vi nhấp và các tùy chọn khác.",
+        "title": "Cài đặt người dùng"
+      }
+    },
+    "sectionStrategy": {
+      "accounts": {
+        "merge": "Thêm",
+        "replace": "Thay thế"
+      },
+      "apiCredentialProfiles": {
+        "merge": "Thêm",
+        "replace": "Thay thế"
+      },
+      "channelConfigs": {
+        "merge": "Thêm",
+        "replace": "Thay thế",
+        "skip": "Bỏ qua"
+      },
+      "preferences": {
+        "replace": "Thay thế",
+        "skip": "Bỏ qua"
+      }
+    },
+    "sectionStrategyHelp": {
+      "accounts": {
+        "merge": "Phù hợp khi mang tài khoản từ máy khác về; tài khoản và dấu trang hiện có sẽ được giữ lại.",
+        "replace": "Tài khoản và dấu trang hiện tại sẽ trở thành danh sách trong bản sao lưu."
+      },
+      "apiCredentialProfiles": {
+        "merge": "Thêm thông tin xác thực API từ bản sao lưu; thông tin hiện có sẽ được giữ lại.",
+        "replace": "Thư viện thông tin xác thực API hiện tại sẽ trở thành nội dung trong bản sao lưu."
+      },
+      "channelConfigs": {
+        "merge": "Thêm hoặc cập nhật quy tắc theo kênh; quy tắc mới hơn trong bản sao lưu sẽ được áp dụng.",
+        "replace": "Cấu hình kênh hiện tại sẽ trở thành nội dung trong bản sao lưu.",
+        "skip": "Giữ lại quy tắc kênh hiện tại."
+      },
+      "preferences": {
+        "replace": "Dùng cài đặt trong bản sao lưu để thay thế cài đặt hiện tại trên thiết bị này.",
+        "skip": "Giữ lại chủ đề, ngôn ngữ và thói quen thao tác hiện tại trên thiết bị này."
+      }
+    },
     "selectBackupFile": "Chọn tệp sao lưu",
     "selectFileImport": "Vui lòng chọn tệp để nhập hoặc nhập dữ liệu",
     "title": "Nhập dữ liệu"
   },
   "notice": {
     "importantNotice": "Thông báo quan trọng",
-    "importWarning1": "Việc nhập dữ liệu sẽ ghi đè lên dữ liệu cùng loại hiện có, vui lòng thao tác cẩn thận",
+    "importWarning1": "Trước khi nhập, bạn có thể chọn thêm, thay thế hoặc bỏ qua từng loại dữ liệu. Theo mặc định, tài khoản/thông tin xác thực API sẽ được thêm vào và cài đặt hiện tại được giữ lại",
     "importWarning2": "Bạn nên xuất dữ liệu hiện tại để sao lưu trước khi nhập",
     "importWarning3": "Chỉ hỗ trợ các tệp định dạng JSON được xuất bởi tiện ích này",
     "importWarning4": "Dữ liệu được nhập có thể chứa thông tin nhạy cảm (Mã thông báo tài khoản và API Key), vui lòng bảo quản tệp sao lưu cẩn thận và đảm bảo nguồn đáng tin cậy"

--- a/src/locales/zh-CN/importExport.json
+++ b/src/locales/zh-CN/importExport.json
@@ -28,16 +28,75 @@
     "formatError": "数据格式错误，请检查JSON格式",
     "formatNotCorrect": "数据格式不正确",
     "importFailed": "导入失败: {{error}}",
+    "importSelectedSuccess": "已导入所选内容",
     "importSuccess": "数据导入成功",
     "noImportableData": "没有找到可导入的数据",
     "pasteJsonData": "粘贴JSON数据或通过上面的文件选择器导入...",
+    "replaceWarning": "将替换当前设备上的部分数据，建议先导出备份。",
+    "sections": {
+      "accounts": {
+        "description": "包括账号、书签和标签。",
+        "title": "账号和书签"
+      },
+      "apiCredentialProfiles": {
+        "description": "包括保存的 API 地址、密钥和相关备注。",
+        "title": "API 凭据库"
+      },
+      "channelConfigs": {
+        "description": "包括模型过滤等渠道规则。",
+        "title": "渠道配置"
+      },
+      "label": "选择要导入的内容",
+      "preferences": {
+        "description": "包括主题、语言、点击行为等偏好设置。",
+        "title": "用户设置"
+      }
+    },
+    "sectionStrategy": {
+      "accounts": {
+        "merge": "添加",
+        "replace": "替换"
+      },
+      "apiCredentialProfiles": {
+        "merge": "添加",
+        "replace": "替换"
+      },
+      "channelConfigs": {
+        "merge": "添加",
+        "replace": "替换",
+        "skip": "不导入"
+      },
+      "preferences": {
+        "replace": "替换",
+        "skip": "不导入"
+      }
+    },
+    "sectionStrategyHelp": {
+      "accounts": {
+        "merge": "适合从另一台电脑带回账号；当前已有账号和书签会保留。",
+        "replace": "当前账号和书签会变成备份里的列表。"
+      },
+      "apiCredentialProfiles": {
+        "merge": "把备份里的 API 凭据加进来；已有凭据会保留。",
+        "replace": "当前 API 凭据库会变成备份里的内容。"
+      },
+      "channelConfigs": {
+        "merge": "按渠道添加或更新规则，较新的备份规则会生效。",
+        "replace": "当前渠道配置会变成备份里的内容。",
+        "skip": "保留当前渠道规则。"
+      },
+      "preferences": {
+        "replace": "用备份里的设置替换这台设备当前设置。",
+        "skip": "保留这台设备当前的主题、语言和操作习惯。"
+      }
+    },
     "selectBackupFile": "选择备份文件",
     "selectFileImport": "请选择要导入的文件或输入数据",
     "title": "导入数据"
   },
   "notice": {
     "importantNotice": "重要提示",
-    "importWarning1": "导入数据将覆盖现有的相同类型数据，请谨慎操作",
+    "importWarning1": "导入前可以逐项选择添加、替换或不导入；默认会添加账号/API 凭据，并保留当前设置",
     "importWarning2": "建议在导入前先导出当前数据进行备份",
     "importWarning3": "仅支持本插件导出的JSON格式文件",
     "importWarning4": "导入的数据可能包含敏感信息（账号令牌与 API Key），请妥善保管备份文件并确保来源可信"

--- a/src/locales/zh-TW/importExport.json
+++ b/src/locales/zh-TW/importExport.json
@@ -28,16 +28,75 @@
     "formatError": "資料格式錯誤，請檢查JSON格式",
     "formatNotCorrect": "資料格式不正確",
     "importFailed": "匯入失敗: {{error}}",
+    "importSelectedSuccess": "已匯入所選內容",
     "importSuccess": "資料匯入成功",
     "noImportableData": "沒有找到可匯入的資料",
     "pasteJsonData": "貼上JSON資料或透過上面的檔案選擇器匯入...",
+    "replaceWarning": "將取代目前裝置上的部分資料，建議先匯出備份。",
+    "sections": {
+      "accounts": {
+        "description": "包括帳號、書籤和標籤。",
+        "title": "帳號和書籤"
+      },
+      "apiCredentialProfiles": {
+        "description": "包括儲存的 API 地址、金鑰和相關備註。",
+        "title": "API 憑據庫"
+      },
+      "channelConfigs": {
+        "description": "包括模型過濾等渠道規則。",
+        "title": "渠道配置"
+      },
+      "label": "選擇要匯入的內容",
+      "preferences": {
+        "description": "包括主題、語言、點擊行為等偏好設定。",
+        "title": "使用者設定"
+      }
+    },
+    "sectionStrategy": {
+      "accounts": {
+        "merge": "加入",
+        "replace": "取代"
+      },
+      "apiCredentialProfiles": {
+        "merge": "加入",
+        "replace": "取代"
+      },
+      "channelConfigs": {
+        "merge": "加入",
+        "replace": "取代",
+        "skip": "不匯入"
+      },
+      "preferences": {
+        "replace": "取代",
+        "skip": "不匯入"
+      }
+    },
+    "sectionStrategyHelp": {
+      "accounts": {
+        "merge": "適合從另一台電腦帶回帳號；目前已有帳號和書籤會保留。",
+        "replace": "目前帳號和書籤會變成備份裡的列表。"
+      },
+      "apiCredentialProfiles": {
+        "merge": "把備份裡的 API 憑據加進來；已有憑據會保留。",
+        "replace": "目前 API 憑據庫會變成備份裡的內容。"
+      },
+      "channelConfigs": {
+        "merge": "按渠道加入或更新規則，較新的備份規則會生效。",
+        "replace": "目前渠道配置會變成備份裡的內容。",
+        "skip": "保留目前渠道規則。"
+      },
+      "preferences": {
+        "replace": "用備份裡的設定取代這台裝置目前設定。",
+        "skip": "保留這台裝置目前的主題、語言和操作習慣。"
+      }
+    },
     "selectBackupFile": "選擇備份檔案",
     "selectFileImport": "請選擇要匯入的檔案或輸入資料",
     "title": "匯入資料"
   },
   "notice": {
     "importantNotice": "重要提示",
-    "importWarning1": "匯入資料將覆蓋現有的相同型別資料，請謹慎操作",
+    "importWarning1": "匯入前可以逐項選擇加入、取代或不匯入；預設會加入帳號/API 憑據，並保留目前設定",
     "importWarning2": "建議在匯入前先匯出當前資料進行備份",
     "importWarning3": "僅支援本外掛匯出的JSON格式檔案",
     "importWarning4": "匯入的資料可能包含敏感資訊（帳號令牌與 API Key），請妥善保管備份檔案並確保來源可信"

--- a/src/services/importExport/importExportService.ts
+++ b/src/services/importExport/importExportService.ts
@@ -154,6 +154,13 @@ export const IMPORT_SECTION_STRATEGIES = {
   Skip: "skip",
 } as const
 
+export const IMPORT_SECTION_KEYS = {
+  Accounts: "accounts",
+  ApiCredentialProfiles: "apiCredentialProfiles",
+  ChannelConfigs: "channelConfigs",
+  Preferences: "preferences",
+} as const
+
 export type ImportSectionStrategy =
   (typeof IMPORT_SECTION_STRATEGIES)[keyof typeof IMPORT_SECTION_STRATEGIES]
 export type ImportMergeStrategy = typeof IMPORT_SECTION_STRATEGIES.Merge
@@ -171,10 +178,10 @@ export interface ImportFromBackupOptions {
 }
 
 export interface ImportPlan {
-  accounts?: ImportSectionStrategy
-  preferences?: ImportPreferenceStrategy
-  channelConfigs?: ImportSectionStrategy
-  apiCredentialProfiles?: ImportSectionStrategy
+  [IMPORT_SECTION_KEYS.Accounts]?: ImportSectionStrategy
+  [IMPORT_SECTION_KEYS.Preferences]?: ImportPreferenceStrategy
+  [IMPORT_SECTION_KEYS.ChannelConfigs]?: ImportSectionStrategy
+  [IMPORT_SECTION_KEYS.ApiCredentialProfiles]?: ImportSectionStrategy
 }
 
 /**
@@ -268,7 +275,10 @@ async function importV1Backup(
   const plan = options?.plan
 
   // accounts: support both legacy partial exports and older full exports
-  if (accountsRequested && shouldImportSection(plan, "accounts")) {
+  if (
+    accountsRequested &&
+    shouldImportSection(plan, IMPORT_SECTION_KEYS.Accounts)
+  ) {
     const rawTagStore = (data as any).tagStore ?? (data.data as any)?.tagStore
     if (rawTagStore) {
       await tagStorage.importTagStore(rawTagStore)
@@ -290,7 +300,10 @@ async function importV1Backup(
   }
 
   // preferences
-  if (preferencesRequested && shouldImportSection(plan, "preferences")) {
+  if (
+    preferencesRequested &&
+    shouldImportSection(plan, IMPORT_SECTION_KEYS.Preferences)
+  ) {
     const preferencesData = data.preferences || data.data?.preferences
     if (preferencesData) {
       const writeResult = options?.preserveWebdav
@@ -308,7 +321,10 @@ async function importV1Backup(
   }
 
   // channel configs: best-effort support if present in V1 backups
-  if (channelConfigsRequested && shouldImportSection(plan, "channelConfigs")) {
+  if (
+    channelConfigsRequested &&
+    shouldImportSection(plan, IMPORT_SECTION_KEYS.ChannelConfigs)
+  ) {
     const channelConfigsData = data.channelConfigs || data.data?.channelConfigs
     if (channelConfigsData) {
       await channelConfigStorage.importConfigs(channelConfigsData)
@@ -798,7 +814,10 @@ function mergeChannelConfigs(
 }
 
 /** Merges V2 accounts/bookmarks into the current account storage. */
-async function importV2AccountsWithMerge(data: BackupV2) {
+async function importV2AccountsWithMerge(
+  data: BackupV2,
+  remoteApiCredentialProfiles: ApiCredentialProfilesConfig["profiles"] = [],
+) {
   const [localAccountsConfig, localTagStore] = await Promise.all([
     accountStorage.exportData(),
     tagStorage.exportTagStore(),
@@ -813,7 +832,7 @@ async function importV2AccountsWithMerge(data: BackupV2) {
     localBookmarks: localAccountsConfig.bookmarks,
     remoteBookmarks: normalizedRemote.bookmarks,
     localTaggables: [],
-    remoteTaggables: [],
+    remoteTaggables: remoteApiCredentialProfiles,
   })
 
   const accounts = mergeByLatestUpdatedAt(
@@ -849,6 +868,9 @@ async function importV2AccountsWithMerge(data: BackupV2) {
     },
   })
   await tagStorage.ensureLegacyMigration()
+  return {
+    remoteApiCredentialProfiles: tagMerge.remoteTaggables,
+  }
 }
 
 /** Merges V2 channel configuration into current channel configuration. */
@@ -864,14 +886,31 @@ async function importV2ChannelConfigsWithMerge(data: BackupV2) {
 async function importV2ApiCredentialProfiles(
   data: BackupV2,
   strategy: ImportWriteStrategy,
-  accountsRequested: boolean,
+  options: {
+    reconcileTags: boolean
+    remoteApiCredentialProfiles?: ApiCredentialProfilesConfig["profiles"]
+  },
 ) {
   const incoming = coerceApiCredentialProfilesConfig(
     (data as BackupFullV2).apiCredentialProfiles,
   )
 
+  if (options.remoteApiCredentialProfiles) {
+    const config = {
+      ...incoming,
+      profiles: options.remoteApiCredentialProfiles,
+    }
+
+    if (strategy === IMPORT_SECTION_STRATEGIES.Replace) {
+      await apiCredentialProfilesStorage.importConfig(config)
+    } else {
+      await apiCredentialProfilesStorage.mergeConfig(config)
+    }
+    return
+  }
+
   if (
-    !accountsRequested &&
+    options.reconcileTags &&
     "tagStore" in (data as any) &&
     (data as any).tagStore
   ) {
@@ -930,12 +969,24 @@ async function importV2BackupWithPlan(
   const preferenceStrategy = plan.preferences
   const channelConfigStrategy = plan.channelConfigs
   const apiCredentialProfilesStrategy = plan.apiCredentialProfiles
+  const apiCredentialProfilesConfig = apiCredentialProfilesRequested
+    ? coerceApiCredentialProfilesConfig(
+        (data as BackupFullV2).apiCredentialProfiles,
+      )
+    : null
+  let remappedApiCredentialProfiles:
+    | ApiCredentialProfilesConfig["profiles"]
+    | undefined
 
   if (accountsRequested && hasWriteStrategy(accountStrategy)) {
     if (accountStrategy === IMPORT_SECTION_STRATEGIES.Replace) {
       await importV2AccountsWithReplace(data)
     } else {
-      await importV2AccountsWithMerge(data)
+      const mergeResult = await importV2AccountsWithMerge(
+        data,
+        apiCredentialProfilesConfig?.profiles ?? [],
+      )
+      remappedApiCredentialProfiles = mergeResult.remoteApiCredentialProfiles
     }
     accountsImported = true
   }
@@ -961,7 +1012,12 @@ async function importV2BackupWithPlan(
     await importV2ApiCredentialProfiles(
       data,
       toWriteStrategy(apiCredentialProfilesStrategy),
-      accountsRequested,
+      {
+        reconcileTags:
+          !accountsImported ||
+          accountStrategy !== IMPORT_SECTION_STRATEGIES.Replace,
+        remoteApiCredentialProfiles: remappedApiCredentialProfiles,
+      },
     )
     apiCredentialProfilesImported = true
   }

--- a/src/services/importExport/importExportService.ts
+++ b/src/services/importExport/importExportService.ts
@@ -7,6 +7,7 @@ import { channelConfigStorage } from "~/services/managedSites/channelConfigStora
 import type { UserPreferences } from "~/services/preferences/userPreferences"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
+import { createDefaultTagStore } from "~/services/tags/tagStoreUtils"
 import type { AccountStorageConfig, TagStore } from "~/types"
 import type { ApiCredentialProfilesConfig } from "~/types/apiCredentialProfiles"
 import type { ChannelConfigMap } from "~/types/channelConfig"
@@ -147,8 +148,61 @@ export interface ImportResult {
   }
 }
 
+export const IMPORT_SECTION_STRATEGIES = {
+  Merge: "merge",
+  Replace: "replace",
+  Skip: "skip",
+} as const
+
+export type ImportSectionStrategy =
+  (typeof IMPORT_SECTION_STRATEGIES)[keyof typeof IMPORT_SECTION_STRATEGIES]
+export type ImportMergeStrategy = typeof IMPORT_SECTION_STRATEGIES.Merge
+export type ImportReplaceStrategy = typeof IMPORT_SECTION_STRATEGIES.Replace
+export type ImportSkipStrategy = typeof IMPORT_SECTION_STRATEGIES.Skip
+export type ImportWriteStrategy = ImportMergeStrategy | ImportReplaceStrategy
+export type ImportPreferenceStrategy =
+  | ImportReplaceStrategy
+  | ImportSkipStrategy
+
 export interface ImportFromBackupOptions {
+  mode?: ImportWriteStrategy
+  plan?: ImportPlan
   preserveWebdav?: boolean
+}
+
+export interface ImportPlan {
+  accounts?: ImportSectionStrategy
+  preferences?: ImportPreferenceStrategy
+  channelConfigs?: ImportSectionStrategy
+  apiCredentialProfiles?: ImportSectionStrategy
+}
+
+/**
+ * Returns whether a legacy import should write a section for the current plan.
+ */
+function shouldImportSection(
+  plan: ImportPlan | undefined,
+  section: keyof ImportPlan,
+) {
+  return !plan || plan[section] !== IMPORT_SECTION_STRATEGIES.Skip
+}
+
+/**
+ * Narrows a selected import strategy to the strategies that write data.
+ */
+function hasWriteStrategy(
+  strategy: ImportSectionStrategy | undefined,
+): strategy is ImportWriteStrategy {
+  return Boolean(strategy && strategy !== IMPORT_SECTION_STRATEGIES.Skip)
+}
+
+/**
+ * Converts any non-skip section strategy into the storage write strategy.
+ */
+function toWriteStrategy(strategy: ImportSectionStrategy): ImportWriteStrategy {
+  return strategy === IMPORT_SECTION_STRATEGIES.Replace
+    ? IMPORT_SECTION_STRATEGIES.Replace
+    : IMPORT_SECTION_STRATEGIES.Merge
 }
 
 /**
@@ -211,9 +265,10 @@ async function importV1Backup(
   const channelConfigsRequested = Boolean(
     data.channelConfigs || data.type === "channelConfigs",
   )
+  const plan = options?.plan
 
   // accounts: support both legacy partial exports and older full exports
-  if (accountsRequested) {
+  if (accountsRequested && shouldImportSection(plan, "accounts")) {
     const rawTagStore = (data as any).tagStore ?? (data.data as any)?.tagStore
     if (rawTagStore) {
       await tagStorage.importTagStore(rawTagStore)
@@ -235,7 +290,7 @@ async function importV1Backup(
   }
 
   // preferences
-  if (preferencesRequested) {
+  if (preferencesRequested && shouldImportSection(plan, "preferences")) {
     const preferencesData = data.preferences || data.data?.preferences
     if (preferencesData) {
       const writeResult = options?.preserveWebdav
@@ -253,7 +308,7 @@ async function importV1Backup(
   }
 
   // channel configs: best-effort support if present in V1 backups
-  if (channelConfigsRequested) {
+  if (channelConfigsRequested && shouldImportSection(plan, "channelConfigs")) {
     const channelConfigsData = data.channelConfigs || data.data?.channelConfigs
     if (channelConfigsData) {
       await channelConfigStorage.importConfigs(channelConfigsData)
@@ -482,6 +537,23 @@ async function importV2Backup(
   data: BackupV2,
   options?: ImportFromBackupOptions,
 ): Promise<ImportResult> {
+  if (options?.plan) {
+    return importV2BackupWithPlan(data, options.plan, options)
+  }
+
+  if (options?.mode === IMPORT_SECTION_STRATEGIES.Merge) {
+    return importV2BackupWithPlan(
+      data,
+      {
+        accounts: IMPORT_SECTION_STRATEGIES.Merge,
+        preferences: IMPORT_SECTION_STRATEGIES.Skip,
+        channelConfigs: IMPORT_SECTION_STRATEGIES.Merge,
+        apiCredentialProfiles: IMPORT_SECTION_STRATEGIES.Merge,
+      },
+      options,
+    )
+  }
+
   let accountsImported = false
   let preferencesImported = false
   let channelConfigsImported = false
@@ -498,47 +570,7 @@ async function importV2Backup(
   // V2 assumes flat structure: accounts / preferences / channelConfigs directly on root
 
   if (accountsRequested) {
-    // Prefer importing tag store first so account tagIds can resolve immediately.
-    if ("tagStore" in (data as any) && (data as any).tagStore) {
-      await tagStorage.importTagStore((data as any).tagStore)
-    }
-
-    const accountsConfig = (data as BackupFullV2 | BackupAccountsPartialV2)
-      .accounts
-
-    const accounts = Array.isArray(accountsConfig)
-      ? accountsConfig
-      : accountsConfig?.accounts || []
-
-    const pinnedAccountIds =
-      !Array.isArray(accountsConfig) &&
-      Array.isArray((accountsConfig as AccountStorageConfig).pinnedAccountIds)
-        ? (accountsConfig as AccountStorageConfig).pinnedAccountIds
-        : []
-
-    const bookmarks =
-      !Array.isArray(accountsConfig) &&
-      Array.isArray((accountsConfig as AccountStorageConfig).bookmarks)
-        ? (accountsConfig as AccountStorageConfig).bookmarks
-        : []
-
-    const orderedAccountIds =
-      !Array.isArray(accountsConfig) &&
-      Array.isArray((accountsConfig as AccountStorageConfig).orderedAccountIds)
-        ? (accountsConfig as AccountStorageConfig).orderedAccountIds
-        : []
-
-    await accountStorage.importData({
-      accounts,
-      bookmarks,
-      pinnedAccountIds,
-      orderedAccountIds,
-      deletedEntryRecords: !Array.isArray(accountsConfig)
-        ? (accountsConfig as AccountStorageConfig).deletedEntryRecords
-        : undefined,
-    })
-    // Ensure legacy imports (string tags) are migrated to tag ids.
-    await tagStorage.ensureLegacyMigration()
+    await importV2AccountsWithReplace(data)
     accountsImported = true
   }
 
@@ -593,6 +625,344 @@ async function importV2Backup(
     } else {
       await apiCredentialProfilesStorage.mergeConfig(incoming)
     }
+    apiCredentialProfilesImported = true
+  }
+
+  const anyImported =
+    accountsImported ||
+    preferencesImported ||
+    channelConfigsImported ||
+    apiCredentialProfilesImported
+
+  if (!anyImported) {
+    throw new ImportExportError("NO_IMPORTABLE_DATA")
+  }
+
+  const allImported =
+    (!accountsRequested || accountsImported) &&
+    (!preferencesRequested || preferencesImported) &&
+    (!channelConfigsRequested || channelConfigsImported) &&
+    (!apiCredentialProfilesRequested || apiCredentialProfilesImported)
+
+  return {
+    allImported,
+    sections: {
+      accounts: accountsImported,
+      preferences: preferencesImported,
+      channelConfigs: channelConfigsImported,
+      apiCredentialProfiles: apiCredentialProfilesImported,
+    },
+  }
+}
+
+/** Imports V2 accounts by replacing the current account/bookmark collection. */
+async function importV2AccountsWithReplace(data: BackupV2) {
+  if ("tagStore" in (data as any) && (data as any).tagStore) {
+    await tagStorage.importTagStore((data as any).tagStore)
+  }
+
+  const accountsConfig = (data as BackupFullV2 | BackupAccountsPartialV2)
+    .accounts
+
+  const accounts = Array.isArray(accountsConfig)
+    ? accountsConfig
+    : accountsConfig?.accounts || []
+
+  const pinnedAccountIds =
+    !Array.isArray(accountsConfig) &&
+    Array.isArray((accountsConfig as AccountStorageConfig).pinnedAccountIds)
+      ? (accountsConfig as AccountStorageConfig).pinnedAccountIds
+      : []
+
+  const bookmarks =
+    !Array.isArray(accountsConfig) &&
+    Array.isArray((accountsConfig as AccountStorageConfig).bookmarks)
+      ? (accountsConfig as AccountStorageConfig).bookmarks
+      : []
+
+  const orderedAccountIds =
+    !Array.isArray(accountsConfig) &&
+    Array.isArray((accountsConfig as AccountStorageConfig).orderedAccountIds)
+      ? (accountsConfig as AccountStorageConfig).orderedAccountIds
+      : []
+
+  await accountStorage.importData({
+    accounts,
+    bookmarks,
+    pinnedAccountIds,
+    orderedAccountIds,
+    deletedEntryRecords: !Array.isArray(accountsConfig)
+      ? (accountsConfig as AccountStorageConfig).deletedEntryRecords
+      : undefined,
+  })
+  await tagStorage.ensureLegacyMigration()
+}
+
+/** Imports V2 preferences by replacing current user preferences. */
+async function importV2PreferencesWithReplace(
+  data: BackupV2,
+  options?: ImportFromBackupOptions,
+) {
+  const { preferences } = data as BackupFullV2 | BackupPreferencesPartialV2
+  const writeResult = options?.preserveWebdav
+    ? await userPreferences.importPreferences(preferences, {
+        preserveWebdav: true,
+      })
+    : await userPreferences.importPreferences(preferences)
+
+  if (!writeResult.ok) {
+    logger.error("Failed to import user preferences from V2 backup")
+    throw new ImportExportError("IMPORT_FAILED")
+  }
+}
+
+/** Imports V2 channel configuration by replacing current channel configuration. */
+async function importV2ChannelConfigsWithReplace(data: BackupV2) {
+  await channelConfigStorage.importConfigs(
+    (data as BackupFullV2).channelConfigs,
+  )
+}
+
+/** Merges local and backup order lists while dropping ids absent from imported entries. */
+function mergeEntryIdList(input: {
+  localIds: string[]
+  remoteIds: string[]
+  validIds: Set<string>
+}) {
+  const merged: string[] = []
+  const seen = new Set<string>()
+
+  for (const id of [...input.localIds, ...input.remoteIds]) {
+    if (!input.validIds.has(id) || seen.has(id)) continue
+    seen.add(id)
+    merged.push(id)
+  }
+
+  return merged
+}
+
+/** Merges records by id, keeping the newer backup record only when its timestamp wins. */
+function mergeByLatestUpdatedAt<T extends { id: string; updated_at?: number }>(
+  localItems: T[],
+  remoteItems: T[],
+) {
+  const merged = new Map<string, T>()
+
+  for (const item of localItems) {
+    merged.set(item.id, item)
+  }
+
+  for (const remoteItem of remoteItems) {
+    const localItem = merged.get(remoteItem.id)
+    if (!localItem) {
+      merged.set(remoteItem.id, remoteItem)
+      continue
+    }
+
+    if ((remoteItem.updated_at || 0) > (localItem.updated_at || 0)) {
+      merged.set(remoteItem.id, remoteItem)
+    }
+  }
+
+  return Array.from(merged.values())
+}
+
+/** Merges channel configuration by channel id, preferring the newest updatedAt value. */
+function mergeChannelConfigs(
+  localChannelConfigs: ChannelConfigMap,
+  remoteChannelConfigs: ChannelConfigMap | null,
+) {
+  const merged: ChannelConfigMap = { ...localChannelConfigs }
+
+  if (!remoteChannelConfigs) {
+    return merged
+  }
+
+  for (const [key, value] of Object.entries(remoteChannelConfigs)) {
+    const channelId = Number(key)
+    if (!Number.isFinite(channelId) || channelId <= 0) continue
+
+    const localConfig = merged[channelId]
+    const remoteConfig = value as ChannelConfigMap[number]
+    const localUpdatedAt =
+      typeof localConfig?.updatedAt === "number" ? localConfig.updatedAt : 0
+    const remoteUpdatedAt =
+      typeof remoteConfig?.updatedAt === "number" ? remoteConfig.updatedAt : 0
+
+    if (!localConfig || remoteUpdatedAt > localUpdatedAt) {
+      merged[channelId] = remoteConfig
+    }
+  }
+
+  return merged
+}
+
+/** Merges V2 accounts/bookmarks into the current account storage. */
+async function importV2AccountsWithMerge(data: BackupV2) {
+  const [localAccountsConfig, localTagStore] = await Promise.all([
+    accountStorage.exportData(),
+    tagStorage.exportTagStore(),
+  ])
+  const normalizedRemote = normalizeV2BackupForMerge(data as BackupFullV2, null)
+
+  const tagMerge = tagStorage.mergeTagStoresForSync({
+    localTagStore,
+    remoteTagStore: normalizedRemote.tagStore ?? createDefaultTagStore(),
+    localAccounts: localAccountsConfig.accounts,
+    remoteAccounts: normalizedRemote.accounts,
+    localBookmarks: localAccountsConfig.bookmarks,
+    remoteBookmarks: normalizedRemote.bookmarks,
+    localTaggables: [],
+    remoteTaggables: [],
+  })
+
+  const accounts = mergeByLatestUpdatedAt(
+    tagMerge.localAccounts,
+    tagMerge.remoteAccounts,
+  )
+  const bookmarks = mergeByLatestUpdatedAt(
+    tagMerge.localBookmarks,
+    tagMerge.remoteBookmarks,
+  )
+  const entryIdSet = new Set([
+    ...accounts.map((account) => account.id),
+    ...bookmarks.map((bookmark) => bookmark.id),
+  ])
+
+  await tagStorage.importTagStore(tagMerge.tagStore)
+  await accountStorage.importData({
+    accounts,
+    bookmarks,
+    pinnedAccountIds: mergeEntryIdList({
+      localIds: localAccountsConfig.pinnedAccountIds || [],
+      remoteIds: normalizedRemote.pinnedAccountIds,
+      validIds: entryIdSet,
+    }),
+    orderedAccountIds: mergeEntryIdList({
+      localIds: localAccountsConfig.orderedAccountIds || [],
+      remoteIds: normalizedRemote.orderedAccountIds,
+      validIds: entryIdSet,
+    }),
+    deletedEntryRecords: {
+      ...(localAccountsConfig.deletedEntryRecords || {}),
+      ...(normalizedRemote.deletedEntryRecords || {}),
+    },
+  })
+  await tagStorage.ensureLegacyMigration()
+}
+
+/** Merges V2 channel configuration into current channel configuration. */
+async function importV2ChannelConfigsWithMerge(data: BackupV2) {
+  const localChannelConfigs = await channelConfigStorage.exportConfigs()
+  const normalizedRemote = normalizeV2BackupForMerge(data as BackupFullV2, null)
+  await channelConfigStorage.importConfigs(
+    mergeChannelConfigs(localChannelConfigs, normalizedRemote.channelConfigs),
+  )
+}
+
+/** Imports V2 API credential profiles using either merge or replace semantics. */
+async function importV2ApiCredentialProfiles(
+  data: BackupV2,
+  strategy: ImportWriteStrategy,
+  accountsRequested: boolean,
+) {
+  const incoming = coerceApiCredentialProfilesConfig(
+    (data as BackupFullV2).apiCredentialProfiles,
+  )
+
+  if (
+    !accountsRequested &&
+    "tagStore" in (data as any) &&
+    (data as any).tagStore
+  ) {
+    const tagMerge = tagStorage.mergeTagStoresForSync({
+      localTagStore: await tagStorage.exportTagStore(),
+      remoteTagStore: (data as any).tagStore,
+      localAccounts: [],
+      remoteAccounts: [],
+      localBookmarks: [],
+      remoteBookmarks: [],
+      localTaggables: [],
+      remoteTaggables: incoming.profiles,
+    })
+
+    await tagStorage.importTagStore(tagMerge.tagStore)
+
+    const config = {
+      ...incoming,
+      profiles: tagMerge.remoteTaggables,
+    }
+
+    if (strategy === IMPORT_SECTION_STRATEGIES.Replace) {
+      await apiCredentialProfilesStorage.importConfig(config)
+    } else {
+      await apiCredentialProfilesStorage.mergeConfig(config)
+    }
+    return
+  }
+
+  if (strategy === IMPORT_SECTION_STRATEGIES.Replace) {
+    await apiCredentialProfilesStorage.importConfig(incoming)
+  } else {
+    await apiCredentialProfilesStorage.mergeConfig(incoming)
+  }
+}
+
+/** Imports V2 backups according to a per-section user import plan. */
+async function importV2BackupWithPlan(
+  data: BackupV2,
+  plan: ImportPlan,
+  options?: ImportFromBackupOptions,
+): Promise<ImportResult> {
+  let accountsImported = false
+  let preferencesImported = false
+  let channelConfigsImported = false
+  let apiCredentialProfilesImported = false
+
+  const accountsRequested = "accounts" in data
+  const preferencesRequested = "preferences" in data
+  const channelConfigsRequested =
+    "channelConfigs" in data && Boolean((data as BackupFullV2).channelConfigs)
+  const apiCredentialProfilesRequested =
+    "apiCredentialProfiles" in data &&
+    Boolean((data as BackupFullV2).apiCredentialProfiles)
+  const accountStrategy = plan.accounts
+  const preferenceStrategy = plan.preferences
+  const channelConfigStrategy = plan.channelConfigs
+  const apiCredentialProfilesStrategy = plan.apiCredentialProfiles
+
+  if (accountsRequested && hasWriteStrategy(accountStrategy)) {
+    if (accountStrategy === IMPORT_SECTION_STRATEGIES.Replace) {
+      await importV2AccountsWithReplace(data)
+    } else {
+      await importV2AccountsWithMerge(data)
+    }
+    accountsImported = true
+  }
+
+  if (preferencesRequested && hasWriteStrategy(preferenceStrategy)) {
+    await importV2PreferencesWithReplace(data, options)
+    preferencesImported = true
+  }
+
+  if (channelConfigsRequested && hasWriteStrategy(channelConfigStrategy)) {
+    if (channelConfigStrategy === IMPORT_SECTION_STRATEGIES.Replace) {
+      await importV2ChannelConfigsWithReplace(data)
+    } else {
+      await importV2ChannelConfigsWithMerge(data)
+    }
+    channelConfigsImported = true
+  }
+
+  if (
+    apiCredentialProfilesRequested &&
+    hasWriteStrategy(apiCredentialProfilesStrategy)
+  ) {
+    await importV2ApiCredentialProfiles(
+      data,
+      toWriteStrategy(apiCredentialProfilesStrategy),
+      accountsRequested,
+    )
     apiCredentialProfilesImported = true
   }
 

--- a/tests/entrypoints/options/ImportExportSearchNavigation.test.tsx
+++ b/tests/entrypoints/options/ImportExportSearchNavigation.test.tsx
@@ -59,11 +59,18 @@ describe("ImportExport search navigation", () => {
       isExporting: false,
       setIsExporting: vi.fn(),
       isImporting: false,
+      importPlan: {
+        accounts: "skip",
+        apiCredentialProfiles: "skip",
+        channelConfigs: "skip",
+        preferences: "skip",
+      },
+      setImportPlan: vi.fn(),
       importData: "",
       setImportData: vi.fn(),
       handleFileImport: vi.fn(),
       handleImport: vi.fn(),
-      validateImportData: () => null,
+      validation: null,
     })
 
     window.history.replaceState(

--- a/tests/features/ImportExport/components/sections.test.tsx
+++ b/tests/features/ImportExport/components/sections.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import ExportSection from "~/features/ImportExport/components/ExportSection"
 import ImportSection from "~/features/ImportExport/components/ImportSection"
 import { WebDAVDecryptPasswordModal } from "~/features/ImportExport/components/WebDAVDecryptPasswordModal"
+import { IMPORT_EXPORT_TEST_IDS } from "~/features/ImportExport/testIds"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
@@ -124,6 +125,7 @@ describe("ImportExport section components", () => {
 
   it("renders import validation details and forwards input events", () => {
     const setImportData = vi.fn()
+    const setImportPlan = vi.fn()
     const handleFileImport = vi.fn()
     const handleImport = vi.fn()
 
@@ -131,6 +133,13 @@ describe("ImportExport section components", () => {
       <ImportSection
         importData='{"version":2}'
         setImportData={setImportData}
+        importPlan={{
+          accounts: "merge",
+          apiCredentialProfiles: "merge",
+          channelConfigs: "skip",
+          preferences: "skip",
+        }}
+        setImportPlan={setImportPlan}
         handleFileImport={handleFileImport}
         handleImport={handleImport}
         isImporting={false}
@@ -162,6 +171,9 @@ describe("ImportExport section components", () => {
       screen.getByRole("button", { name: "common:actions.import" }),
     )
     fireEvent.click(
+      screen.getByTestId(IMPORT_EXPORT_TEST_IDS.importPreferencesReplaceOption),
+    )
+    fireEvent.click(
       screen.getByRole("button", { name: "common:actions.clear" }),
     )
 
@@ -173,6 +185,56 @@ describe("ImportExport section components", () => {
     ).toBeInTheDocument()
     expect(setImportData).toHaveBeenCalledWith('{"version":3}')
     expect(setImportData).toHaveBeenCalledWith("")
+    expect(setImportPlan).toHaveBeenCalledWith(expect.any(Function))
+    const updatePlan = setImportPlan.mock.calls[0]?.[0]
+    expect(
+      updatePlan({
+        accounts: "merge",
+        apiCredentialProfiles: "merge",
+        channelConfigs: "skip",
+        preferences: "skip",
+      }),
+    ).toEqual({
+      accounts: "merge",
+      apiCredentialProfiles: "merge",
+      channelConfigs: "skip",
+      preferences: "replace",
+    })
+    expect(
+      screen.getByRole("button", {
+        name: "importExport:import.sectionStrategy.accounts.merge",
+      }),
+    ).toHaveAttribute("aria-pressed", "true")
+
+    rerender(
+      <I18nextProvider i18n={testI18n}>
+        <ImportSection
+          importData='{"version":2}'
+          setImportData={setImportData}
+          importPlan={{
+            accounts: "merge",
+            apiCredentialProfiles: "merge",
+            channelConfigs: "skip",
+            preferences: "replace",
+          }}
+          setImportPlan={setImportPlan}
+          handleFileImport={handleFileImport}
+          handleImport={handleImport}
+          isImporting={false}
+          validation={{
+            valid: true,
+            hasAccounts: true,
+            hasPreferences: true,
+            hasChannelConfigs: true,
+            hasApiCredentialProfiles: true,
+            timestamp: "2026-03-28",
+          }}
+        />
+      </I18nextProvider>,
+    )
+    expect(
+      screen.getByText("importExport:import.replaceWarning"),
+    ).toBeInTheDocument()
     expect(handleFileImport).toHaveBeenCalledTimes(1)
     expect(handleImport).toHaveBeenCalledTimes(1)
     expect(mockTrackProductAnalyticsActionStarted).not.toHaveBeenCalled()
@@ -182,6 +244,13 @@ describe("ImportExport section components", () => {
         <ImportSection
           importData=""
           setImportData={setImportData}
+          importPlan={{
+            accounts: "skip",
+            apiCredentialProfiles: "skip",
+            channelConfigs: "skip",
+            preferences: "skip",
+          }}
+          setImportPlan={setImportPlan}
           handleFileImport={handleFileImport}
           handleImport={handleImport}
           isImporting

--- a/tests/features/ImportExport/hooks/useImportExport.test.tsx
+++ b/tests/features/ImportExport/hooks/useImportExport.test.tsx
@@ -105,6 +105,13 @@ describe("useImportExport", () => {
     loadPreferencesMock.mockResolvedValue(undefined)
     getLanguageMock.mockResolvedValue("ja")
     applyPreferenceLanguageMock.mockResolvedValue(true)
+    parseBackupSummaryMock.mockReturnValue({
+      valid: true,
+      hasAccounts: false,
+      hasPreferences: false,
+      hasChannelConfigs: false,
+      hasApiCredentialProfiles: false,
+    })
     startProductAnalyticsActionMock.mockReturnValue({
       complete: completeProductAnalyticsActionMock,
     })
@@ -178,9 +185,19 @@ describe("useImportExport", () => {
       const importPromise = result.current.handleImport()
       await Promise.resolve()
 
-      expect(importFromBackupObjectMock).toHaveBeenCalledWith({ version: 3 })
+      expect(importFromBackupObjectMock).toHaveBeenCalledWith(
+        { version: 3 },
+        {
+          plan: {
+            accounts: "skip",
+            apiCredentialProfiles: "skip",
+            channelConfigs: "skip",
+            preferences: "skip",
+          },
+        },
+      )
 
-      resolveImport?.({ allImported: true })
+      resolveImport?.({ allImported: true, sections: { preferences: true } })
       await importPromise
     })
 
@@ -201,14 +218,83 @@ describe("useImportExport", () => {
       PRODUCT_ANALYTICS_RESULTS.Success,
     )
 
-    importFromBackupObjectMock.mockResolvedValueOnce({ allImported: false })
+    importFromBackupObjectMock.mockResolvedValueOnce({
+      allImported: false,
+      sections: { accounts: true },
+    })
 
     await act(async () => {
       await result.current.handleImport()
     })
 
-    expect(toastSuccessMock).toHaveBeenCalledTimes(1)
+    expect(toastSuccessMock).toHaveBeenLastCalledWith(
+      "importExport:import.importSelectedSuccess",
+    )
+    expect(toastSuccessMock).toHaveBeenCalledTimes(2)
     expect(loadPreferencesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("passes the selected section import plan to backup import", async () => {
+    importFromBackupObjectMock.mockResolvedValueOnce({ allImported: true })
+
+    const { result } = renderHook(() => useImportExport())
+
+    act(() => {
+      result.current.setImportData('{"version":3}')
+      result.current.setImportPlan((plan) => ({
+        ...plan,
+        accounts: "replace",
+        preferences: "replace",
+      }))
+    })
+
+    await act(async () => {
+      await result.current.handleImport()
+    })
+
+    expect(importFromBackupObjectMock).toHaveBeenCalledWith(
+      { version: 3 },
+      {
+        plan: {
+          accounts: "replace",
+          apiCredentialProfiles: "skip",
+          channelConfigs: "skip",
+          preferences: "replace",
+        },
+      },
+    )
+  })
+
+  it("updates the default import plan from the parsed backup summary", () => {
+    parseBackupSummaryMock.mockReturnValue({
+      valid: true,
+      hasAccounts: true,
+      hasPreferences: true,
+      hasChannelConfigs: true,
+      hasApiCredentialProfiles: true,
+      timestamp: "2026-03-30",
+    })
+
+    const { result } = renderHook(() => useImportExport())
+
+    act(() => {
+      result.current.setImportData('{"version":3,"accounts":[]}')
+    })
+
+    expect(result.current.validation).toEqual(
+      expect.objectContaining({
+        hasAccounts: true,
+        hasPreferences: true,
+        hasChannelConfigs: true,
+        hasApiCredentialProfiles: true,
+      }),
+    )
+    expect(result.current.importPlan).toEqual({
+      accounts: "merge",
+      apiCredentialProfiles: "merge",
+      channelConfigs: "merge",
+      preferences: "skip",
+    })
   })
 
   it("refreshes and reapplies the persisted language for preference-only imports", async () => {
@@ -230,7 +316,9 @@ describe("useImportExport", () => {
     expect(loadPreferencesMock).toHaveBeenCalledTimes(1)
     expect(getLanguageMock).toHaveBeenCalledTimes(1)
     expect(applyPreferenceLanguageMock).toHaveBeenCalledWith("ja")
-    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "importExport:import.importSelectedSuccess",
+    )
     expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Success,
     )
@@ -286,9 +374,9 @@ describe("useImportExport", () => {
   it("validates parsed summaries and collapses invalid or thrown summaries into a false result", () => {
     const { result } = renderHook(() => useImportExport())
 
-    expect(result.current.validateImportData()).toBeNull()
+    expect(result.current.validation).toBeNull()
 
-    parseBackupSummaryMock.mockReturnValueOnce({
+    parseBackupSummaryMock.mockReturnValue({
       valid: true,
       hasAccounts: true,
       hasPreferences: false,
@@ -298,7 +386,7 @@ describe("useImportExport", () => {
       result.current.setImportData('{"version":5}')
     })
 
-    expect(result.current.validateImportData()).toEqual({
+    expect(result.current.validation).toEqual({
       valid: true,
       hasAccounts: true,
       hasPreferences: false,
@@ -308,12 +396,18 @@ describe("useImportExport", () => {
       "common:labels.unknown",
     )
 
-    parseBackupSummaryMock.mockReturnValueOnce(undefined)
-    expect(result.current.validateImportData()).toEqual({ valid: false })
+    parseBackupSummaryMock.mockReturnValue(undefined)
+    act(() => {
+      result.current.setImportData('{"version":6}')
+    })
+    expect(result.current.validation).toEqual({ valid: false })
 
-    parseBackupSummaryMock.mockImplementationOnce(() => {
+    parseBackupSummaryMock.mockImplementation(() => {
       throw new Error("broken summary")
     })
-    expect(result.current.validateImportData()).toEqual({ valid: false })
+    act(() => {
+      result.current.setImportData('{"version":7}')
+    })
+    expect(result.current.validation).toEqual({ valid: false })
   })
 })

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -61,6 +61,7 @@ vi.mock(
   "~/services/apiCredentialProfiles/apiCredentialProfilesStorage",
   () => ({
     apiCredentialProfilesStorage: {
+      importConfig: vi.fn(),
       mergeConfig: vi.fn(),
       exportConfig: vi.fn(),
     },
@@ -103,6 +104,10 @@ const mockMergeTagStoresForSync =
 
 const mockApiCredentialProfilesMergeConfig =
   apiCredentialProfilesStorage.mergeConfig as unknown as ReturnType<
+    typeof vi.fn
+  >
+const mockApiCredentialProfilesImportConfig =
+  apiCredentialProfilesStorage.importConfig as unknown as ReturnType<
     typeof vi.fn
   >
 
@@ -311,6 +316,245 @@ describe("importFromBackupObject", () => {
       preferences: true,
       channelConfigs: true,
       apiCredentialProfiles: false,
+    })
+  })
+
+  it("merges V2 account backups without importing preferences when merge mode is selected", async () => {
+    mockAccountStorageExportData.mockResolvedValue({
+      accounts: [
+        {
+          id: "local-account",
+          site_name: "Local Account",
+          updated_at: 10,
+        },
+      ],
+      bookmarks: [
+        {
+          id: "local-bookmark",
+          name: "Local Bookmark",
+          updated_at: 10,
+        },
+      ],
+      pinnedAccountIds: ["local-account"],
+      orderedAccountIds: ["local-account", "local-bookmark"],
+      deletedEntryRecords: {},
+      last_updated: 10,
+    })
+    mockTagStoreExport.mockResolvedValue({ version: 1, tagsById: {} })
+    mockChannelConfigExport.mockResolvedValue({
+      1: { channelId: 1, updatedAt: 10 },
+    })
+    mockMergeTagStoresForSync.mockReturnValue({
+      tagStore: { version: 1, tagsById: {} },
+      localAccounts: [
+        {
+          id: "local-account",
+          site_name: "Local Account",
+          updated_at: 10,
+        },
+      ],
+      remoteAccounts: [
+        {
+          id: "remote-account",
+          site_name: "Remote Account",
+          updated_at: 20,
+        },
+      ],
+      localBookmarks: [
+        {
+          id: "local-bookmark",
+          name: "Local Bookmark",
+          updated_at: 10,
+        },
+      ],
+      remoteBookmarks: [
+        {
+          id: "remote-bookmark",
+          name: "Remote Bookmark",
+          updated_at: 20,
+        },
+      ],
+      localTaggables: [],
+      remoteTaggables: [],
+    })
+
+    const backup: BackupFullV2 = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accounts: {
+        accounts: [
+          {
+            id: "remote-account",
+            site_name: "Remote Account",
+            updated_at: 20,
+          } as any,
+        ],
+        bookmarks: [
+          {
+            id: "remote-bookmark",
+            name: "Remote Bookmark",
+            updated_at: 20,
+          } as any,
+        ],
+        pinnedAccountIds: ["remote-account"],
+        orderedAccountIds: ["remote-account", "remote-bookmark"],
+        last_updated: 20,
+      } as any,
+      tagStore: { version: 1, tagsById: {} },
+      preferences: { themeMode: "dark" } as any,
+      channelConfigs: {
+        2: { channelId: 2, updatedAt: 20 },
+      } as any,
+      apiCredentialProfiles: {
+        version: 1,
+        profiles: [],
+        lastUpdated: 20,
+      } as any,
+    }
+
+    const result = await importFromBackupObject(backup as BackupV2, {
+      mode: "merge",
+    })
+
+    expect(mockAccountStorageImportData).toHaveBeenCalledWith({
+      accounts: [
+        expect.objectContaining({ id: "local-account" }),
+        expect.objectContaining({ id: "remote-account" }),
+      ],
+      bookmarks: [
+        expect.objectContaining({ id: "local-bookmark" }),
+        expect.objectContaining({ id: "remote-bookmark" }),
+      ],
+      pinnedAccountIds: ["local-account", "remote-account"],
+      orderedAccountIds: [
+        "local-account",
+        "local-bookmark",
+        "remote-account",
+        "remote-bookmark",
+      ],
+      deletedEntryRecords: {},
+    })
+    expect(mockTagStoreImport).toHaveBeenCalledWith({
+      version: 1,
+      tagsById: {},
+    })
+    expect(mockUserPreferencesImport).not.toHaveBeenCalled()
+    expect(mockChannelConfigImport).toHaveBeenCalledWith({
+      1: { channelId: 1, updatedAt: 10 },
+      2: { channelId: 2, updatedAt: 20 },
+    })
+    expect(mockApiCredentialProfilesMergeConfig).toHaveBeenCalledWith(
+      backup.apiCredentialProfiles,
+    )
+    expect(result).toEqual({
+      allImported: false,
+      sections: {
+        accounts: true,
+        preferences: false,
+        channelConfigs: true,
+        apiCredentialProfiles: true,
+      },
+    })
+  })
+
+  it("applies a section import plan with mixed merge, replace, and skip actions", async () => {
+    mockAccountStorageExportData.mockResolvedValue({
+      accounts: [
+        {
+          id: "local-account",
+          site_name: "Local Account",
+          updated_at: 10,
+        },
+      ],
+      bookmarks: [],
+      pinnedAccountIds: ["local-account"],
+      orderedAccountIds: ["local-account"],
+      deletedEntryRecords: {},
+      last_updated: 10,
+    })
+    mockTagStoreExport.mockResolvedValue({ version: 1, tagsById: {} })
+    mockMergeTagStoresForSync.mockReturnValue({
+      tagStore: { version: 1, tagsById: {} },
+      localAccounts: [
+        {
+          id: "local-account",
+          site_name: "Local Account",
+          updated_at: 10,
+        },
+      ],
+      remoteAccounts: [
+        {
+          id: "remote-account",
+          site_name: "Remote Account",
+          updated_at: 20,
+        },
+      ],
+      localBookmarks: [],
+      remoteBookmarks: [],
+      localTaggables: [],
+      remoteTaggables: [],
+    })
+
+    const backup: BackupFullV2 = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accounts: {
+        accounts: [
+          {
+            id: "remote-account",
+            site_name: "Remote Account",
+            updated_at: 20,
+          } as any,
+        ],
+        pinnedAccountIds: ["remote-account"],
+        orderedAccountIds: ["remote-account"],
+        last_updated: 20,
+      } as any,
+      preferences: { themeMode: "dark" } as any,
+      channelConfigs: {
+        5: { channelId: 5, updatedAt: 20 },
+      } as any,
+      apiCredentialProfiles: {
+        version: 1,
+        profiles: [{ id: "backup-profile" }],
+        lastUpdated: 20,
+      } as any,
+    }
+
+    const result = await importFromBackupObject(backup as BackupV2, {
+      plan: {
+        accounts: "merge",
+        preferences: "skip",
+        channelConfigs: "replace",
+        apiCredentialProfiles: "replace",
+      },
+    })
+
+    expect(mockAccountStorageImportData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accounts: [
+          expect.objectContaining({ id: "local-account" }),
+          expect.objectContaining({ id: "remote-account" }),
+        ],
+        pinnedAccountIds: ["local-account", "remote-account"],
+        orderedAccountIds: ["local-account", "remote-account"],
+      }),
+    )
+    expect(mockUserPreferencesImport).not.toHaveBeenCalled()
+    expect(mockChannelConfigExport).not.toHaveBeenCalled()
+    expect(mockChannelConfigImport).toHaveBeenCalledWith(backup.channelConfigs)
+    expect(mockApiCredentialProfilesMergeConfig).not.toHaveBeenCalled()
+    expect(mockApiCredentialProfilesImportConfig).toHaveBeenCalledWith(
+      backup.apiCredentialProfiles,
+    )
+    expect(result).toEqual({
+      allImported: false,
+      sections: {
+        accounts: true,
+        preferences: false,
+        channelConfigs: true,
+        apiCredentialProfiles: true,
+      },
     })
   })
 
@@ -523,6 +767,70 @@ describe("importFromBackupObject", () => {
       accounts: [{ id: "x" }],
     })
     expect(result.allImported).toBe(true)
+  })
+
+  it("respects section plan skips for legacy V1 backups", async () => {
+    const payload: RawBackupData = {
+      version: "1.0",
+      timestamp: Date.now(),
+      accounts: [{ id: "legacy-account" }],
+      preferences: { themeMode: "dark" },
+      channelConfigs: {
+        1: { channelId: 1, updatedAt: 10 },
+      },
+    }
+
+    const result = await importFromBackupObject(payload, {
+      plan: {
+        accounts: "replace",
+        preferences: "skip",
+        channelConfigs: "skip",
+      },
+    })
+
+    expect(mockAccountStorageImportData).toHaveBeenCalledWith({
+      accounts: [{ id: "legacy-account" }],
+    })
+    expect(mockUserPreferencesImport).not.toHaveBeenCalled()
+    expect(mockChannelConfigImport).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      allImported: false,
+      sections: {
+        accounts: true,
+        preferences: false,
+        channelConfigs: false,
+        apiCredentialProfiles: false,
+      },
+    })
+  })
+
+  it("respects section plan skips for unknown-version fallback imports", async () => {
+    const payload: RawBackupData = {
+      version: "3.0",
+      timestamp: Date.now(),
+      accounts: { accounts: [{ id: "future-account" }] },
+      preferences: { themeMode: "dark" },
+      channelConfigs: {
+        2: { channelId: 2, updatedAt: 20 },
+      },
+    }
+
+    const result = await importFromBackupObject(payload, {
+      plan: {
+        accounts: "merge",
+        preferences: "skip",
+        channelConfigs: "skip",
+      },
+    })
+
+    expect(mockAccountStorageImportData).toHaveBeenCalledWith({
+      accounts: [{ id: "future-account" }],
+    })
+    expect(mockUserPreferencesImport).not.toHaveBeenCalled()
+    expect(mockChannelConfigImport).not.toHaveBeenCalled()
+    expect(result.allImported).toBe(false)
+    expect(result.sections.preferences).toBe(false)
+    expect(result.sections.channelConfigs).toBe(false)
   })
 
   it("throws when legacy preference import cannot be persisted", async () => {

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -492,7 +492,7 @@ describe("importFromBackupObject", () => {
       localBookmarks: [],
       remoteBookmarks: [],
       localTaggables: [],
-      remoteTaggables: [],
+      remoteTaggables: [{ id: "backup-profile" }],
     })
 
     const backup: BackupFullV2 = {
@@ -556,6 +556,311 @@ describe("importFromBackupObject", () => {
         apiCredentialProfiles: true,
       },
     })
+  })
+
+  it("remaps API credential profile tags when account merge reconciles the backup tag store", async () => {
+    mockAccountStorageExportData.mockResolvedValue({
+      accounts: [],
+      bookmarks: [],
+      pinnedAccountIds: [],
+      orderedAccountIds: [],
+      deletedEntryRecords: {},
+      last_updated: 10,
+    })
+    mockTagStoreExport.mockResolvedValue({
+      version: 1,
+      tagsById: {
+        local: { id: "local", name: "Shared", createdAt: 1, updatedAt: 1 },
+      },
+    })
+    mockMergeTagStoresForSync.mockReturnValue({
+      tagStore: {
+        version: 2,
+        tagsById: {
+          local: { id: "local", name: "Shared", createdAt: 1, updatedAt: 2 },
+        },
+      },
+      localAccounts: [],
+      remoteAccounts: [],
+      localBookmarks: [],
+      remoteBookmarks: [],
+      localTaggables: [],
+      remoteTaggables: [
+        {
+          id: "backup-profile",
+          tagIds: ["local"],
+        },
+      ],
+    })
+
+    const backup = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accounts: {
+        accounts: [],
+        last_updated: 20,
+      } as any,
+      tagStore: {
+        version: 1,
+        tagsById: {
+          remote: { id: "remote", name: "Shared", createdAt: 2, updatedAt: 2 },
+        },
+      },
+      apiCredentialProfiles: {
+        version: 1,
+        profiles: [
+          {
+            id: "backup-profile",
+            tagIds: ["remote"],
+          },
+        ],
+        lastUpdated: 20,
+      } as any,
+    } satisfies RawBackupData
+
+    await importFromBackupObject(backup, {
+      plan: {
+        accounts: "merge",
+        apiCredentialProfiles: "merge",
+      },
+    })
+
+    expect(mockMergeTagStoresForSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remoteTagStore: backup.tagStore,
+        remoteTaggables: backup.apiCredentialProfiles?.profiles,
+      }),
+    )
+    expect(mockTagStoreImport).toHaveBeenCalledWith({
+      version: 2,
+      tagsById: {
+        local: { id: "local", name: "Shared", createdAt: 1, updatedAt: 2 },
+      },
+    })
+    expect(mockApiCredentialProfilesMergeConfig).toHaveBeenCalledWith({
+      ...backup.apiCredentialProfiles,
+      profiles: [
+        {
+          id: "backup-profile",
+          tagIds: ["local"],
+        },
+      ],
+    })
+  })
+
+  it("applies planned preference replacement and reports a selected import", async () => {
+    const backup = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      preferences: { themeMode: "dark" } as any,
+    } satisfies RawBackupData
+
+    const result = await importFromBackupObject(backup, {
+      plan: {
+        preferences: "replace",
+      },
+      preserveWebdav: true,
+    })
+
+    expect(mockUserPreferencesImport).toHaveBeenCalledWith(
+      { themeMode: "dark" },
+      { preserveWebdav: true },
+    )
+    expect(result).toEqual({
+      allImported: true,
+      sections: {
+        accounts: false,
+        preferences: true,
+        channelConfigs: false,
+        apiCredentialProfiles: false,
+      },
+    })
+  })
+
+  it("reconciles profile-only tag stores before replacing API credential profiles", async () => {
+    mockTagStoreExport.mockResolvedValue({
+      version: 1,
+      tagsById: {
+        local: { id: "local", name: "Shared", createdAt: 1, updatedAt: 1 },
+      },
+    })
+    mockMergeTagStoresForSync.mockReturnValue({
+      tagStore: {
+        version: 2,
+        tagsById: {
+          local: { id: "local", name: "Shared", createdAt: 1, updatedAt: 2 },
+        },
+      },
+      localAccounts: [],
+      remoteAccounts: [],
+      localBookmarks: [],
+      remoteBookmarks: [],
+      localTaggables: [],
+      remoteTaggables: [
+        {
+          id: "backup-profile",
+          tagIds: ["local"],
+        },
+      ],
+    })
+
+    const backup = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      tagStore: {
+        version: 1,
+        tagsById: {
+          remote: { id: "remote", name: "Shared", createdAt: 2, updatedAt: 2 },
+        },
+      },
+      apiCredentialProfiles: {
+        version: 1,
+        profiles: [
+          {
+            id: "backup-profile",
+            tagIds: ["remote"],
+          },
+        ],
+        lastUpdated: 20,
+      } as any,
+    } satisfies RawBackupData
+
+    await importFromBackupObject(backup, {
+      plan: {
+        apiCredentialProfiles: "replace",
+      },
+    })
+
+    expect(mockMergeTagStoresForSync).toHaveBeenCalledWith({
+      localTagStore: {
+        version: 1,
+        tagsById: {
+          local: { id: "local", name: "Shared", createdAt: 1, updatedAt: 1 },
+        },
+      },
+      remoteTagStore: backup.tagStore,
+      localAccounts: [],
+      remoteAccounts: [],
+      localBookmarks: [],
+      remoteBookmarks: [],
+      localTaggables: [],
+      remoteTaggables: backup.apiCredentialProfiles?.profiles,
+    })
+    expect(mockTagStoreImport).toHaveBeenCalledWith({
+      version: 2,
+      tagsById: {
+        local: { id: "local", name: "Shared", createdAt: 1, updatedAt: 2 },
+      },
+    })
+    expect(mockApiCredentialProfilesImportConfig).toHaveBeenCalledWith({
+      ...backup.apiCredentialProfiles,
+      profiles: [
+        {
+          id: "backup-profile",
+          tagIds: ["local"],
+        },
+      ],
+    })
+  })
+
+  it("applies replace accounts with merged channel configs and profile merge fallback", async () => {
+    mockChannelConfigExport.mockResolvedValue({
+      1: { channelId: 1, updatedAt: 10 },
+      2: { channelId: 2, updatedAt: 30 },
+    })
+
+    const backup = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accounts: {
+        accounts: [{ id: "backup-account" } as any],
+        bookmarks: [{ id: "backup-bookmark" } as any],
+        pinnedAccountIds: ["backup-account"],
+        orderedAccountIds: ["backup-account", "backup-bookmark"],
+        deletedEntryRecords: {
+          removed: {
+            kind: "account",
+            deletedAt: 30,
+            entryUpdatedAt: 20,
+          },
+        },
+        last_updated: 20,
+      } as any,
+      channelConfigs: {
+        2: { channelId: 2, updatedAt: 20 },
+        3: { channelId: 3, updatedAt: 40 },
+      } as any,
+      apiCredentialProfiles: {
+        version: 1,
+        profiles: [{ id: "backup-profile" }],
+        lastUpdated: 20,
+      } as any,
+    } satisfies RawBackupData
+
+    const result = await importFromBackupObject(backup, {
+      plan: {
+        accounts: "replace",
+        channelConfigs: "merge",
+        apiCredentialProfiles: "merge",
+      },
+    })
+
+    expect(mockAccountStorageImportData).toHaveBeenCalledWith({
+      accounts: [{ id: "backup-account" }],
+      bookmarks: [{ id: "backup-bookmark" }],
+      pinnedAccountIds: ["backup-account"],
+      orderedAccountIds: ["backup-account", "backup-bookmark"],
+      deletedEntryRecords: backup.accounts.deletedEntryRecords,
+    })
+    expect(mockChannelConfigImport).toHaveBeenCalledWith({
+      1: { channelId: 1, updatedAt: 10 },
+      2: { channelId: 2, updatedAt: 30 },
+      3: { channelId: 3, updatedAt: 40 },
+    })
+    expect(mockApiCredentialProfilesMergeConfig).toHaveBeenCalledWith(
+      backup.apiCredentialProfiles,
+    )
+    expect(result).toEqual({
+      allImported: true,
+      sections: {
+        accounts: true,
+        preferences: false,
+        channelConfigs: true,
+        apiCredentialProfiles: true,
+      },
+    })
+  })
+
+  it("throws when a plan skips every section present in the backup", async () => {
+    const backup: BackupFullV2 = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accounts: { accounts: [] } as any,
+      preferences: { themeMode: "dark" } as any,
+      channelConfigs: { 1: { channelId: 1 } } as any,
+      apiCredentialProfiles: {
+        version: 1,
+        profiles: [],
+        lastUpdated: 1,
+      } as any,
+    }
+
+    await expect(
+      importFromBackupObject(backup as BackupV2, {
+        plan: {
+          accounts: "skip",
+          preferences: "skip",
+          channelConfigs: "skip",
+          apiCredentialProfiles: "skip",
+        },
+      }),
+    ).rejects.toThrow("importExport:import.noImportableData")
+
+    expect(mockAccountStorageImportData).not.toHaveBeenCalled()
+    expect(mockUserPreferencesImport).not.toHaveBeenCalled()
+    expect(mockChannelConfigImport).not.toHaveBeenCalled()
+    expect(mockApiCredentialProfilesMergeConfig).not.toHaveBeenCalled()
+    expect(mockApiCredentialProfilesImportConfig).not.toHaveBeenCalled()
   })
 
   it("imports legacy V2 account arrays without deletion marker metadata", async () => {


### PR DESCRIPTION
## Summary

- closes #1094
- add planned backup import strategies so manual imports can merge, replace, or skip supported sections
- default account/API credential/channel imports to merge while requiring explicit replace for destructive choices
- add import-section UI controls, settings search target, localized copy, and focused regression coverage

## Validation

- pnpm vitest --run tests/utils/importExportUtils.test.ts tests/features/ImportExport/hooks/useImportExport.test.tsx tests/features/ImportExport/components/sections.test.tsx tests/entrypoints/options/ImportExportSearchNavigation.test.tsx
- pnpm run i18n:extract:ci
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import now lets you choose, per data section, how restore should behave (merge, replace, or skip).
  * Added clearer on-screen guidance, warnings, and “selected content imported” success messaging.
  * Import/export search/navigation now includes an import mode selector for choosing import content behavior.

* **Bug Fixes**
  * Restore behavior now more consistently applies the selected strategy across accounts, preferences, API credentials, and channel configurations.
  * Import validation and button enabling were refined so the UI state matches what will actually be imported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->