### PR TITLE
fix(api-transport): skip temp window for backend 403 errors

### DIFF
--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -63,6 +63,11 @@ interface ContentFetchResponse<T> {
 
 const logger = createLogger("ApiTransportRequest")
 
+interface BackendErrorDetails {
+  message: string
+  isBackendError: boolean
+}
+
 // Throttle log endpoints (`/api/log*`) to reduce burst traffic that can trigger
 // upstream rate limits (e.g. concurrent paging for usage + income).
 const LOG_REQUEST_MIN_INTERVAL_MS = 200
@@ -70,6 +75,53 @@ const LOG_REQUEST_MIN_INTERVAL_MS = 200
 const logRequestRateLimiter = createMinIntervalLimiter({
   minIntervalMs: isTestMode() ? 0 : LOG_REQUEST_MIN_INTERVAL_MS,
 })
+
+const getNonEmptyString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value.trim() : undefined
+
+const KNOWN_BACKEND_ERROR_TYPES = new Set(["new_api_error"])
+
+const isKnownBackendErrorType = (value: unknown): boolean =>
+  typeof value === "string" && KNOWN_BACKEND_ERROR_TYPES.has(value.trim())
+
+/**
+ * Extracts known backend-shaped JSON errors so they are not treated as
+ * WAF/challenge 403s that temp-window fallback can recover.
+ */
+function extractBackendErrorDetails(body: unknown): BackendErrorDetails | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return null
+  }
+
+  const topLevelMessage = getNonEmptyString(
+    (body as { message?: unknown }).message,
+  )
+  if (topLevelMessage) {
+    return {
+      message: topLevelMessage,
+      isBackendError: Boolean(
+        (body as { success?: unknown }).success === false,
+      ),
+    }
+  }
+
+  const error = (body as { error?: unknown }).error
+  if (!error || typeof error !== "object" || Array.isArray(error)) {
+    return null
+  }
+
+  const message = getNonEmptyString((error as { message?: unknown }).message)
+  if (!message) {
+    return null
+  }
+
+  return isKnownBackendErrorType((error as { type?: unknown }).type)
+    ? {
+        message,
+        isBackendError: true,
+      }
+    : null
+}
 
 /**
  * Determine if a given endpoint string matches log API patterns.
@@ -435,13 +487,12 @@ const apiRequest = async <T>(
         const responseBody = (await response.clone().json()) as Partial<
           ApiResponse<unknown>
         >
-        if (
-          responseBody &&
-          typeof responseBody === "object" &&
-          typeof responseBody.message === "string" &&
-          responseBody.message.trim()
-        ) {
-          errorMessage = responseBody.message
+        const backendError = extractBackendErrorDetails(responseBody)
+        if (backendError) {
+          errorMessage = backendError.message
+          if (backendError.isBackendError && response.status === 403) {
+            errorCode = API_ERROR_CODES.BUSINESS_ERROR
+          }
         }
       } catch {
         // Keep the generic HTTP status message when the error body is not parseable JSON.

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -569,6 +569,18 @@ async function shouldUseTempWindowFallback(
     return false
   }
 
+  if (error.code === API_ERROR_CODES.BUSINESS_ERROR) {
+    logSkipTempWindowFallback(
+      "Error is a backend business error; temp window fallback cannot recover it.",
+      context,
+      {
+        statusCode: error.statusCode,
+        code: error.code,
+      },
+    )
+    return false
+  }
+
   if (
     !matchesTempWindowFallbackAllowlist(error, context.tempWindowFallback) &&
     !isCookieAuthUnauthorizedFallback(error, context)

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -1559,6 +1559,78 @@ describe("apiTransport request helpers", () => {
     })
   })
 
+  it("fetchApiData should keep primitive JSON 403 errors eligible for temp-window fallback", async () => {
+    mockGetPreferences.mockResolvedValueOnce({
+      tempWindowFallback: {
+        enabled: false,
+        useInPopup: true,
+        useInSidePanel: true,
+        useInOptions: true,
+        useForAutoRefresh: true,
+        useForManualRefresh: true,
+      },
+    })
+    server.use(
+      http.get(API_URL, () => {
+        return HttpResponse.json("gateway denied", { status: 403 })
+      }),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        },
+        { endpoint: ENDPOINT },
+      ),
+    ).rejects.toMatchObject({
+      code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
+      originalCode: "HTTP_403",
+      message: "请求失败: 403",
+    })
+  })
+
+  it("fetchApiData should keep structured 403 errors without messages eligible for temp-window fallback", async () => {
+    mockGetPreferences.mockResolvedValueOnce({
+      tempWindowFallback: {
+        enabled: false,
+        useInPopup: true,
+        useInSidePanel: true,
+        useInOptions: true,
+        useForAutoRefresh: true,
+        useForManualRefresh: true,
+      },
+    })
+    server.use(
+      http.get(API_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "gateway_denied",
+              type: "gateway_error",
+            },
+          },
+          { status: 403 },
+        )
+      }),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        },
+        { endpoint: ENDPOINT },
+      ),
+    ).rejects.toMatchObject({
+      code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
+      originalCode: "HTTP_403",
+      message: "请求失败: 403",
+    })
+  })
+
   it("fetchApiData should tag eligible errors when temp-window fallback is disabled", async () => {
     mockGetPreferences.mockResolvedValueOnce({
       tempWindowFallback: {

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -115,6 +115,37 @@ const BASE_URL = "https://example.com/base/"
 const ENDPOINT = "/api/test"
 const API_URL = "https://example.com/base/api/test"
 
+function mockTempWindowFallbackDisabledPreference() {
+  mockGetPreferences.mockResolvedValueOnce({
+    tempWindowFallback: {
+      enabled: false,
+      useInPopup: true,
+      useInSidePanel: true,
+      useInOptions: true,
+      useForAutoRefresh: true,
+      useForManualRefresh: true,
+    },
+  })
+}
+
+async function expectTempWindowDisabledFallback(
+  endpoint: string = ENDPOINT,
+): Promise<void> {
+  await expect(
+    fetchApiData(
+      {
+        baseUrl: BASE_URL,
+        auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+      },
+      { endpoint },
+    ),
+  ).rejects.toMatchObject({
+    code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
+    originalCode: "HTTP_403",
+    message: "请求失败: 403",
+  })
+}
+
 describe("apiTransport request helpers", () => {
   beforeEach(async () => {
     // Ensure we always use the real implementations even if other tests mock these modules.
@@ -1519,16 +1550,7 @@ describe("apiTransport request helpers", () => {
   })
 
   it("fetchApiData should keep unknown structured 403 errors eligible for temp-window fallback", async () => {
-    mockGetPreferences.mockResolvedValueOnce({
-      tempWindowFallback: {
-        enabled: false,
-        useInPopup: true,
-        useInSidePanel: true,
-        useInOptions: true,
-        useForAutoRefresh: true,
-        useForManualRefresh: true,
-      },
-    })
+    mockTempWindowFallbackDisabledPreference()
     server.use(
       http.get(API_URL, () => {
         return HttpResponse.json(
@@ -1544,64 +1566,22 @@ describe("apiTransport request helpers", () => {
       }),
     )
 
-    await expect(
-      fetchApiData(
-        {
-          baseUrl: BASE_URL,
-          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
-        },
-        { endpoint: ENDPOINT },
-      ),
-    ).rejects.toMatchObject({
-      code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
-      originalCode: "HTTP_403",
-      message: "请求失败: 403",
-    })
+    await expectTempWindowDisabledFallback()
   })
 
   it("fetchApiData should keep primitive JSON 403 errors eligible for temp-window fallback", async () => {
-    mockGetPreferences.mockResolvedValueOnce({
-      tempWindowFallback: {
-        enabled: false,
-        useInPopup: true,
-        useInSidePanel: true,
-        useInOptions: true,
-        useForAutoRefresh: true,
-        useForManualRefresh: true,
-      },
-    })
+    mockTempWindowFallbackDisabledPreference()
     server.use(
       http.get(API_URL, () => {
         return HttpResponse.json("gateway denied", { status: 403 })
       }),
     )
 
-    await expect(
-      fetchApiData(
-        {
-          baseUrl: BASE_URL,
-          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
-        },
-        { endpoint: ENDPOINT },
-      ),
-    ).rejects.toMatchObject({
-      code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
-      originalCode: "HTTP_403",
-      message: "请求失败: 403",
-    })
+    await expectTempWindowDisabledFallback()
   })
 
   it("fetchApiData should keep structured 403 errors without messages eligible for temp-window fallback", async () => {
-    mockGetPreferences.mockResolvedValueOnce({
-      tempWindowFallback: {
-        enabled: false,
-        useInPopup: true,
-        useInSidePanel: true,
-        useInOptions: true,
-        useForAutoRefresh: true,
-        useForManualRefresh: true,
-      },
-    })
+    mockTempWindowFallbackDisabledPreference()
     server.use(
       http.get(API_URL, () => {
         return HttpResponse.json(
@@ -1616,19 +1596,7 @@ describe("apiTransport request helpers", () => {
       }),
     )
 
-    await expect(
-      fetchApiData(
-        {
-          baseUrl: BASE_URL,
-          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
-        },
-        { endpoint: ENDPOINT },
-      ),
-    ).rejects.toMatchObject({
-      code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
-      originalCode: "HTTP_403",
-      message: "请求失败: 403",
-    })
+    await expectTempWindowDisabledFallback()
   })
 
   it("fetchApiData should tag eligible errors when temp-window fallback is disabled", async () => {

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -1481,6 +1481,84 @@ describe("apiTransport request helpers", () => {
     })
   })
 
+  it("fetchApiData should not invoke temp-window fallback for known backend API 403 errors", async () => {
+    const modelsEndpoint = "/v1/models"
+    const modelsUrl = "https://example.com/base/v1/models"
+
+    server.use(
+      http.get(modelsUrl, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "",
+              message: "Access denied for test group",
+              type: "new_api_error",
+            },
+          },
+          { status: 403 },
+        )
+      }),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        },
+        { endpoint: modelsEndpoint },
+      ),
+    ).rejects.toMatchObject({
+      endpoint: modelsEndpoint,
+      statusCode: 403,
+      code: ApiErrorCodes.BUSINESS_ERROR,
+      message: "Access denied for test group",
+    })
+
+    expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
+  })
+
+  it("fetchApiData should keep unknown structured 403 errors eligible for temp-window fallback", async () => {
+    mockGetPreferences.mockResolvedValueOnce({
+      tempWindowFallback: {
+        enabled: false,
+        useInPopup: true,
+        useInSidePanel: true,
+        useInOptions: true,
+        useForAutoRefresh: true,
+        useForManualRefresh: true,
+      },
+    })
+    server.use(
+      http.get(API_URL, () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "gateway_denied",
+              message: "Gateway denied the request",
+              type: "gateway_error",
+            },
+          },
+          { status: 403 },
+        )
+      }),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        },
+        { endpoint: ENDPOINT },
+      ),
+    ).rejects.toMatchObject({
+      code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
+      originalCode: "HTTP_403",
+      message: "请求失败: 403",
+    })
+  })
+
   it("fetchApiData should tag eligible errors when temp-window fallback is disabled", async () => {
     mockGetPreferences.mockResolvedValueOnce({
       tempWindowFallback: {

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -900,4 +900,32 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       }),
     )
   })
+
+  it("skips fallback for backend business errors even when the response status is 403", async () => {
+    const error = new ApiError(
+      "Backend rejected the request",
+      403,
+      "/v1/models",
+      API_ERROR_CODES.BUSINESS_ERROR,
+    )
+
+    await expect(
+      executeWithTempWindowFallback(buildContext(), async () => {
+        throw error
+      }),
+    ).rejects.toBe(error)
+
+    expect(mocks.sendRuntimeMessageMock).not.toHaveBeenCalled()
+    expect(mocks.logger.debug).toHaveBeenCalledWith(
+      "Temp window fallback skipped",
+      expect.objectContaining({
+        reason:
+          "Error is a backend business error; temp window fallback cannot recover it.",
+        extra: expect.objectContaining({
+          statusCode: 403,
+          code: API_ERROR_CODES.BUSINESS_ERROR,
+        }),
+      }),
+    )
+  })
 })


### PR DESCRIPTION
Summary:
- classify known backend JSON 403 errors with error.type new_api_error as business errors
- skip temp-window fallback for backend business errors even when HTTP status is 403
- cover known backend errors and unknown structured 403 fallback eligibility

Validation:
- pnpm exec vitest --run tests/services/apiTransport/request.test.ts tests/utils/tempWindowFetch.fallback.test.ts
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for 403 error handling in API requests.
  * Verified that known backend business errors do not trigger temp-window fallback messages.
  * Added checks for unknown 403 error formats to ensure they return the expected disabled status and user-facing failure message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->