### PR TITLE
refactor(runtime-keys): finish runtime key UI migration

### DIFF
--- a/src/components/dialogs/VerifyApiDialog/index.tsx
+++ b/src/components/dialogs/VerifyApiDialog/index.tsx
@@ -130,7 +130,7 @@ function isRuntimeKeyCompatibleWithModel(
 }
 
 /**
- * Modal dialog that runs API verification for a selected account token + model.
+ * Modal dialog that runs API verification for a selected runtime key + model.
  */
 export function VerifyApiDialog(props: VerifyApiDialogProps) {
   const {
@@ -144,7 +144,7 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
   const { t } = useTranslation("aiApiVerification")
 
   const [isRunning, setIsRunning] = useState(false)
-  const [isLoadingTokens, setIsLoadingTokens] = useState(false)
+  const [isLoadingRuntimeKeys, setIsLoadingRuntimeKeys] = useState(false)
   const [accountRuntimeKeys, setAccountRuntimeKeys] = useState<
     AccountRuntimeKey[]
   >([])
@@ -200,21 +200,22 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
     () => new Set(compatibleRuntimeKeys.map((runtimeKey) => runtimeKey.id)),
     [compatibleRuntimeKeys],
   )
-  const hasLoadedRuntimeKeys = !isLoadingTokens && accountRuntimeKeys.length > 0
-  const hasNoCompatibleToken =
+  const hasLoadedRuntimeKeys =
+    !isLoadingRuntimeKeys && accountRuntimeKeys.length > 0
+  const hasNoCompatibleRuntimeKey =
     hasModelGroupContext &&
     hasLoadedRuntimeKeys &&
     compatibleRuntimeKeys.length === 0
   const selectedRuntimeKeyIsCompatible =
     !selectedRuntimeKey || compatibleRuntimeKeyIds.has(selectedRuntimeKey.id)
-  const hasIncompatibleSelectedToken =
+  const hasIncompatibleSelectedRuntimeKey =
     hasModelGroupContext &&
     selectedRuntimeKey !== undefined &&
     !selectedRuntimeKeyIsCompatible
-  const tokenCompatibilityHint = hasNoCompatibleToken
-    ? t("verifyDialog.noCompatibleTokenHint")
-    : hasIncompatibleSelectedToken
-      ? t("verifyDialog.selectedTokenIncompatibleHint")
+  const runtimeKeyCompatibilityHint = hasNoCompatibleRuntimeKey
+    ? t("verifyDialog.noCompatibleRuntimeKeyHint")
+    : hasIncompatibleSelectedRuntimeKey
+      ? t("verifyDialog.selectedRuntimeKeyIncompatibleHint")
       : null
 
   const tokenModelHint = useMemo(() => {
@@ -249,8 +250,8 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
     )
   }, [account.baseUrl, account.name, t])
 
