### PR TITLE
feat(managed-sites): list claude code hub providers

### DIFF
--- a/src/services/apiAdapters/managedSites/claudeCodeHub.ts
+++ b/src/services/apiAdapters/managedSites/claudeCodeHub.ts
@@ -13,6 +13,7 @@ import {
   fetchAvailableModels,
   fetchChannelSecretKey,
   hydrateComparableChannelKeys,
+  listChannels,
   prepareChannelFormData,
   searchChannel,
   updateChannel,
@@ -25,6 +26,7 @@ import { emptyManagedSiteQueries } from "./unsupportedQueries"
 export const claudeCodeHubManagedSiteChannels: ManagedSiteChannelsCapability<ClaudeCodeHubConfig> =
   {
     search: searchChannel,
+    list: listChannels,
     create: createChannel,
     update: updateChannel,
     delete: deleteChannel,

--- a/src/services/apiService/claudeCodeHub/index.ts
+++ b/src/services/apiService/claudeCodeHub/index.ts
@@ -443,7 +443,7 @@ export async function validateClaudeCodeHubConfig(
     timeoutMs?: number
   },
 ): Promise<boolean> {
-  await listProvidersFromAction(config, options)
+  await listProviders(config, options)
   return true
 }
 

--- a/src/services/apiService/claudeCodeHub/index.ts
+++ b/src/services/apiService/claudeCodeHub/index.ts
@@ -328,9 +328,9 @@ function extractProviderList(data: unknown): ClaudeCodeHubProviderDisplay[] {
 }
 
 /**
- * Lists Claude Code Hub providers through the admin action API.
+ * Lists Claude Code Hub providers through the legacy admin action API.
  */
-export async function listProviders(
+export async function listProvidersFromAction(
   config: ClaudeCodeHubConfig,
   options?: {
     signal?: AbortSignal
@@ -346,13 +346,34 @@ export async function listProviders(
   return extractProviderList(data)
 }
 
+type ClaudeCodeHubV1ProviderListOptions = {
+  keyword?: string
+  signal?: AbortSignal
+  timeoutMs?: number
+}
+
+/**
+ * Lists Claude Code Hub providers through the admin v1 provider list API.
+ *
+ * Upstream contract: ding113/claude-code-hub
+ * `src/app/api/v1/resources/providers/router.ts` registers
+ * `GET /api/v1/providers` and returns `{ items: ProviderSummary[] }`.
+ */
+export async function listProviders(
+  config: ClaudeCodeHubConfig,
+  options?: {
+    signal?: AbortSignal
+    timeoutMs?: number
+  },
+): Promise<ClaudeCodeHubProviderDisplay[]> {
+  return await fetchV1ProviderList(config, options)
+}
+
 /**
  * Searches Claude Code Hub providers through the admin v1 provider list API.
  *
  * Upstream contract: ding113/claude-code-hub
- * `src/app/api/v1/resources/providers/router.ts` registers
- * `GET /api/v1/providers` with optional `q` search text and returns
- * `{ items: ProviderSummary[] }`.
+ * `GET /api/v1/providers` accepts optional `q` search text.
  */
 export async function searchProviders(
   config: ClaudeCodeHubConfig,
@@ -362,9 +383,22 @@ export async function searchProviders(
     timeoutMs?: number
   },
 ): Promise<ClaudeCodeHubProviderDisplay[]> {
+  return await fetchV1ProviderList(config, {
+    ...options,
+    keyword,
+  })
+}
+
+/**
+ * Fetches the Claude Code Hub v1 provider list, optionally applying search text.
+ */
+async function fetchV1ProviderList(
+  config: ClaudeCodeHubConfig,
+  options?: ClaudeCodeHubV1ProviderListOptions,
+): Promise<ClaudeCodeHubProviderDisplay[]> {
   const baseUrl = normalizeClaudeCodeHubBaseUrl(config.baseUrl)
   const searchParams = new URLSearchParams()
-  const trimmedKeyword = keyword.trim()
+  const trimmedKeyword = options?.keyword?.trim()
   if (trimmedKeyword) {
     searchParams.set("q", trimmedKeyword)
   }
@@ -409,7 +443,7 @@ export async function validateClaudeCodeHubConfig(
     timeoutMs?: number
   },
 ): Promise<boolean> {
-  await listProviders(config, options)
+  await listProvidersFromAction(config, options)
   return true
 }
 

--- a/src/services/managedSites/providers/claudeCodeHub.ts
+++ b/src/services/managedSites/providers/claudeCodeHub.ts
@@ -149,6 +149,26 @@ function getProviderGroupTag(formData: Pick<ChannelFormData, "groups">) {
 }
 
 /**
+ * Converts Claude Code Hub provider rows into the shared managed-site list shape.
+ */
+function toManagedSiteChannelListData(
+  providers: ClaudeCodeHubProviderDisplay[],
+): ManagedSiteChannelListData {
+  const items = providers.map(providerToManagedSiteChannel)
+  const typeCounts = items.reduce<Record<string, number>>((acc, item) => {
+    const type = String(item.type)
+    acc[type] = (acc[type] ?? 0) + 1
+    return acc
+  }, {})
+
+  return {
+    items,
+    total: items.length,
+    type_counts: typeCounts,
+  }
+}
+
+/**
  * Clamps provider weights to Claude Code Hub's expected positive integer shape.
  */
 function toSafeWeight(weight?: number): number {
@@ -221,18 +241,7 @@ async function searchClaudeCodeHubChannels(
   keyword: string,
 ): Promise<ManagedSiteChannelListData> {
   const providers = await claudeCodeHubApi.searchProviders(config, keyword)
-  const items = providers.map(providerToManagedSiteChannel)
-  const typeCounts = items.reduce<Record<string, number>>((acc, item) => {
-    const type = String(item.type)
-    acc[type] = (acc[type] ?? 0) + 1
-    return acc
-  }, {})
-
-  return {
-    items,
-    total: items.length,
-    type_counts: typeCounts,
-  }
+  return toManagedSiteChannelListData(providers)
 }
 
 /**
@@ -380,6 +389,23 @@ export async function searchChannel(
     logger.error("Failed to search Claude Code Hub providers", error)
     return null
   }
+}
+
+/**
+ * Lists Claude Code Hub channels through the provider v1 list API.
+ */
+export async function listChannels(
+  config: ClaudeCodeHubConfig,
+  options?: {
+    signal?: AbortSignal
+    beforeRequest?: () => Promise<void>
+  },
+): Promise<ManagedSiteChannelListData> {
+  await options?.beforeRequest?.()
+  const providers = await claudeCodeHubApi.listProviders(config, {
+    ...(options?.signal ? { signal: options.signal } : {}),
+  })
+  return toManagedSiteChannelListData(providers)
 }
 
 /**

--- a/tests/services/apiAdapters/managedSites/claudeCodeHub.test.ts
+++ b/tests/services/apiAdapters/managedSites/claudeCodeHub.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 const claudeCodeHubProvider = vi.hoisted(() => ({
   checkValidClaudeCodeHubConfig: vi.fn(),
+  listChannels: vi.fn(),
   searchChannel: vi.fn(),
   createChannel: vi.fn(),
   updateChannel: vi.fn(),
@@ -25,6 +26,12 @@ describe("Claude Code Hub managed-site channel capability", () => {
   }
 
   it("exposes secret-key and comparable-key hydration helpers", async () => {
+    const listResponse = {
+      items: [{ id: 1, name: "Claude Code Hub" }],
+      total: 1,
+      type_counts: { claude: 1 },
+    }
+    claudeCodeHubProvider.listChannels.mockResolvedValue(listResponse)
     claudeCodeHubProvider.fetchChannelSecretKey.mockResolvedValue("real-key")
     claudeCodeHubProvider.hydrateComparableChannelKeys.mockResolvedValue([
       { id: 1, key: "real-key" },
@@ -34,6 +41,9 @@ describe("Claude Code Hub managed-site channel capability", () => {
       "~/services/apiAdapters/managedSites/claudeCodeHub"
     )
 
+    await expect(claudeCodeHubManagedSiteChannels.list?.(config)).resolves.toBe(
+      listResponse,
+    )
     await expect(
       claudeCodeHubManagedSiteChannels.fetchSecretKey?.(config, 1),
     ).resolves.toBe("real-key")

--- a/tests/services/apiService/claudeCodeHub/index.test.ts
+++ b/tests/services/apiService/claudeCodeHub/index.test.ts
@@ -220,6 +220,21 @@ describe("Claude Code Hub action API adapter", () => {
     expect(capturedQuery).toBeNull()
   })
 
+  it("throws when the provider v1 list API returns a non-JSON response", async () => {
+    server.use(
+      http.get(
+        PROVIDER_V1_BASE,
+        () =>
+          new HttpResponse("not json", {
+            status: 200,
+            headers: { "Content-Type": "text/plain" },
+          }),
+      ),
+    )
+
+    await expect(listProviders(config)).rejects.toThrow("non-JSON response")
+  })
+
   it("throws redacted errors for provider v1 search failures", async () => {
     server.use(
       http.get(PROVIDER_V1_BASE, () =>
@@ -237,6 +252,88 @@ describe("Claude Code Hub action API adapter", () => {
     await expect(searchProviders(config, "search match")).rejects.toThrow(
       "bad token [REDACTED] while searching",
     )
+  })
+
+  it("throws redacted errors for provider v1 list failures", async () => {
+    server.use(
+      http.get(PROVIDER_V1_BASE, () =>
+        HttpResponse.json(
+          {
+            type: "about:blank",
+            title: "Provider list failed",
+            detail: "bad token admin-secret while listing",
+          },
+          { status: 403 },
+        ),
+      ),
+    )
+
+    await expect(listProviders(config)).rejects.toThrow(
+      "bad token [REDACTED] while listing",
+    )
+  })
+
+  it("wraps provider v1 list network failures in a ClaudeCodeHubApiError", async () => {
+    server.use(http.get(PROVIDER_V1_BASE, () => HttpResponse.error()))
+
+    await expect(listProviders(config)).rejects.toBeInstanceOf(
+      ClaudeCodeHubApiError,
+    )
+  })
+
+  it("combines caller signals for the provider v1 list API", async () => {
+    const controller = new AbortController()
+    let capturedSignal: AbortSignal | null = null
+
+    server.use(
+      http.get(PROVIDER_V1_BASE, ({ request }) => {
+        capturedSignal = request.signal
+        return HttpResponse.json({ items: [] })
+      }),
+    )
+
+    await listProviders(config, { signal: controller.signal })
+
+    expect(capturedSignal).toBeInstanceOf(AbortSignal)
+    expect(capturedSignal).not.toBe(controller.signal)
+    if (!capturedSignal) {
+      throw new Error("Expected request signal to be captured")
+    }
+    const requestSignal: AbortSignal = capturedSignal
+    controller.abort()
+    expect(requestSignal.aborted).toBe(true)
+  })
+
+  it("rejects already-aborted caller signals for the provider v1 list API", async () => {
+    const originalAny = Object.getOwnPropertyDescriptor(AbortSignal, "any")
+    const originalTimeout = Object.getOwnPropertyDescriptor(
+      AbortSignal,
+      "timeout",
+    )
+    const controller = new AbortController()
+    controller.abort()
+
+    Object.defineProperty(AbortSignal, "any", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+    Object.defineProperty(AbortSignal, "timeout", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+
+    try {
+      await expect(
+        listProviders(config, {
+          signal: controller.signal,
+        }),
+      ).rejects.toBeInstanceOf(ClaudeCodeHubApiError)
+    } finally {
+      restoreAbortSignalStatic("any", originalAny)
+      restoreAbortSignalStatic("timeout", originalTimeout)
+    }
   })
 
   it("throws redacted errors for provider v1 reveal failures", async () => {
@@ -502,14 +599,18 @@ describe("Claude Code Hub action API adapter", () => {
     }
   })
 
-  it("validates config by delegating to provider listing", async () => {
+  it("validates config by delegating to the provider v1 list API", async () => {
+    let capturedAuthorization: string | null = null
+
     server.use(
-      http.post(`${PROVIDER_ACTION_BASE}/getProviders`, () =>
-        HttpResponse.json({ ok: true, data: [] }),
-      ),
+      http.get(PROVIDER_V1_BASE, ({ request }) => {
+        capturedAuthorization = request.headers.get("authorization")
+        return HttpResponse.json({ items: [] })
+      }),
     )
 
     await expect(validateClaudeCodeHubConfig(config)).resolves.toBe(true)
+    expect(capturedAuthorization).toBe("Bearer admin-secret")
   })
 
   it("wraps network failures in a ClaudeCodeHubApiError", async () => {

--- a/tests/services/apiService/claudeCodeHub/index.test.ts
+++ b/tests/services/apiService/claudeCodeHub/index.test.ts
@@ -7,6 +7,7 @@ import {
   deleteProvider,
   getUnmaskedProviderKey,
   listProviders,
+  listProvidersFromAction,
   normalizeClaudeCodeHubBaseUrl,
   redactClaudeCodeHubSecrets,
   searchProviders,
@@ -58,7 +59,7 @@ describe("Claude Code Hub action API adapter", () => {
       }),
     )
 
-    await expect(listProviders(config)).resolves.toEqual([
+    await expect(listProvidersFromAction(config)).resolves.toEqual([
       { id: 1, name: "OpenAI", url: "https://api.example.com" },
     ])
     expect(normalizeClaudeCodeHubBaseUrl(config.baseUrl)).toBe(
@@ -187,6 +188,38 @@ describe("Claude Code Hub action API adapter", () => {
     expect(capturedQuery).toBe("search match")
   })
 
+  it("lists providers through the provider v1 list API without search query", async () => {
+    let capturedAuthorization: string | null = null
+    let capturedQuery: string | null = null
+
+    server.use(
+      http.get(PROVIDER_V1_BASE, ({ request }) => {
+        const url = new URL(request.url)
+        capturedAuthorization = request.headers.get("authorization")
+        capturedQuery = url.searchParams.get("q")
+        return HttpResponse.json({
+          items: [
+            {
+              id: 10,
+              name: "Listed Provider",
+              url: "https://listed.example.com",
+            },
+          ],
+        })
+      }),
+    )
+
+    await expect(listProviders(config)).resolves.toEqual([
+      {
+        id: 10,
+        name: "Listed Provider",
+        url: "https://listed.example.com",
+      },
+    ])
+    expect(capturedAuthorization).toBe("Bearer admin-secret")
+    expect(capturedQuery).toBeNull()
+  })
+
   it("throws redacted errors for provider v1 search failures", async () => {
     server.use(
       http.get(PROVIDER_V1_BASE, () =>
@@ -237,7 +270,7 @@ describe("Claude Code Hub action API adapter", () => {
       ),
     )
 
-    await expect(listProviders(config)).resolves.toEqual([
+    await expect(listProvidersFromAction(config)).resolves.toEqual([
       { id: 2, name: "Codex", url: "https://codex.example.com" },
     ])
   })
@@ -252,7 +285,7 @@ describe("Claude Code Hub action API adapter", () => {
       ),
     )
 
-    await expect(listProviders(config)).resolves.toEqual([])
+    await expect(listProvidersFromAction(config)).resolves.toEqual([])
   })
 
   it("throws redacted errors for action failures and malformed responses", async () => {
@@ -306,7 +339,7 @@ describe("Claude Code Hub action API adapter", () => {
       ),
     )
 
-    await expect(listProviders(config)).rejects.toThrow(
+    await expect(listProvidersFromAction(config)).rejects.toThrow(
       "invalid action response",
     )
   })
@@ -333,7 +366,7 @@ describe("Claude Code Hub action API adapter", () => {
       }),
     )
 
-    await listProviders(config, { signal: controller.signal })
+    await listProvidersFromAction(config, { signal: controller.signal })
 
     expect(capturedSignal).toBeInstanceOf(AbortSignal)
     expect(capturedSignal).not.toBe(controller.signal)
@@ -374,7 +407,7 @@ describe("Claude Code Hub action API adapter", () => {
 
     try {
       await expect(
-        listProviders(config, {
+        listProvidersFromAction(config, {
           signal: controller.signal,
         }),
       ).resolves.toEqual([])
@@ -425,7 +458,7 @@ describe("Claude Code Hub action API adapter", () => {
 
     try {
       await expect(
-        listProviders(config, {
+        listProvidersFromAction(config, {
           signal: controller.signal,
         }),
       ).resolves.toEqual([])
@@ -459,7 +492,7 @@ describe("Claude Code Hub action API adapter", () => {
 
     try {
       await expect(
-        listProviders(config, {
+        listProvidersFromAction(config, {
           signal: controller.signal,
         }),
       ).rejects.toBeInstanceOf(ClaudeCodeHubApiError)
@@ -486,7 +519,7 @@ describe("Claude Code Hub action API adapter", () => {
       ),
     )
 
-    await expect(listProviders(config)).rejects.toBeInstanceOf(
+    await expect(listProvidersFromAction(config)).rejects.toBeInstanceOf(
       ClaudeCodeHubApiError,
     )
   })

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -21,6 +21,7 @@ import {
   fetchChannelSecretKey,
   getClaudeCodeHubConfig,
   hydrateComparableChannelKeys,
+  listChannels,
   prepareChannelFormData,
   providerToManagedSiteChannel,
   searchChannel,
@@ -360,6 +361,46 @@ describe("Claude Code Hub managed-site provider", () => {
 
     await expect(checkValidClaudeCodeHubConfig()).resolves.toBe(false)
     expect(claudeCodeHubApi.validateClaudeCodeHubConfig).not.toHaveBeenCalled()
+  })
+
+  it("lists providers through the same normalized channel list shape", async () => {
+    const requestSignal = new AbortController().signal
+    const beforeRequest = vi.fn().mockResolvedValue(undefined)
+    mockListProviders.mockResolvedValue([
+      {
+        id: 22,
+        name: "Provider Beta",
+        providerType: "claude",
+        url: "https://beta.example.com",
+        maskedKey: "sk-***",
+        allowedModels: ["claude-sonnet"],
+        groupTag: "team-b",
+      },
+    ])
+
+    await expect(
+      listChannels(passedClaudeCodeHubConfig, {
+        signal: requestSignal,
+        beforeRequest,
+      }),
+    ).resolves.toMatchObject({
+      total: 1,
+      items: [
+        expect.objectContaining({
+          id: 22,
+          name: "Provider Beta",
+          models: "claude-sonnet",
+        }),
+      ],
+      type_counts: {
+        claude: 1,
+      },
+    })
+    expect(beforeRequest).toHaveBeenCalledTimes(1)
+    expect(mockListProviders).toHaveBeenCalledWith(passedClaudeCodeHubConfig, {
+      signal: requestSignal,
+    })
+    expect(mockSearchProviders).not.toHaveBeenCalled()
   })
 
   it("searches, creates, updates, and deletes providers with passed admin config", async () => {


### PR DESCRIPTION
## Summary
- add an explicit Claude Code Hub managed-site channel list capability backed by the upstream provider list API
- split provider listing from keyword search while keeping the legacy action list path for config validation compatibility
- cover the API wrapper, provider mapping, and managed-site adapter capability with focused tests

## Validation
- pnpm vitest related --run tests/services/apiService/claudeCodeHub/index.test.ts tests/services/managedSites/providers/claudeCodeHub.test.ts tests/services/apiAdapters/managedSites/claudeCodeHub.test.ts
- pnpm compile
- pnpm run validate:staged
- AAH_E2E_MANAGED_SITE_TARGET=claude-code-hub pnpm exec playwright test e2e/realSite/managedSiteChannels.spec.ts --project=chromium --reporter=list --workers=1
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code Hub managed sites can now list available channels.
  * Provider listing now uses the newer v1 provider list flow by default.

* **Bug Fixes**
  * Improved provider search behavior and validation reliability.
  * Channel lists are now normalized consistently, including item details and type counts.
  * Enhanced request cancellation and timeout handling during provider lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->