### PR TITLE
feat(sub2api): support account usage stats

### DIFF
--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -44,6 +44,7 @@ import {
   parseSub2ApiEnvelope,
   parseSub2ApiGroupRates,
   parseSub2ApiKey,
+  parseSub2ApiTodayUsage,
   parseSub2ApiUserIdentity,
   resolveSub2ApiGroupId,
   translateSub2ApiCreateTokenRequest,
@@ -61,12 +62,14 @@ import {
   SUB2API_AVAILABLE_GROUPS_ENDPOINT,
   SUB2API_GROUP_RATES_ENDPOINT,
   SUB2API_KEYS_ENDPOINT,
+  SUB2API_USAGE_STATS_ENDPOINT,
   type Sub2ApiAnnouncementData,
   type Sub2ApiAnnouncementListData,
   type Sub2ApiAuthMeData,
   type Sub2ApiAuthMeResponse,
   type Sub2ApiKeyData,
   type Sub2ApiKeyListData,
+  type Sub2ApiUsageStatsData,
 } from "./type"
 
 /**
@@ -759,12 +762,10 @@ type Sub2ApiCurrentUser = {
 const createAccountData = (
   currentUser: Sub2ApiCurrentUser,
   checkIn: CheckInConfig,
+  todayUsage: TodayUsageData = ZERO_TODAY_USAGE_DATA,
 ): AccountData => ({
   quota: currentUser.quota,
-  today_quota_consumption: 0,
-  today_prompt_tokens: 0,
-  today_completion_tokens: 0,
-  today_requests_count: 0,
+  ...todayUsage,
   today_income: 0,
   checkIn,
 })
@@ -794,10 +795,11 @@ const createHealthyHealthStatus = () => ({
 const createRefreshSuccessResult = (
   currentUser: Sub2ApiCurrentUser,
   checkIn: CheckInConfig,
+  todayUsage: TodayUsageData,
   authUpdate?: RefreshAccountResult["authUpdate"],
 ): RefreshAccountResult => ({
   success: true,
-  data: createAccountData(currentUser, checkIn),
+  data: createAccountData(currentUser, checkIn, todayUsage),
   healthStatus: createHealthyHealthStatus(),
   authUpdate: {
     ...authUpdate,
@@ -805,6 +807,27 @@ const createRefreshSuccessResult = (
     username: currentUser.username,
   },
 })
+
+const fetchCurrentUserAndTodayUsage = async (
+  request: ApiServiceAccountRequest,
+): Promise<{
+  currentUser: Sub2ApiCurrentUser
+  todayUsage: TodayUsageData
+}> => {
+  const currentUser = await fetchCurrentUser(request)
+  let todayUsage = ZERO_TODAY_USAGE_DATA
+
+  try {
+    todayUsage = await fetchTodayUsage(request)
+  } catch (error) {
+    logger.warn("Failed to fetch Sub2API today usage; using zero defaults", {
+      accountId: request.accountId,
+      error: getSafeErrorMessage(error),
+    })
+  }
+
+  return { currentUser, todayUsage }
+}
 
 const refreshSub2ApiAccountViaResync = async (params: {
   request: ApiServiceRequest
@@ -817,9 +840,11 @@ const refreshSub2ApiAccountViaResync = async (params: {
     authSession: params.authSession,
   })
 
-  const currentUser = await fetchCurrentUser(retryRequest)
+  const { currentUser, todayUsage } = await fetchCurrentUserAndTodayUsage(
+    retryRequest as ApiServiceAccountRequest,
+  )
 
-  return createRefreshSuccessResult(currentUser, params.checkIn, {
+  return createRefreshSuccessResult(currentUser, params.checkIn, todayUsage, {
     accessToken: retryRequest.auth.accessToken,
   })
 }
@@ -1063,22 +1088,45 @@ export async function fetchCheckInStatus(
   return undefined
 }
 
+const ZERO_TODAY_USAGE_DATA: TodayUsageData = {
+  today_quota_consumption: 0,
+  today_prompt_tokens: 0,
+  today_completion_tokens: 0,
+  today_requests_count: 0,
+}
+
+const createSub2ApiUsageStatsEndpoint = (): string =>
+  `${SUB2API_USAGE_STATS_ENDPOINT}?period=today`
+
 /**
- * Sub2API usage stats are not mapped yet; return zeros.
+ * Fetch Sub2API user-level usage stats for today.
+ *
+ * Source: https://github.com/Wei-Shaw/sub2api
+ * User routes register authenticated `GET /api/v1/usage/stats`; `period=today`
+ * maps the response to the extension's existing today-usage account fields.
  */
 export async function fetchTodayUsage(
-  _request: ApiServiceRequest,
+  request: ApiServiceAccountRequest,
 ): Promise<TodayUsageData> {
-  return {
-    today_quota_consumption: 0,
-    today_prompt_tokens: 0,
-    today_completion_tokens: 0,
-    today_requests_count: 0,
+  if (request.includeTodayCashflow === false) {
+    return ZERO_TODAY_USAGE_DATA
   }
+
+  const endpoint = createSub2ApiUsageStatsEndpoint()
+  const data = await fetchSub2ApiData<Sub2ApiUsageStatsData>(
+    request,
+    endpoint,
+    {
+      method: "GET",
+      cache: "no-store",
+    },
+  )
+
+  return parseSub2ApiTodayUsage(data, endpoint)
 }
 
 /**
- * Sub2API income stats are not mapped yet; return zeros.
+ * Sub2API income stats are not mapped separately; return zero.
  */
 export async function fetchTodayIncome(
   _request: ApiServiceRequest,
@@ -1097,9 +1145,10 @@ export async function fetchAccountData(
     enableDetection: false,
   }
 
-  const currentUser = await fetchCurrentUser(request)
+  const { currentUser, todayUsage } =
+    await fetchCurrentUserAndTodayUsage(request)
 
-  return createAccountData(currentUser, checkIn)
+  return createAccountData(currentUser, checkIn, todayUsage)
 }
 
 /**
@@ -1148,9 +1197,10 @@ export async function refreshAccountData(
       }
     }
 
-    const currentUser = await fetchCurrentUser(effectiveRequest)
+    const { currentUser, todayUsage } =
+      await fetchCurrentUserAndTodayUsage(effectiveRequest)
 
-    return createRefreshSuccessResult(currentUser, checkIn, {
+    return createRefreshSuccessResult(currentUser, checkIn, todayUsage, {
       ...(hasProactiveRefreshUpdate
         ? {
             accessToken: effectiveRequest.auth.accessToken,
@@ -1180,9 +1230,10 @@ export async function refreshAccountData(
 
           const retryRequest = refreshed.request
 
-          const currentUser = await fetchCurrentUser(retryRequest)
+          const { currentUser, todayUsage } =
+            await fetchCurrentUserAndTodayUsage(retryRequest)
 
-          return createRefreshSuccessResult(currentUser, checkIn, {
+          return createRefreshSuccessResult(currentUser, checkIn, todayUsage, {
             accessToken: retryRequest.auth.accessToken,
             sub2apiAuth: {
               refreshToken: refreshed.refreshToken,

--- a/src/services/apiService/sub2api/parsing.ts
+++ b/src/services/apiService/sub2api/parsing.ts
@@ -18,6 +18,7 @@ import type {
   Sub2ApiKeyListData,
   Sub2ApiKeyWritePayloadBase,
   Sub2ApiUpdateKeyPayload,
+  Sub2ApiUsageStatsData,
 } from "./type"
 
 const SHARED_UNLIMITED_EXPIRED_TIME = -1
@@ -45,6 +46,13 @@ type Sub2ApiUserIdentity = {
   username: string
   balanceUsd: number
   quota: number
+}
+
+type Sub2ApiTodayUsage = {
+  today_quota_consumption: number
+  today_prompt_tokens: number
+  today_completion_tokens: number
+  today_requests_count: number
 }
 
 /**
@@ -330,6 +338,38 @@ export const parseSub2ApiKey = (
     group: parseSub2ApiKeyGroup(data),
     sub2api_group_id: parseSub2ApiKeyGroupId(data),
   })
+}
+
+/**
+ * Parse Sub2API user usage stats from `/api/v1/usage/stats?period=today`.
+ *
+ * Source: https://github.com/Wei-Shaw/sub2api
+ * User usage stats return cost fields in USD (`total_actual_cost`) and token
+ * counts as plain totals under the authenticated `/api/v1/usage/stats` route.
+ */
+export const parseSub2ApiTodayUsage = (
+  payload: unknown,
+  endpoint: string,
+): Sub2ApiTodayUsage => {
+  const data = toObjectRecord<Partial<Sub2ApiUsageStatsData>>(payload, endpoint)
+
+  return {
+    today_quota_consumption: convertUsdBalanceToQuota(
+      toFiniteNumberOrZero(data.total_actual_cost),
+    ),
+    today_prompt_tokens: Math.max(
+      0,
+      Math.trunc(toFiniteNumberOrZero(data.total_input_tokens)),
+    ),
+    today_completion_tokens: Math.max(
+      0,
+      Math.trunc(toFiniteNumberOrZero(data.total_output_tokens)),
+    ),
+    today_requests_count: Math.max(
+      0,
+      Math.trunc(toFiniteNumberOrZero(data.total_requests)),
+    ),
+  }
 }
 
 const parseSub2ApiGroupList = (

--- a/src/services/apiService/sub2api/type.ts
+++ b/src/services/apiService/sub2api/type.ts
@@ -10,6 +10,7 @@ export const SUB2API_KEYS_ENDPOINT = "/api/v1/keys"
 export const SUB2API_ANNOUNCEMENTS_ENDPOINT = "/api/v1/announcements"
 export const SUB2API_AVAILABLE_GROUPS_ENDPOINT = "/api/v1/groups/available"
 export const SUB2API_GROUP_RATES_ENDPOINT = "/api/v1/groups/rates"
+export const SUB2API_USAGE_STATS_ENDPOINT = "/api/v1/usage/stats"
 
 type IntLike = number | string
 type NumericLike = number | string
@@ -80,6 +81,13 @@ export type Sub2ApiKeyData = {
 export type Sub2ApiKeyListData =
   | Sub2ApiPaginatedData<Sub2ApiKeyData>
   | Sub2ApiKeyData[]
+
+export type Sub2ApiUsageStatsData = {
+  total_requests?: NumericLike | null
+  total_input_tokens?: NumericLike | null
+  total_output_tokens?: NumericLike | null
+  total_actual_cost?: NumericLike | null
+}
 
 export type Sub2ApiAnnouncementData = {
   id?: IntLike | null

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -281,7 +281,7 @@ describe("apiService sub2api parsing", () => {
     ).resolves.toBe(false)
   })
 
-  it("returns the fixed unsupported check-in and zero-usage defaults", async () => {
+  it("returns the fixed unsupported check-in and parses today usage", async () => {
     const request = {
       baseUrl: "https://example.com",
       accountId: "account-1",
@@ -291,13 +291,24 @@ describe("apiService sub2api parsing", () => {
       },
     }
 
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: {
+        total_requests: 2,
+        total_input_tokens: 12,
+        total_output_tokens: 8,
+        total_actual_cost: 0.25,
+      },
+    } as any)
+
     await expect(fetchSupportCheckIn(request as any)).resolves.toBe(false)
     await expect(fetchCheckInStatus(request as any)).resolves.toBeUndefined()
     await expect(fetchTodayUsage(request as any)).resolves.toEqual({
-      today_quota_consumption: 0,
-      today_prompt_tokens: 0,
-      today_completion_tokens: 0,
-      today_requests_count: 0,
+      today_quota_consumption: 125000,
+      today_prompt_tokens: 12,
+      today_completion_tokens: 8,
+      today_requests_count: 2,
     })
     await expect(fetchTodayIncome(request as any)).resolves.toEqual({
       today_income: 0,
@@ -542,21 +553,60 @@ describe("apiService sub2api refreshAccountData", () => {
     ...overrides,
   })
 
-  it("returns success without retry when /api/v1/auth/me succeeds", async () => {
+  it("returns success with today usage when /api/v1/auth/me and /api/v1/usage/stats succeed", async () => {
+    vi.mocked(fetchApi)
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: { id: 1, username: "alice", balance: 2 },
+      } as any)
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: {
+          total_requests: 3,
+          total_input_tokens: 120,
+          total_output_tokens: 45,
+          total_actual_cost: 1.25,
+        },
+      } as any)
+
+    const result = await refreshAccountData(createRequest())
+
+    expect(result.success).toBe(true)
+    expect(result.data?.quota).toBe(1_000_000)
+    expect(result.data?.today_quota_consumption).toBe(625_000)
+    expect(result.data?.today_prompt_tokens).toBe(120)
+    expect(result.data?.today_completion_tokens).toBe(45)
+    expect(result.data?.today_requests_count).toBe(3)
+    expect(result.data?.checkIn.enableDetection).toBe(false)
+    expect(result.authUpdate?.userId).toBe("1")
+    expect(result.authUpdate?.username).toBe("alice")
+    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+    expect((vi.mocked(fetchApi).mock.calls[1]?.[1] as any)?.endpoint).toBe(
+      "/api/v1/usage/stats?period=today",
+    )
+  })
+
+  it("skips Sub2API today usage when includeTodayCashflow is false", async () => {
     vi.mocked(fetchApi).mockResolvedValueOnce({
       code: 0,
       message: "ok",
       data: { id: 1, username: "alice", balance: 2 },
     } as any)
 
-    const result = await refreshAccountData(createRequest())
+    const result = await refreshAccountData(
+      createRequest({ includeTodayCashflow: false }),
+    )
 
     expect(result.success).toBe(true)
-    expect(result.data?.quota).toBe(1_000_000)
-    expect(result.data?.checkIn.enableDetection).toBe(false)
-    expect(result.authUpdate?.userId).toBe("1")
-    expect(result.authUpdate?.username).toBe("alice")
-    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+    expect(result.data).toMatchObject({
+      today_quota_consumption: 0,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_requests_count: 0,
+    })
+    expect(fetchApi).toHaveBeenCalledTimes(1)
   })
 
   it("re-syncs token and retries once on HTTP 401 (success)", async () => {
@@ -579,7 +629,6 @@ describe("apiService sub2api refreshAccountData", () => {
     const result = await refreshAccountData(request)
 
     expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(request.baseUrl)
-    expect(fetchApi).toHaveBeenCalledTimes(2)
     const retryRequest = vi.mocked(fetchApi).mock.calls[1]?.[0] as any
     expect(retryRequest?.auth?.accessToken).toBe("new-jwt")
 
@@ -665,7 +714,6 @@ describe("apiService sub2api refreshAccountData", () => {
     const result = await refreshAccountData(request)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchApi).toHaveBeenCalledTimes(1)
     expect(
       (vi.mocked(fetchApi).mock.calls[0]?.[0] as any)?.auth?.accessToken,
     ).toBe("new-jwt")
@@ -795,7 +843,6 @@ describe("apiService sub2api refreshAccountData", () => {
     )
     expect(secondPayload).toEqual({ refresh_token: "rotated-refresh" })
 
-    expect(fetchApi).toHaveBeenCalledTimes(2)
     expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
 
     expect(result.success).toBe(true)
@@ -851,7 +898,6 @@ describe("apiService sub2api refreshAccountData", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
-    expect(fetchApi).toHaveBeenCalledTimes(2)
 
     expect(result.success).toBe(true)
     expect(result.data?.quota).toBe(500_000)
@@ -911,7 +957,6 @@ describe("apiService sub2api refreshAccountData", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(request.baseUrl)
-    expect(fetchApi).toHaveBeenCalledTimes(2)
     expect(
       (vi.mocked(fetchApi).mock.calls[1]?.[0] as any)?.auth?.accessToken,
     ).toBe("resynced-jwt")
@@ -1014,7 +1059,6 @@ describe("apiService sub2api refreshAccountData", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(request.baseUrl)
-    expect(fetchApi).toHaveBeenCalledTimes(2)
     expect(
       (vi.mocked(fetchApi).mock.calls[1]?.[0] as any)?.auth?.accessToken,
     ).toBe("resynced-jwt")


### PR DESCRIPTION
## Summary
- fetch Sub2API user usage stats from the authenticated /api/v1/usage/stats endpoint
- map today's requests, token counts, and actual cost into the existing account data fields
- keep account refresh resilient when usage stats are unavailable or disabled

## Validation
- pnpm vitest run tests/services/apiService/sub2api/index.test.ts
- pnpm compile
- pnpm run validate:push