-  const loadTokens = async () => {
-    setIsLoadingTokens(true)
+  const loadRuntimeKeys = async () => {
+    setIsLoadingRuntimeKeys(true)
     try {
       const runtimeKeys = await fetchDisplayAccountRuntimeKeys(account)
 
@@ -258,7 +259,7 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
 
       setAccountRuntimeKeys(sorted)
 
-      const defaultToken = hasModelGroupContext
+      const defaultRuntimeKey = hasModelGroupContext
         ? sorted.find((runtimeKey) =>
             isRuntimeKeyCompatibleWithModel(runtimeKey, {
               hasModelGroupContext,
@@ -267,9 +268,9 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
             }),
           ) ?? null
         : findDefaultSelectableAccountRuntimeKey(sorted)
-      setSelectedRuntimeKeyId(defaultToken ? defaultToken.id : "")
+      setSelectedRuntimeKeyId(defaultRuntimeKey ? defaultRuntimeKey.id : "")
     } catch (error) {
-      logger.error("Failed to load tokens", {
+      logger.error("Failed to load runtime keys", {
         message: toSanitizedErrorSummary(
           error,
           filterRedactions([account.token, account.cookieAuthSessionCookie]),
@@ -278,7 +279,7 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
       setAccountRuntimeKeys([])
       setSelectedRuntimeKeyId("")
     } finally {
-      setIsLoadingTokens(false)
+      setIsLoadingRuntimeKeys(false)
     }
   }
 
@@ -568,7 +569,7 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
       },
     })
 
-    void loadTokens()
+    void loadRuntimeKeys()
 
     return () => {
       cancelled = true
@@ -605,7 +606,7 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
         <Button
           variant={isRunning ? "destructive" : "success"}
           onClick={isRunning ? stopRun : runAll}
-          disabled={!isRunning && (isLoadingTokens || !canRunAll)}
+          disabled={!isRunning && (isLoadingRuntimeKeys || !canRunAll)}
         >
           {isRunning
             ? t("verifyDialog.actions.stop")
@@ -635,11 +636,14 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           <div className="space-y-1.5">
             <div className="dark:text-dark-text-tertiary text-xs text-gray-500">
-              {t("verifyDialog.meta.token")}
+              {t("verifyDialog.meta.runtimeKey")}
             </div>
             <SearchableSelect
               options={[
-                { value: "", label: t("verifyDialog.meta.tokenPlaceholder") },
+                {
+                  value: "",
+                  label: t("verifyDialog.meta.runtimeKeyPlaceholder"),
+                },
                 ...accountRuntimeKeys.map((runtimeKey) => {
                   const isCompatible = compatibleRuntimeKeyIds.has(
                     runtimeKey.id,
@@ -650,7 +654,7 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
                     disabled: !isCompatible,
                     suffix: isCompatible ? undefined : (
                       <span className="text-xs text-gray-400">
-                        {t("verifyDialog.meta.tokenIncompatible")}
+                        {t("verifyDialog.meta.runtimeKeyIncompatible")}
                       </span>
                     ),
                   }
@@ -658,13 +662,13 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
               ]}
               value={selectedRuntimeKeyId}
               onChange={setSelectedRuntimeKeyId}
-              disabled={isLoadingTokens}
-              placeholder={t("verifyDialog.meta.tokenPlaceholder")}
+              disabled={isLoadingRuntimeKeys}
+              placeholder={t("verifyDialog.meta.runtimeKeyPlaceholder")}
             />
-            {tokenCompatibilityHint ? (
+            {runtimeKeyCompatibilityHint ? (
               <div className="space-y-1.5">
                 <div className="text-xs text-red-500" role="alert">
-                  {tokenCompatibilityHint}
+                  {runtimeKeyCompatibilityHint}
                 </div>
                 {onManageModelKey ? (
                   <Button
@@ -730,8 +734,8 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
 
         {!hasAnyResult && (
           <div className="dark:text-dark-text-secondary text-sm text-gray-600">
-            {isLoadingTokens
-              ? t("verifyDialog.loadingTokensHint")
+            {isLoadingRuntimeKeys
+              ? t("verifyDialog.loadingRuntimeKeysHint")
               : t("verifyDialog.idleHint")}
           </div>
         )}
@@ -836,7 +840,7 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
                     }
                     disabled={
                       isRunning ||
-                      isLoadingTokens ||
+                      isLoadingRuntimeKeys ||
                       (!probe.isRunning &&
                         (!selectedRuntimeKey ||
                           !selectedRuntimeKeyIsCompatible ||

--- a/src/components/dialogs/VerifyCliSupportDialog/index.tsx
+++ b/src/components/dialogs/VerifyCliSupportDialog/index.tsx
@@ -159,6 +159,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
   const toolAbortControllersRef = useRef(
     new Map<(typeof CLI_TOOL_IDS)[number], AbortController>(),
   )
+  const runtimeKeysRequestIdRef = useRef(0)
   const fetchModelsAbortControllerRef = useRef<AbortController | null>(null)
   const fetchModelsRequestIdRef = useRef(0)
 
@@ -220,6 +221,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
   }, [sourceBaseUrl, sourceName, t])
 
   const loadRuntimeKeys = useCallback(async () => {
+    const requestId = (runtimeKeysRequestIdRef.current += 1)
     if (!account) {
       setAccountRuntimeKeys([])
       setSelectedRuntimeKeyId("")
@@ -232,6 +234,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
     setIsLoadingRuntimeKeys(true)
     try {
       const runtimeKeys = await fetchDisplayAccountRuntimeKeys(account)
+      if (runtimeKeysRequestIdRef.current !== requestId) return
 
       const sorted = sortAccountRuntimeKeysActiveFirst(runtimeKeys)
 
@@ -245,10 +248,13 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
           filterRedactions([account.token, account.cookieAuthSessionCookie]),
         ),
       })
+      if (runtimeKeysRequestIdRef.current !== requestId) return
       setAccountRuntimeKeys([])
       setSelectedRuntimeKeyId("")
     } finally {
-      setIsLoadingRuntimeKeys(false)
+      if (runtimeKeysRequestIdRef.current === requestId) {
+        setIsLoadingRuntimeKeys(false)
+      }
     }
   }, [account])
 
@@ -714,6 +720,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
                 onChange={setSelectedRuntimeKeyId}
                 disabled={isLoadingRuntimeKeys}
                 placeholder={t("verifyDialog.meta.runtimeKeyPlaceholder")}
+                data-testid="verify-cli-runtime-key-id"
               />
             </div>
           )}

--- a/src/components/dialogs/VerifyCliSupportDialog/index.tsx
+++ b/src/components/dialogs/VerifyCliSupportDialog/index.tsx
@@ -128,8 +128,8 @@ function extractTokenModelIds(runtimeKey: AccountTokenRuntimeKey) {
 }
 
 /**
- * Modal dialog that runs CLI support simulation for a selected account token or
- * a stored profile.
+ * Modal dialog that runs CLI support simulation for a selected account runtime
+ * key or a stored profile.
  *
  * Each CLI tool implies a fixed API family and endpoint style, so users do not need
  * to pick an API type manually.
@@ -145,7 +145,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
 
   const [modelId, setModelId] = useState<string>(initialModelId?.trim() ?? "")
   const [isRunning, setIsRunning] = useState(false)
-  const [isLoadingTokens, setIsLoadingTokens] = useState(false)
+  const [isLoadingRuntimeKeys, setIsLoadingRuntimeKeys] = useState(false)
   const [accountRuntimeKeys, setAccountRuntimeKeys] = useState<
     AccountRuntimeKey[]
   >([])
@@ -219,25 +219,25 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
     )
   }, [sourceBaseUrl, sourceName, t])
 
-  const loadTokens = useCallback(async () => {
+  const loadRuntimeKeys = useCallback(async () => {
     if (!account) {
       setAccountRuntimeKeys([])
       setSelectedRuntimeKeyId("")
-      setIsLoadingTokens(false)
+      setIsLoadingRuntimeKeys(false)
       return
     }
 
-    setIsLoadingTokens(true)
+    setIsLoadingRuntimeKeys(true)
     try {
       const runtimeKeys = await fetchDisplayAccountRuntimeKeys(account)
 
       const sorted = sortAccountRuntimeKeysActiveFirst(runtimeKeys)
 
       setAccountRuntimeKeys(sorted)
-      const defaultToken = findDefaultSelectableAccountRuntimeKey(sorted)
-      setSelectedRuntimeKeyId(defaultToken ? defaultToken.id : "")
+      const defaultRuntimeKey = findDefaultSelectableAccountRuntimeKey(sorted)
+      setSelectedRuntimeKeyId(defaultRuntimeKey ? defaultRuntimeKey.id : "")
     } catch (error) {
-      logger.error("Failed to load tokens", {
+      logger.error("Failed to load runtime keys", {
         message: toSanitizedErrorSummary(
           error,
           filterRedactions([account.token, account.cookieAuthSessionCookie]),
@@ -246,7 +246,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
       setAccountRuntimeKeys([])
       setSelectedRuntimeKeyId("")
     } finally {
-      setIsLoadingTokens(false)
+      setIsLoadingRuntimeKeys(false)
     }
   }, [account])
 
@@ -641,14 +641,20 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
     if (isProfileSource) {
       setAccountRuntimeKeys([])
       setSelectedRuntimeKeyId("")
-      setIsLoadingTokens(false)
+      setIsLoadingRuntimeKeys(false)
       void loadProfileModels()
     } else {
       setIsLoadingModels(false)
-      void loadTokens()
+      void loadRuntimeKeys()
     }
     setModelId(initialModelId?.trim() ?? "")
-  }, [initialModelId, isOpen, isProfileSource, loadProfileModels, loadTokens])
+  }, [
+    initialModelId,
+    isOpen,
+    isProfileSource,
+    loadProfileModels,
+    loadRuntimeKeys,
+  ])
 
   const canRunAll = hasRunnableSource && resolvedModelId.trim().length > 0
 
@@ -660,7 +666,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
       <Button
         variant={isRunning ? "destructive" : "success"}
         onClick={isRunning ? stopRun : runAll}
-        disabled={!isRunning && (isLoadingTokens || !canRunAll)}
+        disabled={!isRunning && (isLoadingRuntimeKeys || !canRunAll)}
       >
         {isRunning
           ? t("verifyDialog.actions.stop")
@@ -688,11 +694,14 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
           {!isProfileSource && (
             <div className="space-y-1.5">
               <div className="dark:text-dark-text-tertiary text-xs text-gray-500">
-                {t("verifyDialog.meta.token")}
+                {t("verifyDialog.meta.runtimeKey")}
               </div>
               <SearchableSelect
                 options={[
-                  { value: "", label: t("verifyDialog.meta.tokenPlaceholder") },
+                  {
+                    value: "",
+                    label: t("verifyDialog.meta.runtimeKeyPlaceholder"),
+                  },
                   ...accountRuntimeKeys.map((runtimeKey) => ({
                     value: runtimeKey.id,
                     label: runtimeKey.label,
@@ -701,8 +710,8 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
                 ]}
                 value={selectedRuntimeKeyId}
                 onChange={setSelectedRuntimeKeyId}
-                disabled={isLoadingTokens}
-                placeholder={t("verifyDialog.meta.tokenPlaceholder")}
+                disabled={isLoadingRuntimeKeys}
+                placeholder={t("verifyDialog.meta.runtimeKeyPlaceholder")}
               />
             </div>
           )}
@@ -759,8 +768,8 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
               ? isLoadingModels
                 ? t("verifyDialog.loadingModelsHint")
                 : t("verifyDialog.profileIdleHint")
-              : isLoadingTokens
-                ? t("verifyDialog.loadingTokensHint")
+              : isLoadingRuntimeKeys
+                ? t("verifyDialog.loadingRuntimeKeysHint")
                 : t("verifyDialog.idleHint")}
           </div>
         )}
@@ -847,7 +856,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
                     }
                     disabled={
                       isRunning ||
-                      isLoadingTokens ||
+                      isLoadingRuntimeKeys ||
                       (!tool.isRunning &&
                         (!hasRunnableSource || isDisabledForModel))
                     }

--- a/src/components/dialogs/VerifyCliSupportDialog/index.tsx
+++ b/src/components/dialogs/VerifyCliSupportDialog/index.tsx
@@ -227,6 +227,8 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
       return
     }
 
+    setAccountRuntimeKeys([])
+    setSelectedRuntimeKeyId("")
     setIsLoadingRuntimeKeys(true)
     try {
       const runtimeKeys = await fetchDisplayAccountRuntimeKeys(account)

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -31,9 +31,13 @@ import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testId
 import { translateAutoCheckinMessageKey } from "~/features/AutoCheckin/utils/autoCheckin"
 import { exportShareSnapshotWithToast } from "~/features/ShareSnapshots/utils/exportShareSnapshotWithToast"
 import {
-  fetchDisplayAccountRuntimeKeyTokens,
+  accountRuntimeKeyToLegacyAccountToken,
+  collectAccountRuntimeKeySecrets,
+} from "~/services/accounts/accountRuntimeKeys"
+import {
+  fetchDisplayAccountRuntimeKeys,
   InvalidTokenPayloadError,
-  resolveDisplayAccountTokenForSecret,
+  resolveDisplayAccountRuntimeKeySecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { sendAutoCheckinMessage } from "~/services/checkin/autoCheckin/messaging"
 import {
@@ -295,7 +299,7 @@ export default function AccountActionButtons({
     }
   }
 
-  // Smart copy key logic - check token count before deciding action
+  // Smart copy key logic - check runtime-key count before deciding action
   const handleSmartCopyKey = async (e: React.MouseEvent) => {
     e.stopPropagation()
 
@@ -308,49 +312,52 @@ export default function AccountActionButtons({
       entrypoint: optionsEntrypoint,
     })
     setIsCheckingTokens(true)
+    const secretsToRedact = new Set<string>(
+      [site.baseUrl, site.token, site.cookieAuthSessionCookie].filter(
+        Boolean,
+      ) as string[],
+    )
 
     try {
-      // Fetch tokens to check count before deciding action
-      const tokensResponse = await fetchDisplayAccountRuntimeKeyTokens(site)
+      const runtimeKeys = await fetchDisplayAccountRuntimeKeys(site)
+      runtimeKeys
+        .flatMap((runtimeKey) => collectAccountRuntimeKeySecrets([runtimeKey]))
+        .forEach((secret) => secretsToRedact.add(secret))
 
-      if (tokensResponse.length === 1) {
-        // Single token - copy directly
-        const token = tokensResponse[0]
-        const resolvedToken = await resolveDisplayAccountTokenForSecret(
+      if (runtimeKeys.length === 1) {
+        const runtimeKey = runtimeKeys[0]
+        const resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
           site,
-          token,
+          runtimeKey,
         )
-        await navigator.clipboard.writeText(resolvedToken.key)
+        collectAccountRuntimeKeySecrets([resolvedRuntimeKey]).forEach(
+          (secret) => secretsToRedact.add(secret),
+        )
+        await navigator.clipboard.writeText(resolvedRuntimeKey.secret)
         toast.success(t("actions.keyCopied"))
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
           insights: {
-            itemCount: tokensResponse.length,
+            itemCount: runtimeKeys.length,
           },
         })
-      } else if (tokensResponse.length > 1) {
-        // Multiple tokens - open dialog
+      } else if (runtimeKeys.length > 1) {
         onCopyKey(site)
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped, {
           insights: {
-            itemCount: tokensResponse.length,
+            itemCount: runtimeKeys.length,
           },
         })
       } else {
-        // No tokens found - open dialog for actionable empty state
         onCopyKey(site)
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped, {
           insights: {
-            itemCount: tokensResponse.length,
+            itemCount: runtimeKeys.length,
           },
         })
       }
     } catch (error) {
       logger.error("Failed to fetch key list", {
-        diagnostic: toSanitizedErrorSummary(error, [
-          site.baseUrl,
-          site.token,
-          site.cookieAuthSessionCookie ?? "",
-        ]),
+        diagnostic: toSanitizedErrorSummary(error, Array.from(secretsToRedact)),
         siteId: site.id,
         siteType: site.siteType,
       })
@@ -436,32 +443,34 @@ export default function AccountActionButtons({
         ...site,
         baseUrl: accountBaseUrl,
       }
-      const tokensResponse =
-        await fetchDisplayAccountRuntimeKeyTokens(tokenLookupAccount)
+      const runtimeKeys =
+        await fetchDisplayAccountRuntimeKeys(tokenLookupAccount)
+      runtimeKeys
+        .flatMap((runtimeKey) => collectAccountRuntimeKeySecrets([runtimeKey]))
+        .forEach((secret) => secretsToRedact.add(secret))
 
-      if (tokensResponse.length === 0) {
+      if (runtimeKeys.length === 0) {
         return handleChannelLocateFallback(
           t("actions.channelLocateNoKeyFallback"),
         )
       }
 
-      if (tokensResponse.length > 1) {
+      if (runtimeKeys.length > 1) {
         return handleChannelLocateFallback(
           t("actions.channelLocateMultipleKeysFallback"),
         )
       }
 
-      const apiToken = tokensResponse[0]
-      if (apiToken.key) {
-        secretsToRedact.add(apiToken.key)
-      }
-      const resolvedToken = await resolveDisplayAccountTokenForSecret(
+      const runtimeKey = runtimeKeys[0]
+      const resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
         tokenLookupAccount,
-        apiToken,
+        runtimeKey,
       )
-      if (resolvedToken.key) {
-        secretsToRedact.add(resolvedToken.key)
-      }
+      collectAccountRuntimeKeySecrets([resolvedRuntimeKey]).forEach((secret) =>
+        secretsToRedact.add(secret),
+      )
+      const resolvedToken =
+        accountRuntimeKeyToLegacyAccountToken(resolvedRuntimeKey)
       let formData: Awaited<ReturnType<typeof service.prepareChannelFormData>>
       try {
         formData = await service.prepareChannelFormData(

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -164,6 +164,26 @@ const optionsEntrypoint = PRODUCT_ANALYTICS_ENTRYPOINTS.Options
 const rowActionsSurface =
   PRODUCT_ANALYTICS_SURFACE_IDS.OptionsAccountManagementRowActions
 
+const addRedactionSecrets = (
+  secretsToRedact: Set<string>,
+  secrets: Array<string | undefined>,
+) => {
+  secrets.forEach((secret) => {
+    if (secret) {
+      secretsToRedact.add(secret)
+    }
+  })
+}
+
+const addRuntimeKeyRedactionSecrets = (
+  secretsToRedact: Set<string>,
+  runtimeKeys: Parameters<typeof collectAccountRuntimeKeySecrets>[0],
+) => {
+  collectAccountRuntimeKeySecrets(runtimeKeys).forEach((secret) =>
+    secretsToRedact.add(secret),
+  )
+}
+
 const quickCheckinAnalyticsContext: ProductAnalyticsActionContext = {
   featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AutoCheckin,
   actionId: PRODUCT_ANALYTICS_ACTION_IDS.RunQuickCheckin,
@@ -312,17 +332,16 @@ export default function AccountActionButtons({
       entrypoint: optionsEntrypoint,
     })
     setIsCheckingTokens(true)
-    const secretsToRedact = new Set<string>(
-      [site.baseUrl, site.token, site.cookieAuthSessionCookie].filter(
-        Boolean,
-      ) as string[],
-    )
+    const secretsToRedact = new Set<string>()
+    addRedactionSecrets(secretsToRedact, [
+      site.baseUrl,
+      site.token,
+      site.cookieAuthSessionCookie,
+    ])
 
     try {
       const runtimeKeys = await fetchDisplayAccountRuntimeKeys(site)
-      runtimeKeys
-        .flatMap((runtimeKey) => collectAccountRuntimeKeySecrets([runtimeKey]))
-        .forEach((secret) => secretsToRedact.add(secret))
+      addRuntimeKeyRedactionSecrets(secretsToRedact, runtimeKeys)
 
       if (runtimeKeys.length === 1) {
         const runtimeKey = runtimeKeys[0]
@@ -330,19 +349,10 @@ export default function AccountActionButtons({
           site,
           runtimeKey,
         )
-        collectAccountRuntimeKeySecrets([resolvedRuntimeKey]).forEach(
-          (secret) => secretsToRedact.add(secret),
-        )
+        addRuntimeKeyRedactionSecrets(secretsToRedact, [resolvedRuntimeKey])
         await navigator.clipboard.writeText(resolvedRuntimeKey.secret)
         toast.success(t("actions.keyCopied"))
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
-          insights: {
-            itemCount: runtimeKeys.length,
-          },
-        })
-      } else if (runtimeKeys.length > 1) {
-        onCopyKey(site)
-        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped, {
           insights: {
             itemCount: runtimeKeys.length,
           },
@@ -419,9 +429,11 @@ export default function AccountActionButtons({
       showWarningToast(message)
     }
 
-    const secretsToRedact = new Set<string>(
-      [site.token, site.cookieAuthSessionCookie].filter(Boolean) as string[],
-    )
+    const secretsToRedact = new Set<string>()
+    addRedactionSecrets(secretsToRedact, [
+      site.token,
+      site.cookieAuthSessionCookie,
+    ])
 
     try {
       const service = await getManagedSiteService()
@@ -433,11 +445,10 @@ export default function AccountActionButtons({
         )
       }
 
-      collectManagedConfigSecrets(managedConfig).forEach((secret) => {
-        if (secret) {
-          secretsToRedact.add(secret)
-        }
-      })
+      addRedactionSecrets(
+        secretsToRedact,
+        collectManagedConfigSecrets(managedConfig),
+      )
 
       const tokenLookupAccount = {
         ...site,
@@ -445,9 +456,7 @@ export default function AccountActionButtons({
       }
       const runtimeKeys =
         await fetchDisplayAccountRuntimeKeys(tokenLookupAccount)
-      runtimeKeys
-        .flatMap((runtimeKey) => collectAccountRuntimeKeySecrets([runtimeKey]))
-        .forEach((secret) => secretsToRedact.add(secret))
+      addRuntimeKeyRedactionSecrets(secretsToRedact, runtimeKeys)
 
       if (runtimeKeys.length === 0) {
         return handleChannelLocateFallback(
@@ -466,9 +475,7 @@ export default function AccountActionButtons({
         tokenLookupAccount,
         runtimeKey,
       )
-      collectAccountRuntimeKeySecrets([resolvedRuntimeKey]).forEach((secret) =>
-        secretsToRedact.add(secret),
-      )
+      addRuntimeKeyRedactionSecrets(secretsToRedact, [resolvedRuntimeKey])
       const resolvedToken =
         accountRuntimeKeyToLegacyAccountToken(resolvedRuntimeKey)
       let formData: Awaited<ReturnType<typeof service.prepareChannelFormData>>

--- a/src/features/AccountManagement/components/CopyKeyDialog/DialogFooter.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/DialogFooter.tsx
@@ -4,25 +4,23 @@ import { useTranslation } from "react-i18next"
 import { Button } from "~/components/ui"
 
 interface DialogFooterProps {
-  tokenCount: number
+  keyCount: number
   onClose: () => void
 }
 
 /**
- * Footer section for copy key dialog, showing token count summary and close action.
+ * Footer section for copy key dialog, showing key count summary and close action.
  */
-export function DialogFooter({ tokenCount, onClose }: DialogFooterProps) {
+export function DialogFooter({ keyCount, onClose }: DialogFooterProps) {
   const { t } = useTranslation(["ui", "common"])
 
   return (
     <div className="dark:bg-dark-bg-secondary flex items-center justify-between bg-gray-50/50">
       <div className="flex items-center space-x-2">
-        {tokenCount > 0 && (
+        {keyCount > 0 && (
           <div className="dark:text-dark-text-secondary flex items-center space-x-1.5 text-xs text-gray-500">
             <KeyIcon className="h-3 w-3" />
-            <span>
-              {t("ui:dialog.copyKey.totalKeys", { count: tokenCount })}
-            </span>
+            <span>{t("ui:dialog.copyKey.totalKeys", { count: keyCount })}</span>
           </div>
         )}
       </div>

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon, ClockIcon } from "@heroicons/react/24/outline"
 import { Copy } from "lucide-react"
-import { MouseEvent, useState } from "react"
+import { MouseEvent, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { ClaudeCodeRouterImportDialog } from "~/components/ClaudeCodeRouterImportDialog"
@@ -15,11 +15,21 @@ import { ManagedSiteIcon } from "~/components/icons/ManagedSiteIcon"
 import { KiloCodeExportDialog } from "~/components/KiloCodeExportDialog"
 import { IconButton } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { KiloCodeProfileExportDialog } from "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog"
+import {
+  createCliProxyExportPayload,
+  createExportAccount,
+  createExportToken,
+} from "~/features/ApiCredentialProfiles/utils/exportShims"
 import {
   accountRuntimeKeyToLegacyAccountToken,
+  isAccountTokenRuntimeKey,
+  isServiceCredentialRuntimeKey,
   type AccountRuntimeKey,
+  type ServiceCredentialRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
 import { resolveDisplayAccountRuntimeKeySecret } from "~/services/accounts/utils/apiServiceRequest"
+import { buildApiCredentialProfileName } from "~/services/apiCredentialProfiles/accountTokenProfileName"
 import { OpenInCherryStudio } from "~/services/integrations/cherryStudio"
 import { getManagedSiteLabel } from "~/services/managedSites/utils/managedSite"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
@@ -31,7 +41,9 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
 import type { ApiToken, DisplaySiteData } from "~/types"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import { getErrorMessage } from "~/utils/core/error"
 import {
   formatKeyTime,
@@ -40,7 +52,7 @@ import {
 } from "~/utils/core/formatters"
 import { showResultToast } from "~/utils/core/toastHelpers"
 
-interface TokenDetailsProps {
+interface RuntimeKeyDetailsProps {
   runtimeKey: AccountRuntimeKey
   copiedRuntimeKeyId: string | null
   onCopyKey: (runtimeKey: AccountRuntimeKey) => void
@@ -48,16 +60,56 @@ interface TokenDetailsProps {
   onOpenCCSwitchDialog?: (token: ApiToken, account: DisplaySiteData) => void
 }
 
+const SECRET_PREVIEW_PREFIX_LENGTH = 16
+const SECRET_PREVIEW_SUFFIX_LENGTH = 6
+const SECRET_PREVIEW_MASK_LENGTH = 6
+
+const getSecretPreviewParts = (secret: string) => {
+  if (secret.length <= SECRET_PREVIEW_PREFIX_LENGTH) {
+    return {
+      prefix: secret,
+      suffix: "",
+    }
+  }
+
+  return {
+    prefix: secret.slice(0, SECRET_PREVIEW_PREFIX_LENGTH),
+    suffix: secret.slice(-SECRET_PREVIEW_SUFFIX_LENGTH),
+  }
+}
+
+const buildServiceCredentialExportProfile = (
+  account: DisplaySiteData,
+  runtimeKey: ServiceCredentialRuntimeKey,
+): ApiCredentialProfile => {
+  const now = Date.now()
+  return {
+    id: `service-credential:${account.id}:${runtimeKey.service}`,
+    name: buildApiCredentialProfileName({
+      accountName: account.name,
+      fallbackAccountName: account.name,
+      tokenName: runtimeKey.label,
+    }),
+    apiType: API_TYPES.OPENAI_COMPATIBLE,
+    baseUrl: runtimeKey.baseUrl,
+    apiKey: runtimeKey.secret,
+    tagIds: account.tagIds ?? [],
+    notes: "",
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
 /**
- * Displays detailed token metadata, quota information, and export actions inside copy key dialog.
+ * Displays detailed runtime key metadata, quota information, and export actions inside copy key dialog.
  */
-export function TokenDetails({
+export function RuntimeKeyDetails({
   runtimeKey,
   copiedRuntimeKeyId,
   onCopyKey,
   account,
   onOpenCCSwitchDialog,
-}: TokenDetailsProps) {
+}: RuntimeKeyDetailsProps) {
   const { t } = useTranslation(["ui", "keyManagement", "settings"])
   const {
     managedSiteType,
@@ -66,14 +118,24 @@ export function TokenDetails({
     cliProxyBaseUrl,
     cliProxyManagementKey,
   } = useUserPreferencesContext()
-  const { openWithAccount } = useChannelDialog()
+  const { openWithAccount, openWithCredentials } = useChannelDialog()
 
   const [isClaudeCodeRouterOpen, setIsClaudeCodeRouterOpen] = useState(false)
   const [isCliProxyDialogOpen, setIsCliProxyDialogOpen] = useState(false)
   const [isKiloCodeDialogOpen, setIsKiloCodeDialogOpen] = useState(false)
 
   const managedSiteLabel = getManagedSiteLabel(t, managedSiteType)
-  const token = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
+  const accountToken = isAccountTokenRuntimeKey(runtimeKey)
+    ? runtimeKey.token
+    : null
+  const serviceCredentialProfile = useMemo(
+    () =>
+      isServiceCredentialRuntimeKey(runtimeKey)
+        ? buildServiceCredentialExportProfile(account, runtimeKey)
+        : null,
+    [account, runtimeKey],
+  )
+  const secretPreview = getSecretPreviewParts(runtimeKey.secret)
 
   const handleCopy = (event: MouseEvent) => {
     event.stopPropagation()
@@ -91,14 +153,21 @@ export function TokenDetails({
     })
 
     try {
-      const resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
-        account,
-        runtimeKey,
-      )
-      OpenInCherryStudio(
-        account,
-        accountRuntimeKeyToLegacyAccountToken(resolvedRuntimeKey),
-      )
+      if (serviceCredentialProfile) {
+        OpenInCherryStudio(
+          createExportAccount(serviceCredentialProfile),
+          createExportToken(serviceCredentialProfile),
+        )
+      } else {
+        const resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
+          account,
+          runtimeKey,
+        )
+        OpenInCherryStudio(
+          account,
+          accountRuntimeKeyToLegacyAccountToken(resolvedRuntimeKey),
+        )
+      }
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
     } catch (error) {
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -115,7 +184,16 @@ export function TokenDetails({
 
   const handleExportToCCSwitch = (event: MouseEvent) => {
     event.stopPropagation()
-    onOpenCCSwitchDialog?.(token, account)
+    if (serviceCredentialProfile) {
+      onOpenCCSwitchDialog?.(
+        createExportToken(serviceCredentialProfile),
+        createExportAccount(serviceCredentialProfile),
+      )
+      return
+    }
+
+    const legacyToken = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
+    onOpenCCSwitchDialog?.(legacyToken, account)
   }
 
   const handleImportToManagedSite = async (event: MouseEvent) => {
@@ -128,9 +206,27 @@ export function TokenDetails({
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
     })
 
-    const result = await openWithAccount(account, token, (result) => {
-      showResultToast(result)
-    })
+    const result = serviceCredentialProfile
+      ? await openWithCredentials(
+          {
+            name: serviceCredentialProfile.name,
+            baseUrl: serviceCredentialProfile.baseUrl,
+            apiKey: serviceCredentialProfile.apiKey,
+          },
+          (channelResult) => {
+            showResultToast(channelResult)
+          },
+          {
+            managedSiteStatus: undefined,
+          },
+        )
+      : await openWithAccount(
+          account,
+          accountRuntimeKeyToLegacyAccountToken(runtimeKey),
+          (channelResult) => {
+            showResultToast(channelResult)
+          },
+        )
 
     if (result.opened || result.deferred) {
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
@@ -164,63 +260,138 @@ export function TokenDetails({
     setIsClaudeCodeRouterOpen(true)
   }
 
-  return (
-    <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary border-t border-gray-100 bg-gray-50/30 px-3 pb-3">
+  const renderKiloCodeExportDialog = () => {
+    if (!isKiloCodeDialogOpen) return null
+
+    if (serviceCredentialProfile) {
+      return (
+        <KiloCodeProfileExportDialog
+          isOpen={true}
+          onClose={() => setIsKiloCodeDialogOpen(false)}
+          profile={serviceCredentialProfile}
+        />
+      )
+    }
+
+    if (!accountToken) return null
+
+    return (
       <KiloCodeExportDialog
-        isOpen={isKiloCodeDialogOpen}
+        isOpen={true}
         onClose={() => setIsKiloCodeDialogOpen(false)}
         initialSelectedSiteIds={[account.id]}
-        initialSelectedTokenIdsBySite={{ [account.id]: [`${token.id}`] }}
+        initialSelectedTokenIdsBySite={{
+          [account.id]: [`${accountToken.id}`],
+        }}
       />
+    )
+  }
+
+  const renderClaudeCodeRouterImportDialog = () => {
+    if (!isClaudeCodeRouterOpen) return null
+
+    if (serviceCredentialProfile) {
+      return (
+        <ClaudeCodeRouterImportDialog
+          isOpen={true}
+          onClose={() => setIsClaudeCodeRouterOpen(false)}
+          account={createExportAccount(serviceCredentialProfile)}
+          token={createExportToken(serviceCredentialProfile)}
+          routerBaseUrl={claudeCodeRouterBaseUrl}
+          routerApiKey={claudeCodeRouterApiKey}
+        />
+      )
+    }
+
+    const legacyToken = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
+
+    return (
       <ClaudeCodeRouterImportDialog
-        isOpen={isClaudeCodeRouterOpen}
+        isOpen={true}
         onClose={() => setIsClaudeCodeRouterOpen(false)}
         account={account}
-        token={token}
+        token={legacyToken}
         routerBaseUrl={claudeCodeRouterBaseUrl}
         routerApiKey={claudeCodeRouterApiKey}
       />
+    )
+  }
+
+  const renderCliProxyExportDialog = () => {
+    if (!isCliProxyDialogOpen) return null
+
+    if (serviceCredentialProfile) {
+      const cliProxyPayload = createCliProxyExportPayload(
+        serviceCredentialProfile,
+      )
+
+      return (
+        <CliProxyExportDialog
+          isOpen={true}
+          onClose={() => setIsCliProxyDialogOpen(false)}
+          account={cliProxyPayload.account}
+          token={cliProxyPayload.token}
+          apiTypeHint={cliProxyPayload.apiTypeHint}
+        />
+      )
+    }
+
+    const legacyToken = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
+
+    return (
       <CliProxyExportDialog
-        isOpen={isCliProxyDialogOpen}
+        isOpen={true}
         onClose={() => setIsCliProxyDialogOpen(false)}
         account={account}
-        token={token}
+        token={legacyToken}
       />
-      <div className="dark:text-dark-text-secondary mb-3 flex items-center space-x-1 pt-3 text-xs text-gray-500">
-        <ClockIcon className="h-3 w-3" />
-        <span>
-          {t("dialog.copyKey.expireTime", {
-            time: formatKeyTime(token.expired_time),
-          })}
-        </span>
-      </div>
+    )
+  }
 
-      <div className="mb-3 grid grid-cols-2 gap-2">
-        <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary rounded border border-gray-100 bg-white p-2">
-          <div className="dark:text-dark-text-secondary mb-0.5 text-xs text-gray-500">
-            {t("dialog.copyKey.usedQuota")}
+  return (
+    <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary border-t border-gray-100 bg-gray-50/30 px-3 pb-3">
+      {renderKiloCodeExportDialog()}
+      {renderClaudeCodeRouterImportDialog()}
+      {renderCliProxyExportDialog()}
+      {accountToken ? (
+        <div className="dark:text-dark-text-secondary mb-3 flex items-center space-x-1 pt-3 text-xs text-gray-500">
+          <ClockIcon className="h-3 w-3" />
+          <span>
+            {t("dialog.copyKey.expireTime", {
+              time: formatKeyTime(accountToken.expired_time),
+            })}
+          </span>
+        </div>
+      ) : null}
+
+      {accountToken ? (
+        <div className="mb-3 grid grid-cols-2 gap-2">
+          <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary rounded border border-gray-100 bg-white p-2">
+            <div className="dark:text-dark-text-secondary mb-0.5 text-xs text-gray-500">
+              {t("dialog.copyKey.usedQuota")}
+            </div>
+            <div className="dark:text-dark-text-primary text-sm font-semibold text-gray-900">
+              {formatUsedQuota(accountToken)}
+            </div>
           </div>
-          <div className="dark:text-dark-text-primary text-sm font-semibold text-gray-900">
-            {formatUsedQuota(token)}
+          <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary rounded border border-gray-100 bg-white p-2">
+            <div className="dark:text-dark-text-secondary mb-0.5 text-xs text-gray-500">
+              {t("dialog.copyKey.remainingQuota")}
+            </div>
+            <div
+              className={`text-sm font-semibold ${
+                accountToken.unlimited_quota || accountToken.remain_quota < 0
+                  ? "text-green-600"
+                  : accountToken.remain_quota < 1000000
+                    ? "text-orange-600"
+                    : "dark:text-dark-text-primary text-gray-900"
+              }`}
+            >
+              {formatQuota(accountToken)}
+            </div>
           </div>
         </div>
-        <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary rounded border border-gray-100 bg-white p-2">
-          <div className="dark:text-dark-text-secondary mb-0.5 text-xs text-gray-500">
-            {t("dialog.copyKey.remainingQuota")}
-          </div>
-          <div
-            className={`text-sm font-semibold ${
-              token.unlimited_quota || token.remain_quota < 0
-                ? "text-green-600"
-                : token.remain_quota < 1000000
-                  ? "text-orange-600"
-                  : "dark:text-dark-text-primary text-gray-900"
-            }`}
-          >
-            {formatQuota(token)}
-          </div>
-        </div>
-      </div>
+      ) : null}
 
       <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary rounded border border-gray-100 bg-white p-2">
         <div className="mb-1 flex flex-wrap items-center justify-between gap-2">
@@ -303,14 +474,18 @@ export function TokenDetails({
         </div>
         <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary dark:text-dark-text-secondary rounded border border-gray-200 bg-gray-50 px-2 py-1 font-mono text-xs break-all text-gray-700">
           <span className="dark:text-dark-text-primary text-gray-900">
-            {token.key.substring(0, 16)}
+            {secretPreview.prefix}
           </span>
-          <span className="text-gray-400 dark:text-gray-600">
-            {"•".repeat(6)}
-          </span>
-          <span className="dark:text-dark-text-primary text-gray-900">
-            {token.key.substring(token.key.length - 6)}
-          </span>
+          {secretPreview.suffix ? (
+            <>
+              <span className="text-gray-400 dark:text-gray-600">
+                {"•".repeat(SECRET_PREVIEW_MASK_LENGTH)}
+              </span>
+              <span className="dark:text-dark-text-primary text-gray-900">
+                {secretPreview.suffix}
+              </span>
+            </>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
@@ -65,7 +65,10 @@ const SECRET_PREVIEW_SUFFIX_LENGTH = 6
 const SECRET_PREVIEW_MASK_LENGTH = 6
 
 const getSecretPreviewParts = (secret: string) => {
-  if (secret.length <= SECRET_PREVIEW_PREFIX_LENGTH) {
+  if (
+    secret.length <=
+    SECRET_PREVIEW_PREFIX_LENGTH + SECRET_PREVIEW_SUFFIX_LENGTH
+  ) {
     return {
       prefix: secret,
       suffix: "",

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
@@ -12,14 +12,18 @@ import {
   type AccountRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
 import type { ApiToken, DisplaySiteData } from "~/types"
-import {
-  getGroupBadgeStyle,
-  getStatusBadgeStyle,
-} from "~/utils/core/formatters"
+import { getGroupBadgeStyle } from "~/utils/core/formatters"
 
-import { TokenDetails } from "./TokenDetails"
+import { RuntimeKeyDetails } from "./RuntimeKeyDetails"
 
-interface TokenItemProps {
+const getRuntimeKeyStatusBadgeStyle = (
+  runtimeKey: Pick<AccountRuntimeKey, "status">,
+): string =>
+  runtimeKey.status === ACCOUNT_RUNTIME_KEY_STATUSES.Active
+    ? "bg-green-100 text-green-800 border-green-200"
+    : "bg-red-100 text-red-800 border-red-200"
+
+interface RuntimeKeyItemProps {
   runtimeKey: AccountRuntimeKey
   isExpanded: boolean
   copiedRuntimeKeyId: string | null
@@ -30,9 +34,9 @@ interface TokenItemProps {
 }
 
 /**
- * Collapsible card for a single API token showing group, status, and expanded details.
+ * Collapsible card for a single runtime key showing group, status, and expanded details.
  */
-export function TokenItem({
+export function RuntimeKeyItem({
   runtimeKey,
   isExpanded,
   copiedRuntimeKeyId,
@@ -40,13 +44,12 @@ export function TokenItem({
   onCopyKey,
   account,
   onOpenCCSwitchDialog,
-}: TokenItemProps) {
+}: RuntimeKeyItemProps) {
   const { t } = useTranslation("ui")
   const group = isAccountTokenRuntimeKey(runtimeKey)
     ? runtimeKey.token.group
     : ""
-  const status =
-    runtimeKey.status === ACCOUNT_RUNTIME_KEY_STATUSES.Active ? 1 : 2
+  const isActive = runtimeKey.status === ACCOUNT_RUNTIME_KEY_STATUSES.Active
 
   return (
     <Card variant="interactive" padding="none">
@@ -74,11 +77,11 @@ export function TokenItem({
 
           <div className="ml-3 flex items-center space-x-2">
             <Badge
-              variant={status === 1 ? "success" : "secondary"}
+              variant={isActive ? "success" : "secondary"}
               size="sm"
-              className={getStatusBadgeStyle(status)}
+              className={getRuntimeKeyStatusBadgeStyle(runtimeKey)}
             >
-              {status === 1
+              {isActive
                 ? t("dialog.copyKey.enabled")
                 : t("dialog.copyKey.disabled")}
             </Badge>
@@ -101,7 +104,7 @@ export function TokenItem({
       </CardContent>
 
       {isExpanded && (
-        <TokenDetails
+        <RuntimeKeyDetails
           runtimeKey={runtimeKey}
           copiedRuntimeKeyId={copiedRuntimeKeyId}
           onCopyKey={onCopyKey}

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyList.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyList.tsx
@@ -9,9 +9,9 @@ import { Alert, EmptyState } from "~/components/ui"
 import type { AccountRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import type { ApiToken, DisplaySiteData } from "~/types"
 
-import { TokenItem } from "./TokenItem"
+import { RuntimeKeyItem } from "./RuntimeKeyItem"
 
-interface TokenListProps {
+interface RuntimeKeyListProps {
   runtimeKeys: AccountRuntimeKey[]
   expandedRuntimeKeys: Set<string>
   copiedRuntimeKeyId: string | null
@@ -27,9 +27,9 @@ interface TokenListProps {
 }
 
 /**
- * List view wrapper for TokenItem elements, handling empty states and expansion toggles.
+ * List view wrapper for RuntimeKeyItem elements, handling empty states and expansion toggles.
  */
-export function TokenList({
+export function RuntimeKeyList({
   runtimeKeys,
   expandedRuntimeKeys,
   copiedRuntimeKeyId,
@@ -42,7 +42,7 @@ export function TokenList({
   createError,
   onCreateDefaultKey,
   onOpenAddTokenDialog,
-}: TokenListProps) {
+}: RuntimeKeyListProps) {
   const { t } = useTranslation("ui")
 
   if (!Array.isArray(runtimeKeys) || runtimeKeys.length === 0) {
@@ -91,7 +91,7 @@ export function TokenList({
   return (
     <div className="space-y-3">
       {runtimeKeys.map((runtimeKey) => (
-        <TokenItem
+        <RuntimeKeyItem
           key={runtimeKey.id}
           runtimeKey={runtimeKey}
           isExpanded={expandedRuntimeKeys.has(runtimeKey.id)}

--- a/src/features/AccountManagement/components/CopyKeyDialog/TokenDetails.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/TokenDetails.tsx
@@ -15,7 +15,11 @@ import { ManagedSiteIcon } from "~/components/icons/ManagedSiteIcon"
 import { KiloCodeExportDialog } from "~/components/KiloCodeExportDialog"
 import { IconButton } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
-import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  accountRuntimeKeyToLegacyAccountToken,
+  type AccountRuntimeKey,
+} from "~/services/accounts/accountRuntimeKeys"
+import { resolveDisplayAccountRuntimeKeySecret } from "~/services/accounts/utils/apiServiceRequest"
 import { OpenInCherryStudio } from "~/services/integrations/cherryStudio"
 import { getManagedSiteLabel } from "~/services/managedSites/utils/managedSite"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
@@ -37,9 +41,9 @@ import {
 import { showResultToast } from "~/utils/core/toastHelpers"
 
 interface TokenDetailsProps {
-  token: ApiToken
-  copiedTokenId: number | null
-  onCopyKey: (token: ApiToken) => void
+  runtimeKey: AccountRuntimeKey
+  copiedRuntimeKeyId: string | null
+  onCopyKey: (runtimeKey: AccountRuntimeKey) => void
   account: DisplaySiteData
   onOpenCCSwitchDialog?: (token: ApiToken, account: DisplaySiteData) => void
 }
@@ -48,8 +52,8 @@ interface TokenDetailsProps {
  * Displays detailed token metadata, quota information, and export actions inside copy key dialog.
  */
 export function TokenDetails({
-  token,
-  copiedTokenId,
+  runtimeKey,
+  copiedRuntimeKeyId,
   onCopyKey,
   account,
   onOpenCCSwitchDialog,
@@ -69,10 +73,11 @@ export function TokenDetails({
   const [isKiloCodeDialogOpen, setIsKiloCodeDialogOpen] = useState(false)
 
   const managedSiteLabel = getManagedSiteLabel(t, managedSiteType)
+  const token = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
 
   const handleCopy = (event: MouseEvent) => {
     event.stopPropagation()
-    void onCopyKey(token)
+    void onCopyKey(runtimeKey)
   }
 
   const handleUseInCherry = async (event: MouseEvent) => {
@@ -86,11 +91,14 @@ export function TokenDetails({
     })
 
     try {
-      const resolvedToken = await resolveDisplayAccountTokenForSecret(
+      const resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
         account,
-        token,
+        runtimeKey,
       )
-      OpenInCherryStudio(account, resolvedToken)
+      OpenInCherryStudio(
+        account,
+        accountRuntimeKeyToLegacyAccountToken(resolvedRuntimeKey),
+      )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
     } catch (error) {
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -222,7 +230,7 @@ export function TokenDetails({
           <div className="flex flex-wrap items-center gap-1 sm:gap-1.5">
             <IconButton
               aria-label={
-                copiedTokenId === token.id
+                copiedRuntimeKeyId === runtimeKey.id
                   ? t("dialog.copyKey.copied")
                   : t("dialog.copyKey.copy")
               }
@@ -230,7 +238,7 @@ export function TokenDetails({
               size="sm"
               onClick={handleCopy}
             >
-              {copiedTokenId === token.id ? (
+              {copiedRuntimeKeyId === runtimeKey.id ? (
                 <CheckIcon className="h-4 w-4 text-green-500" />
               ) : (
                 <Copy className="dark:text-dark-text-tertiary h-4 w-4 text-gray-500" />

--- a/src/features/AccountManagement/components/CopyKeyDialog/TokenItem.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/TokenItem.tsx
@@ -6,6 +6,8 @@ import {
 import { useTranslation } from "react-i18next"
 
 import { Badge, Card, CardContent, IconButton } from "~/components/ui"
+import { accountRuntimeKeyToLegacyAccountToken } from "~/services/accounts/accountRuntimeKeys"
+import type { AccountRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import type { ApiToken, DisplaySiteData } from "~/types"
 import {
   getGroupBadgeStyle,
@@ -15,11 +17,11 @@ import {
 import { TokenDetails } from "./TokenDetails"
 
 interface TokenItemProps {
-  token: ApiToken
+  runtimeKey: AccountRuntimeKey
   isExpanded: boolean
-  copiedTokenId: number | null
+  copiedRuntimeKeyId: string | null
   onToggle: () => void
-  onCopyKey: (token: ApiToken) => void
+  onCopyKey: (runtimeKey: AccountRuntimeKey) => void
   account: DisplaySiteData
   onOpenCCSwitchDialog?: (token: ApiToken, account: DisplaySiteData) => void
 }
@@ -28,15 +30,16 @@ interface TokenItemProps {
  * Collapsible card for a single API token showing group, status, and expanded details.
  */
 export function TokenItem({
-  token,
+  runtimeKey,
   isExpanded,
-  copiedTokenId,
+  copiedRuntimeKeyId,
   onToggle,
   onCopyKey,
   account,
   onOpenCCSwitchDialog,
 }: TokenItemProps) {
   const { t } = useTranslation("ui")
+  const token = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
 
   return (
     <Card variant="interactive" padding="none">
@@ -92,8 +95,8 @@ export function TokenItem({
 
       {isExpanded && (
         <TokenDetails
-          token={token}
-          copiedTokenId={copiedTokenId}
+          runtimeKey={runtimeKey}
+          copiedRuntimeKeyId={copiedRuntimeKeyId}
           onCopyKey={onCopyKey}
           account={account}
           onOpenCCSwitchDialog={onOpenCCSwitchDialog}

--- a/src/features/AccountManagement/components/CopyKeyDialog/TokenItem.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/TokenItem.tsx
@@ -6,8 +6,11 @@ import {
 import { useTranslation } from "react-i18next"
 
 import { Badge, Card, CardContent, IconButton } from "~/components/ui"
-import { accountRuntimeKeyToLegacyAccountToken } from "~/services/accounts/accountRuntimeKeys"
-import type { AccountRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
+import {
+  ACCOUNT_RUNTIME_KEY_STATUSES,
+  isAccountTokenRuntimeKey,
+  type AccountRuntimeKey,
+} from "~/services/accounts/accountRuntimeKeys"
 import type { ApiToken, DisplaySiteData } from "~/types"
 import {
   getGroupBadgeStyle,
@@ -39,7 +42,11 @@ export function TokenItem({
   onOpenCCSwitchDialog,
 }: TokenItemProps) {
   const { t } = useTranslation("ui")
-  const token = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
+  const group = isAccountTokenRuntimeKey(runtimeKey)
+    ? runtimeKey.token.group
+    : ""
+  const status =
+    runtimeKey.status === ACCOUNT_RUNTIME_KEY_STATUSES.Active ? 1 : 2
 
   return (
     <Card variant="interactive" padding="none">
@@ -51,27 +58,27 @@ export function TokenItem({
         <div className="flex items-center justify-between">
           <div className="min-w-0 flex-1 space-y-1.5">
             <h4 className="dark:text-dark-text-primary truncate text-sm font-medium text-gray-900">
-              {token.name}
+              {runtimeKey.label}
             </h4>
             <div className="flex items-center space-x-1.5">
               <UserGroupIcon className="h-3 w-3 text-gray-400 dark:text-gray-500" />
               <Badge
                 variant="outline"
                 size="sm"
-                className={getGroupBadgeStyle(token.group || "")}
+                className={getGroupBadgeStyle(group || "")}
               >
-                {token.group || t("dialog.copyKey.defaultGroup")}
+                {group || t("dialog.copyKey.defaultGroup")}
               </Badge>
             </div>
           </div>
 
           <div className="ml-3 flex items-center space-x-2">
             <Badge
-              variant={token.status === 1 ? "success" : "secondary"}
+              variant={status === 1 ? "success" : "secondary"}
               size="sm"
-              className={getStatusBadgeStyle(token.status)}
+              className={getStatusBadgeStyle(status)}
             >
-              {token.status === 1
+              {status === 1
                 ? t("dialog.copyKey.enabled")
                 : t("dialog.copyKey.disabled")}
             </Badge>

--- a/src/features/AccountManagement/components/CopyKeyDialog/TokenList.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/TokenList.tsx
@@ -6,16 +6,17 @@ import {
 import { useTranslation } from "react-i18next"
 
 import { Alert, EmptyState } from "~/components/ui"
+import type { AccountRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import type { ApiToken, DisplaySiteData } from "~/types"
 
 import { TokenItem } from "./TokenItem"
 
 interface TokenListProps {
-  tokens: ApiToken[]
-  expandedTokens: Set<number>
-  copiedTokenId: number | null
-  onToggleToken: (id: number) => void
-  onCopyKey: (token: ApiToken) => void
+  runtimeKeys: AccountRuntimeKey[]
+  expandedRuntimeKeys: Set<string>
+  copiedRuntimeKeyId: string | null
+  onToggleRuntimeKey: (id: string) => void
+  onCopyKey: (runtimeKey: AccountRuntimeKey) => void
   account: DisplaySiteData
   onOpenCCSwitchDialog?: (token: ApiToken, account: DisplaySiteData) => void
   canCreateDefaultKey?: boolean
@@ -29,10 +30,10 @@ interface TokenListProps {
  * List view wrapper for TokenItem elements, handling empty states and expansion toggles.
  */
 export function TokenList({
-  tokens,
-  expandedTokens,
-  copiedTokenId,
-  onToggleToken,
+  runtimeKeys,
+  expandedRuntimeKeys,
+  copiedRuntimeKeyId,
+  onToggleRuntimeKey,
   onCopyKey,
   account,
   onOpenCCSwitchDialog,
@@ -44,7 +45,7 @@ export function TokenList({
 }: TokenListProps) {
   const { t } = useTranslation("ui")
 
-  if (!Array.isArray(tokens) || tokens.length === 0) {
+  if (!Array.isArray(runtimeKeys) || runtimeKeys.length === 0) {
     const actions = [
       ...(onCreateDefaultKey
         ? [
@@ -89,13 +90,13 @@ export function TokenList({
 
   return (
     <div className="space-y-3">
-      {tokens.map((token) => (
+      {runtimeKeys.map((runtimeKey) => (
         <TokenItem
-          key={token.id}
-          token={token}
-          isExpanded={expandedTokens.has(token.id)}
-          copiedTokenId={copiedTokenId}
-          onToggle={() => onToggleToken(token.id)}
+          key={runtimeKey.id}
+          runtimeKey={runtimeKey}
+          isExpanded={expandedRuntimeKeys.has(runtimeKey.id)}
+          copiedRuntimeKeyId={copiedRuntimeKeyId}
+          onToggle={() => onToggleRuntimeKey(runtimeKey.id)}
           onCopyKey={onCopyKey}
           account={account}
           onOpenCCSwitchDialog={onOpenCCSwitchDialog}

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -3,6 +3,10 @@ import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { resolveDefaultTokenQuickCreateResolution } from "~/services/accounts/accountOperations"
+import {
+  buildDisplayAccountTokenRuntimeKey,
+  type AccountRuntimeKey,
+} from "~/services/accounts/accountRuntimeKeys"
 import { shouldShowOneTimeKeyDialogForCreatedToken } from "~/services/accounts/createdTokenSecretHandling"
 import {
   canCreateAccountApiTokens,
@@ -11,10 +15,10 @@ import {
 import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
 import {
   createDisplayAccountApiContext,
-  fetchDisplayAccountRuntimeKeyTokens,
+  fetchDisplayAccountRuntimeKeys,
   InvalidTokenPayloadError,
   requireDisplayAccountKeyManagement,
-  resolveDisplayAccountTokenForSecret,
+  resolveDisplayAccountRuntimeKeySecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { formatOptionalSkPrefixSiteToken } from "~/services/accountTokens/apiTokenKey"
 import { TOKEN_PROVISIONING_ERRORS } from "~/services/apiAdapters/contracts/tokenProvisioning"
@@ -62,7 +66,7 @@ export function useCopyKeyDialog(
   account: DisplaySiteData | null,
 ) {
   const { t } = useTranslation(["ui", "messages"])
-  const [tokens, setTokens] = useState<ApiToken[]>([])
+  const [runtimeKeys, setRuntimeKeys] = useState<AccountRuntimeKey[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isCreating, setIsCreating] = useState(false)
@@ -70,8 +74,12 @@ export function useCopyKeyDialog(
   const [oneTimeToken, setOneTimeToken] = useState<ApiToken | null>(null)
   const [defaultTokenCreateAllowedGroups, setDefaultTokenCreateAllowedGroups] =
     useState<string[] | null>(null)
-  const [copiedTokenId, setCopiedTokenId] = useState<number | null>(null)
-  const [expandedTokens, setExpandedTokens] = useState<Set<number>>(new Set())
+  const [copiedRuntimeKeyId, setCopiedRuntimeKeyId] = useState<string | null>(
+    null,
+  )
+  const [expandedRuntimeKeys, setExpandedRuntimeKeys] = useState<Set<string>>(
+    new Set(),
+  )
   const copiedTokenResetTimeoutRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null)
@@ -103,13 +111,13 @@ export function useCopyKeyDialog(
     if (!account) return
     if (!canLoadRuntimeKeys) {
       fetchRequestIdRef.current += 1
-      setTokens([])
+      setRuntimeKeys([])
       setError(null)
       setCreateError(null)
       setOneTimeToken(null)
       clearDefaultTokenCreateAllowedGroups()
-      setCopiedTokenId(null)
-      setExpandedTokens(new Set())
+      setCopiedRuntimeKeyId(null)
+      setExpandedRuntimeKeys(new Set())
       setIsLoading(false)
       return
     }
@@ -121,9 +129,9 @@ export function useCopyKeyDialog(
     clearDefaultTokenCreateAllowedGroups()
 
     try {
-      const tokensResponse = await fetchDisplayAccountRuntimeKeyTokens(account)
+      const loadedRuntimeKeys = await fetchDisplayAccountRuntimeKeys(account)
       if (fetchRequestIdRef.current !== requestId) return
-      setTokens(tokensResponse)
+      setRuntimeKeys(loadedRuntimeKeys)
     } catch (error) {
       if (fetchRequestIdRef.current !== requestId) return
       logger.error("Failed to load key list", {
@@ -149,14 +157,14 @@ export function useCopyKeyDialog(
       fetchTokens()
     } else {
       clearCopiedTokenResetTimeout()
-      setTokens([])
+      setRuntimeKeys([])
       setError(null)
       setIsCreating(false)
       setCreateError(null)
       setOneTimeToken(null)
       clearDefaultTokenCreateAllowedGroups()
-      setCopiedTokenId(null)
-      setExpandedTokens(new Set())
+      setCopiedRuntimeKeyId(null)
+      setExpandedRuntimeKeys(new Set())
     }
   }, [
     account,
@@ -173,24 +181,24 @@ export function useCopyKeyDialog(
   }, [clearCopiedTokenResetTimeout])
 
   const copyKey = useCallback(
-    async (token: ApiToken) => {
+    async (runtimeKey: AccountRuntimeKey) => {
       if (!account) return
 
       const tracker = startProductAnalyticsAction(copyKeyAnalyticsContext)
 
       try {
-        const resolvedToken = await resolveDisplayAccountTokenForSecret(
+        const resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
           account,
-          token,
+          runtimeKey,
         )
-        await navigator.clipboard.writeText(resolvedToken.key)
-        setCopiedTokenId(token.id)
+        await navigator.clipboard.writeText(resolvedRuntimeKey.secret)
+        setCopiedRuntimeKeyId(runtimeKey.id)
         toast.success(t("ui:dialog.copyKey.keyCopied"))
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
 
         clearCopiedTokenResetTimeout()
         copiedTokenResetTimeoutRef.current = setTimeout(() => {
-          setCopiedTokenId(null)
+          setCopiedRuntimeKeyId(null)
           copiedTokenResetTimeoutRef.current = null
         }, 2000)
       } catch (error) {
@@ -234,30 +242,34 @@ export function useCopyKeyDialog(
           shouldShowOneTimeKeyDialogForCreatedToken(account, createdToken)
 
         if (createdToken && shouldShowOneTimeKeyDialog) {
-          setTokens((currentTokens) => {
-            const withoutCreated = currentTokens.filter(
-              (token) => token.id !== createdToken.id,
+          const createdRuntimeKey = buildDisplayAccountTokenRuntimeKey(
+            account,
+            createdToken,
+          )
+          setRuntimeKeys((currentRuntimeKeys) => {
+            const withoutCreated = currentRuntimeKeys.filter(
+              (runtimeKey) => runtimeKey.id !== createdRuntimeKey.id,
             )
-            return [...withoutCreated, createdToken]
+            return [...withoutCreated, createdRuntimeKey]
           })
           setOneTimeToken(
             formatOptionalSkPrefixSiteToken(createdToken, account.siteType),
           )
-          await copyKey(createdToken)
+          await copyKey(createdRuntimeKey)
           return
         }
 
-        const refreshedTokens =
-          await fetchDisplayAccountRuntimeKeyTokens(account)
-        setTokens(refreshedTokens)
+        const refreshedRuntimeKeys =
+          await fetchDisplayAccountRuntimeKeys(account)
+        setRuntimeKeys(refreshedRuntimeKeys)
 
-        if (refreshedTokens.length === 0) {
+        if (refreshedRuntimeKeys.length === 0) {
           setCreateError(t("ui:dialog.copyKey.noKeyFoundAfterCreate"))
           return
         }
 
-        if (refreshedTokens.length === 1) {
-          await copyKey(refreshedTokens[0])
+        if (refreshedRuntimeKeys.length === 1) {
+          await copyKey(refreshedRuntimeKeys[0])
           return
         }
 
@@ -347,34 +359,34 @@ export function useCopyKeyDialog(
     t,
   ])
 
-  const toggleTokenExpansion = (tokenId: number) => {
-    setExpandedTokens((prev) => {
+  const toggleRuntimeKeyExpansion = (runtimeKeyId: string) => {
+    setExpandedRuntimeKeys((prev) => {
       const newSet = new Set(prev)
-      if (newSet.has(tokenId)) {
-        newSet.delete(tokenId)
+      if (newSet.has(runtimeKeyId)) {
+        newSet.delete(runtimeKeyId)
       } else {
-        newSet.add(tokenId)
+        newSet.add(runtimeKeyId)
       }
       return newSet
     })
   }
 
   return {
-    tokens,
+    runtimeKeys,
     isLoading,
     error,
     isCreating,
     createError,
     oneTimeToken,
     defaultTokenCreateAllowedGroups,
-    copiedTokenId,
-    expandedTokens,
+    copiedRuntimeKeyId,
+    expandedRuntimeKeys,
     canCreateDefaultKey,
     fetchTokens,
     copyKey,
     createDefaultKey,
     refreshTokensAfterCreate,
-    toggleTokenExpansion,
+    toggleRuntimeKeyExpansion,
     clearDefaultTokenCreateAllowedGroups,
     clearOneTimeToken: () => setOneTimeToken(null),
   }

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { resolveDefaultTokenQuickCreateResolution } from "~/services/accounts/accountOperations"
 import {
+  appendOrReplaceAccountRuntimeKey,
   buildDisplayAccountTokenRuntimeKey,
   type AccountRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
@@ -16,12 +17,15 @@ import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQu
 import {
   createDisplayAccountApiContext,
   fetchDisplayAccountRuntimeKeys,
-  InvalidTokenPayloadError,
+  getRuntimeKeyInventoryErrorMessage,
   requireDisplayAccountKeyManagement,
   resolveDisplayAccountRuntimeKeySecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { formatOptionalSkPrefixSiteToken } from "~/services/accountTokens/apiTokenKey"
-import { TOKEN_PROVISIONING_ERRORS } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import {
+  isCreatedApiToken,
+  TOKEN_PROVISIONING_ERRORS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -36,7 +40,7 @@ import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
 /**
- * Logger scoped to the "copy key" dialog so token-loading and clipboard failures can be diagnosed safely.
+ * Logger scoped to the "copy key" dialog so runtime-key loading and clipboard failures can be diagnosed safely.
  */
 const logger = createLogger("CopyKeyDialogHook")
 const copyKeyAnalyticsContext = {
@@ -46,20 +50,11 @@ const copyKeyAnalyticsContext = {
   entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
 }
 
-const isCreatedApiToken = (value: unknown): value is ApiToken =>
-  !!value &&
-  typeof value === "object" &&
-  typeof (value as Partial<ApiToken>).id === "number" &&
-  typeof (value as Partial<ApiToken>).key === "string"
-
-const getTokenInventoryErrorMessage = (error: unknown, fallback: string) =>
-  error instanceof InvalidTokenPayloadError ? fallback : getErrorMessage(error)
-
 /**
- * CopyKeyDialog 核心逻辑 hook，负责加载 token、处理复制与展开状态。
+ * CopyKeyDialog 核心逻辑 hook，负责加载 runtime key、处理复制与展开状态。
  * @param isOpen 对话框是否打开
  * @param account 当前账号（可能为空）
- * @returns token 数据、加载状态、错误以及相关操作方法
+ * @returns runtime key 数据、加载状态、错误以及相关操作方法
  */
 export function useCopyKeyDialog(
   isOpen: boolean,
@@ -80,10 +75,10 @@ export function useCopyKeyDialog(
   const [expandedRuntimeKeys, setExpandedRuntimeKeys] = useState<Set<string>>(
     new Set(),
   )
-  const copiedTokenResetTimeoutRef = useRef<ReturnType<
+  const copiedRuntimeKeyResetTimeoutRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null)
-  // Incremented to invalidate slower token inventory requests after account eligibility changes.
+  // Incremented to invalidate slower runtime-key inventory requests after account eligibility changes.
   const fetchRequestIdRef = useRef(0)
 
   const canCreateDefaultKey = useMemo(
@@ -96,18 +91,18 @@ export function useCopyKeyDialog(
     [account],
   )
 
-  const clearCopiedTokenResetTimeout = useCallback(() => {
-    if (copiedTokenResetTimeoutRef.current === null) return
+  const clearCopiedRuntimeKeyResetTimeout = useCallback(() => {
+    if (copiedRuntimeKeyResetTimeoutRef.current === null) return
 
-    clearTimeout(copiedTokenResetTimeoutRef.current)
-    copiedTokenResetTimeoutRef.current = null
+    clearTimeout(copiedRuntimeKeyResetTimeoutRef.current)
+    copiedRuntimeKeyResetTimeoutRef.current = null
   }, [])
 
   const clearDefaultTokenCreateAllowedGroups = useCallback(() => {
     setDefaultTokenCreateAllowedGroups(null)
   }, [])
 
-  const fetchTokens = useCallback(async () => {
+  const fetchRuntimeKeys = useCallback(async () => {
     if (!account) return
     if (!canLoadRuntimeKeys) {
       fetchRequestIdRef.current += 1
@@ -140,7 +135,7 @@ export function useCopyKeyDialog(
         baseUrl: account.baseUrl,
         siteType: account.siteType,
       })
-      const errorMessage = getTokenInventoryErrorMessage(
+      const errorMessage = getRuntimeKeyInventoryErrorMessage(
         error,
         t("ui:dialog.copyKey.getFailed"),
       )
@@ -154,9 +149,9 @@ export function useCopyKeyDialog(
 
   useEffect(() => {
     if (isOpen && account) {
-      fetchTokens()
+      fetchRuntimeKeys()
     } else {
-      clearCopiedTokenResetTimeout()
+      clearCopiedRuntimeKeyResetTimeout()
       setRuntimeKeys([])
       setError(null)
       setIsCreating(false)
@@ -168,17 +163,17 @@ export function useCopyKeyDialog(
     }
   }, [
     account,
-    clearCopiedTokenResetTimeout,
+    clearCopiedRuntimeKeyResetTimeout,
     clearDefaultTokenCreateAllowedGroups,
-    fetchTokens,
+    fetchRuntimeKeys,
     isOpen,
   ])
 
   useEffect(() => {
     return () => {
-      clearCopiedTokenResetTimeout()
+      clearCopiedRuntimeKeyResetTimeout()
     }
-  }, [clearCopiedTokenResetTimeout])
+  }, [clearCopiedRuntimeKeyResetTimeout])
 
   const copyKey = useCallback(
     async (runtimeKey: AccountRuntimeKey) => {
@@ -196,10 +191,10 @@ export function useCopyKeyDialog(
         toast.success(t("ui:dialog.copyKey.keyCopied"))
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
 
-        clearCopiedTokenResetTimeout()
-        copiedTokenResetTimeoutRef.current = setTimeout(() => {
+        clearCopiedRuntimeKeyResetTimeout()
+        copiedRuntimeKeyResetTimeoutRef.current = setTimeout(() => {
           setCopiedRuntimeKeyId(null)
-          copiedTokenResetTimeoutRef.current = null
+          copiedRuntimeKeyResetTimeoutRef.current = null
         }, 2000)
       } catch (error) {
         logger.error("Failed to copy key to clipboard", { error })
@@ -211,13 +206,13 @@ export function useCopyKeyDialog(
         })
       }
     },
-    [account, clearCopiedTokenResetTimeout, t],
+    [account, clearCopiedRuntimeKeyResetTimeout, t],
   )
 
   /**
-   * Refreshes token inventory after a successful create flow and applies the same UX rules:
-   * - If no token is found, show an actionable error.
-   * - If exactly one token exists, auto-copy it.
+   * Refreshes runtime-key inventory after a successful create flow and applies the same UX rules:
+   * - If no runtime key is found, show an actionable error.
+   * - If exactly one runtime key exists, auto-copy it.
    * - Otherwise, keep the list visible and show a success toast.
    *
    * Some sites, including AIHubMix, only return the full key in the create
@@ -225,7 +220,7 @@ export function useCopyKeyDialog(
    * token directly should pass it here so the secret can be copied before any
    * follow-up inventory refresh loses it.
    */
-  const refreshTokensAfterCreate = useCallback(
+  const refreshRuntimeKeysAfterCreate = useCallback(
     async (createdToken?: ApiToken) => {
       if (!account) return
 
@@ -246,12 +241,12 @@ export function useCopyKeyDialog(
             account,
             createdToken,
           )
-          setRuntimeKeys((currentRuntimeKeys) => {
-            const withoutCreated = currentRuntimeKeys.filter(
-              (runtimeKey) => runtimeKey.id !== createdRuntimeKey.id,
-            )
-            return [...withoutCreated, createdRuntimeKey]
-          })
+          setRuntimeKeys((currentRuntimeKeys) =>
+            appendOrReplaceAccountRuntimeKey(
+              currentRuntimeKeys,
+              createdRuntimeKey,
+            ),
+          )
           setOneTimeToken(
             formatOptionalSkPrefixSiteToken(createdToken, account.siteType),
           )
@@ -275,13 +270,13 @@ export function useCopyKeyDialog(
 
         toast.success(t("ui:dialog.copyKey.createSuccess"))
       } catch (error) {
-        logger.error("Failed to refresh token list after create", {
+        logger.error("Failed to refresh runtime-key list after create", {
           error,
           accountId: account.id,
           baseUrl: account.baseUrl,
           siteType: account.siteType,
         })
-        const errorMessage = getTokenInventoryErrorMessage(
+        const errorMessage = getRuntimeKeyInventoryErrorMessage(
           error,
           t("ui:dialog.copyKey.getFailed"),
         )
@@ -333,7 +328,7 @@ export function useCopyKeyDialog(
         throw new Error(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
       }
 
-      await refreshTokensAfterCreate(
+      await refreshRuntimeKeysAfterCreate(
         isCreatedApiToken(created) ? created : undefined,
       )
     } catch (error) {
@@ -355,7 +350,7 @@ export function useCopyKeyDialog(
     canCreateDefaultKey,
     clearDefaultTokenCreateAllowedGroups,
     isCreating,
-    refreshTokensAfterCreate,
+    refreshRuntimeKeysAfterCreate,
     t,
   ])
 
@@ -382,10 +377,10 @@ export function useCopyKeyDialog(
     copiedRuntimeKeyId,
     expandedRuntimeKeys,
     canCreateDefaultKey,
-    fetchTokens,
+    fetchRuntimeKeys,
     copyKey,
     createDefaultKey,
-    refreshTokensAfterCreate,
+    refreshRuntimeKeysAfterCreate,
     toggleRuntimeKeyExpansion,
     clearDefaultTokenCreateAllowedGroups,
     clearOneTimeToken: () => setOneTimeToken(null),

--- a/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
@@ -40,21 +40,21 @@ export default function CopyKeyDialog({
     account: DisplaySiteData
   } | null>(null)
   const {
-    tokens,
+    runtimeKeys,
     isLoading,
     error,
     isCreating,
     createError,
     oneTimeToken,
     defaultTokenCreateAllowedGroups,
-    copiedTokenId,
-    expandedTokens,
+    copiedRuntimeKeyId,
+    expandedRuntimeKeys,
     canCreateDefaultKey,
     fetchTokens,
     copyKey,
     createDefaultKey,
     refreshTokensAfterCreate,
-    toggleTokenExpansion,
+    toggleRuntimeKeyExpansion,
     clearDefaultTokenCreateAllowedGroups,
     clearOneTimeToken,
   } = useCopyKeyDialog(isOpen, account)
@@ -139,10 +139,10 @@ export default function CopyKeyDialog({
     }
     return (
       <TokenList
-        tokens={tokens}
-        expandedTokens={expandedTokens}
-        copiedTokenId={copiedTokenId}
-        onToggleToken={toggleTokenExpansion}
+        runtimeKeys={runtimeKeys}
+        expandedRuntimeKeys={expandedRuntimeKeys}
+        copiedRuntimeKeyId={copiedRuntimeKeyId}
+        onToggleRuntimeKey={toggleRuntimeKeyExpansion}
         onCopyKey={copyKey}
         account={account}
         onOpenCCSwitchDialog={handleOpenCCSwitchDialog}
@@ -162,7 +162,9 @@ export default function CopyKeyDialog({
         onClose={onClose}
         panelClassName="max-h-[85vh] overflow-hidden flex flex-col"
         header={<DialogHeader account={account} />}
-        footer={<DialogFooter tokenCount={tokens.length} onClose={onClose} />}
+        footer={
+          <DialogFooter tokenCount={runtimeKeys.length} onClose={onClose} />
+        }
       >
         <div className="flex-1 overflow-y-auto">{renderContent()}</div>
       </Modal>

--- a/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
@@ -15,7 +15,7 @@ import { DialogFooter } from "./DialogFooter"
 import { DialogHeader } from "./DialogHeader"
 import { ErrorDisplay } from "./ErrorDisplay"
 import { LoadingIndicator } from "./LoadingIndicator"
-import { TokenList } from "./TokenList"
+import { RuntimeKeyList } from "./RuntimeKeyList"
 
 interface CopyKeyDialogProps {
   isOpen: boolean
@@ -50,10 +50,10 @@ export default function CopyKeyDialog({
     copiedRuntimeKeyId,
     expandedRuntimeKeys,
     canCreateDefaultKey,
-    fetchTokens,
+    fetchRuntimeKeys,
     copyKey,
     createDefaultKey,
-    refreshTokensAfterCreate,
+    refreshRuntimeKeysAfterCreate,
     toggleRuntimeKeyExpansion,
     clearDefaultTokenCreateAllowedGroups,
     clearOneTimeToken,
@@ -82,7 +82,7 @@ export default function CopyKeyDialog({
   }
   const handleAddTokenSuccess = (createdToken?: ApiToken) => {
     clearDefaultTokenCreateAllowedGroups()
-    return refreshTokensAfterCreate(createdToken)
+    return refreshRuntimeKeysAfterCreate(createdToken)
   }
 
   useEffect(() => {
@@ -132,13 +132,13 @@ export default function CopyKeyDialog({
       return <LoadingIndicator />
     }
     if (error) {
-      return <ErrorDisplay error={error} onRetry={fetchTokens} />
+      return <ErrorDisplay error={error} onRetry={fetchRuntimeKeys} />
     }
     if (!account) {
       return null
     }
     return (
-      <TokenList
+      <RuntimeKeyList
         runtimeKeys={runtimeKeys}
         expandedRuntimeKeys={expandedRuntimeKeys}
         copiedRuntimeKeyId={copiedRuntimeKeyId}
@@ -163,7 +163,7 @@ export default function CopyKeyDialog({
         panelClassName="max-h-[85vh] overflow-hidden flex flex-col"
         header={<DialogHeader account={account} />}
         footer={
-          <DialogFooter tokenCount={runtimeKeys.length} onClose={onClose} />
+          <DialogFooter keyCount={runtimeKeys.length} onClose={onClose} />
         }
       >
         <div className="flex-1 overflow-y-auto">{renderContent()}</div>

--- a/src/features/KeyManagement/components/TokenList.tsx
+++ b/src/features/KeyManagement/components/TokenList.tsx
@@ -621,7 +621,7 @@ export function TokenList(props: TokenListProps) {
     const tracker = startProductAnalyticsAction({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
       actionId:
-        PRODUCT_ANALYTICS_ACTION_IDS.SaveAccountTokensToApiCredentialProfiles,
+        PRODUCT_ANALYTICS_ACTION_IDS.SaveAccountRuntimeKeysToApiCredentialProfiles,
       surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementPage,
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
     })

--- a/src/features/KeyManagement/components/TokenList.tsx
+++ b/src/features/KeyManagement/components/TokenList.tsx
@@ -18,7 +18,6 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { saveAccountRuntimeKeysToApiCredentialProfiles } from "~/features/TokenProvisioning/utils/apiCredentialProfileSaveAction"
 import { cn } from "~/lib/utils"
 import {
-  accountRuntimeKeyToLegacyAccountToken,
   isAccountTokenRuntimeKey,
   isServiceCredentialRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
@@ -53,6 +52,7 @@ import {
   buildAccountTokenKeyManagementEntry,
   buildServiceCredentialKeyManagementEntry,
   buildTokenIdentityKey,
+  toLegacyAccountTokenForKeyManagementEntry,
 } from "../utils"
 import { BatchCliProxyExportDialog } from "./BatchCliProxyExportDialog"
 import { ManagedSiteTokenBatchExportDialog } from "./ManagedSiteTokenBatchExportDialog"
@@ -911,11 +911,8 @@ export function TokenList(props: TokenListProps) {
                           )
                         }
 
-                        const token = isAccountTokenRuntimeKey(entry.runtimeKey)
-                          ? entry.runtimeKey.token
-                          : accountRuntimeKeyToLegacyAccountToken(
-                              entry.runtimeKey,
-                            )
+                        const token =
+                          toLegacyAccountTokenForKeyManagementEntry(entry)
                         const tokenIdentityKey = buildTokenIdentityKey(
                           token.accountId,
                           token.id,
@@ -973,9 +970,7 @@ export function TokenList(props: TokenListProps) {
               )
             }
 
-            const token = isAccountTokenRuntimeKey(entry.runtimeKey)
-              ? entry.runtimeKey.token
-              : accountRuntimeKeyToLegacyAccountToken(entry.runtimeKey)
+            const token = toLegacyAccountTokenForKeyManagementEntry(entry)
             const account = accountById.get(token.accountId)
             if (!account) {
               return null

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -6,11 +6,9 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { useAccountData } from "~/hooks/useAccountData"
 import {
-  accountRuntimeKeyToLegacyAccountToken,
   buildServiceCredentialRuntimeKey,
   isAccountTokenRuntimeKey,
   type AccountRuntimeKey,
-  type ServiceCredentialRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
 import {
   createDisplayAccountApiContext,
@@ -47,8 +45,11 @@ import {
   buildAccountRuntimeKeyEntryIdentityKey,
   buildAccountTokenKeyManagementEntry,
   buildServiceCredentialKeyManagementEntry,
+  buildServiceCredentialManagedSiteStatusTarget,
   buildTokenIdentityKey,
   isManagedSiteStatusIdentityForAccount,
+  loadServiceCredentialKeyManagementRuntimeKey,
+  type ManagedSiteStatusCheckTargetInput,
 } from "../utils"
 
 /**
@@ -171,31 +172,6 @@ type ManagedSiteTokenChannelStatusResult = Awaited<
 
 interface RefreshManagedSiteTokenStatusOptions {
   resolvedChannelKeysById?: Record<number, string>
-}
-
-interface ManagedSiteStatusCheckTargetInput {
-  identityKey: string
-  account: DisplaySiteData
-  token: AccountToken
-}
-
-const buildServiceCredentialManagedSiteStatusTarget = (
-  account: DisplaySiteData,
-  runtimeKey: ServiceCredentialRuntimeKey,
-): ManagedSiteStatusCheckTargetInput => {
-  const statusAccount = {
-    ...account,
-    baseUrl: runtimeKey.baseUrl,
-  }
-
-  return {
-    identityKey: buildAccountRuntimeKeyEntryIdentityKey(runtimeKey.id),
-    account: statusAccount,
-    token: accountRuntimeKeyToLegacyAccountToken({
-      ...runtimeKey,
-      account: statusAccount,
-    }),
-  }
 }
 
 const toDisplayManagedSiteTokenStatusResult = (
@@ -725,19 +701,27 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
         const { keyManagement, serviceCredential, request } =
           createDisplayAccountApiContext(account)
 
-        if (!keyManagement && serviceCredential) {
-          setServiceCredentials((prev) => ({
-            ...prev,
-            [accountId]: {
-              status: "loading",
-              credential: prev[accountId]?.credential,
-              errorMessage: undefined,
-              isRotating: false,
+        const serviceCredentialLoad =
+          await loadServiceCredentialKeyManagementRuntimeKey({
+            account,
+            keyManagement,
+            serviceCredential,
+            request: toApiServiceRequest(request),
+            onBeforeFetch: () => {
+              setServiceCredentials((prev) => ({
+                ...prev,
+                [accountId]: {
+                  status: "loading",
+                  credential: prev[accountId]?.credential,
+                  errorMessage: undefined,
+                  isRotating: false,
+                },
+              }))
             },
-          }))
-          const credential = await serviceCredential.fetch(
-            toApiServiceRequest(request),
-          )
+          })
+
+        if (serviceCredentialLoad) {
+          const { credential, runtimeKey } = serviceCredentialLoad
 
           if (!isEpochActive(loadEpoch)) return null
           if (!isLatestAccountRequest(accountId, requestEpoch)) return null
@@ -761,13 +745,6 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
             },
           }))
           delete tokenLoadErrorCategoriesRef.current[accountId]
-          const runtimeKey = buildServiceCredentialRuntimeKey(
-            account,
-            credential,
-            {
-              canRotate: typeof serviceCredential.rotate === "function",
-            },
-          )
           void runManagedSiteStatusChecks({
             tokens: [],
             targets: [

--- a/src/features/KeyManagement/utils.ts
+++ b/src/features/KeyManagement/utils.ts
@@ -24,6 +24,11 @@ export const buildTokenIdentityKey = (accountId: string, tokenId: number) =>
 export const buildAccountRuntimeKeyEntryIdentityKey = (runtimeKeyId: string) =>
   ["runtime_key", runtimeKeyId].join(":")
 
+const buildAccountRuntimeKeyEntryIdentityPrefix = (
+  source: (typeof ACCOUNT_RUNTIME_KEY_SOURCES)[keyof typeof ACCOUNT_RUNTIME_KEY_SOURCES],
+  accountId: string,
+) => buildAccountRuntimeKeyEntryIdentityKey(`${source}:${accountId}:`)
+
 export interface ManagedSiteStatusCheckTargetInput {
   identityKey: string
   account: DisplaySiteData
@@ -36,13 +41,15 @@ export const isManagedSiteStatusIdentityForAccount = (
 ) =>
   identityKey.startsWith(`${accountId}:`) ||
   identityKey.startsWith(
-    buildAccountRuntimeKeyEntryIdentityKey(
-      `${ACCOUNT_RUNTIME_KEY_SOURCES.AccountToken}:${accountId}:`,
+    buildAccountRuntimeKeyEntryIdentityPrefix(
+      ACCOUNT_RUNTIME_KEY_SOURCES.AccountToken,
+      accountId,
     ),
   ) ||
   identityKey.startsWith(
-    buildAccountRuntimeKeyEntryIdentityKey(
-      `${ACCOUNT_RUNTIME_KEY_SOURCES.ServiceCredential}:${accountId}:`,
+    buildAccountRuntimeKeyEntryIdentityPrefix(
+      ACCOUNT_RUNTIME_KEY_SOURCES.ServiceCredential,
+      accountId,
     ),
   )
 

--- a/src/features/KeyManagement/utils.ts
+++ b/src/features/KeyManagement/utils.ts
@@ -1,9 +1,17 @@
 import { UI_CONSTANTS } from "~/constants/ui"
 import {
   ACCOUNT_RUNTIME_KEY_SOURCES,
+  accountRuntimeKeyToLegacyAccountToken,
   buildAccountTokenRuntimeKey,
   buildServiceCredentialRuntimeKey,
+  type ServiceCredentialRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import type {
+  AccountServiceCredential,
+  ServiceCredentialCapability,
+} from "~/services/apiAdapters/contracts/serviceCredential"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { AccountToken, DisplaySiteData } from "~/types"
 import { t } from "~/utils/i18n/core"
 
@@ -15,6 +23,12 @@ export const buildTokenIdentityKey = (accountId: string, tokenId: number) =>
 
 export const buildAccountRuntimeKeyEntryIdentityKey = (runtimeKeyId: string) =>
   ["runtime_key", runtimeKeyId].join(":")
+
+export interface ManagedSiteStatusCheckTargetInput {
+  identityKey: string
+  account: DisplaySiteData
+  token: AccountToken
+}
 
 export const isManagedSiteStatusIdentityForAccount = (
   identityKey: string,
@@ -67,6 +81,53 @@ export const buildServiceCredentialKeyManagementEntry = (params: {
     uiState: {
       isRotating: serviceCredential.isRotating === true,
     },
+  }
+}
+
+export const toLegacyAccountTokenForKeyManagementEntry = (
+  entry: Pick<KeyManagementEntry, "runtimeKey">,
+): AccountToken => accountRuntimeKeyToLegacyAccountToken(entry.runtimeKey)
+
+export const buildServiceCredentialManagedSiteStatusTarget = (
+  account: DisplaySiteData,
+  runtimeKey: ServiceCredentialRuntimeKey,
+): ManagedSiteStatusCheckTargetInput => {
+  const statusAccount = {
+    ...account,
+    baseUrl: runtimeKey.baseUrl,
+  }
+
+  return {
+    identityKey: buildAccountRuntimeKeyEntryIdentityKey(runtimeKey.id),
+    account: statusAccount,
+    token: accountRuntimeKeyToLegacyAccountToken({
+      ...runtimeKey,
+      account: statusAccount,
+    }),
+  }
+}
+
+export const loadServiceCredentialKeyManagementRuntimeKey = async (params: {
+  account: DisplaySiteData
+  keyManagement: KeyManagementCapability | undefined
+  serviceCredential: ServiceCredentialCapability | undefined
+  request: ApiServiceRequest
+  onBeforeFetch?: () => void
+}): Promise<{
+  credential: AccountServiceCredential
+  runtimeKey: ServiceCredentialRuntimeKey
+} | null> => {
+  const { account, keyManagement, serviceCredential, request, onBeforeFetch } =
+    params
+  if (keyManagement || !serviceCredential) return null
+
+  onBeforeFetch?.()
+  const credential = await serviceCredential.fetch(request)
+  return {
+    credential,
+    runtimeKey: buildServiceCredentialRuntimeKey(account, credential, {
+      canRotate: typeof serviceCredential.rotate === "function",
+    }),
   }
 }
 

--- a/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
+++ b/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
@@ -100,7 +100,7 @@ type BatchVerifyRow = {
   latencyMs: number
   summary: string
   results: ApiVerificationProbeResult[]
-  tokenName?: string
+  runtimeKeyName?: string
   errorCategory?: ProductAnalyticsErrorCategory
 }
 
@@ -550,7 +550,7 @@ export function BatchVerifyModelsDialog({
         latencyMs: 0,
         summary: t("modelList:batchVerify.status.running"),
         results: [],
-        tokenName: undefined,
+        runtimeKeyName: undefined,
         errorCategory: undefined,
       })
 
@@ -565,7 +565,7 @@ export function BatchVerifyModelsDialog({
             ? {
                 baseUrl: item.source.profile.baseUrl,
                 apiKey: item.source.profile.apiKey,
-                tokenName: undefined,
+                runtimeKeyName: undefined,
               }
             : await (async () => {
                 if (!isAccountBatchVerifyModelItem(item)) return null
@@ -579,7 +579,7 @@ export function BatchVerifyModelsDialog({
                 )
                 if (!runtimeKey) {
                   const summary = t(
-                    "modelList:batchVerify.messages.noCompatibleToken",
+                    "modelList:batchVerify.messages.noCompatibleRuntimeKey",
                   )
                   updateRow(item.key, {
                     status: BATCH_VERIFY_ROW_STATUSES.SKIPPED,
@@ -612,7 +612,7 @@ export function BatchVerifyModelsDialog({
                 return {
                   baseUrl: resolvedRuntimeKey.baseUrl || account.baseUrl,
                   apiKey: resolvedRuntimeKey.secret,
-                  tokenName: runtimeKey.label,
+                  runtimeKeyName: runtimeKey.label,
                   token: resolvedToken,
                 }
               })()
@@ -634,7 +634,7 @@ export function BatchVerifyModelsDialog({
             latencyMs: 0,
             summary: t("modelList:batchVerify.messages.noApplicableProbes"),
             results: [],
-            tokenName: credentials.tokenName,
+            runtimeKeyName: credentials.runtimeKeyName,
           })
           return BATCH_VERIFY_ROW_STATUSES.SKIPPED
         }
@@ -747,7 +747,7 @@ export function BatchVerifyModelsDialog({
             unsupported,
           }),
           results,
-          tokenName: credentials.tokenName,
+          runtimeKeyName: credentials.runtimeKeyName,
           errorCategory,
         })
         return status
@@ -1002,10 +1002,10 @@ export function BatchVerifyModelsDialog({
             <div className="dark:text-dark-text-secondary mt-1 text-xs text-gray-600">
               {row.summary || t("modelList:batchVerify.messages.pending")}
             </div>
-            {row.tokenName ? (
+            {row.runtimeKeyName ? (
               <div className="dark:text-dark-text-tertiary mt-1 text-xs text-gray-500">
-                {t("modelList:batchVerify.tokenUsed", {
-                  name: row.tokenName,
+                {t("modelList:batchVerify.runtimeKeyUsed", {
+                  name: row.runtimeKeyName,
                 })}
               </div>
             ) : null}

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -3,6 +3,12 @@ import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { buildGroupDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import {
+  buildDisplayAccountTokenRuntimeKey,
+  hasUsableAccountRuntimeKeySecret,
+  isAccountTokenRuntimeKey,
+  type AccountRuntimeKey,
+} from "~/services/accounts/accountRuntimeKeys"
 import { shouldShowOneTimeKeyDialogForCreatedToken } from "~/services/accounts/createdTokenSecretHandling"
 import {
   canCreateAccountApiTokens,
@@ -10,11 +16,11 @@ import {
 } from "~/services/accounts/keyProductCapabilities"
 import {
   createDisplayAccountApiContext,
-  fetchDisplayAccountRuntimeKeyTokens,
+  fetchDisplayAccountRuntimeKeys,
   fetchDisplayAccountTokens,
   InvalidTokenPayloadError,
   requireDisplayAccountKeyManagement,
-  resolveDisplayAccountTokenForSecret,
+  resolveDisplayAccountRuntimeKeySecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { formatOptionalSkPrefixSiteToken } from "~/services/accountTokens/apiTokenKey"
 import { TOKEN_PROVISIONING_ERRORS } from "~/services/apiAdapters/contracts/tokenProvisioning"
@@ -49,6 +55,24 @@ type UseModelKeyDialogParams = {
   modelEnableGroups?: string[]
 }
 
+const buildAccountTokenRuntimeKeys = (
+  account: DisplaySiteData,
+  tokens: ApiToken[],
+) => tokens.map((token) => buildDisplayAccountTokenRuntimeKey(account, token))
+
+const isRuntimeKeyCompatibleWithModel = (
+  runtimeKey: AccountRuntimeKey,
+  model: { id: string; enableGroups?: string[] | null },
+) => {
+  if (isAccountTokenRuntimeKey(runtimeKey)) {
+    return isTokenCompatibleWithModel(runtimeKey.token, model)
+  }
+
+  return (
+    model.id.trim().length > 0 && hasUsableAccountRuntimeKeySecret(runtimeKey)
+  )
+}
+
 /**
  * Dialog state + actions for the model→key compatibility flow.
  */
@@ -56,11 +80,13 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
   const { isOpen, account, modelId, modelEnableGroups } = params
   const { t } = useTranslation(["modelList", "common", "messages"])
 
-  const [tokens, setTokens] = useState<ApiToken[]>([])
+  const [runtimeKeys, setRuntimeKeys] = useState<AccountRuntimeKey[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const [selectedTokenId, setSelectedTokenId] = useState<number | null>(null)
+  const [selectedRuntimeKeyId, setSelectedRuntimeKeyId] = useState<
+    string | null
+  >(null)
 
   const [isCreating, setIsCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
@@ -90,12 +116,12 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
     return t("modelList:keyDialog.ineligible.missingCredentials")
   }, [account, canCreateToken, canLoadRuntimeKeys, t])
 
-  const fetchTokens = useCallback(async () => {
+  const fetchRuntimeKeys = useCallback(async () => {
     if (!account) return false
     if (!canLoadRuntimeKeys) {
       fetchRequestIdRef.current += 1
-      setTokens([])
-      setSelectedTokenId(null)
+      setRuntimeKeys([])
+      setSelectedRuntimeKeyId(null)
       setError(null)
       setCreateError(null)
       setOneTimeToken(null)
@@ -109,9 +135,9 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
     setCreateError(null)
 
     try {
-      const fetchedTokens = await fetchDisplayAccountRuntimeKeyTokens(account)
+      const fetchedRuntimeKeys = await fetchDisplayAccountRuntimeKeys(account)
       if (fetchRequestIdRef.current !== requestId) return false
-      setTokens(fetchedTokens)
+      setRuntimeKeys(fetchedRuntimeKeys)
       return true
     } catch (error) {
       if (fetchRequestIdRef.current !== requestId) return false
@@ -147,57 +173,61 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
     [modelEnableGroups, modelId],
   )
 
-  const compatibleTokens = useMemo(
+  const compatibleRuntimeKeys = useMemo(
     () =>
-      tokens.filter((token) => isTokenCompatibleWithModel(token, modelContext)),
-    [modelContext, tokens],
+      runtimeKeys.filter((runtimeKey) =>
+        isRuntimeKeyCompatibleWithModel(runtimeKey, modelContext),
+      ),
+    [modelContext, runtimeKeys],
   )
 
   useEffect(() => {
     if (!isOpen || !account) {
-      setTokens([])
+      setRuntimeKeys([])
       setIsLoading(false)
       setError(null)
-      setSelectedTokenId(null)
+      setSelectedRuntimeKeyId(null)
       setIsCreating(false)
       setCreateError(null)
       setOneTimeToken(null)
       return
     }
 
-    fetchTokens()
-  }, [account, fetchTokens, isOpen])
+    fetchRuntimeKeys()
+  }, [account, fetchRuntimeKeys, isOpen])
 
   useEffect(() => {
     if (!isOpen) return
 
-    setSelectedTokenId((prev) => {
+    setSelectedRuntimeKeyId((prev) => {
       if (
         prev !== null &&
-        compatibleTokens.some((token) => token.id === prev)
+        compatibleRuntimeKeys.some((runtimeKey) => runtimeKey.id === prev)
       ) {
         return prev
       }
 
-      if (compatibleTokens.length === 1) {
-        return compatibleTokens[0].id
+      if (compatibleRuntimeKeys.length === 1) {
+        return compatibleRuntimeKeys[0].id
       }
 
       return null
     })
-  }, [compatibleTokens, isOpen])
+  }, [compatibleRuntimeKeys, isOpen])
 
-  const selectedToken = useMemo(
+  const selectedRuntimeKey = useMemo(
     () =>
-      selectedTokenId !== null
-        ? compatibleTokens.find((token) => token.id === selectedTokenId) ?? null
+      selectedRuntimeKeyId !== null
+        ? compatibleRuntimeKeys.find(
+            (runtimeKey) => runtimeKey.id === selectedRuntimeKeyId,
+          ) ?? null
         : null,
-    [compatibleTokens, selectedTokenId],
+    [compatibleRuntimeKeys, selectedRuntimeKeyId],
   )
 
   const fetchTokensUntilCompatibleAfterCreate = useCallback(async () => {
     if (!account) {
-      return { refreshedTokens: [], refreshedCompatible: [] }
+      return { refreshedRuntimeKeys: [], refreshedCompatible: [] }
     }
 
     for (
@@ -205,33 +235,36 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
       attempt <= POST_CREATE_TOKEN_REFRESH_ATTEMPTS;
       attempt++
     ) {
-      const refreshedTokens = await fetchDisplayAccountTokens(account)
-      const refreshedCompatible = refreshedTokens.filter((token) =>
-        isTokenCompatibleWithModel(token, modelContext),
+      const refreshedRuntimeKeys = buildAccountTokenRuntimeKeys(
+        account,
+        await fetchDisplayAccountTokens(account),
+      )
+      const refreshedCompatible = refreshedRuntimeKeys.filter((runtimeKey) =>
+        isRuntimeKeyCompatibleWithModel(runtimeKey, modelContext),
       )
 
       if (
         refreshedCompatible.length > 0 ||
         attempt === POST_CREATE_TOKEN_REFRESH_ATTEMPTS
       ) {
-        return { refreshedTokens, refreshedCompatible }
+        return { refreshedRuntimeKeys, refreshedCompatible }
       }
 
       await sleep(POST_CREATE_TOKEN_REFRESH_INTERVAL_MS)
     }
 
-    return { refreshedTokens: [], refreshedCompatible: [] }
+    return { refreshedRuntimeKeys: [], refreshedCompatible: [] }
   }, [account, modelContext])
 
   const copySelectedKey = useCallback(async () => {
-    if (!account || !selectedToken) return
+    if (!account || !selectedRuntimeKey) return
 
     try {
-      const resolvedToken = await resolveDisplayAccountTokenForSecret(
+      const resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
         account,
-        selectedToken,
+        selectedRuntimeKey,
       )
-      await navigator.clipboard.writeText(resolvedToken.key)
+      await navigator.clipboard.writeText(resolvedRuntimeKey.secret)
       toast.success(t("modelList:keyDialog.keyCopied"))
     } catch (error) {
       const errorMessage = getErrorMessage(
@@ -243,7 +276,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
       })
       toast.error(errorMessage)
     }
-  }, [account, selectedToken, t])
+  }, [account, selectedRuntimeKey, t])
 
   const refreshTokensAfterCreate = useCallback(
     async (createdToken?: ApiToken) => {
@@ -263,14 +296,20 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
           shouldShowOneTimeKeyDialogForCreatedToken(account, createdToken)
 
         if (createdToken && shouldShowOneTimeKeyDialog) {
-          setTokens((currentTokens) => {
-            const withoutCreated = currentTokens.filter(
-              (token) => token.id !== createdToken.id,
+          const createdRuntimeKey = buildDisplayAccountTokenRuntimeKey(
+            account,
+            createdToken,
+          )
+          setRuntimeKeys((currentRuntimeKeys) => {
+            const withoutCreated = currentRuntimeKeys.filter(
+              (runtimeKey) => runtimeKey.id !== createdRuntimeKey.id,
             )
-            return [...withoutCreated, createdToken]
+            return [...withoutCreated, createdRuntimeKey]
           })
-          if (isTokenCompatibleWithModel(createdToken, modelContext)) {
-            setSelectedTokenId(createdToken.id)
+          if (
+            isRuntimeKeyCompatibleWithModel(createdRuntimeKey, modelContext)
+          ) {
+            setSelectedRuntimeKeyId(createdRuntimeKey.id)
             setOneTimeToken(
               formatOptionalSkPrefixSiteToken(createdToken, account.siteType),
             )
@@ -286,9 +325,9 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
           }
         }
 
-        const { refreshedTokens, refreshedCompatible } =
+        const { refreshedRuntimeKeys, refreshedCompatible } =
           await fetchTokensUntilCompatibleAfterCreate()
-        setTokens(refreshedTokens)
+        setRuntimeKeys(refreshedRuntimeKeys)
 
         if (refreshedCompatible.length === 0) {
           setCreateError(
@@ -394,19 +433,19 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
   )
 
   return {
-    tokens,
-    compatibleTokens,
+    runtimeKeys,
+    compatibleRuntimeKeys,
     isLoading,
     error,
-    selectedTokenId,
-    setSelectedTokenId,
-    selectedToken,
+    selectedRuntimeKeyId,
+    setSelectedRuntimeKeyId,
+    selectedRuntimeKey,
     canCreateToken,
     ineligibleDescription,
     isCreating,
     createError,
     oneTimeToken,
-    fetchTokens,
+    fetchTokens: fetchRuntimeKeys,
     copySelectedKey,
     createDefaultKey,
     refreshTokensAfterCreate,

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -217,36 +217,35 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
     [compatibleRuntimeKeys, selectedRuntimeKeyId],
   )
 
-  const fetchRuntimeKeysUntilCompatibleAfterCreate = useCallback(async () => {
-    if (!account) {
-      return { refreshedRuntimeKeys: [], refreshedCompatible: [] }
-    }
-
-    for (
-      let attempt = 1;
-      attempt <= POST_CREATE_TOKEN_REFRESH_ATTEMPTS;
-      attempt++
-    ) {
-      const refreshedRuntimeKeys = buildAccountTokenRuntimeKeys(
-        account,
-        await fetchDisplayAccountTokens(account),
-      )
-      const refreshedCompatible = refreshedRuntimeKeys.filter((runtimeKey) =>
-        isRuntimeKeyCompatibleWithModel(runtimeKey, modelContext),
-      )
-
-      if (
-        refreshedCompatible.length > 0 ||
-        attempt === POST_CREATE_TOKEN_REFRESH_ATTEMPTS
+  const fetchRuntimeKeysUntilCompatibleAfterCreate = useCallback(
+    async (currentAccount: DisplaySiteData) => {
+      for (
+        let attempt = 1;
+        attempt <= POST_CREATE_TOKEN_REFRESH_ATTEMPTS;
+        attempt++
       ) {
-        return { refreshedRuntimeKeys, refreshedCompatible }
+        const refreshedRuntimeKeys = buildAccountTokenRuntimeKeys(
+          currentAccount,
+          await fetchDisplayAccountTokens(currentAccount),
+        )
+        const refreshedCompatible = refreshedRuntimeKeys.filter((runtimeKey) =>
+          isRuntimeKeyCompatibleWithModel(runtimeKey, modelContext),
+        )
+
+        if (
+          refreshedCompatible.length > 0 ||
+          attempt === POST_CREATE_TOKEN_REFRESH_ATTEMPTS
+        ) {
+          return { refreshedRuntimeKeys, refreshedCompatible }
+        }
+
+        await sleep(POST_CREATE_TOKEN_REFRESH_INTERVAL_MS)
       }
 
-      await sleep(POST_CREATE_TOKEN_REFRESH_INTERVAL_MS)
-    }
-
-    return { refreshedRuntimeKeys: [], refreshedCompatible: [] }
-  }, [account, modelContext])
+      return { refreshedRuntimeKeys: [], refreshedCompatible: [] }
+    },
+    [modelContext],
+  )
 
   const copySelectedKey = useCallback(async () => {
     if (!account || !selectedRuntimeKey) return
@@ -318,7 +317,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
         }
 
         const { refreshedRuntimeKeys, refreshedCompatible } =
-          await fetchRuntimeKeysUntilCompatibleAfterCreate()
+          await fetchRuntimeKeysUntilCompatibleAfterCreate(account)
         setRuntimeKeys(refreshedRuntimeKeys)
 
         if (refreshedCompatible.length === 0) {

--- a/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
+++ b/src/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog.ts
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { buildGroupDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
+  appendOrReplaceAccountRuntimeKey,
   buildDisplayAccountTokenRuntimeKey,
   hasUsableAccountRuntimeKeySecret,
   isAccountTokenRuntimeKey,
@@ -18,12 +19,16 @@ import {
   createDisplayAccountApiContext,
   fetchDisplayAccountRuntimeKeys,
   fetchDisplayAccountTokens,
-  InvalidTokenPayloadError,
+  getInvalidTokenPayloadLogContext,
+  getRuntimeKeyInventoryErrorMessage,
   requireDisplayAccountKeyManagement,
   resolveDisplayAccountRuntimeKeySecret,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { formatOptionalSkPrefixSiteToken } from "~/services/accountTokens/apiTokenKey"
-import { TOKEN_PROVISIONING_ERRORS } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import {
+  isCreatedApiToken,
+  TOKEN_PROVISIONING_ERRORS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { isTokenCompatibleWithModel } from "~/services/models/utils/tokenModelCompatibility"
 import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
 import { sleep } from "~/utils/core/async"
@@ -31,17 +36,11 @@ import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
 /**
- * Logger scoped to the "model key" dialog so token loading and clipboard failures can be diagnosed safely.
+ * Logger scoped to the "model key" dialog so runtime-key loading and clipboard failures can be diagnosed safely.
  */
 const logger = createLogger("ModelKeyDialogHook")
 const POST_CREATE_TOKEN_REFRESH_ATTEMPTS = 5
 const POST_CREATE_TOKEN_REFRESH_INTERVAL_MS = 1_000
-
-const isCreatedApiToken = (value: unknown): value is ApiToken =>
-  !!value &&
-  typeof value === "object" &&
-  typeof (value as Partial<ApiToken>).id === "number" &&
-  typeof (value as Partial<ApiToken>).key === "string"
 
 export type ModelKeyDialogCreateResult = "success" | "failure" | "skipped"
 
@@ -91,7 +90,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
   const [isCreating, setIsCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const [oneTimeToken, setOneTimeToken] = useState<ApiToken | null>(null)
-  // Incremented to invalidate slower token inventory requests after account eligibility changes.
+  // Incremented to invalidate slower runtime-key inventory requests after account eligibility changes.
   const fetchRequestIdRef = useRef(0)
 
   const canCreateToken = useMemo(
@@ -141,23 +140,16 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
       return true
     } catch (error) {
       if (fetchRequestIdRef.current !== requestId) return false
-      const errorMessage =
-        error instanceof InvalidTokenPayloadError
-          ? t("messages:errors.unknown")
-          : getErrorMessage(error)
-      logger.error("Failed to load token list for model key dialog", {
+      const errorMessage = getRuntimeKeyInventoryErrorMessage(
+        error,
+        t("messages:errors.unknown"),
+      )
+      logger.error("Failed to load runtime-key list for model key dialog", {
         message: errorMessage,
         accountId: account.id,
         baseUrl: account.baseUrl,
         siteType: account.siteType,
-        ...(error instanceof InvalidTokenPayloadError
-          ? {
-              payloadAccountId: error.accountId,
-              payloadBaseUrl: error.baseUrl,
-              payloadSiteType: error.siteType,
-              payloadResponseType: error.responseType,
-            }
-          : {}),
+        ...getInvalidTokenPayloadLogContext(error),
       })
       setError(t("modelList:keyDialog.loadFailed", { error: errorMessage }))
       return false
@@ -225,7 +217,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
     [compatibleRuntimeKeys, selectedRuntimeKeyId],
   )
 
-  const fetchTokensUntilCompatibleAfterCreate = useCallback(async () => {
+  const fetchRuntimeKeysUntilCompatibleAfterCreate = useCallback(async () => {
     if (!account) {
       return { refreshedRuntimeKeys: [], refreshedCompatible: [] }
     }
@@ -278,7 +270,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
     }
   }, [account, selectedRuntimeKey, t])
 
-  const refreshTokensAfterCreate = useCallback(
+  const refreshRuntimeKeysAfterCreate = useCallback(
     async (createdToken?: ApiToken) => {
       if (!account) return "skipped" as const
 
@@ -300,12 +292,12 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
             account,
             createdToken,
           )
-          setRuntimeKeys((currentRuntimeKeys) => {
-            const withoutCreated = currentRuntimeKeys.filter(
-              (runtimeKey) => runtimeKey.id !== createdRuntimeKey.id,
-            )
-            return [...withoutCreated, createdRuntimeKey]
-          })
+          setRuntimeKeys((currentRuntimeKeys) =>
+            appendOrReplaceAccountRuntimeKey(
+              currentRuntimeKeys,
+              createdRuntimeKey,
+            ),
+          )
           if (
             isRuntimeKeyCompatibleWithModel(createdRuntimeKey, modelContext)
           ) {
@@ -326,7 +318,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
         }
 
         const { refreshedRuntimeKeys, refreshedCompatible } =
-          await fetchTokensUntilCompatibleAfterCreate()
+          await fetchRuntimeKeysUntilCompatibleAfterCreate()
         setRuntimeKeys(refreshedRuntimeKeys)
 
         if (refreshedCompatible.length === 0) {
@@ -339,25 +331,18 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
         toast.success(t("modelList:keyDialog.createSuccess"))
         return "success" as const
       } catch (error) {
-        const errorMessage =
-          error instanceof InvalidTokenPayloadError
-            ? t("messages:errors.unknown")
-            : getErrorMessage(error)
+        const errorMessage = getRuntimeKeyInventoryErrorMessage(
+          error,
+          t("messages:errors.unknown"),
+        )
         logger.error(
-          "Failed to refresh token list after create (model key dialog)",
+          "Failed to refresh runtime-key list after create (model key dialog)",
           {
             message: errorMessage,
             accountId: account.id,
             baseUrl: account.baseUrl,
             siteType: account.siteType,
-            ...(error instanceof InvalidTokenPayloadError
-              ? {
-                  payloadAccountId: error.accountId,
-                  payloadBaseUrl: error.baseUrl,
-                  payloadSiteType: error.siteType,
-                  payloadResponseType: error.responseType,
-                }
-              : {}),
+            ...getInvalidTokenPayloadLogContext(error),
           },
         )
         setCreateError(
@@ -371,7 +356,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
     [
       account,
       canCreateToken,
-      fetchTokensUntilCompatibleAfterCreate,
+      fetchRuntimeKeysUntilCompatibleAfterCreate,
       modelContext,
       modelId,
       t,
@@ -410,7 +395,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
           throw new Error(TOKEN_PROVISIONING_ERRORS.CreateTokenFailed)
         }
 
-        return await refreshTokensAfterCreate(
+        return await refreshRuntimeKeysAfterCreate(
           isCreatedApiToken(created) ? created : undefined,
         )
       } catch (error) {
@@ -429,7 +414,7 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
         setIsCreating(false)
       }
     },
-    [account, canCreateToken, isCreating, refreshTokensAfterCreate, t],
+    [account, canCreateToken, isCreating, refreshRuntimeKeysAfterCreate, t],
   )
 
   return {
@@ -445,10 +430,10 @@ export function useModelKeyDialog(params: UseModelKeyDialogParams) {
     isCreating,
     createError,
     oneTimeToken,
-    fetchTokens: fetchRuntimeKeys,
+    fetchRuntimeKeys,
     copySelectedKey,
     createDefaultKey,
-    refreshTokensAfterCreate,
+    refreshRuntimeKeysAfterCreate,
     clearOneTimeToken: () => setOneTimeToken(null),
   }
 }

--- a/src/features/ModelList/components/ModelKeyDialog/index.tsx
+++ b/src/features/ModelList/components/ModelKeyDialog/index.tsx
@@ -51,6 +51,18 @@ const optionsEntrypoint = PRODUCT_ANALYTICS_ENTRYPOINTS.Options
 const keyDialogSurface = PRODUCT_ANALYTICS_SURFACE_IDS.OptionsModelListKeyDialog
 const logger = createLogger("ModelKeyDialog")
 
+const analyticsResultByCreateResult: Record<
+  ModelKeyDialogCreateResult,
+  (typeof PRODUCT_ANALYTICS_RESULTS)[keyof typeof PRODUCT_ANALYTICS_RESULTS]
+> = {
+  success: PRODUCT_ANALYTICS_RESULTS.Success,
+  failure: PRODUCT_ANALYTICS_RESULTS.Failure,
+  skipped: PRODUCT_ANALYTICS_RESULTS.Skipped,
+}
+
+const normalizeModelGroup = (group: unknown) =>
+  typeof group === "string" ? group.trim() : ""
+
 /**
  * Builds a compact label that disambiguates same-named keys across groups.
  */
@@ -64,6 +76,21 @@ function getCompatibleRuntimeKeyLabel(runtimeKey: AccountRuntimeKey) {
       ? runtimeKey.token.group.trim()
       : ""
   return `${runtimeKey.label} · ${group || DEFAULT_MODEL_GROUP}`
+}
+
+/**
+ * Builds the group choices available to the model-compatible key creation flow.
+ */
+function buildCreateGroupOptions(modelEnableGroups?: readonly string[]) {
+  const options = Array.from(
+    new Set(
+      (modelEnableGroups ?? [])
+        .map(normalizeModelGroup)
+        .filter((group) => group.length > 0),
+    ),
+  )
+
+  return options.length > 0 ? options : [DEFAULT_MODEL_GROUP]
 }
 
 /**
@@ -101,22 +128,10 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
   const createGroupSelectId = `model-key-dialog-create-group-${useId()}`
   const compatibleKeySelectId = `model-key-dialog-compatible-key-${useId()}`
 
-  const createGroupOptions = useMemo(() => {
-    const seen = new Set<string>()
-    const options: string[] = []
-    const groups = modelEnableGroups ?? []
-
-    groups
-      .map((group) => (typeof group === "string" ? group.trim() : ""))
-      .filter(Boolean)
-      .forEach((group) => {
-        if (seen.has(group)) return
-        seen.add(group)
-        options.push(group)
-      })
-
-    return options.length > 0 ? options : [DEFAULT_MODEL_GROUP]
-  }, [modelEnableGroups])
+  const createGroupOptions = useMemo(
+    () => buildCreateGroupOptions(modelEnableGroups),
+    [modelEnableGroups],
+  )
 
   const requiresCreateGroupSelection = createGroupOptions.length > 1
 
@@ -151,10 +166,10 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
     isCreating,
     createError,
     oneTimeToken,
-    fetchTokens,
+    fetchRuntimeKeys,
     copySelectedKey,
     createDefaultKey,
-    refreshTokensAfterCreate,
+    refreshRuntimeKeysAfterCreate,
     clearOneTimeToken,
   } = useModelKeyDialog({
     isOpen,
@@ -190,7 +205,7 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
   const handleOpenAddTokenDialog = () => setIsAddTokenDialogOpen(true)
   const handleCloseAddTokenDialog = () => setIsAddTokenDialogOpen(false)
   const handleTokenCreated = async (createdToken?: ApiToken) => {
-    await refreshTokensAfterCreate(createdToken)
+    await refreshRuntimeKeysAfterCreate(createdToken)
   }
   const handleOpenKeysPage = () => {
     void openKeysPage(account.id)
@@ -201,14 +216,14 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
   )
   const customCreateTokenRequest =
     buildGroupDefaultTokenRequest(customCreateGroup)
-  const handleRetryFetchTokens = async () => {
+  const handleRetryFetchRuntimeKeys = async () => {
     const tracker = startProductAnalyticsAction({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ModelList,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.RefreshModelKeyCandidates,
       surfaceId: keyDialogSurface,
       entrypoint: optionsEntrypoint,
     })
-    const isLoaded = await fetchTokens()
+    const isLoaded = await fetchRuntimeKeys()
     if (isLoaded) {
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
       return
@@ -226,14 +241,6 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
       entrypoint: optionsEntrypoint,
     })
     const result = await createDefaultKey(group)
-    const analyticsResultByCreateResult: Record<
-      ModelKeyDialogCreateResult,
-      (typeof PRODUCT_ANALYTICS_RESULTS)[keyof typeof PRODUCT_ANALYTICS_RESULTS]
-    > = {
-      success: PRODUCT_ANALYTICS_RESULTS.Success,
-      failure: PRODUCT_ANALYTICS_RESULTS.Failure,
-      skipped: PRODUCT_ANALYTICS_RESULTS.Skipped,
-    }
 
     if (result === "failure") {
       tracker.complete(analyticsResultByCreateResult[result], {
@@ -303,7 +310,7 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
             <div className="mt-3">
               <Button
                 onClick={() => {
-                  void handleRetryFetchTokens()
+                  void handleRetryFetchRuntimeKeys()
                 }}
                 variant="destructive"
                 size="sm"

--- a/src/features/ModelList/components/ModelKeyDialog/index.tsx
+++ b/src/features/ModelList/components/ModelKeyDialog/index.tsx
@@ -23,6 +23,10 @@ import {
   buildGroupDefaultTokenRequest,
   resolvePreferredDefaultUserGroup,
 } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import {
+  isAccountTokenRuntimeKey,
+  type AccountRuntimeKey,
+} from "~/services/accounts/accountRuntimeKeys"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
@@ -50,9 +54,16 @@ const logger = createLogger("ModelKeyDialog")
 /**
  * Builds a compact label that disambiguates same-named keys across groups.
  */
-function getCompatibleTokenLabel(token: Pick<ApiToken, "name" | "group">) {
-  const group = typeof token.group === "string" ? token.group.trim() : ""
-  return `${token.name} · ${group || DEFAULT_MODEL_GROUP}`
+function getCompatibleRuntimeKeyLabel(runtimeKey: AccountRuntimeKey) {
+  if (!isAccountTokenRuntimeKey(runtimeKey)) {
+    return runtimeKey.label
+  }
+
+  const group =
+    typeof runtimeKey.token.group === "string"
+      ? runtimeKey.token.group.trim()
+      : ""
+  return `${runtimeKey.label} · ${group || DEFAULT_MODEL_GROUP}`
 }
 
 /**
@@ -130,11 +141,11 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
   }, [createGroupOptions, isOpen])
 
   const {
-    compatibleTokens,
+    compatibleRuntimeKeys,
     isLoading,
     error,
-    selectedTokenId,
-    setSelectedTokenId,
+    selectedRuntimeKeyId,
+    setSelectedRuntimeKeyId,
     canCreateToken,
     ineligibleDescription,
     isCreating,
@@ -164,13 +175,17 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
       })
     : undefined
 
-  const requiresExplicitSelection = compatibleTokens.length > 1
+  const requiresExplicitSelection = compatibleRuntimeKeys.length > 1
 
   const canCopy = useMemo(() => {
-    if (compatibleTokens.length === 0) return false
+    if (compatibleRuntimeKeys.length === 0) return false
     if (!requiresExplicitSelection) return true
-    return selectedTokenId !== null
-  }, [compatibleTokens.length, requiresExplicitSelection, selectedTokenId])
+    return selectedRuntimeKeyId !== null
+  }, [
+    compatibleRuntimeKeys.length,
+    requiresExplicitSelection,
+    selectedRuntimeKeyId,
+  ])
 
   const handleOpenAddTokenDialog = () => setIsAddTokenDialogOpen(true)
   const handleCloseAddTokenDialog = () => setIsAddTokenDialogOpen(false)
@@ -324,7 +339,7 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
             />
           ) : null}
 
-          {compatibleTokens.length === 0 ? (
+          {compatibleRuntimeKeys.length === 0 ? (
             <div className="space-y-4">
               <EmptyState
                 icon={<KeyIcon className="h-12 w-12" />}
@@ -426,10 +441,10 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
                 <div className="mt-2">
                   <Select
                     value={
-                      selectedTokenId === null ? "" : String(selectedTokenId)
+                      selectedRuntimeKeyId === null ? "" : selectedRuntimeKeyId
                     }
-                    onValueChange={(value) => setSelectedTokenId(Number(value))}
-                    disabled={compatibleTokens.length === 1}
+                    onValueChange={(value) => setSelectedRuntimeKeyId(value)}
+                    disabled={compatibleRuntimeKeys.length === 1}
                   >
                     <SelectTrigger
                       id={compatibleKeySelectId}
@@ -440,15 +455,15 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
                       />
                     </SelectTrigger>
                     <SelectContent>
-                      {compatibleTokens.map((token) => (
-                        <SelectItem key={token.id} value={String(token.id)}>
-                          {getCompatibleTokenLabel(token)}
+                      {compatibleRuntimeKeys.map((runtimeKey) => (
+                        <SelectItem key={runtimeKey.id} value={runtimeKey.id}>
+                          {getCompatibleRuntimeKeyLabel(runtimeKey)}
                         </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
                 </div>
-                {requiresExplicitSelection && selectedTokenId === null ? (
+                {requiresExplicitSelection && selectedRuntimeKeyId === null ? (
                   <p className="dark:text-dark-text-tertiary mt-2 text-sm text-gray-500">
                     {t("modelList:keyDialog.selectHint")}
                   </p>

--- a/src/features/ModelList/components/StatusIndicator.tsx
+++ b/src/features/ModelList/components/StatusIndicator.tsx
@@ -53,7 +53,7 @@ export function StatusIndicator({
   accountFallback,
 }: StatusIndicatorProps) {
   const { t } = useTranslation("modelList")
-  const fallbackTokenSelectId = `model-list-fallback-token-${useId()}`
+  const fallbackRuntimeKeySelectId = `model-list-fallback-runtime-key-${useId()}`
   if (!selectedSource) {
     return (
       <EmptyState
@@ -97,12 +97,12 @@ export function StatusIndicator({
         <div>
           <h4 className="dark:text-dark-text-primary text-sm font-semibold text-gray-900">
             {isKeyScopedStatus
-              ? t("status.tokenScopedCatalogFallbackTitle")
+              ? t("status.runtimeKeyScopedCatalogFallbackTitle")
               : t("status.fallback.title")}
           </h4>
           <p className="dark:text-dark-text-secondary mt-1 text-sm text-gray-600">
             {isKeyScopedStatus
-              ? t("status.tokenScopedCatalogFallbackDescription")
+              ? t("status.runtimeKeyScopedCatalogFallbackDescription")
               : t("status.fallback.description")}
           </p>
         </div>
@@ -110,7 +110,7 @@ export function StatusIndicator({
         {accountFallback.runtimeKeyLoadErrorMessage ? (
           <Alert
             variant="destructive"
-            title={t("status.fallback.tokensLoadFailedTitle")}
+            title={t("status.fallback.runtimeKeysLoadFailedTitle")}
             description={accountFallback.runtimeKeyLoadErrorMessage}
           >
             <div className="mt-3">
@@ -168,7 +168,7 @@ export function StatusIndicator({
           <div className="space-y-3">
             <div>
               <label
-                htmlFor={fallbackTokenSelectId}
+                htmlFor={fallbackRuntimeKeySelectId}
                 className="dark:text-dark-text-secondary text-sm font-medium text-gray-700"
               >
                 {t("status.fallback.selectLabel")}
@@ -189,7 +189,7 @@ export function StatusIndicator({
                   }
                 >
                   <SelectTrigger
-                    id={fallbackTokenSelectId}
+                    id={fallbackRuntimeKeySelectId}
                     aria-label={t("status.fallback.selectLabel")}
                   >
                     <SelectValue
@@ -256,8 +256,8 @@ export function StatusIndicator({
       <Alert
         variant="info"
         className="mb-6"
-        title={t("status.tokenScopedCatalogTitle")}
-        description={t("status.tokenScopedCatalogDescription")}
+        title={t("status.runtimeKeyScopedCatalogTitle")}
+        description={t("status.runtimeKeyScopedCatalogDescription")}
         aria-live="polite"
       >
         {renderAccountFallbackSection()}

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -31,7 +31,7 @@ import {
   fetchApiCredentialModelIds,
 } from "~/services/apiCredentialProfiles/modelCatalog"
 import {
-  ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED,
+  ACCOUNT_RUNTIME_KEY_FALLBACK_LOAD_FAILED,
   canLoadModelListAccountFallbackRuntimeKeys,
   loadAccountRuntimeKeyFallbackPricingResponse,
   MODEL_LIST_ACCOUNT_SOURCE_ROUTES,
@@ -916,7 +916,8 @@ function useSingleAccountModelData(params: {
 
       const errorMessage = getErrorMessage(error)
       const sanitizedMessage =
-        errorMessage && errorMessage !== ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED
+        errorMessage &&
+        errorMessage !== ACCOUNT_RUNTIME_KEY_FALLBACK_LOAD_FAILED
           ? errorMessage
           : t("status.fallback.loadModelsFailedFallback")
 

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -22,7 +22,6 @@ import {
 } from "~/services/accounts/accountSiteProfile"
 import {
   canManageDisplayAccountTokens,
-  createDisplayAccountApiContext,
   fetchDisplayAccountRuntimeKeys,
   InvalidTokenPayloadError,
 } from "~/services/accounts/utils/apiServiceRequest"
@@ -33,6 +32,7 @@ import {
 } from "~/services/apiCredentialProfiles/modelCatalog"
 import {
   ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED,
+  canLoadModelListAccountFallbackRuntimeKeys,
   loadAccountRuntimeKeyFallbackPricingResponse,
   MODEL_LIST_ACCOUNT_SOURCE_ROUTES,
   resolveModelListAccountSourceReadiness,
@@ -435,17 +435,6 @@ function hasValidPricingData(data: PricingResponse) {
   return Array.isArray(data.data)
 }
 
-/** Returns whether fallback loading can use a singleton service credential. */
-function canLoadDisplayAccountFallbackRuntimeKeys(
-  account: DisplaySiteData | null | undefined,
-) {
-  if (!account) return false
-
-  const { keyManagement, serviceCredential } =
-    createDisplayAccountApiContext(account)
-  return Boolean(serviceCredential && !keyManagement)
-}
-
 /** Maps items through async workers while preserving input order. */
 async function mapWithConcurrency<T, R>(
   items: T[],
@@ -679,7 +668,7 @@ function useSingleAccountModelData(params: {
   const fallbackAvailable = useMemo(
     () =>
       canManageDisplayAccountTokens(currentAccount) ||
-      canLoadDisplayAccountFallbackRuntimeKeys(currentAccount),
+      canLoadModelListAccountFallbackRuntimeKeys(currentAccount),
     [currentAccount],
   )
 

--- a/src/locales/en/aiApiVerification.json
+++ b/src/locales/en/aiApiVerification.json
@@ -27,18 +27,18 @@
       "clear": "Clear history",
       "lastVerified": "Last verified"
     },
-    "idleHint": "Select a token to start verification. Model id is required for model-dependent probes.",
-    "loadingTokensHint": "Loading tokens...",
+    "idleHint": "Select a key to start verification. Model id is required for model-dependent probes.",
+    "loadingRuntimeKeysHint": "Loading keys...",
     "meta": {
       "apiType": "API type",
       "apiTypePlaceholder": "Select API type",
       "model": "Model",
       "modelPlaceholder": "Enter model id",
-      "token": "Token",
-      "tokenIncompatible": "Not available for this model",
-      "tokenPlaceholder": "Select token"
+      "runtimeKey": "Key",
+      "runtimeKeyIncompatible": "Not available for this model",
+      "runtimeKeyPlaceholder": "Select key"
     },
-    "noCompatibleTokenHint": "No token is available for this model's group. Create or choose a token for an enabled group in Key Management.",
+    "noCompatibleRuntimeKeyHint": "No key is available for this model's group. Create or choose a key for an enabled group in Key Management.",
     "notRunYet": "Not run yet",
     "probes": {
       "models": "Models endpoint (/v1/models)",
@@ -48,7 +48,7 @@
       "web-search": "Web search / grounding"
     },
     "requiresModelId": "Enter a model id to run this test.",
-    "selectedTokenIncompatibleHint": "The selected token is not available for this model's group. Choose a compatible token before running verification.",
+    "selectedRuntimeKeyIncompatibleHint": "The selected key is not available for this model's group. Choose a compatible key before running verification.",
     "status": {
       "fail": "Fail",
       "pass": "Pass",

--- a/src/locales/en/cliSupportVerification.json
+++ b/src/locales/en/cliSupportVerification.json
@@ -12,14 +12,14 @@
       "input": "Input",
       "output": "Output"
     },
-    "idleHint": "Select a token, then run the simulation. Provide a model id if the token cannot be used to infer one.",
+    "idleHint": "Select a key, then run the simulation. Provide a model id if the key cannot be used to infer one.",
     "loadingModelsHint": "Loading models...",
-    "loadingTokensHint": "Loading tokens...",
+    "loadingRuntimeKeysHint": "Loading keys...",
     "meta": {
       "model": "Model",
       "modelPlaceholder": "Enter model id",
-      "token": "Token",
-      "tokenPlaceholder": "Select token"
+      "runtimeKey": "Key",
+      "runtimeKeyPlaceholder": "Select key"
     },
     "modelHint": "Model hint from token: {{modelId}}",
     "modelPickerPlaceholder": "Select or enter model id",
@@ -40,7 +40,7 @@
       "invalidResponse": "Unexpected response format",
       "networkError": "Network error / blocked request",
       "noModelIdProvided": "No model id available",
-      "noRuntimeKeySecret": "No API key is available for this runtime key.",
+      "noRuntimeKeySecret": "No API key is available for the selected key.",
       "noToolCallDetected": "No tool call detected (tool calling may not be supported)",
       "stopped": "Stopped by user.",
       "supported": "Supported",

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -63,7 +63,7 @@
     "idleHint": "This will batch-verify the currently filtered models with the selected test items.",
     "messages": {
       "noApplicableProbes": "None of the selected test items apply to this model.",
-      "noCompatibleRuntimeKey": "No enabled compatible token was found for this model.",
+      "noCompatibleRuntimeKey": "No enabled compatible key was found for this model.",
       "notSelected": "This model was not selected, so it was skipped in this batch run.",
       "pending": "Waiting to test",
       "probeSummary_one": "Ran {{count}} item, passed {{pass}}, failed {{fail}}, unsupported {{unsupported}}",
@@ -84,7 +84,7 @@
       "label": "Test items",
       "noneSelected": "Select at least one test item."
     },
-    "runtimeKeyUsed": "Token: {{name}}",
+    "runtimeKeyUsed": "Key: {{name}}",
     "status": {
       "fail": "Fail",
       "pass": "Pass",

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -63,7 +63,7 @@
     "idleHint": "This will batch-verify the currently filtered models with the selected test items.",
     "messages": {
       "noApplicableProbes": "None of the selected test items apply to this model.",
-      "noCompatibleToken": "No enabled compatible token was found for this model.",
+      "noCompatibleRuntimeKey": "No enabled compatible token was found for this model.",
       "notSelected": "This model was not selected, so it was skipped in this batch run.",
       "pending": "Waiting to test",
       "probeSummary_one": "Ran {{count}} item, passed {{pass}}, failed {{fail}}, unsupported {{unsupported}}",
@@ -84,6 +84,7 @@
       "label": "Test items",
       "noneSelected": "Select at least one test item."
     },
+    "runtimeKeyUsed": "Token: {{name}}",
     "status": {
       "fail": "Fail",
       "pass": "Pass",
@@ -96,7 +97,6 @@
     "summary_one": "Completed {{completed}} / {{count}} model, passed {{pass}}, failed {{fail}}, skipped {{skipped}}",
     "summary_other": "Completed {{completed}} / {{count}} models, passed {{pass}}, failed {{fail}}, skipped {{skipped}}",
     "title": "Batch Test Models",
-    "tokenUsed": "Token: {{name}}",
     "warning": "Batch testing runs the selected items according to each model’s resolved API type. Inapplicable items are skipped automatically. Results are advisory; rely on real tool calls for final confirmation."
   },
   "billingMode": "Billing Mode",
@@ -143,7 +143,7 @@
       "accountDisabled": "This account is disabled.",
       "missingAuth": "This account does not have authentication configured.",
       "missingCredentials": "This account is missing required credentials.",
-      "readOnlyRuntimeKeys": "This account can read existing runtime keys, but it cannot create new API keys."
+      "readOnlyRuntimeKeys": "This account can read existing keys, but it cannot create new API keys."
     },
     "keyCopied": "Key copied",
     "loadFailed": "Failed to load keys: {{error}}",
@@ -194,8 +194,8 @@
   "realAmount": "Real Recharge Amount",
   "refreshData": "Refresh Data",
   "runtimeKeyFallbackSourceNotice": {
-    "description": "This catalog is loaded through an existing runtime key for this account, so it only supports model discovery and verification. This account cannot create new API keys here; Refresh Data will retry the direct account route.",
-    "title": "Runtime-key model catalog"
+    "description": "This catalog is loaded through an existing key for this account, so it only supports model discovery and verification. This account cannot create new API keys here; Refresh Data will retry the direct account route.",
+    "title": "Account key model catalog"
   },
   "searchModels": "Search Models",
   "searchPlaceholder": "Enter model name or description...",
@@ -230,11 +230,11 @@
       "noKeysTitle": "No available keys found",
       "reloadKeys": "Reload keys",
       "retryLoadWithKey": "Retry selected key",
+      "runtimeKeysLoadFailedTitle": "Failed to load account keys",
       "selectHint": "This account has multiple eligible keys. Choose the one you want to use before loading the fallback catalog.",
       "selectLabel": "Key for fallback loading",
       "selectPlaceholder": "Select a key",
-      "title": "Load models with an account key",
-      "tokensLoadFailedTitle": "Failed to load account keys"
+      "title": "Load models with an account key"
     },
     "formatNotStandard": "The model data format of the current site does not meet the standard, please manually check the site pricing page",
     "genericLoadFailedTitle": "Failed to load model data",
@@ -247,10 +247,10 @@
     "profileLoadFailed": "Failed to load models for this API credential: {{errorMessage}}",
     "profileLoadFailedTitle": "Failed to load models for this API credential",
     "retryLoad": "Retry Load",
-    "tokenScopedCatalogDescription": "This source account does not provide an account-level model list. The extension fetches the models available to this account through its API keys.",
-    "tokenScopedCatalogFallbackDescription": "Select an API key. If only one available key exists, the extension will use it automatically.",
-    "tokenScopedCatalogFallbackTitle": "Fetch models through a key",
-    "tokenScopedCatalogTitle": "Fetching the model list through an API key"
+    "runtimeKeyScopedCatalogDescription": "This source account does not provide an account-level model list. The extension fetches the models available to this account through its API keys.",
+    "runtimeKeyScopedCatalogFallbackDescription": "Select an API key. If only one available key exists, the extension will use it automatically.",
+    "runtimeKeyScopedCatalogFallbackTitle": "Fetch models through a key",
+    "runtimeKeyScopedCatalogTitle": "Fetching the model list through an API key"
   },
   "title": "Model List",
   "totalModels_one": "Total {{count}} model",

--- a/src/locales/ja/aiApiVerification.json
+++ b/src/locales/ja/aiApiVerification.json
@@ -27,18 +27,18 @@
       "clear": "履歴をクリア",
       "lastVerified": "前回の検証"
     },
-    "idleHint": "検証を開始するにはトークンを選択してください。モデル依存のプローブにはモデル ID が必要です。",
-    "loadingTokensHint": "トークンを読み込み中...",
+    "idleHint": "検証を開始するにはキーを選択してください。モデル依存のプローブにはモデル ID が必要です。",
+    "loadingRuntimeKeysHint": "キーを読み込み中...",
     "meta": {
       "apiType": "API 種別",
       "apiTypePlaceholder": "API 種別を選択",
       "model": "モデル",
       "modelPlaceholder": "モデル ID を入力",
-      "token": "トークン",
-      "tokenIncompatible": "このモデルでは使用不可",
-      "tokenPlaceholder": "トークンを選択"
+      "runtimeKey": "キー",
+      "runtimeKeyIncompatible": "このモデルでは使用不可",
+      "runtimeKeyPlaceholder": "キーを選択"
     },
-    "noCompatibleTokenHint": "このモデルのグループで使用できるトークンがありません。キー管理で有効なグループのトークンを作成するか選択してください。",
+    "noCompatibleRuntimeKeyHint": "このモデルのグループで使用できるキーがありません。キー管理で有効なグループのキーを作成するか選択してください。",
     "notRunYet": "未実行",
     "probes": {
       "models": "Models エンドポイント (/v1/models)",
@@ -48,7 +48,7 @@
       "web-search": "Web 検索 / grounding"
     },
     "requiresModelId": "このテストを実行するにはモデル ID を入力してください。",
-    "selectedTokenIncompatibleHint": "選択中のトークンはこのモデルのグループでは使用できません。互換性のあるトークンを選択してから検証してください。",
+    "selectedRuntimeKeyIncompatibleHint": "選択中のキーはこのモデルのグループでは使用できません。互換性のあるキーを選択してから検証してください。",
     "status": {
       "fail": "失敗",
       "pass": "成功",

--- a/src/locales/ja/cliSupportVerification.json
+++ b/src/locales/ja/cliSupportVerification.json
@@ -12,14 +12,14 @@
       "input": "入力",
       "output": "出力"
     },
-    "idleHint": "トークンを選択してからシミュレーションを実行してください。トークンからモデルを推定できない場合は、モデル ID を指定してください。",
+    "idleHint": "キーを選択してからシミュレーションを実行してください。キーからモデルを推定できない場合は、モデル ID を指定してください。",
     "loadingModelsHint": "モデルを読み込み中...",
-    "loadingTokensHint": "トークンを読み込み中...",
+    "loadingRuntimeKeysHint": "キーを読み込み中...",
     "meta": {
       "model": "モデル",
       "modelPlaceholder": "モデル ID を入力",
-      "token": "トークン",
-      "tokenPlaceholder": "トークンを選択"
+      "runtimeKey": "キー",
+      "runtimeKeyPlaceholder": "キーを選択"
     },
     "modelHint": "トークンから推定したモデル: {{modelId}}",
     "modelPickerPlaceholder": "モデル ID を選択または入力",
@@ -40,7 +40,7 @@
       "invalidResponse": "予期しない応答形式です",
       "networkError": "ネットワークエラー / リクエストがブロックされました",
       "noModelIdProvided": "利用可能なモデル ID がありません",
-      "noRuntimeKeySecret": "このランタイムキーで利用できる API キーがありません。",
+      "noRuntimeKeySecret": "選択したキーで利用できる API キーがありません。",
       "noToolCallDetected": "ツール呼び出しが検出されませんでした（ツール呼び出し未対応の可能性があります）",
       "stopped": "ユーザーが停止しました。",
       "supported": "対応",

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -61,7 +61,7 @@
     "idleHint": "選択したテスト項目で、現在フィルターされたモデルを一括検証します。",
     "messages": {
       "noApplicableProbes": "選択したテスト項目はこのモデルに適用できません。",
-      "noCompatibleToken": "このモデルに対応する有効なトークンが見つかりません。",
+      "noCompatibleRuntimeKey": "このモデルに対応する有効なトークンが見つかりません。",
       "notSelected": "このモデルは選択されていないため、今回の一括テストではスキップされました。",
       "pending": "テスト待ち",
       "probeSummary_other": "{{count}} 件実行、成功 {{pass}}、失敗 {{fail}}、非対応 {{unsupported}}",
@@ -80,6 +80,7 @@
       "label": "テスト項目",
       "noneSelected": "少なくとも 1 つのテスト項目を選択してください。"
     },
+    "runtimeKeyUsed": "トークン: {{name}}",
     "status": {
       "fail": "失敗",
       "pass": "成功",
@@ -90,7 +91,6 @@
     "subtitle_other": "フィルター済み {{count}} モデル",
     "summary_other": "完了 {{completed}} / {{count}}、成功 {{pass}}、失敗 {{fail}}、スキップ {{skipped}}",
     "title": "モデルを一括テスト",
-    "tokenUsed": "トークン: {{name}}",
     "warning": "一括テストは、各モデルで解決された API 種別に応じて選択項目を実行します。適用できない項目は自動的にスキップされます。結果は参考情報です。最終確認は実際のツール呼び出しで行ってください。"
   },
   "billingMode": "課金方式",
@@ -137,7 +137,7 @@
       "accountDisabled": "このアカウントは無効です。",
       "missingAuth": "このアカウントには認証設定がありません。",
       "missingCredentials": "このアカウントには必要な認証情報が不足しています。",
-      "readOnlyRuntimeKeys": "このアカウントは既存のランタイムキーを読み取れますが、新しい API キーは作成できません。"
+      "readOnlyRuntimeKeys": "このアカウントは既存のキーを読み取れますが、新しい API キーは作成できません。"
     },
     "keyCopied": "キーをコピーしました",
     "loadFailed": "キーの読み込みに失敗しました: {{error}}",
@@ -188,8 +188,8 @@
   "realAmount": "実際のチャージ額",
   "refreshData": "データを更新",
   "runtimeKeyFallbackSourceNotice": {
-    "description": "このカタログは、このアカウントの既存ランタイムキー経由で読み込まれているため、モデル検出と検証のみ利用できます。このアカウントではここから新しい API キーを作成できません。[データを更新] を押すと直接のアカウント経路を再試行します。",
-    "title": "ランタイムキーモデルカタログ"
+    "description": "このカタログは、このアカウントの既存キー経由で読み込まれているため、モデル検出と検証のみ利用できます。このアカウントではここから新しい API キーを作成できません。[データを更新] を押すと直接のアカウント経路を再試行します。",
+    "title": "アカウントキーモデルカタログ"
   },
   "searchModels": "モデルを検索",
   "searchPlaceholder": "モデル名または説明を入力...",
@@ -223,11 +223,11 @@
       "noKeysTitle": "利用可能なキーが見つかりません",
       "reloadKeys": "キーを再読み込み",
       "retryLoadWithKey": "選択したキーで再試行",
+      "runtimeKeysLoadFailedTitle": "アカウントキーの読み込みに失敗しました",
       "selectHint": "このアカウントには利用可能なキーが複数あります。フォールバックカタログを読み込む前に使うキーを選択してください。",
       "selectLabel": "フォールバック読み込みに使うキー",
       "selectPlaceholder": "キーを選択",
-      "title": "アカウントキーでモデルを読み込む",
-      "tokensLoadFailedTitle": "アカウントキーの読み込みに失敗しました"
+      "title": "アカウントキーでモデルを読み込む"
     },
     "formatNotStandard": "現在のサイトのモデルデータ形式は標準仕様に準拠していません。サイトの料金ページを手動で確認してください",
     "genericLoadFailedTitle": "モデルデータの読み込みに失敗しました",
@@ -240,10 +240,10 @@
     "profileLoadFailed": "この API 認証情報のモデル読み込みに失敗しました: {{errorMessage}}",
     "profileLoadFailedTitle": "この API 認証情報のモデル読み込みに失敗しました",
     "retryLoad": "再読み込み",
-    "tokenScopedCatalogDescription": "このソースアカウントはアカウント単位のモデル一覧を提供していません。拡張機能は、このアカウントの API キーを使って実際に利用できるモデルを取得します。",
-    "tokenScopedCatalogFallbackDescription": "API キーを選択してください。利用可能なキーが 1 つだけの場合は、拡張機能が自動的にそのキーでモデルを読み込みます。",
-    "tokenScopedCatalogFallbackTitle": "キーでモデルを取得",
-    "tokenScopedCatalogTitle": "API キーでモデル一覧を取得しています"
+    "runtimeKeyScopedCatalogDescription": "このソースアカウントはアカウント単位のモデル一覧を提供していません。拡張機能は、このアカウントの API キーを使って実際に利用できるモデルを取得します。",
+    "runtimeKeyScopedCatalogFallbackDescription": "API キーを選択してください。利用可能なキーが 1 つだけの場合は、拡張機能が自動的にそのキーでモデルを読み込みます。",
+    "runtimeKeyScopedCatalogFallbackTitle": "キーでモデルを取得",
+    "runtimeKeyScopedCatalogTitle": "API キーでモデル一覧を取得しています"
   },
   "title": "モデル一覧",
   "totalModels_other": "合計 {{count}} モデル",

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -61,7 +61,7 @@
     "idleHint": "選択したテスト項目で、現在フィルターされたモデルを一括検証します。",
     "messages": {
       "noApplicableProbes": "選択したテスト項目はこのモデルに適用できません。",
-      "noCompatibleRuntimeKey": "このモデルに対応する有効なトークンが見つかりません。",
+      "noCompatibleRuntimeKey": "このモデルに対応する有効なキーが見つかりません。",
       "notSelected": "このモデルは選択されていないため、今回の一括テストではスキップされました。",
       "pending": "テスト待ち",
       "probeSummary_other": "{{count}} 件実行、成功 {{pass}}、失敗 {{fail}}、非対応 {{unsupported}}",
@@ -80,7 +80,7 @@
       "label": "テスト項目",
       "noneSelected": "少なくとも 1 つのテスト項目を選択してください。"
     },
-    "runtimeKeyUsed": "トークン: {{name}}",
+    "runtimeKeyUsed": "キー: {{name}}",
     "status": {
       "fail": "失敗",
       "pass": "成功",

--- a/src/locales/vi/aiApiVerification.json
+++ b/src/locales/vi/aiApiVerification.json
@@ -28,17 +28,17 @@
       "lastVerified": "Lần xác minh gần nhất"
     },
     "idleHint": "Vui lòng chọn khóa để bắt đầu xác minh; thăm dò liên quan đến mô hình cần điền ID mô hình.",
-    "loadingTokensHint": "Đang tải khóa...",
+    "loadingRuntimeKeysHint": "Đang tải khóa...",
     "meta": {
       "apiType": "Loại API",
       "apiTypePlaceholder": "Chọn loại API",
       "model": "Mô hình",
       "modelPlaceholder": "Nhập ID mô hình",
-      "token": "Khóa",
-      "tokenIncompatible": "Không dùng được cho mô hình này",
-      "tokenPlaceholder": "Chọn khóa"
+      "runtimeKey": "Khóa",
+      "runtimeKeyIncompatible": "Không dùng được cho mô hình này",
+      "runtimeKeyPlaceholder": "Chọn khóa"
     },
-    "noCompatibleTokenHint": "Không có khóa nào dùng được cho nhóm của mô hình này. Hãy tạo hoặc chọn khóa thuộc nhóm khả dụng trong Quản lý khóa.",
+    "noCompatibleRuntimeKeyHint": "Không có khóa nào dùng được cho nhóm của mô hình này. Hãy tạo hoặc chọn khóa thuộc nhóm khả dụng trong Quản lý khóa.",
     "notRunYet": "Chưa chạy",
     "probes": {
       "models": "API danh sách mô hình (/v1/models)",
@@ -48,7 +48,7 @@
       "web-search": "Tìm kiếm web / Grounding"
     },
     "requiresModelId": "Vui lòng nhập ID mô hình trước khi chạy bài kiểm tra này.",
-    "selectedTokenIncompatibleHint": "Khóa đang chọn không dùng được cho nhóm của mô hình này. Hãy chọn khóa tương thích trước khi xác minh.",
+    "selectedRuntimeKeyIncompatibleHint": "Khóa đang chọn không dùng được cho nhóm của mô hình này. Hãy chọn khóa tương thích trước khi xác minh.",
     "status": {
       "fail": "Thất bại",
       "pass": "Thành công",
@@ -61,6 +61,7 @@
       "forbidden": "Cấm truy cập (403): Truy cập bị từ chối",
       "httpError": "Lỗi HTTP ({{status}})",
       "modelsFetched": "Lấy thành công {{count}} mô hình.",
+      "modelsFetched_other": "Lấy thành công {{count}} mô hình.",
       "modelsProbeUnsupportedForApiType": "Loại API hiện tại không hỗ trợ thăm dò danh sách mô hình.",
       "noModelAvailableToRunProbes": "Không có mô hình khả dụng, không thể chạy thăm dò.",
       "noModelIdProvided": "Chưa cung cấp ID mô hình, không thể chạy thăm dò.",

--- a/src/locales/vi/cliSupportVerification.json
+++ b/src/locales/vi/cliSupportVerification.json
@@ -12,14 +12,14 @@
       "input": "Đầu vào",
       "output": "Đầu ra"
     },
-    "idleHint": "Vui lòng chọn API Key để bắt đầu xác thực. Nếu không thể suy đoán mô hình từ API Key, vui lòng nhập thủ công ID mô hình.",
+    "idleHint": "Vui lòng chọn khóa để bắt đầu xác thực. Nếu không thể suy đoán mô hình từ khóa này, vui lòng nhập thủ công ID mô hình.",
     "loadingModelsHint": "Đang tải mô hình...",
-    "loadingTokensHint": "Đang tải API Key...",
+    "loadingRuntimeKeysHint": "Đang tải khóa...",
     "meta": {
       "model": "Mô hình",
       "modelPlaceholder": "Nhập ID mô hình",
-      "token": "API Key",
-      "tokenPlaceholder": "Chọn API Key"
+      "runtimeKey": "Khóa",
+      "runtimeKeyPlaceholder": "Chọn khóa"
     },
     "modelHint": "Mô hình suy đoán từ API Key: {{modelId}}",
     "modelPickerPlaceholder": "Chọn hoặc nhập ID mô hình",
@@ -40,7 +40,7 @@
       "invalidResponse": "Định dạng phản hồi không như mong đợi",
       "networkError": "Lỗi mạng / Yêu cầu bị chặn",
       "noModelIdProvided": "Không có ID mô hình khả dụng",
-      "noRuntimeKeySecret": "Runtime key này không có API Key khả dụng.",
+      "noRuntimeKeySecret": "Khóa đã chọn không có API Key khả dụng.",
       "noToolCallDetected": "Không phát hiện gọi công cụ (có thể không hỗ trợ tool/function calling)",
       "stopped": "Đã dừng bởi người dùng.",
       "supported": "Hỗ trợ",

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -61,7 +61,7 @@
     "idleHint": "Sẽ kiểm tra hàng loạt các mô hình đã lọc theo mục kiểm tra đã chọn.",
     "messages": {
       "noApplicableProbes": "Mục kiểm tra hiện tại không áp dụng cho mô hình này.",
-      "noCompatibleToken": "Không tìm thấy khóa khả dụng tương thích với mô hình này.",
+      "noCompatibleRuntimeKey": "Không tìm thấy khóa khả dụng tương thích với mô hình này.",
       "notSelected": "Chưa chọn mô hình này, đã bỏ qua trong lần kiểm tra hàng loạt này.",
       "pending": "Đang chờ kiểm tra",
       "probeSummary_other": "Đã chạy {{count}} mục, thành công {{pass}}, thất bại {{fail}}, không hỗ trợ {{unsupported}}",
@@ -80,6 +80,7 @@
       "label": "Mục kiểm tra",
       "noneSelected": "Vui lòng chọn ít nhất một mục kiểm tra."
     },
+    "runtimeKeyUsed": "Khóa: {{name}}",
     "status": {
       "fail": "Thất bại",
       "pass": "Thành công",
@@ -90,7 +91,6 @@
     "subtitle_other": "Hiện đang lọc {{count}} mô hình",
     "summary_other": "Đã hoàn thành {{completed}} / {{count}}, thành công {{pass}}, thất bại {{fail}}, bỏ qua {{skipped}}",
     "title": "Kiểm tra hàng loạt mô hình",
-    "tokenUsed": "Khóa: {{name}}",
     "warning": "Kiểm tra hàng loạt sẽ thực hiện các mục đã chọn theo loại API đã phân tích cho từng mô hình; các mục không áp dụng sẽ tự động bị bỏ qua. Kết quả kiểm tra chỉ mang tính tham khảo, vui lòng dựa trên tình hình gọi thực tế của công cụ."
   },
   "billingMode": "Phương thức tính phí",
@@ -137,7 +137,7 @@
       "accountDisabled": "Tài khoản này đã bị vô hiệu hóa.",
       "missingAuth": "Tài khoản này chưa được cấu hình thông tin xác thực.",
       "missingCredentials": "Tài khoản này thiếu các thông tin xác thực cần thiết.",
-      "readOnlyRuntimeKeys": "Tài khoản này có thể đọc các khóa runtime hiện có, nhưng không thể tạo khóa API mới."
+      "readOnlyRuntimeKeys": "Tài khoản này có thể đọc các khóa hiện có, nhưng không thể tạo khóa API mới."
     },
     "keyCopied": "Đã sao chép khóa",
     "loadFailed": "Tải khóa thất bại: {{error}}",
@@ -188,8 +188,8 @@
   "realAmount": "Số tiền nạp thực tế",
   "refreshData": "Làm mới dữ liệu",
   "runtimeKeyFallbackSourceNotice": {
-    "description": "Danh mục mô hình hiện tại được tải bằng khóa runtime hiện có của tài khoản này, chỉ hỗ trợ phát hiện và xác minh mô hình. Tài khoản này không thể tạo khóa API mới tại đây; nhấp vào làm mới dữ liệu sẽ thử lại API của tài khoản.",
-    "title": "Danh mục mô hình bằng khóa runtime"
+    "description": "Danh mục mô hình hiện tại được tải bằng khóa hiện có của tài khoản này, chỉ hỗ trợ phát hiện và xác minh mô hình. Tài khoản này không thể tạo khóa API mới tại đây; nhấp vào làm mới dữ liệu sẽ thử lại API của tài khoản.",
+    "title": "Danh mục mô hình bằng khóa tài khoản"
   },
   "searchModels": "Tìm kiếm mô hình",
   "searchPlaceholder": "Nhập tên hoặc mô tả mô hình...",
@@ -223,11 +223,11 @@
       "noKeysTitle": "Không tìm thấy khóa khả dụng",
       "reloadKeys": "Tải lại khóa",
       "retryLoadWithKey": "Thử lại khóa đã chọn",
+      "runtimeKeysLoadFailedTitle": "Tải khóa tài khoản thất bại",
       "selectHint": "Tài khoản này có nhiều khóa khả dụng, vui lòng chọn rõ ràng khóa bạn muốn sử dụng trước.",
       "selectLabel": "Khóa dùng để tải dự phòng",
       "selectPlaceholder": "Vui lòng chọn khóa",
-      "title": "Chuyển sang sử dụng khóa tài khoản để tải mô hình",
-      "tokensLoadFailedTitle": "Tải khóa tài khoản thất bại"
+      "title": "Chuyển sang sử dụng khóa tài khoản để tải mô hình"
     },
     "formatNotStandard": "Định dạng dữ liệu mô hình của trang web hiện tại không đạt chuẩn, vui lòng xem trang định giá của trang web theo cách thủ công",
     "genericLoadFailedTitle": "Tải dữ liệu mô hình thất bại",
@@ -240,10 +240,10 @@
     "profileLoadFailed": "Tải mô hình của thông tin xác thực API này thất bại: {{errorMessage}}",
     "profileLoadFailedTitle": "Tải mô hình của thông tin xác thực API này thất bại",
     "retryLoad": "Thử tải lại",
-    "tokenScopedCatalogDescription": "Tài khoản nguồn này không cung cấp danh sách mô hình ở cấp tài khoản. Tiện ích sẽ dùng API key của tài khoản này để lấy các mô hình thực sự có thể sử dụng.",
-    "tokenScopedCatalogFallbackDescription": "Chọn một API key. Nếu chỉ có một key khả dụng, tiện ích sẽ tự động dùng key đó để tải mô hình.",
-    "tokenScopedCatalogFallbackTitle": "Lấy mô hình qua key",
-    "tokenScopedCatalogTitle": "Đang lấy danh sách mô hình qua API key"
+    "runtimeKeyScopedCatalogDescription": "Tài khoản nguồn này không cung cấp danh sách mô hình ở cấp tài khoản. Tiện ích sẽ dùng API key của tài khoản này để lấy các mô hình thực sự có thể sử dụng.",
+    "runtimeKeyScopedCatalogFallbackDescription": "Chọn một API key. Nếu chỉ có một key khả dụng, tiện ích sẽ tự động dùng key đó để tải mô hình.",
+    "runtimeKeyScopedCatalogFallbackTitle": "Lấy mô hình qua key",
+    "runtimeKeyScopedCatalogTitle": "Đang lấy danh sách mô hình qua API key"
   },
   "title": "Danh sách mô hình",
   "totalModels_other": "Tổng cộng {{count}} mô hình",

--- a/src/locales/zh-CN/aiApiVerification.json
+++ b/src/locales/zh-CN/aiApiVerification.json
@@ -28,17 +28,17 @@
       "lastVerified": "最近验证"
     },
     "idleHint": "请选择密钥开始验证；模型相关探测需要填写模型 ID。",
-    "loadingTokensHint": "正在加载密钥...",
+    "loadingRuntimeKeysHint": "正在加载密钥...",
     "meta": {
       "apiType": "接口类型",
       "apiTypePlaceholder": "选择接口类型",
       "model": "模型",
       "modelPlaceholder": "输入模型 ID",
-      "token": "密钥",
-      "tokenIncompatible": "不适用于该模型",
-      "tokenPlaceholder": "选择密钥"
+      "runtimeKey": "密钥",
+      "runtimeKeyIncompatible": "不适用于该模型",
+      "runtimeKeyPlaceholder": "选择密钥"
     },
-    "noCompatibleTokenHint": "当前没有适用于该模型分组的密钥。请在密钥管理中创建或选择可用分组的密钥。",
+    "noCompatibleRuntimeKeyHint": "当前没有适用于该模型分组的密钥。请在密钥管理中创建或选择可用分组的密钥。",
     "notRunYet": "尚未运行",
     "probes": {
       "models": "模型列表接口 (/v1/models)",
@@ -48,7 +48,7 @@
       "web-search": "联网搜索 / Grounding"
     },
     "requiresModelId": "请输入模型 ID 后运行该测试。",
-    "selectedTokenIncompatibleHint": "当前选择的密钥不适用于该模型分组。请先选择适用的密钥后再测试。",
+    "selectedRuntimeKeyIncompatibleHint": "当前选择的密钥不适用于该模型分组。请先选择适用的密钥后再测试。",
     "status": {
       "fail": "失败",
       "pass": "通过",

--- a/src/locales/zh-CN/cliSupportVerification.json
+++ b/src/locales/zh-CN/cliSupportVerification.json
@@ -14,12 +14,12 @@
     },
     "idleHint": "请选择密钥后开始验证。如无法从密钥推测模型，请手动填写模型 ID。",
     "loadingModelsHint": "正在加载模型...",
-    "loadingTokensHint": "正在加载密钥...",
+    "loadingRuntimeKeysHint": "正在加载密钥...",
     "meta": {
       "model": "模型",
       "modelPlaceholder": "输入模型 ID",
-      "token": "密钥",
-      "tokenPlaceholder": "选择密钥"
+      "runtimeKey": "密钥",
+      "runtimeKeyPlaceholder": "选择密钥"
     },
     "modelHint": "从密钥推测的模型：{{modelId}}",
     "modelPickerPlaceholder": "选择或输入模型 ID",
@@ -40,7 +40,7 @@
       "invalidResponse": "返回格式不符合预期",
       "networkError": "网络错误 / 请求被阻止",
       "noModelIdProvided": "没有可用的模型 ID",
-      "noRuntimeKeySecret": "当前运行密钥没有可用的 API Key。",
+      "noRuntimeKeySecret": "当前选择的密钥没有可用的 API Key。",
       "noToolCallDetected": "未检测到工具调用（可能不支持 tool/function calling）",
       "stopped": "已停止。",
       "supported": "支持",

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -61,7 +61,7 @@
     "idleHint": "将按所选测试项目批量验证当前筛选模型。",
     "messages": {
       "noApplicableProbes": "当前选择的测试项目不适用于该模型。",
-      "noCompatibleToken": "未找到兼容该模型的可用密钥。",
+      "noCompatibleRuntimeKey": "未找到兼容该模型的可用密钥。",
       "notSelected": "未选择该模型，本次批量测试已跳过。",
       "pending": "等待测试",
       "probeSummary": "已运行 {{count}} 项，通过 {{pass}}，失败 {{fail}}，不支持 {{unsupported}}",
@@ -80,6 +80,7 @@
       "label": "测试项目",
       "noneSelected": "请至少选择一个测试项目。"
     },
+    "runtimeKeyUsed": "密钥：{{name}}",
     "status": {
       "fail": "失败",
       "pass": "通过",
@@ -90,7 +91,6 @@
     "subtitle": "当前筛选 {{count}} 个模型",
     "summary": "已完成 {{completed}} / {{count}}，通过 {{pass}}，失败 {{fail}}，跳过 {{skipped}}",
     "title": "批量测试模型",
-    "tokenUsed": "密钥：{{name}}",
     "warning": "批量测试会按每个模型解析后的接口类型执行所选项目；不适用的项目会自动跳过。检测结果仅供参考，请以工具实际调用情况为准。"
   },
   "billingMode": "计费方式",
@@ -137,7 +137,7 @@
       "accountDisabled": "该账号已被禁用。",
       "missingAuth": "该账号未配置认证信息。",
       "missingCredentials": "该账号缺少必要的凭据。",
-      "readOnlyRuntimeKeys": "该账号可读取已有运行时密钥，但不支持创建新的 API 密钥。"
+      "readOnlyRuntimeKeys": "该账号可读取已有密钥，但不支持创建新的 API 密钥。"
     },
     "keyCopied": "密钥已复制",
     "loadFailed": "加载密钥失败：{{error}}",
@@ -188,8 +188,8 @@
   "realAmount": "真实充值金额",
   "refreshData": "刷新数据",
   "runtimeKeyFallbackSourceNotice": {
-    "description": "当前模型目录通过该账号已有的运行时密钥加载，仅支持模型发现与验证。该账号不支持在此创建新的 API 密钥；点击刷新数据会重新尝试账号接口。",
-    "title": "运行时密钥模型目录"
+    "description": "当前模型目录通过该账号已有的密钥加载，仅支持模型发现与验证。该账号不支持在此创建新的 API 密钥；点击刷新数据会重新尝试账号接口。",
+    "title": "账号密钥模型目录"
   },
   "searchModels": "搜索模型",
   "searchPlaceholder": "输入模型名称或描述...",
@@ -223,11 +223,11 @@
       "noKeysTitle": "未找到可用密钥",
       "reloadKeys": "重新加载密钥",
       "retryLoadWithKey": "重试所选密钥",
+      "runtimeKeysLoadFailedTitle": "加载账号密钥失败",
       "selectHint": "该账号存在多个可用密钥，请先明确选择要使用的密钥。",
       "selectLabel": "用于回退加载的密钥",
       "selectPlaceholder": "请选择密钥",
-      "title": "改用账号密钥加载模型",
-      "tokensLoadFailedTitle": "加载账号密钥失败"
+      "title": "改用账号密钥加载模型"
     },
     "formatNotStandard": "当前站点的模型数据格式不符合标准，请手动查看站点定价页面",
     "genericLoadFailedTitle": "加载模型数据失败",
@@ -240,10 +240,10 @@
     "profileLoadFailed": "加载该 API 凭据的模型失败：{{errorMessage}}",
     "profileLoadFailedTitle": "加载该 API 凭据的模型失败",
     "retryLoad": "重新尝试加载",
-    "tokenScopedCatalogDescription": "该来源账号不提供账号级模型列表。插件会通过账号下的 API 密钥获取实际可用模型。",
-    "tokenScopedCatalogFallbackDescription": "请选择一个 API 密钥；如果只有一个可用密钥，插件会自动使用它加载模型。",
-    "tokenScopedCatalogFallbackTitle": "通过密钥获取模型",
-    "tokenScopedCatalogTitle": "正在通过 API 密钥获取模型列表"
+    "runtimeKeyScopedCatalogDescription": "该来源账号不提供账号级模型列表。插件会通过账号下的 API 密钥获取实际可用模型。",
+    "runtimeKeyScopedCatalogFallbackDescription": "请选择一个 API 密钥；如果只有一个可用密钥，插件会自动使用它加载模型。",
+    "runtimeKeyScopedCatalogFallbackTitle": "通过密钥获取模型",
+    "runtimeKeyScopedCatalogTitle": "正在通过 API 密钥获取模型列表"
   },
   "title": "模型列表",
   "totalModels": "总计 {{count}} 个模型",

--- a/src/locales/zh-TW/aiApiVerification.json
+++ b/src/locales/zh-TW/aiApiVerification.json
@@ -28,17 +28,17 @@
       "lastVerified": "最近驗證"
     },
     "idleHint": "請選擇金鑰開始驗證；模型相關探測需要填寫模型 ID。",
-    "loadingTokensHint": "正在載入金鑰...",
+    "loadingRuntimeKeysHint": "正在載入金鑰...",
     "meta": {
       "apiType": "介面型別",
       "apiTypePlaceholder": "選擇介面型別",
       "model": "模型",
       "modelPlaceholder": "輸入模型 ID",
-      "token": "金鑰",
-      "tokenIncompatible": "不適用於此模型",
-      "tokenPlaceholder": "選擇金鑰"
+      "runtimeKey": "金鑰",
+      "runtimeKeyIncompatible": "不適用於此模型",
+      "runtimeKeyPlaceholder": "選擇金鑰"
     },
-    "noCompatibleTokenHint": "目前沒有適用於此模型分組的金鑰。請在金鑰管理中建立或選擇可用分組的金鑰。",
+    "noCompatibleRuntimeKeyHint": "目前沒有適用於此模型分組的金鑰。請在金鑰管理中建立或選擇可用分組的金鑰。",
     "notRunYet": "尚未執行",
     "probes": {
       "models": "模型列表介面 (/v1/models)",
@@ -48,7 +48,7 @@
       "web-search": "聯網搜尋 / Grounding"
     },
     "requiresModelId": "請輸入模型 ID 後執行該測試。",
-    "selectedTokenIncompatibleHint": "目前選擇的金鑰不適用於此模型分組。請先選擇適用的金鑰後再測試。",
+    "selectedRuntimeKeyIncompatibleHint": "目前選擇的金鑰不適用於此模型分組。請先選擇適用的金鑰後再測試。",
     "status": {
       "fail": "失敗",
       "pass": "透過",
@@ -61,6 +61,7 @@
       "forbidden": "禁止訪問（403）：訪問被拒絕",
       "httpError": "HTTP 錯誤（{{status}}）",
       "modelsFetched": "成功獲取 {{count}} 個模型。",
+      "modelsFetched_other": "成功獲取 {{count}} 個模型。",
       "modelsProbeUnsupportedForApiType": "當前介面型別不支援模型列表探測。",
       "noModelAvailableToRunProbes": "沒有可用模型，無法執行探測。",
       "noModelIdProvided": "未提供模型 ID，無法執行探測。",

--- a/src/locales/zh-TW/cliSupportVerification.json
+++ b/src/locales/zh-TW/cliSupportVerification.json
@@ -14,12 +14,12 @@
     },
     "idleHint": "請選擇金鑰後開始驗證。如無法從金鑰推測模型，請手動填寫模型 ID。",
     "loadingModelsHint": "正在載入模型...",
-    "loadingTokensHint": "正在載入金鑰...",
+    "loadingRuntimeKeysHint": "正在載入金鑰...",
     "meta": {
       "model": "模型",
       "modelPlaceholder": "輸入模型 ID",
-      "token": "金鑰",
-      "tokenPlaceholder": "選擇金鑰"
+      "runtimeKey": "金鑰",
+      "runtimeKeyPlaceholder": "選擇金鑰"
     },
     "modelHint": "從金鑰推測的模型：{{modelId}}",
     "modelPickerPlaceholder": "選擇或輸入模型 ID",
@@ -40,7 +40,7 @@
       "invalidResponse": "返回格式不符合預期",
       "networkError": "網路錯誤 / 請求被阻止",
       "noModelIdProvided": "沒有可用的模型 ID",
-      "noRuntimeKeySecret": "目前執行階段金鑰沒有可用的 API Key。",
+      "noRuntimeKeySecret": "目前選擇的金鑰沒有可用的 API Key。",
       "noToolCallDetected": "未檢測到工具呼叫（可能不支援 tool/function calling）",
       "stopped": "已停止。",
       "supported": "支援",

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -61,7 +61,7 @@
     "idleHint": "將按所選測試項目批量驗證目前篩選模型。",
     "messages": {
       "noApplicableProbes": "目前選擇的測試項目不適用於此模型。",
-      "noCompatibleToken": "未找到相容該模型的可用金鑰。",
+      "noCompatibleRuntimeKey": "未找到相容該模型的可用金鑰。",
       "notSelected": "未選擇此模型，本次批量測試已跳過。",
       "pending": "等待測試",
       "probeSummary_other": "已執行 {{count}} 項，通過 {{pass}}，失敗 {{fail}}，不支援 {{unsupported}}",
@@ -80,6 +80,7 @@
       "label": "測試項目",
       "noneSelected": "請至少選擇一個測試項目。"
     },
+    "runtimeKeyUsed": "金鑰：{{name}}",
     "status": {
       "fail": "失敗",
       "pass": "通過",
@@ -90,7 +91,6 @@
     "subtitle_other": "目前篩選 {{count}} 個模型",
     "summary_other": "已完成 {{completed}} / {{count}}，通過 {{pass}}，失敗 {{fail}}，跳過 {{skipped}}",
     "title": "批量測試模型",
-    "tokenUsed": "金鑰：{{name}}",
     "warning": "批量測試會按每個模型解析後的介面型別執行所選項目；不適用的項目會自動跳過。檢測結果僅供參考，請以工具實際呼叫情況為準。"
   },
   "billingMode": "計費方式",
@@ -137,7 +137,7 @@
       "accountDisabled": "該帳號已被禁用。",
       "missingAuth": "該帳號未配置認證資訊。",
       "missingCredentials": "該帳號缺少必要的憑據。",
-      "readOnlyRuntimeKeys": "此帳號可讀取既有執行階段金鑰，但不支援建立新的 API 金鑰。"
+      "readOnlyRuntimeKeys": "此帳號可讀取既有金鑰，但不支援建立新的 API 金鑰。"
     },
     "keyCopied": "金鑰已複製",
     "loadFailed": "載入金鑰失敗：{{error}}",
@@ -188,8 +188,8 @@
   "realAmount": "真實充值金額",
   "refreshData": "重新整理資料",
   "runtimeKeyFallbackSourceNotice": {
-    "description": "目前模型目錄是透過此帳號既有的執行階段金鑰載入，僅支援模型發現與驗證。此帳號不支援在此建立新的 API 金鑰；點擊重新整理資料會重新嘗試帳號介面。",
-    "title": "執行階段金鑰模型目錄"
+    "description": "目前模型目錄是透過此帳號既有的金鑰載入，僅支援模型發現與驗證。此帳號不支援在此建立新的 API 金鑰；點擊重新整理資料會重新嘗試帳號介面。",
+    "title": "帳號金鑰模型目錄"
   },
   "searchModels": "搜尋模型",
   "searchPlaceholder": "輸入模型名稱或描述...",
@@ -223,11 +223,11 @@
       "noKeysTitle": "找不到可用金鑰",
       "reloadKeys": "重新載入金鑰",
       "retryLoadWithKey": "重試所選金鑰",
+      "runtimeKeysLoadFailedTitle": "載入帳號金鑰失敗",
       "selectHint": "此帳號有多個可用金鑰，請先明確選擇要使用的金鑰。",
       "selectLabel": "用於回退載入的金鑰",
       "selectPlaceholder": "請選擇金鑰",
-      "title": "改用帳號金鑰載入模型",
-      "tokensLoadFailedTitle": "載入帳號金鑰失敗"
+      "title": "改用帳號金鑰載入模型"
     },
     "formatNotStandard": "當前站點的模型資料格式不符合標準，請手動檢視站點定價頁面",
     "genericLoadFailedTitle": "載入模型資料失敗",
@@ -240,10 +240,10 @@
     "profileLoadFailed": "載入該 API 憑據的模型失敗：{{errorMessage}}",
     "profileLoadFailedTitle": "載入該 API 憑據的模型失敗",
     "retryLoad": "重新嘗試載入",
-    "tokenScopedCatalogDescription": "此來源帳號不提供帳號級模型列表。擴充功能會透過該帳號下的 API 密鑰取得實際可用模型。",
-    "tokenScopedCatalogFallbackDescription": "請選擇一個 API 密鑰；如果只有一個可用密鑰，擴充功能會自動使用它載入模型。",
-    "tokenScopedCatalogFallbackTitle": "透過密鑰取得模型",
-    "tokenScopedCatalogTitle": "正在透過 API 密鑰取得模型列表"
+    "runtimeKeyScopedCatalogDescription": "此來源帳號不提供帳號級模型列表。擴充功能會透過該帳號下的 API 密鑰取得實際可用模型。",
+    "runtimeKeyScopedCatalogFallbackDescription": "請選擇一個 API 密鑰；如果只有一個可用密鑰，擴充功能會自動使用它載入模型。",
+    "runtimeKeyScopedCatalogFallbackTitle": "透過密鑰取得模型",
+    "runtimeKeyScopedCatalogTitle": "正在透過 API 密鑰取得模型列表"
   },
   "title": "模型列表",
   "totalModels_other": "總計 {{count}} 個模型",

--- a/src/services/accounts/accountRuntimeKeys.ts
+++ b/src/services/accounts/accountRuntimeKeys.ts
@@ -33,6 +33,12 @@ type AccountRuntimeKeyAccount = Pick<
   | "userId"
 >
 
+type AccountRuntimeKeyAccountSource = Omit<
+  AccountRuntimeKeyAccount,
+  "name" | "tagIds"
+> &
+  Partial<Pick<AccountRuntimeKeyAccount, "name" | "tagIds">>
+
 type AccountRuntimeKeyCapabilities = {
   copy: boolean
   export: boolean
@@ -84,6 +90,14 @@ export const buildServiceCredentialRuntimeKeyId = (
   accountId: string,
   service: AccountServiceCredential["service"],
 ) => `${ACCOUNT_RUNTIME_KEY_SOURCES.ServiceCredential}:${accountId}:${service}`
+
+export const buildAccountRuntimeKeyAccount = (
+  account: AccountRuntimeKeyAccountSource,
+): AccountRuntimeKeyAccount => ({
+  ...account,
+  name: account.name || account.id,
+  tagIds: account.tagIds ?? [],
+})
 
 export const deriveServiceCredentialRuntimeKeyFields = (
   credential: AccountServiceCredential,
@@ -198,6 +212,24 @@ export const buildAccountTokenRuntimeKey = (
   tokenId: token.id,
   token,
 })
+
+export const buildDisplayAccountTokenRuntimeKey = (
+  account: AccountRuntimeKeyAccountSource,
+  token: ApiToken | AccountToken,
+): AccountTokenRuntimeKey => {
+  const runtimeKeyAccount = buildAccountRuntimeKeyAccount(account)
+  return buildAccountTokenRuntimeKey(runtimeKeyAccount, {
+    ...token,
+    accountId:
+      "accountId" in token && typeof token.accountId === "string"
+        ? token.accountId
+        : runtimeKeyAccount.id,
+    accountName:
+      "accountName" in token && typeof token.accountName === "string"
+        ? token.accountName
+        : runtimeKeyAccount.name,
+  })
+}
 
 export const buildServiceCredentialRuntimeKey = (
   account: AccountRuntimeKeyAccount,

--- a/src/services/accounts/accountRuntimeKeys.ts
+++ b/src/services/accounts/accountRuntimeKeys.ts
@@ -156,6 +156,11 @@ export const findDefaultSelectableAccountRuntimeKey = (
   runtimeKeys.find(isAccountTokenRuntimeKey) ??
   null
 
+export const appendOrReplaceAccountRuntimeKey = (
+  runtimeKeys: AccountRuntimeKey[],
+  runtimeKey: AccountRuntimeKey,
+) => [...runtimeKeys.filter(({ id }) => id !== runtimeKey.id), runtimeKey]
+
 const accountTokenStatusToRuntimeKeyStatus = (
   status: AccountToken["status"],
 ): AccountRuntimeKeyStatus => {

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -30,6 +30,7 @@ import {
   type DisplaySiteData,
   type SiteAccount,
 } from "~/types"
+import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
 const hasNonEmptyString = (value: unknown): value is string =>
@@ -88,6 +89,24 @@ export class InvalidTokenPayloadError extends Error {
     this.responseType = params.responseType
   }
 }
+
+export const getRuntimeKeyInventoryErrorMessage = (
+  error: unknown,
+  invalidPayloadFallback: string,
+) =>
+  error instanceof InvalidTokenPayloadError
+    ? invalidPayloadFallback
+    : getErrorMessage(error)
+
+export const getInvalidTokenPayloadLogContext = (error: unknown) =>
+  error instanceof InvalidTokenPayloadError
+    ? {
+        payloadAccountId: error.accountId,
+        payloadBaseUrl: error.baseUrl,
+        payloadSiteType: error.siteType,
+        payloadResponseType: error.responseType,
+      }
+    : {}
 
 export class StoredAccountApiContextError extends Error {
   readonly code:
@@ -388,14 +407,22 @@ export async function resolveDisplayAccountTokenForSecret<
   const resolutionRequest = options.abortSignal
     ? { ...request, abortSignal: options.abortSignal }
     : request
-  const resolvedKey = keyManagement
-    ? await keyManagement.resolveTokenKey({ request: resolutionRequest, token })
-    : serviceCredential
-      ? (await serviceCredential.fetch(resolutionRequest)).key
-      : await requireDisplayAccountKeyManagement(
-          account,
-          keyManagement,
-        ).resolveTokenKey({ request: resolutionRequest, token })
+  let resolvedKey: string
+
+  if (keyManagement) {
+    resolvedKey = await keyManagement.resolveTokenKey({
+      request: resolutionRequest,
+      token,
+    })
+  } else if (serviceCredential) {
+    resolvedKey = (await serviceCredential.fetch(resolutionRequest)).key
+  } else {
+    resolvedKey = await requireDisplayAccountKeyManagement(
+      account,
+      keyManagement,
+    ).resolveTokenKey({ request: resolutionRequest, token })
+  }
+
   return formatOptionalSkPrefixSiteToken(
     resolvedKey === token.key ? token : { ...token, key: resolvedKey },
     account.siteType,

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -1,7 +1,7 @@
 import type { AccountSiteType } from "~/constants/siteType"
 import {
-  accountRuntimeKeyToLegacyApiToken,
-  buildAccountTokenRuntimeKey,
+  buildAccountRuntimeKeyAccount,
+  buildDisplayAccountTokenRuntimeKey,
   buildServiceCredentialRuntimeKey,
   deriveServiceCredentialRuntimeKeyFields,
   formatAccountRuntimeKeySecretForSite,
@@ -114,11 +114,6 @@ export interface DisplayAccountApiSnapshot {
   token: DisplaySiteData["token"]
   cookieAuthSessionCookie?: DisplaySiteData["cookieAuthSessionCookie"]
   tagIds?: DisplaySiteData["tagIds"]
-}
-
-type DisplayAccountRuntimeKeySnapshot = DisplayAccountApiSnapshot & {
-  name: DisplaySiteData["name"]
-  tagIds: NonNullable<DisplaySiteData["tagIds"]>
 }
 
 export interface AccountApiContext {
@@ -346,14 +341,6 @@ export async function fetchDisplayAccountTokens(
   })
 }
 
-const createAccountRuntimeKeyAccount = (
-  account: DisplayAccountApiSnapshot,
-): DisplayAccountRuntimeKeySnapshot => ({
-  ...account,
-  name: account.name || account.id,
-  tagIds: account.tagIds ?? [],
-})
-
 /**
  * Fetch account runtime keys for verification/model probing flows.
  *
@@ -366,16 +353,12 @@ export async function fetchDisplayAccountRuntimeKeys(
 ): Promise<AccountRuntimeKey[]> {
   const { keyManagement, serviceCredential, request } =
     createDisplayAccountApiContext(account)
-  const runtimeKeyAccount = createAccountRuntimeKeyAccount(account)
+  const runtimeKeyAccount = buildAccountRuntimeKeyAccount(account)
 
   if (keyManagement || !serviceCredential) {
     const tokens = await fetchDisplayAccountTokens(account)
     return tokens.map((token) =>
-      buildAccountTokenRuntimeKey(runtimeKeyAccount, {
-        ...token,
-        accountId: account.id,
-        accountName: runtimeKeyAccount.name,
-      }),
+      buildDisplayAccountTokenRuntimeKey(runtimeKeyAccount, token),
     )
   }
 
@@ -387,16 +370,6 @@ export async function fetchDisplayAccountRuntimeKeys(
       canRotate: typeof serviceCredential.rotate === "function",
     }),
   ]
-}
-
-/**
- * Converts account runtime keys to the legacy ApiToken shape for staged callers.
- */
-export async function fetchDisplayAccountRuntimeKeyTokens(
-  account: DisplayAccountApiSnapshot,
-): Promise<ApiToken[]> {
-  const runtimeKeys = await fetchDisplayAccountRuntimeKeys(account)
-  return runtimeKeys.map(accountRuntimeKeyToLegacyApiToken)
 }
 
 /**

--- a/src/services/modelList/accountSources/index.ts
+++ b/src/services/modelList/accountSources/index.ts
@@ -1,3 +1,3 @@
 export * from "./readiness"
 export * from "./sub2apiEstimates"
-export * from "./tokenScopedFallback"
+export * from "./runtimeKeyFallback"

--- a/src/services/modelList/accountSources/readiness.ts
+++ b/src/services/modelList/accountSources/readiness.ts
@@ -7,6 +7,7 @@ import {
   type AccountSiteModelListDisplayCapabilitySource,
   type AccountSiteModelListStatusScope,
 } from "~/services/accounts/accountSiteProfile"
+import { canListAccountRuntimeKeys } from "~/services/accounts/keyProductCapabilities"
 import type { ModelCatalogCapability } from "~/services/apiAdapters/contracts/modelCatalog"
 import type { ModelPricingCapability } from "~/services/apiAdapters/contracts/modelPricing"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
@@ -46,6 +47,10 @@ type ModelListAccountSourceReadiness =
       route: typeof MODEL_LIST_ACCOUNT_SOURCE_ROUTES.Unsupported
       reason: ModelListAccountSourceUnsupportedReason
     })
+
+type ModelListAccountRuntimeKeyFallbackContext = Parameters<
+  typeof canListAccountRuntimeKeys
+>[0]
 
 /**
  * Resolves which account-backed model-list source can be used for an account site.
@@ -111,4 +116,18 @@ export function resolveModelListAccountSourceReadiness(account: {
     route: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.Unsupported,
     reason: MODEL_LIST_ACCOUNT_SOURCE_UNSUPPORTED_REASONS.NoSupportedRoute,
   }
+}
+
+/**
+ * Returns whether Model List can load fallback catalogs through account runtime keys.
+ */
+export function canLoadModelListAccountFallbackRuntimeKeys(
+  account: ModelListAccountRuntimeKeyFallbackContext,
+): boolean {
+  if (!canListAccountRuntimeKeys(account)) return false
+
+  return (
+    resolveModelListAccountSourceReadiness(account).route ===
+    MODEL_LIST_ACCOUNT_SOURCE_ROUTES.TokenScopedRuntimeCatalog
+  )
 }

--- a/src/services/modelList/accountSources/runtimeKeyFallback.ts
+++ b/src/services/modelList/accountSources/runtimeKeyFallback.ts
@@ -52,8 +52,8 @@ interface LoadAccountRuntimeKeyFallbackPricingParams {
   abortSignal?: AbortSignal
 }
 
-export const ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED =
-  "ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED"
+export const ACCOUNT_RUNTIME_KEY_FALLBACK_LOAD_FAILED =
+  "ACCOUNT_RUNTIME_KEY_FALLBACK_LOAD_FAILED"
 
 const createMissingModelCatalogCapabilityError = (siteType: string) =>
   new Error(`modelCatalog is not implemented for ${siteType}`)
@@ -128,7 +128,7 @@ const resolveFallbackRuntimeKeySecret = async (
 }
 
 /**
- * Loads a minimal model catalog for an account token by combining selected-token
+ * Loads a minimal model catalog for a runtime key by combining selected-key
  * visibility with the source account's Model List readiness route.
  */
 export async function loadAccountRuntimeKeyFallbackPricingResponse(
@@ -255,8 +255,11 @@ export async function loadAccountRuntimeKeyFallbackPricingResponse(
       ...resolvedRuntimeKeySecrets,
     ])
 
-    throw new Error(sanitizedMessage || ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED, {
-      cause: error,
-    })
+    throw new Error(
+      sanitizedMessage || ACCOUNT_RUNTIME_KEY_FALLBACK_LOAD_FAILED,
+      {
+        cause: error,
+      },
+    )
   }
 }

--- a/src/services/productAnalytics/contracts.ts
+++ b/src/services/productAnalytics/contracts.ts
@@ -500,8 +500,8 @@ export const PRODUCT_ANALYTICS_ACTION_IDS = {
   RetryFailedManagedSiteModelSync: "retry_failed_managed_site_model_sync",
   SaveAccountTokenToApiCredentialProfile:
     "save_account_token_to_api_credential_profile",
-  SaveAccountTokensToApiCredentialProfiles:
-    "save_account_tokens_to_api_credential_profiles",
+  SaveAccountRuntimeKeysToApiCredentialProfiles:
+    "save_account_runtime_keys_to_api_credential_profiles",
   SaveManagedSiteChannelModelFilters: "save_managed_site_channel_model_filters",
   ScanDuplicateAccounts: "scan_duplicate_accounts",
   SearchAccounts: "search_accounts",

--- a/tests/components/ManagedSiteLogo.test.tsx
+++ b/tests/components/ManagedSiteLogo.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
-import { TokenDetails } from "~/features/AccountManagement/components/CopyKeyDialog/TokenDetails"
+import { RuntimeKeyDetails } from "~/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails"
 import { TokenHeader } from "~/features/KeyManagement/components/TokenListItem/TokenHeader"
 import { buildDisplayAccountTokenRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
@@ -172,7 +172,7 @@ describe("Managed site logo", () => {
     })
 
     render(
-      <TokenDetails
+      <RuntimeKeyDetails
         runtimeKey={createRuntimeKeyStub()}
         copiedRuntimeKeyId={null}
         onCopyKey={vi.fn()}
@@ -191,7 +191,7 @@ describe("Managed site logo", () => {
     })
 
     render(
-      <TokenDetails
+      <RuntimeKeyDetails
         runtimeKey={createRuntimeKeyStub()}
         copiedRuntimeKeyId={null}
         onCopyKey={vi.fn()}

--- a/tests/components/ManagedSiteLogo.test.tsx
+++ b/tests/components/ManagedSiteLogo.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import { TokenDetails } from "~/features/AccountManagement/components/CopyKeyDialog/TokenDetails"
 import { TokenHeader } from "~/features/KeyManagement/components/TokenListItem/TokenHeader"
+import { buildDisplayAccountTokenRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
 import { render, screen } from "~~/tests/test-utils/render"
 
@@ -72,6 +73,10 @@ function createTokenStub(overrides: Record<string, unknown> = {}) {
     accountName: "Test Account",
     ...overrides,
   }
+}
+
+function createRuntimeKeyStub(account = createAccountStub()) {
+  return buildDisplayAccountTokenRuntimeKey(account, createTokenStub())
 }
 
 describe("Managed site logo", () => {
@@ -168,11 +173,8 @@ describe("Managed site logo", () => {
 
     render(
       <TokenDetails
-        token={createTokenStub({
-          accountId: undefined,
-          accountName: undefined,
-        })}
-        copiedTokenId={null}
+        runtimeKey={createRuntimeKeyStub()}
+        copiedRuntimeKeyId={null}
         onCopyKey={vi.fn()}
         account={createAccountStub()}
       />,
@@ -190,11 +192,8 @@ describe("Managed site logo", () => {
 
     render(
       <TokenDetails
-        token={createTokenStub({
-          accountId: undefined,
-          accountName: undefined,
-        })}
-        copiedTokenId={null}
+        runtimeKey={createRuntimeKeyStub()}
+        copiedRuntimeKeyId={null}
         onCopyKey={vi.fn()}
         account={createAccountStub()}
       />,

--- a/tests/components/VerifyApiDialog.test.tsx
+++ b/tests/components/VerifyApiDialog.test.tsx
@@ -76,18 +76,7 @@ vi.mock(
 
       const tokens = await mockFetchAccountTokens(account)
       return tokens.map((token: any) =>
-        runtimeKeyHelpers.buildAccountTokenRuntimeKey(
-          {
-            ...account,
-            name: account.name || account.id,
-            tagIds: account.tagIds ?? [],
-          },
-          {
-            ...token,
-            accountId: account.id,
-            accountName: account.name || account.id,
-          },
-        ),
+        runtimeKeyHelpers.buildDisplayAccountTokenRuntimeKey(account, token),
       )
     }
 
@@ -95,10 +84,6 @@ vi.mock(
       ...actual,
       fetchDisplayAccountRuntimeKeys: (...args: any[]) =>
         toRuntimeKeys(args[0]),
-      fetchDisplayAccountRuntimeKeyTokens: async (...args: any[]) =>
-        (await toRuntimeKeys(args[0])).map(
-          runtimeKeyHelpers.accountRuntimeKeyToLegacyApiToken,
-        ),
       resolveDisplayAccountRuntimeKeySecret: async (...args: any[]) => {
         const resolvedRuntimeKey =
           await mockResolveDisplayAccountRuntimeKeySecret(...args)
@@ -140,11 +125,7 @@ vi.mock(
         return runtimeKeyHelpers.accountRuntimeKeyToLegacyApiToken(
           runtimeKeyHelpers.formatAccountRuntimeKeySecretForSite(
             runtimeKeyHelpers.buildAccountTokenRuntimeKey(
-              {
-                ...account,
-                name: account.name || account.id,
-                tagIds: account.tagIds ?? [],
-              },
+              runtimeKeyHelpers.buildAccountRuntimeKeyAccount(account),
               { ...token, key: resolvedKey },
             ),
           ),

--- a/tests/components/VerifyApiDialog.test.tsx
+++ b/tests/components/VerifyApiDialog.test.tsx
@@ -503,6 +503,48 @@ describe("VerifyApiDialog", () => {
     )
   })
 
+  it("keeps probes disabled when runtime-key loading fails", async () => {
+    mockFetchDisplayAccountRuntimeKeys.mockRejectedValueOnce(
+      new Error("inventory offline"),
+    )
+
+    render(
+      <VerifyApiDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={{
+          id: "a1",
+          name: "Account",
+          username: "u",
+          balance: { USD: 0, CNY: 0 },
+          todayConsumption: { USD: 0, CNY: 0 },
+          todayIncome: { USD: 0, CNY: 0 },
+          todayTokens: { upload: 0, download: 0 },
+          health: { status: "healthy" as any },
+          siteType: SITE_TYPES.NEW_API,
+          baseUrl: "https://example.com",
+          token: "t",
+          userId: "1",
+          authType: "access_token" as any,
+          checkIn: { enableDetection: false } as any,
+        }}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    await waitFor(() =>
+      expect(mockFetchDisplayAccountRuntimeKeys).toHaveBeenCalledTimes(1),
+    )
+
+    const probeCard = await screen.findByTestId("verify-probe-text-generation")
+    const runButton = within(probeCard).getByRole("button", {
+      name: "aiApiVerification:verifyDialog.actions.runOne",
+    })
+    expect(runButton).toBeDisabled()
+    fireEvent.click(runButton)
+    expect(mockRunApiVerificationProbe).not.toHaveBeenCalled()
+  })
+
   it("verifies service-credential runtime keys without token conversion", async () => {
     const account = {
       id: "a1",

--- a/tests/components/VerifyApiDialog.test.tsx
+++ b/tests/components/VerifyApiDialog.test.tsx
@@ -308,7 +308,7 @@ describe("VerifyApiDialog", () => {
       name: "aiApiVerification:verifyDialog.actions.runOne",
     })
 
-    // The action button is disabled until tokens are fetched and a token is selected.
+    // The action button is disabled until runtime keys are fetched and selected.
     await waitFor(() => expect(runButton).toBeEnabled())
     fireEvent.click(runButton)
 
@@ -696,7 +696,9 @@ describe("VerifyApiDialog", () => {
 
     await waitFor(() => expect(mockFetchAccountTokens).toHaveBeenCalledTimes(1))
     expect(
-      screen.getByText("aiApiVerification:verifyDialog.noCompatibleTokenHint"),
+      screen.getByText(
+        "aiApiVerification:verifyDialog.noCompatibleRuntimeKeyHint",
+      ),
     ).toBeInTheDocument()
     const manageButton = screen.getByRole("button", {
       name: "aiApiVerification:verifyDialog.actions.manageModelKey",
@@ -784,7 +786,7 @@ describe("VerifyApiDialog", () => {
 
     expect(
       screen.getByText(
-        "aiApiVerification:verifyDialog.selectedTokenIncompatibleHint",
+        "aiApiVerification:verifyDialog.selectedRuntimeKeyIncompatibleHint",
       ),
     ).toBeInTheDocument()
     expect(runButton).toBeDisabled()

--- a/tests/components/VerifyCliSupportDialog.test.tsx
+++ b/tests/components/VerifyCliSupportDialog.test.tsx
@@ -44,6 +44,8 @@ function getCliToolCardTestId(toolId: string) {
   return `verify-cli-${toolId}`
 }
 
+const VERIFY_CLI_RUNTIME_KEY_TEST_ID = "verify-cli-runtime-key-id"
+
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
   let reject!: (reason?: unknown) => void
@@ -308,9 +310,9 @@ describe("VerifyCliSupportDialog", () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByRole("combobox")).toHaveTextContent(
-        "First runtime key",
-      )
+      expect(
+        screen.getByTestId(VERIFY_CLI_RUNTIME_KEY_TEST_ID),
+      ).toHaveTextContent("First runtime key")
     })
 
     rerender(
@@ -325,14 +327,102 @@ describe("VerifyCliSupportDialog", () => {
     await waitFor(() =>
       expect(mockFetchDisplayAccountRuntimeKeys).toHaveBeenCalledTimes(2),
     )
-    expect(screen.getByRole("combobox")).not.toHaveTextContent(
-      "First runtime key",
-    )
+    expect(
+      screen.getByTestId(VERIFY_CLI_RUNTIME_KEY_TEST_ID),
+    ).not.toHaveTextContent("First runtime key")
 
     await act(async () => {
       pendingSecondRuntimeKeys.resolve([])
       await pendingSecondRuntimeKeys.promise
     })
+  })
+
+  it("ignores stale account runtime-key responses after another account loads", async () => {
+    const firstAccount = {
+      id: "a1",
+      name: "First Account",
+      username: "u1",
+      balance: { USD: 0, CNY: 0 },
+      todayConsumption: { USD: 0, CNY: 0 },
+      todayIncome: { USD: 0, CNY: 0 },
+      todayTokens: { upload: 0, download: 0 },
+      health: { status: "healthy" as any },
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://first.example.invalid",
+      token: "t1",
+      userId: "1",
+      authType: "access_token" as any,
+      checkIn: { enableDetection: false } as any,
+      tagIds: [],
+    }
+    const secondAccount = {
+      ...firstAccount,
+      id: "a2",
+      name: "Second Account",
+      baseUrl: "https://second.example.invalid",
+      token: "t2",
+    }
+    const firstRuntimeKey = buildServiceCredentialRuntimeKey(firstAccount, {
+      kind: "singleton_service_key",
+      service: "codex",
+      label: "First runtime key",
+      key: "first-secret",
+      isAuthenticated: true,
+      baseUrl: "https://first-runtime.example.invalid",
+    })
+    const secondRuntimeKey = buildServiceCredentialRuntimeKey(secondAccount, {
+      kind: "singleton_service_key",
+      service: "codex",
+      label: "Second runtime key",
+      key: "second-secret",
+      isAuthenticated: true,
+      baseUrl: "https://second-runtime.example.invalid",
+    })
+    const pendingFirstRuntimeKeys = createDeferred<AccountRuntimeKey[]>()
+
+    mockFetchDisplayAccountRuntimeKeys
+      .mockReturnValueOnce(pendingFirstRuntimeKeys.promise)
+      .mockResolvedValueOnce([secondRuntimeKey])
+
+    const { rerender } = render(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={firstAccount}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    await waitFor(() =>
+      expect(mockFetchDisplayAccountRuntimeKeys).toHaveBeenCalledTimes(1),
+    )
+
+    rerender(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={secondAccount}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(VERIFY_CLI_RUNTIME_KEY_TEST_ID),
+      ).toHaveTextContent("Second runtime key")
+    })
+
+    await act(async () => {
+      pendingFirstRuntimeKeys.resolve([firstRuntimeKey])
+      await pendingFirstRuntimeKeys.promise
+    })
+
+    expect(
+      screen.getByTestId(VERIFY_CLI_RUNTIME_KEY_TEST_ID),
+    ).toHaveTextContent("Second runtime key")
+    expect(
+      screen.getByTestId(VERIFY_CLI_RUNTIME_KEY_TEST_ID),
+    ).not.toHaveTextContent("First runtime key")
   })
 
   it("fetches profile models and lets the user choose one", async () => {

--- a/tests/components/VerifyCliSupportDialog.test.tsx
+++ b/tests/components/VerifyCliSupportDialog.test.tsx
@@ -224,6 +224,30 @@ describe("VerifyCliSupportDialog", () => {
     expect(mockFetchAccountTokens).not.toHaveBeenCalled()
   })
 
+  it("keeps account-mode tools disabled when the account is unavailable", async () => {
+    render(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={null as any}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    expect(
+      await screen.findByText("cliSupportVerification:verifyDialog.idleHint"),
+    ).toBeInTheDocument()
+
+    const toolCard = await screen.findByTestId(getCliToolCardTestId("claude"))
+    const runButton = within(toolCard).getByRole("button", {
+      name: "cliSupportVerification:verifyDialog.actions.runOne",
+    })
+    expect(runButton).toBeDisabled()
+    fireEvent.click(runButton)
+    expect(mockFetchAccountTokens).not.toHaveBeenCalled()
+    expect(mockRunCliSupportTool).not.toHaveBeenCalled()
+  })
+
   it("fetches profile models and lets the user choose one", async () => {
     mockFetchApiCredentialModelIds.mockResolvedValueOnce([
       "gpt-4o-mini",

--- a/tests/components/VerifyCliSupportDialog.test.tsx
+++ b/tests/components/VerifyCliSupportDialog.test.tsx
@@ -81,41 +81,13 @@ vi.mock(
         _account: unknown,
         keyManagement: unknown,
       ) => keyManagement,
-      fetchDisplayAccountRuntimeKeyTokens: async (...args: any[]) =>
-        (await mockFetchAccountTokens(...args)).map((token: any) =>
-          runtimeKeyHelpers.accountRuntimeKeyToLegacyApiToken(
-            runtimeKeyHelpers.buildAccountTokenRuntimeKey(
-              {
-                ...args[0],
-                name: args[0].name || args[0].id,
-                tagIds: args[0].tagIds ?? [],
-              },
-              {
-                ...token,
-                accountId: args[0].id,
-                accountName: args[0].name || args[0].id,
-              },
-            ),
-          ),
-        ),
       fetchDisplayAccountRuntimeKeys: async (...args: any[]) => {
         const runtimeKeys = await mockFetchDisplayAccountRuntimeKeys(...args)
         if (runtimeKeys !== undefined) return runtimeKeys
         const [account] = args
         const tokens = await mockFetchAccountTokens(...args)
         return tokens.map((token: any) =>
-          runtimeKeyHelpers.buildAccountTokenRuntimeKey(
-            {
-              ...account,
-              name: account.name || account.id,
-              tagIds: account.tagIds ?? [],
-            },
-            {
-              ...token,
-              accountId: account.id,
-              accountName: account.name || account.id,
-            },
-          ),
+          runtimeKeyHelpers.buildDisplayAccountTokenRuntimeKey(account, token),
         )
       },
       resolveDisplayAccountRuntimeKeySecret: async (...args: any[]) => {

--- a/tests/components/VerifyCliSupportDialog.test.tsx
+++ b/tests/components/VerifyCliSupportDialog.test.tsx
@@ -44,6 +44,17 @@ function getCliToolCardTestId(toolId: string) {
   return `verify-cli-${toolId}`
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+
+  return { promise, resolve, reject }
+}
+
 vi.mock(
   "~/services/accounts/utils/apiServiceRequest",
   async (importOriginal) => {
@@ -246,6 +257,82 @@ describe("VerifyCliSupportDialog", () => {
     fireEvent.click(runButton)
     expect(mockFetchAccountTokens).not.toHaveBeenCalled()
     expect(mockRunCliSupportTool).not.toHaveBeenCalled()
+  })
+
+  it("clears stale account runtime-key labels while loading another account", async () => {
+    const firstAccount = {
+      id: "a1",
+      name: "First Account",
+      username: "u1",
+      balance: { USD: 0, CNY: 0 },
+      todayConsumption: { USD: 0, CNY: 0 },
+      todayIncome: { USD: 0, CNY: 0 },
+      todayTokens: { upload: 0, download: 0 },
+      health: { status: "healthy" as any },
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://first.example.invalid",
+      token: "t1",
+      userId: "1",
+      authType: "access_token" as any,
+      checkIn: { enableDetection: false } as any,
+      tagIds: [],
+    }
+    const secondAccount = {
+      ...firstAccount,
+      id: "a2",
+      name: "Second Account",
+      baseUrl: "https://second.example.invalid",
+      token: "t2",
+    }
+    const firstRuntimeKey = buildServiceCredentialRuntimeKey(firstAccount, {
+      kind: "singleton_service_key",
+      service: "codex",
+      label: "First runtime key",
+      key: "first-secret",
+      isAuthenticated: true,
+      baseUrl: "https://first-runtime.example.invalid",
+    })
+    const pendingSecondRuntimeKeys = createDeferred<AccountRuntimeKey[]>()
+
+    mockFetchDisplayAccountRuntimeKeys
+      .mockResolvedValueOnce([firstRuntimeKey])
+      .mockReturnValueOnce(pendingSecondRuntimeKeys.promise)
+
+    const { rerender } = render(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={firstAccount}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox")).toHaveTextContent(
+        "First runtime key",
+      )
+    })
+
+    rerender(
+      <VerifyCliSupportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={secondAccount}
+        initialModelId="gpt-test"
+      />,
+    )
+
+    await waitFor(() =>
+      expect(mockFetchDisplayAccountRuntimeKeys).toHaveBeenCalledTimes(2),
+    )
+    expect(screen.getByRole("combobox")).not.toHaveTextContent(
+      "First runtime key",
+    )
+
+    await act(async () => {
+      pendingSecondRuntimeKeys.resolve([])
+      await pendingSecondRuntimeKeys.promise
+    })
   })
 
   it("fetches profile models and lets the user choose one", async () => {

--- a/tests/entrypoints/options/pages/ApiCredentialProfiles/ApiCredentialProfiles.test.tsx
+++ b/tests/entrypoints/options/pages/ApiCredentialProfiles/ApiCredentialProfiles.test.tsx
@@ -522,7 +522,7 @@ describe("ApiCredentialProfiles page", () => {
       await screen.findByRole("option", { name: "gpt-4o-mini" }),
     ).toBeInTheDocument()
     expect(
-      screen.queryByText("cliSupportVerification:verifyDialog.meta.token"),
+      screen.queryByText("cliSupportVerification:verifyDialog.meta.runtimeKey"),
     ).not.toBeInTheDocument()
   })
 

--- a/tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx
@@ -6,6 +6,12 @@ import { TokenList } from "~/features/KeyManagement/components/TokenList"
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "~/features/KeyManagement/constants"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { buildServiceCredentialRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+} from "~/services/productAnalytics/contracts"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 import {
   createAccount,
@@ -550,6 +556,13 @@ describe("TokenList batch export selection", () => {
 
     await user.click(saveButton)
 
+    expect(mockStartProductAnalyticsAction).toHaveBeenCalledWith({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
+      actionId:
+        PRODUCT_ANALYTICS_ACTION_IDS.SaveAccountRuntimeKeysToApiCredentialProfiles,
+      surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementPage,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    })
     expect(mockSaveApiCredentialProfiles).toHaveBeenCalledWith(
       expect.objectContaining({
         items: [

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -230,7 +230,7 @@ describe("ModelKeyDialog", () => {
     })
   })
 
-  it("copies selected key when exactly one compatible token exists", async () => {
+  it("copies selected key when exactly one compatible runtime key exists", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
 
     const user = userEvent.setup()
@@ -322,7 +322,7 @@ describe("ModelKeyDialog", () => {
     expect(screen.getByText("shared key · vip")).toBeInTheDocument()
   })
 
-  it("shows empty state and explicit create actions when no compatible tokens exist", async () => {
+  it("shows empty state and explicit create actions when no compatible runtime keys exist", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
 
     render(
@@ -648,7 +648,7 @@ describe("ModelKeyDialog", () => {
     )
   })
 
-  it("refreshes tokens when default create returns a token-shaped object with an invalid secret", async () => {
+  it("refreshes runtime keys when default create returns a token-shaped object with an invalid secret", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([]).mockResolvedValueOnce([
       {
         ...TOKEN,
@@ -752,7 +752,7 @@ describe("ModelKeyDialog", () => {
     )
   })
 
-  it("shows a create error when refreshed inventory has no compatible token", async () => {
+  it("shows a create error when refreshed inventory has no compatible runtime key", async () => {
     fetchAccountTokensMock
       .mockResolvedValueOnce([])
       .mockResolvedValue([{ ...TOKEN, id: 11, group: "vip" }])
@@ -942,7 +942,7 @@ describe("ModelKeyDialog", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("clears loaded token state when the selected account becomes ineligible", async () => {
+  it("clears loaded runtime-key state when the selected account becomes ineligible", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
 
     const { rerender } = render(
@@ -978,7 +978,7 @@ describe("ModelKeyDialog", () => {
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
   })
 
-  it("ignores stale token fetch completions after the selected account becomes ineligible", async () => {
+  it("ignores stale runtime-key fetch completions after the selected account becomes ineligible", async () => {
     const pendingTokens = createDeferred<(typeof TOKEN)[]>()
     fetchAccountTokensMock.mockReturnValueOnce(pendingTokens.promise)
 
@@ -1019,7 +1019,7 @@ describe("ModelKeyDialog", () => {
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
   })
 
-  it("uses the unknown fallback when token inventory payload is invalid", async () => {
+  it("uses the unknown fallback when runtime-key inventory payload is invalid", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce(null)
 
     render(
@@ -1069,7 +1069,7 @@ describe("ModelKeyDialog", () => {
     )
   })
 
-  it("supports retry when token loading fails", async () => {
+  it("supports retry when runtime-key loading fails", async () => {
     fetchAccountTokensMock
       .mockRejectedValueOnce(new Error("boom"))
       .mockResolvedValueOnce([TOKEN])
@@ -1118,7 +1118,7 @@ describe("ModelKeyDialog", () => {
     ).toBeInTheDocument()
   })
 
-  it("tracks retry completion when token loading fails again", async () => {
+  it("tracks retry completion when runtime-key loading fails again", async () => {
     fetchAccountTokensMock
       .mockRejectedValueOnce(new Error("first boom"))
       .mockRejectedValueOnce(new Error("retry boom"))

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import ModelKeyDialog from "~/features/ModelList/components/ModelKeyDialog"
+import { useModelKeyDialog } from "~/features/ModelList/components/ModelKeyDialog/hooks/useModelKeyDialog"
 import { TOKEN_PROVISIONING_TEST_IDS } from "~/features/TokenProvisioning/testIds"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -14,7 +15,13 @@ import {
 } from "~/services/productAnalytics/contracts"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { AuthTypeEnum } from "~/types"
-import { act, render, screen, waitFor } from "~~/tests/test-utils/render"
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "~~/tests/test-utils/render"
 
 const {
   fetchAccountTokensMock,
@@ -1051,6 +1058,33 @@ describe("ModelKeyDialog", () => {
       screen.queryByRole("button", { name: "common:actions.copyKey" }),
     ).not.toBeInTheDocument()
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("clears runtime-key hook state when the dialog closes", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) =>
+        useModelKeyDialog({
+          isOpen,
+          account: ACCOUNT,
+          modelId: "gpt-4",
+          modelEnableGroups: ["default"],
+        }),
+      {
+        initialProps: { isOpen: true },
+      },
+    )
+
+    await waitFor(() => expect(result.current.runtimeKeys).toHaveLength(1))
+
+    rerender({ isOpen: false })
+
+    await waitFor(() => {
+      expect(result.current.runtimeKeys).toEqual([])
+      expect(result.current.selectedRuntimeKeyId).toBeNull()
+      expect(result.current.isLoading).toBe(false)
+    })
   })
 
   it("ignores stale runtime-key fetch completions after the selected account becomes ineligible", async () => {

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -21,7 +21,7 @@ const {
   adapterCreateTokenMock,
   toastSuccessMock,
   toastErrorMock,
-  resolveDisplayAccountTokenForSecretMock,
+  resolveDisplayAccountRuntimeKeySecretMock,
   openKeysPageMock,
   startProductAnalyticsActionMock,
   completeProductAnalyticsActionMock,
@@ -32,7 +32,7 @@ const {
   adapterCreateTokenMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
-  resolveDisplayAccountTokenForSecretMock: vi.fn(),
+  resolveDisplayAccountRuntimeKeySecretMock: vi.fn(),
   openKeysPageMock: vi.fn(),
   startProductAnalyticsActionMock: vi.fn(),
   completeProductAnalyticsActionMock: vi.fn(),
@@ -56,8 +56,13 @@ vi.mock(
       >()
     return {
       ...original,
-      resolveDisplayAccountTokenForSecret: (...args: any[]) =>
-        resolveDisplayAccountTokenForSecretMock(...args),
+      resolveDisplayAccountTokenForSecret: () => {
+        throw new Error(
+          "resolveDisplayAccountTokenForSecret should not be used by model key dialog",
+        )
+      },
+      resolveDisplayAccountRuntimeKeySecret: (...args: any[]) =>
+        resolveDisplayAccountRuntimeKeySecretMock(...args),
     }
   },
 )
@@ -181,7 +186,7 @@ describe("ModelKeyDialog", () => {
     adapterCreateTokenMock.mockReset()
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
-    resolveDisplayAccountTokenForSecretMock.mockReset()
+    resolveDisplayAccountRuntimeKeySecretMock.mockReset()
     openKeysPageMock.mockReset()
     startProductAnalyticsActionMock.mockReset()
     completeProductAnalyticsActionMock.mockReset()
@@ -190,8 +195,8 @@ describe("ModelKeyDialog", () => {
     startProductAnalyticsActionMock.mockReturnValue({
       complete: completeProductAnalyticsActionMock,
     })
-    resolveDisplayAccountTokenForSecretMock.mockImplementation(
-      async (_account, token) => token,
+    resolveDisplayAccountRuntimeKeySecretMock.mockImplementation(
+      async (_account, runtimeKey) => runtimeKey,
     )
   })
 
@@ -260,7 +265,7 @@ describe("ModelKeyDialog", () => {
 
   it("shows the resolver error message when copying the selected key fails", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
-    resolveDisplayAccountTokenForSecretMock.mockRejectedValueOnce(
+    resolveDisplayAccountRuntimeKeySecretMock.mockRejectedValueOnce(
       new Error("resolver failed"),
     )
 

--- a/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelKeyDialog.test.tsx
@@ -322,6 +322,46 @@ describe("ModelKeyDialog", () => {
     expect(screen.getByText("shared key · vip")).toBeInTheDocument()
   })
 
+  it("copies the runtime key selected from multiple compatible options", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([
+      { ...TOKEN, id: 1, key: "sk-default", name: "shared key", group: null },
+      { ...TOKEN, id: 2, key: "sk-vip", name: "shared key", group: "vip" },
+    ])
+
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+
+    render(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={ACCOUNT}
+        modelId="gpt-4"
+        modelEnableGroups={["default", "vip"]}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("combobox", {
+        name: "modelList:keyDialog.selectLabel",
+      }),
+    )
+    expect(screen.getByText("shared key · default")).toBeInTheDocument()
+
+    await user.click(
+      await screen.findByRole("option", { name: "shared key · vip" }),
+    )
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.copyKey" }),
+    )
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("sk-vip")
+    })
+  })
+
   it("shows empty state and explicit create actions when no compatible runtime keys exist", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
 
@@ -787,6 +827,41 @@ describe("ModelKeyDialog", () => {
         "modelList:keyDialog.noCompatibleFoundAfterCreate",
       ),
     ).toBeInTheDocument()
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },
+    )
+  })
+
+  it("shows a create error when post-create runtime-key refresh fails", async () => {
+    fetchAccountTokensMock
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("inventory offline"))
+    adapterCreateTokenMock.mockResolvedValueOnce(true)
+
+    const user = userEvent.setup()
+
+    render(
+      <ModelKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={ACCOUNT}
+        modelId="gpt-4"
+        modelEnableGroups={["default"]}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "modelList:keyDialog.createKey",
+      }),
+    )
+
+    expect(
+      await screen.findByText("modelList:keyDialog.createFailed"),
+    ).toBeInTheDocument()
+    expect(adapterCreateTokenMock).toHaveBeenCalledTimes(1)
+    expect(fetchAccountTokensMock).toHaveBeenCalledTimes(2)
     expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
       { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },

--- a/tests/entrypoints/options/pages/ModelList/StatusIndicator.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/StatusIndicator.test.tsx
@@ -63,17 +63,17 @@ describe("StatusIndicator", () => {
     )
 
     expect(
-      await screen.findByText("modelList:status.tokenScopedCatalogTitle"),
+      await screen.findByText("modelList:status.runtimeKeyScopedCatalogTitle"),
     ).toBeInTheDocument()
     expect(
-      screen.getByText("modelList:status.tokenScopedCatalogDescription"),
+      screen.getByText("modelList:status.runtimeKeyScopedCatalogDescription"),
     ).toBeInTheDocument()
     expect(
-      screen.getByText("modelList:status.tokenScopedCatalogFallbackTitle"),
+      screen.getByText("modelList:status.runtimeKeyScopedCatalogFallbackTitle"),
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "modelList:status.tokenScopedCatalogFallbackDescription",
+        "modelList:status.runtimeKeyScopedCatalogFallbackDescription",
       ),
     ).toBeInTheDocument()
     expect(
@@ -115,7 +115,7 @@ describe("StatusIndicator", () => {
     )
 
     expect(
-      await screen.findByText("modelList:status.tokenScopedCatalogTitle"),
+      await screen.findByText("modelList:status.runtimeKeyScopedCatalogTitle"),
     ).toBeInTheDocument()
     expect(
       screen.queryByText("modelList:status.genericLoadFailedTitle"),
@@ -154,7 +154,7 @@ describe("StatusIndicator", () => {
       await screen.findByText("modelList:status.fallback.loadingKeys"),
     ).toBeInTheDocument()
     expect(
-      screen.queryByText("modelList:status.tokenScopedCatalogTitle"),
+      screen.queryByText("modelList:status.runtimeKeyScopedCatalogTitle"),
     ).not.toBeInTheDocument()
     expect(
       screen.queryByRole("button", {

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -132,7 +132,8 @@ vi.mock("~/services/modelList/accountSources", async (importOriginal) => {
 
   return {
     ...actual,
-    ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED: "ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED",
+    ACCOUNT_RUNTIME_KEY_FALLBACK_LOAD_FAILED:
+      "ACCOUNT_RUNTIME_KEY_FALLBACK_LOAD_FAILED",
     loadAccountRuntimeKeyFallbackPricingResponse: (...args: unknown[]) =>
       mockLoadAccountRuntimeKeyFallbackPricingResponse(...args),
   }
@@ -3299,7 +3300,7 @@ describe("useModelData all-accounts loading", () => {
     expect(fetchPricing).toHaveBeenCalledTimes(pricingCallCountBeforeRefresh)
   })
 
-  it("discards stale fallback token results after switching accounts", async () => {
+  it("discards stale fallback runtime-key results after switching accounts", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 
@@ -3740,7 +3741,7 @@ describe("useModelData all-accounts loading", () => {
     )
   })
 
-  it("does not load fallback tokens for single-account invalid-format responses", async () => {
+  it("does not load fallback runtime keys for single-account invalid-format responses", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
 

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -87,7 +87,7 @@ vi.mock(
       await importOriginal<
         typeof import("~/services/accounts/utils/apiServiceRequest")
       >()
-    const { buildAccountTokenRuntimeKey } = await import(
+    const { buildDisplayAccountTokenRuntimeKey } = await import(
       "~/services/accounts/accountRuntimeKeys"
     )
 
@@ -95,19 +95,13 @@ vi.mock(
       ...actual,
       fetchDisplayAccountTokens: (...args: unknown[]) =>
         mockFetchDisplayAccountTokens(...args),
-      fetchDisplayAccountRuntimeKeyTokens: (...args: unknown[]) =>
-        mockFetchDisplayAccountTokens(...args),
       fetchDisplayAccountRuntimeKeys: async (...args: unknown[]) => {
         const [account] = args as [DisplaySiteData]
         const runtimeKeys = await mockFetchDisplayAccountRuntimeKeys(account)
         return runtimeKeys.map((runtimeKey: any) =>
           runtimeKey?.source && runtimeKey?.accountId
             ? runtimeKey
-            : buildAccountTokenRuntimeKey(account, {
-                ...runtimeKey,
-                accountId: account.id,
-                accountName: account.name,
-              }),
+            : buildDisplayAccountTokenRuntimeKey(account, runtimeKey),
         )
       },
     }

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -43,7 +43,7 @@ const {
   startProductAnalyticsActionMock,
   completeProductAnalyticsActionMock,
   resolveProductAnalyticsErrorCategoryFromErrorMock,
-  resolveDisplayAccountTokenForSecretMock,
+  resolveDisplayAccountRuntimeKeySecretMock,
 } = vi.hoisted(() => ({
   mockHandleSetAccountDisabled: vi.fn(),
   mockTogglePinAccount: vi.fn(),
@@ -83,7 +83,7 @@ const {
   startProductAnalyticsActionMock: vi.fn(),
   completeProductAnalyticsActionMock: vi.fn(),
   resolveProductAnalyticsErrorCategoryFromErrorMock: vi.fn(),
-  resolveDisplayAccountTokenForSecretMock: vi.fn(),
+  resolveDisplayAccountRuntimeKeySecretMock: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -180,6 +180,9 @@ vi.mock(
       await importOriginal<
         typeof import("~/services/accounts/utils/apiServiceRequest")
       >()
+    const runtimeKeyHelpers = await import(
+      "~/services/accounts/accountRuntimeKeys"
+    )
 
     return {
       ...actual,
@@ -196,23 +199,18 @@ vi.mock(
           responseType: typeof result,
         })
       },
-      fetchDisplayAccountRuntimeKeyTokens: async (...args: unknown[]) => {
-        const result = await fetchAccountTokensMock(...args)
-        if (Array.isArray(result)) {
-          return result
-        }
-
-        throw new actual.InvalidTokenPayloadError({
-          accountId: "test-account",
-          baseUrl: "https://example.com",
-          siteType: "test-site",
-          responseType: typeof result,
-        })
-      },
       fetchDisplayAccountRuntimeKeys: async (...args: unknown[]) => {
         const result = await fetchAccountTokensMock(...args)
         if (Array.isArray(result)) {
-          return result
+          const account = args[0] as any
+          return result.map((token) =>
+            "source" in Object(token)
+              ? token
+              : runtimeKeyHelpers.buildDisplayAccountTokenRuntimeKey(
+                  account,
+                  token as any,
+                ),
+          )
         }
 
         throw new actual.InvalidTokenPayloadError({
@@ -222,10 +220,15 @@ vi.mock(
           responseType: typeof result,
         })
       },
-      resolveDisplayAccountTokenForSecret: async (
+      resolveDisplayAccountTokenForSecret: async () => {
+        throw new Error(
+          "resolveDisplayAccountTokenForSecret should not be used by account row actions",
+        )
+      },
+      resolveDisplayAccountRuntimeKeySecret: async (
         account: unknown,
-        token: { key: string },
-      ) => resolveDisplayAccountTokenForSecretMock(account, token),
+        runtimeKey: { secret: string },
+      ) => resolveDisplayAccountRuntimeKeySecretMock(account, runtimeKey),
     }
   },
 )
@@ -253,8 +256,8 @@ describe("AccountActionButtons", () => {
       PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
     )
     completeProductAnalyticsActionMock.mockResolvedValue(undefined)
-    resolveDisplayAccountTokenForSecretMock.mockImplementation(
-      async (_account: unknown, token: { key: string }) => token,
+    resolveDisplayAccountRuntimeKeySecretMock.mockImplementation(
+      async (_account: unknown, runtimeKey: unknown) => runtimeKey,
     )
     exportShareSnapshotWithToastMock.mockResolvedValue(undefined)
   })
@@ -1819,11 +1822,14 @@ describe("AccountActionButtons", () => {
         baseUrl: "https://api.example.com/v1/openai",
       }),
     )
-    expect(resolveDisplayAccountTokenForSecretMock).toHaveBeenCalledWith(
+    expect(resolveDisplayAccountRuntimeKeySecretMock).toHaveBeenCalledWith(
       expect.objectContaining({
         baseUrl: "https://api.example.com/v1/openai",
       }),
-      expect.objectContaining({ key: "" }),
+      expect.objectContaining({
+        secret: "",
+        token: expect.objectContaining({ key: "" }),
+      }),
     )
     expect(openManagedSiteChannelsForChannelMock).not.toHaveBeenCalled()
   })

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -43,6 +43,14 @@ const {
   toastSuccessMock,
   toastErrorMock,
   createApiCredentialProfileMock,
+  fetchServiceCredentialMock,
+  ccSwitchDialogMock,
+  cliProxyDialogMock,
+  claudeCodeRouterDialogMock,
+  kiloCodeExportDialogMock,
+  kiloCodeProfileExportDialogMock,
+  openWithCredentialsMock,
+  userPreferencesContextMock,
 } = vi.hoisted(() => ({
   fetchAccountTokensMock: vi.fn(),
   createApiTokenMock: vi.fn(),
@@ -56,6 +64,22 @@ const {
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
   createApiCredentialProfileMock: vi.fn(),
+  fetchServiceCredentialMock: vi.fn(),
+  ccSwitchDialogMock: vi.fn(),
+  cliProxyDialogMock: vi.fn(),
+  claudeCodeRouterDialogMock: vi.fn(),
+  kiloCodeExportDialogMock: vi.fn(),
+  kiloCodeProfileExportDialogMock: vi.fn(),
+  openWithCredentialsMock: vi.fn(),
+  userPreferencesContextMock: {
+    claudeCodeRouterApiKey: "ccr-management-key",
+    claudeCodeRouterBaseUrl: "https://router.example.invalid",
+    cliProxyBaseUrl: "https://cliproxy.example.invalid",
+    cliProxyManagementKey: "cliproxy-management-key",
+    managedSiteType: "new-api",
+    themeMode: "system",
+    updateThemeMode: vi.fn(),
+  },
 }))
 
 const normalizeGroupNames = (groups: Record<string, unknown>): string[] =>
@@ -144,27 +168,85 @@ vi.mock("react-hot-toast", () => ({
 }))
 
 vi.mock("~/services/apiAdapters/registry", () => ({
-  getSiteTypeCapabilities: () => ({
-    account: {
-      keyManagement: {
-        fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
-        createToken: (...args: any[]) => createApiTokenMock(...args),
-        resolveTokenKey: (...args: any[]) => resolveApiTokenKeyMock(...args),
-        deleteToken: vi.fn(),
-        fetchAvailableModels: (...args: any[]) =>
-          fetchAccountAvailableModelsMock(...args),
-        userGroups: {
-          fetch: (...args: any[]) => fetchUserGroupsMock(...args),
+  getSiteTypeCapabilities: (siteType: string) => {
+    if (siteType === SITE_TYPES.SHAREDCHAT) {
+      return {
+        account: {
+          serviceCredential: {
+            fetch: (...args: any[]) => fetchServiceCredentialMock(...args),
+          },
         },
+      }
+    }
+
+    return {
+      account: {
+        keyManagement: {
+          fetchTokens: (...args: any[]) => fetchAccountTokensMock(...args),
+          createToken: (...args: any[]) => createApiTokenMock(...args),
+          resolveTokenKey: (...args: any[]) => resolveApiTokenKeyMock(...args),
+          deleteToken: vi.fn(),
+          fetchAvailableModels: (...args: any[]) =>
+            fetchAccountAvailableModelsMock(...args),
+          userGroups: {
+            fetch: (...args: any[]) => fetchUserGroupsMock(...args),
+          },
+        },
+        tokenProvisioning: createSub2ApiTokenProvisioningMock(),
       },
-      tokenProvisioning: createSub2ApiTokenProvisioningMock(),
-    },
-  }),
+    }
+  },
 }))
 
 vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
-  useChannelDialog: () => ({ openWithAccount: openWithAccountMock }),
+  useChannelDialog: () => ({
+    openWithAccount: openWithAccountMock,
+    openWithCredentials: openWithCredentialsMock,
+  }),
+}))
+
+vi.mock("~/components/CCSwitchExportDialog", () => ({
+  CCSwitchExportDialog: (props: unknown) => {
+    ccSwitchDialogMock(props)
+    return null
+  },
+}))
+
+vi.mock("~/components/ClaudeCodeRouterImportDialog", () => ({
+  ClaudeCodeRouterImportDialog: (props: unknown) => {
+    claudeCodeRouterDialogMock(props)
+    return null
+  },
+}))
+
+vi.mock("~/components/CliProxyExportDialog", () => ({
+  CliProxyExportDialog: (props: unknown) => {
+    cliProxyDialogMock(props)
+    return null
+  },
+}))
+
+vi.mock("~/components/KiloCodeExportDialog", () => ({
+  KiloCodeExportDialog: (props: unknown) => {
+    kiloCodeExportDialogMock(props)
+    return null
+  },
+}))
+
+vi.mock(
+  "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog",
+  () => ({
+    KiloCodeProfileExportDialog: (props: unknown) => {
+      kiloCodeProfileExportDialogMock(props)
+      return null
+    },
+  }),
+)
+
+vi.mock("~/contexts/UserPreferencesContext", () => ({
+  UserPreferencesProvider: ({ children }: { children: ReactNode }) => children,
+  useUserPreferencesContext: () => userPreferencesContextMock,
 }))
 
 vi.mock("~/services/integrations/cherryStudio", () => ({
@@ -250,12 +332,57 @@ function createDeferred<T>() {
   return { promise, resolve, reject }
 }
 
+const SHAREDCHAT_SERVICE_CREDENTIAL = {
+  kind: "singleton_service_key" as const,
+  service: "codex" as const,
+  label: "Codex service key",
+  key: "sk-service-credential-secret",
+  isAuthenticated: true,
+  baseUrl: "https://api.example.invalid/v1",
+}
+
+const SHAREDCHAT_ACCOUNT = {
+  ...ACCOUNT,
+  id: "sharedchat-account",
+  name: "SharedChat",
+  siteType: SITE_TYPES.SHAREDCHAT,
+  baseUrl: "https://sharedchat.example.invalid",
+  authType: AuthTypeEnum.Cookie,
+  token: "",
+  cookieAuthSessionCookie: "session=example",
+} as any
+
+async function renderExpandedServiceCredentialDialog() {
+  fetchServiceCredentialMock.mockResolvedValue(SHAREDCHAT_SERVICE_CREDENTIAL)
+
+  const user = userEvent.setup()
+
+  render(
+    <CopyKeyDialog
+      isOpen={true}
+      onClose={() => {}}
+      account={SHAREDCHAT_ACCOUNT}
+    />,
+  )
+
+  await user.click(await screen.findByText("Codex service key"))
+
+  return user
+}
+
 describe("CopyKeyDialog", () => {
   beforeEach(() => {
     fetchAccountTokensMock.mockReset()
     createApiTokenMock.mockReset()
     fetchAccountAvailableModelsMock.mockReset()
     fetchUserGroupsMock.mockReset()
+    fetchServiceCredentialMock.mockReset()
+    ccSwitchDialogMock.mockReset()
+    cliProxyDialogMock.mockReset()
+    claudeCodeRouterDialogMock.mockReset()
+    kiloCodeExportDialogMock.mockReset()
+    kiloCodeProfileExportDialogMock.mockReset()
+    openWithCredentialsMock.mockReset()
     resolveApiTokenKeyMock.mockReset()
     openInCherryStudioMock.mockReset()
     openWithAccountMock.mockReset()
@@ -287,6 +414,14 @@ describe("CopyKeyDialog", () => {
     )
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
+    openWithCredentialsMock.mockResolvedValue({ opened: true })
+    userPreferencesContextMock.claudeCodeRouterApiKey = "ccr-management-key"
+    userPreferencesContextMock.claudeCodeRouterBaseUrl =
+      "https://router.example.invalid"
+    userPreferencesContextMock.cliProxyBaseUrl =
+      "https://cliproxy.example.invalid"
+    userPreferencesContextMock.cliProxyManagementKey = "cliproxy-management-key"
+    userPreferencesContextMock.managedSiteType = SITE_TYPES.NEW_API
   })
 
   it("creates token then refreshes and auto-copies when exactly one token exists", async () => {
@@ -474,7 +609,7 @@ describe("CopyKeyDialog", () => {
     expect(screen.queryByText("invalid_token_payload")).not.toBeInTheDocument()
   })
 
-  it("shows a load error when the initial token inventory request fails", async () => {
+  it("shows a load error when the initial runtime-key inventory request fails", async () => {
     fetchAccountTokensMock.mockRejectedValueOnce(new Error("load failed"))
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
@@ -484,7 +619,7 @@ describe("CopyKeyDialog", () => {
     ).toBeInTheDocument()
   })
 
-  it("shows a load error when the initial token inventory is malformed", async () => {
+  it("shows a load error when the initial runtime-key inventory is malformed", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce(null)
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
@@ -911,6 +1046,156 @@ describe("CopyKeyDialog", () => {
         PRODUCT_ANALYTICS_RESULTS.Success,
       )
     })
+  })
+
+  it("renders service credential details without token-only quota or expiry metadata", async () => {
+    await renderExpandedServiceCredentialDialog()
+
+    expect(
+      screen.getByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "ui:dialog.copyKey.useInCherry" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.exportToKiloCode",
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByText("sk-service-crede")).toBeInTheDocument()
+    expect(screen.getByText("secret")).toBeInTheDocument()
+    expect(
+      screen.queryByText("ui:dialog.copyKey.expireTime"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("ui:dialog.copyKey.usedQuota"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("ui:dialog.copyKey.remainingQuota"),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("-1")).not.toBeInTheDocument()
+  })
+
+  it("exports service credentials with the credential API base URL", async () => {
+    const user = await renderExpandedServiceCredentialDialog()
+
+    await user.click(
+      screen.getByRole("button", { name: "ui:dialog.copyKey.useInCherry" }),
+    )
+
+    await waitFor(() => {
+      expect(openInCherryStudioMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://api.example.invalid/v1",
+          name: "SharedChat - Codex service key",
+        }),
+        expect.objectContaining({
+          key: "sk-service-credential-secret",
+          name: "SharedChat - Codex service key",
+        }),
+      )
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.copyKey.exportToCCSwitch",
+      }),
+    )
+    await waitFor(() => {
+      expect(ccSwitchDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({
+            baseUrl: "https://api.example.invalid/v1",
+          }),
+          token: expect.objectContaining({
+            key: "sk-service-credential-secret",
+          }),
+        }),
+      )
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.importToCliProxy",
+      }),
+    )
+    await waitFor(() => {
+      expect(cliProxyDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({
+            baseUrl: "https://api.example.invalid/v1",
+          }),
+          token: expect.objectContaining({
+            key: "sk-service-credential-secret",
+          }),
+          apiTypeHint: API_TYPES.OPENAI_COMPATIBLE,
+        }),
+      )
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.importToClaudeCodeRouter",
+      }),
+    )
+    await waitFor(() => {
+      expect(claudeCodeRouterDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({
+            baseUrl: "https://api.example.invalid/v1",
+          }),
+          token: expect.objectContaining({
+            key: "sk-service-credential-secret",
+          }),
+          routerApiKey: "ccr-management-key",
+          routerBaseUrl: "https://router.example.invalid",
+        }),
+      )
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.importToManagedSite",
+      }),
+    )
+    await waitFor(() => {
+      expect(openWithCredentialsMock).toHaveBeenCalledWith(
+        {
+          name: "SharedChat - Codex service key",
+          baseUrl: "https://api.example.invalid/v1",
+          apiKey: "sk-service-credential-secret",
+        },
+        expect.any(Function),
+        {
+          managedSiteStatus: undefined,
+        },
+      )
+      expect(openWithAccountMock).not.toHaveBeenCalled()
+    })
+  })
+
+  it("opens Kilo Code profile export for service credentials", async () => {
+    const user = await renderExpandedServiceCredentialDialog()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.exportToKiloCode",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(kiloCodeProfileExportDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isOpen: true,
+          profile: expect.objectContaining({
+            baseUrl: "https://api.example.invalid/v1",
+            apiKey: "sk-service-credential-secret",
+            name: "SharedChat - Codex service key",
+          }),
+        }),
+      )
+    })
+    expect(kiloCodeExportDialogMock).not.toHaveBeenCalled()
   })
 
   it("keeps masked-key copy failures localized to the action and shows the error message", async () => {

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -1016,7 +1016,12 @@ describe("CopyKeyDialog", () => {
 
   it("tracks managed-site single token import when the copied token flow opens", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
-    openWithAccountMock.mockResolvedValueOnce({ opened: true })
+    openWithAccountMock.mockImplementationOnce(
+      async (_account, _token, onResult) => {
+        onResult({ success: false, message: "managed import failed" })
+        return { opened: true }
+      },
+    )
 
     const user = userEvent.setup()
 
@@ -1042,9 +1047,156 @@ describe("CopyKeyDialog", () => {
         expect.objectContaining({ id: 1 }),
         expect.any(Function),
       )
+      expect(toastErrorMock).toHaveBeenCalledWith("managed import failed")
       expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
         PRODUCT_ANALYTICS_RESULTS.Success,
       )
+    })
+  })
+
+  it("resets copied state after showing the copied action label", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(await screen.findByText("default"))
+    await user.click(
+      await screen.findByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    )
+
+    expect(
+      await screen.findByRole("button", {
+        name: "ui:dialog.copyKey.copied",
+      }),
+    ).toBeInTheDocument()
+    expect(writeText).toHaveBeenCalledWith("sk-test")
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "ui:dialog.copyKey.copy" }),
+        ).toBeInTheDocument()
+      },
+      { timeout: 2500 },
+    )
+
+    expect(
+      screen.queryByRole("button", {
+        name: "ui:dialog.copyKey.copied",
+      }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders disabled token state and collapses expanded token details", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([
+      {
+        ...TOKEN,
+        status: 2,
+        remain_quota: 2000000,
+        unlimited_quota: false,
+      },
+    ])
+
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    expect(await screen.findByText("default")).toBeInTheDocument()
+    expect(screen.getByText("ui:dialog.copyKey.disabled")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "ui:dialog.expand" }))
+    expect(
+      screen.getByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "ui:dialog.collapse" }))
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("exports account tokens to external tools with the account token payload", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(await screen.findByText("default"))
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.copyKey.exportToCCSwitch",
+      }),
+    )
+    await waitFor(() => {
+      expect(ccSwitchDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({ id: "acc-1" }),
+          token: expect.objectContaining({ id: 1, key: "sk-test" }),
+        }),
+      )
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.exportToKiloCode",
+      }),
+    )
+    await waitFor(() => {
+      expect(kiloCodeExportDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isOpen: true,
+          initialSelectedSiteIds: ["acc-1"],
+          initialSelectedTokenIdsBySite: {
+            "acc-1": ["1"],
+          },
+        }),
+      )
+    })
+    act(() => {
+      kiloCodeExportDialogMock.mock.calls[0]?.[0].onClose()
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.importToCliProxy",
+      }),
+    )
+    await waitFor(() => {
+      expect(cliProxyDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({ id: "acc-1" }),
+          token: expect.objectContaining({ id: 1, key: "sk-test" }),
+        }),
+      )
+    })
+    act(() => {
+      cliProxyDialogMock.mock.calls[0]?.[0].onClose()
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.importToClaudeCodeRouter",
+      }),
+    )
+    await waitFor(() => {
+      expect(claudeCodeRouterDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: expect.objectContaining({ id: "acc-1" }),
+          token: expect.objectContaining({ id: 1, key: "sk-test" }),
+          routerApiKey: "ccr-management-key",
+          routerBaseUrl: "https://router.example.invalid",
+        }),
+      )
+    })
+    act(() => {
+      claudeCodeRouterDialogMock.mock.calls[0]?.[0].onClose()
     })
   })
 
@@ -1077,6 +1229,12 @@ describe("CopyKeyDialog", () => {
   })
 
   it("exports service credentials with the credential API base URL", async () => {
+    openWithCredentialsMock.mockImplementationOnce(
+      async (_credential, onResult) => {
+        onResult({ success: true, message: "credential import queued" })
+        return { deferred: true }
+      },
+    )
     const user = await renderExpandedServiceCredentialDialog()
 
     await user.click(
@@ -1132,6 +1290,9 @@ describe("CopyKeyDialog", () => {
         }),
       )
     })
+    act(() => {
+      cliProxyDialogMock.mock.calls[0]?.[0].onClose()
+    })
 
     await user.click(
       screen.getByRole("button", {
@@ -1152,6 +1313,9 @@ describe("CopyKeyDialog", () => {
         }),
       )
     })
+    act(() => {
+      claudeCodeRouterDialogMock.mock.calls[0]?.[0].onClose()
+    })
 
     await user.click(
       screen.getByRole("button", {
@@ -1171,6 +1335,7 @@ describe("CopyKeyDialog", () => {
         },
       )
       expect(openWithAccountMock).not.toHaveBeenCalled()
+      expect(toastSuccessMock).toHaveBeenCalledWith("credential import queued")
     })
   })
 
@@ -1194,6 +1359,9 @@ describe("CopyKeyDialog", () => {
           }),
         }),
       )
+    })
+    act(() => {
+      kiloCodeProfileExportDialogMock.mock.calls[0]?.[0].onClose()
     })
     expect(kiloCodeExportDialogMock).not.toHaveBeenCalled()
   })

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -1092,6 +1092,25 @@ describe("CopyKeyDialog", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("does not mask short secrets when the preview would not elide characters", async () => {
+    const shortSecret = "abcdefghijklmnopqrstuv"
+    fetchAccountTokensMock.mockResolvedValueOnce([
+      {
+        ...TOKEN,
+        key: shortSecret,
+      },
+    ])
+
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(await screen.findByText("default"))
+
+    expect(screen.getByText(shortSecret)).toBeInTheDocument()
+    expect(screen.queryByText("••••••")).not.toBeInTheDocument()
+  })
+
   it("renders disabled token state and collapses expanded token details", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([
       {

--- a/tests/features/KeyManagement/utils.test.ts
+++ b/tests/features/KeyManagement/utils.test.ts
@@ -5,14 +5,19 @@ import {
   buildAccountRuntimeKeyEntryIdentityKey,
   buildAccountTokenKeyManagementEntry,
   buildServiceCredentialKeyManagementEntry,
+  buildServiceCredentialManagedSiteStatusTarget,
   buildTokenIdentityKey,
   formatKey,
   formatQuota,
   isManagedSiteStatusIdentityForAccount,
+  loadServiceCredentialKeyManagementRuntimeKey,
+  toLegacyAccountTokenForKeyManagementEntry,
 } from "~/features/KeyManagement/utils"
 import {
+  ACCOUNT_RUNTIME_KEY_LEGACY_TOKEN_ID,
   ACCOUNT_RUNTIME_KEY_SOURCES,
   ACCOUNT_RUNTIME_KEY_STATUSES,
+  buildServiceCredentialRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
 import {
   buildApiToken,
@@ -126,6 +131,67 @@ describe("KeyManagement utils", () => {
       })
     })
 
+    it("loads service-credential runtime keys only when token CRUD is unavailable", async () => {
+      const account = buildDisplaySiteData({
+        id: "account-1",
+        name: "Example Account",
+        baseUrl: "https://new.sharedchat.cc",
+      })
+      const request = {
+        baseUrl: account.baseUrl,
+        accountId: account.id,
+        auth: {
+          authType: account.authType,
+          userId: account.userId,
+          accessToken: account.token,
+          cookie: account.cookieAuthSessionCookie,
+        },
+      }
+      const fetch = vi.fn().mockResolvedValue({
+        kind: "singleton_service_key",
+        service: "codex",
+        label: "Codex",
+        key: "service-secret",
+        isAuthenticated: true,
+        baseUrl: "https://codex.example.invalid",
+      })
+      const serviceCredential = { fetch }
+
+      await expect(
+        loadServiceCredentialKeyManagementRuntimeKey({
+          account,
+          keyManagement: { fetchTokens: vi.fn() } as any,
+          serviceCredential,
+          request,
+        }),
+      ).resolves.toBeNull()
+      expect(fetch).not.toHaveBeenCalled()
+
+      await expect(
+        loadServiceCredentialKeyManagementRuntimeKey({
+          account,
+          keyManagement: undefined,
+          serviceCredential,
+          request,
+        }),
+      ).resolves.toEqual({
+        credential: expect.objectContaining({
+          key: "service-secret",
+        }),
+        runtimeKey: expect.objectContaining({
+          id: "service_credential:account-1:codex",
+          source: ACCOUNT_RUNTIME_KEY_SOURCES.ServiceCredential,
+          baseUrl: "https://codex.example.invalid",
+          capabilities: expect.objectContaining({
+            updateToken: false,
+            deleteToken: false,
+            rotate: false,
+          }),
+        }),
+      })
+      expect(fetch).toHaveBeenCalledWith(request)
+    })
+
     it("matches legacy token and runtime-key status identities by account", () => {
       expect(
         isManagedSiteStatusIdentityForAccount("account-1:42", "account-1"),
@@ -148,6 +214,74 @@ describe("KeyManagement utils", () => {
           "account-1",
         ),
       ).toBe(false)
+    })
+
+    it("converts key-management entries to legacy account tokens at the feature boundary", () => {
+      const account = buildDisplaySiteData({
+        id: "account-1",
+        name: "Example Account",
+      })
+      const entry = buildServiceCredentialKeyManagementEntry({
+        account,
+        serviceCredential: {
+          status: "loaded",
+          credential: {
+            kind: "singleton_service_key",
+            service: "codex",
+            label: "Codex",
+            key: "service-secret",
+            isAuthenticated: true,
+          },
+        },
+        canRotate: true,
+      })
+
+      expect(entry).not.toBeNull()
+      expect(toLegacyAccountTokenForKeyManagementEntry(entry!)).toMatchObject({
+        id: ACCOUNT_RUNTIME_KEY_LEGACY_TOKEN_ID,
+        accountId: "account-1",
+        accountName: "Example Account",
+        key: "service-secret",
+        name: "Codex",
+        status: 1,
+      })
+    })
+
+    it("builds managed-site status targets for service credentials with runtime-key identity", () => {
+      const account = buildDisplaySiteData({
+        id: "account-1",
+        name: "Example Account",
+        baseUrl: "https://new-api.example.invalid",
+      })
+      const runtimeKey = buildServiceCredentialRuntimeKey(
+        account,
+        {
+          kind: "singleton_service_key",
+          service: "codex",
+          label: "Codex",
+          key: "service-secret",
+          isAuthenticated: true,
+          baseUrl: "https://codex.example.invalid",
+        },
+        { canRotate: true },
+      )
+
+      expect(
+        buildServiceCredentialManagedSiteStatusTarget(account, runtimeKey),
+      ).toMatchObject({
+        identityKey: "runtime_key:service_credential:account-1:codex",
+        account: {
+          id: "account-1",
+          baseUrl: "https://codex.example.invalid",
+        },
+        token: {
+          id: ACCOUNT_RUNTIME_KEY_LEGACY_TOKEN_ID,
+          accountId: "account-1",
+          accountName: "Example Account",
+          key: "service-secret",
+          name: "Codex",
+        },
+      })
     })
   })
 

--- a/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
+++ b/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
@@ -61,14 +61,12 @@ vi.mock(
       await importOriginal<
         typeof import("~/services/accounts/utils/apiServiceRequest")
       >()
-    const { buildAccountTokenRuntimeKey } = await import(
+    const { buildDisplayAccountTokenRuntimeKey } = await import(
       "~/services/accounts/accountRuntimeKeys"
     )
 
     return {
       ...actual,
-      fetchDisplayAccountRuntimeKeyTokens: (...args: any[]) =>
-        mockFetchDisplayAccountTokens(...args),
       fetchDisplayAccountRuntimeKeys: async (...args: any[]) => {
         const [account] = args
         const runtimeKeys = await mockFetchDisplayAccountRuntimeKeys(...args)
@@ -76,21 +74,13 @@ vi.mock(
           return runtimeKeys.map((runtimeKey: any) =>
             runtimeKey?.source && runtimeKey?.accountId
               ? runtimeKey
-              : buildAccountTokenRuntimeKey(account, {
-                  ...runtimeKey,
-                  accountId: account.id,
-                  accountName: account.name,
-                }),
+              : buildDisplayAccountTokenRuntimeKey(account, runtimeKey),
           )
         }
 
         const tokens = await mockFetchDisplayAccountTokens(...args)
         return tokens.map((token: any) =>
-          buildAccountTokenRuntimeKey(account, {
-            ...token,
-            accountId: account.id,
-            accountName: account.name,
-          }),
+          buildDisplayAccountTokenRuntimeKey(account, token),
         )
       },
       fetchDisplayAccountTokens: (...args: any[]) =>

--- a/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
+++ b/tests/features/ModelList/components/BatchVerifyModelsDialog.test.tsx
@@ -409,7 +409,7 @@ describe("BatchVerifyModelsDialog", () => {
       ).length,
     ).toBeGreaterThan(0)
     expect(
-      await screen.findByText("modelList:batchVerify.tokenUsed"),
+      await screen.findByText("modelList:batchVerify.runtimeKeyUsed"),
     ).toBeInTheDocument()
     expect(mockUpsertLatestSummary).toHaveBeenCalledTimes(1)
   })
@@ -1177,7 +1177,7 @@ describe("BatchVerifyModelsDialog", () => {
     })
   })
 
-  it("completes batch verification analytics as skipped when no compatible token exists", async () => {
+  it("completes batch verification analytics as skipped when no compatible runtime key exists", async () => {
     mockFetchDisplayAccountTokens.mockResolvedValueOnce([
       {
         id: 1,
@@ -1352,7 +1352,7 @@ describe("BatchVerifyModelsDialog", () => {
       status: "fail",
       latencyMs: 22,
       summary: "",
-      summaryKey: "verifyDialog.noCompatibleTokenHint",
+      summaryKey: "verifyDialog.noCompatibleRuntimeKeyHint",
     })
 
     renderDialog([
@@ -1375,7 +1375,7 @@ describe("BatchVerifyModelsDialog", () => {
     )
     await waitFor(() => {
       expect(row).toHaveTextContent(
-        "aiApiVerification:verifyDialog.noCompatibleTokenHint",
+        "aiApiVerification:verifyDialog.noCompatibleRuntimeKeyHint",
       )
     })
     expect(row).not.toHaveTextContent(
@@ -1604,7 +1604,7 @@ describe("BatchVerifyModelsDialog", () => {
     ).toBeInTheDocument()
   })
 
-  it("skips an account model when no compatible token exists", async () => {
+  it("skips an account model when no compatible runtime key exists", async () => {
     mockFetchDisplayAccountTokens.mockResolvedValueOnce([
       {
         id: 1,
@@ -1635,7 +1635,7 @@ describe("BatchVerifyModelsDialog", () => {
 
     expect(
       await screen.findByText(
-        "modelList:batchVerify.messages.noCompatibleToken",
+        "modelList:batchVerify.messages.noCompatibleRuntimeKey",
       ),
     ).toBeInTheDocument()
     expect(mockRunApiVerificationProbe).not.toHaveBeenCalled()
@@ -1732,7 +1732,7 @@ describe("BatchVerifyModelsDialog", () => {
     })
   })
 
-  it("refetches tokens after a failed run when rerunning the batch", async () => {
+  it("refetches runtime keys after a failed run when rerunning the batch", async () => {
     mockFetchDisplayAccountTokens
       .mockRejectedValueOnce(new Error("temporary token failure"))
       .mockResolvedValueOnce([

--- a/tests/services/accounts/accountRuntimeKeys.test.ts
+++ b/tests/services/accounts/accountRuntimeKeys.test.ts
@@ -8,6 +8,7 @@ import {
   accountRuntimeKeyToLegacyApiToken,
   buildAccountTokenRuntimeKey,
   buildAccountTokenRuntimeKeyId,
+  buildDisplayAccountTokenRuntimeKey,
   buildServiceCredentialRuntimeKey,
   buildServiceCredentialRuntimeKeyId,
   collectAccountRuntimeKeySecrets,
@@ -98,6 +99,32 @@ describe("accountRuntimeKeys", () => {
     expect(
       buildAccountTokenRuntimeKey(account, { ...token, status: 99 }).status,
     ).toBe(ACCOUNT_RUNTIME_KEY_STATUSES.Unknown)
+  })
+
+  it("builds display-account token runtime keys with normalized account fields", () => {
+    const runtimeKey = buildDisplayAccountTokenRuntimeKey(
+      {
+        ...account,
+        name: "",
+        tagIds: undefined,
+      },
+      {
+        ...token,
+        accountId: undefined as unknown as string,
+        accountName: undefined as unknown as string,
+      },
+    )
+
+    expect(runtimeKey.account).toMatchObject({
+      id: account.id,
+      name: account.id,
+      tagIds: [],
+    })
+    expect(runtimeKey.accountName).toBe(account.id)
+    expect(runtimeKey.token).toMatchObject({
+      accountId: account.id,
+      accountName: account.id,
+    })
   })
 
   it("builds stable service-credential runtime keys", () => {

--- a/tests/services/accounts/accountRuntimeKeys.test.ts
+++ b/tests/services/accounts/accountRuntimeKeys.test.ts
@@ -6,6 +6,7 @@ import {
   ACCOUNT_RUNTIME_KEY_STATUSES,
   accountRuntimeKeyToLegacyAccountToken,
   accountRuntimeKeyToLegacyApiToken,
+  appendOrReplaceAccountRuntimeKey,
   buildAccountTokenRuntimeKey,
   buildAccountTokenRuntimeKeyId,
   buildDisplayAccountTokenRuntimeKey,
@@ -326,6 +327,31 @@ describe("accountRuntimeKeys", () => {
     expect(
       findDefaultSelectableAccountRuntimeKey([inactiveServiceRuntimeKey]),
     ).toBeNull()
+  })
+
+  it("appends a new runtime key while replacing an existing key with the same id", () => {
+    const existingRuntimeKey = buildAccountTokenRuntimeKey(account, token)
+    const otherRuntimeKey = buildServiceCredentialRuntimeKey(account, {
+      kind: "singleton_service_key",
+      service: "codex",
+      label: "Codex",
+      key: "service-secret",
+      isAuthenticated: true,
+    })
+    const updatedRuntimeKey = buildAccountTokenRuntimeKey(account, {
+      ...token,
+      key: "sk-updated-token-secret",
+    })
+
+    expect(
+      appendOrReplaceAccountRuntimeKey(
+        [existingRuntimeKey, otherRuntimeKey],
+        updatedRuntimeKey,
+      ),
+    ).toEqual([otherRuntimeKey, updatedRuntimeKey])
+    expect(
+      appendOrReplaceAccountRuntimeKey([existingRuntimeKey], otherRuntimeKey),
+    ).toEqual([existingRuntimeKey, otherRuntimeKey])
   })
 
   it("formats account-token runtime key secrets for compatible site auth", () => {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -964,6 +964,22 @@ describe("fetchDisplayAccountTokens", () => {
     expect(result.token.key).toBe("sk-plain-secret")
   })
 
+  it("throws when resolving a token secret without key-management or service-credential support", async () => {
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue({
+      siteType: "unsupported",
+    } as any)
+
+    await expect(
+      resolveDisplayAccountTokenForSecret(
+        {
+          ...ACCOUNT,
+          siteType: "unsupported",
+        } as any,
+        { id: 1, key: "sk-masked", status: 1, name: "Masked" } as any,
+      ),
+    ).rejects.toThrow("keyManagement is not implemented for unsupported")
+  })
+
   it("throws when adapter key management is not implemented", async () => {
     vi.mocked(getSiteTypeCapabilities).mockReturnValue({
       siteType: "unsupported",

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
-  ACCOUNT_RUNTIME_KEY_LEGACY_TOKEN_ID,
   buildAccountTokenRuntimeKey,
   type AccountRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
@@ -14,7 +13,6 @@ import {
   createDisplayAccountApiContext,
   createDisplayAccountRequestContext,
   fetchDisplayAccountRuntimeKeys,
-  fetchDisplayAccountRuntimeKeyTokens,
   fetchDisplayAccountTokens,
   InvalidTokenPayloadError,
   resolveDisplayAccountRuntimeKeySecret,
@@ -248,42 +246,6 @@ describe("fetchDisplayAccountTokens", () => {
       }),
     )
     expect(fetchTokens).not.toHaveBeenCalled()
-  })
-
-  it("exposes a clearly named compatibility helper for legacy token-shaped consumers", async () => {
-    const serviceCredentialAccount = {
-      ...ACCOUNT,
-      siteType: SITE_TYPES.SHAREDCHAT,
-      baseUrl: "https://runtime.example.invalid",
-    }
-    capabilities = {
-      siteType: SITE_TYPES.SHAREDCHAT,
-      account: {
-        serviceCredential: {
-          fetch: fetchServiceCredential,
-        },
-      },
-    }
-    vi.mocked(getSiteTypeCapabilities).mockReturnValue(capabilities as any)
-    fetchServiceCredential.mockResolvedValueOnce({
-      kind: "singleton_service_key",
-      service: "codex",
-      label: "Codex",
-      key: "service-credential-secret",
-      isAuthenticated: true,
-    })
-
-    const result = await fetchDisplayAccountRuntimeKeyTokens(
-      serviceCredentialAccount as any,
-    )
-
-    expect(result).toEqual([
-      expect.objectContaining({
-        id: ACCOUNT_RUNTIME_KEY_LEGACY_TOKEN_ID,
-        name: "Codex",
-        key: "service-credential-secret",
-      }),
-    ])
   })
 
   it("keeps runtime key loading on key management when token inventory is supported", async () => {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -14,6 +14,8 @@ import {
   createDisplayAccountRequestContext,
   fetchDisplayAccountRuntimeKeys,
   fetchDisplayAccountTokens,
+  getInvalidTokenPayloadLogContext,
+  getRuntimeKeyInventoryErrorMessage,
   InvalidTokenPayloadError,
   resolveDisplayAccountRuntimeKeySecret,
   resolveDisplayAccountTokenForSecret,
@@ -640,6 +642,34 @@ describe("fetchDisplayAccountTokens", () => {
       expect(error.siteType).toBe("new-api")
       expect(error.responseType).toBe("object")
     }
+  })
+
+  it("keeps invalid token payload errors user-safe while exposing diagnostic log context", () => {
+    const error = new InvalidTokenPayloadError({
+      accountId: "account-1",
+      baseUrl: "https://example.com",
+      siteType: "new-api",
+      responseType: "object",
+    })
+
+    expect(getRuntimeKeyInventoryErrorMessage(error, "fallback")).toBe(
+      "fallback",
+    )
+    expect(getInvalidTokenPayloadLogContext(error)).toEqual({
+      payloadAccountId: "account-1",
+      payloadBaseUrl: "https://example.com",
+      payloadSiteType: "new-api",
+      payloadResponseType: "object",
+    })
+  })
+
+  it("preserves ordinary runtime key inventory error messages without payload diagnostics", () => {
+    const error = new Error("network failed")
+
+    expect(getRuntimeKeyInventoryErrorMessage(error, "fallback")).toBe(
+      "network failed",
+    )
+    expect(getInvalidTokenPayloadLogContext(error)).toEqual({})
   })
 
   it("returns the original token object when the resolved secret key is unchanged", async () => {

--- a/tests/services/modelList/accountSources/readiness.test.ts
+++ b/tests/services/modelList/accountSources/readiness.test.ts
@@ -8,10 +8,12 @@ import {
 } from "~/services/accounts/accountSiteProfile"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import {
+  canLoadModelListAccountFallbackRuntimeKeys,
   MODEL_LIST_ACCOUNT_SOURCE_ROUTES,
   MODEL_LIST_ACCOUNT_SOURCE_UNSUPPORTED_REASONS,
   resolveModelListAccountSourceReadiness,
 } from "~/services/modelList/accountSources/readiness"
+import { AuthTypeEnum } from "~/types"
 
 vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteTypeCapabilities: vi.fn(),
@@ -23,6 +25,16 @@ const modelPricing = {
 
 const modelCatalog = {
   fetchModels: vi.fn(),
+}
+
+const runtimeKeyFallbackAccount = {
+  id: "sharedchat-account",
+  siteType: SITE_TYPES.SHAREDCHAT,
+  baseUrl: "https://new.sharedchat.cc",
+  authType: AuthTypeEnum.Cookie,
+  userId: "user-1",
+  token: "access-token",
+  cookieAuthSessionCookie: "session=redacted",
 }
 
 describe("resolveModelListAccountSourceReadiness", () => {
@@ -92,6 +104,33 @@ describe("resolveModelListAccountSourceReadiness", () => {
       displayCapabilitiesSource:
         ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
     })
+  })
+
+  it("exposes whether model-list fallback can load account runtime keys", () => {
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue({
+      siteType: SITE_TYPES.SHAREDCHAT,
+      account: {
+        modelCatalog,
+        serviceCredential: {
+          fetch: vi.fn(),
+        },
+      },
+    } as any)
+
+    expect(
+      canLoadModelListAccountFallbackRuntimeKeys(runtimeKeyFallbackAccount),
+    ).toBe(true)
+
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue({
+      siteType: SITE_TYPES.SHAREDCHAT,
+      account: {
+        modelCatalog,
+      },
+    } as any)
+
+    expect(
+      canLoadModelListAccountFallbackRuntimeKeys(runtimeKeyFallbackAccount),
+    ).toBe(false)
   })
 
   it("returns missing model-catalog capability for token-scoped profiles without modelCatalog", () => {

--- a/tests/services/modelList/accountSources/runtimeKeyFallback.test.ts
+++ b/tests/services/modelList/accountSources/runtimeKeyFallback.test.ts
@@ -7,9 +7,9 @@ import {
 } from "~/services/accounts/accountRuntimeKeys"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import {
-  ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED,
+  ACCOUNT_RUNTIME_KEY_FALLBACK_LOAD_FAILED,
   loadAccountRuntimeKeyFallbackPricingResponse,
-} from "~/services/modelList/accountSources/tokenScopedFallback"
+} from "~/services/modelList/accountSources/runtimeKeyFallback"
 import {
   MODEL_LIST_SOURCE_KINDS,
   MODEL_PRICE_PRECISION_KINDS,
@@ -647,7 +647,7 @@ describe("loadAccountRuntimeKeyFallbackPricingResponseFromToken", () => {
     ])
   })
 
-  it("passes abort signals through token-scoped catalog fallback requests", async () => {
+  it("passes abort signals through runtime-key catalog fallback requests", async () => {
     const abortController = new AbortController()
     resolveDisplayAccountTokenForSecretMock.mockResolvedValueOnce({
       ...TOKEN,
@@ -883,7 +883,7 @@ describe("loadAccountRuntimeKeyFallbackPricingResponseFromToken", () => {
     expect(message).not.toContain("sk-real-secret")
     expect(message).not.toContain("https://example.com")
     expect(message.length).toBeGreaterThan(0)
-    expect(message).not.toBe(ACCOUNT_TOKEN_FALLBACK_LOAD_FAILED)
+    expect(message).not.toBe(ACCOUNT_RUNTIME_KEY_FALLBACK_LOAD_FAILED)
   })
 
   it("redacts account auth secrets when account-scoped pricing fails", async () => {

--- a/tests/services/modelList/accountSources/runtimeKeyFallbackTestUtils.ts
+++ b/tests/services/modelList/accountSources/runtimeKeyFallbackTestUtils.ts
@@ -1,5 +1,5 @@
 import { buildAccountTokenRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
-import { loadAccountRuntimeKeyFallbackPricingResponse } from "~/services/modelList/accountSources/tokenScopedFallback"
+import { loadAccountRuntimeKeyFallbackPricingResponse } from "~/services/modelList/accountSources/runtimeKeyFallback"
 import type { ApiToken, DisplaySiteData } from "~/types"
 
 export const loadAccountRuntimeKeyFallbackPricingResponseFromToken = (params: {

--- a/tests/services/productAnalytics/events.test.ts
+++ b/tests/services/productAnalytics/events.test.ts
@@ -131,8 +131,8 @@ describe("product analytics event enums", () => {
       RepairMissingAccountKeys: "repair_missing_account_keys",
       SaveAccountTokenToApiCredentialProfile:
         "save_account_token_to_api_credential_profile",
-      SaveAccountTokensToApiCredentialProfiles:
-        "save_account_tokens_to_api_credential_profiles",
+      SaveAccountRuntimeKeysToApiCredentialProfiles:
+        "save_account_runtime_keys_to_api_credential_profiles",
       VerifyAccountTokenApi: "verify_account_token_api",
       VerifyAccountTokenCliSupport: "verify_account_token_cli_support",
       RefreshManagedSiteTokenStatus: "refresh_managed_site_token_status",

--- a/tests/services/productAnalytics/privacy.test.ts
+++ b/tests/services/productAnalytics/privacy.test.ts
@@ -338,7 +338,7 @@ describe("product analytics privacy filtering", () => {
     },
     {
       actionId:
-        PRODUCT_ANALYTICS_ACTION_IDS.SaveAccountTokensToApiCredentialProfiles,
+        PRODUCT_ANALYTICS_ACTION_IDS.SaveAccountRuntimeKeysToApiCredentialProfiles,
       surfaceId: PRODUCT_ANALYTICS_SURFACE_IDS.OptionsKeyManagementPage,
       result: PRODUCT_ANALYTICS_RESULTS.Success,
       errorCategory: undefined,


### PR DESCRIPTION
## Summary

- Replace token-shaped runtime-key bridge usage with `AccountRuntimeKey` flows in account copy, model key, and verification UI.
- Add centralized helpers for display-account runtime keys, service-credential key-management entries, fallback readiness, and inventory error handling.
- Rename token-scoped runtime catalog/copy surfaces to runtime-key terminology across UI, analytics, locales, and tests.
- Cover service-credential copy/export paths, runtime-key fallback readiness, analytics/privacy allow-list changes, and updated UI behavior.

## Validation

- `pnpm run validate:push`
- pre-push `pnpm run validate:push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API verification, CLI support verification, key-management, and model key selection now operate on **runtime keys**, including updated selectors, loading behavior, and compatibility messaging.
  * Batch verification/model probes now report the **runtime key used** and update skip/compatibility states accordingly.
  * Copy Key dialog UI now renders runtime-key details (including service-credential export/import where applicable).
* **Bug Fixes**
  * Improved runtime-key loading/refresh, retry enablement, and “empty/incompatible” handling.
  * Enhanced secret-masking and runtime-key inventory/secret-resolution error messaging.
* **Documentation**
  * Updated end-user UI wording across supported languages from “tokens” to **“runtime keys”** (hints, labels, placeholders, and incompatibility messages).
* **Tests**
  * Updated and added coverage for runtime-key terminology and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->